### PR TITLE
Fix the Get-Item Pester test

### DIFF
--- a/test/powershell/Get-Item.Tests.ps1
+++ b/test/powershell/Get-Item.Tests.ps1
@@ -8,7 +8,7 @@ Describe "Get-Item" {
 
     It "Should return the name of the current working directory when a dot is used" {
         (Get-Item $here).GetType().BaseType | Should Be 'System.IO.FileSystemInfo'
-        (Get-Item $here).Name | Should Be 'pester-tests'
+        (Get-Item $here).Name | Should Be 'powershell'
     }
 
     It "Should return the proper Name and BaseType for directory objects vs file system objects" {


### PR DESCRIPTION
Failed because we renamed the test directory.

This is why I need to do #4 :smile: 
