### PR TITLE
Emit powershell executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Build with `./build.sh`, which does the following steps.
 ### Managed
 
 Builds with `dotnet-cli`. Publishes all dependencies into the `bin` directory.
-Emits its own native host as `bin/Microsoft.PowerShell.Linux.Host`.
+Emits its own native host as `bin/powershell`.
 
 ```sh
 cd src/Microsoft.PowerShell.Linux.Host
@@ -187,7 +187,7 @@ make -j
 
 ## Running
 
-- launch local shell with `./bin/Microsoft.PowerShell.Linux.Host`
+- launch local shell with `./bin/powershell`
 - launch local shell in LLDB with `./debug.sh`
 - launch `omiserver` for PSRP (and in LLDB) with `./prsp.sh`, and connect with `Enter-PSSession` from Windows
 

--- a/debug.sh
+++ b/debug.sh
@@ -1,1 +1,1 @@
-lldb-3.6 -o "plugin load ./bin/libsosplugin.so" -- ./bin/Microsoft.PowerShell.Linux.Host $@
+lldb-3.6 -o "plugin load ./bin/libsosplugin.so" -- ./bin/powershell $@

--- a/pester.sh
+++ b/pester.sh
@@ -1,3 +1,3 @@
-./bin/Microsoft.PowerShell.Linux.Host -c "Invoke-Pester test/powershell/$1 -OutputFile pester-tests.xml -OutputFormat NUnitXml"
+./bin/powershell -c "Invoke-Pester test/powershell/$1 -OutputFile pester-tests.xml -OutputFormat NUnitXml"
 # XML files are not executable
 chmod -x pester-tests.xml

--- a/src/Microsoft.PowerShell.Linux.Host/project.json
+++ b/src/Microsoft.PowerShell.Linux.Host/project.json
@@ -1,24 +1,25 @@
 {
+    "name": "powershell",
     "version": "1.0.0-*",
     "description": "PowerShell On Linux Console",
     "authors": [ "andschwa" ],
 
     "compilationOptions": {
-        "emitEntryPoint": true
+	"emitEntryPoint": true
     },
 
     "dependencies": {
 	"NETStandard.Library": "1.0.0-rc2-23712",
 	"Newtonsoft.Json": "8.0.2",
-        "Microsoft.PowerShell.Commands.Management": {
+	"Microsoft.PowerShell.Commands.Management": {
 	    "type": "build",
 	    "version": "1.0.0-*"
 	},
-        "Microsoft.PowerShell.Commands.Omi": {
+	"Microsoft.PowerShell.Commands.Omi": {
 	    "type": "build",
 	    "version": "1.0.0-*"
 	},
-        "Microsoft.PowerShell.Commands.Utility": {
+	"Microsoft.PowerShell.Commands.Utility": {
 	    "type": "build",
 	    "version": "1.0.0-*"
 	}

--- a/src/System.Management.Automation/AssemblyInfo.cs
+++ b/src/System.Management.Automation/AssemblyInfo.cs
@@ -5,8 +5,7 @@ using System.Reflection;
 [assembly:InternalsVisibleTo("Microsoft.PowerShell.Commands.Utility")]
 [assembly:InternalsVisibleTo("Microsoft.PowerShell.Security")]
 [assembly:InternalsVisibleTo("Microsoft.PowerShell.CoreCLR.AssemblyLoadContext")]
-[assembly:InternalsVisibleTo("Microsoft.PowerShell.Linux.Host")]
-[assembly:InternalsVisibleTo("Microsoft.PowerShell.Linux.UnitTests")]
+[assembly:InternalsVisibleTo("powershell")]
 [assembly:AssemblyFileVersionAttribute("3.0.0.0")]
 [assembly:AssemblyVersion("3.0.0.0")]
 


### PR DESCRIPTION
Instead of Microsoft.PowerShell.Linux.Host

Since this changes the name of the library,
System.Management.Automation's assembly info needed to be updated.
