### PR TITLE
Enable Windows support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# PowerShell on Linux
+# PowerShell on Linux / OS X / Windows
 
 ## Obtain the source code
 
@@ -77,16 +77,24 @@ fast-forward merge.
 ## Setup build environment
 
 We use the [.NET Command Line Interface][dotnet-cli] (`dotnet-cli`) to build
-the managed components, and [CMake][] to build the native components. Install
-`dotnet-cli` by following their documentation (make sure to install the
-`dotnet-dev` package to get the latest version). Then install the following
-dependencies (assuming Ubuntu 14.04):
+the managed components, and [CMake][] to build the native components (on
+non-Windows platforms). Install `dotnet-cli` by following their documentation
+(make sure to install the `dotnet-dev` package on Linux to get the latest
+version). Then install the following dependencies Linux and OS X.
+
+> Note that OS X dependency installation instructions are not yet documented,
+> and Windows only needs `dotnet-cli`.
+
+### Linux
+
+Tested on Ubuntu 14.04 and OS X 10.11.
+
 
 ```sh
 sudo apt-get install g++ cmake make lldb-3.6 strace
 ```
 
-### OMI
+#### OMI
 
 To develop on the PowerShell Remoting Protocol (PSRP), you'll need to be able
 to compile OMI, which additionally requires:
@@ -100,12 +108,36 @@ sudo apt-get install libpam0g-dev libssl-dev libcurl4-openssl-dev libboost-files
 
 ## Building
 
-The command `dotnet restore` must be done at least once from the top directory
-to obtain all the necessary .NET packages.
+*The command `dotnet restore` must be done at least once from the top directory
+to obtain all the necessary .NET packages.*
 
-Build with `./build.sh`, which does the following steps.
+Build with `./build.sh` on Linux and OS X, and `./build.ps1` on Windows.
 
-> The variable `$BIN` is the output directory, `bin`.
+## Running
+
+### Linux / OS X
+
+- launch local shell with `./bin/powershell`
+- launch local shell in LLDB with `./debug.sh`
+- launch `omiserver` for PSRP (and in LLDB) with `./prsp.sh`, and connect with `Enter-PSSession` from Windows
+
+### Windows
+
+Launch `./bin/powershell.exe`. The console output isn't the prettiest, bet the
+vast majority of Pester tests pass.
+
+## Known Issues
+
+### xUnit
+
+Sadly, `dotnet-test` is not fully supported on Linux, so our xUnit tests do not
+currently run. We may be able to work around this, or get the `dotnet-cli` team
+to fix their xUnit runner. GitHub
+[issue](https://github.com/dotnet/cli/issues/18).
+
+## Detailed Build Notes
+
+The variable `$BIN` is the output directory, `bin`.
 
 ### Managed
 
@@ -152,6 +184,9 @@ cp api-ms-win-core-registry-l1-1-0.dll $BIN
 PSRP communication is tunneled through OMI using the `omi-provider`.
 These build steps are not part of the `./build.sh` script.
 
+> PSRP has been observed working on OS X, but the changes made to OMI to
+> accomplish this are not even beta-ready and need to be done correctly.
+
 #### OMI
 
 ```sh
@@ -185,17 +220,3 @@ ln -s ../omi/Unix/ omi-1.0.8
 make -j
 ```
 
-## Running
-
-- launch local shell with `./bin/powershell`
-- launch local shell in LLDB with `./debug.sh`
-- launch `omiserver` for PSRP (and in LLDB) with `./prsp.sh`, and connect with `Enter-PSSession` from Windows
-
-## Known Issues
-
-### xUnit
-
-Sadly, `dotnet-test` is not fully supported on Linux, so our xUnit tests do not
-currently run. We may be able to work around this, or get the `dotnet-cli` team
-to fix their xUnit runner. GitHub
-[issue](https://github.com/dotnet/cli/issues/407).

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Build with `./build.sh`, which does the following steps.
 ### Managed
 
 Builds with `dotnet-cli`. Publishes all dependencies into the `bin` directory.
-Emits its own native host as `bin/Microsoft.PowerShell.Linux.Host`.
+Emits its own native host as `bin/powershell`.
 
 ```sh
 cd src/Microsoft.PowerShell.Linux.Host
@@ -187,7 +187,7 @@ make -j
 
 ## Running
 
-- launch local shell with `./bin/Microsoft.PowerShell.Linux.Host`
+- launch local shell with `./bin/powershell`
 - launch local shell in LLDB with `./debug.sh`
 - launch `omiserver` for PSRP (and in LLDB) with `./prsp.sh`, and connect with `Enter-PSSession` from Windows
 

--- a/build.ps1
+++ b/build.ps1
@@ -1,0 +1,35 @@
+$BIN = "${pwd}/bin"
+
+mkdir $BIN/Modules -ErrorAction SilentlyContinue
+
+# Deploy PowerShell modules
+cd $BIN/Modules
+robocopy ../../test/Pester Pester /s /e 
+robocopy ../../src/monad/monad/miscfiles/modules/Microsoft.PowerShell.Utility Microsoft.PowerShell.Utility /s /e 
+cd ../..
+
+# Publish PowerShell
+cd src/Microsoft.PowerShell.Linux.Host
+dotnet publish --framework dnxcore50 --output $BIN
+# Copy files that dotnet-publish does not currently deploy
+cp *_profile.ps1 $BIN
+cd ../..
+
+# Symlink types and format files to correct names
+cd $BIN
+
+cp ../src/monad/monad/miscfiles/types/CoreClr/types.ps1xml .
+cp ../src/monad/monad/miscfiles/types/CoreClr/typesv3.ps1xml .
+
+cp ../src/monad/monad/miscfiles/display/Certificate.format.ps1xml .
+cp ../src/monad/monad/miscfiles/display/Diagnostics.Format.ps1xml Diagnostics.format.ps1xml
+cp ../src/monad/monad/miscfiles/display/DotNetTypes.format.ps1xml .
+cp ../src/monad/monad/miscfiles/display/Event.format.ps1xml .
+cp ../src/monad/monad/miscfiles/display/FileSystem.format.ps1xml .
+cp ../src/monad/monad/miscfiles/display/Help.format.ps1xml .
+cp ../src/monad/monad/miscfiles/display/HelpV3.format.ps1xml .
+cp ../src/monad/monad/miscfiles/display/PowerShellCore.format.ps1xml .
+cp ../src/monad/monad/miscfiles/display/PowerShellTrace.format.ps1xml .
+cp ../src/monad/monad/miscfiles/display/Registry.format.ps1xml .
+cp ../src/monad/monad/miscfiles/display/WSMan.format.ps1xml .
+cd ..

--- a/debug.sh
+++ b/debug.sh
@@ -1,1 +1,1 @@
-lldb-3.6 -o "plugin load ./bin/libsosplugin.so" -- ./bin/Microsoft.PowerShell.Linux.Host $@
+lldb-3.6 -o "plugin load ./bin/libsosplugin.so" -- ./bin/powershell $@

--- a/pester.sh
+++ b/pester.sh
@@ -1,3 +1,3 @@
-./bin/Microsoft.PowerShell.Linux.Host -c "Invoke-Pester test/powershell/$1 -OutputFile pester-tests.xml -OutputFormat NUnitXml"
+./bin/powershell -c "Invoke-Pester test/powershell/$1 -OutputFile pester-tests.xml -OutputFormat NUnitXml"
 # XML files are not executable
 chmod -x pester-tests.xml

--- a/src/Microsoft.PowerShell.Linux.Host/project.json
+++ b/src/Microsoft.PowerShell.Linux.Host/project.json
@@ -1,24 +1,25 @@
 {
+    "name": "powershell",
     "version": "1.0.0-*",
     "description": "PowerShell On Linux Console",
     "authors": [ "andschwa" ],
 
     "compilationOptions": {
-        "emitEntryPoint": true
+	"emitEntryPoint": true
     },
 
     "dependencies": {
 	"NETStandard.Library": "1.0.0-rc2-23712",
 	"Newtonsoft.Json": "8.0.2",
-        "Microsoft.PowerShell.Commands.Management": {
+	"Microsoft.PowerShell.Commands.Management": {
 	    "type": "build",
 	    "version": "1.0.0-*"
 	},
-        "Microsoft.PowerShell.Commands.Omi": {
+	"Microsoft.PowerShell.Commands.Omi": {
 	    "type": "build",
 	    "version": "1.0.0-*"
 	},
-        "Microsoft.PowerShell.Commands.Utility": {
+	"Microsoft.PowerShell.Commands.Utility": {
 	    "type": "build",
 	    "version": "1.0.0-*"
 	}

--- a/src/System.Management.Automation/AssemblyInfo.cs
+++ b/src/System.Management.Automation/AssemblyInfo.cs
@@ -5,8 +5,7 @@ using System.Reflection;
 [assembly:InternalsVisibleTo("Microsoft.PowerShell.Commands.Utility")]
 [assembly:InternalsVisibleTo("Microsoft.PowerShell.Security")]
 [assembly:InternalsVisibleTo("Microsoft.PowerShell.CoreCLR.AssemblyLoadContext")]
-[assembly:InternalsVisibleTo("Microsoft.PowerShell.Linux.Host")]
-[assembly:InternalsVisibleTo("Microsoft.PowerShell.Linux.UnitTests")]
+[assembly:InternalsVisibleTo("powershell")]
 [assembly:AssemblyFileVersionAttribute("3.0.0.0")]
 [assembly:AssemblyVersion("3.0.0.0")]
 


### PR DESCRIPTION
This enables full cross-platform support (Linux, OS X, and Windows), using `dotnet-cli` to produce a self-contained PowerShell build.

It is very rough around the edges, especially the console. However, over 500 of our Pester tests pass on Windows.

Note that this includes #11 and so the emitted executable is `bin/powershell`. This also bumps the PowerShell submodule.
