### PR TITLE
Link Waffle.io scrum board in readme

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,9 @@
 
 Don't forget to commit early and often!
 
+Please add `[ci skip]` to commits that should be ignored by the CI systems
+(e.g. changes to documentation).
+
 ## New to Git?
 
 If you're new to Git, learn the following commands: `checkout`, `branch`,

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 |---------|:------:|:------:|
 |master|[![Build Status](https://travis-ci.com/PowerShell/PowerShell-Linux.svg?token=31YifM4jfyVpBmEGitCm&branch=master)](https://travis-ci.com/PowerShell/PowerShell-Linux)|[![Build status](https://ci.appveyor.com/api/projects/status/wb0a0apbn4aiccp1/branch/master?svg=true)](https://ci.appveyor.com/project/PowerShell/powershell-linux/branch/master)|
 
+## [Waffle.io scrum board](https://waffle.io/PowerShell/PowerShell-Linux)
 
 ## Obtain the source code
 


### PR DESCRIPTION
Add note to skip CI tests for documentation changes.
