### PR TITLE
Enable full CLR sanitary tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 bin/
+binFull/
+build/
 obj/
 /lib/
 /approot/

--- a/PowerShellGithubDev.psm1
+++ b/PowerShellGithubDev.psm1
@@ -4,14 +4,15 @@ function Start-DevPSGithub
         [switch]$ZapDisable,
         [string[]]$ArgumentList = '',
         [switch]$LoadProfile,
-        [string]$binDir = "$PSScriptRoot\binFull"
+        [string]$binDir = "$PSScriptRoot\binFull",
+        [switch]$NoNewWindow
     )
 
     try
     {
         if ($LoadProfile -eq $false)
         {
-            $ArgumentList += '-noprofile'
+            $ArgumentList = @('-noprofile') + $ArgumentList
         }
 
         $env:DEVPATH = $binDir
@@ -32,8 +33,16 @@ function Start-DevPSGithub
 "@
             $configContents | Out-File -Encoding Ascii $binDir\powershell.exe.config
         }
-
-        Start-Process -FilePath $binDir\powershell.exe -ArgumentList "$ArgumentList"
+        
+        # splatting for the win      
+        $startProcessArgs = @{
+            FilePath = "$binDir\powershell.exe"
+            ArgumentList = "$ArgumentList"
+            NoNewWindow = $NoNewWindow 
+            Wait = $NoNewWindow
+        }  
+        
+        Start-Process @startProcessArgs
     }
     finally
     {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,10 +25,23 @@ build_script:
 
 test_script:
   - ps: |
+      # CoreCLR
       $testResultsFile = ".\TestsResults.xml"
       .\bin\powershell.exe --noprofile -c "Invoke-Pester test/powershell -OutputFormat NUnitXml -OutputFile $testResultsFile"
       (New-Object 'System.Net.WebClient').UploadFile("https://ci.appveyor.com/api/testresults/nunit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path $testResultsFile))
-
+      # For now we don't fail the build if these tests failed
+      #
+      # FullCLR
+      Import-Module .\PowerShellGithubDev.psm1
+      $testResultsFile = ".\TestsResults.FullCLR.xml"
+      Start-DevPSGithub -binDir $pwd\binFull -NoNewWindow -ArgumentList '-command', 'Import-Module .\test\Pester; Invoke-Pester test/fullCLR -OutputFormat NUnitXml -OutputFile $testResultsFile'
+      (New-Object 'System.Net.WebClient').UploadFile("https://ci.appveyor.com/api/testresults/nunit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path $testResultsFile))
+      # we want to fail the build, if these tests failed
+      $x = [xml](cat -raw .\TestsResults.FullCLR.xml)
+      if ([int]$x.'test-results'.failures -gt 0)
+      {
+        throw "$($x.'test-results'.failures) tests in test/fullCLR failed"
+      }
 
 deploy_script: 
   - ps: |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,7 +34,7 @@ test_script:
       # FullCLR
       Import-Module .\PowerShellGithubDev.psm1
       $testResultsFile = ".\TestsResults.FullCLR.xml"
-      Start-DevPSGithub -binDir $pwd\binFull -NoNewWindow -ArgumentList '-command', 'Import-Module .\test\Pester; Invoke-Pester test/fullCLR -OutputFormat NUnitXml -OutputFile $testResultsFile'
+      Start-DevPSGithub -binDir $pwd\binFull -NoNewWindow -ArgumentList '-command', "Import-Module .\test\Pester; Invoke-Pester test/fullCLR -OutputFormat NUnitXml -OutputFile $testResultsFile"
       (New-Object 'System.Net.WebClient').UploadFile("https://ci.appveyor.com/api/testresults/nunit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path $testResultsFile))
       # we want to fail the build, if these tests failed
       $x = [xml](cat -raw .\TestsResults.FullCLR.xml)

--- a/build.FullCLR.ps1
+++ b/build.FullCLR.ps1
@@ -1,6 +1,42 @@
+param(
+    [ValidateSet(
+        "",
+        "Visual Studio 12 2013", 
+        "Visual Studio 12 2013 Win64",
+        "Visual Studio 14 2015", 
+        "Visual Studio 14 2015 Win64")]
+    [string]$cmakeGenerator = ""
+)
+
 $origPWD = $pwd
 try
 {
+    $prechecks = $true    
+    # check per-requests
+    if (-not (get-command cmake -ErrorAction SilentlyContinue))
+    {
+        Write-Warning 'cmake not found. You can install it from https://chocolatey.org/packages/cmake.portable'
+        $prechecks = $false
+    }
+
+    if (-not (get-command msbuild -ErrorAction SilentlyContinue))
+    {
+        Write-Warning 'msbuild not found. Install Visual Studio and add msbuild to $env:PATH'
+        $prechecks = $false
+    }
+
+    if (-not (get-command dotnet -ErrorAction SilentlyContinue))
+    {
+        Write-Warning 'dotnet not found. Install it from http://dotnet.github.io/getting-started/'
+        $prechecks = $false
+    }
+
+    if (-not $prechecks)
+    {
+        return
+    }
+    # end per-requests
+
     $BINFULL = "$pwd/binFull"
     $BUILD = "$pwd/build"
 
@@ -23,7 +59,14 @@ try
     mkdir $build -ErrorAction SilentlyContinue
     cd $build
 
-    cmake ..\src\powershell-native
+    if ($cmakeGenerator)
+    {
+        cmake -G "$cmakeGenerator" ..\src\powershell-native
+    }
+    else
+    {
+        cmake ..\src\powershell-native
+    }
     msbuild powershell.sln
 
     cp -rec Debug\* $BINFULL

--- a/build.FullCLR.ps1
+++ b/build.FullCLR.ps1
@@ -5,7 +5,12 @@ param(
         "Visual Studio 12 2013 Win64",
         "Visual Studio 14 2015", 
         "Visual Studio 14 2015 Win64")]
-    [string]$cmakeGenerator = ""
+    [string]$cmakeGenerator = "",
+
+    [ValidateSet(
+        "Debug",
+        "Release")] 
+    [string]$msbuildConfiguration = "Release"   
 )
 
 $origPWD = $pwd
@@ -67,9 +72,9 @@ try
     {
         cmake ..\src\powershell-native
     }
-    msbuild powershell.sln
+    msbuild powershell.sln /p:Configuration=$msbuildConfiguration
 
-    cp -rec Debug\* $BINFULL
+    cp -rec $msbuildConfiguration\* $BINFULL
 }
 finally
 {

--- a/src/powershell-native/CMakeLists.txt
+++ b/src/powershell-native/CMakeLists.txt
@@ -25,11 +25,11 @@ add_executable(powershell WIN32
     ../../src/monad/monad/nttargets/assemblies/nativemsh/pwrshexe/MainEntry.cpp)
 
 # This subsystem definition is using old policy. TODO: figure out for release and the rest
-set_target_properties(powershell PROPERTIES LINK_FLAGS_DEBUG "/SUBSYSTEM:CONSOLE")
 set_target_properties(powershell PROPERTIES COMPILE_DEFINITIONS "_CONSOLE")
+set_target_properties(powershell PROPERTIES LINK_FLAGS_DEBUG "/SUBSYSTEM:CONSOLE")
 set_target_properties(powershell PROPERTIES LINK_FLAGS_RELWITHDEBINFO "/SUBSYSTEM:CONSOLE")
-set_target_properties(powershell PROPERTIES LINK_FLAGS_RELEASE "/SUBSYSTEM:WINDOWS")
-set_target_properties(powershell PROPERTIES LINK_FLAGS_MINSIZEREL "/SUBSYSTEM:WINDOWS")
+set_target_properties(powershell PROPERTIES LINK_FLAGS_RELEASE "/SUBSYSTEM:CONSOLE")
+set_target_properties(powershell PROPERTIES LINK_FLAGS_MINSIZEREL "/SUBSYSTEM:CONSOLE")
 
 
 target_link_libraries(powershell

--- a/src/powershell-native/CMakeLists.txt
+++ b/src/powershell-native/CMakeLists.txt
@@ -3,6 +3,11 @@ project(PowerShell)
 
 add_compile_options()
 
+# set these flags, so build does static linking for msvcr120.dll
+# otherwise this dll need to be present on the system
+set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /MT")
+set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /MTd")
+
 include_directories(
     ../../src/monad/monad/nttargets/assemblies/nativemsh/pwrshcommon)
 
@@ -21,9 +26,8 @@ add_executable(powershell WIN32
 
 # This subsystem definition is using old policy. TODO: figure out for release and the rest
 set_target_properties(powershell PROPERTIES LINK_FLAGS_DEBUG "/SUBSYSTEM:CONSOLE")
-set_target_properties(powershell PROPERTIES COMPILE_DEFINITIONS_DEBUG "_CONSOLE")
+set_target_properties(powershell PROPERTIES COMPILE_DEFINITIONS "_CONSOLE")
 set_target_properties(powershell PROPERTIES LINK_FLAGS_RELWITHDEBINFO "/SUBSYSTEM:CONSOLE")
-set_target_properties(powershell PROPERTIES COMPILE_DEFINITIONS_RELWITHDEBINFO "_CONSOLE")
 set_target_properties(powershell PROPERTIES LINK_FLAGS_RELEASE "/SUBSYSTEM:WINDOWS")
 set_target_properties(powershell PROPERTIES LINK_FLAGS_MINSIZEREL "/SUBSYSTEM:WINDOWS")
 

--- a/test/fullclr/PowerShellGithubDev.Tests.ps1
+++ b/test/fullclr/PowerShellGithubDev.Tests.ps1
@@ -1,0 +1,32 @@
+Describe 'PowerShellGithubDev.psm1 and powershell.exe' {
+    Context '$env:DEVPATH assemblies loading' {
+        It 'has $env:DEVPATH set' {
+            $env:DEVPATH | Should Not Be $null
+        }
+
+        It 'loads System.Management.Automation.dll' {
+            [psobject].Assembly.Location | Should Be (
+                Join-Path $env:DEVPATH System.Management.Automation.dll)
+        }
+
+        It 'loads Microsoft.PowerShell.Commands.Management.dll' {
+            [Microsoft.PowerShell.Commands.GetChildItemCommand].Assembly.Location | Should Be (
+                Join-Path $env:DEVPATH Microsoft.PowerShell.Commands.Management.dll)
+        }
+
+        It 'loads Microsoft.PowerShell.Commands.Utility.dll' {
+            [Microsoft.PowerShell.Commands.UtilityResources].Assembly.Location | Should Be (
+                Join-Path $env:DEVPATH Microsoft.PowerShell.Commands.Utility.dll)
+        }
+
+        It 'loads Microsoft.PowerShell.ConsoleHost.dll' {
+            [Microsoft.PowerShell.ConsoleShell].Assembly.Location | Should Be (
+                Join-Path $env:DEVPATH Microsoft.PowerShell.ConsoleHost.dll)
+        }
+
+        It 'loads Microsoft.PowerShell.Security.dll' {
+            [Microsoft.PowerShell.Commands.SecurityDescriptorCommandsBase].Assembly.Location | Should Be (
+                Join-Path $env:DEVPATH Microsoft.PowerShell.Security.dll)
+        }
+    }
+}


### PR DESCRIPTION
- Run FullCLR sanitary tests in AppVeyor

This change brings a very minimal set of tests and make
build fail, if we cannot load some PS assamblies on FullCLR
- We should increase test coverage for FullCLR in future.
- Include msvcr120.dll runtime to powershell.exe
