### PR TITLE
Publish AppVeyor artifacts on PRs

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,7 +43,7 @@ test_script:
         throw "$($x.'test-results'.failures) tests in test/fullCLR failed"
       }
 
-deploy_script: 
+on_finish: 
   - ps: |
       # Creating project artifact
       $zipFilePath = Join-Path $pwd "$(Split-Path $pwd -Leaf).zip"


### PR DESCRIPTION
I originally used `deploy_script:` section for publishing artifacts.
This section is not invoked on Pull Requests.
Hence, use `on_finish` section instead, so we can consume artifacts from PRs as well.
