### PR TITLE
Remove temporary dotnet-publish workaround

### DIFF
--- a/build.FullCLR.ps1
+++ b/build.FullCLR.ps1
@@ -16,9 +16,6 @@ try
     cd ..\..\src\Microsoft.PowerShell.Commands.Management
     dotnet publish --framework dnx451 --output $BINFULL
 
-    # Temporary fix for dotnet publish
-    if (Test-Path $BINFULL/Debug/dnx451) { cp $BINFULL/Debug/dnx451/* $BINFULL }
-
     # build native host
     mkdir $build -ErrorAction SilentlyContinue
     cd $build

--- a/build.ps1
+++ b/build.ps1
@@ -15,8 +15,6 @@ cd ../..
 # Publish PowerShell
 cd src/Microsoft.PowerShell.Linux.Host
 dotnet publish --framework dnxcore50 --output $BIN
-# Temporary fix for dotnet publish
-if (Test-Path $BIN/Debug/dnxcore50) { cp $BIN/Debug/dnxcore50/* $BIN }
 # Copy files that dotnet-publish does not currently deploy
 cp *_profile.ps1 $BIN
 cd ../..

--- a/build.sh
+++ b/build.sh
@@ -38,8 +38,6 @@ mkdir -p $BIN/Modules
 (
     cd src/Microsoft.PowerShell.Linux.Host
     dotnet publish --framework dnxcore50 --output $BIN --configuration Linux
-    # Temporary fix for dotnet publish
-    [[ -d $BIN/Debug/dnxcore50 ]] && cp $BIN/Debug/dnxcore50/* $BIN
     # Copy files that dotnet-publish does not currently deploy
     cp *_profile.ps1 $BIN
 )


### PR DESCRIPTION
Latest dotnet-nightly packages have not required this.
