### PR TITLE
Fix for #491: make powershell.exe work in new window

### DIFF
--- a/PowerShellGithubDev.psm1
+++ b/PowerShellGithubDev.psm1
@@ -38,9 +38,12 @@ function Start-DevPSGithub
         $startProcessArgs = @{
             FilePath = "$binDir\powershell.exe"
             ArgumentList = "$ArgumentList"
-            NoNewWindow = $NoNewWindow 
-            Wait = $NoNewWindow
         }  
+
+        if ($NoNewWindow) {
+            $startProcessArgs.NoNewWindow = $true
+            $startProcessArgs.Wait = $true
+        }
         
         Start-Process @startProcessArgs
     }


### PR DESCRIPTION
FullCLR windows host doesn't read keys when run in separate window.
Fix: don't use Start-Process -Wait $false -NoNewWindow $false

Instead, ommit this parameters. Seems like a bug in Start-Process.
