### PR TITLE
Remove versions from frameworkAssemblies

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/project.json
+++ b/src/Microsoft.PowerShell.Commands.Management/project.json
@@ -26,7 +26,7 @@
         },
         "dnx451": {
             "frameworkAssemblies": {
-                "System.ServiceProcess": "4.0.0.0"
+                "System.ServiceProcess": ""
             }
         }
     },

--- a/src/Microsoft.PowerShell.Commands.Utility/project.json
+++ b/src/Microsoft.PowerShell.Commands.Utility/project.json
@@ -34,9 +34,9 @@
         },
         "dnx451": {
             "frameworkAssemblies": {
-                "System.Drawing": "4.0.0.0",
-                "System.Web.Extensions": "4.0.0.0",
-                "Microsoft.JScript": "10.0.0.0"
+                "System.Drawing": "",
+                "System.Web.Extensions": "",
+                "Microsoft.JScript": ""
             }
         }
     },

--- a/src/System.Management.Automation/project.json
+++ b/src/System.Management.Automation/project.json
@@ -65,17 +65,17 @@
         "dnx451": {
             "frameworkAssemblies": {
                 "System.Runtime": "",
-                "System.Xml": "4.0.0.0",
-                "System.Xml.Linq": "4.0.0.0",
-                "System.Numerics": "4.0.0.0",
-                "System.Data": "4.0.0.0",
-                "System.DirectoryServices": "4.0.0.0",
-                "System.Security": "4.0.0.0",
-                "System.Transactions": "4.0.0.0",
-                "System.Runtime.Serialization": "4.0.0.0",
-                "System.Management": "4.0.0.0",
-                "System.Configuration": "4.0.0.0",
-                "System.Configuration.Install": "4.0.0.0"
+                "System.Xml": "",
+                "System.Xml.Linq": "",
+                "System.Numerics": "",
+                "System.Data": "",
+                "System.DirectoryServices": "",
+                "System.Security": "",
+                "System.Transactions": "",
+                "System.Runtime.Serialization": "",
+                "System.Management": "",
+                "System.Configuration": "",
+                "System.Configuration.Install": ""
             }
         }
     },


### PR DESCRIPTION
This should fix bug #499 where building complains about a restore not
having been done, even when it has.
