### PR TITLE
Modernize our nuget.config

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -1,12 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
-    <add key="dotnetcore" value="https://www.myget.org/F/dotnet-core/" />
-    <add key="aspnetvnext" value="https://www.myget.org/F/aspnetvnext/" />
-    <add key="nuget.org" value="https://www.nuget.org/api/v2/" />
+    <clear />
+    <add key="dotnet-core" value="https://www.myget.org/F/dotnet-core/api/v3/index.json" />
+    <add key="aspnetvnext" value="https://www.myget.org/F/aspnetvnext/api/v3/index.json" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
-  <disabledPackageSources />
-  <activePackageSource>
-    <add key="All" value="(Aggregate source)"  />
-  </activePackageSource>
 </configuration>


### PR DESCRIPTION
Use the V3 api, and use the clear directive instead of
`activePackageSources`.

Thanks for reminding me @fearthecowboy.
