### PR TITLE
Use NuGet instead of aspnetvnext for CodeAnalysis

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -3,7 +3,6 @@
   <packageSources>
     <clear />
     <add key="dotnet-core" value="https://www.myget.org/F/dotnet-core/api/v3/index.json" />
-    <add key="aspnetvnext" value="https://www.myget.org/F/aspnetvnext/api/v3/index.json" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
 </configuration>

--- a/src/Microsoft.PowerShell.Commands.Utility/project.json
+++ b/src/Microsoft.PowerShell.Commands.Utility/project.json
@@ -29,7 +29,7 @@
             },
             "imports": "portable-net45+win8",
             "dependencies": {
-                "Microsoft.CodeAnalysis.CSharp": "1.1.0-rc1-20151109-01"
+                "Microsoft.CodeAnalysis.CSharp": "1.1.1"
             }
         },
         "dnx451": {


### PR DESCRIPTION
The `aspnetvnext` MyGet feed was unreliable, and we should prefer NuGet
anyway. This should make automated builds fail less often.
