### PR TITLE
Additional improvements on tab-completion of files and directories

### DIFF
--- a/src/Microsoft.PowerShell.Linux.Host/readline.cs
+++ b/src/Microsoft.PowerShell.Linux.Host/readline.cs
@@ -246,10 +246,10 @@ namespace Microsoft.PowerShell.Linux.Host
             string tabResult = cmdCompleteOpt.CompletionMatches[tabCompletionPos].CompletionText;
 
             // To match behavior on Windows
-            if (cmdCompleteOpt.CompletionMatches[tabCompletionPos].ResultType == CompletionResultType.ProviderContainer
-                && Directory.Exists(tabResult))
+            bool hasQuotes = false;
+            if (cmdCompleteOpt.CompletionMatches[tabCompletionPos].ResultType == CompletionResultType.ProviderContainer)
             {
-                tabResult = GetReplacementTextForDirectory(tabResult);
+                tabResult = GetReplacementTextForDirectory(tabResult, ref hasQuotes);
             }
 
             tabCompletionPos++;
@@ -277,6 +277,11 @@ namespace Microsoft.PowerShell.Linux.Host
 
                 BufferFromString(tabResult);
                 this.Render();
+
+                if (hasQuotes)
+                {
+                    MoveLeft();
+                }
             }
 
         } //end of OnTab()
@@ -284,7 +289,7 @@ namespace Microsoft.PowerShell.Linux.Host
         /// <summary>
         /// Helper function to add trailing slash to directories
         /// </summary>
-        private static string GetReplacementTextForDirectory(string replacementText)
+        private static string GetReplacementTextForDirectory(string replacementText, ref bool hasQuotes)
         {
             string separator = Path.DirectorySeparatorChar.ToString();
             const string singleQuote = "'";
@@ -295,6 +300,7 @@ namespace Microsoft.PowerShell.Linux.Host
                 if (replacementText.EndsWith(separator + singleQuote, StringComparison.Ordinal) 
                     || replacementText.EndsWith(separator + doubleQuote, StringComparison.Ordinal))
                 {
+                    hasQuotes = true;
                     return replacementText;
                 }
                 else if (replacementText.EndsWith(singleQuote, StringComparison.Ordinal) 
@@ -303,6 +309,7 @@ namespace Microsoft.PowerShell.Linux.Host
                     var len = replacementText.Length;
                     char quoteChar = replacementText[len - 1];
                     replacementText = replacementText.Substring(0, len - 1) + separator + quoteChar;
+                    hasQuotes = true;
                 }
                 else
                 {

--- a/src/Microsoft.PowerShell.Linux.Host/readline.cs
+++ b/src/Microsoft.PowerShell.Linux.Host/readline.cs
@@ -2,6 +2,7 @@ namespace Microsoft.PowerShell.Linux.Host
 {
     using System;
     using System.Collections.ObjectModel;
+    using System.IO;
     using System.Management.Automation;
     using System.Management.Automation.Runspaces;
     using System.Text;
@@ -244,17 +245,18 @@ namespace Microsoft.PowerShell.Linux.Host
 
             string tabResult = cmdCompleteOpt.CompletionMatches[tabCompletionPos].CompletionText;
 
+            // To match behavior on Windows
+            if (cmdCompleteOpt.CompletionMatches[tabCompletionPos].ResultType == CompletionResultType.ProviderContainer
+                && Directory.Exists(tabResult))
+            {
+                tabResult = GetReplacementTextForDirectory(tabResult);
+            }
+
             tabCompletionPos++;
 
             //if there is a command for the user before the uncompleted option
             if (!String.IsNullOrEmpty(tabResult))
             {
-                //handle file path slashes
-                if (tabResult.Contains(".\\"))
-                {
-                    tabResult = tabResult.Replace(".\\", "");
-                }
-
                 var replaceIndex = cmdCompleteOpt.ReplacementIndex;
                 string replaceBuffer = this.buffer.ToString();
 
@@ -278,6 +280,37 @@ namespace Microsoft.PowerShell.Linux.Host
             }
 
         } //end of OnTab()
+
+        /// <summary>
+        /// Helper function to add trailing slash to directories
+        /// </summary>
+        private static string GetReplacementTextForDirectory(string replacementText)
+        {
+            string separator = Path.DirectorySeparatorChar.ToString();
+            const string singleQuote = "'";
+            const string doubleQuote = "\"";
+
+            if (!replacementText.EndsWith(separator, StringComparison.Ordinal))
+            {
+                if (replacementText.EndsWith(separator + singleQuote, StringComparison.Ordinal) 
+                    || replacementText.EndsWith(separator + doubleQuote, StringComparison.Ordinal))
+                {
+                    return replacementText;
+                }
+                else if (replacementText.EndsWith(singleQuote, StringComparison.Ordinal) 
+                         || replacementText.EndsWith(doubleQuote, StringComparison.Ordinal))
+                {
+                    var len = replacementText.Length;
+                    char quoteChar = replacementText[len - 1];
+                    replacementText = replacementText.Substring(0, len - 1) + separator + quoteChar;
+                }
+                else
+                {
+                    replacementText = replacementText + separator;
+                }
+            }
+            return replacementText;
+        }
 
         /// <summary>
         /// Set buffer to a string rather than inserting char by char

--- a/src/Microsoft.PowerShell.Linux.Host/readline.cs
+++ b/src/Microsoft.PowerShell.Linux.Host/readline.cs
@@ -246,10 +246,10 @@ namespace Microsoft.PowerShell.Linux.Host
             string tabResult = cmdCompleteOpt.CompletionMatches[tabCompletionPos].CompletionText;
 
             // To match behavior on Windows
-            bool hasQuotes = false;
+            bool moveLeftOneSpace = false;
             if (cmdCompleteOpt.CompletionMatches[tabCompletionPos].ResultType == CompletionResultType.ProviderContainer)
             {
-                tabResult = GetReplacementTextForDirectory(tabResult, ref hasQuotes);
+                tabResult = GetReplacementTextForDirectory(tabResult, ref moveLeftOneSpace);
             }
 
             tabCompletionPos++;
@@ -278,7 +278,7 @@ namespace Microsoft.PowerShell.Linux.Host
                 BufferFromString(tabResult);
                 this.Render();
 
-                if (hasQuotes)
+                if (moveLeftOneSpace)
                 {
                     MoveLeft();
                 }
@@ -289,7 +289,7 @@ namespace Microsoft.PowerShell.Linux.Host
         /// <summary>
         /// Helper function to add trailing slash to directories
         /// </summary>
-        private static string GetReplacementTextForDirectory(string replacementText, ref bool hasQuotes)
+        private static string GetReplacementTextForDirectory(string replacementText, ref bool moveLeftOneSpace)
         {
             string separator = Path.DirectorySeparatorChar.ToString();
             const string singleQuote = "'";
@@ -300,7 +300,7 @@ namespace Microsoft.PowerShell.Linux.Host
                 if (replacementText.EndsWith(separator + singleQuote, StringComparison.Ordinal) 
                     || replacementText.EndsWith(separator + doubleQuote, StringComparison.Ordinal))
                 {
-                    hasQuotes = true;
+                    moveLeftOneSpace = true;
                     return replacementText;
                 }
                 else if (replacementText.EndsWith(singleQuote, StringComparison.Ordinal) 
@@ -309,7 +309,7 @@ namespace Microsoft.PowerShell.Linux.Host
                     var len = replacementText.Length;
                     char quoteChar = replacementText[len - 1];
                     replacementText = replacementText.Substring(0, len - 1) + separator + quoteChar;
-                    hasQuotes = true;
+                    moveLeftOneSpace = true;
                 }
                 else
                 {


### PR DESCRIPTION
1.  Removed hack that removed "." and "\". from filenames
2.  Handle case with filename that starts with "../" or "..\"
3.  Append slash to end of directory names
4.  Handle case where there is a special character (such as space), in middle of file name
