### PR TITLE
Refactor projects for use with .NET CLI 1.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
   - sudo sh -c 'echo "deb [arch=amd64] http://apt-mo.trafficmanager.net/repos/dotnet/ trusty main" > /etc/apt/sources.list.d/dotnetdev.list'
   - sudo apt-key adv --keyserver apt-mo.trafficmanager.net --recv-keys 417A0893
   - sudo apt-get -qq update
-  - sudo apt-get install -y dotnet-nightly=1.0.1.001252-1
+  - sudo apt-get install -y dotnet=1.0.0.001425-1
 script:
   - dotnet restore
   - ./build.sh

--- a/README.md
+++ b/README.md
@@ -57,8 +57,19 @@ We use the [.NET Command Line Interface][dotnet-cli] (`dotnet-cli`) to build
 the managed components, and [CMake][] to build the native components (on
 non-Windows platforms). Install `dotnet-cli` by following their [documentation][].
 
-**Make sure to `apt-get install dotnet-nightly=1.0.1.001252-1` for a known,
-good version.**
+The version of .NET CLI is very important, you want a recent 1.0.0 beta
+(**not** 1.0.1).
+
+These are known good versions:
+
+```sh
+sudo apt-get install dotnet=1.0.0.001425-1
+```
+
+```powershell
+Invoke-WebRequest -Uri https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/install.ps1 -OutFile install.ps1
+./install.ps1 -version 1.0.0.001425 -channel beta
+```
 
 > Note that OS X dependency installation instructions are not yet documented,
 > and Core PowerShell on Windows only needs `dotnet-cli`.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ install:
   - git config --global url.git@github.com:.insteadOf https://github.com/
   - git submodule update --init --recursive -- src/monad src/windows-build src/Microsoft.PowerShell.Linux.Host/Modules/Pester
   - ps: Invoke-WebRequest -Uri https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/install.ps1 -OutFile install.ps1
-  - ps: ./install.ps1 -version "1.0.1.001186"
+  - ps: ./install.ps1 -version 1.0.0.001425 -channel beta
 
 build_script:
   - ps: $env:Path += ";$env:LocalAppData\Microsoft\dotnet\cli\bin"

--- a/build.ps1
+++ b/build.ps1
@@ -1,7 +1,2 @@
-$BIN = "${pwd}/bin"
-
 # Publish PowerShell
-cd src/Microsoft.PowerShell.Linux.Host
-dotnet publish --framework dnxcore50 --output $BIN
-# Copy files that dotnet-publish does not currently deploy
-cd ../..
+dotnet publish "src/Microsoft.PowerShell.Linux.Host" --framework "netstandardapp1.5" --output "bin"

--- a/build.sh
+++ b/build.sh
@@ -12,6 +12,4 @@ cp src/libpsl-native.* $BIN
 popd
 
 # Publish PowerShell
-pushd src/Microsoft.PowerShell.Linux.Host
-dotnet publish --framework dnxcore50 --output $BIN --configuration Linux
-popd
+dotnet publish --output $BIN --configuration Linux src/Microsoft.PowerShell.Linux.Host

--- a/src/Microsoft.Management.Infrastructure.Native/project.json
+++ b/src/Microsoft.Management.Infrastructure.Native/project.json
@@ -1,16 +1,15 @@
 {
+    "name": "Microsoft.Management.Infrastructure.Native",
     "version": "1.0.0-*",
-    "description": "Microsoft.Management.Infrastructure.Native Stub",
+    "description": "Stub to satisfy PowerShell compilation",
     "authors": [ "garretts", "andschwa" ],
 
     "frameworks": {
-        "dnxcore50": {
+        "netstandard1.5": {
+            "imports": [ "dnxcore50" ],
             "dependencies": {
                 "NETStandard.Library": "1.0.0-rc3-23817",
-                "System.Security.SecureString":  {
-                    "type": "build",
-                    "version": "1.0.0-*"
-                }
+                "System.Security.SecureString": "1.0.0-*"
             }
         },
         "dnx451": {

--- a/src/Microsoft.Management.Infrastructure/project.json
+++ b/src/Microsoft.Management.Infrastructure/project.json
@@ -1,6 +1,6 @@
 {
+    "name": "Microsoft.Management.Infrastructure",
     "version": "1.0.0-*",
-    "description": "Microsoft.Management.Infrastructure",
     "authors": [ "garretts", "andschwa" ],
 
     "compilationOptions": {
@@ -8,14 +8,12 @@
     },
 
     "dependencies": {
-        "Microsoft.Management.Infrastructure.Native" : {
-            "type": "build",
-            "version": "1.0.0-*"
-        }
+        "Microsoft.Management.Infrastructure.Native": "1.0.0-*"
     },
 
     "frameworks": {
-        "dnxcore50": {
+        "netstandard1.5": {
+            "imports": [ "dnxcore50" ],
             "compilationOptions": {
                 "define": [ "_CORECLR" ]
             },

--- a/src/Microsoft.PowerShell.Commands.Management/project.json
+++ b/src/Microsoft.PowerShell.Commands.Management/project.json
@@ -1,6 +1,6 @@
 {
+    "name": "Microsoft.PowerShell.Commands.Management",
     "version": "1.0.0-*",
-    "description": "Microsoft.PowerShell.Commands.Management Library",
     "authors": [ "garretts", "andschwa" ],
 
     "compilationOptions": {
@@ -8,14 +8,12 @@
     },
 
     "dependencies": {
-        "Microsoft.PowerShell.Security": {
-            "type": "build",
-            "version": "1.0.0-*"
-        }
+        "Microsoft.PowerShell.Security": "1.0.0-*"
     },
 
     "frameworks": {
-        "dnxcore50": {
+        "netstandard1.5": {
+            "imports": [ "dnxcore50" ],
             "compilationOptions": {
                 "define": [ "CORECLR" ]
             },
@@ -72,7 +70,7 @@
         "../monad/monad/src/commands/management/CommitTransactionCommand.cs",
         "../monad/monad/src/commands/management/Computer.cs",
         "../monad/monad/src/commands/management/ContentCommandBase.cs",
-        
+
         "../monad/monad/src/commands/management/ConvertPathCommand.cs",
         "../monad/monad/src/commands/management/CopyPropertyCommand.cs",
         "../monad/monad/src/commands/management/Eventlog.cs",

--- a/src/Microsoft.PowerShell.Commands.Utility/project.json
+++ b/src/Microsoft.PowerShell.Commands.Utility/project.json
@@ -1,6 +1,6 @@
 {
+    "name": "Microsoft.PowerShell.Commands.Utility",
     "version": "1.0.0-*",
-    "description": "Microsoft.PowerShell.Commands.Utility Library",
     "authors": [ "garretts", "andschwa" ],
 
     "compilationOptions": {
@@ -16,18 +16,15 @@
     },
 
     "dependencies": {
-        "System.Management.Automation": {
-            "type": "build",
-            "version": "1.0.0-*"
-        }
+        "System.Management.Automation": "1.0.0-*"
     },
 
     "frameworks": {
-        "dnxcore50": {
+        "netstandard1.5": {
             "compilationOptions": {
                 "define": [ "CORECLR" ]
             },
-            "imports": "portable-net45+win8",
+            "imports": [ "dnxcore50", "portable-net45+win8" ],
             "dependencies": {
                 "Microsoft.CodeAnalysis.CSharp": "1.1.1",
                 "Newtonsoft.Json": "8.0.2"

--- a/src/Microsoft.PowerShell.ConsoleHost/project.json
+++ b/src/Microsoft.PowerShell.ConsoleHost/project.json
@@ -1,6 +1,7 @@
 {
+    "name": "Microsoft.PowerShell.ConsoleHost",
     "version": "1.0.0-*",
-    "description": "Microsoft.PowerShell.ConsoleHost Library",
+    "description": "Full Windows PowerShell Host (requires native host)",
     "authors": [ "sevoroby", "andschwa" ],
 
     "compilationOptions": {
@@ -8,14 +9,8 @@
     },
 
     "dependencies": {
-        "Microsoft.PowerShell.Commands.Management": {
-            "type": "build",
-            "version": "1.0.0-*"
-        },
-        "Microsoft.PowerShell.Commands.Utility": {
-            "type": "build",
-            "version": "1.0.0-*"
-        }
+        "Microsoft.PowerShell.Commands.Management": "1.0.0-*",
+        "Microsoft.PowerShell.Commands.Utility": "1.0.0-*"
     },
 
     "frameworks": {

--- a/src/Microsoft.PowerShell.CoreCLR.AssemblyLoadContext/project.json
+++ b/src/Microsoft.PowerShell.CoreCLR.AssemblyLoadContext/project.json
@@ -1,6 +1,6 @@
 {
-    "version": "1.0.0.0",
-    "description": "Microsoft.PowerShell.CoreCLR.AssemblyLoadContext Class",
+    "name": "Microsoft.PowerShell.CoreCLR.AssemblyLoadContext",
+    "version": "1.0.0-*",
     "authors": [ "andschwa" ],
 
     "configurations": {
@@ -12,7 +12,8 @@
     },
 
     "frameworks": {
-        "dnxcore50": {
+        "netstandard1.5": {
+            "imports": [ "dnxcore50" ],
             "compilationOptions": {
                 "define": [ "CORECLR" ]
             },

--- a/src/Microsoft.PowerShell.Linux.Host/project.json
+++ b/src/Microsoft.PowerShell.Linux.Host/project.json
@@ -1,7 +1,7 @@
 {
     "name": "powershell",
     "version": "1.0.0-*",
-    "description": "PowerShell On Linux Console",
+    "description": "PowerShell Managed Console for .NET Core",
     "authors": [ "andschwa" ],
 
     "compilationOptions": {
@@ -10,14 +10,8 @@
 
     "dependencies": {
         "Newtonsoft.Json": "8.0.2",
-        "Microsoft.PowerShell.Commands.Management": {
-            "type": "build",
-            "version": "1.0.0-*"
-        },
-        "Microsoft.PowerShell.Commands.Utility": {
-            "type": "build",
-            "version": "1.0.0-*"
-        }
+        "Microsoft.PowerShell.Commands.Management": "1.0.0-*",
+        "Microsoft.PowerShell.Commands.Utility": "1.0.0-*"
     },
 
     "content": [
@@ -41,10 +35,17 @@
         "WSMan.format.ps1xml"
     ],
 
-
     "frameworks": {
-        "dnxcore50": {
-            "imports": "portable-net45+win8"
+        "netstandardapp1.5": {
+            "imports": [ "dnxcore50", "portable-net45+win8" ]
         }
+    },
+
+    "runtimes": {
+        "ubuntu.14.04-x64": { },
+        "win7-x64": { },
+        "win10-x64": { },
+        "osx.10.10-x64": { },
+        "osx.10.11-x64": { }
     }
 }

--- a/src/Microsoft.PowerShell.Security/project.json
+++ b/src/Microsoft.PowerShell.Security/project.json
@@ -1,6 +1,6 @@
 {
+    "name": "Microsoft.PowerShell.Security",
     "version": "1.0.0-*",
-    "description": "Microsoft.PowerShell.Security Library",
     "authors": [ "garretts", "andschwa" ],
 
     "compilationOptions": {
@@ -8,14 +8,12 @@
     },
 
     "dependencies": {
-        "System.Management.Automation": {
-            "type": "build",
-            "version": "1.0.0-*"
-        }
+        "System.Management.Automation": "1.0.0-*"
     },
 
     "frameworks": {
-        "dnxcore50": {
+        "netstandard1.5": {
+            "imports": [ "dnxcore50" ],
             "compilationOptions": {
                 "define": [ "CORECLR" ]
             }

--- a/src/System.Management.Automation/project.json
+++ b/src/System.Management.Automation/project.json
@@ -1,7 +1,6 @@
 {
     "name": "System.Management.Automation",
     "version": "1.0.0-*",
-    "description": "System.Management.Automation Library",
     "authors": [ "garretts", "andschwa" ],
 
     "compilationOptions": {
@@ -17,18 +16,18 @@
     },
 
     "dependencies": {
-        "Microsoft.Management.Infrastructure" : {
-            "type": "build",
-            "version": "1.0.0-*"
-        }
+        "Microsoft.Management.Infrastructure": "1.0.0-*"
     },
 
     "frameworks": {
-        "dnxcore50": {
+        "netstandard1.5": {
+            "imports": [ "dnxcore50" ],
             "compilationOptions": {
                 "define": [ "CORECLR", "NOETW" ]
             },
             "dependencies": {
+		"Microsoft.PowerShell.CoreCLR.AssemblyLoadContext": "1.0.0-*",
+
                 "Microsoft.CSharp": "4.0.1-rc3-23817",
                 "Microsoft.Win32.Registry.AccessControl": "4.0.0-rc3-23817",
                 "System.Collections.Specialized": "4.0.1-rc3-23817",
@@ -56,10 +55,6 @@
                 "System.Xml.XPath.XmlDocument": "4.0.1-rc3-23817",
                 "System.Xml.XmlDocument": "4.0.1-rc3-23817",
                 "System.Xml.XmlSerializer": "4.0.11-rc3-23817",
-                "Microsoft.PowerShell.CoreCLR.AssemblyLoadContext": {
-                    "type": "build",
-                    "version": "1.0.0-*"
-                }
             }
         },
         "dnx451": {

--- a/src/System.Security.SecureString/project.json
+++ b/src/System.Security.SecureString/project.json
@@ -1,13 +1,19 @@
 {
+    "name": "System.Security.SecureString",
     "version": "1.0.0-*",
-    "description": "SecureString Stub",
+    "description": "SecureString Stub borrowed from Mono",
     "authors": [ "garretts" ],
 
-    "compilationOptions": { "allowUnsafe": true },
-
-    "dependencies": {
-	"NETStandard.Library": "1.0.0-rc3-23817"
+    "compilationOptions": {
+        "allowUnsafe": true
     },
 
-    "frameworks": { "dnxcore50": { } }
+    "frameworks": {
+        "netstandard1.5": {
+            "dependencies": {
+                "NETStandard.Library": "1.0.0-rc3-23817"
+            },
+            "imports": [ "dnxcore50" ]
+        }
+    }
 }

--- a/src/TypeCatalogGen/Runtime/project.json
+++ b/src/TypeCatalogGen/Runtime/project.json
@@ -36,5 +36,9 @@
 	"System.Net.NameResolution": "4.0.0-rc3-23817"
 },
 
-    "frameworks": { "dnxcore50": { } }
+    "frameworks": {
+	"netstandard1.5": {
+	    "imports": [ "dnxcore50", "portable-net45+win8" ]
+	}
+    }
 }

--- a/src/TypeCatalogGen/project.json
+++ b/src/TypeCatalogGen/project.json
@@ -1,6 +1,7 @@
 {
+    "name": "TypeCatalogGen",
     "version": "1.0.0-*",
-    "description": "PowerShell TypeCatalogGen.exe",
+    "description": "Generates CorePsTypeCatalog.cs given powershell.inc",
     "authors": [ "andschwa" ],
 
     "compilationOptions": {
@@ -8,21 +9,21 @@
     },
 
     "dependencies": {
-	"System.Reflection.Metadata": "1.1.1-beta-23516",
-	"System.Collections.Immutable": "1.1.38-beta-23516"
+        "System.Reflection.Metadata": "1.1.1-beta-23516",
+        "System.Collections.Immutable": "1.1.38-beta-23516"
     },
 
     "compileFiles": [
-	"../monad/monad/nttargets/assemblies/core/PSAssemblyLoadContext/TypeCatalogGen/TypeCatalogGen.cs"
+        "../monad/monad/nttargets/assemblies/core/PSAssemblyLoadContext/TypeCatalogGen/TypeCatalogGen.cs"
     ],
 
     "frameworks": {
-	"dnx451": {
-	    "frameworkAssemblies": {
-		"System.Runtime": "",
-		"System.IO": "",
-		"System.Reflection.Primitives": ""
-	    }
-	}
+        "dnx451": {
+            "frameworkAssemblies": {
+                "System.Runtime": "",
+                "System.IO": "",
+                "System.Reflection.Primitives": ""
+            }
+        }
     }
 }

--- a/test/csharp/project.json
+++ b/test/csharp/project.json
@@ -5,7 +5,8 @@
     "authors": [ "andschwa" ],
 
     "frameworks": {
-	"dnxcore50": {
+	"netstandard1.5": {
+	    "imports": [ "dnxcore50", "portable-net45+win8" ],
 	    "dependencies": {
 		"Microsoft.PowerShell.Linux.Host": {
 		    "type": "build",
@@ -13,8 +14,7 @@
 		},
 		"xunit": "2.1.0",
 		"dotnet-test-xunit": "1.0.0-dev-*"
-	    },
-	    "imports": "portable-net45+win8"
+	    }
 	}
     },
 


### PR DESCRIPTION
This resolves #532 and puts us at a known, good, soon-to-be-released version of .NET CLI.

**IMPORTANT**: you _must_ uninstall `dotnet-nightly` and install `dotnet`. If it doesn't work, refer to the readme to install a known version.

/cc @PowerShell/linux @palladia 
