### PR TITLE
Improve debug.sh and build.sh scripts

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,15 +1,25 @@
 #!/usr/bin/env bash
 
-export BIN=$(pwd)/bin
-mkdir -p $BIN
+# Test for build dependencies
+hash cmake 2>/dev/null || { echo >&2 "No cmake, please run 'sudo apt-get install cmake'"; exit 1; }
+hash g++ 2>/dev/null || { echo >&2 "No g++, please run 'sudo apt-get install g++'"; exit 1; }
+hash dotnet 2>/dev/null || { echo >&2 "No dotnet, please visit https://dotnet.github.io/getting-started/"; exit 1; }
 
-# Build native components
+# Test for lock file
+test -r src/Microsoft.PowerShell.Linux.Host/project.lock.json || { echo >&2 "Please run 'dotnet restore' to download .NET Core packages"; exit 2; }
+
+# Ensure output directory is made
+BIN="$(pwd)/bin"
+mkdir -p "$BIN"
+
+# Build native library and deploy to bin
 pushd src/libpsl-native
 cmake -DCMAKE_BUILD_TYPE=Debug .
 make -j
 ctest -V
-cp src/libpsl-native.* $BIN
+test -r src/libpsl-native.* || { echo >&2 "Compilation of libpsl-native failed"; exit 3; }
+cp src/libpsl-native.* "$BIN"
 popd
 
-# Publish PowerShell
-dotnet publish --output $BIN --configuration Linux src/Microsoft.PowerShell.Linux.Host
+# Publish PowerShell to bin, with LINUX defined through a configuration
+dotnet publish --output "$BIN" --configuration Linux src/Microsoft.PowerShell.Linux.Host

--- a/debug.sh
+++ b/debug.sh
@@ -1,1 +1,21 @@
-lldb-3.6 -o "plugin load ./bin/libsosplugin.so" -- ./bin/powershell $@
+#!/usr/bin/env bash
+
+hash lldb-3.6 2>/dev/null || { echo >&2 "No lldb-3.6, please run 'sudo apt-get install lldb-3.6'"; exit 1; }
+test -x bin/powershell || { echo >&2 "No bin/powershell, please run './build.sh'"; exit 1; }
+
+cat << EOF
+
+Launching LLDB with SOS plugin...
+Type 'run' or 'r' to start PowerShell.
+Press Ctrl-C to interrupt PowerShell and run LLDB commands.
+Type 'exit' when interrupted to leave LLDB.
+
+Visit https://git.io/v2Jhh for CoreCLR debugging help.
+
+Most useful commands are 'clrstack', 'clrthreads', and 'pe'.
+
+EOF
+
+pushd bin
+lldb-3.6 -o "plugin load libsosplugin.so" -- ./powershell $@
+popd

--- a/pester.sh
+++ b/pester.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+test -x bin/powershell || { echo >&2 "No bin/powershell, please run './build.sh'"; exit 1; }
+
 ./bin/powershell --noprofile -c "Invoke-Pester test/powershell/$1 -OutputFile pester-tests.xml -OutputFormat NUnitXml -EnableExit"
 failed_tests=$?
 


### PR DESCRIPTION
- Move to the `bin` directly so that SOS works properly
- Check for LLDB and PowerShell programs
- Display help text
- Check for cmake, g++, and dotnet programs
- Check for project.lock.json
- Check that libpsl-native was compiled

@PowerShell/linux I think you all will like this.
