### PR TITLE
Fix xUnit tests for `netstandardapp1.5`

### DIFF
--- a/test/csharp/project.json
+++ b/test/csharp/project.json
@@ -4,14 +4,14 @@
     "description": "PowerShell On Linux xUnit Tests",
     "authors": [ "andschwa" ],
 
+    "dependencies": {
+	"Microsoft.PowerShell.Linux.Host": "1.0.0-*"
+    },
+
     "frameworks": {
-	"netstandard1.5": {
-	    "imports": [ "dnxcore50", "portable-net45+win8" ],
+	"dnxcore50": {
+	    "imports": [ "netstandardapp1.5", "portable-net45+win8" ],
 	    "dependencies": {
-		"Microsoft.PowerShell.Linux.Host": {
-		    "type": "build",
-		    "version": "1.0.0-*"
-		},
 		"xunit": "2.1.0",
 		"dotnet-test-xunit": "1.0.0-dev-*"
 	    }

--- a/xunit.sh
+++ b/xunit.sh
@@ -1,5 +1,13 @@
 #!/usr/bin/env bash
 
+# Test for build dependencies
+hash cmake 2>/dev/null || { echo >&2 "No cmake, please run 'sudo apt-get install cmake'"; exit 1; }
+hash g++ 2>/dev/null || { echo >&2 "No g++, please run 'sudo apt-get install g++'"; exit 1; }
+hash dotnet 2>/dev/null || { echo >&2 "No dotnet, please visit https://dotnet.github.io/getting-started/"; exit 1; }
+
+# Test for lock file
+test -r test/csharp/project.lock.json || { echo >&2 "Please run 'dotnet restore' to download .NET Core packages"; exit 2; }
+
 # Build native components
 pushd src/libpsl-native
 cmake -DCMAKE_BUILD_TYPE=Debug .
@@ -14,7 +22,7 @@ pushd test/csharp
 ## Build
 dotnet build
 ## Work-around dotnet/cli#753
-cp -r ../../src/Microsoft.PowerShell.Linux.Host/{Modules,*ps1xml} bin/Debug/dnxcore50/
+cp -r ../../src/Microsoft.PowerShell.Linux.Host/{Modules,*ps1xml} bin/Debug/dnxcore50/ubuntu.14.04-x64
 ## Test
 dotnet test
 popd


### PR DESCRIPTION
With the switch to `netstandardapp1.5` framework for the host, the xUnit test runner broke. For `dotnet test` to work with the .NET Core xUnit runner, it must continue to target `dnxcore50`. Fortunately, we can import our project's framework, and make everything work again.

Also improved the `xunit.sh` script to check for dependencies.

/cc @zach-folwick This should unblock you.
