### PR TITLE
Add Emacs-style readline bindings

### DIFF
--- a/src/Microsoft.PowerShell.Linux.Host/PSL_profile.ps1
+++ b/src/Microsoft.PowerShell.Linux.Host/PSL_profile.ps1
@@ -1,15 +1,3 @@
 function prompt {
-   "PSL " + $(get-location) + "> "
+   "PS " + $(get-location) + "> "
 }
-
-@"
-
-Welcome to Project Magrathea!
-
-This is the Core PowerShell On Linux / OS X / Windows console
-=============================================================
-- Type 'Get-Help' for help
-- Type 'Exit' to exit
-- Type 'Invoke-Pester test/powershell' to run the tests
-
-"@

--- a/src/Microsoft.PowerShell.Linux.Host/main.cs
+++ b/src/Microsoft.PowerShell.Linux.Host/main.cs
@@ -518,7 +518,7 @@ OPTIONS
                     prompt = "PS> ";
                 }
 
-                this.myHost.UI.Write(ConsoleColor.White, ConsoleColor.Black, prompt);
+                this.myHost.UI.Write(ConsoleColor.White, Console.BackgroundColor, prompt);
                 string cmd = consoleReadLine.Read(this.myHost.Runspace);
                 this.Execute(cmd);
             }

--- a/src/Microsoft.PowerShell.Linux.Host/readline.cs
+++ b/src/Microsoft.PowerShell.Linux.Host/readline.cs
@@ -133,61 +133,120 @@ namespace Microsoft.PowerShell.Linux.Host
             {
                 ConsoleKeyInfo key = Console.ReadKey(true);
 
-                switch (key.Key)
+                // TODO: OnDelete(key.Modifiers)
+                // TODO: OnBackspace(key.Modifiers)
+
+                // Basic Emacs-style readline implementation
+                if (key.Modifiers.HasFlag(ConsoleModifiers.Control))
                 {
-                    case ConsoleKey.Backspace:
-                        this.OnBackspace();
-                        break;
-                    case ConsoleKey.Delete:
-                        this.OnDelete();
-                        break;
-                    case ConsoleKey.Enter:
-                        previousKeyPress = key;
-                        return this.OnEnter();
-                    case ConsoleKey.RightArrow:
-                        this.OnRight(key.Modifiers);
-                        break;
-                    case ConsoleKey.LeftArrow:
-                        this.OnLeft(key.Modifiers);
-                        break;
-                    case ConsoleKey.Escape:
-                        this.OnEscape();
-                        break;
-                    case ConsoleKey.Home:
-                        this.OnHome();
-                        break;
-                    case ConsoleKey.End:
-                        this.OnEnd();
-                        break;
-                    case ConsoleKey.Tab:
-                        this.OnTab();
-                        break;
-                    case ConsoleKey.UpArrow:
-                        this.OnUpArrow();
-                        break;
-                    case ConsoleKey.DownArrow:
-                        this.OnDownArrow();
-                        break;
+                    switch (key.Key)
+                    {
+                        case ConsoleKey.A:
+                            this.OnHome();
+                            break;
+                        case ConsoleKey.E:
+                            this.OnEnd();
+                            break;
+                        case ConsoleKey.K:
+                            this.OnEscape();
+                            break;
+                        case ConsoleKey.D:
+                            this.OnDelete();
+                            break;
+                        case ConsoleKey.B:
+                            this.OnLeft(key.Modifiers);
+                            break;
+                        case ConsoleKey.F:
+                            this.OnRight(key.Modifiers);
+                            break;
+                        case ConsoleKey.P:
+                        case ConsoleKey.R:
+                            this.OnUpArrow();
+                            break;
+                        case ConsoleKey.N:
+                        case ConsoleKey.S:
+                            this.OnDownArrow();
+                            break;
+                        case ConsoleKey.J:
+                            this.OnEnter();
+                            break;
+                        case ConsoleKey.L:
+                            this.BufferFromString("clear");
+                            previousKeyPress = key;
+                            return this.OnEnter();
+                    }
+                }
+                else if (key.Modifiers.HasFlag(ConsoleModifiers.Alt))
+                {
+                    switch (key.Key)
+                    {
+                        case ConsoleKey.B:
+                            this.OnLeft(key.Modifiers);
+                            break;
+                        case ConsoleKey.F:
+                            this.OnRight(key.Modifiers);
+                            break;
+                    }
+                }
+                // Unmodified keys
+                else
+                {
+                    switch (key.Key)
+                    {
+                        case ConsoleKey.Backspace:
+                            this.OnBackspace();
+                            break;
+                        case ConsoleKey.Delete:
+                            this.OnDelete();
+                            break;
+                        case ConsoleKey.Enter:
+                            previousKeyPress = key;
+                            return this.OnEnter();
+                        case ConsoleKey.RightArrow:
+                            this.OnRight(key.Modifiers);
+                            break;
+                        case ConsoleKey.LeftArrow:
+                            this.OnLeft(key.Modifiers);
+                            break;
+                        case ConsoleKey.Escape:
+                            this.OnEscape();
+                            break;
+                        case ConsoleKey.Home:
+                            this.OnHome();
+                            break;
+                        case ConsoleKey.End:
+                            this.OnEnd();
+                            break;
+                        case ConsoleKey.Tab:
+                            this.OnTab();
+                            break;
+                        case ConsoleKey.UpArrow:
+                            this.OnUpArrow();
+                            break;
+                        case ConsoleKey.DownArrow:
+                            this.OnDownArrow();
+                            break;
 
-                        // TODO: case ConsoleKey.LeftWindows: not available in linux
-                        // TODO: case ConsoleKey.RightWindows: not available in linux
+                            // TODO: case ConsoleKey.LeftWindows: not available in linux
+                            // TODO: case ConsoleKey.RightWindows: not available in linux
 
-                    default:
+                        default:
 
-                        if (key.KeyChar == '\x0D')
-                        {
-                            goto case ConsoleKey.Enter;      // Ctrl-M
-                        }
+                            if (key.KeyChar == '\x0D')
+                            {
+                                goto case ConsoleKey.Enter;      // Ctrl-M
+                            }
 
-                        if (key.KeyChar == '\x08')
-                        {
-                            goto case ConsoleKey.Backspace;  // Ctrl-H
-                        }
+                            if (key.KeyChar == '\x08')
+                            {
+                                goto case ConsoleKey.Backspace;  // Ctrl-H
+                            }
 
-                        this.Insert(key.KeyChar);
+                            this.Insert(key.KeyChar);
 
-                        this.Render();
-                        break;
+                            this.Render();
+                            break;
+                    }
                 }
                 previousKeyPress = key;
             }
@@ -446,7 +505,7 @@ namespace Microsoft.PowerShell.Linux.Host
         /// and Shift keys.</param>
         private void OnLeft(ConsoleModifiers consoleModifiers)
         {
-            if ((consoleModifiers & ConsoleModifiers.Control) != 0)
+            if (consoleModifiers.HasFlag(ConsoleModifiers.Alt))
             {
                 // Move back to the start of the previous word.
                 if (this.buffer.Length > 0 && this.current != 0)
@@ -493,7 +552,7 @@ namespace Microsoft.PowerShell.Linux.Host
         /// and Shift keys.</param>
         private void OnRight(ConsoleModifiers consoleModifiers)
         {
-            if ((consoleModifiers & ConsoleModifiers.Control) != 0)
+            if (consoleModifiers.HasFlag(ConsoleModifiers.Alt))
             {
                 // Move to the next word.
                 if (this.buffer.Length != 0 && this.current < this.buffer.Length)

--- a/src/Microsoft.PowerShell.Linux.Host/ui.cs
+++ b/src/Microsoft.PowerShell.Linux.Host/ui.cs
@@ -54,7 +54,7 @@ namespace Microsoft.PowerShell.Linux.Host
         {
             this.Write(
                     ConsoleColor.White,
-                    ConsoleColor.Black,
+                    Console.BackgroundColor,
                     caption + System.Environment.NewLine + message + " ");
             Dictionary<string, PSObject> results =
                 new Dictionary<string, PSObject>();
@@ -96,7 +96,7 @@ namespace Microsoft.PowerShell.Linux.Host
             // Write the caption and message strings in Blue.
             this.WriteLine(
                     ConsoleColor.Blue,
-                    ConsoleColor.Black,
+                    Console.BackgroundColor,
                     caption + System.Environment.NewLine + message + System.Environment.NewLine);
 
             // Convert the choice collection into something that is
@@ -124,7 +124,7 @@ namespace Microsoft.PowerShell.Linux.Host
             // chosen, or the loop is interrupted with ctrl-C.
             while (true)
             {
-                this.WriteLine(ConsoleColor.Cyan, ConsoleColor.Black, sb.ToString());
+                this.WriteLine(ConsoleColor.Cyan, Console.BackgroundColor, sb.ToString());
                 string data = Console.ReadLine().Trim().ToUpper();
 
                 // If the choice string was empty, use the default selection.
@@ -170,7 +170,7 @@ namespace Microsoft.PowerShell.Linux.Host
             // Write the caption and message strings in Blue.
             this.WriteLine(
                     ConsoleColor.Blue,
-                    ConsoleColor.Black,
+                    Console.BackgroundColor,
                     caption + System.Environment.NewLine + message + System.Environment.NewLine);
 
             // Convert the choice collection into something that is
@@ -217,7 +217,7 @@ namespace Microsoft.PowerShell.Linux.Host
 
             this.WriteLine(
                     ConsoleColor.Cyan,
-                    ConsoleColor.Black,
+                    Console.BackgroundColor,
                     sb.ToString());
             // Read prompts until a match is made, the default is
             // chosen, or the loop is interrupted with ctrl-C.
@@ -226,7 +226,7 @@ namespace Microsoft.PowerShell.Linux.Host
             {
 ReadNext:
                 string prompt = string.Format(CultureInfo.CurrentCulture, "Choice[{0}]:", results.Count);
-                this.Write(ConsoleColor.Cyan, ConsoleColor.Black, prompt);
+                this.Write(ConsoleColor.Cyan, Console.BackgroundColor, prompt);
                 string data = Console.ReadLine().Trim().ToUpper();
 
                 // If the choice string was empty, no more choices have been made.
@@ -352,7 +352,6 @@ ReadNext:
             Console.ForegroundColor = foregroundColor;
             Console.BackgroundColor = backgroundColor;
             Console.Write(value);
-            //Console.Write(value);
             Console.ResetColor();
         }
 
@@ -361,7 +360,7 @@ ReadNext:
         /// Writes a line of characters to the output display of the host
         /// with foreground and background colors and appends a newline (carriage return).
         /// </summary>
-        /// <param name="foregroundColor">The forground color of the display. </param>
+        /// <param name="foregroundColor">The foreground color of the display. </param>
         /// <param name="backgroundColor">The background color of the display. </param>
         /// <param name="value">The line to be written.</param>
         public override void WriteLine(
@@ -383,7 +382,7 @@ ReadNext:
         {
             this.WriteLine(
                     ConsoleColor.Yellow,
-                    ConsoleColor.Black,
+                    Console.BackgroundColor,
                     String.Format(CultureInfo.CurrentCulture, "DEBUG: {0}", message));
         }
 
@@ -396,7 +395,7 @@ ReadNext:
         {
             this.WriteLine(
                     ConsoleColor.Red,
-                    ConsoleColor.Black,
+                    Console.BackgroundColor,
                     value);
         }
 
@@ -454,7 +453,7 @@ ReadNext:
         {
             this.WriteLine(
                     ConsoleColor.Green,
-                    ConsoleColor.Black,
+                    Console.BackgroundColor,
                     String.Format(CultureInfo.CurrentCulture, "VERBOSE: {0}", message));
         }
 
@@ -466,7 +465,7 @@ ReadNext:
         {
             this.WriteLine(
                     ConsoleColor.Yellow,
-                    ConsoleColor.Black,
+                    Console.BackgroundColor,
                     String.Format(CultureInfo.CurrentCulture, "WARNING: {0}", message));
         }
 


### PR DESCRIPTION
Very simple implementation of C-(A,E,K,D,B,F,P,R,N,S,J,L) and Alt-(B,F).

Resolves #562 and makes it much nicer to play with.
