### PR TITLE
Fix crash when cursor goes 'off screen'

### DIFF
--- a/src/Microsoft.PowerShell.Linux.Host/readline.cs
+++ b/src/Microsoft.PowerShell.Linux.Host/readline.cs
@@ -762,6 +762,8 @@ namespace Microsoft.PowerShell.Linux.Host
             internal void Move(int delta)
             {
                 int position = Console.CursorTop * Console.BufferWidth + Console.CursorLeft + delta;
+                int maxPosition = (Console.BufferWidth * Console.BufferHeight) - 1;
+                position = (position < 0) ? 0 : ((position > maxPosition) ? maxPosition : position);
 
                 Console.CursorLeft = position % Console.BufferWidth;
                 Console.CursorTop = position / Console.BufferWidth;


### PR DESCRIPTION
This happens rarely, but if output is sent to screen while you type, like screen refresh, or debug output, it's possible to go off-screen, and powershell crashes.
