### PR TITLE
Add support for multi-line input

### DIFF
--- a/src/Microsoft.PowerShell.Linux.Host/main.cs
+++ b/src/Microsoft.PowerShell.Linux.Host/main.cs
@@ -178,6 +178,11 @@ OPTIONS
         private string partialLine = string.Empty;
 
         /// <summary>
+        /// To keep track of here-strings
+        /// </summary>
+        private bool hereString = false;
+
+        /// <summary>
         /// Gets or sets a value indicating whether the host application
         /// should exit.
         /// </summary>
@@ -391,15 +396,24 @@ OPTIONS
             catch (IncompleteParseException e)
             {
                 incompleteLine = true;
+                cmd = cmd.Trim();
                 partialLine += cmd;
-                
-                while (partialLine[partialLine.Length - 1] == '`')
-                {
-                    Console.WriteLine("Trimming...");
-                    partialLine = partialLine.Remove(partialLine.Length - 1);
-                }
 
-                partialLine += " ";
+                if (hereString || cmd.EndsWith("@\"") || cmd.EndsWith("@\'"))
+                {
+                    hereString = true;
+
+                    partialLine += System.Environment.NewLine;
+                }
+                else
+                {
+                    while (partialLine[partialLine.Length - 1] == '`')
+                    {
+                        partialLine = partialLine.Remove(partialLine.Length - 1);
+                    }
+
+                    partialLine += " ";
+                }
             }
 
             finally
@@ -416,6 +430,7 @@ OPTIONS
                 if (!incompleteLine)
                 {
                     partialLine = string.Empty;
+                    hereString = false;
                 }
             }
         }

--- a/src/Microsoft.PowerShell.Linux.Host/main.cs
+++ b/src/Microsoft.PowerShell.Linux.Host/main.cs
@@ -178,11 +178,6 @@ OPTIONS
         private string partialLine = string.Empty;
 
         /// <summary>
-        /// To keep track of here-strings
-        /// </summary>
-        private bool hereString = false;
-
-        /// <summary>
         /// Gets or sets a value indicating whether the host application
         /// should exit.
         /// </summary>
@@ -399,21 +394,8 @@ OPTIONS
                 cmd = cmd.Trim();
                 partialLine += cmd;
 
-                if (hereString || cmd.EndsWith("@\"") || cmd.EndsWith("@\'"))
-                {
-                    hereString = true;
+                partialLine += System.Environment.NewLine;
 
-                    partialLine += System.Environment.NewLine;
-                }
-                else
-                {
-                    while (partialLine[partialLine.Length - 1] == '`')
-                    {
-                        partialLine = partialLine.Remove(partialLine.Length - 1);
-                    }
-
-                    partialLine += " ";
-                }
             }
 
             finally
@@ -430,7 +412,6 @@ OPTIONS
                 if (!incompleteLine)
                 {
                     partialLine = string.Empty;
-                    hereString = false;
                 }
             }
         }

--- a/src/Microsoft.PowerShell.Linux.Host/main.cs
+++ b/src/Microsoft.PowerShell.Linux.Host/main.cs
@@ -168,6 +168,16 @@ OPTIONS
         private bool _showHelpMessage;
 
         /// <summary>
+        /// To keep track whether last entered command was complete
+        /// </summary>
+        private bool incompleteLine = false;
+
+        /// <summary>
+        /// To store incomplete lines
+        /// </summary>
+        private string partialLine = string.Empty;
+
+        /// <summary>
         /// Gets or sets a value indicating whether the host application
         /// should exit.
         /// </summary>
@@ -270,7 +280,11 @@ OPTIONS
                 return returnVal;
             }
 
-            // TODO: if we are in block mode, sep the prompt to ">> "
+            if (incompleteLine)
+            {
+                return ">> ";
+            }
+
             Pipeline pipeline = rs.CreatePipeline();
             Command promptCommand = new Command("prompt");
 
@@ -343,7 +357,15 @@ OPTIONS
             {
                 this.currentPowerShell.Runspace = this.myRunSpace;
 
-                this.currentPowerShell.AddScript(cmd);
+                if (incompleteLine)
+                {
+                    this.currentPowerShell.AddScript(partialLine + cmd);
+                }
+                else
+                {
+                    this.currentPowerShell.AddScript(cmd);
+                }
+                incompleteLine = false;
 
                 // Add the default outputter to the end of the pipe and then call the
                 // MergeMyResults method to merge the output and error streams from the
@@ -366,6 +388,20 @@ OPTIONS
                     this.currentPowerShell.Invoke(null, settings);
                 }
             }
+            catch (IncompleteParseException e)
+            {
+                incompleteLine = true;
+                partialLine += cmd;
+                
+                while (partialLine[partialLine.Length - 1] == '`')
+                {
+                    Console.WriteLine("Trimming...");
+                    partialLine = partialLine.Remove(partialLine.Length - 1);
+                }
+
+                partialLine += " ";
+            }
+
             finally
             {
                 // Dispose the PowerShell object and set currentPowerShell to null.
@@ -375,6 +411,11 @@ OPTIONS
                 {
                     this.currentPowerShell.Dispose();
                     this.currentPowerShell = null;
+                }
+
+                if (!incompleteLine)
+                {
+                    partialLine = string.Empty;
                 }
             }
         }


### PR DESCRIPTION
Add support for multi-line input.  

When recalling a command that's multi-line, the display is currently slightly messed up.  If this gets approved, I will open a new bug to address that scenario.
