### PR TITLE
Fix current working directory for CMake

### DIFF
--- a/PowerShellGitHubDev.psm1
+++ b/PowerShellGitHubDev.psm1
@@ -44,9 +44,16 @@ function Start-PSBuild
         $Native = "$PSScriptRoot/src/libpsl-native"
         $Lib = "$Native/src/libpsl-native.$Ext"
         Write-Host "Building $Lib"
-        cmake -DCMAKE_BUILD_TYPE=Debug $Native
-        make -j -C $Native
-        make -C $Native test
+
+        try {
+            pushd $Native
+            cmake -DCMAKE_BUILD_TYPE=Debug .
+            make -j
+            make test
+        } finally {
+            popd
+        }
+
         if (-Not (Test-Path $Lib)) { throw "Compilation of $Lib failed" }
         cp $Lib $Output
     }


### PR DESCRIPTION
There is no way around this. The directory where CMake is invoked is where it writes its build files, so we have to `pushd`. In case anything fails, we `popd` in a finally block.

My bad.
