### PR TITLE
Enabling caching on CI machines

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: cpp
 sudo: required
 dist: trusty
+cache:
+  directories:
+    - $HOME/.nuget
 git:
   submodules: false
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: cpp
 sudo: required
 dist: trusty
 cache:
+  apt: true
   directories:
     - $HOME/.nuget
 git:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,9 @@ environment:
   priv_key:
     secure: <encryped-value>
 
+cache:
+  - '%HOME%\.nuget'
+
 notifications:
   - provider: Slack
     incoming_webhook:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,7 @@ environment:
 
 cache:
   - '%HOME%\.nuget'
+  - '%LocalAppData%\Microsoft\dotnet'
 
 notifications:
   - provider: Slack


### PR DESCRIPTION
This caches the NuGet packages and CLI packages on Travis and AppVeyor.

The apt cache for Travis may not work just yet, but I've contacted support and requested the .NET CLI feed get cached, at which point it'll start picking it up.

Most builds should be a fair bit faster.
