### PR TITLE
Add support for Ctrl-C to interrupt commands, and add multi-line capa…

### DIFF
--- a/src/Microsoft.PowerShell.Linux.Host/readline.cs
+++ b/src/Microsoft.PowerShell.Linux.Host/readline.cs
@@ -6,6 +6,7 @@ namespace Microsoft.PowerShell.Linux.Host
     using System.Management.Automation;
     using System.Management.Automation.Runspaces;
     using System.Text;
+    using System.Threading;
 
     /// <summary>
     /// This class is used to read the command line and color the text as
@@ -91,6 +92,11 @@ namespace Microsoft.PowerShell.Linux.Host
         private string preTabBuffer;
 
         /// <summary>
+        /// To keep track whether we should abort the Console.ReadKey loop
+        /// </summary>
+        private bool abortReadKey = false;
+
+        /// <summary>
         /// Initializes a new instance of the ConsoleReadLine class.
         /// </summary>
         public ConsoleReadLine()
@@ -129,134 +135,142 @@ namespace Microsoft.PowerShell.Linux.Host
             this.powershell.Runspace = runspace;
             this.Initialize();
 
-            while (true)
+            while (abortReadKey != true)
             {
-                ConsoleKeyInfo key = Console.ReadKey(true);
+                if (Console.KeyAvailable)
+                {
+                    ConsoleKeyInfo key = Console.ReadKey(true);
 
-                // Basic Emacs-style readline implementation
-                if (key.Modifiers.HasFlag(ConsoleModifiers.Control))
-                {
-                    switch (key.Key)
+                    // Basic Emacs-style readline implementation
+                    if (key.Modifiers.HasFlag(ConsoleModifiers.Control))
                     {
-                        case ConsoleKey.A:
-                            this.OnHome();
-                            break;
-                        case ConsoleKey.E:
-                            this.OnEnd();
-                            break;
-                        // TODO: save buffer, yank with Ctrl-Y
-                        /*
-                        case ConsoleKey.K:
-                            this.OnEscape();
-                            break;
-                        */
-                        case ConsoleKey.D:
-                            this.OnDelete();
-                            break;
-                        case ConsoleKey.B:
-                            this.OnLeft(key.Modifiers);
-                            break;
-                        case ConsoleKey.F:
-                            this.OnRight(key.Modifiers);
-                            break;
-                        case ConsoleKey.P:
-                        // TODO: incremental search
-                        case ConsoleKey.R:
-                            this.OnUpArrow(nested);
-                            break;
-                        case ConsoleKey.N:
-                        // TODO: incremental search
-                        case ConsoleKey.S:
-                            this.OnDownArrow(nested);
-                            break;
-                        case ConsoleKey.J:
-                            this.OnEnter();
-                            break;
-                        // TODO: save and restore buffer
-                        /*
-                        case ConsoleKey.L:
-                            this.BufferFromString("clear");
-                            previousKeyPress = key;
-                            return this.OnEnter();
-                        */
+                        switch (key.Key)
+                        {
+                            case ConsoleKey.A:
+                                this.OnHome();
+                                break;
+                            case ConsoleKey.E:
+                                this.OnEnd();
+                                break;
+                                // TODO: save buffer, yank with Ctrl-Y
+                                /*
+                                  case ConsoleKey.K:
+                                  this.OnEscape();
+                                  break;
+                                */
+                            case ConsoleKey.D:
+                                this.OnDelete();
+                                break;
+                            case ConsoleKey.B:
+                                this.OnLeft(key.Modifiers);
+                                break;
+                            case ConsoleKey.F:
+                                this.OnRight(key.Modifiers);
+                                break;
+                            case ConsoleKey.P:
+                                // TODO: incremental search
+                            case ConsoleKey.R:
+                                this.OnUpArrow(nested);
+                                break;
+                            case ConsoleKey.N:
+                                // TODO: incremental search
+                            case ConsoleKey.S:
+                                this.OnDownArrow(nested);
+                                break;
+                            case ConsoleKey.J:
+                                this.OnEnter();
+                                break;
+                                // TODO: save and restore buffer
+                                /*
+                                  case ConsoleKey.L:
+                                  this.BufferFromString("clear");
+                                  previousKeyPress = key;
+                                  return this.OnEnter();
+                                */
+                        }
                     }
-                }
-                else if (key.Modifiers.HasFlag(ConsoleModifiers.Alt))
-                {
-                    switch (key.Key)
+                    else if (key.Modifiers.HasFlag(ConsoleModifiers.Alt))
                     {
-                        // TODO: OnDelete(key)
-                        // TODO: OnBackspace(key)
-                        case ConsoleKey.B:
-                            this.OnLeft(key.Modifiers);
-                            break;
-                        case ConsoleKey.F:
-                            this.OnRight(key.Modifiers);
-                            break;
+                        switch (key.Key)
+                        {
+                            // TODO: OnDelete(key)
+                            // TODO: OnBackspace(key)
+                            case ConsoleKey.B:
+                                this.OnLeft(key.Modifiers);
+                                break;
+                            case ConsoleKey.F:
+                                this.OnRight(key.Modifiers);
+                                break;
+                        }
                     }
+                    // Unmodified keys
+                    else
+                    {
+                        switch (key.Key)
+                        {
+                            case ConsoleKey.Backspace:
+                                this.OnBackspace();
+                                break;
+                            case ConsoleKey.Delete:
+                                this.OnDelete();
+                                break;
+                            case ConsoleKey.Enter:
+                                previousKeyPress = key;
+                                return this.OnEnter();
+                            case ConsoleKey.RightArrow:
+                                this.OnRight(key.Modifiers);
+                                break;
+                            case ConsoleKey.LeftArrow:
+                                this.OnLeft(key.Modifiers);
+                                break;
+                            case ConsoleKey.Escape:
+                                this.OnEscape();
+                                break;
+                            case ConsoleKey.Home:
+                                this.OnHome();
+                                break;
+                            case ConsoleKey.End:
+                                this.OnEnd();
+                                break;
+                            case ConsoleKey.Tab:
+                                this.OnTab();
+                                break;
+                            case ConsoleKey.UpArrow:
+                                this.OnUpArrow(nested);
+                                break;
+                            case ConsoleKey.DownArrow:
+                                this.OnDownArrow(nested);
+                                break;
+
+                                // TODO: case ConsoleKey.LeftWindows: not available in linux
+                                // TODO: case ConsoleKey.RightWindows: not available in linux
+
+                            default:
+
+                                if (key.KeyChar == '\x0D')
+                                {
+                                    goto case ConsoleKey.Enter;      // Ctrl-M
+                                }
+
+                                if (key.KeyChar == '\x08')
+                                {
+                                    goto case ConsoleKey.Backspace;  // Ctrl-H
+                                }
+
+                                this.Insert(key.KeyChar);
+
+                                this.Render();
+                                break;
+                        }
+                    }
+                    previousKeyPress = key;
                 }
-                // Unmodified keys
                 else
                 {
-                    switch (key.Key)
-                    {
-                        case ConsoleKey.Backspace:
-                            this.OnBackspace();
-                            break;
-                        case ConsoleKey.Delete:
-                            this.OnDelete();
-                            break;
-                        case ConsoleKey.Enter:
-                            previousKeyPress = key;
-                            return this.OnEnter();
-                        case ConsoleKey.RightArrow:
-                            this.OnRight(key.Modifiers);
-                            break;
-                        case ConsoleKey.LeftArrow:
-                            this.OnLeft(key.Modifiers);
-                            break;
-                        case ConsoleKey.Escape:
-                            this.OnEscape();
-                            break;
-                        case ConsoleKey.Home:
-                            this.OnHome();
-                            break;
-                        case ConsoleKey.End:
-                            this.OnEnd();
-                            break;
-                        case ConsoleKey.Tab:
-                            this.OnTab();
-                            break;
-                        case ConsoleKey.UpArrow:
-                            this.OnUpArrow(nested);
-                            break;
-                        case ConsoleKey.DownArrow:
-                            this.OnDownArrow(nested);
-                            break;
-
-                        // TODO: case ConsoleKey.LeftWindows: not available in linux
-                        // TODO: case ConsoleKey.RightWindows: not available in linux
-
-                        default:
-
-                            if (key.KeyChar == '\x0D')
-                            {
-                                goto case ConsoleKey.Enter;      // Ctrl-M
-                            }
-
-                            if (key.KeyChar == '\x08')
-                            {
-                                goto case ConsoleKey.Backspace;  // Ctrl-H
-                            }
-
-                            this.Insert(key.KeyChar);
-
-                            this.Render();
-                            break;
-                    }
+                    Thread.Sleep(250);
                 }
-                previousKeyPress = key;
             }
+            return string.Empty;
         }
 
         /// <summary>
@@ -270,6 +284,7 @@ namespace Microsoft.PowerShell.Linux.Host
             this.current = 0;
             this.rendered = 0;
             this.cursor = new Cursor();
+            this.abortReadKey = false;
         }
 
         /// <summary>
@@ -731,6 +746,18 @@ namespace Microsoft.PowerShell.Linux.Host
 
             this.rendered = text.Length;
             this.cursor.Place(this.current);
+        }
+
+        /// <summary>
+        ///   Abort current command
+        /// </summary>
+        public void Abort()
+        {
+            ConsoleColor saveFGColor = Console.ForegroundColor;
+            Console.ForegroundColor = ConsoleColor.Red;
+            Console.Out.WriteLine("^C");
+            Console.ForegroundColor = saveFGColor;
+            this.abortReadKey = true;
         }
 
         /// <summary>

--- a/src/Microsoft.PowerShell.Linux.Host/readline.cs
+++ b/src/Microsoft.PowerShell.Linux.Host/readline.cs
@@ -97,6 +97,12 @@ namespace Microsoft.PowerShell.Linux.Host
         private bool abortReadKey = false;
 
         /// <summary>
+        /// Amount of time to sleep before checking for user keystroke,
+        /// in milliseconds
+        /// </summary>
+        private const int sleepTime = 80;
+
+        /// <summary>
         /// Initializes a new instance of the ConsoleReadLine class.
         /// </summary>
         public ConsoleReadLine()
@@ -134,8 +140,9 @@ namespace Microsoft.PowerShell.Linux.Host
         {
             this.powershell.Runspace = runspace;
             this.Initialize();
+            bool finishedTyping = false;
 
-            while (abortReadKey != true)
+            while (!abortReadKey)
             {
                 if (Console.KeyAvailable)
                 {
@@ -144,133 +151,165 @@ namespace Microsoft.PowerShell.Linux.Host
                     // Basic Emacs-style readline implementation
                     if (key.Modifiers.HasFlag(ConsoleModifiers.Control))
                     {
-                        switch (key.Key)
-                        {
-                            case ConsoleKey.A:
-                                this.OnHome();
-                                break;
-                            case ConsoleKey.E:
-                                this.OnEnd();
-                                break;
-                                // TODO: save buffer, yank with Ctrl-Y
-                                /*
-                                  case ConsoleKey.K:
-                                  this.OnEscape();
-                                  break;
-                                */
-                            case ConsoleKey.D:
-                                this.OnDelete();
-                                break;
-                            case ConsoleKey.B:
-                                this.OnLeft(key.Modifiers);
-                                break;
-                            case ConsoleKey.F:
-                                this.OnRight(key.Modifiers);
-                                break;
-                            case ConsoleKey.P:
-                                // TODO: incremental search
-                            case ConsoleKey.R:
-                                this.OnUpArrow(nested);
-                                break;
-                            case ConsoleKey.N:
-                                // TODO: incremental search
-                            case ConsoleKey.S:
-                                this.OnDownArrow(nested);
-                                break;
-                            case ConsoleKey.J:
-                                this.OnEnter();
-                                break;
-                                // TODO: save and restore buffer
-                                /*
-                                  case ConsoleKey.L:
-                                  this.BufferFromString("clear");
-                                  previousKeyPress = key;
-                                  return this.OnEnter();
-                                */
-                        }
+                        finishedTyping = ProcessControlKey(key, nested);
                     }
                     else if (key.Modifiers.HasFlag(ConsoleModifiers.Alt))
                     {
-                        switch (key.Key)
-                        {
-                            // TODO: OnDelete(key)
-                            // TODO: OnBackspace(key)
-                            case ConsoleKey.B:
-                                this.OnLeft(key.Modifiers);
-                                break;
-                            case ConsoleKey.F:
-                                this.OnRight(key.Modifiers);
-                                break;
-                        }
+                        finishedTyping = ProcessAltKey(key);
                     }
                     // Unmodified keys
                     else
                     {
-                        switch (key.Key)
-                        {
-                            case ConsoleKey.Backspace:
-                                this.OnBackspace();
-                                break;
-                            case ConsoleKey.Delete:
-                                this.OnDelete();
-                                break;
-                            case ConsoleKey.Enter:
-                                previousKeyPress = key;
-                                return this.OnEnter();
-                            case ConsoleKey.RightArrow:
-                                this.OnRight(key.Modifiers);
-                                break;
-                            case ConsoleKey.LeftArrow:
-                                this.OnLeft(key.Modifiers);
-                                break;
-                            case ConsoleKey.Escape:
-                                this.OnEscape();
-                                break;
-                            case ConsoleKey.Home:
-                                this.OnHome();
-                                break;
-                            case ConsoleKey.End:
-                                this.OnEnd();
-                                break;
-                            case ConsoleKey.Tab:
-                                this.OnTab();
-                                break;
-                            case ConsoleKey.UpArrow:
-                                this.OnUpArrow(nested);
-                                break;
-                            case ConsoleKey.DownArrow:
-                                this.OnDownArrow(nested);
-                                break;
-
-                                // TODO: case ConsoleKey.LeftWindows: not available in linux
-                                // TODO: case ConsoleKey.RightWindows: not available in linux
-
-                            default:
-
-                                if (key.KeyChar == '\x0D')
-                                {
-                                    goto case ConsoleKey.Enter;      // Ctrl-M
-                                }
-
-                                if (key.KeyChar == '\x08')
-                                {
-                                    goto case ConsoleKey.Backspace;  // Ctrl-H
-                                }
-
-                                this.Insert(key.KeyChar);
-
-                                this.Render();
-                                break;
-                        }
+                        finishedTyping = ProcessNormalKey(key, nested);
                     }
                     previousKeyPress = key;
                 }
                 else
                 {
-                    Thread.Sleep(250);
+                    Thread.Sleep(sleepTime);
+                }
+
+                if (finishedTyping)
+                {
+                    return this.OnEnter();
                 }
             }
             return string.Empty;
+        }
+
+        /// <summary>
+        /// Process Control-Key combo
+        /// </summary>
+        private bool ProcessControlKey(ConsoleKeyInfo key, bool nested)
+        {
+            switch (key.Key)
+            {
+                case ConsoleKey.A:
+                    this.OnHome();
+                    break;
+                case ConsoleKey.E:
+                    this.OnEnd();
+                    break;
+                    // TODO: save buffer, yank with Ctrl-Y
+                    /*
+                      case ConsoleKey.K:
+                      this.OnEscape();
+                      break;
+                    */
+                case ConsoleKey.D:
+                    this.OnDelete();
+                    break;
+                case ConsoleKey.B:
+                    this.OnLeft(key.Modifiers);
+                    break;
+                case ConsoleKey.F:
+                    this.OnRight(key.Modifiers);
+                    break;
+                case ConsoleKey.P:
+                    // TODO: incremental search
+                case ConsoleKey.R:
+                    this.OnUpArrow(nested);
+                    break;
+                case ConsoleKey.N:
+                    // TODO: incremental search
+                case ConsoleKey.S:
+                    this.OnDownArrow(nested);
+                    break;
+                case ConsoleKey.J:
+                    this.OnEnter();
+                    break;
+                    // TODO: save and restore buffer
+                    /*
+                      case ConsoleKey.L:
+                      this.BufferFromString("clear");
+                      previousKeyPress = key;
+                      return this.OnEnter();
+                    */
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Process Alt-Key combo
+        /// </summary>
+        private bool ProcessAltKey(ConsoleKeyInfo key)
+        {
+            switch (key.Key)
+            {
+                // TODO: OnDelete(key)
+                // TODO: OnBackspace(key)
+                case ConsoleKey.B:
+                    this.OnLeft(key.Modifiers);
+                    break;
+                case ConsoleKey.F:
+                    this.OnRight(key.Modifiers);
+                    break;
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Process normal key
+        /// </summary>
+        private bool ProcessNormalKey(ConsoleKeyInfo key, bool nested)
+        {
+            switch (key.Key)
+            {
+                case ConsoleKey.Backspace:
+                    this.OnBackspace();
+                    break;
+                case ConsoleKey.Delete:
+                    this.OnDelete();
+                    break;
+                case ConsoleKey.Enter:
+                    previousKeyPress = key;
+                    return true;
+                case ConsoleKey.RightArrow:
+                    this.OnRight(key.Modifiers);
+                    break;
+                case ConsoleKey.LeftArrow:
+                    this.OnLeft(key.Modifiers);
+                    break;
+                case ConsoleKey.Escape:
+                    this.OnEscape();
+                    break;
+                case ConsoleKey.Home:
+                    this.OnHome();
+                    break;
+                case ConsoleKey.End:
+                    this.OnEnd();
+                    break;
+                case ConsoleKey.Tab:
+                    this.OnTab();
+                    break;
+                case ConsoleKey.UpArrow:
+                    this.OnUpArrow(nested);
+                    break;
+                case ConsoleKey.DownArrow:
+                    this.OnDownArrow(nested);
+                    break;
+
+                    // TODO: case ConsoleKey.LeftWindows: not available in linux
+                    // TODO: case ConsoleKey.RightWindows: not available in linux
+
+                default:
+
+                    if (key.KeyChar == '\x0D')
+                    {
+                        goto case ConsoleKey.Enter;      // Ctrl-M
+                    }
+
+                    if (key.KeyChar == '\x08')
+                    {
+                        goto case ConsoleKey.Backspace;  // Ctrl-H
+                    }
+
+                    this.Insert(key.KeyChar);
+
+                    this.Render();
+                    break;
+            }
+            return false;
         }
 
         /// <summary>


### PR DESCRIPTION
This update fixes two things:
1.  Add support for Ctrl-C to interrupt current command input.  Similar to Windows behavior, it appends ^C to end of command line, and prints a new prompt.
2.  Add multi-line command capability for script debugger that was mistakenly left out in a previous update.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/powershell/613)

<!-- Reviewable:end -->
