### PR TITLE
Fix AppContext.BaseDirectory when remoting

### DIFF
--- a/test/powershell/Json.Tests.ps1
+++ b/test/powershell/Json.Tests.ps1
@@ -6,12 +6,7 @@
 
 Describe "Json.NET LINQ Parsing" {
     # load third party Json.NET library
-    if ([string]::IsNullOrEmpty($env:CORE_ROOT)) {
-	$base = [System.AppContext]::BaseDirectory
-    } else {
-	$base = $env:CORE_ROOT
-    }
-
+    $base = [System.AppContext]::BaseDirectory
     $path = Join-Path $base Newtonsoft.Json.dll
     [Microsoft.PowerShell.CoreCLR.AssemblyExtensions]::LoadFrom($path)
 


### PR DESCRIPTION
The native host for PSRP now sets the AppContext.BaseDirectory key so that the value is correct inside the managed PowerShell session. This enables us to remove a work-around in the JSON tests (which also test the ability to load a third-party library).
