### PR TITLE
Fix #528 : make powershell.exe build with VS 2015

### DIFF
--- a/PowerShellGitHubDev.psm1
+++ b/PowerShellGitHubDev.psm1
@@ -40,7 +40,7 @@ function Start-PSBuild
         [switch]$FullCLR,
 
         [Parameter(ParameterSetName='FullCLR')]
-        [string]$cmakeGenerator = "Visual Studio 12 2013",
+        [string]$cmakeGenerator = "Visual Studio 14 2015",
 
         [Parameter(ParameterSetName='FullCLR')]
         [ValidateSet("Debug",

--- a/README.md
+++ b/README.md
@@ -344,7 +344,7 @@ On Windows, we also build Full PowerShell for .NET 4.5.1
 
 * You need Visual Studio to compile the native host `powershell.exe`.
 
-If you don't have any visual studio installed, you can use [Visual Studio 2013
+If you don't have any visual studio installed, you can use [Visual Studio 2015
 Community edition][vs].
 
 * Add `msbuild` to `PATH` / create PowerShell alias to it.
@@ -363,8 +363,8 @@ choco install cmake.portable
 
 * Install dotnet-cli via their [documentation][]
 
-[vs]: https://www.visualstudio.com/en-us/news/vs2013-community-vs.aspx
-[chocolately]: https://chocolatey.org/packages/cmake.portable
+[vs]: https://www.visualstudio.com/en-us/products/visual-studio-community-vs.aspx
+[Chocolatey]: https://chocolatey.org/packages/cmake.portable
 [manually]: https://cmake.org/download/
 
 #### Building

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,5 @@
+image: Visual Studio 2015
+
 version: 0.2.0.{build}
 
 environment:

--- a/src/powershell-native/CMakeLists.txt
+++ b/src/powershell-native/CMakeLists.txt
@@ -36,4 +36,5 @@ target_link_libraries(powershell
     mscoree.lib
     MUILoad.lib
     kernel32.lib
-    msxml6.lib)
+    msxml6.lib
+    legacy_stdio_definitions.lib)


### PR DESCRIPTION
Add legacy_stdio_definitions.lib to the list of linked assemblies
