### PR TITLE
Use Start-PSBuild on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
   - sudo sh -c 'echo "deb [arch=amd64] http://apt-mo.trafficmanager.net/repos/dotnet/ trusty main" > /etc/apt/sources.list.d/dotnetdev.list'
   - sudo apt-key adv --keyserver apt-mo.trafficmanager.net --recv-keys 417A0893
   - sudo apt-get -qq update
-  - sudo apt-get install -y dotnet=1.0.0.001425-1
+  - sudo apt-get install -y dotnet=1.0.0.001675-1
 script:
   - dotnet restore
   - ./build.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,10 @@ before_install:
   - sudo apt-key adv --keyserver apt-mo.trafficmanager.net --recv-keys 417A0893
   - sudo apt-get -qq update
   - sudo apt-get install -y dotnet=1.0.0.001675-1
+  - ./download.sh
+  - sudo dpkg -i powershell.deb
 script:
-  - dotnet restore
-  - ./build.sh
+  - powershell -c "Import-Module ./PowerShellGitHubDev.psm1; Start-PSBuild"
   - ./pester.sh
 notifications:
   slack:

--- a/download.sh
+++ b/download.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+[[ -n $GITHUB_TOKEN ]] || { echo >&2 "GITHUB_TOKEN variable is undefined, please provide token"; exit 1; }
+
+# Authorizes with read-only access to GitHub API
+# Retrieves URL of v0.2.0 release asset
+# Downloads asset to powershell.deb
+curl -s -i \
+     -H "Authorization: token $GITHUB_TOKEN " \
+     -H 'Accept: application/octet-stream' \
+     'https://api.github.com/repos/PowerShell/PowerShell/releases/assets/1398546' |
+    grep location |
+    sed 's/location: //g' |
+    wget -i - -O powershell.deb


### PR DESCRIPTION
This downloads installs the v0.2.0 version of PowerShell for Ubuntu on Travis. It then builds the development PowerShell using `Start-PSBuild` instead of `./build.sh`.

Thus, `./build.sh` is deprecated and can be removed when all developers are comfortable doing so.

This is the preliminary step to finishing #678.

By the way, Travis's CLI was slightly out-of-date.
