### PR TITLE
Fix powershell -c 'throw error'

### DIFF
--- a/src/Microsoft.PowerShell.Linux.Host/main.cs
+++ b/src/Microsoft.PowerShell.Linux.Host/main.cs
@@ -233,7 +233,7 @@ OPTIONS
             // run the initial script
             if (initialScript != null)
             {
-                ExecuteHelper(initialScript, null);
+                Execute(initialScript);
             }
         }
 
@@ -432,6 +432,9 @@ OPTIONS
         {
             if (e != null)
             {
+                // Return non-zero exit code if an exception is thrown
+                this.ExitCode = 1;
+
                 object error;
                 IContainsErrorRecord icer = e as IContainsErrorRecord;
                 if (icer != null)
@@ -547,6 +550,9 @@ OPTIONS
             // the user calling "exit".
             while (!this.ShouldExit && this.myHost.Runspace != null)
             {
+                // Reset exit code for each command
+                this.ExitCode = 0;
+
                 // If the prompt function failed for any reason, use a sane default
                 string prompt;
                 try


### PR DESCRIPTION
When executing a single command block, two bugs existed.

1) Exceptions were not reported, instead it core dumped
2) The error code was not set, instead 0 was returned

Fixing 1) required calling `Execute` instead of `ExecuteHelper` as the latter handles exception through `ReportException`.

Fixing 2) required setting the listener's error code when an exception was thrown, and resetting it for each command when an interactive session is running.
