### PR TITLE
Remove explicit msbuild requirement

### DIFF
--- a/PowerShellGitHubDev.psm1
+++ b/PowerShellGitHubDev.psm1
@@ -84,8 +84,15 @@ function Start-PSBuild
     {
         # cmake is needed to build powershell.exe
         $precheck = $precheck -and (precheck 'cmake' 'cmake not found. You can install it from https://chocolatey.org/packages/cmake.portable')
+        
         # msbuild is needed to build powershell.exe
-        $precheck = $precheck -and (precheck 'msbuild' 'msbuild not found. Install Visual Studio and add msbuild to $env:PATH')
+        # msbuild is part of .NET Framework, we can try to get it from well-known location.
+        if (-not (Get-Command -Name msbuild -ErrorAction Ignore))
+        {
+            $env:path += ";${env:SystemRoot}\Microsoft.Net\Framework\v4.0.30319"
+        }
+
+        $precheck = $precheck -and (precheck 'msbuild' 'msbuild not found. Install Visual Studio 2015.')
     }
     
     if (-not $precheck) { return }

--- a/README.md
+++ b/README.md
@@ -359,12 +359,6 @@ If you don't have any Visual Studio installed, you can use
 `C` and `CXX` compilers, you either don't have Visual Studio, or you
 don't have the Visual C++ Compiler component installed.
 
-* Add `msbuild` to `PATH`, or create a PowerShell alias to it.
-
-```powershell
-Set-Alias msbuild C:\WINDOWS\Microsoft.NET\Framework\v4.0.30319\MSBuild.exe
-```
-
 * Install CMake and add it to `PATH.`
 
 You can install it from [Chocolatey][] or [manually][].


### PR DESCRIPTION
Fix #684
We already require VS 2015 installation.
Grab msbuild automatically from .NET framework folder.
