### PR TITLE
Ctrl Key mega patch that adds support for a number of Ctrl keys for command-line editing

### DIFF
--- a/src/Microsoft.PowerShell.Linux.Host/readline.cs
+++ b/src/Microsoft.PowerShell.Linux.Host/readline.cs
@@ -771,6 +771,10 @@ namespace Microsoft.PowerShell.Linux.Host
 
             string text = this.buffer.ToString();
 
+            // TODO: Rendering of a multiline command on separate lines.  
+            // For now, just display it as a single-line command.
+            text = text.Replace(System.Environment.NewLine, " ");
+
             // The PowerShell tokenizer is used to decide how to colorize
             // the input.  Any errors in the input are returned in 'errors',
             // but we won't be looking at those here.

--- a/src/Microsoft.PowerShell.Linux.Host/readline.cs
+++ b/src/Microsoft.PowerShell.Linux.Host/readline.cs
@@ -128,10 +128,10 @@ namespace Microsoft.PowerShell.Linux.Host
         {
             this.powershell.Runspace = runspace;
             this.Initialize();
-            bool finishedTyping = false;
+            bool commandComplete = false;
             abort = false;
 //            Console.WriteLine("Default value of TreatCtrlCAsInput: {0}", Console.TreatControlCAsInput);
-//            Console.TreatControlCAsInput = false;
+            Console.TreatControlCAsInput = false;
 
             while (true)
             {
@@ -140,29 +140,28 @@ namespace Microsoft.PowerShell.Linux.Host
                 // Basic Emacs-style readline implementation
                 if (key.Modifiers.HasFlag(ConsoleModifiers.Control))
                 {
-                    finishedTyping = ProcessControlKey(key, nested, ref abort);
+                    commandComplete = ProcessControlKey(key, nested, ref abort);
                     if (abort)
                     {
-                        Console.WriteLine();
-//                        Console.TreatControlCAsInput = true;
+                        Console.TreatControlCAsInput = true;
                         return String.Empty;
                     }
                 }
                 else if (key.Modifiers.HasFlag(ConsoleModifiers.Alt))
                 {
-                    finishedTyping = ProcessAltKey(key);
+                    commandComplete = ProcessAltKey(key);
                 }
                 // Unmodified keys
                 else
                 {
-                    finishedTyping = ProcessNormalKey(key, nested);
+                    commandComplete = ProcessNormalKey(key, nested);
                 }
 
                 previousKeyPress = key;
 
-                if (finishedTyping)
+                if (commandComplete)
                 {
-//                    Console.TreatControlCAsInput = true;
+                    Console.TreatControlCAsInput = true;
                     return this.OnEnter();
                 }
             }
@@ -217,10 +216,9 @@ namespace Microsoft.PowerShell.Linux.Host
                       return this.OnEnter();
                     */
                 case ConsoleKey.C:
-                    Console.WriteLine("received Ctrl-C");
                     this.Abort();
                     abort = true;
-                    break;
+                    return true;
             }
             return false;
         }

--- a/src/Microsoft.PowerShell.Linux.Host/readline.cs
+++ b/src/Microsoft.PowerShell.Linux.Host/readline.cs
@@ -104,7 +104,7 @@ namespace Microsoft.PowerShell.Linux.Host
             {
                 this.command = cmd;
                 this.state = s;
-                Console.TreatControlCAsInput = true;
+                Console.TreatControlCAsInput = false;
             }
 
             public enum State {Complete, Abort, Redraw}
@@ -161,7 +161,7 @@ namespace Microsoft.PowerShell.Linux.Host
                 this.Render();
             }
 
-            Console.TreatControlCAsInput = false;
+            Console.TreatControlCAsInput = true;
 
             while (true)
             {


### PR DESCRIPTION
Add support for Ctrl-C, Ctrl-K, Ctrl-Y, Ctrl-L, Ctrl-Arrow, Ctrl-Home, and Ctrl-End.

Add additional support for multi-line.

Fix render bug if command contains leading spaces.

Needs update once polarity fix for TreatControlCAsInput is pulled in.
