### PR TITLE
Fix the AssemblyLoadContext and Trusted Platform Assemblies problem

### DIFF
--- a/src/Microsoft.PowerShell.Linux.Host/main.cs
+++ b/src/Microsoft.PowerShell.Linux.Host/main.cs
@@ -22,7 +22,7 @@ namespace Microsoft.PowerShell.Linux.Host
             // analyze the libraries for types, functions, cmdlets, etc. and
             // provide the ability to load assemblies by file path. Doing this
             // here eliminates the need for a custom native host.
-            PowerShellAssemblyLoadContextInitializer.SetPowerShellAssemblyLoadContext(AppContext.BaseDirectory);
+            PowerShellAssemblyLoadContextInitializer.SetPowerShellAssemblyLoadContext(string.Empty);
 
             // Argument parsing
             string initialScript = null;


### PR DESCRIPTION
Requires PowerShell/psl-monad#44. Due to the difference in assembly layouts between the old and new build systems, some re-architecturing had to be done. This reverts the prior work-around and integrates the necessary fix in a more correct way.
## Remove IsNullOrEmpty requirement of basePaths

Not every host must send a list of base paths. The cross-platform host,
built with .NET Core's `corehost`, has every dependent assembly in the
Trusted Platform Assemblies list, and so does not have any path to give
the AssemblyLoadContext. However, due to coupling, the initialization
function must still be called so that the type catalog gets initialized.
## Disable PsSnapIn strong name assertion

The (sort of deprecated) PsSnapIn system has an assertion that the
loaded assemblies' strong names include the processor architecture.
However, assemblies built with .NET CLI do not include this in their
strong name, so we need to ignore the check. The better solution would
be to change the strong name contained in the PsSnapIn, but that's
nowhere to be found. The best solution would be to actually deprecate
the PsSnapIn system.
## Load via Assembly.Load with fallback to Path

This brings back the original code in the AssemblyLoadContext that
attempts to load assemblies from their absolute path. We want this in
order to not change Core PowerShell's behavior on Windows when built
outside of .NET CLI. However, when published as a .NET Core app, all the
assemblies are in the Trusted Platform Assemblies list, and so must be
loaded via `Assembly.Load` instead of the path. Loading a TPA from an
absolute path is designed to fail.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/powershell/750)

<!-- Reviewable:end -->
