### PR TITLE
Deprecate build.sh script

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,30 +1,8 @@
 #!/usr/bin/env bash
 
-# Test for build dependencies
-hash cmake 2>/dev/null || { echo >&2 "No cmake, please run 'sudo apt-get install cmake'"; exit 1; }
-hash g++ 2>/dev/null || { echo >&2 "No g++, please run 'sudo apt-get install g++'"; exit 1; }
-hash dotnet 2>/dev/null || { echo >&2 "No dotnet, please visit https://dotnet.github.io/getting-started/"; exit 1; }
-
-TOP="$(pwd)/src/Microsoft.PowerShell.Host"
-
-# Test for lock file
-test -r "$TOP/project.lock.json" || { echo >&2 "Please run 'dotnet restore' to download .NET Core packages"; exit 2; }
-
-# Ensure output directory is made
-BIN="$(pwd)/bin"
-mkdir -p "$BIN"
-
-# Build native library and deploy to bin
-pushd src/libpsl-native
-cmake -DCMAKE_BUILD_TYPE=Debug .
-make -j
-make test
-popd
-
-test -r $TOP/libpsl-native.* || { echo >&2 "Compilation of libpsl-native failed"; exit 3; }
-
-# Publish PowerShell to bin, with LINUX defined through a configuration
-dotnet publish --output "$BIN" --configuration Linux "$TOP"
-
-# Fix permissions for packaging
-chmod -R go=u "$BIN"
+if hash powershell 2>/dev/null; then
+    echo 'Continuing with `powershell -c Start-PSBuild`'
+    powershell -c Start-PSBuild
+else
+    echo 'No `powershell`, see docs/building/linux.md or osx.md to build PowerShell!'
+fi


### PR DESCRIPTION
If `powershell` is installed, run `Start-PSBuild` to ensure DWIM. Else, direct user to Linux / OS X build documentation.

Resolves #767.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/powershell/780)

<!-- Reviewable:end -->
