### PR TITLE
Try Assembly.Load correctly

### DIFF
--- a/src/Microsoft.PowerShell.CoreCLR.AssemblyLoadContext/CoreCLR/CorePsAssemblyLoadContext.cs
+++ b/src/Microsoft.PowerShell.CoreCLR.AssemblyLoadContext/CoreCLR/CorePsAssemblyLoadContext.cs
@@ -186,10 +186,12 @@ namespace System.Management.Automation
 
                 // Try loading it from the TPA list. All PowerShell dependencies are in the
                 // TPA list when published with dotnet-cli.
-                asmLoaded = Assembly.Load(assemblyName);
-
+                try
+                {
+                    asmLoaded = Assembly.Load(assemblyName);
+                }
                 // If it wasn't there, try loading from path
-                if (asmLoaded == null)
+                catch (FileNotFoundException)
                 {
                     asmLoaded = asmFilePath.EndsWith(".ni.dll", StringComparison.OrdinalIgnoreCase)
                         ? LoadFromNativeImagePath(asmFilePath, null)
@@ -250,9 +252,12 @@ namespace System.Management.Automation
 
                 // Try loading it from the TPA list. All PowerShell dependencies are in the
                 // TPA list when published with dotnet-cli.
-                asmLoaded = Assembly.Load(assemblyName);
-
-                if (asmLoaded == null)
+                try
+                {
+                    asmLoaded = Assembly.Load(assemblyName);
+                }
+                // If it wasn't there, try loading from path
+                catch (FileNotFoundException)
                 {
                     // Load the assembly through 'LoadFromNativeImagePath' or 'LoadFromAssemblyPath'
                     asmLoaded = assemblyPath.EndsWith(".ni.dll", StringComparison.OrdinalIgnoreCase)


### PR DESCRIPTION
This should resolve #791.

Instead of checking if `Assembly.Load` returned null (it doesn't), check
if it threw `FileNotFoundException`, which it will if it doesn't find
the assembly.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/powershell/792)

<!-- Reviewable:end -->
