### PR TITLE
Make Add-Type work without a flat folder structure

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/AddType.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/AddType.cs
@@ -1059,8 +1059,9 @@ namespace Microsoft.PowerShell.Commands
         private static PortableExecutableReference ObjectImplementationAssemblyReference =
             MetadataReference.CreateFromFile(typeof(object).GetTypeInfo().Assembly.Location);
 
+        // This assembly should be System.Runtime.dll
         private static PortableExecutableReference ObjectDeclaredAssemblyReference =
-            MetadataReference.CreateFromFile(System.IO.Path.Combine(FrameworkFolder, "System.Runtime.dll"));
+            MetadataReference.CreateFromFile(ClrFacade.GetAssemblies(typeof(object).FullName).First().Location);
 
         private static MetadataReference[] defaultAssemblies = new MetadataReference[]
         {

--- a/test/powershell/Add-Type.Tests.ps1
+++ b/test/powershell/Add-Type.Tests.ps1
@@ -1,5 +1,5 @@
 Describe "Add-Type" {
-    It "Should not throw given a simple class definition" -Skip {
+    It "Should not throw given a simple class definition" {
 	{ Add-Type -TypeDefinition "public static class foo { }" } | Should Not Throw
     }
 }


### PR DESCRIPTION
- Get rid of the assumption that all framework assemlbies live in
  the same place
- Enable build scenario (assemlbies are referenced directly from unpacked
  nuget packages)
- Fix #766
- Re-enable Add-Type tests

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/powershell/796)

<!-- Reviewable:end -->
