### PR TITLE
Fix Get-Help -Online

### DIFF
--- a/src/System.Management.Automation/help/HelpCommands.cs
+++ b/src/System.Management.Automation/help/HelpCommands.cs
@@ -688,7 +688,16 @@ namespace Microsoft.PowerShell.Commands
                 this.WriteVerbose(string.Format(CultureInfo.InvariantCulture, HelpDisplayStrings.OnlineHelpUri, uriToLaunch.OriginalString));
                 System.Diagnostics.Process browserProcess = new System.Diagnostics.Process();
                 browserProcess.StartInfo.UseShellExecute = true;
-                browserProcess.StartInfo.FileName = uriToLaunch.OriginalString;
+                if (Platform.IsWindows)
+                {
+                    browserProcess.StartInfo.FileName = uriToLaunch.OriginalString;
+                } else if (Platform.IsOSX) {
+                    browserProcess.StartInfo.FileName = "open";
+                    browserProcess.StartInfo.Arguments = uriToLaunch.OriginalString;
+                } else if (Platform.IsLinux) {
+                    browserProcess.StartInfo.FileName = "xdg-open";
+                    browserProcess.StartInfo.Arguments = uriToLaunch.OriginalString;
+                }
                 browserProcess.Start();
             }
             catch (InvalidOperationException ioe)


### PR DESCRIPTION
While Windows will automatically open a URL used as a process by
launching a browser, OS X needs to use `open <URL>`, and Linux needs to
use `xdg-open <URL>` (the most distribution-independent way).

Resolves #802.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/powershell/803)

<!-- Reviewable:end -->
