### PR TITLE
Remove alias tests for Write-Output

### DIFF
--- a/test/powershell/Write-Output.Tests.ps1
+++ b/test/powershell/Write-Output.Tests.ps1
@@ -35,22 +35,6 @@ Describe "Write-Output" {
 	}
     }
 
-    Context "Alias Tests" {
-	It "Should have the same result between the echo alias and the cmdlet" {
-	    $alias  = echo -InputObject $testString
-	    $cmdlet = Write-Output -InputObject $testString
-
-	    $alias | Should Be $cmdlet
-	}
-
-	It "Should have the same result between the write alias and the cmdlet" {
-	    $alias  = write -InputObject $testString
-	    $cmdlet = Write-Output -InputObject $testString
-
-	    $alias | Should Be $cmdlet
-	}
-    }
-
     Context "Enumerate Objects" {
 	$enumerationObject = @(1,2,3)
 	It "Should see individual objects when not using the NoEnumerate switch" {


### PR DESCRIPTION
The `echo` and `write` aliases were removed, which make these tests
inaccurate (but did not fail them).

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/powershell/812)

<!-- Reviewable:end -->
