### PR TITLE
Host code to enable PSReadLine, and remove checking of .NET Framework…

### DIFF
--- a/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
@@ -2010,7 +2010,8 @@ namespace Microsoft.PowerShell.Commands
             }
 
             // Test the required .NET Framework version
-            Version requestedDotNetFrameworkVersion;
+            Version requestedDotNetFrameworkVersion = new Version (0, 0, 0, 0);
+#if !CORECLR
             if (
                 !GetScalarFromData(data, moduleManifestPath, "DotNetFrameworkVersion", manifestProcessingFlags,
                     out requestedDotNetFrameworkVersion))
@@ -2044,6 +2045,7 @@ namespace Microsoft.PowerShell.Commands
                     WriteVerbose(cannotDetectNetFrameworkVersionMessage);
                 }
             }
+#endif
 
             // HelpInfo URI
             string helpInfoUri = null;


### PR DESCRIPTION
Add check in host to look for PSConsoleHostReadLine.  This allows private ReadLine implementations, such as PSReadLine to be used instead of default implementation.

Also removed checking for .NET Framework in Module manifest files, if PS is built with CoreCLR.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/powershell/834)

<!-- Reviewable:end -->
