### PR TITLE
Revert ClrFacade.Load

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/AddType.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/AddType.cs
@@ -1138,7 +1138,7 @@ namespace Microsoft.PowerShell.Commands
             // First try by strong name
             try
             {
-                loadedAssembly = ClrFacade.Load(new AssemblyName(assemblyName));
+                loadedAssembly = Assembly.Load(new AssemblyName(assemblyName));
             }
             // Generates a FileNotFoundException if you can't load the strong type.
             // So we'll try from the short name.
@@ -2031,7 +2031,7 @@ namespace Microsoft.PowerShell.Commands
             // First try by strong name
             try
             {
-                loadedAssembly = ClrFacade.Load(assemblyName);
+                loadedAssembly = Assembly.Load(assemblyName);
             }
             // Generates a FileNotFoundException if you can't load the strong type.
             // So we'll try from the short name.
@@ -2043,7 +2043,7 @@ namespace Microsoft.PowerShell.Commands
             // Next, try an exact match
             if (StrongNames.Value.ContainsKey(assemblyName))
             {
-                return ClrFacade.Load(StrongNames.Value[assemblyName]);
+                return Assembly.Load(StrongNames.Value[assemblyName]);
             }
 
             // If the assembly name doesn't contain wildcards, return null. The caller generates an error here.
@@ -2086,7 +2086,7 @@ namespace Microsoft.PowerShell.Commands
                 return null;
 
             // Otherwise, load the assembly.
-            return ClrFacade.Load(matchedStrongName);
+            return Assembly.Load(matchedStrongName);
         }
 
         private static ConcurrentDictionary<string, string> InitializeStrongNameDictionary()

--- a/src/System.Management.Automation/engine/ExecutionContext.cs
+++ b/src/System.Management.Automation/engine/ExecutionContext.cs
@@ -1559,7 +1559,7 @@ namespace System.Management.Automation
 
                 try
                 {
-                    loadedAssembly = ClrFacade.Load(new AssemblyName(assemblyString));
+                    loadedAssembly = Assembly.Load(new AssemblyName(assemblyString));
                 }
                 catch (FileNotFoundException fileNotFound)
                 {

--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -5669,7 +5669,7 @@ if($paths) {
             try
             {
                 // WARNING: DUPLICATE CODE see RunspaceConfigForSingleShell
-                assembly = ClrFacade.Load(new AssemblyName(psSnapInInfo.AssemblyName));
+                assembly = Assembly.Load(new AssemblyName(psSnapInInfo.AssemblyName));
             }
             catch (BadImageFormatException e)
             {

--- a/src/System.Management.Automation/engine/remoting/fanin/InitialSessionStateProvider.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/InitialSessionStateProvider.cs
@@ -662,7 +662,7 @@ namespace System.Management.Automation.Remoting
             {
                 try
                 {
-                    result = ClrFacade.Load(new AssemblyName(assemblyName));
+                    result = Assembly.Load(new AssemblyName(assemblyName));
                 }
                 catch (FileLoadException e)
                 {

--- a/src/System.Management.Automation/help/HelpSystem.cs
+++ b/src/System.Management.Automation/help/HelpSystem.cs
@@ -667,7 +667,7 @@ namespace System.Management.Automation
             }
             else
             {
-                providerAssembly = ClrFacade.Load(providerInfo.AssemblyName);
+                providerAssembly = Assembly.Load(providerInfo.AssemblyName);
             }
 
             try

--- a/src/System.Management.Automation/singleshell/config/RunspaceConfigForSingleShell.cs
+++ b/src/System.Management.Automation/singleshell/config/RunspaceConfigForSingleShell.cs
@@ -618,7 +618,7 @@ namespace System.Management.Automation.Runspaces
             try
             {
                 // WARNING: DUPLICATE CODE see InitialSessionState
-                assembly = ClrFacade.Load(new AssemblyName(mshsnapinInfo.AssemblyName));
+                assembly = Assembly.Load(new AssemblyName(mshsnapinInfo.AssemblyName));
             }
             catch (FileLoadException e)
             {

--- a/src/System.Management.Automation/utils/ClrFacade.cs
+++ b/src/System.Management.Automation/utils/ClrFacade.cs
@@ -309,20 +309,6 @@ namespace System.Management.Automation
 #endif
 
         /// <summary>
-        /// Porting note: Load assembly by name through the AssemblyLoadContext.
-        /// This is to ensure that the types get cached.
-        /// </summary>
-        internal static Assembly Load(AssemblyName assembly)
-        {
-#if CORECLR
-            var psAssemblyLoader = GetAssemblyLoadContext();
-            return psAssemblyLoader.LoadFromAssemblyName(assembly);
-#else
-            return Assembly.Load(assembly);
-#endif
-        }
-
-        /// <summary>
         /// Same as the above, but overloaded for a name in a string.
         /// </summary>
         internal static Assembly Load(string assembly)


### PR DESCRIPTION
**Do not merge, this is a bug repro**

Per discussion with @daxian-dbw, `Assembly.Load` will fall back to the `ALC.Load` if it does not find the assembly.

However, this highlights the problem with the PowerShell type analysis being coupled to assembly loading. Since `Assembly.Load` will successfully load the PowerShell assemblies (`System.Management.Automation` etc.) from the TPA (due to the publish layout of .NET CLI), PowerShell's custom `AssemblyLoadContext` is completely skipped, thus also leaving us without some PowerShell types, leading to very weird errors:

``` powershell
~/PowerShell |-/ & (Get-PSOutput)
One or more errors occurred. (One or more errors occurred. (Value cannot be null.
Parameter name: type)) (Value cannot be null.
Parameter name: type)
~/PowerShell |-/ $Error[0]
Unable to find type [System.Management.Automation.Language.Ast].
```

@daxian-dbw and I are working to resolve this correctly and support each PowerShell deployment scenario in #839.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/powershell/854)

<!-- Reviewable:end -->
