### PR TITLE
Fix build scripts for windows build

### DIFF
--- a/PowerShellGitHubDev.psm1
+++ b/PowerShellGitHubDev.psm1
@@ -125,7 +125,7 @@ function Start-PSBuild {
 
         $RestoreArguments += "$PSScriptRoot"
 
-        dotnet restore $RestoreArguments
+        Start-NativeExecution { dotnet restore $RestoreArguments }
     }
 
     # Build native components
@@ -164,7 +164,7 @@ function Start-PSBuild {
                 cmake .
             }
 
-            msbuild powershell.vcxproj /p:Configuration=$msbuildConfiguration
+            Start-NativeExecution { msbuild powershell.vcxproj /p:Configuration=$msbuildConfiguration }
 
         } finally {
             Pop-Location
@@ -175,7 +175,7 @@ function Start-PSBuild {
         # Relative paths do not work well if cwd is not changed to project
         Push-Location $Options.Top
         log "Run dotnet $Arguments from $pwd"
-        dotnet $Arguments
+        Start-NativeExecution { dotnet $Arguments }
         log "PowerShell output: $($Options.Output)"
     } finally {
         Pop-Location
@@ -321,9 +321,9 @@ function Start-PSxUnit {
     $Arguments = "--configuration", "Linux"
     try {
         Push-Location $PSScriptRoot/test/csharp
-        dotnet build $Arguments
+        Start-NativeExecution { dotnet build $Arguments }
         Copy-Item -ErrorAction SilentlyContinue -Recurse -Path $Content/* -Include Modules,libpsl-native* -Destination "./bin/Linux/netstandardapp1.5/ubuntu.14.04-x64"
-        dotnet test $Arguments
+        Start-NativeExecution { dotnet test $Arguments }
         if ($LASTEXITCODE -ne 0) {
             throw "$LASTEXITCODE xUnit tests failed"
         }
@@ -758,6 +758,27 @@ function script:Convert-PSObjectToHashtable {
     }
 }
 
+# this function wraps native command Execution
+# for more information, read https://mnaoumov.wordpress.com/2015/01/11/execution-of-external-commands-in-powershell-done-right/
+function script:Start-NativeExecution([scriptblock]$sb)
+{
+    $backupEAP = $script:ErrorActionPreference
+    $script:ErrorActionPreference = "Continue"
+    try
+    {
+        & $sb
+        # note, if $sb doens't have a native invokation, $LASTEXITCODE will
+        # point to the obsolete value
+        if ($LASTEXITCODE -ne 0)
+        {
+            throw "Execution failed with exit code $LASTEXITCODE"
+        }
+    }
+    finally
+    {
+        $script:ErrorActionPreference = $backupEAP
+    }
+}
 
 function script:Get-StronglyTypeCsFileForResx
 {

--- a/PowerShellGitHubDev.psm1
+++ b/PowerShellGitHubDev.psm1
@@ -74,7 +74,7 @@ function Start-PSBuild {
 
         # msbuild is needed to build powershell.exe
         # msbuild is part of .NET Framework, we can try to get it from well-known location.
-        if (-nopt $NoPath -and -not (Get-Command -Name msbuild -ErrorAction Ignore)) {
+        if (-not $NoPath -and -not (Get-Command -Name msbuild -ErrorAction Ignore)) {
             Write-Verbose "Appending probable Visual C++ tools path"
             $env:path += ";${env:SystemRoot}\Microsoft.Net\Framework\v4.0.30319"
         }

--- a/PowerShellGitHubDev.psm1
+++ b/PowerShellGitHubDev.psm1
@@ -173,8 +173,8 @@ function Start-PSBuild {
 
     try {
         # Relative paths do not work well if cwd is not changed to project
-        log "Run `dotnet build $Arguments` from $pwd"
         Push-Location $Options.Top
+        log "Run dotnet $Arguments from $pwd"
         dotnet $Arguments
         log "PowerShell output: $($Options.Output)"
     } finally {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,6 +22,7 @@ install:
 
 build_script:
   - ps: |
+      $ErrorActionPreference = 'Stop'
       Import-Module .\PowerShellGitHubDev.psm1
       Start-PSBuild -Publish
       Start-PSBuild -FullCLR
@@ -62,6 +63,7 @@ test_script:
 
 on_finish: 
   - ps: |
+      $ErrorActionPreference = 'Stop'
       # Creating project artifact
       $name = git describe
       $zipFilePath = Join-Path $pwd "$name.zip"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -64,19 +64,23 @@ test_script:
 on_finish: 
   - ps: |
       $ErrorActionPreference = 'Stop'
-      # Creating project artifact
-      $name = git describe
-      $zipFilePath = Join-Path $pwd "$name.zip"
-      $zipFileFullPath = Join-Path $pwd "$name.FullCLR.zip"
-      Add-Type -assemblyname System.IO.Compression.FileSystem
-      [System.IO.Compression.ZipFile]::CreateFromDirectory($env:CoreOutput, $zipFilePath)
-      [System.IO.Compression.ZipFile]::CreateFromDirectory($env:FullOutput, $zipFileFullPath)
-      
-      @(
-          # You can add other artifacts here
-          $zipFilePath,
-          $zipFileFullPath
-      ) | % { 
-          Write-Host "Pushing package $_ as Appveyor artifact"
-          Push-AppveyorArtifact $_
-        }
+      try {
+        # Creating project artifact
+        $name = git describe
+        $zipFilePath = Join-Path $pwd "$name.zip"
+        $zipFileFullPath = Join-Path $pwd "$name.FullCLR.zip"
+        Add-Type -assemblyname System.IO.Compression.FileSystem
+        [System.IO.Compression.ZipFile]::CreateFromDirectory($env:CoreOutput, $zipFilePath)
+        [System.IO.Compression.ZipFile]::CreateFromDirectory($env:FullOutput, $zipFileFullPath)
+        
+        @(
+            # You can add other artifacts here
+            $zipFilePath,
+            $zipFileFullPath
+        ) | % { 
+            Write-Host "Pushing package $_ as Appveyor artifact"
+            Push-AppveyorArtifact $_
+          }
+      } catch {
+        Write-Host -Foreground Red $_
+      }


### PR DESCRIPTION
- Fix `Start-PSBuild -FullCLR`
- Make build fail, if `Start-PSBuild` failed
- Avoid AppVeyor hang [#669](https://github.com/appveyor/ci/issues/669) with a try-catch workaround

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/powershell/871)

<!-- Reviewable:end -->
