### PR TITLE
Fix clear variable test

### DIFF
--- a/test/powershell/Clear-Variable.Tests.ps1
+++ b/test/powershell/Clear-Variable.Tests.ps1
@@ -54,7 +54,6 @@ Describe "Clear-Variable DRT Unit Tests" -Tags DRT{
 	It "Clear-Variable Private variable Name should works and Get-Variable with local scope should throw exception"{
 		Set-Variable foo bar -Option Private
 		&{
-			Clear-Variable -Name foo
 			try {
 					Get-Variable -Name foo -Scope local -EA Stop
 					Throw "Execution OK"

--- a/test/powershell/Clear-Variable.Tests.ps1
+++ b/test/powershell/Clear-Variable.Tests.ps1
@@ -1,4 +1,3 @@
-
 Describe "Clear-Variable DRT Unit Tests" -Tags DRT{
 	It "Clear-Variable normal variable Name should works"{
 		Set-Variable foo bar
@@ -9,19 +8,19 @@ Describe "Clear-Variable DRT Unit Tests" -Tags DRT{
 		$var1.Options|Should Be "None"
 		$var1.Description|Should Be ""
 	}
-	
+
 	It "Clear-Variable ReadOnly variable Name should throw exception and force Clear-Variable should works"{
 		Set-Variable foo bar -Option ReadOnly
-		
+
 		try {
 			Clear-Variable -Name foo -EA Stop
 			Throw "Execution OK"
-		} 
+		}
 		catch {
 			$_.CategoryInfo| Should Match "SessionStateUnauthorizedAccessException"
 			$_.FullyQualifiedErrorId | Should Be "VariableNotWritable,Microsoft.PowerShell.Commands.ClearVariableCommand"
 		}
-		
+
 		Clear-Variable -Name foo -Force
 		$var1=Get-Variable -Name foo
 		$var1.Name|Should Be "foo"
@@ -29,67 +28,67 @@ Describe "Clear-Variable DRT Unit Tests" -Tags DRT{
 		$var1.Options|Should Be "ReadOnly"
 		$var1.Description|Should Be ""
 	}
-	
+
 	It "Clear-Variable normal variable Name with local scope should works"{
 		Set-Variable foo bar
 		&{
 			Set-Variable foo baz
 			$foo | should be baz
 			Clear-Variable -Name foo -Scope "local"
-		
+
 			$var1=Get-Variable -Name foo -Scope "local"
 			$var1.Name|Should Be "foo"
 			$var1.Value|Should Be $null
 			$var1.Options|Should Be "None"
 			$var1.Description|Should Be ""
 		}
-		
+
 		$var1=Get-Variable -Name foo
 		$var1.Name|Should Be "foo"
 		$var1.Value|Should Be "bar"
 		$var1.Options|Should Be "None"
 		$var1.Description|Should Be ""
 	}
-	
+
 	It "Clear-Variable Private variable Name should works and Get-Variable with local scope should throw exception"{
 		Set-Variable foo bar -Option Private
 		&{
 			try {
 					Get-Variable -Name foo -Scope local -EA Stop
 					Throw "Execution OK"
-			} 
+			}
 			catch {
 					$_.CategoryInfo| Should Match "ItemNotFoundException"
 					$_.FullyQualifiedErrorId | Should Be "VariableNotFound,Microsoft.PowerShell.Commands.GetVariableCommand"
 			}
 		}
-		
+
 		$var1=Get-Variable -Name foo
 		$var1.Name|Should Be "foo"
 		$var1.Value|Should Be "bar"
 		$var1.Options|Should Be "Private"
 		$var1.Description|Should Be ""
 	}
-	
+
 	It "Clear-Variable normal variable Name with local scope should works in different scope"{
 		Set-Variable foo bar
 		&{
 			Set-Variable foo baz
 			Clear-Variable -Name foo -Scope "local"
-		
+
 			$var1=Get-Variable -Name foo -Scope "local"
 			$var1.Name|Should Be "foo"
 			$var1.Value|Should Be $null
 			$var1.Options|Should Be "None"
 			$var1.Description|Should Be ""
 		}
-		
+
 		$var1=Get-Variable -Name foo
 		$var1.Name|Should Be "foo"
 		$var1.Value|Should Be "bar"
 		$var1.Options|Should Be "None"
 		$var1.Description|Should Be ""
-		
+
 		$var1=Get-Variable -Name foo -Scope "local"
 		$var1.Name|Should Be "foo"
 		$var1.Value|Should Be "bar"
@@ -99,29 +98,29 @@ Describe "Clear-Variable DRT Unit Tests" -Tags DRT{
 }
 
 Describe "Clear-Variable" {
-    BeforeEach {
+		BeforeEach {
 	$var1 = 3
-    }
+		}
 
-    It "Should be able to clear a variable using the Name switch" {
+		It "Should be able to clear a variable using the Name switch" {
 	Clear-Variable -Name var1
 	$var1 | Should BeNullOrEmpty
 	{ Get-Variable var1 } | Should Not Throw
-    }
+		}
 
-    It "Should be able to clear a variable without using the Name switch" {
+		It "Should be able to clear a variable without using the Name switch" {
 	Clear-Variable var1
 	$var1 | Should BeNullOrEmpty
 	{ Get-Variable var1 } | Should Not Throw
-    }
+		}
 
-    It "Should work using the clv alias" {
+		It "Should work using the clv alias" {
 	clv -Name var1
 	$var1 | Should BeNullOrEmpty
 	{ Get-Variable var1 } | Should Not Throw
-    }
+		}
 
-    It "Should be able to include a set of variables to clear" {
+		It "Should be able to include a set of variables to clear" {
 	$var1      = 2
 	$var2      = 3
 	$var3      = 4
@@ -141,9 +140,9 @@ Describe "Clear-Variable" {
 	$var2 | Should Not BeNullOrEmpty
 	$var3 | Should Not BeNullOrEmpty
 
-    }
+		}
 
-    It "Should be able to exclude a set of variables to clear" {
+		It "Should be able to exclude a set of variables to clear" {
 	$var1      = 2
 	$var2      = 3
 	$var3      = 4
@@ -162,19 +161,19 @@ Describe "Clear-Variable" {
 	$var3      | Should Not BeNullOrEmpty
 
 	$w         | Should BeNullOrEmpty
-    }
+		}
 
-    It "Should be able to pass the cleared object through the pipeline using the passthru switch" {
+		It "Should be able to pass the cleared object through the pipeline using the passthru switch" {
 	{ Clear-Variable -Name var1 -PassThru | Format-Wide -Property Value } | Should Not Throw
-    }
+		}
 
-    It "Should not clear environment variables" {
+		It "Should not clear environment variables" {
 	$env:TEMPVARIABLE = "test data"
 
 	{Clear-Variable -Name env:TEMPVARIABLE -ErrorAction Stop} | Should Throw
-    }
+		}
 
-    It "Should clear variable even if it is read-only using the Force parameter" {
+		It "Should clear variable even if it is read-only using the Force parameter" {
 	try
 	{
 		New-Variable -Name var2 -Option ReadOnly -Value 100
@@ -189,9 +188,9 @@ Describe "Clear-Variable" {
 	{
 		Remove-Variable -Name var2 -Force
 	}
-    }
+		}
 
-    It "Should throw error when trying to clear variable that is read-only without using the Force parameter" {
+		It "Should throw error when trying to clear variable that is read-only without using the Force parameter" {
 		New-Variable -Name var2 -Option ReadOnly -Value 100
 		try {
 			Clear-Variable -Name var2 -ea stop
@@ -203,67 +202,67 @@ Describe "Clear-Variable" {
 		$var2 | Should Not BeNullOrEmpty
 
 		Remove-Variable -Name var2 -Force
-    }
+		}
 
-    Context "Scope Tests" {
+		Context "Scope Tests" {
 	# This will violate the DRY principle.  Tread softly.
 
 	It "Should be able to clear a global scope variable using the global switch" {
-	    New-Variable globalVar -Value 1 -Scope global -Force
+			New-Variable globalVar -Value 1 -Scope global -Force
 
-	    Clear-Variable -Name globalVar -Scope global
+			Clear-Variable -Name globalVar -Scope global
 
-	    $globalVar | Should BeNullOrEmpty
+			$globalVar | Should BeNullOrEmpty
 	}
 
 	It "Should not be able to clear a global scope variable using the local switch" {
-	    New-Variable globalVar -Value 1 -Scope global -Force
+			New-Variable globalVar -Value 1 -Scope global -Force
 
-	    {Clear-Variable -Name globalVar -Scope local -ErrorAction Stop} | Should Throw
+			{Clear-Variable -Name globalVar -Scope local -ErrorAction Stop} | Should Throw
 	}
 
 	It "Should not be able to clear a global variable using the script scope switch" {
-	    New-Variable globalVar -Value 1 -Scope global -Force
+			New-Variable globalVar -Value 1 -Scope global -Force
 
-	    {Clear-Variable -Name localVar -Scope script -ErrorAction Stop} | Should Throw
+			{Clear-Variable -Name localVar -Scope script -ErrorAction Stop} | Should Throw
 	}
 
 	It "Should be able to clear an item locally using the local switch" {
-	    New-Variable localVar -Value 2 -Scope local -Force
+			New-Variable localVar -Value 2 -Scope local -Force
 
-	    Clear-Variable -Name localVar -Scope local
+			Clear-Variable -Name localVar -Scope local
 
-	    $localVar | Should BeNullOrEmpty
+			$localVar | Should BeNullOrEmpty
 
-	    {Clear-Variable -Name localVar -Scope script -ErrorAction Stop} | Should Throw
+			{Clear-Variable -Name localVar -Scope script -ErrorAction Stop} | Should Throw
 	}
 
 	It "Should not be able to clear an item locally using the global switch" {
-	    New-Variable localVar -Value 2 -Scope local -Force
+			New-Variable localVar -Value 2 -Scope local -Force
 
-	    {Clear-Variable -Name localVar -Scope global -ErrorAction Stop} | Should Throw
+			{Clear-Variable -Name localVar -Scope global -ErrorAction Stop} | Should Throw
 	}
 
 	It "Should not be able to clear a local variable using the script scope switch" {
-	    New-Variable localVar -Value 2 -Scope local -Force
+			New-Variable localVar -Value 2 -Scope local -Force
 
-	    {Clear-Variable -Name localVar -Scope script -ErrorAction Stop} | Should Throw
+			{Clear-Variable -Name localVar -Scope script -ErrorAction Stop} | Should Throw
 	}
 
 	It "Should be able to clear a script variable created using the script switch" {
-	    {
+			{
 		New-Variable -Name derp2 -Value 3 -Scope script -Force
 
 		Clear-Variable -Name derp2 -Scope script
-	    }| Should Not Throw
+			}| Should Not Throw
 	}
 
 	It "Should be able to clear a global script variable that was created using the script scope switch" {
-	    {
+			{
 		New-Variable -Name derpx -Value 4 -Scope script -Force
 
 		Clear-Variable -Name derpx -Scope script
-	    } | Should Not Throw
+			} | Should Not Throw
 	}
-    }
+		}
 }


### PR DESCRIPTION
When the Pester tests were invoked over PSRP and the environment was
more pristine than a local client, the lack of a "foo" variable in some
scope caused the Pester test suite to emit an error at the end, failing
the PSRP build.

Removing the Clear-Variable directive eliminates this error, and is not
necessary for the Pester test itself.

/cc @paulcallen @JamesWTruher

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/powershell/881)

<!-- Reviewable:end -->
