### PR TITLE
Porting Management DRT TTests from psl-monad to Pester.

### DIFF
--- a/test/powershell/Add-Content.Tests.ps1
+++ b/test/powershell/Add-Content.Tests.ps1
@@ -1,0 +1,47 @@
+Describe "Add-Content cmdlet tests" {
+    $file1 = "file1.txt"
+    Setup -File "$file1"
+
+    Context "Add-Content should actually add content" {
+        It "should Add-Content to testdrive:\$file1" {
+            $result=add-content -path testdrive:\$file1 -value "ExpectedContent" -passthru 
+            $result| Should be "ExpectedContent"
+        }
+        It "should return expected string from testdrive:\$file1" {
+            $result = get-content -path testdrive:\$file1
+            $result | Should BeExactly "ExpectedContent"
+        }
+        It "should Add-Content to testdrive:\dynamicfile.txt with dynamic parameters" {
+            $result=add-content -path testdrive:\dynamicfile.txt -value "ExpectedContent" -passthru
+            $result| Should BeExactly "ExpectedContent"
+        }
+        It "should return expected string from testdrive:\dynamicfile.txt" {
+            $result = get-content -path testdrive:\dynamicfile.txt
+            $result | Should BeExactly "ExpectedContent"
+        }
+        It "should Add-Content to testdrive:\$file1 even when -Value is `$null" {
+            $AsItWas=get-content testdrive:\$file1
+            {add-content -path testdrive:\$file1 -value $null -ea stop} | Should Not Throw
+            get-content testdrive:\$file1 | Should BeExactly $AsItWas
+        }
+        It "should throw `"Cannot bind argument to parameter 'Path'`" when -Path is `$null" {
+            {add-content -path $null -value "ShouldNotWorkBecausePathIsNull" -ea stop} | Should Throw "Cannot bind argument to parameter 'Path'"
+        }
+        It "should throw `"Cannot bind argument to parameter 'Path'`" when -Path is `$()" {
+            #[DRT][BugId(BugDatabase.WindowsOutOfBandReleases, 903880)]
+            {add-content -path $() -value "ShouldNotWorkBecausePathIsInvalid" -ea stop} | Should Throw "Cannot bind argument to parameter 'Path'"
+        }
+        It "should throw 'PSNotSupportedException' when you add-content to an unsupported provider" {
+            #[DRT][BugId(BugDatabase.WindowsOutOfBandReleases, 906022)]
+            {add-content -path HKLM:\\software\\microsoft -value "ShouldNotWorkBecausePathIsUnsupported" -ea stop} | Should Throw "IContentCmdletProvider interface is not implemented"
+        }
+        It "should be able to pass multiple [string]`$objects to Add-Content through the pipeline to output a dynamic Path file" {
+            #[DRT][BugId(BugDatabase.WindowsOutOfBandReleases, 9058182)]
+            "hello","world"|add-content testdrive:\dynamicfile2.txt
+            $result=get-content testdrive:\dynamicfile2.txt
+            $result.length |Should be 2
+            $result[0]     |Should be "hello"
+            $result[1]     |Should be "world"
+        }
+    }
+} 

--- a/test/powershell/Clear-Content.Tests.ps1
+++ b/test/powershell/Clear-Content.Tests.ps1
@@ -1,0 +1,27 @@
+Describe "Clear-Content cmdlet tests" {
+    $file1 = "file1.txt"
+    Setup -File "$file1"
+
+    Context "Clear-Content should actually clear content" {
+        It "should clear-Content of testdrive:\$file1" {
+            set-content -path testdrive:\$file1 -value "ExpectedContent" -passthru | Should be "ExpectedContent"
+            clear-content -Path testdrive:\$file1
+        }
+        It "shouldn't get any content from testdrive:\$file1" {
+            $result = get-content -path testdrive:\$file1
+            $result | Should BeExactly $null
+        }
+
+        It "should throw `"Cannot bind argument to parameter 'Path'`" when -Path is `$null" {
+            {clear-content -path $null -ea stop} | Should Throw "Cannot bind argument to parameter 'Path'"
+        }
+        It "should throw `"Cannot bind argument to parameter 'Path'`" when -Path is `$()" {
+            #[DRT][BugId(BugDatabase.WindowsOutOfBandReleases, 903880)]
+            {clear-content -path $() -ea stop} | Should Throw "Cannot bind argument to parameter 'Path'"
+        }
+        It "should throw 'PSNotSupportedException' when you set-content to an unsupported provider" {
+            #[DRT][BugId(BugDatabase.WindowsOutOfBandReleases, 906022)]
+            {clear-content -path HKLM:\\software\\microsoft -ea stop} | Should Throw "IContentCmdletProvider interface is not implemented"
+        }
+    }
+} 

--- a/test/powershell/Get-Content.Tests.ps1
+++ b/test/powershell/Get-Content.Tests.ps1
@@ -24,80 +24,121 @@ Describe "Get-Content" {
     }
 
     It "Should throw an error on a directory  " {
-	# also tests that -erroraction SilentlyContinue will work.
-	Get-Content . -ErrorAction SilentlyContinue | Should Throw
+	    # also tests that -erroraction SilentlyContinue will work.
+	    Get-Content . -ErrorAction SilentlyContinue | Should Throw
     }
-
     It "Should return an Object when listing only a single line" {
-	(Get-Content -Path $testPath).GetType().BaseType.Name | Should Be "Object"
+	    (Get-Content -Path $testPath).GetType().BaseType.Name | Should Be "Object"
     }
-
     It "Should deliver an array object when listing a file with multiple lines" {
-	(Get-Content -Path $testPath2).GetType().BaseType.Name | Should Be "Array"
+	    (Get-Content -Path $testPath2).GetType().BaseType.Name | Should Be "Array"
     }
-
     It "Should return the correct information from a file" {
-	(Get-Content -Path $testPath) | Should Be $testString
+	    (Get-Content -Path $testPath) | Should Be $testString
     }
-
     It "Should be able to call using the gc alias" {
-	{ gc -Path $testPath } | Should Not Throw
+	    { gc -Path $testPath } | Should Not Throw
     }
-
     It "Should be able to call using the type alias" {
-	{ type -Path $testPath } | Should Not Throw
+	    { type -Path $testPath } | Should Not Throw
     }
-
     It "Should return the same values for aliases" {
-	$getContentAlias = Get-Content -Path $testPath
-	$gcAlias         = gc -Path $testPath
-	$typeAlias       = type -Path $testPath
-
-	$getContentAlias | Should Be $gcAlias
-	$getContentAlias | Should Be $typeAlias
+	    $getContentAlias = Get-Content -Path $testPath
+	    $gcAlias         = gc -Path $testPath
+	    $typeAlias       = type -Path $testPath
+        $getContentAlias | Should Be $gcAlias
+        $getContentAlias | Should Be $typeAlias
     }
-
     It "Should be able to return a specific line from a file" {
-	(Get-Content -Path $testPath2)[1] | Should be $secondline
+	    (Get-Content -Path $testPath2)[1] | Should be $secondline
     }
-
     It "Should be able to specify the number of lines to get the content of using the TotalCount switch" {
-	$returnArray = (Get-Content -Path $testPath2 -TotalCount 2)
-
-	$returnArray[0] | Should Be $firstline
-	$returnArray[1] | Should Be $secondline
+	    $returnArray    = (Get-Content -Path $testPath2 -TotalCount 2)
+    	$returnArray[0] | Should Be $firstline
+	    $returnArray[1] | Should Be $secondline
     }
-
     It "Should be able to specify the number of lines to get the content of using the Head switch" {
-	$returnArray = (Get-Content -Path $testPath2 -Head 2)
-
-	$returnArray[0] | Should Be $firstline
-	$returnArray[1] | Should Be $secondline
+	    $returnArray    = (Get-Content -Path $testPath2 -Head 2)
+        $returnArray[0] | Should Be $firstline
+	    $returnArray[1] | Should Be $secondline
     }
-
     It "Should be able to specify the number of lines to get the content of using the First switch" {
-	$returnArray = (Get-Content -Path $testPath2 -First 2)
-
-	$returnArray[0] | Should Be $firstline
-	$returnArray[1] | Should Be $secondline
+	    $returnArray    = (Get-Content -Path $testPath2 -First 2)
+    	$returnArray[0] | Should Be $firstline
+	    $returnArray[1] | Should Be $secondline
     }
-
     It "Should return the last line of a file using the Tail switch" {
-	Get-Content -Path $testPath -Tail 1 | Should Be $testString
+	    Get-Content -Path $testPath -Tail 1 | Should Be $testString
     }
-
-
     It "Should return the last lines of a file using the Last alias" {
-	Get-Content -Path $testPath2 -Last 1 | Should Be $fifthline
+	    Get-Content -Path $testPath2 -Last 1 | Should Be $fifthline
     }
-
     It "Should be able to get content within a different drive" {
-	pushd env:
-	$expectedoutput = [Environment]::GetEnvironmentVariable("PATH");
+	    pushd env:
+	    $expectedoutput = [Environment]::GetEnvironmentVariable("PATH");
+        { Get-Content PATH } | Should Not Throw
+	    Get-Content PATH     | Should Be $expectedoutput
+    	popd
+    }
+    It "should throw 'PSNotSupportedException' when you set-content to an unsupported provider" {
+        #[DRT][BugId(BugDatabase.WindowsOutOfBandReleases, 906022)]
+        {get-content -path HKLM:\\software\\microsoft -ea stop} | Should Throw "IContentCmdletProvider interface is not implemented"
+    }
+    It "should Get-Content with a variety of -Tail and -ReadCount values" {
+        #[DRT]
+        set-content -path $testPath "Hello,World","Hello2,World2","Hello3,World3","Hello4,World4"
+        $result=get-content -path $testPath -readcount:-1 -tail 5
+        $result.Length | Should Be 4
+        $expected = "Hello,World","Hello2,World2","Hello3,World3","Hello4,World4"
+        for ($i = 0; $i -lt $result.Length ; $i++) { $result[$i]  | Should BeExactly $expected[$i]}
 
-	{ Get-Content PATH } | Should Not Throw
-	Get-Content PATH     | Should Be $expectedoutput
+        $result=get-content -path $testPath -readcount 0 -tail 3
+        $result.Length    | Should Be 3
+        $expected = "Hello2,World2","Hello3,World3","Hello4,World4"
+        for ($i = 0; $i -lt $result.Length ; $i++) { $result[$i]  | Should BeExactly $expected[$i]}
 
-	popd
+        $result=get-content -path $testPath -readcount 1 -tail 3
+        $result.Length    | Should Be 3
+        $expected = "Hello2,World2","Hello3,World3","Hello4,World4"
+        for ($i = 0; $i -lt $result.Length ; $i++) { $result[$i]  | Should BeExactly $expected[$i]}
+
+        $result=get-content -path $testPath -readcount 99999 -tail 3
+        $result.Length    | Should Be 3
+        $expected = "Hello2,World2","Hello3,World3","Hello4,World4"
+        for ($i = 0; $i -lt $result.Length ; $i++) { $result[$i]  | Should BeExactly $expected[$i]}
+
+        $result=get-content -path $testPath -readcount 2 -tail 3
+        $result.Length    | Should Be 2
+        $expected = "Hello2,World2","Hello3,World3"
+        $expected = $expected,"Hello4,World4"
+        for ($i = 0; $i -lt $result.Length ; $i++) { $result[$i]  | Should BeExactly $expected[$i]}
+
+        $result=get-content -path $testPath -readcount 2 -tail 2
+        $result.Length    | Should Be 2
+        $expected = "Hello3,World3","Hello4,World4"
+        for ($i = 0; $i -lt $result.Length ; $i++) { $result[$i]  | Should BeExactly $expected[$i]}
+
+        $result=get-content -path $testPath -delimiter "," -tail 2
+        $result.Length    | Should Be 2
+        $expected = "World3`r`nHello4,","World4`r`n"
+        for ($i = 0; $i -lt $result.Length ; $i++) { $result[$i]  | Should BeExactly $expected[$i]}
+        
+        $result=get-content -path $testPath -delimiter "o" -tail 3
+        $result.Length    | Should Be 3
+        $expected = "rld3`r`nHello","4,Wo","rld4"
+        for ($i = 0; $i -lt $result.Length ; $i++) { $result[$i].Trim()  | Should BeExactly $expected[$i]}
+
+        $result=get-content -path $testPath -encoding:Byte -tail 10
+        $result.Length    | Should Be 10
+        $expected = "52","44","87","111","114","108","100","52","13","10"
+        for ($i = 0; $i -lt $result.Length ; $i++) { $result[$i]  | Should BeExactly $expected[$i]}
+    }
+    It "should get-content that matches the input string"{
+        #[DRT][BugId(BugDatabase.WindowsOutOfBandReleases, 905829)]
+        set-content $testPath "Hello,llllWorlld","Hello2,llllWorlld2"
+        $result=get-content $testPath -delimiter "ll" 
+        $result.Length    | Should Be 9
+        $expected = "Hell","o,ll","ll","Worll","d`r`nHell","o2,ll","ll","Worll","d2`r`n"
+        for ($i = 0; $i -lt $result.Length ; $i++) { $result[$i]  | Should BeExactly $expected[$i]}
     }
 }

--- a/test/powershell/Rename-Computer.Tests.ps1
+++ b/test/powershell/Rename-Computer.Tests.ps1
@@ -1,0 +1,25 @@
+<#
+  [DRT] for Win7:499005	- Using invalid new computer name in Rename-Computer will cause all subsequent Rename/Remove-Computer cmdlet to fail 
+  
+  Ported to Pester from TTest https://github.com/PowerShell/psl-monad/tree/master/monad/tests/monad/DRT/commands/management/UnitTests/Computer.cs
+#>
+
+Describe "Rename-Computer" {
+    Context "Check Rename-Computer behavior" {
+	  It "Should throw if 'NewName' is null or empty" -Pending:($IsLinux -Or $IsOSX) {
+	    { Rename-Computer -NewName $null} | Should Throw "Cannot validate argument on parameter 'NewName'. The argument is null or empty."
+	  }
+	  
+      It "Should throw if 'NewName' is the same as the 'OldName'" -Pending:($IsLinux -Or $IsOSX) {
+	    { Rename-Computer -NewName $env:COMPUTERNAME -ea stop} | Should Throw ("Skip computer '"+$env:COMPUTERNAME+"' with new name '"+$env:COMPUTERNAME)
+	  }
+
+	  It "Should throw if 'NewName' contains invalid chars" -Pending:($IsLinux -Or $IsOSX) {
+	    { Rename-Computer -NewName "a.invA?lid.com" -ea stop} | Should Throw "Standard names may contain letters (a-z, A-Z), numbers (0-9), and hyphens (-), but no spaces or periods"
+	  }
+	  	  
+      It "Should throw if 'NewName' contains a period" -Pending:($IsLinux -Or $IsOSX) {
+	    { Rename-Computer -NewName "a." -ea stop} | Should Throw "Standard names may contain letters (a-z, A-Z), numbers (0-9), and hyphens (-), but no spaces or periods"
+	  }
+  }
+}

--- a/test/powershell/Set-Content.Tests.ps1
+++ b/test/powershell/Set-Content.Tests.ps1
@@ -1,0 +1,50 @@
+Describe "Set-Content cmdlet tests" {
+    $file1 = "file1.txt"
+    Setup -File "$file1" -Content $file1
+
+    Context "Set-Content should actually set content" {
+        It "should set-Content of testdrive:\$file1" {
+            $result=set-content -path testdrive:\$file1 -value "ExpectedContent" -passthru 
+            $result| Should be "ExpectedContent"
+        }
+        It "should return expected string from testdrive:\$file1" {
+            $result = get-content -path testdrive:\$file1
+            $result | Should BeExactly "ExpectedContent"
+        }
+        It "should Set-Content to testdrive:\dynamicfile.txt with dynamic parameters" {
+            $result=set-content -path testdrive:\dynamicfile.txt -value "ExpectedContent" -passthru
+            $result| Should BeExactly "ExpectedContent"
+        }
+        It "should return expected string from testdrive:\dynamicfile.txt" {
+            $result = get-content -path testdrive:\dynamicfile.txt
+            $result | Should BeExactly "ExpectedContent"
+        }
+        It "should remove existing content from testdrive:\$file1 when the -Value is `$null" {
+            $AsItWas=get-content testdrive:\$file1
+            $AsItWas |Should BeExactly "ExpectedContent"
+            {set-content -path testdrive:\$file1 -value $null -ea stop} | Should Not Throw
+            $AsItIs=get-content testdrive:\$file1
+            $AsItIs| Should Not Be $AsItWas
+
+        }
+        It "should throw `"Cannot bind argument to parameter 'Path'`" when -Path is `$null" {
+            {set-content -path $null -value "ShouldNotWorkBecausePathIsNull" -ea stop} | Should Throw "Cannot bind argument to parameter 'Path'"
+        }
+        It "should throw `"Cannot bind argument to parameter 'Path'`" when -Path is `$()" {
+            #[DRT][BugId(BugDatabase.WindowsOutOfBandReleases, 903880)]
+            {set-content -path $() -value "ShouldNotWorkBecausePathIsInvalid" -ea stop} | Should Throw "Cannot bind argument to parameter 'Path'"
+        }
+        It "should throw 'PSNotSupportedException' when you set-content to an unsupported provider" {
+            #[DRT][BugId(BugDatabase.WindowsOutOfBandReleases, 906022)]
+            {set-content -path HKLM:\\software\\microsoft -value "ShouldNotWorkBecausePathIsUnsupported" -ea stop} | Should Throw "IContentCmdletProvider interface is not implemented"
+        }
+        It "should be able to pass multiple [string]`$objects to Set-Content through the pipeline to output a dynamic Path file" {
+            #[DRT][BugId(BugDatabase.WindowsOutOfBandReleases, 9058182)]
+            "hello","world"|set-content testdrive:\dynamicfile2.txt
+            $result=get-content testdrive:\dynamicfile2.txt
+            $result.length |Should be 2
+            $result[0]     |Should be "hello"
+            $result[1]     |Should be "world"
+        }
+    }
+} 


### PR DESCRIPTION
<!-- Reviewable:start -->

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/powershell/883)

<!-- Reviewable:end -->
