### PR TITLE
Add -EncodedCommand tests

### DIFF
--- a/src/Microsoft.PowerShell.CoreConsoleHost/main.cs
+++ b/src/Microsoft.PowerShell.CoreConsoleHost/main.cs
@@ -146,7 +146,7 @@ OPTIONS
                                 break;
                             case Options.EncodedCommand:
                                 byte[] data = Convert.FromBase64String(nextArg);
-                                initialScript = Encoding.UTF8.GetString(data);
+                                initialScript = Encoding.Unicode.GetString(data);
                                 ++i;
                                 break;
                             default:

--- a/test/powershell/CoreConsoleHost.Tests.ps1
+++ b/test/powershell/CoreConsoleHost.Tests.ps1
@@ -8,5 +8,14 @@ Describe "CoreConsoleHost unit tests" {
                 & $powershell -noprofile $x | ?{ $_ -match "usage: powershell" } | Should Not BeNullOrEmpty
             }
         }
+
+        It "Should accept a Base64 encoded command" {
+            $commandString = "Get-Location"
+            $encodedCommand = [System.Convert]::ToBase64String([System.Text.Encoding]::Unicode.GetBytes($commandString))
+            # We don't compare to `Get-Location` directly because object and formatted output comparisons are difficult
+            $expected = & $powershell -noprofile -command $commandString
+            $actual = & $powershell -noprofile -EncodedCommand $encodedCommand
+            $actual | Should Be $expected
+        }
     }
 }


### PR DESCRIPTION
This switches from UTF8 to Unicode per #712 (and adds tests).

We're not totally sold on using Unicode over UTF8, as it means using output from `base64` on Linux will fail with `-EncodedCommand`. But not using Unicode means this feature does not work the same as on Windows.

As it stands, this PR resolves the code to act the same as PowerShell's [original behavior](https://github.com/PowerShell/PowerShell/blob/master/src/System.Management.Automation/engine/hostifaces/PowerShellProcessInstance.cs#L98).
