### PR TITLE
Remove aspnetvnext and dotnet-cli feeds

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -3,8 +3,6 @@
   <packageSources>
     <clear />
     <add key="CI Builds (dotnet-core)" value="https://www.myget.org/F/dotnet-core/api/v3/index.json" />
-    <add key="CI Builds (dotnet-cli)" value="https://dotnet.myget.org/F/dotnet-cli/api/v3/index.json" />
-    <add key="CI Builds (aspnetvnext)" value="https://www.myget.org/F/aspnetvnext/api/v3/index.json" />
     <add key="CI Builds (aspnetcidev)" value="http://myget.org/F/aspnetcidev/api/v3/index.json" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
     <add key="local" value="./src/windows-build/nuget-feed" />


### PR DESCRIPTION
The dotnet-core and aspnetcidev feeds provide all our required packages. The aspnetvnext causes `dotnet restore` to take an inordinate amount of time, which terminates our CI builds.

Reducing the number of feeds brings restore time from scratch down to 3 seconds on my machine.

Resolves #896.

The aspnetvnext feed was originally added for the CoreCLR xUnit runner packages; but is no longer necessary.
