### PR TITLE
Fix bug when loading bad profiles

### DIFF
--- a/src/Microsoft.PowerShell.CoreConsoleHost/main.cs
+++ b/src/Microsoft.PowerShell.CoreConsoleHost/main.cs
@@ -354,8 +354,13 @@ OPTIONS
                 // accessed by the ctrl-C handler.
                 lock (this.instanceLock)
                 {
-                    this.currentPowerShell.Dispose();
-                    this.currentPowerShell = null;
+                    // The PowerShell instance will be null if it failed to
+                    // start due to, say, a parse exception in a profile.
+                    if (this.currentPowerShell != null) {
+                        this.currentPowerShell.Dispose();
+                        this.currentPowerShell = null;
+                    }
+
                 }
             }
         }
@@ -760,12 +765,12 @@ OPTIONS
                 // Stream output from command processing to console.
                 var output = new PSDataCollection<PSObject>();
                 output.DataAdded += (dSender, dArgs) =>
-                {
-                    foreach (var item in output.ReadAll())
                     {
-                        this.myHost.UI.WriteLine(item.ToString());
-                    }
-                };
+                        foreach (var item in output.ReadAll())
+                        {
+                            this.myHost.UI.WriteLine(item.ToString());
+                        }
+                    };
 
                 // Process command.
                 // The Debugger.ProcesCommand method will parse and handle debugger specific


### PR DESCRIPTION
This resolves #817.

A PowerShell instance is created to load and execute profile code.
However, if the profile has a parse error, the instance never gets
created, thus we have to check that it's not null before disposing it.
