### PR TITLE
Fix comparison of keys in dispatch dictionary

### DIFF
--- a/src/Microsoft.PowerShell.PSReadLine/KeyBindings.cs
+++ b/src/Microsoft.PowerShell.PSReadLine/KeyBindings.cs
@@ -82,12 +82,21 @@ namespace Microsoft.PowerShell
         {
             public bool Equals(ConsoleKeyInfo x, ConsoleKeyInfo y)
             {
-                return x.Key == y.Key && x.KeyChar == y.KeyChar && x.Modifiers == y.Modifiers;
+                // We *must not* compare the KeyChar field as its value is platform-dependent.
+                // We compare exactly the ConsoleKey enum field (which is platform-agnostic)
+                // and the modifiers.
+
+                return x.Key == y.Key && x.Modifiers == y.Modifiers;
             }
 
             public int GetHashCode(ConsoleKeyInfo obj)
             {
-                return obj.GetHashCode();
+                // Because a comparison of two ConsoleKeyInfo objects is a comparison of the
+                // combination of the ConsoleKey and Modifiers, we must combine their hashes.
+                // This is based on Tuple.GetHashCode
+                int h1 = obj.Key.GetHashCode();
+                int h2 = obj.Modifiers.GetHashCode();
+                return unchecked(((h1 << 5) + h1) ^ h2);
             }
         }
 

--- a/src/Microsoft.PowerShell.PSReadLine/Keys.cs
+++ b/src/Microsoft.PowerShell.PSReadLine/Keys.cs
@@ -11,22 +11,6 @@ namespace Microsoft.PowerShell
 {
     internal static class Keys
     {
-        static Keys()
-        {
-#if CORECLR
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-            {
-                Enter = new ConsoleKeyInfo((char)10, ConsoleKey.Enter, false, false, false);
-            }
-            else
-            {
-                Enter = new ConsoleKeyInfo((char)13, ConsoleKey.Enter, false, false, false);
-            }
-#else
-            Enter = new ConsoleKeyInfo((char)13, ConsoleKey.Enter, false, false, false);
-#endif
-        }
-
         public static ConsoleKeyInfo A = new ConsoleKeyInfo('a', ConsoleKey.A, false, false, false);
         public static ConsoleKeyInfo B = new ConsoleKeyInfo('b', ConsoleKey.B, false, false, false);
         public static ConsoleKeyInfo C = new ConsoleKeyInfo('c', ConsoleKey.C, false, false, false);
@@ -224,7 +208,7 @@ namespace Microsoft.PowerShell
         public static ConsoleKeyInfo End          = new ConsoleKeyInfo((char)0, ConsoleKey.End, false, false, false);
         public static ConsoleKeyInfo CtrlEnd      = new ConsoleKeyInfo((char)0, ConsoleKey.End, false, false, true);
         public static ConsoleKeyInfo ShiftEnd     = new ConsoleKeyInfo((char)0, ConsoleKey.End, true, false, false);
-        public static ConsoleKeyInfo Enter; 
+        public static ConsoleKeyInfo Enter        = new ConsoleKeyInfo((char)13, ConsoleKey.Enter, false, false, false);
         public static ConsoleKeyInfo Escape       = new ConsoleKeyInfo((char)27, ConsoleKey.Escape, false, false, false);
         public static ConsoleKeyInfo Home         = new ConsoleKeyInfo((char)0, ConsoleKey.Home, false, false, false);
         public static ConsoleKeyInfo CtrlHome     = new ConsoleKeyInfo((char)0, ConsoleKey.Home, false, false, true);


### PR DESCRIPTION
This resolves a part of #924, where the erase key was not working on my machine. This should resolve all cases of such platform/configuration differences, as we now compare just the ConsoleKey and Modifiers.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/powershell/931)

<!-- Reviewable:end -->
