### PR TITLE
Fix MenuComplete

### DIFF
--- a/src/Microsoft.PowerShell.PSReadLine/Completion.cs
+++ b/src/Microsoft.PowerShell.PSReadLine/Completion.cs
@@ -303,8 +303,16 @@ namespace Microsoft.PowerShell
             for (int i = 0; i < menuColumnWidth; i++)
             {
                 int j = i + start;
+#if CORECLR                
+                ConsoleColor tempColor = (int)buffer[j].ForegroundColor == -1 
+                    ? ConsoleColor.White : buffer[j].ForegroundColor;
+                buffer[j].ForegroundColor = (int)buffer[j].BackgroundColor == -1 
+                    ? ConsoleColor.Black : buffer[j].BackgroundColor;
+                buffer[j].BackgroundColor = tempColor;
+#else
                 buffer[j].ForegroundColor = (ConsoleColor)((int)buffer[j].ForegroundColor ^ 7);
                 buffer[j].BackgroundColor = (ConsoleColor)((int)buffer[j].BackgroundColor ^ 7);
+#endif
             }
         }
 


### PR DESCRIPTION
Fix MenuComplete command so it doesn't crash with invalid colors.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/powershell/937)

<!-- Reviewable:end -->
