### PR TITLE
Fix directory completion for different file-systems

### DIFF
--- a/src/Microsoft.PowerShell.PSReadLine/Completion.cs
+++ b/src/Microsoft.PowerShell.PSReadLine/Completion.cs
@@ -23,6 +23,9 @@ namespace Microsoft.PowerShell
         private CommandCompletion _tabCompletions;
         private Runspace _runspace;
 
+        // String helper for directory paths
+        private static string DirectorySeparatorString = System.IO.Path.DirectorySeparatorChar.ToString();
+
         // Stub helper method so completion can be mocked
 #if !CORECLR
         [ExcludeFromCodeCoverage]
@@ -275,21 +278,23 @@ namespace Microsoft.PowerShell
 
         private static string GetReplacementTextForDirectory(string replacementText, ref int cursorAdjustment)
         {
-            if (!replacementText.EndsWith("\\", StringComparison.Ordinal))
+            if (!replacementText.EndsWith(DirectorySeparatorString , StringComparison.Ordinal))
             {
-                if (replacementText.EndsWith("\\'", StringComparison.Ordinal) || replacementText.EndsWith("\\\"", StringComparison.Ordinal))
+                if (replacementText.EndsWith(String.Format("{0}\'", DirectorySeparatorString), StringComparison.Ordinal) ||
+                    replacementText.EndsWith(String.Format("{0}\"", DirectorySeparatorString), StringComparison.Ordinal))
                 {
                     cursorAdjustment = -1;
                 }
-                else if (replacementText.EndsWith("'", StringComparison.Ordinal) || replacementText.EndsWith("\"", StringComparison.Ordinal))
+                else if (replacementText.EndsWith("'", StringComparison.Ordinal) ||
+                         replacementText.EndsWith("\"", StringComparison.Ordinal))
                 {
                     var len = replacementText.Length;
-                    replacementText = replacementText.Substring(0, len - 1) + '\\' + replacementText[len - 1];
+                    replacementText = replacementText.Substring(0, len - 1) + System.IO.Path.DirectorySeparatorChar + replacementText[len - 1];
                     cursorAdjustment = -1;
                 }
                 else
                 {
-                    replacementText = replacementText + '\\';
+                    replacementText = replacementText + System.IO.Path.DirectorySeparatorChar;
                 }
             }
             return replacementText;


### PR DESCRIPTION
Part of #924; make the tab completion work for Linux / OS X. Otherwise it appends a backslash.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/powershell/938)

<!-- Reviewable:end -->
