### PR TITLE
Fix display of certain keybindings, and duplicates with tab-completions

### DIFF
--- a/src/Microsoft.PowerShell.PSReadLine/Keys.cs
+++ b/src/Microsoft.PowerShell.PSReadLine/Keys.cs
@@ -108,9 +108,17 @@ namespace Microsoft.PowerShell
         new
         public static ConsoleKeyInfo Equals      = new ConsoleKeyInfo('=', ConsoleKey.OemPlus, false, false, false);
 
+#if CORECLR
+        public static ConsoleKeyInfo CtrlAt       = new ConsoleKeyInfo('@', ConsoleKey.D2, true, false, true);
+#else
         public static ConsoleKeyInfo CtrlAt       = new ConsoleKeyInfo((char)0, ConsoleKey.D2, true, false, true);
+#endif
         public static ConsoleKeyInfo AltUnderbar = new ConsoleKeyInfo('_', ConsoleKey.OemMinus, true, true, false);
+#if CORECLR
+        public static ConsoleKeyInfo CtrlUnderbar = new ConsoleKeyInfo('_', ConsoleKey.OemMinus, true, false, true);
+#else
         public static ConsoleKeyInfo CtrlUnderbar = new ConsoleKeyInfo((char)31, ConsoleKey.OemMinus, true, false, true);
+#endif
         public static ConsoleKeyInfo AltEquals    = new ConsoleKeyInfo('=', ConsoleKey.OemPlus, false, true, false);
         public static ConsoleKeyInfo Space        = new ConsoleKeyInfo(' ', ConsoleKey.Spacebar, false, false, false);
         // Useless because it's caught by the console to bring up the system menu.
@@ -118,10 +126,19 @@ namespace Microsoft.PowerShell
         public static ConsoleKeyInfo CtrlSpace   = new ConsoleKeyInfo(' ', ConsoleKey.Spacebar, false, false, true);
         public static ConsoleKeyInfo AltLess     = new ConsoleKeyInfo('<', ConsoleKey.OemComma, true, true, false);
         public static ConsoleKeyInfo AltGreater  = new ConsoleKeyInfo('>', ConsoleKey.OemPeriod, true, true, false);
+#if CORECLR
+        public static ConsoleKeyInfo CtrlRBracket = new ConsoleKeyInfo(']', ConsoleKey.Oem6, false, false, true);
+        public static ConsoleKeyInfo AltCtrlRBracket = new ConsoleKeyInfo(']', ConsoleKey.Oem6, false, true, true);
+#else
         public static ConsoleKeyInfo CtrlRBracket = new ConsoleKeyInfo((char)29, ConsoleKey.Oem6, false, false, true);
         public static ConsoleKeyInfo AltCtrlRBracket = new ConsoleKeyInfo((char)0, ConsoleKey.Oem6, false, true, true);
+#endif
         public static ConsoleKeyInfo AltPeriod    = new ConsoleKeyInfo('.', ConsoleKey.OemPeriod, false, true, false);
+#if CORECLR
+        public static ConsoleKeyInfo CtrlAltQuestion  = new ConsoleKeyInfo('?', ConsoleKey.Oem2, true, true, true);
+#else
         public static ConsoleKeyInfo CtrlAltQuestion  = new ConsoleKeyInfo((char)0, ConsoleKey.Oem2, true, true, true);
+#endif
         public static ConsoleKeyInfo AltQuestion  = new ConsoleKeyInfo('?', ConsoleKey.Oem2, true, true, false);
 
         public static ConsoleKeyInfo Alt0 = new ConsoleKeyInfo('0', ConsoleKey.D0, false, true, false);

--- a/src/Microsoft.PowerShell.PSReadLine/Keys.cs
+++ b/src/Microsoft.PowerShell.PSReadLine/Keys.cs
@@ -108,17 +108,9 @@ namespace Microsoft.PowerShell
         new
         public static ConsoleKeyInfo Equals      = new ConsoleKeyInfo('=', ConsoleKey.OemPlus, false, false, false);
 
-#if CORECLR
         public static ConsoleKeyInfo CtrlAt       = new ConsoleKeyInfo('@', ConsoleKey.D2, true, false, true);
-#else
-        public static ConsoleKeyInfo CtrlAt       = new ConsoleKeyInfo((char)0, ConsoleKey.D2, true, false, true);
-#endif
         public static ConsoleKeyInfo AltUnderbar = new ConsoleKeyInfo('_', ConsoleKey.OemMinus, true, true, false);
-#if CORECLR
         public static ConsoleKeyInfo CtrlUnderbar = new ConsoleKeyInfo('_', ConsoleKey.OemMinus, true, false, true);
-#else
-        public static ConsoleKeyInfo CtrlUnderbar = new ConsoleKeyInfo((char)31, ConsoleKey.OemMinus, true, false, true);
-#endif
         public static ConsoleKeyInfo AltEquals    = new ConsoleKeyInfo('=', ConsoleKey.OemPlus, false, true, false);
         public static ConsoleKeyInfo Space        = new ConsoleKeyInfo(' ', ConsoleKey.Spacebar, false, false, false);
         // Useless because it's caught by the console to bring up the system menu.
@@ -126,19 +118,10 @@ namespace Microsoft.PowerShell
         public static ConsoleKeyInfo CtrlSpace   = new ConsoleKeyInfo(' ', ConsoleKey.Spacebar, false, false, true);
         public static ConsoleKeyInfo AltLess     = new ConsoleKeyInfo('<', ConsoleKey.OemComma, true, true, false);
         public static ConsoleKeyInfo AltGreater  = new ConsoleKeyInfo('>', ConsoleKey.OemPeriod, true, true, false);
-#if CORECLR
         public static ConsoleKeyInfo CtrlRBracket = new ConsoleKeyInfo(']', ConsoleKey.Oem6, false, false, true);
         public static ConsoleKeyInfo AltCtrlRBracket = new ConsoleKeyInfo(']', ConsoleKey.Oem6, false, true, true);
-#else
-        public static ConsoleKeyInfo CtrlRBracket = new ConsoleKeyInfo((char)29, ConsoleKey.Oem6, false, false, true);
-        public static ConsoleKeyInfo AltCtrlRBracket = new ConsoleKeyInfo((char)0, ConsoleKey.Oem6, false, true, true);
-#endif
         public static ConsoleKeyInfo AltPeriod    = new ConsoleKeyInfo('.', ConsoleKey.OemPeriod, false, true, false);
-#if CORECLR
         public static ConsoleKeyInfo CtrlAltQuestion  = new ConsoleKeyInfo('?', ConsoleKey.Oem2, true, true, true);
-#else
-        public static ConsoleKeyInfo CtrlAltQuestion  = new ConsoleKeyInfo((char)0, ConsoleKey.Oem2, true, true, true);
-#endif
         public static ConsoleKeyInfo AltQuestion  = new ConsoleKeyInfo('?', ConsoleKey.Oem2, true, true, false);
 
         public static ConsoleKeyInfo Alt0 = new ConsoleKeyInfo('0', ConsoleKey.D0, false, true, false);


### PR DESCRIPTION
This request fixes two items:
1.  Certain keybindings don't show up properly when one executes "Get-PSReadlineKeyHandler".  This is because some of the ConsoleKeyInfo.KeyChar fields were defined with non-viewable characters.  With the recent change to the comparison of ConsoleKeyInfo, to not compare the KeyChar field, we can now modify the Key table to have actualy-viewable characters for KeyChar field.
2. Some of the tab-related commands sometimes show duplicates as tab-completion choices.  In my testing, I've only seen this with PSReadLine cmdlets, e.g. two choices of Get-PSReadlineKeyHandler. Duplicates happen because PSReadLine cmdlets show up pre-pended with the Module name also. For example, Get-PSReadlineKeyHandler also show up as PSReadLine\Get-PSReadlineKeyHandler. To eliminate the duplicate, I investigated several options.  Since it looks like the CommandCompletion class does generate duplicates intentionally, I've decided to go the filter route and remove the duplicates myself.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/powershell/948)

<!-- Reviewable:end -->
