### PR TITLE
remove dependency on native GetHostname

### DIFF
--- a/src/System.Management.Automation/CoreCLR/CorePsExtensions.cs
+++ b/src/System.Management.Automation/CoreCLR/CorePsExtensions.cs
@@ -1070,17 +1070,6 @@ namespace System.Management.Automation
             }
         }
 
-        internal static string WinGetMachineName()
-        {
-            // In future release of operating systems, you might be able to rename a machine without
-            // rebooting.  Therefore, don't cache this machine name.
-            StringBuilder buf = new StringBuilder(MaxMachineNameLength);
-            int len = MaxMachineNameLength;
-            if (Win32Native.GetComputerName(buf, ref len) == 0)
-                throw new InvalidOperationException(CoreClrStubResources.CannotGetComputerName);
-            return buf.ToString();
-        }
-
         /// <summary>
         /// MachineName
         /// </summary>
@@ -1088,14 +1077,7 @@ namespace System.Management.Automation
         {
             get
             {
-                if (Platform.IsWindows)
-                {
-                    return WinGetMachineName();
-                }
-                else
-                {
-                    return Platform.NonWindowsGetMachineName();
-                }
+                return System.Environment.MachineName;
             }
         }
 
@@ -1275,9 +1257,6 @@ namespace System.Management.Automation
             [DllImport("SspiCli.dll", CharSet = CharSet.Unicode, SetLastError = true)]
             // Win32 return type is BOOLEAN (which is 1 byte and not BOOL which is 4bytes)
             internal static extern byte GetUserNameEx(int format, [Out] StringBuilder domainName, ref uint domainNameLen);
-
-            [DllImport("api-ms-win-downlevel-kernel32-l2-1-0.dll", CharSet = CharSet.Unicode, SetLastError = true)]
-            internal extern static int GetComputerName([Out]StringBuilder nameBuffer, ref int bufferSize);
 
             [DllImport("api-ms-win-core-localization-l1-2-1.dll", CharSet = CharSet.Unicode)]
             internal static extern int FormatMessage(int dwFlags, IntPtr lpSource, int dwMessageId, 

--- a/src/System.Management.Automation/CoreCLR/CorePsPlatform.cs
+++ b/src/System.Management.Automation/CoreCLR/CorePsPlatform.cs
@@ -351,18 +351,6 @@ namespace System.Management.Automation
             }
         }
 
-        internal static string NonWindowsGetMachineName()
-        {
-            if (!IsWindows)
-            {
-                return LinuxPlatform.HostName;
-            }
-            else
-            {
-                throw new PlatformNotSupportedException();
-            }
-        }
-
         // Hostname in this context seems to be the FQDN
         internal static string NonWindowsGetHostName()
         {
@@ -470,22 +458,6 @@ namespace System.Management.Automation
 
     internal static class LinuxPlatform
     {
-        public static string HostName
-        {
-            get
-            {
-                StringBuilder value = new StringBuilder(1024);
-                uint valueLen = (uint)value.Capacity;
-                string computerName = Native.GetComputerName();
-                if (string.IsNullOrEmpty(computerName))
-                {
-                    int lastError = Marshal.GetLastWin32Error();
-                    throw new InvalidOperationException("LinuxPlatform.HostName error: " + lastError);
-                }
-                return computerName;
-            }
-        }
-
         private static string _userName;
         public static string UserName
         {
@@ -695,10 +667,6 @@ namespace System.Management.Automation
             [DllImport(psLib, CharSet = CharSet.Ansi, SetLastError = true)]
             [return: MarshalAs(UnmanagedType.LPStr)]
             internal static extern string GetUserName();
-
-            [DllImport(psLib, CharSet = CharSet.Ansi, SetLastError = true)]
-            [return: MarshalAs(UnmanagedType.LPStr)]
-            internal static extern string GetComputerName();
 
             [DllImport(psLib, CharSet = CharSet.Ansi, SetLastError = true)]
             internal static extern int GetLinkCount([MarshalAs(UnmanagedType.LPStr)]string filePath, out int linkCount);

--- a/test/csharp/test_CorePsPlatform.cs
+++ b/test/csharp/test_CorePsPlatform.cs
@@ -99,7 +99,7 @@ namespace PSTests
                 // The process should return an exit code of 0 on success
                 Assert.Equal(0, process.ExitCode);
                 // It should be the same as what our platform code returns
-                Assert.Equal(hostname, Platform.NonWindowsGetMachineName());
+                Assert.Equal(hostname, System.Management.Automation.Environment.MachineName);
             }
         }
 


### PR DESCRIPTION
Use .NET's Environment.MachineName to get host name.  I removed both Window's and Linux's native implementation, and updated the XUnit test.  I did not remove the GetComputerName from libpsl-native, or its native tests.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/powershell/949)

<!-- Reviewable:end -->
