### PR TITLE
Make GetAssemblies and GetAssemblyLoadContext public

### DIFF
--- a/src/System.Management.Automation/CoreCLR/CorePsExtensions.cs
+++ b/src/System.Management.Automation/CoreCLR/CorePsExtensions.cs
@@ -1673,6 +1673,16 @@ namespace Microsoft.PowerShell.CoreCLR
 
             return ClrFacade.LoadFrom(assemblyFile);
         }
+
+        public static IEnumerable<Assembly> GetAssemblies(string namespaceQualifiedTypeName = null)
+        {
+            return ClrFacade.GetAssemblies(namespaceQualifiedTypeName);
+        }
+
+        public static System.Runtime.Loader.AssemblyLoadContext GetAssemblyLoadContext()
+        {
+            return ClrFacade.GetAssemblyLoadContext();
+        }
     }
 }
 


### PR DESCRIPTION
This allows:

``` powershell
> [Microsoft.PowerShell.CoreCLR.AssemblyExtensions]::GetAssemblies().GetTypes()

IsPublic IsSerial Name                                     BaseType
-------- -------- ----                                     --------
True     False    PSConsoleReadLine                        System.Object
True     True     TokenClassification                      System.Enum
...

> [Microsoft.PowerShell.CoreCLR.AssemblyExtensions]::GetAssemblyLoadContext() | Get-Member

   TypeName: System.Management.Automation.PowerShellAssemblyLoadContext

Name                       MemberType Definition
----                       ---------- ----------
Resolving                  Event      System.Func`3[System.Runtime.Loader.AssemblyLoadContext,System.Reflection.AssemblyName,System.Reflection.Assembly] Resolving(S...
Unloading                  Event      System.Action`1[System.Runtime.Loader.AssemblyLoadContext] Unloading(System.Runtime.Loader.AssemblyLoadContext)
Equals                     Method     bool Equals(System.Object obj)
GetHashCode                Method     int GetHashCode()
GetType                    Method     type GetType()
LoadFromAssemblyName       Method     System.Reflection.Assembly LoadFromAssemblyName(System.Reflection.AssemblyName assemblyName)
LoadFromAssemblyPath       Method     System.Reflection.Assembly LoadFromAssemblyPath(string assemblyPath)
LoadFromNativeImagePath    Method     System.Reflection.Assembly LoadFromNativeImagePath(string nativeImagePath, string assemblyPath)
LoadFromStream             Method     System.Reflection.Assembly LoadFromStream(System.IO.Stream assembly), System.Reflection.Assembly LoadFromStream(System.IO.Stre...
SetProfileOptimizationRoot Method     void SetProfileOptimizationRoot(string directoryPath)
StartProfileOptimization   Method     void StartProfileOptimization(string profile)
ToString                   Method     string ToString()

```

These are very useful. However, this change is a public API exposure, and so
should be documented and go through whatever process is necessary.

This also needs tests.

/cc @BrucePay @daxian-dbw

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/powershell/953)

<!-- Reviewable:end -->
