### PR TITLE
For Windows, update the expected location of dotnet.exe to $env:Local…

### DIFF
--- a/PowerShellGitHubDev.psm1
+++ b/PowerShellGitHubDev.psm1
@@ -61,7 +61,7 @@ function Start-PSBuild {
     if (-not $NoPath) {
         Write-Verbose "Appending probable .NET CLI tool path"
         if ($IsWindows) {
-            $env:Path += ";$env:LocalAppData\Microsoft\dotnet\cli"
+            $env:Path += ";$env:LocalAppData\Microsoft\dotnet"
         } elseif ($IsOSX) {
             $env:PATH += ":/usr/local/share/dotnet"
         }


### PR DESCRIPTION
Resolves build failure when building for windows - the expected location of dotnet.exe is incorrect. 
Manually verified by building -FullClr, -runtime ubuntu.14.04-x64 and -runtime win7-x64

Start-PSBuild was expecting dotnet.exe to be located at $env:LocalAppData\Microsoft\dotnet\cli.  However, my tests indicate it is located in the parent directory; $env:LocalAppData\Microsoft\dotnet and cli does not exist.  Confirmed by manually removing dotnet cli then running the Invoke-WebRequest/Install.ps1 steps manually.

DSC doesn't see this error because we build PowerShell through our DSC build script with sets up the  environment and avoids the issue.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/powershell/971)

<!-- Reviewable:end -->
