### PR TITLE
Update location where Start-PSBuild expects to find dotnet.exe

### DIFF
--- a/PowerShellGitHubDev.psm1
+++ b/PowerShellGitHubDev.psm1
@@ -61,7 +61,7 @@ function Start-PSBuild {
     if (-not $NoPath) {
         Write-Verbose "Appending probable .NET CLI tool path"
         if ($IsWindows) {
-            $env:Path += ";$env:LocalAppData\Microsoft\dotnet\cli"
+            $env:Path += ";$env:LocalAppData\Microsoft\dotnet"
         } elseif ($IsOSX) {
             $env:PATH += ":/usr/local/share/dotnet"
         }


### PR DESCRIPTION
Start-PSBuild expected to find dotnet.exe under %LOCALAPPDATA%\Microsoft\dotnet\cli.  it is now in the parent directory and Start-PSBuild will fail unless the environment has been set to point at the parent.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/powershell/973)

<!-- Reviewable:end -->
