### PR TITLE
Add regression test for CallDepthOverflow

### DIFF
--- a/test/powershell/ConsoleHost.Tests.ps1
+++ b/test/powershell/ConsoleHost.Tests.ps1
@@ -142,4 +142,24 @@ Describe "ConsoleHost unit tests" {
             EnsureChildHasExited $process
         }
     }
+
+    Context "Exception handling" {
+        It "Should handle a CallDepthOverflow" {
+            # Infinite recursion
+            function recurse
+            {
+                recurse $args
+            }
+
+            try
+            {
+                recurse "args"
+                Throw "Incorrect exception"
+            }
+            catch
+            {
+                $_.FullyQualifiedErrorId | Should Be "CallDepthOverflow"
+            }
+        }
+    }
 }


### PR DESCRIPTION
This resolves #560 with a regression test.

Please note that this test is _slow_, taking ~7 [seconds](https://travis-ci.com/PowerShell/PowerShell/jobs/40420622#L904).

@JamesWTruher I investigated speeding this by using a thread with a much smaller stack size, but the needed constructor is not available in [.NET Core](https://github.com/dotnet/corefx/blob/master/src/System.Threading.Thread/ref/System.Threading.Thread.cs).

Perhaps we need to start separating unit tests from _slow_ regression etc. tests.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/powershell/1007)

<!-- Reviewable:end -->
