### PR TITLE
Refactor to get latest asset ID using API

### DIFF
--- a/download.sh
+++ b/download.sh
@@ -2,32 +2,38 @@
 
 [[ -n $GITHUB_TOKEN ]] || { echo >&2 "GITHUB_TOKEN variable is undefined, please provide token"; exit 1; }
 
-# Set OS specific asset ID and package name
+# Authorizes with read-only access to GitHub API
+curl_() {
+    curl -s -i -H "Authorization: token $GITHUB_TOKEN" "$@"
+}
+
+# Retrieves asset ID and package name of asset ending in argument
+# $info looks like: "id": 1698239, "name": "powershell_0.4.0-1_amd64.deb",
+get_info() {
+    curl_ https://api.github.com/repos/PowerShell/PowerShell/releases/latest | grep -B 1 "name.*$1"
+}
+
+# Get OS specific asset ID and package name
 case "$OSTYPE" in
     linux*)
-        asset='1536045'
-        package='powershell_0.3.0-1_amd64.deb'
         # Install curl and wget to download package
         sudo apt-get install -y curl wget
+        info=$(get_info deb)
         ;;
     darwin*)
-        asset='1536063'
-        package='powershell-0.3.0.pkg'
+        info=$(get_info pkg)
         ;;
     *)
         exit 2 >&2 "$OSTYPE not supported!"
         ;;
 esac
 
-# Authorizes with read-only access to GitHub API
-# Retrieves URL of v0.3.0 release asset
-curl -s -i \
-     -H "Authorization: token $GITHUB_TOKEN " \
-     -H 'Accept: application/octet-stream' \
-     "https://api.github.com/repos/PowerShell/PowerShell/releases/assets/$asset" |
-    grep location |
-    sed 's/location: //g' |
-    wget -i - -O $package
+# Parses $info for asset ID and package name
+read asset package <<< $(echo $info | sed 's/[,"]//g' | awk '{ print $2; print $4 }')
+
+# Downloads asset to file
+curl_ -H 'Accept: application/octet-stream' https://api.github.com/repos/PowerShell/PowerShell/releases/assets/$asset |
+    grep location | sed 's/location: //g' | wget -i - -O $package
 
 # Installs PowerShell package
 case "$OSTYPE" in


### PR DESCRIPTION
This resolves #1004 and will use the latest released asset in the future.

The download script is as complicated as it is because this is a private repo, thus access to the assets must be done through the API with authentication. This all can go away when we go public.

I'm not a big fan of the Perl usage, but `grep -oP` is not available on OS X.

@JamesWTruher is probably about to come up with a much better Perl expression :ocean: 

/cc @vors

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/powershell/1008)

<!-- Reviewable:end -->
