### PR TITLE
update PSVersionTable code to use powershell.version rather than .version…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ install.ps1
 
 # We copy powershell.exe as a content in host dotnet cli projects
 *.exe
+
+# ignore the version file as it is generated at build time
+powershell.version

--- a/build.psm1
+++ b/build.psm1
@@ -53,7 +53,7 @@ function Start-PSBuild {
         [string]$msbuildConfiguration = "Release"
     )
 
-    git describe --dirty --abbrev=60 > "$psscriptroot/.version"
+    git describe --dirty --abbrev=60 > "$psscriptroot/powershell.version"
 
     # simplify ParameterSetNames
     if ($PSCmdlet.ParameterSetName -eq 'FullCLR') {

--- a/src/Microsoft.PowerShell.ConsoleHost/project.json
+++ b/src/Microsoft.PowerShell.ConsoleHost/project.json
@@ -19,7 +19,7 @@
         "Modules",
         "../Modules",
         "powershell.exe",
-        "../../.version"
+        "../../powershell.version"
     ],
 
     "frameworks": {

--- a/src/System.Management.Automation/engine/PSVersionInfo.cs
+++ b/src/System.Management.Automation/engine/PSVersionInfo.cs
@@ -82,12 +82,12 @@ namespace System.Management.Automation
             return new Version(buildVersion);
         }
 
-        // Get the commit id from the .version file. If the .version file doesn't exist, use the string "N/A"
+        // Get the commit id from the powershell.version file. If the powershell.version file doesn't exist, use the string "N/A"
         static internal string GetCommitInfo()
         {
             try {
                 string assemblyPath = IO.Path.GetDirectoryName(typeof(PSVersionInfo).GetTypeInfo().Assembly.Location);
-                return (IO.File.ReadAllLines(IO.Path.Combine(assemblyPath,".version"))[0]);
+                return (IO.File.ReadAllLines(IO.Path.Combine(assemblyPath,"powershell.version"))[0]);
             }
             catch (Exception e){
                 return e.Message;

--- a/src/powershell/project.json
+++ b/src/powershell/project.json
@@ -19,7 +19,8 @@
         "../Modules",
         "*_profile.ps1",
         "*.so",
-        "*.dylib"
+        "*.dylib",
+        "../../powershell.version"
     ],
 
     "frameworks": {

--- a/test/powershell/PSVersionTable.Tests.ps1
+++ b/test/powershell/PSVersionTable.Tests.ps1
@@ -15,6 +15,9 @@ Describe "PSVersionTable" {
 	$PSVersionTable.ContainsKey("GitCommitId")               | Should Be True
 
     }
+    It "GitCommitId property should not contain an error" {
+        $PSVersionTable.GitCommitId | Should not match "powershell.version"
+    }
 
     It "Should have the correct edition" -Skip:(!$IsCore) {
 	$expected =


### PR DESCRIPTION
 because on Linux the .version file doesn't seem to be binplaced. I postulate this is because it's a hidden file.

this also adds an addition test which validates the actual value of GitCommitId that it doesn't contain an error message (or rather a reference to powershell.version, the file which is opened which has the commit info in it)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/powershell/1009)

<!-- Reviewable:end -->
