### PR TITLE
Skip slow Pester tests

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -311,7 +311,7 @@ function Get-PSOutput {
 
 function Start-PSPester {
     [CmdletBinding()]param(
-        [string]$Flags = '-EnableExit -OutputFile pester-tests.xml -OutputFormat NUnitXml',
+        [string]$Flags = "-ExcludeTag 'Slow' -EnableExit -OutputFile pester-tests.xml -OutputFormat NUnitXml",
         [string]$Tests = "*",
         [ValidateScript({ Test-Path -PathType Container $_})]
         [string]$Directory = "$PSScriptRoot/test/powershell"

--- a/docs/cmdlet-example/SendGreeting.Tests.ps1
+++ b/docs/cmdlet-example/SendGreeting.Tests.ps1
@@ -1,4 +1,4 @@
-Describe "Send-Greeting cmdlet" {
+Describe "Send-Greeting cmdlet" -Tag 'Slow' {
     It "Should be able build the cmdlet" {
         Remove-Item -Recurse -Force bin -ErrorAction SilentlyContinue
         dotnet restore --verbosity Error | Should BeNullOrEmpty

--- a/test/powershell/ConsoleHost.Tests.ps1
+++ b/test/powershell/ConsoleHost.Tests.ps1
@@ -1,6 +1,6 @@
 using namespace System.Diagnostics
 
-Describe "ConsoleHost unit tests" {
+Describe "ConsoleHost unit tests" -Tag 'Slow' {
     $powershell = Join-Path -Path $PsHome -ChildPath "powershell"
 
     Context "CommandLine" {


### PR DESCRIPTION
This skips the slow Pester tests for Linux / OS X.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/powershell/1011)

<!-- Reviewable:end -->
