### PR TITLE
Bump System.Security.SecureString to 4.0.0

### DIFF
--- a/src/Microsoft.PowerShell.CoreCLR.Eventing/project.json
+++ b/src/Microsoft.PowerShell.CoreCLR.Eventing/project.json
@@ -15,7 +15,7 @@
             }
         }
     },
-    
+
     "frameworks": {
         "netstandard1.5": {
             "imports": [ "dnxcore50" ],
@@ -26,7 +26,7 @@
                 "System.Security.Principal": "4.0.1-rc2-24103",
                 "System.Security.Principal.Windows": "4.0.0-rc2-24103",
                 "System.Diagnostics.TraceSource": "4.0.0-rc2-24103",
-                "System.Security.SecureString": "1.0.0-*"
+                "System.Security.SecureString": "4.0.0-*"
             }
         }
     },

--- a/src/System.Security.SecureString/project.json
+++ b/src/System.Security.SecureString/project.json
@@ -1,6 +1,6 @@
 {
     "name": "System.Security.SecureString",
-    "version": "1.0.0-*",
+    "version": "4.0.0-*",
     "description": "SecureString Stub borrowed from Mono",
     "authors": [ "garretts" ],
 


### PR DESCRIPTION
This resolves #1012 by bumping the stub's version to 4.0.0.

The Eventing project dependency was updated, but MMIN was not as the package needs to be rebuilt (and does not fail since it depends on 1.0.0, which is satisfied by 4.0.0).

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/powershell/1015)

<!-- Reviewable:end -->
