### PR TITLE
Update xUnit runner

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -336,7 +336,7 @@ function Start-PSxUnit {
     }
 
     $Content = Split-Path -Parent (Get-PSOutput)
-    $Arguments = "--configuration", "Linux"
+    $Arguments = "--configuration", "Linux", "-verbose", "-parallel", "none"
     try {
         Push-Location $PSScriptRoot/test/csharp
         # Path manipulation to obtain test project output directory

--- a/test/csharp/project.json
+++ b/test/csharp/project.json
@@ -13,7 +13,7 @@
             "imports": [ "dnxcore50", "portable-net45+win8" ],
             "dependencies": {
                 "xunit": "2.1.0",
-                "dotnet-test-xunit": "1.0.0-rc2-173384-19"
+                "dotnet-test-xunit": "1.0.0-rc2-192208-24"
             }
         }
     },

--- a/test/csharp/project.json
+++ b/test/csharp/project.json
@@ -5,7 +5,7 @@
     "authors": [ "andschwa" ],
 
     "dependencies": {
-        "Microsoft.PowerShell.ConsoleHost": "1.0.0-*"
+        "powershell": "1.0.0-*"
     },
 
     "frameworks": {

--- a/test/csharp/test_Runspace.cs
+++ b/test/csharp/test_Runspace.cs
@@ -12,7 +12,7 @@ namespace PSTests
     public class RunspaceTests
     {
         private static int count = 3;
-        private static string script = String.Format($"get-process | select-object -first {count}");
+        private static string script = String.Format($"get-command | select-object -first {count}");
 
         [Fact]
         public void TestRunspaceWithPipeline()


### PR DESCRIPTION
To begin #1005, this updates the xUnit runner and makes `Start-PSxUnit` run the tests verbosely and not in parallel, which is necessary to see which test fails (and then causes the runner to abort).

The failing tests are still failing, and out of scope of this PR.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/powershell/1017)

<!-- Reviewable:end -->
