### PR TITLE
dotnet team changed their script name, change our bootstrap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@ project.lock.json
 *-tests.xml
 
 # dotnet cli install.ps1 script
-install.ps1
+dotnet-install.ps1
 
 # VS auto-generated solution files for project.json solutions
 *.xproj

--- a/build.psm1
+++ b/build.psm1
@@ -398,8 +398,8 @@ function Start-PSBootstrap {
 
     } elseif ($IsWindows -And -Not $IsCore) {
         Remove-Item -ErrorAction SilentlyContinue -Recurse -Force ~\AppData\Local\Microsoft\dotnet
-        Invoke-WebRequest -Uri https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/install.ps1 -OutFile install.ps1
-        ./install.ps1 -Version 1.0.0-rc2-002655
+        Invoke-WebRequest -Uri https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/dotnet-install.ps1 -OutFile dotnet-install.ps1
+        ./dotnet-install.ps1
 
     } else {
         Write-Warning "Start-PSBootstrap cannot be run in Core PowerShell on Windows (need Invoke-WebRequest!)"


### PR DESCRIPTION
Resolves errors during dotnet cli install that started appear in master, i.e.
https://ci.appveyor.com/project/PowerShell/powershell/build/0.2.0.2013

It didn't affected the whole install, probably because of appveyor cache.
