### PR TITLE
Suppressing taskname in tasks.json so 'build' is not being sent as cmd

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -3,12 +3,13 @@
     "command": "powershell",
     "isShellCommand": true,
     "showOutput": "always",
-    "args": [ "-c" ],
+    "suppressTaskName": true,
+    "args": [ "-command" ],
 
     "tasks": [
         {
             "taskName": "build",
-            "args": [ "Import-Module ${workspaceRoot}/PowerShellGitHubDev.psm1; Start-PSBuild -Output debug" ],
+            "args": [ "Import-Module ${workspaceRoot}/build.psm1; Start-PSBuild -Output debug" ],
             "isBuildCommand": true,
             "problemMatcher": "$msCompile"
         }


### PR DESCRIPTION
Resolves failure to debug in VSCode due to new changes to taskname and suppresstaskname.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/powershell/1035)

<!-- Reviewable:end -->
