### PR TITLE
Remove more references to CoreConsoleHost

### DIFF
--- a/docs/building/linux.md
+++ b/docs/building/linux.md
@@ -114,7 +114,7 @@ Start-PSBuild
 
 Congratulations! If everything went right, PowerShell is now built.
 The `Start-PSBuild` script will output the location of the executable:
-`./src/Microsoft.PowerShell.CoreConsoleHost/bin/Linux/netcoreapp1.0/ubuntu.14.04-x64/powershell`.
+`./src/powershell/bin/Linux/netcoreapp1.0/ubuntu.14.04-x64/powershell`.
 
 You can run our cross-platform Pester tests with `Start-PSPester`, and
 our xUnit tests with `Start-PSxUnit`.
@@ -138,23 +138,20 @@ make test
 popd
 ```
 
-This library will be emitted in the `src/Microsoft.PowerShell.CoreConsoleHost`
-project, where `dotnet` consumes it as "content" and thus
-automatically deploys it.
+This library will be emitted in the `src/powershell` project, where `dotnet`
+consumes it as "content" and thus automatically deploys it.
 
 Build the managed projects
 --------------------------
 
-The `Microsoft.PowerShell.CoreConsoleHost` project is the cross-platform host for
-PowerShell targetting .NET Core. It is the top level project, so
-`dotnet build` transitively builds all its dependencies, and emits a
-`powershell` executable. The `--configuration Linux` flag is
-necessary to ensure that the preprocessor definition `LINUX` is
-defined (see [issue #673][]).
+The `powershell` project is the .NET Core PowerShell host. It is the top level
+project, so `dotnet build` transitively builds all its dependencies, and emits a
+`powershell` executable. The `--configuration Linux` flag is necessary to ensure
+that the preprocessor definition `LINUX` is defined (see [issue #673][]).
 
 ```sh
 dotnet restore
-cd src/Microsoft.PowerShell.CoreConsoleHost
+cd src/powershell
 dotnet build --configuration Linux
 ```
 

--- a/docs/building/osx.md
+++ b/docs/building/osx.md
@@ -78,7 +78,7 @@ module.
 
 The output directory will be slightly different because your runtime
 identifier is different. PowerShell will be at
-`./src/Microsoft.PowerShell.CoreConsoleHost/bin/Linux/netcoreapp1.0/osx.10.11-x64/powershell`,
+`./src/powershell/bin/Linux/netcoreapp1.0/osx.10.11-x64/powershell`,
 or `osx.10.10` depending on your operating system version. Note that
 configration is still `Linux` because it would be silly to make yet
 another separate configuration when it's used soley to work-around a

--- a/docs/building/windows-core.md
+++ b/docs/building/windows-core.md
@@ -71,22 +71,20 @@ Start-PSBuild
 ```
 
 Congratulations! If everything went right, PowerShell is now built and
-executable as `./src/Microsoft.PowerShell.CoreConsoleHost/bin/Debug/netcoreapp1.0/win10-x64/powershell`.
+executable as `./src/powershell/bin/Debug/netcoreapp1.0/win10-x64/powershell`.
 
 This location is of the form
-`./[project]/bin/[configuration]/[framework]/[rid]/[binary name]`, and
-our project is `Microsoft.PowerShell.CoreConsoleHost`, configuration is `Debug`
-by default, framework is `netcoreapp1.0`, runtime identifier is
-**probably** `win10-x64` (but will depend on your operating system;
-don't worry, `dotnet --info` will tell you what it was), and binary
-name is `powershell`. The function `Get-PSOutput` will return the path
-to the executable; thus you can execute the development copy via `&
+`./[project]/bin/[configuration]/[framework]/[rid]/[binary name]`, and our
+project is `powershell`, configuration is `Debug` by default, framework is
+`netcoreapp1.0`, runtime identifier is **probably** `win10-x64` (but will depend
+on your operating system; don't worry, `dotnet --info` will tell you what it
+was), and binary name is `powershell`. The function `Get-PSOutput` will return
+the path to the executable; thus you can execute the development copy via `&
 (Get-PSOutput)`.
 
-The `Microsoft.PowerShell.CoreConsoleHost` project is the cross-platform host for
-PowerShell targetting .NET Core. It is the top level project, so
-`dotnet build` transitively builds all its dependencies, and emits a
-`powershell` executable. The cross-platform host has built-in
-documentation via `--help`.
+The `powershell` project is the .NET Core PowerShell host. It is the top level
+project, so `dotnet build` transitively builds all its dependencies, and emits a
+`powershell` executable. The cross-platform host has built-in documentation via
+`--help`.
 
 You can run our cross-platform Pester tests with `Start-PSPester`.

--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -2058,7 +2058,7 @@ namespace System.Management.Automation.Runspaces
                 // Only load the core snapins at this point...
                 if (Environment.GetEnvironmentVariable("PowerShellMinimal") != null)
                 {
-                    if (si.Name.Equals("Microsoft.PowerShell.CoreConsoleHost", StringComparison.OrdinalIgnoreCase))
+                    if (si.Name.Equals("Microsoft.PowerShell.Host", StringComparison.OrdinalIgnoreCase))
                         break;
                 }
 #endif
@@ -5578,7 +5578,7 @@ if($paths) {
                                                                 "Microsoft.PowerShell.Utility",
                                                                 "Microsoft.PowerShell.Management",
                                                                 "Microsoft.PowerShell.Diagnostics",
-                                                                "Microsoft.PowerShell.CoreConsoleHost",
+                                                                "Microsoft.PowerShell.Host",
                                                                 "Microsoft.PowerShell.Security",
                                                                 "Microsoft.WSMan.Management"
                                                             };
@@ -5596,14 +5596,14 @@ if($paths) {
                                                                                              { "Microsoft.PowerShell.Utility", "Microsoft.PowerShell.Commands.Utility"},
                                                                                              { "Microsoft.PowerShell.Management", "Microsoft.PowerShell.Commands.Management"},
                                                                                              { "Microsoft.PowerShell.Diagnostics", "Microsoft.PowerShell.Commands.Diagnostics"},
-                                                                                             { "Microsoft.PowerShell.CoreConsoleHost", "Microsoft.PowerShell.ConsoleHost"},
+                                                                                             { "Microsoft.PowerShell.Host", "Microsoft.PowerShell.ConsoleHost"},
                                                                                          };
         internal static Dictionary<string, string> NestedModuleEngineModuleMapping = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
                                                                                          {
                                                                                              { "Microsoft.PowerShell.Commands.Utility", "Microsoft.PowerShell.Utility"},
                                                                                              { "Microsoft.PowerShell.Commands.Management", "Microsoft.PowerShell.Management"},
                                                                                              { "Microsoft.PowerShell.Commands.Diagnostics", "Microsoft.PowerShell.Diagnostics"},
-                                                                                             { "Microsoft.PowerShell.ConsoleHost", "Microsoft.PowerShell.CoreConsoleHost"},
+                                                                                             { "Microsoft.PowerShell.ConsoleHost", "Microsoft.PowerShell.Host"},
                                                                                              { "Microsoft.PowerShell.Security", "Microsoft.PowerShell.Security"},
                                                                                              { "Microsoft.WSMan.Management", "Microsoft.WSMan.Management"},
                                                                                          };

--- a/src/System.Management.Automation/help/CommandHelpProvider.cs
+++ b/src/System.Management.Automation/help/CommandHelpProvider.cs
@@ -45,7 +45,7 @@ namespace System.Management.Automation
             engineModuleHelpFileCache.Add("Microsoft.PowerShell.Diagnostics", "Microsoft.PowerShell.Commands.Diagnostics.dll-Help.xml");
             engineModuleHelpFileCache.Add("Microsoft.PowerShell.Core", "System.Management.Automation.dll-Help.xml");
             engineModuleHelpFileCache.Add("Microsoft.PowerShell.Utility", "Microsoft.PowerShell.Commands.Utility.dll-Help.xml");
-            engineModuleHelpFileCache.Add("Microsoft.PowerShell.CoreConsoleHost", "Microsoft.PowerShell.ConsoleHost.dll-Help.xml");
+            engineModuleHelpFileCache.Add("Microsoft.PowerShell.Host", "Microsoft.PowerShell.ConsoleHost.dll-Help.xml");
             engineModuleHelpFileCache.Add("Microsoft.PowerShell.Management", "Microsoft.PowerShell.Commands.Management.dll-Help.xml");
             engineModuleHelpFileCache.Add("Microsoft.PowerShell.Security", "Microsoft.PowerShell.Security.dll-Help.xml");
             engineModuleHelpFileCache.Add("Microsoft.WSMan.Management", "Microsoft.Wsman.Management.dll-Help.xml");

--- a/src/System.Management.Automation/help/UpdatableHelpCommandBase.cs
+++ b/src/System.Management.Automation/help/UpdatableHelpCommandBase.cs
@@ -161,7 +161,7 @@ namespace Microsoft.PowerShell.Commands
             metadataCache.Add("Microsoft.PowerShell.Diagnostics", "http://go.microsoft.com/fwlink/?linkid=390783");
             metadataCache.Add("Microsoft.PowerShell.Core", "http://go.microsoft.com/fwlink/?linkid=390782");
             metadataCache.Add("Microsoft.PowerShell.Utility", "http://go.microsoft.com/fwlink/?linkid=390787");
-            metadataCache.Add("Microsoft.PowerShell.CoreConsoleHost", "http://go.microsoft.com/fwlink/?linkid=390784");
+            metadataCache.Add("Microsoft.PowerShell.Host", "http://go.microsoft.com/fwlink/?linkid=390784");
             metadataCache.Add("Microsoft.PowerShell.Management", " http://go.microsoft.com/fwlink/?linkid=390785");
             metadataCache.Add("Microsoft.PowerShell.Security", " http://go.microsoft.com/fwlink/?linkid=390786");
             metadataCache.Add("Microsoft.WSMan.Management", "http://go.microsoft.com/fwlink/?linkid=390788");

--- a/src/System.Management.Automation/singleshell/config/MshSnapinInfo.cs
+++ b/src/System.Management.Automation/singleshell/config/MshSnapinInfo.cs
@@ -64,7 +64,7 @@ namespace System.Management.Automation
 
         //Name of default mshsnapins
         internal const string CoreMshSnapinName = "Microsoft.PowerShell.Core";
-        internal const string HostMshSnapinName = "Microsoft.PowerShell.CoreConsoleHost";
+        internal const string HostMshSnapinName = "Microsoft.PowerShell.Host";
         internal const string ManagementMshSnapinName = "Microsoft.PowerShell.Management";
         internal const string SecurityMshSnapinName = "Microsoft.PowerShell.Security";
         internal const string UtilityMshSnapinName = "Microsoft.PowerShell.Utility";

--- a/src/TypeCatalogParser/Main.cs
+++ b/src/TypeCatalogParser/Main.cs
@@ -7,7 +7,7 @@ using Microsoft.DotNet.ProjectModel;
 using Microsoft.DotNet.ProjectModel.Graph;
 using Microsoft.Extensions.DependencyModel.Resolution;
 
-namespace ConsoleApplication
+namespace TypeCatalogParser
 {
     public class Program
     {
@@ -17,7 +17,7 @@ namespace ConsoleApplication
             var outputPath = "../TypeCatalogGen/powershell.inc";
 
             // Get a context for our top level project
-            var context = ProjectContext.Create("../Microsoft.PowerShell.CoreConsoleHost", NuGetFramework.Parse("netcoreapp1.0"));
+            var context = ProjectContext.Create("../powershell", NuGetFramework.Parse("netcoreapp1.0"));
 
             System.IO.File.WriteAllLines(outputPath,
                                          // Get the target for the current runtime


### PR DESCRIPTION
This removes the final references to `CoreConsoleHost` from `System.Management.Automation`, `TypeCatalogParser`, and the documentation.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/powershell/1053)

<!-- Reviewable:end -->
