### PR TITLE
Fix and improve Start-PSxUnit

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -53,7 +53,8 @@ function Start-PSBuild {
         [string]$msbuildConfiguration = "Release"
     )
 
-    git describe --dirty --abbrev=60 > "$psscriptroot/powershell.version"
+    # save Git description to file for PowerShell to include in PSVersionTable
+    git --git-dir="$PSScriptRoot/.git" describe --dirty --abbrev=60 > "$psscriptroot/powershell.version"
 
     # simplify ParameterSetNames
     if ($PSCmdlet.ParameterSetName -eq 'FullCLR') {


### PR DESCRIPTION
- Last PR had a typo in "TestAruments" which caused the configuration not to get picked up
- Now bails appropriately if PowerShell wasn't built, instead of rebuilding it every time
- Passes `-verbose` to the xUnit runner, not dotnet, so we can see which test failed
- Also Make git describe work relative to script, so that you don't have to watch your CWD when running commands from the build module.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/powershell/1065)

<!-- Reviewable:end -->
