### PR TITLE
Add Debian 8 RID

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -33,6 +33,7 @@ function Start-PSBuild {
         # These runtimes must match those in project.json
         # We do not use ValidateScript since we want tab completion
         [ValidateSet("ubuntu.14.04-x64",
+                     "debian.8-x64",
                      "centos.7.1-x64",
                      "win7-x64",
                      "win81-x64",
@@ -211,6 +212,7 @@ function New-PSOptions {
         # We do not use ValidateScript since we want tab completion
         [ValidateSet("",
                      "ubuntu.14.04-x64",
+                     "debian.8-x64",
                      "centos.7.1-x64",
                      "win7-x64",
                      "win81-x64",

--- a/src/powershell/project.json
+++ b/src/powershell/project.json
@@ -37,6 +37,7 @@
 
     "runtimes": {
         "ubuntu.14.04-x64": { },
+        "debian.8-x64": { },
         "centos.7.1-x64": { },
         "win7-x64": { },
         "win81-x64": { },

--- a/test/csharp/project.json
+++ b/test/csharp/project.json
@@ -22,6 +22,7 @@
 
     "runtimes": {
         "ubuntu.14.04-x64": { },
+        "debian.8-x64": { },
         "centos.7.1-x64": { },
         "win7-x64": { },
         "win81-x64": { },


### PR DESCRIPTION
This adds the ability to restore for (and thus build on) Debian.

Please see [this comment](https://github.com/dotnet/corefx/issues/8228#issuecomment-216357314) for why we use only "8" and not a patch version like "8.2" etc.
