### PR TITLE
Make PowerShell slash-agnostic on Linux

### DIFF
--- a/docs/KNOWNISSUES.md
+++ b/docs/KNOWNISSUES.md
@@ -87,3 +87,38 @@ following cmdlets that exist in the FullCLR version:
 - Send-MailMessage
 - Show-Command
 - Update-List
+
+## File paths with literal backward slashes
+
+On some filesystems (Linux, OS X), file paths are allowed to contain literal
+backward slashes, '\', as valid filename characters. These slashes, when
+escaped, are not directory separators. In Bash, the backward slash is the escape
+character, so a `path/with/a\\slash` is two directories, `path` and `with`, and
+one file, `a\slash`. In PowerShell, we *will* support this using the normal
+backtick escape character, so a `path\with\a``\slash` or a
+`path/with/a``\slash`, but this edge case is *currently unsupported*.
+
+That being said, native commands will work as expected. Thus this is the current
+scenario:
+
+```powershell
+PS > Get-Content a`\slash
+Get-Content : Cannot find path '/home/andrew/src/PowerShell/a/slash' because it does not exist.
+At line:1 char:1
++ Get-Content a`\slash
++ ~~~~~~~~~~~~~~~~~~~~
+    + CategoryInfo          : ObjectNotFound: (/home/andrew/src/PowerShell/a/slash:String) [Get-Co
+   ntent], ItemNotFoundException
+    + FullyQualifiedErrorId : PathNotFound,Microsoft.PowerShell.Commands.GetContentCommand
+
+PS > /bin/cat a\slash
+hi
+
+```
+
+The PowerShell cmdlet `Get-Content` cannot yet understand the escaped backward
+slash, but the path is passed literally to the native command `/bin/cat`. Most
+file operations are thus implicitly supported by the native commands. The
+notable exception is `cd` since it is not a command, but a shell built-in,
+`Set-Location`. So until this issue is resolved, PowerShell cannot change to a
+directory whose name contains a literal backward slash.

--- a/src/System.Management.Automation/engine/SessionStateStrings.cs
+++ b/src/System.Management.Automation/engine/SessionStateStrings.cs
@@ -26,6 +26,9 @@ namespace System.Management.Automation
 
         /// <summary>
         /// The default path separator used by the base implementation of the providers.
+        ///
+        /// Porting note: IO.Path.DirectorySeparatorChar is correct for all platforms. On Windows,
+        /// it is '\', and on Linux, it is '/', as expected.
         /// </summary>
         /// 
         internal static readonly char DefaultPathSeparator = System.IO.Path.DirectorySeparatorChar;
@@ -33,9 +36,14 @@ namespace System.Management.Automation
 
         /// <summary>
         /// The alternate path separator used by the base implementation of the providers.
+        ///
+        /// Porting note: we do not use .NET's AlternatePathSeparatorChar here because it correctly
+        /// states that both the default and alternate are '/' on Linux. However, for PowerShell to
+        /// be "slash agnostic", we need to use the assumption that a '\' is the alternate path
+        /// separator on Linux.
         /// </summary>
         /// 
-        internal static readonly char AlternatePathSeparator = System.IO.Path.AltDirectorySeparatorChar;
+        internal static readonly char AlternatePathSeparator = Platform.IsWindows ? '/' : '\\';
         internal static readonly string AlternatePathSeparatorString = AlternatePathSeparator.ToString();
 
         /// <summary>

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -951,7 +951,7 @@ namespace Microsoft.PowerShell.Commands
                         // add the filesystem with the root "/" to the initial drive list,
                         // otherwise path handling will not work correctly because there
                         // is no : available to separate the filesystems from each other
-                        if (Platform.HasSingleRootFilesystem() && root != "/")
+                        if (Platform.HasSingleRootFilesystem() && root != StringLiterals.DefaultPathSeparatorString)
                             continue;
 
                         // Porting notes: On non-windows platforms .net can report two
@@ -4765,12 +4765,13 @@ namespace Microsoft.PowerShell.Commands
             return parentPath;
         } // GetParentPath
 
+        // Note: we don't use IO.Path.IsPathRooted as this deals with "invalid" i.e. unnormalized paths
         private static bool IsAbsolutePath(string path)
         {
             bool result = false;
 
-            // this needs to be done differently on single root filesystems
-            if (Platform.HasSingleRootFilesystem() && path.StartsWith("/"))
+            // check if we're on a single root filesystem and it's an absolute path
+            if (LocationGlobber.IsSingleFileSystemAbsolutePath(path))
             {
                 return true;
             }

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -5240,18 +5240,15 @@ namespace Microsoft.PowerShell.Commands
 
         private string RemoveRelativeTokens(string path)
         {
-            string sep = System.IO.Path.DirectorySeparatorChar.ToString();
-            string altSep = System.IO.Path.AltDirectorySeparatorChar.ToString();
-
-            string testPath = path.Replace(altSep,sep);
+            string testPath = path.Replace('/', '\\');
             if (
-                (testPath.IndexOf(sep, StringComparison.OrdinalIgnoreCase) < 0) ||
-                testPath.StartsWith("." + sep, StringComparison.OrdinalIgnoreCase) ||
-                testPath.StartsWith(".." + sep, StringComparison.OrdinalIgnoreCase) ||
-                testPath.EndsWith(sep + ".", StringComparison.OrdinalIgnoreCase) ||
-                testPath.EndsWith(sep + "..", StringComparison.OrdinalIgnoreCase) ||
-                (testPath.IndexOf(sep + "." + sep, StringComparison.OrdinalIgnoreCase) > 0) ||
-                (testPath.IndexOf(sep + ".." + sep, StringComparison.OrdinalIgnoreCase) > 0))
+                (testPath.IndexOf("\\", StringComparison.OrdinalIgnoreCase) < 0) ||
+                testPath.StartsWith(".\\", StringComparison.OrdinalIgnoreCase) ||
+                testPath.StartsWith("..\\", StringComparison.OrdinalIgnoreCase) ||
+                testPath.EndsWith("\\.", StringComparison.OrdinalIgnoreCase) ||
+                testPath.EndsWith("\\..", StringComparison.OrdinalIgnoreCase) ||
+                (testPath.IndexOf("\\.\\", StringComparison.OrdinalIgnoreCase) > 0) ||
+                (testPath.IndexOf("\\..\\", StringComparison.OrdinalIgnoreCase) > 0))
             {
                 try
                 {

--- a/src/System.Management.Automation/namespaces/LocationGlobber.cs
+++ b/src/System.Management.Automation/namespaces/LocationGlobber.cs
@@ -3343,13 +3343,10 @@ namespace System.Management.Automation
             }
 
             string result = path;
+            bool treatAsRelative = true;
 
-            // platform notes:
-            // this needs to be implemented differently depending if the drive uses colon to separate paths
             if (drive.VolumeSeparatedByColon)
             {
-                bool treatAsRelative = true;
-
                 // Ensure the drive name is the same as the portion of the path before
                 // :. If not add the drive name and colon as if it was a relative path
 
@@ -3370,29 +3367,37 @@ namespace System.Management.Automation
                         }
                     }
                 }
-
-                if (treatAsRelative)
-                {
-                    string formatString = "{0}:" + StringLiterals.DefaultPathSeparator + "{1}";
-
-                    if (path.StartsWith(StringLiterals.DefaultPathSeparator.ToString(), StringComparison.Ordinal))
-                    {
-                        formatString = "{0}:{1}";
-                    }
-                    result =
-                        String.Format(
-                            System.Globalization.CultureInfo.InvariantCulture,
-                            formatString,
-                            drive.Name,
-                            path);
-                }
             }
             else
             {
-                if (path.StartsWith(drive.Name))
-                    result = path;
+                if (IsAbsolutePath(path))
+                {
+                    treatAsRelative = false;
+                }
+            }
+
+            if (treatAsRelative)
+            {
+                string formatString;
+                if (drive.VolumeSeparatedByColon)
+                {
+                    formatString = "{0}:" + StringLiterals.DefaultPathSeparator + "{1}";
+                    if (path.StartsWith(StringLiterals.DefaultPathSeparatorString, StringComparison.Ordinal))
+                    {
+                        formatString = "{0}:{1}";
+                    }
+                }
                 else
-                    result = drive.Name + path;
+                {
+                    formatString = "{0}{1}";
+                }
+
+                result =
+                    String.Format(
+                                  System.Globalization.CultureInfo.InvariantCulture,
+                                  formatString,
+                                  drive.Name,
+                                  path);
             }
 
             tracer.WriteLine("result = {0}", result);

--- a/src/System.Management.Automation/namespaces/LocationGlobber.cs
+++ b/src/System.Management.Automation/namespaces/LocationGlobber.cs
@@ -1571,6 +1571,30 @@ namespace System.Management.Automation
         } // IsProviderQualifiedPath
 
         /// <summary>
+        /// Determines if the given path is absolute while on a single root filesystem.
+        /// </summary>
+        ///
+        /// <remarks>
+        /// Porting notes: absolute paths on non-Windows filesystems start with a '/' (no "C:" drive
+        /// prefix, the slash is the prefix). We compare against both '/' and '\' (default and
+        /// alternate path separator) in order for PowerShell to be slash agnostic.
+        /// </remarks>
+        ///
+        /// <param name="path">
+        /// The path used in the determination
+        /// </param>
+        ///
+        /// <returns>
+        /// Returns true if we're on a single root filesystem and the path is absolute.
+        /// </returns>
+        internal static bool IsSingleFileSystemAbsolutePath(string path)
+        {
+            return Platform.HasSingleRootFilesystem() &&
+                (path.StartsWith(StringLiterals.DefaultPathSeparatorString, StringComparison.Ordinal) ||
+                 path.StartsWith(StringLiterals.AlternatePathSeparatorString, StringComparison.Ordinal));
+        } // IsSingleFileSystemAbsolutePath
+
+        /// <summary>
         /// Determines if the given path is relative or absolute
         /// </summary>
         /// 
@@ -1619,11 +1643,8 @@ namespace System.Management.Automation
                     break;
                 }
 
-                // non-windows porting notes:
-                // this needs to be handled differently on non-windows, paths starting with / are always absolute
-                // -> still continue with other isAbsolute processing, colons can still happen in drives
-                //    of other providers 
-                if (Platform.HasSingleRootFilesystem() && path.StartsWith("/",StringComparison.Ordinal))
+                // check if we're on a single root filesystem and it's an absolute path
+                if (IsSingleFileSystemAbsolutePath(path))
                 {
                     result = true;
                     break;
@@ -1716,13 +1737,10 @@ namespace System.Management.Automation
                     break;
                 }
 
-                // non-windows porting notes:
-                // this needs to be handled differently on non-windows, paths starting with / are always absolute
-                // -> still continue with other isAbsolute processing, colons can still happen in drives
-                //    of other providers 
-                if (Platform.HasSingleRootFilesystem() && path.StartsWith("/",StringComparison.Ordinal))
+                // check if we're on a single root filesystem and it's an absolute path
+                if (IsSingleFileSystemAbsolutePath(path))
                 {
-                    driveName = "/";
+                    driveName = StringLiterals.DefaultPathSeparatorString;
                     result = true;
                     break;
                 }

--- a/src/System.Management.Automation/namespaces/LocationGlobber.cs
+++ b/src/System.Management.Automation/namespaces/LocationGlobber.cs
@@ -2284,7 +2284,8 @@ namespace System.Management.Automation
 
                 driveRootRelativeWorkingPath = String.Empty;
 
-                // Remove the \ or / from the drive relative path
+                // Remove the \ or / from the drive relative
+                // path
 
                 path = path.Substring(1);
 
@@ -2460,41 +2461,18 @@ namespace System.Management.Automation
 
         private bool HasRelativePathTokens(string path)
         {
-            if (System.IO.Path.DirectorySeparatorChar == '/')
-            {
-                string comparePath = path;
+            string comparePath = path.Replace('/', '\\');
 
-                // the next line will only replace something, if the directory separators
-                // are different on the platform
-                if (System.IO.Path.DirectorySeparatorChar != System.IO.Path.AltDirectorySeparatorChar)
-                    comparePath = path.Replace(System.IO.Path.AltDirectorySeparatorChar,System.IO.Path.DirectorySeparatorChar);
-
-                return (
-                        comparePath.Equals(".", StringComparison.OrdinalIgnoreCase) ||
-                        comparePath.Equals("..", StringComparison.OrdinalIgnoreCase) ||
-                        comparePath.Contains("/./") ||
-                        comparePath.Contains("/../") ||
-                        comparePath.EndsWith("/..", StringComparison.OrdinalIgnoreCase) ||
-                        comparePath.EndsWith("/.", StringComparison.OrdinalIgnoreCase) ||
-                        comparePath.StartsWith("../", StringComparison.OrdinalIgnoreCase) ||
-                        comparePath.StartsWith("./", StringComparison.OrdinalIgnoreCase) ||
-                        comparePath.StartsWith("~", StringComparison.OrdinalIgnoreCase));
-            }
-            else
-            {
-                string comparePath = path.Replace('/', '\\');
-
-                return (
-                    comparePath.Equals(".", StringComparison.OrdinalIgnoreCase) ||
-                    comparePath.Equals("..", StringComparison.OrdinalIgnoreCase) ||
-                    comparePath.Contains("\\.\\") ||
-                    comparePath.Contains("\\..\\") ||
-                    comparePath.EndsWith("\\..", StringComparison.OrdinalIgnoreCase) ||
-                    comparePath.EndsWith("\\.", StringComparison.OrdinalIgnoreCase) ||
-                    comparePath.StartsWith("..\\", StringComparison.OrdinalIgnoreCase) ||
-                    comparePath.StartsWith(".\\", StringComparison.OrdinalIgnoreCase) ||
-                    comparePath.StartsWith("~", StringComparison.OrdinalIgnoreCase));
-            }
+            return (
+                comparePath.Equals(".", StringComparison.OrdinalIgnoreCase) ||
+                comparePath.Equals("..", StringComparison.OrdinalIgnoreCase) ||
+                comparePath.Contains("\\.\\") ||
+                comparePath.Contains("\\..\\") ||
+                comparePath.EndsWith("\\..", StringComparison.OrdinalIgnoreCase) ||
+                comparePath.EndsWith("\\.", StringComparison.OrdinalIgnoreCase) ||
+                comparePath.StartsWith("..\\", StringComparison.OrdinalIgnoreCase) ||
+                comparePath.StartsWith(".\\", StringComparison.OrdinalIgnoreCase) ||
+                comparePath.StartsWith("~", StringComparison.OrdinalIgnoreCase));
         }
 
         /// <summary>
@@ -3179,11 +3157,11 @@ namespace System.Management.Automation
                     }
 
                     string resolvedPath =
-                            String.Format(
-                                System.Globalization.CultureInfo.InvariantCulture,
-                                formatString,
-                                drive.Name,
-                                unescapedPath);
+                        String.Format(
+                            System.Globalization.CultureInfo.InvariantCulture,
+                            formatString,
+                            drive.Name,
+                            unescapedPath);
 
                     // Since we didn't do globbing, be sure the path exists
                     if (allowNonexistingPaths || 
@@ -3394,13 +3372,12 @@ namespace System.Management.Automation
 
                 result =
                     String.Format(
-                                  System.Globalization.CultureInfo.InvariantCulture,
-                                  formatString,
-                                  drive.Name,
-                                  path);
+                        System.Globalization.CultureInfo.InvariantCulture,
+                        formatString,
+                        drive.Name,
+                        path);
             }
 
-            tracer.WriteLine("result = {0}", result);
             return result;
         } // GetDriveQualifiedPath
 

--- a/src/System.Management.Automation/namespaces/NavigationProviderBase.cs
+++ b/src/System.Management.Automation/namespaces/NavigationProviderBase.cs
@@ -416,8 +416,8 @@ namespace System.Management.Automation.Provider
                     }
                     else
                     {
-                        // Normalize the path so that only the backslash is used as a separator even if the
-                        // user types a forward slash.
+                        // Normalize the path so that only the default path separator is used as a
+                        // separator even if the user types the alternate slash.
 
                         parent = parent.Replace(StringLiterals.AlternatePathSeparator, StringLiterals.DefaultPathSeparator);
                         child = child.Replace(StringLiterals.AlternatePathSeparator, StringLiterals.DefaultPathSeparator);

--- a/src/System.Management.Automation/namespaces/RegistryProvider.cs
+++ b/src/System.Management.Automation/namespaces/RegistryProvider.cs
@@ -3888,7 +3888,7 @@ namespace Microsoft.PowerShell.Commands
 
             if (!String.IsNullOrEmpty(path))
             {
-                result = path.Replace('/', '\\');
+                result = path.Replace(StringLiterals.AlternatePathSeparator, StringLiterals.DefaultPathSeparator);
 
                 // Remove relative path tokens
                 if (HasRelativePathTokens(path))

--- a/test/powershell/Hierarchical-Path.Tests.ps1
+++ b/test/powershell/Hierarchical-Path.Tests.ps1
@@ -1,0 +1,46 @@
+Describe "Hierarchical paths" {
+    BeforeAll {
+        $data = "Hello World"
+        Setup -File testFile.txt -Content $data
+    }
+
+    It "should work with Join-Path " {
+        $testPath = Join-Path $TestDrive testFile.txt
+        Get-Content $testPath | Should Be $data
+    }
+
+    It "should work with platform's slashes" {
+        $testPath = "$TestDrive$([IO.Path]::DirectorySeparatorChar)testFile.txt"
+        Get-Content $testPath | Should Be $data
+    }
+
+    It "should work with forward slashes" {
+        $testPath = "$TestDrive/testFile.txt"
+        Get-Content $testPath | Should Be $data
+    }
+
+    It "should work with backward slashes" {
+        $testPath = "$TestDrive\testFile.txt"
+        Get-Content $testPath | Should Be $data
+    }
+
+    It "should work with backward slashes for each separator" {
+        $testPath = "$TestDrive\testFile.txt".Replace("/","\")
+        Get-Content $testPath | should be $data
+    }
+
+    It "should work with forward slashes for each separator" {
+        $testPath = "$TestDrive/testFile.txt".Replace("\","/")
+        Get-Content $testPath | should be $data
+    }
+
+    It "should work even if there are too many forward slashes" {
+        $testPath = "$TestDrive//////testFile.txt"
+        Get-Content $testPath | should be $data
+    }
+
+    It "should work even if there are too many backward slashes" {
+        $testPath = "$TestDrive\\\\\\\testFile.txt"
+        Get-Content $testPath | should be $data
+    }
+}


### PR DESCRIPTION
Resolves #570.

PowerShell cmdlets now accept both '/' and '\' as directory separators on Linux.

This is _work in progress_ as now I need to get escaping of backslashes to work correctly.
