### PR TITLE
Fix Broken Powershell Debugging 

### DIFF
--- a/src/System.Management.Automation/project.json
+++ b/src/System.Management.Automation/project.json
@@ -24,7 +24,7 @@
         "netstandard1.5": {
             "imports": [ "dnxcore50" ],
             "buildOptions": {
-                "define": [ "CORECLR" ],
+                "define": [ "CORECLR", "PORTABLE" ],
                 "compile": {
                     "exclude": [
                         "cimSupport/cmdletization/xml/cmdlets-over-objects.objectModel.autogen.cs",

--- a/src/System.Management.Automation/singleshell/config/MshSnapinInfo.cs
+++ b/src/System.Management.Automation/singleshell/config/MshSnapinInfo.cs
@@ -1427,7 +1427,7 @@ namespace System.Management.Automation
                                     "SecurityMshSnapInResources,Description","SecurityMshSnapInResources,Vendor")
                             };
 
-#if !CORECLR //TODO:CORECLR - The 'Microsoft.WSMan.Management' module will be available on OneCore soon
+#if !LINUX
                             if (!Utils.IsWinPEHost())
                             {
                                 defaultMshSnapins.Add(new DefaultPSSnapInInformation("Microsoft.WSMan.Management", "Microsoft.WSMan.Management", null,

--- a/src/System.Management.Automation/singleshell/config/MshSnapinInfo.cs
+++ b/src/System.Management.Automation/singleshell/config/MshSnapinInfo.cs
@@ -1408,7 +1408,7 @@ namespace System.Management.Automation
                         {
                             defaultMshSnapins = new List<DefaultPSSnapInInformation>()
                             {
-#if !LINUX // Microsoft.PowerShell.Commands.Diagnostics.dll needs to be ported
+#if !PORTABLE // Microsoft.PowerShell.Commands.Diagnostics.dll needs to be ported
                                 new DefaultPSSnapInInformation("Microsoft.PowerShell.Diagnostics", "Microsoft.PowerShell.Commands.Diagnostics", null,
                                     "GetEventResources,Description", "GetEventResources,Vendor"),
 #endif
@@ -1427,7 +1427,7 @@ namespace System.Management.Automation
                                     "SecurityMshSnapInResources,Description","SecurityMshSnapInResources,Vendor")
                             };
 
-#if !LINUX
+#if !CORECLR //TODO:CORECLR - The 'Microsoft.WSMan.Management' module will be available on OneCore soon
                             if (!Utils.IsWinPEHost())
                             {
                                 defaultMshSnapins.Add(new DefaultPSSnapInInformation("Microsoft.WSMan.Management", "Microsoft.WSMan.Management", null,

--- a/test/powershell/PSDebugging.Tests.ps1
+++ b/test/powershell/PSDebugging.Tests.ps1
@@ -1,0 +1,148 @@
+using namespace System.Diagnostics
+
+Describe "PowerShell Command Debugging"{
+        $powershell = Join-Path -Path $PsHome -ChildPath "powershell"
+
+function NewProcessStartInfo([string]$CommandLine, [switch]$RedirectStdIn)
+        {
+            return [ProcessStartInfo]@{
+                FileName               = $powershell
+                Arguments              = $CommandLine
+                RedirectStandardInput  = $RedirectStdIn
+                RedirectStandardOutput = $true
+                RedirectStandardError  = $true
+                UseShellExecute        = $false
+            }
+        }
+        
+          function RunPowerShell([ProcessStartInfo]$debugfn)
+        {
+            $process = [Process]::Start($debugfn)
+            return $process
+        }
+        
+        
+        function EnsureChildHasExited([Process]$process, [int]$WaitTimeInMS = 15000)
+        {
+            $process.WaitForExit($WaitTimeInMS)
+
+            if (!$process.HasExited)
+            {
+                $process.HasExited | Should Be $true
+                $process.Kill()
+            }
+        }
+        
+    It "Should be able to step into debugging"{ 
+        $debugfn = NewProcessStartInfo "-noprofile ""`$function:foo = { 'bar' }""" -RedirectStdIn
+        $process = RunPowerShell $debugfn
+        $process.StandardInput.Write("Set-PsBreakpoint -command foo`n")
+
+	foreach ($i in 1..2) {
+	    $process.StandardOutput.ReadLine()
+	}
+
+        $process.StandardInput.Write("foo`n")
+	
+	foreach ($i in 1..13) {
+            $process.StandardOutput.ReadLine()
+	}
+
+	$process.StandardInput.Write("s`n")
+
+	foreach ($i in 1..3) {
+            $process.StandardOutput.ReadLine() }
+
+	$process.StandardInput.Write("s`n")
+
+	foreach ($i in 1..3) {
+            $process.StandardOutput.ReadLine()
+	}
+
+	$process.StandardInput.Write("s`n")
+
+	foreach ($i in 1..3) {
+            $process.StandardOutput.ReadLine()
+	}
+
+        $process.StandardInput.Close() 
+	        
+        EnsureChildHasExited $process
+        $process.ExitCode | Should Be 0
+    }   
+  
+    It "Should be able to continue into debugging"{ 
+        $debugfn = NewProcessStartInfo "-noprofile ""`$function:foo = { 'bar' }""" -RedirectStdIn
+        $process = RunPowerShell $debugfn
+        $process.StandardInput.Write("Set-PsBreakpoint -command foo`n")
+
+	foreach ($i in 1..2) {
+	    $process.StandardOutput.ReadLine()
+	}
+
+        $process.StandardInput.Write("foo`n")
+	
+	foreach ($i in 1..13) {
+            $process.StandardOutput.ReadLine()
+	}
+
+	$process.StandardInput.Write("c`n")
+        $process.StandardOutput.ReadLine() 
+        $process.StandardOutput.ReadLine() 
+
+        $process.StandardInput.Close() 
+	        
+        EnsureChildHasExited $process
+        $process.ExitCode | Should Be 0
+    }   
+
+    It "Should be able to list help for debugging"{ 
+        $debugfn = NewProcessStartInfo "-noprofile ""`$function:foo = { 'bar' }""" -RedirectStdIn
+        $process = RunPowerShell $debugfn
+        $process.StandardInput.Write("Set-PsBreakpoint -command foo`n")
+
+	foreach ($i in 1..2) {
+	    $process.StandardOutput.ReadLine()
+	}
+
+        $process.StandardInput.Write("foo`n")
+	
+	foreach ($i in 1..13) {
+            $process.StandardOutput.ReadLine()
+	}
+	$process.StandardInput.Write("h`n")
+	foreach ($i in 1..23) {
+            $line = $process.StandardOutput.ReadLine() 
+	}
+
+	$process.StandardInput.Write("s`n")
+
+	foreach ($i in 1..3) {
+           $process.StandardOutput.ReadLine() 
+	}
+
+	$process.StandardInput.Write("s`n")
+
+	foreach ($i in 1..3) {
+           $process.StandardOutput.ReadLine()
+	}
+
+	$process.StandardInput.Write("s`n")
+
+	foreach ($i in 1..3) {
+           $process.StandardOutput.ReadLine()
+	}
+
+        $process.StandardInput.Close() 
+	        
+        EnsureChildHasExited $process
+	$line | Should Be  "For instructions about how to customize your debugger prompt, type `"help about_prompt`"."
+#        $process.ExitCode | Should Be 0
+
+   
+
+    }   
+}
+
+
+

--- a/test/powershell/PSDebugging.Tests.ps1
+++ b/test/powershell/PSDebugging.Tests.ps1
@@ -1,182 +1,182 @@
 using namespace System.Diagnostics
 
 Describe "PowerShell Command Debugging"{
-        $powershell = Join-Path -Path $PsHome -ChildPath "powershell"
+    $powershell = Join-Path -Path $PsHome -ChildPath "powershell"
 
-function NewProcessStartInfo([string]$CommandLine, [switch]$RedirectStdIn)
-        {
-            return [ProcessStartInfo]@{
-                FileName               = $powershell
-                Arguments              = $CommandLine
-                RedirectStandardInput  = $RedirectStdIn
-                RedirectStandardOutput = $true
-                RedirectStandardError  = $true
-                UseShellExecute        = $false
-            }
+    function NewProcessStartInfo([string]$CommandLine, [switch]$RedirectStdIn)
+    {
+        return [ProcessStartInfo]@{
+            FileName               = $powershell
+            Arguments              = $CommandLine
+            RedirectStandardInput  = $RedirectStdIn
+            RedirectStandardOutput = $true
+            RedirectStandardError  = $true
+            UseShellExecute        = $false
         }
-        
-          function RunPowerShell([ProcessStartInfo]$debugfn)
-        {
-            $process = [Process]::Start($debugfn)
-            return $process
-        }
-        
-        
-        function EnsureChildHasExited([Process]$process, [int]$WaitTimeInMS = 15000)
-        {
-            $process.WaitForExit($WaitTimeInMS)
+    }
 
-            if (!$process.HasExited)
-            {
-                $process.HasExited | Should Be $true
-                $process.Kill()
-            }
+    function RunPowerShell([ProcessStartInfo]$debugfn)
+    {
+        $process = [Process]::Start($debugfn)
+        return $process
+    }
+
+
+    function EnsureChildHasExited([Process]$process, [int]$WaitTimeInMS = 15000)
+    {
+        $process.WaitForExit($WaitTimeInMS)
+
+        if (!$process.HasExited)
+        {
+            $process.HasExited | Should Be $true
+            $process.Kill()
         }
-        
-    It "Should be able to step into debugging"{ 
+    }
+
+    It "Should be able to step into debugging"{
         $debugfn = NewProcessStartInfo "-noprofile ""`$function:foo = { 'bar' }""" -RedirectStdIn
         $process = RunPowerShell $debugfn
         $process.StandardInput.Write("Set-PsBreakpoint -command foo`n")
 
         $process.StandardInput.Write("foo`n")
-	
-	$process.StandardInput.Write("s`n")
 
-	$process.StandardInput.Write("s`n")
+        $process.StandardInput.Write("s`n")
 
-	$process.StandardInput.Write("s`n")
+        $process.StandardInput.Write("s`n")
 
-        $process.StandardInput.Close() 
-	        
+        $process.StandardInput.Write("s`n")
+
+        $process.StandardInput.Close()
+
         EnsureChildHasExited $process
         $process.ExitCode | Should Be 0
-    }   
-  
-    It "Should be able to continue into debugging"{ 
+    }
+
+    It "Should be able to continue into debugging"{
         $debugfn = NewProcessStartInfo "-noprofile ""`$function:foo = { 'bar' }""" -RedirectStdIn
         $process = RunPowerShell $debugfn
         $process.StandardInput.Write("Set-PsBreakpoint -command foo`n")
 
         $process.StandardInput.Write("foo`n")
-	
-	$process.StandardInput.Write("c`n")
-        $process.StandardOutput.ReadLine() 
-        $process.StandardOutput.ReadLine() 
 
-        $process.StandardInput.Close() 
-	        
+        $process.StandardInput.Write("c`n")
+        $process.StandardOutput.ReadLine()
+        $process.StandardOutput.ReadLine()
+
+        $process.StandardInput.Close()
+
         EnsureChildHasExited $process
         $process.ExitCode | Should Be 0
-    }   
+    }
 
-    It "Should be able to list help for debugging"{ 
+    It "Should be able to list help for debugging"{
         $debugfn = NewProcessStartInfo "-noprofile ""`$function:foo = { 'bar' }""" -RedirectStdIn
         $process = RunPowerShell $debugfn
         $process.StandardInput.Write("Set-PsBreakpoint -command foo`n")
 
         $process.StandardInput.Write("foo`n")
-	
-	$process.StandardInput.Write("h`n")
 
-	foreach ($i in 1..38) {
-            $line = $process.StandardOutput.ReadLine() 
-	}
+        $process.StandardInput.Write("h`n")
 
-	$process.StandardInput.Write("s`n")
-	$process.StandardInput.Write("s`n")
-	$process.StandardInput.Write("s`n")
-        $process.StandardInput.Close() 
-	        
+        foreach ($i in 1..38) {
+            $line = $process.StandardOutput.ReadLine()
+        }
+
+        $process.StandardInput.Write("s`n")
+        $process.StandardInput.Write("s`n")
+        $process.StandardInput.Write("s`n")
+        $process.StandardInput.Close()
+
         EnsureChildHasExited $process
-	$line | Should Be  "For instructions about how to customize your debugger prompt, type `"help about_prompt`"."
-    }   
+        $line | Should Be  "For instructions about how to customize your debugger prompt, type `"help about_prompt`"."
+    }
 
 
-    It "Should be able to step over debugging"{ 
+    It "Should be able to step over debugging"{
         $debugfn = NewProcessStartInfo "-noprofile ""`$function:foo = { 'bar' }""" -RedirectStdIn
         $process = RunPowerShell $debugfn
         $process.StandardInput.Write("Set-PsBreakpoint -command foo`n")
 
-        $process.StandardInput.Write("foo`n")	
-	$process.StandardInput.Write("v`n")
-	$process.StandardInput.Write("v`n")
-	$process.StandardInput.Write("v`n")
+        $process.StandardInput.Write("foo`n")
+        $process.StandardInput.Write("v`n")
+        $process.StandardInput.Write("v`n")
+        $process.StandardInput.Write("v`n")
 
-        $process.StandardInput.Close() 
-	        
+        $process.StandardInput.Close()
+
         EnsureChildHasExited $process
         $process.ExitCode | Should Be 0
-    }   
+    }
 
 
-    It "Should be able to step out of debugging"{ 
+    It "Should be able to step out of debugging"{
         $debugfn = NewProcessStartInfo "-noprofile ""`$function:foo = { 'bar' }""" -RedirectStdIn
         $process = RunPowerShell $debugfn
         $process.StandardInput.Write("Set-PsBreakpoint -command foo`n")
 
-        $process.StandardInput.Write("foo`n")	
-	$process.StandardInput.Write("o`n")
+        $process.StandardInput.Write("foo`n")
+        $process.StandardInput.Write("o`n")
 
-        $process.StandardInput.Close() 
-	        
+        $process.StandardInput.Close()
+
         EnsureChildHasExited $process
         $process.ExitCode | Should Be 0
-    }   
+    }
 
-    It "Should be able to quit debugging"{ 
+    It "Should be able to quit debugging"{
         $debugfn = NewProcessStartInfo "-noprofile ""`$function:foo = { 'bar' }""" -RedirectStdIn
         $process = RunPowerShell $debugfn
         $process.StandardInput.Write("Set-PsBreakpoint -command foo`n")
 
-        $process.StandardInput.Write("foo`n")	
-	$process.StandardInput.Write("q`n")
+        $process.StandardInput.Write("foo`n")
+        $process.StandardInput.Write("q`n")
 
-        $process.StandardInput.Close() 
-	        
+        $process.StandardInput.Close()
+
         EnsureChildHasExited $process
         $process.ExitCode | Should Be 0
-    }   
+    }
 
-    It "Should be able to list source code in debugging"{ 
+    It "Should be able to list source code in debugging"{
         $debugfn = NewProcessStartInfo "-noprofile ""`$function:foo = { 'bar' }""" -RedirectStdIn
         $process = RunPowerShell $debugfn
         $process.StandardInput.Write("Set-PsBreakpoint -command foo`n") | Write-Host
 
-        $process.StandardInput.Write("foo`n") | Write-Host 
-	$process.StandardInput.Write("l`n") | Write-Host
+        $process.StandardInput.Write("foo`n") | Write-Host
+        $process.StandardInput.Write("l`n") | Write-Host
 
-	foreach ($i in 1..19) {
-            $line = $process.StandardOutput.ReadLine() 
-	}
+        foreach ($i in 1..19) {
+            $line = $process.StandardOutput.ReadLine()
+        }
 
-	$process.StandardInput.Write("`n")
-	$process.StandardInput.Write("`n")
-	$process.StandardInput.Write("`n")
+        $process.StandardInput.Write("`n")
+        $process.StandardInput.Write("`n")
+        $process.StandardInput.Write("`n")
 
-	$line | Should Be "    1:* `$function:foo = { 'bar' }"
-        $process.StandardInput.Close()         
+        $line | Should Be "    1:* `$function:foo = { 'bar' }"
+        $process.StandardInput.Close()
         EnsureChildHasExited $process
 
-    }   
+    }
 
 
-   It "Should be able to get the call stack in debugging"{ 
+    It "Should be able to get the call stack in debugging"{
         $debugfn = NewProcessStartInfo "-noprofile ""`$function:foo = { 'bar' }""" -RedirectStdIn
         $process = RunPowerShell $debugfn
         $process.StandardInput.Write("Set-PsBreakpoint -command foo`n") | Write-Host
 
-        $process.StandardInput.Write("foo`n") | Write-Host 
-	$process.StandardInput.Write("k`n") | Write-Host
+        $process.StandardInput.Write("foo`n") | Write-Host
+        $process.StandardInput.Write("k`n") | Write-Host
 
-	foreach ($i in 1..20) {
-            $line = $process.StandardOutput.ReadLine() 
-	}
+        foreach ($i in 1..20) {
+            $line = $process.StandardOutput.ReadLine()
+        }
 
-	$line | Should Be "foo           {}        <No file>"
-        $process.StandardInput.Close()         
+        $line | Should Be "foo           {}        <No file>"
+        $process.StandardInput.Close()
         EnsureChildHasExited $process
 
-    }   
+    }
 
 
 }

--- a/test/powershell/PSDebugging.Tests.ps1
+++ b/test/powershell/PSDebugging.Tests.ps1
@@ -1,7 +1,17 @@
 using namespace System.Diagnostics
 
-Describe "PowerShell Command Debugging"{
-    $powershell = Join-Path -Path $PsHome -ChildPath "powershell"
+Describe "PowerShell Command Debugging" {
+
+    BeforeAll {
+        # These tests cannot yet be run on OS X on Travis, or on any Windows, due to redirected stdin problems
+        if ($env:TRAVIS_OS_NAME -eq "osx" -or $IsWindows) {
+            $ItArgs = @{ pending = $true }
+        } else {
+            $ItArgs = @{}
+        }
+
+        $powershell = Join-Path -Path $PsHome -ChildPath "powershell"
+    }
 
     function NewProcessStartInfo([string]$CommandLine, [switch]$RedirectStdIn)
     {
@@ -33,7 +43,7 @@ Describe "PowerShell Command Debugging"{
         }
     }
 
-    It "Should be able to step into debugging"{
+    It @ItArgs "Should be able to step into debugging" {
         $debugfn = NewProcessStartInfo "-noprofile ""`$function:foo = { 'bar' }""" -RedirectStdIn
         $process = RunPowerShell $debugfn
         $process.StandardInput.Write("Set-PsBreakpoint -command foo`n")
@@ -52,7 +62,7 @@ Describe "PowerShell Command Debugging"{
         $process.ExitCode | Should Be 0
     }
 
-    It "Should be able to continue into debugging"{
+    It @ItArgs "Should be able to continue into debugging" {
         $debugfn = NewProcessStartInfo "-noprofile ""`$function:foo = { 'bar' }""" -RedirectStdIn
         $process = RunPowerShell $debugfn
         $process.StandardInput.Write("Set-PsBreakpoint -command foo`n")
@@ -69,7 +79,7 @@ Describe "PowerShell Command Debugging"{
         $process.ExitCode | Should Be 0
     }
 
-    It "Should be able to list help for debugging"{
+    It @ItArgs "Should be able to list help for debugging" {
         $debugfn = NewProcessStartInfo "-noprofile ""`$function:foo = { 'bar' }""" -RedirectStdIn
         $process = RunPowerShell $debugfn
         $process.StandardInput.Write("Set-PsBreakpoint -command foo`n")
@@ -92,7 +102,7 @@ Describe "PowerShell Command Debugging"{
     }
 
 
-    It "Should be able to step over debugging"{
+    It @ItArgs "Should be able to step over debugging" {
         $debugfn = NewProcessStartInfo "-noprofile ""`$function:foo = { 'bar' }""" -RedirectStdIn
         $process = RunPowerShell $debugfn
         $process.StandardInput.Write("Set-PsBreakpoint -command foo`n")
@@ -109,7 +119,7 @@ Describe "PowerShell Command Debugging"{
     }
 
 
-    It "Should be able to step out of debugging"{
+    It @ItArgs "Should be able to step out of debugging" {
         $debugfn = NewProcessStartInfo "-noprofile ""`$function:foo = { 'bar' }""" -RedirectStdIn
         $process = RunPowerShell $debugfn
         $process.StandardInput.Write("Set-PsBreakpoint -command foo`n")
@@ -123,7 +133,7 @@ Describe "PowerShell Command Debugging"{
         $process.ExitCode | Should Be 0
     }
 
-    It "Should be able to quit debugging"{
+    It @ItArgs "Should be able to quit debugging" {
         $debugfn = NewProcessStartInfo "-noprofile ""`$function:foo = { 'bar' }""" -RedirectStdIn
         $process = RunPowerShell $debugfn
         $process.StandardInput.Write("Set-PsBreakpoint -command foo`n")
@@ -137,7 +147,7 @@ Describe "PowerShell Command Debugging"{
         $process.ExitCode | Should Be 0
     }
 
-    It "Should be able to list source code in debugging"{
+    It @ItArgs "Should be able to list source code in debugging" {
         $debugfn = NewProcessStartInfo "-noprofile ""`$function:foo = { 'bar' }""" -RedirectStdIn
         $process = RunPowerShell $debugfn
         $process.StandardInput.Write("Set-PsBreakpoint -command foo`n") | Write-Host
@@ -160,7 +170,7 @@ Describe "PowerShell Command Debugging"{
     }
 
 
-    It "Should be able to get the call stack in debugging"{
+    It @ItArgs "Should be able to get the call stack in debugging" {
         $debugfn = NewProcessStartInfo "-noprofile ""`$function:foo = { 'bar' }""" -RedirectStdIn
         $process = RunPowerShell $debugfn
         $process.StandardInput.Write("Set-PsBreakpoint -command foo`n") | Write-Host


### PR DESCRIPTION
Resolves Issue #1058. Diagnostics is not available yet as per Issue #1042 and #1031. Re-guarding that portion out of MshSnapinInfo.

Added Pester cases to catch a seg fault again as this problem was not caught in build. 
