### PR TITLE
Better CentOS 7 support

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -396,11 +396,11 @@ function Start-PSBootstrap {
     try {
         # Install dependencies for Linux and OS X
         if ($IsLinux) {
-            if ($LinuxInfo.ID -match 'ubuntu' -and $LinuxInfo.Version -match '14.04') {
+            if ($LinuxInfo.ID -match 'ubuntu' -and $LinuxInfo.VERSION_ID -match '14.04') {
                 # Install ours and .NET's dependencies
                 sudo apt-get install -y -qq curl make g++ cmake libc6 libgcc1 libstdc++6 libcurl3 libgssapi-krb5-2 libicu52 liblldb-3.6 liblttng-ust0 libssl1.0.0 libunwind8 libuuid1 zlib1g clang-3.5
-            } elseif ($LinuxInfo.ID -match 'centos' -and $LinuxInfo.Version -match '7') {
-                sudo apt-get install -y -q curl make gcc cmake glibc libgcc libstdc++ libcurl krb5-libs libicu lldb openssl-libs libunwind libuuid zlib clang
+            } elseif ($LinuxInfo.ID -match 'centos' -and $LinuxInfo.VERSION_ID -match '7') {
+                sudo yum install -y -q curl make gcc cmake glibc libgcc libstdc++ libcurl krb5-libs libicu lldb openssl-libs libunwind libuuid zlib clang
             } else {
                 Write-Warning "This script only supports Ubuntu 14.04 and CentOS 7, you must install dependencies manually!"
             }

--- a/build.psm1
+++ b/build.psm1
@@ -483,7 +483,7 @@ Built upon .NET Core, it is also a C# REPL.
         $appxPackagePath = New-AppxPackage -PackageVersion $Version -SourcePath $Source -AssetsPath "$PSScriptRoot\Assets" -Verbose
 
         $packages = @($msiPackagePath, $appxPackagePath)
-        
+
         return $packages
     }
 
@@ -493,7 +493,17 @@ Built upon .NET Core, it is also a C# REPL.
 
     # Decide package output type
     if (-not $Type) {
-        $Type = if ($IsLinux) { "deb" } elseif ($IsOSX) { "osxpkg" }
+        $Type = if ($IsLinux) {
+            if ($LinuxInfo.ID -match 'ubuntu') {
+                "deb"
+            } elseif ($LinuxInfo.ID -match 'centos') {
+                "rpm"
+            } else {
+                throw "Building packages for $($LinuxInfo.PRETTY_NAME) is unsupported!"
+            }
+        } elseif ($IsOSX) {
+            'osxpkg'
+        }
         Write-Warning "-Type was not specified, continuing with $Type"
     }
 

--- a/build.psm1
+++ b/build.psm1
@@ -397,12 +397,12 @@ function Start-PSBootstrap {
         # Install dependencies for Linux and OS X
         if ($IsLinux) {
             precheck 'curl' "Bootstrap dependency 'curl' not found in PATH, please install!" > $null
-            if ($LinuxInfo.ID -eq 'ubuntu' -and $LinuxInfo.Version -eq '"14.04"') {
+            if ($LinuxInfo.ID -match 'ubuntu' -and $LinuxInfo.Version -match '14.04') {
                 # Install ours and .NET's dependencies
                 sudo apt-get update -qq
                 sudo apt-get install -y -qq make g++ cmake libc6 libgcc1 libstdc++6 libcurl3 libgssapi-krb5-2 libicu52 liblldb-3.6 liblttng-ust0 libssl1.0.0 libunwind8 libuuid1 zlib1g clang-3.5
-            } elseif ($LinuxInfo.ID -eq 'centos' -and $LinuxInfo.Version -eq '"7"') {
                 sudo apt-get install -y -q make gcc cmake glibc libgcc libstdc++ libcurl krb5-libs libicu lldb openssl-libs libunwind libuuid zlib clang
+            } elseif ($LinuxInfo.ID -match 'centos' -and $LinuxInfo.Version -match '7') {
             } else {
                 Write-Warning "This script only supports Ubuntu 14.04 and CentOS 7, you must install dependencies manually!"
             }

--- a/build.psm1
+++ b/build.psm1
@@ -400,7 +400,7 @@ function Start-PSBootstrap {
                 # Install ours and .NET's dependencies
                 sudo apt-get install -y -qq curl make g++ cmake libc6 libgcc1 libstdc++6 libcurl3 libgssapi-krb5-2 libicu52 liblldb-3.6 liblttng-ust0 libssl1.0.0 libunwind8 libuuid1 zlib1g clang-3.5
             } elseif ($LinuxInfo.ID -match 'centos' -and $LinuxInfo.VERSION_ID -match '7') {
-                sudo yum install -y -q curl make gcc cmake glibc libgcc libstdc++ libcurl krb5-libs libicu lldb openssl-libs libunwind libuuid zlib clang
+                sudo yum install -y -q curl make gcc-c++ cmake glibc libgcc libstdc++ libcurl krb5-libs libicu lldb openssl-libs libunwind libuuid zlib clang
             } else {
                 Write-Warning "This script only supports Ubuntu 14.04 and CentOS 7, you must install dependencies manually!"
             }

--- a/build.psm1
+++ b/build.psm1
@@ -396,13 +396,11 @@ function Start-PSBootstrap {
     try {
         # Install dependencies for Linux and OS X
         if ($IsLinux) {
-            precheck 'curl' "Bootstrap dependency 'curl' not found in PATH, please install!" > $null
             if ($LinuxInfo.ID -match 'ubuntu' -and $LinuxInfo.Version -match '14.04') {
                 # Install ours and .NET's dependencies
-                sudo apt-get update -qq
-                sudo apt-get install -y -qq make g++ cmake libc6 libgcc1 libstdc++6 libcurl3 libgssapi-krb5-2 libicu52 liblldb-3.6 liblttng-ust0 libssl1.0.0 libunwind8 libuuid1 zlib1g clang-3.5
-                sudo apt-get install -y -q make gcc cmake glibc libgcc libstdc++ libcurl krb5-libs libicu lldb openssl-libs libunwind libuuid zlib clang
+                sudo apt-get install -y -qq curl make g++ cmake libc6 libgcc1 libstdc++6 libcurl3 libgssapi-krb5-2 libicu52 liblldb-3.6 liblttng-ust0 libssl1.0.0 libunwind8 libuuid1 zlib1g clang-3.5
             } elseif ($LinuxInfo.ID -match 'centos' -and $LinuxInfo.Version -match '7') {
+                sudo apt-get install -y -q curl make gcc cmake glibc libgcc libstdc++ libcurl krb5-libs libicu lldb openssl-libs libunwind libuuid zlib clang
             } else {
                 Write-Warning "This script only supports Ubuntu 14.04 and CentOS 7, you must install dependencies manually!"
             }
@@ -410,7 +408,7 @@ function Start-PSBootstrap {
             precheck 'brew' "Bootstrap dependency 'brew' not found, must install Homebrew! See http://brew.sh/"
 
             # Install ours and .NET's dependencies
-            brew install cmake wget openssl
+            brew install curl cmake openssl
             brew link --force openssl
         }
 

--- a/src/libpsl-native/CMakeLists.txt
+++ b/src/libpsl-native/CMakeLists.txt
@@ -1,7 +1,8 @@
-cmake_minimum_required(VERSION 2.8.4)
+cmake_minimum_required(VERSION 2.8.11)
 project(PSL-NATIVE)
 
-add_compile_options(-std=c++11 -Wall -Werror)
+# Can't use add_compile_options with 2.8.11
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Werror")
 set(LIBRARY_OUTPUT_PATH "${PROJECT_SOURCE_DIR}/../powershell")
 
 # test in BUILD_DIR


### PR DESCRIPTION
Supports building PowerShell on CentOS 7 natively (rather than just publishing for the target runtime from an Ubuntu system). Note that this is a best-effort basis, so the docs are not updated, and still recommend Ubuntu 14.04 (same as .NET Core).

Also resolves #1096.
