### PR TITLE
Remove src/windows-build submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "src/windows-build"]
-	path = src/windows-build
-	url = https://github.com/PowerShell/psl-windows-build.git
 [submodule "src/Modules/Pester"]
 	path = src/Modules/Pester
 	url = https://github.com/PowerShell/psl-pester.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ git:
   submodules: false
 before_install:
   - git config --global url.git@github.com:.insteadOf https://github.com/
-  - git submodule update --init -- src/windows-build src/Modules/Pester src/libpsl-native/test/googletest
+  - git submodule update --init -- src/Modules/Pester src/libpsl-native/test/googletest
   - ./tools/download.sh
 script:
   - ulimit -n 4096; powershell -c "Import-Module ./build.psm1; Start-PSBootstrap; Start-PSBuild; Start-PSxUnit; Start-PSPester"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,7 +18,7 @@ install:
   - ps: $fileContent += "`n-----END RSA PRIVATE KEY-----`n"
   - ps: Set-Content c:\users\appveyor\.ssh\id_rsa $fileContent
   - git config --global url.git@github.com:.insteadOf https://github.com/
-  - git submodule update --init -- src/windows-build src/Modules/Pester
+  - git submodule update --init -- src/Modules/Pester
   - ps: Import-Module .\build.psm1; Start-PSBootstrap
 
 build_script:

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -46,13 +46,6 @@ more information.
 I just pulled master, why did my build fail?
 ============================================
 
-There are two likely reasons:
-
-If the `src/windows-build` submodule was changed, you need to manually run `git
-submodule update` to check your sources out to the correct commits. Pulling does
-not automatically do this. When a submodule is out-of-date, you will likely be
-missing required build files.
-
 If package dependencies were changed in any `project.json`, you need to manually
 run `dotnet restore` to update your local dependency graphs. `Start-PSBuild
 -Restore` can automatically do this.
@@ -105,7 +98,6 @@ If they're initialized, it will look like this:
 ```
  f23641488f8d7bf8630ca3496e61562aa3a64009 src/Modules/Pester (f23641488)
  c99458533a9b4c743ed51537e25989ea55944908 src/libpsl-native/test/googletest (release-1.7.0)
- e6bf85694ae8352d77175c4c7d304946e018808c src/windows-build (monad/cc6afbeb-3/31)
 ```
 
 If they're not, there will be minuses in front (and the folders will
@@ -114,7 +106,6 @@ be empty):
 ```
 -f23641488f8d7bf8630ca3496e61562aa3a64009 src/Modules/Pester (f23641488)
 -c99458533a9b4c743ed51537e25989ea55944908 src/libpsl-native/test/googletest (release-1.7.0)
--e6bf85694ae8352d77175c4c7d304946e018808c src/windows-build (monad/cc6afbeb-3/31)
 ```
 
 Please note that the commit hashes for the submodules have likely changed since
@@ -148,13 +139,6 @@ This means you're not signed into AppVeyor. Follow these steps carefully:
 6. Go back to the original link you followed to AppVeyor and click it again
 
 You should now be signed into AppVeyor and able to access our builds.
-
-Why did `dotnet restore` say `error: Failed to retrieve information from remote source './src/windows-build/nuget-feed'`?
-=========================================================================================================================
-
-Your `src/windows-build` submodule is probably empty. See "Why is my submodule
-empty?" above. This submodule contains a local NuGet feed with packages
-necessary for the build. The quick fix is `git submodule update --init`.
 
 Why did my Travis CI build fail with `GITHUB_TOKEN variable is undefined, please provide token`?
 ================================================================================================

--- a/docs/git/committing.md
+++ b/docs/git/committing.md
@@ -1,10 +1,8 @@
 Commit Dance
 ============
 
-**Update:** commit dance became much simpler after
-[removing psl-monad submodule](https://github.com/PowerShell/PowerShell/issues/656).
-Thus, this really only applies to `src/windows-build` and
-`src/Modules/Pester`. If you need to touch their content, this doc
+This process only applies to `src/Modules/Pester`. 
+If you need to touch their content, this doc
 provides the overview of the process. Remember that it's written
 against `src/monad` submodule, which doesn't exist anymore.
 

--- a/docs/git/submodules.md
+++ b/docs/git/submodules.md
@@ -10,16 +10,6 @@ submodules currently in this project are:
 - `src/libpsl-native/test/googletest`: The GoogleTest framework for
   Linux native code
 
-- `src/windows-build`: Collection of pre-generated artifacts required
-  until .NET CLI deprecates them (C# resource bindings) and NuGet
-  packages that will soon be moved to a MyGet feed
-
-- `src/omi`: The Open Management Infrastructure project for PSRP on
-  Linux (to be removed)
-
-- `src/omi-provider`: The OMI provider for PSRP on Linux (to be
-  removed)
-
 [submodules]: https://www.git-scm.com/book/en/v2/Git-Tools-Submodules
 
 Rebase and Fast-Forward Merge Pull Requests in Submodules

--- a/nuget.config
+++ b/nuget.config
@@ -12,6 +12,12 @@
     <add key="CI Builds (xUnit)" value="https://www.myget.org/F/coreclr-xunit/api/v3/index.json" />
     <add key="CI Builds (aspnetcidev)" value="http://myget.org/F/aspnetcidev/api/v3/index.json" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-    <add key="local" value="./src/windows-build/nuget-feed" />
+    <add key="appveyor-psl-windows-build" value="https://ci.appveyor.com/nuget/psl-windows-build-buunqeauqyp5" />
   </packageSources>
+  <packageSourceCredentials>
+    <appveyor-psl-windows-build>
+      <add key="Username" value="xvors.x@gmail.com" />
+      <add key="ClearTextPassword" value="1a017c69bc74332896cabed5ef0c470777bc31c1" />
+    </appveyor-psl-windows-build>
+  </packageSourceCredentials>
 </configuration>


### PR DESCRIPTION
We only use the submodule for nuget feed.
This change uses appveyor-hosted nuget feed from the same repo, instead of a submodule version.
If you need to add a new package, just push it in https://github.com/PowerShell/psl-windows-build/tree/master/nuget-feed

When this change is merged, issue to change password on CI account should be opened, because currently we expose a clear-text password (secure password doesn't work on Linux for dotnet cli at the moment).
