### PR TITLE
Bump the version of dependent WsMan.Mgmt nuget package to 1.0.1-rc1

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/project.json
+++ b/src/Microsoft.PowerShell.Commands.Management/project.json
@@ -57,7 +57,7 @@
                 "System.Web.Services": ""
             },
             "dependencies": {
-                "Microsoft.WSMan.Management": "1.0.0-*"
+                "Microsoft.WSMan.Management": "1.0.1-*"
             },
             "buildOptions": {
                 "compile": {


### PR DESCRIPTION
This is part of #1118 
The version of WsMan.Management nupkg was bumped to 1.0.1-rc1 in order to let appveyor pick the new package to the feed. So I need to update the project.json of Microsoft.PowerShell.Commands.Management to depend on the 1.0.1-\* version of WsMan.Management nupkg.
cc @vors It turns out the 1.0.0 version WsMan.mgmt.nupkg is still kept in the feed, so I have to update this project.json file to make it depend on the new nupkg.
