### PR TITLE
Add *.Activities dlls in Full build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 0.4.0.{build}
+version: 0.5.0.{build}
 
 nuget:
   project_feed: true

--- a/build.psm1
+++ b/build.psm1
@@ -1045,13 +1045,13 @@ $Script:XamlProj = @"
 
     <ItemGroup>
 {2}
-        <Reference Include="${env:SystemRoot}\Microsoft.Net\Framework\v4.0.30319\WPF\WindowsBase.dll">
+        <Reference Include="WindowsBase.dll">
             <Private>False</Private>
         </Reference>
-        <Reference Include="${env:SystemRoot}\Microsoft.Net\Framework\v4.0.30319\WPF\PresentationCore.dll">
+        <Reference Include="PresentationCore.dll">
             <Private>False</Private>
         </Reference>
-        <Reference Include="${env:SystemRoot}\Microsoft.Net\Framework\v4.0.30319\WPF\PresentationFramework.dll">
+        <Reference Include="PresentationFramework.dll">
             <Private>False</Private>
         </Reference>
     </ItemGroup>

--- a/build.psm1
+++ b/build.psm1
@@ -1090,7 +1090,7 @@ function script:ConvertFrom-Xaml {
     $XamlProjPath = Join-Path -Path $OutputDir -ChildPath xaml.proj
     Set-Content -Path $XamlProjPath -Value $XamlProjContent -Encoding Ascii -NoNewline -Force
 
-    msbuild $XamlProjPath > $null
+    msbuild $XamlProjPath | Write-Verbose
 
     if ($LASTEXITCODE -ne 0)
     {

--- a/build.psm1
+++ b/build.psm1
@@ -1110,27 +1110,23 @@ function script:ConvertFrom-Xaml {
 
 
 function script:Use-MSBuild {
-    # we should ALWAYS use msbuild from Microsoft.Net\Framework folder\v4.0.30319
-    # other versions may have differences in their behavior
-    # (i.e. 14.0.25123.0 has a difference in behavior about generating .cs files from XAML)
-    $canonicalMsBuildLocation = "${env:SystemRoot}\Microsoft.Net\Framework\v4.0.30319\msbuild"
+    # TODO: we probably should require a particular version of msbuild, if we are taking this dependency
+    # msbuild v14 and msbuild v4 behaviors are different for XAML generation
+    $frameworkMsBuildLocation = "${env:SystemRoot}\Microsoft.Net\Framework\v4.0.30319\msbuild"
 
-    $msbuild = get-command msbuild -Type Alias -ErrorAction SilentlyContinue
+    $msbuild = get-command msbuild -ErrorAction SilentlyContinue
     if ($msbuild)
     {
-        if ($msbuild.Definition -eq $canonicalMsBuildLocation)
-        {
-            # all good, nothing to do
-            return
-        }
+        # all good, nothing to do
+        return
     }
 
-    if (-not (Test-Path $canonicalMsBuildLocation))
+    if (-not (Test-Path $frameworkMsBuildLocation))
     {
-        throw "msbuild not found in '$canonicalMsBuildLocation'. Install Visual Studio 2015."
+        throw "msbuild not found in '$frameworkMsBuildLocation'. Install Visual Studio 2015."
     }
 
-    Set-Alias msbuild $canonicalMsBuildLocation -Scope Script
+    Set-Alias msbuild $frameworkMsBuildLocation -Scope Script
 }
 
 

--- a/src/Microsoft.PowerShell.Activities/Xamls/InlineScriptDesigner.xaml
+++ b/src/Microsoft.PowerShell.Activities/Xamls/InlineScriptDesigner.xaml
@@ -6,7 +6,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"   
     xmlns:s="clr-namespace:System;assembly=mscorlib"   
     xmlns:conv="clr-namespace:System.Activities.Presentation.Converters;assembly=System.Activities.Presentation"   
-    xmlns:sap="clr-namespace:System.Activities.Presentation;assembly=System.Activities.Presentation"   
+    xmlns:sap="clr-namespace:System.Activities.Presentation"   
     xmlns:sapv="clr-namespace:System.Activities.Presentation.View;assembly=System.Activities.Presentation"
     mc:Ignorable="d" 
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/src/Microsoft.PowerShell.Activities/Xamls/PipelineDesigner.xaml
+++ b/src/Microsoft.PowerShell.Activities/Xamls/PipelineDesigner.xaml
@@ -1,7 +1,7 @@
 ﻿<swd:ActivityDesigner x:Class="Microsoft.PowerShell.Activities.PipelineDesigner"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:swd="clr-namespace:System.Activities.Presentation;assembly=System.Activities.Presentation">
+    xmlns:swd="clr-namespace:System.Activities.Presentation">
 
     <Grid>
         <Grid.RowDefinitions>

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterface.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterface.cs
@@ -238,7 +238,7 @@ namespace Microsoft.PowerShell
                 result = ReadLineSafe(true, printToken);
             }
             SecureString secureResult = result as SecureString;
-            Diagnostics.Assert(secureResult != null, "ReadLineSafe did not return a SecureString");
+            System.Management.Automation.Diagnostics.Assert(secureResult != null, "ReadLineSafe did not return a SecureString");
 
             return secureResult;
         }

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterfacePrompt.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterfacePrompt.cs
@@ -400,7 +400,7 @@ namespace Microsoft.PowerShell
                 {
                     object userInput = ReadLineSafe(false, null);
                     string userInputString = userInput as string;
-                    Diagnostics.Assert(userInputString != null, "ReadLineSafe did not return a string");
+                    System.Management.Automation.Diagnostics.Assert(userInputString != null, "ReadLineSafe did not return a string");
                     rawInputString = userInputString;
                 }
                 if (rawInputString == null)

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterfacePromptForChoice.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterfacePromptForChoice.cs
@@ -315,7 +315,7 @@ namespace Microsoft.PowerShell
             Dictionary<int, bool> defaultChoiceKeys, 
             bool shouldEmulateForMultipleChoiceSelection)
         {
-            Diagnostics.Assert(defaultChoiceKeys != null, "defaultChoiceKeys cannot be null.");
+            System.Management.Automation.Diagnostics.Assert(defaultChoiceKeys != null, "defaultChoiceKeys cannot be null.");
 
             ConsoleColor fg = RawUI.ForegroundColor;
             ConsoleColor bg = RawUI.BackgroundColor;

--- a/src/Microsoft.PowerShell.ConsoleHost/project.json
+++ b/src/Microsoft.PowerShell.ConsoleHost/project.json
@@ -53,7 +53,14 @@
             "dependencies": {
                 "Microsoft.PowerShell.ScheduledJob": "1.0.0-*",
                 "Microsoft.PowerShell.Workflow.ServiceCore": "1.0.0-*",
-                "Microsoft.PowerShell.GraphicalHost": "1.0.0-*"
+                "Microsoft.PowerShell.GraphicalHost": "1.0.0-*",
+                "Microsoft.PowerShell.Activities": "1.0.0-*",
+                "Microsoft.PowerShell.Core.Activities": "1.0.0-*",
+                "Microsoft.PowerShell.Diagnostics.Activities": "1.0.0-*",
+                "Microsoft.PowerShell.Management.Activities": "1.0.0-*",
+                "Microsoft.PowerShell.Security.Activities": "1.0.0-*",
+                "Microsoft.PowerShell.Utility.Activities": "1.0.0-*",
+                "Microsoft.WSMan.Management.Activities": "1.0.0-*"
             }
         }
     }

--- a/src/Microsoft.PowerShell.ConsoleHost/project.json
+++ b/src/Microsoft.PowerShell.ConsoleHost/project.json
@@ -25,6 +25,9 @@
             "../Modules",
             "powershell.exe",
             "../../powershell.version"
+        ],
+        "exclude": [
+            "../Modules/Pester/.git"
         ]
     },
 

--- a/src/powershell-native/CMakeLists.txt
+++ b/src/powershell-native/CMakeLists.txt
@@ -30,8 +30,8 @@ add_executable(powershell WIN32
 add_library(pwrshplugin
     nativemsh/pwrshplugin/entrypoints.cpp
     nativemsh/pwrshplugin/pwrshclrhost.cpp
-    nativemsh/pwrshplugin/pwrshpluginerrorcodes.mc
-    nativemsh/pwrshplugin/pwrshpluginerrorcodes.rc
+    #nativemsh/pwrshplugin/pwrshpluginerrorcodes.mc
+    #nativemsh/pwrshplugin/pwrshpluginerrorcodes.rc
     nativemsh/pwrshplugin/pwrshplugin.def)
 
 

--- a/src/powershell/project.json
+++ b/src/powershell/project.json
@@ -25,6 +25,9 @@
             "*.so",
             "*.dylib",
             "../../powershell.version"
+        ],
+        "exclude": [
+            "../Modules/Pester/.git"
         ]
     },
 


### PR DESCRIPTION
Part of #1118
- Add activities as a dependency to ConsoleHost
- This creates a minor ambiguity in the type resolution in ConsoleHost.
  We are specifying a namespace name to workaround it.
