### PR TITLE
Add official Microsoft Open Source Code of Conduct

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,3 +82,16 @@ Legal and Licensing
 `TODO` Missing license details
 
 `TODO` Missing link to contributor agreement
+
+Code of Conduct
+---------------
+
+This project has adopted the
+[Microsoft Open Source Code of Conduct][conduct-code]. For more information see
+the [Code of Conduct FAQ][conduct-faq] or contact
+[opencode@microsoft.com][conduct-email] with any additional questions or
+comments.
+
+[conduct-code]: http://opensource.microsoft.com/codeofconduct/
+[conduct-FAQ]: http://opensource.microsoft.com/codeofconduct/faq/
+[conduct-email]: mailto:opencode@microsoft.com


### PR DESCRIPTION
Resolves #1104.

This was mandated by the Open Source Programs Office and Open Source Executive Council, and it's a good code of conduct, which we were missing.

/cc @jianyunt @DonGill @joeyaiello 
