### PR TITLE
Revert Unix specific Split-Path -Qualifier code

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/ParsePathCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/ParsePathCommand.cs
@@ -553,9 +553,12 @@ namespace Microsoft.PowerShell.Commands
 
                 if (SessionState.Path.IsPSAbsolute(path, out driveName))
                 {
-                    // Remove the drive name and colon
-
-                    result = path.Substring(driveName.Length + 1);
+                    var driveNameLength = driveName.Length;
+                    if (path.Length > (driveNameLength + 1) && path[driveNameLength] == ':')
+                    {
+                        // Remove the drive name and colon
+                        result = path.Substring(driveNameLength + 1);
+                    }
                 }
             }
 

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/ParsePathCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/ParsePathCommand.cs
@@ -272,7 +272,6 @@ namespace Microsoft.PowerShell.Commands
 
         #region Command code
 
-        private static string volumeSeparatorCharAsString = System.IO.Path.VolumeSeparatorChar.ToString();
         /// <summary>
         /// Parses the specified path and returns the portion determined by the 
         /// boolean parameters.
@@ -396,7 +395,7 @@ namespace Microsoft.PowerShell.Commands
                         continue;
 
                     case qualifierSet :
-                        int separatorIndex = pathsToParse[index].IndexOf(volumeSeparatorCharAsString, StringComparison.CurrentCulture);
+                        int separatorIndex = pathsToParse[index].IndexOf(":", StringComparison.CurrentCulture);
 
                         if (separatorIndex < 0)
                         {
@@ -538,12 +537,7 @@ namespace Microsoft.PowerShell.Commands
 
             string result = path;
 
-            // Platform notes: On single root fileystems, there is no such thing
-            // as a drive qualifier, and so this is a noop
-            if (Platform.HasSingleRootFilesystem())
-            {
-            }
-            else if (SessionState.Path.IsProviderQualified(path))
+            if (SessionState.Path.IsProviderQualified(path))
             {
                 int index = path.IndexOf("::", StringComparison.CurrentCulture);
 
@@ -559,8 +553,8 @@ namespace Microsoft.PowerShell.Commands
 
                 if (SessionState.Path.IsPSAbsolute(path, out driveName))
                 {
-
                     // Remove the drive name and colon
+
                     result = path.Substring(driveName.Length + 1);
                 }
             }


### PR DESCRIPTION
The -Qualifier code for Split-Path made some incorrect assumptions:
- That a path only referred to the file system
- That drives cannot be used on Unix systems

These assumptions were both wrong, so I've reverted the change so we
do not have any Unix specific code in Split-Path now.

Fixes #1176
