### PR TITLE
Re-enable checking of assemblies with strong names

### DIFF
--- a/src/System.Management.Automation/CoreCLR/CorePsPlatform.cs
+++ b/src/System.Management.Automation/CoreCLR/CorePsPlatform.cs
@@ -208,11 +208,6 @@ namespace System.Management.Automation
             return IsWindows;
         }
 
-        internal static bool UsesCodeSignedAssemblies()
-        {
-            return !Platform.IsCore;
-        }
-
         // This is mainly with respect to the auto-mounting of
         // disconnected network drives on Windows
         internal static bool HasDriveAutoMounting()

--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -1263,25 +1263,8 @@ namespace System.Management.Automation
             public static extern bool FindClose(IntPtr hFindFile);
         }
 
-        // Porting note: PublicKeyToken must be null if code signed
-        // assemblies aren't supported
-        private static string strongNamePublicKeyToken
-        {
-            get
-            {
-                if (Platform.UsesCodeSignedAssemblies())
-                {
-                    return "31bf3856ad364e35";
-                }
-                else
-                {
-                    return "null";
-                }
-            }
-        }
-
         internal static readonly string PowerShellAssemblyStrongNameFormat =
-            "{0}, Version=3.0.0.0, Culture=neutral, PublicKeyToken={1}";
+            "{0}, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35";
 
         internal static readonly HashSet<string> PowerShellAssemblies =
             new HashSet<string>(StringComparer.OrdinalIgnoreCase)
@@ -1338,8 +1321,7 @@ namespace System.Management.Automation
 
                 if ((fixedName != null) && PowerShellAssemblies.Contains(fixedName))
                 {
-                    return string.Format(CultureInfo.InvariantCulture, PowerShellAssemblyStrongNameFormat,
-                                         fixedName, strongNamePublicKeyToken);
+                    return string.Format(CultureInfo.InvariantCulture, PowerShellAssemblyStrongNameFormat, fixedName);
                 }
             }
 

--- a/src/System.Management.Automation/singleshell/config/MshSnapinInfo.cs
+++ b/src/System.Management.Automation/singleshell/config/MshSnapinInfo.cs
@@ -1018,21 +1018,9 @@ namespace System.Management.Automation
             byte[] publicTokens = currentAssembly.GetName().GetPublicKeyToken();
             if (publicTokens.Length == 0)
             {
-                if (Platform.UsesCodeSignedAssemblies())
-                {
-                    throw PSTraceSource.NewArgumentException("PublicKeyToken", MshSnapinInfo.PublicKeyTokenAccessFailed);
-                }
-                else
-                {
-                    // Platform note: set this to null when code signed assemblies are
-                    // unsupported (rather than blank)
-                    publicKeyToken = "null";
-                }
+                throw PSTraceSource.NewArgumentException("PublicKeyToken", MshSnapinInfo.PublicKeyTokenAccessFailed);
             }
-            else
-            {
-                publicKeyToken = ConvertByteArrayToString(publicTokens);
-            }
+            publicKeyToken = ConvertByteArrayToString(publicTokens);
             // save some cpu cycles by hardcoding the culture to neutral
             // assembly should never be targeted to a particular culture
             culture = "neutral";
@@ -1082,12 +1070,6 @@ namespace System.Management.Automation
                         {"Certificate.format.ps1xml","DotNetTypes.format.ps1xml","FileSystem.format.ps1xml",
                          "Help.format.ps1xml","HelpV3.format.ps1xml","PowerShellCore.format.ps1xml","PowerShellTrace.format.ps1xml",
                          "Registry.format.ps1xml"});
-
-            // If code signing is not supported, the token must be set to "null"
-            if (!Platform.UsesCodeSignedAssemblies())
-            {
-                publicKeyToken = "null";
-            }
 
             string strongName = string.Format(CultureInfo.InvariantCulture, "{0}, Version={1}, Culture={2}, PublicKeyToken={3}, ProcessorArchitecture={4}",
                 CoreSnapin.AssemblyName, assemblyVersion, culture, publicKeyToken, architecture);

--- a/test/csharp/test_CorePsPlatform.cs
+++ b/test/csharp/test_CorePsPlatform.cs
@@ -28,12 +28,6 @@ namespace PSTests
         }
 
         [Fact]
-        public static void TestUsesCodeSignedAssemblies()
-        {
-            Assert.False(Platform.UsesCodeSignedAssemblies());
-        }
-
-        [Fact]
         public static void TestHasDriveAutoMounting()
         {
             Assert.False(Platform.HasDriveAutoMounting());

--- a/test/csharp/test_MshSnapinInfo.cs
+++ b/test/csharp/test_MshSnapinInfo.cs
@@ -22,7 +22,7 @@ namespace PSTests
         public void TestReadCoreEngineSnapIn()
         {
             PSSnapInInfo pSSnapInInfo = PSSnapInReader.ReadCoreEngineSnapIn();
-            Assert.Contains("PublicKeyToken=null", pSSnapInInfo.AssemblyName);
+            Assert.Contains("PublicKeyToken=31bf3856ad364e35", pSSnapInInfo.AssemblyName);
         }
     }
 }


### PR DESCRIPTION
This resolves #459.
