### PR TITLE
Added ability to choose install location when using MSI, fixed issue #1135

### DIFF
--- a/assets/Product.wxs
+++ b/assets/Product.wxs
@@ -36,11 +36,8 @@
     <!-- Embed Cabinet Files in Product-->
     <MediaTemplate EmbedCab="yes" />
     
-    <!-- In Your Wix Setup Project, Add A Reference To WixUIExtension.dll -->
-    <!-- This is a minimal User Interface.  In fact, it only displays a license -->
-    <!-- acceptance dialog.  It doesn’t do anything else except provide -->
-    <!-- basic status during installation. -->
-    <UIRef Id="WixUI_Minimal" />
+    <!-- In Your Wix Setup Project, Add A Reference To WixUIExtension.dll -->    
+    <UIRef Id="WixUI_InstallDir" />
 
     <!-- Features are mandatory.  Need At Least One. -->
     <Feature Id="ProductFeature" Title="PowerShell" Level="1">
@@ -49,8 +46,8 @@
       <ComponentRef Id="ApplicationProgramsMenuShortcut"/>
     </Feature>
 
-    <!--We need to show EULA, but not provide option to customize download location-->    
-    <Property Id="WixUI_Minimal" Value="$(var.ProductVersionWithName)" />
+    <!--We need to show EULA, and provide option to customize download location-->        
+    <Property Id="WIXUI_INSTALLDIR" Value="INSTALLFOLDER" />
 
     <Directory Id="TARGETDIR" Name="SourceDir">
       <Directory Id="ProgramFiles64Folder">


### PR DESCRIPTION
1) Now you can customize the install location when running the MSI interactively or using msiexec.

For silent mode use:
msiexec.exe /i "PowerShell_0.5.2.msi" INSTALLFOLDER="c:\MyApps" /q

2) Fixed issue #1135 
[Package creation fails when New-MSIPackage / New-APPXPackage is supplied with a version that looks like major.minor.build]

-Raghu
