### PR TITLE
WIP/RFC path normalization

### DIFF
--- a/src/Microsoft.PowerShell.Security/security/CertificateProvider.cs
+++ b/src/Microsoft.PowerShell.Security/security/CertificateProvider.cs
@@ -829,7 +829,6 @@ namespace Microsoft.PowerShell.Commands
                                 string path,
                                 bool recurse)
         {            
-            path = NormalizePath(path);
             bool isContainer = false;
             bool fDeleteKey = false;
 
@@ -944,10 +943,6 @@ namespace Microsoft.PowerShell.Commands
                                 string path,
                                 string destination)
         {    
-            //normalize path
-            path = NormalizePath(path);
-            destination = NormalizePath(destination);
-
             //get elements from the path
             string[] pathElements = GetPathElements(path);
             string[] destElements = GetPathElements(destination); 
@@ -1095,8 +1090,6 @@ namespace Microsoft.PowerShell.Commands
                 AttemptToImportPkiModule();
             }
 
-            path = NormalizePath(path);
-
             //get the elements from the path
             string[] pathElements = GetPathElements(path);
 
@@ -1207,8 +1200,6 @@ namespace Microsoft.PowerShell.Commands
 
             Utils.CheckArgForNull(path, "path");
 
-            path = NormalizePath(path);
-
             if (path.Length == 0)
             {
                 return true;
@@ -1259,7 +1250,6 @@ namespace Microsoft.PowerShell.Commands
         /// </returns>
         protected override bool IsValidPath(string path)
         {
-            path = NormalizePath(path);
             path = EnsureDriveIsRooted(path);
 
             bool isCertPath = CertPathRegex.Match(path).Success;
@@ -1323,7 +1313,6 @@ namespace Microsoft.PowerShell.Commands
             bool isContainer = false;
             object item = null;
 
-            path = NormalizePath(path); 
 
             if (path.Length == 0)
             {
@@ -1389,8 +1378,6 @@ namespace Microsoft.PowerShell.Commands
         protected override void GetItem(string path) 
         { 
             bool isContainer = false;
-            
-            path = NormalizePath(path);
             object item = GetItemAtPath(path, false, out isContainer);
             CertificateFilterInfo filter = GetFilter();
 
@@ -1555,9 +1542,6 @@ namespace Microsoft.PowerShell.Commands
                 throw PSTraceSource.NewArgumentException("path");
             }
 
-            // Normalize the path
-            path = path.Replace(StringLiterals.AlternatePathSeparator, StringLiterals.DefaultPathSeparator);
-
             // Trim trailing back slashes
             path = path.TrimEnd(StringLiterals.DefaultPathSeparator);
             string result = null;
@@ -1587,7 +1571,6 @@ namespace Microsoft.PowerShell.Commands
         /// </param>
         protected override void InvokeDefaultAction(string path)
         {
-            path = NormalizePath(path);
             string action = CertificateProviderStrings.Action_Invoke;
             string certmgr = "certmgr.msc";
             string certPath = System.IO.Path.Combine(
@@ -1734,25 +1717,6 @@ namespace Microsoft.PowerShell.Commands
             ErrorRecord er = CreateErrorRecord(path, itemType);
        
             ThrowTerminatingError(er);
-        }
-
-        static private string NormalizePath(string path)
-        {
-            if (path.Length > 0)
-            {
-                char lastChar = path[path.Length-1];
-
-                if ((lastChar == '/') || (lastChar == '\\'))
-                {
-                    path = path.Substring(0, path.Length-1);
-                }
-
-                string[] elts = GetPathElements(path);
-
-                path = String.Join("\\", elts);
-            }
-
-            return path;
         }
 
         static private string[] GetPathElements(string path)
@@ -2388,8 +2352,6 @@ namespace Microsoft.PowerShell.Commands
         /// 
         protected override void GetChildItems(string path, bool recurse) 
         { 
-            path = NormalizePath(path);
-
             GetChildItemsOrNames(path, recurse, ReturnContainers.ReturnAllContainers, false, GetFilter());
         }
 
@@ -2425,7 +2387,6 @@ namespace Microsoft.PowerShell.Commands
             string path,
             ReturnContainers returnContainers) 
         {
-            path = NormalizePath(path);
             GetChildItemsOrNames(path, false, returnContainers, true, GetFilter());
         } // GetChildNames
 
@@ -2457,7 +2418,6 @@ namespace Microsoft.PowerShell.Commands
         /// 
         protected override bool IsItemContainer(string path) 
         {
-            path = NormalizePath(path);
             Utils.CheckArgForNull(path, "path");
             bool isContainer = false;
 

--- a/src/System.Management.Automation/engine/SessionStateNavigation.cs
+++ b/src/System.Management.Automation/engine/SessionStateNavigation.cs
@@ -1281,7 +1281,7 @@ namespace System.Management.Automation
                     // the default provider is FileSystem
                     provider = PublicSessionState.Internal.GetSingleProvider(Microsoft.PowerShell.Commands.FileSystemProvider.ProviderName);
 
-                    workingPath = path.Replace(StringLiterals.AlternatePathSeparator, StringLiterals.DefaultPathSeparator);
+                    workingPath = LocationGlobber.NormalizePath(path);
                     workingPath = workingPath.TrimEnd(StringLiterals.DefaultPathSeparator);
                 }
                 else

--- a/src/System.Management.Automation/engine/regex.cs
+++ b/src/System.Management.Automation/engine/regex.cs
@@ -374,7 +374,7 @@ namespace System.Management.Automation
 
         private static bool IsWildcardChar(char ch)
         {
-            return (ch == '*') || (ch == '?') || (ch == '[') || (ch == ']');
+            return (ch == '*') || (ch == '?') || (ch == '[') || (ch == ']') || (!Platform.IsWindows && (ch == StringLiterals.AlternatePathSeparator));
         }
 
         /// <summary>

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -87,24 +87,6 @@ namespace Microsoft.PowerShell.Commands
         private Collection<WildcardPattern> excludeMatcher = null;
 
         /// <summary>
-        /// Converts all / in the path to \
-        /// </summary>
-        /// 
-        /// <param name="path">
-        /// The path to normalize.
-        /// </param>
-        /// 
-        /// <returns>
-        /// The path with all / normalized to \
-        /// </returns>
-        /// 
-        private static string NormalizePath(string path)
-        {
-            return path.Replace(StringLiterals.AlternatePathSeparator, StringLiterals.DefaultPathSeparator);
-        } // NormalizePath
-
-
-        /// <summary>
         ///  Checks if the item exist at the specified path. if it exists then creates
         /// appropriate directoryinfo or fileinfo object.
         /// </summary>
@@ -1052,8 +1034,6 @@ namespace Microsoft.PowerShell.Commands
             }
 
 
-            //Normalize the path
-            path = NormalizePath(path);
             path = EnsureDriveIsRooted(path);
 
             // Remove alternate data stream references
@@ -1226,8 +1206,6 @@ namespace Microsoft.PowerShell.Commands
 
         private FileSystemInfo GetFileSystemItem(string path, ref bool isContainer, bool showHidden)
         {
-            path = NormalizePath(path);
-
             FileSystemInfo result = null;
 
             // First see if the path is to a file by
@@ -1322,8 +1300,6 @@ namespace Microsoft.PowerShell.Commands
             {
                 throw PSTraceSource.NewArgumentException("path");
             }
-
-            path = NormalizePath(path);
 
             string action = FileSystemProviderStrings.InvokeItemAction;
 
@@ -1486,8 +1462,6 @@ namespace Microsoft.PowerShell.Commands
             {
                 throw PSTraceSource.NewArgumentException("path");
             }
-
-            path = NormalizePath(path);
 
             // Get the directory object
             bool isDirectory;
@@ -1867,8 +1841,6 @@ namespace Microsoft.PowerShell.Commands
                 throw PSTraceSource.NewArgumentException("path");
             }
 
-            path = NormalizePath(path);
-
             if (String.IsNullOrEmpty(newName))
             
             {
@@ -2028,8 +2000,6 @@ namespace Microsoft.PowerShell.Commands
             {
                 type = "file";
             }
-
-            path = NormalizePath(path);
 
             if (Force)
             {
@@ -2695,8 +2665,6 @@ namespace Microsoft.PowerShell.Commands
 
             try
             {
-                path = NormalizePath(path);
-
                 bool removeStreams = false;
                 FileSystemProviderRemoveItemDynamicParameters dynamicParameters = null;
 
@@ -3203,8 +3171,6 @@ namespace Microsoft.PowerShell.Commands
 
             bool result = false;
 
-            path = NormalizePath(path);
-
             try
             {
                 bool notUsed;
@@ -3319,8 +3285,6 @@ namespace Microsoft.PowerShell.Commands
                 throw PSTraceSource.NewArgumentException("path");
             }
 
-            path = NormalizePath(path);
-
             // First check to see if it is a directory
 
             try
@@ -3433,9 +3397,6 @@ namespace Microsoft.PowerShell.Commands
             {
                 throw PSTraceSource.NewArgumentException("destinationPath");
             }
-
-            path = NormalizePath(path);
-            destinationPath = NormalizePath(destinationPath);
 
             PSSession fromSession = null;
             PSSession toSession = null;
@@ -4916,13 +4877,11 @@ namespace Microsoft.PowerShell.Commands
 
             do // false loop
             {
-                path = NormalizePath(path);
                 path = EnsureDriveIsRooted(path);
 
                 // If it's not fully normalized, normalize it.
                 path = NormalizeRelativePathHelper(path, basePath);
 
-                basePath = NormalizePath(basePath);
                 basePath = EnsureDriveIsRooted(basePath);
 
                 result = path;
@@ -5112,15 +5071,14 @@ namespace Microsoft.PowerShell.Commands
 
             do // false loop
             {
-                // Convert to the correct path separators and trim trailing separators
-                path = path.Replace (StringLiterals.AlternatePathSeparator, StringLiterals.DefaultPathSeparator);
                 string originalPath = path;
 
                 path = path.TrimEnd (StringLiterals.DefaultPathSeparator);
-                basePath = basePath.Replace (StringLiterals.AlternatePathSeparator, StringLiterals.DefaultPathSeparator);
                 basePath = basePath.TrimEnd (StringLiterals.DefaultPathSeparator);
 
+                tracer.WriteLine($"Cleaned {path}");
                 path = RemoveRelativeTokens(path);
+                tracer.WriteLine($"Relative tokens removed from {path}");
 
                 // See if the base and the path are already the same. We resolve this to
                 // ..\Leaf, since resolving "." to "." doesn't offer much information.
@@ -5521,10 +5479,6 @@ namespace Microsoft.PowerShell.Commands
                 throw PSTraceSource.NewArgumentException("path");
             }
 
-            // Normalize the path
-
-            path = path.Replace(StringLiterals.AlternatePathSeparator, StringLiterals.DefaultPathSeparator);
-
             // Trim trailing back slashes
 
             path = path.TrimEnd(StringLiterals.DefaultPathSeparator);
@@ -5609,8 +5563,6 @@ namespace Microsoft.PowerShell.Commands
                 throw PSTraceSource.NewArgumentException("path");
             }
 
-            path = NormalizePath(path);
-
             return Utils.NativeDirectoryExists(path);
         }
 
@@ -5651,9 +5603,6 @@ namespace Microsoft.PowerShell.Commands
             {
                 throw PSTraceSource.NewArgumentException("destination");
             }
-
-            path = NormalizePath(path);
-            destination = NormalizePath(destination);
 
             // Verify that the target doesn't represent a device name
             if (PathIsReservedDeviceName(destination, "MoveError"))
@@ -6026,8 +5975,6 @@ namespace Microsoft.PowerShell.Commands
                 throw PSTraceSource.NewArgumentException("path");
             }
 
-            path = NormalizePath(path);
-
             PSObject result = null;
 
             try
@@ -6193,8 +6140,6 @@ namespace Microsoft.PowerShell.Commands
             {
                 throw PSTraceSource.NewArgumentNullException("propertyToSet");
             }
-
-            path = NormalizePath(path);
 
             PSObject results = new PSObject();
             PSObject fileSystemInfoShell = null;
@@ -6393,8 +6338,6 @@ namespace Microsoft.PowerShell.Commands
                 throw PSTraceSource.NewArgumentException("path");
             }
 
-            path = NormalizePath(path);
-
             if (propertiesToClear == null ||
                 propertiesToClear.Count == 0)
             {
@@ -6522,8 +6465,6 @@ namespace Microsoft.PowerShell.Commands
             {
                 throw PSTraceSource.NewArgumentException("path");
             }
-
-            path = NormalizePath(path);
 
             // Defaults for the file read operation
             string delimiter = "\n";
@@ -6686,8 +6627,6 @@ namespace Microsoft.PowerShell.Commands
                 throw PSTraceSource.NewArgumentException("path");
             }
 
-            path = NormalizePath(path);
-
             // If this is true, then the content will be read as bytes
             bool usingByteEncoding = false;
             bool streamTypeSpecified = false;
@@ -6802,8 +6741,6 @@ namespace Microsoft.PowerShell.Commands
             {
                 throw PSTraceSource.NewArgumentException("path");
             }
-
-            path = NormalizePath(path);
 
             try
             {

--- a/src/System.Management.Automation/namespaces/FileSystemSecurity.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemSecurity.cs
@@ -48,7 +48,6 @@ namespace Microsoft.PowerShell.Commands
                                           AccessControlSections sections)
         {
             ObjectSecurity sd=null;
-            path = NormalizePath(path);
 
             if (String.IsNullOrEmpty(path))
             {
@@ -115,8 +114,6 @@ namespace Microsoft.PowerShell.Commands
             {
                 throw PSTraceSource.NewArgumentException("path");
             }
-
-            path = NormalizePath(path);
 
             if (securityDescriptor == null)
             {

--- a/src/System.Management.Automation/namespaces/RegistryProvider.cs
+++ b/src/System.Management.Automation/namespaces/RegistryProvider.cs
@@ -184,7 +184,7 @@ namespace Microsoft.PowerShell.Commands
                 // There really aren't any illegal characters or syntactical patterns
                 // to validate, so just ensure that the path starts with one of the hive roots.
 
-                string root = NormalizePath(path);
+                string root = path;
                 root = root.TrimStart (StringLiterals.DefaultPathSeparator);
                 root = root.TrimEnd (StringLiterals.DefaultPathSeparator);
 
@@ -3870,35 +3870,6 @@ namespace Microsoft.PowerShell.Commands
             }
         } // MoveProperty
 
-        /// <summary>
-        /// Converts all / in the path to \
-        /// </summary>
-        /// 
-        /// <param name="path">
-        /// The path to normalize.
-        /// </param>
-        /// 
-        /// <returns>
-        /// The path with all / normalized to \
-        /// </returns>
-        /// 
-        private string NormalizePath(string path)
-        {
-            string result = path;
-
-            if (!String.IsNullOrEmpty(path))
-            {
-                result = path.Replace(StringLiterals.AlternatePathSeparator, StringLiterals.DefaultPathSeparator);
-
-                // Remove relative path tokens
-                if (HasRelativePathTokens(path))
-                {
-                    result = NormalizeRelativePath(result, null);
-                }
-            }
-
-            return result;
-        } // NormalizePath
 
         private bool HasRelativePathTokens(string path)
         {
@@ -4269,11 +4240,8 @@ namespace Microsoft.PowerShell.Commands
             try
             {
 
-                // 1. Normalize path ( for "//","." etc )
                 // 2. Open the root
                 // 3. Create subkey
-
-                path = NormalizePath(path);
 
                 int index = path.IndexOf("\\", StringComparison.Ordinal);
                 if (index == 0)
@@ -4529,7 +4497,7 @@ namespace Microsoft.PowerShell.Commands
                                 !remainingPath.StartsWith(subKey + StringLiterals.DefaultPathSeparator, StringComparison.OrdinalIgnoreCase))
                             {
                                 // Actually normalize the subkey and then check again
-                                normalizedSubkey = NormalizePath(subKey);
+                                normalizedSubkey = subKey;
 
                                 if (!remainingPath.Equals(normalizedSubkey, StringComparison.OrdinalIgnoreCase) &&
                                     !remainingPath.StartsWith(normalizedSubkey + StringLiterals.DefaultPathSeparator, StringComparison.OrdinalIgnoreCase))

--- a/src/System.Management.Automation/namespaces/RegistrySecurity.cs
+++ b/src/System.Management.Automation/namespaces/RegistrySecurity.cs
@@ -63,9 +63,7 @@ namespace Microsoft.PowerShell.Commands
                 throw PSTraceSource.NewArgumentException("sections");
             }
 
-            path = NormalizePath(path);                
-
-            key = GetRegkeyForPathWriteIfError(path, false);               
+            key = GetRegkeyForPathWriteIfError(path, false);
 
             if (key != null)
             {
@@ -108,8 +106,6 @@ namespace Microsoft.PowerShell.Commands
             {
                 throw PSTraceSource.NewArgumentNullException("securityDescriptor");
             }
-
-            path = NormalizePath(path);
 
             ObjectSecurity sd;
             if (TransactionAvailable())

--- a/test/powershell/Hierarchical-Path.Tests.ps1
+++ b/test/powershell/Hierarchical-Path.Tests.ps1
@@ -24,6 +24,14 @@ Describe "Hierarchical paths" {
         Get-Content $testPath | Should Be $data
     }
 
+    It "Should allow escaped `\ on Linux" -Skip:$IsWindows {
+        $name = "a`\weird`\file"
+        $data = "Hello World"
+        Setup -File $name -Content $data
+        $testPath = Join-Path $TestDrive $name
+        $testPath | write-host
+    }
+
     It "should work with backward slashes for each separator" {
         $testPath = "$TestDrive\testFile.txt".Replace("/","\")
         Get-Content $testPath | should be $data


### PR DESCRIPTION
This PR is a request for comment of my work-in-progress to support literal backslashes in filenames (as is allowed on some filesystems, like Linux). Right now, this PR is really no good, but shows what's going on.

This highlights the main problem: PowerShell has no single say in path normalization; instead there are several different "normalization" functions that are all variations on the same theme, and another dozen calls to `path.Replace` to normalize, skipping the functions entirely. This is not unsurprising, given the age and size of the code-base.

However, it presents us with a problem, since supporting literal backslashes in a file-path mandates that the path is both normalized and processed for escape characters once (and only once). We should maybe process globs at the same time, to share code, but on the hand hand, since glob expanding is conditional, perhaps we need to process escape characters only for backslash at first, and later assume the path has been normalized.

No matter what: we need to normalize each path once and only once, accounting for backtick-escaped backslashes.

It would probably be helpful to be passing around path objects (this is PowerShell, isn't it?) instead of strings, but given the public APIs, this would be a bit more work.

/cc @JamesWTruher @lzybkr 
