### PR TITLE
Remove IsReadOnlyCaretVisible property from HelpWindow.xaml

### DIFF
--- a/src/Microsoft.PowerShell.GraphicalHost/xamls/HelpWindow.xaml
+++ b/src/Microsoft.PowerShell.GraphicalHost/xamls/HelpWindow.xaml
@@ -45,7 +45,7 @@
         </Grid>
 
         <ScrollViewer x:Name="Scroll" HorizontalAlignment="Stretch" Grid.Row="1" AutomationProperties.Name="{Binding HelpTitle}">
-            <RichTextBox x:Name="HelpText" FontFamily="Consolas" VerticalScrollBarVisibility="Disabled" BorderThickness="0" IsReadOnly="True" IsReadOnlyCaretVisible="True" AutomationProperties.Name="{Binding HelpTitle}">
+            <RichTextBox x:Name="HelpText" FontFamily="Consolas" VerticalScrollBarVisibility="Disabled" BorderThickness="0" IsReadOnly="True" AutomationProperties.Name="{Binding HelpTitle}">
                 <RichTextBox.LayoutTransform>
                     <ScaleTransform ScaleX="{Binding Path=ZoomLevel}" ScaleY="{Binding Path=ZoomLevel}"/>
                 </RichTextBox.LayoutTransform>


### PR DESCRIPTION
Graphical Host build stop worked on msbuild v4, this change makes it buildable
