### PR TITLE
Exclude Microsoft.WSMan.Management from the list of default snapins

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -156,7 +156,7 @@ function Start-PSBuild {
 
     # handle xaml files
     # Heuristic to resolve xaml on the fresh machine
-    if ($FullCLR -and ($XamlGen -or -not (Test-Path "$PSScriptRoot/src/Microsoft.PowerShell.Activities/gen/*.g.resources")))
+    if ($FullCLR -and ($XamlGen -or -not (Test-Path "$PSScriptRoot/src/Microsoft.PowerShell.Activities/gen/*.g.cs")))
     {
         log "Run XamlGen (generating .g.cs and .resources for .xaml files)"
         Start-XamlGen -MSBuildConfiguration $msbuildConfiguration

--- a/src/System.Management.Automation/singleshell/config/MshSnapinInfo.cs
+++ b/src/System.Management.Automation/singleshell/config/MshSnapinInfo.cs
@@ -1409,7 +1409,7 @@ namespace System.Management.Automation
                                     "SecurityMshSnapInResources,Description","SecurityMshSnapInResources,Vendor")
                             };
 
-#if !LINUX
+#if !PORTABLE
                             if (!Utils.IsWinPEHost())
                             {
                                 defaultMshSnapins.Add(new DefaultPSSnapInInformation("Microsoft.WSMan.Management", "Microsoft.WSMan.Management", null,

--- a/test/powershell/engine/BasicEngine.Tests.ps1
+++ b/test/powershell/engine/BasicEngine.Tests.ps1
@@ -1,0 +1,7 @@
+Describe 'Basic engine APIs' {
+    Context 'powershell::Create' {
+        It 'can create default instance' {
+            [powershell]::Create() | Should Not Be $null
+        }
+    }
+}


### PR DESCRIPTION
- [x] State that it "Resolves #1180".
- [x] Ensure your code is up-to-date with `master`.
- [x] Add tests that fail without your changes.
- [x] Update all relevant [documentation](../docs).
- [x] Assign the PR to the appropriate subsystem [maintainer](https://aka.ms/psowners).
- [x] Check that your commits follow our [contributing guidelines](CONTRIBUTING.md)

Fix #1180
