### PR TITLE
Make DefineTypes aware of / as a path delimiter on non-windows systems

### DIFF
--- a/src/System.Management.Automation/engine/parser/PSType.cs
+++ b/src/System.Management.Automation/engine/parser/PSType.cs
@@ -1124,7 +1124,10 @@ namespace System.Management.Automation.Language
             // Two replaces at the end are for not-allowed characters. They are replaced by similar-looking chars.
             string assemblyName = ClrFacade.FIRST_CHAR_PSASSEMBLY_MARK + (string.IsNullOrWhiteSpace(rootAst.Extent.File)
                                       ? "powershell"
-                                      : rootAst.Extent.File.Replace('\\', (char)0x29f9).Replace(':', (char)0x0589));
+                                      : rootAst.Extent.File
+                                      .Replace('\\', (char)0x29f9)
+                                      .Replace('/', (char)0x29f9)
+                                      .Replace(':', (char)0x0589));
                                       
             var assembly = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName(assemblyName),
                                                                  AssemblyBuilderAccess.RunAndCollect, GetAssemblyAttributeBuilders());


### PR DESCRIPTION
- [x] Resolves #932
- [x] Ensure your code is up-to-date with `master`.
- [ ] Add tests that fail without your changes. - tests would be added as part of @JamesWTruher work about porting existing tests.
- [ ] Update all relevant [documentation](../docs). - N/A
- [x] Assign the PR to the appropriate subsystem [maintainer](https://aka.ms/psowners).
- [x] Check that your commits follow our [contributing guidelines](CONTRIBUTING.md)
