### PR TITLE
Add CoreCLR nuget packages

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -631,7 +631,9 @@ function Publish-NuGetFeed
 'Microsoft.PowerShell.ConsoleHost',
 'Microsoft.PowerShell.PSReadLine',
 'Microsoft.PowerShell.Security',
-'System.Management.Automation'
+'System.Management.Automation',
+'Microsoft.PowerShell.CoreCLR.AssemblyLoadContext',
+'Microsoft.PowerShell.CoreCLR.Eventing'
     ) | % {
         if ($VersionSuffix)
         {


### PR DESCRIPTION
<!--
Before submitting this pull request, please first:

- [ ] State that it "Resolves #xyz".
- [ ] Ensure your code is up-to-date with `master`.
- [ ] Add tests that fail without your changes.
- [ ] Update all relevant [documentation](../docs).
- [ ] Assign the PR to the appropriate subsystem [maintainer](https://aka.ms/psowners).
- [ ] Check that your commits follow our [contributing guidelines](CONTRIBUTING.md)
-->

PSScriptAnalyzer takes dependency on System.Management.Automation.dll. While restoring nuget packages, it requires CoreCLR.AssemblyLoadContext and CoreCLR.Eventing. Hence, they are added to the NuGet feed.
