### PR TITLE
Fix mapping of $env:OS

### DIFF
--- a/src/System.Management.Automation/CoreCLR/CorePsExtensions.cs
+++ b/src/System.Management.Automation/CoreCLR/CorePsExtensions.cs
@@ -833,7 +833,7 @@ namespace System.Management.Automation
                 switch (variable)
                 {
                     case "OS":
-                        return "Linux";
+                        return System.Environment.GetEnvironmentVariable("OSTYPE");
 
                     case "COMPUTERNAME":
                         return System.Environment.GetEnvironmentVariable("HOSTNAME");

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Environment-Variables.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Environment-Variables.Tests.ps1
@@ -34,4 +34,21 @@ Describe "Environment-Variables" {
         $ENV:TESTENVIRONMENTVARIABLE | Should Be $expected
 
     }
+
+    It "Should have the correct OS" {
+        $expected = if ($IsWindows) {
+            "Windows"
+        } elseif ($IsLinux) {
+            "linux-gnu"
+        } elseif ($IsOSX) {
+            "darwin"
+        }
+
+        # Use match because there are version suffixes
+        $env:OS | Should Match $expected
+    }
+
+    It "Should map OS to OSTYPE when not on Windows" -skip:$IsWindows {
+        $env:OS | Should Be $env:OSTYPE
+    }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Environment-Variables.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Environment-Variables.Tests.ps1
@@ -1,43 +1,37 @@
 Describe "Environment-Variables" {
 
     It "Should have environment variables" {
-	Get-Item ENV: | Should Not BeNullOrEmpty
+        Get-Item ENV: | Should Not BeNullOrEmpty
     }
 
     It "Should have a nonempty PATH" {
-	$ENV:PATH | Should Not BeNullOrEmpty
+        $ENV:PATH | Should Not BeNullOrEmpty
     }
 
     It "Should contain /bin in the PATH" {
-	if ($IsWindows)
-	{
-	    $ENV:PATH | Should Match "C:"
-	}
-	else
-	{
-	    $ENV:PATH | Should Match "/bin"
-	}
+        if ($IsWindows) {
+            $ENV:PATH | Should Match "C:"
+        } else {
+            $ENV:PATH | Should Match "/bin"
+        }
     }
 
     It "Should have the correct HOME" {
-	if ($IsWindows)
-	{
-	    $expected = "\Users"
-	    Split-Path $ENV:HOMEPATH -Parent | Should Be $expected
-	}
-	else
-	{
-	    $expected = /bin/bash -c "cd ~ && pwd"
-	    $ENV:HOME | Should Be $expected
-	}
+        if ($IsWindows) {
+            $expected = "\Users"
+            Split-Path $ENV:HOMEPATH -Parent | Should Be $expected
+        } else {
+            $expected = /bin/bash -c "cd ~ && pwd"
+            $ENV:HOME | Should Be $expected
+        }
     }
 
     It "Should be able to set the environment variables" {
-	$expected = "this is a test environment variable"
-	{ $ENV:TESTENVIRONMENTVARIABLE = $expected  } | Should Not Throw
+        $expected = "this is a test environment variable"
+        { $ENV:TESTENVIRONMENTVARIABLE = $expected  } | Should Not Throw
 
-	$ENV:TESTENVIRONMENTVARIABLE | Should Not BeNullOrEmpty
-	$ENV:TESTENVIRONMENTVARIABLE | Should Be $expected
+        $ENV:TESTENVIRONMENTVARIABLE | Should Not BeNullOrEmpty
+        $ENV:TESTENVIRONMENTVARIABLE | Should Be $expected
 
     }
 }


### PR DESCRIPTION
<!--
Before submitting this pull request, please first:

- [ ] State that it "Resolves #xyz".
- [ ] Ensure your code is up-to-date with `master`.
- [ ] Add tests that fail without your changes.
- [ ] Update all relevant [documentation](../docs).
- [ ] Assign the PR to the appropriate subsystem [maintainer](https://aka.ms/psowners).
- [ ] Check that your commits follow our [contributing guidelines](CONTRIBUTING.md)
-->

This should be mapped to `OSTYPE`, not defined to be `LINUX`.
