### PR TITLE
Fixing symlink to use absolute paths instead of relative

### DIFF
--- a/src/libpsl-native/src/followsymlink.cpp
+++ b/src/libpsl-native/src/followsymlink.cpp
@@ -7,7 +7,7 @@
 #include <string>
 #include <iostream>
 #include "followsymlink.h"
-
+#include "issymlink.h"
 //! @brief Followsymlink determines target path of a sym link
 //!
 //! Followsymlink
@@ -48,16 +48,14 @@ char* FollowSymLink(const char* fileName)
     char actualpath[PATH_MAX+1];
     char* realPath = realpath(fileName, actualpath);
     
-
     /* if realPath does not return a value, continue with previous implementation of symlink*/
-    if (realPath == NULL) 
+    if (IsSymLink(fileName)) 
     {
         char buffer[PATH_MAX];
-         ssize_t sz = readlink(fileName, buffer, PATH_MAX);
+        ssize_t sz = readlink(fileName, buffer, PATH_MAX);
     
         if  (sz == -1)
         {
-
             switch(errno)
 
             {

--- a/src/libpsl-native/src/followsymlink.cpp
+++ b/src/libpsl-native/src/followsymlink.cpp
@@ -45,46 +45,99 @@ char* FollowSymLink(const char* fileName)
         return NULL;
     }
 
-    char buffer[PATH_MAX];
-    ssize_t sz = readlink(fileName, buffer, PATH_MAX);
+    char actualpath[PATH_MAX+1];
+    char* realPath = realpath(fileName, actualpath);
+    
 
-    if  (sz == -1)
+    /* if realPath does not return a value, continue with previous implementation of symlink*/
+    if (realPath == NULL) 
     {
-        switch(errno)
+        char buffer[PATH_MAX];
+         ssize_t sz = readlink(fileName, buffer, PATH_MAX);
+    
+        if  (sz == -1)
         {
-        case EACCES:
-            errno = ERROR_ACCESS_DENIED;
-            break;
-        case EFAULT:
-            errno = ERROR_INVALID_ADDRESS;
-            break;
-        case EINVAL:
-            errno = ERROR_INVALID_NAME;
-            break;
-        case EIO:
-            errno = ERROR_GEN_FAILURE;
-            break;
-        case ELOOP:
-            errno = ERROR_STOPPED_ON_SYMLINK;
-            break;
-        case ENAMETOOLONG:
-            errno = ERROR_BAD_PATH_NAME;
-            break;
-        case ENOENT:
-            errno = ERROR_FILE_NOT_FOUND;
-            break;
-        case ENOMEM:
-            errno = ERROR_OUTOFMEMORY;
-            break;
-        case ENOTDIR:
-            errno = ERROR_BAD_PATH_NAME;
-            break;
-        default:
-            errno = ERROR_INVALID_FUNCTION;
-        }
-        return NULL;
-    }
 
-    buffer[sz] = '\0';
-    return strndup(buffer, sz + 1);
+            switch(errno)
+
+            {
+                case EACCES:
+                    errno = ERROR_ACCESS_DENIED;
+                    break;
+                case EFAULT:
+                    errno = ERROR_INVALID_ADDRESS;
+                    break;
+                case EINVAL:
+                    errno = ERROR_INVALID_NAME;
+                    break;
+                case EIO:
+                    errno = ERROR_GEN_FAILURE;
+                    break;
+                case ELOOP:
+                    errno = ERROR_STOPPED_ON_SYMLINK;
+                    break;
+                case ENAMETOOLONG:
+                    errno = ERROR_BAD_PATH_NAME;
+                    break;
+                case ENOENT:
+                    errno = ERROR_FILE_NOT_FOUND;
+                    break;
+                case ENOMEM:
+                    errno = ERROR_OUTOFMEMORY;
+                    break;
+                case ENOTDIR:
+                    errno = ERROR_BAD_PATH_NAME;
+                    break;
+                default:
+                    errno = ERROR_INVALID_FUNCTION;
+                }
+                return NULL;
+        }
+
+        buffer[sz] = '\0';
+        return strndup(buffer, sz + 1);
+    }
+    
+/*else realpath returned a valid resolved path*/
+    else 
+    {
+        if  (sizeof(realPath) == -1)
+        {
+            switch(errno)
+            {
+                case EACCES:
+                    errno = ERROR_ACCESS_DENIED;
+                    break;
+                case EFAULT:
+                    errno = ERROR_INVALID_ADDRESS;
+                    break;
+                case EINVAL:
+                    errno = ERROR_INVALID_NAME;
+                    break;
+                case EIO:
+                    errno = ERROR_GEN_FAILURE;
+                    break;
+                case ELOOP:
+                    errno = ERROR_STOPPED_ON_SYMLINK;
+                    break;
+                case ENAMETOOLONG:
+                    errno = ERROR_BAD_PATH_NAME;
+                    break;
+                case ENOENT:
+                    errno = ERROR_FILE_NOT_FOUND;
+                    break;
+                case ENOMEM:
+                    errno = ERROR_OUTOFMEMORY;
+                    break;
+                case ENOTDIR:
+                    errno = ERROR_BAD_PATH_NAME;
+                    break;
+                default:
+                    errno = ERROR_INVALID_FUNCTION;
+                }
+                return NULL;
+        }
+
+        return strndup(realPath, strlen(realPath) + 1 );
+    }
 }

--- a/src/libpsl-native/src/followsymlink.cpp
+++ b/src/libpsl-native/src/followsymlink.cpp
@@ -49,64 +49,13 @@ char* FollowSymLink(const char* fileName)
     //if lstat in IsSymLink returns -1, path does not exist
     if (IsSymLink(fileName) == -1)
     {
-        printf("-1 %s", fileName);
         return NULL;
     }
 
     /*If the path is a symlink, the function return the absolute filepath if valid. if not valid, return null*/     
-    if (IsSymLink(fileName) == 1)
+    if (IsSymLink(fileName) == 0)
     {
-        printf("readlink %s", fileName);
-        char buffer[PATH_MAX];
-        ssize_t sz = readlink(fileName, buffer, PATH_MAX);
     
-        if  (sz == -1)
-        {
-            switch(errno)
-            {
-                case EACCES:
-                    errno = ERROR_ACCESS_DENIED;
-                    break;
-                case EFAULT:
-                    errno = ERROR_INVALID_ADDRESS;
-                    break;
-                case EINVAL:
-                    errno = ERROR_INVALID_NAME;
-                    break;
-                case EIO:
-                    errno = ERROR_GEN_FAILURE;
-                    break;
-                case ELOOP:
-                    errno = ERROR_STOPPED_ON_SYMLINK;
-                    break;
-                case ENAMETOOLONG:
-                    errno = ERROR_BAD_PATH_NAME;
-                    break;
-                case ENOENT:
-                    errno = ERROR_FILE_NOT_FOUND;
-                    break;
-                case ENOMEM:
-                    errno = ERROR_OUTOFMEMORY;
-                    break;
-                case ENOTDIR:
-                    errno = ERROR_BAD_PATH_NAME;
-                    break;
-                default:
-                    errno = ERROR_INVALID_FUNCTION;
-                }
-
-                return NULL;
-        }
-
-        buffer[sz] = '\0';
-        return strndup(buffer, sz + 1);
-     
-    } 
-
-    /*else the path is not a symlink - but attempt to resolve*/
-    else 
-    {
-        printf("realpath %s", fileName);
         //Attempt to resolve with the absolute filepath
         char actualpath[PATH_MAX+1];
         char* realPath = realpath(fileName, actualpath);
@@ -150,5 +99,53 @@ char* FollowSymLink(const char* fileName)
         }
 
        return strndup(realPath, strlen(realPath) + 1 );
-    }
+    
+    } 
+
+    /*else the path is not a symlink - but attempt to resolve*/
+    else 
+    {
+        char buffer[PATH_MAX];
+        ssize_t sz = readlink(fileName, buffer, PATH_MAX);
+    
+        if  (sz == -1)
+        {
+            switch(errno)
+            {
+                case EACCES:
+                    errno = ERROR_ACCESS_DENIED;
+                    break;
+                case EFAULT:
+                    errno = ERROR_INVALID_ADDRESS;
+                    break;
+                case EINVAL:
+                    errno = ERROR_INVALID_NAME;
+                case EIO:
+                    errno = ERROR_GEN_FAILURE;
+                    break;
+                case ELOOP:
+                    errno = ERROR_STOPPED_ON_SYMLINK;
+                    break;
+                case ENAMETOOLONG:
+                    errno = ERROR_BAD_PATH_NAME;
+                    break;
+                case ENOENT:
+                    errno = ERROR_FILE_NOT_FOUND;
+                    break;
+                case ENOMEM:
+                    errno = ERROR_OUTOFMEMORY;
+                    break;
+                case ENOTDIR:
+                    errno = ERROR_BAD_PATH_NAME;
+                    break;
+                default:
+                    errno = ERROR_INVALID_FUNCTION;
+                }
+
+                return NULL;
+        }
+
+        buffer[sz] = '\0';
+        return strndup(buffer, sz + 1);
+}
 }

--- a/src/libpsl-native/src/followsymlink.cpp
+++ b/src/libpsl-native/src/followsymlink.cpp
@@ -53,99 +53,108 @@ char* FollowSymLink(const char* fileName)
     }
 
     /*If the path is a symlink, the function return the absolute filepath if valid. if not valid, return null*/     
-    if (IsSymLink(fileName) == 0)
+    if (IsSymLink(fileName))
     {
-    
         //Attempt to resolve with the absolute filepath
         char actualpath[PATH_MAX+1];
         char* realPath = realpath(fileName, actualpath);
-
-        if  (sizeof(realPath) == -1)
-        {
-            switch(errno)
+    
+        //if realPath is null, go onto the readlink implementation
+        if (realPath == NULL)
+        {       
+            char buffer[PATH_MAX];
+            ssize_t sz = readlink(fileName, buffer, PATH_MAX);
+    
+            if  (sz == -1)
             {
-                case EACCES:
-                    errno = ERROR_ACCESS_DENIED;
-                    break;
-                case EFAULT:
-                    errno = ERROR_INVALID_ADDRESS;
-                    break;
-                case EINVAL:
-                    errno = ERROR_INVALID_NAME;
-                    break;
-                case EIO:
-                    errno = ERROR_GEN_FAILURE;
-                    break;
-                case ELOOP:
-                    errno = ERROR_STOPPED_ON_SYMLINK;
-                    break;
-                case ENAMETOOLONG:
-                    errno = ERROR_BAD_PATH_NAME;
-                    break;
-                case ENOENT:
-                    errno = ERROR_FILE_NOT_FOUND;
-                    break;
-                case ENOMEM:
-                    errno = ERROR_OUTOFMEMORY;
-                    break;
-                case ENOTDIR:
-                    errno = ERROR_BAD_PATH_NAME;
-                    break;
-                default:
-                    errno = ERROR_INVALID_FUNCTION;
+                switch(errno)
+                {
+                    case EACCES:
+                        errno = ERROR_ACCESS_DENIED;
+                        break;
+                    case EFAULT:
+                        errno = ERROR_INVALID_ADDRESS;   /*If the path is a symlink, the function return the absolute filepath if valid. if not valid, return null*/     
+                        break;
+                    case EINVAL:
+                        errno = ERROR_INVALID_NAME;
+                    case EIO:
+                        errno = ERROR_GEN_FAILURE;
+                        break;
+                    case ELOOP:
+                        errno = ERROR_STOPPED_ON_SYMLINK;
+                        break;
+                    case ENAMETOOLONG:
+                        errno = ERROR_BAD_PATH_NAME;
+                        break;
+                    case ENOENT:
+                        errno = ERROR_FILE_NOT_FOUND;
+                        break;
+                    case ENOMEM:
+                        errno = ERROR_OUTOFMEMORY;
+                        break;
+                    case ENOTDIR:
+                        errno = ERROR_BAD_PATH_NAME;
+                        break;
+                    default:
+                        errno = ERROR_INVALID_FUNCTION;
                 }
 
                 return NULL;
+           }
+
+            buffer[sz] = '\0';
+            return strndup(buffer, sz + 1);
         }
-
-       return strndup(realPath, strlen(realPath) + 1 );
+        else
+        {
+            return strndup(realPath, strlen(realPath) + 1 );
+        }
+    }
     
-    } 
-
-    /*else the path is not a symlink - but attempt to resolve*/
-    else 
+    else
     {
-        char buffer[PATH_MAX];
-        ssize_t sz = readlink(fileName, buffer, PATH_MAX);
+          char buffer[PATH_MAX];
+            ssize_t sz = readlink(fileName, buffer, PATH_MAX);
     
-        if  (sz == -1)
-        {
-            switch(errno)
+            if  (sz == -1)
             {
-                case EACCES:
-                    errno = ERROR_ACCESS_DENIED;
-                    break;
-                case EFAULT:
-                    errno = ERROR_INVALID_ADDRESS;
-                    break;
-                case EINVAL:
-                    errno = ERROR_INVALID_NAME;
-                case EIO:
-                    errno = ERROR_GEN_FAILURE;
-                    break;
-                case ELOOP:
-                    errno = ERROR_STOPPED_ON_SYMLINK;
-                    break;
-                case ENAMETOOLONG:
-                    errno = ERROR_BAD_PATH_NAME;
-                    break;
-                case ENOENT:
-                    errno = ERROR_FILE_NOT_FOUND;
-                    break;
-                case ENOMEM:
-                    errno = ERROR_OUTOFMEMORY;
-                    break;
-                case ENOTDIR:
-                    errno = ERROR_BAD_PATH_NAME;
-                    break;
-                default:
-                    errno = ERROR_INVALID_FUNCTION;
+                switch(errno)
+                {
+                    case EACCES:
+                        errno = ERROR_ACCESS_DENIED;
+                        break;
+                    case EFAULT:
+                        errno = ERROR_INVALID_ADDRESS;   /*If the path is a symlink, the function return the absolute filepath if valid. if not valid, return null*/     
+                        break;
+                    case EINVAL:
+                        errno = ERROR_INVALID_NAME;
+                    case EIO:
+                        errno = ERROR_GEN_FAILURE;
+                        break;
+                    case ELOOP:
+                        errno = ERROR_STOPPED_ON_SYMLINK;
+                        break;
+                    case ENAMETOOLONG:
+                        errno = ERROR_BAD_PATH_NAME;
+                        break;
+                    case ENOENT:
+                        errno = ERROR_FILE_NOT_FOUND;
+                        break;
+                    case ENOMEM:
+                        errno = ERROR_OUTOFMEMORY;
+                        break;
+                    case ENOTDIR:
+                        errno = ERROR_BAD_PATH_NAME;
+                        break;
+                    default:
+                        errno = ERROR_INVALID_FUNCTION;
                 }
 
                 return NULL;
-        }
+           }
 
-        buffer[sz] = '\0';
-        return strndup(buffer, sz + 1);
-}
+            buffer[sz] = '\0';
+            return strndup(buffer, sz + 1);
+
+    }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/New-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/New-Item.Tests.ps1
@@ -36,7 +36,7 @@ Describe "New-Item" {
     It "Should create a file without error" {
 	New-Item -Name $testfile -Path $tmpDirectory -ItemType file
 
-	Test-Path $FullyQualifiedFile | Should Be $true
+	    Test-Path $FullyQualifiedFile | Should Be $true
 
         $fileInfo = Get-ChildItem $FullyQualifiedFile
         $fileInfo.Target | Should Be $null
@@ -105,14 +105,15 @@ Describe "New-Item" {
     }
 
     It "Should create a symbolic link of a file without error" {
-	New-Item -Name $testfile -Path $tmpDirectory -ItemType file
-	Test-Path $FullyQualifiedFile | Should Be $true
+	    New-Item -Name $testfile -Path $tmpDirectory -ItemType file
+	    Test-Path $FullyQualifiedFile | Should Be $true
 
-	New-Item -ItemType SymbolicLink -Target $FullyQualifiedFile -Name $testlink -Path $tmpDirectory
-	Test-Path $FullyQualifiedLink | Should Be $true
+	    New-Item -ItemType SymbolicLink -Target $FullyQualifiedFile -Name $testlink -Path $tmpDirectory
+	    Test-Path $FullyQualifiedLink | Should Be $true
 
+        $target = $FullyQualifiedFile 
         $fileInfo = Get-ChildItem $FullyQualifiedLink
-        $fileInfo.Target | Should Be $FullyQualifiedFile
+        $fileInfo.Target | Should Be $target
         $fileInfo.LinkType | Should Be "SymbolicLink"
     }
 
@@ -128,18 +129,18 @@ Describe "New-Item" {
     }
 
     It "Should create a symbolic link from directory without error" {
-	New-Item -Name $testFolder -Path $tmpDirectory -ItemType directory
-	Test-Path $FullyQualifiedFolder | Should Be $true
+	    New-Item -Name $testFolder -Path $tmpDirectory -ItemType directory
+	    Test-Path $FullyQualifiedFolder | Should Be $true
 
-	New-Item -ItemType SymbolicLink -Target $FullyQualifiedFolder -Name $testlink -Path $tmpDirectory
-	Test-Path $FullyQualifiedLink | Should Be $true
+	    New-Item -ItemType SymbolicLink -Target $FullyQualifiedFolder -Name $testlink -Path $tmpDirectory
+	    Test-Path $FullyQualifiedLink | Should Be $true
 
         $fileInfo = Get-ChildItem $FullyQualifiedLink
         $fileInfo.Target | Should Be $FullyQualifiedFolder
         $fileInfo.LinkType | Should Be "SymbolicLink"
 
-	# Remove the link explicitly to avoid broken symlink issue
-	Remove-Item $FullyQualifiedLink -Force
+	    # Remove the link explicitly to avoid broken symlink issue
+	    Remove-Item $FullyQualifiedLink -Force
     }
 
     It "Should create a hard link of a file without error" {
@@ -153,7 +154,5 @@ Describe "New-Item" {
         $fileInfo.Target | Should Be $null
         $fileInfo.LinkType | Should Be "HardLink"
     }
-
-
 
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/New-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/New-Item.Tests.ps1
@@ -112,7 +112,7 @@ Describe "New-Item" {
 	    Test-Path $FullyQualifiedLink | Should Be $true
 
         $fileInfo = Get-ChildItem $FullyQualifiedLink
-        $fileInfo.Target | Should Match $FullyQualifiedFile
+        $fileInfo.Target | Should Match ([regex]::Escape($FullyQualifiedFile))
         $fileInfo.LinkType | Should Be "SymbolicLink"
     }
 
@@ -135,7 +135,7 @@ Describe "New-Item" {
 	    Test-Path $FullyQualifiedLink | Should Be $true
 
         $fileInfo = Get-ChildItem $FullyQualifiedLink
-        $fileInfo.Target | Should Match $FullyQualifiedFolder
+        $fileInfo.Target | Should Match ([regex]::Escape($FullyQualifiedFolder))
         $fileInfo.LinkType | Should Be "SymbolicLink"
 
 	    # Remove the link explicitly to avoid broken symlink issue

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/New-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/New-Item.Tests.ps1
@@ -111,9 +111,8 @@ Describe "New-Item" {
 	    New-Item -ItemType SymbolicLink -Target $FullyQualifiedFile -Name $testlink -Path $tmpDirectory
 	    Test-Path $FullyQualifiedLink | Should Be $true
 
-        $target = $FullyQualifiedFile 
         $fileInfo = Get-ChildItem $FullyQualifiedLink
-        $fileInfo.Target | Should Be $target
+        $fileInfo.Target | Should Match $FullyQualifiedFile
         $fileInfo.LinkType | Should Be "SymbolicLink"
     }
 
@@ -136,7 +135,7 @@ Describe "New-Item" {
 	    Test-Path $FullyQualifiedLink | Should Be $true
 
         $fileInfo = Get-ChildItem $FullyQualifiedLink
-        $fileInfo.Target | Should Be $FullyQualifiedFolder
+        $fileInfo.Target | Should Match $FullyQualifiedFolder
         $fileInfo.LinkType | Should Be "SymbolicLink"
 
 	    # Remove the link explicitly to avoid broken symlink issue


### PR DESCRIPTION
Revised bug issue, to fix: Get-ChildItem of Symbolic Link Does Not Work Outside Parent Directory #1263

<!--
Before submitting this pull request, please first:

- [ ] State that it "Resolves #xyz".
- [ ] Ensure your code is up-to-date with `master`.
- [ ] Add tests that fail without your changes.
- [ ] Update all relevant [documentation](../docs).
- [ ] Assign the PR to the appropriate subsystem [maintainer](https://aka.ms/psowners).
- [ ] Check that your commits follow our [contributing guidelines](CONTRIBUTING.md)
-->
