### PR TITLE
Update Start-PSPester

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -379,7 +379,7 @@ function Start-PSPester {
         [string]$Directory = "$PSScriptRoot/test/powershell"
     )
 
-    & (Get-PSOutput) -noprofile -c "Import-Module '$PSScriptRoot/src/Modules/Pester'; Invoke-Pester $Flags $Directory/$Tests"
+    & (Get-PSOutput) -noprofile -c "Invoke-Pester $Flags $Directory/$Tests"
     if ($LASTEXITCODE -ne 0) {
         throw "$LASTEXITCODE Pester tests failed"
     }


### PR DESCRIPTION
Remove direct import call, since we are leveraging auto-discovery for Pester module
