### PR TITLE
Disable verbosity during package creation - now that we are stable

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -525,8 +525,8 @@ Built upon .NET Core, it is also a C# REPL.
     Write-Verbose "Packaging $Source"
 
     if ($IsWindows) {
-        $msiPackagePath = New-MSIPackage -ProductSourcePath $Source -ProductVersion $Version -AssetsPath "$PSScriptRoot\Assets" -Verbose
-        $appxPackagePath = New-AppxPackage -PackageVersion $Version -SourcePath $Source -AssetsPath "$PSScriptRoot\Assets" -Verbose
+        $msiPackagePath = New-MSIPackage -ProductSourcePath $Source -ProductVersion $Version -AssetsPath "$PSScriptRoot\Assets"
+        $appxPackagePath = New-AppxPackage -PackageVersion $Version -SourcePath $Source -AssetsPath "$PSScriptRoot\Assets"
 
         $packages = @($msiPackagePath, $appxPackagePath)
 


### PR DESCRIPTION
I had added extensive verbosity during Appx/MSI package creation to catch any issues.

Now that we are stable in terms of packaging, need to disable the verbosity to optimize CI logs.
