### PR TITLE
 Comment out mc.exe search logic 

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -99,7 +99,7 @@ function Start-PSBuild {
         Use-MSBuild
 
         #mc.exe is Message Compiler for native resources
-        <# This current doesn't work reliably. Removing for now since mc.exe is not being used yet.
+        <# This currently doesn't work reliably and clean systems. Removing for now since mc.exe is not being used yet.
         $mcexe = Get-ChildItem "${env:ProgramFiles(x86)}\Microsoft SDKs\Windows\" -Recurse -Filter 'mc.exe' | ? {$_.FullName -match 'x64'} | select -First 1 | % {$_.FullName}
         if (-not $mcexe) {
             throw 'mc.exe not found. Install Microsoft Windows SDK.'

--- a/build.psm1
+++ b/build.psm1
@@ -97,11 +97,14 @@ function Start-PSBuild {
         $precheck = $precheck -and (precheck 'cmake' 'cmake not found. You can install it from https://chocolatey.org/packages/cmake.portable')
 
         Use-MSBuild
+
         #mc.exe is Message Compiler for native resources
+        <# This current doesn't work reliably. Removing for now since mc.exe is not being used yet.
         $mcexe = Get-ChildItem "${env:ProgramFiles(x86)}\Microsoft SDKs\Windows\" -Recurse -Filter 'mc.exe' | ? {$_.FullName -match 'x64'} | select -First 1 | % {$_.FullName}
         if (-not $mcexe) {
             throw 'mc.exe not found. Install Microsoft Windows SDK.'
         }
+        #>
 
         # setup msbuild configuration
         if ($Configuration -eq 'Debug' -or $Configuration -eq 'Release')


### PR DESCRIPTION
Searching for mc.exe is currently breaking on clean systems that follow the PowerShell FullCLR build installation instructions.  Since mc.exe isn't currently used, commenting out discovery to unblock users.

The script should probably be updated to use the Windows 10 SDK and the MD file updated accordingly. 
