### PR TITLE
Implement ReadLineSafe for Linux

### DIFF
--- a/docs/KNOWNISSUES.md
+++ b/docs/KNOWNISSUES.md
@@ -1,18 +1,5 @@
 # Known Issues
 
-## SecureString
-
-The `SecureString` class is *not* the well-known C# `SecureString`, as the
-library is not available in .NET Core. However, PowerShell continues to use the
-type for two main reasons: FullCLR compatibility, and as a specially-treated
-type (that is, behavior is dependent on the type being `SecureString`). Instead,
-the `SecureString` is Mono's completely not secure whatsoever, but open-source
-and "compatible" stub that acts just like a plaintext `StringBuilder`. **It has
-no encryption.**
-
-Additionally `ReadLineSafe` is not implemented, meaning `Get-Credential` fails
-with `PlatformNotSupportedException`.
-
 ## Files excluded from the build
 
 #### Microsoft.PowerShell.Commands.Management

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterface.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterface.cs
@@ -1865,7 +1865,8 @@ namespace Microsoft.PowerShell
                     continue;
                 }
 
-                if (keyInfo.Key == ConsoleKey.Delete)
+                if (keyInfo.Key == ConsoleKey.Delete
+                    || (keyInfo.Key == ConsoleKey.D && keyInfo.Modifiers.HasFlag(ConsoleModifiers.Control)))
                 {
                     if (index < s.Length)
                     {

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterface.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterface.cs
@@ -351,7 +351,6 @@ namespace Microsoft.PowerShell
                     //
 #if LINUX
                     ConsoleKeyInfo keyInfo = Console.ReadKey(true);
-                    char k = keyInfo.KeyChar;
 #else
                     uint unused = 0;
                     string key = ConsoleControl.ReadConsole(handle, string.Empty, 1, false, out unused);
@@ -399,7 +398,7 @@ namespace Microsoft.PowerShell
                         }
                     }
 #if LINUX
-                    else if (Char.IsControl(k))
+                    else if (Char.IsControl(keyInfo.KeyChar))
                     {
                         // blacklist control characters
                         continue;
@@ -413,7 +412,7 @@ namespace Microsoft.PowerShell
                         if (isSecureString)
                         {
 #if LINUX
-                            secureResult.AppendChar(k);
+                            secureResult.AppendChar(keyInfo.KeyChar);
 #else
                             secureResult.AppendChar(key[0]);
 #endif
@@ -421,7 +420,7 @@ namespace Microsoft.PowerShell
                         else
                         {
 #if LINUX
-                            result.Append(k);
+                            result.Append(keyInfo.KeyChar);
 #else
                             result.Append(key);
 #endif
@@ -1941,8 +1940,7 @@ namespace Microsoft.PowerShell
                     continue;
                 }
 
-                char k = keyInfo.KeyChar;
-                else if (Char.IsControl(k))
+                if (Char.IsControl(keyInfo.KeyChar))
                 {
                     // blacklist control characters
                     continue;
@@ -1953,7 +1951,7 @@ namespace Microsoft.PowerShell
                 {
                     s = s.Remove(index, 1);
                 }
-                s = s.Insert(index, k.ToString());
+                s = s.Insert(index, keyInfo.KeyChar.ToString());
                 index++;
 
                 // Redisplay string

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterface.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterface.cs
@@ -1720,11 +1720,17 @@ namespace Microsoft.PowerShell
             // the empty string.
 
 #if LINUX
+            bool treatControlCAsInput = Console.TreatControlCAsInput;
+
+            try
+            {
+
             ConsoleKeyInfo keyInfo;
             string s = "";
             int index = 0;
             int cursorLeft = Console.CursorLeft;
             int cursorCurrent = cursorLeft;
+            Console.TreatControlCAsInput = true;
 #else
             rawui.ClearKeyCache();
             uint keyState = 0;
@@ -1900,6 +1906,13 @@ namespace Microsoft.PowerShell
                        "s should only be null if input ended with a break");
 
             return s;
+#if LINUX
+            }
+            finally
+            {
+                Console.TreatControlCAsInput = treatControlCAsInput;
+            }
+#endif
         }
 
         /// <summary>

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterface.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterface.cs
@@ -299,7 +299,7 @@ namespace Microsoft.PowerShell
             StringBuilder result = new StringBuilder();
 #if LINUX
             bool treatControlCAsInput = Console.TreatControlCAsInput;
-#endif
+#else
             ConsoleHandle handle = ConsoleControl.GetConioDeviceHandle();
             ConsoleControl.ConsoleModes originalMode = ConsoleControl.GetMode(handle);
             bool isModeChanged = true; // assume ConsoleMode is changed so that if ReadLineSetMode

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterface.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterface.cs
@@ -399,10 +399,9 @@ namespace Microsoft.PowerShell
                         }
                     }
 #if LINUX
-                    else if (!(Char.IsLetterOrDigit(k) || Char.IsPunctuation(k) || Char.IsSymbol(k) || Char.IsWhiteSpace(k)))
+                    else if (Char.IsControl(k))
                     {
-                        // Whitelist valid input characters: letters, digits, punctuation, symbols whitespace
-                        // This is to avoid edge cases like Pause, Print Screen, function keys, and Oem keys, etc.
+                        // blacklist control characters
                         continue;
                     }
 #endif
@@ -1941,10 +1940,9 @@ namespace Microsoft.PowerShell
                 }
 
                 char k = keyInfo.KeyChar;
-                if (!(Char.IsLetterOrDigit(k) || Char.IsPunctuation(k) || Char.IsSymbol(k) || Char.IsWhiteSpace(k)))
+                else if (Char.IsControl(k))
                 {
-                    // Whitelist valid input characters: letters, digits, punctuation, symbols whitespace
-                    // This is to avoid edge cases like Pause, Print Screen, function keys, and Oem keys, etc.
+                    // blacklist control characters
                     continue;
                 }
 

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterface.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterface.cs
@@ -1879,7 +1879,8 @@ namespace Microsoft.PowerShell
                     continue;
                 }
 
-                if (keyInfo.Key == ConsoleKey.LeftArrow)
+                if (keyInfo.Key == ConsoleKey.LeftArrow
+                    || (keyInfo.Key == ConsoleKey.B && keyInfo.Modifiers.HasFlag(ConsoleModifiers.Control)))
                 {
                     if (Console.CursorLeft > cursorLeft)
                     {
@@ -1889,7 +1890,8 @@ namespace Microsoft.PowerShell
                     continue;
                 }
 
-                if (keyInfo.Key == ConsoleKey.RightArrow)
+                if (keyInfo.Key == ConsoleKey.RightArrow
+                    || (keyInfo.Key == ConsoleKey.F && keyInfo.Modifiers.HasFlag(ConsoleModifiers.Control)))
                 {
                     if (Console.CursorLeft < cursorLeft + s.Length)
                     {

--- a/test/powershell/Host/Read-Host.Tests.ps1
+++ b/test/powershell/Host/Read-Host.Tests.ps1
@@ -1,0 +1,20 @@
+Describe "Read-Host" {
+    Context "[Console]::ReadKey() implementation on non-Windows" {
+        BeforeAll {
+            $powershell = Join-Path -Path $PsHome -ChildPath "powershell"
+            $assetsDir = Join-Path -Path $PSScriptRoot -ChildPath assets
+            if ($IsWindows) {
+                $ItArgs = @{ skip = $true }
+            } elseif (-not (Get-Command expect -ErrorAction Ignore)) {
+                $ItArgs = @{ pending = $true }
+            } else {
+                $ItArgs = @{ }
+            }
+        }
+
+        It @ItArgs "Should output correctly" {
+            & (Join-Path $assetsDir "Read-Host.Output.expect") $powershell | Out-Null
+            $LASTEXITCODE | Should Be 0
+        }
+    }
+}

--- a/test/powershell/Host/assets/Read-Host.Output.expect
+++ b/test/powershell/Host/assets/Read-Host.Output.expect
@@ -5,7 +5,7 @@ exp_internal 1
 # Expects path to PowerShell as first argument
 set powershell [lindex $argv 0]
 
-set timeout 5
+set timeout 60
 
 spawn $powershell -nologo -noprofile Read-Host prompt
 

--- a/test/powershell/Host/assets/Read-Host.Output.expect
+++ b/test/powershell/Host/assets/Read-Host.Output.expect
@@ -1,0 +1,27 @@
+#!/usr/bin/expect -f
+
+exp_internal 1
+
+# Expects path to PowerShell as first argument
+set powershell [lindex $argv 0]
+
+set timeout 5
+
+spawn $powershell -nologo -noprofile Read-Host prompt
+
+expect "prompt: $" {
+    send "input\r"
+}
+
+# This is the old, incorrect behavior
+expect "input\r\ninput\r" {
+    exit 2
+}
+
+# This is the expected behavior
+expect "input\r\n" {
+    exit 0
+}
+
+# Anything else is wrong
+exit 1


### PR DESCRIPTION
<!--
Before submitting this pull request, please first:

- [ ] State that it "Resolves #xyz".
- [ ] Ensure your code is up-to-date with `master`.
- [ ] Add tests that fail without your changes.
- [ ] Update all relevant [documentation](../docs).
- [ ] Assign the PR to the appropriate subsystem [maintainer](https://aka.ms/psowners).
- [ ] Check that your commits follow our [contributing guidelines](CONTRIBUTING.md)
-->

This uses System.Console instead of ConsoleControl to read keys into a
SecureString in a portable manner. The Windows implementation is left
untouched.

Resolves #470, #715, #1179, and #1143.
