### PR TITLE
Fix use of Get-Command when more than one exists

### DIFF
--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -4740,7 +4740,7 @@ $RawUI.SetBufferContents(
             else
             {
                 // Porting note: non-Windows platforms use `clear`
-                return "& (Get-Command -CommandType Application clear).Definition | Select-Object -First 1";
+                return "& (Get-Command -CommandType Application clear | Select-Object -First 1).Definition";
             }
         }
 
@@ -5483,11 +5483,11 @@ $OutputEncoding = if ($IsWindows -and $IsCore) {
 
 # Respect PAGER, use more on Windows, and use less on Linux
 if (Test-Path env:PAGER) {
-    $moreCommand = (Get-Command -CommandType Application $env:PAGER).Definition | Select-Object -First 1
+    $moreCommand = (Get-Command -CommandType Application $env:PAGER | Select-Object -First 1).Definition
 } elseif ($IsWindows) {
-    $moreCommand = (Get-Command -CommandType Application more).Definition | Select-Object -First 1
+    $moreCommand = (Get-Command -CommandType Application more | Select-Object -First 1).Definition
 } else {
-    $moreCommand = (Get-Command -CommandType Application less).Definition | Select-Object -First 1
+    $moreCommand = (Get-Command -CommandType Application less | Select-Object -First 1).Definition
 }
 
 if($paths) {


### PR DESCRIPTION
<!--
Before submitting this pull request, please first:

- [ ] State that it "Resolves #xyz".
- [ ] Ensure your code is up-to-date with `master`.
- [ ] Add tests that fail without your changes.
- [ ] Update all relevant [documentation](../docs).
- [ ] Assign the PR to the appropriate subsystem [maintainer](https://aka.ms/psowners).
- [ ] Check that your commits follow our [contributing guidelines](CONTRIBUTING.md)
-->

This is a difficult behavior to test. I happened to be on a system that had both `/bin/clear` and `/usr/bin/clear`, thus revealing this bug. The use of `head` was in the wrong place.
