### PR TITLE
Fix use of UseShellExecute for .NET Core

### DIFF
--- a/src/Microsoft.PackageManagement/Implementation/ProviderServicesImpl.cs
+++ b/src/Microsoft.PackageManagement/Implementation/ProviderServicesImpl.cs
@@ -190,9 +190,14 @@ namespace Microsoft.PackageManagement.Internal.Implementation {
         public int StartProcess(string filename, string arguments, bool requiresElevation, out string standardOutput, IRequest requestObject) {
             Process p = new Process();
 
-            if (requiresElevation) {
+#if !CORECLR
+            if (requiresElevation)
+            {
                 p.StartInfo.UseShellExecute = true;
-            } else {
+            }
+            else
+#endif
+            {
                 p.StartInfo.UseShellExecute = false;
                 p.StartInfo.RedirectStandardOutput = true;
             }

--- a/src/System.Management.Automation/help/HelpCommands.cs
+++ b/src/System.Management.Automation/help/HelpCommands.cs
@@ -704,8 +704,20 @@ namespace Microsoft.PowerShell.Commands
 
                 if (Platform.IsWindows)
                 {
+                    // this is a re-implementation of the unavailable (on .NET Core) UseShellExecute,
+                    // where we manually execute a cmd.exe shell, and use its start command to
+                    // launch the default application for the given path
                     browserProcess.StartInfo.FileName = "cmd.exe";
-                    browserProcess.StartInfo.Arguments = string.Format(@"/c ""start /b """" {0}""", uriToLaunch.OriginalString);
+
+                    // start is very picky: the "optional" TITLE as the first argument should always
+                    // be included, otherwise it can silently fail
+                    browserProcess.StartInfo.Arguments = string.Format(CultureInfo.InvariantCulture,
+                                                                       @"/c ""start /b """" {0}""", uriToLaunch.OriginalString);
+
+                    // please note that there is currently no way to differentiate between running
+                    // on Nano as an OS and having targeted the .NET Core framework, thus this code
+                    // will continue to fail on Nano (as there is no browser), but at least is
+                    // implemented for .NET Core PowerShell on Windows
                 }
                 else if (Platform.IsOSX)
                 {

--- a/src/System.Management.Automation/help/HelpCommands.cs
+++ b/src/System.Management.Automation/help/HelpCommands.cs
@@ -699,17 +699,25 @@ namespace Microsoft.PowerShell.Commands
             {
                 this.WriteVerbose(string.Format(CultureInfo.InvariantCulture, HelpDisplayStrings.OnlineHelpUri, uriToLaunch.OriginalString));
                 System.Diagnostics.Process browserProcess = new System.Diagnostics.Process();
+
                 browserProcess.StartInfo.UseShellExecute = false;
+
                 if (Platform.IsWindows)
                 {
-                    browserProcess.StartInfo.FileName = uriToLaunch.OriginalString;
-                } else if (Platform.IsOSX) {
+                    browserProcess.StartInfo.FileName = "cmd.exe";
+                    browserProcess.StartInfo.Arguments = string.Format(@"/c ""start /b """" {0}""", uriToLaunch.OriginalString);
+                }
+                else if (Platform.IsOSX)
+                {
                     browserProcess.StartInfo.FileName = "open";
                     browserProcess.StartInfo.Arguments = uriToLaunch.OriginalString;
-                } else if (Platform.IsLinux) {
+                }
+                else if (Platform.IsLinux)
+                {
                     browserProcess.StartInfo.FileName = "xdg-open";
                     browserProcess.StartInfo.Arguments = uriToLaunch.OriginalString;
                 }
+
                 browserProcess.Start();
             }
             catch (InvalidOperationException ioe)

--- a/src/System.Management.Automation/help/HelpCommands.cs
+++ b/src/System.Management.Automation/help/HelpCommands.cs
@@ -700,37 +700,16 @@ namespace Microsoft.PowerShell.Commands
                 this.WriteVerbose(string.Format(CultureInfo.InvariantCulture, HelpDisplayStrings.OnlineHelpUri, uriToLaunch.OriginalString));
                 System.Diagnostics.Process browserProcess = new System.Diagnostics.Process();
 
-                browserProcess.StartInfo.UseShellExecute = false;
-
-                if (Platform.IsWindows)
-                {
-                    // this is a re-implementation of the unavailable (on .NET Core) UseShellExecute,
-                    // where we manually execute a cmd.exe shell, and use its start command to
-                    // launch the default application for the given path
-                    browserProcess.StartInfo.FileName = "cmd.exe";
-
-                    // start is very picky: the "optional" TITLE as the first argument should always
-                    // be included, otherwise it can silently fail
-                    browserProcess.StartInfo.Arguments = string.Format(CultureInfo.InvariantCulture,
-                                                                       @"/c ""start /b """" {0}""", uriToLaunch.OriginalString);
-
-                    // please note that there is currently no way to differentiate between running
-                    // on Nano as an OS and having targeted the .NET Core framework, thus this code
-                    // will continue to fail on Nano (as there is no browser), but at least is
-                    // implemented for .NET Core PowerShell on Windows
-                }
-                else if (Platform.IsOSX)
-                {
-                    browserProcess.StartInfo.FileName = "open";
-                    browserProcess.StartInfo.Arguments = uriToLaunch.OriginalString;
-                }
-                else if (Platform.IsLinux)
-                {
-                    browserProcess.StartInfo.FileName = "xdg-open";
-                    browserProcess.StartInfo.Arguments = uriToLaunch.OriginalString;
-                }
-
+#if LINUX
+                browserProcess.StartInfo.FileName = Platform.IsLinux ? "xdg-open" : /* OS X */ "open";
+                browserProcess.StartInfo.Arguments = uriToLaunch.OriginalString;
                 browserProcess.Start();
+#elif CORECLR
+                throw new PlatformNotSupportedException();
+#else
+                browserProcess.StartInfo.FileName = uriToLaunch.OriginalString;
+                browserProcess.Start();
+#endif
             }
             catch (InvalidOperationException ioe)
             {

--- a/src/System.Management.Automation/help/HelpCommands.cs
+++ b/src/System.Management.Automation/help/HelpCommands.cs
@@ -699,7 +699,7 @@ namespace Microsoft.PowerShell.Commands
             {
                 this.WriteVerbose(string.Format(CultureInfo.InvariantCulture, HelpDisplayStrings.OnlineHelpUri, uriToLaunch.OriginalString));
                 System.Diagnostics.Process browserProcess = new System.Diagnostics.Process();
-                browserProcess.StartInfo.UseShellExecute = true;
+                browserProcess.StartInfo.UseShellExecute = false;
                 if (Platform.IsWindows)
                 {
                     browserProcess.StartInfo.FileName = uriToLaunch.OriginalString;

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -1333,14 +1333,18 @@ namespace Microsoft.PowerShell.Commands
             {
                 System.Diagnostics.Process invokeProcess = new System.Diagnostics.Process();
 
+                invokeProcess.StartInfo.UseShellExecute = false;
+
                 if (Platform.IsWindows)
                 {
-                    System.Diagnostics.Process.Start(path);
-                } 
+                    invokeProcess.StartInfo.FileName = "cmd.exe";
+                    // start is very picky: the "optional" TITLE as the first argument should always be included, otherwise it can silently fail
+                    invokeProcess.StartInfo.Arguments = string.Format(@"/c ""start /b """" ""{0}""""", path);
+                }
                 else if (Platform.IsOSX) {
                     invokeProcess.StartInfo.FileName = "open";
                     invokeProcess.StartInfo.Arguments = path;
-                } 
+                }
                 else if (Platform.IsLinux) {
                     invokeProcess.StartInfo.FileName = "xdg-open";
                     invokeProcess.StartInfo.Arguments = path;

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -1337,9 +1337,20 @@ namespace Microsoft.PowerShell.Commands
 
                 if (Platform.IsWindows)
                 {
+                    // this is a re-implementation of the unavailable (on .NET Core) UseShellExecute,
+                    // where we manually execute a cmd.exe shell, and use its start command to
+                    // launch the default application for the given path
                     invokeProcess.StartInfo.FileName = "cmd.exe";
-                    // start is very picky: the "optional" TITLE as the first argument should always be included, otherwise it can silently fail
-                    invokeProcess.StartInfo.Arguments = string.Format(@"/c ""start /b """" ""{0}""""", path);
+
+                    // start is very picky: the "optional" TITLE as the first argument should always
+                    // be included, otherwise it can silently fail
+                    invokeProcess.StartInfo.Arguments = string.Format(CultureInfo.InvariantCulture,
+                                                                      @"/c ""start /b """" ""{0}""""", path);
+
+                    // please note that there is currently no way to differentiate between running
+                    // on Nano as an OS and having targeted the .NET Core framework, thus this code
+                    // will continue to fail on Nano (as there is no browser), but at least is
+                    // implemented for .NET Core PowerShell on Windows
                 }
                 else if (Platform.IsOSX) {
                     invokeProcess.StartInfo.FileName = "open";

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Invoke-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Invoke-Item.Tests.ps1
@@ -37,10 +37,14 @@ Describe "Invoke-Item" {
         $testfile = Join-Path $TestDrive testfile.txt
     }
 
-    It "Should invoke a text file without error" {
+    It "Should invoke a text file without error" -Skip:($IsWindows -and $IsCore) {
         $debugfn = NewProcessStartInfo "-noprofile ""``Invoke-Item $testfile`n" -RedirectStdIn
         $process = RunPowerShell $debugfn
         EnsureChildHasExited $process
         $process.ExitCode | Should Be 0
+    }
+
+    It "Should throw not supported on Windows with .NET Core" -Skip:($IsLinux -or $IsOSX -or !$IsCore) {
+        { Invoke-Item $testfile }| Should Throw "Operation is not supported on this platform."
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Invoke-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Invoke-Item.Tests.ps1
@@ -2,14 +2,6 @@ using namespace System.Diagnostics
 
 Describe "Invoke-Item" {
 
-    $tmpDirectory         = $TestDrive
-    $testfile             = "testfile.txt"
-    $testfolder           = "newDirectory"
-    $testlink             = "testlink"
-    $FullyQualifiedFile   = Join-Path -Path $tmpDirectory -ChildPath $testfile
-    $FullyQualifiedFolder = Join-Path -Path $tmpDirectory -ChildPath $testfolder
-    $FullyQualifiedLink   = Join-Path -Path $tmpDirectory -ChildPath $testlink
- 
     function NewProcessStartInfo([string]$CommandLine, [switch]$RedirectStdIn)
     {
         return [ProcessStartInfo]@{
@@ -39,38 +31,16 @@ Describe "Invoke-Item" {
         }
     }
 
-    function Clean-State
-    {
-        if (Test-Path $FullyQualifiedLink)
-        {
-	        Remove-Item $FullyQualifiedLink -Force
-        }
-
-        if (Test-Path $FullyQualifiedFile)
-        {
-	        Remove-Item $FullyQualifiedFile -Force
-        }
-
-        if (Test-Path $FullyQualifiedFolder)
-        {
-	    Remove-Item $FullyQualifiedFolder -Force
-        }
-    }
-
     BeforeAll {
         $powershell = Join-Path -Path $PsHome -ChildPath "powershell"
+        Setup -File testfile.txt -Content "Hello World"
+        $testfile = Join-Path $TestDrive testfile.txt
     }
 
-#Both tests are pending due to a bug in Invoke-Item on Windows. Fixed for Linux
-
-    It "Should call the function without error" -Pending:$IsWindows { 
-        { New-Item -Name $testfile -Path $tmpDirectory -ItemType file } | Should Not Throw
-    }
-
-    It "Should invoke a text file without error" -Pending:$IsWindows {
-        $debugfn = NewProcessStartInfo "-noprofile ""``Invoke-Item $FullyQualifiedFile`n" -RedirectStdIn
+    It "Should invoke a text file without error" {
+        $debugfn = NewProcessStartInfo "-noprofile ""``Invoke-Item $testfile`n" -RedirectStdIn
         $process = RunPowerShell $debugfn
         EnsureChildHasExited $process
         $process.ExitCode | Should Be 0
-    }    
+    }
 }


### PR DESCRIPTION
<!--
Before submitting this pull request, please first:

- [ ] State that it "Resolves #xyz".
- [ ] Ensure your code is up-to-date with `master`.
- [ ] Add tests that fail without your changes.
- [ ] Update all relevant [documentation](../docs).
- [ ] Assign the PR to the appropriate subsystem [maintainer](https://aka.ms/psowners).
- [ ] Check that your commits follow our [contributing guidelines](CONTRIBUTING.md)
-->

`UseShellExecute` is not supported on .NET Core because it is only MTA.
