### PR TITLE
Fix UNIX/Windows/CORE story for PSReadLine

### DIFF
--- a/src/Microsoft.PowerShell.PSReadLine/Completion.cs
+++ b/src/Microsoft.PowerShell.PSReadLine/Completion.cs
@@ -27,9 +27,7 @@ namespace Microsoft.PowerShell
         private static string DirectorySeparatorString = System.IO.Path.DirectorySeparatorChar.ToString();
 
         // Stub helper method so completion can be mocked
-#if !CORECLR
         [ExcludeFromCodeCoverage]
-#endif
         CommandCompletion IPSConsoleReadLineMockableMethods.CompleteInput(string input, int cursorIndex, Hashtable options, System.Management.Automation.PowerShell powershell)
         {
             return CalloutUsingDefaultConsoleMode(
@@ -308,7 +306,7 @@ namespace Microsoft.PowerShell
             for (int i = 0; i < menuColumnWidth; i++)
             {
                 int j = i + start;
-#if CORECLR                
+#if LINUX // TODO: use real inverse
                 ConsoleColor tempColor = (int)buffer[j].ForegroundColor == -1 
                     ? ConsoleColor.White : buffer[j].ForegroundColor;
                 buffer[j].ForegroundColor = (int)buffer[j].BackgroundColor == -1 

--- a/src/Microsoft.PowerShell.PSReadLine/Completion.cs
+++ b/src/Microsoft.PowerShell.PSReadLine/Completion.cs
@@ -307,9 +307,9 @@ namespace Microsoft.PowerShell
             {
                 int j = i + start;
 #if LINUX // TODO: use real inverse
-                ConsoleColor tempColor = (int)buffer[j].ForegroundColor == -1 
+                ConsoleColor tempColor = buffer[j].ForegroundColor == UnknownColor
                     ? ConsoleColor.White : buffer[j].ForegroundColor;
-                buffer[j].ForegroundColor = (int)buffer[j].BackgroundColor == -1 
+                buffer[j].ForegroundColor = buffer[j].BackgroundColor == UnknownColor
                     ? ConsoleColor.Black : buffer[j].BackgroundColor;
                 buffer[j].BackgroundColor = tempColor;
 #else

--- a/src/Microsoft.PowerShell.PSReadLine/Completion.cs
+++ b/src/Microsoft.PowerShell.PSReadLine/Completion.cs
@@ -298,24 +298,14 @@ namespace Microsoft.PowerShell
             return replacementText;
         }
 
-        private static void InvertSelectedCompletion(CHAR_INFO[] buffer, int selectedItem, int menuColumnWidth, int menuRows)
+        private static void InvertSelectedCompletion(BufferChar[] buffer, int selectedItem, int menuColumnWidth, int menuRows)
         {
             var selectedX = selectedItem / menuRows;
             var selectedY = selectedItem - (selectedX * menuRows);
             var start = selectedY * _singleton._console.BufferWidth + selectedX * menuColumnWidth;
             for (int i = 0; i < menuColumnWidth; i++)
             {
-                int j = i + start;
-#if LINUX // TODO: use real inverse
-                ConsoleColor tempColor = buffer[j].ForegroundColor == UnknownColor
-                    ? ConsoleColor.White : buffer[j].ForegroundColor;
-                buffer[j].ForegroundColor = buffer[j].BackgroundColor == UnknownColor
-                    ? ConsoleColor.Black : buffer[j].BackgroundColor;
-                buffer[j].BackgroundColor = tempColor;
-#else
-                buffer[j].ForegroundColor = (ConsoleColor)((int)buffer[j].ForegroundColor ^ 7);
-                buffer[j].BackgroundColor = (ConsoleColor)((int)buffer[j].BackgroundColor ^ 7);
-#endif
+                buffer[i + start].Inverse = true;
             }
         }
 

--- a/src/Microsoft.PowerShell.PSReadLine/ConsoleBufferBuilder.cs
+++ b/src/Microsoft.PowerShell.PSReadLine/ConsoleBufferBuilder.cs
@@ -10,18 +10,18 @@ namespace Microsoft.PowerShell
 {
     internal class ConsoleBufferBuilder
     {
-        private List<CHAR_INFO> buffer;
+        private List<BufferChar> buffer;
         private IConsole _console;
 
         public ConsoleBufferBuilder(int capacity, IConsole console)
         {
-            buffer = new List<CHAR_INFO>(capacity);
+            buffer = new List<BufferChar>(capacity);
             _console = console;
         }
 
-        CHAR_INFO NewCharInfo(char c)
+        BufferChar NewCharInfo(char c)
         {
-            return new CHAR_INFO
+            return new BufferChar
             {
                 UnicodeChar = c,
                 BackgroundColor = _console.BackgroundColor,
@@ -45,7 +45,7 @@ namespace Microsoft.PowerShell
             }
         }
 
-        public CHAR_INFO[] ToArray()
+        public BufferChar[] ToArray()
         {
             return buffer.ToArray();
         }

--- a/src/Microsoft.PowerShell.PSReadLine/ConsoleKeyChordConverter.cs
+++ b/src/Microsoft.PowerShell.PSReadLine/ConsoleKeyChordConverter.cs
@@ -6,7 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-#if CORECLR
+#if LINUX
 using System.Reflection;
 #endif
 using System.Runtime.InteropServices;
@@ -214,7 +214,7 @@ namespace Microsoft.PowerShell
         {
             // default for unprintables and unhandled
             char keyChar = '\u0000';
-#if CORECLR
+#if LINUX
             Type keyType = typeof (Keys);
             FieldInfo[] keyFields = keyType.GetFields();
             

--- a/src/Microsoft.PowerShell.PSReadLine/ConsoleLib.cs
+++ b/src/Microsoft.PowerShell.PSReadLine/ConsoleLib.cs
@@ -317,7 +317,7 @@ namespace Microsoft.PowerShell.Internal
         public CHAR_INFO(char c, ConsoleColor foreground, ConsoleColor background)
         {
             UnicodeChar = c;
-            Attributes = (ushort)(((int)background << 4) | (int)foreground);
+            Attributes = (ushort)((((int)background << 4) & 0xf) | ((int)foreground & 0xf));
         }
 
         [ExcludeFromCodeCoverage]
@@ -330,7 +330,7 @@ namespace Microsoft.PowerShell.Internal
         [ExcludeFromCodeCoverage]
         public ConsoleColor BackgroundColor
         {
-            get { return (ConsoleColor)((Attributes & 0xf0) >> 4); }
+            get { return (ConsoleColor)((Attributes & 0x00f0) >> 4); }
             set { Attributes = (ushort)((Attributes & 0xff0f) | (((int)value & 0xf) << 4)); }
         }
 
@@ -426,6 +426,7 @@ namespace Microsoft.PowerShell.Internal
         }
     }
 
+#if !LINUX
     internal class ConhostConsole : IConsole
     {
         [SuppressMessage("Microsoft.Reliability", "CA2006:UseSafeHandleToEncapsulateNativeResources")]
@@ -482,18 +483,42 @@ namespace Microsoft.PowerShell.Internal
             return new SafeFileHandle(handle, true);
         });
 
-        public uint GetConsoleInputMode()
+        public object GetConsoleInputMode()
         {
+            uint mode;
             var handle = _inputHandle.Value.DangerousGetHandle();
-            uint result;
-            NativeMethods.GetConsoleMode(handle, out result);
-            return result;
+            NativeMethods.GetConsoleMode(handle, out mode);
+            return mode;
         }
 
-        public void SetConsoleInputMode(uint mode)
+        public void SetConsoleInputMode(object modeObj)
         {
-            var handle = _inputHandle.Value.DangerousGetHandle();
-            NativeMethods.SetConsoleMode(handle, mode);
+            if (modeObj is uint)
+            {
+                // Clear a couple flags so we can actually receive certain keys:
+                //     ENABLE_PROCESSED_INPUT - enables Ctrl+C
+                //     ENABLE_LINE_INPUT - enables Ctrl+S
+                // Also clear a couple flags so we don't mask the input that we ignore:
+                //     ENABLE_MOUSE_INPUT - mouse events
+                //     ENABLE_WINDOW_INPUT - window resize events
+                var mode = (uint)modeObj &
+                           ~(NativeMethods.ENABLE_PROCESSED_INPUT |
+                             NativeMethods.ENABLE_LINE_INPUT |
+                             NativeMethods.ENABLE_WINDOW_INPUT |
+                             NativeMethods.ENABLE_MOUSE_INPUT);
+
+                var handle = _inputHandle.Value.DangerousGetHandle();
+                NativeMethods.SetConsoleMode(handle, mode);
+            }
+        }
+
+        public void RestoreConsoleInputMode(object modeObj)
+        {
+            if (modeObj is uint)
+            {
+                var handle = _inputHandle.Value.DangerousGetHandle();
+                NativeMethods.SetConsoleMode(handle, (uint)modeObj);
+            }
         }
 
         public ConsoleKeyInfo ReadKey()
@@ -601,24 +626,7 @@ namespace Microsoft.PowerShell.Internal
                 ScrollBuffer(scrollCount);
                 top -= scrollCount;
             }
-#if LINUX
-            ConsoleColor foregroundColor = Console.ForegroundColor;
-            ConsoleColor backgroundColor = Console.BackgroundColor;
 
-            Console.SetCursorPosition(0, (top>=0) ? top : 0);
-
-            for (int i = 0; i < buffer.Length; ++i)
-            {
-                // TODO: use escape sequences for better perf
-                Console.ForegroundColor =  buffer[i].ForegroundColor;
-                Console.BackgroundColor =  buffer[i].BackgroundColor;
-
-                Console.Write((char)buffer[i].UnicodeChar);
-            }
-
-            Console.BackgroundColor = backgroundColor;
-            Console.ForegroundColor = foregroundColor;
-#else
             var handle = NativeMethods.GetStdHandle((uint) StandardHandleId.Output);
             var bufferSize = new COORD
             {
@@ -643,18 +651,10 @@ namespace Microsoft.PowerShell.Internal
             {
                 Console.CursorTop = bottom;
             }
-#endif
         }
 
         public void ScrollBuffer(int lines)
         {
-#if LINUX
-            for (int i=0; i<lines; ++i)
-            {
-                Console.SetCursorPosition(Console.BufferWidth, Console.BufferHeight - 1);
-                Console.WriteLine();
-            }
-#else
             var handle = NativeMethods.GetStdHandle((uint) StandardHandleId.Output);
 
             var scrollRectangle = new SMALL_RECT
@@ -667,20 +667,11 @@ namespace Microsoft.PowerShell.Internal
             var destinationOrigin = new COORD {X = 0, Y = 0};
             var fillChar = new CHAR_INFO(' ', Console.ForegroundColor, Console.BackgroundColor);
             NativeMethods.ScrollConsoleScreenBuffer(handle, ref scrollRectangle, IntPtr.Zero, destinationOrigin, ref fillChar);
-#endif
         }
 
         public CHAR_INFO[] ReadBufferLines(int top, int count)
         {
             var result = new CHAR_INFO[BufferWidth * count];
-#if LINUX
-            for (int i=0; i<BufferWidth*count; ++i)
-            {
-                result[i].UnicodeChar = ' ';
-                result[i].ForegroundColor = Console.ForegroundColor;
-                result[i].BackgroundColor = Console.BackgroundColor;
-            }
-#else
             var handle = NativeMethods.GetStdHandle((uint) StandardHandleId.Output);
 
             var readBufferSize = new COORD {
@@ -696,7 +687,7 @@ namespace Microsoft.PowerShell.Internal
             };
             NativeMethods.ReadConsoleOutput(handle, result,
                 readBufferSize, readBufferCoord, ref readRegion);
-#endif
+
             return result;
         }
 
@@ -891,14 +882,196 @@ namespace Microsoft.PowerShell.Internal
                 NativeMethods.ReleaseDC(_hwnd, _hDC);
             }
         }
+    }
 
-#if LINUX // TODO: this is not correct, PSReadline never clears the screen, it should only scroll
+#else
+
+    internal class TTYConsole : IConsole
+    {
+        public object GetConsoleInputMode()
+        {
+            return Console.TreatControlCAsInput;
+        }
+
+        public void SetConsoleInputMode(object modeObj)
+        {
+            Console.TreatControlCAsInput = true;
+        }
+
+        public void RestoreConsoleInputMode(object modeObj)
+        {
+            if (modeObj is bool)
+            {
+                Console.TreatControlCAsInput = (bool)modeObj;
+            }
+        }
+
+        public ConsoleKeyInfo ReadKey()
+        {
+            return Console.ReadKey(true);
+        }
+
+        public bool KeyAvailable
+        {
+            get { return Console.KeyAvailable; }
+        }
+
+        public int CursorLeft
+        {
+            get { return Console.CursorLeft; }
+            set { Console.CursorLeft = value; }
+        }
+
+        public int CursorTop
+        {
+            get { return Console.CursorTop; }
+            set { Console.CursorTop = value; }
+        }
+
+        public int CursorSize
+        {
+            get { return Console.CursorSize; }
+            set { Console.CursorSize = value; }
+        }
+
+        public int BufferWidth
+        {
+            get { return Console.BufferWidth; }
+            set { Console.BufferWidth = value; }
+        }
+
+        public int BufferHeight
+        {
+            get { return Console.BufferHeight; }
+            set { Console.BufferHeight = value; }
+        }
+
+        public int WindowWidth
+        {
+            get { return Console.WindowWidth; }
+            set { Console.WindowWidth = value; }
+        }
+
+        public int WindowHeight
+        {
+            get { return Console.WindowHeight; }
+            set { Console.WindowHeight = value; }
+        }
+
+        public int WindowTop
+        {
+            get { return Console.WindowTop; }
+            set { Console.WindowTop = value; }
+        }
+
+        public ConsoleColor BackgroundColor
+        {
+            get { return Console.BackgroundColor; }
+            set { Console.BackgroundColor = value; }
+        }
+
+        public ConsoleColor ForegroundColor
+        {
+            get { return Console.ForegroundColor; }
+            set { Console.ForegroundColor = value; }
+        }
+
+        public void SetWindowPosition(int left, int top)
+        {
+            Console.SetWindowPosition(left, top);
+        }
+
+        public void SetCursorPosition(int left, int top)
+        {
+            Console.SetCursorPosition(left, top);
+        }
+
+        public void Write(string value)
+        {
+            Console.Write(value);
+        }
+
+        public void WriteLine(string value)
+        {
+            Console.WriteLine(value);
+        }
+
+        public void WriteBufferLines(CHAR_INFO[] buffer, ref int top)
+        {
+            WriteBufferLines(buffer, ref top, true);
+        }
+
+        public void WriteBufferLines(CHAR_INFO[] buffer, ref int top, bool ensureBottomLineVisible)
+        {
+            int bufferWidth = Console.BufferWidth;
+            int bufferLineCount = buffer.Length / bufferWidth;
+            if ((top + bufferLineCount) > Console.BufferHeight)
+            {
+                var scrollCount = (top + bufferLineCount) - Console.BufferHeight;
+                ScrollBuffer(scrollCount);
+                top -= scrollCount;
+            }
+
+            ConsoleColor foregroundColor = Console.ForegroundColor;
+            ConsoleColor backgroundColor = Console.BackgroundColor;
+
+            Console.SetCursorPosition(0, (top>=0) ? top : 0);
+
+            for (int i = 0; i < buffer.Length; ++i)
+            {
+                // TODO: use escape sequences for better perf
+                Console.ForegroundColor =  buffer[i].ForegroundColor;
+                Console.BackgroundColor =  buffer[i].BackgroundColor;
+
+                Console.Write((char)buffer[i].UnicodeChar);
+            }
+
+            Console.BackgroundColor = backgroundColor;
+            Console.ForegroundColor = foregroundColor;
+        }
+
+        public void ScrollBuffer(int lines)
+        {
+            for (int i=0; i<lines; ++i)
+            {
+                Console.SetCursorPosition(Console.BufferWidth, Console.BufferHeight - 1);
+                Console.WriteLine();
+            }
+        }
+
+        public CHAR_INFO[] ReadBufferLines(int top, int count)
+        {
+            var result = new CHAR_INFO[BufferWidth * count];
+            for (int i=0; i<BufferWidth*count; ++i)
+            {
+                result[i].UnicodeChar = ' ';
+                result[i].ForegroundColor = Console.ForegroundColor;
+                result[i].BackgroundColor = Console.BackgroundColor;
+            }
+            return result;
+        }
+
+        public int LengthInBufferCells(char c)
+        {
+            return 1;
+        }
+
+
+        public void StartRender()
+        {
+        }
+
+        public void EndRender()
+        {
+        }
+
+        // TODO: this is not correct, PSReadline never clears the screen, it should only scroll
         public void Clear()
         {
             Console.Clear();
         }
-#endif
     }
+#endif
 
 #if CORECLR // TODO: remove if CORECLR adds this attribute back
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Constructor | AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Event)]

--- a/src/Microsoft.PowerShell.PSReadLine/HistoryQueue.cs
+++ b/src/Microsoft.PowerShell.PSReadLine/HistoryQueue.cs
@@ -6,12 +6,13 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+#if CORECLR
+using Microsoft.PowerShell.Internal;
+#endif
 
 namespace Microsoft.PowerShell
 {
-#if !CORECLR
-        [ExcludeFromCodeCoverage]
-#endif
+    [ExcludeFromCodeCoverage]
     internal sealed class QueueDebugView<T>
     {
         private readonly HistoryQueue<T> _queue;
@@ -116,9 +117,7 @@ namespace Microsoft.PowerShell
             return result;
         }
 
-#if !CORECLR
         [ExcludeFromCodeCoverage]
-#endif
         public T this[int index]
         {
             get

--- a/src/Microsoft.PowerShell.PSReadLine/KeyBindings.cs
+++ b/src/Microsoft.PowerShell.PSReadLine/KeyBindings.cs
@@ -142,7 +142,7 @@ namespace Microsoft.PowerShell
                 { Keys.CtrlSpace,              MakeKeyHandler(MenuComplete,              "MenuComplete") },
                 { Keys.Tab,                    MakeKeyHandler(TabCompleteNext,           "TabCompleteNext") },
                 { Keys.ShiftTab,               MakeKeyHandler(TabCompletePrevious,       "TabCompletePrevious") },
-#if !CORECLR
+#if !LINUX
                 { Keys.VolumeDown,             MakeKeyHandler(Ignore,                    "Ignore") },
                 { Keys.VolumeUp,               MakeKeyHandler(Ignore,                    "Ignore") },
                 { Keys.VolumeMute,             MakeKeyHandler(Ignore,                    "Ignore") },
@@ -181,7 +181,7 @@ namespace Microsoft.PowerShell
                 { Keys.ShiftF3,                MakeKeyHandler(CharacterSearchBackward,   "CharacterSearchBackward") },
                 { Keys.F8,                     MakeKeyHandler(HistorySearchBackward,     "HistorySearchBackward") },
                 { Keys.ShiftF8,                MakeKeyHandler(HistorySearchForward,      "HistorySearchForward") },
-#if !CORECLR
+#if !LINUX
                 { Keys.PageUp,                 MakeKeyHandler(ScrollDisplayUp,           "ScrollDisplayUp") },
                 { Keys.PageDown,               MakeKeyHandler(ScrollDisplayDown,         "ScrollDisplayDown") },
                 { Keys.CtrlPageUp,             MakeKeyHandler(ScrollDisplayUpLine,       "ScrollDisplayUpLine") },
@@ -265,7 +265,7 @@ namespace Microsoft.PowerShell
                 { Keys.AltPeriod,       MakeKeyHandler(YankLastArg,          "YankLastArg") },
                 { Keys.AltUnderbar,     MakeKeyHandler(YankLastArg,          "YankLastArg") },
                 { Keys.AltCtrlY,        MakeKeyHandler(YankNthArg,           "YankNthArg") },
-#if !CORECLR
+#if !LINUX
                 { Keys.VolumeDown,      MakeKeyHandler(Ignore,               "Ignore") },
                 { Keys.VolumeUp,        MakeKeyHandler(Ignore,               "Ignore") },
                 { Keys.VolumeMute,      MakeKeyHandler(Ignore,               "Ignore") },

--- a/src/Microsoft.PowerShell.PSReadLine/KeyBindings.vi.cs
+++ b/src/Microsoft.PowerShell.PSReadLine/KeyBindings.vi.cs
@@ -70,7 +70,7 @@ namespace Microsoft.PowerShell
                 { Keys.Tab,             MakeKeyHandler(ViTabCompleteNext,      "ViTabCompleteNext") },
                 { Keys.ShiftTab,        MakeKeyHandler(ViTabCompletePrevious,  "ViTabCompletePrevious") },
                 { Keys.CtrlV,           MakeKeyHandler(Paste,                  "Paste") },
-#if !CORECLR
+#if !LINUX
                 { Keys.VolumeDown,      MakeKeyHandler(Ignore,                 "Ignore") },
                 { Keys.VolumeUp,        MakeKeyHandler(Ignore,                 "Ignore") },
                 { Keys.VolumeMute,      MakeKeyHandler(Ignore,                 "Ignore") },
@@ -109,7 +109,7 @@ namespace Microsoft.PowerShell
                 { Keys.Tab,             MakeKeyHandler(TabCompleteNext,      "TabCompleteNext") },
                 { Keys.ShiftTab,        MakeKeyHandler(TabCompletePrevious,  "TabCompletePrevious") },
                 { Keys.CtrlV,           MakeKeyHandler(Paste,                "Paste") },
-#if !CORECLR
+#if !LINUX
                 { Keys.VolumeDown,      MakeKeyHandler(Ignore,               "Ignore") },
                 { Keys.VolumeUp,        MakeKeyHandler(Ignore,               "Ignore") },
                 { Keys.VolumeMute,      MakeKeyHandler(Ignore,               "Ignore") },

--- a/src/Microsoft.PowerShell.PSReadLine/Keys.cs
+++ b/src/Microsoft.PowerShell.PSReadLine/Keys.cs
@@ -290,10 +290,10 @@ namespace Microsoft.PowerShell
         public static ConsoleKeyInfo ShiftF8 = new ConsoleKeyInfo((char)0, ConsoleKey.F8, true, false, false);
 
         // Keys to ignore 
-#if !CORECLR
-        public static ConsoleKeyInfo VolumeUp   = new ConsoleKeyInfo((char)0, ConsoleKey.VolumeUp, false, false, false);
-        public static ConsoleKeyInfo VolumeDown = new ConsoleKeyInfo((char)0, ConsoleKey.VolumeDown, false, false, false);
-        public static ConsoleKeyInfo VolumeMute = new ConsoleKeyInfo((char)0, ConsoleKey.VolumeMute, false, false, false);
+#if !LINUX
+        public static ConsoleKeyInfo VolumeUp   = new ConsoleKeyInfo((char)0, /*ConsoleKey.VolumeUp*/(ConsoleKey)175, false, false, false);
+        public static ConsoleKeyInfo VolumeDown = new ConsoleKeyInfo((char)0, /*ConsoleKey.VolumeDown*/(ConsoleKey)174, false, false, false);
+        public static ConsoleKeyInfo VolumeMute = new ConsoleKeyInfo((char)0, /*ConsoleKey.VolumeMute*/(ConsoleKey)173, false, false, false);
 #endif
     }
 }

--- a/src/Microsoft.PowerShell.PSReadLine/KillYank.cs
+++ b/src/Microsoft.PowerShell.PSReadLine/KillYank.cs
@@ -6,7 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Management.Automation.Language;
-#if !CORECLR
+#if !CORECLR // TODO: clipboard
 using System.Windows.Forms;
 #endif
 
@@ -478,7 +478,7 @@ namespace Microsoft.PowerShell
         [SuppressMessage("Microsoft.Design", "CA1026:DefaultParametersShouldNotBeUsed")]
         public static void Paste(ConsoleKeyInfo? key = null, object arg = null)
         {
-#if !CORECLR
+#if !CORECLR // TODO: clipboard
             string textToPaste = null;
             ExecuteOnSTAThread(() => {
                 if (Clipboard.ContainsText())
@@ -510,7 +510,7 @@ namespace Microsoft.PowerShell
         [SuppressMessage("Microsoft.Design", "CA1026:DefaultParametersShouldNotBeUsed")]
         public static void Copy(ConsoleKeyInfo? key = null, object arg = null)
         {
-#if !CORECLR
+#if !CORECLR // TODO: clipboard
             string textToSet;
             if (_singleton._visualSelectionCommandCount > 0)
             {
@@ -551,15 +551,15 @@ namespace Microsoft.PowerShell
         [SuppressMessage("Microsoft.Design", "CA1026:DefaultParametersShouldNotBeUsed")]
         public static void Cut(ConsoleKeyInfo? key = null, object arg = null)
         {
-#if !CORECLR
             if (_singleton._visualSelectionCommandCount > 0)
             {
                 int start, length;
                 _singleton.GetRegion(out start, out length);
+#if !CORECLR // TODO: clipboard
                 ExecuteOnSTAThread(() => Clipboard.SetText(_singleton._buffer.ToString(start, length)));
+#endif
                 Delete(start, length);
             }
-#endif
         }
     }
 }

--- a/src/Microsoft.PowerShell.PSReadLine/Movement.cs
+++ b/src/Microsoft.PowerShell.PSReadLine/Movement.cs
@@ -434,7 +434,7 @@ namespace Microsoft.PowerShell
         public static void ClearScreen(ConsoleKeyInfo? key = null, object arg = null)
         {
             var console = _singleton._console;
-#if CORECLR
+#if LINUX // TODO: this is not correct, it should only scroll
             console.Clear();
             _singleton._initialY = 0; 
             _singleton.Render();

--- a/src/Microsoft.PowerShell.PSReadLine/PublicAPI.cs
+++ b/src/Microsoft.PowerShell.PSReadLine/PublicAPI.cs
@@ -54,7 +54,7 @@ namespace Microsoft.PowerShell
             void StartRender();
             int LengthInBufferCells(char c);
             void EndRender();
-#if CORECLR
+#if LINUX
             void Clear();
 #endif
         }

--- a/src/Microsoft.PowerShell.PSReadLine/PublicAPI.cs
+++ b/src/Microsoft.PowerShell.PSReadLine/PublicAPI.cs
@@ -28,8 +28,9 @@ namespace Microsoft.PowerShell
         [SuppressMessage("Microsoft.MSInternal", "CA903:InternalNamespaceShouldNotContainPublicTypes")]
         public interface IConsole
         {
-            uint GetConsoleInputMode();
-            void SetConsoleInputMode(uint mode);
+            object GetConsoleInputMode();
+            void SetConsoleInputMode(object mode);
+            void RestoreConsoleInputMode(object mode);
             ConsoleKeyInfo ReadKey();
             bool KeyAvailable { get; }
             int CursorLeft { get; set; }

--- a/src/Microsoft.PowerShell.PSReadLine/PublicAPI.cs
+++ b/src/Microsoft.PowerShell.PSReadLine/PublicAPI.cs
@@ -47,10 +47,10 @@ namespace Microsoft.PowerShell
             void SetCursorPosition(int left, int top);
             void WriteLine(string s);
             void Write(string s);
-            void WriteBufferLines(CHAR_INFO[] buffer, ref int top);
-            void WriteBufferLines(CHAR_INFO[] buffer, ref int top, bool ensureBottomLineVisible);
+            void WriteBufferLines(BufferChar[] buffer, ref int top);
+            void WriteBufferLines(BufferChar[] buffer, ref int top, bool ensureBottomLineVisible);
             void ScrollBuffer(int lines);
-            CHAR_INFO[] ReadBufferLines(int top, int count);
+            BufferChar[] ReadBufferLines(int top, int count);
 
             void StartRender();
             int LengthInBufferCells(char c);

--- a/src/Microsoft.PowerShell.PSReadLine/ReadLine.cs
+++ b/src/Microsoft.PowerShell.PSReadLine/ReadLine.cs
@@ -544,7 +544,12 @@ namespace Microsoft.PowerShell
             _initialY = _console.CursorTop - Options.ExtraPromptLineCount;
             _initialBackgroundColor = _console.BackgroundColor;
             _initialForegroundColor = _console.ForegroundColor;
-            _space = new CHAR_INFO(' ', _initialForegroundColor, _initialBackgroundColor);
+            _space = new BufferChar
+            {
+                UnicodeChar = ' ',
+                BackgroundColor = _initialBackgroundColor,
+                ForegroundColor = _initialForegroundColor
+            };
             _bufferWidth = _console.BufferWidth;
             _killCommandCount = 0;
             _yankCommandCount = 0;

--- a/src/Microsoft.PowerShell.PSReadLine/Render.cs
+++ b/src/Microsoft.PowerShell.PSReadLine/Render.cs
@@ -13,6 +13,7 @@ namespace Microsoft.PowerShell
 {
     public partial class PSConsoleReadLine
     {
+        private const ConsoleColor UnknownColor = (ConsoleColor) (-1);
         private CHAR_INFO[] _consoleBuffer;
         private int _initialX;
         private int _initialY;
@@ -464,8 +465,8 @@ namespace Microsoft.PowerShell
                 // but looks best with the 2 default color schemes - starting PowerShell
                 // from it's shortcut or from a cmd shortcut.
 #if LINUX // TODO: set Inverse attribute and let render choose what to do.
-                ConsoleColor tempColor = ((int)foregroundColor == -1) ? ConsoleColor.White : foregroundColor;
-                foregroundColor = ((int)backgroundColor == -1) ? ConsoleColor.Black : backgroundColor;
+                ConsoleColor tempColor = (foregroundColor == UnknownColor) ? ConsoleColor.White : foregroundColor;
+                foregroundColor = (backgroundColor == UnknownColor) ? ConsoleColor.Black : backgroundColor;
                 backgroundColor = tempColor;
 #else
                 foregroundColor = (ConsoleColor)((int)foregroundColor ^ 7);

--- a/src/Microsoft.PowerShell.PSReadLine/Render.cs
+++ b/src/Microsoft.PowerShell.PSReadLine/Render.cs
@@ -656,7 +656,11 @@ namespace Microsoft.PowerShell
             case BellStyle.None:
                 break;
             case BellStyle.Audible:
+#if LINUX
+                Console.Beep();
+#else
                 Console.Beep(Options.DingTone, Options.DingDuration);
+#endif
                 break;
             case BellStyle.Visual:
                 // TODO: flash prompt? command line?

--- a/src/Microsoft.PowerShell.PSReadLine/Render.cs
+++ b/src/Microsoft.PowerShell.PSReadLine/Render.cs
@@ -100,10 +100,7 @@ namespace Microsoft.PowerShell
 
             try
             {
-#if !CORECLR
                 _console.StartRender();
-#endif
-
                 bufferLineCount = ConvertOffsetToCoordinates(text.Length).Y - _initialY + 1 + statusLineCount;
                 if (_consoleBuffer.Length != bufferLineCount * bufferWidth)
                 {
@@ -231,16 +228,12 @@ namespace Microsoft.PowerShell
                         else if (size > 1)
                         {
                             _consoleBuffer[j].UnicodeChar = charToRender;
-#if !CORECLR
                             _consoleBuffer[j].Attributes = (ushort)(_consoleBuffer[j].Attributes |
                                                            (uint)CHAR_INFO_Attributes.COMMON_LVB_LEADING_BYTE);
-#endif
                             MaybeEmphasize(ref _consoleBuffer[j++], i, foregroundColor, backgroundColor);
                             _consoleBuffer[j].UnicodeChar = charToRender;
-#if !CORECLR
                             _consoleBuffer[j].Attributes = (ushort)(_consoleBuffer[j].Attributes |
                                                            (uint)CHAR_INFO_Attributes.COMMON_LVB_TRAILING_BYTE);
-#endif
                             MaybeEmphasize(ref _consoleBuffer[j++], i, foregroundColor, backgroundColor);
                         }
                         else
@@ -253,9 +246,7 @@ namespace Microsoft.PowerShell
             }
             finally
             {
-#if !CORECLR
                 _console.EndRender();
-#endif
             }
 
             for (; j < (_consoleBuffer.Length - (statusLineCount * _bufferWidth)); j++)
@@ -319,7 +310,7 @@ namespace Microsoft.PowerShell
 
             if ((_initialY + bufferLineCount) > (_console.WindowTop + _console.WindowHeight))
             {
-#if !CORECLR               
+#if !LINUX // TODO: verify this isn't necessary for LINUX
                 _console.WindowTop = _initialY + bufferLineCount - _console.WindowHeight;
 #endif
             }
@@ -472,7 +463,7 @@ namespace Microsoft.PowerShell
                 // to invert only the lower 3 bits to change the color is somewhat
                 // but looks best with the 2 default color schemes - starting PowerShell
                 // from it's shortcut or from a cmd shortcut.
-#if CORECLR                
+#if LINUX // TODO: set Inverse attribute and let render choose what to do.
                 ConsoleColor tempColor = ((int)foregroundColor == -1) ? ConsoleColor.White : foregroundColor;
                 foregroundColor = ((int)backgroundColor == -1) ? ConsoleColor.Black : backgroundColor;
                 backgroundColor = tempColor;
@@ -654,12 +645,9 @@ namespace Microsoft.PowerShell
             return (_statusLinePrompt.Length + _statusBuffer.Length) / _console.BufferWidth + 1;
         }
 
-#if !CORECLR
         [ExcludeFromCodeCoverage]
-#endif
         void IPSConsoleReadLineMockableMethods.Ding()
         {
-#if !CORECLR
             switch (Options.BellStyle)
             {
             case BellStyle.None:
@@ -671,7 +659,6 @@ namespace Microsoft.PowerShell
                 // TODO: flash prompt? command line?
                 break;
             }
-#endif
         }
 
         /// <summary>
@@ -696,7 +683,7 @@ namespace Microsoft.PowerShell
 
         #region Screen scrolling
 
-#if !CORECLR
+#if !LINUX
         /// <summary>
         /// Scroll the display up one screen.
         /// </summary>

--- a/src/Microsoft.PowerShell.PSReadLine/VisualEditing.vi.cs
+++ b/src/Microsoft.PowerShell.PSReadLine/VisualEditing.vi.cs
@@ -96,7 +96,6 @@ namespace Microsoft.PowerShell
         private static string GetPreferredEditor()
         {
             string[] names = {"VISUAL", "EDITOR"};
-#if CORECLR
             foreach (string name in names)
             {
                 string editor = Environment.GetEnvironmentVariable(name);
@@ -105,24 +104,7 @@ namespace Microsoft.PowerShell
                     return editor;
                 }
             }
-#else
-            EnvironmentVariableTarget[] targets = {
-                                                      EnvironmentVariableTarget.Machine,
-                                                      EnvironmentVariableTarget.Process,
-                                                      EnvironmentVariableTarget.User
-                                                  };
-            foreach (string name in names)
-            {
-                foreach (EnvironmentVariableTarget target in targets)
-                {
-                    string editor = Environment.GetEnvironmentVariable(name, target);
-                    if (!string.IsNullOrWhiteSpace(editor))
-                    {
-                        return editor;
-                    }
-                }
-            }
-#endif
+
             return null;
         }
     }

--- a/src/Microsoft.PowerShell.PSReadLine/project.json
+++ b/src/Microsoft.PowerShell.PSReadLine/project.json
@@ -9,6 +9,14 @@
         "warningsAsErrors": true
     },
 
+    "configurations": {
+        "Linux": {
+            "buildOptions": {
+                "define": [ "LINUX" ]
+            }
+        }
+    },
+
     "dependencies": {
         "System.Management.Automation": "1.0.0-*"
     },


### PR DESCRIPTION
<!-- PR checklist -->
- [ ] Resolves #1080 (I think)
- [ ] Code is up-to-date with `master`.
- [ ] Add tests that fail without your changes.
- [ ] Update all relevant [documentation](../docs).

<!-- Provide more details about the PR below -->

The initial port of PSReadLine to LINUX ignored the fact that PSReadLine would also run under CORECLR on Windows.  I've fixed that, so most of the Windows specific capabilities of PSReadLine have been restored, with the notable exception of access to the clipboard.

I also introduced a new implementation of the IConsole interface to simplify the differences b/w using conhost vs. a tty.

Remaining work (I will create issues for these):
- Guard Windows P/Invokes under LINUX (b/c they are useless)
- Bring back clipboard support under CORECLR
- Improve perf on LINUX by not writing character by character (at a minimum, writing substrings that all have the same colors, better would be to use escape sequences and a single write)
- Remove the scraping of the prompt, it doesn't actually work on Linux and only slightly simplifies rendering.
