### PR TITLE
Switch to Xcode 8beta image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ matrix:
       dist: trusty
       sudo: required
     - os: osx
-      osx_image: xcode7.3
+      osx_image: xcode8
       language: generic
 addons:
   artifacts:


### PR DESCRIPTION
The 7.3 image is failing.

This _might_ bring OS X builds back online.

/cc @vors @daxian-dbw 
