### PR TITLE
Fix issue #682 - [system.manage<Tab>] doesn't work

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Diagnostics/CommonUtils.cs
+++ b/src/Microsoft.PowerShell.Commands.Diagnostics/CommonUtils.cs
@@ -11,6 +11,7 @@ namespace Microsoft.PowerShell.Commands.Diagnostics.Common
 
     internal static class CommonUtilities
     {
+#if !CORECLR
         //
         // StringArrayToString helper converts a string array into a comma-separated string.
         // Note this has only limited use, individual strings cannot have commas.
@@ -111,13 +112,13 @@ namespace Microsoft.PowerShell.Commands.Diagnostics.Common
             }
             return formatError;
         }
+#endif
 
         public static ResourceManager GetResourceManager()
         {
             // this naming pattern is dictated by the dotnet cli
             return new ResourceManager("Microsoft.PowerShell.Commands.Diagnostics.resources.GetEventResources", typeof(CommonUtilities).GetTypeInfo().Assembly);
         }
-
     }
 }
 

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -5907,21 +5907,32 @@ namespace System.Management.Automation
         /// <param name="namespace">The namespace</param>
         private static void HandleNamespace(Dictionary<string, TypeCompletionMapping> entryCache, string @namespace)
         {
-            if (!string.IsNullOrEmpty(@namespace))
+            if (string.IsNullOrEmpty(@namespace))
             {
+                return;
+            }
+
+            int dotIndex = 0;
+            while (dotIndex != -1)
+            {
+                dotIndex = @namespace.IndexOf('.', dotIndex + 1);
+                string subNamespace = dotIndex != -1
+                                        ? @namespace.Substring(0, dotIndex)
+                                        : @namespace;
+
                 TypeCompletionMapping entry;
-                if (!entryCache.TryGetValue(@namespace, out entry))
+                if (!entryCache.TryGetValue(subNamespace, out entry))
                 {
                     entry = new TypeCompletionMapping
                     {
-                        Key = @namespace,
-                        Completions = { new NamespaceCompletion { Namespace = @namespace } }
+                        Key = subNamespace,
+                        Completions = { new NamespaceCompletion { Namespace = subNamespace } }
                     };
-                    entryCache.Add(@namespace, entry);
+                    entryCache.Add(subNamespace, entry);
                 }
                 else if (!entry.Completions.OfType<NamespaceCompletion>().Any())
                 {
-                    entry.Completions.Add(new NamespaceCompletion { Namespace = @namespace });
+                    entry.Completions.Add(new NamespaceCompletion { Namespace = subNamespace });
                 }
             }
         }

--- a/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
@@ -1818,7 +1818,7 @@ namespace Microsoft.PowerShell.Commands
                 DirectoryInfo parent = null;
                 try
                 {
-                    parent = ClrFacade.GetParent(moduleManifestPath);
+                    parent = Directory.GetParent(moduleManifestPath);
                 }
                 catch (IOException)
                 {

--- a/src/System.Management.Automation/engine/Modules/TestModuleManifestCommand.cs
+++ b/src/System.Management.Automation/engine/Modules/TestModuleManifestCommand.cs
@@ -241,7 +241,7 @@ namespace Microsoft.PowerShell.Commands
                 DirectoryInfo parent = null;
                 try
                 {
-                    parent = ClrFacade.GetParent(filePath);
+                    parent = Directory.GetParent(filePath);
                 }
                 catch (IOException) { }
                 catch (UnauthorizedAccessException) { }

--- a/src/System.Management.Automation/resources/ParserStrings.resx
+++ b/src/System.Management.Automation/resources/ParserStrings.resx
@@ -1351,8 +1351,8 @@ ModuleVersion : Version of module to import. If used, ModuleName must represent 
   <data name="CantActivateDocumentInPowerShellCore" xml:space="preserve">
     <value>Cannot run a document in PowerShell Core: {0}.</value>
   </data>
-  <data name="InvalidAssemblyLoadContextInUse" xml:space="preserve">
-    <value>The default AssemblyLoadContext in use is invalid. The default AssemblyLoadContext for PowerShell Core should be of type 'PowerShellAssemblyLoader'.</value>
+  <data name="LoadContextNotInitialized" xml:space="preserve">
+    <value>'PowerShellAssemblyLoadContext' is not initialized.</value>
   </data>
   <data name="MultipleTypeConstraintsOnMethodParam" xml:space="preserve">
     <value>Multiple type constraints are not allowed on a method parameter.</value>

--- a/src/System.Management.Automation/utils/ClrFacade.cs
+++ b/src/System.Management.Automation/utils/ClrFacade.cs
@@ -344,6 +344,10 @@ namespace System.Management.Automation
         {
             get
             {
+                if (PowerShellAssemblyLoadContext.Instance == null)
+                {
+                    throw new InvalidOperationException(ParserStrings.LoadContextNotInitialized);
+                }
                 return PowerShellAssemblyLoadContext.Instance;
             }
         }
@@ -510,15 +514,6 @@ namespace System.Management.Automation
 #else
             return System.Runtime.Remoting.RemotingServices.IsTransparentProxy(obj);
 #endif
-        }
-
-        /// <summary>
-        /// Facade for Directory.GetParent(string)
-        /// </summary>
-        internal static DirectoryInfo GetParent(string path)
-        {
-            // Porting note: this is in recent CoreCLR
-            return Directory.GetParent(path);
         }
 
         /// <summary>

--- a/src/powershell-native/nativemsh/pwrshcommon/pwrshcommon.cpp
+++ b/src/powershell-native/nativemsh/pwrshcommon/pwrshcommon.cpp
@@ -1454,14 +1454,14 @@ namespace NativeMsh
         props[nProps] = L"TRUSTED_PLATFORM_ASSEMBLIES";        
         std::wstring tempStr = assemblyList.str();
         vals[nProps] = tempStr.c_str();
-		nProps++;
+        nProps++;
 
         props[nProps] = L"APP_PATHS";
-        vals[nProps] = hostEnvironment.GetHostDirectoryPath();
+        vals[nProps] = L"";
         nProps++;
 
         props[nProps] = L"APP_NI_PATHS";
-        vals[nProps] = hostEnvironment.GetHostDirectoryPath();
+        vals[nProps] = L"";
         nProps++;
 
         // Create the customized AppDomainManager out of the SandboxHelper class

--- a/test/powershell/Host/TabCompletion/BugFix.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/BugFix.Tests.ps1
@@ -1,0 +1,9 @@
+Describe "Issue#682 - [system.manage<tab>] should work" {
+    
+    It "[system.manage<tab>" {
+        $result = TabExpansion2 -inputScript "[system.manage" -cursorColumn "[system.manage".Length
+        $result | Should Not BeNullOrEmpty
+        $result.CompletionMatches.Count | Should Be 1
+        $result.CompletionMatches[0].CompletionText | Should Be "System.Management"
+    }
+}


### PR DESCRIPTION
Resolves #682 
The issue happens to CoreCLR build but not FullCLR built because the `System.Management` namespace exists and is available in FullCLR (WMIv1 managed APIs), but it's not in CoreCLR. The fix makes sure we can expand a namespace even if partial name of the namespace doesn't really exist as a namespace or a type name.

This PR also include the most recent changes to ALC that were checked into RS2 branch. It has been reviewed by Mike and Andy when checking in to SD.

@lzybkr can you please review the type completion fix?
cc @vors for the change in CommonUtilities.cs
