### PR TITLE
Exclude PackageSourceList from building on *nix platforms

### DIFF
--- a/src/Microsoft.PackageManagement.PackageSourceListProvider/Extensions/PackageListExtensions.cs
+++ b/src/Microsoft.PackageManagement.PackageSourceListProvider/Extensions/PackageListExtensions.cs
@@ -1,4 +1,6 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+﻿#if !LINUX
+
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -90,3 +92,5 @@ namespace Microsoft.PackageManagement.PackageSourceListProvider
         }
     }
 }
+
+#endif

--- a/src/Microsoft.PackageManagement.PackageSourceListProvider/PackageList/ExePackageInstaller.cs
+++ b/src/Microsoft.PackageManagement.PackageSourceListProvider/PackageList/ExePackageInstaller.cs
@@ -1,4 +1,6 @@
-﻿// 
+﻿#if !LINUX
+
+// 
 //  Copyright (c) Microsoft Corporation. All rights reserved. 
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
@@ -592,3 +594,5 @@ namespace Microsoft.PackageManagement.PackageSourceListProvider
         }
     }
 }
+
+#endif

--- a/src/Microsoft.PackageManagement.PackageSourceListProvider/PackageList/NupkgInstaller.cs
+++ b/src/Microsoft.PackageManagement.PackageSourceListProvider/PackageList/NupkgInstaller.cs
@@ -1,4 +1,6 @@
-﻿// 
+﻿#if !LINUX
+
+// 
 //  Copyright (c) Microsoft Corporation. All rights reserved. 
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
@@ -233,3 +235,5 @@ namespace Microsoft.PackageManagement.PackageSourceListProvider
         }
     }
 }
+
+#endif

--- a/src/Microsoft.PackageManagement.PackageSourceListProvider/PackageList/PackageListParser.cs
+++ b/src/Microsoft.PackageManagement.PackageSourceListProvider/PackageList/PackageListParser.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#if !LINUX
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.IO;
@@ -440,3 +442,5 @@ namespace Microsoft.PackageManagement.PackageSourceListProvider
         }
     } 
 }
+
+#endif

--- a/src/Microsoft.PackageManagement.PackageSourceListProvider/PackageList/PackageListProvider.cs
+++ b/src/Microsoft.PackageManagement.PackageSourceListProvider/PackageList/PackageListProvider.cs
@@ -1,4 +1,6 @@
-﻿// 
+﻿#if !LINUX
+
+// 
 //  Copyright (c) Microsoft Corporation. All rights reserved. 
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
@@ -869,3 +871,5 @@ namespace Microsoft.PackageManagement.PackageSourceListProvider
         }      
     }
 }
+
+#endif

--- a/src/Microsoft.PackageManagement.PackageSourceListProvider/PackageList/PackageListRequest.cs
+++ b/src/Microsoft.PackageManagement.PackageSourceListProvider/PackageList/PackageListRequest.cs
@@ -1,3 +1,5 @@
+#if !LINUX
+
 // 
 //  Copyright (c) Microsoft Corporation. All rights reserved. 
 //  Licensed under the Apache License, Version 2.0 (the "License");
@@ -1071,3 +1073,5 @@ namespace Microsoft.PackageManagement.PackageSourceListProvider
         }
     }
 }
+
+#endif

--- a/src/Microsoft.PackageManagement.PackageSourceListProvider/PackageList/PackageQuery.cs
+++ b/src/Microsoft.PackageManagement.PackageSourceListProvider/PackageList/PackageQuery.cs
@@ -1,4 +1,6 @@
-﻿// 
+﻿#if !LINUX
+
+// 
 //  Copyright (c) Microsoft Corporation. All rights reserved. 
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
@@ -152,3 +154,5 @@ namespace Microsoft.PackageManagement.PackageSourceListProvider
       }
     }
 }
+
+#endif

--- a/src/Microsoft.PackageManagement.PackageSourceListProvider/PackageList/PackageSource.cs
+++ b/src/Microsoft.PackageManagement.PackageSourceListProvider/PackageList/PackageSource.cs
@@ -1,4 +1,6 @@
-﻿// 
+﻿#if !LINUX
+
+// 
 //  Copyright (c) Microsoft Corporation. All rights reserved. 
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
@@ -41,3 +43,5 @@ namespace Microsoft.PackageManagement.PackageSourceListProvider
         }
     }
 }
+
+#endif

--- a/src/Microsoft.PackageManagement.PackageSourceListProvider/PackageList/PowerShellArtifactInstaller.cs
+++ b/src/Microsoft.PackageManagement.PackageSourceListProvider/PackageList/PowerShellArtifactInstaller.cs
@@ -1,4 +1,6 @@
-﻿// 
+﻿#if !LINUX
+
+// 
 //  Copyright (c) Microsoft Corporation. All rights reserved. 
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
@@ -198,3 +200,5 @@ namespace Microsoft.PackageManagement.PackageSourceListProvider
 
     }
 }
+
+#endif

--- a/src/Microsoft.PackageManagement.PackageSourceListProvider/PackageList/ProgressTracker.cs
+++ b/src/Microsoft.PackageManagement.PackageSourceListProvider/PackageList/ProgressTracker.cs
@@ -1,4 +1,6 @@
-﻿// 
+﻿#if !LINUX
+
+// 
 //  Copyright (c) Microsoft Corporation. All rights reserved. 
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
@@ -51,3 +53,5 @@ namespace Microsoft.PackageManagement.PackageSourceListProvider
         }
     }
 }
+
+#endif

--- a/src/Microsoft.PackageManagement.PackageSourceListProvider/PackageList/WebDownloader.cs
+++ b/src/Microsoft.PackageManagement.PackageSourceListProvider/PackageList/WebDownloader.cs
@@ -1,4 +1,6 @@
-﻿//
+﻿#if !LINUX
+
+//
 //  Copyright (c) Microsoft Corporation. All rights reserved.
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
@@ -238,3 +240,5 @@ namespace Microsoft.PackageManagement.PackageSourceListProvider
         }
     }
 }
+
+#endif

--- a/src/Microsoft.PackageManagement.PackageSourceListProvider/PackageList/ZipPackageInstaller.cs
+++ b/src/Microsoft.PackageManagement.PackageSourceListProvider/PackageList/ZipPackageInstaller.cs
@@ -1,4 +1,6 @@
-﻿// 
+﻿#if !LINUX
+
+// 
 //  Copyright (c) Microsoft Corporation. All rights reserved. 
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
@@ -213,3 +215,5 @@ namespace Microsoft.PackageManagement.PackageSourceListProvider
         }
     }
 }
+
+#endif

--- a/src/Microsoft.PackageManagement.PackageSourceListProvider/Sdk/Constants.cs
+++ b/src/Microsoft.PackageManagement.PackageSourceListProvider/Sdk/Constants.cs
@@ -1,3 +1,4 @@
+#if !LINUX
 
 namespace Microsoft.PackageManagement.PackageSourceListProvider
 {
@@ -153,3 +154,5 @@ namespace Microsoft.PackageManagement.PackageSourceListProvider
         #endregion
     }
 }
+
+#endif

--- a/src/Microsoft.PackageManagement.PackageSourceListProvider/project.json
+++ b/src/Microsoft.PackageManagement.PackageSourceListProvider/project.json
@@ -10,8 +10,7 @@
 	"configurations": {
 		"Linux": {
 			"buildOptions": {
-        "define": [ "LINUX" ],
-        "exclude": [ "**/*" ]
+        "define": [ "LINUX" ] 
 			}
 		}
 	},
@@ -61,7 +60,8 @@
             "../Microsoft.PackageManagement/Providers/Inbox/Common/Extensions/*.cs",
             "../Microsoft.PackageManagement/Providers/Inbox/Common/Utility/*.cs",
             "../Microsoft.PackageManagement/Providers/Inbox/Common/Version/*.cs"
-          ]
+          ],          
+            "exclude": [ "**/*" ]         
 				}
 			},
       "dependencies": {

--- a/src/Microsoft.PackageManagement.PackageSourceListProvider/project.json
+++ b/src/Microsoft.PackageManagement.PackageSourceListProvider/project.json
@@ -60,8 +60,7 @@
             "../Microsoft.PackageManagement/Providers/Inbox/Common/Extensions/*.cs",
             "../Microsoft.PackageManagement/Providers/Inbox/Common/Utility/*.cs",
             "../Microsoft.PackageManagement/Providers/Inbox/Common/Version/*.cs"
-          ],          
-            "exclude": [ "**/*" ]         
+          ]     
 				}
 			},
       "dependencies": {

--- a/src/Microsoft.PackageManagement.PackageSourceListProvider/project.json
+++ b/src/Microsoft.PackageManagement.PackageSourceListProvider/project.json
@@ -10,7 +10,8 @@
 	"configurations": {
 		"Linux": {
 			"buildOptions": {
-				"define": ["LINUX"]
+        "define": [ "LINUX" ],
+        "exclude": [ "**/*" ]
 			}
 		}
 	},


### PR DESCRIPTION
We want to use the native packagemangement technologies (such as apt-get, rpm) on *nix platforms.
