### PR TITLE
Implement Get-Process -IncludeUserName for Linux

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
@@ -866,6 +866,9 @@ namespace Microsoft.PowerShell.Commands
         private static string RetrieveProcessUserName(Process process, Cmdlet cmdlet)
         {
             string userName = null;
+#if LINUX
+            userName = Platform.NonWindowsGetFileOwner("/proc/" + process.Id);
+#else
             IntPtr tokenUserInfo = IntPtr.Zero;
             IntPtr processTokenHandler = IntPtr.Zero;
 
@@ -955,6 +958,7 @@ namespace Microsoft.PowerShell.Commands
                 }
             }
 
+#endif
             return userName;
         }
 

--- a/src/System.Management.Automation/CoreCLR/CorePsPlatform.cs
+++ b/src/System.Management.Automation/CoreCLR/CorePsPlatform.cs
@@ -354,6 +354,18 @@ namespace System.Management.Automation
             }
         }
 
+        internal static string NonWindowsGetFileOwner(string path)
+        {
+            if (!IsWindows)
+            {
+                return LinuxPlatform.GetFileOwner(path);
+            }
+            else
+            {
+                throw new PlatformNotSupportedException();
+            }
+        }
+
 #if CORECLR
         internal static string NonWindowsGetFolderPath(SpecialFolder folder)
         {
@@ -740,6 +752,11 @@ namespace System.Management.Automation
             return Native.FollowSymLink(path);
         }
 
+        public static string GetFileOwner(string path)
+        {
+            return Native.GetFileOwner(path);
+        }
+
         [StructLayout(LayoutKind.Sequential)]
         internal class SetDateInfoInternal
         {
@@ -809,6 +826,9 @@ namespace System.Management.Automation
             [return: MarshalAs(UnmanagedType.LPStr)]
             internal static extern string FollowSymLink([MarshalAs(UnmanagedType.LPStr)]string filePath);
 
+            [DllImport(psLib, CharSet = CharSet.Ansi, SetLastError = true)]
+            [return: MarshalAs(UnmanagedType.LPStr)]
+            internal static extern string GetFileOwner([MarshalAs(UnmanagedType.LPStr)]string filePath);
         }
     }
 

--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -960,21 +960,20 @@ namespace System.Management.Automation
 
         internal static bool IsAdministrator()
         {
-            // Porting note: only Windows supports the
-            // SecurityPrincipal API of .net for now assume Linux
-            // users have no concept of "Administrator" for now and
-            // specifically do not map to a check for root user
-            if (Platform.IsWindows)
-            {
-                System.Security.Principal.WindowsIdentity currentIdentity = System.Security.Principal.WindowsIdentity.GetCurrent();
-                System.Security.Principal.WindowsPrincipal principal = new System.Security.Principal.WindowsPrincipal(currentIdentity);
+            // Porting note: only Windows supports the SecurityPrincipal API of .NET. Due to
+            // advanced privilege models, the correct approach on Unix is to assume the user has
+            // permissions, attempt the task, and error gracefully if the task fails due to
+            // permissions. To fit into PowerShell's existing model of pre-emptively checking
+            // permissions (which cannot be assumed on Unix), we "assume" the user is an
+            // administrator by returning true, thus nullifying this check on Unix.
+#if LINUX
+            return true;
+#else
+            System.Security.Principal.WindowsIdentity currentIdentity = System.Security.Principal.WindowsIdentity.GetCurrent();
+            System.Security.Principal.WindowsPrincipal principal = new System.Security.Principal.WindowsPrincipal(currentIdentity);
 
-                return principal.IsInRole(System.Security.Principal.WindowsBuiltInRole.Administrator);
-            }
-            else
-            {
-                return false;
-            }
+            return principal.IsInRole(System.Security.Principal.WindowsBuiltInRole.Administrator);
+#endif
         }
 
         internal static bool NativeItemExists(string path)

--- a/src/libpsl-native/src/CMakeLists.txt
+++ b/src/libpsl-native/src/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_library(psl-native SHARED
   getstat.cpp
+  getfileowner.cpp
   getcurrentprocessorid.cpp
   getusername.cpp
   getcomputername.cpp

--- a/src/libpsl-native/src/CMakeLists.txt
+++ b/src/libpsl-native/src/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_library(psl-native SHARED
+  getstat.cpp
   getcurrentprocessorid.cpp
   getusername.cpp
   getcomputername.cpp

--- a/src/libpsl-native/src/getfileowner.cpp
+++ b/src/libpsl-native/src/getfileowner.cpp
@@ -1,0 +1,105 @@
+//! @file getfileowner.cpp
+//! @author Andrew Schwartzmeyer <andschwa@microsoft.com>
+//! @brief returns the owner of a file
+
+#include <errno.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <pwd.h>
+#include <string.h>
+#include <unistd.h>
+#include "getstat.h"
+#include "getfileowner.h"
+
+//! @brief GetFileOwner returns the owner of a file
+//!
+//! GetFileOwner
+//!
+//! @param[in] fileName
+//! @parblock
+//! A pointer to the buffer that contains the file name
+//!
+//! char* is marshaled as an LPStr, which on Linux is UTF-8.
+//! @endparblock
+//!
+//! @exception errno Passes these errors via errno to GetLastError:
+//! - ERROR_INVALID_PARAMETER: parameter is not valid
+//! - ERROR_FILE_NOT_FOUND: file does not exist
+//! - ERROR_ACCESS_DENIED: access is denied
+//! - ERROR_INVALID_ADDRESS: attempt to access invalid address
+//! - ERROR_STOPPED_ON_SYMLINK: too many symbolic links
+//! - ERROR_GEN_FAILURE: I/O error occurred
+//! - ERROR_INVALID_NAME: file provided is not a symbolic link
+//! - ERROR_INVALID_FUNCTION: incorrect function
+//! - ERROR_BAD_PATH_NAME: pathname is too long
+//! - ERROR_OUTOFMEMORY insufficient kernal memory
+//!
+//! @retval file owner, or NULL if unsuccessful
+//!
+char* GetFileOwner(const char* fileName)
+{
+    int32_t ret = 0;
+    errno = 0;
+
+    if (!fileName)
+    {
+        errno = ERROR_INVALID_PARAMETER;
+        return NULL;
+    }
+
+    struct stat fileStat;
+    ret = GetStat(fileName, &fileStat);
+    if (ret != 0)
+    {
+        return NULL;
+    }
+
+    struct passwd pwd;
+    struct passwd* result = NULL;
+    char* buf;
+
+    int buflen = sysconf(_SC_GETPW_R_SIZE_MAX);
+    if (buflen < 1)
+    {
+        buflen = 2048;
+    }
+
+allocate:
+    buf = (char*)calloc(buflen, sizeof(char));
+
+    ret = getpwuid_r(fileStat.st_uid, &pwd, buf, buflen, &result);
+
+    if (ret != 0)
+    {
+        switch(errno)
+        {
+        case ERANGE:
+            free(buf);
+            buflen *= 2;
+            goto allocate;
+        case ENOENT:
+        case ESRCH:
+        case EBADF:
+        case EPERM:
+            errno = ERROR_NO_SUCH_USER;
+            break;
+        case ENOMEM:
+            errno = ERROR_OUTOFMEMORY;
+            break;
+       default:
+            errno = ERROR_GEN_FAILURE;
+        }
+        return NULL;
+    }
+
+    // no result
+    if (result == NULL)
+    {
+        return NULL;
+    }
+
+    size_t userlen = strnlen(pwd.pw_name, buflen);
+    char* username = strndup(pwd.pw_name, userlen);
+    free(buf);
+    return username;
+}

--- a/src/libpsl-native/src/getfileowner.h
+++ b/src/libpsl-native/src/getfileowner.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "pal.h"
+
+PAL_BEGIN_EXTERNC
+
+char* GetFileOwner(const char* fileName);
+
+PAL_END_EXTERNC

--- a/src/libpsl-native/src/getstat.cpp
+++ b/src/libpsl-native/src/getstat.cpp
@@ -1,0 +1,96 @@
+//! @file getstat.cpp
+//! @author Andrew Schwartzmeyer <andschwa@microsoft.com>
+//! @brief returns the stat of a file
+
+#include <errno.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <pwd.h>
+#include <string.h>
+#include <unistd.h>
+#include "getstat.h"
+
+//! @brief GetStat returns the stat of a file. This simply delegates to the
+//! stat() system call and maps errno to the expected values for GetLastError.
+//!
+//! GetStat
+//!
+//! @param[in] path
+//! @parblock
+//! A pointer to the buffer that contains the file name
+//!
+//! char* is marshaled as an LPStr, which on Linux is UTF-8.
+//! @endparblock
+//!
+//! @param[in] stat
+//! @parblock
+//! A pointer to the buffer in which to place the stat information
+//! @endparblock
+//!
+//! @exception errno Passes these errors via errno to GetLastError:
+//! - ERROR_INVALID_PARAMETER: parameter is not valid
+//! - ERROR_FILE_NOT_FOUND: file does not exist
+//! - ERROR_ACCESS_DENIED: access is denied
+//! - ERROR_INVALID_ADDRESS: attempt to access invalid address
+//! - ERROR_STOPPED_ON_SYMLINK: too many symbolic links
+//! - ERROR_GEN_FAILURE: I/O error occurred
+//! - ERROR_INVALID_NAME: file provided is not a symbolic link
+//! - ERROR_INVALID_FUNCTION: incorrect function
+//! - ERROR_BAD_PATH_NAME: pathname is too long
+//! - ERROR_OUTOFMEMORY insufficient kernel memory
+//!
+//! @retval 0 if successful
+//! @retval -1 if failed
+//!
+
+int32_t GetStat(const char* path, struct stat* buf)
+{
+    errno = 0;
+
+    if (!path)
+    {
+        errno = ERROR_INVALID_PARAMETER;
+        return -1;
+    }
+
+    int32_t ret = stat(path, buf);
+
+    if (ret != 0)
+    {
+        switch(errno)
+        {
+        case EACCES:
+            errno = ERROR_ACCESS_DENIED;
+            break;
+        case EBADF:
+            errno = ERROR_FILE_NOT_FOUND;
+            break;
+        case EFAULT:
+            errno = ERROR_INVALID_ADDRESS;
+            break;
+        case ELOOP:
+            errno = ERROR_STOPPED_ON_SYMLINK;
+            break;
+        case ENAMETOOLONG:
+            errno = ERROR_GEN_FAILURE;
+            break;
+        case ENOENT:
+            errno = ERROR_FILE_NOT_FOUND;
+            break;
+        case ENOMEM:
+            errno = ERROR_NO_SUCH_USER;
+            break;
+        case ENOTDIR:
+            errno = ERROR_INVALID_NAME;
+            break;
+        case EOVERFLOW:
+            errno = ERROR_BUFFER_OVERFLOW;
+            break;
+        default:
+            errno = ERROR_INVALID_FUNCTION;
+        }
+        return -1;
+    }
+
+    return 0;
+}

--- a/src/libpsl-native/src/getstat.h
+++ b/src/libpsl-native/src/getstat.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <sys/stat.h>
+#include "pal.h"
+
+PAL_BEGIN_EXTERNC
+
+int32_t GetStat(const char* path, struct stat* buf);
+
+PAL_END_EXTERNC

--- a/src/libpsl-native/test/CMakeLists.txt
+++ b/src/libpsl-native/test/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_subdirectory(googletest)
 
 add_executable(psl-native-test
+  test-getfileowner.cpp
   test-locale.cpp
   test-getcurrentprocessid.cpp
   test-getusername.cpp

--- a/src/libpsl-native/test/test-getfileowner.cpp
+++ b/src/libpsl-native/test/test-getfileowner.cpp
@@ -1,0 +1,32 @@
+//! @file test-getfileowner.cpp
+//! @author Andrew Schwartzmeyer <andschwa@microsoft.com>
+//! @brief Tests GetFileOwner
+
+#include <gtest/gtest.h>
+#include <errno.h>
+#include <unistd.h>
+#include "getfileowner.h"
+
+using namespace std;
+
+//! Test fixture for GetFileOwner
+class GetFileOwnerTest : public ::testing::Test
+{
+};
+
+TEST_F(GetFileOwnerTest, CanGetOwnerOfRoot)
+{
+    ASSERT_STREQ(GetFileOwner("/"), "root");
+}
+
+TEST_F(GetFileOwnerTest, CannotGetOwnerOfFakeFile)
+{
+    EXPECT_STREQ(GetFileOwner("SomeMadeUpFileNameThatDoesNotExist"), NULL);
+    EXPECT_EQ(errno, ERROR_FILE_NOT_FOUND);
+}
+
+TEST_F(GetFileOwnerTest, ReturnsNullForNullInput)
+{
+    EXPECT_STREQ(GetFileOwner(NULL), NULL);
+    EXPECT_EQ(errno, ERROR_INVALID_PARAMETER);
+}

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Process.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Process.Tests.ps1
@@ -1,4 +1,8 @@
 Describe "Get-Process" {
+    It "Should support -IncludeUserName" {
+        (Get-Process powershell -IncludeUserName).UserName | Should Be $env:USER
+    }
+
     # These tests are no good, please replace!
     It "Should return a type of Object[] for Get-Process cmdlet" -Pending:$IsOSX {
         (Get-Process).GetType().BaseType | Should Be 'array'


### PR DESCRIPTION
- [x] Resolves #1208.
- [x] Code is up-to-date with `master`.
- [x] Add tests that fail without your changes.

Still need to add (lots) of tests, and find where else `GetFileOwner` needs to be plumbed (looking at you filesystem cmdlets).
