### PR TITLE
Enable cache on CI machines

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ matrix:
     - os: osx
       osx_image: xcode8
       language: generic
+cache:
+  directories:
+    - $HOME/.dotnet
+    - $HOME/.nuget
 addons:
   artifacts:
     s3_region: "us-west-2"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,8 @@
 version: 0.5.0.{build}
 
+cache:
+  - '%LocalAppData%\Microsoft\dotnet'
+
 nuget:
   project_feed: true
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 0.5.0.{build}
+version: 0.6.0.{build}
 
 cache:
   - '%LocalAppData%\Microsoft\dotnet'


### PR DESCRIPTION
Hopefully this speeds them up.

Caching dotnet and NuGet packages, of which we see much less churn.

I want to see builds on top of this utilize the cache.
