### PR TITLE
Import Pester from new location

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -382,7 +382,7 @@ function Start-PSPester {
         [string]$Directory = "$PSScriptRoot/test/powershell"
     )
 
-    & (Get-PSOutput) -noprofile -c "Import-Module '$PSScriptRoot/src/Modules/Pester'; Invoke-Pester $Flags $Directory/$Tests"
+    & (Get-PSOutput) -noprofile -c "Import-Module '$PSScriptRoot/src/Modules/Shared/Pester'; Invoke-Pester $Flags $Directory/$Tests"
     if ($LASTEXITCODE -ne 0) {
         throw "$LASTEXITCODE Pester tests failed"
     }


### PR DESCRIPTION
This is somewhat temporary as we're about to investigate using upstream Pester without needing to have it as a submodule, and failing that, moving it to a vendor folder.

I can't seem to do Linux builds without this currently. This replaces #1275, but only so we can get blocked.

/cc @vors @lzybkr 
