### PR TITLE
Ignoring the errors from Receive-Job cmdlet in Uninstall-module logic…

### DIFF
--- a/src/Modules/Shared/PowerShellGet/PSModule.psm1
+++ b/src/Modules/Shared/PowerShellGet/PSModule.psm1
@@ -10982,7 +10982,7 @@ function Uninstall-Package
                             }
             $dependentModulesJob =  Microsoft.PowerShell.Core\Start-Job -ScriptBlock $dependentModuleScript -ArgumentList $moduleName
             Microsoft.PowerShell.Core\Wait-Job -job $dependentModulesJob
-            $dependentModules = Microsoft.PowerShell.Core\Receive-Job -job $dependentModulesJob
+            $dependentModules = Microsoft.PowerShell.Core\Receive-Job -job $dependentModulesJob -ErrorAction Ignore
 
             if(-not $Force -and $dependentModules)
             {


### PR DESCRIPTION
This is a workaround for #1365
