### PR TITLE
Use Emacs as DefaultEditMode on Linux / OS X

### DIFF
--- a/src/Microsoft.PowerShell.PSReadLine/Cmdlets.cs
+++ b/src/Microsoft.PowerShell.PSReadLine/Cmdlets.cs
@@ -92,7 +92,12 @@ namespace Microsoft.PowerShell
         public const ConsoleColor DefaultEmphasisForegroundColor  = ConsoleColor.Cyan;
         public const ConsoleColor DefaultErrorForegroundColor     = ConsoleColor.Red;
 
-        public const EditMode DefaultEditMode = EditMode.Windows;
+        public const EditMode DefaultEditMode =
+#if LINUX
+            EditMode.Emacs;
+#else
+            EditMode.Windows;
+#endif
 
         public const string DefaultContinuationPrompt = ">> ";
 

--- a/src/Microsoft.PowerShell.PSReadLine/KeyBindings.cs
+++ b/src/Microsoft.PowerShell.PSReadLine/KeyBindings.cs
@@ -114,6 +114,25 @@ namespace Microsoft.PowerShell
         private Dictionary<ConsoleKeyInfo, KeyHandler> _dispatchTable;
         private Dictionary<ConsoleKeyInfo, Dictionary<ConsoleKeyInfo, KeyHandler>> _chordDispatchTable; 
 
+        /// <summary>
+        /// Helper to set bindings based on EditMode
+        /// </summary>
+        void SetDefaultBindings(EditMode editMode)
+        {
+            switch (editMode)
+            {
+                case EditMode.Emacs:
+                    SetDefaultEmacsBindings();
+                    break;
+                case EditMode.Vi:
+                    SetDefaultViBindings();
+                    break;
+                case EditMode.Windows:
+                    SetDefaultWindowsBindings();
+                    break;
+            }
+        }
+
         void SetDefaultWindowsBindings()
         {
             _dispatchTable = new Dictionary<ConsoleKeyInfo, KeyHandler>(new ConsoleKeyInfoComparer())

--- a/src/Microsoft.PowerShell.PSReadLine/Options.cs
+++ b/src/Microsoft.PowerShell.PSReadLine/Options.cs
@@ -96,18 +96,7 @@ namespace Microsoft.PowerShell
                 // Switching/resetting modes - clear out chord dispatch table
                 _chordDispatchTable.Clear();
 
-                switch (options._editMode)
-                {
-                case EditMode.Emacs:
-                    SetDefaultEmacsBindings();
-                    break;
-                case EditMode.Vi:
-                    SetDefaultViBindings();
-                    break;
-                case EditMode.Windows:
-                    SetDefaultWindowsBindings();
-                    break;
-                }
+                SetDefaultBindings(Options.EditMode);
             }
             if (options._showToolTips.HasValue)
             {

--- a/src/Microsoft.PowerShell.PSReadLine/ReadLine.cs
+++ b/src/Microsoft.PowerShell.PSReadLine/ReadLine.cs
@@ -485,8 +485,6 @@ namespace Microsoft.PowerShell
             _console = new ConhostConsole();
 #endif
 
-            SetDefaultWindowsBindings();
-
             _buffer = new StringBuilder(8 * 1024);
             _statusBuffer = new StringBuilder(256);
             _savedCurrentLine = new HistoryItem();
@@ -516,6 +514,7 @@ namespace Microsoft.PowerShell
                 hostName = "PSReadline";
             }
             _options = new PSConsoleReadlineOptions(hostName);
+            SetDefaultBindings(_options.EditMode);
         }
 
         private void Initialize(Runspace runspace, EngineIntrinsics engineIntrinsics)

--- a/test/powershell/Modules/PSReadLine/PSReadLine.Tests.ps1
+++ b/test/powershell/Modules/PSReadLine/PSReadLine.Tests.ps1
@@ -13,6 +13,16 @@ Describe "PSReadLine" {
         $module.Version | Should Be "1.2"
     }
 
+    It "Should use Emacs Bindings on Linux and OS X" -skip:$IsWindows {
+        (Get-PSReadLineOption).EditMode | Should Be Emacs
+        (Get-PSReadlineKeyHandler | where { $_.Key -eq "Ctrl+A" }).Function | Should Be BeginningOfLine
+    }
+
+    It "Should use Windows Bindings on Windows" -skip:(-not $IsWindows) {
+        (Get-PSReadLineOption).EditMode | Should Be Windows
+        (Get-PSReadlineKeyHandler | where { $_.Key -eq "Ctrl+A" }).Function | Should Be SelectAll
+    }
+
     It "Should set the edit mode" {
         Set-PSReadlineOption -EditMode Windows
         (Get-PSReadlineKeyHandler | where { $_.Key -eq "Ctrl+A" }).Function | Should Be SelectAll


### PR DESCRIPTION
Per #1085, there was confusing over keybindings on Linux / OS X. Since we use PSReadLine, it is up to the user to choose a preferred editing mode, and PSReadLine reasonably defaulted to Windows. However, this leads to a subpar experience on non-Windows platforms, where almost everything respects Emacs keybindings (especially shells).

This fixes PSReadLine so that the key bindings are set based on the default edit mode, and sets the default edit mode to Emacs when `LINUX` is defined. Pester tests are included.

I do, however, have an open question for @lzybkr about the need to `_chordDispatchTable.Clear()` when changing key bindings. Each of `SetDefaultWindowsBindings()`, `SetDefaultEmacsBindings()` and `SetDefaultVimBindings()` bind `_chordDispatchTable` to a new dictionary, thus overwriting it. Is it actually necessary then  to clear the previous value? 
