### PR TITLE
Fix Set-Content on linux when used with DRIVE:

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/ContentCommandBase.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/ContentCommandBase.cs
@@ -815,7 +815,15 @@ namespace Microsoft.PowerShell.Commands
                                 currentCommandContext,
                                 out provider,
                                 out drive);
-
+#if LINUX
+                        PathInfo pathInfo =
+                            new PathInfo(
+                                null,
+                                provider,
+                                unresolvedPath,
+                                SessionState);
+                        results.Add(pathInfo);
+#else
                         PathInfo pathInfo =
                             new PathInfo(
                                 drive,
@@ -823,6 +831,7 @@ namespace Microsoft.PowerShell.Commands
                                 unresolvedPath,
                                 SessionState);
                         results.Add(pathInfo);
+#endif
                     }
                     else
                     {


### PR DESCRIPTION
- Resolves unlisted issue where Set-Content DriveName:FileName would fail on Linux system
- [x] Code is up-to-date with `master`.
- Tests coming

the issue is that there are no drive letters on Linux, so we have to be careful when creating our PathInfo objects
