### PR TITLE
Add GitHub token as insecure environment variable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 language: cpp
-matrix:
-  include:
-    - os: linux
-      dist: trusty
-      sudo: required
-    - os: osx
-      osx_image: xcode8
-      language: generic
+
+os:
+  - linux
+  - osx
+sudo: required
+dist: trusty
+osx_image: xcode8
+
 env:
   - GITHUB_TOKEN=a27573e27bea23fb05393ead69511b09e3b224be
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ matrix:
     - os: osx
       osx_image: xcode8
       language: generic
+env:
+  - GITHUB_TOKEN=a27573e27bea23fb05393ead69511b09e3b224be
 cache:
   directories:
     - $HOME/.dotnet

--- a/tools/download.sh
+++ b/tools/download.sh
@@ -16,15 +16,27 @@ get_info() {
 # Get OS specific asset ID and package name
 case "$OSTYPE" in
     linux*)
+        source /etc/os-release
+        echo $ID
         # Install curl and wget to download package
-        sudo apt-get install -y curl wget
-        info=$(get_info deb)
+        case "$ID" in
+            centos*)
+                sudo yum install -y curl wget
+                info=$(get_info rpm)
+                ;;
+            ubuntu)
+                sudo apt-get install -y curl wget
+                info=$(get_info deb)
+                ;;
+            *)
+                exit 2 >&2 "$NAME is not supported!"
+        esac
         ;;
     darwin*)
         info=$(get_info pkg)
         ;;
     *)
-        exit 2 >&2 "$OSTYPE not supported!"
+        exit 2 >&2 "$OSTYPE is not supported!"
         ;;
 esac
 
@@ -38,9 +50,19 @@ curl_ -H 'Accept: application/octet-stream' https://api.github.com/repos/PowerSh
 # Installs PowerShell package
 case "$OSTYPE" in
     linux*)
+        source /etc/os-release
         # Install dependencies
-        sudo apt-get install -y libunwind8 libicu52
-        sudo dpkg -i ./$package
+        case "$ID" in
+            centos)
+                sudo yum install -y libicu libunwind
+                sudo yum install "./$package"
+                ;;
+            ubuntu)
+                sudo apt-get install -y libunwind8 libicu52
+                sudo dpkg -i "./$package"
+                ;;
+            *)
+        esac
         ;;
     darwin*)
         sudo installer -pkg ./$package -target /


### PR DESCRIPTION
This should enable building via PR from forks.

This token has read-only access to download the installer packages, but
should nonetheless be revoked and replaced with a wget download when the
repository goes public.
