### PR TITLE
Disable building packages on Travis CI for Pull Requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,3 @@ install:
   - (cd tools && ./download.sh)
 script:
   - ulimit -n 4096; powershell -c "Import-Module ./build.psm1; Start-PSBootstrap -Package; Start-PSBuild -Publish; Start-PSPackage; Start-PSPester; Start-PSxUnit"
-notifications:
-  slack:
-    secure: sKYd4n61+ZFzGZuWGUl8V1kN0NM16wRVOFVlNhlFCwnkrEsKROb++EvXf5uwnKuzxkhEjvPWO+UFgeshQDoR93y4s5YLfhC5JupK4nUzjPzWs208KTrh8u/x9MY8X6Ojxi85EEAiku5GzMoMlkucSStZUYwbIfnelzqdw8uoRwmm2MW4XCPwsuEuDUVghyiva0Mdx1G6MopCrK8T96WywJXT3chhfZQgVt+sQCBt9g+2kjDaObKrzG0P07IVK43ZpDgnu6AoxlyBzIx9mJH2Oa/tki3/kTO72Wcp3ps3qvmiStADamzVKR9p1VlWCLWAd6VOehxuByCGEyujpzk135Wud2DZYO+8LD6inZVhFe3Wt5pCU9BDXZppiATfMCqgXEH7nK54pEn79yHcjthRJ2+Z9ot7As2fu3RSBmTAi8nRP0fxRyX/jctR3S6P0qt0y1ynx9nzBfhmhPQW0PMVazWS/nruQIvK/3iiYXjZxM5bBwIvabmwV00EYeTdbL6ufXWNgQcG1ZWkDsi2I3vst/ytUbHwaFYg83bXWpxg9DCzJeWLVUvE5/3NfBxRAuCTot/fgTEA9IYScvrlL7Q/bT0cOt0vEM98MPf1UO+WP85uxhsRgHtwDEo+jMaL6ZFkPhlV6mmmED4NdY2//a571cLNXdnuMAze5O3TWGBG53g=

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,19 +9,23 @@ osx_image: xcode8
 
 env:
   - GITHUB_TOKEN=a27573e27bea23fb05393ead69511b09e3b224be
+
 cache:
   directories:
     - $HOME/.dotnet
     - $HOME/.nuget
+
 addons:
   artifacts:
     s3_region: "us-west-2"
     paths: $(ls powershell*{deb,pkg} | tr "\n" ":")
+
 git:
   submodules: false
+
 install:
   - git config --global url.git@github.com:.insteadOf https://github.com/
   - git submodule update --init
   - (cd tools && ./download.sh)
-script:
-  - ulimit -n 4096; powershell -c "Import-Module ./build.psm1; Start-PSBootstrap -Package; Start-PSBuild -Publish; Start-PSPackage; Start-PSPester; Start-PSxUnit"
+
+script: ./tools/travis.sh

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,11 +10,6 @@ environment:
   priv_key:
     secure: <encryped-value>
 
-notifications:
-  - provider: Slack
-    incoming_webhook:
-      secure: bwwXBTeJBtRFea6FSQKzVENLwL0AOeusUSUFIh/TeHA4y0UFk7bC9+OcxgZW+YfIC0VZyTpZClJHlPFFHSgiQs4g9om17RxzJEeq4EjsW5g=
-
 install:
   - ps: $fileContent = "-----BEGIN RSA PRIVATE KEY-----`n"
   - ps: $fileContent += $env:priv_key.Replace(' ', "`n")

--- a/tools/travis.sh
+++ b/tools/travis.sh
@@ -1,0 +1,7 @@
+ulimit -n 4096
+# Only build packages for branches, not pull requests
+if [[ $TRAVIS_PULL_REQUEST == false ]]; then
+    powershell -c "Import-Module ./build.psm1; Start-PSBootstrap -Package; Start-PSBuild -Publish; Start-PSPackage; Start-PSPester; Start-PSxUnit"
+else
+    powershell -c "Import-Module ./build.psm1; Start-PSBootstrap; Start-PSBuild; Start-PSPester; Start-PSxUnit"
+fi


### PR DESCRIPTION
This disables the Slack CI notifications so we can archive the #ci channel, and disables building Linux / OS X packages for pull requests.

This should save a fair bit of time for the Travis CI builds, while still building packages for the master branch (and any feature branch).

@raghushantha, @vors, do we want to do something similar for AppVeyor? I'm not so concerned about the time there, as it's already much faster than Travis CI.
