### PR TITLE
Fix use of rm alias in tests

### DIFF
--- a/test/powershell/Modules/PackageManagement/Install-PackageProvider.Tests.ps1
+++ b/test/powershell/Modules/PackageManagement/Install-PackageProvider.Tests.ps1
@@ -273,7 +273,7 @@ Describe "Install-Save-Package with multiple sources" -Tags @('BVT', 'DRT'){
             Register-PackageSource -Name foo -Location $InternalGallery -ProviderName 'PowerShellGet' -Trusted  -ErrorAction SilentlyContinue
             Register-PackageSource -Name bar -Location $InternalGallery -ProviderName 'NuGet'  -ErrorAction SilentlyContinue
             if (test-path "$destination") {
-                rm $destination -force -Recurse
+                Remove-Item $destination -force -Recurse
             }
 
          
@@ -291,7 +291,7 @@ Describe "Install-Save-Package with multiple sources" -Tags @('BVT', 'DRT'){
         
             (test-path "$destination\TSDProvider*") | should be $true
             if (test-path "$destination\TSDProvider*") {
-                rm $destination\TSDProvider* -force -Recurse
+                Remove-Item $destination\TSDProvider* -force -Recurse
             }
         }
         finally
@@ -362,7 +362,7 @@ Describe "Install-Save-Package with multiple sources" -Tags @('BVT', 'DRT'){
             Register-PackageSource -Name foobar -Location http://www.nuget.org/api/v2 -ProviderName 'NuGet'  -ErrorAction SilentlyContinue
 
             if (test-path "$destination") {
-                rm $destination -force -Recurse
+                Remove-Item $destination -force -Recurse
             }
 
          
@@ -379,7 +379,7 @@ Describe "Install-Save-Package with multiple sources" -Tags @('BVT', 'DRT'){
         
             (test-path "$destination\jquery*") | should be $true
             if (test-path "$destination\jquery*") {
-                rm $destination\jquery* -force -Recurse
+                Remove-Item $destination\jquery* -force -Recurse
             }
         }
         finally
@@ -398,7 +398,7 @@ Describe "Install-Save-Package with multiple sources" -Tags @('BVT', 'DRT'){
         
 
         if (test-path "$destination") {
-            rm $destination -force -Recurse
+            Remove-Item $destination -force -Recurse
         }
 
          
@@ -417,14 +417,14 @@ Describe "Install-Save-Package with multiple sources" -Tags @('BVT', 'DRT'){
         
         (test-path "$destination\Contoso*") | should be $true
         if (test-path "$destination\Contoso*") {
-            rm $destination\Contoso* -force -Recurse
+            Remove-Item $destination\Contoso* -force -Recurse
         }
 
     }
 
     It "save-package with array of registered sources, Expect succeed" -Pending {
         if (test-path "$destination") {
-            rm $destination -force -Recurse
+            Remove-Item $destination -force -Recurse
         }
 
         $x= save-package TSDProvider -force -Source @($InternalSource, $InternalSource2) -path $destination  -ProviderName @('PowershellGet', 'NuGet')   
@@ -433,13 +433,13 @@ Describe "Install-Save-Package with multiple sources" -Tags @('BVT', 'DRT'){
 
         (test-path "$destination\TSDProvider*") | should be $true
         if (test-path "$destination\TSDProvider*") {
-            rm $destination\TSDProvider* -force -Recurse
+            Remove-Item $destination\TSDProvider* -force -Recurse
         }
     }
 
     It "save-package with array of sources, Expect succeed" -Skip {
         if (test-path "$destination") {
-            rm $destination -force -Recurse
+            Remove-Item $destination -force -Recurse
         }
 
         $x= save-package jquery -force -Source @('fffffbbbbb', 'https://www.nuget.org/api/v2') -path $destination   -ProviderName @('Nuget', 'Chocolatey')     
@@ -449,7 +449,7 @@ Describe "Install-Save-Package with multiple sources" -Tags @('BVT', 'DRT'){
         
         (test-path "$destination\jquery*") | should be $true
         if (test-path "$destination\jquery*") {
-            rm $destination\jquery* -force -Recurse
+            Remove-Item $destination\jquery* -force -Recurse
         }
     }
 }

--- a/test/powershell/Modules/PackageManagement/Nuget.Tests.ps1
+++ b/test/powershell/Modules/PackageManagement/Nuget.Tests.ps1
@@ -497,10 +497,10 @@ Describe Save-Package -Tags @('BVT', 'DRT'){
         $package.Name | should be "TSDProvider"
         (test-path "$dest\TSDProvider*") | should be $true
         if (test-path "$dest\TSDProvider*") {
-            rm $dest\TSDProvider* -force
+            Remove-Item $dest\TSDProvider* -force
         }
         if (test-path "$dest") {
-            rm $dest -force
+            Remove-Item $dest -force
         }
     }
 
@@ -511,7 +511,7 @@ Describe Save-Package -Tags @('BVT', 'DRT'){
         $package.Name | should be "TSDProvider"
         (test-path "$destination\TSDProvider*") | should be $true
         if (test-path "$destination\TSDProvider*") {
-            rm $destination\TSDProvider* -force
+            Remove-Item $destination\TSDProvider* -force
         }
     }
 
@@ -522,10 +522,10 @@ Describe Save-Package -Tags @('BVT', 'DRT'){
         $package.Name | should be "TSDProvider"
         (test-path "$dest\TSDProvider*") | should be $true
         if (test-path "$dest\TSDProvider*") {
-            rm $dest\TSDProvider* -force
+            Remove-Item $dest\TSDProvider* -force
         }
         if (test-path "$dest") {
-            rm $dest -force
+            Remove-Item $dest -force
         }
     }
 
@@ -535,7 +535,7 @@ Describe Save-Package -Tags @('BVT', 'DRT'){
         $package.Name | should be "TSDProvider"
         (test-path "$destination\TSDProvider*") | should be $true
         if (test-path "$destination\TSDProvider*") {
-            rm $destination\TSDProvider* -force
+            Remove-Item $destination\TSDProvider* -force
         }
     }
 
@@ -592,7 +592,7 @@ Describe Save-Package -Tags @('BVT', 'DRT'){
             }
 
 		    if (Test-Path $destination\zlib*) {
-			    rm $destination\zlib*
+			    Remove-Item $destination\zlib*
 		    }
 
         }
@@ -618,7 +618,7 @@ Describe Save-Package -Tags @('BVT', 'DRT'){
             }
 
 		    if (Test-Path $destination\zlib*) {
-			    rm $destination\zlib*
+			    Remove-Item $destination\zlib*
 		    }
 
         }
@@ -632,7 +632,7 @@ Describe Save-Package -Tags @('BVT', 'DRT'){
         }
         finally {
             if (Test-Path $destination\ModuleWithDependenciesLoop*) {
-                rm $destination\ModuleWithDependenciesLoop*
+                Remove-Item $destination\ModuleWithDependenciesLoop*
             }
         }
     }
@@ -644,7 +644,7 @@ Describe Save-Package -Tags @('BVT', 'DRT'){
         }
         finally {
             if (Test-Path $destination\TestPackage*) {
-                rm $destination\TestPackage*
+                Remove-Item $destination\TestPackage*
             }
         }
     }
@@ -663,7 +663,7 @@ Describe Save-Package -Tags @('BVT', 'DRT'){
         (Test-Path $destination\contoso*) | should be $true
 
         if (Test-Path $destination\contoso*) {
-            rm $destination\contoso*
+            Remove-Item $destination\contoso*
         }
     }
 
@@ -685,7 +685,7 @@ Describe Save-Package -Tags @('BVT', 'DRT'){
 	    (find-package -name "zlib" -provider $nuget -source $source | save-package -Path $destination)
 	    (Test-Path -Path $destination\zlib*) | should be $true
 	    if (Test-Path -Path $destination\zlib*) {
-		    rm $destination\zlib*
+		    Remove-Item $destination\zlib*
         }
     }
 

--- a/test/powershell/Modules/PackageManagement/Nuget.Tests.ps1
+++ b/test/powershell/Modules/PackageManagement/Nuget.Tests.ps1
@@ -515,7 +515,7 @@ Describe Save-Package -Tags @('BVT', 'DRT'){
         }
     }
 
-    It "EXPECTED success: save-package -LiteralPath" {
+    It "EXPECTED success: save-package -LiteralPath" -Pending:(!$IsWindows) {
         $dest = "$destination\NeverEverExists"
         $package = save-package -LiteralPath $dest -ProviderName nuget -Source $dtlgallery -name TSDProvider -force
        

--- a/test/powershell/Modules/PackageManagement/Nuget.Tests.ps1
+++ b/test/powershell/Modules/PackageManagement/Nuget.Tests.ps1
@@ -357,7 +357,7 @@ Describe "Find-Package" -Tags @('BVT', 'DRT'){
 
     }
 
-    It "EXPECTED: Finds package with Credential" {
+    It "EXPECTED: Finds package with Credential" -Pending {
         $credPackage = Find-Package Contoso -Credential $vstsCredential -Source $vstsFeed -ProviderName $Nuget
         $credPackage.Count | should be 1
         $credPackage.Name | should match "Contoso"
@@ -1368,7 +1368,7 @@ Describe Register-PackageSource -Tags @('BVT', 'DRT'){
         }
 	}
 
-    it "EXPECTED: Registers a package source that requires a credential with skipvalidate" {
+    it "EXPECTED: Registers a package source that requires a credential with skipvalidate" -Pending {
         (register-packagesource -name "psgettestfeed" -provider $nuget -location $vstsFeed -SKipValidate)
         try {
             (Find-Package -Source "psgettestfeed" -Name ContosoClient -Credential $vstsCredential).Name | should be "ContosoClient"
@@ -1382,7 +1382,7 @@ Describe Register-PackageSource -Tags @('BVT', 'DRT'){
     }
 
 
-    it "EXPECTED: Registers a package source that requires a credential" {
+    it "EXPECTED: Registers a package source that requires a credential" -Pending {
         (register-packagesource -name "psgettestfeed" -provider $nuget -location $vstsFeed -Credential $vstsCredential)
         try {
             (Find-Package -Source "psgettestfeed" -Name ContosoClient -Credential $vstsCredential).Name | should be "ContosoClient"


### PR DESCRIPTION
Resolves #1417.

This is not an alias on Linux / OS X.
