### PR TITLE
Enable XML documentation generation

### DIFF
--- a/src/Microsoft.PowerShell.Activities/project.json
+++ b/src/Microsoft.PowerShell.Activities/project.json
@@ -3,6 +3,7 @@
     "version": "1.0.0-*",
 
     "buildOptions": {
+        "nowarn": [ "CS1570" ],
         "xmlDoc": true,
         "keyFile": "../signing/visualstudiopublic.snk",
         "delaySign": true,

--- a/src/Microsoft.PowerShell.Activities/project.json
+++ b/src/Microsoft.PowerShell.Activities/project.json
@@ -3,6 +3,7 @@
     "version": "1.0.0-*",
 
     "buildOptions": {
+        "xmlDoc": true,
         "keyFile": "../signing/visualstudiopublic.snk",
         "delaySign": true,
         "publicSign": false,

--- a/src/Microsoft.PowerShell.Commands.Diagnostics/GetEventCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Diagnostics/GetEventCommand.cs
@@ -27,9 +27,9 @@ namespace Microsoft.PowerShell.Commands
   [Cmdlet(VerbsCommon.Get, "WinEvent" , DefaultParameterSetName = "GetLogSet", HelpUri = "http://go.microsoft.com/fwlink/?LinkID=138336")]
   public sealed class GetWinEventCommand : PSCmdlet
   {
-    //
-    // ListLog parameter
-    //  
+    /// <summary>
+    /// ListLog parameter
+    /// </summary>
     [Parameter(
             Position = 0, 
             Mandatory = true,
@@ -51,9 +51,9 @@ namespace Microsoft.PowerShell.Commands
     }
     private string[] _listLog = {"*"};
 
-    //
-    // GetLog parameter
-    //  
+    /// <summary>
+    /// GetLog parameter
+    /// </summary>
     [Parameter(
             Position = 0,
             ParameterSetName="GetLogSet", 
@@ -73,9 +73,9 @@ namespace Microsoft.PowerShell.Commands
     private string[] _logName = {"*"};
 
 
-    //
-    // ListProvider parameter
-    //  
+    /// <summary>
+    /// ListProvider parameter
+    /// </summary>
     [Parameter(
             Position = 0, 
             Mandatory = true,
@@ -99,9 +99,9 @@ namespace Microsoft.PowerShell.Commands
     private string[] _listProvider = {"*"};
 
 
-    //
-    // ProviderName parameter
-    //  
+    /// <summary>
+    /// ProviderName parameter
+    /// </summary>
     [Parameter(
             Position = 0, 
             Mandatory = true,
@@ -123,9 +123,9 @@ namespace Microsoft.PowerShell.Commands
     private string[] _providerName;
 
 
-    //
-    // Path parameter
-    //  
+    /// <summary>
+    /// Path parameter
+    /// </summary>
     [Parameter(
             Position = 0, 
             Mandatory = true,
@@ -147,9 +147,9 @@ namespace Microsoft.PowerShell.Commands
     private string[] _path;
     
 
-    //
-    // MaxEvents parameter
-    //
+    /// <summary>
+    /// MaxEvents parameter
+    /// </summary>
     [Parameter(
             ParameterSetName="FileSet",
             ValueFromPipeline = false,  
@@ -188,9 +188,9 @@ namespace Microsoft.PowerShell.Commands
     }
     private Int64 _maxEvents = -1;
 
-    //
-    // ComputerName parameter
-    //
+    /// <summary>
+    /// ComputerName parameter
+    /// </summary>
     [Parameter(
             ParameterSetName="ListProviderSet",
             HelpMessageBaseName = "GetEventResources",
@@ -225,9 +225,9 @@ namespace Microsoft.PowerShell.Commands
     }
     private string _computerName = string.Empty;
 
-    //
-    // Credential parameter
-    //    
+    /// <summary>
+    /// Credential parameter
+    /// </summary>
     [Parameter(ParameterSetName="ListProviderSet")]
     [Parameter(ParameterSetName="GetProviderSet")]
     [Parameter(ParameterSetName="ListLogSet")]
@@ -244,9 +244,9 @@ namespace Microsoft.PowerShell.Commands
     private PSCredential _credential = PSCredential.Empty;
 
 
-    //
-    // FilterXPath parameter
-    //
+    /// <summary>
+    /// FilterXPath parameter
+    /// </summary>
     [Parameter(
             ParameterSetName="FileSet",
             ValueFromPipeline = false,  
@@ -270,9 +270,9 @@ namespace Microsoft.PowerShell.Commands
     }
     private string _filter = "*";
     
-    //
-    // FilterXml parameter
-    //
+    /// <summary>
+    /// FilterXml parameter
+    /// </summary>
     [Parameter(
             Position = 0, 
             Mandatory = true,
@@ -294,9 +294,9 @@ namespace Microsoft.PowerShell.Commands
     private XmlDocument _xmlQuery = null;
 
     
-    //
-    // FilterHashtable parameter
-    //
+    /// <summary>
+    /// FilterHashtable parameter
+    /// </summary>
     [Parameter(
             Position = 0, 
             Mandatory = true,
@@ -317,9 +317,9 @@ namespace Microsoft.PowerShell.Commands
     }
     private Hashtable[] _selector;
 
-    //
-    // Force switch
-    //
+    /// <summary>
+    /// Force switch
+    /// </summary>
     [Parameter(ParameterSetName="ListLogSet")]
     [Parameter(ParameterSetName="GetProviderSet")]
     [Parameter(ParameterSetName="GetLogSet")]
@@ -332,9 +332,9 @@ namespace Microsoft.PowerShell.Commands
     }
     private SwitchParameter _force;
 
-    //
-    // Oldest switch
-    //
+    /// <summary>
+    /// Oldest switch
+    /// </summary>
     [Parameter(ParameterSetName="FileSet")]
     [Parameter(ParameterSetName="GetProviderSet")]
     [Parameter(ParameterSetName="GetLogSet")]
@@ -391,18 +391,18 @@ namespace Microsoft.PowerShell.Commands
     private const string hashkey_data_lc="data";   
 
 
-    //
-    // BeginProcessing() is invoked once per pipeline: we will load System.Core.dll here
-    //
+    /// <summary>
+    /// BeginProcessing() is invoked once per pipeline: we will load System.Core.dll here
+    /// </summary>
     protected override void BeginProcessing()
     {
         _resourceMgr = Microsoft.PowerShell.Commands.Diagnostics.Common.CommonUtilities.GetResourceManager();
     }
 
         
-    //
-    // EndProcessing() is invoked once per pipeline
-    //
+    /// <summary>
+    /// EndProcessing() is invoked once per pipeline
+    /// </summary>
     protected override void EndProcessing()
     {
        
@@ -426,10 +426,10 @@ namespace Microsoft.PowerShell.Commands
     }
 
 
-    //
-    // ProcessRecord() override.
-    // This is the main entry point for the cmdlet.
-    //       
+    /// <summary>
+    /// ProcessRecord() override.
+    /// This is the main entry point for the cmdlet.
+    /// </summary>
     protected override void ProcessRecord()
     {
           switch (ParameterSetName)

--- a/src/Microsoft.PowerShell.Commands.Diagnostics/PdhHelper.cs
+++ b/src/Microsoft.PowerShell.Commands.Diagnostics/PdhHelper.cs
@@ -479,6 +479,7 @@ namespace Microsoft.Powershell.Commands.GetCounter.PdhNative
         /// A helper reading in a Unicode string with embedded NULLs and splitting it into a StringCollection.
         /// </summary>
         /// <param name="strNative"></param>
+        /// <param name="strSize"></param>
         /// <param name="strColl"></param>
 
         private void ReadPdhMultiString(ref IntPtr strNative, Int32 strSize, ref StringCollection strColl)

--- a/src/Microsoft.PowerShell.Commands.Diagnostics/project.json
+++ b/src/Microsoft.PowerShell.Commands.Diagnostics/project.json
@@ -2,17 +2,18 @@
     "name": "Microsoft.PowerShell.Commands.Diagnostics",
     "version": "1.0.0-*",
     "buildOptions": {
+        "nowarn": [ "CS1591" ],
         "xmlDoc": true,
         "keyFile": "../signing/visualstudiopublic.snk",
         "delaySign": true,
         "publicSign": false,
         "warningsAsErrors": true
     },
-    
+
     "dependencies": {
         "System.Management.Automation": "1.0.0-*"
     },
-    
+
     "frameworks": {
         "netstandard1.6": {
             "imports": [ "dnxcore50" ],

--- a/src/Microsoft.PowerShell.Commands.Diagnostics/project.json
+++ b/src/Microsoft.PowerShell.Commands.Diagnostics/project.json
@@ -2,6 +2,7 @@
     "name": "Microsoft.PowerShell.Commands.Diagnostics",
     "version": "1.0.0-*",
     "buildOptions": {
+        "xmlDoc": true,
         "keyFile": "../signing/visualstudiopublic.snk",
         "delaySign": true,
         "publicSign": false,

--- a/src/Microsoft.PowerShell.Commands.Management/project.json
+++ b/src/Microsoft.PowerShell.Commands.Management/project.json
@@ -3,6 +3,7 @@
     "version": "1.0.0-*",
 
     "buildOptions": {
+        "nowarn": [ "CS1570" ],
         "xmlDoc": true,
         "keyFile": "../signing/visualstudiopublic.snk",
         "delaySign": true,

--- a/src/Microsoft.PowerShell.Commands.Management/project.json
+++ b/src/Microsoft.PowerShell.Commands.Management/project.json
@@ -3,6 +3,7 @@
     "version": "1.0.0-*",
 
     "buildOptions": {
+        "xmlDoc": true,
         "keyFile": "../signing/visualstudiopublic.snk",
         "delaySign": true,
         "publicSign": false,

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
@@ -156,7 +156,7 @@ namespace Microsoft.PowerShell.Commands
         /// Returns the base name of the file containing the matching line.
         /// <remarks>
         /// It will be the string "InputStream" if the object came from the input stream.
-        /// This is a readonly propery calculated from <paramref name="Path"/>.
+        /// This is a readonly property calculated from the path. <see cref="Path"/>
         /// </remarks>
         /// </summary>
         /// <value>The file name</value>

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Send-MailMessage.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Send-MailMessage.cs
@@ -261,7 +261,7 @@ namespace Microsoft.PowerShell.Commands
         private SwitchParameter usessl;
 
         /// <summary>
-        /// Specifies the Port to be used on <paramref name="SmtpServer"/>
+        /// Specifies the Port to be used on the server. <see cref="SmtpServer"/>
         /// </summary>
         /// <remarks>
         /// Value must be greater than zero.

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/sort-object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/sort-object.cs
@@ -23,7 +23,7 @@ namespace Microsoft.PowerShell.Commands
             set { DescendingOrder = value; }
         }
         /// <summary>
-        /// 
+        /// This param specifies if only unique objects are filtered.
         /// </summary>
         /// <value></value>
         [Parameter]
@@ -37,7 +37,7 @@ namespace Microsoft.PowerShell.Commands
 
 
         /// <summary>
-        /// Remove Duplicated from <paramref name="sortedList"/>
+        /// Remove duplicates.
         /// </summary>
         private static void RemoveDuplicates(OrderByProperty orderByProperty)
         {

--- a/src/Microsoft.PowerShell.Commands.Utility/project.json
+++ b/src/Microsoft.PowerShell.Commands.Utility/project.json
@@ -3,6 +3,7 @@
     "version": "1.0.0-*",
 
     "buildOptions": {
+        "nowarn": [ "CS1570" ],
         "xmlDoc": true,
         "keyFile": "../signing/visualstudiopublic.snk",
         "delaySign": true,

--- a/src/Microsoft.PowerShell.Commands.Utility/project.json
+++ b/src/Microsoft.PowerShell.Commands.Utility/project.json
@@ -3,6 +3,7 @@
     "version": "1.0.0-*",
 
     "buildOptions": {
+        "xmlDoc": true,
         "keyFile": "../signing/visualstudiopublic.snk",
         "delaySign": true,
         "publicSign": false,

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
@@ -286,14 +286,12 @@ namespace Microsoft.PowerShell
 
 
 
-        /// <summary>
-        /// 
-        /// The break handler for the program.  Dispatches a break event to the current Executor.
-        /// 
-        /// </summary>
-        /// <param name="signal"></param>
-        /// <returns></returns>
 #if LINUX
+        /// <summary>
+        ///
+        /// The break handler for the program.  Dispatches a break event to the current Executor.
+        ///
+        /// </summary>
         private static void MyBreakHandler(object sender, ConsoleCancelEventArgs args)
         {
             // Set the Cancel property to true to prevent the process from terminating.
@@ -310,6 +308,13 @@ namespace Microsoft.PowerShell
             }
         }
 #else
+        /// <summary>
+        ///
+        /// The break handler for the program.  Dispatches a break event to the current Executor.
+        ///
+        /// </summary>
+        /// <param name="signal"></param>
+        /// <returns></returns>
         private static bool MyBreakHandler(ConsoleControl.ConsoleBreakSignal signal)
         {
             switch (signal)

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterface.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterface.cs
@@ -1978,12 +1978,12 @@ namespace Microsoft.PowerShell
 #endif
         }
 
+#if !LINUX
         /// <summary>
         /// Get the character at the cursor when the user types 'tab' in the middle of line.
         /// </summary>
         /// <param name="cursorPosition">the cursor position where 'tab' is hit</param>
         /// <returns></returns>
-#if !LINUX
         private char GetCharacterUnderCursor(Coordinates cursorPosition)
         {
             Rectangle region = new Rectangle(0, cursorPosition.Y, RawUI.BufferSize.Width - 1, cursorPosition.Y);

--- a/src/Microsoft.PowerShell.ConsoleHost/project.json
+++ b/src/Microsoft.PowerShell.ConsoleHost/project.json
@@ -4,6 +4,7 @@
     "description": "PowerShell Host",
 
     "buildOptions": {
+        "xmlDoc": true,
         "keyFile": "../signing/visualstudiopublic.snk",
         "delaySign": true,
         "publicSign": false,

--- a/src/Microsoft.PowerShell.ConsoleHost/project.json
+++ b/src/Microsoft.PowerShell.ConsoleHost/project.json
@@ -4,6 +4,7 @@
     "description": "PowerShell Host",
 
     "buildOptions": {
+        "nowarn": [ "CS1570" ],
         "xmlDoc": true,
         "keyFile": "../signing/visualstudiopublic.snk",
         "delaySign": true,

--- a/src/Microsoft.PowerShell.Core.Activities/project.json
+++ b/src/Microsoft.PowerShell.Core.Activities/project.json
@@ -3,6 +3,7 @@
     "version": "1.0.0-*",
 
     "buildOptions": {
+        "xmlDoc": true,
         "keyFile": "../signing/visualstudiopublic.snk",
         "delaySign": true,
         "publicSign": false,

--- a/src/Microsoft.PowerShell.CoreCLR.AssemblyLoadContext/project.json
+++ b/src/Microsoft.PowerShell.CoreCLR.AssemblyLoadContext/project.json
@@ -3,6 +3,7 @@
     "version": "1.0.0-*",
 
     "buildOptions": {
+        "xmlDoc": true,
         "keyFile": "../signing/visualstudiopublic.snk",
         "delaySign": true,
         "publicSign": false,

--- a/src/Microsoft.PowerShell.CoreCLR.Eventing/project.json
+++ b/src/Microsoft.PowerShell.CoreCLR.Eventing/project.json
@@ -3,6 +3,7 @@
     "version": "1.0.0-*",
 
     "buildOptions": {
+        "xmlDoc": true,
         "keyFile": "../signing/visualstudiopublic.snk",
         "delaySign": true,
         "publicSign": false,

--- a/src/Microsoft.PowerShell.CoreCLR.Eventing/project.json
+++ b/src/Microsoft.PowerShell.CoreCLR.Eventing/project.json
@@ -3,6 +3,7 @@
     "version": "1.0.0-*",
 
     "buildOptions": {
+        "nowarn": [ "CS1591" ],
         "xmlDoc": true,
         "keyFile": "../signing/visualstudiopublic.snk",
         "delaySign": true,

--- a/src/Microsoft.PowerShell.Diagnostics.Activities/project.json
+++ b/src/Microsoft.PowerShell.Diagnostics.Activities/project.json
@@ -3,6 +3,7 @@
     "version": "1.0.0-*",
 
     "buildOptions": {
+        "xmlDoc": true,
         "keyFile": "../signing/visualstudiopublic.snk",
         "delaySign": true,
         "publicSign": false,

--- a/src/Microsoft.PowerShell.GraphicalHost/project.json
+++ b/src/Microsoft.PowerShell.GraphicalHost/project.json
@@ -3,6 +3,7 @@
     "version": "1.0.0-*",
 
     "buildOptions": {
+        "xmlDoc": true,
         "keyFile": "../signing/visualstudiopublic.snk",
         "delaySign": true,
         "publicSign": false,

--- a/src/Microsoft.PowerShell.GraphicalHost/project.json
+++ b/src/Microsoft.PowerShell.GraphicalHost/project.json
@@ -3,11 +3,12 @@
     "version": "1.0.0-*",
 
     "buildOptions": {
+        "nowarn": [ "CS1570" ],
         "xmlDoc": true,
         "keyFile": "../signing/visualstudiopublic.snk",
         "delaySign": true,
         "publicSign": false,
-        "warningsAsErrors": true,
+        "warningsAsErrors": true
     },
 
     "dependencies": {

--- a/src/Microsoft.PowerShell.LocalAccounts/project.json
+++ b/src/Microsoft.PowerShell.LocalAccounts/project.json
@@ -3,6 +3,7 @@
     "version": "1.0.0-*",
 
     "buildOptions": {
+        "xmlDoc": true,
         "keyFile": "../signing/visualstudiopublic.snk",
         "delaySign": true,
         "publicSign": false,

--- a/src/Microsoft.PowerShell.Management.Activities/project.json
+++ b/src/Microsoft.PowerShell.Management.Activities/project.json
@@ -3,6 +3,7 @@
     "version": "1.0.0-*",
 
     "buildOptions": {
+        "xmlDoc": true,
         "keyFile": "../signing/visualstudiopublic.snk",
         "delaySign": true,
         "publicSign": false,

--- a/src/Microsoft.PowerShell.PSReadLine/ReadLine.cs
+++ b/src/Microsoft.PowerShell.PSReadLine/ReadLine.cs
@@ -876,6 +876,11 @@ namespace Microsoft.PowerShell
             _singleton.Render();
         }
 
+        /// <summary>
+        /// Gets the current prompt as possibly defined by the user through the
+        /// prompt function, and returns a default prompt if no other is
+        /// available. Also handles remote prompts.
+        /// </summary>
         public static string GetPrompt()
         {
             var runspaceIsRemote = _singleton._mockableMethods.RunspaceIsRemote(_singleton._runspace);

--- a/src/Microsoft.PowerShell.PSReadLine/project.json
+++ b/src/Microsoft.PowerShell.PSReadLine/project.json
@@ -3,6 +3,7 @@
     "version": "1.0.0-*",
 
     "buildOptions": {
+        "xmlDoc": true,
         "keyFile": "../signing/visualstudiopublic.snk",
         "delaySign": true,
         "publicSign": false,

--- a/src/Microsoft.PowerShell.ScheduledJob/project.json
+++ b/src/Microsoft.PowerShell.ScheduledJob/project.json
@@ -3,6 +3,7 @@
     "version": "1.0.0-*",
 
     "buildOptions": {
+        "xmlDoc": true,
         "keyFile": "../signing/visualstudiopublic.snk",
         "delaySign": true,
         "publicSign": false,

--- a/src/Microsoft.PowerShell.Security.Activities/project.json
+++ b/src/Microsoft.PowerShell.Security.Activities/project.json
@@ -3,6 +3,7 @@
     "version": "1.0.0-*",
 
     "buildOptions": {
+        "xmlDoc": true,
         "keyFile": "../signing/visualstudiopublic.snk",
         "delaySign": true,
         "publicSign": false,

--- a/src/Microsoft.PowerShell.Security/project.json
+++ b/src/Microsoft.PowerShell.Security/project.json
@@ -3,6 +3,7 @@
     "version": "1.0.0-*",
 
     "buildOptions": {
+        "nowarn": [ "CS1570" ],
         "xmlDoc": true,
         "keyFile": "../signing/visualstudiopublic.snk",
         "delaySign": true,

--- a/src/Microsoft.PowerShell.Security/project.json
+++ b/src/Microsoft.PowerShell.Security/project.json
@@ -3,6 +3,7 @@
     "version": "1.0.0-*",
 
     "buildOptions": {
+        "xmlDoc": true,
         "keyFile": "../signing/visualstudiopublic.snk",
         "delaySign": true,
         "publicSign": false,

--- a/src/Microsoft.PowerShell.Utility.Activities/project.json
+++ b/src/Microsoft.PowerShell.Utility.Activities/project.json
@@ -3,6 +3,7 @@
     "version": "1.0.0-*",
 
     "buildOptions": {
+        "xmlDoc": true,
         "keyFile": "../signing/visualstudiopublic.snk",
         "delaySign": true,
         "publicSign": false,

--- a/src/Microsoft.PowerShell.Workflow.ServiceCore/project.json
+++ b/src/Microsoft.PowerShell.Workflow.ServiceCore/project.json
@@ -4,6 +4,7 @@
     "authors": [ "OPS" ],
 
     "buildOptions": {
+        "xmlDoc": true,
         "keyFile": "../signing/visualstudiopublic.snk",
         "delaySign": true,
         "publicSign": false,

--- a/src/Microsoft.PowerShell.Workflow.ServiceCore/project.json
+++ b/src/Microsoft.PowerShell.Workflow.ServiceCore/project.json
@@ -4,6 +4,7 @@
     "authors": [ "OPS" ],
 
     "buildOptions": {
+        "nowarn": [ "CS1570" ],
         "xmlDoc": true,
         "keyFile": "../signing/visualstudiopublic.snk",
         "delaySign": true,

--- a/src/System.Management.Automation/CoreCLR/CorePsPlatform.cs
+++ b/src/System.Management.Automation/CoreCLR/CorePsPlatform.cs
@@ -31,7 +31,9 @@ namespace System.Management.Automation
     public static class Platform
     {
 
-        // Platform variables used to defined corresponding PowerShell built-in variables
+        /// <summary>
+        /// True if the current platform is Linux.
+        /// </summary>
         public static bool IsLinux
         {
             get
@@ -44,21 +46,9 @@ namespace System.Management.Automation
             }
         }
 
-        //enum for selecting the xdgpaths
-        public enum XDG_Type
-        {
-            // location to store configuration file
-            CONFIG,
-            // location for powershell modules
-            MODULES,
-            // location to store temporary files
-            CACHE,
-            // location to store data that application needs
-            DATA,
-            // default location
-            DEFAULT
-        }
-
+        /// <summary>
+        /// True if the current platform is OS X.
+        /// </summary>
         public static bool IsOSX
         {
             get
@@ -71,6 +61,9 @@ namespace System.Management.Automation
             }
         }
 
+        /// <summary>
+        /// True if the current platform is Windows.
+        /// </summary>
         public static bool IsWindows
         {
             get
@@ -83,6 +76,9 @@ namespace System.Management.Automation
             }
         }
 
+        /// <summary>
+        /// True if PowerShell was built targeting .NET Core.
+        /// </summary>
         public static bool IsCore
         {
             get
@@ -111,7 +107,26 @@ namespace System.Management.Automation
                 "WSMan.format.ps1xml"
             };
 
-        // function for choosing directory location of PowerShell for profile loading
+        /// <summary>
+        /// X Desktop Group configuration type enum.
+        /// </summary>
+        public enum XDG_Type
+        {
+            /// <summary> XDG_CONFIG_HOME/powershell </summary>
+            CONFIG,
+            /// <summary> XDG_CACHE_HOME/powershell </summary>
+            CACHE,
+            /// <summary> XDG_DATA_HOME/powershell </summary>
+            DATA,
+            /// <summary> XDG_DATA_HOME/powershell/Modules </summary>
+            MODULES,
+            /// <summary> XDG_CONFIG_HOME/powershell </summary>
+            DEFAULT
+        }
+
+        /// <summary>
+        /// function for choosing directory location of PowerShell for profile loading
+        /// </summary>
         public static string SelectProductNameForDirectory (Platform.XDG_Type dirpath)
         {
 
@@ -356,7 +371,7 @@ namespace System.Management.Automation
         /// <summary>
         /// This models the native call CommandLineToArgvW in managed code.
         /// </summary>
-        public static string[] CommandLineToArgv(string command)
+        internal static string[] CommandLineToArgv(string command)
         {
             StringBuilder arguments  = new StringBuilder();
             int len                  = command.Length;

--- a/src/System.Management.Automation/engine/remoting/fanin/WSManPluginFacade.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/WSManPluginFacade.cs
@@ -627,7 +627,7 @@ namespace System.Management.Automation.Remoting
          /// <summary>
         /// Operation shutdown notification that was registered with the native layer for each of the shellCreate operations.
         /// </summary>
-        /// <param name="shellContext">IntPtr</param>
+        /// <param name="shutdownContext">IntPtr</param>
         public static void WSManPSShutdown(         
             IntPtr shutdownContext)
         {   

--- a/src/System.Management.Automation/project.json
+++ b/src/System.Management.Automation/project.json
@@ -3,6 +3,7 @@
     "version": "1.0.0-*",
 
     "buildOptions": {
+        "nowarn": [ "CS1570", "CS1734" ],
         "xmlDoc": true,
         "keyFile": "../signing/visualstudiopublic.snk",
         "delaySign": true,

--- a/src/System.Management.Automation/project.json
+++ b/src/System.Management.Automation/project.json
@@ -3,6 +3,7 @@
     "version": "1.0.0-*",
 
     "buildOptions": {
+        "xmlDoc": true,
         "keyFile": "../signing/visualstudiopublic.snk",
         "delaySign": true,
         "publicSign": false,

--- a/src/powershell/project.json
+++ b/src/powershell/project.json
@@ -4,6 +4,7 @@
     "description": ".NET CLI PowerShell app",
 
     "buildOptions": {
+        "xmlDoc": true,
         "warningsAsErrors": true,
         "allowUnsafe": true,
         "emitEntryPoint": true,


### PR DESCRIPTION
This turns on the XML documentation generation for the Core PowerShell projects.

This does _not_ include the following:
- `docs/cmdlet-example/project.json`
- `src/Microsoft.PackageManagement.ArchiverProviders/project.json`
- `src/Microsoft.PackageManagement.CoreProviders/project.json`
- `src/Microsoft.PackageManagement.MetaProvider.PowerShell/project.json`
- `src/Microsoft.PackageManagement.MsiProvider/project.json`
- `src/Microsoft.PackageManagement.MsuProvider/project.json`
- `src/Microsoft.PackageManagement.NuGetProvider/project.json`
- `src/Microsoft.PackageManagement.PackageSourceListProvider/project.json`
- `src/Microsoft.PackageManagement/project.json`
- `src/Microsoft.PowerShell.PackageManagement/project.json`
- `src/Microsoft.WSMan.Management.Activities/project.json`
- `src/TypeCatalogGen/project.json`
- `src/TypeCatalogParser/project.json`
- `src/Microsoft.Management.Infrastructure.CimCmdlets/project.json`
- `src/Microsoft.WSMan.Management/project.json`
- `src/Microsoft.WSMan.Runtime/project.json`
- `test/PSReadLine/project.json`
- `test/csharp/project.json`

@joeyaiello I know you were investigating this at some point, I think this is what you wanted.
