### PR TITLE
Enabling DSC MOF compilation on Linux

### DIFF
--- a/src/System.Management.Automation/utils/PsUtils.cs
+++ b/src/System.Management.Automation/utils/PsUtils.cs
@@ -574,6 +574,17 @@ namespace System.Management.Automation
         /// <returns></returns>
         internal static bool IsRunningOnProcessorArchitectureARM()
         {
+#if CORECLR
+            Architecture arch = RuntimeInformation.OSArchitecture;
+            if (arch == Architecture.Arm || arch == Architecture.Arm64)
+            {
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+#else
             // Important:
             // this functiona has a clone in Workflow.ServiceCore in admin\monad\src\m3p\product\ServiceCore\WorkflowCore\WorkflowRuntimeCompilation.cs
             // if you are making any changes specific to this function then update the clone as well.
@@ -581,6 +592,7 @@ namespace System.Management.Automation
             var sysInfo = new NativeMethods.SYSTEM_INFO();
             NativeMethods.GetSystemInfo(ref sysInfo);
             return sysInfo.wProcessorArchitecture == NativeMethods.PROCESSOR_ARCHITECTURE_ARM;
+#endif
         }
 
         internal static string GetHostName()


### PR DESCRIPTION
<!-- PR checklist -->
- [ X] Resolves issue #xyz.
- [ X] Code is up-to-date with `master`.
- [ X] Add tests that fail without your changes.
- [ ] Update all relevant [documentation](../docs).

<!-- Provide more details about the PR below -->

These changes rely on some new Microsoft.Management.Infrastructure (MMI) and Microsoft.Management.Infrastructure.Native (MMIN) nuget packages.  The packages and this changeset will need to in together, or the build will break due to MMI having some internal types name changed.  

The newly added Microsoft.Management.Infrastructure.CimCmdlets sources have two files which reference some MMI internal types, and those will need to be fixed at some point when we have the entirety of MMI working. For now, I've commented out the relevant references (in two files: ExportBinaryMiLogCommand.cs and ImportBinaryMiLogCommand.cs).

The new end-to-end tests of DSC MOF compilation from a configuration block will work when the new MMI and MMIN nuget packages are available on the nuget package server. I am not familiar with how one would go about publishing those, and I would like assistance from someone who is more familiar with it than I am!
