### PR TITLE
Setting MMI dependency in SMA to full version instead of wildcard

### DIFF
--- a/src/System.Management.Automation/project.json
+++ b/src/System.Management.Automation/project.json
@@ -21,7 +21,7 @@
     },
 
     "dependencies": {
-        "Microsoft.Management.Infrastructure": "1.0.0-*"
+        "Microsoft.Management.Infrastructure": "1.0.0-rc2"
     },
 
     "frameworks": {


### PR DESCRIPTION
This will allow us to push the latest MMI packages to the nuget server without breaking PowerShell before other MMI related changes are merged.

Related to what I talked with @andschwa  this morning about
