### PR TITLE
Fixing mc.exe detection and installing required tools in Start-PSBootstrap. Fixes #1451

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,7 +17,7 @@ install:
   - ps: Set-Content c:\users\appveyor\.ssh\id_rsa $fileContent
   - git config --global url.git@github.com:.insteadOf https://github.com/
   - git submodule update --init
-  - ps: Import-Module .\build.psm1; Start-PSBootstrap
+  - ps: Import-Module .\build.psm1; Start-PSBootstrap -Force
 
 build_script:
   - ps: |

--- a/build.psm1
+++ b/build.psm1
@@ -638,6 +638,20 @@ function Start-PSBootstrap {
                 }
             }
 
+            # Install Windows 10 SDK   
+            $sdkPath = "${env:ProgramFiles(x86)}\Microsoft SDKs\Windows\v10.0A"
+            $packageName = "windows-sdk-10.0"
+
+            if (-not (Test-Path -Path $sdkPath -PathType Container))
+            {
+                log "Windows 10 SDK not present. Installing $packageName."
+                choco install windows-sdk-10.0 -y
+            }
+            else
+            {
+                log "Windows 10 SDK present. Skipping installation."
+            }
+            
             # Update machine environment path
             if ($newMachineEnvironmentPath -ne $machinePath)
             {

--- a/build.psm1
+++ b/build.psm1
@@ -548,8 +548,6 @@ function Start-PSBootstrap {
             brew install $Deps
             # OpenSSL libraries must be updated
             brew link --force openssl
-        } else {
-            Write-Warning "This script only supports Ubuntu 14.04, CentOS 7, and OS X, you must install dependencies manually!"
         }
 
         # Install [fpm](https://github.com/jordansissel/fpm)
@@ -595,7 +593,8 @@ function Start-PSBootstrap {
 
             # Install chocolatey
             $chocolateyPath = "$env:AllUsersProfile\chocolatey\bin"
-            if(Get-Command "choco" -ErrorAction SilentlyContinue)
+            
+            if(precheck 'choco' $null)
             {
                 log "Chocolatey is already installed. Skipping installation."
             }
@@ -618,7 +617,7 @@ function Start-PSBootstrap {
 
             # Install cmake
             $cmakePath = "${env:ProgramFiles(x86)}\CMake\bin"
-            if(Get-Command "cmake" -ErrorAction SilentlyContinue)
+            if(precheck 'cmake' $null)
             {
                 log "Cmake is already installed. Skipping installation."
             }
@@ -1370,7 +1369,10 @@ function script:log([string]$message) {
 function script:precheck([string]$command, [string]$missedMessage) {
     $c = Get-Command $command -ErrorAction SilentlyContinue
     if (-not $c) {
-        Write-Warning $missedMessage
+        if ($missedMessage -ne $null)
+        {
+            Write-Warning $missedMessage
+        }
         return $false
     } else {
         return $true

--- a/build.psm1
+++ b/build.psm1
@@ -119,9 +119,9 @@ function Start-PSBuild {
         Use-MSBuild
 
         #mc.exe is Message Compiler for native resources
-        $mcexe = Get-ChildItem "${env:ProgramFiles(x86)}\Microsoft SDKs\Windows\" -Recurse -Filter 'mc.exe' | ? {$_.FullName -match 'x64'} | select -First 1 | % {$_.FullName}
+        $mcexe = Get-ChildItem "${env:ProgramFiles(x86)}\Windows Kits\10\" -Recurse -Filter 'mc.exe' | ? {$_.FullName -match 'x64'} | select -First 1 | % {$_.FullName}
         if (-not $mcexe) {
-            throw 'mc.exe not found. Install Microsoft Windows SDK.'
+            throw 'mc.exe not found. Install Microsoft Windows 10 SDK from https://developer.microsoft.com/en-US/windows/downloads/windows-10-sdk'
         }
 
         $vcVarsPath = (Get-Item(Join-Path -Path "$env:VS140COMNTOOLS" -ChildPath '../../vc')).FullName

--- a/build.psm1
+++ b/build.psm1
@@ -589,6 +589,31 @@ function Start-PSBootstrap {
             $installScript = "dotnet-install.ps1"
             Invoke-WebRequest -Uri $obtainUrl/$installScript -OutFile $installScript
             & ./$installScript -c $Channel -v $Version
+
+            # Install chocolatey
+            $machinePath = [Environment]::GetEnvironmentVariable('Path', 'MACHINE')
+            $chocolateyPath = "$env:AllUsersProfile\chocolatey\bin"
+            if(Get-Command "choco" -ErrorAction SilentlyContinue)
+            {
+                log "Chocolatey is already installed. Skipping installation."
+            }
+            else 
+            {
+                log "Chocolatey not present. Installing chocolatey."
+                Invoke-Expression ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))
+
+                if (-not ($machinePath.ToLower().Contains($chocolateyPath.ToLower())))
+                {
+                    log "Adding $chocolateyPath to Path environment variable"
+                    $env:Path += ";$chocolateyPath"
+                    $machinePath += ";$chocolateyPath"
+                    [Environment]::SetEnvironmentVariable('Path', $machinePath, 'MACHINE')    
+                }
+                else
+                {
+                    log "$chocolateyPath already present in Path environment variable"
+                }
+            }
         } elseif ($IsWindows) {
             Write-Warning "Start-PSBootstrap cannot be run in Core PowerShell on Windows (need Invoke-WebRequest!)"
         }

--- a/build.psm1
+++ b/build.psm1
@@ -114,14 +114,14 @@ function Start-PSBuild {
     $precheck = precheck 'dotnet' "Build dependency 'dotnet' not found in PATH. Run Start-PSBootstrap. Also see: https://dotnet.github.io/getting-started/"
     if ($FullCLR) {
         # cmake is needed to build powershell.exe
-        $precheck = $precheck -and (precheck 'cmake' 'cmake not found. You can install it from https://chocolatey.org/packages/cmake.portable')
+        $precheck = $precheck -and (precheck 'cmake' 'cmake not found. Run Start-PSBootstrap. You can also install it from https://chocolatey.org/packages/cmake.portable')
 
         Use-MSBuild
 
         #mc.exe is Message Compiler for native resources
         $mcexe = Get-ChildItem "${env:ProgramFiles(x86)}\Windows Kits\10\" -Recurse -Filter 'mc.exe' | ? {$_.FullName -match 'x64'} | select -First 1 | % {$_.FullName}
         if (-not $mcexe) {
-            throw 'mc.exe not found. Install Microsoft Windows 10 SDK from https://developer.microsoft.com/en-US/windows/downloads/windows-10-sdk'
+            throw 'mc.exe not found. Run Start-PSBootstrap or install Microsoft Windows 10 SDK from https://developer.microsoft.com/en-US/windows/downloads/windows-10-sdk'
         }
 
         $vcVarsPath = (Get-Item(Join-Path -Path "$env:VS140COMNTOOLS" -ChildPath '../../vc')).FullName
@@ -590,14 +590,16 @@ function Start-PSBootstrap {
             Invoke-WebRequest -Uri $obtainUrl/$installScript -OutFile $installScript
             & ./$installScript -c $Channel -v $Version
 
-            # Install chocolatey
             $machinePath = [Environment]::GetEnvironmentVariable('Path', 'MACHINE')
+            $newMachineEnvironmentPath = $machinePath
+
+            # Install chocolatey
             $chocolateyPath = "$env:AllUsersProfile\chocolatey\bin"
             if(Get-Command "choco" -ErrorAction SilentlyContinue)
             {
                 log "Chocolatey is already installed. Skipping installation."
             }
-            else 
+            else
             {
                 log "Chocolatey not present. Installing chocolatey."
                 Invoke-Expression ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))
@@ -606,14 +608,43 @@ function Start-PSBootstrap {
                 {
                     log "Adding $chocolateyPath to Path environment variable"
                     $env:Path += ";$chocolateyPath"
-                    $machinePath += ";$chocolateyPath"
-                    [Environment]::SetEnvironmentVariable('Path', $machinePath, 'MACHINE')    
+                    $newMachineEnvironmentPath += ";$chocolateyPath"    
                 }
                 else
                 {
                     log "$chocolateyPath already present in Path environment variable"
                 }
             }
+
+            # Install cmake
+            $cmakePath = "${env:ProgramFiles(x86)}\CMake\bin"
+            if(Get-Command "cmake" -ErrorAction SilentlyContinue)
+            {
+                log "Cmake is already installed. Skipping installation."
+            }
+            else
+            {
+                log "Cmake not present. Installing cmake."
+                choco install cmake.portable -y --version 3.6.0
+                
+                if (-not ($machinePath.ToLower().Contains($cmakePath.ToLower())))
+                {
+                    log "Adding $cmakePath to Path environment variable"
+                    $env:Path += ";$cmakePath"
+                    $newMachineEnvironmentPath = "$cmakePath;$newMachineEnvironmentPath"
+                }
+                else
+                {
+                    log "$cmakePath already present in Path environment variable"
+                }
+            }
+
+            # Update machine environment path
+            if ($newMachineEnvironmentPath -ne $machinePath)
+            {
+                [Environment]::SetEnvironmentVariable('Path', $newMachineEnvironmentPath, 'MACHINE')        
+            }
+
         } elseif ($IsWindows) {
             Write-Warning "Start-PSBootstrap cannot be run in Core PowerShell on Windows (need Invoke-WebRequest!)"
         }


### PR DESCRIPTION
- Detecting mc.exe in the right folder.
- Improving error message
- Adding installation of choco, cmake and Win 10 SDK to Start-PSBootstrap
