### PR TITLE
Rename IsCore to IsCoreCLR

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -4,14 +4,14 @@ try {
     $Runtime = [System.Runtime.InteropServices.RuntimeInformation]
     $OSPlatform = [System.Runtime.InteropServices.OSPlatform]
 
-    $IsCore = $true
+    $IsCoreCLR = $true
     $IsLinux = $Runtime::IsOSPlatform($OSPlatform::Linux)
     $IsOSX = $Runtime::IsOSPlatform($OSPlatform::OSX)
     $IsWindows = $Runtime::IsOSPlatform($OSPlatform::Windows)
 } catch {
     # If these are already set, then they're read-only and we're done
     try {
-        $IsCore = $false
+        $IsCoreCLR = $false
         $IsLinux = $false
         $IsOSX = $false
         $IsWindows = $true
@@ -602,7 +602,7 @@ function Start-PSBootstrap {
         }
 
         # Install for Windows
-        if ($IsWindows -and -not $IsCore) {
+        if ($IsWindows -and -not $IsCoreCLR) {
             Remove-Item -ErrorAction SilentlyContinue -Recurse -Force ~\AppData\Local\Microsoft\dotnet
             $installScript = "dotnet-install.ps1"
             Invoke-WebRequest -Uri $obtainUrl/$installScript -OutFile $installScript

--- a/src/Modules/Shared/PowerShellGet/PSModule.psm1
+++ b/src/Modules/Shared/PowerShellGet/PSModule.psm1
@@ -17,7 +17,7 @@ $script:isNanoServer = $null -ne ('System.Runtime.Loader.AssemblyLoadContext' -a
 function IsWindows { $PSVariable = Get-Variable -Name IsWindows -ErrorAction Ignore; return (-not $PSVariable -or $PSVariable.Value) }
 function IsLinux { $PSVariable = Get-Variable -Name IsLinux -ErrorAction Ignore; return ($PSVariable -and $PSVariable.Value) }
 function IsOSX { $PSVariable = Get-Variable -Name IsOSX -ErrorAction Ignore; return ($PSVariable -and $PSVariable.Value) }
-function IsCore { $PSVariable = Get-Variable -Name IsCore -ErrorAction Ignore; return ($PSVariable -and $PSVariable.Value) }
+function IsCoreCLR { $PSVariable = Get-Variable -Name IsCoreCLR -ErrorAction Ignore; return ($PSVariable -and $PSVariable.Value) }
 
 if(IsWindows)
 {
@@ -727,7 +727,7 @@ function Publish-Module
 
     Begin
     {
-        if($script:isNanoServer -or (IsCore)) {
+        if($script:isNanoServer -or (IsCoreCLR)) {
             $message = $LocalizedData.PublishPSArtifactUnsupportedOnNano -f "Module"
             ThrowError -ExceptionName "System.InvalidOperationException" `
                         -ExceptionMessage $message `
@@ -2526,7 +2526,7 @@ function Publish-Script
 
     Begin
     {
-        if($script:isNanoServer -or (IsCore)) {
+        if($script:isNanoServer -or (IsCoreCLR)) {
             $message = $LocalizedData.PublishPSArtifactUnsupportedOnNano -f "Script"
             ThrowError -ExceptionName "System.InvalidOperationException" `
                         -ExceptionMessage $message `
@@ -7322,7 +7322,7 @@ function Install-NuGetClientBinaries
     }
     
     # On Nano server we don't need NuGet.exe
-    if(-not $bootstrapNuGetProvider -and ($script:isNanoServer -or (IsCore) -or -not $BootstrapNuGetExe))
+    if(-not $bootstrapNuGetProvider -and ($script:isNanoServer -or (IsCoreCLR) -or -not $BootstrapNuGetExe))
     {
         return
     }
@@ -7379,7 +7379,7 @@ function Install-NuGetClientBinaries
             }
         }
 
-        if($BootstrapNuGetExe -and -not $script:isNanoServer -and -not (IsCore))
+        if($BootstrapNuGetExe -and -not $script:isNanoServer -and -not (IsCoreCLR))
         {
             Write-Verbose -Message $LocalizedData.DownloadingNugetExe
 

--- a/src/System.Management.Automation/CoreCLR/CorePsPlatform.cs
+++ b/src/System.Management.Automation/CoreCLR/CorePsPlatform.cs
@@ -79,7 +79,7 @@ namespace System.Management.Automation
         /// <summary>
         /// True if PowerShell was built targeting .NET Core.
         /// </summary>
-        public static bool IsCore
+        public static bool IsCoreCLR
         {
             get
             {

--- a/src/System.Management.Automation/commands/utility/FormatAndOutput/common/DisplayDatabase/typeDataXmlLoader.cs
+++ b/src/System.Management.Automation/commands/utility/FormatAndOutput/common/DisplayDatabase/typeDataXmlLoader.cs
@@ -1815,8 +1815,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
 
 
             // optional pre-load and binding verification
-            // Porting Note: DLL.resources are not currently available on Linux
-            if (!Platform.IsCore && this.VerifyStringResources)
+            if (this.VerifyStringResources)
             {
                 DisplayResourceManagerCache.LoadingResult result;
                 DisplayResourceManagerCache.AssemblyBindingStatus bindingStatus;

--- a/src/System.Management.Automation/engine/CommandDiscovery.cs
+++ b/src/System.Management.Automation/engine/CommandDiscovery.cs
@@ -1321,14 +1321,16 @@ namespace System.Management.Automation
                             }
                         }
 
+                        // TODO: this causes AppVeyor builds to fail due to invalid XML being output
+#if !CORECLR
                         // Close the progress pane that may have popped up from analyzing UNC paths.
-                        // Porting note: we don't like this message
-                        if (!Platform.IsCore && context.CurrentCommandProcessor != null)
+                        if (context.CurrentCommandProcessor != null)
                         {
                             ProgressRecord analysisProgress = new ProgressRecord(0, Modules.ScriptAnalysisPreparing, " ");
                             analysisProgress.RecordType = ProgressRecordType.Completed;
                             context.CurrentCommandProcessor.CommandRuntime.WriteProgress(analysisProgress);
                         }
+#endif
                     }
                 }
             }

--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -5122,8 +5122,8 @@ end
                 ScopedItemOptions.ReadOnly | ScopedItemOptions.AllScope),
 
             new SessionStateVariableEntry(
-                SpecialVariables.IsCore,
-                Platform.IsCore,
+                SpecialVariables.IsCoreCLR,
+                Platform.IsCoreCLR,
                 String.Empty,
                 ScopedItemOptions.ReadOnly | ScopedItemOptions.AllScope),
             #endregion
@@ -5475,7 +5475,7 @@ end
         internal const string DefaultMoreFunctionText = @"
 param([string[]]$paths)
 # Nano needs to use Unicode, but Windows and Linux need the default
-$OutputEncoding = if ($IsWindows -and $IsCore) {
+$OutputEncoding = if ($IsWindows -and $IsCoreCLR) {
     [System.Text.Encoding]::Unicode
 } else {
     [System.Console]::OutputEncoding

--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -5698,11 +5698,7 @@ if($paths) {
             {
                 AssemblyName assemblyName = ClrFacade.GetAssemblyName(psSnapInInfo.AbsoluteModulePath);
 
-                // Porting note: the snapins still require 'ProcessorArchitecture=MSIL' in
-                // the strong name, which is not in the strong name of assemblies created
-                // by dotnet-cli
-                if (!Platform.IsCore &&
-                    !string.Equals(assemblyName.FullName, psSnapInInfo.AssemblyName, StringComparison.OrdinalIgnoreCase))
+                if (!string.Equals(assemblyName.FullName, psSnapInInfo.AssemblyName, StringComparison.OrdinalIgnoreCase))
                 {
                     string message = StringUtil.Format(ConsoleInfoErrorStrings.PSSnapInAssemblyNameMismatch, psSnapInInfo.AbsoluteModulePath, psSnapInInfo.AssemblyName);
                     _PSSnapInTracer.TraceError(message);

--- a/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
@@ -778,12 +778,13 @@ namespace System.Management.Automation
             {
                 // Now handle the case where the environment variable is already set.
 
-                // Porting note: Open PowerShell has a Modules folder in the the application base path which contains the built-in modules
-                // It must be in the front of the path no matter what.
-                if (Platform.IsCore)
-                {
-                    currentProcessModulePath = AddToPath(currentProcessModulePath, GetSystemwideModulePath(), 0);
-                }
+                // CoreCLR PowerShell on Windows has a Modules folder in the the application base
+                // path which contains the built-in modules It must be in the front of the path no
+                // matter what, regardless of inherited path.
+#if CORECLR && !UNIX
+                // TODO: #1184 will resolve this work-around
+                currentProcessModulePath = AddToPath(currentProcessModulePath, GetSystemwideModulePath(), 0);
+#endif
 
                 // If there is no personal path key, then if the env variable doesn't match the system variable,
                 // the user modified it somewhere, else prepend the default personel module path

--- a/src/System.Management.Automation/engine/SpecialVariables.cs
+++ b/src/System.Management.Automation/engine/SpecialVariables.cs
@@ -166,8 +166,8 @@ namespace System.Management.Automation
         internal const string IsWindows = "IsWindows";
         internal static VariablePath IsWindowsPath = new VariablePath("IsWindows");
 
-        internal const string IsCore = "IsCore";
-        internal static VariablePath IsCorePath = new VariablePath("IsCore");
+        internal const string IsCoreCLR = "IsCoreCLR";
+        internal static VariablePath IsCoreCLRPath = new VariablePath("IsCoreCLR");
 
         #endregion
         #region Preference Variables

--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -231,15 +231,18 @@ namespace System.Management.Automation
         /// </exception>
         internal static string GetApplicationBase(string shellId)
         {
-            if (!Platform.IsCore)
+            // TODO: #1184 will resolve this work-around
+            // The application base cannot be resolved from the registry for side-by-side versions
+            // of PowerShell.
+#if !CORECLR
+            // try to get the path from the registry first
+            string result = GetApplicationBaseFromRegistry(shellId);
+            if (result != null)
             {
-                // try to get the path from the registry first
-                string result = GetApplicationBaseFromRegistry(shellId);
-                if (result != null)
-                {
-                    return result;
-                }
+                return result;
             }
+#endif
+
 
 #if CORECLR // Use the location of SMA.dll as the application base
             // Assembly.GetEntryAssembly is not in CoreCLR. GAC is not in CoreCLR.

--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -296,14 +296,14 @@ namespace System.Management.Automation
 
                 // And built-in modules
                 string progFileDir;
-                if (Platform.IsCore)
-                {
-                    progFileDir = Path.Combine(appBase, "Modules");
-                }
-                else
-                {
-                    progFileDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles), "WindowsPowerShell", "Modules");
-                }
+                // TODO: #1184 will resolve this work-around
+                // Side-by-side versions of PowerShell use modules from their application base, not
+                // the system installation path.
+#if CORECLR
+                progFileDir = Path.Combine(appBase, "Modules");
+#else
+                progFileDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles), "WindowsPowerShell", "Modules");
+#endif
 
                 if (!string.IsNullOrEmpty(progFileDir))
                 {

--- a/test/csharp/test_CorePsPlatform.cs
+++ b/test/csharp/test_CorePsPlatform.cs
@@ -10,9 +10,9 @@ namespace PSTests
     public static class PlatformTests
     {
         [Fact]
-        public static void TestIsCore()
+        public static void TestIsCoreCLR()
         {
-            Assert.True(Platform.IsCore);
+            Assert.True(Platform.IsCoreCLR);
         }
 
         [Fact]

--- a/test/powershell/Host/PSVersionTable.Tests.ps1
+++ b/test/powershell/Host/PSVersionTable.Tests.ps1
@@ -19,7 +19,7 @@ Describe "PSVersionTable" {
         $PSVersionTable.GitCommitId | Should not match "powershell.version"
     }
 
-    It "Should have the correct edition" -Skip:(!$IsCore) {
+    It "Should have the correct edition" -Skip:(!$IsCoreCLR) {
 	$PSVersionTable["PSEdition"] | Should Be "PowerShellCore"
     }
 }

--- a/test/powershell/Language/Classes/Scripting.Classes.BasicParsing.Tests.ps1
+++ b/test/powershell/Language/Classes/Scripting.Classes.BasicParsing.Tests.ps1
@@ -471,7 +471,7 @@ Describe 'PositiveReturnSelfClassTypeFromMemberFunction Test' -Tags "CI" {
     }
 
 Describe 'TestMultipleArguments Test' -Tags "CI" {
-        if ( $IsCore ) { $maxCount = 14 } else { $maxCount = 16 }
+        if ( $IsCoreCLR ) { $maxCount = 14 } else { $maxCount = 16 }
         for ($i = 0; $i -lt $maxCount; $i++)
         {
             $properties = $(for ($j = 0; $j -le $i; $j++) {

--- a/test/powershell/Language/Parser/MethodInvocation.Tests.ps1
+++ b/test/powershell/Language/Parser/MethodInvocation.Tests.ps1
@@ -1,4 +1,4 @@
-if ( $IsCore ) {
+if ( $IsCoreCLR ) {
     return
 }
 

--- a/test/powershell/Language/Parser/TypeAccelerator.Tests.ps1
+++ b/test/powershell/Language/Parser/TypeAccelerator.Tests.ps1
@@ -11,7 +11,7 @@ Describe "Type accelerators" -Tags "DRT" {
     }
 
     It "Can query type accelerators" {
-        if ( $IsCore ) { $count = 80 } else { $count = 82 }
+        if ( $IsCoreCLR ) { $count = 80 } else { $count = 82 }
         $TypeAccelerators.Count -gt $count | Should Be $true
         $TypeAccelerators['xml'] | Should Be ([System.Xml.XmlDocument])
         $TypeAccelerators['AllowNull'] | Should Be ([System.Management.Automation.AllowNullAttribute])

--- a/test/powershell/Language/Scripting/Debugging/DebuggerScriptTests.Tests.ps1
+++ b/test/powershell/Language/Scripting/Debugging/DebuggerScriptTests.Tests.ps1
@@ -215,7 +215,7 @@ Describe "Line breakpoints on commands in multi-line pipelines" -tags 'Innerloop
     Context "COM TESTS" {
         # DRT for 133807 SetBreakpointWithShortPath
         BeforeAll {
-            if ( $IsCore ) { return } # no COM on core
+            if ( $IsCoreCLR ) { return } # no COM on core
             $scriptPath1 = Join-Path $TestDrive SBPShortPathBug133807.DRT.tmp.ps1
             $scriptPath1 = setup -f SBPShortPathBug133807.DRT.tmp.ps1 -content '
             1..3 |
@@ -230,19 +230,19 @@ Describe "Line breakpoints on commands in multi-line pipelines" -tags 'Innerloop
         }
 
         AfterAll {
-            if ( $IsCore ) { return }
+            if ( $IsCoreCLR ) { return }
             if ($breakpoints -ne $null) { $breakpoints | Remove-PSBreakpoint }
         }
 
-        It "Short path Breakpoint on line 1 hit count" -skip:$IsCore {
+        It "Short path Breakpoint on line 1 hit count" -skip:$IsCoreCLR {
             $breakpoints[0].HitCount | Should Be 1
         }
 
-        It "Short path Breakpoint on line 2 hit count" -skip:$IsCore {
+        It "Short path Breakpoint on line 2 hit count" -skip:$IsCoreCLR {
             $breakpoints[1].HitCount | Should Be 3
         }
 
-        It "Short path Breakpoint on line 3 hit count" -skip:$IsCore {
+        It "Short path Breakpoint on line 3 hit count" -skip:$IsCoreCLR {
             $breakpoints[2].HitCount | Should Be 1
         }
     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Clear-EventLog.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Clear-EventLog.Tests.ps1
@@ -1,4 +1,4 @@
-if ($IsWindows -and !$IsCore) {
+if ($IsWindows -and !$IsCoreCLR) {
   #check to see whether we're running as admin in Windows...
   $windowsIdentity = [Security.Principal.WindowsIdentity]::GetCurrent()
   $windowsPrincipal = new-object 'Security.Principal.WindowsPrincipal' $windowsIdentity

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-EventLog.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-EventLog.Tests.ps1
@@ -1,4 +1,4 @@
-﻿if ($IsWindows -and !$IsCore) {
+﻿if ($IsWindows -and !$IsCoreCLR) {
   #check to see whether we're running as admin in Windows...
   $windowsIdentity = [Security.Principal.WindowsIdentity]::GetCurrent()
   $windowsPrincipal = new-object 'Security.Principal.WindowsPrincipal' $windowsIdentity

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/New-EventLog.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/New-EventLog.Tests.ps1
@@ -1,4 +1,4 @@
-﻿if ($IsWindows -and !$IsCore) {
+﻿if ($IsWindows -and !$IsCoreCLR) {
     #check to see whether we're running as admin in Windows...
     $windowsIdentity = [Security.Principal.WindowsIdentity]::GetCurrent()
     $windowsPrincipal = new-object 'Security.Principal.WindowsPrincipal' $windowsIdentity

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Remove-EventLog.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Remove-EventLog.Tests.ps1
@@ -1,4 +1,4 @@
-﻿if ($IsWindows -and !$IsCore) {
+﻿if ($IsWindows -and !$IsCoreCLR) {
   #check to see whether we're running as admin in Windows...
   $windowsIdentity = [Security.Principal.WindowsIdentity]::GetCurrent()
   $windowsPrincipal = new-object 'Security.Principal.WindowsPrincipal' $windowsIdentity

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Invoke-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Invoke-Item.Tests.ps1
@@ -37,14 +37,14 @@ Describe "Invoke-Item" {
         $testfile = Join-Path $TestDrive testfile.txt
     }
 
-    It "Should invoke a text file without error" -Skip:($IsWindows -and $IsCore) {
+    It "Should invoke a text file without error" -Skip:($IsWindows -and $IsCoreCLR) {
         $debugfn = NewProcessStartInfo "-noprofile ""``Invoke-Item $testfile`n" -RedirectStdIn
         $process = RunPowerShell $debugfn
         EnsureChildHasExited $process
         $process.ExitCode | Should Be 0
     }
 
-    It "Should throw not supported on Windows with .NET Core" -Skip:($IsLinux -or $IsOSX -or !$IsCore) {
+    It "Should throw not supported on Windows with .NET Core" -Skip:($IsLinux -or $IsOSX -or !$IsCoreCLR) {
         { Invoke-Item $testfile }| Should Throw "Operation is not supported on this platform."
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Trace-Command.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Trace-Command.Tests.ps1
@@ -13,7 +13,7 @@ Describe "Trace-Command" -tags "P1", "RI" {
         }
         
         # LogicalOperationStack is not in .NET Core
-        It "LogicalOperationStack works" -Skip:$IsCore {
+        It "LogicalOperationStack works" -Skip:$IsCoreCLR {
             $keyword = "Trace_Command_ListenerOption_LogicalOperationStack_Foo"
             $stack = [System.Diagnostics.Trace]::CorrelationManager.LogicalOperationStack
             $stack.Push($keyword)
@@ -25,7 +25,7 @@ Describe "Trace-Command" -tags "P1", "RI" {
         } 
 
         # GetStackTrace is not in .NET Core
-        It "Callstack works" -Skip:$IsCore {
+        It "Callstack works" -Skip:$IsCoreCLR {
             Trace-Command -Name * -Expression {echo Foo} -ListenerOption Callstack -FilePath $logfile
             $log = Get-Content $logfile | Where-Object {$_ -like "*Callstack=   * System.Environment.GetStackTrace(Exception e, Boolean needFileInfo)*"}
             $log.Count | Should BeGreaterThan 0


### PR DESCRIPTION
Resolves #1230.
- Removes the runtime uses of `IsCore` and replaces with `CORECLR` (and notes for @mirichmo)
- Renames `IsCore` to `IsCoreCLR`
- Removes some deprecated guards
