### PR TITLE
Whitelist master and test branches for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 language: cpp
 
+branches:
+  only:
+    - master
+    - /^test.*$/
+
 os:
   - linux
   - osx


### PR DESCRIPTION
Only pull requests, merges to master, and branches starting with the prefix "test" will trigger Travis CI builds.

/cc @vors @lzybkr @lilyfang @JamesWTruher 

I would still like to explore speeding up the build by:
- tagging many more tests as slow
- running OS X builds only for merges to master

As it is, our builds take about 18 minutes on Linux, and 22 on OS X. The majority of the time is spent waiting for the queue to free up, and once building, spent running Pester tests.
