### PR TITLE
Fix ConvertFrom-Json to handle mutlilines

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/ConvertFromJsonCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/ConvertFromJsonCommand.cs
@@ -93,6 +93,12 @@ namespace Microsoft.PowerShell.Commands
                         // The first input string does not represent a complete Json Syntax. 
                         // Hence consider the the entire input as a single Json content.
                     }
+#if CORECLR
+                    catch (Newtonsoft.Json.JsonSerializationException)
+                    {
+                        // we use another serializer for CORECLR implementation
+                    }
+#endif
                     if (successfullyConverted)
                     {
                         for (int index = 1; index < inputObjectBuffer.Count; index++)

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertFrom-Json.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertFrom-Json.Tests.ps1
@@ -1,0 +1,16 @@
+Describe 'ConvertFrom-Json' {
+    It 'can convert a single-line object' {
+        ('{"a" : "1"}' | ConvertFrom-Json).a | Should Be 1
+    }
+
+    It 'can convert one string-per-object' {
+        $json = @('{"a" : "1"}', '{"a" : "x"}') | ConvertFrom-Json
+        $json.Count | Should Be 2
+        $json[1].a | Should Be 'x'
+    }
+
+    It 'can convert mutli-line object' {
+        $json = @('{"a" :', '"x"}') | ConvertFrom-Json
+        $json.a | Should Be 'x'
+    }
+}


### PR DESCRIPTION
<!-- PR checklist -->
- [x] Resolves issue #956.
- [x] Code is up-to-date with `master`.
- [x] Add tests that fail without your changes.
- [ ] Update all relevant [documentation](../docs).

<!-- Provide more details about the PR below -->

Fix #956

Add Newtonsoft.Json.JsonSerializationException to catch block
that determines which mode to use: single-string or multi-string
