### PR TITLE
Fix for handling alphanumeric characters in package build field

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -1555,12 +1555,13 @@ function Get-PackageVersionAsMajorMinorBuildRevision
     if (1 -eq $packageVersionTokens.Count)
     {           
         # In case the input is of the form a.b.c, add a '0' at the end for revision field
-       $packageVersion = $packageVersion + '.0'
+        $packageVersion = $packageVersion + '.0'
     }
     elseif (1 -lt $packageVersionTokens.Count)
     {
         # We have all the four fields
-       $packageVersion = $packageVersion + '.' + $packageVersionTokens[1]
+        $packageBuildTokens = ([regex]::Matches($packageVersionTokens[1], "\d+"))[0].value
+        $packageVersion = $packageVersion + '.' + $packageBuildTokens[0]
     }
 
     return $packageVersion


### PR DESCRIPTION
if the package version is of the form 0.6.0-alpha.7-4-xxxxxxxx, the numeric part of build number 'alpha.7' was not extracted correctly. This fixes the issue.

We only need the numeric part of the build field for generating appx/msi packages. The package manifest of these do not like alpha characters in the field
