### PR TITLE
Make Get-Item env: case-aware on Unix

### DIFF
--- a/src/System.Management.Automation/namespaces/EnvironmentProvider.cs
+++ b/src/System.Management.Automation/namespaces/EnvironmentProvider.cs
@@ -190,8 +190,15 @@ namespace Microsoft.PowerShell.Commands
         /// 
         internal override IDictionary GetSessionStateTable ()
         {
+            // Environment variables are case-sensitive on Unix and
+            // case-insensitive on Windows
+#if UNIX
+            Dictionary<string, DictionaryEntry> providerTable =
+                new Dictionary<string, DictionaryEntry>(StringComparer.Ordinal);
+#else
             Dictionary<string, DictionaryEntry> providerTable =
                 new Dictionary<string, DictionaryEntry>(StringComparer.OrdinalIgnoreCase);
+#endif
 
             // The environment variables returns a dictionary of keys and values that are 
             // both strings. We want to return a dictionary with the key as a string and

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ChildItem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ChildItem.Tests.ps1
@@ -1,36 +1,59 @@
 Describe "Get-ChildItem" -Tags "CI" {
-    It "Should list the contents of the current folder" {
-	(Get-ChildItem .).Name.Length | Should BeGreaterThan 0
+
+    Context 'FileSystem provider' {
+
+        It "Should list the contents of the current folder" {
+            (Get-ChildItem .).Name.Length | Should BeGreaterThan 0
+        }
+
+        It "Should list the contents of the home directory" {
+            pushd $HOME
+            (Get-ChildItem .).Name.Length | Should BeGreaterThan 0
+            popd
+        }
+
+        It "Should have a the proper fields and be populated" {
+            $var = Get-Childitem .
+
+            $var.Name.Length   | Should BeGreaterThan 0
+            $var.Mode.Length   | Should BeGreaterThan 0
+            $var.LastWriteTime | Should BeGreaterThan 0
+            $var.Length.Length | Should BeGreaterThan 0
+
+        }
+
+        It "Should list files in sorted order" {
+            New-Item -Path $TestDrive -Name "a" -ItemType "File" -Force
+            New-Item -Path $TestDrive -Name "B" -ItemType "File" -Force
+            New-Item -Path $TestDrive -Name "c" -ItemType "File" -Force
+            New-Item -Path $TestDrive -Name "D" -ItemType "File" -Force
+            New-Item -Path $TestDrive -Name "E" -ItemType "Directory" -Force
+
+            $files = Get-ChildItem -Path $TestDrive
+            $files[0].Name     | Should Be "E"
+            $files[1].Name     | Should Be "a"
+            $files[2].Name     | Should Be "B"
+            $files[3].Name     | Should Be "c"
+            $files[4].Name     | Should Be "D"
+        }
     }
 
-    It "Should list the contents of the home directory" {
-	pushd $HOME
-	(Get-ChildItem .).Name.Length | Should BeGreaterThan 0
-	popd
-    }
+    Context 'Env: Provider' {
 
-    It "Should have a the proper fields and be populated" {
-	$var = Get-Childitem .
+        It 'can handle mixed case in Env variables' {
+            try
+            {
+                $env:__FOOBAR = 'foo'
+                $env:__foobar = 'bar'
 
-	$var.Name.Length   | Should BeGreaterThan 0
-	$var.Mode.Length   | Should BeGreaterThan 0
-	$var.LastWriteTime | Should BeGreaterThan 0
-	$var.Length.Length | Should BeGreaterThan 0
-
-    }
-
-    It "Should list files in sorted order" {
-	New-Item -Path $TestDrive -Name "a" -ItemType "File" -Force
-	New-Item -Path $TestDrive -Name "B" -ItemType "File" -Force
-	New-Item -Path $TestDrive -Name "c" -ItemType "File" -Force
-	New-Item -Path $TestDrive -Name "D" -ItemType "File" -Force
-	New-Item -Path $TestDrive -Name "E" -ItemType "Directory" -Force
-
-	$files = Get-ChildItem -Path $TestDrive
-	$files[0].Name     | Should Be "E"
-	$files[1].Name     | Should Be "a"
-	$files[2].Name     | Should Be "B"
-	$files[3].Name     | Should Be "c"
-	$files[4].Name     | Should Be "D"
+                $foobar = Get-Childitem env: | ? {$_.Name -eq '__foobar'}
+                $count = if ($IsWindows) { 1 } else { 2 }
+                ($foobar | measure).Count | Should Be $count
+            }
+            catch
+            {
+                Get-ChildItem env: | ? {$_.Name -eq '__foobar'} | Remove-Item -ErrorAction SilentlyContinue
+            }
+        }
     }
 }


### PR DESCRIPTION
- [x] Resolves issue #1196.
- [x] Code is [rebased](https://github.com/PowerShell/PowerShell/blob/master/docs/git/powershell-repository-101.md#sync-your-local-repo) on `origin/master`.
- [x] Add tests that fail without your changes.
- [ ] Update all relevant [documentation](https://github.com/PowerShell/PowerShell/tree/master/docs).
