### PR TITLE
Fix PSReadLine custom key binding on Linux

### DIFF
--- a/src/Microsoft.PowerShell.PSReadLine/ConsoleLib.cs
+++ b/src/Microsoft.PowerShell.PSReadLine/ConsoleLib.cs
@@ -386,24 +386,6 @@ namespace Microsoft.PowerShell.Internal
                 sb.Append("Alt");
             }
 
-#if UNIX
-            if (sb.Length > 0)
-                sb.Append("+");
-            // TODO: find better way to map these characters to something more friendly
-            if ((key.Key >= ConsoleKey.D0 && key.Key <= ConsoleKey.D9)
-                || (key.Key >= ConsoleKey.Oem1 && key.Key <= ConsoleKey.Oem8))
-            {
-                sb.Append(key.KeyChar);
-            }
-            else
-            {
-                if (key.Modifiers.HasFlag(ConsoleModifiers.Shift))
-                {
-                    sb.Append("Shift+");
-                }
-                sb.Append(key.Key);
-            }
-#else
             char c = key.KeyChar;
             if (char.IsControl(c) || char.IsWhiteSpace(c))
             {
@@ -423,7 +405,6 @@ namespace Microsoft.PowerShell.Internal
                     sb.Append("+");
                 sb.Append(c);
             }
-#endif
             return sb.ToString();
         }
     }

--- a/src/Microsoft.PowerShell.PSReadLine/ConsoleLib.cs
+++ b/src/Microsoft.PowerShell.PSReadLine/ConsoleLib.cs
@@ -404,8 +404,7 @@ namespace Microsoft.PowerShell.Internal
                 sb.Append(key.Key);
             }
 #else
-            char c = ConsoleKeyChordConverter.GetCharFromConsoleKey(key.Key,
-                (mods & ConsoleModifiers.Shift) != 0 ? ConsoleModifiers.Shift : 0);
+            char c = key.KeyChar;
             if (char.IsControl(c) || char.IsWhiteSpace(c))
             {
                 if (key.Modifiers.HasFlag(ConsoleModifiers.Shift))

--- a/src/Microsoft.PowerShell.PSReadLine/ConsoleLib.cs
+++ b/src/Microsoft.PowerShell.PSReadLine/ConsoleLib.cs
@@ -386,7 +386,13 @@ namespace Microsoft.PowerShell.Internal
                 sb.Append("Alt");
             }
 
+#if UNIX
             char c = key.KeyChar;
+#else
+            // Windows cannot use KeyChar as some chords (like Ctrl+[) show up as control characters.
+            char c = ConsoleKeyChordConverter.GetCharFromConsoleKey(key.Key,
+                (mods & ConsoleModifiers.Shift) != 0 ? ConsoleModifiers.Shift : 0);
+#endif
             if (char.IsControl(c) || char.IsWhiteSpace(c))
             {
                 if (key.Modifiers.HasFlag(ConsoleModifiers.Shift))

--- a/src/Microsoft.PowerShell.PSReadLine/KeyBindings.cs
+++ b/src/Microsoft.PowerShell.PSReadLine/KeyBindings.cs
@@ -93,9 +93,13 @@ namespace Microsoft.PowerShell
             {
                 // Because a comparison of two ConsoleKeyInfo objects is a comparison of the
                 // combination of the ConsoleKey and Modifiers, we must combine their hashes.
-                // This is based on Tuple.GetHashCode
-                int h1 = obj.Key.GetHashCode();
+                // Note that if the ConsoleKey is default, we must fall back to the KeyChar,
+                // otherwise every non-special key will compare as the same.
+                int h1 = obj.Key == default(ConsoleKey)
+                    ? obj.KeyChar.GetHashCode()
+                    : obj.Key.GetHashCode();
                 int h2 = obj.Modifiers.GetHashCode();
+                // This is based on Tuple.GetHashCode
                 return unchecked(((h1 << 5) + h1) ^ h2);
             }
         }

--- a/test/powershell/Modules/PSReadLine/PSReadLine.Tests.ps1
+++ b/test/powershell/Modules/PSReadLine/PSReadLine.Tests.ps1
@@ -20,7 +20,7 @@ Describe "PSReadLine" -tags "CI" {
 
     It "Should use Windows Bindings on Windows" -skip:(-not $IsWindows) {
         (Get-PSReadLineOption).EditMode | Should Be Windows
-        (Get-PSReadlineKeyHandler | where { $_.Key -eq "Ctrl+A" }).Function | Should Be SelectAll
+        (Get-PSReadlineKeyHandler | where { $_.Key -eq "Ctrl+a" }).Function | Should Be SelectAll
     }
 
     It "Should set the edit mode" {
@@ -29,6 +29,17 @@ Describe "PSReadLine" -tags "CI" {
 
         Set-PSReadlineOption -EditMode Emacs
         (Get-PSReadlineKeyHandler | where { $_.Key -eq "Ctrl+A" }).Function | Should Be BeginningOfLine
+    }
+
+    It "Should allow custom bindings for plain keys" {
+        Set-PSReadlineKeyHandler -Key '"' -Function SelfInsert
+        (Get-PSReadLineKeyHandler | where { $_.Key -eq '"' }).Function | Should Be SelfInsert
+    }
+
+    It "Should report Capitalized bindings correctly" {
+        Set-PSReadlineOption -EditMode Emacs
+        (Get-PSReadLineKeyHandler | where { $_.Key -ceq "Alt+b" }).Function | Should Be BackwardWord
+        (Get-PSReadLineKeyHandler | where { $_.Key -ceq "Alt+B" }).Function | Should Be SelectBackwardWord
     }
 
     AfterAll {


### PR DESCRIPTION
Resolves #1431.

Setting custom key bindings for things like `"` now works.

This PR specifically fixes the comparison and display of keys; it _does not_ address the fact that we have some incorrect key definitions for Linux (due to limitations of System.Console), which will need to be addressed in the future.

@lzybkr please review 😄 

Where `$masterkeys` is `Get-PSReadLineKeyHandler` for the master branch, and `$charkeys` is for this feature branch, here is the diff of the two for the key property (note that the function property diff was empty).

``` powershell
> Compare-Object $masterkeys $charkeys -Property key                                                                                                                                                                               
key                 SideIndicator
---                 -------------
Ctrl+Shift+D2       =>           
Ctrl+Shift+OemMinus =>           
Ctrl+Oem6           =>           
Ctrl+Alt+Oem6       =>           
Alt+B               =>           
Alt+F               =>           
Ctrl+Alt+Shift+Oem2 =>           
Ctrl+              <=           
Ctrl+              <=           
Ctrl+              <=           
Ctrl+Alt+          <=           
Alt+Shift+B         <=           
Alt+Shift+F         <=           
Ctrl+Alt+          <=           
```

The keys with missing characters following the `+` are from the master branch, where they are not displayed correctly as they are special keys. For instance:

``` powershell
> $charkeys | where { $_.Key -eq "Ctrl+Shift+D2" }                                                      

Key           Function Description                    
---           -------- -----------                    
Ctrl+Shift+D2 SetMark  Mark the location of the cursor


> $masterkeys | where { $_.Function -eq "SetMark" }                                                     

Key          Function Description                    
---          -------- -----------                    
Ctrl+       SetMark  Mark the location of the cursor
Alt+Spacebar SetMark  Mark the location of the cursor
```

So SetMark is bound to `Ctrl+@`. While `Ctrl+@` would be the best thing to display, we currently display `Ctrl+`, and this fixes it to at least show correctly (if not the most clearly) `Ctrl+Shift+D2`.

Another instance:

``` powershell
> $charkeys | where { $_.Key -eq "Ctrl+Shift+OemMinus" }                                                

Key                 Function Description         
---                 -------- -----------         
Ctrl+Shift+OemMinus Undo     Undo a previous edit


> $masterkeys | where { $_.Function -eq "Undo" }                                                        

Key           Function Description         
---           -------- -----------         
Ctrl+        Undo     Undo a previous edit
Ctrl+X,Ctrl+U Undo     Undo a previous edit
```

This brings us to the point of `OemMinus` not being the correct key on Linux (`System.Console`'s Linux implementation will never provide a key with `OemMinus`). However, this is a big enough problem that it merits a separate set of changes to rectify (all the key definitions need to be manually reconciled with the Linux implementation of `System.Console`).

Finally, this fixes the display of the `Alt+B` binding, which was previously being incorrectly displayed as `Alt+Shift+B`.
