### PR TITLE
Revert back to old MMI package, until we fix regression

### DIFF
--- a/src/System.Management.Automation/project.json
+++ b/src/System.Management.Automation/project.json
@@ -21,7 +21,7 @@
     },
 
     "dependencies": {
-        "Microsoft.Management.Infrastructure": "1.0.0-alpha-01"
+        "Microsoft.Management.Infrastructure": "1.0.0-rc2"
     },
 
     "frameworks": {


### PR DESCRIPTION
Fixes master

Current error in master is introduced by updated MMI package

```
Could not load type 'Microsoft.Management.Infrastructure.Native.MI_UserCredentials' from assembly 'Microsoft.Management.Infrastructure, 
Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35' because it contains an object field at offset 4 that is incorrectly 
aligned or overlapped by a non-object field.
```

Error manifests itself only on `-Publish` builds (layout-dependent).

cc @daxian-dbw @johnkord 
