### PR TITLE
Update building instructions to use correct TOP directories

### DIFF
--- a/docs/building/linux.md
+++ b/docs/building/linux.md
@@ -106,7 +106,7 @@ Start-PSBuild
 Congratulations! If everything went right, PowerShell is now built.
 The `Start-PSBuild` script will output the location of the executable:
 
-`./src/powershell/bin/Linux/netcoreapp1.0/ubuntu.14.04-x64/powershell`.
+`./src/powershell-unix/bin/Linux/netcoreapp1.0/ubuntu.14.04-x64/powershell`.
 
 You should now be running the `powershell` that you just built, if your run the above executable.
 You can run our cross-platform Pester tests with `Start-PSPester`, and our xUnit tests with `Start-PSxUnit`.
@@ -129,7 +129,7 @@ make test
 popd
 ```
 
-This library will be emitted in the `src/powershell` project, 
+This library will be emitted in the `src/powershell-unix` project,
 where `dotnet` consumes it as "content" and thus automatically deploys it.
 
 Build the managed projects
@@ -141,7 +141,7 @@ The `--configuration Linux` flag is necessary to ensure that the preprocessor de
 
 ```sh
 dotnet restore
-cd src/powershell
+cd src/powershell-unix
 dotnet build --configuration Linux
 ```
 

--- a/docs/building/osx.md
+++ b/docs/building/osx.md
@@ -76,6 +76,6 @@ download the `pkg` from our GitHub releases page using your browser, complete th
 start a `powershell` session, and use `Start-PSBuild` from the module.
 
 The output directory will be slightly different because your runtime identifier is different.
-PowerShell will be at `./src/powershell/bin/Linux/netcoreapp1.0/osx.10.11-x64/powershell`,
+PowerShell will be at `./src/powershell-unix/bin/Linux/netcoreapp1.0/osx.10.11-x64/powershell`,
 or `osx.10.10` depending on your operating system version.
 Note that configration is still `Linux` because it would be silly to make yet another separate configuration when it's used soley to work-around a CLI issue.

--- a/docs/building/windows-core.md
+++ b/docs/building/windows-core.md
@@ -72,7 +72,7 @@ Start-PSBuild
 ```
 
 Congratulations! If everything went right, PowerShell is now built and
-executable as `./src/powershell/bin/Debug/netcoreapp1.0/win10-x64/powershell`.
+executable as `./src/powershell-win-core/bin/Debug/netcoreapp1.0/win10-x64/powershell`.
 
 This location is of the form
 `./[project]/bin/[configuration]/[framework]/[rid]/[binary name]`, and our

--- a/docs/building/windows-full.md
+++ b/docs/building/windows-full.md
@@ -48,14 +48,11 @@ Build using our module
 Use `Start-PSBuild -FullCLR` from the `build.psm1`
 module.
 
-Because the `ConsoleHost` project (*not* the `Host` project) is a
-library and not an application (in the sense that .NET CLI does not
-emit a native executable using .NET Core's `corehost`), it targets the
-framework `netstandard1.6`, *not* `netcoreapp1.0`, and the build
-output will *not* have a runtime identifier in the path.
+The output location of `powershell.exe` will be
 
-Thus the output location of `powershell.exe` will be
-`./src/Microsoft.PowerShell.ConsoleHost/bin/Debug/net451/powershell.exe`
+```
+.\src\powershell-win-full\bin\Debug\net451\win10-x64\publish\powershell.exe
+```
 
 Build manually
 ==============
@@ -99,7 +96,7 @@ This command has a reasonable default to run `powershell.exe` from the build out
 If you are building an unusual configuration (i.e. not `Debug`), you can explicitly specify path to the bin directory
 
 ```powershell
-Start-DevPowerShell -FullCLR -binDir .\src\Microsoft.PowerShell.ConsoleHost\bin\Debug\net451
+Start-DevPowerShell -FullCLR -binDir .\src\powershell-win-full\bin\Debug\net451\win10-x64\publish
 ```
 
 Or more programmatically:


### PR DESCRIPTION
Update build docs

The paragraph about RID is removed from windows-full.md, because now we use `dotnet publish` which creates RID folder even for libs.

cc @andschwa @daviwil 
