### PR TITLE
Bump MMI dependency to alpha04

### DIFF
--- a/src/System.Management.Automation/project.json
+++ b/src/System.Management.Automation/project.json
@@ -21,7 +21,7 @@
     },
 
     "dependencies": {
-        "Microsoft.Management.Infrastructure": "1.0.0-alpha02"
+        "Microsoft.Management.Infrastructure": "1.0.0-alpha04"
     },
 
     "frameworks": {


### PR DESCRIPTION
alpha04 has following changes:
- libmi.so is not included in this package. It will be brough
  as a separate nuget package later.
- all unix runtimes are replaced by generic unix runtimes to
  enable easier builds on new unix platforms.
