### PR TITLE
Fix remoting that broke from $PSVersionTable.PSVersion use of SemanticVersion

### DIFF
--- a/src/System.Management.Automation/engine/PSVersionInfo.cs
+++ b/src/System.Management.Automation/engine/PSVersionInfo.cs
@@ -81,6 +81,14 @@ namespace System.Management.Automation
             return s_psVersionTable;
         }
 
+        internal static Hashtable GetPSVersionTableForDownLevel()
+        {
+            var result = (Hashtable)s_psVersionTable.Clone();
+            // Downlevel systems don't support SemanticVersion, but Version is most likely good enough anyway.
+            result[PSVersionInfo.PSVersionName] = (Version)(SemanticVersion)s_psVersionTable[PSVersionInfo.PSVersionName];
+            return result;
+        }
+
         internal static Version GetBuildVersion()
         {
             string assemblyPath = typeof(PSVersionInfo).GetTypeInfo().Assembly.Location;

--- a/src/System.Management.Automation/engine/SerializationStrings.cs
+++ b/src/System.Management.Automation/engine/SerializationStrings.cs
@@ -236,6 +236,11 @@ namespace System.Management.Automation
         internal const string VersionTag = "Version";
 
         /// <summary>
+        /// Element tag for SemanticVersion property
+        /// </summary>
+        internal const string SemanticVersionTag = "SemanticVersion";
+
+        /// <summary>
         /// Element tag for XmlDocument
         /// </summary>
         internal const string XmlDocumentTag = "XD";

--- a/src/System.Management.Automation/engine/serialization.cs
+++ b/src/System.Management.Automation/engine/serialization.cs
@@ -2465,6 +2465,24 @@ namespace System.Management.Automation
         }
 
         /// <summary>
+        /// Writes SemanticVersion
+        /// </summary>
+        /// <param name="serializer">The serializer to which the object is serialized.</param>
+        /// <param name="streamName"></param>
+        /// <param name="property">name of property. pass null for item</param>
+        /// <param name="source">Version to write</param>
+        /// <param name="entry">serialization information about source</param>
+        internal static void WriteSemanticVersion(InternalSerializer serializer, string streamName, string property, object source, TypeSerializationInfo entry)
+        {
+            Dbg.Assert(serializer != null, "caller should have validated the information");
+            Dbg.Assert(source != null, "caller should have validated the information");
+            Dbg.Assert(source is SemanticVersion, "Caller should verify that typeof(source) is Version");
+            Dbg.Assert(entry != null, "caller should have validated the information");
+
+            WriteRawString(serializer, streamName, property, Convert.ToString(source, CultureInfo.InvariantCulture), entry);
+        }
+
+        /// <summary>
         /// Serialize scriptblock as item or property
         /// </summary>
         /// <param name="serializer">The serializer to which the object is serialized.</param>
@@ -4210,6 +4228,29 @@ namespace System.Management.Automation
             throw deserializer.NewXmlException(Serialization.InvalidPrimitiveType, recognizedException, typeof(Version).FullName);
         }
 
+        internal static object DeserializeSemanticVersion(InternalDeserializer deserializer)
+        {
+            Dbg.Assert(deserializer != null, "Caller should validate the parameter");
+            Exception recognizedException = null;
+            try
+            {
+                return new SemanticVersion(deserializer._reader.ReadElementContentAsString());
+            }
+            catch (ArgumentException e)
+            {
+                recognizedException = e;
+            }
+            catch (FormatException e)
+            {
+                recognizedException = e;
+            }
+            catch (OverflowException e)
+            {
+                recognizedException = e;
+            }
+            throw deserializer.NewXmlException(Serialization.InvalidPrimitiveType, recognizedException, typeof(Version).FullName);
+        }
+
         internal static object DeserializeInt16(InternalDeserializer deserializer)
         {
             Dbg.Assert(deserializer != null, "Caller should validate the parameter");
@@ -5149,6 +5190,13 @@ namespace System.Management.Automation
                                       SerializationStrings.VersionTag,
                                       InternalSerializer.WriteVersion,
                                       InternalDeserializer.DeserializeVersion),
+
+            new TypeSerializationInfo(typeof(SemanticVersion),
+                                      SerializationStrings.SemanticVersionTag,
+                                      SerializationStrings.SemanticVersionTag,
+                                      InternalSerializer.WriteSemanticVersion,
+                                      InternalDeserializer.DeserializeSemanticVersion),
+
             s_xdInfo,
 
             new TypeSerializationInfo(typeof(ProgressRecord),
@@ -5162,7 +5210,7 @@ namespace System.Management.Automation
                                       SerializationStrings.SecureStringTag,
                                       InternalSerializer.WriteSecureString,
                                       InternalDeserializer.DeserializeSecureString),
-};
+        };
 
         /// <summary>
         /// Hashtable of knowntypes. 

--- a/src/System.Management.Automation/engine/serialization.cs
+++ b/src/System.Management.Automation/engine/serialization.cs
@@ -6438,7 +6438,10 @@ namespace System.Management.Automation
             {
                 result = new PSPrimitiveDictionary();
             }
-            PSPrimitiveDictionary versionTable = new PSPrimitiveDictionary(PSVersionInfo.GetPSVersionTable());
+            PSPrimitiveDictionary versionTable = new PSPrimitiveDictionary(PSVersionInfo.GetPSVersionTableForDownLevel())
+            {
+                {"PSSemanticVersion", PSVersionInfo.PSVersion.ToString()}
+            };
             result.Add(PSVersionInfo.PSVersionTableName, versionTable);
 
             return result;

--- a/test/powershell/engine/SemanticVersion.Tests.ps1
+++ b/test/powershell/engine/SemanticVersion.Tests.ps1
@@ -184,4 +184,22 @@ Describe "SemanticVersion api tests" -Tags 'CI' {
             { [SemanticVersion]::new([Version]::new("1.2")) } | Should Throw # PSArgumentException
         }
     }
+
+    Context "Serialization" {
+        $testCases = @(
+            @{ expectedResult = "1.0.0"; semver = [SemanticVersion]::new(1, 0, 0) }
+            @{ expectedResult = "1.0.1"; semver = [SemanticVersion]::new(1, 0, 1) }
+            @{ expectedResult = "1.0.0-alpha"; semver = [SemanticVersion]::new(1, 0, 0, "alpha") }
+            @{ expectedResult = "1.0.0-beta"; semver = [SemanticVersion]::new(1, 0, 0, "beta") }
+        )
+        It "Can round trip" -TestCases $testCases {
+            param($semver, $expectedResult)
+
+            $ser = [PSSerializer]::Serialize($semver)
+            $des = [PSSerializer]::Deserialize($ser)
+
+            $des | Should BeOfType System.Management.Automation.SemanticVersion
+            $des.ToString() | Should Be $expectedResult
+        }
+    }
 }


### PR DESCRIPTION
- [x] Resolves issue #1589
- [x] Code is [rebased](https://github.com/PowerShell/PowerShell/blob/master/docs/git/README.md#sync-your-local-repo) on `origin/master`.
- [x] Add tests that fail without your changes.
- [NA] Update all relevant [documentation](https://github.com/PowerShell/PowerShell/tree/master/docs).

We didn't serialize SemanticVersion when creating the PSPrimitiveDictionary used during the remoting handshake.

Instead of adding support, I just replace the SemanticVersion with a Version (dropping the semantic label) so that we can connect to older PS endpoints that don't know anything about SemanticVersion.
