### PR TITLE
Revert the changes made in #1457. Desktop and Core are the PowerShell Edition names. Remove Linux as edition name.

### DIFF
--- a/demos/crontab/CronTab/CronTab.psd1
+++ b/demos/crontab/CronTab/CronTab.psd1
@@ -7,7 +7,7 @@ RootModule = 'CronTab.psm1'
 ModuleVersion = '0.1.0.0'
 
 # Supported PSEditions
-CompatiblePSEditions = @('Linux')
+CompatiblePSEditions = @('Core')
 
 # ID used to uniquely identify this module
 GUID = '508bb97f-de2e-482e-aae2-01caec0be8c7'

--- a/docs/learning-powershell/powershell-beginners-guide.md
+++ b/docs/learning-powershell/powershell-beginners-guide.md
@@ -186,7 +186,7 @@ Type **$PSVersionTable** in your PowerShell session, you will see something like
 Name                           Value
 ----                           -----
 PSVersion                      5.1.10032.0
-PSEdition                      Linux
+PSEdition                      Core
 PSCompatibleVersions           {1.0, 2.0, 3.0, 4.0...}
 BuildVersion                   3.0.0.0
 CLRVersion                     

--- a/src/Microsoft.PowerShell.PackageManagement/Cmdlets/CmdletWithSearchAndSource.cs
+++ b/src/Microsoft.PowerShell.PackageManagement/Cmdlets/CmdletWithSearchAndSource.cs
@@ -43,7 +43,7 @@ namespace Microsoft.PowerShell.PackageManagement.Cmdlets {
         internal readonly OrderedDictionary<string, List<SoftwareIdentity>> _resultsPerName = new OrderedDictionary<string, List<SoftwareIdentity>>();
         protected List<PackageProvider> _providersNotFindingAnything = new List<PackageProvider>();
 #if CORECLR
-        internal static readonly string[] ProviderFilters = new[] { "Packagemanagement", "Provider", "PSEdition_PowerShellCore" };
+        internal static readonly string[] ProviderFilters = new[] { "Packagemanagement", "Provider", "PSEdition_Core" };
 #else
         internal static readonly string[] ProviderFilters = new[] { "Packagemanagement", "Provider" };
 #endif

--- a/src/Modules/Shared/Microsoft.PowerShell.Archive/Microsoft.PowerShell.Archive.psm1
+++ b/src/Modules/Shared/Microsoft.PowerShell.Archive/Microsoft.PowerShell.Archive.psm1
@@ -464,7 +464,7 @@ function GetResolvedPathHelper
 
 function Add-CompressionAssemblies {
     
-    if ($PSEdition -eq "WindowsPowerShell")
+    if ($PSEdition -eq "Desktop")
     {
         Add-Type -AssemblyName System.IO.Compression
         Add-Type -AssemblyName System.IO.Compression.FileSystem

--- a/src/Modules/Shared/Microsoft.PowerShell.Utility/Microsoft.PowerShell.Utility.psm1
+++ b/src/Modules/Shared/Microsoft.PowerShell.Utility/Microsoft.PowerShell.Utility.psm1
@@ -587,7 +587,7 @@ function ConvertFrom-SddlString
     Begin
     {
         # On CoreCLR CryptoKeyRights and ActiveDirectoryRights are not supported.
-        if ($PSEdition -eq "PowerShellCore" -and ($Type -eq "CryptoKeyRights" -or $Type -eq "ActiveDirectoryRights"))
+        if ($PSEdition -eq "Core" -and ($Type -eq "CryptoKeyRights" -or $Type -eq "ActiveDirectoryRights"))
         {
             $errorId = "TypeNotSupported"
             $errorCategory = [System.Management.Automation.ErrorCategory]::InvalidArgument
@@ -622,7 +622,7 @@ function ConvertFrom-SddlString
         {
             param($AccessMask, $Type)
 
-            if ($PSEdition -eq "PowerShellCore")
+            if ($PSEdition -eq "Core")
             {
                 ## All the types of access rights understood by .NET Core
                 $rightTypes = [Ordered] @{

--- a/src/Modules/Shared/PowerShellGet/PSModule.psm1
+++ b/src/Modules/Shared/PowerShellGet/PSModule.psm1
@@ -12545,7 +12545,7 @@ function Update-ModuleManifest
         $ProcessorArchitecture,
 
         [Parameter()]
-        [ValidateSet('WindowsPowerShell','PowerShellCore')]
+        [ValidateSet('Desktop','Core')]
         [string[]]
         $CompatiblePSEditions,
 
@@ -14147,8 +14147,6 @@ function Test-MicrosoftCertificate
         $AuthenticodeSignature
     )
 
-    $result = $false
-
     if($AuthenticodeSignature.SignerCertificate)
     {
         try
@@ -14162,11 +14160,10 @@ function Test-MicrosoftCertificate
         }
 
         $SafeX509ChainHandle = [Microsoft.PowerShell.Commands.PowerShellGet.Win32Helpers]::CertDuplicateCertificateChain($X509Chain.ChainContext)
-        $result = [Microsoft.PowerShell.Commands.PowerShellGet.Win32Helpers]::IsMicrosoftCertificate($SafeX509ChainHandle)
-        $SafeX509ChainHandle.Close()
+        return [Microsoft.PowerShell.Commands.PowerShellGet.Win32Helpers]::IsMicrosoftCertificate($SafeX509ChainHandle)
     }
 
-    return $result
+    return $false
 }
 
 function Test-ValidManifestModule

--- a/src/Modules/Windows-Core+Full/PSDiagnostics/PSDiagnostics.psm1
+++ b/src/Modules/Windows-Core+Full/PSDiagnostics/PSDiagnostics.psm1
@@ -433,7 +433,7 @@ namespace Microsoft.PowerShell.Diagnostics
 "@
 
 
-if ($psedition.ToLower() -eq "core")
+if ($psedition -eq 'Core')
  {
     # Currently we only support these cmdlets as logman.exe is not working on Nano/Lot system.
     Export-ModuleMember Enable-PSTrace, Disable-PSTrace, Get-LogProperties, Set-LogProperties

--- a/src/Modules/Windows-Core+Full/PSDiagnostics/PSDiagnostics.psm1
+++ b/src/Modules/Windows-Core+Full/PSDiagnostics/PSDiagnostics.psm1
@@ -433,7 +433,7 @@ namespace Microsoft.PowerShell.Diagnostics
 "@
 
 
-if ($psedition.ToLower() -eq "powershellcore")
+if ($psedition.ToLower() -eq "core")
  {
     # Currently we only support these cmdlets as logman.exe is not working on Nano/Lot system.
     Export-ModuleMember Enable-PSTrace, Disable-PSTrace, Get-LogProperties, Set-LogProperties

--- a/src/System.Management.Automation/engine/Modules/NewModuleManifestCommand.cs
+++ b/src/System.Management.Automation/engine/Modules/NewModuleManifestCommand.cs
@@ -386,7 +386,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         [Parameter]
         [AllowEmptyCollection]
-        [ValidateSet("WindowsPowerShell", "PowerShellCore")]
+        [ValidateSet("Desktop", "Core")]
         [SuppressMessage("Microsoft.Performance",
             "CA1819:PropertiesShouldNotReturnArrays", Justification = "Cmdlets use arrays for parameters.")]
         public string[] CompatiblePSEditions

--- a/src/System.Management.Automation/engine/PSVersionInfo.cs
+++ b/src/System.Management.Automation/engine/PSVersionInfo.cs
@@ -50,9 +50,11 @@ namespace System.Management.Automation
         /// Linux -- All PS on Linux flavors. This may need to be subdivided based on compatibility between distros.
         /// </remarks>
 #if !CORECLR
-        internal const string PSEditionValue = "WindowsPowerShell";
+        internal const string PSEditionValue = "Desktop";
+#elif LINUX
+        internal const string PSEditionValue = "Linux";
 #else
-        internal const string PSEditionValue = "PowerShellCore";
+        internal const string PSEditionValue = "Core";
 #endif
 
         // Static Constructor.

--- a/src/System.Management.Automation/engine/PSVersionInfo.cs
+++ b/src/System.Management.Automation/engine/PSVersionInfo.cs
@@ -51,8 +51,6 @@ namespace System.Management.Automation
         /// </remarks>
 #if !CORECLR
         internal const string PSEditionValue = "Desktop";
-#elif LINUX
-        internal const string PSEditionValue = "Linux";
 #else
         internal const string PSEditionValue = "Core";
 #endif

--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -71,7 +71,7 @@ namespace System.Management.Automation
         /// <summary>
         /// Allowed PowerShell Editions
         /// </summary>
-        internal static string[] AllowedEditionValues = { "WindowsPowerShell", "PowerShellCore" };
+        internal static string[] AllowedEditionValues = { "Desktop", "Core" };
 
         /// <summary>
         /// helper fn to check byte[] arg for null.

--- a/test/powershell/Host/PSVersionTable.Tests.ps1
+++ b/test/powershell/Host/PSVersionTable.Tests.ps1
@@ -20,6 +20,6 @@ Describe "PSVersionTable" -Tags "CI" {
     }
 
     It "Should have the correct edition" -Skip:(!$IsCoreCLR) {
-	$PSVersionTable["PSEdition"] | Should Be "PowerShellCore"
+	$PSVersionTable["PSEdition"] | Should Be "Core"
     }
 }


### PR DESCRIPTION
- [x ] Resolves issue #1631.

Revert the changes made in #1457 as PSEdition rename is a breaking change for Windows Server 2106 RTM Users.
Only Desktop and Core are the PowerShell Edition names.
Remove Linux as edition name.
