### PR TITLE
Fixing path to remove ILs after the ngen binary is generated. This fixes issue ##1636

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -1739,7 +1739,7 @@ function Start-CrossGen {
             Push-Location $crossgenFolder
 
             # Generate the ngen assembly
-            Write-Verbose "Generating assembly $niAssemblyName" -Verbose
+            Write-Verbose "Generating assembly $niAssemblyName"
             Start-NativeExecution {
                 & $CrossgenPath /MissingDependenciesOK /in $AssemblyPath /out $outputAssembly /Platform_Assemblies_Paths $platformAssembliesPath
             } | Write-Verbose

--- a/build.psm1
+++ b/build.psm1
@@ -1739,7 +1739,7 @@ function Start-CrossGen {
             Push-Location $crossgenFolder
 
             # Generate the ngen assembly
-            Write-Verbose "Generating assembly $niAssemblyName"
+            Write-Verbose "Generating assembly $niAssemblyName" -Verbose
             Start-NativeExecution {
                 & $CrossgenPath /MissingDependenciesOK /in $AssemblyPath /out $outputAssembly /Platform_Assemblies_Paths $platformAssembliesPath
             } | Write-Verbose
@@ -1843,6 +1843,7 @@ function Start-CrossGen {
     Write-Verbose "PowerShell Ngen assemblies have been generated, deleting ILs..." -Verbose
     foreach ($assemblyName in $psCoreAssemblyList) {
         # Remove the IL assembly and its symbols.
+        $assemblyPath = Join-Path $PublishPath $assemblyName
         $symbolsPath = $assemblyPath.Replace(".dll", ".pdb")
         Remove-Item $assemblyPath -Force -ErrorAction SilentlyContinue
         Remove-Item $symbolsPath -Force -ErrorAction SilentlyContinue


### PR DESCRIPTION
- [ ] Resolves issue #1636 .
- [ ] Code is [rebased](https://github.com/PowerShell/PowerShell/blob/master/docs/git/README.md#sync-your-local-repo) on `origin/master`.
  Yes
- [ ] Add tests that fail without your changes.
  No tests needed
- [ ] Update all relevant [documentation](https://github.com/PowerShell/PowerShell/tree/master/docs).
