### PR TITLE
Temporarily disable OS X builds on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ branches:
 
 os:
   - linux
-  - osx
 sudo: required
 dist: trusty
 osx_image: xcode8


### PR DESCRIPTION
OS X is failing due to home brew's OpenSSL package changes. Until we've resolved .NET Core's use of the libraries, we need to disable the build.

/cc @daxian-dbw @Francisco-Gamino @lzybkr 
