### PR TITLE
Fix OS X OpenSSL link for .NET Core

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,6 @@ sudo: required
 dist: trusty
 osx_image: xcode8
 
-cache:
-  directories:
-    - $HOME/.dotnet
-    - $HOME/.nuget
-
 addons:
   artifacts:
     s3_region: "us-west-2"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ branches:
 
 os:
   - linux
+  - osx
 sudo: required
 dist: trusty
 osx_image: xcode8


### PR DESCRIPTION
Due to https://github.com/Homebrew/brew/pull/597, .NET Core's installation instructions of `brew link --force openssl` are now invalid (for good reasons, due to security holes). Until .NET Core updates their libraries to find the OpenSSL libraries correctly, we can update them as part of `Start-PSBootstrap`.

See https://github.com/dotnet/cli/issues/3964

This re-enables OS X builds, and patches the necessary libraries. It also disables the Travis CI cache (again) because it's unbearably slow on OS X.
