### PR TITLE
Fix FPM on Travis CI OS X

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ os:
   - osx
 sudo: required
 dist: trusty
-osx_image: xcode8
+osx_image: xcode7.3
 
 addons:
   artifacts:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,5 +24,6 @@ install:
   - git config --global url.git@github.com:.insteadOf https://github.com/
   - git submodule update --init
   - (cd tools && ./download.sh)
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then rvm use 2.2.1; fi # Default 2.0.0 Ruby is buggy
 
 script: ./tools/travis.sh

--- a/build.psm1
+++ b/build.psm1
@@ -635,8 +635,6 @@ function Start-PSBootstrap {
             $Deps += "curl", "cmake"
             # .NET Core required runtime libraries
             $Deps += "openssl"
-            # Packaging tools
-            if ($Package) { $Deps += "ruby" }
             # Install dependencies
             brew install $Deps
         }

--- a/tools/travis.sh
+++ b/tools/travis.sh
@@ -1,3 +1,4 @@
+set -x
 ulimit -n 4096
 # Only build packages for branches, not pull requests
 if [[ $TRAVIS_PULL_REQUEST == false ]]; then

--- a/tools/travis.sh
+++ b/tools/travis.sh
@@ -1,7 +1,7 @@
 set -x
 ulimit -n 4096
 # Only build packages for branches, not pull requests
-if [[ $TRAVIS_PULL_REQUEST == false ]]; then
+if [[ "$TRAVIS_PULL_REQUEST" == "false" ]]; then
     powershell -c "Import-Module ./build.psm1; Start-PSBootstrap -Package; Start-PSBuild -CrossGen; Start-PSPackage; Start-PSPester; Start-PSxUnit"
 else
     powershell -c "Import-Module ./build.psm1; Start-PSBootstrap; Start-PSBuild -CrossGen; Start-PSPester; Start-PSxUnit"


### PR DESCRIPTION
This fixes the failing build on master. We don't install the dependencies or build packages for pull requests (there is no need, they cannot be uploaded and they take extra time) so only branch builds (e.g. merges to master) were failing.

FPM was installing fine less than 24 hours ago. I'm chalking this up to Travis CI image changes and / or home brew changes.

Switching back to the stable Xcode image and explicitly using Ruby 2.2.1 (rather than attempting to install Ruby from home brew) fixes the problem. FPM installs just fine now. See https://travis-ci.com/PowerShell/PowerShell/jobs/46987178.
