### PR TITLE
Fixing Start-PSPester for non-Windows environments. Fixes regression caused by PR #1530

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -539,7 +539,12 @@ function Start-PSPester {
 
     Write-Verbose "Import-Module '$moduleDir'; Invoke-Pester $tagString $Path"
     $powershellexe = get-psoutput
-    & $powershell -noprofile -c "Set-ExecutionPolicy -Scope Process Unrestricted; Import-Module '$moduleDir'; Invoke-Pester $tagString $Path"
+    $execPolicy = ""
+    if ($IsWindows)
+    {
+        $execPolicy = "Set-ExecutionPolicy -Scope Process Unrestricted; "
+    }
+    & $powershell -noprofile -c "$execPolicy Import-Module '$moduleDir'; Invoke-Pester $tagString $Path"
     if ($LASTEXITCODE -ne 0) {
         throw "$LASTEXITCODE Pester tests failed"
     }


### PR DESCRIPTION
- [x] Resolves issue #1187 and PR #1530.
- [x] Code is [rebased](https://github.com/PowerShell/PowerShell/blob/master/docs/git/README.md#sync-your-local-repo) on `origin/master`.
