### PR TITLE
Remove PackageSourceListProvider from build

### DIFF
--- a/src/Microsoft.PowerShell.PackageManagement/project.json
+++ b/src/Microsoft.PowerShell.PackageManagement/project.json
@@ -20,8 +20,7 @@
     "Microsoft.PackageManagement.NuGetProvider": "1.0.0-*",
     "Microsoft.PackageManagement.CoreProviders": "1.0.0-*",
     "Microsoft.PackageManagement.MetaProvider.PowerShell": "1.0.0-*",
-    "Microsoft.PackageManagement.ArchiverProviders": "1.0.0-*",
-    "Microsoft.PackageManagement.PackageSourceListProvider": "1.0.0-*"
+    "Microsoft.PackageManagement.ArchiverProviders": "1.0.0-*"
   },
 
 	"frameworks": {


### PR DESCRIPTION
PackageSourceListProvider functionalities are not fully implemented yet so we want to remove it from the build for now.
