### PR TITLE
Fix if/def guards to allow engine to load WsMan and Diagnostics snapins by default when RunspaceConfiguration is used to create a runspace

### DIFF
--- a/src/System.Management.Automation/singleshell/config/MshSnapinInfo.cs
+++ b/src/System.Management.Automation/singleshell/config/MshSnapinInfo.cs
@@ -1284,7 +1284,7 @@ namespace System.Management.Automation
                         {
                             s_defaultMshSnapins = new List<DefaultPSSnapInInformation>()
                             {
-#if !PORTABLE // Microsoft.PowerShell.Commands.Diagnostics.dll needs to be ported
+#if !UNIX
                                 new DefaultPSSnapInInformation("Microsoft.PowerShell.Diagnostics", "Microsoft.PowerShell.Commands.Diagnostics", null,
                                     "GetEventResources,Description", "GetEventResources,Vendor"),
 #endif
@@ -1303,7 +1303,7 @@ namespace System.Management.Automation
                                     "SecurityMshSnapInResources,Description","SecurityMshSnapInResources,Vendor")
                             };
 
-#if !PORTABLE
+#if !UNIX
                             if (!Utils.IsWinPEHost())
                             {
                                 s_defaultMshSnapins.Add(new DefaultPSSnapInInformation("Microsoft.WSMan.Management", "Microsoft.WSMan.Management", null,

--- a/test/powershell/engine/BasicEngine.Tests.ps1
+++ b/test/powershell/engine/BasicEngine.Tests.ps1
@@ -3,5 +3,14 @@ Describe 'Basic engine APIs' -Tags "CI" {
         It 'can create default instance' {
             [powershell]::Create() | Should Not Be $null
         }
+
+        It "can load the default snapin 'Microsoft.WSMan.Management'" -skip:(-not $IsWindows) {
+            $ps = [powershell]::Create()
+            $ps.AddScript("Get-Command -Name Test-WSMan") > $null
+            
+            $result = $ps.Invoke()
+            $result.Count | Should Be 1
+            $result[0].PSSnapIn.Name | Should Be "Microsoft.WSMan.Management"
+        }
     }
 }


### PR DESCRIPTION
- [x] Resolves issue #1609.
- [x] Code is [rebased][sync] on `origin/master`.
- [x] Add tests that fail without your changes.
- [ ] Update all relevant [documentation][docs].

Root cause: Microsoft.WSMan.Management  and  Microsoft.PowerShell.Commands.Diagnostics  are not put in the default snapin list for win-ops, and thus when a runspace is created using RunspaceConfiguration, those 2 are not loaded as snapins by default, which is a behavior change compared to Nano PS.
Fix: Replace the guard 'PORTABLE' to be 'UNIX' so that they are in the default snapin list when targeting windows platform.
