### PR TITLE
Add Ubuntu 16.04 RID

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -48,6 +48,7 @@ function Start-PSBuild {
         # These runtimes must match those in project.json
         # We do not use ValidateScript since we want tab completion
         [ValidateSet("ubuntu.14.04-x64",
+                     "ubuntu.16.04-x64",
                      "debian.8-x64",
                      "centos.7-x64",
                      "win7-x64",
@@ -353,6 +354,7 @@ function New-PSOptions {
         # We do not use ValidateScript since we want tab completion
         [ValidateSet("",
                      "ubuntu.14.04-x64",
+                     "ubuntu.16.04-x64",
                      "debian.8-x64",
                      "centos.7-x64",
                      "win7-x64",

--- a/src/TypeCatalogGen/project.json
+++ b/src/TypeCatalogGen/project.json
@@ -19,6 +19,7 @@
 
     "runtimes": {
         "ubuntu.14.04-x64": { },
+        "ubuntu.16.04-x64": { },
         "debian.8-x64": { },
         "centos.7-x64": { },
         "win7-x64": { },

--- a/src/TypeCatalogParser/project.json
+++ b/src/TypeCatalogParser/project.json
@@ -18,6 +18,7 @@
 
     "runtimes": {
         "ubuntu.14.04-x64": { },
+        "ubuntu.16.04-x64": { },
         "centos.7-x64": { },
         "win7-x64": { },
         "win10-x64": { },

--- a/src/powershell-unix/project.json
+++ b/src/powershell-unix/project.json
@@ -73,6 +73,7 @@
 
     "runtimes": {
         "ubuntu.14.04-x64": { },
+        "ubuntu.16.04-x64": { },
         "debian.8-x64": { },
         "centos.7-x64": { },
         "osx.10.11-x64": { }

--- a/test/PSReadLine/project.json
+++ b/test/PSReadLine/project.json
@@ -23,6 +23,7 @@
 
     "runtimes": {
         "ubuntu.14.04-x64": { },
+        "ubuntu.16.04-x64": { },
         "centos.7-x64": { },
         "win7-x64": { },
         "win10-x64": { },

--- a/test/csharp/project.json
+++ b/test/csharp/project.json
@@ -27,6 +27,7 @@
 
     "runtimes": {
         "ubuntu.14.04-x64": { },
+        "ubuntu.16.04-x64": { },
         "debian.8-x64": { },
         "centos.7-x64": { },
         "win7-x64": { },


### PR DESCRIPTION
This purposefully does not add packages nor build instructions. Those will come later (with the packaging update and next release). This adds the runtime identifier so that users can restore on Ubuntu 16.04 systems, thus allowing them to build manually (or build using PowerShell if they manually resolved .NET Core's dependencies).

/cc @Francisco-Gamino @raghushantha 
