### PR TITLE
Safe hostname

### DIFF
--- a/src/System.Management.Automation/CoreCLR/CorePsExtensions.cs
+++ b/src/System.Management.Automation/CoreCLR/CorePsExtensions.cs
@@ -1026,25 +1026,8 @@ namespace System.Management.Automation
                 {
                     return Platform.NonWindowsGetDomainName();
                 }
-            }
-        }
 
-        internal static string WinGetUserName()
-        {
-            StringBuilder domainName = new StringBuilder(1024);
-            uint domainNameLen = (uint)domainName.Capacity;
-
-            byte ret = Win32Native.GetUserNameEx(Win32Native.NameSamCompatible, domainName, ref domainNameLen);
-            if (ret == 1)
-            {
-                string samName = domainName.ToString();
-                int index = samName.IndexOf('\\');
-                if (index != -1)
-                {
-                    return samName.Substring(index + 1);
-                }
             }
-            return string.Empty;
         }
 
         /// <summary>
@@ -1054,14 +1037,24 @@ namespace System.Management.Automation
         {
             get
             {
-                if (Platform.IsWindows)
+                #if UNIX
+                return Platform.Unix.UserName;
+                #else
+                StringBuilder domainName = new StringBuilder(1024);
+                uint domainNameLen = (uint)domainName.Capacity;
+
+                byte ret = Win32Native.GetUserNameEx(Win32Native.NameSamCompatible, domainName, ref domainNameLen);
+                if (ret == 1)
                 {
-                    return WinGetUserName();
+                    string samName = domainName.ToString();
+                    int index = samName.IndexOf('\\');
+                    if (index != -1)
+                    {
+                        return samName.Substring(index + 1);
+                    }
                 }
-                else
-                {
-                    return Platform.NonWindowsGetUserName();
-                }
+                return string.Empty;
+                #endif
             }
         }
 

--- a/src/System.Management.Automation/CoreCLR/CorePsPlatform.cs
+++ b/src/System.Management.Automation/CoreCLR/CorePsPlatform.cs
@@ -314,11 +314,6 @@ namespace System.Management.Automation
             return string.Empty;
         }
 
-        internal static string NonWindowsGetUserName()
-        {
-            return Unix.UserName;
-        }
-
         // Hostname in this context seems to be the FQDN
         internal static string NonWindowsGetHostName()
         {

--- a/src/System.Management.Automation/CoreCLR/CorePsPlatform.cs
+++ b/src/System.Management.Automation/CoreCLR/CorePsPlatform.cs
@@ -312,20 +312,18 @@ namespace System.Management.Automation
 
         internal static string NonWindowsGetDomainName()
         {
-            string fullyQualifiedName = Unix.NativeMethods.GetFullyQualifiedName();
-            if (string.IsNullOrEmpty(fullyQualifiedName))
+            string name = Unix.NativeMethods.GetFullyQualifiedName();
+            if (!string.IsNullOrEmpty(name))
             {
-                int lastError = Marshal.GetLastWin32Error();
-                throw new InvalidOperationException("Unix.NonWindowsGetDomainName error: " + lastError);
+                // name is hostname.domainname, so extract domainname
+                int index = name.IndexOf('.');
+                if (index >= 0)
+                {
+                    return name.Substring(index + 1);
+                }
             }
-
-            int index = fullyQualifiedName.IndexOf('.');
-            if (index >= 0)
-            {
-                return fullyQualifiedName.Substring(index + 1);
-            }
-
-            return "";
+            // if the domain name could not be found, do not throw, just return empty
+            return string.Empty;
         }
 
         internal static string NonWindowsGetUserName()
@@ -336,13 +334,7 @@ namespace System.Management.Automation
         // Hostname in this context seems to be the FQDN
         internal static string NonWindowsGetHostName()
         {
-            string hostName = Unix.NativeMethods.GetFullyQualifiedName();
-            if (string.IsNullOrEmpty(hostName))
-            {
-                int lastError = Marshal.GetLastWin32Error();
-                throw new InvalidOperationException("Unix.NonWindowsHostName error: " + lastError);
-            }
-            return hostName;
+            return Unix.NativeMethods.GetFullyQualifiedName() ?? string.Empty;
         }
 
         internal static bool NonWindowsIsFile(string path)
@@ -377,13 +369,8 @@ namespace System.Management.Automation
                 if (string.IsNullOrEmpty(s_userName))
                 {
                     s_userName = NativeMethods.GetUserName();
-                    if (string.IsNullOrEmpty(s_userName))
-                    {
-                        int lastError = Marshal.GetLastWin32Error();
-                        throw new InvalidOperationException("Unix.UserName error: " + lastError);
-                    }
                 }
-                return s_userName;
+                return s_userName ?? string.Empty;
             }
         }
 

--- a/src/System.Management.Automation/CoreCLR/CorePsPlatform.cs
+++ b/src/System.Management.Automation/CoreCLR/CorePsPlatform.cs
@@ -14,11 +14,6 @@ using Microsoft.Win32;
 using Microsoft.Win32.SafeHandles;
 using System.IO;
 
-#if CORECLR
-// SMA.Environment is only available on CoreCLR
-using SpecialFolder = System.Management.Automation.Environment.SpecialFolder;
-#endif
-
 namespace System.Management.Automation
 {
     /// <summary>
@@ -271,13 +266,6 @@ namespace System.Management.Automation
             return Unix.NativeMethods.GetUserFromPid(path);
         }
 
-#if CORECLR
-        internal static string NonWindowsGetFolderPath(SpecialFolder folder)
-        {
-            return Unix.GetFolderPath(folder);
-        }
-#endif
-
         internal static string NonWindowsInternalGetLinkType(FileSystemInfo fileInfo)
         {
             if (NonWindowsIsSymLink(fileInfo))
@@ -392,41 +380,6 @@ namespace System.Management.Automation
                 return "/tmp";
             }
         }
-
-#if CORECLR
-        public static string GetFolderPath(SpecialFolder folder)
-        {
-            string s = null;
-            switch (folder)
-            {
-                case SpecialFolder.ProgramFiles:
-                    s = "/bin";
-                    break;
-                case SpecialFolder.ProgramFilesX86:
-                    s = "/usr/bin";
-                    break;
-                case SpecialFolder.System:
-                    s = "/sbin";
-                    break;
-                case SpecialFolder.SystemX86:
-                    s = "/sbin";
-                    break;
-                case SpecialFolder.Personal:
-                    s = System.Environment.GetEnvironmentVariable("HOME");
-                    break;
-                case SpecialFolder.LocalApplicationData:
-                    s = System.IO.Path.Combine(System.Environment.GetEnvironmentVariable("HOME"), ".config");
-                    if (!System.IO.Directory.Exists(s))
-                    {
-                        System.IO.Directory.CreateDirectory(s);
-                    }
-                    break;
-                default:
-                    throw new NotSupportedException();
-            }
-            return s;
-        }
-#endif
 
         public static bool IsHardLink(ref IntPtr handle)
         {

--- a/src/System.Management.Automation/engine/InformationRecord.cs
+++ b/src/System.Management.Automation/engine/InformationRecord.cs
@@ -6,6 +6,10 @@ using Dbg = System.Management.Automation.Diagnostics;
 using System.Runtime.Serialization;
 using System.Collections.Generic;
 
+#if CORECLR
+using Environment = System.Management.Automation.Environment;
+#endif
+
 namespace System.Management.Automation
 {
     /// <summary>
@@ -38,15 +42,12 @@ namespace System.Management.Automation
 
             this.TimeGenerated = DateTime.Now;
             this.Tags = new List<string>();
-            if (Platform.IsWindows)
-            {
-                this.User = System.Security.Principal.WindowsIdentity.GetCurrent().Name;
-            }
-            else
-            {
-                this.User = Platform.NonWindowsGetUserName();
-            }
-            // Porting note: PsUtils.GetHostName() already handles platform specifics
+            // domain\user on Windows, just user on Unix
+            #if UNIX
+            this.User = Platform.Unix.UserName;
+            #else
+            this.User = System.Security.Principal.WindowsIdentity.GetCurrent().Name;
+            #endif
             this.Computer = PsUtils.GetHostName();
             this.ProcessId = (uint)System.Diagnostics.Process.GetCurrentProcess().Id;
             this.NativeThreadId = PsUtils.GetNativeThreadId();

--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -3148,7 +3148,13 @@ namespace System.Management.Automation.Runspaces
             // otherwise use the current user name.
             var userName = (!string.IsNullOrEmpty(this.UserDriveUserName)) ?
                 this.UserDriveUserName :
-                System.Security.Principal.WindowsIdentity.GetCurrent().Name;
+                // domain\user on Windows, just user on Unix
+                #if UNIX
+                Platform.Unix.UserName
+                #else
+                System.Security.Principal.WindowsIdentity.GetCurrent().Name
+                #endif
+                ;
 
             // Ensure that user name contains no invalid path characters.
             // MSDN indicates that logon names cannot contain any of these invalid characters,

--- a/test/csharp/test_CorePsPlatform.cs
+++ b/test/csharp/test_CorePsPlatform.cs
@@ -34,7 +34,7 @@ namespace PSTests
                 // The process should return an exit code of 0 on success
                 Assert.Equal(0, process.ExitCode);
                 // It should be the same as what our platform code returns
-                Assert.Equal(username, Platform.NonWindowsGetUserName());
+                Assert.Equal(username, Platform.Unix.UserName());
             }
         }
 


### PR DESCRIPTION
Resolves #1663.

There's yet more clean up to do of the platform class (and I have some ongoing), but wanted to get this out first. This was primarily concerned with not throwing when unable to get the Unix domain or user name. After some discussion with @daxian-dbw, we're foregoing removing the current code to use `IPGlobalProperties` in order to reduce churn, as .NET Core 1.1 will bring back all the necessary APIs for us to delete much of this code.

This also has the refactor of `InternalGetFolderPath` as I happened to do it while I was in the file, and unfortunately then moved the `Unix` class under `Platform`, so moving 3f9889d6d after ec3414c11 would be a pain.
