### PR TITLE
Fix remoting break caused by refactoring

### DIFF
--- a/src/System.Management.Automation/engine/hostifaces/MshHostRawUserInterface.cs
+++ b/src/System.Management.Automation/engine/hostifaces/MshHostRawUserInterface.cs
@@ -25,21 +25,31 @@ namespace System.Management.Automation.Host
     public
     struct Coordinates
     {
+        // DO NOT REMOVE OR RENAME THESE FIELDS - it will break remoting
+        private int x;
+        private int y;
+
         /// <summary>
         /// 
         /// Gets and sets the X coordinate
         /// 
         /// </summary>
-
-        public int X { get; set; }
+        public int X
+        {
+            get { return x; }
+            set { x = value; }
+        }
 
         /// <summary>
         /// 
         /// Gets and sets the Y coordinate 
         /// 
         /// </summary>
-
-        public int Y { get; set; }
+        public int Y
+        {
+            get { return y; }
+            set { y = value; }
+        }
 
 
         /// <summary>
@@ -57,12 +67,11 @@ namespace System.Management.Automation.Host
         /// The Y coordinate 
         /// 
         /// </param>
-
         public
         Coordinates(int x, int y)
         {
-            X = x;
-            Y = y;
+            this.x = x;
+            this.y = y;
         }
 
 
@@ -258,21 +267,31 @@ namespace System.Management.Automation.Host
     public
     struct Size
     {
+        // DO NOT REMOVE OR RENAME THESE FIELDS - it will break remoting
+        private int width;
+        private int height;
+
         /// <summary>
         /// 
         /// Gets and sets the Width
         /// 
         /// </summary>
-
-        public int Width { get; set; }
+        public int Width
+        {
+            get { return width; }
+            set { width = value; }
+        }
 
         /// <summary>
         /// 
         /// Gets and sets the Height
         /// 
         /// </summary>
-
-        public int Height { get; set; }
+        public int Height
+        {
+            get { return height; }
+            set { height = value; }
+        }
 
 
         /// <summary>
@@ -290,12 +309,11 @@ namespace System.Management.Automation.Host
         /// The Height
         /// 
         /// </param>
-
         public
         Size(int width, int height)
         {
-            Width = width;
-            Height = height;
+            this.width = width;
+            this.height = height;
         }
 
 

--- a/src/System.Management.Automation/engine/remoting/common/WireDataFormat/RemoteSessionCapability.cs
+++ b/src/System.Management.Automation/engine/remoting/common/WireDataFormat/RemoteSessionCapability.cs
@@ -167,14 +167,15 @@ namespace System.Management.Automation.Remoting
         /// <summary>
         /// Data.
         /// </summary>
-        private Dictionary<HostDefaultDataId, object> _data;
+        // DO NOT REMOVE OR RENAME THESE FIELDS - it will break remoting
+        private Dictionary<HostDefaultDataId, object> data;
 
         /// <summary>
         /// Private constructor to force use of Create.
         /// </summary>
         private HostDefaultData()
         {
-            _data = new Dictionary<HostDefaultDataId, object>();
+            data = new Dictionary<HostDefaultDataId, object>();
         }
 
         /// <summary>
@@ -193,7 +194,7 @@ namespace System.Management.Automation.Remoting
         /// </summary>
         internal bool HasValue(HostDefaultDataId id)
         {
-            return _data.ContainsKey(id);
+            return data.ContainsKey(id);
         }
 
         /// <summary>
@@ -201,7 +202,7 @@ namespace System.Management.Automation.Remoting
         /// </summary>
         internal void SetValue(HostDefaultDataId id, object dataValue)
         {
-            _data[id] = dataValue;
+            data[id] = dataValue;
         }
 
         /// <summary>
@@ -210,7 +211,7 @@ namespace System.Management.Automation.Remoting
         internal object GetValue(HostDefaultDataId id)
         {
             object result;
-            _data.TryGetValue(id, out result);
+            data.TryGetValue(id, out result);
             return result;
         }
 
@@ -340,7 +341,10 @@ namespace System.Management.Automation.Remoting
         /// <summary>
         /// Host default data.
         /// </summary>
-        internal HostDefaultData HostDefaultData { get; }
+        internal HostDefaultData HostDefaultData
+        {
+            get { return _hostDefaultData; }
+        }
 
         /// <summary>
         /// Is host null.
@@ -373,6 +377,10 @@ namespace System.Management.Automation.Remoting
 
         private readonly bool _isHostNull;
 
+        // DO NOT REMOVE OR RENAME THESE FIELDS - it will break remoting
+        private readonly HostDefaultData _hostDefaultData;
+        private bool _useRunspaceHost;
+
         /// <summary>
         /// Is host raw ui null.
         /// </summary>
@@ -387,7 +395,11 @@ namespace System.Management.Automation.Remoting
         /// <summary>
         /// Use runspace host.
         /// </summary>
-        internal bool UseRunspaceHost { get; set; }
+        internal bool UseRunspaceHost
+        {
+            get { return _useRunspaceHost; }
+            set { _useRunspaceHost = value; }
+        }
 
         /// <summary>
         /// Constructor for HostInfo.
@@ -400,7 +412,7 @@ namespace System.Management.Automation.Remoting
             // If raw UI is non-null then get the host-info object.
             if (!_isHostUINull && !_isHostRawUINull)
             {
-                HostDefaultData = HostDefaultData.Create(host.UI.RawUI);
+                _hostDefaultData = HostDefaultData.Create(host.UI.RawUI);
             }
         }
 


### PR DESCRIPTION
- [ ] Resolves issue #abcd.
- [ ] Code is [rebased](https://github.com/PowerShell/PowerShell/blob/master/docs/git/README.md#sync-your-local-repo) on `origin/master`.
- [ ] Add tests that fail without your changes.
- [ ] Update all relevant [documentation](https://github.com/PowerShell/PowerShell/tree/master/docs).

Remoting apparently depends on the names of private fields
not changing between versions of PowerShell.

Because of this, these refactorings broke remoting:
- rename private fields
- convert to auto-property
