### PR TITLE
Resolves a JsonConfigFileAccessor constructor exception to fix #1689

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,7 +34,7 @@ build_script:
 test_script:
   - ps: |
       # fail tests execution, if any PS error detected
-      $ErrorActionPreference = 'Stop'
+      $ErrorActionPreference = 'Continue'
       #
       # CoreCLR
       $env:CoreOutput = Split-Path -Parent (Get-PSOutput -Options (New-PSOptions -Publish))

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,7 +34,7 @@ build_script:
 test_script:
   - ps: |
       # fail tests execution, if any PS error detected
-      $ErrorActionPreference = 'Continue'
+      $ErrorActionPreference = 'Stop'
       #
       # CoreCLR
       $env:CoreOutput = Split-Path -Parent (Get-PSOutput -Options (New-PSOptions -Publish))

--- a/src/System.Management.Automation/engine/PropertyAccessor.cs
+++ b/src/System.Management.Automation/engine/PropertyAccessor.cs
@@ -147,25 +147,15 @@ namespace System.Management.Automation
         internal JsonConfigFileAccessor()
         {
             //
-            // Initialize (and create if necessary) the system-wide configuration directory
+            // Sets the system-wide configuration directory
             //
             Assembly assembly = typeof(PSObject).GetTypeInfo().Assembly;
-            psHomeConfigDirectory = Path.Combine(Path.GetDirectoryName(assembly.Location), configDirectoryName);
-
-            if (!Directory.Exists(psHomeConfigDirectory))
-            {
-                Directory.CreateDirectory(psHomeConfigDirectory);
-            }
+            psHomeConfigDirectory = Path.GetDirectoryName(assembly.Location);
 
             //
-            // Initialize (and create if necessary) the per-user configuration directory
+            // Sets the per-user configuration directory
             //
-            appDataConfigDirectory = Path.Combine(Utils.GetUserSettingsDirectory(), configDirectoryName);
-
-            if (!Directory.Exists(appDataConfigDirectory))
-            {
-                Directory.CreateDirectory(appDataConfigDirectory);
-            }
+            appDataConfigDirectory = Utils.GetUserSettingsDirectory();
         }
 
         /// <summary>

--- a/src/System.Management.Automation/engine/PropertyAccessor.cs
+++ b/src/System.Management.Automation/engine/PropertyAccessor.cs
@@ -134,7 +134,6 @@ namespace System.Management.Automation
     {
         private string psHomeConfigDirectory;
         private string appDataConfigDirectory;
-        private const string configDirectoryName = "Configuration";
         private const string configFileName = "PowerShellProperties.json";
 
         /// <summary>
@@ -156,6 +155,38 @@ namespace System.Management.Automation
             // Sets the per-user configuration directory
             //
             appDataConfigDirectory = Utils.GetUserSettingsDirectory();
+            if (!Directory.Exists(appDataConfigDirectory))
+            {
+                try
+                {
+                    Directory.CreateDirectory(appDataConfigDirectory);
+                }
+                catch (UnauthorizedAccessException)
+                {
+                    // Do nothing now. This failure shouldn't block initialization
+                    appDataConfigDirectory = null;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Enables delayed creation of the user settings directory so it does not interfere with PowerShell initialization
+        /// </summary>
+        /// <returns>Returns the directory if present or creatable. Throws otherwise.</returns>
+        private string GetAppDataConfigDirectory()
+        {
+            if (null == appDataConfigDirectory)
+            {
+                string tempAppDataConfigDir = Utils.GetUserSettingsDirectory();
+                if (!Directory.Exists(tempAppDataConfigDir))
+                {
+                    Directory.CreateDirectory(tempAppDataConfigDir);
+                    // Only assign it if creation succeeds. It will throw if it fails.
+                    appDataConfigDirectory = tempAppDataConfigDir;
+                }
+                // Do not catch exceptions here. Let them flow up.
+            }
+            return appDataConfigDirectory;
         }
 
         /// <summary>
@@ -170,7 +201,7 @@ namespace System.Management.Automation
             // Defaults to system wide.
             if (PropertyScope.CurrentUser == scope)
             {
-                scopeDirectory = appDataConfigDirectory;
+                scopeDirectory = GetAppDataConfigDirectory();
             }
 
             string fileName = Path.Combine(scopeDirectory, configFileName);
@@ -205,7 +236,7 @@ namespace System.Management.Automation
             // Defaults to system wide.
             if(PropertyScope.CurrentUser == scope)
             {
-                scopeDirectory = appDataConfigDirectory;
+                scopeDirectory = GetAppDataConfigDirectory();
             }
 
             string fileName = Path.Combine(scopeDirectory, configFileName);
@@ -226,7 +257,7 @@ namespace System.Management.Automation
             // Defaults to system wide.
             if (PropertyScope.CurrentUser == scope)
             {
-                scopeDirectory = appDataConfigDirectory;
+                scopeDirectory = GetAppDataConfigDirectory();
             }
 
             string fileName = Path.Combine(scopeDirectory, configFileName);
@@ -241,7 +272,7 @@ namespace System.Management.Automation
             // Defaults to system wide.
             if (PropertyScope.CurrentUser == scope)
             {
-                scopeDirectory = appDataConfigDirectory;
+                scopeDirectory = GetAppDataConfigDirectory();
             }
 
             string fileName = Path.Combine(scopeDirectory, configFileName);

--- a/src/System.Management.Automation/engine/PropertyAccessor.cs
+++ b/src/System.Management.Automation/engine/PropertyAccessor.cs
@@ -170,7 +170,8 @@ namespace System.Management.Automation
         }
 
         /// <summary>
-        /// Enables delayed creation of the user settings directory so it does not interfere with PowerShell initialization
+        /// Enables delayed creation of the user settings directory so it does 
+        /// not interfere with PowerShell initialization
         /// </summary>
         /// <returns>Returns the directory if present or creatable. Throws otherwise.</returns>
         private string GetAppDataConfigDirectory()


### PR DESCRIPTION
- [x] Resolves issue #1689.
- [x] Code is [rebased][sync] on `origin/master`.

Fixes the bug where PowerShell failed to start locally when run for the first time as a regular user.

Here is the fixed behavior:

``` powershell
PS C:\Program Files\PowerShell\6.0.0.7> set-executionpolicy -Scope localmachine bypass
set-executionpolicy : Access to the path 'c:\Program Files\PowerShell\6.0.0.7\PowerShellProperties.json' is denied.
To change the execution policy for the default (LocalMachine) scope, start Windows PowerShell with the "Run as
administrator" option. To change the execution policy for the current user, run "Set-ExecutionPolicy -Scope
CurrentUser".
At line:1 char:1
+ set-executionpolicy -Scope localmachine bypass
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : PermissionDenied: (:) [Set-ExecutionPolicy], UnauthorizedAccessException
    + FullyQualifiedErrorId : System.UnauthorizedAccessException,Microsoft.PowerShell.Commands.SetExecutionPolicyCo
   mmand
PS C:\Program Files\PowerShell\6.0.0.7> set-executionpolicy -Scope CurrentUser bypass
PS C:\Program Files\PowerShell\6.0.0.7> get-executionpolicy -list

        Scope ExecutionPolicy
        ----- ---------------
MachinePolicy       Undefined
   UserPolicy       Undefined
      Process       Undefined
  CurrentUser          Bypass
 LocalMachine       Undefined
```

Compared to inbox PowerShell's behavior in the same scenario:

``` powershell
PS C:\Users\mirichmo> set-executionpolicy -Scope LocalMachine Unrestricted

Execution Policy Change
The execution policy helps protect you from scripts that you do not trust. Changing the execution policy might expose you to the security risks described in
the about_Execution_Policies help topic at http://go.microsoft.com/fwlink/?LinkID=135170. Do you want to change the execution policy?
[Y] Yes  [A] Yes to All  [N] No  [L] No to All  [S] Suspend  [?] Help (default is "N"): y
set-executionpolicy : Access to the registry key 'HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\PowerShell\1\ShellIds\Microsoft.PowerShell' is denied. To change the
execution policy for the default (LocalMachine) scope, start Windows PowerShell with the "Run as administrator" option. To change the execution policy for the
current user, run "Set-ExecutionPolicy -Scope CurrentUser".
At line:1 char:1
+ set-executionpolicy -Scope LocalMachine Unrestricted
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : PermissionDenied: (:) [Set-ExecutionPolicy], UnauthorizedAccessException
    + FullyQualifiedErrorId : System.UnauthorizedAccessException,Microsoft.PowerShell.Commands.SetExecutionPolicyCommand
```
