### PR TITLE
PwrshPlugin Fix to List Microsoft.PowerShell.CoreCLR.AssemblyLoadContext Once in the TPA List

### DIFF
--- a/src/powershell-native/nativemsh/pwrshcommon/pwrshcommon.cpp
+++ b/src/powershell-native/nativemsh/pwrshcommon/pwrshcommon.cpp
@@ -1361,9 +1361,11 @@ namespace NativeMsh
         bool listEmpty = true;
         this->GetTrustedAssemblyList(hostEnvironment.GetCoreCLRDirectoryPath(), assemblyList, listEmpty);
 
-        // Fall back to attempt to load the CLR from the inbox location if 
-        // the configuration file pointed to an invalid directory.
-        if (listEmpty)
+        // Fall back to attempt to load the CLR from the alternate inbox location
+        // or if the ALC was not located in the CoreCLR directory.
+        std::string assemblyListToSearch = assemblyList.str();
+        if (listEmpty ||
+            (std::string::npos == assemblyListToSearch.rfind("Microsoft.PowerShell.CoreCLR.AssemblyLoadContext")))
         {
             char coreCLRPowerShellExtInstallPath[MAX_PATH];
             ::ExpandEnvironmentStringsA(coreCLRPowerShellExtInstallDirectory, coreCLRPowerShellExtInstallPath, MAX_PATH);


### PR DESCRIPTION
- [x] Addresses issue #1440.
- [x] Code is [rebased][sync] on `origin/master`.

The is the last bug blocking side-by-side remoting on Nano Server. The root cause of this issue was that M.P.ALC.dll was getting included in the TPA list twice. Once for the side by side PSHOME and once for the inbox location. This caused CoreCLR to load the inbox version of the assembly when it should load the side-by-side version instead.
