### PR TITLE
Fix Execution Policy

### DIFF
--- a/src/Modules/Unix/Microsoft.PowerShell.Security/Microsoft.PowerShell.Security.psd1
+++ b/src/Modules/Unix/Microsoft.PowerShell.Security/Microsoft.PowerShell.Security.psd1
@@ -7,7 +7,7 @@ ModuleVersion="3.0.0.0"
 PowerShellVersion="3.0"
 AliasesToExport = @()
 FunctionsToExport = @()
-CmdletsToExport="Get-Credential", "ConvertFrom-SecureString", "ConvertTo-SecureString"
+CmdletsToExport="Get-Credential", "Get-ExecutionPolicy", "Set-ExecutionPolicy", "ConvertFrom-SecureString", "ConvertTo-SecureString"
 NestedModules="Microsoft.PowerShell.Security.dll"
 HelpInfoURI = 'http://go.microsoft.com/fwlink/?linkid=390786'
 }

--- a/src/powershell-unix/project.json
+++ b/src/powershell-unix/project.json
@@ -37,6 +37,7 @@
             "Modules/" : {
                 "include": [
                     "../Modules/Windows+Unix-Core",
+                    "../Modules/Unix",
                     "../Modules/Shared"
                 ],
                 "exclude": [


### PR DESCRIPTION
Resolves #1682.

Whether or not remove the execution policy tests from the *nix build is an open question. However, with them removed currently, we have a test regression. This PR fixes that.

/cc @JamesWTruher @daxian-dbw 
