### PR TITLE
Fixing Crash on File Name Extending BufferWidth

### DIFF
--- a/src/Microsoft.PowerShell.PSReadLine/ReadLine.cs
+++ b/src/Microsoft.PowerShell.PSReadLine/ReadLine.cs
@@ -557,13 +557,18 @@ namespace Microsoft.PowerShell
             _visualSelectionCommandCount = 0;
             _statusIsErrorMessage = false;
 
-            _consoleBuffer = ReadBufferLines(_initialY, 1 + Options.ExtraPromptLineCount);
+            
 #if UNIX // TODO: not necessary if ReadBufferLines worked, or if rendering worked on spans instead of complete lines
             string newPrompt = GetPrompt();
+            var bufferLineCount = (newPrompt.Length) / (_console.BufferWidth) + 1;
+            _consoleBuffer = ReadBufferLines(_initialY, bufferLineCount);
+            
             for (int i=0; i<newPrompt.Length; ++i)
             {
                 _consoleBuffer[i].UnicodeChar = newPrompt[i];
             }
+#else
+            _consoleBuffer = ReadBufferLines(_initialY, 1 + Options.ExtraPromptLineCount);
 #endif
             _lastRenderTime = Stopwatch.StartNew();
 


### PR DESCRIPTION
- [X] Resolves issue #1471 
- [X] Code is [rebased](https://github.com/PowerShell/PowerShell/blob/master/docs/git/README.md#sync-your-local-repo) on `origin/master`.
- [X] Add tests that fail without your changes.
- [X] Update all relevant [documentation](https://github.com/PowerShell/PowerShell/tree/master/docs).
