### PR TITLE
Use pronoun consistently in cloning instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Downloading the Source Code
 
 The PowerShell repository has a number of other repositories embedded as submodules.
 
-To make things easy, we can just clone recursively:
+To make things easy, you can just clone recursively:
 
 ```sh
 git clone --recursive https://github.com/PowerShell/PowerShell.git


### PR DESCRIPTION
This is top-level README.md.
It consistently use `you` in all other places, where documentation refers to the reader.
This is the only place where it says `we`.
