### PR TITLE
Update project.json files to depend on Microsoft.NETCore.Runtime.CoreCLR.1.0.4 and Newtonsoft.Json.9.0.1

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/project.json
+++ b/src/Microsoft.PowerShell.Commands.Utility/project.json
@@ -86,7 +86,7 @@
             "imports": [ "dnxcore50", "portable-net45+win8" ],
             "dependencies": {
                 "Microsoft.CodeAnalysis.CSharp": "1.1.1",
-                "Newtonsoft.Json": "7.0.1",
+                "Newtonsoft.Json": "9.0.1",
                 "System.Diagnostics.TextWriterTraceListener": "4.0.0"
             }
         },

--- a/src/Microsoft.PowerShell.ConsoleHost/project.json
+++ b/src/Microsoft.PowerShell.ConsoleHost/project.json
@@ -45,7 +45,7 @@
                 }
             },
             "dependencies": {
-                "Newtonsoft.Json": "7.0.1",
+                "Newtonsoft.Json": "9.0.1",
                 "System.Xml.XDocument": "4.0.11",
                 "System.IO.MemoryMappedFiles": "4.0.0"
             }

--- a/src/System.Management.Automation/project.json
+++ b/src/System.Management.Automation/project.json
@@ -144,7 +144,7 @@
 
                 "Microsoft.CSharp": "4.0.1",
                 "Microsoft.Win32.Registry.AccessControl": "4.0.0",
-                "Newtonsoft.Json": "7.0.1",
+                "Newtonsoft.Json": "9.0.1",
                 "System.Collections.Specialized": "4.0.1",
                 "System.Collections.NonGeneric": "4.0.1",
                 "System.ComponentModel.EventBasedAsync": "4.0.11",

--- a/src/powershell-unix/project.json
+++ b/src/powershell-unix/project.json
@@ -66,7 +66,8 @@
                 "define": [ "CORECLR" ]
             },
             "dependencies": {
-                "Microsoft.NETCore.App": "1.0.0"
+                "Microsoft.NETCore.App": "1.0.0",
+                "Microsoft.NETCore.Runtime.CoreCLR": "1.0.4"
             }
         }
     },

--- a/src/powershell-win-core/project.json
+++ b/src/powershell-win-core/project.json
@@ -69,7 +69,8 @@
                 "define": [ "CORECLR" ]
             },
             "dependencies": {
-                "Microsoft.NETCore.App": "1.0.0"
+                "Microsoft.NETCore.App": "1.0.0",
+                "Microsoft.NETCore.Runtime.CoreCLR": "1.0.4"
             }
         }
     },


### PR DESCRIPTION
- [x] Resolves issue #1617.
- [x] Code is [rebased][sync] on `origin/master`.

Update project.json files to depend on Microsoft.NETCore.Runtime.CoreCLR.1.0.4 to get 2 fixes that will unblock PS remoting for side-by-side  PowerShell.
Also switch back to depend on the latest Newtonsoft.Json.9.0.1.
