### PR TITLE
Remove Windows branding

### DIFF
--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ManagedEntrance.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ManagedEntrance.cs
@@ -114,12 +114,21 @@ namespace Microsoft.PowerShell
                 int exitCode = 0;
                 try
                 {
+                #if CORECLR
+                    exitCode = Microsoft.PowerShell.ConsoleShell.Start(
+                        configuration,
+                        ManagedEntranceStrings.ShellBannerNonWindowsPowerShell,
+                        ManagedEntranceStrings.ShellHelp,
+                        warning == null ? null : warning.Message,
+                        args);
+                #else
                     exitCode = Microsoft.PowerShell.ConsoleShell.Start(
                         configuration,
                         ManagedEntranceStrings.ShellBanner,
                         ManagedEntranceStrings.ShellHelp,
                         warning == null ? null : warning.Message,
                         args);
+                #endif
                 }
                 catch (System.Management.Automation.Host.HostException e)
                 {

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/ManagedEntranceStrings.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/ManagedEntranceStrings.resx
@@ -121,6 +121,10 @@
     <value>Windows PowerShell 
 Copyright (C) 2016 Microsoft Corporation. All rights reserved.</value>
   </data>
+  <data name="ShellBannerNonWindowsPowerShell" xml:space="preserve">
+    <value>PowerShell 
+Copyright (C) 2016 Microsoft Corporation. All rights reserved.</value>
+  </data>
   <data name="ShellHelp" xml:space="preserve">
     <value>PowerShell[.exe] [-PSConsoleFile &lt;file&gt; | -Version &lt;version&gt;]
     [-NoLogo] [-NoExit] [-Sta] [-Mta] [-NoProfile] [-NonInteractive]


### PR DESCRIPTION
- [x] Resolves issue #1033 .
- [x] Code is [rebased](https://github.com/PowerShell/PowerShell/blob/master/docs/git/README.md#sync-your-local-repo) on `origin/master`.

According to Joey's latest update, the decision made by lawyer is like following:

Basically, there's Windows PowerShell (which is FullCLR based) and PowerShell Core (which is CoreCLR based and works on Windows, Mac, Nano, Linux). The former, Windows PowerShell, should still say Windows PowerShell. The latter, PowerShell Core, should just say PowerShell
And all of them should keep the copyright

Please add Joey for review as well.
