### PR TITLE
Update AppVeyor build number to 6.0.0-alpha.8

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 0.6.0.{build}
+version: 6.0.0-alpha.8-{build}
 
 cache:
   - '%LocalAppData%\Microsoft\dotnet'


### PR DESCRIPTION
Didn't realize until after #1742 that this was in the configuration file and not through the site's settings.

We never updated it for alpha.7.
