### PR TITLE
Cleanup mis-formatting of preprocessor directives

### DIFF
--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ManagedEntrance.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ManagedEntrance.cs
@@ -114,21 +114,17 @@ namespace Microsoft.PowerShell
                 int exitCode = 0;
                 try
                 {
-                #if CORECLR
+#if CORECLR
+                    var banner = ManagedEntranceStrings.ShellBannerNonWindowsPowerShell;
+#else
+                    var banner = ManagedEntranceStrings.ShellBanner;
+#endif
                     exitCode = Microsoft.PowerShell.ConsoleShell.Start(
                         configuration,
-                        ManagedEntranceStrings.ShellBannerNonWindowsPowerShell,
+                        banner,
                         ManagedEntranceStrings.ShellHelp,
                         warning == null ? null : warning.Message,
                         args);
-                #else
-                    exitCode = Microsoft.PowerShell.ConsoleShell.Start(
-                        configuration,
-                        ManagedEntranceStrings.ShellBanner,
-                        ManagedEntranceStrings.ShellHelp,
-                        warning == null ? null : warning.Message,
-                        args);
-                #endif
                 }
                 catch (System.Management.Automation.Host.HostException e)
                 {

--- a/src/System.Management.Automation/CoreCLR/CorePsExtensions.cs
+++ b/src/System.Management.Automation/CoreCLR/CorePsExtensions.cs
@@ -977,11 +977,11 @@ namespace System.Management.Automation
         {
             get
             {
-                #if UNIX
+#if UNIX
                 return Platform.Unix.UserName;
-                #else
+#else
                 return WinGetUserName();
-                #endif
+#endif
             }
         }
 
@@ -1043,7 +1043,7 @@ namespace System.Management.Automation
             // The API 'SHGetFolderPath' is not available on OneCore, so we have to rely on environment variables
             string folderPath = null;
 
-            #if UNIX
+#if UNIX
             switch (folder)
             {
                 case SpecialFolder.ProgramFiles:
@@ -1069,7 +1069,7 @@ namespace System.Management.Automation
                 default:
                     throw new NotSupportedException();
             }
-            #else
+#else
             string systemRoot = null;
             string userProfile = null;
 
@@ -1136,7 +1136,7 @@ namespace System.Management.Automation
                 default:
                     throw new NotSupportedException();
             }
-            #endif
+#endif
 
             return folderPath ?? string.Empty;
         }

--- a/src/System.Management.Automation/CoreCLR/CorePsPlatform.cs
+++ b/src/System.Management.Automation/CoreCLR/CorePsPlatform.cs
@@ -22,11 +22,11 @@ namespace System.Management.Automation
         {
             get
             {
-                #if CORECLR
+#if CORECLR
                 return RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
-                #else
+#else
                 return false;
-                #endif
+#endif
             }
         }
 
@@ -37,11 +37,11 @@ namespace System.Management.Automation
         {
             get
             {
-                #if CORECLR
+#if CORECLR
                 return RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
-                #else
+#else
                 return false;
-                #endif
+#endif
             }
         }
 
@@ -52,11 +52,11 @@ namespace System.Management.Automation
         {
             get
             {
-                #if CORECLR
+#if CORECLR
                 return RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
-                #else
+#else
                 return true;
-                #endif
+#endif
             }
         }
 
@@ -67,11 +67,11 @@ namespace System.Management.Automation
         {
             get
             {
-                #if CORECLR
+#if CORECLR
                 return true;
-                #else
+#else
                 return false;
-                #endif
+#endif
             }
         }
         

--- a/src/System.Management.Automation/engine/InformationRecord.cs
+++ b/src/System.Management.Automation/engine/InformationRecord.cs
@@ -43,11 +43,11 @@ namespace System.Management.Automation
             this.TimeGenerated = DateTime.Now;
             this.Tags = new List<string>();
             // domain\user on Windows, just user on Unix
-            #if UNIX
+#if UNIX
             this.User = Platform.Unix.UserName;
-            #else
+#else
             this.User = System.Security.Principal.WindowsIdentity.GetCurrent().Name;
-            #endif
+#endif
             this.Computer = PsUtils.GetHostName();
             this.ProcessId = (uint)System.Diagnostics.Process.GetCurrentProcess().Id;
             this.NativeThreadId = PsUtils.GetNativeThreadId();

--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -3149,11 +3149,11 @@ namespace System.Management.Automation.Runspaces
             var userName = (!string.IsNullOrEmpty(this.UserDriveUserName)) ?
                 this.UserDriveUserName :
                 // domain\user on Windows, just user on Unix
-                #if UNIX
+#if UNIX
                 Platform.Unix.UserName
-                #else
+#else
                 System.Security.Principal.WindowsIdentity.GetCurrent().Name
-                #endif
+#endif
                 ;
 
             // Ensure that user name contains no invalid path characters.
@@ -5362,14 +5362,14 @@ if($paths) {
             SessionStateFunctionEntry.GetDelayParsedFunctionEntry("more", DefaultMoreFunctionText, isProductCode: true),
             SessionStateFunctionEntry.GetDelayParsedFunctionEntry("help", GetHelpPagingFunctionText(), isProductCode: true),
             // Porting note: we remove mkdir on Linux because it is a conflict
-            #if !UNIX
+#if !UNIX
             SessionStateFunctionEntry.GetDelayParsedFunctionEntry("mkdir", GetMkdirFunctionText(), isProductCode: true),
-            #endif
+#endif
             SessionStateFunctionEntry.GetDelayParsedFunctionEntry("Get-Verb", GetGetVerbText(), isProductCode: true),
             SessionStateFunctionEntry.GetDelayParsedFunctionEntry("oss", GetOSTFunctionText(), isProductCode: true),
 
             // Porting note: we remove the drive functions from Linux because they make no sense
-            #if !UNIX
+#if !UNIX
             // Default drives
             SessionStateFunctionEntry.GetDelayParsedFunctionEntry("A:", DefaultSetDriveFunctionText, SetDriveScriptBlock),
             SessionStateFunctionEntry.GetDelayParsedFunctionEntry("B:", DefaultSetDriveFunctionText, SetDriveScriptBlock),
@@ -5397,7 +5397,7 @@ if($paths) {
             SessionStateFunctionEntry.GetDelayParsedFunctionEntry("X:", DefaultSetDriveFunctionText, SetDriveScriptBlock),
             SessionStateFunctionEntry.GetDelayParsedFunctionEntry("Y:", DefaultSetDriveFunctionText, SetDriveScriptBlock),
             SessionStateFunctionEntry.GetDelayParsedFunctionEntry("Z:", DefaultSetDriveFunctionText, SetDriveScriptBlock),
-            #endif
+#endif
 
             SessionStateFunctionEntry.GetDelayParsedFunctionEntry("cd..", "Set-Location ..", isProductCode: true),
             SessionStateFunctionEntry.GetDelayParsedFunctionEntry("cd\\", "Set-Location \\", isProductCode: true),

--- a/src/System.Management.Automation/help/HelpSystem.cs
+++ b/src/System.Management.Automation/help/HelpSystem.cs
@@ -604,10 +604,10 @@ namespace System.Management.Automation
             _helpProviders.Add(helpProvider);
 
             /* TH Bug#3141590 - Disable DscResourceHelp for ClientRTM due to perf issue.
-            #if !CORECLR // TODO:CORECLR Add this back in once we support Get-DscResource
-                        helpProvider = new DscResourceHelpProvider(this);
-                        _helpProviders.Add(helpProvider);
-            #endif
+#if !CORECLR // TODO:CORECLR Add this back in once we support Get-DscResource
+            helpProvider = new DscResourceHelpProvider(this);
+            _helpProviders.Add(helpProvider);
+#endif
             */
             helpProvider = new HelpFileHelpProvider(this);
             _helpProviders.Add(helpProvider);


### PR DESCRIPTION
This PR un-indents `#if` statements that were indented by the code formatting tool
It also cleans up some review feedback for the banner to reduce the scope of `#if`.
