### PR TITLE
Add PowerShell remoting over SSH feature (replacing PR 1507)

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -6,7 +6,6 @@
   </config>
   <packageSources>
     <clear />
-    <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
     <add key="appveyor-psl-windows-build" value="https://ci.appveyor.com/nuget/psl-windows-build-buunqeauqyp5" />
   </packageSources>

--- a/nuget.config
+++ b/nuget.config
@@ -6,6 +6,7 @@
   </config>
   <packageSources>
     <clear />
+    <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
     <add key="appveyor-psl-windows-build" value="https://ci.appveyor.com/nuget/psl-windows-build-buunqeauqyp5" />
   </packageSources>

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
@@ -155,6 +155,11 @@ namespace Microsoft.PowerShell
             get { return _namedPipeServerMode; }
         }
 
+        internal bool SSHServerMode
+        {
+            get { return sshServerMode; }
+        }
+
         internal bool ServerMode
         {
             get
@@ -393,6 +398,10 @@ namespace Microsoft.PowerShell
                 else if (MatchSwitch(switchKey, "namedpipeservermode", "nam"))
                 {
                     _namedPipeServerMode = true;
+                }
+                else if (MatchSwitch(switchKey, "sshservermode", "sshs"))
+                {
+                    sshServerMode = true;
                 }
                 else if (MatchSwitch(switchKey, "configurationname", "config"))
                 {
@@ -932,19 +941,20 @@ namespace Microsoft.PowerShell
             return true;
         }
 
-        private bool _socketServerMode;
-        private bool _serverMode;
-        private bool _namedPipeServerMode;
-        private string _configurationName;
-        private ConsoleHost _parent;
-        private ConsoleHostUserInterface _ui;
-        private bool _showHelp;
-        private bool _showBanner = true;
-        private bool _noInteractive;
-        private string _bannerText;
-        private string _helpText;
-        private bool _abortStartup;
-        private bool _skipUserInit;
+        private bool socketServerMode;
+        private bool serverMode;
+        private bool namedPipeServerMode;
+        private bool sshServerMode;
+        private string configurationName;
+        private ConsoleHost parent;
+        private ConsoleHostUserInterface ui;
+        private bool showHelp;
+        private bool showBanner = true;
+        private bool noInteractive;
+        private string bannerText;
+        private string helpText;
+        private bool abortStartup;
+        private bool skipUserInit;
         // Win8: 182409 PowerShell 3.0 should run in STA mode by default
         // -sta and -mta are mutually exclusive..so tracking them using nullable boolean
         // if true, then sta is specified on the command line.

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
@@ -157,7 +157,7 @@ namespace Microsoft.PowerShell
 
         internal bool SSHServerMode
         {
-            get { return sshServerMode; }
+            get { return _sshServerMode; }
         }
 
         internal bool ServerMode
@@ -401,7 +401,7 @@ namespace Microsoft.PowerShell
                 }
                 else if (MatchSwitch(switchKey, "sshservermode", "sshs"))
                 {
-                    sshServerMode = true;
+                    _sshServerMode = true;
                 }
                 else if (MatchSwitch(switchKey, "configurationname", "config"))
                 {
@@ -941,20 +941,20 @@ namespace Microsoft.PowerShell
             return true;
         }
 
-        private bool socketServerMode;
-        private bool serverMode;
-        private bool namedPipeServerMode;
-        private bool sshServerMode;
-        private string configurationName;
-        private ConsoleHost parent;
-        private ConsoleHostUserInterface ui;
-        private bool showHelp;
-        private bool showBanner = true;
-        private bool noInteractive;
-        private string bannerText;
-        private string helpText;
-        private bool abortStartup;
-        private bool skipUserInit;
+        private bool _socketServerMode;
+        private bool _serverMode;
+        private bool _namedPipeServerMode;
+        private bool _sshServerMode;
+        private string _configurationName;
+        private ConsoleHost _parent;
+        private ConsoleHostUserInterface _ui;
+        private bool _showHelp;
+        private bool _showBanner = true;
+        private bool _noInteractive;
+        private string _bannerText;
+        private string _helpText;
+        private bool _abortStartup;
+        private bool _skipUserInit;
         // Win8: 182409 PowerShell 3.0 should run in STA mode by default
         // -sta and -mta are mutually exclusive..so tracking them using nullable boolean
         // if true, then sta is specified on the command line.

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
@@ -249,13 +249,13 @@ namespace Microsoft.PowerShell
                         s_cpp.ConfigurationName);
                     exitCode = 0;
                 }
-                else if (cpp.SSHServerMode)
+                else if (s_cpp.SSHServerMode)
                 {
                     ClrFacade.StartProfileOptimization("StartupProfileData-SSHServerMode");
-                    System.Management.Automation.Remoting.Server.SSHProcessMediator.Run(cpp.InitialCommand);
+                    System.Management.Automation.Remoting.Server.SSHProcessMediator.Run(s_cpp.InitialCommand);
                     exitCode = 0;
                 }
-                else if (cpp.SocketServerMode)
+                else if (s_cpp.SocketServerMode)
                 {
                     ClrFacade.StartProfileOptimization("StartupProfileData-SocketServerMode");
                     System.Management.Automation.Remoting.Server.HyperVSocketMediator.Run(s_cpp.InitialCommand,

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
@@ -249,7 +249,13 @@ namespace Microsoft.PowerShell
                         s_cpp.ConfigurationName);
                     exitCode = 0;
                 }
-                else if (s_cpp.SocketServerMode)
+                else if (cpp.SSHServerMode)
+                {
+                    ClrFacade.StartProfileOptimization("StartupProfileData-SSHServerMode");
+                    System.Management.Automation.Remoting.Server.SSHProcessMediator.Run(cpp.InitialCommand);
+                    exitCode = 0;
+                }
+                else if (cpp.SocketServerMode)
                 {
                     ClrFacade.StartProfileOptimization("StartupProfileData-SocketServerMode");
                     System.Management.Automation.Remoting.Server.HyperVSocketMediator.Run(s_cpp.InitialCommand,

--- a/src/System.Management.Automation/engine/hostifaces/Connection.cs
+++ b/src/System.Management.Automation/engine/hostifaces/Connection.cs
@@ -436,7 +436,12 @@ namespace System.Management.Automation.Runspaces
         /// <summary>
         /// Runspace is based on a VM socket transport.
         /// </summary>
-        VMSocketTransport = 0x4
+        VMSocketTransport = 0x4,
+
+        /// <summary>
+        /// Runspace is based on SSH transport.
+        /// </summary>
+        SSHTransport = 0x8
     }
 
     #endregion

--- a/src/System.Management.Automation/engine/hostifaces/ConnectionFactory.cs
+++ b/src/System.Management.Automation/engine/hostifaces/ConnectionFactory.cs
@@ -663,6 +663,7 @@ namespace System.Management.Automation.Runspaces
             if ((!(connectionInfo is WSManConnectionInfo)) &&
                 (!(connectionInfo is NewProcessConnectionInfo)) &&
                 (!(connectionInfo is NamedPipeConnectionInfo)) &&
+                (!(connectionInfo is SSHConnectionInfo)) &&
                 (!(connectionInfo is VMConnectionInfo)) &&
                 (!(connectionInfo is ContainerConnectionInfo)))
             {

--- a/src/System.Management.Automation/engine/remoting/client/remoterunspace.cs
+++ b/src/System.Management.Automation/engine/remoting/client/remoterunspace.cs
@@ -974,6 +974,10 @@ namespace System.Management.Automation
             {
                 returnCaps |= RunspaceCapability.VMSocketTransport;
             }
+            else if (_connectionInfo is SSHConnectionInfo)
+            {
+                returnCaps |= RunspaceCapability.SSHTransport;
+            }
             else
             {
                 ContainerConnectionInfo containerConnectionInfo = _connectionInfo as ContainerConnectionInfo;

--- a/src/System.Management.Automation/engine/remoting/client/remoterunspaceinfo.cs
+++ b/src/System.Management.Automation/engine/remoting/client/remoterunspaceinfo.cs
@@ -263,8 +263,8 @@ namespace System.Management.Automation.Runspaces
             }
             else
             {
-                name = AutoGenerateRunspaceName(sessionid);
-                remoteRunspace.PSSessionName = name;
+                Name = AutoGenerateRunspaceName(Id);
+                remoteRunspace.PSSessionName = Name;
             }
 
             // WSMan session
@@ -302,8 +302,8 @@ namespace System.Management.Automation.Runspaces
             SSHConnectionInfo sshConnectionInfo = remoteRunspace.ConnectionInfo as SSHConnectionInfo;
             if (sshConnectionInfo != null)
             {
-                computerType = TargetMachineType.RemoteMachine;
-                shell = "DefaultShell";
+                ComputerType = TargetMachineType.RemoteMachine;
+                ConfigurationName = "DefaultShell";
                 return;
             }
 
@@ -323,24 +323,24 @@ namespace System.Management.Automation.Runspaces
         {
             string sessionIdStr = id.ToString(System.Globalization.NumberFormatInfo.InvariantInfo);
 
-            if (this.remoteRunspace.ConnectionInfo is WSManConnectionInfo)
+            if (_remoteRunspace.ConnectionInfo is WSManConnectionInfo)
             {
                 return "WinRM" + sessionIdStr;
             }
-            else if (this.remoteRunspace.ConnectionInfo is SSHConnectionInfo)
+            else if (_remoteRunspace.ConnectionInfo is SSHConnectionInfo)
             {
                 return "SSH" + sessionIdStr;
             }
-            else if ((this.remoteRunspace.ConnectionInfo is NamedPipeConnectionInfo) ||
-                     (this.remoteRunspace.ConnectionInfo is ContainerConnectionInfo))
+            else if ((_remoteRunspace.ConnectionInfo is NamedPipeConnectionInfo) ||
+                     (_remoteRunspace.ConnectionInfo is ContainerConnectionInfo))
             {
                 return "NamedPipe" + sessionIdStr;
             }
-            else if (this.remoteRunspace.ConnectionInfo is NewProcessConnectionInfo)
+            else if (_remoteRunspace.ConnectionInfo is NewProcessConnectionInfo)
             {
                 return "Process" + sessionIdStr;
             }
-            else if (this.remoteRunspace.ConnectionInfo is VMConnectionInfo)
+            else if (_remoteRunspace.ConnectionInfo is VMConnectionInfo)
             {
                 return "Socket" + sessionIdStr;
             }

--- a/src/System.Management.Automation/engine/remoting/client/remoterunspaceinfo.cs
+++ b/src/System.Management.Automation/engine/remoting/client/remoterunspaceinfo.cs
@@ -263,8 +263,8 @@ namespace System.Management.Automation.Runspaces
             }
             else
             {
-                Name = AutoGenerateRunspaceName();
-                remoteRunspace.PSSessionName = Name;
+                name = AutoGenerateRunspaceName(sessionid);
+                remoteRunspace.PSSessionName = name;
             }
 
             // WSMan session
@@ -298,6 +298,15 @@ namespace System.Management.Automation.Runspaces
                 return;
             }
 
+            // SSH session
+            SSHConnectionInfo sshConnectionInfo = remoteRunspace.ConnectionInfo as SSHConnectionInfo;
+            if (sshConnectionInfo != null)
+            {
+                computerType = TargetMachineType.RemoteMachine;
+                shell = "DefaultShell";
+                return;
+            }
+
             // We only support WSMan/VM/Container sessions now.
             Dbg.Assert(false, "Invalid Runspace");
         }
@@ -310,9 +319,35 @@ namespace System.Management.Automation.Runspaces
         /// Generates and returns the runspace name
         /// </summary>
         /// <returns>auto generated name</returns>
-        private String AutoGenerateRunspaceName()
+        private string AutoGenerateRunspaceName(int id)
         {
-            return "Session" + Id.ToString(System.Globalization.NumberFormatInfo.InvariantInfo);
+            string sessionIdStr = id.ToString(System.Globalization.NumberFormatInfo.InvariantInfo);
+
+            if (this.remoteRunspace.ConnectionInfo is WSManConnectionInfo)
+            {
+                return "WinRM" + sessionIdStr;
+            }
+            else if (this.remoteRunspace.ConnectionInfo is SSHConnectionInfo)
+            {
+                return "SSH" + sessionIdStr;
+            }
+            else if ((this.remoteRunspace.ConnectionInfo is NamedPipeConnectionInfo) ||
+                     (this.remoteRunspace.ConnectionInfo is ContainerConnectionInfo))
+            {
+                return "NamedPipe" + sessionIdStr;
+            }
+            else if (this.remoteRunspace.ConnectionInfo is NewProcessConnectionInfo)
+            {
+                return "Process" + sessionIdStr;
+            }
+            else if (this.remoteRunspace.ConnectionInfo is VMConnectionInfo)
+            {
+                return "Socket" + sessionIdStr;
+            }
+            else
+            {
+                return "Session" + sessionIdStr;
+            }
         }
 
         /// <summary>
@@ -360,7 +395,7 @@ namespace System.Management.Automation.Runspaces
         /// <returns>Runspace name</returns>
         internal static string ComposeRunspaceName(int id)
         {
-            return "Session" + id.ToString(System.Globalization.NumberFormatInfo.InvariantInfo);
+            return "WinRM" + id.ToString(System.Globalization.NumberFormatInfo.InvariantInfo);
         }
 
         #endregion

--- a/src/System.Management.Automation/engine/remoting/commands/InvokeCommandCommand.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/InvokeCommandCommand.cs
@@ -386,6 +386,8 @@ namespace Microsoft.PowerShell.Commands
         [Parameter(ParameterSetName = InvokeCommandCommand.FilePathVMIdParameterSet)]
         [Parameter(ParameterSetName = InvokeCommandCommand.FilePathVMNameParameterSet)]
         [Parameter(ParameterSetName = InvokeCommandCommand.FilePathContainerIdParameterSet)]
+        [Parameter(ParameterSetName = InvokeCommandCommand.SSHHostParameterSet)]
+        [Parameter(ParameterSetName = InvokeCommandCommand.FilePathSSHHostParameterSet)]
         public SwitchParameter AsJob
         {
             get
@@ -443,6 +445,8 @@ namespace Microsoft.PowerShell.Commands
         [Parameter(ParameterSetName = InvokeCommandCommand.FilePathVMIdParameterSet)]
         [Parameter(ParameterSetName = InvokeCommandCommand.FilePathVMNameParameterSet)]
         [Parameter(ParameterSetName = InvokeCommandCommand.FilePathContainerIdParameterSet)]
+        [Parameter(ParameterSetName = InvokeCommandCommand.SSHHostParameterSet)]
+        [Parameter(ParameterSetName = InvokeCommandCommand.FilePathSSHHostParameterSet)]
         [Alias("HCN")]
         public SwitchParameter HideComputerName
         {
@@ -505,6 +509,9 @@ namespace Microsoft.PowerShell.Commands
         [Parameter(Position = 1,
                    Mandatory = true,
                    ParameterSetName = InvokeCommandCommand.ContainerIdParameterSet)]
+        [Parameter(Position = 1,
+                   Mandatory = true,
+                   ParameterSetName = InvokeCommandCommand.SSHHostParameterSet)]
         [ValidateNotNull]
         [Alias("Command")]
         public override ScriptBlock ScriptBlock
@@ -548,6 +555,9 @@ namespace Microsoft.PowerShell.Commands
         [Parameter(Position = 1,
                    Mandatory = true,
                    ParameterSetName = FilePathContainerIdParameterSet)]
+        [Parameter(Position = 1,
+                   Mandatory = true,
+                   ParameterSetName = FilePathSSHHostParameterSet)]
         [ValidateNotNull]
         [Alias("PSPath")]
         public override string FilePath
@@ -648,6 +658,49 @@ namespace Microsoft.PowerShell.Commands
             get { return base.RunAsAdministrator; }
             set { base.RunAsAdministrator = value; }
         }
+
+        #region SSH Parameters
+
+        /// <summary>
+        /// Host Name
+        /// </summary>
+        [ValidateNotNullOrEmpty()]
+        [Parameter(Position = 0, Mandatory = true, ParameterSetName = InvokeCommandCommand.SSHHostParameterSet)]
+        [Parameter(Position = 0, Mandatory = true, ParameterSetName = InvokeCommandCommand.FilePathSSHHostParameterSet)]
+        public override string HostName
+        {
+            get { return base.HostName; }
+
+            set { base.HostName = value; }
+        }
+
+        /// <summary>
+        /// User Name
+        /// </summary>
+        [Parameter(Mandatory = true, ParameterSetName = InvokeCommandCommand.SSHHostParameterSet)]
+        [Parameter(Mandatory = true, ParameterSetName = InvokeCommandCommand.FilePathSSHHostParameterSet)]
+        [ValidateNotNullOrEmpty()]
+        public override string UserName
+        {
+            get { return base.UserName; }
+
+            set { base.UserName = value; }
+        }
+
+        /// <summary>
+        /// Key Path
+        /// </summary>
+        [Parameter(ParameterSetName = InvokeCommandCommand.SSHHostParameterSet)]
+        [Parameter(ParameterSetName = InvokeCommandCommand.FilePathSSHHostParameterSet)]
+        [ValidateNotNullOrEmpty()]
+        public override string KeyPath
+        {
+            get { return base.KeyPath; }
+
+            set { base.KeyPath = value; }
+        }
+
+        #endregion
 
         #endregion Parameters
 
@@ -926,6 +979,18 @@ namespace Microsoft.PowerShell.Commands
                                         this.JobRepository.Add(job);
                                         WriteObject(job);
                                     }
+                                }
+                                break;
+
+                            case InvokeCommandCommand.SSHHostParameterSet:
+                            case InvokeCommandCommand.FilePathSSHHostParameterSet:
+                                {
+                                    var job = new PSRemotingJob(new string[] { this.HostName }, Operations,
+                                        ScriptBlock.ToString(), ThrottleLimit, name);
+                                    job.PSJobTypeName = RemoteJobType;
+                                    job.HideComputerName = hideComputerName;
+                                    this.JobRepository.Add(job);
+                                    WriteObject(job);
                                 }
                                 break;
 

--- a/src/System.Management.Automation/engine/remoting/commands/InvokeCommandCommand.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/InvokeCommandCommand.cs
@@ -986,9 +986,9 @@ namespace Microsoft.PowerShell.Commands
                             case InvokeCommandCommand.FilePathSSHHostParameterSet:
                                 {
                                     var job = new PSRemotingJob(new string[] { this.HostName }, Operations,
-                                        ScriptBlock.ToString(), ThrottleLimit, name);
+                                        ScriptBlock.ToString(), ThrottleLimit, _name);
                                     job.PSJobTypeName = RemoteJobType;
-                                    job.HideComputerName = hideComputerName;
+                                    job.HideComputerName = _hideComputerName;
                                     this.JobRepository.Add(job);
                                     WriteObject(job);
                                 }

--- a/src/System.Management.Automation/engine/remoting/commands/PSRemotingCmdlet.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/PSRemotingCmdlet.cs
@@ -177,6 +177,11 @@ namespace Microsoft.PowerShell.Commands
         protected const string VMNameParameterSet = "VMName";
 
         /// <summary>
+        /// SSH host parameter set
+        /// </summary>
+        protected const string SSHHostParameterSet = "SSHHost";
+
+        /// <summary>
         /// runspace parameter set
         /// </summary>
         protected const string SessionParameterSet = "Session";
@@ -673,6 +678,43 @@ namespace Microsoft.PowerShell.Commands
         }
         private string _thumbPrint = null;
 
+        #region SSHHostParameters
+
+        /// <summary>
+        /// SSH Target Host Name
+        /// </summary>
+        [Parameter(ParameterSetName = PSRemotingBaseCmdlet.SSHHostParameterSet)]
+        [ValidateNotNullOrEmpty()]
+        public virtual string HostName
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// SSH User Name
+        /// </summary>
+        [Parameter(ParameterSetName = PSRemotingBaseCmdlet.SSHHostParameterSet)]
+        [ValidateNotNullOrEmpty()]
+        public virtual string UserName
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// SSH Key Path
+        /// </summary>
+        [Parameter(ParameterSetName = PSRemotingBaseCmdlet.SSHHostParameterSet)]
+        [ValidateNotNullOrEmpty()]
+        public virtual string KeyPath
+        {
+            get;
+            set;
+        }
+
+        #endregion
+
         #endregion Properties
 
         #region Internal Static Methods
@@ -864,6 +906,11 @@ namespace Microsoft.PowerShell.Commands
         /// Container ID file path parameter set.
         /// </summary>
         protected const string FilePathContainerIdParameterSet = "FilePathContainerId";
+
+        /// <summary>
+        /// SSH Host file path parameter set.
+        /// </summary>
+        protected const string FilePathSSHHostParameterSet = "FilePathSSHHost";
 
         #endregion
 
@@ -1112,6 +1159,21 @@ namespace Microsoft.PowerShell.Commands
                 Operations.Add(operation);
             }
         }// CreateHelpersForSpecifiedComputerNames
+
+        /// <summary>
+        /// Creates helper objects for host names for PSRP over SSH
+        /// remoting.
+        /// </summary>
+        protected void CreateHelpersForSpecifiedHostNames()
+        {
+            var sshConnectionInfo = new SSHConnectionInfo(this.UserName, this.HostName, this.KeyPath);
+            var typeTable = TypeTable.LoadDefaultTypeFiles();
+            var remoteRunspace = RunspaceFactory.CreateRunspace(sshConnectionInfo, this.Host, typeTable) as RemoteRunspace;
+            var pipeline = CreatePipeline(remoteRunspace);
+
+            var operation = new ExecutionCmdletHelperComputerName(remoteRunspace, pipeline);
+            Operations.Add(operation);
+        }
 
         /// <summary>
         /// Creates helper objects with the specified command for 
@@ -1718,6 +1780,11 @@ namespace Microsoft.PowerShell.Commands
 
                         CreateHelpersForSpecifiedComputerNames();
                     }
+                    break;
+
+                case PSExecutionCmdlet.SSHHostParameterSet:
+                case PSExecutionCmdlet.FilePathSSHHostParameterSet:
+                    CreateHelpersForSpecifiedHostNames();
                     break;
 
                 case PSExecutionCmdlet.FilePathSessionParameterSet:

--- a/src/System.Management.Automation/engine/remoting/commands/PushRunspaceCommand.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/PushRunspaceCommand.cs
@@ -297,6 +297,10 @@ namespace Microsoft.PowerShell.Commands
                 case ContainerIdParameterSet:
                     remoteRunspace = GetRunspaceForContainerSession();
                     break;
+
+                case SSHHostParameterSet:
+                    remoteRunspace = GetRunspaceForSSHSession();
+                    break;
             }
 
             // If runspace is null then the error record has already been written and we can exit.
@@ -1235,6 +1239,20 @@ namespace Microsoft.PowerShell.Commands
 
                 WriteError(errorRecord);
             }
+
+            return remoteRunspace;
+        }
+
+        /// <summary>
+        /// Create remote runspace for SSH session
+        /// </summary>
+        private RemoteRunspace GetRunspaceForSSHSession()
+        {
+            var sshConnectionInfo = new SSHConnectionInfo(this.UserName, this.HostName, this.KeyPath);
+            var typeTable = TypeTable.LoadDefaultTypeFiles();
+            var remoteRunspace = RunspaceFactory.CreateRunspace(sshConnectionInfo, this.Host, typeTable) as RemoteRunspace;
+            remoteRunspace.Open();
+            remoteRunspace.ShouldCloseOnPop = true;
 
             return remoteRunspace;
         }

--- a/src/System.Management.Automation/engine/remoting/commands/newrunspacecommand.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/newrunspacecommand.cs
@@ -238,6 +238,12 @@ namespace Microsoft.PowerShell.Commands
                     }
                     break;
 
+                case NewPSSessionCommand.SSHHostParameterSet:
+                    {
+                        remoteRunspaces = CreateRunspacesForSSHHostParameterSet();
+                    }
+                    break;
+
                 default:
                     {
                         Dbg.Assert(false, "Missing paramenter set in switch statement");
@@ -1048,6 +1054,23 @@ namespace Microsoft.PowerShell.Commands
 
             return remoteRunspaces;
         }// CreateRunspacesWhenContainerParameterSpecified
+
+        /// <summary>
+        /// CreateRunspacesForSSHHostParameterSet
+        /// </summary>
+        /// <returns></returns>
+        private List<RemoteRunspace> CreateRunspacesForSSHHostParameterSet()
+        {
+            var remoteRunspaces = new List<RemoteRunspace>();
+            var sshConnectionInfo = new SSHConnectionInfo(
+                this.UserName,
+                this.HostName,
+                this.KeyPath);
+            var typeTable = TypeTable.LoadDefaultTypeFiles();
+            remoteRunspaces.Add(RunspaceFactory.CreateRunspace(sshConnectionInfo, this.Host, typeTable) as RemoteRunspace);
+
+            return remoteRunspaces;
+        }
 
         /// <summary>
         /// Helper method to either get a user supplied runspace/session name

--- a/src/System.Management.Automation/engine/remoting/common/RemoteSessionNamedPipe.cs
+++ b/src/System.Management.Automation/engine/remoting/common/RemoteSessionNamedPipe.cs
@@ -222,10 +222,10 @@ namespace System.Management.Automation.Remoting
            uint nDefaultTimeOut,
            SECURITY_ATTRIBUTES securityAttributes);
 
-        internal static SECURITY_ATTRIBUTES GetSecurityAttributes(GCHandle securityDescriptorPinnedHandle)
+        internal static SECURITY_ATTRIBUTES GetSecurityAttributes(GCHandle securityDescriptorPinnedHandle, bool inheritHandle = false)
         {
             SECURITY_ATTRIBUTES securityAttributes = new NamedPipeNative.SECURITY_ATTRIBUTES();
-            securityAttributes.InheritHandle = false;
+            securityAttributes.InheritHandle = inheritHandle;
             securityAttributes.NLength = (int)Marshal.SizeOf(securityAttributes);
             securityAttributes.LPSecurityDescriptor = securityDescriptorPinnedHandle.AddrOfPinnedObject();
             return securityAttributes;
@@ -590,7 +590,7 @@ namespace System.Management.Automation.Remoting
 
         #region Private Methods
 
-        private static CommonSecurityDescriptor GetServerPipeSecurity()
+        internal static CommonSecurityDescriptor GetServerPipeSecurity()
         {
             // Built-in Admin SID
             SecurityIdentifier adminSID = new SecurityIdentifier(WellKnownSidType.BuiltinAdministratorsSid, null);

--- a/src/System.Management.Automation/engine/remoting/common/RunspaceConnectionInfo.cs
+++ b/src/System.Management.Automation/engine/remoting/common/RunspaceConnectionInfo.cs
@@ -4,9 +4,12 @@ Copyright (c) Microsoft Corporation.  All rights reserved.
 
 using System.Net;
 using System.Net.Sockets;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
+using System.IO.Pipes;
+using System.ComponentModel; // Win32Exception
 using System.Management.Automation.Tracing;
 using System.Management.Automation.Remoting;
 using System.Management.Automation.Internal;
@@ -14,6 +17,8 @@ using System.Management.Automation.Remoting.Client;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Threading;
+using System.Security.AccessControl;
+using Microsoft.Win32.SafeHandles;
 using Dbg = System.Management.Automation.Diagnostics;
 using WSManAuthenticationMechanism = System.Management.Automation.Remoting.Client.WSManNativeApi.WSManAuthenticationMechanism;
 
@@ -1555,7 +1560,6 @@ namespace System.Management.Automation.Runspaces
         /// </summary>
         public override string ComputerName
         {
-            // TODO: should this be different
             get { return "localhost"; }
             set { throw new NotImplementedException(); }
         }
@@ -1817,6 +1821,487 @@ namespace System.Management.Automation.Runspaces
                 instanceId,
                 cryptoHelper);
         }
+
+        #endregion
+    }
+
+    /// <summary>
+    /// Class used to create a connection through an SSH.exe client to a remote host machine.
+    /// Connection information includes SSH target (user name and host machine) along with
+    /// client key used for key based user authorization.
+    /// </summary>
+    public sealed class SSHConnectionInfo : RunspaceConnectionInfo
+    {
+        #region Properties
+
+        /// <summary>
+        /// User Name
+        /// </summary>
+        public string UserName
+        {
+            get;
+            private set;
+        }
+
+        /// <summary>
+        /// Key Path
+        /// </summary>
+        private string KeyPath
+        {
+            get;
+            set;
+        }
+
+        #endregion
+
+        #region Constructors
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        private SSHConnectionInfo()
+        { }
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="userName">User Name</param>
+        /// <param name="computerName">Computer Name</param>
+        /// <param name="keyPath">Key Path</param>
+        public SSHConnectionInfo(
+            string userName,
+            string computerName,
+            string keyPath)
+        {
+            if (userName == null) { throw new PSArgumentNullException("userName"); }
+            if (computerName == null) { throw new PSArgumentNullException("computerName"); }
+
+            this.UserName = userName;
+            this.ComputerName = computerName;
+            this.KeyPath = keyPath;
+        }
+
+        #endregion
+
+        #region Overrides
+
+        /// <summary>
+        /// Computer is always localhost.
+        /// </summary>
+        public override string ComputerName
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// Credential
+        /// </summary>
+        public override PSCredential Credential
+        {
+            get { return null; }
+            set { throw new NotImplementedException(); }
+        }
+
+        /// <summary>
+        /// Authentication
+        /// </summary>
+        public override AuthenticationMechanism AuthenticationMechanism
+        {
+            get { return AuthenticationMechanism.Default; }
+            set { throw new NotImplementedException(); }
+        }
+
+        /// <summary>
+        /// CertificateThumbprint
+        /// </summary>
+        public override string CertificateThumbprint
+        {
+            get { return string.Empty; }
+            set { throw new NotImplementedException(); }
+        }
+
+        /// <summary>
+        /// Shallow copy of current instance.
+        /// </summary>
+        /// <returns>NamedPipeConnectionInfo</returns>
+        internal override RunspaceConnectionInfo InternalCopy()
+        {
+            SSHConnectionInfo newCopy = new SSHConnectionInfo();
+            newCopy.ComputerName = this.ComputerName;
+            newCopy.UserName = this.UserName;
+            newCopy.KeyPath = this.KeyPath;
+
+            return newCopy;
+        }
+
+        /// <summary>
+        /// CreateClientSessionTransportManager
+        /// </summary>
+        /// <param name="instanceId"></param>
+        /// <param name="sessionName"></param>
+        /// <param name="cryptoHelper"></param>
+        /// <returns></returns>
+        internal override BaseClientSessionTransportManager CreateClientSessionTransportManager(Guid instanceId, string sessionName, PSRemotingCryptoHelper cryptoHelper)
+        {
+            return new SSHClientSessionTransportManager(
+                this,
+                instanceId,
+                cryptoHelper);
+        }
+
+        #endregion
+
+        #region Internal Methods
+
+        /// <summary>
+        /// StartSSHProcess
+        /// </summary>
+        /// <returns></returns>
+        internal System.Diagnostics.Process StartSSHProcess(
+            out StreamWriter stdInWriterVar,
+            out StreamReader stdOutReaderVar,
+            out StreamReader stdErrReaderVar)
+        {
+            string filePath = string.Empty;
+#if !UNIX
+            var context = Runspaces.LocalPipeline.GetExecutionContextFromTLS();
+            if (context != null)
+            {
+                var cmdInfo = context.CommandDiscovery.LookupCommandInfo("ssh.exe", CommandOrigin.Internal) as ApplicationInfo;
+                if (cmdInfo != null)
+                {
+                    filePath = cmdInfo.Path;
+                }
+            }
+#else
+            filePath = @"ssh";
+#endif
+
+            // Extract an optional domain name if provided.
+            string domainName = null;
+            string userName = this.UserName;
+#if !UNIX
+            var parts = this.UserName.Split(Utils.Separators.Backslash);
+            if (parts.Length == 2)
+            {
+                domainName = parts[0];
+                userName = parts[1];
+            }
+#endif
+
+            // Create client ssh process that hosts powershell.exe as a subsystem and is configured
+            // to be in server mode for PSRP over SSHD:
+            //   powershell -Version 5.1 -sshs -NoLogo -NoProfile
+            //   See sshd_configuration file, subsystems section and it will have this entry:
+            //     Subsystem       powershell C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -Version 5.1 -sshs -NoLogo -NoProfile
+            string arguments;
+            if (!string.IsNullOrEmpty(this.KeyPath))
+            {
+                arguments = (string.IsNullOrEmpty(domainName)) ?
+                    string.Format(CultureInfo.InvariantCulture, @"-i ""{0}"" {1}@{2} -s powershell", this.KeyPath, userName, this.ComputerName) :
+                    string.Format(CultureInfo.InvariantCulture, @"-i ""{0}"" -l {1}@{2} {3} -s powershell", this.KeyPath, userName, domainName, this.ComputerName);
+            }
+            else
+            {
+                arguments = (string.IsNullOrEmpty(domainName)) ?
+                    string.Format(CultureInfo.InvariantCulture, @"{0}@{1} -s powershell", userName, this.ComputerName) :
+                    string.Format(CultureInfo.InvariantCulture, @"-l {0}@{1} {2} -s powershell", userName, domainName, this.ComputerName);
+            }
+
+            System.Diagnostics.ProcessStartInfo startInfo = new System.Diagnostics.ProcessStartInfo(
+                filePath,
+                arguments);
+            startInfo.WorkingDirectory = System.IO.Path.GetDirectoryName(filePath);
+            startInfo.CreateNoWindow = true;
+            startInfo.UseShellExecute = false;
+
+            return StartSSHProcessImpl(startInfo, out stdInWriterVar, out stdOutReaderVar, out stdErrReaderVar);
+        }
+
+        #endregion
+
+        #region SSH Process Creation
+
+#if UNIX
+
+        /// <summary>
+        /// Create a process through managed APIs and return StdIn, StdOut, StdError reader/writers
+        /// This works for non-Windows platforms and is simpler.
+        /// </summary>
+        private static System.Diagnostics.Process StartSSHProcessImpl(
+            System.Diagnostics.ProcessStartInfo startInfo,
+            out StreamWriter stdInWriterVar,
+            out StreamReader stdOutReaderVar,
+            out StreamReader stdErrReaderVar)
+        {
+            startInfo.RedirectStandardInput = true;
+            startInfo.RedirectStandardOutput = true;
+            startInfo.RedirectStandardError = true;
+
+            System.Diagnostics.Process process = new Process();
+            process.StartInfo = startInfo;
+
+            process.Start();
+
+            stdInWriterVar = process.StandardInput;
+            stdOutReaderVar = process.StandardOutput;
+            stdErrReaderVar = process.StandardError;
+
+            return process;
+        }
+
+#else
+
+        /// <summary>
+        /// Create a process through native Win32 APIs and return StdIn, StdOut, StdError reader/writers
+        /// This needs to be done via Win32 APIs because managed code creates anonymous synchronous pipes 
+        /// for redirected StdIn/Out and SSH (and PSRP) require asynchrous (overlapped) pipes, which must
+        /// be through named pipes.  Managed code for named pipes is unreliable and so this is done via
+        /// P-Invoking native APIs.
+        /// </summary>
+        private static System.Diagnostics.Process StartSSHProcessImpl(
+            System.Diagnostics.ProcessStartInfo startInfo,
+            out StreamWriter stdInWriterVar,
+            out StreamReader stdOutReaderVar,
+            out StreamReader stdErrReaderVar)
+        {
+            Exception ex = null;
+            System.Diagnostics.Process sshProcess = null;
+            //
+            // These std pipe handles are bound to managed Reader/Writer objects and returned to the transport
+            // manager object, which uses them for PSRP communication.  The lifetime of these handles are then
+            // tied to the reader/writer objects which the transport is responsible for disposing (see 
+            // SSHClientSessionTransportManger and the CloseConnection() method.
+            //
+            SafePipeHandle stdInPipeServer = null;
+            SafePipeHandle stdOutPipeServer = null;
+            SafePipeHandle stdErrPipeServer = null;
+            try
+            {
+                sshProcess = CreateProcessWithRedirectedStd(
+                    startInfo,
+                    out stdInPipeServer,
+                    out stdOutPipeServer,
+                    out stdErrPipeServer);
+            }
+            catch (InvalidOperationException e) { ex = e; }
+            catch (ArgumentException e) { ex = e; }
+            catch (FileNotFoundException e) { ex = e; }
+            catch (System.ComponentModel.Win32Exception e) { ex = e; }
+
+            if ((ex != null) ||
+                (sshProcess == null) ||
+                (sshProcess.HasExited == true))
+            {
+                throw new InvalidOperationException(RemotingErrorIdStrings.CannotStartSSHClient, ex);
+            }
+
+            // Create the std in writer/readers needed for communication with ssh.exe.
+            stdInWriterVar = null;
+            stdOutReaderVar = null;
+            stdErrReaderVar = null;
+            try
+            {
+                stdInWriterVar = new StreamWriter(new NamedPipeServerStream(PipeDirection.Out, true, true, stdInPipeServer));
+                stdOutReaderVar = new StreamReader(new NamedPipeServerStream(PipeDirection.In, true, true, stdOutPipeServer));
+                stdErrReaderVar = new StreamReader(new NamedPipeServerStream(PipeDirection.In, true, true, stdErrPipeServer));
+            }
+            catch (Exception e)
+            {
+                CommandProcessorBase.CheckForSevereException(e);
+                if (stdInWriterVar != null) { stdInWriterVar.Dispose(); } else { stdInPipeServer.Dispose(); }
+                if (stdOutReaderVar != null) { stdInWriterVar.Dispose(); } else { stdOutPipeServer.Dispose(); }
+                if (stdErrReaderVar != null) { stdInWriterVar.Dispose(); } else { stdErrPipeServer.Dispose(); }
+
+                throw;
+            }
+
+            return sshProcess;
+        }
+
+        /// <summary>
+        /// CreateProcessWithRedirectedStd
+        /// </summary>
+        private static Process CreateProcessWithRedirectedStd(
+            ProcessStartInfo startInfo,
+            out SafePipeHandle stdInPipeServer,
+            out SafePipeHandle stdOutPipeServer,
+            out SafePipeHandle stdErrPipeServer)
+        {
+            //
+            // Create named (async) pipes for reading/writing to std.
+            //
+            stdInPipeServer = null;
+            stdOutPipeServer = null;
+            stdErrPipeServer = null;
+            SafePipeHandle stdInPipeClient = null;
+            SafePipeHandle stdOutPipeClient = null;
+            SafePipeHandle stdErrPipeClient = null;
+            string randomName = System.IO.Path.GetFileNameWithoutExtension(System.IO.Path.GetRandomFileName());
+
+            try
+            {
+                // Get default pipe security (Admin and current user access)
+                var securityDesc = RemoteSessionNamedPipeServer.GetServerPipeSecurity();
+
+                var stdInPipeName = @"\\.\pipe\StdIn" + randomName;
+                stdInPipeServer = CreateNamedPipe(stdInPipeName, securityDesc);
+                stdInPipeClient = GetNamedPipeHandle(stdInPipeName);
+
+                var stdOutPipeName = @"\\.\pipe\StdOut" + randomName;
+                stdOutPipeServer = CreateNamedPipe(stdOutPipeName, securityDesc);
+                stdOutPipeClient = GetNamedPipeHandle(stdOutPipeName);
+
+                var stdErrPipeName = @"\\.\pipe\StdErr" + randomName;
+                stdErrPipeServer = CreateNamedPipe(stdErrPipeName, securityDesc);
+                stdErrPipeClient = GetNamedPipeHandle(stdErrPipeName);
+            }
+            catch (Exception e)
+            {
+                CommandProcessorBase.CheckForSevereException(e);
+
+                if (stdInPipeServer != null) { stdInPipeServer.Dispose(); }
+                if (stdInPipeClient != null) { stdInPipeClient.Dispose(); }
+                if (stdOutPipeServer != null) { stdOutPipeServer.Dispose(); }
+                if (stdOutPipeClient != null) { stdOutPipeClient.Dispose(); }
+                if (stdErrPipeServer != null) { stdErrPipeServer.Dispose(); }
+                if (stdErrPipeClient != null) { stdErrPipeClient.Dispose(); }
+
+                throw;
+            }
+
+            // Create process
+            PlatformInvokes.STARTUPINFO lpStartupInfo = new PlatformInvokes.STARTUPINFO();
+            PlatformInvokes.PROCESS_INFORMATION lpProcessInformation = new PlatformInvokes.PROCESS_INFORMATION();
+            int creationFlags = 0;
+
+            try
+            {
+                var cmdLine = String.Format(CultureInfo.InvariantCulture, @"""{0}"" {1}", startInfo.FileName, startInfo.Arguments);
+
+                lpStartupInfo.hStdInput = new SafeFileHandle(stdInPipeClient.DangerousGetHandle(), false);
+                lpStartupInfo.hStdOutput = new SafeFileHandle(stdOutPipeClient.DangerousGetHandle(), false);
+                lpStartupInfo.hStdError = new SafeFileHandle(stdErrPipeClient.DangerousGetHandle(), false);
+                lpStartupInfo.dwFlags = 0x100;
+
+                // No new window: Inherit the parent process's console window
+                creationFlags = 0x00000000;
+
+                // Create the new process suspended so we have a chance to get a corresponding Process object in case it terminates quickly.
+                creationFlags |= 0x00000004;
+
+                PlatformInvokes.SECURITY_ATTRIBUTES lpProcessAttributes = new PlatformInvokes.SECURITY_ATTRIBUTES();
+                PlatformInvokes.SECURITY_ATTRIBUTES lpThreadAttributes = new PlatformInvokes.SECURITY_ATTRIBUTES();
+                bool success = PlatformInvokes.CreateProcess(
+                    null,
+                    cmdLine,
+                    lpProcessAttributes,
+                    lpThreadAttributes,
+                    true,
+                    creationFlags,
+                    IntPtr.Zero,
+                    startInfo.WorkingDirectory,
+                    lpStartupInfo,
+                    lpProcessInformation);
+
+                if (!success)
+                {
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+                }
+
+                // At this point, we should have a suspended process.  Get the .Net Process object, resume the process, and return.
+                Process result = Process.GetProcessById(lpProcessInformation.dwProcessId);
+                PlatformInvokes.ResumeThread(lpProcessInformation.hThread);
+
+                return result;
+            }
+            catch (Exception e)
+            {
+                CommandProcessorBase.CheckForSevereException(e);
+                if (stdInPipeServer != null) { stdInPipeServer.Dispose(); }
+                if (stdInPipeClient != null) { stdInPipeClient.Dispose(); }
+                if (stdOutPipeServer != null) { stdOutPipeServer.Dispose(); }
+                if (stdOutPipeClient != null) { stdOutPipeClient.Dispose(); }
+                if (stdErrPipeServer != null) { stdErrPipeServer.Dispose(); }
+                if (stdErrPipeClient != null) { stdErrPipeClient.Dispose(); }
+
+                throw;
+            }
+            finally
+            {
+                lpProcessInformation.Dispose();
+            }
+        }
+
+        private static SafePipeHandle GetNamedPipeHandle(string pipeName)
+        {
+            // Create pipe flags for asynchronous pipes.
+            uint pipeFlags = NamedPipeNative.FILE_FLAG_OVERLAPPED;
+
+            // We want an inheritable handle.
+            PlatformInvokes.SECURITY_ATTRIBUTES securityAttributes = new PlatformInvokes.SECURITY_ATTRIBUTES();
+
+            // Get handle to pipe.
+            var fileHandle = PlatformInvokes.CreateFileW(
+                pipeName,
+                NamedPipeNative.GENERIC_READ | NamedPipeNative.GENERIC_WRITE,
+                0,
+                securityAttributes,
+                NamedPipeNative.OPEN_EXISTING,
+                pipeFlags,
+                IntPtr.Zero);
+
+            int lastError = Marshal.GetLastWin32Error();
+            if (fileHandle == PlatformInvokes.INVALID_HANDLE_VALUE)
+            {
+                throw new System.ComponentModel.Win32Exception(lastError);
+            }
+
+            return new SafePipeHandle(fileHandle, true);
+        }
+
+        private static SafePipeHandle CreateNamedPipe(
+            string pipeName,
+            CommonSecurityDescriptor securityDesc)
+        {
+            // Create optional security attributes based on provided PipeSecurity.
+            NamedPipeNative.SECURITY_ATTRIBUTES securityAttributes = null;
+            GCHandle? securityDescHandle = null;
+            if (securityDesc != null)
+            {
+                byte[] securityDescBuffer = new byte[securityDesc.BinaryLength];
+                securityDesc.GetBinaryForm(securityDescBuffer, 0);
+                securityDescHandle = GCHandle.Alloc(securityDescBuffer, GCHandleType.Pinned);
+                securityAttributes = NamedPipeNative.GetSecurityAttributes(securityDescHandle.Value, true); ;
+            }
+
+            // Create async named pipe.
+            SafePipeHandle pipeHandle = NamedPipeNative.CreateNamedPipe(
+                pipeName,
+                NamedPipeNative.PIPE_ACCESS_DUPLEX | NamedPipeNative.FILE_FLAG_FIRST_PIPE_INSTANCE | NamedPipeNative.FILE_FLAG_OVERLAPPED,
+                NamedPipeNative.PIPE_TYPE_MESSAGE | NamedPipeNative.PIPE_READMODE_MESSAGE,
+                1,
+                32768,
+                32768,
+                0,
+                securityAttributes);
+
+            int lastError = Marshal.GetLastWin32Error();
+            if (securityDescHandle != null)
+            {
+                securityDescHandle.Value.Free();
+            }
+
+            if (pipeHandle.IsInvalid)
+            {
+                throw new Win32Exception(lastError);
+            }
+
+            return pipeHandle;
+        }
+
+#endif
 
         #endregion
     }

--- a/src/System.Management.Automation/engine/remoting/fanin/OutOfProcTransportManager.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/OutOfProcTransportManager.cs
@@ -423,7 +423,8 @@ namespace System.Management.Automation.Remoting
 
             lock (_syncObject)
             {
-                _writer.WriteLine(data);
+                writer.WriteLine(data);
+                writer.Flush();
             }
         }
 
@@ -1403,6 +1404,174 @@ namespace System.Management.Automation.Remoting.Client
         #endregion
     }
 
+    internal sealed class SSHClientSessionTransportManager : OutOfProcessClientSessionTransportManagerBase
+    {
+        #region Data
+
+        private SSHConnectionInfo _connectionInfo;
+        private Process _sshProcess;
+        private StreamWriter _stdInWriter;
+        private StreamReader _stdOutReader;
+        private StreamReader _stdErrReader;
+        private const string _threadName = "SSHTransport Reader Thread";
+
+        #endregion
+
+        #region Constructors
+
+        internal SSHClientSessionTransportManager(
+            SSHConnectionInfo connectionInfo,
+            Guid runspaceId,
+            PSRemotingCryptoHelper cryptoHelper)
+            : base(runspaceId, cryptoHelper)
+        {
+            if (connectionInfo == null) { throw new PSArgumentException("connectionInfo"); }
+
+            _connectionInfo = connectionInfo;
+        }
+
+        #endregion
+
+        #region Overrides
+
+        internal override void Dispose(bool isDisposing)
+        {
+            base.Dispose(isDisposing);
+
+            if (isDisposing)
+            {
+                CloseConnection();
+            }
+        }
+
+        protected override void CleanupConnection()
+        {
+            CloseConnection();
+        }
+
+        /// <summary>
+        /// Create an SSH connection to the target host and set up
+        /// transport reader/writer.
+        /// </summary>
+        internal override void CreateAsync()
+        {
+            // Create the ssh client process with connection to host target.
+            _sshProcess = _connectionInfo.StartSSHProcess(
+                out _stdInWriter,
+                out _stdOutReader,
+                out _stdErrReader);
+
+            _sshProcess.Exited += (sender, args) =>
+            {
+                CloseConnection();
+            };
+
+            // Create writer for named pipe.
+            stdInWriter = new OutOfProcessTextWriter(_stdInWriter);
+
+            // Create reader thread and send first PSRP message.
+            StartReaderThread(_stdOutReader);
+        }
+
+        #endregion
+
+        #region Private Methods
+
+        private void CloseConnection()
+        {
+            var stdInWriter = _stdInWriter;
+            if (stdInWriter != null) { stdInWriter.Dispose(); }
+
+            var stdOutReader = _stdOutReader;
+            if (stdOutReader != null) { stdOutReader.Dispose(); }
+
+            var stdErrReader = _stdErrReader;
+            if (stdErrReader != null) { stdErrReader.Dispose(); }
+
+            var sshProcess = _sshProcess;
+            if ((sshProcess != null) && !sshProcess.HasExited)
+            {
+                _sshProcess = null;
+                try
+                {
+                    sshProcess.Kill();
+                }
+                catch (InvalidOperationException) { }
+                catch (NotSupportedException) { }
+                catch (System.ComponentModel.Win32Exception) { }
+            }
+        }
+
+        private void StartReaderThread(
+            StreamReader reader)
+        {
+            Thread readerThread = new Thread(ProcessReaderThread);
+            readerThread.Name = _threadName;
+            readerThread.IsBackground = true;
+            readerThread.Start(reader);
+        }
+
+        private void ProcessReaderThread(object state)
+        {
+            try
+            {
+                StreamReader reader = state as StreamReader;
+                Dbg.Assert(reader != null, "Reader cannot be null.");
+
+                // Send one fragment.
+                SendOneItem();
+
+                // Start reader loop.
+                while (true)
+                {
+                    string data = reader.ReadLine();
+                    if (data == null)
+                    {
+                        // End of stream indicates the target process was lost.
+                        // Raise transport exception to invalidate the client remote runspace.
+                        PSRemotingTransportException psrte = new PSRemotingTransportException(
+                            PSRemotingErrorId.IPCServerProcessReportedError,
+                            RemotingErrorIdStrings.IPCServerProcessReportedError,
+                            RemotingErrorIdStrings.NamedPipeTransportProcessEnded);
+                        RaiseErrorHandler(new TransportErrorOccuredEventArgs(psrte, TransportMethodEnum.ReceiveShellOutputEx));
+                        break;
+                    }
+
+                    if (data.StartsWith(System.Management.Automation.Remoting.Server.NamedPipeErrorTextWriter.ErrorPrepend, StringComparison.OrdinalIgnoreCase))
+                    {
+                        // Error message from the server.
+                        string errorData = data.Substring(System.Management.Automation.Remoting.Server.NamedPipeErrorTextWriter.ErrorPrepend.Length);
+                        HandleErrorDataReceived(errorData);
+                    }
+                    else
+                    {
+                        // Normal output data.
+                        HandleOutputDataReceived(data);
+                    }
+                }
+            }
+            catch (ObjectDisposedException)
+            {
+                // Normal reader thread end.
+            }
+            catch (Exception e)
+            {
+                CommandProcessorBase.CheckForSevereException(e);
+
+                if (e is ArgumentOutOfRangeException)
+                {
+                    Dbg.Assert(false, "Need to adjust transport fragmentor to accomodate read buffer size.");
+                }
+
+                string errorMsg = (e.Message != null) ? e.Message : string.Empty;
+                _tracer.WriteMessage("SSHClientSessionTransportManager", "StartReaderThread", Guid.Empty,
+                    "Transport manager reader thread ended with error: {0}", errorMsg);
+            }
+        }
+
+        #endregion
+    }
+
     internal abstract class NamedPipeClientSessionTransportManagerBase : OutOfProcessClientSessionTransportManagerBase
     {
         #region Data
@@ -1979,8 +2148,8 @@ namespace System.Management.Automation.Remoting.Server
 
         #region Constructors
 
-        internal OutOfProcessServerSessionTransportManager(OutOfProcessTextWriter outWriter, OutOfProcessTextWriter errWriter)
-            : base(BaseTransportManager.DefaultFragmentSize, new PSRemotingCryptoHelperServer())
+        internal OutOfProcessServerSessionTransportManager(OutOfProcessTextWriter outWriter, OutOfProcessTextWriter errWriter, PSRemotingCryptoHelperServer cryptoHelper)
+            : base(BaseTransportManager.DefaultFragmentSize, cryptoHelper)
         {
             Dbg.Assert(null != outWriter, "outWriter cannot be null.");
             Dbg.Assert(null != errWriter, "errWriter cannot be null.");

--- a/src/System.Management.Automation/engine/remoting/fanin/OutOfProcTransportManager.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/OutOfProcTransportManager.cs
@@ -423,8 +423,8 @@ namespace System.Management.Automation.Remoting
 
             lock (_syncObject)
             {
-                writer.WriteLine(data);
-                writer.Flush();
+                _writer.WriteLine(data);
+                _writer.Flush();
             }
         }
 

--- a/src/System.Management.Automation/engine/remoting/server/OutOfProcServerMediator.cs
+++ b/src/System.Management.Automation/engine/remoting/server/OutOfProcServerMediator.cs
@@ -625,6 +625,7 @@ namespace System.Management.Automation.Remoting.Server
 
                 s_singletonInstance = new NamedPipeProcessMediator(namedPipeServer);
             }
+
 #if !CORECLR
             // AppDomain is not available in CoreCLR
             AppDomain.CurrentDomain.UnhandledException += new UnhandledExceptionEventHandler(AppDomainUnhandledException);

--- a/src/System.Management.Automation/engine/remoting/server/OutOfProcServerMediator.cs
+++ b/src/System.Management.Automation/engine/remoting/server/OutOfProcServerMediator.cs
@@ -7,6 +7,8 @@ using System.IO;
 using System.Threading;
 using System.Security.Principal;
 using System.Management.Automation.Internal;
+using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
 using Dbg = System.Management.Automation.Diagnostics;
 
 namespace System.Management.Automation.Remoting.Server
@@ -296,14 +298,21 @@ namespace System.Management.Automation.Remoting.Server
 
         #region Methods
 
-        protected OutOfProcessServerSessionTransportManager CreateSessionTransportManager(string configurationName)
+        protected OutOfProcessServerSessionTransportManager CreateSessionTransportManager(string configurationName, PSRemotingCryptoHelperServer cryptoHelper)
         {
+            PSSenderInfo senderInfo;
+#if !UNIX
             WindowsIdentity currentIdentity = WindowsIdentity.GetCurrent();
             PSPrincipal userPrincipal = new PSPrincipal(new PSIdentity("", true, currentIdentity.Name, null),
                 currentIdentity);
-            PSSenderInfo senderInfo = new PSSenderInfo(userPrincipal, "http://localhost");
+            senderInfo = new PSSenderInfo(userPrincipal, "http://localhost");
+#else
+            PSPrincipal userPrincipal = new PSPrincipal(new PSIdentity("", true, "", null),
+                null);
+            senderInfo = new PSSenderInfo(userPrincipal, "http://localhost");
+#endif
 
-            OutOfProcessServerSessionTransportManager tm = new OutOfProcessServerSessionTransportManager(originalStdOut, originalStdErr);
+            OutOfProcessServerSessionTransportManager tm = new OutOfProcessServerSessionTransportManager(originalStdOut, originalStdErr, cryptoHelper);
 
             ServerRemoteSession srvrRemoteSession = ServerRemoteSession.CreateServerRemoteSession(senderInfo,
                 _initialCommand, tm, configurationName);
@@ -311,11 +320,11 @@ namespace System.Management.Automation.Remoting.Server
             return tm;
         }
 
-        protected void Start(string initialCommand, string configurationName = null)
+        protected void Start(string initialCommand, PSRemotingCryptoHelperServer cryptoHelper, string configurationName = null)
         {
             _initialCommand = initialCommand;
 
-            sessionTM = CreateSessionTransportManager(configurationName);
+            sessionTM = CreateSessionTransportManager(configurationName, cryptoHelper);
 
             try
             {
@@ -326,7 +335,7 @@ namespace System.Management.Automation.Remoting.Server
                     {
                         if (sessionTM == null)
                         {
-                            sessionTM = CreateSessionTransportManager(configurationName);
+                            sessionTM = CreateSessionTransportManager(configurationName, cryptoHelper);
                         }
                     }
                     if (string.IsNullOrEmpty(data))
@@ -474,7 +483,76 @@ namespace System.Management.Automation.Remoting.Server
             // Setup unhandled exception to log events
             AppDomain.CurrentDomain.UnhandledException += new UnhandledExceptionEventHandler(AppDomainUnhandledException);
 #endif
-            s_singletonInstance.Start(initialCommand);
+            s_singletonInstance.Start(initialCommand, new PSRemotingCryptoHelperServer());
+        }
+
+        #endregion
+    }
+
+    internal sealed class SSHProcessMediator : OutOfProcessMediatorBase
+    {
+        #region Private Data
+
+        private static SSHProcessMediator SingletonInstance;
+
+        #endregion
+
+        #region Constructors
+
+        private SSHProcessMediator() : base(true)
+        {
+#if !UNIX
+            var inputHandle = PlatformInvokes.GetStdHandle((uint)PlatformInvokes.StandardHandleId.Input);
+                originalStdIn = new StreamReader(
+                    new FileStream(new SafeFileHandle(inputHandle, false), FileAccess.Read));
+
+            var outputHandle = PlatformInvokes.GetStdHandle((uint)PlatformInvokes.StandardHandleId.Output);
+            originalStdOut = new OutOfProcessTextWriter(
+                new StreamWriter(
+                    new FileStream(new SafeFileHandle(outputHandle, false), FileAccess.Write)));
+
+            var errorHandle = PlatformInvokes.GetStdHandle((uint)PlatformInvokes.StandardHandleId.Error);
+            originalStdErr = new OutOfProcessTextWriter(
+                new StreamWriter(
+                    new FileStream(new SafeFileHandle(errorHandle, false), FileAccess.Write)));
+#else
+            originalStdIn = new StreamReader(Console.OpenStandardInput(), true);
+            originalStdOut = new OutOfProcessTextWriter(
+                new StreamWriter(Console.OpenStandardOutput()));
+            originalStdErr = new OutOfProcessTextWriter(
+                new StreamWriter(Console.OpenStandardError()));
+#endif
+        }
+
+        #endregion
+
+        #region Static Methods
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="initialCommand"></param>
+        internal static void Run(string initialCommand)
+        {
+            lock (SyncObject)
+            {
+                if (SingletonInstance != null)
+                {
+                    Dbg.Assert(false, "Run should not be called multiple times");
+                    return;
+                }
+
+                SingletonInstance = new SSHProcessMediator();
+            }
+
+            PSRemotingCryptoHelperServer cryptoHelper;
+#if !UNIX
+            cryptoHelper = new PSRemotingCryptoHelperServer();
+#else
+            cryptoHelper = null;
+#endif
+
+            SingletonInstance.Start(initialCommand, cryptoHelper);
         }
 
         #endregion
@@ -547,12 +625,11 @@ namespace System.Management.Automation.Remoting.Server
 
                 s_singletonInstance = new NamedPipeProcessMediator(namedPipeServer);
             }
-
 #if !CORECLR
             // AppDomain is not available in CoreCLR
             AppDomain.CurrentDomain.UnhandledException += new UnhandledExceptionEventHandler(AppDomainUnhandledException);
 #endif
-            s_singletonInstance.Start(initialCommand, namedPipeServer.ConfigurationName);
+            s_singletonInstance.Start(initialCommand, new PSRemotingCryptoHelperServer(), namedPipeServer.ConfigurationName);
         }
 
         #endregion
@@ -638,12 +715,12 @@ namespace System.Management.Automation.Remoting.Server
                 s_instance = new HyperVSocketMediator();
             }
 
-#if !CORECLR 
+#if !CORECLR
             // AppDomain is not available in CoreCLR
             AppDomain.CurrentDomain.UnhandledException += new UnhandledExceptionEventHandler(AppDomainUnhandledException);
 #endif
 
-            s_instance.Start(initialCommand, configurationName);
+            s_instance.Start(initialCommand, new PSRemotingCryptoHelperServer(), configurationName);
         }
 
         #endregion

--- a/src/System.Management.Automation/engine/remoting/server/OutOfProcServerMediator.cs
+++ b/src/System.Management.Automation/engine/remoting/server/OutOfProcServerMediator.cs
@@ -493,7 +493,7 @@ namespace System.Management.Automation.Remoting.Server
     {
         #region Private Data
 
-        private static SSHProcessMediator SingletonInstance;
+        private static SSHProcessMediator s_singletonInstance;
 
         #endregion
 
@@ -536,13 +536,13 @@ namespace System.Management.Automation.Remoting.Server
         {
             lock (SyncObject)
             {
-                if (SingletonInstance != null)
+                if (s_singletonInstance != null)
                 {
                     Dbg.Assert(false, "Run should not be called multiple times");
                     return;
                 }
 
-                SingletonInstance = new SSHProcessMediator();
+                s_singletonInstance = new SSHProcessMediator();
             }
 
             PSRemotingCryptoHelperServer cryptoHelper;
@@ -552,7 +552,7 @@ namespace System.Management.Automation.Remoting.Server
             cryptoHelper = null;
 #endif
 
-            SingletonInstance.Start(initialCommand, cryptoHelper);
+            s_singletonInstance.Start(initialCommand, cryptoHelper);
         }
 
         #endregion

--- a/src/System.Management.Automation/engine/remoting/server/serverremotesession.cs
+++ b/src/System.Management.Automation/engine/remoting/server/serverremotesession.cs
@@ -132,20 +132,20 @@ namespace System.Management.Automation.Remoting
             _senderInfo = senderInfo;
             _configProviderId = configurationProviderId;
             _initParameters = initializationParameters;
-            if (Platform.IsWindows)
-            {
-                _cryptoHelper = (PSRemotingCryptoHelperServer)transportManager.CryptoHelper;
-                _cryptoHelper.Session = this;
-            }
-
-            Context = new ServerRemoteSessionContext();
-            SessionDataStructureHandler = new ServerRemoteSessionDSHandlerlImpl(this, transportManager);
-            BaseSessionDataStructureHandler = SessionDataStructureHandler;
-            SessionDataStructureHandler.CreateRunspacePoolReceived += HandleCreateRunspacePool;
-            SessionDataStructureHandler.NegotiationReceived += HandleNegotiationReceived;
-            SessionDataStructureHandler.SessionClosing += HandleSessionDSHandlerClosing;
-            SessionDataStructureHandler.PublicKeyReceived +=
-                new EventHandler<RemoteDataEventArgs<string>>(HandlePublicKeyReceived);
+#if !UNIX
+            _cryptoHelper = (PSRemotingCryptoHelperServer)transportManager.CryptoHelper;
+            _cryptoHelper.Session = this;
+#else
+            _cryptoHelper = null;
+#endif
+            _context = new ServerRemoteSessionContext();
+            _sessionDSHandler = new ServerRemoteSessionDSHandlerlImpl(this, transportManager);
+            BaseSessionDataStructureHandler = _sessionDSHandler;
+            _sessionDSHandler.CreateRunspacePoolReceived += HandleCreateRunspacePool;
+            _sessionDSHandler.NegotiationReceived += HandleNegotiationReceived;
+            _sessionDSHandler.SessionClosing += HandleSessionDSHandlerClosing;
+            _sessionDSHandler.PublicKeyReceived += 
+                new EventHandler<RemoteDataEventArgs<string>>(HandlePublicKeyReceived);      
             transportManager.Closing += HandleResourceClosing;
 
             // update the quotas from sessionState..start with default size..and
@@ -457,7 +457,7 @@ namespace System.Management.Automation.Remoting
             SessionDataStructureHandler.StateMachine.RaiseEvent(args);
         }
 
-        #endregion Overrides
+#endregion Overrides
 
         #region Properties
 
@@ -865,8 +865,12 @@ namespace System.Management.Automation.Remoting
                 throw new PSRemotingDataStructureException(RemotingErrorIdStrings.RunspaceAlreadyExists,
                     _runspacePoolDriver.InstanceId);
             }
-
+            
+#if !UNIX
             bool isAdministrator = _senderInfo.UserInfo.IsInRole(System.Security.Principal.WindowsBuiltInRole.Administrator);
+#else
+            bool isAdministrator = false;
+#endif
 
             ServerRunspacePoolDriver tmpDriver = new ServerRunspacePoolDriver(
                 clientRunspacePoolId,

--- a/src/System.Management.Automation/engine/remoting/server/serverremotesession.cs
+++ b/src/System.Management.Automation/engine/remoting/server/serverremotesession.cs
@@ -138,13 +138,13 @@ namespace System.Management.Automation.Remoting
 #else
             _cryptoHelper = null;
 #endif
-            _context = new ServerRemoteSessionContext();
-            _sessionDSHandler = new ServerRemoteSessionDSHandlerlImpl(this, transportManager);
-            BaseSessionDataStructureHandler = _sessionDSHandler;
-            _sessionDSHandler.CreateRunspacePoolReceived += HandleCreateRunspacePool;
-            _sessionDSHandler.NegotiationReceived += HandleNegotiationReceived;
-            _sessionDSHandler.SessionClosing += HandleSessionDSHandlerClosing;
-            _sessionDSHandler.PublicKeyReceived += 
+            Context = new ServerRemoteSessionContext();
+            SessionDataStructureHandler = new ServerRemoteSessionDSHandlerlImpl(this, transportManager);
+            BaseSessionDataStructureHandler = SessionDataStructureHandler;
+            SessionDataStructureHandler.CreateRunspacePoolReceived += HandleCreateRunspacePool;
+            SessionDataStructureHandler.NegotiationReceived += HandleNegotiationReceived;
+            SessionDataStructureHandler.SessionClosing += HandleSessionDSHandlerClosing;
+            SessionDataStructureHandler.PublicKeyReceived += 
                 new EventHandler<RemoteDataEventArgs<string>>(HandlePublicKeyReceived);      
             transportManager.Closing += HandleResourceClosing;
 

--- a/src/System.Management.Automation/resources/RemotingErrorIdStrings.resx
+++ b/src/System.Management.Automation/resources/RemotingErrorIdStrings.resx
@@ -936,7 +936,7 @@ Do you want to continue?</value>
     <value>{0} may need to restart the WinRM service if a configuration using this name has recently been unregistered, certain system data structures may still be cached. In that case, a restart of WinRM may be required.
 All WinRM sessions connected to Windows PowerShell session configurations, such as Microsoft.PowerShell and session configurations that are created with the Register-PSSessionConfiguration cmdlet, are disconnected.</value>
   </data>
-   <data name="WinRMForceRestartWarning" xml:space="preserve">
+  <data name="WinRMForceRestartWarning" xml:space="preserve">
     <value>You are running in a remote session and have selected the Force option which means the WinRM service may restart.If the WinRM service restarts then this remote session will be terminated and you will need to create a new session to continue</value>
   </data>
   <data name="JobSourceAdapterCannotSaveNullJob" xml:space="preserve">
@@ -1608,5 +1608,8 @@ All WinRM sessions connected to Windows PowerShell session configurations, such 
   <data name="RemotingErrorNoLogonSessionExist" xml:space="preserve">
     <value> Other Possible Cause:
   -The domain or computer name was not included with the specified credential, for example: DOMAIN\UserName or COMPUTER\UserName.</value>
+  </data>
+  <data name="CannotStartSSHClient" xml:space="preserve">
+    <value>An error occurred when starting the SSH.exe client needed for the remoting connection.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/security/wldpNativeMethods.cs
+++ b/src/System.Management.Automation/security/wldpNativeMethods.cs
@@ -258,6 +258,13 @@ namespace System.Management.Automation.Security
                             (System.Security.Principal.WindowsIdentity.GetCurrent().ImpersonationLevel == System.Security.Principal.TokenImpersonationLevel.Impersonation) ?
                             SaferPolicy.Allowed : SaferPolicy.Disallowed;
                     }
+                    catch (ArgumentException)
+                    {
+                        // This is for IO.Path.GetTempPath() call when temp paths are not accessible.
+                        result =
+                           (System.Security.Principal.WindowsIdentity.GetCurrent().ImpersonationLevel == System.Security.Principal.TokenImpersonationLevel.Impersonation) ?
+                           SaferPolicy.Allowed : SaferPolicy.Disallowed;
+                    }
                     finally
                     {
                         if (IO.File.Exists(testPathScript)) { IO.File.Delete(testPathScript); }


### PR DESCRIPTION
@PaulHigin, Please review to ensure this is what you actually wanted.
From @PaulHigin  #1507 
These changes add support for PowerShell remoting over SSH. This includes creating new transport objects to use SSH as the PSRP remoting transport along with a new parameter set for the New-PSSession, Invoke-Command, and Enter-PSSession cmdlets. The parameters are HostName, UserName, and KeyPath to allow both SSH password prompt (for interactive sessions) and key based user authentication.

This check in is to support PowerShell SSH remoting demos and the final parameter sets will likely change in the future. I also have a list of known issues that will be added to this GitHub repo.

The changes affect Win32 full, core, and Linux versions. For Linux, some types such as WindowsIdentity information were left null. Also, the crypto helper that is based on Win32 native APIs is abandoned for Linux since SSH provides the encrypt/decrypt.

PowerShell SSH remoting requires SSH to be installed on both client (ssh.exe) and server (sshd.exe) along with a PowerShell build including these changes. In addition, the server (sshd.exe) configuration must include the ability to launch a PowerShell subsystem in server mode, and I'll add a new document to describe how to do this.
