### PR TITLE
PowerShell remoting over SSH.

### DIFF
--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
@@ -155,6 +155,11 @@ namespace Microsoft.PowerShell
             get { return _namedPipeServerMode; }
         }
 
+        internal bool SSHServerMode
+        {
+            get { return _sshServerMode; }
+        }
+
         internal bool ServerMode
         {
             get
@@ -393,6 +398,10 @@ namespace Microsoft.PowerShell
                 else if (MatchSwitch(switchKey, "namedpipeservermode", "nam"))
                 {
                     _namedPipeServerMode = true;
+                }
+                else if (MatchSwitch(switchKey, "sshservermode", "sshs"))
+                {
+                    _sshServerMode = true;
                 }
                 else if (MatchSwitch(switchKey, "configurationname", "config"))
                 {
@@ -935,6 +944,7 @@ namespace Microsoft.PowerShell
         private bool _socketServerMode;
         private bool _serverMode;
         private bool _namedPipeServerMode;
+        private bool _sshServerMode;
         private string _configurationName;
         private ConsoleHost _parent;
         private ConsoleHostUserInterface _ui;

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
@@ -249,6 +249,12 @@ namespace Microsoft.PowerShell
                         s_cpp.ConfigurationName);
                     exitCode = 0;
                 }
+                else if (s_cpp.SSHServerMode)
+                {
+                    ClrFacade.StartProfileOptimization("StartupProfileData-SSHServerMode");
+                    System.Management.Automation.Remoting.Server.SSHProcessMediator.Run(s_cpp.InitialCommand);
+                    exitCode = 0;
+                }
                 else if (s_cpp.SocketServerMode)
                 {
                     ClrFacade.StartProfileOptimization("StartupProfileData-SocketServerMode");

--- a/src/System.Management.Automation/engine/hostifaces/Connection.cs
+++ b/src/System.Management.Automation/engine/hostifaces/Connection.cs
@@ -436,7 +436,12 @@ namespace System.Management.Automation.Runspaces
         /// <summary>
         /// Runspace is based on a VM socket transport.
         /// </summary>
-        VMSocketTransport = 0x4
+        VMSocketTransport = 0x4,
+
+        /// <summary>
+        /// Runspace is based on SSH transport.
+        /// </summary>
+        SSHTransport = 0x8
     }
 
     #endregion

--- a/src/System.Management.Automation/engine/hostifaces/ConnectionFactory.cs
+++ b/src/System.Management.Automation/engine/hostifaces/ConnectionFactory.cs
@@ -663,6 +663,7 @@ namespace System.Management.Automation.Runspaces
             if ((!(connectionInfo is WSManConnectionInfo)) &&
                 (!(connectionInfo is NewProcessConnectionInfo)) &&
                 (!(connectionInfo is NamedPipeConnectionInfo)) &&
+                (!(connectionInfo is SSHConnectionInfo)) &&
                 (!(connectionInfo is VMConnectionInfo)) &&
                 (!(connectionInfo is ContainerConnectionInfo)))
             {

--- a/src/System.Management.Automation/engine/remoting/client/remoterunspace.cs
+++ b/src/System.Management.Automation/engine/remoting/client/remoterunspace.cs
@@ -974,6 +974,10 @@ namespace System.Management.Automation
             {
                 returnCaps |= RunspaceCapability.VMSocketTransport;
             }
+            else if (_connectionInfo is SSHConnectionInfo)
+            {
+                returnCaps |= RunspaceCapability.SSHTransport;
+            }
             else
             {
                 ContainerConnectionInfo containerConnectionInfo = _connectionInfo as ContainerConnectionInfo;

--- a/src/System.Management.Automation/engine/remoting/commands/InvokeCommandCommand.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/InvokeCommandCommand.cs
@@ -386,6 +386,8 @@ namespace Microsoft.PowerShell.Commands
         [Parameter(ParameterSetName = InvokeCommandCommand.FilePathVMIdParameterSet)]
         [Parameter(ParameterSetName = InvokeCommandCommand.FilePathVMNameParameterSet)]
         [Parameter(ParameterSetName = InvokeCommandCommand.FilePathContainerIdParameterSet)]
+        [Parameter(ParameterSetName = InvokeCommandCommand.SSHHostParameterSet)]
+        [Parameter(ParameterSetName = InvokeCommandCommand.FilePathSSHHostParameterSet)]
         public SwitchParameter AsJob
         {
             get
@@ -443,6 +445,8 @@ namespace Microsoft.PowerShell.Commands
         [Parameter(ParameterSetName = InvokeCommandCommand.FilePathVMIdParameterSet)]
         [Parameter(ParameterSetName = InvokeCommandCommand.FilePathVMNameParameterSet)]
         [Parameter(ParameterSetName = InvokeCommandCommand.FilePathContainerIdParameterSet)]
+        [Parameter(ParameterSetName = InvokeCommandCommand.SSHHostParameterSet)]
+        [Parameter(ParameterSetName = InvokeCommandCommand.FilePathSSHHostParameterSet)]
         [Alias("HCN")]
         public SwitchParameter HideComputerName
         {
@@ -505,6 +509,9 @@ namespace Microsoft.PowerShell.Commands
         [Parameter(Position = 1,
                    Mandatory = true,
                    ParameterSetName = InvokeCommandCommand.ContainerIdParameterSet)]
+        [Parameter(Position = 1,
+                   Mandatory = true,
+                   ParameterSetName = InvokeCommandCommand.SSHHostParameterSet)]
         [ValidateNotNull]
         [Alias("Command")]
         public override ScriptBlock ScriptBlock
@@ -548,6 +555,9 @@ namespace Microsoft.PowerShell.Commands
         [Parameter(Position = 1,
                    Mandatory = true,
                    ParameterSetName = FilePathContainerIdParameterSet)]
+        [Parameter(Position = 1,
+                   Mandatory = true,
+                   ParameterSetName = FilePathSSHHostParameterSet)]
         [ValidateNotNull]
         [Alias("PSPath")]
         public override string FilePath
@@ -648,6 +658,49 @@ namespace Microsoft.PowerShell.Commands
             get { return base.RunAsAdministrator; }
             set { base.RunAsAdministrator = value; }
         }
+
+        #region SSH Parameters
+
+        /// <summary>
+        /// Host Name
+        /// </summary>
+        [ValidateNotNullOrEmpty()]
+        [Parameter(Position = 0, Mandatory = true, ParameterSetName = InvokeCommandCommand.SSHHostParameterSet)]
+        [Parameter(Position = 0, Mandatory = true, ParameterSetName = InvokeCommandCommand.FilePathSSHHostParameterSet)]
+        public override string HostName
+        {
+            get { return base.HostName; }
+
+            set { base.HostName = value; }
+        }
+
+        /// <summary>
+        /// User Name
+        /// </summary>
+        [Parameter(Mandatory = true, ParameterSetName = InvokeCommandCommand.SSHHostParameterSet)]
+        [Parameter(Mandatory = true, ParameterSetName = InvokeCommandCommand.FilePathSSHHostParameterSet)]
+        [ValidateNotNullOrEmpty()]
+        public override string UserName
+        {
+            get { return base.UserName; }
+
+            set { base.UserName = value; }
+        }
+
+        /// <summary>
+        /// Key Path
+        /// </summary>
+        [Parameter(ParameterSetName = InvokeCommandCommand.SSHHostParameterSet)]
+        [Parameter(ParameterSetName = InvokeCommandCommand.FilePathSSHHostParameterSet)]
+        [ValidateNotNullOrEmpty()]
+        public override string KeyPath
+        {
+            get { return base.KeyPath; }
+
+            set { base.KeyPath = value; }
+        }
+
+        #endregion
 
         #endregion Parameters
 
@@ -926,6 +979,18 @@ namespace Microsoft.PowerShell.Commands
                                         this.JobRepository.Add(job);
                                         WriteObject(job);
                                     }
+                                }
+                                break;
+
+                            case InvokeCommandCommand.SSHHostParameterSet:
+                            case InvokeCommandCommand.FilePathSSHHostParameterSet:
+                                {
+                                    var job = new PSRemotingJob(new string[] { this.HostName }, Operations,
+                                        ScriptBlock.ToString(), ThrottleLimit, _name);
+                                    job.PSJobTypeName = RemoteJobType;
+                                    job.HideComputerName = _hideComputerName;
+                                    this.JobRepository.Add(job);
+                                    WriteObject(job);
                                 }
                                 break;
 

--- a/src/System.Management.Automation/engine/remoting/commands/PSRemotingCmdlet.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/PSRemotingCmdlet.cs
@@ -177,6 +177,11 @@ namespace Microsoft.PowerShell.Commands
         protected const string VMNameParameterSet = "VMName";
 
         /// <summary>
+        /// SSH host parameter set
+        /// </summary>
+        protected const string SSHHostParameterSet = "SSHHost";
+
+        /// <summary>
         /// runspace parameter set
         /// </summary>
         protected const string SessionParameterSet = "Session";
@@ -673,6 +678,43 @@ namespace Microsoft.PowerShell.Commands
         }
         private string _thumbPrint = null;
 
+        #region SSHHostParameters
+
+        /// <summary>
+        /// SSH Target Host Name
+        /// </summary>
+        [Parameter(ParameterSetName = PSRemotingBaseCmdlet.SSHHostParameterSet)]
+        [ValidateNotNullOrEmpty()]
+        public virtual string HostName
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// SSH User Name
+        /// </summary>
+        [Parameter(ParameterSetName = PSRemotingBaseCmdlet.SSHHostParameterSet)]
+        [ValidateNotNullOrEmpty()]
+        public virtual string UserName
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// SSH Key Path
+        /// </summary>
+        [Parameter(ParameterSetName = PSRemotingBaseCmdlet.SSHHostParameterSet)]
+        [ValidateNotNullOrEmpty()]
+        public virtual string KeyPath
+        {
+            get;
+            set;
+        }
+
+        #endregion
+
         #endregion Properties
 
         #region Internal Static Methods
@@ -864,6 +906,11 @@ namespace Microsoft.PowerShell.Commands
         /// Container ID file path parameter set.
         /// </summary>
         protected const string FilePathContainerIdParameterSet = "FilePathContainerId";
+
+        /// <summary>
+        /// SSH Host file path parameter set.
+        /// </summary>
+        protected const string FilePathSSHHostParameterSet = "FilePathSSHHost";
 
         #endregion
 
@@ -1112,6 +1159,21 @@ namespace Microsoft.PowerShell.Commands
                 Operations.Add(operation);
             }
         }// CreateHelpersForSpecifiedComputerNames
+
+        /// <summary>
+        /// Creates helper objects for host names for PSRP over SSH
+        /// remoting.
+        /// </summary>
+        protected void CreateHelpersForSpecifiedHostNames()
+        {
+            var sshConnectionInfo = new SSHConnectionInfo(this.UserName, this.HostName, this.KeyPath);
+            var typeTable = TypeTable.LoadDefaultTypeFiles();
+            var remoteRunspace = RunspaceFactory.CreateRunspace(sshConnectionInfo, this.Host, typeTable) as RemoteRunspace;
+            var pipeline = CreatePipeline(remoteRunspace);
+
+            var operation = new ExecutionCmdletHelperComputerName(remoteRunspace, pipeline);
+            Operations.Add(operation);
+        }
 
         /// <summary>
         /// Creates helper objects with the specified command for 
@@ -1718,6 +1780,11 @@ namespace Microsoft.PowerShell.Commands
 
                         CreateHelpersForSpecifiedComputerNames();
                     }
+                    break;
+
+                case PSExecutionCmdlet.SSHHostParameterSet:
+                case PSExecutionCmdlet.FilePathSSHHostParameterSet:
+                    CreateHelpersForSpecifiedHostNames();
                     break;
 
                 case PSExecutionCmdlet.FilePathSessionParameterSet:

--- a/src/System.Management.Automation/engine/remoting/commands/PushRunspaceCommand.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/PushRunspaceCommand.cs
@@ -297,6 +297,10 @@ namespace Microsoft.PowerShell.Commands
                 case ContainerIdParameterSet:
                     remoteRunspace = GetRunspaceForContainerSession();
                     break;
+
+                case SSHHostParameterSet:
+                    remoteRunspace = GetRunspaceForSSHSession();
+                    break;
             }
 
             // If runspace is null then the error record has already been written and we can exit.
@@ -1235,6 +1239,20 @@ namespace Microsoft.PowerShell.Commands
 
                 WriteError(errorRecord);
             }
+
+            return remoteRunspace;
+        }
+
+        /// <summary>
+        /// Create remote runspace for SSH session
+        /// </summary>
+        private RemoteRunspace GetRunspaceForSSHSession()
+        {
+            var sshConnectionInfo = new SSHConnectionInfo(this.UserName, this.HostName, this.KeyPath);
+            var typeTable = TypeTable.LoadDefaultTypeFiles();
+            var remoteRunspace = RunspaceFactory.CreateRunspace(sshConnectionInfo, this.Host, typeTable) as RemoteRunspace;
+            remoteRunspace.Open();
+            remoteRunspace.ShouldCloseOnPop = true;
 
             return remoteRunspace;
         }

--- a/src/System.Management.Automation/engine/remoting/commands/newrunspacecommand.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/newrunspacecommand.cs
@@ -238,6 +238,12 @@ namespace Microsoft.PowerShell.Commands
                     }
                     break;
 
+                case NewPSSessionCommand.SSHHostParameterSet:
+                    {
+                        remoteRunspaces = CreateRunspacesForSSHHostParameterSet();
+                    }
+                    break;
+
                 default:
                     {
                         Dbg.Assert(false, "Missing paramenter set in switch statement");
@@ -1048,6 +1054,23 @@ namespace Microsoft.PowerShell.Commands
 
             return remoteRunspaces;
         }// CreateRunspacesWhenContainerParameterSpecified
+
+        /// <summary>
+        /// CreateRunspacesForSSHHostParameterSet
+        /// </summary>
+        /// <returns></returns>
+        private List<RemoteRunspace> CreateRunspacesForSSHHostParameterSet()
+        {
+            var remoteRunspaces = new List<RemoteRunspace>();
+            var sshConnectionInfo = new SSHConnectionInfo(
+                this.UserName,
+                this.HostName,
+                this.KeyPath);
+            var typeTable = TypeTable.LoadDefaultTypeFiles();
+            remoteRunspaces.Add(RunspaceFactory.CreateRunspace(sshConnectionInfo, this.Host, typeTable) as RemoteRunspace);
+
+            return remoteRunspaces;
+        }
 
         /// <summary>
         /// Helper method to either get a user supplied runspace/session name

--- a/src/System.Management.Automation/engine/remoting/common/RemoteSessionNamedPipe.cs
+++ b/src/System.Management.Automation/engine/remoting/common/RemoteSessionNamedPipe.cs
@@ -222,10 +222,10 @@ namespace System.Management.Automation.Remoting
            uint nDefaultTimeOut,
            SECURITY_ATTRIBUTES securityAttributes);
 
-        internal static SECURITY_ATTRIBUTES GetSecurityAttributes(GCHandle securityDescriptorPinnedHandle)
+        internal static SECURITY_ATTRIBUTES GetSecurityAttributes(GCHandle securityDescriptorPinnedHandle, bool inheritHandle = false)
         {
             SECURITY_ATTRIBUTES securityAttributes = new NamedPipeNative.SECURITY_ATTRIBUTES();
-            securityAttributes.InheritHandle = false;
+            securityAttributes.InheritHandle = inheritHandle;
             securityAttributes.NLength = (int)Marshal.SizeOf(securityAttributes);
             securityAttributes.LPSecurityDescriptor = securityDescriptorPinnedHandle.AddrOfPinnedObject();
             return securityAttributes;
@@ -590,7 +590,7 @@ namespace System.Management.Automation.Remoting
 
         #region Private Methods
 
-        private static CommonSecurityDescriptor GetServerPipeSecurity()
+        internal static CommonSecurityDescriptor GetServerPipeSecurity()
         {
             // Built-in Admin SID
             SecurityIdentifier adminSID = new SecurityIdentifier(WellKnownSidType.BuiltinAdministratorsSid, null);

--- a/src/System.Management.Automation/engine/remoting/common/RunspaceConnectionInfo.cs
+++ b/src/System.Management.Automation/engine/remoting/common/RunspaceConnectionInfo.cs
@@ -4,9 +4,12 @@ Copyright (c) Microsoft Corporation.  All rights reserved.
 
 using System.Net;
 using System.Net.Sockets;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
+using System.IO.Pipes;
+using System.ComponentModel; // Win32Exception
 using System.Management.Automation.Tracing;
 using System.Management.Automation.Remoting;
 using System.Management.Automation.Internal;
@@ -14,6 +17,8 @@ using System.Management.Automation.Remoting.Client;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Threading;
+using System.Security.AccessControl;
+using Microsoft.Win32.SafeHandles;
 using Dbg = System.Management.Automation.Diagnostics;
 using WSManAuthenticationMechanism = System.Management.Automation.Remoting.Client.WSManNativeApi.WSManAuthenticationMechanism;
 
@@ -1555,7 +1560,6 @@ namespace System.Management.Automation.Runspaces
         /// </summary>
         public override string ComputerName
         {
-            // TODO: should this be different
             get { return "localhost"; }
             set { throw new NotImplementedException(); }
         }
@@ -1817,6 +1821,487 @@ namespace System.Management.Automation.Runspaces
                 instanceId,
                 cryptoHelper);
         }
+
+        #endregion
+    }
+
+    /// <summary>
+    /// Class used to create a connection through an SSH.exe client to a remote host machine.
+    /// Connection information includes SSH target (user name and host machine) along with
+    /// client key used for key based user authorization.
+    /// </summary>
+    public sealed class SSHConnectionInfo : RunspaceConnectionInfo
+    {
+        #region Properties
+
+        /// <summary>
+        /// User Name
+        /// </summary>
+        public string UserName
+        {
+            get;
+            private set;
+        }
+
+        /// <summary>
+        /// Key Path
+        /// </summary>
+        private string KeyPath
+        {
+            get;
+            set;
+        }
+
+        #endregion
+
+        #region Constructors
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        private SSHConnectionInfo()
+        { }
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="userName">User Name</param>
+        /// <param name="computerName">Computer Name</param>
+        /// <param name="keyPath">Key Path</param>
+        public SSHConnectionInfo(
+            string userName,
+            string computerName,
+            string keyPath)
+        {
+            if (userName == null) { throw new PSArgumentNullException("userName"); }
+            if (computerName == null) { throw new PSArgumentNullException("computerName"); }
+
+            this.UserName = userName;
+            this.ComputerName = computerName;
+            this.KeyPath = keyPath;
+        }
+
+        #endregion
+
+        #region Overrides
+
+        /// <summary>
+        /// Computer is always localhost.
+        /// </summary>
+        public override string ComputerName
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// Credential
+        /// </summary>
+        public override PSCredential Credential
+        {
+            get { return null; }
+            set { throw new NotImplementedException(); }
+        }
+
+        /// <summary>
+        /// Authentication
+        /// </summary>
+        public override AuthenticationMechanism AuthenticationMechanism
+        {
+            get { return AuthenticationMechanism.Default; }
+            set { throw new NotImplementedException(); }
+        }
+
+        /// <summary>
+        /// CertificateThumbprint
+        /// </summary>
+        public override string CertificateThumbprint
+        {
+            get { return string.Empty; }
+            set { throw new NotImplementedException(); }
+        }
+
+        /// <summary>
+        /// Shallow copy of current instance.
+        /// </summary>
+        /// <returns>NamedPipeConnectionInfo</returns>
+        internal override RunspaceConnectionInfo InternalCopy()
+        {
+            SSHConnectionInfo newCopy = new SSHConnectionInfo();
+            newCopy.ComputerName = this.ComputerName;
+            newCopy.UserName = this.UserName;
+            newCopy.KeyPath = this.KeyPath;
+
+            return newCopy;
+        }
+
+        /// <summary>
+        /// CreateClientSessionTransportManager
+        /// </summary>
+        /// <param name="instanceId"></param>
+        /// <param name="sessionName"></param>
+        /// <param name="cryptoHelper"></param>
+        /// <returns></returns>
+        internal override BaseClientSessionTransportManager CreateClientSessionTransportManager(Guid instanceId, string sessionName, PSRemotingCryptoHelper cryptoHelper)
+        {
+            return new SSHClientSessionTransportManager(
+                this,
+                instanceId,
+                cryptoHelper);
+        }
+
+        #endregion
+
+        #region Internal Methods
+
+        /// <summary>
+        /// StartSSHProcess
+        /// </summary>
+        /// <returns></returns>
+        internal System.Diagnostics.Process StartSSHProcess(
+            out StreamWriter stdInWriterVar,
+            out StreamReader stdOutReaderVar,
+            out StreamReader stdErrReaderVar)
+        {
+            string filePath = string.Empty;
+#if !UNIX
+            var context = Runspaces.LocalPipeline.GetExecutionContextFromTLS();
+            if (context != null)
+            {
+                var cmdInfo = context.CommandDiscovery.LookupCommandInfo("ssh.exe", CommandOrigin.Internal) as ApplicationInfo;
+                if (cmdInfo != null)
+                {
+                    filePath = cmdInfo.Path;
+                }
+            }
+#else
+            filePath = @"ssh";
+#endif
+
+            // Extract an optional domain name if provided.
+            string domainName = null;
+            string userName = this.UserName;
+#if !UNIX
+            var parts = this.UserName.Split(Utils.Separators.Backslash);
+            if (parts.Length == 2)
+            {
+                domainName = parts[0];
+                userName = parts[1];
+            }
+#endif
+
+            // Create client ssh process that hosts powershell.exe as a subsystem and is configured
+            // to be in server mode for PSRP over SSHD:
+            //   powershell -Version 5.1 -sshs -NoLogo -NoProfile
+            //   See sshd_configuration file, subsystems section and it will have this entry:
+            //     Subsystem       powershell C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -Version 5.1 -sshs -NoLogo -NoProfile
+            string arguments;
+            if (!string.IsNullOrEmpty(this.KeyPath))
+            {
+                arguments = (string.IsNullOrEmpty(domainName)) ?
+                    string.Format(CultureInfo.InvariantCulture, @"-i ""{0}"" {1}@{2} -s powershell", this.KeyPath, userName, this.ComputerName) :
+                    string.Format(CultureInfo.InvariantCulture, @"-i ""{0}"" -l {1}@{2} {3} -s powershell", this.KeyPath, userName, domainName, this.ComputerName);
+            }
+            else
+            {
+                arguments = (string.IsNullOrEmpty(domainName)) ?
+                    string.Format(CultureInfo.InvariantCulture, @"{0}@{1} -s powershell", userName, this.ComputerName) :
+                    string.Format(CultureInfo.InvariantCulture, @"-l {0}@{1} {2} -s powershell", userName, domainName, this.ComputerName);
+            }
+
+            System.Diagnostics.ProcessStartInfo startInfo = new System.Diagnostics.ProcessStartInfo(
+                filePath,
+                arguments);
+            startInfo.WorkingDirectory = System.IO.Path.GetDirectoryName(filePath);
+            startInfo.CreateNoWindow = true;
+            startInfo.UseShellExecute = false;
+
+            return StartSSHProcessImpl(startInfo, out stdInWriterVar, out stdOutReaderVar, out stdErrReaderVar);
+        }
+
+        #endregion
+
+        #region SSH Process Creation
+
+#if UNIX
+
+        /// <summary>
+        /// Create a process through managed APIs and return StdIn, StdOut, StdError reader/writers
+        /// This works for non-Windows platforms and is simpler.
+        /// </summary>
+        private static System.Diagnostics.Process StartSSHProcessImpl(
+            System.Diagnostics.ProcessStartInfo startInfo,
+            out StreamWriter stdInWriterVar,
+            out StreamReader stdOutReaderVar,
+            out StreamReader stdErrReaderVar)
+        {
+            startInfo.RedirectStandardInput = true;
+            startInfo.RedirectStandardOutput = true;
+            startInfo.RedirectStandardError = true;
+
+            System.Diagnostics.Process process = new Process();
+            process.StartInfo = startInfo;
+
+            process.Start();
+
+            stdInWriterVar = process.StandardInput;
+            stdOutReaderVar = process.StandardOutput;
+            stdErrReaderVar = process.StandardError;
+
+            return process;
+        }
+
+#else
+
+        /// <summary>
+        /// Create a process through native Win32 APIs and return StdIn, StdOut, StdError reader/writers
+        /// This needs to be done via Win32 APIs because managed code creates anonymous synchronous pipes 
+        /// for redirected StdIn/Out and SSH (and PSRP) require asynchrous (overlapped) pipes, which must
+        /// be through named pipes.  Managed code for named pipes is unreliable and so this is done via
+        /// P-Invoking native APIs.
+        /// </summary>
+        private static System.Diagnostics.Process StartSSHProcessImpl(
+            System.Diagnostics.ProcessStartInfo startInfo,
+            out StreamWriter stdInWriterVar,
+            out StreamReader stdOutReaderVar,
+            out StreamReader stdErrReaderVar)
+        {
+            Exception ex = null;
+            System.Diagnostics.Process sshProcess = null;
+            //
+            // These std pipe handles are bound to managed Reader/Writer objects and returned to the transport
+            // manager object, which uses them for PSRP communication.  The lifetime of these handles are then
+            // tied to the reader/writer objects which the transport is responsible for disposing (see 
+            // SSHClientSessionTransportManger and the CloseConnection() method.
+            //
+            SafePipeHandle stdInPipeServer = null;
+            SafePipeHandle stdOutPipeServer = null;
+            SafePipeHandle stdErrPipeServer = null;
+            try
+            {
+                sshProcess = CreateProcessWithRedirectedStd(
+                    startInfo,
+                    out stdInPipeServer,
+                    out stdOutPipeServer,
+                    out stdErrPipeServer);
+            }
+            catch (InvalidOperationException e) { ex = e; }
+            catch (ArgumentException e) { ex = e; }
+            catch (FileNotFoundException e) { ex = e; }
+            catch (System.ComponentModel.Win32Exception e) { ex = e; }
+
+            if ((ex != null) ||
+                (sshProcess == null) ||
+                (sshProcess.HasExited == true))
+            {
+                throw new InvalidOperationException(RemotingErrorIdStrings.CannotStartSSHClient, ex);
+            }
+
+            // Create the std in writer/readers needed for communication with ssh.exe.
+            stdInWriterVar = null;
+            stdOutReaderVar = null;
+            stdErrReaderVar = null;
+            try
+            {
+                stdInWriterVar = new StreamWriter(new NamedPipeServerStream(PipeDirection.Out, true, true, stdInPipeServer));
+                stdOutReaderVar = new StreamReader(new NamedPipeServerStream(PipeDirection.In, true, true, stdOutPipeServer));
+                stdErrReaderVar = new StreamReader(new NamedPipeServerStream(PipeDirection.In, true, true, stdErrPipeServer));
+            }
+            catch (Exception e)
+            {
+                CommandProcessorBase.CheckForSevereException(e);
+                if (stdInWriterVar != null) { stdInWriterVar.Dispose(); } else { stdInPipeServer.Dispose(); }
+                if (stdOutReaderVar != null) { stdInWriterVar.Dispose(); } else { stdOutPipeServer.Dispose(); }
+                if (stdErrReaderVar != null) { stdInWriterVar.Dispose(); } else { stdErrPipeServer.Dispose(); }
+
+                throw;
+            }
+
+            return sshProcess;
+        }
+
+        /// <summary>
+        /// CreateProcessWithRedirectedStd
+        /// </summary>
+        private static Process CreateProcessWithRedirectedStd(
+            ProcessStartInfo startInfo,
+            out SafePipeHandle stdInPipeServer,
+            out SafePipeHandle stdOutPipeServer,
+            out SafePipeHandle stdErrPipeServer)
+        {
+            //
+            // Create named (async) pipes for reading/writing to std.
+            //
+            stdInPipeServer = null;
+            stdOutPipeServer = null;
+            stdErrPipeServer = null;
+            SafePipeHandle stdInPipeClient = null;
+            SafePipeHandle stdOutPipeClient = null;
+            SafePipeHandle stdErrPipeClient = null;
+            string randomName = System.IO.Path.GetFileNameWithoutExtension(System.IO.Path.GetRandomFileName());
+
+            try
+            {
+                // Get default pipe security (Admin and current user access)
+                var securityDesc = RemoteSessionNamedPipeServer.GetServerPipeSecurity();
+
+                var stdInPipeName = @"\\.\pipe\StdIn" + randomName;
+                stdInPipeServer = CreateNamedPipe(stdInPipeName, securityDesc);
+                stdInPipeClient = GetNamedPipeHandle(stdInPipeName);
+
+                var stdOutPipeName = @"\\.\pipe\StdOut" + randomName;
+                stdOutPipeServer = CreateNamedPipe(stdOutPipeName, securityDesc);
+                stdOutPipeClient = GetNamedPipeHandle(stdOutPipeName);
+
+                var stdErrPipeName = @"\\.\pipe\StdErr" + randomName;
+                stdErrPipeServer = CreateNamedPipe(stdErrPipeName, securityDesc);
+                stdErrPipeClient = GetNamedPipeHandle(stdErrPipeName);
+            }
+            catch (Exception e)
+            {
+                CommandProcessorBase.CheckForSevereException(e);
+
+                if (stdInPipeServer != null) { stdInPipeServer.Dispose(); }
+                if (stdInPipeClient != null) { stdInPipeClient.Dispose(); }
+                if (stdOutPipeServer != null) { stdOutPipeServer.Dispose(); }
+                if (stdOutPipeClient != null) { stdOutPipeClient.Dispose(); }
+                if (stdErrPipeServer != null) { stdErrPipeServer.Dispose(); }
+                if (stdErrPipeClient != null) { stdErrPipeClient.Dispose(); }
+
+                throw;
+            }
+
+            // Create process
+            PlatformInvokes.STARTUPINFO lpStartupInfo = new PlatformInvokes.STARTUPINFO();
+            PlatformInvokes.PROCESS_INFORMATION lpProcessInformation = new PlatformInvokes.PROCESS_INFORMATION();
+            int creationFlags = 0;
+
+            try
+            {
+                var cmdLine = String.Format(CultureInfo.InvariantCulture, @"""{0}"" {1}", startInfo.FileName, startInfo.Arguments);
+
+                lpStartupInfo.hStdInput = new SafeFileHandle(stdInPipeClient.DangerousGetHandle(), false);
+                lpStartupInfo.hStdOutput = new SafeFileHandle(stdOutPipeClient.DangerousGetHandle(), false);
+                lpStartupInfo.hStdError = new SafeFileHandle(stdErrPipeClient.DangerousGetHandle(), false);
+                lpStartupInfo.dwFlags = 0x100;
+
+                // No new window: Inherit the parent process's console window
+                creationFlags = 0x00000000;
+
+                // Create the new process suspended so we have a chance to get a corresponding Process object in case it terminates quickly.
+                creationFlags |= 0x00000004;
+
+                PlatformInvokes.SECURITY_ATTRIBUTES lpProcessAttributes = new PlatformInvokes.SECURITY_ATTRIBUTES();
+                PlatformInvokes.SECURITY_ATTRIBUTES lpThreadAttributes = new PlatformInvokes.SECURITY_ATTRIBUTES();
+                bool success = PlatformInvokes.CreateProcess(
+                    null,
+                    cmdLine,
+                    lpProcessAttributes,
+                    lpThreadAttributes,
+                    true,
+                    creationFlags,
+                    IntPtr.Zero,
+                    startInfo.WorkingDirectory,
+                    lpStartupInfo,
+                    lpProcessInformation);
+
+                if (!success)
+                {
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+                }
+
+                // At this point, we should have a suspended process.  Get the .Net Process object, resume the process, and return.
+                Process result = Process.GetProcessById(lpProcessInformation.dwProcessId);
+                PlatformInvokes.ResumeThread(lpProcessInformation.hThread);
+
+                return result;
+            }
+            catch (Exception e)
+            {
+                CommandProcessorBase.CheckForSevereException(e);
+                if (stdInPipeServer != null) { stdInPipeServer.Dispose(); }
+                if (stdInPipeClient != null) { stdInPipeClient.Dispose(); }
+                if (stdOutPipeServer != null) { stdOutPipeServer.Dispose(); }
+                if (stdOutPipeClient != null) { stdOutPipeClient.Dispose(); }
+                if (stdErrPipeServer != null) { stdErrPipeServer.Dispose(); }
+                if (stdErrPipeClient != null) { stdErrPipeClient.Dispose(); }
+
+                throw;
+            }
+            finally
+            {
+                lpProcessInformation.Dispose();
+            }
+        }
+
+        private static SafePipeHandle GetNamedPipeHandle(string pipeName)
+        {
+            // Create pipe flags for asynchronous pipes.
+            uint pipeFlags = NamedPipeNative.FILE_FLAG_OVERLAPPED;
+
+            // We want an inheritable handle.
+            PlatformInvokes.SECURITY_ATTRIBUTES securityAttributes = new PlatformInvokes.SECURITY_ATTRIBUTES();
+
+            // Get handle to pipe.
+            var fileHandle = PlatformInvokes.CreateFileW(
+                pipeName,
+                NamedPipeNative.GENERIC_READ | NamedPipeNative.GENERIC_WRITE,
+                0,
+                securityAttributes,
+                NamedPipeNative.OPEN_EXISTING,
+                pipeFlags,
+                IntPtr.Zero);
+
+            int lastError = Marshal.GetLastWin32Error();
+            if (fileHandle == PlatformInvokes.INVALID_HANDLE_VALUE)
+            {
+                throw new System.ComponentModel.Win32Exception(lastError);
+            }
+
+            return new SafePipeHandle(fileHandle, true);
+        }
+
+        private static SafePipeHandle CreateNamedPipe(
+            string pipeName,
+            CommonSecurityDescriptor securityDesc)
+        {
+            // Create optional security attributes based on provided PipeSecurity.
+            NamedPipeNative.SECURITY_ATTRIBUTES securityAttributes = null;
+            GCHandle? securityDescHandle = null;
+            if (securityDesc != null)
+            {
+                byte[] securityDescBuffer = new byte[securityDesc.BinaryLength];
+                securityDesc.GetBinaryForm(securityDescBuffer, 0);
+                securityDescHandle = GCHandle.Alloc(securityDescBuffer, GCHandleType.Pinned);
+                securityAttributes = NamedPipeNative.GetSecurityAttributes(securityDescHandle.Value, true); ;
+            }
+
+            // Create async named pipe.
+            SafePipeHandle pipeHandle = NamedPipeNative.CreateNamedPipe(
+                pipeName,
+                NamedPipeNative.PIPE_ACCESS_DUPLEX | NamedPipeNative.FILE_FLAG_FIRST_PIPE_INSTANCE | NamedPipeNative.FILE_FLAG_OVERLAPPED,
+                NamedPipeNative.PIPE_TYPE_MESSAGE | NamedPipeNative.PIPE_READMODE_MESSAGE,
+                1,
+                32768,
+                32768,
+                0,
+                securityAttributes);
+
+            int lastError = Marshal.GetLastWin32Error();
+            if (securityDescHandle != null)
+            {
+                securityDescHandle.Value.Free();
+            }
+
+            if (pipeHandle.IsInvalid)
+            {
+                throw new Win32Exception(lastError);
+            }
+
+            return pipeHandle;
+        }
+
+#endif
 
         #endregion
     }

--- a/src/System.Management.Automation/engine/remoting/server/OutOfProcServerMediator.cs
+++ b/src/System.Management.Automation/engine/remoting/server/OutOfProcServerMediator.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Threading;
 using System.Security.Principal;
 using System.Management.Automation.Internal;
+using Microsoft.Win32.SafeHandles;
 using Dbg = System.Management.Automation.Diagnostics;
 
 namespace System.Management.Automation.Remoting.Server
@@ -296,14 +297,21 @@ namespace System.Management.Automation.Remoting.Server
 
         #region Methods
 
-        protected OutOfProcessServerSessionTransportManager CreateSessionTransportManager(string configurationName)
+        protected OutOfProcessServerSessionTransportManager CreateSessionTransportManager(string configurationName, PSRemotingCryptoHelperServer cryptoHelper)
         {
+            PSSenderInfo senderInfo;
+#if !UNIX
             WindowsIdentity currentIdentity = WindowsIdentity.GetCurrent();
             PSPrincipal userPrincipal = new PSPrincipal(new PSIdentity("", true, currentIdentity.Name, null),
                 currentIdentity);
-            PSSenderInfo senderInfo = new PSSenderInfo(userPrincipal, "http://localhost");
+            senderInfo = new PSSenderInfo(userPrincipal, "http://localhost");
+#else
+            PSPrincipal userPrincipal = new PSPrincipal(new PSIdentity("", true, "", null),
+                null);
+            senderInfo = new PSSenderInfo(userPrincipal, "http://localhost");
+#endif
 
-            OutOfProcessServerSessionTransportManager tm = new OutOfProcessServerSessionTransportManager(originalStdOut, originalStdErr);
+            OutOfProcessServerSessionTransportManager tm = new OutOfProcessServerSessionTransportManager(originalStdOut, originalStdErr, cryptoHelper);
 
             ServerRemoteSession srvrRemoteSession = ServerRemoteSession.CreateServerRemoteSession(senderInfo,
                 _initialCommand, tm, configurationName);
@@ -311,11 +319,11 @@ namespace System.Management.Automation.Remoting.Server
             return tm;
         }
 
-        protected void Start(string initialCommand, string configurationName = null)
+        protected void Start(string initialCommand, PSRemotingCryptoHelperServer cryptoHelper, string configurationName = null)
         {
             _initialCommand = initialCommand;
 
-            sessionTM = CreateSessionTransportManager(configurationName);
+            sessionTM = CreateSessionTransportManager(configurationName, cryptoHelper);
 
             try
             {
@@ -326,7 +334,7 @@ namespace System.Management.Automation.Remoting.Server
                     {
                         if (sessionTM == null)
                         {
-                            sessionTM = CreateSessionTransportManager(configurationName);
+                            sessionTM = CreateSessionTransportManager(configurationName, cryptoHelper);
                         }
                     }
                     if (string.IsNullOrEmpty(data))
@@ -474,7 +482,76 @@ namespace System.Management.Automation.Remoting.Server
             // Setup unhandled exception to log events
             AppDomain.CurrentDomain.UnhandledException += new UnhandledExceptionEventHandler(AppDomainUnhandledException);
 #endif
-            s_singletonInstance.Start(initialCommand);
+            s_singletonInstance.Start(initialCommand, new PSRemotingCryptoHelperServer());
+        }
+
+        #endregion
+    }
+
+    internal sealed class SSHProcessMediator : OutOfProcessMediatorBase
+    {
+        #region Private Data
+
+        private static SSHProcessMediator s_singletonInstance;
+
+        #endregion
+
+        #region Constructors
+
+        private SSHProcessMediator() : base(true)
+        {
+#if !UNIX
+            var inputHandle = PlatformInvokes.GetStdHandle((uint)PlatformInvokes.StandardHandleId.Input);
+            originalStdIn = new StreamReader(
+                new FileStream(new SafeFileHandle(inputHandle, false), FileAccess.Read));
+
+            var outputHandle = PlatformInvokes.GetStdHandle((uint)PlatformInvokes.StandardHandleId.Output);
+            originalStdOut = new OutOfProcessTextWriter(
+                new StreamWriter(
+                    new FileStream(new SafeFileHandle(outputHandle, false), FileAccess.Write)));
+
+            var errorHandle = PlatformInvokes.GetStdHandle((uint)PlatformInvokes.StandardHandleId.Error);
+            originalStdErr = new OutOfProcessTextWriter(
+                new StreamWriter(
+                    new FileStream(new SafeFileHandle(errorHandle, false), FileAccess.Write)));
+#else
+            originalStdIn = new StreamReader(Console.OpenStandardInput(), true);
+            originalStdOut = new OutOfProcessTextWriter(
+                new StreamWriter(Console.OpenStandardOutput()));
+            originalStdErr = new OutOfProcessTextWriter(
+                new StreamWriter(Console.OpenStandardError()));
+#endif
+        }
+
+        #endregion
+
+        #region Static Methods
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="initialCommand"></param>
+        internal static void Run(string initialCommand)
+        {
+            lock (SyncObject)
+            {
+                if (s_singletonInstance != null)
+                {
+                    Dbg.Assert(false, "Run should not be called multiple times");
+                    return;
+                }
+
+                s_singletonInstance = new SSHProcessMediator();
+            }
+
+            PSRemotingCryptoHelperServer cryptoHelper;
+#if !UNIX
+            cryptoHelper = new PSRemotingCryptoHelperServer();
+#else
+            cryptoHelper = null;
+#endif
+
+            s_singletonInstance.Start(initialCommand, cryptoHelper);
         }
 
         #endregion
@@ -552,7 +629,7 @@ namespace System.Management.Automation.Remoting.Server
             // AppDomain is not available in CoreCLR
             AppDomain.CurrentDomain.UnhandledException += new UnhandledExceptionEventHandler(AppDomainUnhandledException);
 #endif
-            s_singletonInstance.Start(initialCommand, namedPipeServer.ConfigurationName);
+            s_singletonInstance.Start(initialCommand, new PSRemotingCryptoHelperServer(), namedPipeServer.ConfigurationName);
         }
 
         #endregion
@@ -643,7 +720,7 @@ namespace System.Management.Automation.Remoting.Server
             AppDomain.CurrentDomain.UnhandledException += new UnhandledExceptionEventHandler(AppDomainUnhandledException);
 #endif
 
-            s_instance.Start(initialCommand, configurationName);
+            s_instance.Start(initialCommand, new PSRemotingCryptoHelperServer(), configurationName);
         }
 
         #endregion

--- a/src/System.Management.Automation/engine/remoting/server/serverremotesession.cs
+++ b/src/System.Management.Automation/engine/remoting/server/serverremotesession.cs
@@ -132,11 +132,12 @@ namespace System.Management.Automation.Remoting
             _senderInfo = senderInfo;
             _configProviderId = configurationProviderId;
             _initParameters = initializationParameters;
-            if (Platform.IsWindows)
-            {
-                _cryptoHelper = (PSRemotingCryptoHelperServer)transportManager.CryptoHelper;
-                _cryptoHelper.Session = this;
-            }
+#if !UNIX
+            _cryptoHelper = (PSRemotingCryptoHelperServer)transportManager.CryptoHelper;
+            _cryptoHelper.Session = this;
+#else
+            _cryptoHelper = null;
+#endif
 
             Context = new ServerRemoteSessionContext();
             SessionDataStructureHandler = new ServerRemoteSessionDSHandlerlImpl(this, transportManager);
@@ -162,9 +163,9 @@ namespace System.Management.Automation.Remoting
             transportManager.ReceivedDataCollection.MaximumReceivedDataSize = null;
         }
 
-        #endregion Constructors
+#endregion Constructors
 
-        #region Creation Factory
+#region Creation Factory
 
         /// <summary>
         /// Creates a server remote session for the supplied <paramref name="configuratioinProviderId"/>
@@ -240,9 +241,9 @@ namespace System.Management.Automation.Remoting
             return result;
         }
 
-        #endregion
+#endregion
 
-        #region Overrides
+#region Overrides
 
         /// <summary>
         /// This indicates the remote session object is Client, Server or Listener.
@@ -457,9 +458,9 @@ namespace System.Management.Automation.Remoting
             SessionDataStructureHandler.StateMachine.RaiseEvent(args);
         }
 
-        #endregion Overrides
+#endregion Overrides
 
-        #region Properties
+#region Properties
 
         /// <summary>
         /// This property returns the ServerRemoteSessionContext object created inside
@@ -473,9 +474,9 @@ namespace System.Management.Automation.Remoting
         /// </summary>
         internal ServerRemoteSessionDataStructureHandler SessionDataStructureHandler { get; }
 
-        #endregion
+#endregion
 
-        #region Private/Internal Methods
+#region Private/Internal Methods
 
         /// <summary>
         /// Let the session clear its resources.
@@ -866,7 +867,11 @@ namespace System.Management.Automation.Remoting
                     _runspacePoolDriver.InstanceId);
             }
 
+#if !UNIX
             bool isAdministrator = _senderInfo.UserInfo.IsInRole(System.Security.Principal.WindowsBuiltInRole.Administrator);
+#else
+            bool isAdministrator = false;
+#endif
 
             ServerRunspacePoolDriver tmpDriver = new ServerRunspacePoolDriver(
                 clientRunspacePoolId,
@@ -1158,6 +1163,6 @@ namespace System.Management.Automation.Remoting
             cmdTransportManager.ReceivedDataCollection.MaximumReceivedObjectSize = _maxRecvdObjectSize;
         }
 
-        #endregion
+#endregion
     }
 }

--- a/src/System.Management.Automation/resources/RemotingErrorIdStrings.resx
+++ b/src/System.Management.Automation/resources/RemotingErrorIdStrings.resx
@@ -1609,4 +1609,7 @@ All WinRM sessions connected to Windows PowerShell session configurations, such 
     <value> Other Possible Cause:
   -The domain or computer name was not included with the specified credential, for example: DOMAIN\UserName or COMPUTER\UserName.</value>
   </data>
+  <data name="CannotStartSSHClient" xml:space="preserve">
+    <value>An error occurred when starting the SSH.exe client needed for the remoting connection.</value>
+  </data>
 </root>

--- a/src/System.Management.Automation/security/wldpNativeMethods.cs
+++ b/src/System.Management.Automation/security/wldpNativeMethods.cs
@@ -258,6 +258,13 @@ namespace System.Management.Automation.Security
                             (System.Security.Principal.WindowsIdentity.GetCurrent().ImpersonationLevel == System.Security.Principal.TokenImpersonationLevel.Impersonation) ?
                             SaferPolicy.Allowed : SaferPolicy.Disallowed;
                     }
+                    catch (ArgumentException)
+                    {
+                        // This is for IO.Path.GetTempPath() call when temp paths are not accessible.
+                        result =
+                           (System.Security.Principal.WindowsIdentity.GetCurrent().ImpersonationLevel == System.Security.Principal.TokenImpersonationLevel.Impersonation) ?
+                           SaferPolicy.Allowed : SaferPolicy.Disallowed;
+                    }
                     finally
                     {
                         if (IO.File.Exists(testPathScript)) { IO.File.Delete(testPathScript); }


### PR DESCRIPTION
These changes include code review feedback comments.

The changes add support for PowerShell remoting over SSH. This includes creating new transport objects to use SSH as the PSRP remoting transport along with a new parameter set for the New-PSSession, Invoke-Command, and Enter-PSSession cmdlets. The parameters are HostName, UserName, and KeyPath to allow both SSH password prompt (for interactive sessions) and key based user authentication.

This check in is to support PowerShell SSH remoting demos and the final parameter may change in the future.  There are a number of currently known issues that have been added to this repo.

PowerShell SSH remoting works on Win32 full, core, Linux (Ubuntu) platforms.  It requires SSH to be installed on both client (ssh.exe) and server (sshd.exe) along with a PowerShell having these changes. 
Windows platforms require Win32-OpenSSH.

Documents on how to set up PowerShell SSH remoting on Windows and Linux platforms is forthcoming.
