### PR TITLE
Create license for thirdparty,proprietary file - Ensure installed root location contains this file

### DIFF
--- a/license_thirdparty_proprietary.txt
+++ b/license_thirdparty_proprietary.txt
@@ -1,39 +1,78 @@
 PowerShell 6.0
 Copyright (c) Microsoft Corporation
-All rights reserved.†
+All rights reserved. 
 MIT License
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+Permission is hereby granted, free of charge, to any person obtaining a copy of this 
+software and associated documentation files (the "Software"), to deal in the Software 
+without restriction, including without limitation the rights to use, copy, modify, 
+merge, publish, distribute, sublicense, and/or sell copies of the Software, and to 
+permit persons to whom the Software is furnished to do so, subject to the following 
+conditions:
+The above copyright notice and this permission notice shall be included in all copies 
+or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, 
+INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A 
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT 
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF 
+CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE 
+OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-IMPORTANT NOTICE:  THE SOFTWARE ALSO CONTAINS THIRD PARTY AND OTHER PROPIETARY SOFTWARE THAT ARE GOVERNED BY SEPARATE LICENSE TERMS. BY ACCEPTING THE LICENSE TERMS ABOVE, YOU ALSO ACCEPT THE LICENSE TERMS GOVERNING THE THIRD PARTY AND OTHER SOFTWARE, WHICH ARE SET FORTH BELOW:
-The following components listed are governed by the license terms that follow the component(s) name:  
+IMPORTANT NOTICE:  THE SOFTWARE ALSO CONTAINS THIRD PARTY AND OTHER 
+PROPIETARY SOFTWARE THAT ARE GOVERNED BY SEPARATE LICENSE TERMS. BY ACCEPTING 
+THE LICENSE TERMS ABOVE, YOU ALSO ACCEPT THE LICENSE TERMS GOVERNING THE 
+THIRD PARTY AND OTHER SOFTWARE, WHICH ARE SET FORTH BELOW:
+The following components listed are governed by the license terms that follow the 
+component(s) name:  
 ------------------------------------------------------
 Libmi.so
 ------------------------------------------------------
 Copyright (c) Microsoft Corporation
-All rights reserved.†
+All rights reserved. 
 MIT License
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-The following components are governed by the MIT license, a copy of which appears below the list of components:  
+Permission is hereby granted, free of charge, to any person obtaining a copy of this 
+software and associated documentation files (the "Software"), to deal in the Software 
+without restriction, including without limitation the rights to use, copy, modify, 
+merge, publish, distribute, sublicense, and/or sell copies of the Software, and to 
+permit persons to whom the Software is furnished to do so, subject to the following 
+conditions:
+The above copyright notice and this permission notice shall be included in all copies 
+or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, 
+INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A 
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT 
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF 
+CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE 
+OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+The following components are governed by the MIT license, a copy of which appears 
+below the list of components:  
 ------------------------------------------------------
 Newtonsoft.Json
 ------------------------------------------------------
 Copyright (c) 2007 James Newton-King
-All rights reserved.†
+All rights reserved. 
 MIT License
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+Permission is hereby granted, free of charge, to any person obtaining a copy of this 
+software and associated documentation files (the "Software"), to deal in the Software 
+without restriction, including without limitation the rights to use, copy, modify, 
+merge, publish, distribute, sublicense, and/or sell copies of the Software, and to 
+permit persons to whom the Software is furnished to do so, subject to the following 
+conditions:
+The above copyright notice and this permission notice shall be included in all copies 
+or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, 
+INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A 
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT 
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF 
+CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE 
+OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ---------------------------------------------------------
 Libuv v.1.9.0
 ---------------------------------------------------------
 
 https://raw.githubusercontent.com/aspnet/libuv-package/dev/content/License.txt
 
-This software is licensed to you by Microsoft Corporation under the original terms of the copyright holder provided below:
+This software is licensed to you by Microsoft Corporation under the original terms of 
+the copyright holder provided below:
 
 =========================================
 
@@ -72,7 +111,8 @@ The externally maintained libraries used by libuv are:
   - tree.h (from FreeBSD), copyright Niels Provos. Two clause BSD license.
 
   - inet_pton and inet_ntop implementations, contained in src/inet.c, are
-copyright the Internet Systems Consortium, Inc., and licensed under the ISC license.
+copyright the Internet Systems Consortium, Inc., and licensed under the ISC 
+license.
 
   - stdint-msvc2008.h (from msinttypes), copyright Alexander Chemeris. Three
     clause BSD license.
@@ -80,22 +120,23 @@ copyright the Internet Systems Consortium, Inc., and licensed under the ISC lice
   - pthread-fixes.h, pthread-fixes.c, copyright Google Inc. and Sony Mobile
     Communications AB. Three clause BSD license.
 
-  - android-ifaddrs.h, android-ifaddrs.c, copyright Berkeley Software Design Inc, Kenneth MacKay and Emergya (Cloud4all, FP7/2007-2013, grant agreement
-    n∞ 289016). Three clause BSD license.
+  - android-ifaddrs.h, android-ifaddrs.c, copyright Berkeley Software Design Inc, 
+Kenneth MacKay and Emergya (Cloud4all, FP7/2007-2013, grant agreement
+    n¬∞ 289016). Three clause BSD license.
 
 =========================================
 
 
 ----------------------------------------------------
-* dotnet-test-xunit 2.2.0-preview2-build1029
-* xunit
-* xunit.abstractions
-* xunit.assert
-* xunit.core
-* xunit.extensibility.core
-* xunit.extensibility.execution
-* xunit.runner.reporters
-* xunit.runner.utility
+ÔÇß	dotnet-test-xunit 2.2.0-preview2-build1029
+ÔÇß	xunit
+ÔÇß	xunit.abstractions
+ÔÇß	xunit.assert
+ÔÇß	xunit.core
+ÔÇß	xunit.extensibility.core
+ÔÇß	xunit.extensibility.execution
+ÔÇß	xunit.runner.reporters
+ÔÇß	xunit.runner.utility
 ----------------------------------------------------
 
 https://www.nuget.org/packages
@@ -116,343 +157,409 @@ limitations under the License.
 
 
 --------------------------------------------------
-* Microsoft.CodeAnalysis.Analyzers
-* Microsoft.CodeAnalysis.Common
-* Microsoft.CodeAnalysis.CSharp
-* Microsoft.CodeAnalysis.VisualBasic
-* Microsoft.CSharp
-* Microsoft.DiaSymReader
-* Microsoft.DiaSymReader.Native
-* Microsoft.DotNet.Cli.Utils
-* Microsoft.DotNet.InternalAbstractions
-* Microsoft.DotNet.ProjectModel
-* Microsoft.Extensions.DependencyModel
-* Microsoft.Extensions.Testing.Abstractions
-* Microsoft.NETCore
-* Microsoft.NETCore.App
-* Microsoft.NETCore.DotNetHost
-* Microsoft.NETCore.DotNetHostPolicy
-* Microsoft.NETCore.DotNetHostResolver
-* Microsoft.NETCore.Jit
-* Microsoft.NETCore.Platforms
-* Microsoft.NETCore.Portable.Compatibility
-* Microsoft.NETCore.Runtime
-* Microsoft.NETCore.Runtime.CoreCLR
-* Microsoft.NETCore.Runtime.Native
-* Microsoft.NETCore.Targets
-* Microsoft.NETCore.Windows.ApiSets
-* Microsoft.VisualBasic
-* Microsoft.Win32.Primitives
-* Microsoft.Win32.Registry
-* Microsoft.Win32.Registry.AccessControl
-* NETStandard.Library
-* runtime.any.System.Collections
-* runtime.any.System.Diagnostics.Tools
-* runtime.any.System.Diagnostics.Tracing
-* runtime.any.System.Globalization
-* runtime.any.System.Globalization.Calendars
-* runtime.any.System.IO
-* runtime.any.System.Reflection
-* runtime.any.System.Reflection.Extensions
-* runtime.any.System.Reflection.Primitives
-* runtime.any.System.Resources.ResourceManager
-* runtime.any.System.Runtime
-* runtime.any.System.Runtime.Handles
-* runtime.any.System.Runtime.InteropServices
-* runtime.any.System.Text.Encoding
-* runtime.any.System.Text.Encoding.Extensions
-* runtime.any.System.Threading.Tasks
-* runtime.any.System.Threading.Timer
-* runtime.debian.8-x64.Microsoft.NETCore.DotNetHost
-* runtime.debian.8-x64.Microsoft.NETCore.DotNetHostPolicy
-* runtime.debian.8-x64.Microsoft.NETCore.DotNetHostResolver
-* runtime.debian.8-x64.Microsoft.NETCore.Jit
-* runtime.debian.8-x64.Microsoft.NETCore.Runtime.CoreCLR
-* runtime.debian.8-x64.runtime.native.System
-* runtime.debian.8-x64.runtime.native.System.IO.Compression
-* runtime.debian.8-x64.runtime.native.System.Net.Http
-* runtime.debian.8-x64.runtime.native.System.Net.Security
-* runtime.debian.8-x64.runtime.native.System.Security.Cryptography
-* runtime.native.System
-* runtime.native.System.Data.SqlClient.sni
-* runtime.native.System.IO.Compression
-* runtime.native.System.Net.Http
-* runtime.native.System.Net.Security
-* runtime.native.System.Security.Cryptography
-* runtime.osx.10.10-x64.Microsoft.NETCore.DotNetHost
-* runtime.osx.10.10-x64.Microsoft.NETCore.DotNetHostPolicy
-* runtime.osx.10.10-x64.Microsoft.NETCore.DotNetHostResolver
-* runtime.osx.10.10-x64.Microsoft.NETCore.Jit
-* runtime.osx.10.10-x64.Microsoft.NETCore.Runtime.CoreCLR
-* runtime.osx.10.10-x64.runtime.native.System
-* runtime.osx.10.10-x64.runtime.native.System.IO.Compression
-* runtime.osx.10.10-x64.runtime.native.System.Net.Http
-* runtime.osx.10.10-x64.runtime.native.System.Net.Security
-* runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography
-* runtime.rhel.7-x64.Microsoft.NETCore.DotNetHost
-* runtime.rhel.7-x64.Microsoft.NETCore.DotNetHostPolicy
-* runtime.rhel.7-x64.Microsoft.NETCore.DotNetHostResolver
-* runtime.rhel.7-x64.Microsoft.NETCore.Jit
-* runtime.rhel.7-x64.Microsoft.NETCore.Runtime.CoreCLR
-* runtime.rhel.7-x64.runtime.native.System
-* runtime.rhel.7-x64.runtime.native.System.IO.Compression
-* runtime.rhel.7-x64.runtime.native.System.Net.Http
-* runtime.rhel.7-x64.runtime.native.System.Net.Security
-* runtime.rhel.7-x64.runtime.native.System.Security.Cryptography
-* runtime.ubuntu.14.04-x64.Microsoft.NETCore.DotNetHost
-* runtime.ubuntu.14.04-x64.Microsoft.NETCore.DotNetHostPolicy
-* runtime.ubuntu.14.04-x64.Microsoft.NETCore.DotNetHostResolver
-* runtime.ubuntu.14.04-x64.Microsoft.NETCore.Jit
-* runtime.ubuntu.14.04-x64.Microsoft.NETCore.Runtime.CoreCLR
-* runtime.ubuntu.14.04-x64.runtime.native.System
-* runtime.ubuntu.14.04-x64.runtime.native.System.IO.Compression
-* runtime.ubuntu.14.04-x64.runtime.native.System.Net.Http
-* runtime.ubuntu.14.04-x64.runtime.native.System.Net.Security
-* runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography
-* runtime.ubuntu.16.04-x64.Microsoft.NETCore.DotNetHost
-* runtime.ubuntu.16.04-x64.Microsoft.NETCore.DotNetHostPolicy
-* runtime.ubuntu.16.04-x64.Microsoft.NETCore.DotNetHostResolver
-* runtime.ubuntu.16.04-x64.Microsoft.NETCore.Jit
-* runtime.ubuntu.16.04-x64.Microsoft.NETCore.Runtime.CoreCLR
-* runtime.ubuntu.16.04-x64.runtime.native.System
-* runtime.ubuntu.16.04-x64.runtime.native.System.IO.Compression
-* runtime.ubuntu.16.04-x64.runtime.native.System.Net.Http
-* runtime.ubuntu.16.04-x64.runtime.native.System.Net.Security
-* runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography
-* runtime.unix.Microsoft.Win32.Primitives
-* runtime.unix.System.Console
-* runtime.unix.System.Diagnostics.Debug
-* runtime.unix.System.IO.FileSystem
-* runtime.unix.System.Net.Primitives
-* runtime.unix.System.Net.Sockets
-* runtime.unix.System.Private.Uri
-* runtime.unix.System.Runtime.Extensions
-* runtime.win.Microsoft.Win32.Primitives
-* runtime.win.System.Console
-* runtime.win.System.Diagnostics.Debug
-* runtime.win.System.IO.FileSystem
-* runtime.win.System.Net.Primitives
-* runtime.win.System.Net.Sockets
-* runtime.win.System.Runtime.Extensions
-* runtime.win7-x64.Microsoft.NETCore.DotNetHost
-* runtime.win7-x64.Microsoft.NETCore.DotNetHostPolicy
-* runtime.win7-x64.Microsoft.NETCore.DotNetHostResolver
-* runtime.win7-x64.Microsoft.NETCore.Jit
-* runtime.win7-x64.Microsoft.NETCore.Runtime.CoreCLR
-* runtime.win7-x64.Microsoft.NETCore.Windows.ApiSets
-* runtime.win7-x64.runtime.native.System.Data.SqlClient.sni
-* runtime.win7-x64.runtime.native.System.IO.Compression
-* runtime.win7-x86.runtime.native.System.Data.SqlClient.sni
-* runtime.win7.System.Private.Uri
-* runtime.win81-x64.Microsoft.NETCore.Windows.ApiSets
-* System.AppContext
-* System.Buffers
-* System.Collections
-* System.Collections.Concurrent
-* System.Collections.Immutable
-* System.Collections.NonGeneric
-* System.Collections.Specialized
-* System.ComponentModel
-* System.ComponentModel.Annotations
-* System.ComponentModel.EventBasedAsync
-* System.ComponentModel.Primitives
-* System.ComponentModel.TypeConverter
-* System.Console
-* System.Data.Common
-* System.Data.SqlClient
-* System.Diagnostics.Contracts
-* System.Diagnostics.Debug
-* System.Diagnostics.DiagnosticSource
-* System.Diagnostics.FileVersionInfo
-* System.Diagnostics.Process
-* System.Diagnostics.StackTrace
-* System.Diagnostics.TextWriterTraceListener
-* System.Diagnostics.Tools
-* System.Diagnostics.TraceSource
-* System.Diagnostics.Tracing
-* System.Dynamic.Runtime
-* System.Globalization
-* System.Globalization.Calendars
-* System.Globalization.Extensions
-* System.IO
-* System.IO.Compression
-* System.IO.Compression.ZipFile
-* System.IO.FileSystem
-* System.IO.FileSystem.AccessControl
-* System.IO.FileSystem.DriveInfo
-* System.IO.FileSystem.Primitives
-* System.IO.FileSystem.Watcher
-* System.IO.MemoryMappedFiles
-* System.IO.Packaging
-* System.IO.Pipes
-* System.IO.UnmanagedMemoryStream
-* System.Linq
-* System.Linq.Expressions
-* System.Linq.Parallel
-* System.Linq.Queryable
-* System.Net.Http
-* System.Net.Http.WinHttpHandler
-* System.Net.NameResolution
-* System.Net.NetworkInformation
-* System.Net.Ping
-* System.Net.Primitives
-* System.Net.Requests
-* System.Net.Security
-* System.Net.Sockets
-* System.Net.WebHeaderCollection
-* System.Net.WebSockets
-* System.Net.WebSockets.Client
-* System.Numerics.Vectors
-* System.ObjectModel
-* System.Private.DataContractSerialization
-* System.Private.ServiceModel
-* System.Private.Uri
-* System.Reflection
-* System.Reflection.DispatchProxy
-* System.Reflection.Emit
-* System.Reflection.Emit.ILGeneration
-* System.Reflection.Emit.Lightweight
-* System.Reflection.Extensions
-* System.Reflection.Metadata
-* System.Reflection.Primitives
-* System.Reflection.TypeExtensions
-* System.Resources.Reader
-* System.Resources.ResourceManager
-* System.Runtime
-* System.Runtime.CompilerServices.VisualC
-* System.Runtime.Extensions
-* System.Runtime.Handles
-* System.Runtime.InteropServices
-* System.Runtime.InteropServices.PInvoke
-* System.Runtime.InteropServices.RuntimeInformation
-* System.Runtime.Loader
-* System.Runtime.Numerics
-* System.Runtime.Serialization.Json
-* System.Runtime.Serialization.Primitives
-* System.Runtime.Serialization.Xml
-* System.Security.AccessControl
-* System.Security.Claims
-* System.Security.Cryptography.Algorithms
-* System.Security.Cryptography.Cng
-* System.Security.Cryptography.Csp
-* System.Security.Cryptography.Encoding
-* System.Security.Cryptography.OpenSsl
-* System.Security.Cryptography.Pkcs
-* System.Security.Cryptography.Primitives
-* System.Security.Cryptography.X509Certificates
-* System.Security.Principal
-* System.Security.Principal.Windows
-* System.Security.SecureString
-* System.ServiceModel.Duplex
-* System.ServiceModel.Http
-* System.ServiceModel.NetTcp
-* System.ServiceModel.Primitives
-* System.ServiceModel.Security
-* System.ServiceProcess.ServiceController
-* System.Text.Encoding
-* System.Text.Encoding.CodePages
-* System.Text.Encoding.Extensions
-* System.Text.Encodings.Web
-* System.Text.RegularExpressions
-* System.Threading
-* System.Threading.AccessControl
-* System.Threading.Overlapped
-* System.Threading.Tasks
-* System.Threading.Tasks.Dataflow
-* System.Threading.Tasks.Extensions
-* System.Threading.Tasks.Parallel
-* System.Threading.Thread
-* System.Threading.ThreadPool
-* System.Threading.Timer
-* System.Xml.ReaderWriter
-* System.Xml.XDocument
-* System.Xml.XmlDocument
-* System.Xml.XmlSerializer
-* System.Xml.XPath
-* System.Xml.XPath.XDocument
-* System.Xml.XPath.XmlDocument
+ÔÇß	Microsoft.CodeAnalysis.Analyzers
+ÔÇß	Microsoft.CodeAnalysis.Common
+ÔÇß	Microsoft.CodeAnalysis.CSharp
+ÔÇß	Microsoft.CodeAnalysis.VisualBasic
+ÔÇß	Microsoft.CSharp
+ÔÇß	Microsoft.DiaSymReader
+ÔÇß	Microsoft.DiaSymReader.Native
+ÔÇß	Microsoft.DotNet.Cli.Utils
+ÔÇß	Microsoft.DotNet.InternalAbstractions
+ÔÇß	Microsoft.DotNet.ProjectModel
+ÔÇß	Microsoft.Extensions.DependencyModel
+ÔÇß	Microsoft.Extensions.Testing.Abstractions
+ÔÇß	Microsoft.NETCore
+ÔÇß	Microsoft.NETCore.App
+ÔÇß	Microsoft.NETCore.DotNetHost
+ÔÇß	Microsoft.NETCore.DotNetHostPolicy
+ÔÇß	Microsoft.NETCore.DotNetHostResolver
+ÔÇß	Microsoft.NETCore.Jit
+ÔÇß	Microsoft.NETCore.Platforms
+ÔÇß	Microsoft.NETCore.Portable.Compatibility
+ÔÇß	Microsoft.NETCore.Runtime
+ÔÇß	Microsoft.NETCore.Runtime.CoreCLR
+ÔÇß	Microsoft.NETCore.Runtime.Native
+ÔÇß	Microsoft.NETCore.Targets
+ÔÇß	Microsoft.NETCore.Windows.ApiSets
+ÔÇß	Microsoft.VisualBasic
+ÔÇß	Microsoft.Win32.Primitives
+ÔÇß	Microsoft.Win32.Registry
+ÔÇß	Microsoft.Win32.Registry.AccessControl
+ÔÇß	NETStandard.Library
+ÔÇß	runtime.any.System.Collections
+ÔÇß	runtime.any.System.Diagnostics.Tools
+ÔÇß	runtime.any.System.Diagnostics.Tracing
+ÔÇß	runtime.any.System.Globalization
+ÔÇß	runtime.any.System.Globalization.Calendars
+ÔÇß	runtime.any.System.IO
+ÔÇß	runtime.any.System.Reflection
+ÔÇß	runtime.any.System.Reflection.Extensions
+ÔÇß	runtime.any.System.Reflection.Primitives
+ÔÇß	runtime.any.System.Resources.ResourceManager
+ÔÇß	runtime.any.System.Runtime
+ÔÇß	runtime.any.System.Runtime.Handles
+ÔÇß	runtime.any.System.Runtime.InteropServices
+ÔÇß	runtime.any.System.Text.Encoding
+ÔÇß	runtime.any.System.Text.Encoding.Extensions
+ÔÇß	runtime.any.System.Threading.Tasks
+ÔÇß	runtime.any.System.Threading.Timer
+ÔÇß	runtime.debian.8-x64.Microsoft.NETCore.DotNetHost
+ÔÇß	runtime.debian.8-x64.Microsoft.NETCore.DotNetHostPolicy
+ÔÇß	runtime.debian.8-x64.Microsoft.NETCore.DotNetHostResolver
+ÔÇß	runtime.debian.8-x64.Microsoft.NETCore.Jit
+ÔÇß	runtime.debian.8-x64.Microsoft.NETCore.Runtime.CoreCLR
+ÔÇß	runtime.debian.8-x64.runtime.native.System
+ÔÇß	runtime.debian.8-x64.runtime.native.System.IO.Compression
+ÔÇß	runtime.debian.8-x64.runtime.native.System.Net.Http
+ÔÇß	runtime.debian.8-x64.runtime.native.System.Net.Security
+ÔÇß	runtime.debian.8-x64.runtime.native.System.Security.Cryptography
+ÔÇß	runtime.native.System
+ÔÇß	runtime.native.System.Data.SqlClient.sni
+ÔÇß	runtime.native.System.IO.Compression
+ÔÇß	runtime.native.System.Net.Http
+ÔÇß	runtime.native.System.Net.Security
+ÔÇß	runtime.native.System.Security.Cryptography
+ÔÇß	runtime.osx.10.10-x64.Microsoft.NETCore.DotNetHost
+ÔÇß	runtime.osx.10.10-x64.Microsoft.NETCore.DotNetHostPolicy
+ÔÇß	runtime.osx.10.10-x64.Microsoft.NETCore.DotNetHostResolver
+ÔÇß	runtime.osx.10.10-x64.Microsoft.NETCore.Jit
+ÔÇß	runtime.osx.10.10-x64.Microsoft.NETCore.Runtime.CoreCLR
+ÔÇß	runtime.osx.10.10-x64.runtime.native.System
+ÔÇß	runtime.osx.10.10-x64.runtime.native.System.IO.Compression
+ÔÇß	runtime.osx.10.10-x64.runtime.native.System.Net.Http
+ÔÇß	runtime.osx.10.10-x64.runtime.native.System.Net.Security
+ÔÇß	runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography
+ÔÇß	runtime.rhel.7-x64.Microsoft.NETCore.DotNetHost
+ÔÇß	runtime.rhel.7-x64.Microsoft.NETCore.DotNetHostPolicy
+ÔÇß	runtime.rhel.7-x64.Microsoft.NETCore.DotNetHostResolver
+ÔÇß	runtime.rhel.7-x64.Microsoft.NETCore.Jit
+ÔÇß	runtime.rhel.7-x64.Microsoft.NETCore.Runtime.CoreCLR
+ÔÇß	runtime.rhel.7-x64.runtime.native.System
+ÔÇß	runtime.rhel.7-x64.runtime.native.System.IO.Compression
+ÔÇß	runtime.rhel.7-x64.runtime.native.System.Net.Http
+ÔÇß	runtime.rhel.7-x64.runtime.native.System.Net.Security
+ÔÇß	runtime.rhel.7-x64.runtime.native.System.Security.Cryptography
+ÔÇß	runtime.ubuntu.14.04-x64.Microsoft.NETCore.DotNetHost
+ÔÇß	runtime.ubuntu.14.04-x64.Microsoft.NETCore.DotNetHostPolicy
+ÔÇß	runtime.ubuntu.14.04-x64.Microsoft.NETCore.DotNetHostResolver
+ÔÇß	runtime.ubuntu.14.04-x64.Microsoft.NETCore.Jit
+ÔÇß	runtime.ubuntu.14.04-x64.Microsoft.NETCore.Runtime.CoreCLR
+ÔÇß	runtime.ubuntu.14.04-x64.runtime.native.System
+ÔÇß	runtime.ubuntu.14.04-x64.runtime.native.System.IO.Compression
+ÔÇß	runtime.ubuntu.14.04-x64.runtime.native.System.Net.Http
+ÔÇß	runtime.ubuntu.14.04-x64.runtime.native.System.Net.Security
+ÔÇß	runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography
+ÔÇß	runtime.ubuntu.16.04-x64.Microsoft.NETCore.DotNetHost
+ÔÇß	runtime.ubuntu.16.04-x64.Microsoft.NETCore.DotNetHostPolicy
+ÔÇß	runtime.ubuntu.16.04-x64.Microsoft.NETCore.DotNetHostResolver
+ÔÇß	runtime.ubuntu.16.04-x64.Microsoft.NETCore.Jit
+ÔÇß	runtime.ubuntu.16.04-x64.Microsoft.NETCore.Runtime.CoreCLR
+ÔÇß	runtime.ubuntu.16.04-x64.runtime.native.System
+ÔÇß	runtime.ubuntu.16.04-x64.runtime.native.System.IO.Compression
+ÔÇß	runtime.ubuntu.16.04-x64.runtime.native.System.Net.Http
+ÔÇß	runtime.ubuntu.16.04-x64.runtime.native.System.Net.Security
+ÔÇß	runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography
+ÔÇß	runtime.unix.Microsoft.Win32.Primitives
+ÔÇß	runtime.unix.System.Console
+ÔÇß	runtime.unix.System.Diagnostics.Debug
+ÔÇß	runtime.unix.System.IO.FileSystem
+ÔÇß	runtime.unix.System.Net.Primitives
+ÔÇß	runtime.unix.System.Net.Sockets
+ÔÇß	runtime.unix.System.Private.Uri
+ÔÇß	runtime.unix.System.Runtime.Extensions
+ÔÇß	runtime.win.Microsoft.Win32.Primitives
+ÔÇß	runtime.win.System.Console
+ÔÇß	runtime.win.System.Diagnostics.Debug
+ÔÇß	runtime.win.System.IO.FileSystem
+ÔÇß	runtime.win.System.Net.Primitives
+ÔÇß	runtime.win.System.Net.Sockets
+ÔÇß	runtime.win.System.Runtime.Extensions
+ÔÇß	runtime.win7-x64.Microsoft.NETCore.DotNetHost
+ÔÇß	runtime.win7-x64.Microsoft.NETCore.DotNetHostPolicy
+ÔÇß	runtime.win7-x64.Microsoft.NETCore.DotNetHostResolver
+ÔÇß	runtime.win7-x64.Microsoft.NETCore.Jit
+ÔÇß	runtime.win7-x64.Microsoft.NETCore.Runtime.CoreCLR
+ÔÇß	runtime.win7-x64.Microsoft.NETCore.Windows.ApiSets
+ÔÇß	runtime.win7-x64.runtime.native.System.Data.SqlClient.sni
+ÔÇß	runtime.win7-x64.runtime.native.System.IO.Compression
+ÔÇß	runtime.win7-x86.runtime.native.System.Data.SqlClient.sni
+ÔÇß	runtime.win7.System.Private.Uri
+ÔÇß	runtime.win81-x64.Microsoft.NETCore.Windows.ApiSets
+ÔÇß	System.AppContext
+ÔÇß	System.Buffers
+ÔÇß	System.Collections
+ÔÇß	System.Collections.Concurrent
+ÔÇß	System.Collections.Immutable
+ÔÇß	System.Collections.NonGeneric
+ÔÇß	System.Collections.Specialized
+ÔÇß	System.ComponentModel
+ÔÇß	System.ComponentModel.Annotations
+ÔÇß	System.ComponentModel.EventBasedAsync
+ÔÇß	System.ComponentModel.Primitives
+ÔÇß	System.ComponentModel.TypeConverter
+ÔÇß	System.Console
+ÔÇß	System.Data.Common
+ÔÇß	System.Data.SqlClient
+ÔÇß	System.Diagnostics.Contracts
+ÔÇß	System.Diagnostics.Debug
+ÔÇß	System.Diagnostics.DiagnosticSource
+ÔÇß	System.Diagnostics.FileVersionInfo
+ÔÇß	System.Diagnostics.Process
+ÔÇß	System.Diagnostics.StackTrace
+ÔÇß	System.Diagnostics.TextWriterTraceListener
+ÔÇß	System.Diagnostics.Tools
+ÔÇß	System.Diagnostics.TraceSource
+ÔÇß	System.Diagnostics.Tracing
+ÔÇß	System.Dynamic.Runtime
+ÔÇß	System.Globalization
+ÔÇß	System.Globalization.Calendars
+ÔÇß	System.Globalization.Extensions
+ÔÇß	System.IO
+ÔÇß	System.IO.Compression
+ÔÇß	System.IO.Compression.ZipFile
+ÔÇß	System.IO.FileSystem
+ÔÇß	System.IO.FileSystem.AccessControl
+ÔÇß	System.IO.FileSystem.DriveInfo
+ÔÇß	System.IO.FileSystem.Primitives
+ÔÇß	System.IO.FileSystem.Watcher
+ÔÇß	System.IO.MemoryMappedFiles
+ÔÇß	System.IO.Packaging
+ÔÇß	System.IO.Pipes
+ÔÇß	System.IO.UnmanagedMemoryStream
+ÔÇß	System.Linq
+ÔÇß	System.Linq.Expressions
+ÔÇß	System.Linq.Parallel
+ÔÇß	System.Linq.Queryable
+ÔÇß	System.Net.Http
+ÔÇß	System.Net.Http.WinHttpHandler
+ÔÇß	System.Net.NameResolution
+ÔÇß	System.Net.NetworkInformation
+ÔÇß	System.Net.Ping
+ÔÇß	System.Net.Primitives
+ÔÇß	System.Net.Requests
+ÔÇß	System.Net.Security
+ÔÇß	System.Net.Sockets
+ÔÇß	System.Net.WebHeaderCollection
+ÔÇß	System.Net.WebSockets
+ÔÇß	System.Net.WebSockets.Client
+ÔÇß	System.Numerics.Vectors
+ÔÇß	System.ObjectModel
+ÔÇß	System.Private.DataContractSerialization
+ÔÇß	System.Private.ServiceModel
+ÔÇß	System.Private.Uri
+ÔÇß	System.Reflection
+ÔÇß	System.Reflection.DispatchProxy
+ÔÇß	System.Reflection.Emit
+ÔÇß	System.Reflection.Emit.ILGeneration
+ÔÇß	System.Reflection.Emit.Lightweight
+ÔÇß	System.Reflection.Extensions
+ÔÇß	System.Reflection.Metadata
+ÔÇß	System.Reflection.Primitives
+ÔÇß	System.Reflection.TypeExtensions
+ÔÇß	System.Resources.Reader
+ÔÇß	System.Resources.ResourceManager
+ÔÇß	System.Runtime
+ÔÇß	System.Runtime.CompilerServices.VisualC
+ÔÇß	System.Runtime.Extensions
+ÔÇß	System.Runtime.Handles
+ÔÇß	System.Runtime.InteropServices
+ÔÇß	System.Runtime.InteropServices.PInvoke
+ÔÇß	System.Runtime.InteropServices.RuntimeInformation
+ÔÇß	System.Runtime.Loader
+ÔÇß	System.Runtime.Numerics
+ÔÇß	System.Runtime.Serialization.Json
+ÔÇß	System.Runtime.Serialization.Primitives
+ÔÇß	System.Runtime.Serialization.Xml
+ÔÇß	System.Security.AccessControl
+ÔÇß	System.Security.Claims
+ÔÇß	System.Security.Cryptography.Algorithms
+ÔÇß	System.Security.Cryptography.Cng
+ÔÇß	System.Security.Cryptography.Csp
+ÔÇß	System.Security.Cryptography.Encoding
+ÔÇß	System.Security.Cryptography.OpenSsl
+ÔÇß	System.Security.Cryptography.Pkcs
+ÔÇß	System.Security.Cryptography.Primitives
+ÔÇß	System.Security.Cryptography.X509Certificates
+ÔÇß	System.Security.Principal
+ÔÇß	System.Security.Principal.Windows
+ÔÇß	System.Security.SecureString
+ÔÇß	System.ServiceModel.Duplex
+ÔÇß	System.ServiceModel.Http
+ÔÇß	System.ServiceModel.NetTcp
+ÔÇß	System.ServiceModel.Primitives
+ÔÇß	System.ServiceModel.Security
+ÔÇß	System.ServiceProcess.ServiceController
+ÔÇß	System.Text.Encoding
+ÔÇß	System.Text.Encoding.CodePages
+ÔÇß	System.Text.Encoding.Extensions
+ÔÇß	System.Text.Encodings.Web
+ÔÇß	System.Text.RegularExpressions
+ÔÇß	System.Threading
+ÔÇß	System.Threading.AccessControl
+ÔÇß	System.Threading.Overlapped
+ÔÇß	System.Threading.Tasks
+ÔÇß	System.Threading.Tasks.Dataflow
+ÔÇß	System.Threading.Tasks.Extensions
+ÔÇß	System.Threading.Tasks.Parallel
+ÔÇß	System.Threading.Thread
+ÔÇß	System.Threading.ThreadPool
+ÔÇß	System.Threading.Timer
+ÔÇß	System.Xml.ReaderWriter
+ÔÇß	System.Xml.XDocument
+ÔÇß	System.Xml.XmlDocument
+ÔÇß	System.Xml.XmlSerializer
+ÔÇß	System.Xml.XPath
+ÔÇß	System.Xml.XPath.XDocument
+ÔÇß	System.Xml.XPath.XmlDocument
 -------------------------------------------------------
 
 MICROSOFT SOFTWARE LICENSE TERMS 
 MICROSOFT .NET LIBRARY 
-These license terms are an agreement between Microsoft Corporation (or based on where you live, one of its affiliates) and you. Please read them. They apply to the software named above, which includes the media on which you received it, if any. The terms also apply to any Microsoft 
-*†††††††††updates, 
-*†††††††††supplements, 
-*††††††††† Internet-based services, and 
-*††††††††† support services 
+These license terms are an agreement between Microsoft Corporation (or based on where you 
+live, one of its affiliates) and you. Please read them. They apply to the software named above, 
+which includes the media on which you received it, if any. The terms also apply to any Microsoft 
+‚Ä¢         updates, 
+‚Ä¢         supplements, 
+‚Ä¢          Internet-based services, and 
+‚Ä¢          support services 
 for this software, unless other terms accompany those items. If so, those terms apply. 
-BY USING THE SOFTWARE, YOU ACCEPT THESE TERMS. IF YOU DO NOT ACCEPT THEM, DO NOT USE THE SOFTWARE. 
+BY USING THE SOFTWARE, YOU ACCEPT THESE TERMS. IF YOU DO NOT ACCEPT THEM, DO NOT 
+USE THE SOFTWARE. 
 IF YOU COMPLY WITH THESE LICENSE TERMS, YOU HAVE THE PERPETUAL RIGHTS BELOW. 
-1. †††† INSTALLATION AND USE RIGHTS. 
-a. †††† Installation and Use. †You may install and use any number of copies of the software to design, develop and test your programs. 
-b. †††† Third Party Programs. †The software may include third party programs that Microsoft, not the third party, licenses to you under this agreement. Notices, if any, for the third party program are included for your information only. 
-2. †††† DATA.† The software may collect information about you and your use of the software, and send that to Microsoft. Microsoft may use this information to improve our products and services.†You can learn more about data collection and use in the help documentation and the privacy statement at† http://go.microsoft.com/fwlink/?LinkId=528096 . Your use of the software operates as your consent to these practices. 
-3. †††† ADDITIONAL LICENSING REQUIREMENTS AND/OR USE RIGHTS. 
-a. †††† DISTRIBUTABLE CODE.†† The software is comprised of Distributable Code. ìDistributable Codeî is code that you are permitted to distribute in programs you develop if you comply with the terms below. 
-i . †††††† Right to Use and Distribute. 
-*††††††††† You may copy and distribute the object code form of the software. 
-*††††††††† Third Party Distribution. You may permit distributors of your programs to copy and distribute the Distributable Code as part of those programs. 
-ii. †††† Distribution Requirements. † For any Distributable Code you distribute, you must 
-*††††††††† add significant primary functionality to it in your programs; 
-*††††††††† require distributors and external end users to agree to terms that protect it at least as much as this agreement; 
-*††††††††† display your valid copyright notice on your programs; and 
-*††††††††† indemnify, defend, and hold harmless Microsoft from any claims, including attorneysí fees, related to the distribution or use of your programs. 
-iii. ††† Distribution Restrictions. †You may not 
-*††††††††† alter any copyright, trademark or patent notice in the Distributable Code; 
-*††††††††† use Microsoftís trademarks in your programsí names or in a way that suggests your programs come from or are endorsed by Microsoft; 
-*††††††††† include Distributable Code in malicious, deceptive or unlawful programs; or 
-*††††††††† modify or distribute the source code of any Distributable Code so that any part of it becomes subject to an Excluded License. An Excluded License is one that requires, as a condition of use, modification or distribution, that 
-*††††††††† the code be disclosed or distributed in source code form; or 
-*††††††††† others have the right to modify it. 
-4. †††† SCOPE OF LICENSE.† The software is licensed, not sold. This agreement only gives you some rights to use the software. Microsoft reserves all other rights. Unless applicable law gives you more rights despite this limitation, you may use the software only as expressly permitted in this agreement. In doing so, you must comply with any technical limitations in the software that only allow you to use it in certain ways. You may not 
-*††††††††† work around any technical limitations in the software; 
-*††††††††† reverse engineer, decompile or disassemble the software, except and only to the extent that applicable law expressly permits, despite this limitation; 
-*††††††††† publish the software for others to copy; 
-*††††††††† rent, lease or lend the software; 
-*††††††††† transfer the software or this agreement to any third party; or 
-*††††††††† use the software for commercial software hosting services. 
-5. †††† BACKUP COPY.† You may make one backup copy of the software. You may use it only to reinstall the software. 
-6. †††† DOCUMENTATION.† Any person that has valid access to your computer or internal network may copy and use the documentation for your internal, reference purposes. 
-7. †††† EXPORT RESTRICTIONS.† The software is subject to United States export laws and regulations. You must comply with all domestic and international export laws and regulations that apply to the software. These laws include restrictions on destinations, end users and end use. For additional information, see† www.microsoft.com/exporting. 
-8. †††† SUPPORT SERVICES.† Because this software is ìas is,î we may not provide support services for it. 
-9. †††† ENTIRE AGREEMENT.† This agreement, and the terms for supplements, updates, Internet-based services and support services that you use, are the entire agreement for the software and support services. 
-10. ††† APPLICABLE LAW. 
-a. †††† United States.† If you acquired the software in the United States, Washington state law governs the interpretation of this agreement and applies to claims for breach of it, regardless of conflict of laws principles. The laws of the state where you live govern all other claims, including claims under state consumer protection laws, unfair competition laws, and in tort. 
-b. †††† Outside the United States. If you acquired the software in any other country, the laws of that country apply. 
-11. †† LEGAL EFFECT.† This agreement describes certain legal rights. You may have other rights under the laws of your country. You may also have rights with respect to the party from whom you acquired the software. This agreement does not change your rights under the laws of your country if the laws of your country do not permit it to do so. 
-12. †† DISCLAIMER OF WARRANTY. THE SOFTWARE IS LICENSED ìAS-IS.î YOU BEAR THE RISK OF USING IT. MICROSOFT GIVES NO EXPRESS WARRANTIES, GUARANTEES OR CONDITIONS. YOU MAY HAVE ADDITIONAL CONSUMER RIGHTS OR STATUTORY GUARANTEES UNDER YOUR LOCAL LAWS WHICH THIS AGREEMENT CANNOT CHANGE. TO THE EXTENT PERMITTED UNDER YOUR LOCAL LAWS, MICROSOFT EXCLUDES THE IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. 
-FOR AUSTRALIA ñ YOU HAVE STATUTORY GUARANTEES UNDER THE AUSTRALIAN CONSUMER LAW AND NOTHING IN THESE TERMS IS INTENDED TO AFFECT THOSE RIGHTS. 
-13. †† LIMITATION ON AND EXCLUSION OF REMEDIES AND DAMAGES. YOU CAN RECOVER FROM MICROSOFT AND ITS SUPPLIERS ONLY DIRECT DAMAGES UP TO U.S. $5.00. YOU CANNOT RECOVER ANY OTHER DAMAGES, INCLUDING CONSEQUENTIAL, LOST PROFITS, SPECIAL, INDIRECT OR INCIDENTAL DAMAGES. 
+1.      INSTALLATION AND USE RIGHTS. 
+a.      Installation and Use.  You may install and use any number of copies of the software to design, 
+develop and test your programs. 
+b.      Third Party Programs.  The software may include third party programs that Microsoft, not the 
+third party, licenses to you under this agreement. Notices, if any, for the third party program are 
+included for your information only. 
+2.      DATA.  The software may collect information about you and your use of the software, and send that 
+to Microsoft. Microsoft may use this information to improve our products and services. You can learn 
+more about data collection and use in the help documentation and the privacy statement 
+at  http://go.microsoft.com/fwlink/?LinkId=528096 . Your use of the software operates as your 
+consent to these practices. 
+3.      ADDITIONAL LICENSING REQUIREMENTS AND/OR USE RIGHTS. 
+a.      DISTRIBUTABLE CODE.   The software is comprised of Distributable Code. ‚ÄúDistributable 
+Code‚Äù is code that you are permitted to distribute in programs you develop if you comply with 
+the terms below. 
+i .        Right to Use and Distribute. 
+‚Ä¢          You may copy and distribute the object code form of the software. 
+‚Ä¢          Third Party Distribution. You may permit distributors of your programs to copy and 
+distribute the Distributable Code as part of those programs. 
+ii.      Distribution Requirements.   For any Distributable Code you distribute, you must 
+‚Ä¢          add significant primary functionality to it in your programs; 
+‚Ä¢          require distributors and external end users to agree to terms that protect it at least as 
+much as this agreement; 
+‚Ä¢          display your valid copyright notice on your programs; and 
+‚Ä¢          indemnify, defend, and hold harmless Microsoft from any claims, including attorneys‚Äô 
+fees, related to the distribution or use of your programs. 
+iii.     Distribution Restrictions.  You may not 
+‚Ä¢          alter any copyright, trademark or patent notice in the Distributable Code; 
+‚Ä¢          use Microsoft‚Äôs trademarks in your programs‚Äô names or in a way that suggests your 
+programs come from or are endorsed by Microsoft; 
+‚Ä¢          include Distributable Code in malicious, deceptive or unlawful programs; or 
+‚Ä¢          modify or distribute the source code of any Distributable Code so that any part of it 
+becomes subject to an Excluded License. An Excluded License is one that requires, as a 
+condition of use, modification or distribution, that 
+‚Ä¢          the code be disclosed or distributed in source code form; or 
+‚Ä¢          others have the right to modify it. 
+4.      SCOPE OF LICENSE.  The software is licensed, not sold. This agreement only gives you some rights to 
+use the software. Microsoft reserves all other rights. Unless applicable law gives you more rights despite 
+this limitation, you may use the software only as expressly permitted in this agreement. In doing so, you 
+must comply with any technical limitations in the software that only allow you to use it in certain ways. 
+You may not 
+‚Ä¢          work around any technical limitations in the software; 
+‚Ä¢          reverse engineer, decompile or disassemble the software, except and only to the extent that 
+applicable law expressly permits, despite this limitation; 
+‚Ä¢          publish the software for others to copy; 
+‚Ä¢          rent, lease or lend the software; 
+‚Ä¢          transfer the software or this agreement to any third party; or 
+‚Ä¢          use the software for commercial software hosting services. 
+5.      BACKUP COPY.  You may make one backup copy of the software. You may use it only to reinstall the 
+software. 
+6.      DOCUMENTATION.  Any person that has valid access to your computer or internal network may copy 
+and use the documentation for your internal, reference purposes. 
+7.      EXPORT RESTRICTIONS.  The software is subject to United States export laws and regulations. You 
+must comply with all domestic and international export laws and regulations that apply to the software. 
+These laws include restrictions on destinations, end users and end use. For additional information, 
+see  www.microsoft.com/exporting. 
+8.      SUPPORT SERVICES.  Because this software is ‚Äúas is,‚Äù we may not provide support services for it. 
+9.      ENTIRE AGREEMENT.  This agreement, and the terms for supplements, updates, Internet-based 
+services and support services that you use, are the entire agreement for the software and support 
+services. 
+10.     APPLICABLE LAW. 
+a.      United States.  If you acquired the software in the United States, Washington state law governs the 
+interpretation of this agreement and applies to claims for breach of it, regardless of conflict of laws 
+principles. The laws of the state where you live govern all other claims, including claims under state 
+consumer protection laws, unfair competition laws, and in tort. 
+b.      Outside the United States. If you acquired the software in any other country, the laws of 
+that country apply. 
+11.    LEGAL EFFECT.  This agreement describes certain legal rights. You may have other rights under the 
+laws of your country. You may also have rights with respect to the party from whom you acquired the 
+software. This agreement does not change your rights under the laws of your country if the laws of your 
+country do not permit it to do so. 
+12.    DISCLAIMER OF WARRANTY. THE SOFTWARE IS LICENSED ‚ÄúAS-IS.‚Äù YOU BEAR THE RISK OF 
+USING IT. MICROSOFT GIVES NO EXPRESS WARRANTIES, GUARANTEES OR CONDITIONS. 
+YOU MAY HAVE ADDITIONAL CONSUMER RIGHTS OR STATUTORY GUARANTEES UNDER YOUR 
+LOCAL LAWS WHICH THIS AGREEMENT CANNOT CHANGE. TO THE EXTENT PERMITTED 
+UNDER YOUR LOCAL LAWS, MICROSOFT EXCLUDES THE IMPLIED WARRANTIES OF 
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. 
+FOR AUSTRALIA ‚Äì YOU HAVE STATUTORY GUARANTEES UNDER THE AUSTRALIAN CONSUMER 
+LAW AND NOTHING IN THESE TERMS IS INTENDED TO AFFECT THOSE RIGHTS. 
+13.    LIMITATION ON AND EXCLUSION OF REMEDIES AND DAMAGES. YOU CAN RECOVER FROM 
+MICROSOFT AND ITS SUPPLIERS ONLY DIRECT DAMAGES UP TO U.S. $5.00. YOU CANNOT 
+RECOVER ANY OTHER DAMAGES, INCLUDING CONSEQUENTIAL, LOST PROFITS, SPECIAL, 
+INDIRECT OR INCIDENTAL DAMAGES. 
 This limitation applies to 
-*††††††††† anything related to the software, services, content (including code) on third party Internet sites, or third party programs; and 
-*††††††††† claims for breach of contract, breach of warranty, guarantee or condition, strict liability, negligence, or other tort to the extent permitted by applicable law. 
-It also applies even if Microsoft knew or should have known about the possibility of the damages. The above limitation or exclusion may not apply to you because your country may not allow the exclusion or limitation of incidental, consequential or other damages. 
-Please note: As this software is distributed in Quebec, Canada, some of the clauses in this agreement are provided below in French. 
-Remarque : Ce logiciel Ètant distribuÈ au QuÈbec, Canada, certaines des clauses dans ce contrat sont fournies ci-dessous en franÁais. 
-EXON…RATION DE GARANTIE.† Le logiciel visÈ par une licence est offert ´ tel quel ª. Toute utilisation de ce logiciel est ‡ votre seule risque et pÈril. Microsoft níaccorde aucune autre garantie expresse. Vous pouvez bÈnÈficier de droits additionnels en vertu du droit local sur la protection des consommateurs, que ce contrat ne peut modifier. La ou elles sont permises par le droit locale, les garanties implicites de qualitÈ marchande, díadÈquation ‡ un usage particulier et díabsence de contrefaÁon sont exclues. 
-LIMITATION DES DOMMAGES-INT…R TS ET EXCLUSION DE RESPONSABILIT… POUR LES DOMMAGES.† Vous pouvez obtenir de Microsoft et de ses fournisseurs une indemnisation en cas de dommages directs uniquement ‡ hauteur de 5,00 $ US. Vous ne pouvez prÈtendre ‡ aucune indemnisation pour les autres dommages, y compris les dommages spÈciaux, indirects ou accessoires et pertes de bÈnÈfices. 
+‚Ä¢          anything related to the software, services, content (including code) on third party Internet sites, or 
+third party programs; and 
+‚Ä¢          claims for breach of contract, breach of warranty, guarantee or condition, strict liability, negligence, 
+or other tort to the extent permitted by applicable law. 
+It also applies even if Microsoft knew or should have known about the possibility of the damages. The above 
+limitation or exclusion may not apply to you because your country may not allow the exclusion or limitation of 
+incidental, consequential or other damages. 
+Please note: As this software is distributed in Quebec, Canada, some of the clauses in this agreement are 
+provided below in French. 
+Remarque : Ce logiciel √©tant distribu√© au Qu√©bec, Canada, certaines des clauses dans ce contrat sont fournies 
+ci-dessous en fran√ßais. 
+EXON√âRATION DE GARANTIE.  Le logiciel vis√© par une licence est offert ¬´ tel quel ¬ª. Toute utilisation de ce 
+logiciel est √† votre seule risque et p√©ril. Microsoft n‚Äôaccorde aucune autre garantie expresse. Vous pouvez 
+b√©n√©ficier de droits additionnels en vertu du droit local sur la protection des consommateurs, que ce contrat ne 
+peut modifier. La ou elles sont permises par le droit locale, les garanties implicites de qualit√© marchande, 
+d‚Äôad√©quation √† un usage particulier et d‚Äôabsence de contrefa√ßon sont exclues. 
+LIMITATION DES DOMMAGES-INT√âR√äTS ET EXCLUSION DE RESPONSABILIT√â POUR LES 
+DOMMAGES.  Vous pouvez obtenir de Microsoft et de ses fournisseurs une indemnisation en cas de 
+dommages directs uniquement √† hauteur de 5,00 $ US. Vous ne pouvez pr√©tendre √† aucune indemnisation 
+pour les autres dommages, y compris les dommages sp√©ciaux, indirects ou accessoires et pertes de b√©n√©fices. 
 Cette limitationconcerne: 
-*††††††††† tout ce qui est reliÈ au logiciel, aux services ou au contenu (y compris le code) figurant sur des sites Internet tiers ou dans des programmes tiers ; et 
-*††††††††† les rÈclamations au titre de violation de contrat ou de garantie, ou au titre de responsabilitÈ stricte, de nÈgligence ou díune autre faute dans la limite autorisÈe par la loi en vigueur. 
-Elle síapplique Ègalement, mÍme si Microsoft connaissait ou devrait connaÓtre líÈventualitÈ díun tel dommage. Si votre pays níautorise pas líexclusion ou la limitation de responsabilitÈ pour les dommages indirects, accessoires ou de quelque nature que ce soit, il se peut que la limitation ou líexclusion ci-dessus ne síappliquera pas ‡ votre Ègard. 
-EFFET JURIDIQUE.† Le prÈsent contrat dÈcrit certains droits juridiques. Vous pourriez avoir díautres droits prÈvus par les lois de votre pays. Le prÈsent contrat ne modifie pas les droits que vous confËrent les lois de votre pays si celles-ci ne le permettent pas. 
+‚Ä¢          tout ce qui est reli√© au logiciel, aux services ou au contenu (y compris le code) figurant sur des 
+sites Internet tiers ou dans des programmes tiers ; et 
+‚Ä¢          les r√©clamations au titre de violation de contrat ou de garantie, ou au titre de responsabilit√© 
+stricte, de n√©gligence ou d‚Äôune autre faute dans la limite autoris√©e par la loi en vigueur. 
+Elle s‚Äôapplique √©galement, m√™me si Microsoft connaissait ou devrait conna√Ætre l‚Äô√©ventualit√© d‚Äôun tel dommage. 
+Si votre pays n‚Äôautorise pas l‚Äôexclusion ou la limitation de responsabilit√© pour les dommages indirects, 
+accessoires ou de quelque nature que ce soit, il se peut que la limitation ou l‚Äôexclusion ci-dessus ne 
+s‚Äôappliquera pas √† votre √©gard. 
+EFFET JURIDIQUE.  Le pr√©sent contrat d√©crit certains droits juridiques. Vous pourriez avoir d‚Äôautres droits 
+pr√©vus par les lois de votre pays. Le pr√©sent contrat ne modifie pas les droits que vous conf√®rent les lois de 
+votre pays si celles-ci ne le permettent pas. 
 
 
 --------------------------------------------------------
-* NuGet.Common
-* NuGet.Configuration
-* NuGet.DependencyResolver.Core
-* NuGet.Frameworks
-* NuGet.LibraryModel
-* NuGet.Packaging
-* NuGet.Packaging.Core
-* NuGet.Packaging.Core.Types
-* NuGet.ProjectModel
-* NuGet.Protocol.Core.Types
-* NuGet.Protocol.Core.v3
-* NuGet.Repositories
-* NuGet.RuntimeModel
-* NuGet.Versioning
+ÔÇß	NuGet.Common
+ÔÇß	NuGet.Configuration
+ÔÇß	NuGet.DependencyResolver.Core
+ÔÇß	NuGet.Frameworks
+ÔÇß	NuGet.LibraryModel
+ÔÇß	NuGet.Packaging
+ÔÇß	NuGet.Packaging.Core
+ÔÇß	NuGet.Packaging.Core.Types
+ÔÇß	NuGet.ProjectModel
+ÔÇß	NuGet.Protocol.Core.Types
+ÔÇß	NuGet.Protocol.Core.v3
+ÔÇß	NuGet.Repositories
+ÔÇß	NuGet.RuntimeModel
+ÔÇß	NuGet.Versioning
 ----------------------------------------------------------
 
 Copyright (c) .NET Foundation. All rights reserved.
@@ -470,58 +577,147 @@ specific language governing permissions and limitations under the License.
 
 
 ---------------------------------------------------------
-* Microsoft.Management.Infrastructure.dll
-* Microsoft.Management.Infrastructure.Native.dll
-* Microsoft.Management.Infrastructure.Unmanaged.dll
+ÔÇß	Microsoft.Management.Infrastructure.dll
+ÔÇß	Microsoft.Management.Infrastructure.Native.dll
+ÔÇß	Microsoft.Management.Infrastructure.Unmanaged.dll
 ----------------------------------------------------------
 MICROSOFT SOFTWARE LICENSE TERMS
 MANAGEMENT.INFRASTRUCTURE.DLL 
-MANAGEMENT.INFRASTRUCTURE.NATIVE.DLL MANAGEMENT.INFRASTRUCTURE.UNMANAGED.DLL
+MANAGEMENT.INFRASTRUCTURE.NATIVE.DLL 
+MANAGEMENT.INFRASTRUCTURE.UNMANAGED.DLL
+ 
+These license terms are an agreement between you and Microsoft Corporation (or one of its affiliates). They 
+apply to the software named above and any Microsoft services or software updates (except to the extent such 
+services or updates are accompanied by new or additional terms, in which case those different terms apply 
+prospectively and do not alter your or Microsoft‚Äôs rights relating to pre-updated software or services). IF YOU 
+COMPLY WITH THESE LICENSE TERMS, YOU HAVE THE RIGHTS BELOW. BY USING THE SOFTWARE, YOU 
+ACCEPT THESE TERMS.
+1.	INSTALLATION AND USE RIGHTS
+a)	General. You may install and use any number of copies of the software on your devices.
+b)	Included Microsoft Applications. The software may include other Microsoft applications. These 
+license terms apply to those included applications, if any, unless other license terms are provided with 
+the other Microsoft applications.
+c)	Third Party Software. The software may include third party applications that are licensed to you 
+under this agreement or under their own terms. License terms, notices, and acknowledgements, if any, 
+for the third party applications may be accessible online at http://aka.ms/thirdpartynotices or in an 
+accompanying notices file. Even if such applications are governed by other agreements, the disclaimer, 
+limitations on, and exclusions of damages below also apply to the extent allowed by applicable law.
+2.	TIME-SENSITIVE SOFTWARE
+a)	Period. The software is time-sensitive and may stop running on a date that is defined in the software.
+b)	Notice. You may receive periodic reminder notices of this date through the software.
+c)	Access to data. You may not be able to access data used in the software when it stops running.
+3.	PRE-RELEASE SOFTWARE. The software is a pre-release version. It may not operate correctly. It may be 
+different from the commercially released version.
+4.	FEEDBACK. If you give feedback about the software to Microsoft, you give to Microsoft, without charge, 
+the right to use, share and commercialize your feedback in any way and for any purpose. You will not give 
+feedback that is subject to a license that requires Microsoft to license its software or documentation to 
+third parties because Microsoft includes your feedback in them. These rights survive this agreement.
+5.	DATA COLLECTION. The software may collect information about you and your use of the software and 
+send that to Microsoft. Microsoft may use this information to provide services and improve Microsoft‚Äôs 
+products and services. Your opt-out rights, if any, are described in the product documentation. Some 
+features in the software may enable collection of data from users of your applications that access or use the 
+software. If you use these features to enable data collection in your applications, you must comply with 
+applicable law, including getting any required user consent, and maintain a prominent privacy policy that 
+accurately informs users about how you use, collect, and share their data. You can learn more about 
+Microsoft‚Äôs data collection and use in the product documentation and the Microsoft Privacy Statement at 
+https://go.microsoft.com/fwlink/?LinkId=521839. You agree to comply with all applicable provisions of the 
+Microsoft Privacy Statement.
+6.	FONTS. While the software is running, you may use its fonts to display and print content. You may only (i) 
+embed fonts in content as permitted by the embedding restrictions in the fonts; and (ii) temporarily 
+download them to a printer or other output device to help print content.
+7.	SCOPE OF LICENSE. The software is licensed, not sold. Microsoft reserves all other rights. Unless applicable 
+law gives you more rights despite this limitation, you will not (and have no right to):
+a)	work around any technical limitations in the software that only allow you to use it in certain ways;
+b)	reverse engineer, decompile or disassemble the software;
+c)	remove, minimize, block, or modify any notices of Microsoft or its suppliers in the software;
+d)	use the software in any way that is against the law or to create or propagate malware; or
+e)	share, publish, distribute, or lend the software, provide the software as a stand-alone hosted solution 
+for others to use, or transfer the software or this agreement to any third party.
+8.	EXPORT RESTRICTIONS. You must comply with all domestic and international export laws and regulations 
+that apply to the software, which include restrictions on destinations, end users, and end use. For further 
+information on export restrictions, visit http://aka.ms/exporting.
+9.	SUPPORT SERVICES. Microsoft is not obligated under this agreement to provide any support services for 
+the software. Any support provided is ‚Äúas is‚Äù, ‚Äúwith all faults‚Äù, and without warranty of any kind.
+10.	UPDATES. The software may periodically check for updates, and download and install them for you. You 
+may obtain updates only from Microsoft or authorized sources. Microsoft may need to update your system 
+to provide you with updates. You agree to receive these automatic updates without any additional notice. 
+Updates may not include or support all existing software features, services, or peripheral devices.
+11.	ENTIRE AGREEMENT. This agreement, and any other terms Microsoft may provide for supplements, 
+updates, or third-party applications, is the entire agreement for the software.
+12.	APPLICABLE LAW AND PLACE TO RESOLVE DISPUTES. If you acquired the software in the United States 
+or Canada, the laws of the state or province where you live (or, if a business, where your principal place of 
+business is located) govern the interpretation of this agreement, claims for its breach, and all other claims 
+(including consumer protection, unfair competition, and tort claims), regardless of conflict of laws 
+principles. If you acquired the software in any other country, its laws apply. If U.S. federal jurisdiction exists, 
+you and Microsoft consent to exclusive jurisdiction and venue in the federal court in King County, 
+Washington for all disputes heard in court. If not, you and Microsoft consent to exclusive jurisdiction and 
+venue in the Superior Court of King County, Washington for all disputes heard in court.
+13.	CONSUMER RIGHTS; REGIONAL VARIATIONS. This agreement describes certain legal rights. You may 
+have other rights, including consumer rights, under the laws of your state, province, or country. Separate 
+and apart from your relationship with Microsoft, you may also have rights with respect to the party from 
+which you acquired the software. This agreement does not change those other rights if the laws of your 
+state, province, or country do not permit it to do so. For example, if you acquired the software in one of the 
+below regions, or mandatory country law applies, then the following provisions apply to you:
+a)	Australia. You have statutory guarantees under the Australian Consumer Law and nothing in this 
+agreement is intended to affect those rights.
+b)	Canada. If you acquired this software in Canada, you may stop receiving updates by turning off the 
+automatic update feature, disconnecting your device from the Internet (if and when you re-connect to 
+the Internet, however, the software will resume checking for and installing updates), or uninstalling the 
+software. The product documentation, if any, may also specify how to turn off updates for your specific 
+device or software.
+c)	Germany and Austria.
+i.	Warranty. The properly licensed software will perform substantially as described in 
+any Microsoft materials that accompany the software. However, Microsoft gives no 
+contractual guarantee in relation to the licensed software.
+ii.	Limitation of Liability. In case of intentional conduct, gross negligence, claims based 
+on the Product Liability Act, as well as, in case of death or personal or physical injury, 
+Microsoft is liable according to the statutory law.
+Subject to the foregoing clause ii., Microsoft will only be liable for slight negligence if Microsoft is in 
+breach of such material contractual obligations, the fulfillment of which facilitate the due performance 
+of this agreement, the breach of which would endanger the purpose of this agreement and the 
+compliance with which a party may constantly trust in (so-called "cardinal obligations"). In other cases 
+of slight negligence, Microsoft will not be liable for slight negligence.
+14.	DISCLAIMER OF WARRANTY. THE SOFTWARE IS LICENSED ‚ÄúAS IS.‚Äù YOU BEAR THE RISK OF USING 
+IT. MICROSOFT GIVES NO EXPRESS WARRANTIES, GUARANTEES, OR CONDITIONS. TO THE EXTENT 
+PERMITTED UNDER APPLICABLE LAWS, MICROSOFT EXCLUDES ALL IMPLIED WARRANTIES, 
+INCLUDING MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NON-INFRINGEMENT.
+15.	LIMITATION ON AND EXCLUSION OF DAMAGES. IF YOU HAVE ANY BASIS FOR RECOVERING 
+DAMAGES DESPITE THE PRECEDING DISCLAIMER OF WARRANTY, YOU CAN RECOVER FROM 
+MICROSOFT AND ITS SUPPLIERS ONLY DIRECT DAMAGES UP TO U.S. $5.00. YOU CANNOT RECOVER 
+ANY OTHER DAMAGES, INCLUDING CONSEQUENTIAL, LOST PROFITS, SPECIAL, INDIRECT OR 
+INCIDENTAL DAMAGES.
+This limitation applies to (a) anything related to the software, services, content (including code) on 
+third party Internet sites, or third party applications; and (b) claims for breach of contract, warranty, 
+guarantee, or condition; strict liability, negligence, or other tort; or any other claim; in each case to 
+the extent permitted by applicable law.
+It also applies even if Microsoft knew or should have known about the possibility of the damages. 
+The above limitation or exclusion may not apply to you because your state, province, or country 
+may not allow the exclusion or limitation of incidental, consequential, or other damages.
 
-These license terms are an agreement between you and Microsoft Corporation (or one of its affiliates). They apply to the software named above and any Microsoft services or software updates (except to the extent such services or updates are accompanied by new or additional terms, in which case those different terms apply prospectively and do not alter your or Microsoftís rights relating to pre-updated software or services). IF YOU COMPLY WITH THESE LICENSE TERMS, YOU HAVE THE RIGHTS BELOW. BY USING THE SOFTWARE, YOU ACCEPT THESE TERMS.
-1. INSTALLATION AND USE RIGHTS
-a) General. You may install and use any number of copies of the software on your devices.
-b) Included Microsoft Applications. The software may include other Microsoft applications. These license terms apply to those included applications, if any, unless other license terms are provided with the other Microsoft applications.
-c) Third Party Software. The software may include third party applications that are licensed to you under this agreement or under their own terms. License terms, notices, and acknowledgements, if any, for the third party applications may be accessible online at http://aka.ms/thirdpartynotices or in an accompanying notices file. Even if such applications are governed by other agreements, the disclaimer, limitations on, and exclusions of damages below also apply to the extent allowed by applicable law.
-2. TIME-SENSITIVE SOFTWARE
-a) Period. The software is time-sensitive and may stop running on a date that is defined in the software.
-b) Notice. You may receive periodic reminder notices of this date through the software.
-c) Access to data. You may not be able to access data used in the software when it stops running.
-3. PRE-RELEASE SOFTWARE. The software is a pre-release version. It may not operate correctly. It may be different from the commercially released version.
-4. FEEDBACK. If you give feedback about the software to Microsoft, you give to Microsoft, without charge, the right to use, share and commercialize your feedback in any way and for any purpose. You will not give feedback that is subject to a license that requires Microsoft to license its software or documentation to third parties because Microsoft includes your feedback in them. These rights survive this agreement.
-5. DATA COLLECTION. The software may collect information about you and your use of the software and send that to Microsoft. Microsoft may use this information to provide services and improve Microsoftís products and services. Your opt-out rights, if any, are described in the product documentation. Some features in the software may enable collection of data from users of your applications that access or use the software. If you use these features to enable data collection in your applications, you must comply with applicable law, including getting any required user consent, and maintain a prominent privacy policy that accurately informs users about how you use, collect, and share their data. You can learn more about Microsoftís data collection and use in the product documentation and the Microsoft Privacy Statement at https://go.microsoft.com/fwlink/?LinkId=521839. You agree to comply with all applicable provisions of the Microsoft Privacy Statement.
-6. FONTS. While the software is running, you may use its fonts to display and print content. You may only (i) embed fonts in content as permitted by the embedding restrictions in the fonts; and (ii) temporarily download them to a printer or other output device to help print content.
-7. SCOPE OF LICENSE. The software is licensed, not sold. Microsoft reserves all other rights. Unless applicable law gives you more rights despite this limitation, you will not (and have no right to):
-a) work around any technical limitations in the software that only allow you to use it in certain ways;
-b) reverse engineer, decompile or disassemble the software;
-c) remove, minimize, block, or modify any notices of Microsoft or its suppliers in the software;
-d) use the software in any way that is against the law or to create or propagate malware; or
-e) share, publish, distribute, or lend the software, provide the software as a stand-alone hosted solution for others to use, or transfer the software or this agreement to any third party.
-8. EXPORT RESTRICTIONS. You must comply with all domestic and international export laws and regulations that apply to the software, which include restrictions on destinations, end users, and end use. For further information on export restrictions, visit http://aka.ms/exporting.
-9. SUPPORT SERVICES. Microsoft is not obligated under this agreement to provide any support services for the software. Any support provided is ìas isî, ìwith all faultsî, and without warranty of any kind.
-10. UPDATES. The software may periodically check for updates, and download and install them for you. You may obtain updates only from Microsoft or authorized sources. Microsoft may need to update your system to provide you with updates. You agree to receive these automatic updates without any additional notice. Updates may not include or support all existing software features, services, or peripheral devices.
-11. ENTIRE AGREEMENT. This agreement, and any other terms Microsoft may provide for supplements, updates, or third-party applications, is the entire agreement for the software.
-12. APPLICABLE LAW AND PLACE TO RESOLVE DISPUTES. If you acquired the software in the United States or Canada, the laws of the state or province where you live (or, if a business, where your principal place of business is located) govern the interpretation of this agreement, claims for its breach, and all other claims (including consumer protection, unfair competition, and tort claims), regardless of conflict of laws principles. If you acquired the software in any other country, its laws apply. If U.S. federal jurisdiction exists, you and Microsoft consent to exclusive jurisdiction and venue in the federal court in King County, Washington for all disputes heard in court. If not, you and Microsoft consent to exclusive jurisdiction and venue in the Superior Court of King County, Washington for all disputes heard in court.
-13. CONSUMER RIGHTS; REGIONAL VARIATIONS. This agreement describes certain legal rights. You may have other rights, including consumer rights, under the laws of your state, province, or country. Separate and apart from your relationship with Microsoft, you may also have rights with respect to the party from which you acquired the software. This agreement does not change those other rights if the laws of your state, province, or country do not permit it to do so. For example, if you acquired the software in one of the below regions, or mandatory country law applies, then the following provisions apply to you:
-a) Australia. You have statutory guarantees under the Australian Consumer Law and nothing in this agreement is intended to affect those rights.
-b) Canada. If you acquired this software in Canada, you may stop receiving updates by turning off the automatic update feature, disconnecting your device from the Internet (if and when you re-connect to the Internet, however, the software will resume checking for and installing updates), or uninstalling the software. The product documentation, if any, may also specify how to turn off updates for your specific device or software.
-c) Germany and Austria.
-i.	Warranty. The properly licensed software will perform substantially as described in any Microsoft materials that accompany the software. However, Microsoft gives no contractual guarantee in relation to the licensed software.
-ii.	Limitation of Liability. In case of intentional conduct, gross negligence, claims based on the Product Liability Act, as well as, in case of death or personal or physical injury, Microsoft is liable according to the statutory law.
-Subject to the foregoing clause ii., Microsoft will only be liable for slight negligence if Microsoft is in breach of such material contractual obligations, the fulfillment of which facilitate the due performance of this agreement, the breach of which would endanger the purpose of this agreement and the compliance with which a party may constantly trust in (so-called "cardinal obligations"). In other cases of slight negligence, Microsoft will not be liable for slight negligence.
-14. DISCLAIMER OF WARRANTY. THE SOFTWARE IS LICENSED ìAS IS.î YOU BEAR THE RISK OF USING IT. MICROSOFT GIVES NO EXPRESS WARRANTIES, GUARANTEES, OR CONDITIONS. TO THE EXTENT PERMITTED UNDER APPLICABLE LAWS, MICROSOFT EXCLUDES ALL IMPLIED WARRANTIES, INCLUDING MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NON-INFRINGEMENT.
-15. LIMITATION ON AND EXCLUSION OF DAMAGES. IF YOU HAVE ANY BASIS FOR RECOVERING DAMAGES DESPITE THE PRECEDING DISCLAIMER OF WARRANTY, YOU CAN RECOVER FROM MICROSOFT AND ITS SUPPLIERS ONLY DIRECT DAMAGES UP TO U.S. $5.00. YOU CANNOT RECOVER ANY OTHER DAMAGES, INCLUDING CONSEQUENTIAL, LOST PROFITS, SPECIAL, INDIRECT OR INCIDENTAL DAMAGES.
-This limitation applies to (a) anything related to the software, services, content (including code) on third party Internet sites, or third party applications; and (b) claims for breach of contract, warranty, guarantee, or condition; strict liability, negligence, or other tort; or any other claim; in each case to the extent permitted by applicable law.
-It also applies even if Microsoft knew or should have known about the possibility of the damages. The above limitation or exclusion may not apply to you because your state, province, or country may not allow the exclusion or limitation of incidental, consequential, or other damages.
-
-Please note: As this software is distributed in Canada, some of the clauses in this agreement are provided below in French.
-Remarque: Ce logiciel Ètant distribuÈ au Canada, certaines des clauses dans ce contrat sont fournies ci-dessous en franÁais.
-EXON…RATION DE GARANTIE. Le logiciel visÈ par une licence est offert ´ tel quel ª. Toute utilisation de ce logiciel est ‡ votre seule risque et pÈril. Microsoft níaccorde aucune autre garantie expresse. Vous pouvez bÈnÈficier de droits additionnels en vertu du droit local sur la protection des consommateurs, que ce contrat ne peut modifier. La ou elles sont permises par le droit locale, les garanties implicites de qualitÈ marchande, díadÈquation ‡ un usage particulier et díabsence de contrefaÁon sont exclues.
-LIMITATION DES DOMMAGES-INT…R TS ET EXCLUSION DE RESPONSABILIT… POUR LES DOMMAGES. Vous pouvez obtenir de Microsoft et de ses fournisseurs une indemnisation en cas de dommages directs uniquement ‡ hauteur de 5,00 $ US. Vous ne pouvez prÈtendre ‡ aucune indemnisation pour les autres dommages, y compris les dommages spÈciaux, indirects ou accessoires et pertes de bÈnÈfices.
+Please note: As this software is distributed in Canada, some of the clauses in this agreement are 
+provided below in French.
+Remarque: Ce logiciel √©tant distribu√© au Canada, certaines des clauses dans ce contrat sont fournies ci-
+dessous en fran√ßais.
+EXON√âRATION DE GARANTIE. Le logiciel vis√© par une licence est offert ¬´ tel quel ¬ª. Toute utilisation de 
+ce logiciel est √† votre seule risque et p√©ril. Microsoft n‚Äôaccorde aucune autre garantie expresse. Vous 
+pouvez b√©n√©ficier de droits additionnels en vertu du droit local sur la protection des consommateurs, 
+que ce contrat ne peut modifier. La ou elles sont permises par le droit locale, les garanties implicites de 
+qualit√© marchande, d‚Äôad√©quation √† un usage particulier et d‚Äôabsence de contrefa√ßon sont exclues.
+LIMITATION DES DOMMAGES-INT√âR√äTS ET EXCLUSION DE RESPONSABILIT√â POUR LES DOMMAGES. 
+Vous pouvez obtenir de Microsoft et de ses fournisseurs une indemnisation en cas de dommages directs 
+uniquement √† hauteur de 5,00 $ US. Vous ne pouvez pr√©tendre √† aucune indemnisation pour les autres 
+dommages, y compris les dommages sp√©ciaux, indirects ou accessoires et pertes de b√©n√©fices.
 Cette limitation concerne:
-ï	tout ce qui est reliÈ au logiciel, aux services ou au contenu (y compris le code) figurant sur des sites Internet tiers ou dans des programmes tiers; et
-ï	les rÈclamations au titre de violation de contrat ou de garantie, ou au titre de responsabilitÈ stricte, de nÈgligence ou díune autre faute dans la limite autorisÈe par la loi en vigueur.
-Elle síapplique Ègalement, mÍme si Microsoft connaissait ou devrait connaÓtre líÈventualitÈ díun tel dommage. Si votre pays níautorise pas líexclusion ou la limitation de responsabilitÈ pour les dommages indirects, accessoires ou de quelque nature que ce soit, il se peut que la limitation ou líexclusion ci-dessus ne síappliquera pas ‡ votre Ègard.
-EFFET JURIDIQUE. Le prÈsent contrat dÈcrit certains droits juridiques. Vous pourriez avoir díautres droits prÈvus par les lois de votre pays. Le prÈsent contrat ne modifie pas les droits que vous confËrent les lois de votre pays si celles-ci ne le permettent pas.
+‚Ä¢	tout ce qui est reli√© au logiciel, aux services ou au contenu (y compris le code) figurant sur des sites 
+Internet tiers ou dans des programmes tiers; et
+‚Ä¢	les r√©clamations au titre de violation de contrat ou de garantie, ou au titre de responsabilit√© stricte, 
+de n√©gligence ou d‚Äôune autre faute dans la limite autoris√©e par la loi en vigueur.
+Elle s‚Äôapplique √©galement, m√™me si Microsoft connaissait ou devrait conna√Ætre l‚Äô√©ventualit√© d‚Äôun tel 
+dommage. Si votre pays n‚Äôautorise pas l‚Äôexclusion ou la limitation de responsabilit√© pour les dommages 
+indirects, accessoires ou de quelque nature que ce soit, il se peut que la limitation ou l‚Äôexclusion ci-
+dessus ne s‚Äôappliquera pas √† votre √©gard.
+EFFET JURIDIQUE. Le pr√©sent contrat d√©crit certains droits juridiques. Vous pourriez avoir d‚Äôautres droits 
+pr√©vus par les lois de votre pays. Le pr√©sent contrat ne modifie pas les droits que vous conf√®rent les lois 
+de votre pays si celles-ci ne le permettent pas.
 
 

--- a/license_thirdparty_proprietary.txt
+++ b/license_thirdparty_proprietary.txt
@@ -1,0 +1,527 @@
+PowerShell 6.0
+Copyright (c) Microsoft Corporation
+All rights reserved. 
+MIT License
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+IMPORTANT NOTICE:  THE SOFTWARE ALSO CONTAINS THIRD PARTY AND OTHER PROPIETARY SOFTWARE THAT ARE GOVERNED BY SEPARATE LICENSE TERMS. BY ACCEPTING THE LICENSE TERMS ABOVE, YOU ALSO ACCEPT THE LICENSE TERMS GOVERNING THE THIRD PARTY AND OTHER SOFTWARE, WHICH ARE SET FORTH BELOW:
+The following components listed are governed by the license terms that follow the component(s) name:  
+------------------------------------------------------
+Libmi.so
+------------------------------------------------------
+Copyright (c) Microsoft Corporation
+All rights reserved. 
+MIT License
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+The following components are governed by the MIT license, a copy of which appears below the list of components:  
+------------------------------------------------------
+Newtonsoft.Json
+------------------------------------------------------
+Copyright (c) 2007 James Newton-King
+All rights reserved. 
+MIT License
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+---------------------------------------------------------
+Libuv v.1.9.0
+---------------------------------------------------------
+
+https://raw.githubusercontent.com/aspnet/libuv-package/dev/content/License.txt
+
+This software is licensed to you by Microsoft Corporation under the original terms of the copyright holder provided below:
+
+=========================================
+
+libuv is part of the Node project: http://nodejs.org/
+libuv may be distributed alone under Node's license:
+
+====
+
+Copyright Joyent, Inc. and other Node contributors. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to
+deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+IN THE SOFTWARE.
+
+====
+
+This license applies to all parts of libuv that are not externally
+maintained libraries.
+
+The externally maintained libraries used by libuv are:
+
+  - tree.h (from FreeBSD), copyright Niels Provos. Two clause BSD license.
+
+  - inet_pton and inet_ntop implementations, contained in src/inet.c, are
+copyright the Internet Systems Consortium, Inc., and licensed under the ISC license.
+
+  - stdint-msvc2008.h (from msinttypes), copyright Alexander Chemeris. Three
+    clause BSD license.
+
+  - pthread-fixes.h, pthread-fixes.c, copyright Google Inc. and Sony Mobile
+    Communications AB. Three clause BSD license.
+
+  - android-ifaddrs.h, android-ifaddrs.c, copyright Berkeley Software Design Inc, Kenneth MacKay and Emergya (Cloud4all, FP7/2007-2013, grant agreement
+    n° 289016). Three clause BSD license.
+
+=========================================
+
+
+----------------------------------------------------
+* dotnet-test-xunit 2.2.0-preview2-build1029
+* xunit
+* xunit.abstractions
+* xunit.assert
+* xunit.core
+* xunit.extensibility.core
+* xunit.extensibility.execution
+* xunit.runner.reporters
+* xunit.runner.utility
+----------------------------------------------------
+
+https://www.nuget.org/packages
+
+Copyright 2015 Outercurve Foundation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+
+--------------------------------------------------
+* Microsoft.CodeAnalysis.Analyzers
+* Microsoft.CodeAnalysis.Common
+* Microsoft.CodeAnalysis.CSharp
+* Microsoft.CodeAnalysis.VisualBasic
+* Microsoft.CSharp
+* Microsoft.DiaSymReader
+* Microsoft.DiaSymReader.Native
+* Microsoft.DotNet.Cli.Utils
+* Microsoft.DotNet.InternalAbstractions
+* Microsoft.DotNet.ProjectModel
+* Microsoft.Extensions.DependencyModel
+* Microsoft.Extensions.Testing.Abstractions
+* Microsoft.NETCore
+* Microsoft.NETCore.App
+* Microsoft.NETCore.DotNetHost
+* Microsoft.NETCore.DotNetHostPolicy
+* Microsoft.NETCore.DotNetHostResolver
+* Microsoft.NETCore.Jit
+* Microsoft.NETCore.Platforms
+* Microsoft.NETCore.Portable.Compatibility
+* Microsoft.NETCore.Runtime
+* Microsoft.NETCore.Runtime.CoreCLR
+* Microsoft.NETCore.Runtime.Native
+* Microsoft.NETCore.Targets
+* Microsoft.NETCore.Windows.ApiSets
+* Microsoft.VisualBasic
+* Microsoft.Win32.Primitives
+* Microsoft.Win32.Registry
+* Microsoft.Win32.Registry.AccessControl
+* NETStandard.Library
+* runtime.any.System.Collections
+* runtime.any.System.Diagnostics.Tools
+* runtime.any.System.Diagnostics.Tracing
+* runtime.any.System.Globalization
+* runtime.any.System.Globalization.Calendars
+* runtime.any.System.IO
+* runtime.any.System.Reflection
+* runtime.any.System.Reflection.Extensions
+* runtime.any.System.Reflection.Primitives
+* runtime.any.System.Resources.ResourceManager
+* runtime.any.System.Runtime
+* runtime.any.System.Runtime.Handles
+* runtime.any.System.Runtime.InteropServices
+* runtime.any.System.Text.Encoding
+* runtime.any.System.Text.Encoding.Extensions
+* runtime.any.System.Threading.Tasks
+* runtime.any.System.Threading.Timer
+* runtime.debian.8-x64.Microsoft.NETCore.DotNetHost
+* runtime.debian.8-x64.Microsoft.NETCore.DotNetHostPolicy
+* runtime.debian.8-x64.Microsoft.NETCore.DotNetHostResolver
+* runtime.debian.8-x64.Microsoft.NETCore.Jit
+* runtime.debian.8-x64.Microsoft.NETCore.Runtime.CoreCLR
+* runtime.debian.8-x64.runtime.native.System
+* runtime.debian.8-x64.runtime.native.System.IO.Compression
+* runtime.debian.8-x64.runtime.native.System.Net.Http
+* runtime.debian.8-x64.runtime.native.System.Net.Security
+* runtime.debian.8-x64.runtime.native.System.Security.Cryptography
+* runtime.native.System
+* runtime.native.System.Data.SqlClient.sni
+* runtime.native.System.IO.Compression
+* runtime.native.System.Net.Http
+* runtime.native.System.Net.Security
+* runtime.native.System.Security.Cryptography
+* runtime.osx.10.10-x64.Microsoft.NETCore.DotNetHost
+* runtime.osx.10.10-x64.Microsoft.NETCore.DotNetHostPolicy
+* runtime.osx.10.10-x64.Microsoft.NETCore.DotNetHostResolver
+* runtime.osx.10.10-x64.Microsoft.NETCore.Jit
+* runtime.osx.10.10-x64.Microsoft.NETCore.Runtime.CoreCLR
+* runtime.osx.10.10-x64.runtime.native.System
+* runtime.osx.10.10-x64.runtime.native.System.IO.Compression
+* runtime.osx.10.10-x64.runtime.native.System.Net.Http
+* runtime.osx.10.10-x64.runtime.native.System.Net.Security
+* runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography
+* runtime.rhel.7-x64.Microsoft.NETCore.DotNetHost
+* runtime.rhel.7-x64.Microsoft.NETCore.DotNetHostPolicy
+* runtime.rhel.7-x64.Microsoft.NETCore.DotNetHostResolver
+* runtime.rhel.7-x64.Microsoft.NETCore.Jit
+* runtime.rhel.7-x64.Microsoft.NETCore.Runtime.CoreCLR
+* runtime.rhel.7-x64.runtime.native.System
+* runtime.rhel.7-x64.runtime.native.System.IO.Compression
+* runtime.rhel.7-x64.runtime.native.System.Net.Http
+* runtime.rhel.7-x64.runtime.native.System.Net.Security
+* runtime.rhel.7-x64.runtime.native.System.Security.Cryptography
+* runtime.ubuntu.14.04-x64.Microsoft.NETCore.DotNetHost
+* runtime.ubuntu.14.04-x64.Microsoft.NETCore.DotNetHostPolicy
+* runtime.ubuntu.14.04-x64.Microsoft.NETCore.DotNetHostResolver
+* runtime.ubuntu.14.04-x64.Microsoft.NETCore.Jit
+* runtime.ubuntu.14.04-x64.Microsoft.NETCore.Runtime.CoreCLR
+* runtime.ubuntu.14.04-x64.runtime.native.System
+* runtime.ubuntu.14.04-x64.runtime.native.System.IO.Compression
+* runtime.ubuntu.14.04-x64.runtime.native.System.Net.Http
+* runtime.ubuntu.14.04-x64.runtime.native.System.Net.Security
+* runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography
+* runtime.ubuntu.16.04-x64.Microsoft.NETCore.DotNetHost
+* runtime.ubuntu.16.04-x64.Microsoft.NETCore.DotNetHostPolicy
+* runtime.ubuntu.16.04-x64.Microsoft.NETCore.DotNetHostResolver
+* runtime.ubuntu.16.04-x64.Microsoft.NETCore.Jit
+* runtime.ubuntu.16.04-x64.Microsoft.NETCore.Runtime.CoreCLR
+* runtime.ubuntu.16.04-x64.runtime.native.System
+* runtime.ubuntu.16.04-x64.runtime.native.System.IO.Compression
+* runtime.ubuntu.16.04-x64.runtime.native.System.Net.Http
+* runtime.ubuntu.16.04-x64.runtime.native.System.Net.Security
+* runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography
+* runtime.unix.Microsoft.Win32.Primitives
+* runtime.unix.System.Console
+* runtime.unix.System.Diagnostics.Debug
+* runtime.unix.System.IO.FileSystem
+* runtime.unix.System.Net.Primitives
+* runtime.unix.System.Net.Sockets
+* runtime.unix.System.Private.Uri
+* runtime.unix.System.Runtime.Extensions
+* runtime.win.Microsoft.Win32.Primitives
+* runtime.win.System.Console
+* runtime.win.System.Diagnostics.Debug
+* runtime.win.System.IO.FileSystem
+* runtime.win.System.Net.Primitives
+* runtime.win.System.Net.Sockets
+* runtime.win.System.Runtime.Extensions
+* runtime.win7-x64.Microsoft.NETCore.DotNetHost
+* runtime.win7-x64.Microsoft.NETCore.DotNetHostPolicy
+* runtime.win7-x64.Microsoft.NETCore.DotNetHostResolver
+* runtime.win7-x64.Microsoft.NETCore.Jit
+* runtime.win7-x64.Microsoft.NETCore.Runtime.CoreCLR
+* runtime.win7-x64.Microsoft.NETCore.Windows.ApiSets
+* runtime.win7-x64.runtime.native.System.Data.SqlClient.sni
+* runtime.win7-x64.runtime.native.System.IO.Compression
+* runtime.win7-x86.runtime.native.System.Data.SqlClient.sni
+* runtime.win7.System.Private.Uri
+* runtime.win81-x64.Microsoft.NETCore.Windows.ApiSets
+* System.AppContext
+* System.Buffers
+* System.Collections
+* System.Collections.Concurrent
+* System.Collections.Immutable
+* System.Collections.NonGeneric
+* System.Collections.Specialized
+* System.ComponentModel
+* System.ComponentModel.Annotations
+* System.ComponentModel.EventBasedAsync
+* System.ComponentModel.Primitives
+* System.ComponentModel.TypeConverter
+* System.Console
+* System.Data.Common
+* System.Data.SqlClient
+* System.Diagnostics.Contracts
+* System.Diagnostics.Debug
+* System.Diagnostics.DiagnosticSource
+* System.Diagnostics.FileVersionInfo
+* System.Diagnostics.Process
+* System.Diagnostics.StackTrace
+* System.Diagnostics.TextWriterTraceListener
+* System.Diagnostics.Tools
+* System.Diagnostics.TraceSource
+* System.Diagnostics.Tracing
+* System.Dynamic.Runtime
+* System.Globalization
+* System.Globalization.Calendars
+* System.Globalization.Extensions
+* System.IO
+* System.IO.Compression
+* System.IO.Compression.ZipFile
+* System.IO.FileSystem
+* System.IO.FileSystem.AccessControl
+* System.IO.FileSystem.DriveInfo
+* System.IO.FileSystem.Primitives
+* System.IO.FileSystem.Watcher
+* System.IO.MemoryMappedFiles
+* System.IO.Packaging
+* System.IO.Pipes
+* System.IO.UnmanagedMemoryStream
+* System.Linq
+* System.Linq.Expressions
+* System.Linq.Parallel
+* System.Linq.Queryable
+* System.Net.Http
+* System.Net.Http.WinHttpHandler
+* System.Net.NameResolution
+* System.Net.NetworkInformation
+* System.Net.Ping
+* System.Net.Primitives
+* System.Net.Requests
+* System.Net.Security
+* System.Net.Sockets
+* System.Net.WebHeaderCollection
+* System.Net.WebSockets
+* System.Net.WebSockets.Client
+* System.Numerics.Vectors
+* System.ObjectModel
+* System.Private.DataContractSerialization
+* System.Private.ServiceModel
+* System.Private.Uri
+* System.Reflection
+* System.Reflection.DispatchProxy
+* System.Reflection.Emit
+* System.Reflection.Emit.ILGeneration
+* System.Reflection.Emit.Lightweight
+* System.Reflection.Extensions
+* System.Reflection.Metadata
+* System.Reflection.Primitives
+* System.Reflection.TypeExtensions
+* System.Resources.Reader
+* System.Resources.ResourceManager
+* System.Runtime
+* System.Runtime.CompilerServices.VisualC
+* System.Runtime.Extensions
+* System.Runtime.Handles
+* System.Runtime.InteropServices
+* System.Runtime.InteropServices.PInvoke
+* System.Runtime.InteropServices.RuntimeInformation
+* System.Runtime.Loader
+* System.Runtime.Numerics
+* System.Runtime.Serialization.Json
+* System.Runtime.Serialization.Primitives
+* System.Runtime.Serialization.Xml
+* System.Security.AccessControl
+* System.Security.Claims
+* System.Security.Cryptography.Algorithms
+* System.Security.Cryptography.Cng
+* System.Security.Cryptography.Csp
+* System.Security.Cryptography.Encoding
+* System.Security.Cryptography.OpenSsl
+* System.Security.Cryptography.Pkcs
+* System.Security.Cryptography.Primitives
+* System.Security.Cryptography.X509Certificates
+* System.Security.Principal
+* System.Security.Principal.Windows
+* System.Security.SecureString
+* System.ServiceModel.Duplex
+* System.ServiceModel.Http
+* System.ServiceModel.NetTcp
+* System.ServiceModel.Primitives
+* System.ServiceModel.Security
+* System.ServiceProcess.ServiceController
+* System.Text.Encoding
+* System.Text.Encoding.CodePages
+* System.Text.Encoding.Extensions
+* System.Text.Encodings.Web
+* System.Text.RegularExpressions
+* System.Threading
+* System.Threading.AccessControl
+* System.Threading.Overlapped
+* System.Threading.Tasks
+* System.Threading.Tasks.Dataflow
+* System.Threading.Tasks.Extensions
+* System.Threading.Tasks.Parallel
+* System.Threading.Thread
+* System.Threading.ThreadPool
+* System.Threading.Timer
+* System.Xml.ReaderWriter
+* System.Xml.XDocument
+* System.Xml.XmlDocument
+* System.Xml.XmlSerializer
+* System.Xml.XPath
+* System.Xml.XPath.XDocument
+* System.Xml.XPath.XmlDocument
+-------------------------------------------------------
+
+MICROSOFT SOFTWARE LICENSE TERMS 
+MICROSOFT .NET LIBRARY 
+These license terms are an agreement between Microsoft Corporation (or based on where you live, one of its affiliates) and you. Please read them. They apply to the software named above, which includes the media on which you received it, if any. The terms also apply to any Microsoft 
+*         updates, 
+*         supplements, 
+*          Internet-based services, and 
+*          support services 
+for this software, unless other terms accompany those items. If so, those terms apply. 
+BY USING THE SOFTWARE, YOU ACCEPT THESE TERMS. IF YOU DO NOT ACCEPT THEM, DO NOT USE THE SOFTWARE. 
+IF YOU COMPLY WITH THESE LICENSE TERMS, YOU HAVE THE PERPETUAL RIGHTS BELOW. 
+1.      INSTALLATION AND USE RIGHTS. 
+a.      Installation and Use.  You may install and use any number of copies of the software to design, develop and test your programs. 
+b.      Third Party Programs.  The software may include third party programs that Microsoft, not the third party, licenses to you under this agreement. Notices, if any, for the third party program are included for your information only. 
+2.      DATA.  The software may collect information about you and your use of the software, and send that to Microsoft. Microsoft may use this information to improve our products and services. You can learn more about data collection and use in the help documentation and the privacy statement at  http://go.microsoft.com/fwlink/?LinkId=528096 . Your use of the software operates as your consent to these practices. 
+3.      ADDITIONAL LICENSING REQUIREMENTS AND/OR USE RIGHTS. 
+a.      DISTRIBUTABLE CODE.   The software is comprised of Distributable Code. “Distributable Code” is code that you are permitted to distribute in programs you develop if you comply with the terms below. 
+i .        Right to Use and Distribute. 
+*          You may copy and distribute the object code form of the software. 
+*          Third Party Distribution. You may permit distributors of your programs to copy and distribute the Distributable Code as part of those programs. 
+ii.      Distribution Requirements.   For any Distributable Code you distribute, you must 
+*          add significant primary functionality to it in your programs; 
+*          require distributors and external end users to agree to terms that protect it at least as much as this agreement; 
+*          display your valid copyright notice on your programs; and 
+*          indemnify, defend, and hold harmless Microsoft from any claims, including attorneys’ fees, related to the distribution or use of your programs. 
+iii.     Distribution Restrictions.  You may not 
+*          alter any copyright, trademark or patent notice in the Distributable Code; 
+*          use Microsoft’s trademarks in your programs’ names or in a way that suggests your programs come from or are endorsed by Microsoft; 
+*          include Distributable Code in malicious, deceptive or unlawful programs; or 
+*          modify or distribute the source code of any Distributable Code so that any part of it becomes subject to an Excluded License. An Excluded License is one that requires, as a condition of use, modification or distribution, that 
+*          the code be disclosed or distributed in source code form; or 
+*          others have the right to modify it. 
+4.      SCOPE OF LICENSE.  The software is licensed, not sold. This agreement only gives you some rights to use the software. Microsoft reserves all other rights. Unless applicable law gives you more rights despite this limitation, you may use the software only as expressly permitted in this agreement. In doing so, you must comply with any technical limitations in the software that only allow you to use it in certain ways. You may not 
+*          work around any technical limitations in the software; 
+*          reverse engineer, decompile or disassemble the software, except and only to the extent that applicable law expressly permits, despite this limitation; 
+*          publish the software for others to copy; 
+*          rent, lease or lend the software; 
+*          transfer the software or this agreement to any third party; or 
+*          use the software for commercial software hosting services. 
+5.      BACKUP COPY.  You may make one backup copy of the software. You may use it only to reinstall the software. 
+6.      DOCUMENTATION.  Any person that has valid access to your computer or internal network may copy and use the documentation for your internal, reference purposes. 
+7.      EXPORT RESTRICTIONS.  The software is subject to United States export laws and regulations. You must comply with all domestic and international export laws and regulations that apply to the software. These laws include restrictions on destinations, end users and end use. For additional information, see  www.microsoft.com/exporting. 
+8.      SUPPORT SERVICES.  Because this software is “as is,” we may not provide support services for it. 
+9.      ENTIRE AGREEMENT.  This agreement, and the terms for supplements, updates, Internet-based services and support services that you use, are the entire agreement for the software and support services. 
+10.     APPLICABLE LAW. 
+a.      United States.  If you acquired the software in the United States, Washington state law governs the interpretation of this agreement and applies to claims for breach of it, regardless of conflict of laws principles. The laws of the state where you live govern all other claims, including claims under state consumer protection laws, unfair competition laws, and in tort. 
+b.      Outside the United States. If you acquired the software in any other country, the laws of that country apply. 
+11.    LEGAL EFFECT.  This agreement describes certain legal rights. You may have other rights under the laws of your country. You may also have rights with respect to the party from whom you acquired the software. This agreement does not change your rights under the laws of your country if the laws of your country do not permit it to do so. 
+12.    DISCLAIMER OF WARRANTY. THE SOFTWARE IS LICENSED “AS-IS.” YOU BEAR THE RISK OF USING IT. MICROSOFT GIVES NO EXPRESS WARRANTIES, GUARANTEES OR CONDITIONS. YOU MAY HAVE ADDITIONAL CONSUMER RIGHTS OR STATUTORY GUARANTEES UNDER YOUR LOCAL LAWS WHICH THIS AGREEMENT CANNOT CHANGE. TO THE EXTENT PERMITTED UNDER YOUR LOCAL LAWS, MICROSOFT EXCLUDES THE IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. 
+FOR AUSTRALIA – YOU HAVE STATUTORY GUARANTEES UNDER THE AUSTRALIAN CONSUMER LAW AND NOTHING IN THESE TERMS IS INTENDED TO AFFECT THOSE RIGHTS. 
+13.    LIMITATION ON AND EXCLUSION OF REMEDIES AND DAMAGES. YOU CAN RECOVER FROM MICROSOFT AND ITS SUPPLIERS ONLY DIRECT DAMAGES UP TO U.S. $5.00. YOU CANNOT RECOVER ANY OTHER DAMAGES, INCLUDING CONSEQUENTIAL, LOST PROFITS, SPECIAL, INDIRECT OR INCIDENTAL DAMAGES. 
+This limitation applies to 
+*          anything related to the software, services, content (including code) on third party Internet sites, or third party programs; and 
+*          claims for breach of contract, breach of warranty, guarantee or condition, strict liability, negligence, or other tort to the extent permitted by applicable law. 
+It also applies even if Microsoft knew or should have known about the possibility of the damages. The above limitation or exclusion may not apply to you because your country may not allow the exclusion or limitation of incidental, consequential or other damages. 
+Please note: As this software is distributed in Quebec, Canada, some of the clauses in this agreement are provided below in French. 
+Remarque : Ce logiciel étant distribué au Québec, Canada, certaines des clauses dans ce contrat sont fournies ci-dessous en français. 
+EXONÉRATION DE GARANTIE.  Le logiciel visé par une licence est offert « tel quel ». Toute utilisation de ce logiciel est à votre seule risque et péril. Microsoft n’accorde aucune autre garantie expresse. Vous pouvez bénéficier de droits additionnels en vertu du droit local sur la protection des consommateurs, que ce contrat ne peut modifier. La ou elles sont permises par le droit locale, les garanties implicites de qualité marchande, d’adéquation à un usage particulier et d’absence de contrefaçon sont exclues. 
+LIMITATION DES DOMMAGES-INTÉRÊTS ET EXCLUSION DE RESPONSABILITÉ POUR LES DOMMAGES.  Vous pouvez obtenir de Microsoft et de ses fournisseurs une indemnisation en cas de dommages directs uniquement à hauteur de 5,00 $ US. Vous ne pouvez prétendre à aucune indemnisation pour les autres dommages, y compris les dommages spéciaux, indirects ou accessoires et pertes de bénéfices. 
+Cette limitationconcerne: 
+*          tout ce qui est relié au logiciel, aux services ou au contenu (y compris le code) figurant sur des sites Internet tiers ou dans des programmes tiers ; et 
+*          les réclamations au titre de violation de contrat ou de garantie, ou au titre de responsabilité stricte, de négligence ou d’une autre faute dans la limite autorisée par la loi en vigueur. 
+Elle s’applique également, même si Microsoft connaissait ou devrait connaître l’éventualité d’un tel dommage. Si votre pays n’autorise pas l’exclusion ou la limitation de responsabilité pour les dommages indirects, accessoires ou de quelque nature que ce soit, il se peut que la limitation ou l’exclusion ci-dessus ne s’appliquera pas à votre égard. 
+EFFET JURIDIQUE.  Le présent contrat décrit certains droits juridiques. Vous pourriez avoir d’autres droits prévus par les lois de votre pays. Le présent contrat ne modifie pas les droits que vous confèrent les lois de votre pays si celles-ci ne le permettent pas. 
+
+
+--------------------------------------------------------
+* NuGet.Common
+* NuGet.Configuration
+* NuGet.DependencyResolver.Core
+* NuGet.Frameworks
+* NuGet.LibraryModel
+* NuGet.Packaging
+* NuGet.Packaging.Core
+* NuGet.Packaging.Core.Types
+* NuGet.ProjectModel
+* NuGet.Protocol.Core.Types
+* NuGet.Protocol.Core.v3
+* NuGet.Repositories
+* NuGet.RuntimeModel
+* NuGet.Versioning
+----------------------------------------------------------
+
+Copyright (c) .NET Foundation. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+these files except in compliance with the License. You may obtain a copy of the
+License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+
+
+---------------------------------------------------------
+* Microsoft.Management.Infrastructure.dll
+* Microsoft.Management.Infrastructure.Native.dll
+* Microsoft.Management.Infrastructure.Unmanaged.dll
+----------------------------------------------------------
+MICROSOFT SOFTWARE LICENSE TERMS
+MANAGEMENT.INFRASTRUCTURE.DLL 
+MANAGEMENT.INFRASTRUCTURE.NATIVE.DLL MANAGEMENT.INFRASTRUCTURE.UNMANAGED.DLL
+
+These license terms are an agreement between you and Microsoft Corporation (or one of its affiliates). They apply to the software named above and any Microsoft services or software updates (except to the extent such services or updates are accompanied by new or additional terms, in which case those different terms apply prospectively and do not alter your or Microsoft’s rights relating to pre-updated software or services). IF YOU COMPLY WITH THESE LICENSE TERMS, YOU HAVE THE RIGHTS BELOW. BY USING THE SOFTWARE, YOU ACCEPT THESE TERMS.
+1. INSTALLATION AND USE RIGHTS
+a) General. You may install and use any number of copies of the software on your devices.
+b) Included Microsoft Applications. The software may include other Microsoft applications. These license terms apply to those included applications, if any, unless other license terms are provided with the other Microsoft applications.
+c) Third Party Software. The software may include third party applications that are licensed to you under this agreement or under their own terms. License terms, notices, and acknowledgements, if any, for the third party applications may be accessible online at http://aka.ms/thirdpartynotices or in an accompanying notices file. Even if such applications are governed by other agreements, the disclaimer, limitations on, and exclusions of damages below also apply to the extent allowed by applicable law.
+2. TIME-SENSITIVE SOFTWARE
+a) Period. The software is time-sensitive and may stop running on a date that is defined in the software.
+b) Notice. You may receive periodic reminder notices of this date through the software.
+c) Access to data. You may not be able to access data used in the software when it stops running.
+3. PRE-RELEASE SOFTWARE. The software is a pre-release version. It may not operate correctly. It may be different from the commercially released version.
+4. FEEDBACK. If you give feedback about the software to Microsoft, you give to Microsoft, without charge, the right to use, share and commercialize your feedback in any way and for any purpose. You will not give feedback that is subject to a license that requires Microsoft to license its software or documentation to third parties because Microsoft includes your feedback in them. These rights survive this agreement.
+5. DATA COLLECTION. The software may collect information about you and your use of the software and send that to Microsoft. Microsoft may use this information to provide services and improve Microsoft’s products and services. Your opt-out rights, if any, are described in the product documentation. Some features in the software may enable collection of data from users of your applications that access or use the software. If you use these features to enable data collection in your applications, you must comply with applicable law, including getting any required user consent, and maintain a prominent privacy policy that accurately informs users about how you use, collect, and share their data. You can learn more about Microsoft’s data collection and use in the product documentation and the Microsoft Privacy Statement at https://go.microsoft.com/fwlink/?LinkId=521839. You agree to comply with all applicable provisions of the Microsoft Privacy Statement.
+6. FONTS. While the software is running, you may use its fonts to display and print content. You may only (i) embed fonts in content as permitted by the embedding restrictions in the fonts; and (ii) temporarily download them to a printer or other output device to help print content.
+7. SCOPE OF LICENSE. The software is licensed, not sold. Microsoft reserves all other rights. Unless applicable law gives you more rights despite this limitation, you will not (and have no right to):
+a) work around any technical limitations in the software that only allow you to use it in certain ways;
+b) reverse engineer, decompile or disassemble the software;
+c) remove, minimize, block, or modify any notices of Microsoft or its suppliers in the software;
+d) use the software in any way that is against the law or to create or propagate malware; or
+e) share, publish, distribute, or lend the software, provide the software as a stand-alone hosted solution for others to use, or transfer the software or this agreement to any third party.
+8. EXPORT RESTRICTIONS. You must comply with all domestic and international export laws and regulations that apply to the software, which include restrictions on destinations, end users, and end use. For further information on export restrictions, visit http://aka.ms/exporting.
+9. SUPPORT SERVICES. Microsoft is not obligated under this agreement to provide any support services for the software. Any support provided is “as is”, “with all faults”, and without warranty of any kind.
+10. UPDATES. The software may periodically check for updates, and download and install them for you. You may obtain updates only from Microsoft or authorized sources. Microsoft may need to update your system to provide you with updates. You agree to receive these automatic updates without any additional notice. Updates may not include or support all existing software features, services, or peripheral devices.
+11. ENTIRE AGREEMENT. This agreement, and any other terms Microsoft may provide for supplements, updates, or third-party applications, is the entire agreement for the software.
+12. APPLICABLE LAW AND PLACE TO RESOLVE DISPUTES. If you acquired the software in the United States or Canada, the laws of the state or province where you live (or, if a business, where your principal place of business is located) govern the interpretation of this agreement, claims for its breach, and all other claims (including consumer protection, unfair competition, and tort claims), regardless of conflict of laws principles. If you acquired the software in any other country, its laws apply. If U.S. federal jurisdiction exists, you and Microsoft consent to exclusive jurisdiction and venue in the federal court in King County, Washington for all disputes heard in court. If not, you and Microsoft consent to exclusive jurisdiction and venue in the Superior Court of King County, Washington for all disputes heard in court.
+13. CONSUMER RIGHTS; REGIONAL VARIATIONS. This agreement describes certain legal rights. You may have other rights, including consumer rights, under the laws of your state, province, or country. Separate and apart from your relationship with Microsoft, you may also have rights with respect to the party from which you acquired the software. This agreement does not change those other rights if the laws of your state, province, or country do not permit it to do so. For example, if you acquired the software in one of the below regions, or mandatory country law applies, then the following provisions apply to you:
+a) Australia. You have statutory guarantees under the Australian Consumer Law and nothing in this agreement is intended to affect those rights.
+b) Canada. If you acquired this software in Canada, you may stop receiving updates by turning off the automatic update feature, disconnecting your device from the Internet (if and when you re-connect to the Internet, however, the software will resume checking for and installing updates), or uninstalling the software. The product documentation, if any, may also specify how to turn off updates for your specific device or software.
+c) Germany and Austria.
+i.	Warranty. The properly licensed software will perform substantially as described in any Microsoft materials that accompany the software. However, Microsoft gives no contractual guarantee in relation to the licensed software.
+ii.	Limitation of Liability. In case of intentional conduct, gross negligence, claims based on the Product Liability Act, as well as, in case of death or personal or physical injury, Microsoft is liable according to the statutory law.
+Subject to the foregoing clause ii., Microsoft will only be liable for slight negligence if Microsoft is in breach of such material contractual obligations, the fulfillment of which facilitate the due performance of this agreement, the breach of which would endanger the purpose of this agreement and the compliance with which a party may constantly trust in (so-called "cardinal obligations"). In other cases of slight negligence, Microsoft will not be liable for slight negligence.
+14. DISCLAIMER OF WARRANTY. THE SOFTWARE IS LICENSED “AS IS.” YOU BEAR THE RISK OF USING IT. MICROSOFT GIVES NO EXPRESS WARRANTIES, GUARANTEES, OR CONDITIONS. TO THE EXTENT PERMITTED UNDER APPLICABLE LAWS, MICROSOFT EXCLUDES ALL IMPLIED WARRANTIES, INCLUDING MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NON-INFRINGEMENT.
+15. LIMITATION ON AND EXCLUSION OF DAMAGES. IF YOU HAVE ANY BASIS FOR RECOVERING DAMAGES DESPITE THE PRECEDING DISCLAIMER OF WARRANTY, YOU CAN RECOVER FROM MICROSOFT AND ITS SUPPLIERS ONLY DIRECT DAMAGES UP TO U.S. $5.00. YOU CANNOT RECOVER ANY OTHER DAMAGES, INCLUDING CONSEQUENTIAL, LOST PROFITS, SPECIAL, INDIRECT OR INCIDENTAL DAMAGES.
+This limitation applies to (a) anything related to the software, services, content (including code) on third party Internet sites, or third party applications; and (b) claims for breach of contract, warranty, guarantee, or condition; strict liability, negligence, or other tort; or any other claim; in each case to the extent permitted by applicable law.
+It also applies even if Microsoft knew or should have known about the possibility of the damages. The above limitation or exclusion may not apply to you because your state, province, or country may not allow the exclusion or limitation of incidental, consequential, or other damages.
+
+Please note: As this software is distributed in Canada, some of the clauses in this agreement are provided below in French.
+Remarque: Ce logiciel étant distribué au Canada, certaines des clauses dans ce contrat sont fournies ci-dessous en français.
+EXONÉRATION DE GARANTIE. Le logiciel visé par une licence est offert « tel quel ». Toute utilisation de ce logiciel est à votre seule risque et péril. Microsoft n’accorde aucune autre garantie expresse. Vous pouvez bénéficier de droits additionnels en vertu du droit local sur la protection des consommateurs, que ce contrat ne peut modifier. La ou elles sont permises par le droit locale, les garanties implicites de qualité marchande, d’adéquation à un usage particulier et d’absence de contrefaçon sont exclues.
+LIMITATION DES DOMMAGES-INTÉRÊTS ET EXCLUSION DE RESPONSABILITÉ POUR LES DOMMAGES. Vous pouvez obtenir de Microsoft et de ses fournisseurs une indemnisation en cas de dommages directs uniquement à hauteur de 5,00 $ US. Vous ne pouvez prétendre à aucune indemnisation pour les autres dommages, y compris les dommages spéciaux, indirects ou accessoires et pertes de bénéfices.
+Cette limitation concerne:
+•	tout ce qui est relié au logiciel, aux services ou au contenu (y compris le code) figurant sur des sites Internet tiers ou dans des programmes tiers; et
+•	les réclamations au titre de violation de contrat ou de garantie, ou au titre de responsabilité stricte, de négligence ou d’une autre faute dans la limite autorisée par la loi en vigueur.
+Elle s’applique également, même si Microsoft connaissait ou devrait connaître l’éventualité d’un tel dommage. Si votre pays n’autorise pas l’exclusion ou la limitation de responsabilité pour les dommages indirects, accessoires ou de quelque nature que ce soit, il se peut que la limitation ou l’exclusion ci-dessus ne s’appliquera pas à votre égard.
+EFFET JURIDIQUE. Le présent contrat décrit certains droits juridiques. Vous pourriez avoir d’autres droits prévus par les lois de votre pays. Le présent contrat ne modifie pas les droits que vous confèrent les lois de votre pays si celles-ci ne le permettent pas.
+
+

--- a/src/powershell-unix/project.json
+++ b/src/powershell-unix/project.json
@@ -23,7 +23,7 @@
             "include": [
                 "*.so",
                 "*.dylib",
-                "../../LICENSE.txt",
+                "../../license_thirdparty_proprietary.txt",
                 "../../powershell.version"
             ]
         },
@@ -47,7 +47,7 @@
         "include": [
             "*.so",
             "*.dylib",
-            "../../LICENSE.txt",
+            "../../license_thirdparty_proprietary.txt",
             "../../powershell.version"
         ]
     },

--- a/src/powershell-win-core/project.json
+++ b/src/powershell-win-core/project.json
@@ -22,7 +22,7 @@
                 }
             },
             "include": [
-                "../../LICENSE.txt",
+                "../../license_thirdparty_proprietary.txt",
                 "../../powershell.version"
             ]
         },
@@ -49,7 +49,7 @@
             "pwrshplugin.dll",
             "pwrshplugin.pdb",
             "Install-PowerShellRemoting.ps1",
-            "../../LICENSE.txt",
+            "../../license_thirdparty_proprietary.txt",
             "../../powershell.version"
         ]
     },


### PR DESCRIPTION
The package installed location needs to have a file describing licensing, third party and proprietary information
