### PR TITLE
Fix the test that fails in Travis CI build

### DIFF
--- a/test/powershell/Language/Classes/Scripting.Classes.Modules.Tests.ps1
+++ b/test/powershell/Language/Classes/Scripting.Classes.Modules.Tests.ps1
@@ -12,21 +12,20 @@ Describe 'use of a module from two runspaces' -Tags "CI" {
             [string]$Content
         )
         
-        Setup -Dir $Name
+        $TestModulePath = Join-Path -Path $TestDrive -ChildPath "TestModule"
+        $ModuleFolder = Join-Path -Path $TestModulePath -ChildPath $Name
+        New-Item -Path $ModuleFolder -ItemType Directory -Force > $null
+        
+        Set-Content -Path "$ModuleFolder\$Name.psm1" -Value $Content
+
         $manifestParams = @{
-            Path = "TestDrive:\$Name\$Name.psd1"
+            Path = "$ModuleFolder\$Name.psd1"
+            RootModule = "$Name.psm1"
         }
-        
-        if ($Content) {
-            Set-Content -Path "${TestDrive}\$Name\$Name.psm1" -Value $Content
-            $manifestParams['RootModule'] = "$Name.psm1"
-        }
-        
         New-ModuleManifest @manifestParams
 
-        $resolvedTestDrivePath = Split-Path ((get-childitem TestDrive:\)[0].FullName)
-        if (-not ($env:PSMODULEPATH -like "*$resolvedTestDrivePath*")) {
-            $env:PSMODULEPATH += "$([System.IO.Path]::PathSeparator)$resolvedTestDrivePath"
+        if ($env:PSMODULEPATH -notlike "*$TestModulePath*") {
+            $env:PSMODULEPATH += "$([System.IO.Path]::PathSeparator)$TestModulePath"
         }
     }
 


### PR DESCRIPTION
The test `use of a module from two runspaces` set `/tmp/<guid-number>` in `$env:PSMODULEPATH`. However, the file `/tmp/powershell` somehow exists in the Travis CI build machine. So when the test create a powershell object by `[powershell]::create()`, the module path calculation logic incorrectly believed that `/tmp/<guid-number>` is a PSHome module path derived from parent process and thus removed it.

The detection of a derived PSHome module path could be smarter, it's tracked in #1744
This PR will resolve the failure from the test side, so that our build can be fixed.
