### PR TITLE
Better win 10 sdk folder to test

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -754,8 +754,8 @@ function Start-PSBootstrap {
             $newMachineEnvironmentPath = $machinePath
 
             $cmakePresent = precheck 'cmake' $null
-            $sdkPath = "${env:ProgramFiles(x86)}\Microsoft SDKs\Windows\v10.0A"
-            $sdkPresent = Test-Path -Path $sdkPath -PathType Container
+            $win10sdkBinPath = "${env:ProgramFiles(x86)}\Windows Kits\10\bin\x64"
+            $sdkPresent = Test-Path -Path $win10sdkBinPath -PathType Container
 
             # Install chocolatey
             $chocolateyPath = "$env:AllUsersProfile\chocolatey\bin"


### PR DESCRIPTION
The `Start-PSBootstrap` command currently checks for the existence of `${env:ProgramFiles(x86)}\Microsoft SDKs\Windows\v10.0A` to see whether or not to install the win10 sdk. However, if Visual Studio is installed, that directory may already be present without the full win 10 SDK. This is what happened to me on my first build attempt and I got an error when it tried to find `mc.exe`

This change tests a different path `${env:ProgramFiles(x86)}\Windows Kits\10\bin\x64` and is the same path used in `Start-PSBuild` and will not be present unless the full win 10 sdk is installed.
