### PR TITLE
Provide a more actionable message when vcvarsall.bat is missing

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -139,7 +139,7 @@ function Start-PSBuild {
 
         $vcVarsPath = (Get-Item(Join-Path -Path "$env:VS140COMNTOOLS" -ChildPath '../../vc')).FullName
         if ((Test-Path -Path $vcVarsPath\vcvarsall.bat) -eq $false) {
-            throw "Could not find Visual Studio vcvarsall.bat at" + $vcVarsPath
+            throw "Could not find Visual Studio vcvarsall.bat at $vcVarsPath. Please ensure the optional feature 'Common Tools for Visual C++' is installed."
         }
 
         # setup msbuild configuration


### PR DESCRIPTION
This was another error that made me partner with google on my personal journey to building powershell. If you are not a c++ dev, the current error message: `Could not find Visual Studio vcvarsall.bat at $vcVarsPath` may not mean alot. This PR adds to check that the right optional VS feature is enabled. I personally leave this feature out of my setup.
