### PR TITLE
Remove misleading note about dotnet 1.0.1

### DIFF
--- a/docs/building/windows-core.md
+++ b/docs/building/windows-core.md
@@ -49,12 +49,6 @@ you will also need to install
 [Visual C++ Redistributable for Visual Studio 2012 Update 4][redist-2012]
 and [Visual C++ Redistributable for Visual Studio 2015][redist-2015].
 
-The version of .NET CLI is very important, you want a recent build of
-1.0.0 (**not** 1.0.1).
-
-Previous installations of DNX, `dnvm`, or older installations of .NET
-CLI can cause odd failures when running. Please check your version.
-
 [dotnet-cli]: https://github.com/dotnet/cli#new-to-net-cli
 [cli-docs]: https://dotnet.github.io/getting-started/
 [redist-2012]: https://www.microsoft.com/en-us/download/confirmation.aspx?id=30679


### PR DESCRIPTION
I found the note regarding the dotnet CLI version misleading. I initially had compile errors due to an unrelated issue and spent a good chunk of time trying to ensure the dotnet cli 1.0.0 was installed. On a clean VM, after `start-psbootstrap` running `dotnet` produces:

```
PS C:\dev\powershell> dotnet

Microsoft .NET Core Shared Framework Host

  Version  : 1.0.1
  Build    : cee57bf6c981237d80aa1631cfe83cb9ba329f12
```

So I thought this may have been my issue but it actually was not and once I worked out my real issue, this version worked fine.
