### PR TITLE
Clarify that visual studio with c++ compiler is required

### DIFF
--- a/docs/building/windows-core.md
+++ b/docs/building/windows-core.md
@@ -44,10 +44,7 @@ Invoke-WebRequest -Uri https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/sc
 If you have any problems installing `dotnet`,
 please see their [documentation][cli-docs].
 
-If you are using Windows 7, Windows Server 2008 or Windows Server 2012
-you will also need to install
-[Visual C++ Redistributable for Visual Studio 2012 Update 4][redist-2012]
-and [Visual C++ Redistributable for Visual Studio 2015][redist-2015].
+You will also need to install a recent version of Visual Studio with the optional feature 'Common Tools for Visual C++' installed. The free [Community edition of Visual Studio 2015](https://beta.visualstudio.com/visual-studio-community-vs/) should work fine.
 
 The version of .NET CLI is very important, you want a recent build of
 1.0.0 (**not** 1.0.1).
@@ -57,8 +54,6 @@ CLI can cause odd failures when running. Please check your version.
 
 [dotnet-cli]: https://github.com/dotnet/cli#new-to-net-cli
 [cli-docs]: https://dotnet.github.io/getting-started/
-[redist-2012]: https://www.microsoft.com/en-us/download/confirmation.aspx?id=30679
-[redist-2015]: https://www.microsoft.com/en-us/download/details.aspx?id=48145
 
 Build using our module
 ======================


### PR DESCRIPTION
Walking through these instructions I found that `Start-PSBuild` required `vsvarsall.bat` which is only installed with Visual Studio and its optional feature Common Tools for Visual C++ so the readme should specify this and in this case (I think this is right), the other redist packages are redundant.
