### PR TITLE
Fix obsolete links in documentation

### DIFF
--- a/docs/community/governance.md
+++ b/docs/community/governance.md
@@ -112,7 +112,7 @@ If you are an Area Expert:
 1. **DO** ask people to resend a pull request, if it [doesn't target `master`](../../.github/CONTRIBUTING.md#lifecycle-of-a-pull-request).
 1. **DO** ensure that contributors [write Pester tests][pester] for all new/changed functionality
 1. **DO** ensure that contributors [write documentation][docs-contributing] for all new-/changed functionality
-1. **DO** encourage contributors to refer to issues in their pull request description per the [pull request template](../../.github/PULL_REQUEST_TEMPLATE.md) (e.g. `Resolves issue #123`)
+1. **DO** encourage contributors to refer to issues in their pull request description (e.g. `Resolves issue #123`).
 1. **DO** encourage contributors to create meaningful titles for all PRs. Edit title if necessary.
 1. **DO** verify that all contributors are following the [Coding Guidelines](../dev-process/coding-guidelines.md).
 

--- a/docs/maintainers/README.md
+++ b/docs/maintainers/README.md
@@ -46,7 +46,7 @@ This includes adding extra reviewers when it makes sense
 1. **SHOULD** ask people to resend a pull request, if it [doesn't target `master`](../../.github/CONTRIBUTING.md#lifecycle-of-a-pull-request)
 1. **SHOULD** wait for the [CI system][ci-system] build to pass for pull requests 
 (unless, for instance, the pull request is being submitted to fix broken CI)
-1. **SHOULD** encourage contributors to refer to issues in their pull request description per the [pull request template](../../.github/PULL_REQUEST_TEMPLATE.md) (e.g. `Resolves issue #123`).
+1. **SHOULD** encourage contributors to refer to issues in their pull request description (e.g. `Resolves issue #123`).
 If a user did not create an issue prior to submitting their pull request, their pull request should not be rejected.
 However, they should be reminded to create an issue in the future to frontload any potential problems with the work and to minimize duplication of efforts. 
 1. **SHOULD** encourage contributors to create meaningful titles for all PRs.

--- a/docs/maintainers/pull-request-process.md
+++ b/docs/maintainers/pull-request-process.md
@@ -1,10 +1,8 @@
 # Pull Request Process
 
-Our [pull request template][pr-template] includes the bare minimum requirements for a pull request to be accepted into PowerShell. This includes:
+Requirements for a pull request to be accepted into PowerShell
 * Writing tests
-* Writing documentation (where does thie one live already? is it where this guidance should exist all up?)
-* Our [code review process][code-review]
-* Repository maintainer sign-off, per our [governance model][governance]
+* Writing documentation
 
 ## Pull Request Workflow
 
@@ -30,8 +28,5 @@ In these cases:
   - If the changes required to merge the pull request are significant but needed, create a new branch with the changes and open an issue to merge the code into the dev branch. Mention the original pull request ID in the description of the new issue and close the abandoned pull request. 
   - If the changes in an abandoned pull request are no longer needed (e.g. due to refactoring of the code base or a design change), simply close the pull request.
 
-[pr-template]: ../../.github/PULL_REQUEST_TEMPLATE.md
-[code-review]: code-review-guidelines.md
-[governance]: ../community/governance.md
 [repository-maintainer]: ../community/governance.md#repository-maintainers
 [area-expert]: ../community/governance.md#area-experts#area-experts


### PR DESCRIPTION
- In 110c627be8f773511e4f6d5803ad578caf90c8e7 PR template was removed.
  That created few broken links.
- Not sure what happened with `code-review-guidelines.md`, I cannot find any mentions of it in the history, so I assume this document haven't been written.

**Ask**: when you are doing significant documentation changes, consider validating links in the documentation. You can use [MarkdownLinkCheck](https://github.com/vors/MarkdownLinkCheck) or other tools.
