### PR TITLE
Removes Style Tag That Truncates Man Page 

### DIFF
--- a/assets/powershell.1.ronn
+++ b/assets/powershell.1.ronn
@@ -2,19 +2,19 @@ POWERSHELL(1)                     User Manuals                    POWERSHELL(1)
 
 
 NAME
-    powershell - commandline shell and C# REPL. 
+    powershell - commandline shell and .NET REPL. 
 
 SYNOPSIS
     powershell[.exe][.exe] [-PSConsoleFile <file> | -Version <version>]
     [-NoLogo] [-NoExit] [-Sta] [-Mta] [-NoProfile] [-NonInteractive]
     [-InputFormat {Text | XML}] [-OutputFormat {Text | XML}] 
-    [-WindowStyle <style>] [-EncodedCommand <Base64EncodedCommand>] 
+    [-WindowStyle] [-EncodedCommand <Base64EncodedCommand>] 
     [-File <filePath> <args>] [-ExecutionPolicy <ExecutionPolicy>]
     [-Command { - | <script-block> [-args <arg-array>]
                   | <string> [<CommandParameters>] } ]
 
 DESCRIPTION
-     powershell commandline shell and C# REPL.
+     powershell commandline shell and .NET REPL.
 
 OPTIONS
     


### PR DESCRIPTION
Removes the style tag in the original "About Powershell" page that truncates the man page. 
