### PR TITLE
Stop using 'Open PowerShell' and OPS in code

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -658,7 +658,7 @@ function Start-PSBootstrap {
         [switch]$Force
     )
 
-    log "Installing Open PowerShell build dependencies"
+    log "Installing PowerShell build dependencies"
 
     Push-Location $PSScriptRoot/tools
 

--- a/src/Microsoft.PackageManagement.PackageSourceListProvider/Sdk/Constants.cs
+++ b/src/Microsoft.PackageManagement.PackageSourceListProvider/Sdk/Constants.cs
@@ -20,7 +20,7 @@ namespace Microsoft.PackageManagement.PackageSourceListProvider
         public static readonly string SettingsFileName = "PSL.config";
 
         /// <summary>
-        /// Sample JSON file containing open powershell entry
+        /// Sample JSON file containing powershell entry
         /// </summary>
         public static readonly string JSONFileName = "PSL.json";
         public static readonly string CatFileName = "PSL.cat";

--- a/src/powershell-native/Install-PowerShellRemoting.ps1
+++ b/src/powershell-native/Install-PowerShellRemoting.ps1
@@ -37,7 +37,7 @@ function Register-WinRmPlugin
         $pluginAbsolutePath,
 
         #
-        # Expected Example: microsoft.ops.5.1
+        # Expected Example: microsoft.powershell-core.6.0
         #
         [string]
         [parameter(Mandatory=$true)]

--- a/src/powershell/Program.cs
+++ b/src/powershell/Program.cs
@@ -22,7 +22,7 @@ namespace Microsoft.PowerShell
         public static int Main(string[] args)
         {
 #if CORECLR
-            // Open PowerShell has to set the ALC here, since we don't own the native host
+            // PowerShell has to set the ALC here, since we don't own the native host
             string appBase = System.IO.Path.GetDirectoryName(typeof(ManagedPSEntry).GetTypeInfo().Assembly.Location);
             return (int)PowerShellAssemblyLoadContextInitializer.
                            InitializeAndCallEntryMethod(

--- a/test/powershell/Modules/PackageManagement/Install-PackageProvider.Tests.ps1
+++ b/test/powershell/Modules/PackageManagement/Install-PackageProvider.Tests.ps1
@@ -510,7 +510,7 @@ Describe "Install-Save-Package with multiple sources" -Tags "Feature" {
 }
 
 Describe "install-packageprovider with Scope" -Tags "Feature" {
-    # PENDING a lot of these tests because jobs are broken on OPS
+    # PENDING a lot of these tests because jobs are broken on PowerShell from GitHub
 
     BeforeAll {
         if ($IsWindows)


### PR DESCRIPTION
We aren't using the term "Open PowerShell" or OPS anymore, so we should stop using these terms in our code.
