### PR TITLE
Correcting Powershell profile paths for Windows and Linux 

### DIFF
--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
@@ -1722,10 +1722,13 @@ namespace Microsoft.PowerShell
                 // configuration to get the shell ID from, so we'll use the default...
                 string shellId = null;
                 if (_configuration != null)
-                    shellId = _configuration.ShellId;
+                        shellId = _configuration.ShellId;
                 else
-                    shellId = "Microsoft.PowerShell"; // TODO: what will happen for custom shells built using Make-Shell.exe
-
+#if CORECLR                
+                shellId = Platform.IsInbox ?  "Microsoft.PowerShell" : "PowerShell";
+#else
+                shellId = "Microsoft.PowerShell"; // TODO: what will happen for custom shells built using Make-Shell.exe
+#endif
                 // If the system lockdown policy says "Enforce", do so. Do this after types / formatting, default functions, etc
                 // are loaded so that they are trusted. (Validation of their signatures is done in F&O)
                 if (SystemPolicy.GetSystemLockdownPolicy() == SystemEnforcementMode.Enforce)

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
@@ -1722,12 +1722,12 @@ namespace Microsoft.PowerShell
                 // configuration to get the shell ID from, so we'll use the default...
                 string shellId = null;
                 if (_configuration != null)
-                        shellId = _configuration.ShellId;
+                    shellId = _configuration.ShellId;
                 else
 #if CORECLR                
-                shellId = Platform.IsInbox ?  "Microsoft.PowerShell" : "PowerShell";
+                    shellId = Platform.IsInbox ?  "Microsoft.PowerShell" : "PowerShell";
 #else
-                shellId = "Microsoft.PowerShell"; // TODO: what will happen for custom shells built using Make-Shell.exe
+                    shellId = "Microsoft.PowerShell"; // TODO: what will happen for custom shells built using Make-Shell.exe
 #endif
                 // If the system lockdown policy says "Enforce", do so. Do this after types / formatting, default functions, etc
                 // are loaded so that they are trusted. (Validation of their signatures is done in F&O)


### PR DESCRIPTION
The Profiles were getting loaded from wrong paths. Correcting all profile paths. 
