### PR TITLE
initialsession: remove curl and wget aliases

### DIFF
--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -5229,10 +5229,6 @@ end
                         "Show-Command",     "", ScopedItemOptions.ReadOnly | ScopedItemOptions.AllScope),
                     new SessionStateAliasEntry("trcm",
                         "Trace-Command",   "", ScopedItemOptions.ReadOnly | ScopedItemOptions.AllScope),
-                    new SessionStateAliasEntry("wget",
-                        "Invoke-WebRequest",   "", ScopedItemOptions.AllScope),
-                    new SessionStateAliasEntry("curl",
-                        "Invoke-WebRequest",   "", ScopedItemOptions.AllScope),
                     new SessionStateAliasEntry("lp",
                         "Out-Printer",     "", ScopedItemOptions.AllScope),
 #endif


### PR DESCRIPTION
They block use of the commonly used command line tools without providing
even an attempt to offer the same functionality. They serve no purpose
for PowerShell users but cause confusion and problems to existing curl
and wget users.

**Update:** Stay polite and to the point when commenting here. This pull-request is not an excuse to be rude or off-topic.
