### PR TITLE
Add initial FreeBSD tooling support

### DIFF
--- a/tools/download.sh
+++ b/tools/download.sh
@@ -34,6 +34,9 @@ case "$OSTYPE" in
                 exit 2 >&2 "$NAME is not supported!"
         esac
         ;;
+    freebsd*)
+        version=pkg
+        ;;
     darwin*)
         version=pkg
         ;;


### PR DESCRIPTION
- Add FreeBSD OS support so that the base powershell image can be downloaded
- Fix case so that it avoids bash exit with 'too many arguments' on FreeBSD 10 / bash4
