### PR TITLE
Pester tests wouldn't run from build directory with spaces

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -554,7 +554,7 @@ function Start-PSPester {
         [switch]$DisableExit,
         [string[]]$ExcludeTag = "Slow",
         [string[]]$Tag = "CI",
-        [string]$Path = "$PSScriptRoot/test/powershell"
+        [string]$Path = "'$PSScriptRoot/test/powershell'"
     )
 
     $powershell = Get-PSOutput
@@ -568,7 +568,7 @@ function Start-PSPester {
     }
 
     $PesterModule = [IO.Path]::Combine((Split-Path $powershell), "Modules", "Pester")
-    $Command += "Import-Module $PesterModule; "
+    $Command += "Import-Module '$PesterModule'; "
     $Command += "Invoke-Pester "
 
     $Command += "-OutputFormat ${OutputFormat} -OutputFile ${OutputFile} "


### PR DESCRIPTION
Added quotes at the appropriate places to enable running commands that
contained spaces in the filename/path.  Also needed to add pester.psm1
to path of Import-Module.
