### PR TITLE
clarify that visual studio with c++ compiler is required

### DIFF
--- a/docs/building/windows-core.md
+++ b/docs/building/windows-core.md
@@ -23,6 +23,11 @@ Using Git requires it to be setup correctly; refer to the
 This guide assumes that you have recursively cloned the PowerShell
 repository and `cd`ed into it.
 
+Visual Studio
+----------------
+
+You will need to install an edition of Visual Studio 2015 (Community, Enterprise, or Professional) with the optional feature 'Common Tools for Visual C++' installed. The free Community edition of Visual Studio 2015 can be downloaded [here](https://beta.visualstudio.com/visual-studio-community-vs/).
+
 .NET CLI
 --------
 
@@ -44,11 +49,6 @@ Invoke-WebRequest -Uri https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/sc
 If you have any problems installing `dotnet`,
 please see their [documentation][cli-docs].
 
-If you are using Windows 7, Windows Server 2008 or Windows Server 2012
-you will also need to install
-[Visual C++ Redistributable for Visual Studio 2012 Update 4][redist-2012]
-and [Visual C++ Redistributable for Visual Studio 2015][redist-2015].
-
 The version of .NET CLI is very important, you want a recent build of
 1.0.0 (**not** 1.0.1).
 
@@ -57,8 +57,6 @@ CLI can cause odd failures when running. Please check your version.
 
 [dotnet-cli]: https://github.com/dotnet/cli#new-to-net-cli
 [cli-docs]: https://dotnet.github.io/getting-started/
-[redist-2012]: https://www.microsoft.com/en-us/download/confirmation.aspx?id=30679
-[redist-2015]: https://www.microsoft.com/en-us/download/details.aspx?id=48145
 
 Build using our module
 ======================


### PR DESCRIPTION
Continuation of PR #1802 . Moving to new PR since the original fork was no longer valid after the repo went public.
