### PR TITLE
Getting tests to run from build directory with spaces in it

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -275,7 +275,7 @@ function Start-PSBuild {
                 $nativeResourcesFolder = $_
                 Get-ChildItem $nativeResourcesFolder -Filter "*.mc" | % {
                     $command = @"
-cmd.exe /C cd /d "$currentLocation" "&" "$($vcVarsPath)\vcvarsall.bat" "$NativeHostArch" "&" mc.exe -o -d -c -U $($_.FullName) -h "$nativeResourcesFolder" -r "$nativeResourcesFolder"
+cmd.exe /C cd /d "$currentLocation" "&" "$($vcVarsPath)\vcvarsall.bat" "$NativeHostArch" "&" mc.exe -o -d -c -U "$($_.FullName)" -h "$nativeResourcesFolder" -r "$nativeResourcesFolder"
 "@
                     log "  Executing mc.exe Command: $command"
                     Start-NativeExecution { Invoke-Expression -Command:$command }

--- a/build.psm1
+++ b/build.psm1
@@ -568,7 +568,7 @@ function Start-PSPester {
     }
 
     $PesterModule = [IO.Path]::Combine((Split-Path $powershell), "Modules", "Pester")
-    $Command += "Import-Module $PesterModule; "
+    $Command += "Import-Module '$PesterModule'; "
     $Command += "Invoke-Pester "
 
     $Command += "-OutputFormat ${OutputFormat} -OutputFile ${OutputFile} "
@@ -582,8 +582,8 @@ function Start-PSPester {
         $Command += "-Tag @('" + (${Tag} -join "','") + "') "
     }
 
-    $Command += $Path
-
+    $Command += "'" + $Path + "'"
+        
     Write-Verbose $Command
     # To ensure proper testing, the module path must not be inherited by the spawned process
     try {

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/FileCatalog.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/FileCatalog.Tests.ps1
@@ -208,7 +208,7 @@ Describe "Test suite for NewFileCatalogAndTestFileCatalogCmdlets" -Tags "CI" {
             $catalogPath = "$env:TEMP\UserConfigProv\NewFileCatalogFolderWhenCatlogFileIsCreatedInsideSameFolder.cat"
             try
             {
-                copy-item $testDataPath\UserConfigProv $env:temp -Recurse -ErrorAction SilentlyContinue             
+                copy-item "$testDataPath\UserConfigProv" $env:temp -Recurse -ErrorAction SilentlyContinue             
                 $null = New-FileCatalog -Path $env:temp\UserConfigProv\ -CatalogFilePath $catalogPath -CatalogVersion 1.0                   
                 $result = Test-FileCatalog -Path $env:temp\UserConfigProv\ -CatalogFilePath $catalogPath                     
             }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Invoke-Expression.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Invoke-Expression.Tests.ps1
@@ -13,17 +13,17 @@ Describe "Invoke-Expression" -Tags "CI" {
 	It "Should return the echoed text from a script" {
 	    $testfile = Join-Path -Path (Join-Path $PSScriptRoot -ChildPath assets) -ChildPath echoscript.ps1
 	    $testcommand = "echo pestertestscript"
-	    $testcommand | Add-Content -Path $testfile
-	    (Invoke-Expression $testfile) | Should Be "pestertestscript"
-	    Remove-Item $testfile
+	    $testcommand | Add-Content -Path "$testfile"
+	    (Invoke-Expression "& '$testfile'") | Should Be "pestertestscript"
+	    Remove-Item "$testfile"
 	}
 
 	It "Should return the echoed text from a script from the alias" {
 	    $testfile = Join-Path -Path (Join-Path $PSScriptRoot -ChildPath assets) -ChildPath echoscript.ps1
 	    $testcommand = "echo pestertestscript"
-	    $testcommand | Add-Content -Path $testfile
-	    (iex $testfile) | Should Be "pestertestscript"
-	    Remove-Item $testfile
+	    $testcommand | Add-Content -Path "$testfile"
+	    (iex "& '$testfile'") | Should Be "pestertestscript"
+	    Remove-Item "$testfile"
 	}
     }
 }


### PR DESCRIPTION
Found a few locations where paths weren't quoted or escaped with '& ...' that are needed to get tests to run from build directories with spaces in them.
