### PR TITLE
Updated URL to dotnet install.

### DIFF
--- a/docs/building/windows-core.md
+++ b/docs/building/windows-core.md
@@ -42,7 +42,7 @@ Start-PSBootstrap
 The `Start-PSBootstrap` function itself does exactly this:
 
 ```powershell
-Invoke-WebRequest -Uri https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/install.ps1 -OutFile install.ps1
+Invoke-WebRequest -Uri https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/dotnet-install.ps1 -OutFile install.ps1
 ./install.ps1
 ```
 


### PR DESCRIPTION
The current URL ends in a 404 error. It looks like the filename was changed from install.ps1 to dotnet-install.ps1
