### PR TITLE
Replace & for && in condition

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/CopyPropertyCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/CopyPropertyCommand.cs
@@ -75,7 +75,7 @@ namespace Microsoft.PowerShell.Commands
         /// 
         internal override object GetDynamicParameters(CmdletProviderContext context)
         {
-            if (Path != null & Path.Length > 0)
+            if (Path != null && Path.Length > 0)
             {
                 return InvokeProvider.Property.CopyPropertyDynamicParameters(
                     Path[0],


### PR DESCRIPTION
Replace & for && to prevent NullReferenceException
