### PR TITLE
Enable WebRequestPSCmdlet to not validate HTTPS certificates

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -88,6 +88,12 @@ namespace Microsoft.PowerShell.Commands
         [ValidateNotNull]
         public virtual X509Certificate Certificate { get; set; }
 
+        /// <summary>
+        /// gets or sets the IgnoreCertificateCheck property
+        /// </summary>
+        [Parameter]
+        public virtual SwitchParameter IgnoreCertificateCheck { get; set; }
+
         #endregion
 
         #region Headers

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -89,10 +89,10 @@ namespace Microsoft.PowerShell.Commands
         public virtual X509Certificate Certificate { get; set; }
 
         /// <summary>
-        /// gets or sets the IgnoreCertificateCheck property
+        /// gets or sets the NoCertificateCheck property
         /// </summary>
         [Parameter]
-        public virtual SwitchParameter IgnoreCertificateCheck { get; set; }
+        public virtual SwitchParameter NoCertificateCheck { get; set; }
 
         #endregion
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -89,10 +89,10 @@ namespace Microsoft.PowerShell.Commands
         public virtual X509Certificate Certificate { get; set; }
 
         /// <summary>
-        /// gets or sets the NoCertificateCheck property
+        /// gets or sets the SkipCertificateCheck property
         /// </summary>
         [Parameter]
-        public virtual SwitchParameter NoCertificateCheck { get; set; }
+        public virtual SwitchParameter SkipCertificateCheck { get; set; }
 
         #endregion
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebRequestPSCmdlet.CoreClr.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebRequestPSCmdlet.CoreClr.cs
@@ -97,7 +97,7 @@ namespace Microsoft.PowerShell.Commands
                 handler.ClientCertificates = WebSession.Certificates;
             }*/
 
-            if (IgnoreCertificateCheck)
+            if (NoCertificateCheck)
             {
                 handler.ServerCertificateCustomValidationCallback = delegate { return true; };
             }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebRequestPSCmdlet.CoreClr.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebRequestPSCmdlet.CoreClr.cs
@@ -97,7 +97,7 @@ namespace Microsoft.PowerShell.Commands
                 handler.ClientCertificates = WebSession.Certificates;
             }*/
 
-            if (NoCertificateCheck)
+            if (SkipCertificateCheck)
             {
                 handler.ServerCertificateCustomValidationCallback = delegate { return true; };
             }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebRequestPSCmdlet.CoreClr.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebRequestPSCmdlet.CoreClr.cs
@@ -97,6 +97,11 @@ namespace Microsoft.PowerShell.Commands
                 handler.ClientCertificates = WebSession.Certificates;
             }*/
 
+            if (IgnoreCertificateCheck)
+            {
+                handler.ServerCertificateCustomValidationCallback = delegate { return true; };
+            }
+
             if (WebSession.MaximumRedirection > -1)
             {
                 if (WebSession.MaximumRedirection == 0)

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -382,9 +382,14 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
     It "Validate Invoke-WebRequest -SkipCertificateCheck" {
 
         # validate that exception is thrown for URI with expired certificate
-        Invoke-WebRequest -Uri 'https://expired.badssl.com' | Should Throw
+        $command = "Invoke-WebRequest -Uri 'https://expired.badssl.com'"
+        $result = ExecuteWebCommand -command $command
+        $result.Error.FullyQualifiedErrorId | Should Be "WebCmdletWebResponseException,Microsoft.PowerShell.Commands.InvokeWebRequestCommand"
+
         # validate that no exception is thrown for URI with expired certificate when using -SkipCertificateCheck option
-        Invoke-WebRequest -Uri 'https://expired.badssl.com' -SkipCertificateCheck | Should Not Throw
+        $command = "Invoke-WebRequest -Uri 'https://expired.badssl.com' -SkipCertificateCheck"
+        $result = ExecuteWebCommand -command $command
+        $result.Error | Should BeNullOrEmpty
     }
 
 }
@@ -606,9 +611,14 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
 
         # HTTP method HEAD must be used to not retrieve an unparsable HTTP body
         # validate that exception is thrown for URI with expired certificate
-        Invoke-RestMethod -Uri 'https://expired.badssl.com' -Method HEAD | Should Throw
+        $command = "Invoke-RestMethod -Uri 'https://expired.badssl.com' -Method HEAD"
+        $result = ExecuteWebCommand -command $command
+        $result.Error.FullyQualifiedErrorId | Should Be "WebCmdletWebResponseException,Microsoft.PowerShell.Commands.InvokeRestMethodCommand"
+
         # validate that no exception is thrown for URI with expired certificate when using -SkipCertificateCheck option
-        Invoke-RestMethod -Uri 'https://expired.badssl.com' -SkipCertificateCheck -Method HEAD | Should Not Throw
+        $command = "Invoke-RestMethod -Uri 'https://expired.badssl.com' -SkipCertificateCheck -Method HEAD"
+        $result = ExecuteWebCommand -command $command
+        $result.Error | Should BeNullOrEmpty
     }
 
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -379,6 +379,14 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
         $jsonContent.headers.'User-Agent' | Should Match "WindowsPowerShell"
     }
 
+    It "Validate Invoke-WebRequest -SkipCertificateCheck" {
+
+        # validate that exception is thrown for URI with expired certificate
+        Invoke-WebRequest -Uri 'https://expired.badssl.com' | Should Throw
+        # validate that no exception is thrown for URI with expired certificate when using -SkipCertificateCheck option
+        Invoke-WebRequest -Uri 'https://expired.badssl.com' -SkipCertificateCheck | Should Not Throw
+    }
+
 }
 
 Describe "Invoke-RestMethod tests" -Tags "Feature" {
@@ -593,4 +601,14 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
         $jsonContent.headers.Host | Should Match "httpbin.org"
         $jsonContent.headers.'User-Agent' | Should Match "WindowsPowerShell"
     }
+
+    It "Validate Invoke-RestMethod -SkipCertificateCheck" {
+
+        # HTTP method HEAD must be used to not retrieve an unparsable HTTP body
+        # validate that exception is thrown for URI with expired certificate
+        Invoke-RestMethod -Uri 'https://expired.badssl.com' -Method HEAD | Should Throw
+        # validate that no exception is thrown for URI with expired certificate when using -SkipCertificateCheck option
+        Invoke-RestMethod -Uri 'https://expired.badssl.com' -SkipCertificateCheck -Method HEAD | Should Not Throw
+    }
+
 }


### PR DESCRIPTION
Added switch parameter SkipCertificateCheck to WebRequestPSCmdlet to enable Invoke-WebRequest and Invoke-RestMethod to not validate the HTTPS certificate of the server if required.

Implemented as discussed in issue #1945 
