### PR TITLE
Added Debian compatibility notice

### DIFF
--- a/docs/installation/linux.md
+++ b/docs/installation/linux.md
@@ -46,6 +46,7 @@ sudo dpkg -i powershell_6.0.0-alpha.9-1ubuntu1.16.04.1_amd64.deb
 
 [Ubuntu 16.04]: http://releases.ubuntu.com/16.04/
 
+This works for Debian Stretch (now testing) as well.
 
 CentOS 7
 ========


### PR DESCRIPTION
Ubuntu 16.04 LTS is very similar to Debian 9 Strech (now in testing). I can confirm, the instructions work and PS will install successfully.
