### PR TITLE
Join multiple paths in one call to Join-Path

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/CombinePathCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/CombinePathCommand.cs
@@ -34,7 +34,7 @@ namespace Microsoft.PowerShell.Commands
         [AllowNull]
         [AllowEmptyString]
         [AllowEmptyCollection]
-        public string[] ChildPath { get; set; } = new string[0];
+        public string[] ChildPath { get; set; } = Utils.EmptyArray<string>();
 
         /// <summary>
         /// Determines if the path should be resolved after being joined

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/CombinePathCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/CombinePathCommand.cs
@@ -30,11 +30,20 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Gets or sets the childPath parameter to the command
         /// </summary>
-        [Parameter(Position = 1, Mandatory = true, ValueFromPipelineByPropertyName = true, ValueFromRemainingArguments = true)]
+        [Parameter(Position = 1, Mandatory = true, ValueFromPipelineByPropertyName = true)]
+        [AllowNull]
+        [AllowEmptyString]
+        public string ChildPath { get; set; }
+
+        /// <summary>
+        /// Gets or sets additional childPaths to the command.
+        /// </summary>
+
+        [Parameter(Position = 2, Mandatory = false, ValueFromPipelineByPropertyName = true, ValueFromRemainingArguments = true)]
         [AllowNull]
         [AllowEmptyString]
         [AllowEmptyCollection]
-        public string[] ChildPath { get; set; } = Utils.EmptyArray<string>();
+        public string[] AdditionalChildPath { get; set; } = Utils.EmptyArray<string>();
 
         /// <summary>
         /// Determines if the path should be resolved after being joined
@@ -57,21 +66,14 @@ namespace Microsoft.PowerShell.Commands
                 Path != null,
                 "Since Path is a mandatory parameter, paths should never be null");
 
-            string combinedChildPath = String.Empty;
+            string combinedChildPath = ChildPath;
 
             // join the ChildPath elements
-            if (ChildPath != null)
+            if (AdditionalChildPath != null)
             {
-                foreach (string childPath in ChildPath)
+                foreach (string childPath in AdditionalChildPath)
                 {
-                    if (String.IsNullOrEmpty(combinedChildPath))
-                    {
-                        combinedChildPath = childPath;
-                    }
-                    else
-                    {
-                        combinedChildPath = SessionState.Path.Combine(combinedChildPath, childPath, CmdletProviderContext);
-                    }
+                    combinedChildPath = SessionState.Path.Combine(combinedChildPath, childPath, CmdletProviderContext);
                 }
             }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Join-Path.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Join-Path.Tests.ps1
@@ -43,4 +43,9 @@ Describe "Join-Path cmdlet tests" -Tags "CI" {
     $result.Count | Should be 1
     $result       | Should BeExactly ("Env:"+$SepChar+"foo")
   }
+  It "should be able to join multiple child paths passed by position with remaining arguments" {
+    $result = Join-Path one two three four five
+    $result.Count | Should Be 1
+    $result       | Should BeExactly "one${sepChar}two${sepChar}three${sepChar}four${sepChar}five"
+  }
 }


### PR DESCRIPTION
Now that we've got cross-platform PowerShell, this is a quality of life improvement for script authors who want to make code compatible across Windows and Linux.  In the current implementation (on Windows), if you want to join paths multiple levels deep, you'd do this:

``` posh
Join-Path $someParentPath 'child1\child2\child3'
```

Since you knew what the entire child path needed to be, there was no need for "join" logic there.  Now, we'd prefer to see a path completely built up with the proper directory separator character for the platform.  That would have looked something like this mess:

``` posh
Join-Path $someParentPath (Join-Path child1 (Join-Path child2 child3))
```

With this PR, it becomes much more pleasant:

``` posh
Join-Path $someParentPath child1 child2 child3
```

Question for the team:  do I need to update JoinPathActivity.cs in this PR to reflect the new `string[]` parameter type as well, or do those workflow activity files get automatically regenerated later?
