### PR TITLE
Filling test gaps (issue 2022) - this replaces PR 1834

### DIFF
--- a/test/powershell/Modules/Microsoft.PowerShell.Core/History.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/History.Tests.ps1
@@ -1,4 +1,51 @@
 ﻿Describe "History cmdlet test cases" -Tags "CI" {
+    Context "Simple History Tests" {
+        BeforeEach {
+            $setting = [system.management.automation.psinvocationsettings]::New()
+            $setting.AddToHistory = $true
+            $ps = [PowerShell]::Create("NewRunspace")
+            # we need to be sure that history is added, so use the proper
+            # Invoke variant
+            $null = $ps.addcommand("Get-Date").Invoke($null,$setting)
+            $ps.commands.clear()
+            $null = $ps.addscript("1+1").Invoke($null,$setting)
+            $ps.commands.clear()
+            $null = $ps.addcommand("Get-Location").Invoke($null,$setting)
+            $ps.commands.clear()
+        }
+        AfterEach {
+            $ps.Dispose()
+        }
+        It "Get-History returns proper history" {
+            # for this case, we'll *not* add to history
+            $result = $ps.AddCommand("Get-History").Invoke()
+            $result.Count | should be 3
+            $result[0].CommandLine | should be "Get-Date"
+            $result[1].CommandLine | should be "1+1"
+            $result[2].CommandLine | should be "Get-Location"
+        }
+        It "Invoke-History invokes proper command" {
+            $result = $ps.AddScript("Invoke-History 2").Invoke()
+            $result | Should be 2
+        }
+        It "Clear-History removes history" {
+            $ps.AddCommand("Clear-History").Invoke()
+            $ps.commands.clear()
+            $result = $ps.AddCommand("Get-History").Invoke()
+            $result | should BeNullOrEmpty
+        }
+        It "Add-History actually adds to history" {
+            # add this invocation to history
+            $ps.AddScript("Get-History|Add-History").Invoke($null,$setting)
+            # that's 4 history lines * 2
+            $ps.Commands.Clear()
+            $result = $ps.AddCommand("Get-History").Invoke()
+            $result.Count | Should be 8
+            for($i = 0; $i -lt 4; $i++) {
+                $result[$i+4].CommandLine | Should be $result[$i].CommandLine
+            }
+        }
+    }
 	
 	It "Tests Invoke-History on a cmdlet that generates output on all streams" {
         $streamSpammer = '

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Job.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Job.Tests.ps1
@@ -1,0 +1,76 @@
+Describe "Job Cmdlet Tests" -Tag "CI" {
+    Context "Simple Jobs" {
+        AfterEach {
+            Get-Job | Remove-Job -force
+        }
+        BeforeEach {
+            $j = start-job -scriptblock { 1 + 1 }
+        }
+        It "Start-Job produces a job object" {
+            $j.gettype().fullname | should be "System.Management.Automation.PSRemotingJob"
+        }
+        It "Get-Job retrieves a job object" {
+            (Get-Job -id $j.id).gettype().fullname | should be "System.Management.Automation.PSRemotingJob"
+        }
+        It "Remove-Job can remove a job" {
+            remove-job $j -force
+            try {
+                get-job $j -ea Stop
+                throw "Execution OK"
+            }
+            catch {
+                $_.FullyQualifiedErrorId | should be "JobWithSpecifiedNameNotFound,Microsoft.PowerShell.Commands.GetJobCommand"
+            }
+        }
+        It "Receive-Job can retrieve job results" -pending {
+            $waitjob = Wait-Job -Timeout 10 -id $j.id
+            if ( $waitJob ) {
+                $result = receive-job -id $j.id
+                $result.id | Should be 2
+            }
+        }
+    }
+    Context "jobs which take time" {
+        BeforeEach {
+            $j = start-job -scriptblock { Start-Sleep 15 }
+        }
+        AfterEach {
+            Get-Job | Remove-Job -force
+        }
+        It "Wait-Job will wait for a job" {
+            $result = wait-Job $j
+            $result | should be $j
+        }
+        It "Stop-Job will stop a job" -pending {
+            Stop-Job -id $j.id 
+            $j.Status |Should be Stopped
+        }
+    }
+}
+Describe "Debug-job test" -tag "Feature" {
+    BeforeAll {
+        $rs = [runspacefactory]::CreateRunspace()
+        $rs.Open()
+        $rs.Debugger.SetDebugMode([System.Management.Automation.DebugModes]::RemoteScript)
+        $rs.Debugger.add_DebuggerStop({$true})
+        $ps = [powershell]::Create()
+        $ps.Runspace = $rs
+    }
+    AfterAll {
+        $rs.Dispose()
+        $ps.Dispose()
+    }
+    # we check this via implication.
+    # if we're debugging a job, then the debugger will have a callstack
+    It "Debug-Job will break into debugger" -pending {
+        $ps.AddScript('$job = start-job { 1..300 | % { sleep 1 } }').Invoke()
+        $ps.Commands.Clear()
+        $ps.Runspace.Debugger.GetCallStack() | Should BeNullOrEmpty
+        start-sleep 3
+        $asyncResult = $ps.AddScript('debug-job $job').BeginInvoke()
+        $ps.commands.clear()
+        start-sleep 2
+        $result = $ps.runspace.Debugger.GetCallStack()
+        $result.Command | Should be "<ScriptBlock>"
+    }
+}

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Clear-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Clear-Item.Tests.ps1
@@ -1,0 +1,11 @@
+Describe "Clear-Item tests" -Tag "CI" {
+    BeforeAll {
+        ${myClearItemVariableTest} = "Value is here"
+    }
+    It "Clear-Item can clear an item" {
+        $myClearItemVariableTest | Should be "Value is here"
+        Clear-Item variable:myClearItemVariableTest
+        test-path variable:myClearItemVariableTest | should be $true
+        $myClearItemVariableTest | Should BeNullOrEmpty
+    }
+}

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/ItemProperty.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/ItemProperty.Tests.ps1
@@ -1,0 +1,19 @@
+Describe "Simple ItemProperty Tests" -Tag "CI" {
+    It "Can retrieve the PropertyValue with Get-ItemPropertyValue" {
+        Get-ItemPropertyValue -path $TESTDRIVE -Name Attributes | should be "Directory"
+    }
+    It "Can clear the PropertyValue with Clear-ItemProperty" {
+        setup -f file1.txt
+        Set-ItemProperty $TESTDRIVE/file1.txt -Name Attributes -Value ReadOnly
+        Get-ItemPropertyValue -path $TESTDRIVE/file1.txt -Name Attributes | should match "ReadOnly"
+        Clear-ItemProperty $TESTDRIVE/file1.txt -Name Attributes
+        Get-ItemPropertyValue -path $TESTDRIVE/file1.txt -Name Attributes | should not match "ReadOnly"
+    }
+    # these cmdlets are targeted at the windows registry, and don't have an linux equivalent
+    Context "Registry targeted cmdlets" {
+        It "Copy ItemProperty" -pending { }
+        It "Move ItemProperty" -pending { }
+        It "New ItemProperty" -pending { }
+        It "Rename ItemProperty" -pending { }
+    }
+}

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Move-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Move-Item.Tests.ps1
@@ -1,0 +1,14 @@
+Describe "Move-Item tests" -Tag "CI" {
+    BeforeAll {
+        $content = "This is content"
+        Setup -f originalfile.txt -content "This is content"
+        $source = "$TESTDRIVE/originalfile.txt"
+        $target = "$TESTDRIVE/ItemWhichHasBeenRenamed.txt"
+    }
+    It "Rename-Item will rename a file" {
+        Rename-Item $source $target
+        test-path $source | Should be $false
+        test-path $target | Should be $true
+        "$target" | Should ContainExactly "This is content"
+    }
+}

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Rename-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Rename-Item.Tests.ps1
@@ -1,0 +1,14 @@
+Describe "Rename-Item tests" -Tag "CI" {
+    BeforeAll {
+        $content = "This is content"
+        Setup -f originalFile.txt -content "This is content"
+        $source = "$TESTDRIVE/originalFile.txt"
+        $target = "$TESTDRIVE/ItemWhichHasBeenRenamed.txt"
+    }
+    It "Rename-Item will rename a file" {
+        Rename-Item $source $target
+        test-path $source | Should be $false
+        test-path $target | Should be $true
+        "$target" | Should ContainExactly "This is content"
+    }
+}

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Resolve-Path.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Resolve-Path.Tests.ps1
@@ -1,0 +1,18 @@
+Describe "Resolve-Path returns proper path" -Tag "CI" {
+    It "Resolve-Path returns resolved paths" {
+        Resolve-Path $TESTDRIVE | Should be "$TESTDRIVE"
+    }
+    It "Resolve-Path handles provider qualified paths" {
+        $result = Resolve-Path Filesystem::$TESTDRIVE
+        $result.providerpath | should be "$TESTDRIVE"
+    }
+    It "Resolve-Path provides proper error on invalid location" {
+        try {
+            Resolve-Path $TESTDRIVE/this.directory.is.invalid -ea stop
+            throw "execution OK"
+        }
+        catch {
+            $_.fullyqualifiederrorid | should be "PathNotFound,Microsoft.PowerShell.Commands.ResolvePathCommand"
+        }
+    }
+}

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Item.Tests.ps1
@@ -1,0 +1,17 @@
+Describe "Set-Item" -Tag "CI" {
+    $testCases = @{ Path = "variable:SetItemTestCase"; Value = "TestData"; Validate = { $SetItemTestCase | Should be "TestData" }; Reset = {remove-item variable:SetItemTestCase} },
+        @{ Path = "alias:SetItemTestCase"; Value = "Get-Alias"; Validate = { (Get-Alias SetItemTestCase).Definition | should be "Get-Alias"}; Reset = { remove-item alias:SetItemTestCase } },
+        @{ Path = "function:SetItemTestCase"; Value = { 1 }; Validate = { SetItemTestCase | should be 1 }; Reset = { remove-item function:SetItemTestCase } },
+        @{ Path = "env:SetItemTestCase"; Value = { 1 }; Validate = { $env:SetItemTestCase | should be 1 }; Reset = { remove-item env:SetItemTestCase } }
+
+    It "Set-Item should be able to handle <Path>" -TestCase $testCases {
+        param ( $Path, $Value, $Validate, $Reset ) 
+        Set-item -path $path -Value $value
+        try {
+            & $Validate
+        }
+        finally {
+            & $reset
+        }
+    }
+}

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/AclCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/AclCmdlets.Tests.ps1
@@ -1,0 +1,18 @@
+Describe "Acl cmdlets are available and operate properly" -Tag CI {
+    It "Get-Acl returns an ACL object" -pending:(!$IsWindows) {
+        $ACL = get-acl $TESTDRIVE
+        $ACL.gettype().FullName | Should be "System.Security.AccessControl.DirectorySecurity"
+    }
+    It "Set-Acl can set the ACL of a directory" -pending {
+        Setup -d testdir
+        $directory = "$TESTDRIVE/testdir"
+        $acl = get-acl $directory
+        $accessRule = [System.Security.AccessControl.FileSystemAccessRule]::New("Everyone","FullControl","ContainerInherit,ObjectInherit","None","Allow")
+        $acl.AddAccessRule($accessRule)
+        { $acl | Set-Acl $directory } | should not throw
+        
+        $newacl = get-acl $directory
+        $newrule = $newacl.Access | ?{ $accessrule.FileSystemRights -eq $_.FileSystemRights -and $accessrule.AccessControlType -eq $_.AccessControlType -and $accessrule.IdentityReference -eq $_.IdentityReference }
+        $newrule |Should not benullorempty
+    }
+}

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Stream.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Stream.Tests.ps1
@@ -68,4 +68,13 @@ Describe "Stream writer tests" -Tags "CI" {
             $Error[0] | Should Match "Test Error Message"
         }
     }
+
+    Context "Write-Information cmdlet" {
+       It "Write-Information outputs an information object" {
+           # redirect the streams is sufficient
+           $result = Write-Information "Test Message" *>&1
+           $result.GetType().Fullname | Should be "System.Management.Automation.InformationRecord"
+           "$result" | Should be "Test Message"
+       }
+    }
 }


### PR DESCRIPTION
This replaces PR 1834 from the private fork I had
it adds approximately 30 new tests for cmdlets which currently have little or no tests
