### PR TITLE
Revert "Pester tests wouldn't run from build directory with spaces"

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -554,7 +554,7 @@ function Start-PSPester {
         [switch]$DisableExit,
         [string[]]$ExcludeTag = "Slow",
         [string[]]$Tag = "CI",
-        [string]$Path = "'$PSScriptRoot/test/powershell'"
+        [string]$Path = "$PSScriptRoot/test/powershell"
     )
 
     $powershell = Get-PSOutput


### PR DESCRIPTION
Reverts PowerShell/PowerShell#1951

I am reverting this PR because it blocks local execution of Start-PSPester. The doubled single quotes at the end of the command (''F:\GitRepos\ForkedPowerShell/test/powershell'') trigger the error. Removing them resolves the issue.

PS F:\GitRepos\ForkedPowerShell> start-pspester -Verbose
VERBOSE: Set-ExecutionPolicy -Scope Process Unrestricted; Import-Module 'F:\GitRepos\ForkedPowerShell\src\powershell-win-core\bin\Debug\netcoreapp1.0\win10-x64\publish\Modules\Pester'; Invoke-Pester -OutputFormat NUnitXml -OutputFile pester-tests.xml -EnableExit
-ExcludeTag @('Slow') -Tag @('CI') ''F:\GitRepos\ForkedPowerShell/test/powershell''

Test-Path : Cannot bind argument to parameter 'LiteralPath' because it is an empty string.
At F:\GitRepos\ForkedPowerShell\src\powershell-win-core\bin\Debug\netcoreapp1.0\win10-x64\publish\Modules\Pester\Pester.psm1:283 char:41
-                 (Test-Path -LiteralPath $unresolvedPath -PathType Lea ...
-                                         ~~~~~~~~~~~~~~~
  - CategoryInfo          : InvalidData: (:) [Test-Path], ParameterBindingValidationException
  - FullyQualifiedErrorId : ParameterArgumentValidationErrorEmptyStringNotAllowed,Microsoft.PowerShell.Commands.TestPathCommand
