### PR TITLE
Fixing the path to the user's JSON configuration file

### DIFF
--- a/src/System.Management.Automation/engine/PropertyAccessor.cs
+++ b/src/System.Management.Automation/engine/PropertyAccessor.cs
@@ -146,7 +146,7 @@ namespace System.Management.Automation
             //
             // Sets the per-user configuration directory
             //
-            appDataConfigDirectory = Utils.GetUserSettingsDirectory();
+            appDataConfigDirectory = Utils.GetUserConfigurationDirectory();
             if (!Directory.Exists(appDataConfigDirectory))
             {
                 try
@@ -166,11 +166,11 @@ namespace System.Management.Automation
         /// not interfere with PowerShell initialization
         /// </summary>
         /// <returns>Returns the directory if present or creatable. Throws otherwise.</returns>
-        private string GetAppDataConfigDirectory()
+        private string GetCurrentUserConfigDirectory()
         {
             if (null == appDataConfigDirectory)
             {
-                string tempAppDataConfigDir = Utils.GetUserSettingsDirectory();
+                string tempAppDataConfigDir = Utils.GetUserConfigurationDirectory();
                 if (!Directory.Exists(tempAppDataConfigDir))
                 {
                     Directory.CreateDirectory(tempAppDataConfigDir);
@@ -194,7 +194,7 @@ namespace System.Management.Automation
             // Defaults to system wide.
             if (PropertyScope.CurrentUser == scope)
             {
-                scopeDirectory = GetAppDataConfigDirectory();
+                scopeDirectory = GetCurrentUserConfigDirectory();
             }
 
             string fileName = Path.Combine(scopeDirectory, configFileName);
@@ -229,7 +229,7 @@ namespace System.Management.Automation
             // Defaults to system wide.
             if(PropertyScope.CurrentUser == scope)
             {
-                scopeDirectory = GetAppDataConfigDirectory();
+                scopeDirectory = GetCurrentUserConfigDirectory();
             }
 
             string fileName = Path.Combine(scopeDirectory, configFileName);
@@ -250,7 +250,7 @@ namespace System.Management.Automation
             // Defaults to system wide.
             if (PropertyScope.CurrentUser == scope)
             {
-                scopeDirectory = GetAppDataConfigDirectory();
+                scopeDirectory = GetCurrentUserConfigDirectory();
             }
 
             string fileName = Path.Combine(scopeDirectory, configFileName);
@@ -265,7 +265,7 @@ namespace System.Management.Automation
             // Defaults to system wide.
             if (PropertyScope.CurrentUser == scope)
             {
-                scopeDirectory = GetAppDataConfigDirectory();
+                scopeDirectory = GetCurrentUserConfigDirectory();
             }
 
             string fileName = Path.Combine(scopeDirectory, configFileName);

--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -282,16 +282,16 @@ namespace System.Management.Automation
 
         /// <summary>
         /// Specifies the per-user configuration settings directory in a platform agnostic manner.
-        /// Windows Ex:
-        ///     %LOCALAPPDATA%\PowerShell
-        /// Non-Windows Ex:
-        ///     ~/.config/PowerShell
         /// </summary>
         /// <returns>The current user's configuration settings directory</returns>
-        internal static string GetUserSettingsDirectory()
+        internal static string GetUserConfigurationDirectory()
         {
-            string appDataPath = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-            return Path.Combine(appDataPath, "PowerShell");
+#if UNIX
+            return Platform.SelectProductNameForDirectory(Platform.XDG_Type.CONFIG);
+#else
+            string basePath = Environment.GetFolderPath(Environment.SpecialFolder.Personal);
+            return IO.Path.Combine(basePath, Utils.ProductNameForDirectory);
+#endif
         }
 
         private static string[] GetProductFolderDirectories()

--- a/src/System.Management.Automation/engine/hostifaces/HostUtilities.cs
+++ b/src/System.Management.Automation/engine/hostifaces/HostUtilities.cs
@@ -182,12 +182,7 @@ namespace System.Management.Automation
 
             if (forCurrentUser)
             {
-#if UNIX
-                basePath = Platform.SelectProductNameForDirectory(Platform.XDG_Type.CONFIG);   
-#else
-                basePath = Environment.GetFolderPath(Environment.SpecialFolder.Personal);
-                basePath = IO.Path.Combine(basePath, Utils.ProductNameForDirectory);
-#endif
+                basePath = Utils.GetUserConfigurationDirectory();
             }
             else
             {


### PR DESCRIPTION
This PR fixes the confusion caused by the camel cased "PowerShell" in the user's configuration directory. It now uses the same directory where the user's profile is stored.
I added additional test coverage to verify that the JSON config file in that directory properly handles IO.

This resolves issue #1823
