### PR TITLE
Fix Parameter Binder bug with Advanced Functions and ValueFromRemainingArguments

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Write-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Write-Object.cs
@@ -55,10 +55,8 @@ namespace Microsoft.PowerShell.Commands
             {
                 enumerate = false;
             }
-            foreach (PSObject inputObject in _inputObjects) // compensate for ValueFromRemainingArguments
-            {
-                WriteObject(inputObject, enumerate);
-            }
+
+            WriteObject(_inputObjects, enumerate);
         }//processrecord
     }//WriteOutputCommand
     #endregion

--- a/test/powershell/engine/ParameterBinding/ParameterBinding.Tests.ps1
+++ b/test/powershell/engine/ParameterBinding/ParameterBinding.Tests.ps1
@@ -228,7 +228,7 @@
             [CmdletBinding()]
             param (
             [array]$Parameter1,
-            [int[]]$Parameter2 
+            [int[]]$Parameter2
             )
 
             Process {
@@ -327,6 +327,100 @@
 
             $result = & $psPath -NoProfile -File $test2File
             $result | Should Be $expected
+        }
+    }
+
+    Context "ValueFromRemainingArguments" {
+        BeforeAll {
+            function Test-BindingFunction {
+                param (
+                    [Parameter(ValueFromRemainingArguments)]
+                    [object[]] $Parameter
+                )
+
+                return [pscustomobject] @{
+                    ArgumentCount = $Parameter.Count
+                    Value = $Parameter
+                }
+            }
+
+            # Deliberately not using TestDrive:\ here because Pester will fail to clean it up due to the
+            # assembly being loaded in our process.
+
+            if ($IsWindows)
+            {
+                $tempDir = $env:temp
+            }
+            else
+            {
+                $tempDir = '/tmp'
+            }
+
+            $dllPath = Join-Path $tempDir TestBindingCmdlet.dll
+
+            Add-Type -OutputAssembly $dllPath -TypeDefinition '
+                using System;
+                using System.Management.Automation;
+
+                [Cmdlet("Test", "BindingCmdlet")]
+                public class TestBindingCommand : PSCmdlet
+                {
+                    [Parameter(Position = 0, ValueFromRemainingArguments = true)]
+                    public string[] Parameter { get; set; }
+
+                    protected override void ProcessRecord()
+                    {
+                        PSObject obj = new PSObject();
+
+                        obj.Properties.Add(new PSNoteProperty("ArgumentCount", Parameter.Length));
+                        obj.Properties.Add(new PSNoteProperty("Value", Parameter));
+
+                        WriteObject(obj);
+                    }
+                }
+            '
+
+            Import-Module $dllPath
+        }
+
+        AfterAll {
+            Get-Module TestBindingCmdlet | Remove-Module -Force
+        }
+
+        It "Binds properly when passing an explicit array to an advanced function" {
+            $result = Test-BindingFunction 1,2,3
+
+            $result.ArgumentCount | Should Be 3
+            $result.Value[0] | Should Be 1
+            $result.Value[1] | Should Be 2
+            $result.Value[2] | Should Be 3
+        }
+
+        It "Binds properly when passing multiple arguments to an advanced function" {
+            $result = Test-BindingFunction 1 2 3
+
+            $result.ArgumentCount | Should Be 3
+            $result.Value[0] | Should Be 1
+            $result.Value[1] | Should Be 2
+            $result.Value[2] | Should Be 3
+        }
+
+        It "Binds properly when passing an explicit array to a cmdlet" {
+            $result = Test-BindingCmdlet 1,2,3
+
+            $result.ArgumentCount | Should Be 3
+            $result.Value[0] | Should Be 1
+            $result.Value[1] | Should Be 2
+            $result.Value[2] | Should Be 3
+        }
+
+        It "Binds properly when passing multiple arguments to a cmdlet" {
+            $result = Test-BindingCmdlet 1 2 3
+
+            $result.ArgumentCount | Should Be 3
+            $result.Value[0] | Should Be 1
+            $result.Value[1] | Should Be 2
+            $result.Value[2] | Should Be 3
         }
     }
 }


### PR DESCRIPTION
Resolves issues #2035 

In the current code, two calls to `BindParameter` are potentially made, and the assumption was that if a caller had specified `Set-ClusterOwnerNode foo,bar` instead of `Set-ClusterOwnerNode foo bar`, the first call would fail.

This was not the case with Advanced Functions, so the logic which was supposed to cover that case in `HandleRemainingArguments()` wasn't being triggered.  This update unwraps a single-element list first, rather than requiring a failed call to `BindParameter` before that happens.

As a result, `Write-Object` no longer needs its own foreach loop to compensate for being sent a `List<Object>` from `HandleRemainingArguments()`.
