### PR TITLE
remove extra 'not' in error message

### DIFF
--- a/src/Microsoft.PackageManagement.PackageSourceListProvider/PackageList/PackageListParser.cs
+++ b/src/Microsoft.PackageManagement.PackageSourceListProvider/PackageList/PackageListParser.cs
@@ -140,7 +140,7 @@ namespace Microsoft.PackageManagement.PackageSourceListProvider
                     }
                     else
                     {
-                        throw new ArgumentException(string.Format("'{0}' is not referencd but not defined in the file '{1}'", dep.Name, package.FilePath));
+                        throw new ArgumentException(string.Format("'{0}' is referencd but not defined in the file '{1}'", dep.Name, package.FilePath));
                     }
 
                 }


### PR DESCRIPTION
Spelling of referenced to be fixed later

This is an attempt to test the waters of your review system.

I have a >700 commit series which would come after this (I'm not done writing it, and would need to remove a commit which is there to help my tooling, but you can peek at my repo to see it).
