### PR TITLE
Add missing OutputType attribute.

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/GetComputerInfoCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/GetComputerInfoCommand.cs
@@ -25,6 +25,7 @@ namespace Microsoft.PowerShell.Commands
     [Cmdlet(VerbsCommon.Get, "ComputerInfo",
         HelpUri = "http://go.microsoft.com/fwlink/?LinkId=799466")]
     [Alias("gin")]
+    [OutputType(typeof(ComputerInfo), typeof(PSCustomObject))]
     public class GetComputerInfoCommand : PSCmdlet
     {
         #region Inner Types

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/GetComputerInfoCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/GetComputerInfoCommand.cs
@@ -25,7 +25,7 @@ namespace Microsoft.PowerShell.Commands
     [Cmdlet(VerbsCommon.Get, "ComputerInfo",
         HelpUri = "http://go.microsoft.com/fwlink/?LinkId=799466")]
     [Alias("gin")]
-    [OutputType(typeof(ComputerInfo), typeof(PSCustomObject))]
+    [OutputType(typeof(ComputerInfo), typeof(PSObject))]
     public class GetComputerInfoCommand : PSCmdlet
     {
         #region Inner Types


### PR DESCRIPTION
Fix for #2041 Added OutputType attribute to Get-ComputerInfo. 

I'm pretty confident about the Microsoft.PowerShell.Commands.ComputerInfo object, but please check syntax for PSCustomObject. SMA is included, but this isn't resolving in Visual Studio. 
