### PR TITLE
Update using-vscode.md to fix broken link

### DIFF
--- a/docs/learning-powershell/using-vscode.md
+++ b/docs/learning-powershell/using-vscode.md
@@ -122,7 +122,7 @@ There are a few blogs that may be helpful to get you started using PowerShell ex
 [ps-extension]:https://blogs.msdn.microsoft.com/cdndevs/2015/12/11/visual-studio-code-powershell-extension/
 [debug]:https://blogs.msdn.microsoft.com/powershell/2015/11/16/announcing-powershell-language-support-for-visual-studio-code-and-more/
 [vscode-guide]:https://johnpapa.net/debugging-with-visual-studio-code/
-[ps-vscode]:https://github.com/PowerShell/vscode-powershell-ops/tree/master/vscode-powershell/examples
+[ps-vscode]:https://github.com/PowerShell/vscode-powershell/tree/master/examples
 
 PowerShell Extension for Visual Studio Code
 ----


### PR DESCRIPTION
This change fixes a broken link in the Using Visual Studio Code
documentation.  This link is pointing to a GitHub repo that will never
made public.  The resolution is to change the link to point to the public
vscode-powershell repo.
