### PR TITLE
spelling fixes: test

### DIFF
--- a/test/csharp/test_CorePsPlatform.cs
+++ b/test/csharp/test_CorePsPlatform.cs
@@ -201,7 +201,7 @@ namespace PSTests
         }
 
         [Fact]
-        public static void TestNonExistantIsHardLink()
+        public static void TestNonExistentIsHardLink()
         {
             // A file that should *never* exist on a test machine:
             string path = @"/tmp/ThisFileShouldNotExistOnTestMachines";

--- a/test/csharp/test_FileSystemProvider.cs
+++ b/test/csharp/test_FileSystemProvider.cs
@@ -76,10 +76,10 @@ namespace PSTests
 			Assert.Equal(FileSystemProvider.Mode(null),String.Empty);
 			FileSystemInfo directoryObject = new DirectoryInfo(@"/");
 			FileSystemInfo fileObject = new FileInfo(@"/etc/hosts");
-			FileSystemInfo excutableObject = new FileInfo(@"/bin/echo");
+			FileSystemInfo executableObject = new FileInfo(@"/bin/echo");
 			Assert.Equal(FileSystemProvider.Mode(PSObject.AsPSObject(directoryObject)).Replace("r","-"),"d-----");
 			Assert.Equal(FileSystemProvider.Mode(PSObject.AsPSObject(fileObject)).Replace("r","-"),"------");
-			Assert.Equal(FileSystemProvider.Mode(PSObject.AsPSObject(excutableObject)).Replace("r","-"),"------");
+			Assert.Equal(FileSystemProvider.Mode(PSObject.AsPSObject(executableObject)).Replace("r","-"),"------");
         }
 		
 		[Fact]

--- a/test/powershell/Host/ConsoleHost.Tests.ps1
+++ b/test/powershell/Host/ConsoleHost.Tests.ps1
@@ -165,7 +165,7 @@ Describe "ConsoleHost unit tests" -tags "Feature" {
         # even though it is redirected - we want to make sure we don't hang.
         # So none of these tests should close StandardInput
 
-        It "Redirected input w/ implict -Command w/ -NonInteractive" {
+        It "Redirected input w/ implicit -Command w/ -NonInteractive" {
             $si = NewProcessStartInfo "-NonInteractive -noprofile 1+1" -RedirectStdIn
             $process = RunPowerShell $si
             $process.StandardOutput.ReadToEnd() | Should Be 2
@@ -179,7 +179,7 @@ Describe "ConsoleHost unit tests" -tags "Feature" {
             EnsureChildHasExited $process
         }
 
-        It "Redirected input w/ explict -Command w/ -NonInteractive" {
+        It "Redirected input w/ explicit -Command w/ -NonInteractive" {
             $si = NewProcessStartInfo "-NonInteractive -noprofile -Command 1+1" -RedirectStdIn
             $process = RunPowerShell $si
             $process.StandardOutput.ReadToEnd() | Should Be 2
@@ -214,7 +214,7 @@ Describe "ConsoleHost unit tests" -tags "Feature" {
         $nl = [Environment]::Newline
 
         # All of the following tests replace the prompt (either via an initial command or interactively)
-        # so that we can read StandardOutput and realiably know exactly what the prompt is.
+        # so that we can read StandardOutput and reliably know exactly what the prompt is.
 
         It "Interactive redirected input" {
             $si = NewProcessStartInfo "-noprofile -nologo" -RedirectStdIn

--- a/test/powershell/Language/Classes/Scripting.Classes.Break.Tests.ps1
+++ b/test/powershell/Language/Classes/Scripting.Classes.Break.Tests.ps1
@@ -38,7 +38,7 @@ class A
             $errors[0].ErrorId | Should be 'LabelNotFound'
         }
 
-        It 'work fine, when break is legite' {
+        It 'work fine, when break is legit' {
             class C
             {
                 static [int] foo()

--- a/test/powershell/Language/Classes/scripting.Classes.inheritance.tests.ps1
+++ b/test/powershell/Language/Classes/scripting.Classes.inheritance.tests.ps1
@@ -464,7 +464,7 @@ Describe 'Classes inheritance ctors' -Tags "CI" {
         '' | Should Be "Exception expected"
     }
     
-    It 'allow use convertion [string -> int] in base ctor call' {
+    It 'allow use conversion [string -> int] in base ctor call' {
         class A { 
             [int]$a 
             A([int]$a) 

--- a/test/powershell/Language/Classes/scripting.Classes.using.tests.ps1
+++ b/test/powershell/Language/Classes/scripting.Classes.using.tests.ps1
@@ -82,7 +82,7 @@ class Bar : Foo.Foo {}
     It "can use modules with classes collision" {
         # we use 3 classes with name Foo at the same time
         # two of them come from 'using module' and one is defined in the scriptblock itself.
-        # we should be able to use first two of them by the module-quilified name and the third one it's name.
+        # we should be able to use first two of them by the module-qualified name and the third one it's name.
         $fooModuleName = [scriptblock]::Create(@"
 using module Foo
 using module FooWithManifest
@@ -106,7 +106,7 @@ class Bar : Foo {}
         $fooModuleName[3] | Should Be 'This'
     }
 
-    It "doesn't mess up two consequitive scripts" {
+    It "doesn't mess up two consecutive scripts" {
         $sb1 = [scriptblock]::Create(@"
 using module Foo
 class Bar : Foo {}
@@ -324,7 +324,7 @@ using module Foo
             New-TestModule -Manifest -Name FooWithManifest -Content 'class Foo { [string] GetModuleName() { return "Foo345" } }' -Version '3.4.5' -ModulePathPrefix 'Modules2'
         }
 
-        # 'using module' behavior must be alligned with Import-Module.
+        # 'using module' behavior must be aligned with Import-Module.
         # Import-Module does the following:
         # 1) find the first directory from $env:PSMODULEPATH that contains the module
         # 2) Import highest available version of the module

--- a/test/powershell/Language/Parser/ExtensibleCompletion.Tests.ps1
+++ b/test/powershell/Language/Parser/ExtensibleCompletion.Tests.ps1
@@ -191,7 +191,7 @@ Describe "Test class based extensible completion" -Tags "CI" {
     } | Get-CompletionTestCaseData | Test-Completions
 }
 
-Describe "Test registration based exensible completion" -Tags "CI" {
+Describe "Test registration based extensible completion" -Tags "CI" {
     Register-ArgumentCompleter -Command TestFunction -Parameter Gamma -ScriptBlock {
         param(
             [string] $CommandName,

--- a/test/powershell/Modules/Microsoft.PowerShell.Archive/Pester.Commands.Cmdlets.Archive.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Archive/Pester.Commands.Cmdlets.Archive.Tests.ps1
@@ -593,7 +593,7 @@ Describe "Test suite for Microsoft.PowerShell.Archive module" -Tags "CI" {
             ArchiveFileEntryContentValidator "$destinationPath" ([io.path]::Combine("SourceDir","ChildDir-1","Sample-3.txt")) $modifiedContent
         }
         
-        It "Validate Compress-Archive cmdlet in pipleline scenario" {
+        It "Validate Compress-Archive cmdlet in pipeline scenario" {
             $destinationPath = "$TestDrive/CompressArchiveFromPipeline.zip"
 
             # Piping a single file path to Compress-Archive
@@ -878,7 +878,7 @@ Describe "Test suite for Microsoft.PowerShell.Archive module" -Tags "CI" {
             Compare-Object -ReferenceObject $extractedList -DifferenceObject $sourceList -PassThru | Should Be $null
         }
 
-        It "Validate Expand-Archive cmdlet in pipleline scenario" {
+        It "Validate Expand-Archive cmdlet in pipeline scenario" {
             $sourcePath = "$TestDrive/SamplePreCreated*.zip"
             $destinationPath = "$TestDrive/PipeToExpandArchive"
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/History.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/History.Tests.ps1
@@ -87,7 +87,7 @@
             $ps.Streams.Information).Count
         $ps.Dispose()
         
-        ## Twice per stream - once for the original invocatgion, and once for the re-invocation
+        ## Twice per stream - once for the original invocation, and once for the re-invocation
         $outputCount | Should be 12
     }   
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/New-EventLog.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/New-EventLog.Tests.ps1
@@ -9,34 +9,34 @@
     BeforeEach {
       Remove-EventLog -LogName TestLog -ea Ignore
     }
-    It "should be able to create a New-EventLog with a -Source paramter" -Skip:($True -Or $NonWinAdmin) {
+    It "should be able to create a New-EventLog with a -Source parameter" -Skip:($True -Or $NonWinAdmin) {
       {New-EventLog -LogName TestLog -Source TestSource -ea stop} | Should Not Throw
       {Write-EventLog -LogName TestLog -Source TestSource -Message "Test" -EventID 1 -ea stop} | Should Not Throw
       $result=Get-EventLog -LogName TestLog
       $result.Count   | Should be 1
     }
-    It "should be able to create a New-EventLog with a -ComputerName paramter" -Skip:($True -Or $NonWinAdmin) {
+    It "should be able to create a New-EventLog with a -ComputerName parameter" -Skip:($True -Or $NonWinAdmin) {
       {New-EventLog -LogName TestLog -Source TestSource -ComputerName $env:COMPUTERNAME -ea stop} | Should Not Throw
       {Write-EventLog -LogName TestLog -Source TestSource -Message "Test" -EventID 1 -ea stop} | Should Not Throw
       $result=Get-EventLog -LogName TestLog
       $result.Count   | Should be 1
       $result.EventID | Should be 1
     }
-    It "should be able to create a New-EventLog with a -CategoryResourceFile paramter" -Skip:($True -Or $NonWinAdmin) {
+    It "should be able to create a New-EventLog with a -CategoryResourceFile parameter" -Skip:($True -Or $NonWinAdmin) {
       {New-EventLog -LogName TestLog -Source TestSource -CategoryResourceFile "CategoryMessageFile" -ea stop} | Should Not Throw
       {Write-EventLog -LogName TestLog -Source TestSource -Message "Test" -EventID 2 -ea stop} | Should Not Throw
       $result=Get-EventLog -LogName TestLog
       $result.Count   | Should be 1
       $result.EventID | Should be 2
     }
-    It "should be able to create a New-EventLog with a -MessageResourceFile paramter" -Skip:($True -Or $NonWinAdmin) {
+    It "should be able to create a New-EventLog with a -MessageResourceFile parameter" -Skip:($True -Or $NonWinAdmin) {
       {New-EventLog -LogName TestLog -Source TestSource -MessageResourceFile "ResourceMessageFile" -ea stop} | Should Not Throw
       {Write-EventLog -LogName TestLog -Source TestSource -Message "Test" -EventID 3 -ea stop} | Should Not Throw
       $result=Get-EventLog -LogName TestLog
       $result.Count   | Should be 1
       $result.EventID | Should be 3
     }
-    It "should be able to create a New-EventLog with a -ParameterResourceFile paramter" -Skip:($True -Or $NonWinAdmin) {
+    It "should be able to create a New-EventLog with a -ParameterResourceFile parameter" -Skip:($True -Or $NonWinAdmin) {
       {New-EventLog -LogName TestLog -Source TestSource -ParameterResourceFile "ParameterMessageFile" -ea stop} | Should Not Throw
       {Write-EventLog -LogName TestLog -Source TestSource -Message "Test" -EventID 4 -ea stop} | Should Not Throw
       $result=Get-EventLog -LogName TestLog

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Path.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Path.Tests.ps1
@@ -8,8 +8,8 @@ Describe "Test-Path" -Tags "CI" {
 	New-Item -Path $testdirectory -Name gatestfile -value 1 -ItemType file | Out-Null
 	New-Item -Path $testdirectory -Name usr -value 1 -ItemType directory | Out-Null
 
-	$nonExistantDir = Join-Path -Path (Join-Path -Path $testdirectory -ChildPath usr) -ChildPath bin
-	$nonExistantPath = Join-Path -Path (Join-Path -Path (Join-Path -Path $testdirectory -ChildPath usr) -ChildPath bin) -ChildPath error
+	$nonExistentDir = Join-Path -Path (Join-Path -Path $testdirectory -ChildPath usr) -ChildPath bin
+	$nonExistentPath = Join-Path -Path (Join-Path -Path (Join-Path -Path $testdirectory -ChildPath usr) -ChildPath bin) -ChildPath error
     }
 
     It "Should be called on an existing path without error" {
@@ -22,15 +22,15 @@ Describe "Test-Path" -Tags "CI" {
 	{ $testdirectory | Test-Path  } | Should Not Throw
 
 	$testdirectory                  | Test-Path | Should Be $true
-	$nonExistantDir                 | Test-Path | Should Be $false
+	$nonExistentDir                 | Test-Path | Should Be $false
     }
 
-    It "Should be called on a nonexistant path without error" {
-	{ Test-Path -Path $nonExistantPath } | Should Not Throw
+    It "Should be called on a nonexistent path without error" {
+	{ Test-Path -Path $nonExistentPath } | Should Not Throw
     }
 
-    It "Should return false for a nonexistant path" {
-	Test-Path -Path $nonExistantPath | Should Be $false
+    It "Should return false for a nonexistent path" {
+	Test-Path -Path $nonExistentPath | Should Be $false
     }
 
     It "Should return true for an existing path" {
@@ -58,7 +58,7 @@ Describe "Test-Path" -Tags "CI" {
 	Test-Path -Path $testfilename -PathType Leaf | Should Be $true
     }
 
-    It "Should return false when the Leaf pathtype is used on a nonexistant file" {
+    It "Should return false when the Leaf pathtype is used on a nonexistent file" {
 	Test-Path -Path "aoeu" -PathType Leaf | Should Be $false
     }
 
@@ -80,7 +80,7 @@ Describe "Test-Path" -Tags "CI" {
     }
 
     It "Should return true if the syntax of the path is correct when using the IsValid switch" {
-	{ Test-Path -Path $nonExistantPath -IsValid } | Should Be $true
+	{ Test-Path -Path $nonExistentPath -IsValid } | Should Be $true
     }
 
     It "Should return false if the syntax of the path is incorrect when using the IsValid switch" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/TimeZone.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/TimeZone.Tests.ps1
@@ -8,7 +8,7 @@
     --------------------------------------
     Localization
         Many of the tests below looking-up timezones by Name do not support localization.
-        That is, the current tests use us english versions of StandardName and DaylighName for tests.
+        That is, the current tests use us english versions of StandardName and DaylightName for tests.
 
         ref: https://msdn.microsoft.com/en-us/library/windows/desktop/ms725481.aspx
            [snippet] Both StandardName and DaylightName are localized according to the current user default UI language.

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/FileCatalog.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/FileCatalog.Tests.ps1
@@ -126,7 +126,7 @@ Describe "Test suite for NewFileCatalogAndTestFileCatalogCmdlets" -Tags "CI" {
             CompareHashTables $result.CatalogItems $expectedPathsAndHashes   
         }
 
-        It "NewFileCatalogWithMutipleFoldersAndFiles" -Skip:$true {
+        It "NewFileCatalogWithMultipleFoldersAndFiles" -Skip:$true {
          
             $expectedPathsAndHashes = @{
                 "UserConfigProv.psd1" = "748E5486814051DA3DFB79FE8964152727213248" ;
@@ -141,7 +141,7 @@ Describe "Test suite for NewFileCatalogAndTestFileCatalogCmdlets" -Tags "CI" {
                 "CatalogTestFile1.mof" = "083B0953D0D70FFF62710F0356FEB86BCE327FE7";
                 "CatalogTestFile2.xml" = "E73BB7A0DD9FAC6A8182F67B750D9CA3094490F1" }
             
-            $catalogPath = "$env:TEMP\NewFileCatalogWithMutipleFoldersAndFiles.cat"             
+            $catalogPath = "$env:TEMP\NewFileCatalogWithMultipleFoldersAndFiles.cat"             
             $catalogDataPath = @("$testDataPath\UserConfigProv\","$testDataPath\CatalogTestFile1.mof","$testDataPath\CatalogTestFile2.xml")
          
             try
@@ -164,7 +164,7 @@ Describe "Test suite for NewFileCatalogAndTestFileCatalogCmdlets" -Tags "CI" {
             CompareHashTables $result.CatalogItems $expectedPathsAndHashes
         }
 
-        It "NewFileCatalogVersion2WithMutipleFoldersAndFiles" -Skip:$true {
+        It "NewFileCatalogVersion2WithMultipleFoldersAndFiles" -Skip:$true {
 
             $expectedPathsAndHashes = @{
                 "UserConfigProv.psd1" = "9FFE4CA2873CD91CDC9D71362526446ECACDA64D26DEA768E6CE489B84D888E4" ;
@@ -181,7 +181,7 @@ Describe "Test suite for NewFileCatalogAndTestFileCatalogCmdlets" -Tags "CI" {
                 "TestImage.gif" = "2D938D255D0D6D547747BD21447CF7295318D34D9B4105D04C1C27487D2FF402" }                 
 
             
-            $catalogPath = "$env:TEMP\NewFileCatalogVersion2WithMutipleFoldersAndFiles.cat"             
+            $catalogPath = "$env:TEMP\NewFileCatalogVersion2WithMultipleFoldersAndFiles.cat"             
             $catalogDataPath = @("$testDataPath\UserConfigProv\","$testDataPath\CatalogTestFile1.mof","$testDataPath\CatalogTestFile2.xml", "$testDataPath\TestImage.gif")            
 
             try
@@ -203,9 +203,9 @@ Describe "Test suite for NewFileCatalogAndTestFileCatalogCmdlets" -Tags "CI" {
             CompareHashTables $result.CatalogItems $expectedPathsAndHashes
         }
 
-        It "NewFileCatalogFolderWhenCatlogFileIsCreatedInsideSameFolder" {
+        It "NewFileCatalogFolderWhenCatalogFileIsCreatedInsideSameFolder" {
             
-            $catalogPath = "$env:TEMP\UserConfigProv\NewFileCatalogFolderWhenCatlogFileIsCreatedInsideSameFolder.cat"
+            $catalogPath = "$env:TEMP\UserConfigProv\NewFileCatalogFolderWhenCatalogFileIsCreatedInsideSameFolder.cat"
             try
             {
                 copy-item "$testDataPath\UserConfigProv" $env:temp -Recurse -ErrorAction SilentlyContinue             
@@ -368,9 +368,9 @@ Describe "Test suite for NewFileCatalogAndTestFileCatalogCmdlets" -Tags "CI" {
             $result | Should Be "Valid"
         }
 
-        It "TestCatalogSkipMuitplePattensDuringValidation" {
+        It "TestCatalogSkipMultiplePattensDuringValidation" {
             
-            $script:catalogPath = "$env:TEMP\TestCatalogSkipMuitplePattensDuringValidation.cat"
+            $script:catalogPath = "$env:TEMP\TestCatalogSkipMultiplePattensDuringValidation.cat"
             $null = New-FileCatalog -Path $testDataPath\UserConfigProv\ -CatalogFilePath $script:catalogPath -CatalogVersion 1.0 
             $result = Test-FileCatalog -Path $testDataPath\UserConfigProv\ -CatalogFilePath $script:catalogPath -FilesToSkip "*.psd1","UserConfigProviderModVersion2.psm1","*ModVersion1.schema.mof"
             $result | Should Be "Valid"

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/TestData/CatalogTestData/UserConfigProv/DSCResources/UserConfigProviderModVersion1/UserConfigProviderModVersion1.psm1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/TestData/CatalogTestData/UserConfigProv/DSCResources/UserConfigProviderModVersion1/UserConfigProviderModVersion1.psm1
@@ -2,7 +2,7 @@
 
 # The Get-TargetResource cmdlet is used to fetch the desired state of the DSC managed node through a powershell script.
 # This cmdlet executes the user supplied script (i.e., the script is responsible for validating the desired state of the 
-# DSC managed node). The result of the script execution is in the form of a hashtable containing all the inormation 
+# DSC managed node). The result of the script execution is in the form of a hashtable containing all the information 
 # gathered from the GetScript execution.
 function Get-TargetResource 
 {
@@ -25,7 +25,7 @@ function Get-TargetResource
 # The Set-TargetResource cmdlet is used to Set the desired state of the DSC managed node through a powershell script.
 # The method executes the user supplied script (i.e., the script is responsible for validating the desired state of the 
 # DSC managed node). If the DSC managed node requires a restart either during or after the execution of the SetScript,
-# the SetScript notifies the PS Infrasturcure by setting the variable $DSCMachineStatus.IsRestartRequired to $true.
+# the SetScript notifies the PS Infrastructure by setting the variable $DSCMachineStatus.IsRestartRequired to $true.
 function Set-TargetResource 
 {
     [CmdletBinding()]

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/TestData/CatalogTestData/UserConfigProv/DSCResources/UserConfigProviderModVersion2/UserConfigProviderModVersion2.psm1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/TestData/CatalogTestData/UserConfigProv/DSCResources/UserConfigProviderModVersion2/UserConfigProviderModVersion2.psm1
@@ -2,7 +2,7 @@
 
 # The Get-TargetResource cmdlet is used to fetch the desired state of the DSC managed node through a powershell script.
 # This cmdlet executes the user supplied script (i.e., the script is responsible for validating the desired state of the 
-# DSC managed node). The result of the script execution is in the form of a hashtable containing all the inormation 
+# DSC managed node). The result of the script execution is in the form of a hashtable containing all the information 
 # gathered from the GetScript execution.
 function Get-TargetResource 
 {
@@ -25,7 +25,7 @@ function Get-TargetResource
 # The Set-TargetResource cmdlet is used to Set the desired state of the DSC managed node through a powershell script.
 # The method executes the user supplied script (i.e., the script is responsible for validating the desired state of the 
 # DSC managed node). If the DSC managed node requires a restart either during or after the execution of the SetScript,
-# the SetScript notifies the PS Infrasturcure by setting the variable $DSCMachineStatus.IsRestartRequired to $true.
+# the SetScript notifies the PS Infrastructure by setting the variable $DSCMachineStatus.IsRestartRequired to $true.
 function Set-TargetResource 
 {
     [CmdletBinding()]

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/TestData/CatalogTestData/UserConfigProv/DSCResources/UserConfigProviderModVersion3/UserConfigProviderModVersion3.psm1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/TestData/CatalogTestData/UserConfigProv/DSCResources/UserConfigProviderModVersion3/UserConfigProviderModVersion3.psm1
@@ -2,7 +2,7 @@
 
 # The Get-TargetResource cmdlet is used to fetch the desired state of the DSC managed node through a powershell script.
 # This cmdlet executes the user supplied script (i.e., the script is responsible for validating the desired state of the 
-# DSC managed node). The result of the script execution is in the form of a hashtable containing all the inormation 
+# DSC managed node). The result of the script execution is in the form of a hashtable containing all the information 
 # gathered from the GetScript execution.
 function Get-TargetResource 
 {
@@ -25,7 +25,7 @@ function Get-TargetResource
 # The Set-TargetResource cmdlet is used to Set the desired state of the DSC managed node through a powershell script.
 # The method executes the user supplied script (i.e., the script is responsible for validating the desired state of the 
 # DSC managed node). If the DSC managed node requires a restart either during or after the execution of the SetScript,
-# the SetScript notifies the PS Infrasturcure by setting the variable $DSCMachineStatus.IsRestartRequired to $true.
+# the SetScript notifies the PS Infrastructure by setting the variable $DSCMachineStatus.IsRestartRequired to $true.
 function Set-TargetResource 
 {
     [CmdletBinding()]

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertFrom-Json.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertFrom-Json.Tests.ps1
@@ -9,7 +9,7 @@ Describe 'ConvertFrom-Json' -tags "CI" {
         $json[1].a | Should Be 'x'
     }
 
-    It 'can convert mutli-line object' {
+    It 'can convert multi-line object' {
         $json = @('{"a" :', '"x"}') | ConvertFrom-Json
         $json.a | Should Be 'x'
     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-List.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-List.Tests.ps1
@@ -107,7 +107,7 @@ Describe "Format-List DRT basic functionality" -Tags "CI" {
 	}
 	
     It "Format-List with complex object for End-To-End should work" {
-        Add-Type -TypeDefinition "public enum MyDayOfWeek{Sun,Mon,Tue,Wed,Thr,Fri,Sat}"
+        Add-Type -TypeDefinition "public enum MyDayOfWeek{Sun,Mon,Tue,Wed,Thu,Fri,Sat}"
         $eto = [MyDayOfWeek]::New()
         $info = @{}
         $info.intArray = 1,2,3,4

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-Table.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-Table.Tests.ps1
@@ -177,7 +177,7 @@ Describe "Format-Table DRT Unit Tests" -Tags "CI" {
 		}
 
 		It "Format-Table with complex object for End-To-End should work" {
-				Add-Type -TypeDefinition "public enum MyDayOfWeek{Sun,Mon,Tue,Wed,Thr,Fri,Sat}"
+				Add-Type -TypeDefinition "public enum MyDayOfWeek{Sun,Mon,Tue,Wed,Thu,Fri,Sat}"
 				$eto = New-Object MyDayOfWeek
 				$info = @{}
 				$info.intArray = 1,2,3,4

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-Wide.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-Wide.Tests.ps1
@@ -81,7 +81,7 @@ Describe "Format-Wide DRT basic functionality" -Tags "CI" {
 	}
 	
    It "Format-Wide with complex object for End-To-End should work" {
-		Add-Type -TypeDefinition "public enum MyDayOfWeek{Sun,Mon,Tue,Wed,Thr,Fri,Sat}"
+		Add-Type -TypeDefinition "public enum MyDayOfWeek{Sun,Mon,Tue,Wed,Thu,Fri,Sat}"
 		$eto = New-Object MyDayOfWeek
 		$info = @{}
 		$info.intArray = 1,2,3,4

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/FormatHex.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/FormatHex.Tests.ps1
@@ -5,7 +5,7 @@
 
 <#
     Purpose:
-        Verify that Format-Hex display the Hexa decmial value for the input data.
+        Verify that Format-Hex display the Hexa decimal value for the input data.
                 
     Action:
         Run Format-Fex.
@@ -49,7 +49,7 @@ Describe "FormatHex" -tags "CI" {
         ($actualResult -match $inputText1) | Should Be $true   
     }
 
-    # This test is to validate to input given through Path paramter set in Format-Hex cmdlet.
+    # This test is to validate to input given through Path parameter set in Format-Hex cmdlet.
     It "ValidatePathParameterSet" {
 
         $result =  Format-Hex -Path $inputFile1
@@ -59,7 +59,7 @@ Describe "FormatHex" -tags "CI" {
         ($actualResult -match $inputText1) | Should Be $true  
     }
 
-    # This test is to validate to Path paramter set is considered as default in Format-Hex cmdlet.
+    # This test is to validate to Path parameter set is considered as default in Format-Hex cmdlet.
     It "ValidatePathAsDefaultParameterSet" {
 
         $result =  Format-Hex $inputFile1
@@ -69,7 +69,7 @@ Describe "FormatHex" -tags "CI" {
         ($actualResult -match $inputText1) | Should Be $true  
     }
 
-    # This test is to validate to input given through LiteralPath paramter set in Format-Hex cmdlet.
+    # This test is to validate to input given through LiteralPath parameter set in Format-Hex cmdlet.
     It "ValidateLiteralPathParameterSet" {
         
         $result =  Format-Hex -LiteralPath $inputFile1

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Random.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Random.Tests.ps1
@@ -15,7 +15,7 @@ Describe "Get-Random DRT Unit Tests" -Tags "CI" {
         @{ Name = 'maximum is Int64.MaxValue'; Maximum = ([int64]::MaxValue); Minimum = $null; GreaterThan = ([int64]-1); LessThan = ([int64]::MaxValue); Type = 'System.Int64' }
         @{ Name = 'maximum is a 64-bit integer'; Maximum = ([int64]100); Minimum = $null; GreaterThan = ([int64]-1); LessThan = ([int64]100); Type = 'System.Int64' }
         @{ Name = 'maximum set to a large integer greater than int32.MaxValue'; Maximum = 100000000000; Minimum = $null; GreaterThan = ([int64]-1); LessThan = ([int64]100000000000); Type = 'System.Int64' }
-        @{ Name = 'maximum set to 0, Minumum set to a negative 64-bit integer'; Maximum = ([int64]0); Minimum = ([int64]-100); GreaterThan = ([int64]-101); LessThan = ([int64]0); Type = 'System.Int64' }
+        @{ Name = 'maximum set to 0, Minimum set to a negative 64-bit integer'; Maximum = ([int64]0); Minimum = ([int64]-100); GreaterThan = ([int64]-101); LessThan = ([int64]0); Type = 'System.Int64' }
         @{ Name = 'maximum set to positive 64-bit number, min set to negative 64-bit number'; Maximum = ([int64]100); Minimum = ([int64]-100); GreaterThan = ([int64]-101); LessThan = ([int64]100); Type = 'System.Int64' }
         @{ Name = 'both are negative 64-bit number'; Maximum = ([int64]-100); Minimum = ([int64]-200); GreaterThan = ([int64]-201); LessThan = ([int64]-100); Type = 'System.Int64' }
         @{ Name = 'both are negative 64-bit number with parentheses'; Maximum = ([int64](-100)); Minimum = ([int64](-200)); GreaterThan = ([int64]-201); LessThan = ([int64]-100); Type = 'System.Int64' }
@@ -39,7 +39,7 @@ Describe "Get-Random DRT Unit Tests" -Tags "CI" {
         @{ Name = 'max set to a special double number'; Maximum = 20.; Minimum = 0.0; GreaterThan = -1.0; LessThan = 20.0; Type = 'System.Double' }
         @{ Name = 'max is double with quote'; Maximum = '20.'; Minimum = 0.0; GreaterThan = -1.0; LessThan = 20.0; Type = 'System.Double' }
         @{ Name = 'max is double with plus sign'; Maximum = +100.0; Minimum = 0; GreaterThan = -1.0; LessThan = 100.0; Type = 'System.Double' }
-        @{ Name = 'max is doulbe with plus sign and enclosed in quote'; Maximum = '+100.0'; Minimum = 0; GreaterThan = -1.0; LessThan = 100.0; Type = 'System.Double' }
+        @{ Name = 'max is double with plus sign and enclosed in quote'; Maximum = '+100.0'; Minimum = 0; GreaterThan = -1.0; LessThan = 100.0; Type = 'System.Double' }
         @{ Name = 'both set to the special numbers as 1.0e+xx '; Maximum = $null; Minimum = 1.0e+100; GreaterThan = 1.0e+99; LessThan = ([double]::MaxValue); Type = 'System.Double' }
         @{ Name = 'max is Double.MaxValue, min is Double.MinValue'; Maximum = ([double]::MaxValue); Minimum = ([double]::MinValue); GreaterThan = ([double]::MinValue); LessThan = ([double]::MaxValue); Type = 'System.Double' }
 
@@ -150,7 +150,7 @@ Describe "Get-Random" -Tags "CI" {
 	$randomNumber | Should Be ("red" -or "yellow" -or "blue")
     }
 
-    It "Should return a number for hexdecimal " {
+    It "Should return a number for hexadecimal " {
 	$randomNumber = Get-Random 0x07FFFFFFFFF
 	$randomNumber | Should BeLessThan 549755813887
 	$randomNumber | Should BeGreaterThan 0
@@ -162,12 +162,12 @@ Describe "Get-Random" -Tags "CI" {
 	$firstRandomNumber | Should Not Be $secondRandomNumber
     }
 
-    It "Should return the same number for hexidemical number and regular number when the switch SetSeed it used " {
+    It "Should return the same number for hexadecimal number and regular number when the switch SetSeed it used " {
 	$firstRandomNumber = Get-Random 0x07FFFFFFFF -SetSeed 20
 	$secondRandomNumber = Get-Random 34359738367 -SetSeed 20
 	$firstRandomNumber | Should Be @secondRandomNumber
     }
-    It "Should throw an error because the hexidecial number is to large " {
+    It "Should throw an error because the hexadecimal number is to large " {
 	{ Get-Random 0x07FFFFFFFFFFFFFFFF } | Should Throw "Value was either too large or too small for a UInt32"
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/New-Object.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/New-Object.Tests.ps1
@@ -112,7 +112,7 @@ Describe "New-Object DRT basic functionality" -Tags "CI" {
 		}
 	}
 	
-	It "New-Object with bad argument for class construtor should throw Exception"{
+	It "New-Object with bad argument for class constructor should throw Exception"{
 		if(-not ([System.Management.Automation.PSTypeName]'Employee').Type)
 		{
 			Add-Type -TypeDefinition "public class Employee{public Employee(string firstName,string lastName,int yearsInMS){FirstName = firstName;LastName=lastName;YearsInMS = yearsInMS;}public string FirstName;public string LastName;public int YearsInMS;}"
@@ -130,7 +130,7 @@ Describe "New-Object DRT basic functionality" -Tags "CI" {
 	}
 	
 	#This case will throw "Execution OK" now, just mark as pending now
-	It "New-Object with not init class construtor should throw Exception" -Pending{
+	It "New-Object with not init class constructor should throw Exception" -Pending{
 		if(-not ([System.Management.Automation.PSTypeName]'Employee').Type)
 		{
 			Add-Type -TypeDefinition "public class Employee{public Employee(string firstName,string lastName,int yearsInMS){FirstName = firstName;LastName=lastName;YearsInMS = yearsInMS;}public string FirstName;public string LastName;public int YearsInMS;}"

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Out-File.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Out-File.Tests.ps1
@@ -1,5 +1,5 @@
 Describe "Out-File DRT Unit Tests" -Tags "CI" {
-    It "Should be able to write the contens into a file with -pspath" {
+    It "Should be able to write the contents into a file with -pspath" {
         $tempFile = Join-Path -Path $TestDrive -ChildPath "ExposeBug928965"
         { 1 | Out-File -PSPath $tempFile } | Should Not Throw
         $fileContents = Get-Content $tempFile
@@ -7,7 +7,7 @@ Describe "Out-File DRT Unit Tests" -Tags "CI" {
         Remove-Item $tempFile -Force
     }
 
-    It "Should be able to write the contens into a file with -pspath" {
+    It "Should be able to write the contents into a file with -pspath" {
         $tempFile = Join-Path -Path $TestDrive -ChildPath "outfileAppendTest.txt"
         { 'This is first line.' | out-file $tempFile } | Should Not Throw
         { 'This is second line.' | out-file -append $tempFile } | Should Not Throw
@@ -38,7 +38,7 @@ Describe "Out-File" -Tags "CI" {
 	$actual | Should Be $expectedContent
     }
 
-    It "Should be able to accept string input via the InputObject swictch" {
+    It "Should be able to accept string input via the InputObject switch" {
 	{ Out-File -FilePath $testfile -InputObject $expectedContent } | Should Not Throw
 
 	$actual = Get-Content $testfile

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Pester.Commands.Cmdlets.Json.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Pester.Commands.Cmdlets.Json.Tests.ps1
@@ -223,7 +223,7 @@ Describe "Json Tests" -Tags "Feature" {
             # add a NoteProperty member called Note with a text note
             $versionObject | Add-Member -MemberType NoteProperty -Name Note -Value "a version object"
 
-            # add an AliasProperty called Rev as an alias to the Revison property
+            # add an AliasProperty called Rev as an alias to the Revision property
             $versionObject | Add-Member -MemberType AliasProperty -Name Rev -Value Revision
 
             # add a ScriptProperty called IsOld which returns whether the version is an older version  
@@ -1407,7 +1407,7 @@ Describe "Json Bug fixes"  -Tags "Feature" {
 
     $testCases = @(
         @{
-            Name = "ConvertTo-Json -Depth 101 throws MaximumAllowedDepthReached when the user specifies a depth greather than 100."
+            Name = "ConvertTo-Json -Depth 101 throws MaximumAllowedDepthReached when the user specifies a depth greater than 100."
             NumberOfElements = 10
             MaxDepth = 101
             FullyQualifiedErrorId = "ReachedMaximumDepthAllowed,Microsoft.PowerShell.Commands.ConvertToJsonCommand"

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Remove-Variable.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Remove-Variable.Tests.ps1
@@ -25,7 +25,7 @@ Describe "Remove-Variable" -Tags "CI" {
     }
 
     It "Should throw error when used with Name field, and named variable does not exist" {
-	Remove-Variable -Name nonexistantVariable -ErrorAction SilentlyContinue | Should Throw
+	Remove-Variable -Name nonexistentVariable -ErrorAction SilentlyContinue | Should Throw
     }
 
     It "Should be able to remove a variable using the rv alias" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-String.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-String.Tests.ps1
@@ -37,7 +37,7 @@ Describe "Select-String" -Tags "CI" {
 	    {$testinputone | Select-String -Pattern "hello" -ca } | Should Not Throw
 	}
 
-	it "Should use the ca alias for casesenstive" {
+	it "Should use the ca alias for casesensitive" {
 	    $firstMatch = $testinputtwo  | Select-String -Pattern "hello" -CaseSensitive
 	    $secondMatch = $testinputtwo | Select-String -Pattern "hello" -ca
 
@@ -86,7 +86,7 @@ Describe "Select-String" -Tags "CI" {
 	}
     }
 
-    Context "Filesytem actions" {
+    Context "Filesystem actions" {
 	$testDirectory = $TestDrive
 	$testInputFile = Join-Path -Path $testDirectory -ChildPath testfile1.txt
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Start-Sleep.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Start-Sleep.Tests.ps1
@@ -3,16 +3,16 @@ Describe "Start-Sleep DRT Unit Tests" -Tags "CI" {
         $dtStart = [DateTime]::Now
         Start-Sleep -Seconds 1
         $dtEnd = [DateTime]::Now
-        $millseconds = (New-TimeSpan -Start $dtStart -End $dtEnd).TotalMilliseconds
-        $millseconds | Should BeGreaterThan 1000
+        $milliseconds = (New-TimeSpan -Start $dtStart -End $dtEnd).TotalMilliseconds
+        $milliseconds | Should BeGreaterThan 1000
     }
 
     It "Should be works properly when sleeping with Milliseconds" {
         $dtStart = [DateTime]::Now
         Start-Sleep -Milliseconds 1000
         $dtEnd = [DateTime]::Now
-        $millseconds = (New-TimeSpan -Start $dtStart -End $dtEnd).TotalMilliseconds
-        $millseconds | Should BeGreaterThan 1000
+        $milliseconds = (New-TimeSpan -Start $dtStart -End $dtEnd).TotalMilliseconds
+        $milliseconds | Should BeGreaterThan 1000
     }
 
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Trace-Command.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Trace-Command.Tests.ps1
@@ -1,7 +1,7 @@
 # This came from monad/tests/ci/PowerShell/tests/Commands/Cmdlets/pester.utility.command.tests.ps1
 Describe "Trace-Command" -tags "CI" {
     
-    Context "Listner options" {
+    Context "Listener options" {
         BeforeAll {
             $logFile = New-Item "TestDrive:/traceCommandLog.txt" -Force
             $actualLogFile = New-Item "TestDrive:/actualTraceCommandLog.txt" -Force

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -153,7 +153,7 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
 
         $response.Error | Should Be $null
 
-        # A sucessful call returns: Status = 200, and StatusDescription = "OK"
+        # A successful call returns: Status = 200, and StatusDescription = "OK"
         $response.Output.StatusDescription | Should Match "OK"
         $response.Output.StatusCode | Should Be 200
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/assets/TestCsv2.csv
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/assets/TestCsv2.csv
@@ -1,3 +1,3 @@
 Name,Planet,Heads,Arms,Brains,Assessment
-Zaphod BeebleBrox,Beetlgeuse,2,3,Indeterminant,Dangerous
+Zaphod BeebleBrox,Beetlgeuse,2,3,Indeterminate,Dangerous
 Arthur Dent,Earth,1,2,Some,Harmless (Mostly)

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/command.tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/command.tests.ps1
@@ -1,6 +1,6 @@
 ﻿Describe "Trace-Command" -tags "Feature" {
     
-    Context "Listner options" {
+    Context "Listener options" {
         BeforeAll {
             $logFile = setup -f traceCommandLog.txt -pass
             $actualLogFile = setup -f actualTraceCommandLog.txt -pass

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/object.tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/object.tests.ps1
@@ -24,9 +24,9 @@
 Describe "Object cmdlets" -Tags "CI" {
     Context "Measure-Object" {
         BeforeAll {
-            ## Powershell language prefers , as an array seperator without "". 
-            ## If a number has comma in them it considers it to be the 1000 seperator like "1,000".
-            ## In de-DE language the comma is used as decimal point, but powershell still uses it as a 1000 seperator.
+            ## Powershell language prefers , as an array separator without "". 
+            ## If a number has comma in them it considers it to be the 1000 separator like "1,000".
+            ## In de-DE language the comma is used as decimal point, but powershell still uses it as a 1000 separator.
             ## In case the number has a comma, it is ignored. So, "99,1" becomes 991. 
             ## To work around that behavior, we use ToString() on the expected answer and . for decimal in the input.
             

--- a/test/powershell/Modules/PackageManagement/Find-PackageProvider.Tests.ps1
+++ b/test/powershell/Modules/PackageManagement/Find-PackageProvider.Tests.ps1
@@ -194,7 +194,7 @@ Describe "find-packageprovider Error Cases" -Tags "Feature" {
         }
     }
 
-    It "EXPECTED:  returns an error when inputing a bad version format" {
+    It "EXPECTED:  returns an error when inputting a bad version format" {
         $Error.Clear()
         find-packageprovider -name Gistprovider -RequiredVersion BOGUSVERSION  -warningaction:silentlycontinue -ea silentlycontinue
         $ERROR[0].FullyQualifiedErrorId | should be "InvalidVersion,Microsoft.PowerShell.PackageManagement.Cmdlets.FindPackageProvider"
@@ -208,13 +208,13 @@ Describe "find-packageprovider Error Cases" -Tags "Feature" {
     }
  
 
-   It "EXPECTED:  returns an error when asking for a provider with RequiredVersoin and MinimumVersion" {
+   It "EXPECTED:  returns an error when asking for a provider with RequiredVersion and MinimumVersion" {
         $Error.Clear()
         find-packageprovider -name NOT_EXISTS -RequiredVersion 1.0 -MinimumVersion 2.0  -warningaction:silentlycontinue -ea silentlycontinue
         $ERROR[0].FullyQualifiedErrorId | should be "VersionRangeAndRequiredVersionCannotBeSpecifiedTogether,Microsoft.PowerShell.PackageManagement.Cmdlets.FindPackageProvider"
     }
 
-   It "EXPECTED:  returns an error when asking for a provider with RequiredVersoin and MaximumVersion" {
+   It "EXPECTED:  returns an error when asking for a provider with RequiredVersion and MaximumVersion" {
         $Error.Clear()
         find-packageprovider -name NOT_EXISTS -RequiredVersion 1.0 -MaximumVersion 2.0  -warningaction:silentlycontinue -ea silentlycontinue
         $ERROR[0].FullyQualifiedErrorId | should be "VersionRangeAndRequiredVersionCannotBeSpecifiedTogether,Microsoft.PowerShell.PackageManagement.Cmdlets.FindPackageProvider"

--- a/test/powershell/Modules/PackageManagement/Import-PackageProvider.Tests.ps1
+++ b/test/powershell/Modules/PackageManagement/Import-PackageProvider.Tests.ps1
@@ -167,7 +167,7 @@ Describe "import-packageprovider Error Cases" -Tags "Feature" {
         $ERROR[0].FullyQualifiedErrorId | should be "InvalidParameter,Microsoft.PowerShell.PackageManagement.Cmdlets.ImportPackageProvider"     
     }
 
-  It "EXPECTED:  returns an error when inputing a bad version format" {
+  It "EXPECTED:  returns an error when inputting a bad version format" {
         $Error.Clear()
         import-packageprovider -name Gistprovider -RequiredVersion BOGUSVERSION -warningaction:silentlycontinue -ea silentlycontinue
         $ERROR[0].FullyQualifiedErrorId | should be "InvalidVersion,Microsoft.PowerShell.PackageManagement.Cmdlets.ImportPackageProvider"
@@ -186,13 +186,13 @@ Describe "import-packageprovider Error Cases" -Tags "Feature" {
     }
  
 
-   It "EXPECTED:  returns an error when asking for a provider with RequiredVersoin and MinimumVersion" {
+   It "EXPECTED:  returns an error when asking for a provider with RequiredVersion and MinimumVersion" {
         $Error.Clear()
         import-packageprovider -name PowerShellGet -RequiredVersion 1.0 -MinimumVersion 2.0  -warningaction:silentlycontinue -ea silentlycontinue
         $ERROR[0].FullyQualifiedErrorId | should be "VersionRangeAndRequiredVersionCannotBeSpecifiedTogether,Microsoft.PowerShell.PackageManagement.Cmdlets.ImportPackageProvider"
     }
 
-   It "EXPECTED:  returns an error when asking for a provider with RequiredVersoin and MaximumVersion" {
+   It "EXPECTED:  returns an error when asking for a provider with RequiredVersion and MaximumVersion" {
         $Error.Clear()
         import-packageprovider -name PowerShellGet -RequiredVersion 1.0 -MaximumVersion 2.0  -warningaction:silentlycontinue -ea silentlycontinue
         $ERROR[0].FullyQualifiedErrorId | should be "VersionRangeAndRequiredVersionCannotBeSpecifiedTogether,Microsoft.PowerShell.PackageManagement.Cmdlets.ImportPackageProvider"

--- a/test/powershell/Modules/PackageManagement/Install-PackageProvider.Tests.ps1
+++ b/test/powershell/Modules/PackageManagement/Install-PackageProvider.Tests.ps1
@@ -128,7 +128,7 @@ Describe "install-packageprovider" -Tags "Feature" {
     }
  }
 
-<# Don't need this test since we are not boostraping
+<# Don't need this test since we are not bootstraping
 Describe "install-packageprovider with local source" -Tags "Feature" {
 
     BeforeAll{
@@ -519,8 +519,8 @@ Describe "install-packageprovider with Scope" -Tags "Feature" {
             $password = "password%1"
             #net user $userName /delete | Out-Null
             net user $userName $password /add
-            $secesurestring = ConvertTo-SecureString $password -AsPlainText -Force
-            $credential = new-object -typename System.Management.Automation.PSCredential -argumentlist $userName, $secesurestring
+            $securestring = ConvertTo-SecureString $password -AsPlainText -Force
+            $credential = new-object -typename System.Management.Automation.PSCredential -argumentlist $userName, $securestring
         }
     }
     
@@ -656,7 +656,7 @@ Describe "install-PackageProvider with Versions" -Tags "Feature" {
 }    
 
 
-Describe "Get-package with mulitiple providers" -Tags "Feature" {
+Describe "Get-package with multiple providers" -Tags "Feature" {
 
     It "Get-package with multiple providers" -Pending {
 
@@ -733,7 +733,7 @@ Describe "install-packageprovider Error Cases" -Tags "Feature" {
         $theError2.FullyQualifiedErrorId| should BeNullOrEmpty
     }
 
-    It "EXPECTED:  returns an error when inputing a bad version format" {
+    It "EXPECTED:  returns an error when inputting a bad version format" {
         $Error.Clear()
         install-packageprovider -name nuget -RequiredVersion BOGUSVERSION  -warningaction:silentlycontinue -ea silentlycontinue
         $ERROR[0].FullyQualifiedErrorId | should be "InvalidVersion,Microsoft.PowerShell.PackageManagement.Cmdlets.InstallPackageProvider"
@@ -747,13 +747,13 @@ Describe "install-packageprovider Error Cases" -Tags "Feature" {
     }
  
 
-   It "EXPECTED:  returns an error when asking for a provider with RequiredVersoin and MinimumVersion" {
+   It "EXPECTED:  returns an error when asking for a provider with RequiredVersion and MinimumVersion" {
         $Error.Clear()
         install-packageprovider -name NOT_EXISTS -Scope CurrentUser -RequiredVersion 1.0 -MinimumVersion 2.0  -warningaction:silentlycontinue -ea silentlycontinue
         $ERROR[0].FullyQualifiedErrorId | should be "VersionRangeAndRequiredVersionCannotBeSpecifiedTogether,Microsoft.PowerShell.PackageManagement.Cmdlets.InstallPackageProvider"
     }
 
-   It "EXPECTED:  returns an error when asking for a provider with RequiredVersoin and MaximumVersion" {
+   It "EXPECTED:  returns an error when asking for a provider with RequiredVersion and MaximumVersion" {
         $Error.Clear()
         install-packageprovider -name NOT_EXISTS -Scope CurrentUser -RequiredVersion 1.0 -MaximumVersion 2.0  -warningaction:silentlycontinue -ea silentlycontinue
         $ERROR[0].FullyQualifiedErrorId | should be "VersionRangeAndRequiredVersionCannotBeSpecifiedTogether,Microsoft.PowerShell.PackageManagement.Cmdlets.InstallPackageProvider"

--- a/test/powershell/engine/ExecutionPolicy.Tests.ps1
+++ b/test/powershell/engine/ExecutionPolicy.Tests.ps1
@@ -13,8 +13,8 @@ Describe "Help work with ExecutionPolicy Restricted " -Tags "Feature" {
     # Validate that 'Get-Help Get-Disk' returns one result when the execution policy is 'Restricted' on Nano
     # From an internal bug - [Regression] Get-Help returns multiple matches when there is an exact match
 
-    # Skip the test if Storage module is not available, return a pesudo result
-    # ExecutionPoliy only works on windows
+    # Skip the test if Storage module is not available, return a pseudo result
+    # ExecutionPolicy only works on windows
     It "Test for Get-Help Get-Disk" -skip:(!(Test-Path (Join-Path -Path $PSHOME -ChildPath Modules\Storage\Storage.psd1)) -or -not $IsWindows) {
 
             try

--- a/test/powershell/enginecore/Parser.Tests.ps1
+++ b/test/powershell/enginecore/Parser.Tests.ps1
@@ -210,7 +210,7 @@ Describe "ParserTests (admin\monad\tests\monad\src\engine\core\ParserTests.cs)" 
         }
     }
 	
-	It "Throws an incomplete parse exeception when a comma follows an expression (line 247)" {
+	It "Throws an incomplete parse exception when a comma follows an expression (line 247)" {
         try {
             ExecuteCommand "(1+ 1)," 
             throw "Execution OK"
@@ -467,7 +467,7 @@ Describe "ParserTests (admin\monad\tests\monad\src\engine\core\ParserTests.cs)" 
         }
     }
 	
-	It "Test that if an exception is thrown from the try block it will be caught in the apprpropriate catch block and that the finally block will run regardless of whether an exception is thrown. (line 1317)" {
+	It "Test that if an exception is thrown from the try block it will be caught in the appropropriate catch block and that the finally block will run regardless of whether an exception is thrown. (line 1317)" {
         $result = ExecuteCommand 'try { try { throw (new-object System.ArgumentException) } catch [System.DivideByZeroException] { } finally { "Finally" } } catch { $_.Exception.GetType().FullName }'
 		$result | should be "Finally", "System.ArgumentException"
     }
@@ -771,7 +771,7 @@ Describe "ParserTests (admin\monad\tests\monad\src\engine\core\ParserTests.cs)" 
 		$result | should be "global"
     }
 	
-	It 'Test piping arguments to a script block. The objects should be accesible from "$input". (line 2870)'{
+	It 'Test piping arguments to a script block. The objects should be accessible from "$input". (line 2870)'{
 		ExecuteCommand '$script = { $input; };$results = @(0,0),-1 | &$script'
 		$result = ExecuteCommand '$results[0][0]'
         $result | Should be "0"


### PR DESCRIPTION
Hopefully, this isn't particularly uncontroversial.

This is PR 3 of N:
- access
- aligned
- appropropriate
- bootstrap
- catalog
- consecutive
- constructor
- contents
- conversion
- daylight
- decimal
- double
- exception
- executable
- existent
- explicit
- extensible
- greater
- hexadecimal
- implicit
- indeterminate
- information
- infrastructure
- inputting
- interpreted
- invocation
- legit
- listener
- milliseconds
- minimum
- multi
- multiple
- parameter
- pipeline
- policy
- pseudo
- qualified
- reliably
- revision
- securestring
- sensitive
- separator
- successful
- switch
- system
- thu
- version

Note: `thu` is http://www.aresearchguide.com/monthdayabb.html

> 1. Thursday - Th., Thu., Thur., or Thurs.
