### PR TITLE
Spelling comments

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -43,7 +43,7 @@ function Start-PSBuild {
         [switch]$TypeGen,
         [switch]$Clean,
 
-        # this switch will re-build only System.Mangement.Automation.dll
+        # this switch will re-build only System.Management.Automation.dll
         # it's useful for development, to do a quick changes in the engine
         [switch]$SMAOnly,
 
@@ -1254,7 +1254,7 @@ function Copy-MappedFiles {
             throw "$pslMonadRoot is not a valid folder"
         }
 
-        # Do some intelligens to prevent shouting us in the foot with CL management
+        # Do some intelligence to prevent shooting us in the foot with CL management
 
         # finding base-line CL
         $cl = git --git-dir="$PSScriptRoot/.git" tag | % {if ($_ -match 'SD.(\d+)$') {[int]$Matches[1]} } | Sort-Object -Descending | Select-Object -First 1
@@ -1360,7 +1360,7 @@ function Get-Mappings
 
 <#
 .EXAMPLE Send-GitDiffToSd -diffArg1 32b90c048aa0c5bc8e67f96a98ea01c728c4a5be~1 -diffArg2 32b90c048aa0c5bc8e67f96a98ea01c728c4a5be -AdminRoot d:\e\ps_dev\admin
-Apply a signle commit to admin folder
+Apply a single commit to admin folder
 #>
 function Send-GitDiffToSd {
     param(
@@ -1633,7 +1633,7 @@ function script:Use-MSBuild {
 
 function script:log([string]$message) {
     Write-Host -Foreground Green $message
-    #reset colors for older package to at return to default after error message on a compiliation error
+    #reset colors for older package to at return to default after error message on a compilation error
     [console]::ResetColor()
 }
 
@@ -1706,7 +1706,7 @@ function script:Start-NativeExecution([scriptblock]$sb)
     $script:ErrorActionPreference = "Continue"
     try {
         & $sb
-        # note, if $sb doens't have a native invocation, $LASTEXITCODE will
+        # note, if $sb doesn't have a native invocation, $LASTEXITCODE will
         # point to the obsolete value
         if ($LASTEXITCODE -ne 0) {
             throw "Execution of {$sb} failed with exit code $LASTEXITCODE"

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CimAsyncOperation.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CimAsyncOperation.cs
@@ -454,7 +454,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         {
             Dispose(true);
             // This object will be cleaned up by the Dispose method.
-            // Therefore, you should call GC.SupressFinalize to
+            // Therefore, you should call GC.SuppressFinalize to
             // take this object off the finalization queue
             // and prevent finalization code for this object
             // from executing a second time.
@@ -553,7 +553,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
 
         /// <summary>
         /// The following is the definition of action queue.
-        /// The queue holding all actions to be exected in the context of either
+        /// The queue holding all actions to be executed in the context of either
         /// ProcessRecord or EndProcessing.
         /// </summary>
         private ConcurrentQueue<CimBaseAction> actionQueue;

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CimBaseAction.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CimBaseAction.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
 
         /// <summary>
         /// <para>
-        /// Execute the write opration to given cmdlet object
+        /// Execute the write operation to given cmdlet object
         /// </para>
         /// </summary>
         /// <param name="cmdlet">
@@ -42,7 +42,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         /// <para>
         /// <see cref="XOperationContextBase"/> object that related to current action.
         /// It may used by action, such as <see cref="CimWriteResultObject"/>,
-        /// since later on action may require namspace, and proxy object to reuse
+        /// since later on action may require namespace, and proxy object to reuse
         /// <see cref="CimSession"/>, <see cref="CimOperationOptions"/> object.
         /// </para>
         /// </summary>
@@ -152,7 +152,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         {
             Dispose(true);
             // This object will be cleaned up by the Dispose method.
-            // Therefore, you should call GC.SupressFinalize to
+            // Therefore, you should call GC.SuppressFinalize to
             // take this object off the finalization queue
             // and prevent finalization code for this object
             // from executing a second time.

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CimCmdletModuleInitialize.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CimCmdletModuleInitialize.cs
@@ -82,13 +82,13 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
             private string _name;
 
             /// <summary>
-            /// The string defining realy cmdlet name
+            /// The string defining real cmdlet name
             /// </summary>
             internal string Value { get { return this._value; } }
             private string _value = String.Empty;
 
             /// <summary>
-            /// The string defining realy cmdlet name
+            /// The string defining real cmdlet name
             /// </summary>
             internal ScopedItemOptions Options { get { return this._options; } }
             private ScopedItemOptions _options = ScopedItemOptions.AllScope | ScopedItemOptions.ReadOnly;

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CimCommandBase.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CimCommandBase.cs
@@ -218,7 +218,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
             this.CloneParameterEntries(parameters, sets);
         }
 
-        #region Two dictionaryies used to determine the bound parameter set
+        #region Two dictionaries used to determine the bound parameter set
 
         /// <summary>
         /// Define the parameter definition entries,
@@ -242,7 +242,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         /// <summary>
         /// <para>
         /// Used to remember the set of parameterset were set
-        /// if any conflition occurred with current parameter,
+        /// if any conflict occurred with current parameter,
         /// throw exception
         /// </para>
         /// </summary>
@@ -256,14 +256,14 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         /// <summary>
         /// <para>
         /// Used to remember the set of parameterset were set before begin process
-        /// if any conflition occurred with current parameter,
+        /// if any conflict occurred with current parameter,
         /// throw exception
         /// </para>
         /// </summary>
         private List<string> parametersetNamesListAtBeginProcess = new List<string>();
 
         /// <summary>
-        /// Parameter names list befre begin process
+        /// Parameter names list before begin process
         /// </summary>
         private List<string> parameterNamesListAtBeginProcess = new List<string>();
 
@@ -594,7 +594,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         {
             Dispose(true);
             // This object will be cleaned up by the Dispose method.
-            // Therefore, you should call GC.SupressFinalize to
+            // Therefore, you should call GC.SuppressFinalize to
             // take this object off the finalization queue
             // and prevent finalization code for this object
             // from executing a second time.

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CimGetInstance.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CimGetInstance.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
 
         /// <summary>
         /// <para>
-        /// Refactory to be reused by Get-CimInstance;Remove-CimInstance;Set-CimInstance
+        /// Refactor to be reused by Get-CimInstance;Remove-CimInstance;Set-CimInstance
         /// </para>
         /// </summary>
         /// <param name="cmdlet"></param>

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CimIndicationWatcher.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CimIndicationWatcher.cs
@@ -161,7 +161,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         /// <param name="computerName"></param>
         /// <param name="nameSpace"></param>
         /// <param name="queryExpression"></param>
-        /// <param name="opreationTimeout"></param>
+        /// <param name="operationTimeout"></param>
         public CimIndicationWatcher(
             string computerName,
             string theNamespace,
@@ -183,7 +183,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         /// <param name="cimSession"></param>
         /// <param name="nameSpace"></param>
         /// <param name="queryExpression"></param>
-        /// <param name="opreationTimeout"></param>
+        /// <param name="operationTimeout"></param>
         public CimIndicationWatcher(
             CimSession cimSession,
             string theNamespace,
@@ -226,7 +226,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
 
         /// <summary>
         /// <para>
-        /// Hanlder of new subscription result
+        /// Handler of new subscription result
         /// </para>
         /// </summary>
         /// <param name="src"></param>

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CimInvokeCimMethod.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CimInvokeCimMethod.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
             }
 
             /// <summary>
-            /// <para>namespce</para>
+            /// <para>namespace</para>
             /// </summary>
             internal string MethodName
             {

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CimRegisterCimIndication.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CimRegisterCimIndication.cs
@@ -112,7 +112,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
     {
         /// <summary>
         /// <para>
-        /// New subscritpion result event
+        /// New subscription result event
         /// </para>
         /// </summary>
         public event EventHandler<CimSubscriptionEventArgs> OnNewSubscriptionResult;
@@ -129,7 +129,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         }
 
         /// <summary>
-        /// Start an indication subsctiption target to the given computer.
+        /// Start an indication subscription target to the given computer.
         /// </summary>
         /// <param name="computerName">null stands for localhost</param>
         /// <param name="nameSpace"></param>
@@ -151,7 +151,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         }
 
         /// <summary>
-        /// Start an indication subsctiption through a given <see cref="CimSession"/>.
+        /// Start an indication subscription through a given <see cref="CimSession"/>.
         /// </summary>
         /// <param name="cimSession">Cannot be null</param>
         /// <param name="nameSpace"></param>

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CimResultObserver.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CimResultObserver.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
     #region AsyncResultEventArgsBase
     /// <summary>
     /// <para>
-    /// Base class of asyn result event argument
+    /// Base class of async result event argument
     /// </para>
     /// </summary>
     internal abstract class AsyncResultEventArgsBase : EventArgs

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CimSessionOperations.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CimSessionOperations.cs
@@ -315,7 +315,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         {
             Dispose(true);
             // This object will be cleaned up by the Dispose method.
-            // Therefore, you should call GC.SupressFinalize to
+            // Therefore, you should call GC.SuppressFinalize to
             // take this object off the finalization queue
             // and prevent finalization code for this object
             // from executing a second time.
@@ -747,7 +747,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
     /// <para>
     /// Base class of all session operation classes.
     /// All sessions created will be held in a ConcurrentDictionary:cimSessions.
-    /// It manages the lifecyclye of the sessions being created for each
+    /// It manages the lifecycle of the sessions being created for each
     /// runspace according to the state of the runspace.
     /// </para>
     /// </summary>
@@ -893,7 +893,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
             }
 
             /// <summary>
-            /// <para>namespce</para>
+            /// <para>namespace</para>
             /// </summary>
             internal CimSessionWrapper CimSessionWrapper
             {
@@ -951,7 +951,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
                 }
                 else
                 {
-                    //CimSession will be retunred as part of TestConnection
+                    //CimSession will be returned as part of TestConnection
                     this.cimTestSession.TestCimSession(computerName, proxy); 
                 }
             }
@@ -1049,7 +1049,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         {
             Dispose(true);
             // This object will be cleaned up by the Dispose method.
-            // Therefore, you should call GC.SupressFinalize to
+            // Therefore, you should call GC.SuppressFinalize to
             // take this object off the finalization queue
             // and prevent finalization code for this object
             // from executing a second time.

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CimSessionProxy.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CimSessionProxy.cs
@@ -27,12 +27,12 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
     /// context base class for cross operations
     /// for example, some cmdlets need to query instance first and then
     /// remove instance, those scenarios need context object transferred
-    /// from one operation to antoher.
+    /// from one operation to another.
     /// </summary>
     internal abstract class XOperationContextBase
     {
         /// <summary>
-        /// <para>namespce</para>
+        /// <para>namespace</para>
         /// </summary>
         internal string Namespace
         {
@@ -117,7 +117,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
     }
     #endregion
 
-    #region Preprossessing of result object interface
+    #region Preprocessing of result object interface
     /// <summary>
     ///  Defines a method to preprocessing an result object before sending to
     ///  output pipeline.
@@ -572,7 +572,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         }        
 
         /// <summary>
-        /// Enable/Disable the methos result streming,
+        /// Enable/Disable the method result streaming,
         /// it is enabled by default.
         /// </summary>
         public bool EnableMethodResultStreaming
@@ -589,7 +589,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         }
 
         /// <summary>
-        /// Enable/Disable prompt user streming,
+        /// Enable/Disable prompt user streaming,
         /// it is enabled by default.
         /// </summary>
         public bool EnablePromptUser
@@ -691,7 +691,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         }
 
         /// <summary>
-        /// Add a new opertion to cache.
+        /// Add a new operation to cache.
         /// </summary>
         /// <param name="operation"></param>
         /// <param name="cancelObject"></param>
@@ -835,7 +835,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
 
         /// <summary>
         /// <para>
-        /// Write opertion start verbose message
+        /// Write operation start verbose message
         /// </para>
         /// </summary>
         /// <param name="operation"></param>
@@ -1534,7 +1534,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         private IObservable<object> operation;
 
         /// <summary>
-        /// the current opration name
+        /// the current operation name
         /// </summary>
         private string operationName;
 
@@ -1544,7 +1544,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         private Hashtable operationParameters = new Hashtable();
 
         /// <summary>
-        /// hanlder used to cancel operation
+        /// handler used to cancel operation
         /// </summary>
         private IDisposable _cancelOperation;
 
@@ -1554,7 +1554,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         private int _cancelOperationDisposed = 0;
 
         /// <summary>
-        /// Dispose the cancel opreation
+        /// Dispose the cancel operation
         /// </summary>
         private void DisposeCancelOperation()
         {
@@ -1571,7 +1571,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         }
 
         /// <summary>
-        /// Set the cancel opreation
+        /// Set the cancel operation
         /// </summary>
         private IDisposable CancelOperation
         {
@@ -1661,7 +1661,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         {
             Dispose(true);
             // This object will be cleaned up by the Dispose method.
-            // Therefore, you should call GC.SupressFinalize to
+            // Therefore, you should call GC.SuppressFinalize to
             // take this object off the finalization queue
             // and prevent finalization code for this object
             // from executing a second time.
@@ -2143,7 +2143,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
                     return match;
                 }
             }
-            DebugHelper.WriteLog("CimClass '{0}' is qulified.", 1, cimClass.CimSystemProperties.ClassName);
+            DebugHelper.WriteLog("CimClass '{0}' is qualified.", 1, cimClass.CimSystemProperties.ClassName);
             return true;
         }
         #endregion

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CimSetCimInstance.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CimSetCimInstance.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         private IDictionary property;
 
         /// <summary>
-        /// <para>prameter set name</para>
+        /// <para>parameter set name</para>
         /// </summary>
         internal string ParameterSetName
         {
@@ -193,7 +193,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         /// <summary>
         /// <para>
         /// Set the properties value to be modified to the given
-        /// <see cref="CimInstanace"/>
+        /// <see cref="CimInstance"/>
         /// </para>
         /// </summary>
         /// <param name="properties"></param>

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/GetCimAssociatedInstanceCommand.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/GetCimAssociatedInstanceCommand.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
     /// is called the source instance, via a given association. In an
     /// association each instance has a named role, and the same instance can
     /// participate in an association in different roles. Hence, the Cmdlet
-    /// takes SourceRole and AssciatorRole parameters in addition to the
+    /// takes SourceRole and AssociatorRole parameters in addition to the
     /// Association parameter.
     /// </para>
     /// </summary>

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/GetCimClassCommand.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/GetCimClassCommand.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
     /// <para>
     /// Enables the user to enumerate the list of CIM Classes under a specific 
     /// Namespace. If no list of classes is given, the Cmdlet returns all
-    /// classes in the given namespce.
+    /// classes in the given namespace.
     /// </para>
     /// <para>
     /// NOTES: The class instance contains the  Namespace properties

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/InvokeCimMethodCommand.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/InvokeCimMethodCommand.cs
@@ -392,7 +392,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         /// <summary>
         /// <para>
         /// Get <see cref="CimInvokeCimMethod"/> object, which is
-        /// used to delegate all Inovke-CimMethod operations.
+        /// used to delegate all Invoke-CimMethod operations.
         /// </para>
         /// </summary>
         CimInvokeCimMethod GetOperationAgent()

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/NewCimSessionOptionCommand.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/NewCimSessionOptionCommand.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         #region cmdlet parameters
 
         /// <summary>
-        /// The following is the definition of the input parameter "NoEncruption".
+        /// The following is the definition of the input parameter "NoEncryption".
         /// Switch indicating if WSMan can use no encryption in the given CimSession (there are also global client and server WSMan settings - AllowUnencrypted).
         /// </summary>
         [Parameter(ParameterSetName = WSManParameterSet)]
@@ -154,7 +154,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         /// <summary>
         /// The following is the definition of the input parameter "Encoding".
         /// Defined the message encoding. 
-        /// The allowed encodings are { Defauolt | Utf8 | Utf16 }. The default value 
+        /// The allowed encodings are { Default | Utf8 | Utf16 }. The default value 
         /// should be Utf8.
         /// </summary>
         [Parameter(ValueFromPipelineByPropertyName = true,

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/RegisterCimIndicationCommand.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/RegisterCimIndicationCommand.cs
@@ -245,7 +245,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
 
         /// <summary>
         /// <para>
-        /// Hanlder to handle unsubcribe event
+        /// Handler to handle unsubscribe event
         /// </para>
         /// </summary>
         /// <param name="sender"></param>

--- a/src/Microsoft.PackageManagement.ArchiverProviders/Compression/ArchiveFileInfo.cs
+++ b/src/Microsoft.PackageManagement.ArchiverProviders/Compression/ArchiveFileInfo.cs
@@ -396,7 +396,7 @@ namespace Microsoft.PackageManagement.Archivers.Internal.Compression
         /// <param name="newFileInfo">Fresh instance for the same file just
         /// read from the archive.</param>
         /// <remarks>
-        /// Subclasses may override this method to refresh sublcass fields.
+        /// Subclasses may override this method to refresh subclass fields.
         /// However they should always call the base implementation first.
         /// </remarks>
         protected virtual void Refresh(ArchiveFileInfo newFileInfo)

--- a/src/Microsoft.PackageManagement.ArchiverProviders/Compression/ArchiveInfo.cs
+++ b/src/Microsoft.PackageManagement.ArchiverProviders/Compression/ArchiveInfo.cs
@@ -352,7 +352,7 @@ namespace Microsoft.PackageManagement.Archivers.Internal.Compression
         /// Extracts multiple files from the archive.
         /// </summary>
         /// <param name="fileNames">A mapping from internal file paths to
-        /// external file paths. Case-senstivity when matching internal paths
+        /// external file paths. Case-sensitivity when matching internal paths
         /// depends on the IDictionary implementation.</param>
         /// <param name="destDirectory">This parameter may be null, but if
         /// specified it is the root directory for any relative external paths
@@ -372,7 +372,7 @@ namespace Microsoft.PackageManagement.Archivers.Internal.Compression
         /// Extracts multiple files from the archive.
         /// </summary>
         /// <param name="fileNames">A mapping from internal file paths to
-        /// external file paths. Case-senstivity when matching internal
+        /// external file paths. Case-sensitivity when matching internal
         /// paths depends on the IDictionary implementation.</param>
         /// <param name="destDirectory">This parameter may be null, but if
         /// specified it is the root directory for any relative external

--- a/src/Microsoft.PackageManagement.ArchiverProviders/Compression/ArchiveProgressType.cs
+++ b/src/Microsoft.PackageManagement.ArchiverProviders/Compression/ArchiveProgressType.cs
@@ -63,7 +63,7 @@ namespace Microsoft.PackageManagement.Archivers.Internal.Compression
         /// <summary>Status message before beginning the packing or unpacking an archive.</summary>
         StartArchive,
 
-        /// <summary>Status message (possibly reported multiple times) during the process of packing or unpacking an archiv.</summary>
+        /// <summary>Status message (possibly reported multiple times) during the process of packing or unpacking an archive.</summary>
         PartialArchive,
 
         /// <summary>Status message after completion of the packing or unpacking of an archive.</summary>

--- a/src/Microsoft.PackageManagement.ArchiverProviders/Compression/Cab/NativeMethods.cs
+++ b/src/Microsoft.PackageManagement.ArchiverProviders/Compression/Cab/NativeMethods.cs
@@ -157,7 +157,7 @@ namespace Microsoft.PackageManagement.Archivers.Internal.Compression.Cab
             internal class Handle : SafeHandle
             {
                 /// <summary>
-                /// Creates a new unintialized handle. The handle will be initialized
+                /// Creates a new uninitialized handle. The handle will be initialized
                 /// when it is marshalled back from native code.
                 /// </summary>
                 internal Handle()
@@ -317,7 +317,7 @@ namespace Microsoft.PackageManagement.Archivers.Internal.Compression.Cab
             internal class Handle : SafeHandle
             {
                 /// <summary>
-                /// Creates a new unintialized handle. The handle will be initialized
+                /// Creates a new uninitialized handle. The handle will be initialized
                 /// when it is marshalled back from native code.
                 /// </summary>
                 internal Handle()

--- a/src/Microsoft.PackageManagement.ArchiverProviders/Compression/CompressionEngine.cs
+++ b/src/Microsoft.PackageManagement.ArchiverProviders/Compression/CompressionEngine.cs
@@ -318,7 +318,7 @@ namespace Microsoft.PackageManagement.Archivers.Internal.Compression
             Predicate<string> fileFilter);
 
         /// <summary>
-        /// Called by sublcasses to distribute a packing or unpacking progress
+        /// Called by subclasses to distribute a packing or unpacking progress
         /// event to listeners.
         /// </summary>
         /// <param name="e">Event details.</param>
@@ -343,7 +343,7 @@ namespace Microsoft.PackageManagement.Archivers.Internal.Compression
         }
 
         /// <summary>
-        /// Compresion utility function for converting old-style
+        /// Compression utility function for converting old-style
         /// date and time values to a DateTime structure.
         /// </summary>
         public static void DosDateAndTimeToDateTime(
@@ -363,7 +363,7 @@ namespace Microsoft.PackageManagement.Archivers.Internal.Compression
         }
 
         /// <summary>
-        /// Compresion utility function for converting a DateTime structure
+        /// Compression utility function for converting a DateTime structure
         /// to old-style date and time values.
         /// </summary>
         public static void DateTimeToDosDateAndTime(

--- a/src/Microsoft.PackageManagement.ArchiverProviders/Compression/CompressionLevel.cs
+++ b/src/Microsoft.PackageManagement.ArchiverProviders/Compression/CompressionLevel.cs
@@ -10,7 +10,7 @@
 namespace Microsoft.PackageManagement.Archivers.Internal.Compression
 {
     /// <summary>
-    /// Specifies the compression level ranging from minimum compresion to
+    /// Specifies the compression level ranging from minimum compression to
     /// maximum compression, or no compression at all.
     /// </summary>
     /// <remarks>
@@ -25,7 +25,7 @@ namespace Microsoft.PackageManagement.Archivers.Internal.Compression
         /// <summary>Minimum compression; fastest.</summary>
         Min = 1,
 
-        /// <summary>A compromize between speed and compression efficiency.</summary>
+        /// <summary>A compromise between speed and compression efficiency.</summary>
         Normal = 6,
 
         /// <summary>Maximum compression; slowest.</summary>

--- a/src/Microsoft.PackageManagement.ArchiverProviders/Compression/Zip/ConcatStream.cs
+++ b/src/Microsoft.PackageManagement.ArchiverProviders/Compression/Zip/ConcatStream.cs
@@ -14,7 +14,7 @@ namespace Microsoft.PackageManagement.Archivers.Internal.Compression.Zip
 
     /// <summary>
     /// Used to trick a DeflateStream into reading from or writing to
-    /// a series of (chunked) streams instead of a single steream.
+    /// a series of (chunked) streams instead of a single stream.
     /// </summary>
     internal class ConcatStream : Stream
     {
@@ -155,7 +155,7 @@ namespace Microsoft.PackageManagement.Archivers.Internal.Compression.Zip
 
 #if !CORECLR
         /// <summary>
-        /// Closes underying stream
+        /// Closes underlying stream
         /// </summary>
         public override void Close()
         {

--- a/src/Microsoft.PackageManagement.ArchiverProviders/Compression/Zip/CrcStream.cs
+++ b/src/Microsoft.PackageManagement.ArchiverProviders/Compression/Zip/CrcStream.cs
@@ -13,7 +13,7 @@ namespace Microsoft.PackageManagement.Archivers.Internal.Compression.Zip
     using System.IO;
 
     /// <summary>
-    /// Wraps a source stream and calcaluates a CRC over all bytes that are read or written.
+    /// Wraps a source stream and calculates a CRC over all bytes that are read or written.
     /// </summary>
     /// <remarks>
     /// The CRC algorithm matches that used in the standard ZIP file format.
@@ -251,7 +251,7 @@ namespace Microsoft.PackageManagement.Archivers.Internal.Compression.Zip
         }
 
         /// <summary>
-        /// Reflects the ordering of certain number of bits. For exmample when reflecting
+        /// Reflects the ordering of certain number of bits. For example when reflecting
         /// one byte, bit one is swapped with bit eight, bit two with bit seven, etc.
         /// </summary>
         private static uint Reflect(uint value, int bits)

--- a/src/Microsoft.PackageManagement.ArchiverProviders/Compression/Zip/ZipEngine.cs
+++ b/src/Microsoft.PackageManagement.ArchiverProviders/Compression/Zip/ZipEngine.cs
@@ -66,7 +66,7 @@ namespace Microsoft.PackageManagement.Archivers.Internal.Compression.Zip
         }
 
         /// <summary>
-        /// Registers a delegate that can create a warpper stream for
+        /// Registers a delegate that can create a wrapper stream for
         /// compressing or uncompressing the data of a source stream.
         /// </summary>
         /// <param name="compressionMethod">Compression method being registered.</param>

--- a/src/Microsoft.PackageManagement.ArchiverProviders/ZipArchiver.cs
+++ b/src/Microsoft.PackageManagement.ArchiverProviders/ZipArchiver.cs
@@ -71,7 +71,7 @@ namespace Microsoft.PackageManagement.Archivers.Internal {
 
 
         /// <summary>
-        /// This is just here as to give us some possibility of knowing when an unexception happens...
+        /// This is just here as to give us some possibility of knowing when an exception happens...
         /// At the very least, we'll write it to the system debug channel, so a developer can find it if they are looking for it.
         /// </summary>
         public void OnUnhandledException(string methodName, Exception exception) {

--- a/src/Microsoft.PackageManagement.CoreProviders/Bootstrap/BootstrapProvider.cs
+++ b/src/Microsoft.PackageManagement.CoreProviders/Bootstrap/BootstrapProvider.cs
@@ -173,7 +173,7 @@ namespace Microsoft.PackageManagement.Providers.Internal.Bootstrap {
                 var wildcardPattern = new WildcardPattern(name, WildcardOptions);
 
                 if (request.GetOptionValue("AllVersions").IsTrue()) {
-                    // Feed.Query() can return an empty provider, so here we need to execlude it by checking p.Name !=null or empty.
+                    // Feed.Query() can return an empty provider, so here we need to exclude it by checking p.Name !=null or empty.
                     foreach (var p in request.Providers.Distinct(PackageEqualityComparer).Where(p => !string.IsNullOrWhiteSpace(p.Name) && (string.IsNullOrWhiteSpace(name) || wildcardPattern.IsMatch(p.Name)))) {
                         FindPackage(p.Name, null, "0.0", null, 0, request);
                     }
@@ -245,7 +245,7 @@ namespace Microsoft.PackageManagement.Providers.Internal.Bootstrap {
 
             request.Debug("Calling '{0}::GetInstalledPackages' '{1}','{2}','{3}','{4}'", PackageProviderName, name, requiredVersion, minimumVersion, maximumVersion);
 
-            //search under the providerAssembies folder for the installed providers
+            //search under the providerAssemblies folder for the installed providers
             var providers = PackageManagementService.AllProvidersFromProviderAssembliesLocation(request).Select(providerFileAssembly => {
                           
                 //get the provider's name\version

--- a/src/Microsoft.PackageManagement.CoreProviders/Bootstrap/BootstrapRequest.cs
+++ b/src/Microsoft.PackageManagement.CoreProviders/Bootstrap/BootstrapRequest.cs
@@ -130,7 +130,7 @@ namespace Microsoft.PackageManagement.Providers.Internal.Bootstrap {
                 if (AdminPrivilege.IsElevated) {
                     return pms.SystemAssemblyLocation;
                 } else {
-                    //a user specifies 'AllUsers' that requires Admin provilege. However his console gets launched by non-elevated.
+                    //a user specifies 'AllUsers' that requires Admin privilege. However his console gets launched by non-elevated.
                     Error(ErrorCategory.InvalidOperation, ErrorCategory.InvalidOperation.ToString(),
                         PackageManagement.Resources.Messages.InstallRequiresCurrentUserScopeParameterForNonAdminUser, pms.SystemAssemblyLocation, pms.UserAssemblyLocation);
                     return null;
@@ -373,7 +373,7 @@ namespace Microsoft.PackageManagement.Providers.Internal.Bootstrap {
                     hashAlgorithm = MD5.Create();
                     packageHash = fileTag.GetAttribute(Iso19770_2.Hash.Md5);
                 } else {
-                    //hash alroghtme not supported, we support 512, 256, md5 only 
+                    //hash algorithm not supported, we support 512, 256, md5 only 
                     Error(ErrorCategory.InvalidData, "Payload", Constants.Messages.UnsupportedHashAlgorithm, hashtag,
                         new[] {Iso19770_2.HashAlgorithm.Sha512, Iso19770_2.HashAlgorithm.Sha256, Iso19770_2.HashAlgorithm.Md5}.JoinWithComma());
                     return false;
@@ -484,7 +484,7 @@ namespace Microsoft.PackageManagement.Providers.Internal.Bootstrap {
                     return !IsCanceled;
                 }
 
-                //installing a package from bootstrap site needs to prompt a user. Only auto-boostrap is not prompted.
+                //installing a package from bootstrap site needs to prompt a user. Only auto-bootstrap is not prompted.
                 var pm = PackageManagementService as PackageManagementService;
                 string isTrustedSource = pm.InternalPackageManagementInstallOnly ? "false" : "true";
                 if (AddMetadata(fastPackageReference, "FromTrustedSource", isTrustedSource) == null) {
@@ -516,7 +516,7 @@ namespace Microsoft.PackageManagement.Providers.Internal.Bootstrap {
                 return null;
             }
 
-            // support providers with .dll file extention only
+            // support providers with .dll file extension only
             if (!Path.GetExtension(filePath).EqualsIgnoreCase(".dll")) {
                 if (!suppressErrorsAndWarnings)
                 {

--- a/src/Microsoft.PackageManagement.CoreProviders/Bootstrap/Feed.cs
+++ b/src/Microsoft.PackageManagement.CoreProviders/Bootstrap/Feed.cs
@@ -34,7 +34,7 @@ namespace Microsoft.PackageManagement.Providers.Internal.Bootstrap {
         }
 
         /// <summary>
-        ///     Follows the feed to find all the *declared latest* versions of packgaes
+        ///     Follows the feed to find all the *declared latest* versions of packages
         /// </summary>
         /// <returns>A set of packages</returns>
         internal IEnumerable<Package> Query() {
@@ -192,7 +192,7 @@ namespace Microsoft.PackageManagement.Providers.Internal.Bootstrap {
             // and the version is either in the specified range of the link, or there is no specified version.
             var packagesByName = Feeds.Where(feedGroup => feedGroup.Any(link => {
                 if (name.EqualsIgnoreCase(link.Attributes[Iso19770_2.Discovery.Name])) {
-                    // first, ensure that the requested miniumum version is lower than the maximum version found in the feed.
+                    // first, ensure that the requested minimum version is lower than the maximum version found in the feed.
                     var maxVer = link.Attributes[Iso19770_2.Discovery.MaximumVersion];
                     if (!string.IsNullOrEmpty(maxVer)) {
                         // since we don't know the version scheme at this point, so we just have to guess.
@@ -202,7 +202,7 @@ namespace Microsoft.PackageManagement.Providers.Internal.Bootstrap {
                         }
                     }
 
-                    // and then ensure that the requested maximum version is greater than the miniumum version found in the feed.
+                    // and then ensure that the requested maximum version is greater than the minimum version found in the feed.
                     var minVer = link.Attributes[Iso19770_2.Discovery.MinimumVersion];
                     if (!string.IsNullOrEmpty(minVer)) {
                         // since we don't know the version scheme at this point, so we just have to guess.

--- a/src/Microsoft.PackageManagement.CoreProviders/ProgramsProvider.cs
+++ b/src/Microsoft.PackageManagement.CoreProviders/ProgramsProvider.cs
@@ -38,7 +38,7 @@ namespace Microsoft.PackageManagement.Providers.Internal {
         /// <summary>
         ///     Returns the name of the Provider.
         /// </summary>
-        /// <returns>The name of this proivder (uses the constant declared at the top of the class)</returns>
+        /// <returns>The name of this provider (uses the constant declared at the top of the class)</returns>
         public string GetPackageProviderName() {
             return ProviderName;
         }

--- a/src/Microsoft.PackageManagement.MetaProvider.PowerShell/PowerShellMetaProvider.cs
+++ b/src/Microsoft.PackageManagement.MetaProvider.PowerShell/PowerShellMetaProvider.cs
@@ -112,7 +112,7 @@ namespace Microsoft.PackageManagement.MetaProvider.PowerShell.Internal {
         private static string _powershellProviderFunctionsPath;
     
         //The reason of using 'object' instead of' PowerShellPackageProvider' is that PowerShellPackageProvider is a provider
-        //that is not visiable to the PackageManagment.
+        //that is not visible to the PackageManagement.
         private readonly IDictionary<string, object> _availableProviders = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
         private readonly IDictionary<string, List<ProviderItem>> _psProviderCacheTable = new Dictionary<string, List<ProviderItem>>(StringComparer.OrdinalIgnoreCase);
         internal const string PowerShellGet = "PowerShellGet";
@@ -282,9 +282,9 @@ namespace Microsoft.PackageManagement.MetaProvider.PowerShell.Internal {
 
         private void AddToPowerShellProviderCacheTable(KeyValuePair<string, PSModuleInfo> moduleInfo) {
 
-            //some times when PrivateData in a provider's .psd1 meta file contains multiple providers (not recommanded way), 
+            //some times when PrivateData in a provider's .psd1 meta file contains multiple providers (not recommended way), 
             //they all reside under the same module path. So we extract each file name and add to the table as dictionary key
-            //to indicate they are actaully different providers. 
+            //to indicate they are actually different providers. 
             if (moduleInfo.Key != null) {
                 var name = Path.GetFileNameWithoutExtension(moduleInfo.Key);
                 if (string.IsNullOrWhiteSpace(name)) {
@@ -531,7 +531,7 @@ namespace Microsoft.PackageManagement.MetaProvider.PowerShell.Internal {
                 var tasks = modules.AsyncForEach(modulePath => AnalyzeModule(request, modulePath.Key, modulePath.Value.Version ?? new Version(0, 0), false, logWarning, modulePath.Value));
                 tasks.WaitAll();
             } else {
-                //find all providers but only load the lastest if no name nor version exists, e.g. get-pp -list 
+                //find all providers but only load the latest if no name nor version exists, e.g. get-pp -list 
 
                 //Scan for the all available providers
                 var results = ScanForModules(request, null, null, null, ProviderOption.AllProvider).ToArray();
@@ -692,7 +692,7 @@ namespace Microsoft.PackageManagement.MetaProvider.PowerShell.Internal {
                 var providerName = provider.GetPackageProviderName();
                 if (!string.IsNullOrWhiteSpace(providerName)) {
                     request.Debug(string.Format(CultureInfo.CurrentCulture, Resources.Messages.SuccessfullyLoadedModule, modulePath));
-                    // looks good to me, let's add this to the list of moduels this meta provider can create.
+                    // looks good to me, let's add this to the list of modules this meta provider can create.
 
                     var packageProvider = new PackageProvider(provider.As<IPackageProvider>()) {
                         IsLoaded = true,

--- a/src/Microsoft.PackageManagement.MsiProvider/Deployment/WindowsInstaller.Linq/QDatabase.cs
+++ b/src/Microsoft.PackageManagement.MsiProvider/Deployment/WindowsInstaller.Linq/QDatabase.cs
@@ -141,7 +141,7 @@ namespace Microsoft.PackageManagement.Msi.Internal.Deployment.WindowsInstaller.L
         public TextWriter Log { get; set; }
 
         /// <summary>
-        /// Gets a queryable table from the datbaase.
+        /// Gets a queryable table from the database.
         /// </summary>
         /// <param name="table">name of the table</param>
         [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]

--- a/src/Microsoft.PackageManagement.MsiProvider/Deployment/WindowsInstaller.Linq/QRecord.cs
+++ b/src/Microsoft.PackageManagement.MsiProvider/Deployment/WindowsInstaller.Linq/QRecord.cs
@@ -350,7 +350,7 @@ namespace Microsoft.PackageManagement.Msi.Internal.Deployment.WindowsInstaller.L
         /// <remarks>
         /// The record (primary keys) may not already exist in the table.
         /// <para>Use <see cref="QTable&lt;TRecord&gt;.NewRecord()"/> to get a new
-        /// record. Prmary keys and all required fields
+        /// record. Primary keys and all required fields
         /// must be filled in before insertion.</para>
         /// </remarks>
         public void Insert()
@@ -366,7 +366,7 @@ namespace Microsoft.PackageManagement.Msi.Internal.Deployment.WindowsInstaller.L
         /// <remarks>
         /// The record (primary keys) may not already exist in the table.
         /// <para>Use <see cref="QTable&lt;TRecord&gt;.NewRecord()"/> to get a new
-        /// record. Prmary keys and all required fields
+        /// record. Primary keys and all required fields
         /// must be filled in before insertion.</para>
         /// </remarks>
         public void Insert(bool temporary)

--- a/src/Microsoft.PackageManagement.MsiProvider/Deployment/WindowsInstaller.Package/InstallPath.cs
+++ b/src/Microsoft.PackageManagement.MsiProvider/Deployment/WindowsInstaller.Package/InstallPath.cs
@@ -48,7 +48,7 @@ namespace Microsoft.PackageManagement.Msi.Internal.Deployment.WindowsInstaller.P
             if(parse.Length == 3)
             {
                 // Syntax was targetshort:sourceshort|targetlong:sourcelong.
-                // Chnage it to targetshort|targetlong:sourceshort|sourcelong.
+                // Change it to targetshort|targetlong:sourceshort|sourcelong.
                 parse = name.Split(new char[] { ':', '|' }, 4);
                 if(parse.Length == 4)
                     parse = new string[] { parse[0] + '|' + parse[2], parse[1] + '|' + parse[3] };
@@ -634,7 +634,7 @@ namespace Microsoft.PackageManagement.Msi.Internal.Deployment.WindowsInstaller.P
         }
 
         /// <summary>
-        /// Gets or sets an install path for a direcotry, component, or file key.
+        /// Gets or sets an install path for a directory, component, or file key.
         /// </summary>
         /// <param name="key">Depending on the type of InstallPathMap, this is the primary key from the
         /// either the Directory, Component, or File table.</param>
@@ -679,7 +679,7 @@ namespace Microsoft.PackageManagement.Msi.Internal.Deployment.WindowsInstaller.P
         }
 
         /// <summary>
-        /// Sets an install path for a direcotry, component, or file key.
+        /// Sets an install path for a directory, component, or file key.
         /// </summary>
         /// <param name="key">Depending on the type of InstallPathMap, this is the primary key from the
         /// either the Directory, Component, or File table.</param>
@@ -707,7 +707,7 @@ namespace Microsoft.PackageManagement.Msi.Internal.Deployment.WindowsInstaller.P
         }
 
         /// <summary>
-        /// Tests whether a direcotry, component, or file key exists in the map.
+        /// Tests whether a directory, component, or file key exists in the map.
         /// </summary>
         /// <param name="key">Depending on the type of InstallPathMap, this is the primary key from the
         /// either the Directory, Component, or File table.</param>

--- a/src/Microsoft.PackageManagement.MsiProvider/Deployment/WindowsInstaller/ColumnEnums.cs
+++ b/src/Microsoft.PackageManagement.MsiProvider/Deployment/WindowsInstaller/ColumnEnums.cs
@@ -687,7 +687,7 @@ namespace Microsoft.PackageManagement.Msi.Internal.Deployment.WindowsInstaller
         /// <summary>Detects the range of versions including the value in VersionMin.</summary>
         VersionMinInclusive = 0x0100,
 
-        /// <summary>Dectects the range of versions including the value in VersionMax.</summary>
+        /// <summary>Detects the range of versions including the value in VersionMax.</summary>
         VersionMaxInclusive = 0x0200,
 
         /// <summary>Detects all languages, excluding the languages listed in the Language column.</summary>

--- a/src/Microsoft.PackageManagement.MsiProvider/Deployment/WindowsInstaller/ComponentInstallation.cs
+++ b/src/Microsoft.PackageManagement.MsiProvider/Deployment/WindowsInstaller/ComponentInstallation.cs
@@ -89,7 +89,7 @@ namespace Microsoft.PackageManagement.Msi.Internal.Deployment.WindowsInstaller
 
         private static string GetProductCode(string component, string szUserSid, UserContexts dwContext)
         {
-            // TODO: We really need what would be MsiGetProductCodeEx, or at least a reasonable facimile thereof (something that restricts the search to the context defined by szUserSid & dwContext)
+            // TODO: We really need what would be MsiGetProductCodeEx, or at least a reasonable facsimile thereof (something that restricts the search to the context defined by szUserSid & dwContext)
             return GetProductCode(component);
         }
 
@@ -298,7 +298,7 @@ namespace Microsoft.PackageManagement.Msi.Internal.Deployment.WindowsInstaller
         /// <summary>
         /// Gets the set of registered qualifiers for the component.
         /// </summary>
-        /// <returns>Enumeration of the qulifiers for the component.</returns>
+        /// <returns>Enumeration of the qualifiers for the component.</returns>
         /// <exception cref="InstallerException">The installer configuration data is corrupt</exception>
         /// <remarks><p>
         /// Because qualifiers are not ordered, any new qualifier has an arbitrary index,

--- a/src/Microsoft.PackageManagement.MsiProvider/Deployment/WindowsInstaller/CustomActionProxy.cs
+++ b/src/Microsoft.PackageManagement.MsiProvider/Deployment/WindowsInstaller/CustomActionProxy.cs
@@ -297,7 +297,7 @@ namespace Microsoft.PackageManagement.Msi.Internal.Deployment.WindowsInstaller
         }
 
         /// <summary>
-        /// Checks if a method has the right return and paramater types
+        /// Checks if a method has the right return and parameter types
         /// for a custom action, and that it is marked by a CustomActionAttribute.
         /// </summary>
         /// <param name="method">Method to be checked.</param>

--- a/src/Microsoft.PackageManagement.MsiProvider/Deployment/WindowsInstaller/Exceptions.cs
+++ b/src/Microsoft.PackageManagement.MsiProvider/Deployment/WindowsInstaller/Exceptions.cs
@@ -546,7 +546,7 @@ namespace Microsoft.PackageManagement.Msi.Internal.Deployment.WindowsInstaller
         }
 
         /// <summary>
-        /// Gets a message that describes the merge conflits.
+        /// Gets a message that describes the merge conflicts.
         /// </summary>
         public override String Message
         {

--- a/src/Microsoft.PackageManagement.MsiProvider/Deployment/WindowsInstaller/FeatureInfo.cs
+++ b/src/Microsoft.PackageManagement.MsiProvider/Deployment/WindowsInstaller/FeatureInfo.cs
@@ -294,7 +294,7 @@ namespace Microsoft.PackageManagement.Msi.Internal.Deployment.WindowsInstaller
         /// <a href="http://msdn.microsoft.com/library/en-us/msi/setup/msigetfeatureinfo.asp">MsiGetFeatureInfo</a>,
         /// <a href="http://msdn.microsoft.com/library/en-us/msi/setup/msisetfeatureattributes.asp">MsiSetFeatureAttributes</a>
         /// </p><p>
-        /// Since the lpAttributes paramter of
+        /// Since the lpAttributes parameter of
         /// <a href="http://msdn.microsoft.com/library/en-us/msi/setup/msigetfeatureinfo.asp">MsiGetFeatureInfo</a>
         /// does not contain an equivalent flag for <see cref="FeatureAttributes.UIDisallowAbsent"/>, this flag will
         /// not be retrieved.

--- a/src/Microsoft.PackageManagement.MsiProvider/Deployment/WindowsInstaller/Handle.cs
+++ b/src/Microsoft.PackageManagement.MsiProvider/Deployment/WindowsInstaller/Handle.cs
@@ -132,7 +132,7 @@ namespace Microsoft.PackageManagement.Msi.Internal.Deployment.WindowsInstaller
         }
 
         /// <summary>
-        /// Gets an object that can be used internally for safe syncronization.
+        /// Gets an object that can be used internally for safe synchronization.
         /// </summary>
         internal object Sync
         {

--- a/src/Microsoft.PackageManagement.MsiProvider/Deployment/WindowsInstaller/Installer.cs
+++ b/src/Microsoft.PackageManagement.MsiProvider/Deployment/WindowsInstaller/Installer.cs
@@ -106,7 +106,7 @@ internal static partial class Installer
     /// </summary>
     /// <param name="logModes">One or more mode flags specifying the type of messages to log</param>
     /// <param name="logFile">Full path to the log file.  A null path disables logging,
-    /// in which case the logModes paraneter is ignored.</param>
+    /// in which case the logModes parameter is ignored.</param>
     /// <exception cref="ArgumentException">an invalid log mode was specified</exception>
     /// <remarks>This method takes effect on any new installation processes.  Calling this
     /// method from within a custom action will not start logging for that installation.</remarks>
@@ -121,7 +121,7 @@ internal static partial class Installer
     /// </summary>
     /// <param name="logModes">One or more mode flags specifying the type of messages to log</param>
     /// <param name="logFile">Full path to the log file.  A null path disables logging,
-    /// in which case the logModes paraneter is ignored.</param>
+    /// in which case the logModes parameter is ignored.</param>
     /// <param name="append">If true, the log lines will be appended to any existing file content.
     /// If false, the log file will be truncated if it exists.  The default is false.</param>
     /// <param name="flushEveryLine">If true, the log will be flushed after every line.

--- a/src/Microsoft.PackageManagement.MsiProvider/Deployment/WindowsInstaller/InstallerUtils.cs
+++ b/src/Microsoft.PackageManagement.MsiProvider/Deployment/WindowsInstaller/InstallerUtils.cs
@@ -27,7 +27,7 @@ namespace Microsoft.PackageManagement.Msi.Internal.Deployment.WindowsInstaller
         {
             get
             {
-                // TODO: Use the extended form of version info to get the 4th component of the verison.
+                // TODO: Use the extended form of version info to get the 4th component of the version.
                 uint[] dllVersionInfo = new uint[5];
                 dllVersionInfo[0] = 20;
                 int hr = NativeMethods.DllGetVersion(dllVersionInfo);

--- a/src/Microsoft.PackageManagement.MsiProvider/Deployment/WindowsInstaller/PatchInstallation.cs
+++ b/src/Microsoft.PackageManagement.MsiProvider/Deployment/WindowsInstaller/PatchInstallation.cs
@@ -205,7 +205,7 @@ namespace Microsoft.PackageManagement.Msi.Internal.Deployment.WindowsInstaller
         }
 
         /// <summary>
-        /// Gets a value indicating whether this patch is marked as obsolte.
+        /// Gets a value indicating whether this patch is marked as obsolete.
         /// </summary>
         [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Obsoleted")]
         [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]

--- a/src/Microsoft.PackageManagement.MsiProvider/Deployment/WindowsInstaller/Session.cs
+++ b/src/Microsoft.PackageManagement.MsiProvider/Deployment/WindowsInstaller/Session.cs
@@ -932,7 +932,7 @@ namespace Microsoft.PackageManagement.Msi.Internal.Deployment.WindowsInstaller
         }
 
         /// <summary>
-        /// Throws an exception if the custom action is not able to access immedate session details.
+        /// Throws an exception if the custom action is not able to access immediate session details.
         /// </summary>
         private void ValidateSessionAccess()
         {

--- a/src/Microsoft.PackageManagement.MsiProvider/Deployment/WindowsInstaller/SummaryInfo.cs
+++ b/src/Microsoft.PackageManagement.MsiProvider/Deployment/WindowsInstaller/SummaryInfo.cs
@@ -139,7 +139,7 @@ namespace Microsoft.PackageManagement.Msi.Internal.Deployment.WindowsInstaller
 
         /// <summary>Gets or sets the Template summary information property.</summary>
         /// <remarks><p>
-        /// The Template summary information propery indicates the platform and language versions supported by the database.
+        /// The Template summary information property indicates the platform and language versions supported by the database.
         /// </p><p>
         /// The syntax of the Template Summary property information is:
         /// [platform property][,platform property][,...];[language id][,language id][,...]

--- a/src/Microsoft.PackageManagement.MsiProvider/MsiProvider.cs
+++ b/src/Microsoft.PackageManagement.MsiProvider/MsiProvider.cs
@@ -42,7 +42,7 @@ namespace Microsoft.PackageManagement.Msi.Internal {
         /// <summary>
         ///     Returns the name of the Provider.
         /// </summary>
-        /// <returns>The name of this proivder (uses the constant declared at the top of the class)</returns>
+        /// <returns>The name of this provider (uses the constant declared at the top of the class)</returns>
         public string GetPackageProviderName() {
             return ProviderName;
         }

--- a/src/Microsoft.PackageManagement.MsuProvider/MsuProvider.cs
+++ b/src/Microsoft.PackageManagement.MsuProvider/MsuProvider.cs
@@ -43,7 +43,7 @@ namespace Microsoft.PackageManagement.Msu.Internal {
         /// <summary>
         ///     Returns the name of the Provider.
         /// </summary>
-        /// <returns>The name of this proivder (uses the constant declared at the top of the class)</returns>
+        /// <returns>The name of this provider (uses the constant declared at the top of the class)</returns>
         public string GetPackageProviderName() {
             return ProviderName;
         }

--- a/src/Microsoft.PackageManagement.NuGetProvider/NugetLightRequest.cs
+++ b/src/Microsoft.PackageManagement.NuGetProvider/NugetLightRequest.cs
@@ -45,10 +45,10 @@
         private string _destinationPath = null;
 
         internal Lazy<bool> SkipValidate;  //??? Seems to be a design choice. Why let a user to decide?
-        // we cannot enable skipdepedencies because this will break downlevel psget which sets skipdependencies to true
+        // we cannot enable skipdependencies because this will break downlevel psget which sets skipdependencies to true
         //internal Lazy<bool> SkipDependencies;     
-        //internal ImplictLazy<bool> ContinueOnFailure;
-        //internal ImplictLazy<bool> FindByCanonicalId;
+        //internal ImplicitLazy<bool> ContinueOnFailure;
+        //internal ImplicitLazy<bool> FindByCanonicalId;
 
         private HttpClient _httpClient;
         private HttpClient _httpClientWithoutAcceptHeader;
@@ -73,8 +73,8 @@
             Scope = new Lazy<string>(() => GetOptionValue("Scope"));
 
             //SkipDependencies = new Lazy<bool>(() => GetOptionValue("SkipDependencies").IsTrue());
-            //ContinueOnFailure = new ImplictLazy<bool>(() => GetOptionValue("ContinueOnFailure").IsTrue());           
-            //FindByCanonicalId = new ImplictLazy<bool>(() => GetOptionValue("FindByCanonicalId").IsTrue());
+            //ContinueOnFailure = new ImplicitLazy<bool>(() => GetOptionValue("ContinueOnFailure").IsTrue());           
+            //FindByCanonicalId = new ImplicitLazy<bool>(() => GetOptionValue("FindByCanonicalId").IsTrue());
 
             Headers = new Lazy<string[]>(() => (GetOptionValues("Headers") ?? new string[0]).ToArray());
             InstalledPackages = new Lazy<PackageBase[]>(() => (GetInstalledPackagesOptionValue()).ToArray());
@@ -984,7 +984,7 @@
 
                         if (pkgItem != null && pkgItem.IsInstalled)
                         {
-                            //A user does not provide any package name in the commandeline, return them all
+                            //A user does not provide any package name in the commandline, return them all
                             if (string.IsNullOrWhiteSpace(name))
                             {
                                 isDup = true;
@@ -1409,7 +1409,7 @@
                 }
 
                 if (AllVersions.Value){
-                    //Display versions from lastest to oldest
+                    //Display versions from latest to oldest
                     pkgs = (from p in pkgs select p).OrderByDescending(x => x.Version);
                 }
 
@@ -1605,7 +1605,7 @@
                 return pkgs;
             }
 
-            //Tags should be performed as *AND* intead of *OR"
+            //Tags should be performed as *AND* instead of *OR"
             //For example -FilterOnTag:{ "A", "B"}, the returned package should have both A and B.
             return pkgs.Where(pkg => FilterOnTag.Value.All(
                 tagFromUser =>
@@ -1681,7 +1681,7 @@
                     //A sample case will be something like find-package sql*Compact*.
 
                     //When the AllVersions property exists, the query like the following containing the wildcards does not work. We need to remove the wild cards and
-                    //replace it with the longest string searhc.
+                    //replace it with the longest string search.
                     //http://www.powershellgallery.com/api/v2/Search()?$orderby=DownloadCount%20desc,Id&searchTerm='tsdprovi*'&targetFramework=''&includePrerelease=false
 
                     if ((!String.IsNullOrWhiteSpace(name) && source.Location.IndexOf("powershellgallery.com", StringComparison.OrdinalIgnoreCase) == -1)
@@ -1714,7 +1714,7 @@
 
                 if (!String.IsNullOrWhiteSpace(name))
                 {
-                    //Filter on the results. This is needed because we replace [...] regex in the searchterm at the begining of this method.
+                    //Filter on the results. This is needed because we replace [...] regex in the searchterm at the beginning of this method.
                     pkgs = FilterOnName(pkgs, name, isNameContainsWildCard);
                 }
 

--- a/src/Microsoft.PackageManagement.NuGetProvider/Package/PackageItem.cs
+++ b/src/Microsoft.PackageManagement.NuGetProvider/Package/PackageItem.cs
@@ -130,7 +130,7 @@
         }
     }
     
-    //Comparer for packges using version and id
+    //Comparer for packages using version and id
     internal class PackageItemComparer : IEqualityComparer<PackageItem>
     {
         public bool Equals(PackageItem packageOne, PackageItem packageTwo)

--- a/src/Microsoft.PackageManagement.NuGetProvider/Repository/HttpClientPackageRepository.cs
+++ b/src/Microsoft.PackageManagement.NuGetProvider/Repository/HttpClientPackageRepository.cs
@@ -100,7 +100,7 @@
             //Usually versions has a limited number, ToArray should be ok. 
             var versions = version.GetComparableVersionStrings().ToArray();
 
-            //Will only enumerate oackages once
+            //Will only enumerate packages once
             return packages.FirstOrDefault(package => packageId.Equals(package.Id, StringComparison.OrdinalIgnoreCase) && versions.Contains(package.Version,StringComparer.OrdinalIgnoreCase));  
         }
 

--- a/src/Microsoft.PackageManagement.NuGetProvider/Repository/LocalPackageRepository.cs
+++ b/src/Microsoft.PackageManagement.NuGetProvider/Repository/LocalPackageRepository.cs
@@ -345,7 +345,7 @@
                 return packages;
             }
 
-            //return the lastest version
+            //return the latest version
             return packages.GroupBy(p => p.Id).Select(each => each.OrderByDescending(pp => pp.Version).FirstOrDefault());
         }
 

--- a/src/Microsoft.PackageManagement.NuGetProvider/Sdk/Request.cs
+++ b/src/Microsoft.PackageManagement.NuGetProvider/Sdk/Request.cs
@@ -13,7 +13,7 @@ namespace Microsoft.PackageManagement.NuGetProvider
         //private Dictionary<string, string[]> _options;
         private string[] _packageSources;
 
-        #region PackageMangaement Interfaces
+        #region PackageManagement Interfaces
 
         [SuppressMessage("Microsoft.Design", "CA1034:NestedTypesShouldNotBeVisible", Justification = "It's a generated code")]
         public interface IProviderServices {
@@ -278,7 +278,7 @@ namespace Microsoft.PackageManagement.NuGetProvider
 
         private static string FixMeFormat(string formatString, object[] args) {
             if (args == null || args.Length == 0) {
-                // not really any args, and not really expectng any
+                // not really any args, and not really expecting any
                 return formatString.Replace('{', '\u00ab').Replace('}', '\u00bb');
             }
             return args.Aggregate(formatString.Replace('{', '\u00ab').Replace('}', '\u00bb'), (current, arg) => current + string.Format(CultureInfo.CurrentCulture, " \u00ab{0}\u00bb", arg));

--- a/src/Microsoft.PackageManagement.NuGetProvider/Utility/PackageUtility.cs
+++ b/src/Microsoft.PackageManagement.NuGetProvider/Utility/PackageUtility.cs
@@ -30,7 +30,7 @@
         internal static string GetPackageNameWithoutVersionInfo(string packageName)
         {
             //Input: JQuery.2.1.3
-            //output: Jqery
+            //output: JQuery
             // An unsupported scenario is if the package has name MyModule2.2 and version 2.0 then we will return version as 2.2.2.0 and packagename as mymodule
 
             string version = String.Empty;
@@ -276,7 +276,7 @@
             }
 
             // Dependencies are of the form "dep1|dep2"
-            // Split them up and process each depedency with ParseDependency function
+            // Split them up and process each dependency with ParseDependency function
             var dependencies = value.Split('|').Select(ParseDependency);
 
             // group the dependencies by target framework
@@ -338,7 +338,7 @@
 
         /// <summary>
         /// Extract the package id.
-        /// From the feed, the package id is eqaul to something like this "http://www.nuget.org/api/v2/Packages(Id='jQuery',Version='2.1.3')".
+        /// From the feed, the package id is equal to something like this "http://www.nuget.org/api/v2/Packages(Id='jQuery',Version='2.1.3')".
         /// But we need id='jQuery'. 
         /// </summary>
         /// <param name="longId"></param>
@@ -416,7 +416,7 @@
         }
 
         /// <summary>
-        /// A help for processing the metatadata tag
+        /// A help for processing the metadata tag
         /// </summary>
         /// <param name="package"></param>
         /// <param name="xElement"></param>
@@ -542,7 +542,7 @@
 
             if (!groups.Any())
             {
-                // since there is no group, we are encoutering
+                // since there is no group, we are encountering
                 // old format, <dependency> is direct child of <dependencies>
                 var dependencySet = new PackageDependencySet
                 {
@@ -586,7 +586,7 @@
         }
 
         /// <summary>
-        /// Make sure the Nuget required xml tags exist witin the metadata tag in the nuspec file.
+        /// Make sure the Nuget required xml tags exist within the metadata tag in the nuspec file.
         /// </summary>
         /// <param name="package"></param>
         private static void EnsureRequiredXmlTags(PackageBase package)

--- a/src/Microsoft.PackageManagement.NuGetProvider/nugetlightprovider.cs
+++ b/src/Microsoft.PackageManagement.NuGetProvider/nugetlightprovider.cs
@@ -18,7 +18,7 @@ namespace Microsoft.PackageManagement.NuGetProvider
     ///
     /// Important notes:
     ///    - Required Methods: Not all methods are required; some package providers do not support some features. If the methods isn't used or implemented it should be removed (or commented out)
-    ///    - Error Handling: Avoid throwing exceptions from these methods. To properly return errors to the user, use the request.Error(...) method to notify the user of an error conditionm and then return.
+    ///    - Error Handling: Avoid throwing exceptions from these methods. To properly return errors to the user, use the request.Error(...) method to notify the user of an error condition and then return.
     ///    - Communicating with the HOST and CORE: each method takes a Request (in reality, an alias for System.Object), which can be used in one of two ways:
     ///         - use the c# 'dynamic' keyword, and call functions on the object directly.
     ///         - use the <code><![CDATA[ .As<Request>() ]]></code> extension method to strongly-type it to the Request type (which calls upon the duck-typer to generate a strongly-typed wrapper). 
@@ -65,7 +65,7 @@ namespace Microsoft.PackageManagement.NuGetProvider
         }
 
         /// <summary>
-        /// This is just here as to give us some possibility of knowing when an unexception happens...
+        /// This is just here as to give us some possibility of knowing when an exception happens...
         /// At the very least, we'll write it to the system debug channel, so a developer can find it if they are looking for it.
         /// </summary>
         public void OnUnhandledException(string methodName, Exception exception) {
@@ -275,7 +275,7 @@ namespace Microsoft.PackageManagement.NuGetProvider
                     request.Verbose(Resources.Messages.SuccessfullyValidated, name);
                 }
 
-                // it's good to check just before you actaully write something to see if the user has cancelled the operation
+                // it's good to check just before you actually write something to see if the user has cancelled the operation
                 if (request.IsCanceled)
                 {
                     return;
@@ -397,7 +397,7 @@ namespace Microsoft.PackageManagement.NuGetProvider
                 return;
             }
 
-            // A user does not provide the package full Name at all Or used wildcard in the name. Let's try searching the entire reposiotry for matches.
+            // A user does not provide the package full Name at all Or used wildcard in the name. Let's try searching the entire repository for matches.
             request.YieldPackages(request.SearchForPackages(name), name);
             }
             catch (Exception ex)

--- a/src/Microsoft.PackageManagement.PackageSourceListProvider/Extensions/PackageListExtensions.cs
+++ b/src/Microsoft.PackageManagement.PackageSourceListProvider/Extensions/PackageListExtensions.cs
@@ -76,7 +76,7 @@ namespace Microsoft.PackageManagement.PackageSourceListProvider
         {
             if (args == null || args.Length == 0)
             {
-                // not really any args, and not really expectng any
+                // not really any args, and not really expecting any
                 return formatString.Replace('{', '\u00ab').Replace('}', '\u00bb');
             }
             return args.Aggregate(formatString.Replace('{', '\u00ab').Replace('}', '\u00bb'), (current, arg) => current + string.Format(CultureInfo.CurrentCulture, " \u00ab{0}\u00bb", arg));

--- a/src/Microsoft.PackageManagement.PackageSourceListProvider/PackageList/ExePackageInstaller.cs
+++ b/src/Microsoft.PackageManagement.PackageSourceListProvider/PackageList/ExePackageInstaller.cs
@@ -214,7 +214,7 @@ namespace Microsoft.PackageManagement.PackageSourceListProvider
 
         private static bool YieldPackages(string hive, RegistryKey regkey, string name, string displayname, string requiredVersion, string minimumVersion, string maximumVersion, PackageJson package, Request request)
         {
-            //TODO make it wildcard match, follow the fastfrence format, get-package git no reults, get-package git*
+            //TODO make it wildcard match, follow the fastfrence format, get-package git no results, get-package git*
 
             if (regkey != null)
             {

--- a/src/Microsoft.PackageManagement.PackageSourceListProvider/PackageList/PackageListProvider.cs
+++ b/src/Microsoft.PackageManagement.PackageSourceListProvider/PackageList/PackageListProvider.cs
@@ -276,7 +276,7 @@ namespace Microsoft.PackageManagement.PackageSourceListProvider
                     }
                 }                   
 
-                // it's good to check just before you actaully write something to see if the user has cancelled the operation
+                // it's good to check just before you actually write something to see if the user has cancelled the operation
                 if (request.IsCanceled) {
                     return;
                 }

--- a/src/Microsoft.PackageManagement/Api/IHostAPI.cs
+++ b/src/Microsoft.PackageManagement/Api/IHostAPI.cs
@@ -18,7 +18,7 @@ namespace Microsoft.PackageManagement.Internal.Api {
     using System.Net;
 
     /// <summary>
-    /// Functions implemented by the HOST to provide contexual information and control to for the current request.
+    /// Functions implemented by the HOST to provide contextual information and control to for the current request.
     /// </summary>
     public interface IHostApi {
 
@@ -198,7 +198,7 @@ namespace Microsoft.PackageManagement.Internal.Api {
         /// </summary>
         /// <param name="requestor">the name of the provider or component requesting the provider.</param>
         /// <param name="providerName">the name of the requested provider</param>
-        /// <param name="providerVersion">the miniumum version of the provider required</param>
+        /// <param name="providerVersion">the minimum version of the provider required</param>
         /// <param name="providerType"></param>
         /// <param name="location">the remote location that the provider is being bootstrapped from</param>
         /// <param name="destination">the target folder where the provider is to be installed.</param>
@@ -214,7 +214,7 @@ namespace Microsoft.PackageManagement.Internal.Api {
         bool ShouldContinueWithUntrustedPackageSource(string package, string packageSource);
 
         /// <summary>
-        /// Allow a package provider to comfirm a user whether the process should continue
+        /// Allow a package provider to confirm a user whether the process should continue
         /// </summary>
         /// <param name="query">Query that inquires whether the cmdlet should continue.</param>
         /// <param name="caption">Caption of the window that might be displayed when the user is prompted whether or not to perform the action.</param>
@@ -224,7 +224,7 @@ namespace Microsoft.PackageManagement.Internal.Api {
         bool ShouldContinue(string query, string caption, ref bool yesToAll, ref bool noToAll);
 
         /// <summary>
-        /// Allow a package provider to comfirm a user whether the process should continue
+        /// Allow a package provider to confirm a user whether the process should continue
         /// </summary>
         /// <param name="query">Query that inquires whether the cmdlet should continue.</param>
         /// <param name="caption">Caption of the window that might be displayed when the user is prompted whether or not to perform the action.</param>

--- a/src/Microsoft.PackageManagement/Implementation/PackageManagementService.cs
+++ b/src/Microsoft.PackageManagement/Implementation/PackageManagementService.cs
@@ -775,7 +775,7 @@ namespace Microsoft.PackageManagement.Internal.Implementation {
 
                     AddToProviderCacheTable(provider.ProviderName, provider);
 
-                    //initialize the warpper package provider
+                    //initialize the wrapper package provider
                     provider.Initialize(request);
 
                     // addOrSet locks the collection anyway.

--- a/src/Microsoft.PackageManagement/Implementation/Request.cs
+++ b/src/Microsoft.PackageManagement/Implementation/Request.cs
@@ -236,7 +236,7 @@ namespace Microsoft.PackageManagement.Internal.Implementation {
 
         private static string FixMeFormat(string formatString, object[] args) {
             if (args == null || args.Length == 0) {
-                // not really any args, and not really expectng any
+                // not really any args, and not really expecting any
                 return formatString.Replace('{', '\u00ab').Replace('}', '\u00bb');
             }
             return args.Aggregate(formatString.Replace('{', '\u00ab').Replace('}', '\u00bb'), (current, arg) => current + string.Format(CultureInfo.CurrentCulture, " \u00ab{0}\u00bb", arg));

--- a/src/Microsoft.PackageManagement/PackageManager.cs
+++ b/src/Microsoft.PackageManagement/PackageManager.cs
@@ -16,7 +16,7 @@ namespace Microsoft.PackageManagement.Internal {
     using Implementation;
 
     /// <summary>
-    ///     The public interface to accessing the fetaures of the Package Management Service
+    ///     The public interface to accessing the features of the Package Management Service
     ///     This offers two possible methods to get the instance of the PackageManagementService.
     ///     If the Host is consuming the PackageManagementService by linking to this assembly, then
     ///     the simplest access is just to use the <code>Instance</code> method.

--- a/src/Microsoft.PackageManagement/Packaging/BaseElement.cs
+++ b/src/Microsoft.PackageManagement/Packaging/BaseElement.cs
@@ -21,7 +21,7 @@ namespace Microsoft.PackageManagement.Internal.Packaging {
 
     /// <summary>
     ///     The base element that is common to all elements in a Swidtag.
-    ///     Swidtag classes are intended to be constructed, but are not mutatable
+    ///     Swidtag classes are intended to be constructed, but are not mutable
     ///     (ie, can't be created and have values modified or removed)
     /// </summary>
     public class BaseElement {
@@ -46,7 +46,7 @@ namespace Microsoft.PackageManagement.Internal.Packaging {
         }
 
         /// <summary>
-        ///     All Swidtag elements can explicity support the xml:lang attribute.
+        ///     All Swidtag elements can explicitly support the xml:lang attribute.
         /// </summary>
         public string Culture {
             get {

--- a/src/Microsoft.PackageManagement/Packaging/Swidtag.cs
+++ b/src/Microsoft.PackageManagement/Packaging/Swidtag.cs
@@ -264,7 +264,7 @@ namespace Microsoft.PackageManagement.Internal.Packaging {
         /// <returns>The ResourceCollection added. If the Payload already exists, returns the current Payload.</returns>
         internal Payload AddPayload() {
             // should we just detect and add the evidence element when a provider is adding items to the evidence
-            // instead of requiring someone to explicity add the element?
+            // instead of requiring someone to explicitly add the element?
             if (Element.Elements(Iso19770_2.Elements.Payload).Any()) {
                 return Payload;
             }
@@ -294,7 +294,7 @@ namespace Microsoft.PackageManagement.Internal.Packaging {
         /// <returns>The added Evidence element. If the Evidence element already exists, returns the current element.</returns>
         internal Evidence AddEvidence() {
             // should we just detect and add the evidence element when a provider is adding items to the evidence
-            // instead of requiring someone to explicity add the element?
+            // instead of requiring someone to explicitly add the element?
             if (Element.Elements(Iso19770_2.Elements.Evidence).Any()) {
                 return Evidence;
             }

--- a/src/Microsoft.PackageManagement/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.PackageManagement/Properties/AssemblyInfo.cs
@@ -29,7 +29,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-// Normally, we wouldn't actaully permit access to the internals of the API
+// Normally, we wouldn't actually permit access to the internals of the API
 // but we're sharing code with the other tightly-coupled providers
 // Third-party providers shouldn't use (or want) to be tightly-coupled
 

--- a/src/Microsoft.PackageManagement/Utility/Collections/PathEqualityComparer.cs
+++ b/src/Microsoft.PackageManagement/Utility/Collections/PathEqualityComparer.cs
@@ -64,7 +64,7 @@ namespace Microsoft.PackageManagement.Internal.Utility.Collections {
             }
             catch (Exception) {
                 //GetFullPath() can throw for the bad path or unsupported path format, e.g. PS:MydriveFolder.
-                //we should not throw in this case. Intead return string.Empty to indicate not matching
+                //we should not throw in this case. Instead return string.Empty to indicate not matching
             }
             return string.Empty;
         }

--- a/src/Microsoft.PackageManagement/Utility/Extensions/FilesystemExtensions.cs
+++ b/src/Microsoft.PackageManagement/Utility/Extensions/FilesystemExtensions.cs
@@ -95,7 +95,7 @@ namespace Microsoft.PackageManagement.Internal.Utility.Extensions {
                 }
 
                 if (File.Exists(location)) {
-                    // err("Unable to forcably remove file '{0}'. This can't be good.", location);
+                    // err("Unable to forcibly remove file '{0}'. This can't be good.", location);
                 }
             }
             return;
@@ -146,7 +146,7 @@ namespace Microsoft.PackageManagement.Internal.Utility.Extensions {
                     catch { }
                 }
 
-                // delete all filese that is older than 2 days
+                // delete all files that is older than 2 days
                 foreach (var filePath in Directory.EnumerateFiles(TempPath))
                 {
                     try
@@ -202,7 +202,7 @@ namespace Microsoft.PackageManagement.Internal.Utility.Extensions {
                     }
 #endif
                 }
-                // not a remote (or resovably-remote) path or
+                // not a remote (or resolvable-remote) path or
                 // it is already a path that is in it's correct form (via localpath)
                 return pathUri.LocalPath;
             } catch (UriFormatException) {

--- a/src/Microsoft.PackageManagement/Utility/Plugin/DynamicTypeExtensions.cs
+++ b/src/Microsoft.PackageManagement/Utility/Plugin/DynamicTypeExtensions.cs
@@ -138,7 +138,7 @@ namespace Microsoft.PackageManagement.Internal.Utility.Plugin
                 // this method isn't returning anything.
                 if (instanceMethod.ReturnType != typeof(void))
                 {
-                    // pop the return value beacuse the generated method is void and the
+                    // pop the return value because the generated method is void and the
                     // method we called actually gave us a result.
                     il.Emit(OpCodes.Pop);
                 }

--- a/src/Microsoft.PackageManagement/providers/IPackageProvider.cs
+++ b/src/Microsoft.PackageManagement/providers/IPackageProvider.cs
@@ -72,7 +72,7 @@ namespace Microsoft.PackageManagement.Internal.Providers {
         /// Expected behavior:
         ///     If request.Sources is null or empty, the provider should return the list of registered sources.
         ///     Otherwise, the provider should return package sources that match the strings in the request.Sources  
-        ///     collction. If the string doesn't match a registered source (either by name or by location) and the 
+        ///     collection. If the string doesn't match a registered source (either by name or by location) and the 
         ///     string can be construed as a package source (ie, passing in a valid URL to a provider that uses URLs 
         ///     for their package sources), then the provider should return a package source for that URL, but marked
         ///     as 'unregistered' (and 'untrusted')
@@ -84,7 +84,7 @@ namespace Microsoft.PackageManagement.Internal.Providers {
         /// <remarks>
         ///     PowerShellMetaProvider notes:
         ///         - may use Resolve-PackageSource as the function name 
-        ///         - $request object is not passed as a parameter, but inserted as a variable before the ca New-PackageSourcell.
+        ///         - $request object is not passed as a parameter, but inserted as a variable before the ca New-PackageSource.
         ///         - Values can be returned using Write-Object for objects returned from the function
         /// </remarks>
         void ResolvePackageSources(IRequest requestObject);
@@ -115,7 +115,7 @@ namespace Microsoft.PackageManagement.Internal.Providers {
         ///     that match sources (either by name or location) in the list of specified strings.
         /// </summary>
         /// <param name="name">matches against the name of a package. If this is null or empty, should return all matching packages.</param>
-        /// <param name="requiredVersion">an exact version of the package to match. If this is specified, miniumum and maximum should be ignored.</param>
+        /// <param name="requiredVersion">an exact version of the package to match. If this is specified, minimum and maximum should be ignored.</param>
         /// <param name="minimumVersion">the minimum version of the package to match. If requiredVersion is specified, this should be ignored.</param>
         /// <param name="maximumVersion">the maximum version of the package to match. If requiredVersion is specified, this should be ignored.</param>
         /// <param name="id">the batch id. If the provider supports batch searches, and this is non-zero,
@@ -226,7 +226,7 @@ namespace Microsoft.PackageManagement.Internal.Providers {
         /// Returns Software Identities for installed packages
         /// </summary>
         /// <param name="name">matches against the name of a package. If this is null or empty, should return all matching packages.</param>
-        /// <param name="requiredVersion">an exact version of the package to match. If this is specified, miniumum and maximum should be ignored.</param>
+        /// <param name="requiredVersion">an exact version of the package to match. If this is specified, minimum and maximum should be ignored.</param>
         /// <param name="minimumVersion">the minimum version of the package to match. If requiredVersion is specified, this should be ignored.</param>
         /// <param name="maximumVersion">the maximum version of the package to match. If requiredVersion is specified, this should be ignored.</param>
         /// <param name="requestObject">The request context passed to the provider.</param>

--- a/src/Microsoft.PackageManagement/providers/inbox/Common/Extensions/FilesystemExtensions.cs
+++ b/src/Microsoft.PackageManagement/providers/inbox/Common/Extensions/FilesystemExtensions.cs
@@ -108,7 +108,7 @@ namespace Microsoft.PackageManagement.Provider.Utility {
 
                 if (File.Exists(location))
                 {
-                    // err("Unable to forcably remove file '{0}'. This can't be good.", location);
+                    // err("Unable to forcibly remove file '{0}'. This can't be good.", location);
                 }
             }
             return;
@@ -213,7 +213,7 @@ namespace Microsoft.PackageManagement.Provider.Utility {
                     //    }
                    // }
                 }
-                // not a remote (or resovably-remote) path or
+                // not a remote (or resolvable-remote) path or
                 // it is already a path that is in it's correct form (via localpath)
                 return pathUri.LocalPath;
             } catch (UriFormatException) {

--- a/src/Microsoft.PackageManagement/providers/inbox/Common/Version/SemanticVersion.cs
+++ b/src/Microsoft.PackageManagement/providers/inbox/Common/Version/SemanticVersion.cs
@@ -14,7 +14,7 @@ namespace Microsoft.PackageManagement.Provider.Utility
     /// Example: EntityFramework 6.1.3-beta1 
     /// Version: 6.1.3
     /// SpecialVersion: -beta1 
-    /// OrginalString: 6.1.3-beta1 
+    /// OriginalString: 6.1.3-beta1 
     /// 
     /// </summary>    
     [TypeConverter(typeof(SemanticVersionTypeConverter))]

--- a/src/Microsoft.PowerShell.Activities/Activities/ActivityGenerator.cs
+++ b/src/Microsoft.PowerShell.Activities/Activities/ActivityGenerator.cs
@@ -109,7 +109,7 @@ namespace {0}
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name=""context"">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {{
@@ -448,7 +448,7 @@ namespace {0}
         /// Generates a complete activity source file from a module.
         /// </summary>
         /// <param name="moduleToProcess"></param>
-        /// <param name="activityNamespace">The namesspace to use for the target classes</param>
+        /// <param name="activityNamespace">The namespace to use for the target classes</param>
         /// <returns>An array of code elements to compile into an assembly</returns>
         static public string[] GenerateFromModuleInfo(PSModuleInfo moduleToProcess, string activityNamespace)
         {

--- a/src/Microsoft.PowerShell.Activities/Activities/GetCimAssociatedInstanceActivity.cs
+++ b/src/Microsoft.PowerShell.Activities/Activities/GetCimAssociatedInstanceActivity.cs
@@ -84,7 +84,7 @@ namespace Microsoft.PowerShell.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Activities/Activities/GetCimClassActivity.cs
+++ b/src/Microsoft.PowerShell.Activities/Activities/GetCimClassActivity.cs
@@ -84,7 +84,7 @@ namespace Microsoft.PowerShell.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Activities/Activities/GetCimInstanceActivity.cs
+++ b/src/Microsoft.PowerShell.Activities/Activities/GetCimInstanceActivity.cs
@@ -107,7 +107,7 @@ namespace Microsoft.PowerShell.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Activities/Activities/GetPSWorkflowData.cs
+++ b/src/Microsoft.PowerShell.Activities/Activities/GetPSWorkflowData.cs
@@ -301,7 +301,7 @@ namespace Microsoft.PowerShell.Activities
 
                         foreach(string varKey in dictionaryParam.Keys)
                         {
-                            // We need to get the values of required runtime variables only, not evrything from DataContext parameters
+                            // We need to get the values of required runtime variables only, not everything from DataContext parameters
                             //
                             if (workflowRuntimeVariables.ContainsKey(varKey))
                             {

--- a/src/Microsoft.PowerShell.Activities/Activities/InlineScript.cs
+++ b/src/Microsoft.PowerShell.Activities/Activities/InlineScript.cs
@@ -159,7 +159,7 @@ namespace Microsoft.PowerShell.Activities
         /// <summary>
         /// Validates the contents of the script block for this command.
         /// </summary>
-        /// <param name="metadata">Metatdata for this activity</param>
+        /// <param name="metadata">Metadata for this activity</param>
         protected override void CacheMetadata(NativeActivityMetadata metadata)
         {
             base.CacheMetadata(metadata);
@@ -195,7 +195,7 @@ namespace Microsoft.PowerShell.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the script to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         [System.Diagnostics.CodeAnalysis.SuppressMessage(
             "Microsoft.Reliability",
@@ -780,7 +780,7 @@ namespace Microsoft.PowerShell.Activities
     public class Suspend : NativeActivity
     {
         /// <summary>
-        /// Optional field used for resuming the worklfow for a specific label.
+        /// Optional field used for resuming the workflow for a specific label.
         /// </summary>
         public string Label { get; set; }
 

--- a/src/Microsoft.PowerShell.Activities/Activities/InvokeCimMethodActivity.cs
+++ b/src/Microsoft.PowerShell.Activities/Activities/InvokeCimMethodActivity.cs
@@ -105,7 +105,7 @@ namespace Microsoft.PowerShell.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Activities/Activities/NewCimInstanceActivity.cs
+++ b/src/Microsoft.PowerShell.Activities/Activities/NewCimInstanceActivity.cs
@@ -91,7 +91,7 @@ namespace Microsoft.PowerShell.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Activities/Activities/NewCimSessionActivity.cs
+++ b/src/Microsoft.PowerShell.Activities/Activities/NewCimSessionActivity.cs
@@ -92,7 +92,7 @@ namespace Microsoft.PowerShell.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Activities/Activities/NewCimSessionOptionActivity.cs
+++ b/src/Microsoft.PowerShell.Activities/Activities/NewCimSessionOptionActivity.cs
@@ -175,7 +175,7 @@ namespace Microsoft.PowerShell.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Activities/Activities/Pipeline.cs
+++ b/src/Microsoft.PowerShell.Activities/Activities/Pipeline.cs
@@ -16,7 +16,7 @@ namespace Microsoft.PowerShell.Activities
     /// <summary>
     /// The implementation of pipeline activity.
     /// This similar concept which we have in PowerShell today like Get-Process | Stop-Process.
-    /// Pipline activity will make sure the piped execution of its child acitities.
+    /// Pipeline activity will make sure the piped execution of its child activities.
     /// </summary>
 #if _NOTARMBUILD_
     [Designer (typeof (PipelineDesigner))]
@@ -65,7 +65,7 @@ namespace Microsoft.PowerShell.Activities
 
         /// <summary>
         /// Validate the required number of activities of pipeline activity.
-        /// Setup the cachemetata with variables and activities.
+        /// Setup the cachemetadata with variables and activities.
         /// </summary>
         /// <param name="metadata"></param>
         protected override void CacheMetadata(NativeActivityMetadata metadata)
@@ -101,7 +101,7 @@ namespace Microsoft.PowerShell.Activities
                 return;
             }
 #endif
-            // Adding variables into the CacheMetatdata of pipeline activity.
+            // Adding variables into the CacheMetadata of pipeline activity.
             metadata.AddImplementationVariable(this.lastIndexHint);
 
             // We use a GUID here to make this name hard to guess. It's not a security issue,
@@ -118,7 +118,7 @@ namespace Microsoft.PowerShell.Activities
                 appendOutput = true;
             }
 
-            // Adding activities into the CacheMetatdata of pipeline activity.
+            // Adding activities into the CacheMetadata of pipeline activity.
             if (count == 1)
             {
 
@@ -285,7 +285,7 @@ namespace Microsoft.PowerShell.Activities
         /// </summary>
         /// <param name="context">The activity context.</param>
         /// <param name="variable">The variable which needs to set.</param>
-        /// <param name="value">The value for the vriable.</param>
+        /// <param name="value">The value for the variable.</param>
         private void SetData(ActivityContext context, Variable<PSDataCollection<PSObject>> variable, PSDataCollection<PSObject> value)
         {
             PropertyDescriptor prop = context.DataContext.GetProperties()[variable.Name];

--- a/src/Microsoft.PowerShell.Activities/Activities/PowerShellValue.cs
+++ b/src/Microsoft.PowerShell.Activities/Activities/PowerShellValue.cs
@@ -40,7 +40,7 @@ namespace Microsoft.PowerShell.Activities
         /// <summary>
         /// Validates the syntax of the script text for this activity.
         /// </summary>
-        /// <param name="metadata">Activity metatdata for this activity</param>
+        /// <param name="metadata">Activity metadata for this activity</param>
         protected override void CacheMetadata(NativeActivityMetadata metadata)
         {
             base.CacheMetadata(metadata);

--- a/src/Microsoft.PowerShell.Activities/Activities/RemoveCimInstanceActivity.cs
+++ b/src/Microsoft.PowerShell.Activities/Activities/RemoveCimInstanceActivity.cs
@@ -75,7 +75,7 @@ namespace Microsoft.PowerShell.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Activities/Activities/SetCimInstanceActivity.cs
+++ b/src/Microsoft.PowerShell.Activities/Activities/SetCimInstanceActivity.cs
@@ -93,7 +93,7 @@ namespace cimcmdlets.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Activities/Activities/WorkflowJobConverter.cs
+++ b/src/Microsoft.PowerShell.Activities/Activities/WorkflowJobConverter.cs
@@ -102,7 +102,7 @@ namespace Microsoft.PowerShell.Workflow
         /// the AST before compilation. This stage should be light-weight and as efficient
         /// as possible.
         /// </summary>
-        /// <param name="ast">The PowerShell AST correpsponding to the job's definition.</param>
+        /// <param name="ast">The PowerShell AST corresponding to the job's definition.</param>
         /// <returns>A collection of PSParseErrors corresponding to any semantic issues in the AST.</returns>
         public List<ParseError> ValidateAst(FunctionDefinitionAst ast)
         {
@@ -113,7 +113,7 @@ namespace Microsoft.PowerShell.Workflow
         /// Converts a PowerShell AST into a script block that represents
         /// the workflow to run.
         /// </summary>
-        /// <param name="ast">The PowerShell AST correpsponding to the job's definition.</param>
+        /// <param name="ast">The PowerShell AST corresponding to the job's definition.</param>
         /// <param name="definingModule">The module that is defining this command (if any)</param>
         /// <returns>
         /// A PowerShell script block that invokes an underlying job,
@@ -138,7 +138,7 @@ namespace Microsoft.PowerShell.Workflow
         /// Converts a PowerShell AST into a script block that represents
         /// the workflow to run.
         /// </summary>
-        /// <param name="ast">The PowerShell AST correpsponding to the job's definition.</param>
+        /// <param name="ast">The PowerShell AST corresponding to the job's definition.</param>
         /// <param name="definingModule">The module that is defining this command (if any)</param>
         /// <param name="rootWorkflowName">Only root Workflow will be compiled</param>
         /// <returns>
@@ -163,7 +163,7 @@ namespace Microsoft.PowerShell.Workflow
         /// Converts a PowerShell AST into a script block that represents
         /// the workflow to run.
         /// </summary>
-        /// <param name="ast">The PowerShell AST correpsponding to the job's definition.</param>
+        /// <param name="ast">The PowerShell AST corresponding to the job's definition.</param>
         /// <param name="definingModule">The module that is defining this command (if any)</param>
         /// <param name="initialSessionState">The initial session state of a runspace.</param>
         /// <param name="parsingErrors">parsing errors</param>
@@ -188,7 +188,7 @@ namespace Microsoft.PowerShell.Workflow
         /// Converts a PowerShell AST into a script block that represents
         /// the workflow to run.
         /// </summary>
-        /// <param name="ast">The PowerShell AST correpsponding to the job's definition.</param>
+        /// <param name="ast">The PowerShell AST corresponding to the job's definition.</param>
         /// <param name="definingModule">The module that is defining this command (if any)</param>
         /// <param name="initialSessionState">The initial session state of a runspace.</param>
         /// <param name="parsingErrors">parsing errors</param>
@@ -206,7 +206,7 @@ namespace Microsoft.PowerShell.Workflow
         /// Converts a PowerShell AST into a script block that represents
         /// the workflow to run.
         /// </summary>
-        /// <param name="ast">The PowerShell AST correpsponding to the job's definition.</param>
+        /// <param name="ast">The PowerShell AST corresponding to the job's definition.</param>
         /// <param name="definingModule">The module that is defining this command (if any).</param>
         /// <param name="initialSessionState">The initial session state of a runspace.</param>
         /// <param name="sourceLanguageMode">Language mode of source that is creating the workflow.</param>
@@ -224,7 +224,7 @@ namespace Microsoft.PowerShell.Workflow
         /// Converts a PowerShell AST into a script block that represents
         /// the workflow to run.
         /// </summary>
-        /// <param name="ast">The PowerShell AST correpsponding to the job's definition.</param>
+        /// <param name="ast">The PowerShell AST corresponding to the job's definition.</param>
         /// <param name="definingModule">The module that is defining this command (if any)</param>
         /// <param name="initialSessionState">The initial session state of a runspace.</param>
         /// <param name="sourceLanguageMode">Language mode of source that is creating the workflow.</param>
@@ -323,7 +323,7 @@ namespace Microsoft.PowerShell.Workflow
                 invoker = System.Management.Automation.PowerShell.Create(initialSessionState);
                 var scopeFromIss = GetScopeFromIss(initialSessionState, invoker, out processedActivityLibraries, out activityMap);
 
-                // Add functionDefinitions, if any, from scopeFromIss to parent scope, so that they will be available for all FunctionDefintionAsts
+                // Add functionDefinitions, if any, from scopeFromIss to parent scope, so that they will be available for all FunctionDefinitionAsts
                 foreach(var entry in scopeFromIss.functionDefinitions)
                 {
                     scope.functionDefinitions.Add(entry.Key, entry.Value);
@@ -908,7 +908,7 @@ namespace Microsoft.PowerShell.Workflow
         /// <param name="referencedAssemblies">The list of additional assemblies to search for workflow activities.</param>
         /// <param name="parameterValidation">Any parameter validation applied to the parameters in the provided AST.</param>
         /// <param name="nestedWorkflows">Any nested workflows required by this PowerShell AST.</param>
-        /// <param name="requiredAssemblies">All assemblies, including provided at API or proiveded in workfow definition, required by this PowerShell Workflow.</param>
+        /// <param name="requiredAssemblies">All assemblies, including provided at API or provided in workflow definition, required by this PowerShell Workflow.</param>
         /// <param name="workflowAttributes">The attribute string for the workflow if these is one.</param>
         public static string Convert(FunctionDefinitionAst ast,
                                      PSModuleInfo definingModule,
@@ -1901,7 +1901,7 @@ namespace Microsoft.PowerShell.Workflow
         /// Block variable scope prefix like "$GLOBAL:" and "$SCRIPT:". In script workflow,
         /// the only valid scope prefix is "$WORKFLOW:". When generating expression for the
         /// PowerShellValue activity, we need to remove the $WORKFLOW part. Otherwise it will
-        /// generate error during execution, becuase the prefix "WORKFLOW" is not actually 
+        /// generate error during execution, because the prefix "WORKFLOW" is not actually 
         /// supported in the PowerShell.
         /// </summary>
         /// <param name="expression"></param>
@@ -2058,7 +2058,7 @@ namespace Microsoft.PowerShell.Workflow
 
         /// <summary>
         /// Used to hold the CmdletBinding attribute string specified in the script workflow text.
-        /// This needs to be propigated to the synthesized driver function .
+        /// This needs to be propagated to the synthesized driver function .
         /// </summary>
         internal string CmdletAttributeText { get; set; }
         
@@ -2398,7 +2398,7 @@ namespace Microsoft.PowerShell.Workflow
             // Generate debug symbol information for variable assignments.
             GenerateSymbolicInformation(value.Extent);
 
-            // Visit the right-hand side of the expression for activitities
+            // Visit the right-hand side of the expression for activities
             PipelineAst rightPipeline = value as PipelineAst;
             if (rightPipeline != null)
             {
@@ -2944,7 +2944,7 @@ namespace Microsoft.PowerShell.Workflow
                                 return null;
                             }
 
-                            // This is now an interative pipeline, remember the nonIterativePipelineVariable as one that needs to be set.
+                            // This is now an interactive pipeline, remember the nonIterativePipelineVariable as one that needs to be set.
                             if (!String.IsNullOrEmpty(nonIterativePipelineVariable) &&
                                 !iterativePipelineVariables.Contains(nonIterativePipelineVariable, StringComparer.OrdinalIgnoreCase))
                             {
@@ -2952,7 +2952,7 @@ namespace Microsoft.PowerShell.Workflow
                             }
                         }
 
-                        // Verify that once they've started an interative pipeline, all commands are
+                        // Verify that once they've started an interactive pipeline, all commands are
                         // Foreach-Object -Sequence or Where-Object -Sequence.
                         if (isIterativePipeline && (! isIterativeCommand))
                         {
@@ -7426,7 +7426,7 @@ namespace Microsoft.PowerShell.Workflow
             if (tryStatementAst.Finally != null)
             {
                 // Close the original try / catch. Since we're bringing the original
-                // finally into a new catch statement, we need to sythesize a dummy one here.
+                // finally into a new catch statement, we need to synthesize a dummy one here.
                 if (tryStatementAst.CatchClauses.Count == 0)
                 {
                     WriteLine("<TryCatch.Finally><Sequence /></TryCatch.Finally>");

--- a/src/Microsoft.PowerShell.Commands.Diagnostics/GetCounterCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Diagnostics/GetCounterCommand.cs
@@ -180,7 +180,7 @@ namespace Microsoft.PowerShell.Commands
         // The localized Pdh resource strings might use Unicode characters that are different from
         // what the user can type with the keyboard to represent a special character.
         //
-        // e.g. the apostrophe in Frence UI culture: it's [char]39 from keyboard, but it's [char]8217
+        // e.g. the apostrophe in French UI culture: it's [char]39 from keyboard, but it's [char]8217
         // in the resource strings.
         //
         // With this dictionary, we can add special mapping if we find other special cases in the future.

--- a/src/Microsoft.PowerShell.Commands.Diagnostics/GetEventCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Diagnostics/GetEventCommand.cs
@@ -816,7 +816,7 @@ namespace Microsoft.PowerShell.Commands
 
         //
         // CreateSession creates an EventLogSession connected to a target machine or localhost.
-        // If _credential argment is PSCredential.Empty, the session will be created for the current context.
+        // If _credential argument is PSCredential.Empty, the session will be created for the current context.
         //
         private EventLogSession CreateSession()
         {
@@ -1139,7 +1139,7 @@ namespace Microsoft.PowerShell.Commands
 
                 //
                 // If none of the logs/paths/providers were valid, queriedLogsQueryMap is empty.
-                // Simply conitnue to the next hashtable since all the errors have been written already.
+                // Simply continue to the next hashtable since all the errors have been written already.
                 //
                 if (queriedLogsQueryMap.Count == 0)
                 {
@@ -1672,7 +1672,7 @@ namespace Microsoft.PowerShell.Commands
         // ValidateAndResolveFilePath helper.
         // Returns a string collection of resolved file paths.
         // Writes non-terminating errors for invalid paths
-        // and returns an empty colleciton.
+        // and returns an empty collection.
         // 
         private StringCollection ValidateAndResolveFilePath(string path)
         {
@@ -1899,7 +1899,7 @@ namespace Microsoft.PowerShell.Commands
         // AddLogsForProviderToInternalMap helper.
         // Retrieves log names to which _providerName writes.
         // NOTE: there are many misconfigured providers in the system.
-        // We therefore catch EventLogException excpetions and write them out as non-terminating errors.
+        // We therefore catch EventLogException exceptions and write them out as non-terminating errors.
         // The results are added to _providersByLogMap dictionary.  
         //
         private void AddLogsForProviderToInternalMap(EventLogSession eventLogSession, string providerName)

--- a/src/Microsoft.PowerShell.Commands.Diagnostics/ImportCounterCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Diagnostics/ImportCounterCommand.cs
@@ -555,7 +555,7 @@ namespace Microsoft.PowerShell.Commands
         // ResolveFilePath helper.
         // Returns a string collection of resolved file paths.
         // Writes non-terminating errors for invalid paths
-        // and returns an empty colleciton.
+        // and returns an empty collection.
         // 
         private bool ResolveFilePaths()
         {

--- a/src/Microsoft.PowerShell.Commands.Diagnostics/PdhHelper.cs
+++ b/src/Microsoft.PowerShell.Commands.Diagnostics/PdhHelper.cs
@@ -1516,7 +1516,7 @@ namespace Microsoft.Powershell.Commands.GetCounter.PdhNative
             //
             // Prior to Vista, PdhCollectQueryDataWithTime() was not available, 
             // so we could not collect a timestamp for the entire sample set.
-            // We will use the last sample's timstamp instead.
+            // We will use the last sample's timestamp instead.
             //
             nextSet = new PerformanceCounterSampleSet(sampleTimeStamp, samplesArr, _firstReading);
             _firstReading = false;

--- a/src/Microsoft.PowerShell.Commands.Management/cimSupport/cmdletization/SessionBasedWrapper.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/cimSupport/cmdletization/SessionBasedWrapper.cs
@@ -109,7 +109,7 @@ namespace Microsoft.PowerShell.Cmdletization
 
         #endregion Common CIM-related parameters
 
-        #region Abstract methods to be overriden in derived classes
+        #region Abstract methods to be overridden in derived classes
 
         /// <summary>
         /// Creates a <see cref="System.Management.Automation.Job"/> object that performs a query against the wrapped object model.
@@ -123,7 +123,7 @@ namespace Microsoft.PowerShell.Cmdletization
         /// </para>
         /// <para>
         /// <see cref="Job.WriteObject" /> (and other methods returning job results) will block to support throttling and flow-control.
-        /// Implementations of Job instance returned from this method should make sure that implementation-specific flow-control mechanism pauses further procesing,
+        /// Implementations of Job instance returned from this method should make sure that implementation-specific flow-control mechanism pauses further processing,
         /// until calls from <see cref="Job.WriteObject" /> (and other methods returning job results) return.
         /// </para>
         /// </remarks>
@@ -174,7 +174,7 @@ namespace Microsoft.PowerShell.Cmdletization
         /// </para>
         /// <para>
         /// <see cref="Job.WriteObject" /> (and other methods returning job results) will block to support throttling and flow-control.
-        /// Implementations of Job instance returned from this method should make sure that implementation-specific flow-control mechanism pauses further procesing,
+        /// Implementations of Job instance returned from this method should make sure that implementation-specific flow-control mechanism pauses further processing,
         /// until calls from <see cref="Job.WriteObject" /> (and other methods returning job results) return.
         /// </para>
         /// </remarks>
@@ -209,7 +209,7 @@ namespace Microsoft.PowerShell.Cmdletization
         /// </para>
         /// <para>
         /// <see cref="Job.WriteObject" /> (and other methods returning job results) will block to support throttling and flow-control.
-        /// Implementations of Job instance returned from this method should make sure that implementation-specific flow-control mechanism pauses further procesing,
+        /// Implementations of Job instance returned from this method should make sure that implementation-specific flow-control mechanism pauses further processing,
         /// until calls from <see cref="Job.WriteObject" /> (and other methods returning job results) return.
         /// </para>
         /// </remarks>
@@ -550,7 +550,7 @@ namespace Microsoft.PowerShell.Cmdletization
         private TSession GetImpliedSession()
         {
             TSession sessionFromImportModule;
-            // When being called from a CIM actiivty, this will be invoked as
+            // When being called from a CIM activity, this will be invoked as
             // a function so there will be no module info
             if (this.PSModuleInfo != null)
             {

--- a/src/Microsoft.PowerShell.Commands.Management/cimSupport/cmdletization/cim/CreateInstanceJob.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/cimSupport/cmdletization/cim/CreateInstanceJob.cs
@@ -103,7 +103,7 @@ namespace Microsoft.PowerShell.Cmdletization.Cim
             if (this.DidUserSuppressTheOperation)
             {
                 // If user suppressed CreateInstance operation, then no instance should be returned by the cmdlet
-                // If the provider's CreateInstance implemenration doesn't post an instance and returns a success, then WMI infra will error out to flag an incorrect implementation of CreateInstance (by design)
+                // If the provider's CreateInstance implementation doesn't post an instance and returns a success, then WMI infra will error out to flag an incorrect implementation of CreateInstance (by design)
                 // Therefore cmdletization layer has to suppress the error and treat this as normal/successful completion
                 this.OnCompleted();
             }

--- a/src/Microsoft.PowerShell.Commands.Management/cimSupport/cmdletization/cim/cimConverter.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/cimSupport/cmdletization/cim/cimConverter.cs
@@ -25,7 +25,7 @@ using Microsoft.PowerShell.CoreClr.Stubs;
 using System.Net.Mail;
 #endif
 
-// TODO/FIXME: Move this class to src/cimSupport/other directory (to map to the namespace it lives in and functionality it implements [cmdletization idependent])
+// TODO/FIXME: Move this class to src/cimSupport/other directory (to map to the namespace it lives in and functionality it implements [cmdletization independent])
 
 namespace Microsoft.PowerShell.Cim
 {

--- a/src/Microsoft.PowerShell.Commands.Management/cimSupport/cmdletization/cim/cimQuery.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/cimSupport/cmdletization/cim/cimQuery.cs
@@ -38,7 +38,7 @@ namespace Microsoft.PowerShell.Cmdletization.Cim
             this.ClientSideQuery = new ClientSideQuery();
         }
 
-        #region WQL proceessing
+        #region WQL processing
 
         private void AddWqlCondition(string condition)
         {

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/CIMHelper.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/CIMHelper.cs
@@ -228,7 +228,7 @@ namespace Microsoft.PowerShell.Commands
         /// A string that may contain backslash characters.
         /// </param>
         /// <returns>
-        /// A new string in which any backshlash characters have been "escaped"
+        /// A new string in which any backslash characters have been "escaped"
         /// by prefacing then with an additional backslash
         /// </returns>
         internal static string EscapePath(string path)
@@ -261,9 +261,9 @@ namespace Extensions
         }
 
         /// <summary>
-        /// Execute a CIM query and return only the first intance in the result.
+        /// Execute a CIM query and return only the first instance in the result.
         /// </summary>
-        /// <param name="session">The CimSesson to be queried</param>
+        /// <param name="session">The CimSession to be queried</param>
         /// <param name="nameSpace">A string containing the namespace to run the query against</param>
         /// <param name="query">A string containing the query to be run</param>
         /// <returns>
@@ -290,9 +290,9 @@ namespace Extensions
         }
 
         /// <summary>
-        /// Execute a CIM query and return only the first intance in the result.
+        /// Execute a CIM query and return only the first instance in the result.
         /// </summary>
-        /// <param name="session">The CimSesson to be queried</param>
+        /// <param name="session">The CimSession to be queried</param>
         /// <param name="query">A string containing the query to be run</param>
         /// <returns>
         /// A <see cref="Microsoft.Management.Infrastructure.CimInstance"/> object

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/ClearRecycleBinCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/ClearRecycleBinCommand.cs
@@ -11,7 +11,7 @@ namespace Microsoft.PowerShell.Commands
 {
     /// <summary>
     /// Defines the implementation of the 'Clear-RecycleBin' cmdlet.
-    /// This cmldet clear all files in the RecycleBin for the given DriveLetter. 
+    /// This cmdlet clear all files in the RecycleBin for the given DriveLetter. 
     /// If not DriveLetter is specified, then the RecycleBin for all drives are cleared. 
     /// </summary>
     [Cmdlet(VerbsCommon.Clear, "RecycleBin", SupportsShouldProcess = true, HelpUri = "http://go.microsoft.com/fwlink/?LinkId=524082", ConfirmImpact = ConfirmImpact.High)]
@@ -197,7 +197,7 @@ namespace Microsoft.PowerShell.Commands
 
             if (_force || (ShouldProcess(clearRecycleBinShouldProcessTarget, "Clear-RecycleBin")))
             {
-                // If driveName is null, then clear the recyclebin for all drives; otherwise, just for the specified drivename. 
+                // If driveName is null, then clear the recyclebin for all drives; otherwise, just for the specified driveName. 
 
                 string activity = String.Format(CultureInfo.InvariantCulture, ClearRecycleBinResources.ClearRecycleBinProgressActivity);
                 string statusDescription;

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Computer.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Computer.cs
@@ -692,7 +692,7 @@ namespace Microsoft.PowerShell.Commands
         public void Dispose()
         {
             this.Dispose(true);
-            // Use SupressFinalize in case a subclass
+            // Use SuppressFinalize in case a subclass
             // of this type implements a finalizer.
             GC.SuppressFinalize(this);
         }
@@ -766,7 +766,7 @@ namespace Microsoft.PowerShell.Commands
                                 continue;
                             }
                             //parameter for Enable method
-                            //if the input drive is not sytem drive 
+                            //if the input drive is not system drive 
                             if (!driveNew.Equals(sysdrive, StringComparison.OrdinalIgnoreCase))
                             {
                                 object[] inputDrive = { driveNew };
@@ -779,7 +779,7 @@ namespace Microsoft.PowerShell.Commands
                                 }
                             }
                             //if not success and if it is not already enabled (error code is 1056 in XP) 
-                            // Error 1717 - The interface is unknown. Eventhough this comes sometimes . The Drive is getting enabled.
+                            // Error 1717 - The interface is unknown. Even though this comes sometimes . The Drive is getting enabled.
                             if (!(retValue.Equals(0)) && !(retValue.Equals(ComputerWMIHelper.ErrorCode_Service)) && !(retValue.Equals(ComputerWMIHelper.ErrorCode_Interface)))
                             {
                                 Exception Ex = new ArgumentException(StringUtil.Format(ComputerResources.NotEnabled, drive));
@@ -873,7 +873,7 @@ namespace Microsoft.PowerShell.Commands
         public void Dispose()
         {
             this.Dispose(true);
-            // Use SupressFinalize in case a subclass
+            // Use SuppressFinalize in case a subclass
             // of this type implements a finalizer.
             GC.SuppressFinalize(this);
         }
@@ -940,7 +940,7 @@ namespace Microsoft.PowerShell.Commands
                     {
                         object[] input = { driveNew };
                         int retValue = Convert.ToInt32(WMIClass.InvokeMethod("Disable", input), System.Globalization.CultureInfo.CurrentCulture);
-                        // Error 1717 - The interface is unknown. Eventhough this comes sometimes . The Drive is getting disabled.
+                        // Error 1717 - The interface is unknown. Even though this comes sometimes . The Drive is getting disabled.
                         if (!(retValue.Equals(0)) && !(retValue.Equals(ComputerWMIHelper.ErrorCode_Interface)))
                         {
                             ErrorRecord er = new ErrorRecord(new ArgumentException(StringUtil.Format(ComputerResources.NotDisabled, drive)), null, ErrorCategory.InvalidOperation, null);
@@ -1431,7 +1431,7 @@ namespace Microsoft.PowerShell.Commands
         public void Dispose()
         {
             this.Dispose(true);
-            // Use SupressFinalize in case a subclass
+            // Use SuppressFinalize in case a subclass
             // of this type implements a finalizer.
             GC.SuppressFinalize(this);
         }
@@ -2037,7 +2037,7 @@ $result
         public void Dispose()
         {
             this.Dispose(true);
-            // Use SupressFinalize in case a subclass
+            // Use SuppressFinalize in case a subclass
             // of this type implements a finalizer.
             GC.SuppressFinalize(this);
         }
@@ -2600,7 +2600,7 @@ $result
             }
             catch (PipelineStoppedException)
             {
-                // powershell.Stop() is invoked becaue timeout expires, or Ctrl+C is pressed
+                // powershell.Stop() is invoked because timeout expires, or Ctrl+C is pressed
             }
             catch (ObjectDisposedException)
             {
@@ -3638,7 +3638,7 @@ $result
         public void Dispose()
         {
             this.Dispose(true);
-            // Use SupressFinalize in case a subclass
+            // Use SuppressFinalize in case a subclass
             // of this type implements a finalizer.
             GC.SuppressFinalize(this);
         }
@@ -3696,7 +3696,7 @@ $result
                         return;
                     }
                 }
-                //confrm with the user before restoring
+                //confirm with the user before restoring
                 string computerName = Environment.MachineName;
                 if (!ShouldProcess(computerName))
                 {
@@ -3817,7 +3817,7 @@ $result
         JoinReadOnly = 0x800,
 
         /// <summary>
-        /// Invoke during insatll
+        /// Invoke during install
         /// </summary>
         InstallInvoke = 0x40000
     }
@@ -3868,7 +3868,7 @@ $result
         /// <summary>
         /// The domain credential.
         /// In DomainParameterSet, it is for the domain to join to.
-        /// In WorkgroupParameterSet, it is for the doamin to disjoin from.
+        /// In WorkgroupParameterSet, it is for the domain to disjoin from.
         /// </summary>
         [Parameter(ParameterSetName = DomainParameterSet, Mandatory = true)]
         [Parameter(ParameterSetName = WorkgroupParameterSet)]
@@ -3971,7 +3971,7 @@ $result
         /// In the DomainParameterSet, the UnjoinDomainCredential is our first choice to unjoin a domain.
         /// But if the UnjoinDomainCredential is not specified, the DomainCredential will be our second 
         /// choice. This is to keep the backward compatibility. In Win7, we can do:
-        ///      Add-Computer -DomianName domain1 -Credential $credForDomain1AndDomain2
+        ///      Add-Computer -DomainName domain1 -Credential $credForDomain1AndDomain2
         /// to switch the local machine that is currently in domain2 to domain1.
         /// 
         /// Since DomainCredential has an alias "Credential", the same command should still work for the
@@ -5893,7 +5893,7 @@ $result
                     ThrowOutLsaError(ret, cmdlet);
                 }
 
-                // Initialize sercret key, new secret
+                // Initialize secret key, new secret
                 SAMAPI.InitLsaString(SecretKey, ref key);
                 SAMAPI.InitLsaString(newPassword, ref newData);
                 bool secretCreated = false;
@@ -6250,7 +6250,7 @@ $result
         }
 
         /// <summary>
-        /// To Reset a passowrd for a computer in domain.
+        /// To Reset a password for a computer in domain.
         /// </summary>
         [DllImport("netapi32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
         internal static extern int I_NetLogonControl2(
@@ -6580,7 +6580,7 @@ $result
         }
 
         /// <summary>
-        /// Chacks whether string[] contains System Drive.
+        /// Checks whether string[] contains System Drive.
         /// </summary>
         /// <param name="drives"></param>
         /// <param name="sysdrive"></param>

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/ContentCommandBase.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/ContentCommandBase.cs
@@ -730,7 +730,7 @@ namespace Microsoft.PowerShell.Commands
         }
 
         /// <summary>
-        /// Dispose method in IDisposeable
+        /// Dispose method in IDisposable
         /// </summary>
         public void Dispose()
         {

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/ControlPanelItemCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/ControlPanelItemCommand.cs
@@ -83,7 +83,7 @@ namespace Microsoft.PowerShell.Commands
         private static string s_verbActionOpenName = null;
 
         /// <summary>
-        /// Canonical name of the control panel item used as a refernece to fetch the verb
+        /// Canonical name of the control panel item used as a reference to fetch the verb
         /// action Open string. This control panel item exists on all SKU's.
         /// </summary>
         private const string RegionCanonicalName = "Microsoft.RegionAndLanguage";
@@ -205,9 +205,9 @@ $result
 
         /// <summary>
         /// CompareVerbActionOpen is a helper function used to perform locale specific
-        /// comparision of the verb action Open exposed by various control panel items.
+        /// comparison of the verb action Open exposed by various control panel items.
         /// </summary>
-        /// <param name="verbActionName">Locale spcific verb action exposed by the control panel item.</param>
+        /// <param name="verbActionName">Locale specific verb action exposed by the control panel item.</param>
         /// <returns>True if the control panel item supports verb action open or else returns false.</returns>
         private static bool CompareVerbActionOpen(string verbActionName)
         {
@@ -644,7 +644,7 @@ $result
                 results.Add(controlPanelItem);
             }
 
-            // Sort the reuslts by Canonical Name
+            // Sort the results by Canonical Name
             results.Sort(CompareControlPanelItems);
             foreach (ControlPanelItem controlPanelItem in results)
             {

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/ConvertPathCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/ConvertPathCommand.cs
@@ -9,7 +9,7 @@ using Dbg = System.Management.Automation;
 namespace Microsoft.PowerShell.Commands
 {
     /// <summary>
-    /// A command to convert a drive qualifed or provider qualified path to 
+    /// A command to convert a drive qualified or provider qualified path to 
     /// a provider internal path.
     /// </summary>
     [Cmdlet(VerbsData.Convert, "Path", DefaultParameterSetName = "Path", SupportsTransactions = true,

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Eventlog.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Eventlog.cs
@@ -419,7 +419,7 @@ namespace Microsoft.PowerShell.Commands
                     }
                     if (!AsBaseObject)
                     {
-                        //wraping in PSobject to insert into PStypesnames
+                        //wrapping in PSobject to insert into PStypesnames
                         PSObject logentry = new PSObject(entry);
                         //inserting at zero position in reverse order
                         logentry.TypeNames.Insert(0, logentry.ImmediateBaseObject + "#" + log.Log + "/" + entry.Source);

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/GetComputerInfoCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/GetComputerInfoCommand.cs
@@ -1939,7 +1939,7 @@ namespace Microsoft.PowerShell.Commands
 #pragma warning restore 649
     #endregion Intermediate WMI classes
 
-    #region Other Imtermediate classes
+    #region Other Intermediate classes
     internal class RegWinNtCurrentVersion
     {
         public string BuildLabEx;
@@ -1953,7 +1953,7 @@ namespace Microsoft.PowerShell.Commands
         public string RegisteredOwner;
         public string SystemRoot;
     }
-    #endregion Other Intermediage classes
+    #endregion Other Intermediate classes
 
     #region Output components
     #region Classes comprising the output object
@@ -2677,7 +2677,7 @@ namespace Microsoft.PowerShell.Commands
         public string CsPrimaryOwnerName { get; internal set; }
 
         /// <summary>
-        /// Indicates if the computer system can be resut.
+        /// Indicates if the computer system can be reset.
         /// </summary>
         public ResetCapability? CsResetCapability { get; internal set; }
 
@@ -2806,7 +2806,7 @@ namespace Microsoft.PowerShell.Commands
 
         /// <summary>
         /// Array of <see cref="HotFix"/> objects containing information about
-        /// any Quick-Fix Enginnering patches (Hot Fixes) applied to the operating
+        /// any Quick-Fix Engineering patches (Hot Fixes) applied to the operating
         /// system
         /// </summary>
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays")]
@@ -3348,7 +3348,7 @@ namespace Microsoft.PowerShell.Commands
         Alpha = 2,
 
         /// <summary>
-        /// Architecture is Motorolla PowerPC
+        /// Architecture is Motorola PowerPC
         /// </summary>
         PowerPC = 3,
 
@@ -3865,17 +3865,17 @@ namespace Microsoft.PowerShell.Commands
     public enum OSEncryptionLevel
     {
         /// <summary>
-        /// 40-bit encription
+        /// 40-bit encryption
         /// </summary>
         Encrypt40Bits = 0,
 
         /// <summary>
-        /// 128-bit encription
+        /// 128-bit encryption
         /// </summary>
         Encrypt128Bits = 1,
 
         /// <summary>
-        /// n-bit encription
+        /// n-bit encryption
         /// </summary>
         EncryptNBits = 2
     }
@@ -4605,7 +4605,7 @@ namespace Microsoft.PowerShell.Commands
 
     /// <summary>
     /// Specifies the type of the computer in use, such as laptop, desktop, or Tablet.
-    /// This is an extended verion of PCSystemType
+    /// This is an extended version of PCSystemType
     /// </summary>
     //TODO: conflate these two enums???
     public enum PCSystemTypeEx
@@ -4776,27 +4776,27 @@ namespace Microsoft.PowerShell.Commands
         Other = 1,
 
         /// <summary>
-        /// Proccessor type is 
+        /// Processor type is 
         /// </summary>
         Unknown = 2,
 
         /// <summary>
-        /// Proccessor is a Central Processing Unit (CPU)
+        /// Processor is a Central Processing Unit (CPU)
         /// </summary>
         CentralProcessor = 3,
 
         /// <summary>
-        /// Proccessor is a Math processor
+        /// Processor is a Math processor
         /// </summary>
         MathProcessor = 4,
 
         /// <summary>
-        /// Proccessor is a Digital Signal processor (DSP)
+        /// Processor is a Digital Signal processor (DSP)
         /// </summary>
         DSPProcessor = 5,
 
         /// <summary>
-        /// Proccessor is a Video processor
+        /// Processor is a Video processor
         /// </summary>
         VideoProcessor = 6
     }
@@ -4973,7 +4973,7 @@ namespace Microsoft.PowerShell.Commands
     public enum ServerLevel
     {
         /// <summary>
-        /// An unknown or unrecognized level was dected
+        /// An unknown or unrecognized level was detected
         /// </summary>
         Unknown = 0,
 

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/GetContentCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/GetContentCommand.cs
@@ -315,7 +315,7 @@ namespace Microsoft.PowerShell.Commands
                     // Create and save the error record. The error record
                     // will be written outside the while loop.
                     // This is to make sure the accumulated results get written
-                    // out before the error recrod when the 'scanForwardForTail' is true.
+                    // out before the error record when the 'scanForwardForTail' is true.
                     error = new ErrorRecord(
                         providerException.ErrorRecord,
                         providerException);
@@ -352,7 +352,7 @@ namespace Microsoft.PowerShell.Commands
                 }
                 else if (ReadCount == 1)
                 {
-                    // Write out the contnet as single object
+                    // Write out the content as single object
                     while (tailResultQueue.Count > 0)
                         WriteContentObject(tailResultQueue.Dequeue(), count++, holder.PathInfo, currentContext);
                 }

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/GetWMIObjectCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/GetWMIObjectCommand.cs
@@ -108,8 +108,8 @@ namespace Microsoft.PowerShell.Commands
         ///            Character   Description Example Match   Comment
         ///             *   Matches zero or more characters starting at the specified position  A*  A,ag,Apple  Supported by PowerShell.
         ///              ?   Matches any character at the specified position ?n  An,in,on (does not match ran)   Supported by PowerShell.
-        ///              _   Matches any character at the specified position    _n  An,in,on (does not match ran)   Supperted by WMI
-        ///             %   Matches zero or more characters starting at the specified position   A%  A,ag,Apple  Supperted by WMI
+        ///              _   Matches any character at the specified position    _n  An,in,on (does not match ran)   Supported by WMI
+        ///             %   Matches zero or more characters starting at the specified position   A%  A,ag,Apple  Supported by WMI
         ///             []  Matches a range of characters  [a-l]ook    Book,cook,look (does not match took)    Supported by WMI and powershell
         ///              []  Matches specified characters   [bc]ook Book,cook, (does not match look)    Supported by WMI and powershell
         ///              ^   Does not Match specified characters. [^bc]ook    Look, took (does not match book, cook)  Supported by WMI.

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Hotfix.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Hotfix.cs
@@ -218,7 +218,7 @@ namespace Microsoft.PowerShell.Commands
         public void Dispose()
         {
             this.Dispose(true);
-            // Use SupressFinalize in case a subclass
+            // Use SuppressFinalize in case a subclass
             // of this type implements a finalizer.
             GC.SuppressFinalize(this);
         }

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Navigation.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Navigation.cs
@@ -1568,7 +1568,7 @@ namespace Microsoft.PowerShell.Commands
 
         /// <summary>
         /// Gets or sets the Persist Switch parameter.
-        /// If this switch parmter is set then the created PSDrive
+        /// If this switch parameter is set then the created PSDrive
         /// would be persisted across PowerShell sessions.
         /// </summary>
         [Parameter(ValueFromPipelineByPropertyName = true)]

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/ParsePathCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/ParsePathCommand.cs
@@ -102,7 +102,7 @@ namespace Microsoft.PowerShell.Commands
         ///
         /// <value>
         /// If true the qualifier of the path will be returned.
-        /// The qualifier is the drive or provider that is qualifing
+        /// The qualifier is the drive or provider that is qualifying
         /// the MSH path.
         /// </value>
         ///
@@ -126,7 +126,7 @@ namespace Microsoft.PowerShell.Commands
         ///
         /// <value>
         /// If true the qualifier of the path will be returned.
-        /// The qualifier is the drive or provider that is qualifing
+        /// The qualifier is the drive or provider that is qualifying
         /// the MSH path.
         /// </value>
         ///

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
@@ -970,7 +970,7 @@ namespace Microsoft.PowerShell.Commands
         }
 
         /// <summary>
-        /// Name of the processes to wait on for termintation
+        /// Name of the processes to wait on for termination
         /// </summary>
         [Parameter(
             ParameterSetName = "Name",
@@ -1570,7 +1570,7 @@ namespace Microsoft.PowerShell.Commands
         }
 
         /// <summary>
-        /// Name of the processes to wait on for termintation
+        /// Name of the processes to wait on for termination
         /// </summary>
         [Parameter(
             ParameterSetName = "Name",
@@ -2712,7 +2712,7 @@ namespace Microsoft.PowerShell.Commands
         }
 
         /// <summary>
-        /// Start API assignes the process to the JobObject and starts monitoring 
+        /// Start API assigns the process to the JobObject and starts monitoring 
         /// the child processes hosted by the process created by Start-Process cmdlet.
         /// </summary>
         internal bool AssignProcessToJobObject(Process process)

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/RegisterWMIEventCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/RegisterWMIEventCommand.cs
@@ -95,7 +95,7 @@ namespace Microsoft.PowerShell.Commands
             returnValue.Append(namespaceParameter);
             return returnValue.ToString();
         }
-        #endregion helper funtions
+        #endregion helper functions
 
 
         /// <summary>

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Service.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Service.cs
@@ -411,7 +411,7 @@ namespace Microsoft.PowerShell.Commands
         /// <returns></returns>
         /// <remarks>
         /// We do not use the ServiceController(string serviceName)
-        /// constructor variant, since thr resultant
+        /// constructor variant, since the resultant
         /// ServiceController.ServiceName is the provided serviceName
         /// even when that differs from the real ServiceName by case.
         /// </remarks>
@@ -1390,7 +1390,7 @@ namespace Microsoft.PowerShell.Commands
                     continue;
                 }
 
-                //Set the NoWait paramater to false since we are not adding this switch to this cmdlet.
+                //Set the NoWait parameter to false since we are not adding this switch to this cmdlet.
                 List<ServiceController> stoppedServices = DoStopService(serviceController, Force, true);
 
                 if (stoppedServices.Count > 0)
@@ -1809,7 +1809,7 @@ namespace Microsoft.PowerShell.Commands
                         }
                         if (PassThru.IsPresent)
                         {
-                            //to display the service,refreshing the service would not show the display name after updation
+                            //to display the service,refreshing the service would not show the display name after updating
                             ServiceController displayservice = new ServiceController(Name, ServiceComputerName);
                             WriteObject(displayservice);
                         }

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/SetClipboardCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/SetClipboardCommand.cs
@@ -16,7 +16,7 @@ namespace Microsoft.PowerShell.Commands
 {
     /// <summary>
     /// Defines the implementation of the 'Set-Clipboard' cmdlet.
-    /// This cmldet get the content from system clipboard. 
+    /// This cmdlet gets the content from system clipboard. 
     /// </summary>
     [Cmdlet(VerbsCommon.Set, "Clipboard", DefaultParameterSetName = "String", SupportsShouldProcess = true, HelpUri = "http://go.microsoft.com/fwlink/?LinkId=526220")]
     [Alias("scb")]

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/WMIHelper.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/WMIHelper.cs
@@ -466,7 +466,7 @@ namespace Microsoft.PowerShell.Commands
         }
 
         /// <summary>
-        /// Do the actual connection to remote machine for Invokd-WMIMethod cmdlet and raise operation complete event.
+        /// Do the actual connection to remote machine for Invoke-WMIMethod cmdlet and raise operation complete event.
         /// </summary>
         private void ConnectInvokeWmi()
         {
@@ -1816,7 +1816,7 @@ namespace Microsoft.PowerShell.Commands
         }
 
         /// <summary>
-        /// it recieves Management objects
+        /// it receives Management objects
         /// </summary>
         private void NewObject(object sender, ObjectReadyEventArgs obj)
         {

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/WebServiceProxy.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/WebServiceProxy.cs
@@ -305,11 +305,11 @@ namespace Microsoft.PowerShell.Commands
         {
             DiscoveryClientProtocol dcp = new DiscoveryClientProtocol();
 
-            //if paramset is defualtcredential, set the flag in wcclient
+            //if paramset is defaultcredential, set the flag in wcclient
             if (_usedefaultcredential.IsPresent)
                 dcp.UseDefaultCredentials = true;
 
-            //if paramset is credential, assign the crdentials
+            //if paramset is credential, assign the credentials
             if (ParameterSetName.Equals("Credential", StringComparison.OrdinalIgnoreCase))
                 dcp.Credentials = _credential.GetNetworkCredential();
 
@@ -396,7 +396,7 @@ namespace Microsoft.PowerShell.Commands
                 this.WriteWarning(warning);
             }
 
-            // add the refernces to the required assemblies
+            // add the references to the required assemblies
             options.ReferencedAssemblies.Add("System.dll");
             options.ReferencedAssemblies.Add("System.Data.dll");
             options.ReferencedAssemblies.Add("System.Xml.dll");

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/WriteContentCommandBase.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/WriteContentCommandBase.cs
@@ -207,7 +207,7 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// This method is called by the base class after getting the content writer
         /// from the provider. If the current position needs to be changed before writing
-        /// the content, this method should be overriden to do that.
+        /// the content, this method should be overridden to do that.
         /// </summary>
         /// 
         /// <param name="contentHolders">

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/AddType.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/AddType.cs
@@ -267,7 +267,7 @@ namespace Microsoft.PowerShell.Commands
                     Collection<string> newPaths = SessionState.Path.GetResolvedProviderPathFromPSPath(path, out provider);
 
                     // If it didn't resolve, add the original back
-                    // for a better error mesage.
+                    // for a better error message.
                     if (newPaths.Count == 0)
                     {
                         resolvedPaths.Add(path);
@@ -959,7 +959,7 @@ namespace Microsoft.PowerShell.Commands
         {
             foreach (string assemblyName in assemblies)
             {
-                // CoreCLR doesn't allow re-load TPA assemblis with different API (i.e. we load them by name and now want to load by path).
+                // CoreCLR doesn't allow re-load TPA assemblies with different API (i.e. we load them by name and now want to load by path).
                 // LoadAssemblyHelper helps us avoid re-loading them, if they already loaded.
                 Assembly assembly = LoadAssemblyHelper(assemblyName);
                 if (assembly == null)
@@ -1018,8 +1018,8 @@ namespace Microsoft.PowerShell.Commands
         private static string s_frameworkFolder = System.IO.Path.GetDirectoryName(typeof(object).GetTypeInfo().Assembly.Location);
 
         // there are two different assemblies: framework contract and framework implementation.
-        // Version 1.1.1 of Microsoft.CodeAnalysis doesn't provide a good way to handle contract separetely from implementation.
-        // To simplify user expirience we always add both of them to references.
+        // Version 1.1.1 of Microsoft.CodeAnalysis doesn't provide a good way to handle contract separately from implementation.
+        // To simplify user experience we always add both of them to references.
         // 1) It's a legitimate scenario, when user provides a custom referenced assembly that was built against the contract assembly 
         // (i.e. System.Management.Automation), so we need the contract one.
         // 2) We have to provide implementation assembly explicitly, Roslyn doesn't have a way to figure out implementation by itself.
@@ -1042,7 +1042,7 @@ namespace Microsoft.PowerShell.Commands
             MetadataReference.CreateFromFile(typeof(System.Security.SecureString).GetTypeInfo().Assembly.Location);
 
 
-        // These assemlbies are always automatically added to ReferencedAssemblies.
+        // These assemblies are always automatically added to ReferencedAssemblies.
         private static PortableExecutableReference[] s_autoReferencedAssemblies = new PortableExecutableReference[]
         {
             s_mscorlibAssemblyReference,
@@ -1051,7 +1051,7 @@ namespace Microsoft.PowerShell.Commands
             s_objectImplementationAssemblyReference
         };
 
-        // These assemlbies are used, when ReferencedAssemblies parameter is not specified.
+        // These assemblies are used, when ReferencedAssemblies parameter is not specified.
         private static PortableExecutableReference[] s_defaultAssemblies = new PortableExecutableReference[]
         {
             s_mscorlibAssemblyReference,
@@ -1441,7 +1441,7 @@ namespace Microsoft.PowerShell.Commands
                 return;
             }
 
-            // Generate if user has specified CompilerParmeters and
+            // Generate if user has specified CompilerParameters and
             // (referencedAssemblies | ignoreWarnings | outputAssembly | outputType)
             if (null != CompilerParameters)
             {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CSVCommands.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CSVCommands.cs
@@ -89,7 +89,7 @@ namespace Microsoft.PowerShell.Commands
 
 
         /// <summary>
-        /// Write the string to a file or pipelin
+        /// Write the string to a file or pipeline
         /// </summary>
         public virtual void WriteCsvLine(string line)
         {
@@ -332,7 +332,7 @@ namespace Microsoft.PowerShell.Commands
                 }
             }
 
-            // If the csv file is empty then even append is treated as regualr export (i.e., both header & values are added to the CSV file).
+            // If the csv file is empty then even append is treated as regular export (i.e., both header & values are added to the CSV file).
             _isActuallyAppending = this.Append && File.Exists(resolvedFilePath) && !isCsvFileEmpty;
 
             if (_isActuallyAppending)
@@ -1311,7 +1311,7 @@ namespace Microsoft.PowerShell.Commands
         {
             //Collection of strings to return
             Collection<string> result = new Collection<string>();
-            //currect string
+            //current string
             StringBuilder current = new StringBuilder();
 
             bool seenBeginQuote = false;
@@ -1383,7 +1383,7 @@ namespace Microsoft.PowerShell.Commands
                     }
                     else if (current.Length == 0)
                     {
-                        //We are at the begining of a new word.
+                        //We are at the beginning of a new word.
                         //This quote is the first quote.
                         seenBeginQuote = true;
                     }
@@ -1391,7 +1391,7 @@ namespace Microsoft.PowerShell.Commands
                     {
                         //We are seeing a quote after the start of 
                         //the word. This is error, however we will be 
-                        //lineient here and do what excel does:
+                        //lenient here and do what excel does:
                         //Ex: foo "ba,r"
                         //In above example word read is ->foo "ba<-
                         //Basically we read till next delimiter
@@ -1419,9 +1419,9 @@ namespace Microsoft.PowerShell.Commands
                     else
                     {
                         //We are not in quote and we are not at the 
-                        //begining of a word. We should not be seeing
+                        //beginning of a word. We should not be seeing
                         //spaces here. This is an error condition, however
-                        //we will be linient here and do what excel does,
+                        //we will be lenient here and do what excel does,
                         //that is read till next delimiter.
                         //Ex: ->foo <- is read as ->foo<-
                         //Ex: ->foo bar<- is read as ->foo bar<-
@@ -1471,7 +1471,7 @@ namespace Microsoft.PowerShell.Commands
                 result.Add(current.ToString());
             }
 
-            //Trim all trailing blackspaces and delimiters ( single/multiple ).
+            //Trim all trailing blankspaces and delimiters ( single/multiple ).
             // If there is only one element in the row and if its a blankspace we dont trim it.
             // A trailing delimiter is represented as a blankspace while being added to result collection
             // which is getting trimmed along with blankspaces supplied through the CSV in the below loop.

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CustomSerialization.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CustomSerialization.cs
@@ -68,7 +68,7 @@ namespace System.Management.Automation
         }
 
         /// <summary>
-        /// Default depth of serializaiton
+        /// Default depth of serialization
         /// </summary>
         public static int MshDefaultSerializationDepth { get; } = 1;
 
@@ -93,7 +93,7 @@ namespace System.Management.Automation
         private bool _firstCall = true;
 
         /// <summary>
-        /// Serialzies passed in object
+        /// Serializes passed in object
         /// </summary>
         /// <param name="source">
         /// object to be serialized
@@ -118,7 +118,7 @@ namespace System.Management.Automation
         }
 
         /// <summary>
-        /// Serialzies passed in object
+        /// Serializes passed in object
         /// </summary>
         /// <param name="source">
         /// object to be serialized
@@ -399,7 +399,7 @@ namespace System.Management.Automation
                     break;
             }
 
-            //An object which is orignially enumerable becomes an PSObject 
+            //An object which is original enumerable becomes an PSObject 
             //with arraylist on deserialization. So on roundtrip it will show up
             //as List. 
             //We serialize properties of enumerable and on deserialization mark the object

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CustomSerializationStrings.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CustomSerializationStrings.cs
@@ -45,12 +45,12 @@ namespace System.Management.Automation
         #region known container tags
 
         /// <summary>
-        /// Value of name attribute for dictionary key part in dictnary entry
+        /// Value of name attribute for dictionary key part in dictionary entry
         /// </summary>
         internal const string DictionaryKey = "Key";
 
         /// <summary>
-        /// Value of name attribute for dictionary value part in dictnary entry
+        /// Value of name attribute for dictionary value part in dictionary entry
         /// </summary>
         internal const string DictionaryValue = "Value";
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/DebugRunspaceCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/DebugRunspaceCommand.cs
@@ -78,7 +78,7 @@ namespace Microsoft.PowerShell.Commands
         }
 
         /// <summary>
-        /// The Id of a Runsapce to be debugged.
+        /// The Id of a Runspace to be debugged.
         /// </summary>
         [Parameter(Position = 0,
                    Mandatory = true,

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/EnableDisableRunspaceDebugCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/EnableDisableRunspaceDebugCommand.cs
@@ -92,7 +92,7 @@ namespace Microsoft.PowerShell.Commands
     #region CommonRunspaceCommandBase class
 
     /// <summary>
-    /// Abstract class that defines common Runpace Command parameters.
+    /// Abstract class that defines common Runspace Command parameters.
     /// </summary>
     public abstract class CommonRunspaceCommandBase : PSCmdlet
     {
@@ -140,7 +140,7 @@ namespace Microsoft.PowerShell.Commands
         }
 
         /// <summary>
-        /// Runpace
+        /// Runspace
         /// </summary>
         [Parameter(Position = 0,
                    Mandatory = true,
@@ -276,7 +276,7 @@ namespace Microsoft.PowerShell.Commands
         }
 
         /// <summary>
-        /// SetDebugPreferenceHelper is a helper method used to enable/disabe debug preference.
+        /// SetDebugPreferenceHelper is a helper method used to enable/disable debug preference.
         /// </summary>
         /// <param name="processName">Process Name</param>
         /// <param name="appDomainName">App Domain Name</param>

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/OutGridView/HeaderInfo.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/OutGridView/HeaderInfo.cs
@@ -27,7 +27,7 @@ namespace Microsoft.PowerShell.Commands
             string[] displayNames = new string[count];
             Type[] types = new Type[count];
 
-            count = 0; // Reuse this variabe to count cycles.
+            count = 0; // Reuse this variable to count cycles.
             foreach (ColumnInfo column in _columns)
             {
                 propertyNames[count] = column.StaleObjectPropertyName();

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/OutGridView/OutGridViewCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/OutGridView/OutGridViewCommand.cs
@@ -25,7 +25,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         None,
         /// <summary>
-        /// Allow selection of one sinlge item to be written to the pipeline.
+        /// Allow selection of one single item to be written to the pipeline.
         /// </summary>
         Single,
         /// <summary>
@@ -60,7 +60,7 @@ namespace Microsoft.PowerShell.Commands
         {
         }
 
-        #endregion Contructors
+        #endregion Constructors
 
         #region Input Parameters
 
@@ -282,7 +282,7 @@ namespace Microsoft.PowerShell.Commands
                 _gridHeader.ProcessInputObject(input);
             }
 
-            // Some thread syncronization needed.
+            // Some thread synchronization needed.
             Exception exception = _windowProxy.GetLastException();
             if (exception != null)
             {
@@ -480,7 +480,7 @@ namespace Microsoft.PowerShell.Commands
         }
 
         /// <summary>
-        /// Dispose method in IDisposeable
+        /// Dispose method in IDisposable
         /// </summary>
         public void Dispose()
         {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/OutGridView/OutWindowProxy.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/OutGridView/OutWindowProxy.cs
@@ -253,7 +253,7 @@ namespace Microsoft.PowerShell.Commands
         }
 
         /// <summary>
-        /// Dispose method in IDisposeable
+        /// Dispose method in IDisposable
         /// </summary>
         public void Dispose()
         {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/common/GetFormatDataCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/common/GetFormatDataCommand.cs
@@ -158,7 +158,7 @@ namespace Microsoft.PowerShell.Commands
                     }
                 }
 
-                // Older version of PowerShell do not know about someting in the control, so
+                // Older version of PowerShell do not know about something in the control, so
                 // don't return it.
                 if (writeOldWay && !control.CompatibleWithOldPowerShell())
                     continue;

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/format-object/format-object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/format-object/format-object.cs
@@ -28,7 +28,7 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Positional parameter for properties, property sets and table sets
         /// specified on the command line.
-        /// The paramater is optional, since the defaults
+        /// The parameter is optional, since the defaults
         /// will be determined using property sets, etc.
         /// </summary>
         [Parameter(Position = 0)]

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/format-wide/Format-Wide.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/format-wide/Format-Wide.cs
@@ -31,7 +31,7 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Positional parameter for properties, property sets and table sets
         /// specified on the command line.
-        /// The paramater is optional, since the defaults
+        /// The parameter is optional, since the defaults
         /// will be determined using property sets, etc.
         /// </summary>
         [Parameter(Position = 0)]

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/out-printer/PrinterLineOutput.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/out-printer/PrinterLineOutput.cs
@@ -131,7 +131,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                     pd.PrinterSettings.PrinterName = _printerName;
                 }
 
-                // set up the callaback mechanism
+                // set up the callback mechanism
                 pd.PrintPage += new PrintPageEventHandler(this.pd_PrintPage);
 
                 // start printing

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetAliasCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetAliasCommand.cs
@@ -115,7 +115,7 @@ namespace Microsoft.PowerShell.Commands
             bool ContainsWildcard = WildcardPattern.ContainsWildcardCharacters(value);
             WildcardPattern wcPattern = WildcardPattern.Get(value, WildcardOptions.IgnoreCase);
 
-            // exlucing patter for Default paramset.
+            // excluding patter for Default paramset.
             Collection<WildcardPattern> excludePatterns =
                       SessionStateUtilities.CreateWildcardsFromStrings(
                           _excludes,

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetDateCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetDateCommand.cs
@@ -522,15 +522,15 @@ namespace Microsoft.PowerShell.Commands
     public enum DisplayHintType
     {
         /// <summary>
-        /// Display prerence Date-Only
+        /// Display preference Date-Only
         /// </summary>
         Date,
         /// <summary>
-        /// Display prerence Time-Only
+        /// Display preference Time-Only
         /// </summary>
         Time,
         /// <summary>
-        /// Display prerence Date and Time
+        /// Display preference Date and Time
         /// </summary>
         DateTime
     }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Import-LocalizedData.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Import-LocalizedData.cs
@@ -333,7 +333,7 @@ namespace Microsoft.PowerShell.Commands
             {
                 // 197751: WR BUG BASH: Powershell: localized text display as garbage
                 // leaving the encoding to be decided by the StreamReader. StreamReader
-                // will read the preamable and decide proper encoding.
+                // will read the preamble and decide proper encoding.
                 using (FileStream scriptStream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read))
                 using (StreamReader scriptReader = new StreamReader(scriptStream))
                 {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/InvokeCommandCmdlet.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/InvokeCommandCmdlet.cs
@@ -8,7 +8,7 @@ using System.Management.Automation.Internal;
 namespace Microsoft.PowerShell.Commands
 {
     /// <summary>
-    /// Class implemeting Invoke-Expression
+    /// Class implementing Invoke-Expression
     /// </summary>
     [Cmdlet("Invoke", "Expression", HelpUri = "http://go.microsoft.com/fwlink/?LinkID=113343")]
     public sealed

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
@@ -217,7 +217,7 @@ namespace Microsoft.PowerShell.Commands
         /// Returns the string representation of the match object same format as ToString()
         /// but trims the path to be relative to the <paramref name="directory"/> argument.
         /// </summary>
-        /// <param name="directory">Directory to use as the root when calcualting the relative path</param>
+        /// <param name="directory">Directory to use as the root when calculating the relative path</param>
         /// <returns>The string representation of the match object</returns>
         public string ToString(string directory)
         {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Measure-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Measure-Object.cs
@@ -500,7 +500,7 @@ namespace Microsoft.PowerShell.Commands
 
                     AnalyzeValue(propertyName, tempExprRes[0].Result);
 
-                    // Remember resolved propertNames that have been counted
+                    // Remember resolved propertyNames that have been counted
                     countedProperties[propertyName] = null;
                 }
             }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/NewTimeSpanCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/NewTimeSpanCommand.cs
@@ -98,7 +98,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         protected override void ProcessRecord()
         {
-            // initally set start and end time to be equal
+            // initially set start and end time to be equal
             DateTime startTime = DateTime.Now;
             DateTime endTime = startTime;
             TimeSpan result;

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ObjectCommandComparer.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ObjectCommandComparer.cs
@@ -49,7 +49,7 @@ namespace Microsoft.PowerShell.Commands
         internal bool IsExistingProperty { get; }
 
         /// <summary>
-        /// Indicates if the Property Value comparion has to be Case sensitive or not.
+        /// Indicates if the Property Value comparison has to be Case sensitive or not.
         /// </summary>
         internal SwitchParameter CaseSensitive
         {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/OrderObjectBase.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/OrderObjectBase.cs
@@ -130,7 +130,7 @@ namespace Microsoft.PowerShell.Commands
     }
 
     /// <summary>
-    /// Base Cmdlet for object cmdlets that deal with Ordering and Camparison.
+    /// Base Cmdlet for object cmdlets that deal with Ordering and Comparison.
     /// </summary>
     public class OrderObjectBase : ObjectBase
     {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Send-MailMessage.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Send-MailMessage.cs
@@ -342,7 +342,7 @@ namespace Microsoft.PowerShell.Commands
                 // return;
             }
 
-            // Set the recepient address of the mail message 
+            // Set the recipient address of the mail message 
             AddAddressesToMailMessage(_to, "to");
 
             // Set the BCC address of the mail message 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ShowCommand/ShowCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ShowCommand/ShowCommand.cs
@@ -24,7 +24,7 @@ namespace Microsoft.PowerShell.Commands
     {
         #region Private Fields
         /// <summary>
-        /// Set to true when ProcessRecord is reached, since it will allways open a window
+        /// Set to true when ProcessRecord is reached, since it will always open a window
         /// </summary>
         private bool _hasOpenedWindow;
 
@@ -163,7 +163,7 @@ namespace Microsoft.PowerShell.Commands
         }
 
         /// <summary>
-        /// Dispose method in IDisposeable
+        /// Dispose method in IDisposable
         /// </summary>
         public void Dispose()
         {
@@ -267,7 +267,7 @@ namespace Microsoft.PowerShell.Commands
 
         #region Private Methods
         /// <summary>
-        /// Runs the script in a new PowerShell instance and  hooks up error stream to pottentlially display error popup.
+        /// Runs the script in a new PowerShell instance and  hooks up error stream to potentially display error popup.
         /// This method has the inconvenience of not showing to the console user the script being executed.
         /// </summary>
         /// <param name="script">script to be run</param>
@@ -505,7 +505,7 @@ namespace Microsoft.PowerShell.Commands
             /// </summary>
             /// <param name="str">string to add to console input buffer</param>
             /// <param name="newLine">true to add Enter after the string</param>
-            /// <returns>true if it was succesfull in adding all characters to console input buffer</returns>
+            /// <returns>true if it was successful in adding all characters to console input buffer</returns>
             internal static bool AddToConsoleInputBuffer(string str, bool newLine)
             {
                 IntPtr handle = ConsoleInputWithNativeMethods.GetStdHandle(ConsoleInputWithNativeMethods.STD_INPUT_HANDLE);
@@ -526,13 +526,13 @@ namespace Microsoft.PowerShell.Commands
                 uint written;
                 if (!ConsoleInputWithNativeMethods.WriteConsoleInput(handle, records, strLen, out written) || written != strLen)
                 {
-                    // I do not know of a case where written is not going to be strlen. Maybe for some charcater that
+                    // I do not know of a case where written is not going to be strlen. Maybe for some character that
                     // is not supported in the console. The API suggests this can happen, 
                     // so we handle it by returning false
                     return false;
                 }
 
-                // Enter is written separetely, because if this is a command, and one of the characters in the command was not written
+                // Enter is written separately, because if this is a command, and one of the characters in the command was not written
                 // (written != strLen) it is desireable to fail (return false) before typing enter and running the command
                 if (newLine)
                 {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/StartSleepCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/StartSleepCommand.cs
@@ -63,7 +63,7 @@ namespace Microsoft.PowerShell.Commands
         //Wait handle which is used by thread to sleep.
         private ManualResetEvent _waitHandle;
 
-        //object used for synchornizes pipeline thread and stop thread
+        //object used for synchronizes pipeline thread and stop thread
         //access to waitHandle
         private object _syncObject = new object();
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Update-TypeData.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Update-TypeData.cs
@@ -228,7 +228,7 @@ namespace Microsoft.PowerShell.Commands
             get { return _propertySerializationSet; }
         }
 
-        // These members are represeted as NoteProperty in types.ps1xml
+        // These members are represented as NoteProperty in types.ps1xml
         private string _serializationMethod;
         private Type _targetTypeForDeserialization;
         private int _serializationDepth = int.MinValue;
@@ -753,7 +753,7 @@ namespace Microsoft.PowerShell.Commands
             { return; }
 
             string action = UpdateDataStrings.UpdateTypeDataAction;
-            // Load the resource once and format it whenver a new target
+            // Load the resource once and format it whenever a new target
             // filename is available
             string target = UpdateDataStrings.UpdateTarget;
 
@@ -927,7 +927,7 @@ namespace Microsoft.PowerShell.Commands
 
             string action = UpdateDataStrings.UpdateFormatDataAction;
 
-            // Load the resource once and format it whenver a new target
+            // Load the resource once and format it whenever a new target
             // filename is available
             string target = UpdateDataStrings.UpdateTarget;
 
@@ -1412,7 +1412,7 @@ namespace Microsoft.PowerShell.Commands
 
     /// <summary>
     /// To make it easier to specify a TypeName, we add an ArgumentTransformationAttribute here.
-    /// * string: retrun the string
+    /// * string: return the string
     /// * Type: return the Type.ToString()
     /// * instance: return instance.GetType().ToString()
     /// </summary>

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/UtilityCommon.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/UtilityCommon.cs
@@ -293,7 +293,7 @@ namespace Microsoft.PowerShell.Commands
                     nextLine.AppendFormat("{0:X2} ", currentByte);
 
                     // If the character is printable, add its ascii representation to
-                    // the right-hand side.  Otherwise, addeter  a dot to the right hand side.
+                    // the right-hand side.  Otherwise, add a dot to the right hand side.
                     if ((currentByte >= 0x20) && (currentByte <= 0xFE))
                     {
                         asciiEnd.Append((char)currentByte);

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Var.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Var.cs
@@ -336,7 +336,7 @@ namespace Microsoft.PowerShell.Commands
         #endregion parameters
 
         /// <summary>
-        /// Implements ProcessRecord() method for get-variabit's le command.
+        /// Implements ProcessRecord() method for get-variable's command.
         /// </summary>
         protected override void ProcessRecord()
         {
@@ -419,7 +419,7 @@ namespace Microsoft.PowerShell.Commands
         public ScopedItemOptions Option { get; set; } = ScopedItemOptions.None;
 
         /// <summary>
-        /// Specifies the visiblity of the new variable...
+        /// Specifies the visibility of the new variable...
         /// </summary>
         [Parameter]
         public SessionStateEntryVisibility Visibility
@@ -891,7 +891,7 @@ namespace Microsoft.PowerShell.Commands
                         }
                         varToSet.Description = Description;
 
-                        // If visiblity was specified, set it on the variable
+                        // If visibility was specified, set it on the variable
                         if (_visibility != null)
                         {
                             varToSet.Visibility = Visibility;
@@ -994,7 +994,7 @@ namespace Microsoft.PowerShell.Commands
                                     }
                                 }
 
-                                // If visiblity was specified, set it on the variable
+                                // If visibility was specified, set it on the variable
                                 if (_visibility != null)
                                 {
                                     matchingVariable.Visibility = Visibility;

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/HtmlWebResponseObject.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/HtmlWebResponseObject.Common.cs
@@ -325,7 +325,7 @@ namespace Microsoft.PowerShell.Commands
                     throw _parsingException;
                 }
 
-                // Parsing was successfull
+                // Parsing was successful
                 _htmlParsed = true;
             }
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/InvokeRestMethodCommand.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/InvokeRestMethodCommand.Common.cs
@@ -54,7 +54,7 @@ namespace Microsoft.PowerShell.Commands
                 {
                     XmlDocument workingDocument = new XmlDocument();
                     // performing a Read() here to avoid rrechecking
-                    // "rss" or "feed" itmes
+                    // "rss" or "feed" items
                     reader.Read();
                     while (!reader.EOF)
                     {
@@ -155,7 +155,7 @@ namespace Microsoft.PowerShell.Commands
         public enum RestReturnType
         {
             /// <summary>
-            /// Return type not defined in reponse, 
+            /// Return type not defined in response, 
             /// best effort detect
             /// </summary>
             Detect,

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -465,14 +465,14 @@ namespace Microsoft.PowerShell.Commands
         /// needed if an HtmlDocument will be created shortly.</param>
         protected bool VerifyInternetExplorerAvailable(bool checkComObject)
         {
-            // TODO: Remove this code once the dependecy on mshtml has been resolved.
+            // TODO: Remove this code once the dependency on mshtml has been resolved.
 #if CORECLR
             return false;
 #else
             bool isInternetExplorerConfigurationComplete = false;
             // Check for IE for both PS Full and PS Core on windows.
             // The registry key DisableFirstRunCustomize can exits at one of the following path.
-            // IE uses the same decending orider (as mentioned) to check for the presence of this key.
+            // IE uses the same descending order (as mentioned) to check for the presence of this key.
             // If the value of DisableFirstRunCustomize key is set to greater than zero then Run first
             // is disabled.
             string[] disableFirstRunCustomizePaths = new string[] {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/ConvertFromJsonCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/ConvertFromJsonCommand.cs
@@ -27,7 +27,7 @@ namespace Microsoft.PowerShell.Commands
         public string InputObject { get; set; }
 
         /// <summary>
-        /// inputObjectBuffer buffers all InputObjet contents avaliable in the pipeline.
+        /// inputObjectBuffer buffers all InputObjet contents available in the pipeline.
         /// </summary>
         private List<string> _inputObjectBuffer = new List<string>();
 
@@ -59,7 +59,7 @@ namespace Microsoft.PowerShell.Commands
         }
 
         /// <summary>
-        ///  Buffers InputObjet contents avaliable in the pipeline.
+        ///  Buffers InputObjet contents available in the pipeline.
         /// </summary>
         protected override void ProcessRecord()
         {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/ConvertToJsonCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/ConvertToJsonCommand.cs
@@ -470,7 +470,7 @@ namespace Microsoft.PowerShell.Commands
                     {
                         if (pso != null && pso.immediateBaseObjectIsEmpty)
                         {
-                            // The obj is a pure PSObject, we convet the original PSObject to a string, 
+                            // The obj is a pure PSObject, we convert the original PSObject to a string, 
                             // instead of its base object in this case
                             rv = LanguagePrimitives.ConvertTo(pso, typeof(string),
                                 CultureInfo.InvariantCulture);
@@ -535,7 +535,7 @@ namespace Microsoft.PowerShell.Commands
             if (pso == null)
                 return obj;
 
-            // when isPurePSObj is true, the obj is guaranteed to be a string convertted by LanguagePrimitives
+            // when isPurePSObj is true, the obj is guaranteed to be a string converted by LanguagePrimitives
             if (isPurePSObj)
                 return obj;
 
@@ -562,7 +562,7 @@ namespace Microsoft.PowerShell.Commands
         /// If the passed in object is a custom object (not a simple object, not a dictionary, not a list, get processed in ProcessCustomObject method),
         /// we also take Adapted properties into account. Otherwise, we only consider the Extended properties.
         /// When the object is a pure PSObject, it also gets processed in "ProcessCustomObject" before reaching this method, so we will
-        /// iterate both extended and adapted proerpties for it. Since it's a pure PSObject, there will be no adapted properties.
+        /// iterate both extended and adapted properties for it. Since it's a pure PSObject, there will be no adapted properties.
         /// </summary>
         /// <param name="psobj">The containing PSObject, or null if the base object was not contained in a PSObject</param>
         /// <param name="receiver">The dictionary to which any additional properties will be appended</param>

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/InvokeRestMethodCommand.CoreClr.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/InvokeRestMethodCommand.CoreClr.cs
@@ -24,7 +24,7 @@ namespace Microsoft.PowerShell.Commands
         #region Virtual Method Overrides
 
         /// <summary>
-        /// Process the web reponse and output corresponding objects. 
+        /// Process the web response and output corresponding objects. 
         /// </summary>
         /// <param name="response"></param>
         internal override void ProcessResponse(HttpResponseMessage response)
@@ -36,7 +36,7 @@ namespace Microsoft.PowerShell.Commands
                 if (ShouldWriteToPipeline)
                 {
                     // First see if it is an RSS / ATOM feed, in which case we can 
-                    // stream it - unless the user has overriden it with a return type of "XML"
+                    // stream it - unless the user has overridden it with a return type of "XML"
                     if (TryProcessFeedStream(responseStream))
                     {
                         // Do nothing, content has been processed.
@@ -54,7 +54,7 @@ namespace Microsoft.PowerShell.Commands
                         string str = StreamHelper.DecodeStream(responseStream, encoding);
                         bool convertSuccess = false;
 
-                        // On CoreCLR, we need to explicity load Json.NET
+                        // On CoreCLR, we need to explicitly load Json.NET
                         JsonObject.ImportJsonDotNetModule(this);
                         if (returnType == RestReturnType.Json)
                         {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/InvokeWebRequestCommand.CoreClr.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/InvokeWebRequestCommand.CoreClr.cs
@@ -21,7 +21,7 @@ namespace Microsoft.PowerShell.Commands
         #region Virtual Method Overrides
 
         /// <summary>
-        /// Process the web reponse and output corresponding objects. 
+        /// Process the web response and output corresponding objects. 
         /// </summary>
         /// <param name="response"></param>
         internal override void ProcessResponse(HttpResponseMessage response)
@@ -48,7 +48,7 @@ namespace Microsoft.PowerShell.Commands
                 WebResponseObject ro = WebResponseObjectFactory.GetResponseObject(response, responseStream, this.Context, UseBasicParsing);
                 WriteObject(ro);
 
-                // use the rawcontent stream from WebRepsonseObject for further 
+                // use the rawcontent stream from WebResponseObject for further 
                 // processing of the stream. This is need because WebResponse's
                 // stream can be used only once.
                 responseStream = ro.RawContentStream;

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebRequestPSCmdlet.CoreClr.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebRequestPSCmdlet.CoreClr.cs
@@ -355,7 +355,7 @@ namespace Microsoft.PowerShell.Commands
                     ProcessResponse(response);
                     UpdateSession(response);
 
-                    // If we hit our maxium redirection count, generate an error.
+                    // If we hit our maximum redirection count, generate an error.
                     // Errors with redirection counts of greater than 0 are handled automatically by .NET, but are
                     // impossible to detect programmatically when we hit this limit. By handling this ourselves
                     // (and still writing out the result), users can debug actual HTTP redirect problems.

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/FormObjectCollection.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/FormObjectCollection.cs
@@ -8,7 +8,7 @@ using System.Collections.ObjectModel;
 namespace Microsoft.PowerShell.Commands
 {
     /// <summary>
-    /// FormObjectColletion used in HtmlWebResponseObject
+    /// FormObjectCollection used in HtmlWebResponseObject
     /// </summary>
     public class FormObjectCollection : Collection<FormObject>
     {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/FullClr/ContentHelper.FullClr.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/FullClr/ContentHelper.FullClr.cs
@@ -23,7 +23,7 @@ namespace Microsoft.PowerShell.Commands
         }
 
         // Gets the content type with safe fallback - in the situation
-        // of FTPWebResponse that retuns NotImplemented.
+        // of FTPWebResponse that returns NotImplemented.
         internal static string GetContentType(WebResponse response)
         {
             string contentType = null;

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/FullClr/InvokeRestMethodCommand.FullClr.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/FullClr/InvokeRestMethodCommand.FullClr.cs
@@ -25,7 +25,7 @@ namespace Microsoft.PowerShell.Commands
         #region Virtual Method Overrides
 
         /// <summary>
-        /// Process the web reponse and output corresponding objects. 
+        /// Process the web response and output corresponding objects. 
         /// </summary>
         /// <param name="response"></param>
         internal override void ProcessResponse(WebResponse response)
@@ -37,7 +37,7 @@ namespace Microsoft.PowerShell.Commands
                 if (ShouldWriteToPipeline)
                 {
                     // First see if it is an RSS / ATOM feed, in which case we can 
-                    // stream it - unless the user has overriden it with a return type of "XML"
+                    // stream it - unless the user has overridden it with a return type of "XML"
                     if (TryProcessFeedStream(responseStream))
                     {
                         // Do nothing, content has been processed.

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/FullClr/InvokeWebRequestCommand.FullClr.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/FullClr/InvokeWebRequestCommand.FullClr.cs
@@ -19,7 +19,7 @@ namespace Microsoft.PowerShell.Commands
         #region Virtual Method Overrides
 
         /// <summary>
-        /// Process the web reponse and output corresponding objects. 
+        /// Process the web response and output corresponding objects. 
         /// </summary>
         /// <param name="response"></param>
         internal override void ProcessResponse(WebResponse response)
@@ -40,7 +40,7 @@ namespace Microsoft.PowerShell.Commands
                 WebResponseObject ro = WebResponseObjectFactory.GetResponseObject(response, responseStream, this.Context, UseBasicParsing);
                 WriteObject(ro);
 
-                // use the rawcontent stream from WebRepsonseObject for further 
+                // use the rawcontent stream from WebResponseObject for further 
                 // processing of the stream. This is need because WebResponse's
                 // stream can be used only once.
                 responseStream = ro.RawContentStream;

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/FullClr/WebRequestPSCmdlet.FullClr.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/FullClr/WebRequestPSCmdlet.FullClr.cs
@@ -438,7 +438,7 @@ namespace Microsoft.PowerShell.Commands
                         ProcessResponse(response);
                         UpdateSession(response);
 
-                        // If we hit our maxium redirection count, generate an error.
+                        // If we hit our maximum redirection count, generate an error.
                         // Errors with redirection counts of greater than 0 are handled automatically by .NET, but are
                         // impossible to detect programmatically when we hit this limit. By handling this ourselves
                         // (and still writing out the result), users can debug actual HTTP redirect problems.

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/JsonObject.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/JsonObject.cs
@@ -61,7 +61,7 @@ namespace Microsoft.PowerShell.Commands
             }
 #else
             //In ConvertTo-Json, to serialize an object with a given depth, we set the RecursionLimit to depth + 2, see JavaScriptSerializer constructor in ConvertToJsonCommand.cs.
-            // Setting RecursionLimit to depth + 2 in order to support '$object | ConverTo-Json –depth <value less than or equal to 100> | ConvertFrom-Json'.
+            // Setting RecursionLimit to depth + 2 in order to support '$object | ConvertTo-Json –depth <value less than or equal to 100> | ConvertFrom-Json'.
             JavaScriptSerializer serializer = new JavaScriptSerializer(new JsonObjectTypeResolver()) { RecursionLimit = (maxDepthAllowed + 2) };
             serializer.MaxJsonLength = Int32.MaxValue;
             object obj = serializer.DeserializeObject(input);

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/StreamHelper.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/StreamHelper.cs
@@ -381,7 +381,7 @@ namespace Microsoft.PowerShell.Commands
 
         /// <summary>
         /// Saves content from stream into filePath.
-        /// Caller need to ensure <paramref name="stream"/> postion is properly set.
+        /// Caller need to ensure <paramref name="stream"/> position is properly set.
         /// </summary>
         /// <param name="stream"></param>
         /// <param name="filePath"></param>

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/WebRequestSession.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/WebRequestSession.cs
@@ -32,7 +32,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         public CookieContainer Cookies { get; set; }
 
-        #region Credetials
+        #region Credentials
 
         /// <summary>
         /// gets or sets the UseDefaultCredentials property

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WriteProgressCmdlet.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WriteProgressCmdlet.cs
@@ -112,7 +112,7 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// 
         /// Identifies whether the activity has completed (and the display for it should be removed),
-        /// or if it is proceededing (and the display for it should be shown).
+        /// or if it is proceeding (and the display for it should be shown).
         /// 
         /// </summary>
         /// <value></value>

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/XmlCommands.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/XmlCommands.cs
@@ -564,7 +564,7 @@ namespace Microsoft.PowerShell.Commands
 
             if (As.Equals("Stream", StringComparison.OrdinalIgnoreCase))
             {
-                // Omit xml declaration in this case becuase we will write out the declaration string in BeginProcess.
+                // Omit xml declaration in this case because we will write out the declaration string in BeginProcess.
                 xmlSettings.OmitXmlDeclaration = true;
             }
 
@@ -1025,7 +1025,7 @@ namespace Microsoft.PowerShell.Commands
 
         # endregion private
 
-        #region overrdies
+        #region override
 
         /// <summary>
         /// ProcessRecord method.

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/group-object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/group-object.cs
@@ -228,7 +228,7 @@ namespace Microsoft.PowerShell.Commands
         }
         private bool _noElement;
         /// <summary>
-        /// the Ashashtable parameter
+        /// the AsHashTable parameter
         /// </summary>
         /// <value></value>
         [Parameter(ParameterSetName = "HashTable")]
@@ -257,7 +257,7 @@ namespace Microsoft.PowerShell.Commands
         /// Utility function called by Group-Object to create Groups.
         /// </summary>
         /// <param name="currentObjectEntry">Input object that needs to be grouped.</param>
-        /// <param name="noElement">true if we are not acumulating objects</param>
+        /// <param name="noElement">true if we are not accumulating objects</param>
         /// <param name="groups">List containing Groups.</param>
         /// <param name="groupInfoDictionary">Dictionary used to keep track of the groups with hash of the property values being the key.</param>
         /// <param name="orderByPropertyComparer">The Comparer to be used while comparing to check if new group has to be created.</param>

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/select-object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/select-object.cs
@@ -23,7 +23,7 @@ namespace Microsoft.PowerShell.Commands
     internal sealed class MshExpressionFilter
     {
         /// <summary>
-        /// construnt the class, using an array of patterns
+        /// construct the class, using an array of patterns
         /// </summary>
         /// <param name="wildcardPatternsStrings">array of pattern strings to use</param>
         internal MshExpressionFilter(string[] wildcardPatternsStrings)
@@ -154,7 +154,7 @@ namespace Microsoft.PowerShell.Commands
 
 
         /// <summary>
-        /// Skips the sepecified number of items from top when used with First,from end when used with Last
+        /// Skips the specified number of items from top when used with First,from end when used with Last
         /// </summary>
         /// <value></value>
         [Parameter(ParameterSetName = "DefaultParameter")]
@@ -267,7 +267,7 @@ namespace Microsoft.PowerShell.Commands
                 }
                 else
                 {
-                    //if last paramater is not mentioned,remove the objects and decrement the skip
+                    //if last parameter is not mentioned,remove the objects and decrement the skip
                     if (_last == 0)
                     {
                         Dequeue();

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/tee-object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/tee-object.cs
@@ -133,7 +133,7 @@ namespace Microsoft.PowerShell.Commands
         }
 
         /// <summary>
-        /// Dispose method in IDisposeable
+        /// Dispose method in IDisposable
         /// </summary>
         public void Dispose()
         {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/trace/TraceExpressionCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/trace/TraceExpressionCommand.cs
@@ -167,7 +167,7 @@ namespace Microsoft.PowerShell.Commands
 
             if (ParameterSetName == "commandSet")
             {
-                // Create the CommmandProcessor and add it to a pipeline
+                // Create the CommandProcessor and add it to a pipeline
 
                 CommandProcessorBase commandProcessor =
                     this.Context.CommandDiscovery.LookupCommandProcessor(Command, CommandOrigin.Runspace, false);
@@ -468,7 +468,7 @@ namespace Microsoft.PowerShell.Commands
         /// If enumerateCollection is true, and <paramref name="obj"/>
         /// is an enumeration according to LanguagePrimitives.GetEnumerable,
         /// the objects in the enumeration will be unrolled and
-        /// written seperately.  Otherwise, <paramref name="obj"/>
+        /// written separately.  Otherwise, <paramref name="obj"/>
         /// will be written as a single object.
         /// </param>
         /// <returns>The number of objects written</returns>

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
@@ -496,7 +496,7 @@ namespace Microsoft.PowerShell
                         catch (Exception e)
                         {
                             // Catch all exceptions - we're just going to exit anyway so there's
-                            // no issue of the system begin destablized. We'll still
+                            // no issue of the system being destabilized. We'll still
                             // Watson on "severe" exceptions to get the reports.
                             ConsoleHost.CheckForSevereException(e);
                             exceptionMessage = e.Message;

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleControl.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleControl.cs
@@ -866,7 +866,7 @@ namespace Microsoft.PowerShell
         /// </param>
         /// <returns>
         /// 
-        /// acutal number of input records peeked
+        /// actual number of input records peeked
         /// 
         /// </returns>
         /// <exception cref="HostException">
@@ -1322,7 +1322,7 @@ namespace Microsoft.PowerShell
             }
             else
             {
-                // use ReadConsoleOutputCJK becaue checking the left and right edges of the existing output
+                // use ReadConsoleOutputCJK because checking the left and right edges of the existing output
                 // is NOT needed
                 BufferCell[,] rightExisting = new BufferCell[existingRegion.Bottom + 1, 2];
                 ReadConsoleOutputCJK(consoleHandle, codePage,

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
@@ -332,7 +332,7 @@ namespace Microsoft.PowerShell
                 case ConsoleControl.ConsoleBreakSignal.Logoff:
                     // Just ignore the logoff signal. This signal is sent to console
                     // apps running as service anytime *any* user logs off which means
-                    // that PowerShell could't be used in servces/tasks if we didn't
+                    // that PowerShell couldn't be used in services/tasks if we didn't
                     // suppress this signal...
                     return true;
 
@@ -372,7 +372,7 @@ namespace Microsoft.PowerShell
 
         /// <summary>
         /// 
-        /// Spin up a new thread to cancel the current pipline.  This will allow subsequent break interrupts to be received even
+        /// Spin up a new thread to cancel the current pipeline.  This will allow subsequent break interrupts to be received even
         /// if the cancellation is blocked (which can be the case when the pipeline blocks and nothing implements Cmdlet.Stop
         /// properly).  That is because the OS will not inject another thread when a break event occurs if one has already been
         /// injected and is running.
@@ -1384,8 +1384,8 @@ namespace Microsoft.PowerShell
         }
 
         /// <summary>
-        /// This method is reatined to make V1 tests compatible with V2 as signature of this method
-        /// is slighlty changed in v2.
+        /// This method is retained to make V1 tests compatible with V2 as signature of this method
+        /// is slightly changed in v2.
         /// </summary>
         /// <param name="bannerText"></param>
         /// <param name="helpText"></param>
@@ -1520,7 +1520,7 @@ namespace Microsoft.PowerShell
             // Don't load PSReadline if:
             //   * we don't think the process will be interactive, e.g. -command or -file
             //     - exception: when -noexit is specified, we will be interactive after the command/file finishes
-            //   * -noniteractive: this should be obvious, they've asked that we don't every prompt
+            //   * -noninteractive: this should be obvious, they've asked that we don't every prompt
             //
             // Note that PSReadline doesn't support redirected stdin/stdout, but we don't check that here because
             // a future version might, and we should automatically load it at that unknown point in the future.
@@ -1629,7 +1629,7 @@ namespace Microsoft.PowerShell
 
         private void OpenConsoleRunspace(Runspace runspace, bool staMode)
         {
-            // staMode will have folowing values:
+            // staMode will have following values:
             // On FullPS: 'true'/'false' = default('true'=STA) + possibility of overload through cmdline parameter '-mta'
             // On NanoPS: always 'false' = default('false'=MTA) + NO possibility of overload through cmdline parameter '-mta'
             // ThreadOptions should match on FullPS and NanoPS for corresponding ApartmentStates.
@@ -2030,7 +2030,7 @@ namespace Microsoft.PowerShell
 
         /// <summary>
         /// 
-        /// Reports an exception accoring to the exception reporting settings in effect.
+        /// Reports an exception according to the exception reporting settings in effect.
         /// 
         /// </summary>
         /// <param name="e">

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostRawUserInterface.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostRawUserInterface.cs
@@ -318,7 +318,7 @@ namespace Microsoft.PowerShell
         /// </exception>
         /// <exception cref="HostException">
         /// 
-        /// If obaining information about the buffer failed
+        /// If obtaining information about the buffer failed
         ///    OR
         ///    Win32's SetConsoleWindowInfo failed
         /// 
@@ -411,7 +411,7 @@ namespace Microsoft.PowerShell
             set
             {
                 // looking in windows/core/ntcon/server/output.c, it looks like the minimum size is 1 row X however many 
-                // charcters will fit in the minimum window size system metric (SM_CXMIN).  Instead of going to the effort of
+                // characters will fit in the minimum window size system metric (SM_CXMIN).  Instead of going to the effort of
                 // computing that minimum here, it is cleaner and cheaper to make the call to SetConsoleScreenBuffer and just
                 // translate any exception that might get thrown.
                 try
@@ -1027,7 +1027,7 @@ namespace Microsoft.PowerShell
         /// 
         /// Provided for clearing regions -- less chatty than passing an array of cells.
         /// Clear screen is:
-        ///    SetBufferContents(new Rectangle(-1, -1, -1, -1), ' ', ForgroundColor, BackgroundColor);
+        ///    SetBufferContents(new Rectangle(-1, -1, -1, -1), ' ', ForegroundColor, BackgroundColor);
         ///    CursorPosition = new Coordinates(0, 0);
         /// 
         /// fill.Type is ignored
@@ -1098,7 +1098,7 @@ namespace Microsoft.PowerShell
             // The FillConsoleOutputXxx functions wrap at the end of a line.  So we need to convert our rectangular region
             // into line segments that don't extend past the end of a line.  We will also clip the rectangle so that the semantics
             // are the same as SetBufferContents(Coordinates, BufferCell[,]), which clips if the rectangle extends past the 
-            // screen buffer bounarides.
+            // screen buffer boundaries.
             if (region.Left >= bufferWidth || region.Top >= bufferHeight || region.Right < 0 || region.Bottom < 0)
             {
                 // region is entirely outside the buffer boundaries
@@ -1144,7 +1144,7 @@ namespace Microsoft.PowerShell
                 }
                 else
                 {
-                    // use ReadConsoleOutputCJK becaue checking the left and right edges of the existing output
+                    // use ReadConsoleOutputCJK because checking the left and right edges of the existing output
                     // is NOT needed
                     BufferCell[,] rightExisting = new BufferCell[existingRegion.Bottom + 1, 2];
                     ConsoleControl.ReadConsoleOutputCJK(handle, codePage,
@@ -1545,7 +1545,7 @@ namespace Microsoft.PowerShell
         {
             get
             {
-                // Console can return zero when a pseduo-TTY is allocated, which
+                // Console can return zero when a pseudo-TTY is allocated, which
                 // is useless for us. Instead, map to the wrap size.
                 return Console.BufferWidth == 0 || Console.BufferHeight == 0
                     ? s_wrapSize
@@ -1618,7 +1618,7 @@ namespace Microsoft.PowerShell
         {
             get
             {
-                // Console can return zero when a pseduo-TTY is allocated, which
+                // Console can return zero when a pseudo-TTY is allocated, which
                 // is useless for us. Instead, map to the wrap size.
                 return Console.LargestWindowWidth == 0 || Console.LargestWindowHeight == 0
                     ? s_wrapSize
@@ -1646,7 +1646,7 @@ namespace Microsoft.PowerShell
         {
             get
             {
-                // Console can return zero when a pseduo-TTY is allocated, which
+                // Console can return zero when a pseudo-TTY is allocated, which
                 // is useless for us. Instead, map to the wrap size.
                 return Console.WindowWidth == 0 || Console.WindowHeight == 0
                     ? s_wrapSize

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterface.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterface.cs
@@ -813,7 +813,7 @@ namespace Microsoft.PowerShell
         /// <summary>
         /// 
         /// This is a poor-man's word-wrapping routine.  It breaks a single string into segments small enough to fit within a
-        /// given number of cells.  A break is determined by the last occurrance of whitespace that allows all prior characters 
+        /// given number of cells.  A break is determined by the last occurrence of whitespace that allows all prior characters 
         /// on a line to be written within a given number of cells.  If there is no whitespace found within that span, then the
         /// largest span that will fit in the bounds is used.
         /// 
@@ -1472,7 +1472,7 @@ namespace Microsoft.PowerShell
 
         /// <summary>
         /// 
-        /// Reads a line of input from the console.  Returns when the user hits enter, a break key, a break event occurrs.  In 
+        /// Reads a line of input from the console.  Returns when the user hits enter, a break key, a break event occurs.  In 
         /// the case that stdin has been redirected, reads from the stdin stream instead of the console.
         /// 
         /// </summary>
@@ -1745,7 +1745,7 @@ namespace Microsoft.PowerShell
                         Coordinates c = RawUI.CursorPosition;
 
                         // before cleaning up the screen, read the active screen buffer to retrieve the character that
-                        // is overriden by the tab
+                        // is overridden by the tab
                         char charUnderCursor = GetCharacterUnderCursor(c);
 
                         Write(new string(' ', leftover));

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterfacePromptForChoice.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterfacePromptForChoice.cs
@@ -164,7 +164,7 @@ namespace Microsoft.PowerShell
         /// Presents a dialog allowing the user to choose options from a set of options.
         /// </summary>
         /// <param name="caption">
-        /// Caption to preceed or title the prompt.  E.g. "Parameters for get-foo (instance 1 of 2)"
+        /// Caption to precede or title the prompt.  E.g. "Parameters for get-foo (instance 1 of 2)"
         /// </param>
         /// <param name="message">
         /// A message that describes what the choice is for.

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleShell.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleShell.cs
@@ -40,7 +40,7 @@ namespace Microsoft.PowerShell
 
         /// <summary>
         /// 
-        /// Entry point in to ConsoleShell. This method is called by the MSHManagedEntrace
+        /// Entry point in to ConsoleShell. This method is called from the native or managed exe host application
         /// 
         /// </summary>
         /// <param name="configuration">

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/Executor.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/Executor.cs
@@ -116,7 +116,7 @@ namespace Microsoft.PowerShell
 
 
         /// <summary>
-        /// This method handles the failure in excecuting pipeline asynchronously
+        /// This method handles the failure in executing pipeline asynchronously
         /// </summary>
         /// <param name="ex"></param>
         private void AsyncPipelineFailureHandler(Exception ex)
@@ -230,7 +230,7 @@ namespace Microsoft.PowerShell
                         {
                             //This exception can occurs when input is closed. This can happen 
                             //for various reasons. For ex:Command in the pipeline is invalid and 
-                            //command discovery throws excecption which closes the pipeline and 
+                            //command discovery throws exception which closes the pipeline and 
                             //hence the Input pipe.
                             break;
                         }
@@ -699,7 +699,7 @@ namespace Microsoft.PowerShell
         ///            restore p1 as current
         ///
         /// Summary: 
-        /// ExecuteCommand always saves/sets/restores CurrentExector
+        /// ExecuteCommand always saves/sets/restores CurrentExecutor
         /// Host.EnterNestedPrompt always saves/clears/restores CurrentExecutor
         /// 
         /// </remarks>

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ManagedEntrance.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ManagedEntrance.cs
@@ -68,7 +68,7 @@ namespace Microsoft.PowerShell
                 // UI fallback language.
                 // CLR does not support this (non-traditional) fallback mechanism. 
                 // The currentUICulture returned NativeCultureResolver supports this non
-                // traditional fallback on Vista. So it is important to set currentUICuluture
+                // traditional fallback on Vista. So it is important to set currentUICulture
                 // in the beginning before we do anything.
                 ClrFacade.SetCurrentThreadUiCulture(NativeCultureResolver.UICulture);
                 ClrFacade.SetCurrentThreadCulture(NativeCultureResolver.Culture);

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/PendingProgress.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/PendingProgress.cs
@@ -637,7 +637,7 @@ namespace Microsoft.PowerShell
 
         /// <summary>
         /// 
-        /// Generates an array of strings representing as much of the outstanding progress activties as possible within the given
+        /// Generates an array of strings representing as much of the outstanding progress activities as possible within the given
         /// space.  As more outstanding activities are collected, nodes are "compressed" (i.e. rendered in an increasing terse
         /// fashion) in order to display as many as possible.  Ultimately, some nodes may be compressed to the point of 
         /// invisibility. The oldest nodes are compressed first.
@@ -1072,7 +1072,7 @@ namespace Microsoft.PowerShell
 
             int nodesCompressed = 0;
 
-            // This algorithm potentially makes many, many passeses over the tree.  It might be possible to optimize 
+            // This algorithm potentially makes many, many passes over the tree.  It might be possible to optimize 
             // that some, but I'm not trying to be too clever just yet.
 
             if (

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ProgressPane.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ProgressPane.cs
@@ -14,7 +14,7 @@ namespace Microsoft.PowerShell
 {
     /// <summary>
     /// 
-    /// ProgressPane is a class that represents the "window" in which outstanding activities for which the host has recevied 
+    /// ProgressPane is a class that represents the "window" in which outstanding activities for which the host has received 
     /// progress updates are shown. 
     /// 
     ///</summary>
@@ -205,7 +205,7 @@ namespace Microsoft.PowerShell
             else
             {
                 // We have shown the pane before. We have to be smart about when we restore the saved region to minimize
-                // flicker. We need to decide if the new contents will change the dimmensions of the progress pane
+                // flicker. We need to decide if the new contents will change the dimensions of the progress pane
                 // currently being shown.  If it will, then restore the saved region, and show the new one.  Otherwise,
                 // just blast the new one on top of the last one shown.
 

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/StartTranscriptCmdlet.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/StartTranscriptCmdlet.cs
@@ -261,7 +261,7 @@ namespace Microsoft.PowerShell.Commands
             }
         }
 
-        /// resolve a user provided file name or path (cluding globbing characters)
+        /// resolve a user provided file name or path (including globbing characters)
         /// to a fully qualified file path, using the file system provider
         private string ResolveFilePath(string filePath, bool isLiteralPath)
         {

--- a/src/Microsoft.PowerShell.Core.Activities/Generated/DisablePSSessionConfigurationActivity.cs
+++ b/src/Microsoft.PowerShell.Core.Activities/Generated/DisablePSSessionConfigurationActivity.cs
@@ -63,7 +63,7 @@ namespace Microsoft.PowerShell.Core.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Core.Activities/Generated/EnablePSRemotingActivity.cs
+++ b/src/Microsoft.PowerShell.Core.Activities/Generated/EnablePSRemotingActivity.cs
@@ -56,7 +56,7 @@ namespace Microsoft.PowerShell.Core.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Core.Activities/Generated/EnablePSSessionConfigurationActivity.cs
+++ b/src/Microsoft.PowerShell.Core.Activities/Generated/EnablePSSessionConfigurationActivity.cs
@@ -77,7 +77,7 @@ namespace Microsoft.PowerShell.Core.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Core.Activities/Generated/ForEachObjectActivity.cs
+++ b/src/Microsoft.PowerShell.Core.Activities/Generated/ForEachObjectActivity.cs
@@ -91,7 +91,7 @@ namespace Microsoft.PowerShell.Core.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Core.Activities/Generated/GetCommandActivity.cs
+++ b/src/Microsoft.PowerShell.Core.Activities/Generated/GetCommandActivity.cs
@@ -140,7 +140,7 @@ namespace Microsoft.PowerShell.Core.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Core.Activities/Generated/GetHelpActivity.cs
+++ b/src/Microsoft.PowerShell.Core.Activities/Generated/GetHelpActivity.cs
@@ -126,7 +126,7 @@ namespace Microsoft.PowerShell.Core.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Core.Activities/Generated/GetJobActivity.cs
+++ b/src/Microsoft.PowerShell.Core.Activities/Generated/GetJobActivity.cs
@@ -126,7 +126,7 @@ namespace Microsoft.PowerShell.Core.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Core.Activities/Generated/GetModuleActivity.cs
+++ b/src/Microsoft.PowerShell.Core.Activities/Generated/GetModuleActivity.cs
@@ -105,7 +105,7 @@ namespace Microsoft.PowerShell.Core.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Core.Activities/Generated/GetPSSessionActivity.cs
+++ b/src/Microsoft.PowerShell.Core.Activities/Generated/GetPSSessionActivity.cs
@@ -175,7 +175,7 @@ namespace Microsoft.PowerShell.Core.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Core.Activities/Generated/GetPSSessionConfigurationActivity.cs
+++ b/src/Microsoft.PowerShell.Core.Activities/Generated/GetPSSessionConfigurationActivity.cs
@@ -56,7 +56,7 @@ namespace Microsoft.PowerShell.Core.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Core.Activities/Generated/NewModuleManifestActivity.cs
+++ b/src/Microsoft.PowerShell.Core.Activities/Generated/NewModuleManifestActivity.cs
@@ -294,7 +294,7 @@ namespace Microsoft.PowerShell.Core.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Core.Activities/Generated/NewPSTransportOptionActivity.cs
+++ b/src/Microsoft.PowerShell.Core.Activities/Generated/NewPSTransportOptionActivity.cs
@@ -112,7 +112,7 @@ namespace Microsoft.PowerShell.Core.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Core.Activities/Generated/ReceiveJobActivity.cs
+++ b/src/Microsoft.PowerShell.Core.Activities/Generated/ReceiveJobActivity.cs
@@ -138,7 +138,7 @@ namespace Microsoft.PowerShell.Core.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Core.Activities/Generated/RegisterPSSessionConfigurationActivity.cs
+++ b/src/Microsoft.PowerShell.Core.Activities/Generated/RegisterPSSessionConfigurationActivity.cs
@@ -203,7 +203,7 @@ namespace Microsoft.PowerShell.Core.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Core.Activities/Generated/RemoveJobActivity.cs
+++ b/src/Microsoft.PowerShell.Core.Activities/Generated/RemoveJobActivity.cs
@@ -98,7 +98,7 @@ namespace Microsoft.PowerShell.Core.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Core.Activities/Generated/RemovePSSessionActivity.cs
+++ b/src/Microsoft.PowerShell.Core.Activities/Generated/RemovePSSessionActivity.cs
@@ -98,7 +98,7 @@ namespace Microsoft.PowerShell.Core.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Core.Activities/Generated/ResumeJobActivity.cs
+++ b/src/Microsoft.PowerShell.Core.Activities/Generated/ResumeJobActivity.cs
@@ -91,7 +91,7 @@ namespace Microsoft.PowerShell.Core.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Core.Activities/Generated/SaveHelpActivity.cs
+++ b/src/Microsoft.PowerShell.Core.Activities/Generated/SaveHelpActivity.cs
@@ -98,7 +98,7 @@ namespace Microsoft.PowerShell.Core.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Core.Activities/Generated/SetPSSessionConfigurationActivity.cs
+++ b/src/Microsoft.PowerShell.Core.Activities/Generated/SetPSSessionConfigurationActivity.cs
@@ -189,7 +189,7 @@ namespace Microsoft.PowerShell.Core.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Core.Activities/Generated/StartJobActivity.cs
+++ b/src/Microsoft.PowerShell.Core.Activities/Generated/StartJobActivity.cs
@@ -140,7 +140,7 @@ namespace Microsoft.PowerShell.Core.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Core.Activities/Generated/StopJobActivity.cs
+++ b/src/Microsoft.PowerShell.Core.Activities/Generated/StopJobActivity.cs
@@ -91,7 +91,7 @@ namespace Microsoft.PowerShell.Core.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Core.Activities/Generated/SuspendJobActivity.cs
+++ b/src/Microsoft.PowerShell.Core.Activities/Generated/SuspendJobActivity.cs
@@ -98,7 +98,7 @@ namespace Microsoft.PowerShell.Core.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Core.Activities/Generated/TestModuleManifestActivity.cs
+++ b/src/Microsoft.PowerShell.Core.Activities/Generated/TestModuleManifestActivity.cs
@@ -49,7 +49,7 @@ namespace Microsoft.PowerShell.Core.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Core.Activities/Generated/TestPSSessionConfigurationFileActivity.cs
+++ b/src/Microsoft.PowerShell.Core.Activities/Generated/TestPSSessionConfigurationFileActivity.cs
@@ -49,7 +49,7 @@ namespace Microsoft.PowerShell.Core.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Core.Activities/Generated/UnregisterPSSessionConfigurationActivity.cs
+++ b/src/Microsoft.PowerShell.Core.Activities/Generated/UnregisterPSSessionConfigurationActivity.cs
@@ -63,7 +63,7 @@ namespace Microsoft.PowerShell.Core.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Core.Activities/Generated/UpdateHelpActivity.cs
+++ b/src/Microsoft.PowerShell.Core.Activities/Generated/UpdateHelpActivity.cs
@@ -105,7 +105,7 @@ namespace Microsoft.PowerShell.Core.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Core.Activities/Generated/WaitJobActivity.cs
+++ b/src/Microsoft.PowerShell.Core.Activities/Generated/WaitJobActivity.cs
@@ -105,7 +105,7 @@ namespace Microsoft.PowerShell.Core.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Core.Activities/Generated/WhereObjectActivity.cs
+++ b/src/Microsoft.PowerShell.Core.Activities/Generated/WhereObjectActivity.cs
@@ -280,7 +280,7 @@ namespace Microsoft.PowerShell.Core.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.CoreCLR.AssemblyLoadContext/CoreCLR/CorePsAssemblyLoadContext.cs
+++ b/src/Microsoft.PowerShell.CoreCLR.AssemblyLoadContext/CoreCLR/CorePsAssemblyLoadContext.cs
@@ -28,7 +28,7 @@ namespace System.Management.Automation
         // Take the 'en-US' culture as an example. When retrieving resource string to construct an exception, ResourceManager calls Assembly.Load(..) in the following order to load the resource dll:
         //     1. Load assembly with culture 'en-US' (Microsoft.PowerShell.CoreCLR.AssemblyLoadContext.resources, Version=3.0.0.0, Culture=en-US, PublicKeyToken=31bf3856ad364e35)
         //     2. Load assembly with culture 'en'    (Microsoft.PowerShell.CoreCLR.AssemblyLoadContext.resources, Version=3.0.0.0, Culture=en, PublicKeyToken=31bf3856ad364e35) 
-        // When the first attempt fails, we again need to retrieve the resouce string to construct another exception, which ends up with an infinite loop.
+        // When the first attempt fails, we again need to retrieve the resource string to construct another exception, which ends up with an infinite loop.
         private const string BaseFolderDoesNotExist = "The base directory '{0}' does not exist.";
         private const string ManifestDefinitionDoesNotMatch = "Could not load file or assembly '{0}' or one of its dependencies. The located assembly's manifest definition does not match the assembly reference.";
         private const string AssemblyPathDoesNotExist = "Could not load file or assembly '{0}' or one of its dependencies. The system cannot find the file specified.";
@@ -152,7 +152,7 @@ namespace System.Management.Automation
         private readonly string[] _extensions = new string[] { ".ni.dll", ".dll" };
 
         /// <summary>
-        /// Assembly cache accross the AppDomain
+        /// Assembly cache across the AppDomain
         /// </summary>
         /// <remarks>
         /// We user the assembly short name (AssemblyName.Name) as the key.
@@ -161,7 +161,7 @@ namespace System.Management.Automation
         /// 
         /// MVID is Module Version Identifier, which is a guid. Its purpose is solely to be unique for each time the module is compiled, and
         /// it gets regenerated for every compilation. That means AssemblyLoadContext cannot handle loading two assemblies with the same name
-        /// but different veresions, not even two asssemblies with the exactly same code and version but built by two separate compilations.
+        /// but different versions, not even two assemblies with the exactly same code and version but built by two separate compilations.
         /// 
         /// Therefore, there is no need to use the full assembly name as the key. Short assembly name is sufficient.
         /// </remarks>
@@ -205,7 +205,7 @@ namespace System.Management.Automation
             // We let the default context load the assemblies included in the type catalog as there
             // appears to be a bug in .NET with method resolution with system libraries loaded by our
             // context and not the default. We use the short name because some packages have inconsistent
-            // verions between reference and runtime assemblies.
+            // versions between reference and runtime assemblies.
             if (_tpaSet.Contains(assemblyName.Name))
                 return null;
 
@@ -329,7 +329,7 @@ namespace System.Management.Automation
         }
 
         /// <summary>
-        /// Load assemlby from byte stream.
+        /// Load assembly from byte stream.
         /// </summary>
         internal Assembly LoadFrom(Stream assembly)
         {

--- a/src/Microsoft.PowerShell.CoreCLR.Eventing/DotNetCode/Eventing/EventProvider.cs
+++ b/src/Microsoft.PowerShell.CoreCLR.Eventing/DotNetCode/Eventing/EventProvider.cs
@@ -122,7 +122,7 @@ namespace System.Diagnostics.Eventing
         {
             //
             // explicit cleanup is done by calling Dispose with true from 
-            // Dispose() or Close(). The disposing arguement is ignored because there
+            // Dispose() or Close(). The disposing argument is ignored because there
             // are no unmanaged resources.
             // The finalizer calls Dispose with false.
             //
@@ -134,7 +134,7 @@ namespace System.Diagnostics.Eventing
 
             if (Interlocked.Exchange(ref _disposed, 1) != 0)
             {
-                // somebody is allready disposing the provider
+                // somebody is already disposing the provider
                 return;
             }
 
@@ -647,7 +647,7 @@ namespace System.Diagnostics.Eventing
                         //
                         // The loop below goes through all the arguments and fills in the data 
                         // descriptors. For strings save the location in the dataString array.
-                        // Caculates the total size of the event by adding the data descriptor
+                        // Calculates the total size of the event by adding the data descriptor
                         // size value set in EncodeObjec method.
                         //
                         for (index = 0; index < eventPayload.Length; index++)

--- a/src/Microsoft.PowerShell.CoreCLR.Eventing/DotNetCode/Eventing/EventProviderTraceListener.cs
+++ b/src/Microsoft.PowerShell.CoreCLR.Eventing/DotNetCode/Eventing/EventProviderTraceListener.cs
@@ -18,7 +18,7 @@ namespace System.Diagnostics.Eventing
         // log events using WriteMessageEvent method. 
         // 
         // Because WriteMessageEvent takes a string as the event payload 
-        // all the overriden loging methods convert the arguments into strings.
+        // all the overridden logging methods convert the arguments into strings.
         // Event payload is "delimiter" separated, which can be configured
         // 
         // 
@@ -53,7 +53,7 @@ namespace System.Diagnostics.Eventing
 
         /// <summary>
         /// This method creates an instance of the ETW provider.
-        /// The guid argument must be a valid GUID or a format exeption will be
+        /// The guid argument must be a valid GUID or a format exception will be
         /// thrown when creating an instance of the ControlGuid. 
         /// We need to be running on Vista or above. If not an 
         /// PlatformNotSupported exception will be thrown by the EventProvider. 
@@ -132,7 +132,7 @@ namespace System.Diagnostics.Eventing
 
         //
         // For all the methods below the string to be logged contains:
-        // m_delimeter seperated data converted to string
+        // m_delimiter separated data converted to string
         //
         // The source parameter is ignored.
         // 

--- a/src/Microsoft.PowerShell.CoreCLR.Eventing/DotNetCode/Eventing/Reader/EventLogSession.cs
+++ b/src/Microsoft.PowerShell.CoreCLR.Eventing/DotNetCode/Eventing/Reader/EventLogSession.cs
@@ -4,7 +4,7 @@
 **
 ** Purpose: 
 ** Defines a session for Event Log operations.  The session can 
-** be configured for a remote machine and can use specfic
+** be configured for a remote machine and can use specific
 ** user credentials.
 ============================================================*/
 
@@ -45,7 +45,7 @@ namespace System.Diagnostics.Eventing.Reader
         internal EventLogHandle renderContextHandleSystem = EventLogHandle.Zero;
         internal EventLogHandle renderContextHandleUser = EventLogHandle.Zero;
 
-        //the dummy sync object for the two contextes.
+        //the dummy sync object for the two contexts.
         private object _syncObject = null;
 
         private string _server;

--- a/src/Microsoft.PowerShell.CoreCLR.Eventing/DotNetCode/Eventing/Reader/NativeWrapper.cs
+++ b/src/Microsoft.PowerShell.CoreCLR.Eventing/DotNetCode/Eventing/Reader/NativeWrapper.cs
@@ -6,7 +6,7 @@
 ** This internal class contains wrapper methods over the Native
 ** Methods of the Eventlog API.   Unlike the raw Native Methods,
 ** these methods throw EventLogExceptions, check platform 
-** availablity and perform additional helper functionality 
+** availability and perform additional helper functionality 
 ** specific to function.  Also, all methods of this class expose
 ** the Link Demand for Unmanaged Permission to callers.
 ** 
@@ -950,7 +950,7 @@ namespace System.Diagnostics.Eventing.Reader
             {
                 //
                 // ERROR_EVT_UNRESOLVED_VALUE_INSERT can be returned.  It means
-                // message may have one or more unsubstitued strings.  This is 
+                // message may have one or more unsubstituted strings.  This is 
                 // not an exception, but we have no way to convey the partial
                 // success out to enduser.
                 //
@@ -1109,7 +1109,7 @@ namespace System.Diagnostics.Eventing.Reader
             {
                 //
                 // ERROR_EVT_UNRESOLVED_VALUE_INSERT can be returned.  It means
-                // message may have one or more unsubstitued strings.  This is 
+                // message may have one or more unsubstituted strings.  This is 
                 // not an exception, but we have no way to convey the partial
                 // success out to enduser.
                 //

--- a/src/Microsoft.PowerShell.Diagnostics.Activities/Generated/ExportCounterActivity.cs
+++ b/src/Microsoft.PowerShell.Diagnostics.Activities/Generated/ExportCounterActivity.cs
@@ -84,7 +84,7 @@ namespace Microsoft.PowerShell.Diagnostics.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Diagnostics.Activities/Generated/GetCounterActivity.cs
+++ b/src/Microsoft.PowerShell.Diagnostics.Activities/Generated/GetCounterActivity.cs
@@ -82,7 +82,7 @@ namespace Microsoft.PowerShell.Diagnostics.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Diagnostics.Activities/Generated/GetWinEventActivity.cs
+++ b/src/Microsoft.PowerShell.Diagnostics.Activities/Generated/GetWinEventActivity.cs
@@ -131,7 +131,7 @@ namespace Microsoft.PowerShell.Diagnostics.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Diagnostics.Activities/Generated/ImportCounterActivity.cs
+++ b/src/Microsoft.PowerShell.Diagnostics.Activities/Generated/ImportCounterActivity.cs
@@ -91,7 +91,7 @@ namespace Microsoft.PowerShell.Diagnostics.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Diagnostics.Activities/Generated/NewWinEventActivity.cs
+++ b/src/Microsoft.PowerShell.Diagnostics.Activities/Generated/NewWinEventActivity.cs
@@ -70,7 +70,7 @@ namespace Microsoft.PowerShell.Diagnostics.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.GraphicalHost/HelpWindow/HelpParagraphBuilder.cs
+++ b/src/Microsoft.PowerShell.GraphicalHost/HelpWindow/HelpParagraphBuilder.cs
@@ -148,7 +148,7 @@ namespace Microsoft.Management.UI.Internal
         /// </summary>
         /// <param name="psObj">PSObject that contains another PSObject as a property</param>
         /// <param name="psObjectName">property name that contains the PSObject</param>
-        /// <param name="propertyName">property name in thye inner PSObject</param>
+        /// <param name="propertyName">property name in the inner PSObject</param>
         /// <returns>the string from the inner psObject property or null if it could not be retrieved</returns>
         private static string GetInnerPSObjectPropertyString(PSObject psObj, string psObjectName, string propertyName)
         {
@@ -200,7 +200,7 @@ namespace Microsoft.Management.UI.Internal
         /// <summary>
         /// Gets the text from a property of type PSObject[] where the first object has a text property
         /// </summary>
-        /// <param name="psObj">objhect to get text from</param>
+        /// <param name="psObj">object to get text from</param>
         /// <param name="propertyText">property with PSObject[] containing text</param>
         /// <returns>the text from a property of type PSObject[] where the first object has a text property</returns>
         private static string GetTextFromArray(PSObject psObj, string propertyText)
@@ -683,7 +683,7 @@ namespace Microsoft.Management.UI.Internal
                         {
                             parameterType = GetPropertyString(parameterTypeData, "name");
 
-                            //If there is no type for the paramter, we expect it is System.Object
+                            //If there is no type for the parameter, we expect it is System.Object
                             if (String.IsNullOrEmpty(parameterType))
                                 parameterType = "object";
                         }
@@ -900,7 +900,7 @@ namespace Microsoft.Management.UI.Internal
         /// </summary>
         /// <param name="setting">true if it should add the segment</param>
         /// <param name="sectionTitle">title of the section</param>
-        /// <param name="inputOrOutputProperty">property with the outter object</param>
+        /// <param name="inputOrOutputProperty">property with the outer object</param>
         /// <param name="inputOrOutputInnerProperty">property with the inner object</param>
         private void AddInputOrOutputEntries(bool setting, string sectionTitle, string inputOrOutputProperty, string inputOrOutputInnerProperty)
         {

--- a/src/Microsoft.PowerShell.GraphicalHost/HelpWindow/HelpViewModel.cs
+++ b/src/Microsoft.PowerShell.GraphicalHost/HelpWindow/HelpViewModel.cs
@@ -274,7 +274,7 @@ namespace Microsoft.Management.UI.Internal
         }
 
         /// <summary>
-        /// Called internally to notify when a proiperty changed
+        /// Called internally to notify when a property changed
         /// </summary>
         /// <param name="propertyName">property name</param>
         private void OnNotifyPropertyChanged(string propertyName)

--- a/src/Microsoft.PowerShell.GraphicalHost/HelpWindow/HelpWindow.xaml.cs
+++ b/src/Microsoft.PowerShell.GraphicalHost/HelpWindow/HelpWindow.xaml.cs
@@ -92,7 +92,7 @@ namespace Microsoft.Management.UI
         }
 
         /// <summary>
-        /// Handles key down to fix the Page/Douwn going to end of help issue
+        /// Handles key down to fix the Page/Down going to end of help issue
         /// And to implement some additional shortcuts like Ctrl+F and ZoomIn/ZoomOut
         /// </summary>
         /// <param name="e">event arguments</param>

--- a/src/Microsoft.PowerShell.GraphicalHost/HelpWindow/ParagraphBuilder.cs
+++ b/src/Microsoft.PowerShell.GraphicalHost/HelpWindow/ParagraphBuilder.cs
@@ -86,12 +86,12 @@ namespace Microsoft.Management.UI.Internal
         /// <summary>
         /// Called after all the AddText calls have been made to build the paragraph
         /// based on the current text.
-        /// This method goes over 3 collections simultaneouslly:
+        /// This method goes over 3 collections simultaneously:
         ///    1) characters in this.textBuilder
         ///    2) spans in this.boldSpans
         ///    3) spans in this.highlightedSpans
         /// And adds the minimal number of Inlines to the paragraph so that all 
-        /// characters that should be bold and/or highlighed are.
+        /// characters that should be bold and/or highlighted are.
         /// </summary>
         internal void BuildParagraph()
         {
@@ -134,7 +134,7 @@ namespace Microsoft.Management.UI.Internal
         }
 
         /// <summary>
-        /// Highlights all ocurrences of <paramref name="search"/>.
+        /// Highlights all occurrences of <paramref name="search"/>.
         /// This is called after all calls to AddText have been made
         /// </summary>
         /// <param name="search">search string</param>
@@ -246,9 +246,9 @@ namespace Microsoft.Management.UI.Internal
         }
 
         /// <summary>
-        /// This is an auxiliar method in BuildParagraph to move the current bold or highlighed spans
+        /// This is an auxiliar method in BuildParagraph to move the current bold or highlighted spans
         /// according to the <paramref name="caracterPosition"/>
-        /// The current bold and higlighed span should be ending ahead of the current position.
+        /// The current bold and highlighted span should be ending ahead of the current position.
         /// Moves <paramref name="currentSpanIndex"/> and <paramref name="currentSpan"/> to the 
         /// propper span in <paramref name="allSpans"/> according to the <paramref name="caracterPosition"/>
         /// This is an auxiliar method in BuildParagraph. 
@@ -276,7 +276,7 @@ namespace Microsoft.Management.UI.Internal
             }
 
             // there is no span ending ahead of current position, so
-            // we set the current span to null to prevent unecessary comparisons against the currentSpan
+            // we set the current span to null to prevent unnecessary comparisons against the currentSpan
             currentSpan = null;
         }
 
@@ -302,7 +302,7 @@ namespace Microsoft.Management.UI.Internal
         }
 
         /// <summary>
-        /// Called internally to notify when a proiperty changed
+        /// Called internally to notify when a property changed
         /// </summary>
         /// <param name="propertyName">property name</param>
         private void OnNotifyPropertyChanged(string propertyName)
@@ -315,7 +315,7 @@ namespace Microsoft.Management.UI.Internal
         }
 
         /// <summary>
-        /// A text span used to mark bold and highlighed segments 
+        /// A text span used to mark bold and highlighted segments 
         /// </summary>
         internal struct TextSpan
         {

--- a/src/Microsoft.PowerShell.GraphicalHost/HelpWindow/ParagraphSearcher.cs
+++ b/src/Microsoft.PowerShell.GraphicalHost/HelpWindow/ParagraphSearcher.cs
@@ -57,15 +57,15 @@ namespace Microsoft.Management.UI.Internal
 
             if (this.currentHighlightedMatch != null)
             {
-                // restore the curent highlighted background to plain highlighted
+                // restore the current highlighted background to plain highlighted
                 this.currentHighlightedMatch.Background = ParagraphSearcher.HighlightBrush;
             }
 
             // If the caret is in the end of a highlight we move to the adjacent run
-            // It has to be in the end because if there is a match at the begining of the file
+            // It has to be in the end because if there is a match at the beginning of the file
             // and the caret has not been touched (so it is in the beginning of the file too)
             // we want to highlight this first match.
-            // Considering the caller allways set the caret to the end of the highlight
+            // Considering the caller always set the caret to the end of the highlight
             // The condition below works well for successive searchs
             // We also need to move to the adjacent run if the caret is at the first run and we
             // are moving backwards so that a search backwards when the first run is highlighted
@@ -92,7 +92,7 @@ namespace Microsoft.Management.UI.Internal
             this.currentHighlightedMatch = currentRun;
             if (this.currentHighlightedMatch != null)
             {
-                // restore the curent highligthed background to current highlighted
+                // restore the current highlighted background to current highlighted
                 this.currentHighlightedMatch.Background = ParagraphSearcher.CurrentHighlightBrush;
             }
 
@@ -153,7 +153,7 @@ namespace Microsoft.Management.UI.Internal
         }
 
         /// <summary>
-        /// Gets the run of an inline. Inlines in a ParagrahBuilder are either a Run or a Bold
+        /// Gets the run of an inline. Inlines in a ParagraphBuilder are either a Run or a Bold
         /// which contains a Run
         /// </summary>
         /// <param name="inline">inline to get the run from</param>
@@ -208,10 +208,10 @@ namespace Microsoft.Management.UI.Internal
         }
 
         /// <summary>
-        /// Returns true if the run is the fiorst run of the paragraph
+        /// Returns true if the run is the first run of the paragraph
         /// </summary>
         /// <param name="run">run to check</param>
-        /// <returns>true if the run is the fiorst run of the paragraph</returns>
+        /// <returns>true if the run is the first run of the paragraph</returns>
         private static bool IsFirstRun(Run run)
         {
             Paragraph paragraph = GetParagraph(run);

--- a/src/Microsoft.PowerShell.GraphicalHost/ManagementList/Common/AutomationTextBlock.cs
+++ b/src/Microsoft.PowerShell.GraphicalHost/ManagementList/Common/AutomationTextBlock.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Management.UI.Internal
 
         #endregion
 
-        #region Overides
+        #region Overrides
 
         /// <summary>
         /// Returns the <see cref="System.Windows.Automation.Peers.AutomationPeer"/> implementations for this control.

--- a/src/Microsoft.PowerShell.GraphicalHost/ManagementList/Common/DataRoutedEventArgs.cs
+++ b/src/Microsoft.PowerShell.GraphicalHost/ManagementList/Common/DataRoutedEventArgs.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Management.UI.Internal
 
     /// <summary>
     /// Routed event args which provide the ability to attach an 
-    /// arbitrary peice of data.
+    /// arbitrary piece of data.
     /// </summary>
     /// <typeparam name="T">There are no restrictions on type T.</typeparam>
     [SuppressMessage("Microsoft.MSInternal", "CA903:InternalNamespaceShouldNotContainPublicTypes")]

--- a/src/Microsoft.PowerShell.GraphicalHost/ManagementList/Common/DismissiblePopup.Generated.cs
+++ b/src/Microsoft.PowerShell.GraphicalHost/ManagementList/Common/DismissiblePopup.Generated.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Management.UI.Internal
 {
     
     /// <summary>
-    /// A popup which child controls can signal to be dimissed.
+    /// A popup which child controls can signal to be dismissed.
     /// </summary>
     /// <remarks>
     /// If a control wants to dismiss the popup then they should execute the DismissPopupCommand on a target in the popup window.

--- a/src/Microsoft.PowerShell.GraphicalHost/ManagementList/Common/Utilities.cs
+++ b/src/Microsoft.PowerShell.GraphicalHost/ManagementList/Common/Utilities.cs
@@ -169,8 +169,8 @@ namespace Microsoft.Management.UI.Internal
         /// <remarks>
         /// Parameter <paramref name="sorted"/> is not generic to type T
         /// since it may be a collection of a subclass of type T,
-        /// and IEnumerable'subclass is not compatible with
-        /// IEnumerable'baseclass.
+        /// and IEnumerable's subclass is not compatible with
+        /// IEnumerable's baseclass.
         /// </remarks>
         public static void ResortObservableCollection<T>(
             ObservableCollection<T> modify,

--- a/src/Microsoft.PowerShell.GraphicalHost/ManagementList/FilterCore/FilterEvaluator.cs
+++ b/src/Microsoft.PowerShell.GraphicalHost/ManagementList/FilterCore/FilterEvaluator.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Management.UI.Internal
     using System.Diagnostics;
 
     /// <summary>
-    /// The FilterEvaluator class is responsible for allowing the registeration of 
+    /// The FilterEvaluator class is responsible for allowing the registration of 
     /// the FilterExpressionProviders and producing a FilterExpression composed of
     /// the FilterExpression returned from the providers.
     /// </summary>

--- a/src/Microsoft.PowerShell.GraphicalHost/ManagementList/FilterProviders/FilterRulePanelItem.cs
+++ b/src/Microsoft.PowerShell.GraphicalHost/ManagementList/FilterProviders/FilterRulePanelItem.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Management.UI.Internal
         }
 
         /// <summary>
-        /// Gets a string that indentifies which group this 
+        /// Gets a string that identifies which group this 
         /// item belongs to.
         /// </summary>
         public string GroupId

--- a/src/Microsoft.PowerShell.GraphicalHost/ManagementList/FilterProviders/InputFieldBackgroundTextConverter.cs
+++ b/src/Microsoft.PowerShell.GraphicalHost/ManagementList/FilterProviders/InputFieldBackgroundTextConverter.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Management.UI.Internal
     using System.Globalization;
 
     /// <summary>
-    /// The InputFieldBackgroundTextConverter is responsible for determing the
+    /// The InputFieldBackgroundTextConverter is responsible for determining the
     /// correct background text to display for a particular type of data.
     /// </summary>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.MSInternal", "CA903:InternalNamespaceShouldNotContainPublicTypes")]

--- a/src/Microsoft.PowerShell.GraphicalHost/ManagementList/ManagementList/InnerListGridView.cs
+++ b/src/Microsoft.PowerShell.GraphicalHost/ManagementList/ManagementList/InnerListGridView.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Management.UI.Internal
         private bool canChangeColumns = false;
 
         /// <summary>
-        /// Instanctiates a new object of this class.
+        /// Instantiates a new object of this class.
         /// </summary>
         public InnerListGridView()
             : this(new ObservableCollection<InnerListColumn>())
@@ -257,7 +257,7 @@ namespace Microsoft.Management.UI.Internal
         }
 
         /// <summary>
-        /// Syncronizes AvailableColumns and Columns preserving the order from Columns that
+        /// Synchronizes AvailableColumns and Columns preserving the order from Columns that
         /// comes from the user moving Columns around.
         /// </summary>
         private void SynchronizeColumns()

--- a/src/Microsoft.PowerShell.GraphicalHost/ManagementList/ManagementList/Innerlist.cs
+++ b/src/Microsoft.PowerShell.GraphicalHost/ManagementList/ManagementList/Innerlist.cs
@@ -303,7 +303,7 @@ namespace Microsoft.Management.UI.Internal
 
             this.itemsSourceIsEmpty = (null != this.ItemsSource && false == this.ItemsSource.GetEnumerator().MoveNext());
 
-            // A view can be created if there is data to auto-generate columns, or columns are added programatically \\
+            // A view can be created if there is data to auto-generate columns, or columns are added programmatically \\
             bool canCreateView = (null != this.ItemsSource) &&
                 (false == this.itemsSourceIsEmpty || false == this.AutoGenerateColumns);
 

--- a/src/Microsoft.PowerShell.GraphicalHost/ShowCommand/Controls/ParameterSetControl.xaml.cs
+++ b/src/Microsoft.PowerShell.GraphicalHost/ShowCommand/Controls/ParameterSetControl.xaml.cs
@@ -339,7 +339,7 @@ namespace Microsoft.PowerShell.Commands.ShowCommandInternal
         }
 
         /// <summary>
-        /// Creates a Lable control and add it to MainGrid
+        /// Creates a Label control and add it to MainGrid
         /// </summary>
         /// <param name="parameterViewModel">DataContext object</param>
         /// <param name="rowNumber">Row number</param>

--- a/src/Microsoft.PowerShell.GraphicalHost/ShowCommand/Controls/ShowModuleControl.xaml.cs
+++ b/src/Microsoft.PowerShell.GraphicalHost/ShowCommand/Controls/ShowModuleControl.xaml.cs
@@ -11,7 +11,7 @@ namespace Microsoft.PowerShell.Commands.ShowCommandInternal
     using System.Windows.Input;
 
     /// <summary>
-    /// Control taht shows cmdlets in a module and details for a selected cmdlet
+    /// Control that shows cmdlets in a module and details for a selected cmdlet
     /// </summary>
     public partial class ShowModuleControl : UserControl
     {
@@ -50,7 +50,7 @@ namespace Microsoft.PowerShell.Commands.ShowCommandInternal
         /// (if the list supported drag and drop, the mouse action would be the same as dragging) it 
         /// will select other list items. 
         /// If the first selection change causes  details for the item to be displayed and resizes the list
-        /// the selection can skip to another list item it happend to be over as the list got resized.
+        /// the selection can skip to another list item it happened to be over as the list got resized.
         /// In summary, resizing the list on selection can cause a selection bug. If the user selects an 
         /// item in the end of the list the next item downwards can be selected.
         /// The WPF drag-and-select feature is not a standard win32 list behavior, and we can do without it

--- a/src/Microsoft.PowerShell.GraphicalHost/ShowCommand/ViewModel/AllModulesViewModel.cs
+++ b/src/Microsoft.PowerShell.GraphicalHost/ShowCommand/ViewModel/AllModulesViewModel.cs
@@ -531,7 +531,7 @@ namespace Microsoft.PowerShell.Commands.ShowCommandInternal
                 return;
             }
 
-            // If there are more modules, create an additional module to agregate all commands
+            // If there are more modules, create an additional module to aggregate all commands
             ModuleViewModel allCommandsModule = new ModuleViewModel(ShowCommandResources.All, null);
             this.modules.Add(allCommandsModule);
             allCommandsModule.SetAllModules(this);

--- a/src/Microsoft.PowerShell.GraphicalHost/ShowCommand/ViewModel/CommandViewModel.cs
+++ b/src/Microsoft.PowerShell.GraphicalHost/ShowCommand/ViewModel/CommandViewModel.cs
@@ -457,7 +457,7 @@ namespace Microsoft.PowerShell.Commands.ShowCommandInternal
         }
 
         /// <summary>
-        /// Showing help information for current actived cmdlet.
+        /// Showing help information for current active cmdlet.
         /// </summary>
         public void OpenHelpWindow()
         {
@@ -465,7 +465,7 @@ namespace Microsoft.PowerShell.Commands.ShowCommandInternal
         }
 
         /// <summary>
-        /// Determins whether current command name and a specifed ParameterSetName have same name.
+        /// Determines whether current command name and a specified ParameterSetName have same name.
         /// </summary>
         /// <param name="name">The name of ShareParameterSet</param>
         /// <returns>Return true is ShareParameterSet. Else return false.</returns>
@@ -479,7 +479,7 @@ namespace Microsoft.PowerShell.Commands.ShowCommandInternal
         /// </summary>
         /// <param name="module">Module to which the CommandViewModel will belong to</param>
         /// <param name="commandInfo">Will showing command</param>
-        /// <param name="noCommonParameters">true to ommit displaying common parameter</param>
+        /// <param name="noCommonParameters">true to omit displaying common parameter</param>
         /// <exception cref="ArgumentNullException">If commandInfo is null</exception>
         /// <exception cref="RuntimeException">
         /// If could not create the CommandViewModel. For instance the ShowCommandCommandInfo corresponding to
@@ -592,7 +592,7 @@ namespace Microsoft.PowerShell.Commands.ShowCommandInternal
         /// <summary>
         /// Compares source and target by being the default parameter set and then by name
         /// </summary>
-        /// <param name="source">source paremeterset</param>
+        /// <param name="source">source parameterset</param>
         /// <param name="target">target parameterset</param>
         /// <returns>0 if they are the same, -1 if source is smaller, 1 if source is larger</returns>
         private int Compare(ParameterSetViewModel source, ParameterSetViewModel target)

--- a/src/Microsoft.PowerShell.GraphicalHost/ShowCommand/ViewModel/ModuleViewModel.cs
+++ b/src/Microsoft.PowerShell.GraphicalHost/ShowCommand/ViewModel/ModuleViewModel.cs
@@ -374,7 +374,7 @@ namespace Microsoft.PowerShell.Commands.ShowCommandInternal
         }
 
         /// <summary>
-        /// Callled in response to a GUI event that requires the command to be run
+        /// Called in response to a GUI event that requires the command to be run
         /// </summary>
         internal void OnRunSelectedCommand()
         {
@@ -417,7 +417,7 @@ namespace Microsoft.PowerShell.Commands.ShowCommandInternal
         /// <param name="filterPattern">pattern corresponding to filter</param>
         /// <param name="commandName">command name string</param>
         /// <param name="filter">filter string</param>
-        /// <returns>true if coparisonText matches str or pattern</returns>
+        /// <returns>true if comparisonText matches str or pattern</returns>
         private static bool Matches(WildcardPattern filterPattern, string commandName, string filter)
         {
             if (filterPattern != null)

--- a/src/Microsoft.PowerShell.GraphicalHost/ShowCommand/ViewModel/ParameterSetViewModel.cs
+++ b/src/Microsoft.PowerShell.GraphicalHost/ShowCommand/ViewModel/ParameterSetViewModel.cs
@@ -40,7 +40,7 @@ namespace Microsoft.PowerShell.Commands.ShowCommandInternal
         /// Initializes a new instance of the ParameterSetViewModel class.
         /// </summary>
         /// <param name="name">The name of the parameterSet</param>
-        /// <param name="parameters">The array parametes of the parameterSet</param>
+        /// <param name="parameters">The array parameters of the parameterSet</param>
         [SuppressMessage("Microsoft.Design", "CA1002:DoNotExposeGenericLists", Justification = "this type is internal, made public only for WPF Binding")]
         public ParameterSetViewModel(
             string name,
@@ -233,12 +233,12 @@ namespace Microsoft.PowerShell.Commands.ShowCommandInternal
         #endregion
         
         /// <summary>
-        /// Gets the delimited poarameter if it needs delimitation and is not delimited
+        /// Gets the delimited parameter if it needs delimitation and is not delimited
         /// </summary>
         /// <param name="parameterValue">value needing delimitation</param>
         /// <param name="openDelimiter">open delimitation</param>
         /// <param name="closeDelimiter">close delimitation</param>
-        /// <returns>the delimited poarameter if it needs delimitation and is not delimited</returns>
+        /// <returns>the delimited parameter if it needs delimitation and is not delimited</returns>
         private static string GetDelimitedParameter(string parameterValue, string openDelimiter, string closeDelimiter)
         {
             string parameterValueTrimmed = parameterValue.Trim();

--- a/src/Microsoft.PowerShell.GraphicalHost/commandHelpers/HelpWindowHelper.cs
+++ b/src/Microsoft.PowerShell.GraphicalHost/commandHelpers/HelpWindowHelper.cs
@@ -18,7 +18,7 @@ namespace Microsoft.PowerShell.Commands.Internal
     using Microsoft.PowerShell.Commands.ShowCommandInternal;
 
     /// <summary>
-    /// Implements thw WPF window part of the the ShowWindow option of get-help
+    /// Implements the WPF window part of the the ShowWindow option of get-help
     /// </summary>
     internal static class HelpWindowHelper
     {

--- a/src/Microsoft.PowerShell.GraphicalHost/commandHelpers/ShowCommandHelper.cs
+++ b/src/Microsoft.PowerShell.GraphicalHost/commandHelpers/ShowCommandHelper.cs
@@ -26,7 +26,7 @@ namespace Microsoft.PowerShell.Commands.ShowCommandInternal
     using Microsoft.PowerShell.Commands.ShowCommandExtension;
 
     /// <summary>
-    /// Implements thw WPF window part of the show-command cmdlet
+    /// Implements the WPF window part of the show-command cmdlet
     /// </summary>
     internal class ShowCommandHelper : IDisposable
     {
@@ -414,7 +414,7 @@ Function PSGetSerializedShowCommandInfo
 
         #region public Dispose
         /// <summary>
-        /// Dispose method in IDisposeable
+        /// Dispose method in IDisposable
         /// </summary>
         public void Dispose()
         {
@@ -681,7 +681,7 @@ Function PSGetSerializedShowCommandInfo
         /// <summary>
         /// Gets an error message to be displayed when failed to import a module
         /// </summary>
-        /// <param name="command">command belongiong to the module to import</param>
+        /// <param name="command">command belonging to the module to import</param>
         /// <param name="module">module to import</param>
         /// <param name="error">error importing the module</param>
         /// <returns>an error message to be displayed when failed to import a module</returns>
@@ -993,7 +993,7 @@ Function PSGetSerializedShowCommandInfo
         }
 
         /// <summary>
-        /// Called from CallMethodThatShowsDialog as the thtead start when there is no host window
+        /// Called from CallMethodThatShowsDialog as the thread start when there is no host window
         /// </summary>
         private void PlainInvokeAndShowDialog()
         {
@@ -1252,7 +1252,7 @@ Function PSGetSerializedShowCommandInfo
         }
 
         /// <summary>
-        /// Sets a succesfull dialog result and then closes the window
+        /// Sets a successful dialog result and then closes the window
         /// </summary>
         /// <param name="sender">event sender</param>
         /// <param name="e">event arguments</param>

--- a/src/Microsoft.PowerShell.GraphicalHost/commandHelpers/outgridview.cs
+++ b/src/Microsoft.PowerShell.GraphicalHost/commandHelpers/outgridview.cs
@@ -397,7 +397,7 @@ namespace Microsoft.Management.UI.Internal
         }
 
         /// <summary>
-        /// Add column defenitions to the underlying management list.
+        /// Add column definitions to the underlying management list.
         /// </summary>
         /// <param name="propertyNames">An array of property names to add.</param>
         /// <param name="displayNames">An array of display names to add.</param>

--- a/src/Microsoft.PowerShell.LocalAccounts/LocalAccounts/Sam.cs
+++ b/src/Microsoft.PowerShell.LocalAccounts/LocalAccounts/Sam.cs
@@ -62,7 +62,7 @@ namespace System.Management.Automation.SecurityAccountsManager
         }
 
         /// <summary>
-        /// Defines a set of flags, each coresponding to a member of LocalUser,
+        /// Defines a set of flags, each corresponding to a member of LocalUser,
         /// which indicate fields to be updated.
         /// </summary>
         /// <remarks>
@@ -2397,7 +2397,7 @@ namespace System.Management.Automation.SecurityAccountsManager
                     present = true;
                 }
 
-                // set the DACL into our new sescurity descriptor
+                // set the DACL into our new security descriptor
                 var ok = Win32.SetSecurityDescriptorDacl(ipsd, present, ipDacl, false);
                 if (!ok)
                 {
@@ -2660,7 +2660,7 @@ namespace System.Management.Automation.SecurityAccountsManager
         /// to look up.
         /// </param>
         /// <returns>
-        /// A <see cref="AccountInfo"/> object containg information about the
+        /// A <see cref="AccountInfo"/> object contains information about the
         /// account, or null if no matching account was found.
         /// </returns>
         private AccountInfo LookupAccountInfo(SecurityIdentifier sid)
@@ -2718,7 +2718,7 @@ namespace System.Management.Automation.SecurityAccountsManager
         /// A string containing the name of the account to look up.
         /// </param>
         /// <returns>
-        /// A <see cref="AccountInfo"/> object containg information about the
+        /// A <see cref="AccountInfo"/> object contains information about the
         /// account, or null if no matching account was found.
         /// </returns>
         private AccountInfo LookupAccountInfo(string accountName)
@@ -2762,7 +2762,7 @@ namespace System.Management.Automation.SecurityAccountsManager
                 // Bug: 7407413 :
                 // If accountname is in the format domain1\user1, 
                 //then AccountName.ToString() will return domain1\domain1\user1
-                // Ideally , accountname should be processed to hold only accout name (without domain)
+                // Ideally , accountname should be processed to hold only account name (without domain)
                 // as we are keeping the domain in 'DomainName' variable.
 
                 int index = accountName.IndexOf("\\", StringComparison.CurrentCultureIgnoreCase);

--- a/src/Microsoft.PowerShell.Management.Activities/Generated/AddComputerActivity.cs
+++ b/src/Microsoft.PowerShell.Management.Activities/Generated/AddComputerActivity.cs
@@ -138,7 +138,7 @@ namespace Microsoft.PowerShell.Management.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Management.Activities/Generated/AddContentActivity.cs
+++ b/src/Microsoft.PowerShell.Management.Activities/Generated/AddContentActivity.cs
@@ -126,7 +126,7 @@ namespace Microsoft.PowerShell.Management.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Management.Activities/Generated/CheckpointComputerActivity.cs
+++ b/src/Microsoft.PowerShell.Management.Activities/Generated/CheckpointComputerActivity.cs
@@ -56,7 +56,7 @@ namespace Microsoft.PowerShell.Management.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Management.Activities/Generated/ClearContentActivity.cs
+++ b/src/Microsoft.PowerShell.Management.Activities/Generated/ClearContentActivity.cs
@@ -98,7 +98,7 @@ namespace Microsoft.PowerShell.Management.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Management.Activities/Generated/ClearEventLogActivity.cs
+++ b/src/Microsoft.PowerShell.Management.Activities/Generated/ClearEventLogActivity.cs
@@ -54,7 +54,7 @@ namespace Microsoft.PowerShell.Management.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Management.Activities/Generated/ClearItemActivity.cs
+++ b/src/Microsoft.PowerShell.Management.Activities/Generated/ClearItemActivity.cs
@@ -91,7 +91,7 @@ namespace Microsoft.PowerShell.Management.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Management.Activities/Generated/ClearItemPropertyActivity.cs
+++ b/src/Microsoft.PowerShell.Management.Activities/Generated/ClearItemPropertyActivity.cs
@@ -105,7 +105,7 @@ namespace Microsoft.PowerShell.Management.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Management.Activities/Generated/ClearRecycleBinActivity.cs
+++ b/src/Microsoft.PowerShell.Management.Activities/Generated/ClearRecycleBinActivity.cs
@@ -56,7 +56,7 @@ namespace Microsoft.PowerShell.Management.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Management.Activities/Generated/ConvertPathActivity.cs
+++ b/src/Microsoft.PowerShell.Management.Activities/Generated/ConvertPathActivity.cs
@@ -56,7 +56,7 @@ namespace Microsoft.PowerShell.Management.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Management.Activities/Generated/CopyItemActivity.cs
+++ b/src/Microsoft.PowerShell.Management.Activities/Generated/CopyItemActivity.cs
@@ -133,7 +133,7 @@ namespace Microsoft.PowerShell.Management.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Management.Activities/Generated/CopyItemPropertyActivity.cs
+++ b/src/Microsoft.PowerShell.Management.Activities/Generated/CopyItemPropertyActivity.cs
@@ -112,7 +112,7 @@ namespace Microsoft.PowerShell.Management.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Management.Activities/Generated/DisableComputerRestoreActivity.cs
+++ b/src/Microsoft.PowerShell.Management.Activities/Generated/DisableComputerRestoreActivity.cs
@@ -49,7 +49,7 @@ namespace Microsoft.PowerShell.Management.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Management.Activities/Generated/EnableComputerRestoreActivity.cs
+++ b/src/Microsoft.PowerShell.Management.Activities/Generated/EnableComputerRestoreActivity.cs
@@ -49,7 +49,7 @@ namespace Microsoft.PowerShell.Management.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Management.Activities/Generated/GetChildItemActivity.cs
+++ b/src/Microsoft.PowerShell.Management.Activities/Generated/GetChildItemActivity.cs
@@ -147,7 +147,7 @@ namespace Microsoft.PowerShell.Management.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Management.Activities/Generated/GetComputerRestorePointActivity.cs
+++ b/src/Microsoft.PowerShell.Management.Activities/Generated/GetComputerRestorePointActivity.cs
@@ -56,7 +56,7 @@ namespace Microsoft.PowerShell.Management.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Management.Activities/Generated/GetContentActivity.cs
+++ b/src/Microsoft.PowerShell.Management.Activities/Generated/GetContentActivity.cs
@@ -147,7 +147,7 @@ namespace Microsoft.PowerShell.Management.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Management.Activities/Generated/GetEventLogActivity.cs
+++ b/src/Microsoft.PowerShell.Management.Activities/Generated/GetEventLogActivity.cs
@@ -138,7 +138,7 @@ namespace Microsoft.PowerShell.Management.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Management.Activities/Generated/GetHotFixActivity.cs
+++ b/src/Microsoft.PowerShell.Management.Activities/Generated/GetHotFixActivity.cs
@@ -68,7 +68,7 @@ namespace Microsoft.PowerShell.Management.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Management.Activities/Generated/GetItemActivity.cs
+++ b/src/Microsoft.PowerShell.Management.Activities/Generated/GetItemActivity.cs
@@ -98,7 +98,7 @@ namespace Microsoft.PowerShell.Management.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Management.Activities/Generated/GetItemPropertyActivity.cs
+++ b/src/Microsoft.PowerShell.Management.Activities/Generated/GetItemPropertyActivity.cs
@@ -91,7 +91,7 @@ namespace Microsoft.PowerShell.Management.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Management.Activities/Generated/GetItemPropertyValueActivity.cs
+++ b/src/Microsoft.PowerShell.Management.Activities/Generated/GetItemPropertyValueActivity.cs
@@ -91,7 +91,7 @@ namespace Microsoft.PowerShell.Management.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Management.Activities/Generated/GetLocationActivity.cs
+++ b/src/Microsoft.PowerShell.Management.Activities/Generated/GetLocationActivity.cs
@@ -70,7 +70,7 @@ namespace Microsoft.PowerShell.Management.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Management.Activities/Generated/GetPSDriveActivity.cs
+++ b/src/Microsoft.PowerShell.Management.Activities/Generated/GetPSDriveActivity.cs
@@ -70,7 +70,7 @@ namespace Microsoft.PowerShell.Management.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Management.Activities/Generated/GetPSProviderActivity.cs
+++ b/src/Microsoft.PowerShell.Management.Activities/Generated/GetPSProviderActivity.cs
@@ -49,7 +49,7 @@ namespace Microsoft.PowerShell.Management.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Management.Activities/Generated/GetProcessActivity.cs
+++ b/src/Microsoft.PowerShell.Management.Activities/Generated/GetProcessActivity.cs
@@ -89,7 +89,7 @@ namespace Microsoft.PowerShell.Management.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Management.Activities/Generated/GetServiceActivity.cs
+++ b/src/Microsoft.PowerShell.Management.Activities/Generated/GetServiceActivity.cs
@@ -96,7 +96,7 @@ namespace Microsoft.PowerShell.Management.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Management.Activities/Generated/InvokeItemActivity.cs
+++ b/src/Microsoft.PowerShell.Management.Activities/Generated/InvokeItemActivity.cs
@@ -84,7 +84,7 @@ namespace Microsoft.PowerShell.Management.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Management.Activities/Generated/JoinPathActivity.cs
+++ b/src/Microsoft.PowerShell.Management.Activities/Generated/JoinPathActivity.cs
@@ -70,7 +70,7 @@ namespace Microsoft.PowerShell.Management.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Management.Activities/Generated/LimitEventLogActivity.cs
+++ b/src/Microsoft.PowerShell.Management.Activities/Generated/LimitEventLogActivity.cs
@@ -75,7 +75,7 @@ namespace Microsoft.PowerShell.Management.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Management.Activities/Generated/MoveItemActivity.cs
+++ b/src/Microsoft.PowerShell.Management.Activities/Generated/MoveItemActivity.cs
@@ -105,7 +105,7 @@ namespace Microsoft.PowerShell.Management.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Management.Activities/Generated/MoveItemPropertyActivity.cs
+++ b/src/Microsoft.PowerShell.Management.Activities/Generated/MoveItemPropertyActivity.cs
@@ -112,7 +112,7 @@ namespace Microsoft.PowerShell.Management.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Management.Activities/Generated/NewEventLogActivity.cs
+++ b/src/Microsoft.PowerShell.Management.Activities/Generated/NewEventLogActivity.cs
@@ -82,7 +82,7 @@ namespace Microsoft.PowerShell.Management.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Management.Activities/Generated/NewItemActivity.cs
+++ b/src/Microsoft.PowerShell.Management.Activities/Generated/NewItemActivity.cs
@@ -84,7 +84,7 @@ namespace Microsoft.PowerShell.Management.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Management.Activities/Generated/NewItemPropertyActivity.cs
+++ b/src/Microsoft.PowerShell.Management.Activities/Generated/NewItemPropertyActivity.cs
@@ -112,7 +112,7 @@ namespace Microsoft.PowerShell.Management.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Management.Activities/Generated/NewServiceActivity.cs
+++ b/src/Microsoft.PowerShell.Management.Activities/Generated/NewServiceActivity.cs
@@ -91,7 +91,7 @@ namespace Microsoft.PowerShell.Management.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Management.Activities/Generated/NewWebServiceProxyActivity.cs
+++ b/src/Microsoft.PowerShell.Management.Activities/Generated/NewWebServiceProxyActivity.cs
@@ -77,7 +77,7 @@ namespace Microsoft.PowerShell.Management.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Management.Activities/Generated/RegisterWmiEventActivity.cs
+++ b/src/Microsoft.PowerShell.Management.Activities/Generated/RegisterWmiEventActivity.cs
@@ -126,7 +126,7 @@ namespace Microsoft.PowerShell.Management.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Management.Activities/Generated/RemoveComputerActivity.cs
+++ b/src/Microsoft.PowerShell.Management.Activities/Generated/RemoveComputerActivity.cs
@@ -89,7 +89,7 @@ namespace Microsoft.PowerShell.Management.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Management.Activities/Generated/RemoveEventLogActivity.cs
+++ b/src/Microsoft.PowerShell.Management.Activities/Generated/RemoveEventLogActivity.cs
@@ -61,7 +61,7 @@ namespace Microsoft.PowerShell.Management.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Management.Activities/Generated/RemoveItemActivity.cs
+++ b/src/Microsoft.PowerShell.Management.Activities/Generated/RemoveItemActivity.cs
@@ -105,7 +105,7 @@ namespace Microsoft.PowerShell.Management.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Management.Activities/Generated/RemoveItemPropertyActivity.cs
+++ b/src/Microsoft.PowerShell.Management.Activities/Generated/RemoveItemPropertyActivity.cs
@@ -98,7 +98,7 @@ namespace Microsoft.PowerShell.Management.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Management.Activities/Generated/RemoveWmiObjectActivity.cs
+++ b/src/Microsoft.PowerShell.Management.Activities/Generated/RemoveWmiObjectActivity.cs
@@ -133,7 +133,7 @@ namespace Microsoft.PowerShell.Management.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Management.Activities/Generated/RenameComputerActivity.cs
+++ b/src/Microsoft.PowerShell.Management.Activities/Generated/RenameComputerActivity.cs
@@ -103,7 +103,7 @@ namespace Microsoft.PowerShell.Management.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Management.Activities/Generated/RenameItemActivity.cs
+++ b/src/Microsoft.PowerShell.Management.Activities/Generated/RenameItemActivity.cs
@@ -84,7 +84,7 @@ namespace Microsoft.PowerShell.Management.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Management.Activities/Generated/RenameItemPropertyActivity.cs
+++ b/src/Microsoft.PowerShell.Management.Activities/Generated/RenameItemPropertyActivity.cs
@@ -112,7 +112,7 @@ namespace Microsoft.PowerShell.Management.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Management.Activities/Generated/ResetComputerMachinePasswordActivity.cs
+++ b/src/Microsoft.PowerShell.Management.Activities/Generated/ResetComputerMachinePasswordActivity.cs
@@ -56,7 +56,7 @@ namespace Microsoft.PowerShell.Management.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Management.Activities/Generated/ResolvePathActivity.cs
+++ b/src/Microsoft.PowerShell.Management.Activities/Generated/ResolvePathActivity.cs
@@ -70,7 +70,7 @@ namespace Microsoft.PowerShell.Management.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Management.Activities/Generated/RestartServiceActivity.cs
+++ b/src/Microsoft.PowerShell.Management.Activities/Generated/RestartServiceActivity.cs
@@ -91,7 +91,7 @@ namespace Microsoft.PowerShell.Management.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Management.Activities/Generated/RestoreComputerActivity.cs
+++ b/src/Microsoft.PowerShell.Management.Activities/Generated/RestoreComputerActivity.cs
@@ -49,7 +49,7 @@ namespace Microsoft.PowerShell.Management.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Management.Activities/Generated/ResumeServiceActivity.cs
+++ b/src/Microsoft.PowerShell.Management.Activities/Generated/ResumeServiceActivity.cs
@@ -84,7 +84,7 @@ namespace Microsoft.PowerShell.Management.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Management.Activities/Generated/SetContentActivity.cs
+++ b/src/Microsoft.PowerShell.Management.Activities/Generated/SetContentActivity.cs
@@ -126,7 +126,7 @@ namespace Microsoft.PowerShell.Management.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Management.Activities/Generated/SetItemActivity.cs
+++ b/src/Microsoft.PowerShell.Management.Activities/Generated/SetItemActivity.cs
@@ -105,7 +105,7 @@ namespace Microsoft.PowerShell.Management.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Management.Activities/Generated/SetItemPropertyActivity.cs
+++ b/src/Microsoft.PowerShell.Management.Activities/Generated/SetItemPropertyActivity.cs
@@ -119,7 +119,7 @@ namespace Microsoft.PowerShell.Management.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Management.Activities/Generated/SetServiceActivity.cs
+++ b/src/Microsoft.PowerShell.Management.Activities/Generated/SetServiceActivity.cs
@@ -96,7 +96,7 @@ namespace Microsoft.PowerShell.Management.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Management.Activities/Generated/SetWmiInstanceActivity.cs
+++ b/src/Microsoft.PowerShell.Management.Activities/Generated/SetWmiInstanceActivity.cs
@@ -147,7 +147,7 @@ namespace Microsoft.PowerShell.Management.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Management.Activities/Generated/SplitPathActivity.cs
+++ b/src/Microsoft.PowerShell.Management.Activities/Generated/SplitPathActivity.cs
@@ -105,7 +105,7 @@ namespace Microsoft.PowerShell.Management.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Management.Activities/Generated/StartProcessActivity.cs
+++ b/src/Microsoft.PowerShell.Management.Activities/Generated/StartProcessActivity.cs
@@ -140,7 +140,7 @@ namespace Microsoft.PowerShell.Management.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Management.Activities/Generated/StartServiceActivity.cs
+++ b/src/Microsoft.PowerShell.Management.Activities/Generated/StartServiceActivity.cs
@@ -84,7 +84,7 @@ namespace Microsoft.PowerShell.Management.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Management.Activities/Generated/StopComputerActivity.cs
+++ b/src/Microsoft.PowerShell.Management.Activities/Generated/StopComputerActivity.cs
@@ -103,7 +103,7 @@ namespace Microsoft.PowerShell.Management.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Management.Activities/Generated/StopProcessActivity.cs
+++ b/src/Microsoft.PowerShell.Management.Activities/Generated/StopProcessActivity.cs
@@ -77,7 +77,7 @@ namespace Microsoft.PowerShell.Management.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Management.Activities/Generated/StopServiceActivity.cs
+++ b/src/Microsoft.PowerShell.Management.Activities/Generated/StopServiceActivity.cs
@@ -98,7 +98,7 @@ namespace Microsoft.PowerShell.Management.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Management.Activities/Generated/SuspendServiceActivity.cs
+++ b/src/Microsoft.PowerShell.Management.Activities/Generated/SuspendServiceActivity.cs
@@ -84,7 +84,7 @@ namespace Microsoft.PowerShell.Management.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Management.Activities/Generated/TestComputerSecureChannelActivity.cs
+++ b/src/Microsoft.PowerShell.Management.Activities/Generated/TestComputerSecureChannelActivity.cs
@@ -63,7 +63,7 @@ namespace Microsoft.PowerShell.Management.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Management.Activities/Generated/TestConnectionActivity.cs
+++ b/src/Microsoft.PowerShell.Management.Activities/Generated/TestConnectionActivity.cs
@@ -140,7 +140,7 @@ namespace Microsoft.PowerShell.Management.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Management.Activities/Generated/TestPathActivity.cs
+++ b/src/Microsoft.PowerShell.Management.Activities/Generated/TestPathActivity.cs
@@ -112,7 +112,7 @@ namespace Microsoft.PowerShell.Management.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Management.Activities/Generated/WaitProcessActivity.cs
+++ b/src/Microsoft.PowerShell.Management.Activities/Generated/WaitProcessActivity.cs
@@ -70,7 +70,7 @@ namespace Microsoft.PowerShell.Management.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Management.Activities/Generated/WriteEventLogActivity.cs
+++ b/src/Microsoft.PowerShell.Management.Activities/Generated/WriteEventLogActivity.cs
@@ -96,7 +96,7 @@ namespace Microsoft.PowerShell.Management.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Management.Activities/RestartComputerActivity.cs
+++ b/src/Microsoft.PowerShell.Management.Activities/RestartComputerActivity.cs
@@ -203,7 +203,7 @@ namespace Microsoft.PowerShell.Management.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.PSReadLine/BasicEditing.cs
+++ b/src/Microsoft.PowerShell.PSReadLine/BasicEditing.cs
@@ -523,7 +523,7 @@ namespace Microsoft.PowerShell
         [SuppressMessage("Microsoft.Design", "CA1026:DefaultParametersShouldNotBeUsed")]
         public static void InsertLineAbove(ConsoleKeyInfo? key = null, object arg = null)
         {
-            // Move the current postion to the beginning of the current line and only the current line.
+            // Move the current position to the beginning of the current line and only the current line.
             if (_singleton.LineIsMultiLine())
             {
                 int i = Math.Max(0, _singleton._current - 1);
@@ -554,7 +554,7 @@ namespace Microsoft.PowerShell
         [SuppressMessage("Microsoft.Design", "CA1026:DefaultParametersShouldNotBeUsed")]
         public static void InsertLineBelow(ConsoleKeyInfo? key = null, object arg = null)
         {
-            // Move the current postion to the end of the current line and only the current line.
+            // Move the current position to the end of the current line and only the current line.
             if (_singleton.LineIsMultiLine())
             {
                 int i = _singleton._current;

--- a/src/Microsoft.PowerShell.PSReadLine/Changes.txt
+++ b/src/Microsoft.PowerShell.PSReadLine/Changes.txt
@@ -154,7 +154,7 @@ New features:
 * SamplePSReadlineProfile.ps1 added with examples of custom key bindings
 * Word movement takes DigitArgument
 * HistoryNoDuplicates now works a little differently
-    - Dupicates are saved (it was a dubious memory optimization anyway)
+    - Duplicates are saved (it was a dubious memory optimization anyway)
     - Recall will recall the most recently executed item instead of the first
 * When at the last word, NextWord/ForwardWord now move to the end of line instead
   of the last character of the word.
@@ -227,7 +227,7 @@ Bugs fixed:
 * Ctrl+R with long search lines no longer causes big problems
 
 Behavior change:
-* Word functions now use delimiters.  The previous behavior is availble 
+* Word functions now use delimiters.  The previous behavior is available 
   via a Shell*Word function, e.g. instead of KillWord, use ShellKillWord.
 
 ### Version 1.0.0.4

--- a/src/Microsoft.PowerShell.PSReadLine/Cmdlets.cs
+++ b/src/Microsoft.PowerShell.PSReadLine/Cmdlets.cs
@@ -120,7 +120,7 @@ namespace Microsoft.PowerShell
 
         /// <summary>
         /// When displaying possible completions, either display
-        /// tooltips or dipslay just the completions.
+        /// tooltips or display just the completions.
         /// </summary>
         public const bool DefaultShowToolTips = false;
 

--- a/src/Microsoft.PowerShell.PSReadLine/ConsoleKeyChordConverter.cs
+++ b/src/Microsoft.PowerShell.PSReadLine/ConsoleKeyChordConverter.cs
@@ -321,12 +321,12 @@ namespace Microsoft.PowerShell
             // get corresponding scan code
             uint scanCode = NativeMethods.MapVirtualKey(virtualKey, NativeMethods.MAPVK_VK_TO_VSC);
 
-            // get corresponding character  - maybe be 0, 1 or 2 in length (diacriticals)
+            // get corresponding character  - maybe be 0, 1 or 2 in length (diacritics)
             var chars = new char[2];
             int charCount = NativeMethods.ToUnicode(
                 virtualKey, scanCode, state, chars, chars.Length, NativeMethods.MENU_IS_INACTIVE);
 
-            // TODO: support diacriticals (charCount == 2)
+            // TODO: support diacritics (charCount == 2)
             if (charCount == 1)
             {
                 keyChar = chars[0];

--- a/src/Microsoft.PowerShell.PSReadLine/KeyBindings.cs
+++ b/src/Microsoft.PowerShell.PSReadLine/KeyBindings.cs
@@ -55,7 +55,7 @@ namespace Microsoft.PowerShell
             // should be included on all handlers that ignore their parameters so they
             // can be called from PowerShell without passing anything.
             //
-            // The first arugment is the key that caused the action to be called
+            // The first argument is the key that caused the action to be called
             // (the second key when it's a 2 key chord).  The default is null (it's nullable)
             // because PowerShell can't handle default(ConsoleKeyInfo) as a default.
             // Most actions will ignore this argument.

--- a/src/Microsoft.PowerShell.PSReadLine/KillYank.cs
+++ b/src/Microsoft.PowerShell.PSReadLine/KillYank.cs
@@ -32,7 +32,7 @@ namespace Microsoft.PowerShell
         private int _visualSelectionCommandCount;
 
         /// <summary>
-        /// Mark the current loction of the cursor for use in a subsequent editing command.
+        /// Mark the current location of the cursor for use in a subsequent editing command.
         /// </summary>
         [SuppressMessage("Microsoft.Design", "CA1026:DefaultParametersShouldNotBeUsed")]
         public static void SetMark(ConsoleKeyInfo? key = null, object arg = null)

--- a/src/Microsoft.PowerShell.PSReadLine/PSReadLineResources.Designer.cs
+++ b/src/Microsoft.PowerShell.PSReadLine/PSReadLineResources.Designer.cs
@@ -106,7 +106,7 @@ namespace Microsoft.PowerShell {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Delete the charcter before the cursor.
+        ///   Looks up a localized string similar to Delete the character before the cursor.
         /// </summary>
         internal static string BackwardDeleteCharDescription {
             get {
@@ -322,7 +322,7 @@ namespace Microsoft.PowerShell {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Delete the character under the cusor.
+        ///   Looks up a localized string similar to Delete the character under the cursor.
         /// </summary>
         internal static string DeleteCharDescription {
             get {
@@ -331,7 +331,7 @@ namespace Microsoft.PowerShell {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Delete the character under the cusor, or if the line is empty, exit the process..
+        ///   Looks up a localized string similar to Delete the character under the cursor, or if the line is empty, exit the process..
         /// </summary>
         internal static string DeleteCharOrExitDescription {
             get {
@@ -502,7 +502,7 @@ namespace Microsoft.PowerShell {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Moves the cursor to the perscribed column..
+        ///   Looks up a localized string similar to Moves the cursor to the prescribed column..
         /// </summary>
         internal static string GotoColumnDescription {
             get {
@@ -990,7 +990,7 @@ namespace Microsoft.PowerShell {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Searches backward for the perscribed character..
+        ///   Looks up a localized string similar to Searches backward for the prescribed character..
         /// </summary>
         internal static string SearchBackwardCharDescription {
             get {
@@ -999,7 +999,7 @@ namespace Microsoft.PowerShell {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Move to the previous occurance of the specified character..
+        ///   Looks up a localized string similar to Move to the previous occurrence of the specified character..
         /// </summary>
         internal static string SearchCharBackwardDescription {
             get {
@@ -1008,7 +1008,7 @@ namespace Microsoft.PowerShell {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Move to the previous occurance of the specified character and then forward one character..
+        ///   Looks up a localized string similar to Move to the previous occurrence of the specified character and then forward one character..
         /// </summary>
         internal static string SearchCharBackwardWithBackoffDescription {
             get {
@@ -1017,7 +1017,7 @@ namespace Microsoft.PowerShell {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Move to the next occurance of the specified character..
+        ///   Looks up a localized string similar to Move to the next occurrence of the specified character..
         /// </summary>
         internal static string SearchCharDescription {
             get {
@@ -1026,7 +1026,7 @@ namespace Microsoft.PowerShell {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Move to he next occurance of the specified character and then back one character..
+        ///   Looks up a localized string similar to Move to he next occurrence of the specified character and then back one character..
         /// </summary>
         internal static string SearchCharWithBackoffDescription {
             get {
@@ -1035,7 +1035,7 @@ namespace Microsoft.PowerShell {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Searches for the perscribed character in the perscribed direction..
+        ///   Looks up a localized string similar to Searches for the prescribed character in the prescribed direction..
         /// </summary>
         internal static string SearchDescription {
             get {
@@ -1488,7 +1488,7 @@ namespace Microsoft.PowerShell {
         /// <summary>
         ///   Looks up a localized string similar to Moves the cursor to the beginning of the line and switches to insert mode..
         /// </summary>
-        internal static string ViInsertAtBeginingDescription {
+        internal static string ViInsertAtBeginningDescription {
             get {
                 return ResourceManager.GetString("ViInsertAtBeginingDescription", resourceCulture);
             }
@@ -1585,7 +1585,7 @@ namespace Microsoft.PowerShell {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Delete to the end of the word, as delimited by white space and common delimters, and enter insert mode..
+        ///   Looks up a localized string similar to Delete to the end of the word, as delimited by white space and common delimiters, and enter insert mode..
         /// </summary>
         internal static string ViReplaceEndOfWordDescription {
             get {
@@ -1639,7 +1639,7 @@ namespace Microsoft.PowerShell {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Starts a new seach backward in the history..
+        ///   Looks up a localized string similar to Starts a new search backward in the history..
         /// </summary>
         internal static string ViSearchHistoryBackwardDescription {
             get {
@@ -1756,7 +1756,7 @@ namespace Microsoft.PowerShell {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Place all characters from before the cursor to the beginning of the previous word, as delimted by white space and common delimiters, into the local clipboard..
+        ///   Looks up a localized string similar to Place all characters from before the cursor to the beginning of the previous word, as delimited by white space and common delimiters, into the local clipboard..
         /// </summary>
         internal static string ViYankPreviousWordDescription {
             get {

--- a/src/Microsoft.PowerShell.PSReadLine/PSReadLineResources.resx
+++ b/src/Microsoft.PowerShell.PSReadLine/PSReadLineResources.resx
@@ -127,7 +127,7 @@
     <value>Move the cursor back one character</value>
   </data>
   <data name="BackwardDeleteCharDescription" xml:space="preserve">
-    <value>Delete the charcter before the cursor</value>
+    <value>Delete the character before the cursor</value>
   </data>
   <data name="BackwardDeleteLineDescription" xml:space="preserve">
     <value>Delete text from the cursor to the start of the line</value>
@@ -154,7 +154,7 @@
     <value>Complete the input if there is a single completion, otherwise complete the input with common prefix for all completions.  Show possible completions if pressed a second time.</value>
   </data>
   <data name="DeleteCharDescription" xml:space="preserve">
-    <value>Delete the character under the cusor</value>
+    <value>Delete the character under the cursor</value>
   </data>
   <data name="ShellBackwardWordDescription" xml:space="preserve">
     <value>Move the cursor to the beginning of the current or previous token or start of the line</value>
@@ -412,7 +412,7 @@ Exception:
 If there are other parse errors, unresolved commands, or incorrect parameters, show the error and continue editing.</value>
   </data>
   <data name="DeleteCharOrExitDescription" xml:space="preserve">
-    <value>Delete the character under the cusor, or if the line is empty, exit the process.</value>
+    <value>Delete the character under the cursor, or if the line is empty, exit the process.</value>
   </data>
   <data name="CantTranslateKey" xml:space="preserve">
     <value>Unable to translate '{0}' to virtual key code: {1}.</value>
@@ -451,10 +451,10 @@ If there are other parse errors, unresolved commands, or incorrect parameters, s
     <value>Repeats the last search.</value>
   </data>
   <data name="SearchBackwardCharDescription" xml:space="preserve">
-    <value>Searches backward for the perscribed character.</value>
+    <value>Searches backward for the prescribed character.</value>
   </data>
   <data name="SearchDescription" xml:space="preserve">
-    <value>Searches for the perscribed character in the perscribed direction.</value>
+    <value>Searches for the prescribed character in the prescribed direction.</value>
   </data>
   <data name="ViAppendAtEndDescription" xml:space="preserve">
     <value>Switches to insert mode after positioning the cursor past the end of the line.</value>
@@ -496,7 +496,7 @@ If there are other parse errors, unresolved commands, or incorrect parameters, s
     <value>Moves the cursor forward to the end of the next word.</value>
   </data>
   <data name="GotoColumnDescription" xml:space="preserve">
-    <value>Moves the cursor to the perscribed column.</value>
+    <value>Moves the cursor to the prescribed column.</value>
   </data>
   <data name="ViInsertModeDescription" xml:space="preserve">
     <value>Switches to insert mode.</value>
@@ -547,7 +547,7 @@ If there are other parse errors, unresolved commands, or incorrect parameters, s
     <value>Delete the current character and insert the next character.</value>
   </data>
   <data name="ViSearchHistoryBackwardDescription" xml:space="preserve">
-    <value>Starts a new seach backward in the history.</value>
+    <value>Starts a new search backward in the history.</value>
   </data>
   <data name="ViTransposeCharsDescription" xml:space="preserve">
     <value>Transposes the current character with the next character in the line.</value>
@@ -565,16 +565,16 @@ If there are other parse errors, unresolved commands, or incorrect parameters, s
     <value>Repeat the last recorded character search.</value>
   </data>
   <data name="SearchCharBackwardDescription" xml:space="preserve">
-    <value>Move to the previous occurance of the specified character.</value>
+    <value>Move to the previous occurrence of the specified character.</value>
   </data>
   <data name="SearchCharBackwardWithBackoffDescription" xml:space="preserve">
-    <value>Move to the previous occurance of the specified character and then forward one character.</value>
+    <value>Move to the previous occurrence of the specified character and then forward one character.</value>
   </data>
   <data name="SearchCharDescription" xml:space="preserve">
-    <value>Move to the next occurance of the specified character.</value>
+    <value>Move to the next occurrence of the specified character.</value>
   </data>
   <data name="SearchCharWithBackoffDescription" xml:space="preserve">
-    <value>Move to he next occurance of the specified character and then back one character.</value>
+    <value>Move to he next occurrence of the specified character and then back one character.</value>
   </data>
   <data name="ViBackwardReplaceWordDescription" xml:space="preserve">
     <value>Replace the previous word.</value>
@@ -622,7 +622,7 @@ If there are other parse errors, unresolved commands, or incorrect parameters, s
     <value>Delete to the beginning of the next word, as delimited by white space, and enter insert mode.</value>
   </data>
   <data name="ViReplaceEndOfWordDescription" xml:space="preserve">
-    <value>Delete to the end of the word, as delimited by white space and common delimters, and enter insert mode.</value>
+    <value>Delete to the end of the word, as delimited by white space and common delimiters, and enter insert mode.</value>
   </data>
   <data name="ViReplaceEndOfGlobDescription" xml:space="preserve">
     <value>Delete to the end of the word, as delimited by white space, and enter insert mode.</value>
@@ -634,7 +634,7 @@ If there are other parse errors, unresolved commands, or incorrect parameters, s
     <value>Place all characters at and after the cursor into the local clipboard.</value>
   </data>
   <data name="ViYankPreviousWordDescription" xml:space="preserve">
-    <value>Place all characters from before the cursor to the beginning of the previous word, as delimted by white space and common delimiters, into the local clipboard.</value>
+    <value>Place all characters from before the cursor to the beginning of the previous word, as delimited by white space and common delimiters, into the local clipboard.</value>
   </data>
   <data name="ViYankPreviousGlobDescription" xml:space="preserve">
     <value>Place all characters from before the cursor to the beginning of the previous word, as delimited by white space, into the local clipboard.</value>

--- a/src/Microsoft.PowerShell.PSReadLine/PublicAPI.cs
+++ b/src/Microsoft.PowerShell.PSReadLine/PublicAPI.cs
@@ -125,7 +125,7 @@ namespace Microsoft.PowerShell
         /// <param name="length">The length to replace</param>
         /// <param name="replacement">The replacement text</param>
         /// <param name="instigator">The action that initiated the replace (used for undo)</param>
-        /// <param name="instigatorArg">The argument to the action that initiaed the replace (used for undo)</param>
+        /// <param name="instigatorArg">The argument to the action that initiated the replace (used for undo)</param>
         public static void Replace(int start, int length, string replacement, Action<ConsoleKeyInfo?, object> instigator = null, object instigatorArg = null)
         {
             if (start < 0 || start > _singleton._buffer.Length)
@@ -224,7 +224,7 @@ namespace Microsoft.PowerShell
 
         /// <summary>
         /// A helper method when your function expects an optional int argument (e.g. from DigitArgument)
-        /// If there is not argument (it's null), returns true and sets numericArg to derfaultNumericArg.
+        /// If there is not argument (it's null), returns true and sets numericArg to defaultNumericArg.
         /// Dings and returns false if the argument is not an int (no conversion is attempted)
         /// Otherwise returns true, and numericArg has the result.
         /// </summary>

--- a/src/Microsoft.PowerShell.PSReadLine/ReadLine.cs
+++ b/src/Microsoft.PowerShell.PSReadLine/ReadLine.cs
@@ -158,7 +158,7 @@ namespace Microsoft.PowerShell
                                 // There is an OnIdle event.  We're idle because we timed out.  Normally
                                 // PowerShell generates this event, but PowerShell assumes the engine is not
                                 // idle because it called PSConsoleHostReadline which isn't returning.
-                                // So we generate the event intstead.
+                                // So we generate the event instead.
                                 _singleton._engineIntrinsics.Events.GenerateEvent("PowerShell.OnIdle", null, null, null);
                                 runPipelineForEventProcessing = true;
                                 break;

--- a/src/Microsoft.PowerShell.PSReadLine/ReadLine.vi.cs
+++ b/src/Microsoft.PowerShell.PSReadLine/ReadLine.vi.cs
@@ -197,7 +197,7 @@ namespace Microsoft.PowerShell
         }
 
         /// <summary>
-        /// Read the next character and then find it, going backard, and then back off a character.
+        /// Read the next character and then find it, going backward, and then back off a character.
         /// This is for 'T' functionality.
         /// </summary>
         public static void SearchCharBackward(ConsoleKeyInfo? key = null, object arg = null)
@@ -219,7 +219,7 @@ namespace Microsoft.PowerShell
         }
 
         /// <summary>
-        /// Read the next character and then find it, going backard, and then back off a character.
+        /// Read the next character and then find it, going backward, and then back off a character.
         /// This is for 'T' functionality.
         /// </summary>
         public static void SearchCharBackwardWithBackoff(ConsoleKeyInfo? key = null, object arg = null)
@@ -570,7 +570,7 @@ namespace Microsoft.PowerShell
         }
 
         /// <summary>
-        /// Switch to Insert mode and position the cursor at the begining of the line.
+        /// Switch to Insert mode and position the cursor at the beginning of the line.
         /// </summary>
         public static void ViInsertAtBegining(ConsoleKeyInfo? key = null, object arg = null)
         {
@@ -887,7 +887,7 @@ namespace Microsoft.PowerShell
         /// <summary>
         /// Prompts for a string for history searching.
         /// </summary>
-        /// <param name="backward">True for seaching backward in the history.</param>
+        /// <param name="backward">True for searching backward in the history.</param>
         private void StartSearch(bool backward)
         {
             _statusLinePrompt = "find: ";

--- a/src/Microsoft.PowerShell.PSReadLine/Render.cs
+++ b/src/Microsoft.PowerShell.PSReadLine/Render.cs
@@ -462,7 +462,7 @@ namespace Microsoft.PowerShell
             else if (_visualSelectionCommandCount > 0 && InRegion(i))
             {
                 // We can't quite emulate real console selection because it inverts
-                // based on actual screen colors, our pallete is limited.  The choice
+                // based on actual screen colors, our palette is limited.  The choice
                 // to invert only the lower 3 bits to change the color is somewhat
                 // but looks best with the 2 default color schemes - starting PowerShell
                 // from it's shortcut or from a cmd shortcut.

--- a/src/Microsoft.PowerShell.PSReadLine/Words.vi.cs
+++ b/src/Microsoft.PowerShell.PSReadLine/Words.vi.cs
@@ -129,7 +129,7 @@ namespace Microsoft.PowerShell
         /// Returns the beginning of the current/next word as defined by wordDelimiters and whitespace.
         /// </summary>
         /// <param name="i">Current cursor location.</param>
-        /// <param name="wordDelimiters">Characters used to deliminate words.</param>
+        /// <param name="wordDelimiters">Characters used to delimit words.</param>
         /// <returns>Location of the beginning of the previous word.</returns>
         private int ViFindPreviousWordPoint(int i, string wordDelimiters)
         {

--- a/src/Microsoft.PowerShell.PSReadLine/en-US/PSReadline.md
+++ b/src/Microsoft.PowerShell.PSReadLine/en-US/PSReadline.md
@@ -10,9 +10,9 @@ If neither -Bound nor -Unbound is specified, returns all bound keys and unbound 
 
 If -Bound is specified and -Unbound is not specified, only bound keys are returned.
 
-If -Unound is specified and -Bound is not specified, only unbound keys are returned.
+If -Unbound is specified and -Bound is not specified, only unbound keys are returned.
 
-If both -Bound and -Unound are specified, returns all bound keys and unbound functions.
+If both -Bound and -Unbound are specified, returns all bound keys and unbound functions.
 
 ## PARAMETERS
 

--- a/src/Microsoft.PowerShell.PackageManagement/Cmdlets/AsyncCmdlet.cs
+++ b/src/Microsoft.PowerShell.PackageManagement/Cmdlets/AsyncCmdlet.cs
@@ -88,7 +88,7 @@ namespace Microsoft.PowerShell.PackageManagement.Cmdlets {
 #endif
 
         /// <summary>
-        ///     Manages the re-entrancy lock for cmdlets
+        ///     Manages the reentrancy lock for cmdlets
         ///     This is abstracted here because (at this point)
         ///     we need this to be static, but per-cmdlet class.
         /// </summary>
@@ -350,7 +350,7 @@ namespace Microsoft.PowerShell.PackageManagement.Cmdlets {
 #if DEBUG
                             Log("ERROR",errorMessage);
 #endif
-                            //Replaced Wait() with ConintueWith(Cancel) to avoid hang if the error message comes in too early, e.g. GetDyanamicParameters(), etc.
+                            //Replaced Wait() with ContinueWith(Cancel) to avoid hang if the error message comes in too early, e.g. GetDynamicParameters(), etc.
                             WriteError(new ErrorRecord(new Exception(errorMessage), DropMsgPrefix(id), errorCategory, string.IsNullOrWhiteSpace(targetObjectValue) ? (object)this : targetObjectValue)).Wait(3000);
                         } catch {
                             // this will throw if the provider thread abends before we get back our result.
@@ -682,7 +682,7 @@ namespace Microsoft.PowerShell.PackageManagement.Cmdlets {
             }
         }
 
-        #region Dynamic Paramters
+        #region Dynamic Parameters
 
         public virtual RuntimeDefinedParameterDictionary DynamicParameterDictionary {
             get {
@@ -826,7 +826,7 @@ namespace Microsoft.PowerShell.PackageManagement.Cmdlets {
                 // let's not even bother doing all this if they didn't even
                 // override the method.
                 if (IsOverridden(Constants.Methods.BeginProcessingAsyncMethod)) {
-                    // just before we kick stuff off, let's make sure we consume the dynamicaparmeters
+                    // just before we kick stuff off, let's make sure we consume the dynamic parameters
                     if (!_consumedDynamicParameters) {
                         ConsumeDynamicParameters();
                         _consumedDynamicParameters = true;
@@ -854,7 +854,7 @@ namespace Microsoft.PowerShell.PackageManagement.Cmdlets {
                 // let's not even bother doing all this if they didn't even
                 // override the method.
                 if (IsOverridden(Constants.Methods.ProcessRecordAsyncMethod)) {
-                    // just before we kick stuff off, let's make sure we consume the dynamicaparmeters
+                    // just before we kick stuff off, let's make sure we consume the dynamic parameters
                     if (!_consumedDynamicParameters) {
                         ConsumeDynamicParameters();
                         _consumedDynamicParameters = true;
@@ -883,7 +883,7 @@ namespace Microsoft.PowerShell.PackageManagement.Cmdlets {
                 // let's not even bother doing all this if they didn't even
                 // override the method.
                 if (IsOverridden(Constants.Methods.EndProcessingAsyncMethod)) {
-                    // just before we kick stuff off, let's make sure we consume the dynamicaparmeters
+                    // just before we kick stuff off, let's make sure we consume the dynamic parameters
                     if (!_consumedDynamicParameters) {
                         ConsumeDynamicParameters();
                         _consumedDynamicParameters = true;

--- a/src/Microsoft.PowerShell.PackageManagement/Cmdlets/CmdletBase.cs
+++ b/src/Microsoft.PowerShell.PackageManagement/Cmdlets/CmdletBase.cs
@@ -254,14 +254,14 @@ namespace Microsoft.PowerShell.PackageManagement.Cmdlets {
             //is expected. However when the install-module starts, the MessageResolver delegate stops responding. This is a PowerShell thing.
             //Once the delegate is blocked, it's blocked for the subsequence log message calls for the current cmdlet, find-module. Note that the
             //next cmdlet, install-module has no impact on the delegate blocking issue, meaning all messages are expected to be logged for install-module.
-            //_messageResolverNotResponding is for avoiding continuesly waiting for unresponsive MessageResolver delegate.
+            //_messageResolverNotResponding is for avoiding continuously waiting for unresponsive MessageResolver delegate.
             if (MessageResolver != null && !_messageResolverNotResponding) {
                 // if the consumer has specified a MessageResolver delegate, we need to call it on the main thread
                 // because powershell won't let us use the default runspace from another thread.
 
                 // if we are anywhere but the end of the pipeline, the delegate here would block on stuff later in the pipe
                 // and since we're blocking *that* based on the the resolution of this, we're better off just skipping
-                // the message resoluion for things earlier in the pipeline.
+                // the message resolution for things earlier in the pipeline.
                 _messageResolverNotResponding = !ExecuteOnMainThread(() =>{
                     result = MessageResolver(messageText, defaultText);
                     if (string.IsNullOrWhiteSpace(result)) {

--- a/src/Microsoft.PowerShell.PackageManagement/Cmdlets/CmdletWithProvider.cs
+++ b/src/Microsoft.PowerShell.PackageManagement/Cmdlets/CmdletWithProvider.cs
@@ -78,7 +78,7 @@ namespace Microsoft.PowerShell.PackageManagement.Cmdlets {
                     // the user gave us provider names that we're not able to resolve.
 
                     if (IsInvocation) {
-                        // and we're in an actual cmdlet invocaton.
+                        // and we're in an actual cmdlet invocation.
                         QueueHeldMessage(() => Error(Constants.Errors.UnknownProviders, ProviderName.JoinWithComma()));
                         IsFailingEarly = true;
                     }
@@ -111,7 +111,7 @@ namespace Microsoft.PowerShell.PackageManagement.Cmdlets {
                     var filteredproviders = registeredSources.Any() ? registeredSources.Select(source => source.Provider).Distinct().ReEnumerable() : potentialSources.Select(source => source.Provider).Distinct().ReEnumerable();
 
                     if (!filteredproviders.Any()) {
-                        // we've filtered out everthing!
+                        // we've filtered out everything!
 
                         if (!didUserSpecifyProviders) {
                             // if cmdlet is generating parameter, we have to log error that source is wrong
@@ -281,7 +281,7 @@ namespace Microsoft.PowerShell.PackageManagement.Cmdlets {
             }
 
             // these warnings only show for providers that would have otherwise be selected.
-            // if not for the missing requrired parameter.
+            // if not for the missing required parameter.
             foreach (var mp in excluded.OrderBy(each => each.Key)) {
                 string optionsValue = mp.Value.JoinWithComma();
 
@@ -493,7 +493,7 @@ namespace Microsoft.PowerShell.PackageManagement.Cmdlets {
                             Console.WriteLine("»»» Cancelled before we got finished doing dynamic parameters");
 #endif
                             // this happens if there is a serious failure early in the cmdlet
-                            // i.e. - if the SelectedProviders comes back empty (due to agressive filtering)
+                            // i.e. - if the SelectedProviders comes back empty (due to aggressive filtering)
 
                             // in this case, we just want to provide a catch-all for remaining arguments so that we can make
                             // output the error that we really want to (that the user specified conditions that filtered them all out)

--- a/src/Microsoft.PowerShell.PackageManagement/Cmdlets/CmdletWithSearchAndSource.cs
+++ b/src/Microsoft.PowerShell.PackageManagement/Cmdlets/CmdletWithSearchAndSource.cs
@@ -472,7 +472,7 @@ namespace Microsoft.PowerShell.PackageManagement.Cmdlets {
          protected IEnumerable<SoftwareIdentity> CheckMatchedDuplicates() {
             // if there are overmatched packages we need to know why:
             // are they found across multiple providers?
-            // are they found accross multiple sources?
+            // are they found across multiple sources?
             // are they all from the same source?
  
             foreach (var list in _resultsPerName.Values.Where(each => each != null && each.Any())) {
@@ -492,7 +492,7 @@ namespace Microsoft.PowerShell.PackageManagement.Cmdlets {
                     //      Example: install-package -Source @('src1', 'src2')
                     //               install-package -Source @('src1', 'src2') -Provider @('p1', 'p2')
                     if (Sources.Any() && (providers.Length != 1 || sources.Length != 1)) {
-                        // let's use the first source as our priority.As long as we find a package, we exit the 'for' loop righ away
+                        // let's use the first source as our priority.As long as we find a package, we exit the 'for' loop right away
                         foreach (var source in Sources) {
                             //select all packages matched source
                             var pkgs = list.Where(package => source.EqualsIgnoreCase(package.Source) || (UserSpecifiedSourcesList.Keys.ContainsIgnoreCase(package.Source) && source.EqualsIgnoreCase(UserSpecifiedSourcesList[package.Source]))).ToArray();

--- a/src/Microsoft.PowerShell.PackageManagement/Cmdlets/FindPackageProvider.cs
+++ b/src/Microsoft.PowerShell.PackageManagement/Cmdlets/FindPackageProvider.cs
@@ -58,7 +58,7 @@ namespace Microsoft.PowerShell.PackageManagement.Cmdlets
         public SwitchParameter IncludeDependencies { get; set; }
     
         protected override void GenerateCmdletSpecificParameters(Dictionary<string, object> unboundArguments) {
-            //this will supress the dynamic parameters from the parent classes
+            //this will suppress the dynamic parameters from the parent classes
             //Noop       
         }
 
@@ -83,7 +83,7 @@ namespace Microsoft.PowerShell.PackageManagement.Cmdlets
                     return false;
                 }
             }
-            //Error out for the case where multiple provider names with any version specififed
+            //Error out for the case where multiple provider names with any version specified
             if (Name.IsNullOrEmpty()) {
                 if ((!string.IsNullOrWhiteSpace(RequiredVersion)) || (!string.IsNullOrWhiteSpace(MinimumVersion)) || (!string.IsNullOrWhiteSpace(MaximumVersion))) {
                     Error(Constants.Errors.MultipleNamesWithVersionNotAllowed);
@@ -130,7 +130,7 @@ namespace Microsoft.PowerShell.PackageManagement.Cmdlets
         {
             var host = this.ProviderSpecific(pv);
             var host1 = host;
-            //add filterontag for finding providers.  Provider keys are: PackageManagment and Provider
+            //add filterontag for finding providers.  Provider keys are: PackageManagement and Provider
             host = host.Extend<IRequest>(
                 new
                 {

--- a/src/Microsoft.PowerShell.PackageManagement/Cmdlets/GetPackage.cs
+++ b/src/Microsoft.PowerShell.PackageManagement/Cmdlets/GetPackage.cs
@@ -153,7 +153,7 @@ namespace Microsoft.PowerShell.PackageManagement.Cmdlets {
                 requests = requests.FilterWithFinalizer(each => each.packages.IsConsumed, each => each.packages.Dispose()).ToArray();
             } // end of WaitForActivity()
             
-            // Peform post-processing only if -AllVersions is not specified            
+            // Perform post-processing only if -AllVersions is not specified            
             if (!AllVersions)
             {
                 // post processing the potential packages as we have to display only
@@ -162,7 +162,7 @@ namespace Microsoft.PowerShell.PackageManagement.Cmdlets {
 
                 // However there are cases when the same package can be found by different providers. in that case, we will show
                 // the packages from different providers even through they have the same package name. This is important because uninstall-package 
-                // inherts from get-package, so that when the first provider does not implement the uninstall-package(), such as Programs, others will
+                // inherits from get-package, so that when the first provider does not implement the uninstall-package(), such as Programs, others will
                 // perform the uninstall.
 
                 //grouping packages by package name first

--- a/src/Microsoft.PowerShell.PackageManagement/Cmdlets/GetPackageSource.cs
+++ b/src/Microsoft.PowerShell.PackageManagement/Cmdlets/GetPackageSource.cs
@@ -51,7 +51,7 @@ namespace Microsoft.PowerShell.PackageManagement.Cmdlets {
             set {
                 _originalName = value;
                 if (!string.IsNullOrWhiteSpace(_originalName) && _originalName.ContainsWildcards()){
-                    //'Name' means package Source Name here. if we pass down the source name with any wildcard charaters, providers cannot resolve them.
+                    //'Name' means package Source Name here. if we pass down the source name with any wildcard characters, providers cannot resolve them.
                     //set it to "" here just as a user does not provide -Name. With that Get-PackageSource returns all and we'll filter on results.
                     _name = string.Empty;
                 } else {

--- a/src/Microsoft.PowerShell.PackageManagement/Cmdlets/ImportPackageProvider.cs
+++ b/src/Microsoft.PowerShell.PackageManagement/Cmdlets/ImportPackageProvider.cs
@@ -68,7 +68,7 @@ namespace Microsoft.PowerShell.PackageManagement.Cmdlets
         }
 
         public override bool ProcessRecordAsync() {
-            //Error out for the case where multiple provider names with any version specififed
+            //Error out for the case where multiple provider names with any version specified
             if (((!Name.IsNullOrEmpty() && Name.Length > 1) || Name[0].ContainsWildcards())
                 && ((RequiredVersion != null) || (MinimumVersion != null) || (MaximumVersion != null)))
             {

--- a/src/Microsoft.PowerShell.PackageManagement/Cmdlets/InstallPackageProvider.cs
+++ b/src/Microsoft.PowerShell.PackageManagement/Cmdlets/InstallPackageProvider.cs
@@ -109,7 +109,7 @@ namespace Microsoft.PowerShell.PackageManagement.Cmdlets
             // only generate these parameters if there is an actual call happening. it won't show in get-command -syntax
             if (IsInvocation) {
                 //Use the InternalPackageManagementInstallOnly flag to indicate we are installing a provider right now.
-                //This will seperate a case from auto-bootstrapping.
+                //This will separate a case from auto-bootstrapping.
                 var packageManagementService = PackageManagementService as PackageManagementService;
                 if (packageManagementService != null) {
                     packageManagementService.InternalPackageManagementInstallOnly = true;
@@ -166,7 +166,7 @@ namespace Microsoft.PowerShell.PackageManagement.Cmdlets
                     return false;
                 }
             }
-            //Error out for the case where multiple provider names with any version specififed
+            //Error out for the case where multiple provider names with any version specified
             if (Name.IsNullOrEmpty()) {
                 if ((!string.IsNullOrWhiteSpace(RequiredVersion)) || (!string.IsNullOrWhiteSpace(MinimumVersion)) || (!string.IsNullOrWhiteSpace(MaximumVersion))) {
                     Error(Constants.Errors.MultipleNamesWithVersionNotAllowed);
@@ -216,7 +216,7 @@ namespace Microsoft.PowerShell.PackageManagement.Cmdlets
         protected override IHostApi GetProviderSpecificOption(PackageProvider pv) {
             var host = this.ProviderSpecific(pv);
             var host1 = host;
-            //add filterontag for finding providers.  Provider keys are: PackageManagment and Providers
+            //add filterontag for finding providers.  Provider keys are: PackageManagement and Providers
             host = host.Extend<IRequest>(
                 new {
                     GetOptionValues = new Func<string, IEnumerable<string>>(key => {
@@ -317,7 +317,7 @@ namespace Microsoft.PowerShell.PackageManagement.Cmdlets
 
                 // there are overmatched packages:
                 // are they found across multiple providers?
-                // are they found accross multiple sources?
+                // are they found across multiple sources?
                 // are they all from the same source?
 
                 var providers = pkgSet.Select(each => each.ProviderName).Distinct().ToArray();
@@ -352,7 +352,7 @@ namespace Microsoft.PowerShell.PackageManagement.Cmdlets
                     }
                 } else {
                     //Handling a case where the multiple providers match one package
-                    //In this case, both boostrap and PowerShellGet found the same package, let's take PowerShellGet as a presendence
+                    //In this case, both bootstrap and PowerShellGet found the same package, let's take PowerShellGet as a precedence
                     foreach (var subset in pkgSet) {
                         if (subset.ProviderName.EqualsIgnoreCase(PowerShellGet)) {
                             //find the match

--- a/src/Microsoft.PowerShell.PackageManagement/Cmdlets/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.PowerShell.PackageManagement/Cmdlets/Properties/AssemblyInfo.cs
@@ -29,7 +29,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-// Normally, we wouldn't actaully permit access to the internals of the PackageManagement  module
+// Normally, we wouldn't actually permit access to the internals of the PackageManagement  module
 // but we're sharing code with the other our tightly-coupled Chocolatey PowerShell module
 
 [assembly: InternalsVisibleTo("Microsoft.PackageManagement.Test")]

--- a/src/Microsoft.PowerShell.PackageManagement/Constants.cs
+++ b/src/Microsoft.PowerShell.PackageManagement/Constants.cs
@@ -53,7 +53,7 @@ namespace Microsoft.PowerShell.PackageManagement {
 
         // Implementation Note:
         // Because PackageManagement allows the application layer closest to the user (host) to be in ultimate
-        // control of spcifying messages to the end user, and falls back up the chain of responsibility
+        // control of specifying messages to the end user, and falls back up the chain of responsibility
         // when resolving Messages from resources, we have prefixed the constants with MSG: in order
         // to *know* when we're trying to resolve a message.
 

--- a/src/Microsoft.PowerShell.ScheduledJob/ScheduledJob.cs
+++ b/src/Microsoft.PowerShell.ScheduledJob/ScheduledJob.cs
@@ -20,7 +20,7 @@ namespace Microsoft.PowerShell.ScheduledJob
     /// running job definition based jobs but can also save and load job
     /// results data from file.  This class is used to load job result
     /// data from previously run jobs so that a user can view results of
-    /// scheduled job runs.  This class also contains the defintion of 
+    /// scheduled job runs.  This class also contains the definition of 
     /// the scheduled job and so can run an instance of the scheduled
     /// job and optionally save results to file.
     /// </summary>

--- a/src/Microsoft.PowerShell.ScheduledJob/ScheduledJobDefinition.cs
+++ b/src/Microsoft.PowerShell.ScheduledJob/ScheduledJobDefinition.cs
@@ -155,7 +155,7 @@ namespace Microsoft.PowerShell.ScheduledJob
         }
 
         /// <summary>
-        /// Returns the PowerShell commond line execution path.
+        /// Returns the PowerShell command line execution path.
         /// </summary>
         public string PSExecutionPath
         {
@@ -312,7 +312,7 @@ namespace Microsoft.PowerShell.ScheduledJob
         }
 
         /// <summary>
-        /// Compares the current ScheduledJobDefintion task scheduler information
+        /// Compares the current ScheduledJobDefinition task scheduler information
         /// with the corresponding information stored in Task Scheduler.  If the
         /// information is different then the task scheduler information in this 
         /// object is updated to match what is in Task Scheduler, since that information
@@ -469,7 +469,7 @@ namespace Microsoft.PowerShell.ScheduledJob
         }
 
         /// <summary>
-        /// Updates existing file with this defintion information.
+        /// Updates existing file with this definition information.
         /// </summary>
         private void UpdateJobStore()
         {
@@ -788,7 +788,7 @@ namespace Microsoft.PowerShell.ScheduledJob
                 InvocationInfo.Definition.Name = newName;
                 _definitionOutputPath = ScheduledJobStore.GetJobRunOutputDirectory(Name);
 
-                // Update job defintion in new job store location.
+                // Update job definition in new job store location.
                 UpdateJobStore();
 
                 // Add new Task Scheduler task with new name.
@@ -1175,7 +1175,7 @@ namespace Microsoft.PowerShell.ScheduledJob
         }
 
         /// <summary>
-        /// Starts registered job defintion running from the Task Scheduler.
+        /// Starts registered job definition running from the Task Scheduler.
         /// </summary>
         public void RunAsTask()
         {
@@ -1920,7 +1920,7 @@ namespace Microsoft.PowerShell.ScheduledJob
             }
             else
             {
-                // Look for definigion in known path.
+                // Look for definition in known path.
                 fs = ScheduledJobStore.GetFileForJobDefinition(
                     definitionName,
                     definitionPath,
@@ -1984,7 +1984,7 @@ namespace Microsoft.PowerShell.ScheduledJob
                     // Wait for job to finish.
                     job.Finished.WaitOne();
 
-                    // Ensure that the job run results are presisted to store.
+                    // Ensure that the job run results are persisted to store.
                     jobManager.PersistJob(job, Definition);
 
                     // Perform a Receive-Job on the job object.  Output data will be dropped
@@ -2290,7 +2290,7 @@ namespace Microsoft.PowerShell.ScheduledJob
 
     #endregion
 
-    #region Utililites
+    #region Utilities
 
     /// <summary>
     /// Simple string formatting helper.

--- a/src/Microsoft.PowerShell.ScheduledJob/ScheduledJobStore.cs
+++ b/src/Microsoft.PowerShell.ScheduledJob/ScheduledJobStore.cs
@@ -15,8 +15,8 @@ namespace Microsoft.PowerShell.ScheduledJob
 {
     /// <summary>
     /// This class encapsulates the work of determining the file location where
-    /// a job definition will be stored and retreived and where job runs will
-    /// be stored and retreived.  Scheduled job definitions are stored in a 
+    /// a job definition will be stored and retrieved and where job runs will
+    /// be stored and retrieved.  Scheduled job definitions are stored in a 
     /// location based on the current user.  Job runs are stored in the 
     /// corresponding scheduled job definition location under an "Output" 
     /// directory, where each run will have a subdirectory with a name derived
@@ -187,7 +187,7 @@ namespace Microsoft.PowerShell.ScheduledJob
         /// <summary>
         /// Returns a FileStream object for a new scheduled job definition run.
         /// </summary>
-        /// <param name="definitionOutputPath">Scheudled job definition path.</param>
+        /// <param name="definitionOutputPath">Scheduled job definition path.</param>
         /// <param name="runStart">DateTime of job run start time.</param>
         /// <param name="runItem">Job run item.</param>
         /// <returns>FileStream object.</returns>
@@ -282,8 +282,8 @@ namespace Microsoft.PowerShell.ScheduledJob
         /// Renames the directory containing the old job definition name
         /// to the new name provided.
         /// </summary>
-        /// <param name="oldDefName">Existing job defintion directory</param>
-        /// <param name="newDefName">Renamed job defintion directory</param>
+        /// <param name="oldDefName">Existing job definition directory</param>
+        /// <param name="newDefName">Renamed job definition directory</param>
         public static void RenameScheduledJobDefDir(
             string oldDefName,
             string newDefName)
@@ -515,7 +515,7 @@ namespace Microsoft.PowerShell.ScheduledJob
         }
 
         /// <summary>
-        /// Returns a directory path for an existing ScheduledJob run result directroy.
+        /// Returns a directory path for an existing ScheduledJob run result directory.
         /// </summary>
         /// <param name="definitionName">Definition name</param>
         /// <param name="runStart">File name</param>

--- a/src/Microsoft.PowerShell.ScheduledJob/ScheduledJobTrigger.cs
+++ b/src/Microsoft.PowerShell.ScheduledJob/ScheduledJobTrigger.cs
@@ -705,7 +705,7 @@ namespace Microsoft.PowerShell.ScheduledJob
         /// </summary>
         /// <param name="sourceValue">The value to convert from</param>
         /// <param name="destinationType">The type to convert to</param>
-        /// <param name="formatProvider">The format provider to use like in IFormatable's ToString</param>
+        /// <param name="formatProvider">The format provider to use like in IFormattable's ToString</param>
         /// <param name="ignoreCase">true if case should be ignored</param>
         /// <returns>the <paramref name="sourceValue"/> parameter converted to the <paramref name="destinationType"/> parameter using formatProvider and ignoreCase</returns>
         /// <exception cref="InvalidCastException">if no conversion was possible</exception>
@@ -762,7 +762,7 @@ namespace Microsoft.PowerShell.ScheduledJob
         /// </summary>
         /// <param name="sourceValue">The value to convert from</param>
         /// <param name="destinationType">The type to convert to</param>
-        /// <param name="formatProvider">The format provider to use like in IFormatable's ToString</param>
+        /// <param name="formatProvider">The format provider to use like in IFormattable's ToString</param>
         /// <param name="ignoreCase">true if case should be ignored</param>
         /// <returns>sourceValue converted to the <paramref name="destinationType"/> parameter using formatProvider and ignoreCase</returns>
         /// <exception cref="InvalidCastException">if no conversion was possible</exception>

--- a/src/Microsoft.PowerShell.ScheduledJob/ScheduledJobWTS.cs
+++ b/src/Microsoft.PowerShell.ScheduledJob/ScheduledJobWTS.cs
@@ -99,7 +99,7 @@ namespace Microsoft.PowerShell.ScheduledJob
         }
 
         /// <summary>
-        /// Retrives options for the provided task Id.
+        /// Retrieves options for the provided task Id.
         /// </summary>
         /// <param name="taskId">Task Id</param>
         /// <exception cref="ScheduledJobException">Task not found.</exception>
@@ -459,7 +459,7 @@ namespace Microsoft.PowerShell.ScheduledJob
         }
 
         /// <summary>
-        /// Creates a ScheuduledJobTrigger object based on a provided WTS ITrigger.
+        /// Creates a ScheduledJobTrigger object based on a provided WTS ITrigger.
         /// </summary>
         /// <param name="iTrigger">ITrigger</param>
         /// <returns>ScheduledJobTrigger</returns>

--- a/src/Microsoft.PowerShell.ScheduledJob/commands/AddJobTrigger.cs
+++ b/src/Microsoft.PowerShell.ScheduledJob/commands/AddJobTrigger.cs
@@ -46,7 +46,7 @@ namespace Microsoft.PowerShell.ScheduledJob
         private ScheduledJobTrigger[] _triggers;
 
         /// <summary>
-        /// ScheduledJobDefition Id.
+        /// ScheduledJobDefinition Id.
         /// </summary>
         [Parameter(Position = 0, Mandatory = true, 
                    ParameterSetName = AddJobTriggerCommand.JobDefinitionIdParameterSet)]

--- a/src/Microsoft.PowerShell.ScheduledJob/commands/DisableJobDefinition.cs
+++ b/src/Microsoft.PowerShell.ScheduledJob/commands/DisableJobDefinition.cs
@@ -19,7 +19,7 @@ namespace Microsoft.PowerShell.ScheduledJob
         #region Properties
 
         /// <summary>
-        /// Returns true if scheduled job defintion should be enabled,
+        /// Returns true if scheduled job definition should be enabled,
         /// false otherwise.
         /// </summary>
         protected override bool Enabled

--- a/src/Microsoft.PowerShell.ScheduledJob/commands/DisableJobDefinitionBase.cs
+++ b/src/Microsoft.PowerShell.ScheduledJob/commands/DisableJobDefinitionBase.cs
@@ -136,7 +136,7 @@ namespace Microsoft.PowerShell.ScheduledJob
         #region Properties
 
         /// <summary>
-        /// Returns true if scheduled job defintion should be enabled,
+        /// Returns true if scheduled job definition should be enabled,
         /// false otherwise.
         /// </summary>
         protected abstract bool Enabled

--- a/src/Microsoft.PowerShell.ScheduledJob/commands/EnableJobDefinition.cs
+++ b/src/Microsoft.PowerShell.ScheduledJob/commands/EnableJobDefinition.cs
@@ -19,7 +19,7 @@ namespace Microsoft.PowerShell.ScheduledJob
         #region Properties
 
         /// <summary>
-        /// Returns true if scheduled job defintion should be enabled,
+        /// Returns true if scheduled job definition should be enabled,
         /// false otherwise.
         /// </summary>
         protected override bool Enabled

--- a/src/Microsoft.PowerShell.ScheduledJob/commands/GetJobDefinition.cs
+++ b/src/Microsoft.PowerShell.ScheduledJob/commands/GetJobDefinition.cs
@@ -23,7 +23,7 @@ namespace Microsoft.PowerShell.ScheduledJob
         private const string DefinitionNameParameterSet = "DefinitionName";
 
         /// <summary>
-        /// ScheduledJobDefintion Id.
+        /// ScheduledJobDefinition Id.
         /// </summary>
         [Parameter(Position = 0, 
                    ParameterSetName = GetScheduledJobCommand.DefinitionIdParameterSet)]

--- a/src/Microsoft.PowerShell.ScheduledJob/commands/GetJobTrigger.cs
+++ b/src/Microsoft.PowerShell.ScheduledJob/commands/GetJobTrigger.cs
@@ -15,7 +15,7 @@ using System.Diagnostics;
 namespace Microsoft.PowerShell.ScheduledJob
 {
     /// <summary>
-    /// This cmdlet gets ScheduledJobTriggers for the specified ScheduledJobDefintion object.
+    /// This cmdlet gets ScheduledJobTriggers for the specified ScheduledJobDefinition object.
     /// </summary>
     [Cmdlet(VerbsCommon.Get, "JobTrigger", DefaultParameterSetName = GetJobTriggerCommand.JobDefinitionParameterSet,
         HelpUri = "http://go.microsoft.com/fwlink/?LinkID=223915")]
@@ -59,7 +59,7 @@ namespace Microsoft.PowerShell.ScheduledJob
         private ScheduledJobDefinition _definition;
 
         /// <summary>
-        /// ScheduledJobDefintion Id.
+        /// ScheduledJobDefinition Id.
         /// </summary>
         [Parameter(Position = 0, Mandatory = true,
                    ParameterSetName = GetJobTriggerCommand.JobDefinitionIdParameterSet)]

--- a/src/Microsoft.PowerShell.ScheduledJob/commands/GetScheduledJobOption.cs
+++ b/src/Microsoft.PowerShell.ScheduledJob/commands/GetScheduledJobOption.cs
@@ -23,7 +23,7 @@ namespace Microsoft.PowerShell.ScheduledJob
         private const string JobDefinitionNameParameterSet = "JobDefinitionName";
 
         /// <summary>
-        /// ScheduledJobDefition Id.
+        /// ScheduledJobDefinition Id.
         /// </summary>
         [Parameter(Position = 0, Mandatory = true, 
                    ParameterSetName = GetScheduledJobOptionCommand.JobDefinitionIdParameterSet)]

--- a/src/Microsoft.PowerShell.ScheduledJob/commands/RemoveJobTrigger.cs
+++ b/src/Microsoft.PowerShell.ScheduledJob/commands/RemoveJobTrigger.cs
@@ -57,7 +57,7 @@ namespace Microsoft.PowerShell.ScheduledJob
         private Int32[] _definitionIds;
 
         /// <summary>
-        /// ScheduledJobDefintion Name.
+        /// ScheduledJobDefinition Name.
         /// </summary>
         [Parameter(Position = 0, Mandatory = true, 
                    ParameterSetName = RemoveJobTriggerCommand.JobDefinitionNameParameterSet)]

--- a/src/Microsoft.PowerShell.ScheduledJob/commands/SetJobDefinition.cs
+++ b/src/Microsoft.PowerShell.ScheduledJob/commands/SetJobDefinition.cs
@@ -364,7 +364,7 @@ namespace Microsoft.PowerShell.ScheduledJob
 
         /// <summary>
         /// Create new ScheduledJobInvocationInfo object with update information and 
-        /// update the job defintion object.
+        /// update the job definition object.
         /// </summary>
         private void UpdateJobInvocationInfo()
         {

--- a/src/Microsoft.PowerShell.ScheduledJob/commands/SetScheduledJobOption.cs
+++ b/src/Microsoft.PowerShell.ScheduledJob/commands/SetScheduledJobOption.cs
@@ -53,7 +53,7 @@ namespace Microsoft.PowerShell.ScheduledJob
         {
             // Update ScheduledJobOptions object with current parameters.
             // Update switch parameters only if they were selected.
-            // Also update the ScheduledJobDefintion object associated with this options object.
+            // Also update the ScheduledJobDefinition object associated with this options object.
             if (MyInvocation.BoundParameters.ContainsKey("StartIfOnBattery"))
             {
                 _jobOptions.StartIfOnBatteries = StartIfOnBattery;

--- a/src/Microsoft.PowerShell.ScheduledJob/commands/UnregisterJobDefinition.cs
+++ b/src/Microsoft.PowerShell.ScheduledJob/commands/UnregisterJobDefinition.cs
@@ -24,7 +24,7 @@ namespace Microsoft.PowerShell.ScheduledJob
         private const string DefinitionParameterSet = "Definition";
 
         /// <summary>
-        /// ScheduledJobDefintion Id.
+        /// ScheduledJobDefinition Id.
         /// </summary>
         [Parameter(Position = 0, Mandatory = true, 
                    ParameterSetName = UnregisterScheduledJobCommand.DefinitionIdParameterSet)]
@@ -111,7 +111,7 @@ namespace Microsoft.PowerShell.ScheduledJob
                     string targetString = StringUtil.Format(ScheduledJobErrorStrings.DefinitionWhatIf, definition.Name);
                     if (ShouldProcess(targetString, VerbsLifecycle.Unregister))
                     {
-                        // Removes the ScheduledJobDefintion from the job store,
+                        // Removes the ScheduledJobDefinition from the job store,
                         // Task Scheduler, and disposes the object.
                         try
                         {
@@ -133,7 +133,7 @@ namespace Microsoft.PowerShell.ScheduledJob
                 (_definitions == null || _definitions.Length < _names.Length))
             {
                 // Make sure there is no PowerShell task in Task Scheduler with removed names.
-                // This covers the case where the scheduled job defintion was manually removed from
+                // This covers the case where the scheduled job definition was manually removed from
                 // the job store but remains as a PowerShell task in Task Scheduler.
                 using (ScheduledJobWTS taskScheduler = new ScheduledJobWTS())
                 {

--- a/src/Microsoft.PowerShell.Security.Activities/Generated/ConvertFromSecureStringActivity.cs
+++ b/src/Microsoft.PowerShell.Security.Activities/Generated/ConvertFromSecureStringActivity.cs
@@ -64,7 +64,7 @@ namespace Microsoft.PowerShell.Security.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Security.Activities/Generated/ConvertToSecureStringActivity.cs
+++ b/src/Microsoft.PowerShell.Security.Activities/Generated/ConvertToSecureStringActivity.cs
@@ -78,7 +78,7 @@ namespace Microsoft.PowerShell.Security.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Security.Activities/Generated/GetAclActivity.cs
+++ b/src/Microsoft.PowerShell.Security.Activities/Generated/GetAclActivity.cs
@@ -99,7 +99,7 @@ namespace Microsoft.PowerShell.Security.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Security.Activities/Generated/GetAuthenticodeSignatureActivity.cs
+++ b/src/Microsoft.PowerShell.Security.Activities/Generated/GetAuthenticodeSignatureActivity.cs
@@ -57,7 +57,7 @@ namespace Microsoft.PowerShell.Security.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Security.Activities/Generated/GetCmsMessageActivity.cs
+++ b/src/Microsoft.PowerShell.Security.Activities/Generated/GetCmsMessageActivity.cs
@@ -64,7 +64,7 @@ namespace Microsoft.PowerShell.Security.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Security.Activities/Generated/GetExecutionPolicyActivity.cs
+++ b/src/Microsoft.PowerShell.Security.Activities/Generated/GetExecutionPolicyActivity.cs
@@ -57,7 +57,7 @@ namespace Microsoft.PowerShell.Security.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Security.Activities/Generated/GetPfxCertificateActivity.cs
+++ b/src/Microsoft.PowerShell.Security.Activities/Generated/GetPfxCertificateActivity.cs
@@ -57,7 +57,7 @@ namespace Microsoft.PowerShell.Security.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Security.Activities/Generated/ProtectCmsMessageActivity.cs
+++ b/src/Microsoft.PowerShell.Security.Activities/Generated/ProtectCmsMessageActivity.cs
@@ -78,7 +78,7 @@ namespace Microsoft.PowerShell.Security.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Security.Activities/Generated/SetAclActivity.cs
+++ b/src/Microsoft.PowerShell.Security.Activities/Generated/SetAclActivity.cs
@@ -120,7 +120,7 @@ namespace Microsoft.PowerShell.Security.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Security.Activities/Generated/SetAuthenticodeSignatureActivity.cs
+++ b/src/Microsoft.PowerShell.Security.Activities/Generated/SetAuthenticodeSignatureActivity.cs
@@ -92,7 +92,7 @@ namespace Microsoft.PowerShell.Security.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Security.Activities/Generated/SetExecutionPolicyActivity.cs
+++ b/src/Microsoft.PowerShell.Security.Activities/Generated/SetExecutionPolicyActivity.cs
@@ -64,7 +64,7 @@ namespace Microsoft.PowerShell.Security.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Security.Activities/Generated/UnprotectCmsMessageActivity.cs
+++ b/src/Microsoft.PowerShell.Security.Activities/Generated/UnprotectCmsMessageActivity.cs
@@ -85,7 +85,7 @@ namespace Microsoft.PowerShell.Security.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Security/security/AclCommands.cs
+++ b/src/Microsoft.PowerShell.Security/security/AclCommands.cs
@@ -622,7 +622,7 @@ namespace Microsoft.PowerShell.Commands
     public sealed class GetAclCommand : SecurityDescriptorCommandsBase
     {
         /// <summary>
-        /// Initialzes a new instance of the GetAclCommand
+        /// Initializes a new instance of the GetAclCommand
         /// class.  Sets the default path to the current location.
         /// </summary>
         public GetAclCommand()

--- a/src/Microsoft.PowerShell.Security/security/CatalogCommands.cs
+++ b/src/Microsoft.PowerShell.Security/security/CatalogCommands.cs
@@ -202,7 +202,7 @@ namespace Microsoft.PowerShell.Commands
 
     /// <summary>
     /// Defines the implementation of the 'Test-FileCatalog' cmdlet.
-    /// This cmdlet validaes the Intgerity of catalog  
+    /// This cmdlet validates the Integrity of catalog  
     /// </summary>
     [Cmdlet(VerbsDiagnostic.Test, "FileCatalog", SupportsShouldProcess = true, DefaultParameterSetName = "ByPath",
         HelpUri = "http://go.microsoft.com/fwlink/?LinkId=786750")]

--- a/src/Microsoft.PowerShell.Security/security/CertificateProvider.cs
+++ b/src/Microsoft.PowerShell.Security/security/CertificateProvider.cs
@@ -553,7 +553,7 @@ namespace Microsoft.PowerShell.Commands
                 {
                     //
                     // the pre-Win8 CAPI2 code does not provide an easy way
-                    // to directly acccess a specific certificate.
+                    // to directly access a specific certificate.
                     // We have to iterate through all certs to find
                     // what we want.
                     //
@@ -975,7 +975,7 @@ namespace Microsoft.PowerShell.Commands
                 if (destElements.Length == 3 &&
                    (String.Equals(pathElements[2], destElements[2], StringComparison.OrdinalIgnoreCase)))
                 {
-                    //in this case we think of destination path as vaild 
+                    //in this case we think of destination path as valid 
                     //and strip the thumbprint part
                     destination = Path.GetDirectoryName(destination);
                 }
@@ -2074,7 +2074,7 @@ namespace Microsoft.PowerShell.Commands
                     }
                 }
 
-                //do remove certifiate
+                //do remove certificate
                 //should not use the original handle
 
                 if (!Security.NativeMethods.CertDeleteCertificateFromStore(
@@ -2686,7 +2686,7 @@ namespace Microsoft.PowerShell.Commands
         }
 
         /// <summary>
-        /// Get cert objects or their name at the specifed path
+        /// Get cert objects or their name at the specified path
         /// </summary>
         ///
         /// <param name="path"> path to cert </param>

--- a/src/Microsoft.PowerShell.Security/security/SecureStringCommands.cs
+++ b/src/Microsoft.PowerShell.Security/security/SecureStringCommands.cs
@@ -37,7 +37,7 @@ namespace Microsoft.PowerShell.Commands
         private string _commandName;
 
         /// <summary>
-        /// Intitializes a new instance of the SecureStringCommandBase
+        /// Initializes a new instance of the SecureStringCommandBase
         /// class.
         /// </summary>
         ///

--- a/src/Microsoft.PowerShell.Security/security/Utils.cs
+++ b/src/Microsoft.PowerShell.Security/security/Utils.cs
@@ -303,7 +303,7 @@ namespace Microsoft.PowerShell
 
 
         /// <summary>
-        /// convert the specifed provider path to a provider path
+        /// convert the specified provider path to a provider path
         /// and make sure that all of the following is true:
         /// -- it represents a FileSystem path
         /// -- it points to a file

--- a/src/Microsoft.PowerShell.Utility.Activities/Generated/AddMemberActivity.cs
+++ b/src/Microsoft.PowerShell.Utility.Activities/Generated/AddMemberActivity.cs
@@ -119,7 +119,7 @@ namespace Microsoft.PowerShell.Utility.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Utility.Activities/Generated/AddTypeActivity.cs
+++ b/src/Microsoft.PowerShell.Utility.Activities/Generated/AddTypeActivity.cs
@@ -154,7 +154,7 @@ namespace Microsoft.PowerShell.Utility.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Utility.Activities/Generated/CompareObjectActivity.cs
+++ b/src/Microsoft.PowerShell.Utility.Activities/Generated/CompareObjectActivity.cs
@@ -105,7 +105,7 @@ namespace Microsoft.PowerShell.Utility.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Utility.Activities/Generated/ConvertFromCsvActivity.cs
+++ b/src/Microsoft.PowerShell.Utility.Activities/Generated/ConvertFromCsvActivity.cs
@@ -70,7 +70,7 @@ namespace Microsoft.PowerShell.Utility.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Utility.Activities/Generated/ConvertFromJsonActivity.cs
+++ b/src/Microsoft.PowerShell.Utility.Activities/Generated/ConvertFromJsonActivity.cs
@@ -49,7 +49,7 @@ namespace Microsoft.PowerShell.Utility.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Utility.Activities/Generated/ConvertFromStringActivity.cs
+++ b/src/Microsoft.PowerShell.Utility.Activities/Generated/ConvertFromStringActivity.cs
@@ -91,7 +91,7 @@ namespace Microsoft.PowerShell.Utility.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Utility.Activities/Generated/ConvertFromStringDataActivity.cs
+++ b/src/Microsoft.PowerShell.Utility.Activities/Generated/ConvertFromStringDataActivity.cs
@@ -49,7 +49,7 @@ namespace Microsoft.PowerShell.Utility.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Utility.Activities/Generated/ConvertToCsvActivity.cs
+++ b/src/Microsoft.PowerShell.Utility.Activities/Generated/ConvertToCsvActivity.cs
@@ -70,7 +70,7 @@ namespace Microsoft.PowerShell.Utility.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Utility.Activities/Generated/ConvertToHtmlActivity.cs
+++ b/src/Microsoft.PowerShell.Utility.Activities/Generated/ConvertToHtmlActivity.cs
@@ -112,7 +112,7 @@ namespace Microsoft.PowerShell.Utility.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Utility.Activities/Generated/ConvertToJsonActivity.cs
+++ b/src/Microsoft.PowerShell.Utility.Activities/Generated/ConvertToJsonActivity.cs
@@ -63,7 +63,7 @@ namespace Microsoft.PowerShell.Utility.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Utility.Activities/Generated/ConvertToXmlActivity.cs
+++ b/src/Microsoft.PowerShell.Utility.Activities/Generated/ConvertToXmlActivity.cs
@@ -70,7 +70,7 @@ namespace Microsoft.PowerShell.Utility.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Utility.Activities/Generated/ExportClixmlActivity.cs
+++ b/src/Microsoft.PowerShell.Utility.Activities/Generated/ExportClixmlActivity.cs
@@ -91,7 +91,7 @@ namespace Microsoft.PowerShell.Utility.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Utility.Activities/Generated/ExportCsvActivity.cs
+++ b/src/Microsoft.PowerShell.Utility.Activities/Generated/ExportCsvActivity.cs
@@ -112,7 +112,7 @@ namespace Microsoft.PowerShell.Utility.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Utility.Activities/Generated/ExportFormatDataActivity.cs
+++ b/src/Microsoft.PowerShell.Utility.Activities/Generated/ExportFormatDataActivity.cs
@@ -84,7 +84,7 @@ namespace Microsoft.PowerShell.Utility.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Utility.Activities/Generated/GetCultureActivity.cs
+++ b/src/Microsoft.PowerShell.Utility.Activities/Generated/GetCultureActivity.cs
@@ -42,7 +42,7 @@ namespace Microsoft.PowerShell.Utility.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Utility.Activities/Generated/GetDateActivity.cs
+++ b/src/Microsoft.PowerShell.Utility.Activities/Generated/GetDateActivity.cs
@@ -119,7 +119,7 @@ namespace Microsoft.PowerShell.Utility.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Utility.Activities/Generated/GetEventActivity.cs
+++ b/src/Microsoft.PowerShell.Utility.Activities/Generated/GetEventActivity.cs
@@ -56,7 +56,7 @@ namespace Microsoft.PowerShell.Utility.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Utility.Activities/Generated/GetEventSubscriberActivity.cs
+++ b/src/Microsoft.PowerShell.Utility.Activities/Generated/GetEventSubscriberActivity.cs
@@ -63,7 +63,7 @@ namespace Microsoft.PowerShell.Utility.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Utility.Activities/Generated/GetHostActivity.cs
+++ b/src/Microsoft.PowerShell.Utility.Activities/Generated/GetHostActivity.cs
@@ -42,7 +42,7 @@ namespace Microsoft.PowerShell.Utility.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Utility.Activities/Generated/GetMemberActivity.cs
+++ b/src/Microsoft.PowerShell.Utility.Activities/Generated/GetMemberActivity.cs
@@ -84,7 +84,7 @@ namespace Microsoft.PowerShell.Utility.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Utility.Activities/Generated/GetRandomActivity.cs
+++ b/src/Microsoft.PowerShell.Utility.Activities/Generated/GetRandomActivity.cs
@@ -77,7 +77,7 @@ namespace Microsoft.PowerShell.Utility.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Utility.Activities/Generated/GetTraceSourceActivity.cs
+++ b/src/Microsoft.PowerShell.Utility.Activities/Generated/GetTraceSourceActivity.cs
@@ -49,7 +49,7 @@ namespace Microsoft.PowerShell.Utility.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Utility.Activities/Generated/GetTypeDataActivity.cs
+++ b/src/Microsoft.PowerShell.Utility.Activities/Generated/GetTypeDataActivity.cs
@@ -49,7 +49,7 @@ namespace Microsoft.PowerShell.Utility.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Utility.Activities/Generated/GetUICultureActivity.cs
+++ b/src/Microsoft.PowerShell.Utility.Activities/Generated/GetUICultureActivity.cs
@@ -42,7 +42,7 @@ namespace Microsoft.PowerShell.Utility.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Utility.Activities/Generated/GetUniqueActivity.cs
+++ b/src/Microsoft.PowerShell.Utility.Activities/Generated/GetUniqueActivity.cs
@@ -63,7 +63,7 @@ namespace Microsoft.PowerShell.Utility.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Utility.Activities/Generated/GroupObjectActivity.cs
+++ b/src/Microsoft.PowerShell.Utility.Activities/Generated/GroupObjectActivity.cs
@@ -91,7 +91,7 @@ namespace Microsoft.PowerShell.Utility.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Utility.Activities/Generated/ImportClixmlActivity.cs
+++ b/src/Microsoft.PowerShell.Utility.Activities/Generated/ImportClixmlActivity.cs
@@ -77,7 +77,7 @@ namespace Microsoft.PowerShell.Utility.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Utility.Activities/Generated/ImportCsvActivity.cs
+++ b/src/Microsoft.PowerShell.Utility.Activities/Generated/ImportCsvActivity.cs
@@ -84,7 +84,7 @@ namespace Microsoft.PowerShell.Utility.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Utility.Activities/Generated/InvokeExpressionActivity.cs
+++ b/src/Microsoft.PowerShell.Utility.Activities/Generated/InvokeExpressionActivity.cs
@@ -49,7 +49,7 @@ namespace Microsoft.PowerShell.Utility.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Utility.Activities/Generated/InvokeRestMethodActivity.cs
+++ b/src/Microsoft.PowerShell.Utility.Activities/Generated/InvokeRestMethodActivity.cs
@@ -203,7 +203,7 @@ namespace Microsoft.PowerShell.Utility.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Utility.Activities/Generated/InvokeWebRequestActivity.cs
+++ b/src/Microsoft.PowerShell.Utility.Activities/Generated/InvokeWebRequestActivity.cs
@@ -203,7 +203,7 @@ namespace Microsoft.PowerShell.Utility.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Utility.Activities/Generated/MeasureCommandActivity.cs
+++ b/src/Microsoft.PowerShell.Utility.Activities/Generated/MeasureCommandActivity.cs
@@ -56,7 +56,7 @@ namespace Microsoft.PowerShell.Utility.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Utility.Activities/Generated/MeasureObjectActivity.cs
+++ b/src/Microsoft.PowerShell.Utility.Activities/Generated/MeasureObjectActivity.cs
@@ -112,7 +112,7 @@ namespace Microsoft.PowerShell.Utility.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Utility.Activities/Generated/NewEventActivity.cs
+++ b/src/Microsoft.PowerShell.Utility.Activities/Generated/NewEventActivity.cs
@@ -70,7 +70,7 @@ namespace Microsoft.PowerShell.Utility.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Utility.Activities/Generated/NewTimeSpanActivity.cs
+++ b/src/Microsoft.PowerShell.Utility.Activities/Generated/NewTimeSpanActivity.cs
@@ -84,7 +84,7 @@ namespace Microsoft.PowerShell.Utility.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Utility.Activities/Generated/OutFileActivity.cs
+++ b/src/Microsoft.PowerShell.Utility.Activities/Generated/OutFileActivity.cs
@@ -105,7 +105,7 @@ namespace Microsoft.PowerShell.Utility.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Utility.Activities/Generated/OutPrinterActivity.cs
+++ b/src/Microsoft.PowerShell.Utility.Activities/Generated/OutPrinterActivity.cs
@@ -56,7 +56,7 @@ namespace Microsoft.PowerShell.Utility.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Utility.Activities/Generated/OutStringActivity.cs
+++ b/src/Microsoft.PowerShell.Utility.Activities/Generated/OutStringActivity.cs
@@ -63,7 +63,7 @@ namespace Microsoft.PowerShell.Utility.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Utility.Activities/Generated/RegisterEngineEventActivity.cs
+++ b/src/Microsoft.PowerShell.Utility.Activities/Generated/RegisterEngineEventActivity.cs
@@ -84,7 +84,7 @@ namespace Microsoft.PowerShell.Utility.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Utility.Activities/Generated/RegisterObjectEventActivity.cs
+++ b/src/Microsoft.PowerShell.Utility.Activities/Generated/RegisterObjectEventActivity.cs
@@ -98,7 +98,7 @@ namespace Microsoft.PowerShell.Utility.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Utility.Activities/Generated/RemoveEventActivity.cs
+++ b/src/Microsoft.PowerShell.Utility.Activities/Generated/RemoveEventActivity.cs
@@ -56,7 +56,7 @@ namespace Microsoft.PowerShell.Utility.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Utility.Activities/Generated/SelectObjectActivity.cs
+++ b/src/Microsoft.PowerShell.Utility.Activities/Generated/SelectObjectActivity.cs
@@ -119,7 +119,7 @@ namespace Microsoft.PowerShell.Utility.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Utility.Activities/Generated/SelectStringActivity.cs
+++ b/src/Microsoft.PowerShell.Utility.Activities/Generated/SelectStringActivity.cs
@@ -140,7 +140,7 @@ namespace Microsoft.PowerShell.Utility.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Utility.Activities/Generated/SelectXmlActivity.cs
+++ b/src/Microsoft.PowerShell.Utility.Activities/Generated/SelectXmlActivity.cs
@@ -84,7 +84,7 @@ namespace Microsoft.PowerShell.Utility.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Utility.Activities/Generated/SendMailMessageActivity.cs
+++ b/src/Microsoft.PowerShell.Utility.Activities/Generated/SendMailMessageActivity.cs
@@ -147,7 +147,7 @@ namespace Microsoft.PowerShell.Utility.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Utility.Activities/Generated/SetDateActivity.cs
+++ b/src/Microsoft.PowerShell.Utility.Activities/Generated/SetDateActivity.cs
@@ -63,7 +63,7 @@ namespace Microsoft.PowerShell.Utility.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Utility.Activities/Generated/SetTraceSourceActivity.cs
+++ b/src/Microsoft.PowerShell.Utility.Activities/Generated/SetTraceSourceActivity.cs
@@ -112,7 +112,7 @@ namespace Microsoft.PowerShell.Utility.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Utility.Activities/Generated/SortObjectActivity.cs
+++ b/src/Microsoft.PowerShell.Utility.Activities/Generated/SortObjectActivity.cs
@@ -84,7 +84,7 @@ namespace Microsoft.PowerShell.Utility.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Utility.Activities/Generated/StartSleepActivity.cs
+++ b/src/Microsoft.PowerShell.Utility.Activities/Generated/StartSleepActivity.cs
@@ -56,7 +56,7 @@ namespace Microsoft.PowerShell.Utility.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Utility.Activities/Generated/TeeObjectActivity.cs
+++ b/src/Microsoft.PowerShell.Utility.Activities/Generated/TeeObjectActivity.cs
@@ -77,7 +77,7 @@ namespace Microsoft.PowerShell.Utility.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Utility.Activities/Generated/UnblockFileActivity.cs
+++ b/src/Microsoft.PowerShell.Utility.Activities/Generated/UnblockFileActivity.cs
@@ -56,7 +56,7 @@ namespace Microsoft.PowerShell.Utility.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Utility.Activities/Generated/UnregisterEventActivity.cs
+++ b/src/Microsoft.PowerShell.Utility.Activities/Generated/UnregisterEventActivity.cs
@@ -63,7 +63,7 @@ namespace Microsoft.PowerShell.Utility.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Utility.Activities/Generated/UpdateListActivity.cs
+++ b/src/Microsoft.PowerShell.Utility.Activities/Generated/UpdateListActivity.cs
@@ -77,7 +77,7 @@ namespace Microsoft.PowerShell.Utility.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Utility.Activities/Generated/WaitEventActivity.cs
+++ b/src/Microsoft.PowerShell.Utility.Activities/Generated/WaitEventActivity.cs
@@ -56,7 +56,7 @@ namespace Microsoft.PowerShell.Utility.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Utility.Activities/Generated/WriteDebugActivity.cs
+++ b/src/Microsoft.PowerShell.Utility.Activities/Generated/WriteDebugActivity.cs
@@ -49,7 +49,7 @@ namespace Microsoft.PowerShell.Utility.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Utility.Activities/Generated/WriteErrorActivity.cs
+++ b/src/Microsoft.PowerShell.Utility.Activities/Generated/WriteErrorActivity.cs
@@ -119,7 +119,7 @@ namespace Microsoft.PowerShell.Utility.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Utility.Activities/Generated/WriteInformationActivity.cs
+++ b/src/Microsoft.PowerShell.Utility.Activities/Generated/WriteInformationActivity.cs
@@ -56,7 +56,7 @@ namespace Microsoft.PowerShell.Utility.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Utility.Activities/Generated/WriteOutputActivity.cs
+++ b/src/Microsoft.PowerShell.Utility.Activities/Generated/WriteOutputActivity.cs
@@ -56,7 +56,7 @@ namespace Microsoft.PowerShell.Utility.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Utility.Activities/Generated/WriteProgressActivity.cs
+++ b/src/Microsoft.PowerShell.Utility.Activities/Generated/WriteProgressActivity.cs
@@ -105,7 +105,7 @@ namespace Microsoft.PowerShell.Utility.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Utility.Activities/Generated/WriteVerboseActivity.cs
+++ b/src/Microsoft.PowerShell.Utility.Activities/Generated/WriteVerboseActivity.cs
@@ -49,7 +49,7 @@ namespace Microsoft.PowerShell.Utility.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Utility.Activities/Generated/WriteWarningActivity.cs
+++ b/src/Microsoft.PowerShell.Utility.Activities/Generated/WriteWarningActivity.cs
@@ -49,7 +49,7 @@ namespace Microsoft.PowerShell.Utility.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Utility.Activities/ImportLocalizedDataActivity.cs
+++ b/src/Microsoft.PowerShell.Utility.Activities/ImportLocalizedDataActivity.cs
@@ -65,7 +65,7 @@ namespace Microsoft.PowerShell.Utility.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.PowerShell.Workflow.ServiceCore/ServiceCore/WorkflowCore/ActivityHostManager.cs
+++ b/src/Microsoft.PowerShell.Workflow.ServiceCore/ServiceCore/WorkflowCore/ActivityHostManager.cs
@@ -94,7 +94,7 @@ namespace Microsoft.PowerShell.Workflow
         #region Overrides
 
         /// <summary>
-        /// Whether the operation reprensented by this method is 
+        /// Whether the operation represented by this method is 
         /// completed
         /// </summary>
         public bool IsCompleted

--- a/src/Microsoft.PowerShell.Workflow.ServiceCore/ServiceCore/WorkflowCore/ActivityHostProcess.cs
+++ b/src/Microsoft.PowerShell.Workflow.ServiceCore/ServiceCore/WorkflowCore/ActivityHostProcess.cs
@@ -168,7 +168,7 @@ namespace Microsoft.PowerShell.Workflow
             catch (Exception e)
             {
                 // RemoteRunspace.Close can throw exceptions when Server process has exited or runspace is invalid.
-                // Ignoring all exceptions as this runpspace was used for previous OOP activity execution.
+                // Ignoring all exceptions as this runspace was used for previous OOP activity execution.
                 //
                 _tracer.TraceException(e);
 
@@ -253,7 +253,7 @@ namespace Microsoft.PowerShell.Workflow
             using (System.Management.Automation.PowerShell ps = System.Management.Automation.PowerShell.Create())
             {
                 ps.Runspace = runspace;
-                // Setting erroaction to stop for import-module since they are required modules. If not present, stop the execution
+                // Setting erroraction to stop for import-module since they are required modules. If not present, stop the execution
                 ps.AddCommand("Import-Module").AddArgument(modules).AddParameter("ErrorAction",ActionPreference.Stop).AddParameter("Force");
                 ps.Invoke();
             }
@@ -339,7 +339,7 @@ namespace Microsoft.PowerShell.Workflow
                 if (_busy) return;
 
                 // Mark this process for removal and set it as busy so that this process will not be assigned to any new activity.
-                // Marking for removal will ensure that servicing thread will remove this object from host processs collection.
+                // Marking for removal will ensure that servicing thread will remove this object from host process collection.
                 //
                 _busy = true;
                 _markForRemoval = true;
@@ -448,7 +448,7 @@ namespace Microsoft.PowerShell.Workflow
                 }
 
                 // Prepare phase is completed without any issues. 
-                // setupSucceeded flag is used in HandleTranportError method to enqueue the current activity for retry. 
+                // setupSucceeded flag is used in HandleTransportError method to enqueue the current activity for retry. 
                 // If there is any PSRemotingTransportException during InvokePowershell current activity will not be enqueued to setup failed requests in ActivityHostManager.
                 //
                 setupSucceeded = true;
@@ -522,7 +522,7 @@ namespace Microsoft.PowerShell.Workflow
         #region IDisposable
 
         /// <summary>
-        /// Dipose 
+        /// Dispose 
         /// </summary>
         public void Dispose()
         {

--- a/src/Microsoft.PowerShell.Workflow.ServiceCore/ServiceCore/WorkflowCore/ConnectionManager.cs
+++ b/src/Microsoft.PowerShell.Workflow.ServiceCore/ServiceCore/WorkflowCore/ConnectionManager.cs
@@ -198,7 +198,7 @@ namespace Microsoft.PowerShell.Workflow
                 System.Management.Automation.PowerShell currentPowerShellInstance = implementationContext.PowerShellInstance;
                 PSActivityContext psActivityContext = args.PSActivityContext;
 
-                // Non-empty guid represtents that args.ImplementationContext.EnableRemotingActivityAutoResume is true
+                // Non-empty guid represents that args.ImplementationContext.EnableRemotingActivityAutoResume is true
                 if (!runspaceId.Equals(Guid.Empty))
                 {
                     Runspace[] runspaces = null;
@@ -946,7 +946,7 @@ namespace Microsoft.PowerShell.Workflow
 
             AssertNotDisposed();
 
-            // this will throw an exeption when a runspace is not successfully
+            // this will throw an exception when a runspace is not successfully
             // available
             result.EndInvoke();
 
@@ -1961,7 +1961,7 @@ namespace Microsoft.PowerShell.Workflow
         }
 
         /// <summary>
-        /// Dipose the connection manager
+        /// Dispose the connection manager
         /// </summary>
         /// <param name="isDisposing"></param>
         protected void Dispose(bool isDisposing)

--- a/src/Microsoft.PowerShell.Workflow.ServiceCore/ServiceCore/WorkflowCore/DefaultWorkflowSessionConfiguration.cs
+++ b/src/Microsoft.PowerShell.Workflow.ServiceCore/ServiceCore/WorkflowCore/DefaultWorkflowSessionConfiguration.cs
@@ -94,7 +94,7 @@ namespace Microsoft.PowerShell.Workflow
                     }
 
                     // Start the workflow job manager, if not started, to add an event handler for zero active sessions changed events
-                    // This is required to auto shudown the workflow type shared process when no workflow jobs have scheduled/inprogress and when no active sessions
+                    // This is required to auto shutdown the workflow type shared process when no workflow jobs have scheduled/inprogress and when no active sessions
                     WorkflowJobSourceAdapter.GetInstance().GetJobManager();
                 }
                 catch(Exception)

--- a/src/Microsoft.PowerShell.Workflow.ServiceCore/ServiceCore/WorkflowCore/FileInstanceStore/InstanceStoreCryptography.cs
+++ b/src/Microsoft.PowerShell.Workflow.ServiceCore/ServiceCore/WorkflowCore/FileInstanceStore/InstanceStoreCryptography.cs
@@ -20,7 +20,7 @@ namespace Microsoft.PowerShell.Workflow
         private static readonly PowerShellTraceSource Tracer = PowerShellTraceSourceFactory.GetTraceSource();
 
         /// <summary>
-        /// The additional entroy for security 'POWERSHELLWORKFLOW'
+        /// The additional entry for security 'POWERSHELLWORKFLOW'
         /// </summary>
         private static byte[] s_aditionalEntropy = { (byte)'P', (byte)'O', (byte)'W', (byte)'E', (byte)'R', (byte)'S', (byte)'H', (byte)'E', (byte)'L', (byte)'L', (byte)'W', (byte)'O', (byte)'R', (byte)'K', (byte)'F', (byte)'L', (byte)'O', (byte)'W' };
         

--- a/src/Microsoft.PowerShell.Workflow.ServiceCore/ServiceCore/WorkflowCore/FileInstanceStore/WorkflowAdditionalStores.cs
+++ b/src/Microsoft.PowerShell.Workflow.ServiceCore/ServiceCore/WorkflowCore/FileInstanceStore/WorkflowAdditionalStores.cs
@@ -1381,7 +1381,7 @@ namespace Microsoft.PowerShell.Workflow
             else
             {
                 // there is no point in hanging around partial data in the store so deleting the store.
-                // and no further persitence allowed after this point
+                // and no further persistence allowed after this point
                 this.InternalDelete();
                 serializationErrorHasOccured = true;
 
@@ -2012,7 +2012,7 @@ namespace Microsoft.PowerShell.Workflow
                     }
                 }
             }
-                // It is safe of absorb an exception here because there might be a possiblity that the mulitiple 
+                // It is safe of absorb an exception here because there might be a possibility that the multiple 
                 // processes are try work on the same endpoint or default end point store folder.
                 // There is a possibility that one process has deleted the a workflow store and the other one is trying to access it for calculating its store size.
                 // And we will set the flag to make sure we calculate the size next time.

--- a/src/Microsoft.PowerShell.Workflow.ServiceCore/ServiceCore/WorkflowCore/GlobalConfiguration.cs
+++ b/src/Microsoft.PowerShell.Workflow.ServiceCore/ServiceCore/WorkflowCore/GlobalConfiguration.cs
@@ -897,7 +897,7 @@ namespace Microsoft.PowerShell.Workflow
         }
 
         /// <summary>
-        /// Get Activity Run Mode InPocess or Out of process
+        /// Get Activity Run Mode InProcess or Out of process
         /// </summary>
         /// <param name="activity"></param>
         /// <returns></returns>

--- a/src/Microsoft.PowerShell.Workflow.ServiceCore/ServiceCore/WorkflowCore/ImportWorkflowCommand.cs
+++ b/src/Microsoft.PowerShell.Workflow.ServiceCore/ServiceCore/WorkflowCore/ImportWorkflowCommand.cs
@@ -442,7 +442,7 @@ namespace Microsoft.PowerShell.Commands
 
         /// <summary>
         /// Executes an instance of the workflow object graph identified by the passed
-        /// GUID, binding parameters from the Parameters hastable.
+        /// GUID, binding parameters from the Parameters hashtable.
         /// </summary>
         /// <param name="command">The powershell command.</param>
         /// <param name="workflowGuid">The GUID used to identify the workflow to run.</param>
@@ -459,7 +459,7 @@ namespace Microsoft.PowerShell.Commands
 
         /// <summary>
         /// Executes an instance of the workflow object graph identified by the passed
-        /// GUID, binding parameters from the Parameters hastable.
+        /// GUID, binding parameters from the Parameters hashtable.
         /// </summary>
         /// <param name="command">The powershell command.</param>
         /// <param name="workflowGuid">The GUID used to identify the workflow to run.</param>
@@ -477,7 +477,7 @@ namespace Microsoft.PowerShell.Commands
 
         /// <summary>
         /// Executes an instance of the workflow object graph identified by the passed
-        /// GUID, binding parameters from the Parameters hastable.
+        /// GUID, binding parameters from the Parameters hashtable.
         /// </summary>
         /// <param name="command">The powershell command.</param>
         /// <param name="workflowGuid">The GUID used to identify the workflow to run.</param>
@@ -585,7 +585,7 @@ namespace Microsoft.PowerShell.Commands
             }
             else if (parameters.Length == 1 && !parameterCollectionProcessed)
             {
-                // If the paramter collection is just the $PSBoundParameters
+                // If the parameter collection is just the $PSBoundParameters
                 // i.e. did not come through the PSParameterCollection list
                 // then just we can use it as is since it's already been processed through the parameter
                 // binder...
@@ -1164,7 +1164,7 @@ namespace Microsoft.PowerShell.Commands
                         continue;
                     }
 
-                    // If the parameter name is one of the expected collisons, don't add it to the list. 
+                    // If the parameter name is one of the expected collisions, don't add it to the list. 
                     if (p.Name.Equals(Constants.ComputerName, StringComparison.OrdinalIgnoreCase) || p.Name.Equals(Constants.PrivateMetadata, StringComparison.OrdinalIgnoreCase))
                     {
                         continue;
@@ -1195,7 +1195,7 @@ namespace Microsoft.PowerShell.Commands
                             var attributeAst = attribute as AttributeAst;
                             if (attributeAst == null || !string.Equals(attribute.TypeName.Name, "Parameter", StringComparison.OrdinalIgnoreCase))
                             {
-                                // If we have a Credential Attribute, it has been added to the inner function, it does not need to be added to the outer definiton.
+                                // If we have a Credential Attribute, it has been added to the inner function, it does not need to be added to the outer definition.
                                 // This will prevent prompting for the cred twice.
                                 if (!string.Equals(attribute.TypeName.FullName, "System.Management.Automation.CredentialAttribute", StringComparison.OrdinalIgnoreCase))
                                 {
@@ -1239,7 +1239,7 @@ namespace Microsoft.PowerShell.Commands
                     // Scriptworkflow ALSO comes through this path.
                     else
                     {
-                        // If the parameter is an In parameter with the RequiredArguement attribute then make it mandatory
+                        // If the parameter is an In parameter with the RequiredArgument attribute then make it mandatory
                         if (typeof(System.Activities.InArgument).IsAssignableFrom(p.Type))
                         {
                             if (p.Attributes != null)
@@ -1341,7 +1341,7 @@ namespace Microsoft.PowerShell.Commands
                             $validated
                         }
 
-                        # If there was no '*' collection, added the paramter defaults
+                        # If there was no '*' collection, added the parameter defaults
                         # to each individual collection if the parameter isn't already there... 
                         if (-not $PSParameterCollectionDefaultsMember)
                         {
@@ -1546,7 +1546,7 @@ namespace Microsoft.PowerShell.Commands
 
             // For inner function, don't add -PSParameterCollection param. AsJob and JobName are needed in the inner function for
             // parameter validation in non-PSParameterCollection cases. For PSParameterCollection, they will be checked for
-            // with a seperate check.
+            // with a separate check.
             // We want it at workflow function, but not in the subfunction that validates the parameter for PSParameterCollection
             if (!innerfunction)
             {

--- a/src/Microsoft.PowerShell.Workflow.ServiceCore/ServiceCore/WorkflowCore/LocalRunspaceProvider.cs
+++ b/src/Microsoft.PowerShell.Workflow.ServiceCore/ServiceCore/WorkflowCore/LocalRunspaceProvider.cs
@@ -267,7 +267,7 @@ namespace Microsoft.PowerShell.Workflow
             if (result == null)
                 throw new ArgumentException(Resources.InvalidAsyncResultSpecified, "asyncResult");
 
-            // this will throw an exeption when a runspace is not successfully
+            // this will throw an exception when a runspace is not successfully
             // available
             result.EndInvoke();
 

--- a/src/Microsoft.PowerShell.Workflow.ServiceCore/ServiceCore/WorkflowCore/NewPSWorkflowExecutionOptionCommand.cs
+++ b/src/Microsoft.PowerShell.Workflow.ServiceCore/ServiceCore/WorkflowCore/NewPSWorkflowExecutionOptionCommand.cs
@@ -636,7 +636,7 @@ namespace Microsoft.PowerShell.Commands
         }
         
         /// <summary>
-        /// UseEnctyption
+        /// UseEncryption
         /// </summary>
         [Parameter]
         public SwitchParameter PersistWithEncryption {

--- a/src/Microsoft.PowerShell.Workflow.ServiceCore/ServiceCore/WorkflowCore/PSActivityBase.cs
+++ b/src/Microsoft.PowerShell.Workflow.ServiceCore/ServiceCore/WorkflowCore/PSActivityBase.cs
@@ -320,7 +320,7 @@ namespace Microsoft.PowerShell.Activities
         }
 
         /// <summary>
-        /// Dipose of managed resources
+        /// Dispose of managed resources
         /// </summary>
         /// <param name="disposing">true if disposing</param>
         private void Dispose(bool disposing)
@@ -1199,7 +1199,7 @@ namespace Microsoft.PowerShell.Activities
             }
 
             // bookmarking will only be enabled when the PSPersist variable is set to 'true' by the author.
-            // so we are retriveing the information before host overrides.
+            // so we are retrieving the information before host overrides.
             // if the value is false or not provided then we will not go into the unloaded mode.
 
             bool intBookmarking = InternalBookmarkingRequired(context);
@@ -1812,7 +1812,7 @@ namespace Microsoft.PowerShell.Activities
             {
                 activityProgMsg = this.PSProgressMessage.Get(context);
 
-                // there is no need to write the progress message since the value of psprogressmessage is explicityly provided with null
+                // there is no need to write the progress message since the value of psprogressmessage is explicitly provided with null
                 if (this.PSProgressMessage.Expression != null && string.IsNullOrEmpty(activityProgMsg))
                     return;
             }
@@ -1948,7 +1948,7 @@ namespace Microsoft.PowerShell.Activities
 
             // this is expected when there would be a disconnected execution
             // here we expects the PSActivityHostArguments to be passed
-            // agrument contains the result from the execution
+            // argument contains the result from the execution
             PSResumableActivityContext arguments = null;
             if (value != null && value.GetType() == typeof(PSResumableActivityContext))
             {
@@ -2129,7 +2129,7 @@ namespace Microsoft.PowerShell.Activities
         }
 
         /// <summary>
-        /// The method is override-able by the drived classes in case they would like to implement different logic at the end of persistence.
+        /// The method is override-able by the derived classes in case they would like to implement different logic at the end of persistence.
         /// The default behavior would be to schedule the 'Persist' activity if the PSPersist flag is true or Host is asking for it.
         /// </summary>
         /// <param name="context">The native activity context of execution engine.</param>
@@ -2613,11 +2613,11 @@ namespace Microsoft.PowerShell.Activities
         /// <summary>
         /// The method for derived activities to return a configured instance of System.Management.Automation.PowerShell.
         /// The implementor should have added all of the commands and parameters required to launch their command through
-        /// the standard AddCommand() and AddParameter() methods. Derived activites should not manage the Runspace property
+        /// the standard AddCommand() and AddParameter() methods. Derived activities should not manage the Runspace property
         /// directly, as the PSActivity class configures the runspace afterward to enable remote connections.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected abstract ActivityImplementationContext GetPowerShell(NativeActivityContext context);
 
@@ -2646,7 +2646,7 @@ namespace Microsoft.PowerShell.Activities
         }
 
         /// <summary>
-        /// Retrievs all of the default arguments from the type and its parents.
+        /// Retrieve all of the default arguments from the type and its parents.
         /// </summary>
         /// <returns>All of the default arguments from the type and its parents</returns>
         protected IEnumerable<PSActivityArgumentInfo> GetActivityArguments()
@@ -2727,7 +2727,7 @@ namespace Microsoft.PowerShell.Activities
         /// <param name="implementationContext">The activity context to use</param>
         /// <param name="psActivityContext">The powershell activity context.</param>
         /// <param name="ActivityType">The activity type.</param>
-        /// <param name="PrepareSession">The prepare session delgate.</param>
+        /// <param name="PrepareSession">The prepare session delegate.</param>
         /// <param name="activityObject">This object representing activity.</param>
         private static void UpdatePowerShell(ActivityImplementationContext implementationContext, PSActivityContext psActivityContext, Type ActivityType, PrepareSessionDelegate PrepareSession, object activityObject)
         {
@@ -3421,7 +3421,7 @@ namespace Microsoft.PowerShell.Activities
                 commandToRun.Runspace.StateChanged += psActivityContext.HandleRunspaceStateChanged;
 
                 // Invocation state can be in running or final state in reconnect scenario
-                // Command should be invoked only when invocation state is not strted,
+                // Command should be invoked only when invocation state is not started,
                 // during the normal scenario, invocation state is always NotStarted as runspace is just assigned
                 if (commandToRun.InvocationStateInfo.State == PSInvocationState.NotStarted)
                 {
@@ -4101,13 +4101,13 @@ namespace Microsoft.PowerShell.Activities
             {
                 Dbg.Assert(activityEnvironment.Modules.Count > 0,
                            "When PSActivityEnvironment is specified and modules are imported, PSActivityEnvironment.Modules need to be populated");
-                // Setting erroaction to stop for import-module since they are required modules. If not present, stop the execution
+                // Setting erroraction to stop for import-module since they are required modules. If not present, stop the execution
                 ps.AddCommand("Import-Module").AddParameter("Name", activityEnvironment.Modules).AddParameter(
                     "ErrorAction", ActionPreference.Stop);
             }
             else
             {
-                // Setting erroaction to stop for import-module since they are required modules. If not present, stop the execution
+                // Setting erroraction to stop for import-module since they are required modules. If not present, stop the execution
                 ps.AddCommand("Import-Module").AddParameter("Name", args.ActivityParameters.PSRequiredModules).AddParameter(
                     "ErrorAction", ActionPreference.Stop);
             }
@@ -5773,7 +5773,7 @@ namespace Microsoft.PowerShell.Activities
         }
 
         /// <summary>
-        /// The paththat the workflow was imported from.
+        /// The path that the workflow was imported from.
         /// </summary>
         public string PSWorkflowPath
         {
@@ -5933,14 +5933,14 @@ namespace Microsoft.PowerShell.Activities
         /// <summary>
         /// Get all additional extensions.
         /// </summary>
-        /// <returns>Retruns no extensions.</returns>
+        /// <returns>Returns no extensions.</returns>
         public IEnumerable<object> GetAdditionalExtensions()
         {
             return null;
         }
 
         /// <summary>
-        /// Set the instance of the worfkow.
+        /// Set the instance of the workflow.
         /// </summary>
         /// <param name="instance">The workflow instance proxy.</param>
         public void SetInstance(WorkflowInstanceProxy instance)
@@ -5954,7 +5954,7 @@ namespace Microsoft.PowerShell.Activities
         /// <param name="bookmark">The bookmark where it will be resumed.</param>
         /// <param name="value">The value which need to be passed to the bookmark.</param>
         /// <param name="callback">The call back function when resuming the bookmark.</param>
-        /// <param name="state">The state of the aysn call.</param>
+        /// <param name="state">The state of the async call.</param>
         /// <returns>Returns the result of async call.</returns>
         public IAsyncResult BeginResumeBookmark(Bookmark bookmark, object value, AsyncCallback callback, object state)
         {
@@ -5964,7 +5964,7 @@ namespace Microsoft.PowerShell.Activities
         /// <summary>
         /// End resuming bookmark.
         /// </summary>
-        /// <param name="asyncResult">The result of asyc all.</param>
+        /// <param name="asyncResult">The result of async all.</param>
         /// <returns>Returns the bookmark resumption result.</returns>
         public BookmarkResumptionResult EndResumeBookmark(IAsyncResult asyncResult)
         {
@@ -5989,7 +5989,7 @@ namespace Microsoft.PowerShell.Activities
     }
 
     /// <summary>
-    /// Abstract base contining the common members and invocation code for the WMI cmdlets.
+    /// Abstract base containing the common members and invocation code for the WMI cmdlets.
     /// </summary>
     public abstract class WmiActivity : PSActivity
     {
@@ -6083,7 +6083,7 @@ namespace Microsoft.PowerShell.Activities
         /// <summary>
         /// Generic version of the function to handle value types
         /// </summary>
-        /// <typeparam name="T">THe type of the intende argument</typeparam>
+        /// <typeparam name="T">The type of the intended argument</typeparam>
         /// <param name="parameterName"></param>
         /// <param name="parameterDefaults"></param>
         /// <returns></returns>
@@ -6199,7 +6199,7 @@ namespace Microsoft.PowerShell.Activities
                 ActivityImplementationContext implementationContext = GetPowerShell(context);
                 System.Management.Automation.PowerShell invoker = implementationContext.PowerShellInstance;
 
-                // Don't add the conputer if it's empty or localhost...
+                // Don't add the computer if it's empty or localhost...
                 if (!String.IsNullOrEmpty(computername) && !String.Equals(computername, "localhost", StringComparison.OrdinalIgnoreCase))
                 {
                     invoker.AddParameter("ComputerName", computername);
@@ -6293,7 +6293,7 @@ namespace Microsoft.PowerShell.Activities
 
         /// <summary>
         /// Default implementation of WriteError - if the error record contains
-        /// an exceptin then that exception will be thrown. If not, then an
+        /// an exception then that exception will be thrown. If not, then an
         /// InvalidOperationException will be constructed and thrown.
         /// </summary>
         /// <param name="errorRecord">Error record instance to process</param>

--- a/src/Microsoft.PowerShell.Workflow.ServiceCore/ServiceCore/WorkflowCore/PSActivityHostManager.cs
+++ b/src/Microsoft.PowerShell.Workflow.ServiceCore/ServiceCore/WorkflowCore/PSActivityHostManager.cs
@@ -88,7 +88,7 @@ namespace Microsoft.PowerShell.Activities
         private readonly ConcurrentDictionary<string, bool> _inProcActivityLookup = new ConcurrentDictionary<string, bool>();
 
         /// <summary>
-        /// Runtime should be provided for excessing the runtime activity mode
+        /// Runtime should be provided for accessing the runtime activity mode
         /// </summary>
         protected PSActivityHostController(PSWorkflowRuntime runtime)
         {
@@ -172,9 +172,9 @@ namespace Microsoft.PowerShell.Activities
         }
 
         /// <summary>
-        /// This property indentifies if the Activity controller is running in disconnected mode 
+        /// This property identifies if the Activity controller is running in disconnected mode 
         /// or not. If it is running in disconnected mode then all the output and data streams will be
-        /// provied as new objects.
+        /// proxied as new objects.
         /// </summary>
         public virtual bool SupportDisconnectedPSStreams
         {

--- a/src/Microsoft.PowerShell.Workflow.ServiceCore/ServiceCore/WorkflowCore/PSCleanupActivity.cs
+++ b/src/Microsoft.PowerShell.Workflow.ServiceCore/ServiceCore/WorkflowCore/PSCleanupActivity.cs
@@ -32,7 +32,7 @@ namespace Microsoft.PowerShell.Activities
         }
 
         /// <summary>
-        /// Method that needs to be overrided to perform the actual
+        /// Method that needs to be overridden to perform the actual
         /// cleanup action
         /// </summary>
         /// <param name="args">RunCommandsArguments</param>
@@ -90,7 +90,7 @@ namespace Microsoft.PowerShell.Activities
         }
 
         /// <summary>
-        /// Method that needs to be overrided to perform the actual
+        /// Method that needs to be overridden to perform the actual
         /// cleanup action
         /// </summary>
         /// <param name="args">RunCommandsArguments</param>

--- a/src/Microsoft.PowerShell.Workflow.ServiceCore/ServiceCore/WorkflowCore/PSSelfRemotingActivitiesBase.cs
+++ b/src/Microsoft.PowerShell.Workflow.ServiceCore/ServiceCore/WorkflowCore/PSSelfRemotingActivitiesBase.cs
@@ -428,7 +428,7 @@ namespace Microsoft.PowerShell.Activities
 
 
     /// <summary>
-    /// Provides additional functionalty for CIM activity implementations.
+    /// Provides additional functionality for CIM activity implementations.
     /// </summary>
     public class CimActivityImplementationContext : ActivityImplementationContext
     {

--- a/src/Microsoft.PowerShell.Workflow.ServiceCore/ServiceCore/WorkflowCore/PowerShellWorkflowHost.cs
+++ b/src/Microsoft.PowerShell.Workflow.ServiceCore/ServiceCore/WorkflowCore/PowerShellWorkflowHost.cs
@@ -73,7 +73,7 @@ namespace Microsoft.PowerShell.Workflow
         }
 
         /// <summary>
-        /// Disope implementation.
+        /// Dispose implementation.
         /// </summary>
         public void Dispose()
         {
@@ -82,7 +82,7 @@ namespace Microsoft.PowerShell.Workflow
         }
 
         /// <summary>
-        /// Disope implementation.
+        /// Dispose implementation.
         /// </summary>
         /// <param name="disposing"></param>
         private void Dispose(bool disposing)

--- a/src/Microsoft.PowerShell.Workflow.ServiceCore/ServiceCore/WorkflowCore/RuntimeBase.cs
+++ b/src/Microsoft.PowerShell.Workflow.ServiceCore/ServiceCore/WorkflowCore/RuntimeBase.cs
@@ -359,7 +359,7 @@ namespace Microsoft.PowerShell.Workflow
         }
 
         /// <summary>
-        /// Synchonization object available to derived classes.
+        /// Synchronization object available to derived classes.
         /// </summary>
         protected object SyncLock
         {

--- a/src/Microsoft.PowerShell.Workflow.ServiceCore/ServiceCore/WorkflowCore/WorkflowDebugger.cs
+++ b/src/Microsoft.PowerShell.Workflow.ServiceCore/ServiceCore/WorkflowCore/WorkflowDebugger.cs
@@ -1524,7 +1524,7 @@ namespace Microsoft.PowerShell.Workflow
                     return false;
                 }
 
-                // Check assigments to known workflow variables.
+                // Check assignments to known workflow variables.
                 foreach (var workflowVariable in allWFVariables)
                 {
                     variableName = workflowVariable.Key;

--- a/src/Microsoft.PowerShell.Workflow.ServiceCore/ServiceCore/WorkflowCore/WorkflowInstance.cs
+++ b/src/Microsoft.PowerShell.Workflow.ServiceCore/ServiceCore/WorkflowCore/WorkflowInstance.cs
@@ -50,7 +50,7 @@ namespace Microsoft.PowerShell.Workflow
 
         /// <summary>
         /// Specifies that the System.Activities.WorkflowApplication should persist and unload the workflow.
-        /// The job will remain in running state because aysnc operation (out of proc or remote operation) is in progress.
+        /// The job will remain in running state because async operation (out of proc or remote operation) is in progress.
         /// The System.Activities.WorkflowApplication will be loaded when async operation gets completed.
         /// </summary>
         Unload = 3,
@@ -336,7 +336,7 @@ namespace Microsoft.PowerShell.Workflow
                         }
 
                         // This method is first time called from OnResumeBookmark, if no resume required it's entry
-                        // needs to be removed fromt the collection as activity execution has finsihed.
+                        // needs to be removed fromt the collection as activity execution has finished.
                         // When an activity entry is removed, remoteActivityState will be persisted 
                         // as part of whole workflow application persistence at the end of activity completion
                         if (activityResumeRequired == false)
@@ -605,7 +605,7 @@ namespace Microsoft.PowerShell.Workflow
             _structuredTracer.Correlate();
             Tracer.WriteMessage("Workflow Application is completed in Aborted state.");
 
-            // if the supend in progress and there is some error it result in the aborted event
+            // if the suspend in progress and there is some error it result in the aborted event
             // explicit faulting the workflow.
             if (this.callSuspendDelegate)
             {
@@ -665,7 +665,7 @@ namespace Microsoft.PowerShell.Workflow
                 return;
 
             // this lock will ensure the synchronization between the persistence and the force suspend (abort) method.
-            // if persitence is going on then it will hold the execution of force suspend
+            // if persistence is going on then it will hold the execution of force suspend
             lock (ReactivateSync)
             {
                 if (Disposed)
@@ -702,7 +702,7 @@ namespace Microsoft.PowerShell.Workflow
                     }
                     catch (Exception e)
                     {
-                        // this may occure in the race condition if there are many persitable workflow and then you tried to shutdown them.
+                        // this may occur in the race condition if there are many persistable workflow and then you tried to shutdown them.
                         Tracer.WriteMessage("PSWorkflowApplicationInstance", "HandlePersistence", id, "There has been exception while persisting the workflow in the background thread.");
                         Tracer.TraceException(e);
                     }
@@ -718,7 +718,7 @@ namespace Microsoft.PowerShell.Workflow
             }
             catch (Exception e)
             {
-                // this may occure in the race condition if there is a persitable workflow which is getting stopped and at the same persit is called.
+                // this may occur in the race condition if there is a persistable workflow which is getting stopped and at the same persist is called.
                 Tracer.WriteMessage("PSWorkflowApplicationInstance", "SafelyHandleFaultedState", id, "There has been exception while marking the workflow in faulted state in the background thread.");
                 Tracer.TraceException(e);
             }
@@ -778,7 +778,7 @@ namespace Microsoft.PowerShell.Workflow
             _structuredTracer.Correlate();
             Tracer.WriteMessage("Workflow Application is idle.");
 
-            // there might be a possiblity that stop job is being called by wfApp is Idle handling it properly so all Async execution .
+            // there might be a possibility that stop job is being called by wfApp is Idle handling it properly so all Async execution .
             if (_job.JobStateInfo.State == JobState.Stopping)
             {
                 this.StopBookMarkedWorkflow();
@@ -875,9 +875,9 @@ namespace Microsoft.PowerShell.Workflow
             Tracer.WriteMessage("Workflow Application is completed in Faulted state.");
 
             // there might be possible of race condition here in case of Winrm shutdown. if the activity is 
-            // excuting on loop back winrm process so there might be possibility that the winrm shuts down the 
-            // activity process fist and cuasing the workflow to fail in the M3P process.
-            // in order to avoid those situations we will ignore the remote exception if the shutdwon is in progress
+            // executing on loop back winrm process so there might be possibility that the winrm shuts down the 
+            // activity process fist and causing the workflow to fail in the M3P process.
+            // in order to avoid those situations we will ignore the remote exception if the shutdown is in progress
             if (WorkflowJobSourceAdapter.GetInstance().IsShutdownInProgress)
             {
                 if (e.GetType() == typeof(RemoteException))
@@ -1620,7 +1620,7 @@ namespace Microsoft.PowerShell.Workflow
             {
                 // this flag ensures that the workflow application will not be loaded again since we are stopping the workflow instance
                 IsTerminalStateAction = true;
-                // this flag ensures that we don't unload the wfApplication instance since we are stopping the worklfow.
+                // this flag ensures that we don't unload the wfApplication instance since we are stopping the workflow.
                 PersistIdleTimerInProgressOrTriggered = false;
             }
 
@@ -1916,7 +1916,7 @@ namespace Microsoft.PowerShell.Workflow
                 
                 // saving the workflow application handle into the temporary variable
                 // then unregistering the workflow application handle
-                // temporary varialbe will be used to call abort if workflow is in running state
+                // temporary variable will be used to call abort if workflow is in running state
                 WorkflowApplication wf = this.workflowApplication;
                 DisposeWorkflowApplication();
 
@@ -2046,7 +2046,7 @@ namespace Microsoft.PowerShell.Workflow
                 _paramDefaults.Parameters[Constants.PrivateMetadata] = this.PSWorkflowContext.PrivateMetadata;
             }
 
-            // Job realted parameters
+            // Job related parameters
             if (this.PSWorkflowContext.JobMetadata.ContainsKey(Constants.JobMetadataName))
             {
                 _paramDefaults.Parameters[TranslateMetaDataName(Constants.JobMetadataName)] = 
@@ -2351,7 +2351,7 @@ namespace Microsoft.PowerShell.Workflow
         {
             // Workflow is currently in booked marked state
             // we will try to cancel all async operations 
-            // and then perform the termial tasks related to stop workflow
+            // and then perform the terminal tasks related to stop workflow
 
             if (Disposed)
                 return;
@@ -2390,7 +2390,7 @@ namespace Microsoft.PowerShell.Workflow
             {
                 // This is not a full fix:
                 // there could be a race condition where we have taken the copy but context is removed from by activity and disposed in that case contextinstance.cancel will throw
-                // there could be one more possiblity that is if copy has been made and after that activity adds a new context and will not get canceled and streams will get closed so async execution might throw
+                // there could be one more possibility that is if copy has been made and after that activity adds a new context and will not get canceled and streams will get closed so async execution might throw
                 // the solution is make every these operation on async execution collection thread safe
 
                 foreach (PSActivityContext psActivityContextInstance in this.asyncExecutionCollection.Values.ToList())
@@ -2471,7 +2471,7 @@ namespace Microsoft.PowerShell.Workflow
                     SetInternalUnloaded(true);
 
                     // Check for the race condition.
-                    // There could be possibilibly workflow application is unloaded because of terminal state is reached.
+                    // There could be possibility workflow application is unloaded because of terminal state is reached.
                     if (this.workflowApplication != null)
                     {
                         try

--- a/src/Microsoft.PowerShell.Workflow.ServiceCore/ServiceCore/WorkflowCore/WorkflowJob2.cs
+++ b/src/Microsoft.PowerShell.Workflow.ServiceCore/ServiceCore/WorkflowCore/WorkflowJob2.cs
@@ -58,7 +58,7 @@ namespace Microsoft.PowerShell.Workflow
         internal WaitHandle Running { get { return this.JobRunning; } }
 
         /// <summary>
-        /// Signaled when job finishes suspending or aboring
+        /// Signaled when job finishes suspending or aborting
         /// </summary>
         internal WaitHandle SuspendedOrAborted { get { return this.JobSuspendedOrAborted; } }
 
@@ -148,7 +148,7 @@ namespace Microsoft.PowerShell.Workflow
         private Dictionary<string, object> _jobMetadata = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
         private Dictionary<string, object> _privateMetadata = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
 
-        // Holds the collection of input objects recieved from the pipeline
+        // Holds the collection of input objects received from the pipeline
         private PSDataCollection<PSObject> _inputCollection;
 
         private ManualResetEvent _jobRunning;
@@ -429,7 +429,7 @@ namespace Microsoft.PowerShell.Workflow
         /// </summary>
         /// <param name="state"></param>
         /// <param name="reason"></param>
-        /// <returns>returns false if state tranition is not possible. Return value is required to update SQM perf counters</returns>
+        /// <returns>returns false if state transition is not possible. Return value is required to update SQM perf counters</returns>
         private bool DoSetJobState(JobState state, Exception reason = null)
         {
             if (IsFinishedState(_previousState) || _isDisposed) return false;
@@ -539,7 +539,7 @@ namespace Microsoft.PowerShell.Workflow
                             {
                                 // If we're self-remoting, location becomes the default computer
                                 // and the PSComputerNames is passed in as an argument instead
-                                // of going to the ubiquitious parameters
+                                // of going to the ubiquitous parameters
                                 _location = Constants.DefaultComputerName;
                                 string parameterName = dynamicActivity.Properties.First(x => x.Name.Equals(Constants.ComputerName, StringComparison.CurrentCultureIgnoreCase)).Name;
                                 _workflowParameters[parameterName] = LanguagePrimitives.ConvertTo<string[]>(parameter.Value);
@@ -603,7 +603,7 @@ namespace Microsoft.PowerShell.Workflow
                             break;
 
                         case Constants.PSParameterCollection:
-                            // Remove this one from the parameter collecton...
+                            // Remove this one from the parameter collection...
                             break;
                         case Constants.PSRunningTime:
                         case Constants.PSElapsedTime:
@@ -792,7 +792,7 @@ namespace Microsoft.PowerShell.Workflow
                     throw new InvalidJobStateException(JobStateInfo.State, Resources.ResumeNotValidState);
                 }
 
-                // this will avoid the race codition between two resume requests and both are trying to load instance and loadstreams.
+                // this will avoid the race condition between two resume requests and both are trying to load instance and loadstreams.
                 _resuming = true;
             }
 
@@ -1123,7 +1123,7 @@ namespace Microsoft.PowerShell.Workflow
             _tracer.WriteMessage(ClassNameTrace, "OnWorkflowSuspended", WorkflowGuidForTraces, this, "BEGIN");
 
             // CheckStopping() was not thread safe.
-            // Now DoSetJobState handles the invalid state transion from stopping to suspended
+            // Now DoSetJobState handles the invalid state transition from stopping to suspended
             if (DoSetJobState(JobState.Suspended))
             {
                 StructuredTracer.WorkflowUnloaded(_workflowInstance.Id);
@@ -1646,7 +1646,7 @@ namespace Microsoft.PowerShell.Workflow
         #region Overrides of Job2
 
         /// <summary>
-        /// Implementation of this method will allow the delayed loadig of streams.
+        /// Implementation of this method will allow the delayed loading of streams.
         /// </summary>
         protected override void DoLoadJobStreams()
         {
@@ -1686,7 +1686,7 @@ namespace Microsoft.PowerShell.Workflow
         /// start a job. The job will be started with the parameters
         /// specified in StartParameters
         /// </summary>
-        /// <remarks>It is redudant to have a method named StartJob
+        /// <remarks>It is redundant to have a method named StartJob
         /// on a job class. However, this is done so as to avoid
         /// an FxCop violation "CA1716:IdentifiersShouldNotMatchKeywords"
         /// Stop and Resume are reserved keyworks in C# and hence cannot
@@ -1716,7 +1716,7 @@ namespace Microsoft.PowerShell.Workflow
             catch (Exception e)
             {
                 // Catching all exceptions is valid here because
-                // Transfering exception with event arguments.
+                // Transferring exception with event arguments.
                 OnStartJobCompleted(new AsyncCompletedEventArgs(e, false, null));
             }
 #pragma warning restore 56500
@@ -2037,7 +2037,7 @@ namespace Microsoft.PowerShell.Workflow
             catch (Exception e)
             {
                 // Catching all exceptions is valid here because
-                // Transfering exception with event arguments.
+                // Transferring exception with event arguments.
                 OnResumeJobCompleted(new AsyncCompletedEventArgs(e, false, null));
             }
 #pragma warning restore 56500
@@ -2075,7 +2075,7 @@ namespace Microsoft.PowerShell.Workflow
             catch (Exception e)
             {
                 // Catching all exceptions is valid here because
-                // Transfering exception with event arguments.
+                // Transferring exception with event arguments.
                 OnResumeJobCompleted(new AsyncCompletedEventArgs(e, false, null));
             }
 #pragma warning restore 56500

--- a/src/Microsoft.PowerShell.Workflow.ServiceCore/ServiceCore/WorkflowCore/WorkflowJobSourceAdapter.cs
+++ b/src/Microsoft.PowerShell.Workflow.ServiceCore/ServiceCore/WorkflowCore/WorkflowJobSourceAdapter.cs
@@ -173,7 +173,7 @@ namespace Microsoft.PowerShell.Workflow
                         psPersitValue = context.PSWorkflowCommonParameters[Constants.Persist] as bool?;
                     }
 
-                    // check for invocation time pspersist value if not true then there is a possiblility that workflow is not suspendable.
+                    // check for invocation time pspersist value if not true then there is a possibility that workflow is not suspendable.
                     if (psPersitValue == null || (psPersitValue == false))
                     {
                         // check for authoring time definition of persist activity 

--- a/src/Microsoft.PowerShell.Workflow.ServiceCore/ServiceCore/WorkflowCore/WorkflowManager.cs
+++ b/src/Microsoft.PowerShell.Workflow.ServiceCore/ServiceCore/WorkflowCore/WorkflowManager.cs
@@ -123,7 +123,7 @@ namespace Microsoft.PowerShell.Workflow
 
 
         /// <summary>
-        /// Disope implementation.
+        /// Dispose implementation.
         /// </summary>
         public void Dispose()
         {
@@ -132,7 +132,7 @@ namespace Microsoft.PowerShell.Workflow
         }
 
         /// <summary>
-        /// Disope implementation.
+        /// Dispose implementation.
         /// </summary>
         /// <param name="disposing"></param>
         private void Dispose(bool disposing)
@@ -310,7 +310,7 @@ namespace Microsoft.PowerShell.Workflow
             {
                 lock (_syncObject)
                 {
-                    // Start the shudown timer when there is no inprogess job, no pending job requests and no active sessions
+                    // Start the shutdown timer when there is no inprogress job, no pending job requests and no active sessions
                     // Otherwise disable it
                     if (_activeSessionsCount == 0 && _inProgressCount == 0 && _pendingQueue.Count == 0)
                     {
@@ -395,7 +395,7 @@ namespace Microsoft.PowerShell.Workflow
 
                     if (_shutdownTimer != null)
                     {
-                        // Start the shudown timer when there is no inprogess job, no pending job requests and no active sessions
+                        // Start the shutdown timer when there is no inprogress job, no pending job requests and no active sessions
                         // Otherwise disable it
                         if (_activeSessionsCount == 0 && _inProgressCount == 0 && _pendingQueue.Count == 0)
                         {
@@ -1118,7 +1118,7 @@ namespace Microsoft.PowerShell.Workflow
 
                     if ((filter.Value is string || filter.Value is WildcardPattern) && value is string)
                     {
-                        // at this point we are guaranteed that the key exists somewehere                    
+                        // at this point we are guaranteed that the key exists somewhere                    
                         WildcardPattern pattern;
                         string stringValue = filter.Value as string;
                         if (stringValue != null)

--- a/src/Microsoft.PowerShell.Workflow.ServiceCore/ServiceCore/WorkflowCore/WorkflowMetadatas.cs
+++ b/src/Microsoft.PowerShell.Workflow.ServiceCore/ServiceCore/WorkflowCore/WorkflowMetadatas.cs
@@ -22,7 +22,7 @@ namespace Microsoft.PowerShell.Workflow
         private Dictionary<string, object> _psWorkflowCommonParameters;
      
         /// <summary>
-        /// The metadata, which contains all the information related to job and client like, job-id, connnection-id and application-id etc.
+        /// The metadata, which contains all the information related to job and client like, job-id, connection-id and application-id etc.
         /// </summary>
         private Dictionary<string, object> jobMetadata;
         
@@ -47,7 +47,7 @@ namespace Microsoft.PowerShell.Workflow
         /// </summary>
         /// <param name="workflowParameters">The parameters, which need to be passed to the workflow engine.</param>
         /// <param name="workflowCommonParameters">The ubiquitous parameters, which are also passed to the engine.</param>
-        /// <param name="jobMetadata">The metadata, which contains all the information related to job and client like, job-id, connnection-id and application-id etc.</param>
+        /// <param name="jobMetadata">The metadata, which contains all the information related to job and client like, job-id, connection-id and application-id etc.</param>
         /// <param name="privateMetadata">The metadata, which is specific to the caller and doesn't contain any information related to workflow execution.</param>
         public PSWorkflowContext(
                                     Dictionary<string, object> workflowParameters,

--- a/src/Microsoft.PowerShell.Workflow.ServiceCore/ServiceCore/WorkflowCore/WorkflowRuntimeCompilation.cs
+++ b/src/Microsoft.PowerShell.Workflow.ServiceCore/ServiceCore/WorkflowCore/WorkflowRuntimeCompilation.cs
@@ -53,7 +53,7 @@ namespace Microsoft.PowerShell.Workflow
         internal string BuildLogPath { get; set; }
 
         /// <summary>
-        /// The runtime gnerated assembly name.
+        /// The runtime generated assembly name.
         /// </summary>
         internal string AssemblyName { get; set; }
 

--- a/src/Microsoft.PowerShell.Workflow.ServiceCore/ServiceCore/WorkflowCore/WorkflowTimers.cs
+++ b/src/Microsoft.PowerShell.Workflow.ServiceCore/ServiceCore/WorkflowCore/WorkflowTimers.cs
@@ -449,7 +449,7 @@ namespace Microsoft.PowerShell.Workflow
         }
 
         /// <summary>
-        /// Disope implementation.
+        /// Dispose implementation.
         /// </summary>
         public void Dispose()
         {

--- a/src/Microsoft.PowerShell.Workflow.ServiceCore/ServiceCore/WorkflowCore/WorkflowTrackingParticipant.cs
+++ b/src/Microsoft.PowerShell.Workflow.ServiceCore/ServiceCore/WorkflowCore/WorkflowTrackingParticipant.cs
@@ -64,7 +64,7 @@ namespace Microsoft.PowerShell.Workflow
         }
 
         /// <summary>
-        /// Retreive each type of tracking record and perform the corresponding fucntionality.
+        /// Retrieve each type of tracking record and perform the corresponding functionality.
         /// </summary>
         /// <param name="record">Represents the tracking record.</param>
         /// <param name="timeout">Time out for the tracking to be completed.</param>

--- a/src/Microsoft.PowerShell.Workflow.ServiceCore/ServiceCore/WorkflowCore/WorkflowUtils.cs
+++ b/src/Microsoft.PowerShell.Workflow.ServiceCore/ServiceCore/WorkflowCore/WorkflowUtils.cs
@@ -243,7 +243,7 @@ namespace Microsoft.PowerShell.Workflow
 
             if (connectionInfo1.ProxyAccessType == ProxyAccessType.None)
             {
-                return true; //stop here if no proxy acess type
+                return true; //stop here if no proxy access type
             }
 
             if (connectionInfo1.ProxyAuthentication != connectionInfo2.ProxyAuthentication)

--- a/src/Microsoft.WSMan.Management.Activities/Generated/ConnectWSManActivity.cs
+++ b/src/Microsoft.WSMan.Management.Activities/Generated/ConnectWSManActivity.cs
@@ -117,7 +117,7 @@ namespace Microsoft.WSMan.Management.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.WSMan.Management.Activities/Generated/DisableWSManCredSSPActivity.cs
+++ b/src/Microsoft.WSMan.Management.Activities/Generated/DisableWSManCredSSPActivity.cs
@@ -49,7 +49,7 @@ namespace Microsoft.WSMan.Management.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.WSMan.Management.Activities/Generated/DisconnectWSManActivity.cs
+++ b/src/Microsoft.WSMan.Management.Activities/Generated/DisconnectWSManActivity.cs
@@ -54,7 +54,7 @@ namespace Microsoft.WSMan.Management.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.WSMan.Management.Activities/Generated/EnableWSManCredSSPActivity.cs
+++ b/src/Microsoft.WSMan.Management.Activities/Generated/EnableWSManCredSSPActivity.cs
@@ -63,7 +63,7 @@ namespace Microsoft.WSMan.Management.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.WSMan.Management.Activities/Generated/GetWSManCredSSPActivity.cs
+++ b/src/Microsoft.WSMan.Management.Activities/Generated/GetWSManCredSSPActivity.cs
@@ -42,7 +42,7 @@ namespace Microsoft.WSMan.Management.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.WSMan.Management.Activities/Generated/GetWSManInstanceActivity.cs
+++ b/src/Microsoft.WSMan.Management.Activities/Generated/GetWSManInstanceActivity.cs
@@ -187,7 +187,7 @@ namespace Microsoft.WSMan.Management.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.WSMan.Management.Activities/Generated/InvokeWSManActionActivity.cs
+++ b/src/Microsoft.WSMan.Management.Activities/Generated/InvokeWSManActionActivity.cs
@@ -152,7 +152,7 @@ namespace Microsoft.WSMan.Management.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.WSMan.Management.Activities/Generated/NewWSManInstanceActivity.cs
+++ b/src/Microsoft.WSMan.Management.Activities/Generated/NewWSManInstanceActivity.cs
@@ -145,7 +145,7 @@ namespace Microsoft.WSMan.Management.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.WSMan.Management.Activities/Generated/NewWSManSessionOptionActivity.cs
+++ b/src/Microsoft.WSMan.Management.Activities/Generated/NewWSManSessionOptionActivity.cs
@@ -112,7 +112,7 @@ namespace Microsoft.WSMan.Management.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.WSMan.Management.Activities/Generated/RemoveWSManInstanceActivity.cs
+++ b/src/Microsoft.WSMan.Management.Activities/Generated/RemoveWSManInstanceActivity.cs
@@ -131,7 +131,7 @@ namespace Microsoft.WSMan.Management.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.WSMan.Management.Activities/Generated/SetWSManInstanceActivity.cs
+++ b/src/Microsoft.WSMan.Management.Activities/Generated/SetWSManInstanceActivity.cs
@@ -159,7 +159,7 @@ namespace Microsoft.WSMan.Management.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.WSMan.Management.Activities/Generated/SetWSManQuickConfigActivity.cs
+++ b/src/Microsoft.WSMan.Management.Activities/Generated/SetWSManQuickConfigActivity.cs
@@ -63,7 +63,7 @@ namespace Microsoft.WSMan.Management.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Microsoft.WSMan.Management.Activities/Generated/TestWSManActivity.cs
+++ b/src/Microsoft.WSMan.Management.Activities/Generated/TestWSManActivity.cs
@@ -96,7 +96,7 @@ namespace Microsoft.WSMan.Management.Activities
         /// Returns a configured instance of System.Management.Automation.PowerShell, pre-populated with the command to run.
         /// </summary>
         /// <param name="context">The NativeActivityContext for the currently running activity.</param>
-        /// <returns>A populated instance of Sytem.Management.Automation.PowerShell</returns>
+        /// <returns>A populated instance of System.Management.Automation.PowerShell</returns>
         /// <remarks>The infrastructure takes responsibility for closing and disposing the PowerShell instance returned.</remarks>
         protected override ActivityImplementationContext GetPowerShell(NativeActivityContext context)
         {

--- a/src/Modules/Shared/Microsoft.PowerShell.Archive/Microsoft.PowerShell.Archive.psm1
+++ b/src/Modules/Shared/Microsoft.PowerShell.Archive/Microsoft.PowerShell.Archive.psm1
@@ -105,7 +105,7 @@ function Compress-Archive
         IsValidFileSystemPath $destinationParentDir | Out-Null
         $DestinationPath = Join-Path -Path $destinationParentDir -ChildPath $achiveFileName
 
-        # GetExtension API does not validate for the actual existance of the path.
+        # GetExtension API does not validate for the actual existence of the path.
         $extension = [system.IO.Path]::GetExtension($DestinationPath)
 
         # If user does not specify .Zip extension, we append it.
@@ -175,15 +175,15 @@ function Compress-Archive
     END 
     {
         # If archive file already exists and if -Force is specified, we delete the 
-        # existing artchive file and create a brand new one.
+        # existing archive file and create a brand new one.
         if(($PsCmdlet.ParameterSetName -eq "PathWithForce" -or 
         $PsCmdlet.ParameterSetName -eq "LiteralPathWithForce") -and $archiveFileExist)
         {
             Remove-Item -Path $DestinationPath -Force -ErrorAction Stop
         }
 
-        # Validate Source Path depeding on parameter set being used.
-        # The specified source path conatins one or more files or directories that needs
+        # Validate Source Path depending on parameter set being used.
+        # The specified source path contains one or more files or directories that needs
         # to be compressed.
         $isLiteralPathUsed = $false
         if($PsCmdlet.ParameterSetName -eq "LiteralPath" -or 
@@ -199,16 +199,16 @@ function Compress-Archive
     
         $sourcePath = $resolvedPaths;
 
-        # CSVHelper: This is a helper function used to append comma after each path specifid by
-        # the $sourcePath array. The comma saperated paths are displayed in the -WhatIf message.
+        # CSVHelper: This is a helper function used to append comma after each path specified by
+        # the $sourcePath array. The comma separated paths are displayed in the -WhatIf message.
         $sourcePathInCsvFormat = CSVHelper $sourcePath
         if($pscmdlet.ShouldProcess($sourcePathInCsvFormat))
         {
             try
             {
-                # StopProcessing is not avaliable in Script cmdlets. However the pipleline execution
+                # StopProcessing is not available in Script cmdlets. However the pipeline execution
                 # is terminated when ever 'CTRL + C' is entered by user to terminate the cmdlet execution.
-                # The finally block is executed whenever pipleline is terminated. 
+                # The finally block is executed whenever pipeline is terminated. 
                 # $isArchiveFileProcessingComplete variable is used to track if 'CTRL + C' is entered by the
                 # user. 
                 $isArchiveFileProcessingComplete = $false
@@ -370,9 +370,9 @@ function Expand-Archive
 
             try
             {
-                # StopProcessing is not avaliable in Script cmdlets. However the pipleline execution
+                # StopProcessing is not available in Script cmdlets. However the pipeline execution
                 # is terminated when ever 'CTRL + C' is entered by user to terminate the cmdlet execution.
-                # The finally block is executed whenever pipleline is terminated. 
+                # The finally block is executed whenever pipeline is terminated. 
                 # $isArchiveFileProcessingComplete variable is used to track if 'CTRL + C' is entered by the
                 # user. 
                 $isArchiveFileProcessingComplete = $false
@@ -406,7 +406,7 @@ function Expand-Archive
                     if($expandedItems.Count -gt 0)
                     {
                         # delete the expanded file/directory as the archive 
-                        # file was not completly expanded.
+                        # file was not completely expanded.
                         $expandedItems | % { Remove-Item $_ -Force -Recurse }
                     }
                 }
@@ -572,7 +572,7 @@ function CompressArchiveHelper
         }
     }
 
-    # The Soure Path contains one or more directory (this directory can have files under it) and no files to be compressed.
+    # The Source Path contains one or more directory (this directory can have files under it) and no files to be compressed.
     if($sourceFilePaths.Count -eq 0 -and $sourceDirPaths.Count -gt 0)
     {
         $currentSegmentWeight = 100/[double]$sourceDirPaths.Count
@@ -585,7 +585,7 @@ function CompressArchiveHelper
         }
     }
 
-    # The Soure Path contains only files to be compressed.
+    # The Source Path contains only files to be compressed.
     elseIf($sourceFilePaths.Count -gt 0 -and $sourceDirPaths.Count -eq 0)
     {
         # $previousSegmentWeight is equal to 0 as there are no prior segments.
@@ -595,10 +595,10 @@ function CompressArchiveHelper
 
         $numberOfItemsArchived = CompressFilesHelper $sourceFilePaths $destinationPath $compressionLevel $isUpdateMode $previousSegmentWeight $currentSegmentWeight
     }
-    # The Soure Path contains one or more files and one or more directories (this directory can have files under it) to be compressed.
+    # The Source Path contains one or more files and one or more directories (this directory can have files under it) to be compressed.
     elseif($sourceFilePaths.Count -gt 0 -and $sourceDirPaths.Count -gt 0)
     {
-        # each directory is considered as an individual segments & all the individual files are clubed in to a separate sgemnet.
+        # each directory is considered as an individual segments & all the individual files are clubed in to a separate segment.
         $currentSegmentWeight = 100/[double]($sourceDirPaths.Count +1)
         $previousSegmentWeight = 0
 
@@ -683,7 +683,7 @@ function CompressSingleDirHelper
         {
             # The currentContent points to a directory.
             # We need to check if the directory is an empty directory, if so such a
-            # directory has to be explictly added to the archive file.
+            # directory has to be explicitly added to the archive file.
             # if there are no files in the directory the GetFiles() API returns an empty array.
             $files = $currentContent.GetFiles()
             if($files.Count -eq 0)
@@ -778,7 +778,7 @@ function ZipArchiveHelper
             $compression = CompressionLevelMapper $compressionLevel
 
             # If a directory needs to be added to an archive file, 
-            # by convention the .Net API's expect the path of the diretcory 
+            # by convention the .Net API's expect the path of the directory 
             # to end with '\' to detect the path as an directory.
             if(!$relativeFilePath.EndsWith(([io.path]::DirectorySeparatorChar), [StringComparison]::OrdinalIgnoreCase))
             {
@@ -890,7 +890,7 @@ function ValidateArchivePathHelper
     {
         $extension = [system.IO.Path]::GetExtension($archiveFile)
 
-        # Invalid file extension is specifed for the zip file.
+        # Invalid file extension is specified for the zip file.
         if($extension -ne $zipFileExtension)
         {
             $errorMessage = ($LocalizedData.InvalidZipFileExtensionError -f $extension, $zipFileExtension)
@@ -924,7 +924,7 @@ function ExpandArchiveHelper
 
     try
     {
-        # The existance of archive file has already been validated by ValidateArchivePathHelper 
+        # The existence of archive file has already been validated by ValidateArchivePathHelper 
         # before calling this helper function.
         $archiveFileStreamArgs = @($archiveFile, [System.IO.FileMode]::Open, [System.IO.FileAccess]::Read)
         $archiveFileStream = New-Object -TypeName System.IO.FileStream -ArgumentList $archiveFileStreamArgs
@@ -986,7 +986,7 @@ function ExpandArchiveHelper
                         if(!(Test-Path -LiteralPath $currentArchiveEntryFileInfo.DirectoryName -PathType Container))
                         {
                             # The directory referred by $currentArchiveEntryFileInfo.DirectoryName was not successfully created.
-                            # This could be because the user has specified -Confirm paramter when Expand-Archive was invoked
+                            # This could be because the user has specified -Confirm parameter when Expand-Archive was invoked
                             # and authorization was not provided when confirmation was prompted. In such a scenario, 
                             # we skip the current file in the archive and continue with the remaining archive file contents.
                             Continue
@@ -1012,7 +1012,7 @@ function ExpandArchiveHelper
                             if(Test-Path -LiteralPath $currentArchiveEntryFileInfo.FullName -PathType Leaf)
                             {
                                 # The file referred by $currentArchiveEntryFileInfo.FullName was not successfully removed.
-                                # This could be because the user has specified -Confirm paramter when Expand-Archive was invoked
+                                # This could be because the user has specified -Confirm parameter when Expand-Archive was invoked
                                 # and authorization was not provided when confirmation was prompted. In such a scenario, 
                                 # we skip the current file in the archive and continue with the remaining archive file contents.
                                 Continue
@@ -1111,7 +1111,7 @@ function ProgressBarHelper
 }
 
 <############################################################################################ 
-# CSVHelper: This is a helper function used to append comma after each path specifid by
+# CSVHelper: This is a helper function used to append comma after each path specified by
 # the SourcePath array. This helper function is used to display all the user supplied paths
 # in the WhatIf message.
 ############################################################################################>
@@ -1122,7 +1122,7 @@ function CSVHelper
         [string[]] $sourcePath
     )
 
-    # SourcePath has already been validated by the calling funcation.
+    # SourcePath has already been validated by the calling function.
     if($sourcePath.Count -gt 1)
     {
         $sourcePathInCsvFormat = "`n"

--- a/src/Modules/Shared/Microsoft.PowerShell.Utility/Microsoft.PowerShell.Utility.psm1
+++ b/src/Modules/Shared/Microsoft.PowerShell.Utility/Microsoft.PowerShell.Utility.psm1
@@ -224,7 +224,7 @@ function Format-Hex
         $inputStreamArray = [System.Collections.ArrayList]::New()
         <############################################################################################ 
         # The ConvertToHexadecimalHelper is a helper method used to fetch unicode bytes from the 
-        # input data and display the hexadecimial representaion of the of the input data in bytes.
+        # input data and display the hexadecimal representation of the of the input data in bytes.
         ############################################################################################>
         function ConvertToHexadecimalHelper
         {
@@ -236,7 +236,7 @@ function Format-Hex
             )
 
             # This section is used to display the hexadecimal 
-            # representaion of the of the input data in bytes.
+            # representation of the of the input data in bytes.
             if($inputBytes -ne $null)
             {
                 $byteCollectionObject =  [Microsoft.PowerShell.Commands.ByteCollection]::new($offset, $inputBytes, $path)
@@ -383,8 +383,8 @@ function Format-Hex
                 # If the input data is of string type then directly get bytes out of it.
                 elseif($InputObject -is [string])
                 {
-                    # The ValidateSet arribute on the Encoding paramter makes sure that only
-                    # valid values (supported on all paltforms where Format-Hex is avaliable)
+                    # The ValidateSet attribute on the Encoding parameter makes sure that only
+                    # valid values (supported on all platforms where Format-Hex is available)
                     # are allowed through user input.
                     $inputBytes = [Text.Encoding]::$Encoding.GetBytes($InputObject)
                     ConvertToHexadecimalHelper $inputBytes $null

--- a/src/Modules/Shared/PackageManagement/PackageProviderFunctions.psm1
+++ b/src/Modules/Shared/PackageManagement/PackageProviderFunctions.psm1
@@ -267,7 +267,7 @@ function New-SoftwareIdentityFromXml {
 }
 
 <#
-	Creates a new instance of a DyamicOption object
+	Creates a new instance of a DynamicOption object
 #>
 function New-DynamicOption {
 	param(

--- a/src/Modules/Shared/PowerShellGet/PSModule.psm1
+++ b/src/Modules/Shared/PowerShellGet/PSModule.psm1
@@ -2153,7 +2153,7 @@ function Get-InstalledModule
 
 #endregion *-Module cmdlets
 
-#region Find-DscResouce cmdlet
+#region Find-DscResource cmdlet
 
 function Find-DscResource
 {
@@ -2259,7 +2259,7 @@ function Find-DscResource
     }
 }
 
-#endregion Find-DscResouce cmdlet
+#endregion Find-DscResource cmdlet
 
 #region Find-Command cmdlet
 
@@ -2936,7 +2936,7 @@ function Find-Script
             $psgalleryRepo = Get-PSRepository -Name $Script:PSGalleryModuleSource `
                                               -ErrorAction SilentlyContinue `
                                               -WarningAction SilentlyContinue
-            # And check for IsDeafult?
+            # And check for IsDefault?
             if($psgalleryRepo)
             {
                 $isRepositoryNullOrPSGallerySpecified = $true
@@ -4547,7 +4547,7 @@ function Test-ScriptFileInfo
 
         if($ast)
         {
-            # Get the block/group comment begining with <#PSScriptInfo
+            # Get the block/group comment beginning with <#PSScriptInfo
             $CommentTokens = $tokens | Microsoft.PowerShell.Core\Where-Object {$_.Kind -eq 'Comment'}
 
             $psscriptInfoComments = $CommentTokens | 
@@ -6655,7 +6655,7 @@ function Set-ModuleSourcesVariable
             }
         }
 
-        # Already registed repositories may not have the ScriptSourceLocation property, try to populate it from the existing SourceLocation
+        # Already registered repositories may not have the ScriptSourceLocation property, try to populate it from the existing SourceLocation
         # Also populate the PublishLocation and ScriptPublishLocation from the SourceLocation if PublishLocation is empty/null.
         # 
         $script:PSGetModuleSources.Keys | Microsoft.PowerShell.Core\ForEach-Object { 
@@ -8930,7 +8930,7 @@ function Add-PackageSource
 
     if($Name -eq $Script:PSGalleryModuleSource)
     {
-        # Add or update the PSGallery repostory
+        # Add or update the PSGallery repository
         $repository = Set-PSGalleryRepository -Trusted:$Trusted
 
         if($repository)
@@ -10550,7 +10550,7 @@ function Install-PackageUtility
 
                 $destinationModulePath = Microsoft.PowerShell.Management\Join-Path -Path $moduleDestination -ChildPath $pkg.Name
 
-                # Side-by-Side module version is avialable on PowerShell 5.0 or later versions only
+                # Side-by-Side module version is available on PowerShell 5.0 or later versions only
                 # By default, PowerShell module versions will be installed/updated Side-by-Side.
                 if(Test-ModuleSxSVersionSupport)
                 {
@@ -12232,7 +12232,7 @@ function Save-ModuleSources
 
 function Test-ModuleSxSVersionSupport
 {
-    # Side-by-Side module version is avialable on PowerShell 5.0 or later versions only
+    # Side-by-Side module version is available on PowerShell 5.0 or later versions only
     # By default, PowerShell module versions will be installed/updated Side-by-Side.
     $PSVersionTable.PSVersion -ge '5.0.0'
 }
@@ -12826,7 +12826,7 @@ function Update-ModuleManifest
     {
         $params.Add("ProcessorArchitecture",$ProcessorArchitecture)
     }
-    #Check if ProcessorArchitecture has a value and is not 'None' on lower verison PS
+    #Check if ProcessorArchitecture has a value and is not 'None' on lower version PS
     elseif($moduleInfo.ProcessorArchitecture -and $moduleInfo.ProcessorArchitecture -ne 'None')
     {
         $params.Add("ProcessorArchitecture",$moduleInfo.ProcessorArchitecture)
@@ -13237,7 +13237,7 @@ function Update-ModuleManifest
         }
         $PrivateDataInput = Get-PrivateData -PrivateData $Data
         
-        #Repleace the PrivateData section by first locating the linenumbers of start line and endline.  
+        #Replace the PrivateData section by first locating the linenumbers of start line and endline.  
         $PrivateDataBegin = Select-String -Path $tempPath -Pattern "PrivateData ="
         $PrivateDataBeginLine = $PrivateDataBegin.LineNumber
     

--- a/src/Modules/Windows-Full/Microsoft.PowerShell.Diagnostics/GetEvent.types.ps1xml
+++ b/src/Modules/Windows-Full/Microsoft.PowerShell.Diagnostics/GetEvent.types.ps1xml
@@ -3,7 +3,7 @@
 These sample files contain formatting information used by the Windows 
 PowerShell engine. Do not edit or change the contents of this file 
 directly. Please see the Windows PowerShell documentation or type 
-Get-Help Update-TypetData for more information.
+Get-Help Update-TypeData for more information.
 
 Copyright (c) Microsoft Corporation.  All rights reserved.
 

--- a/src/Modules/Windows-Full/Microsoft.PowerShell.ODataUtils/Microsoft.PowerShell.ODataAdapter.ps1
+++ b/src/Modules/Windows-Full/Microsoft.PowerShell.ODataUtils/Microsoft.PowerShell.ODataAdapter.ps1
@@ -69,7 +69,7 @@ function ParseMetaData
 
     # Check the OData version in the fetched metadata to make sure that
     # OData version (and hence the protocol) used in the metadata is
-    # supported by the adatapter used for executing the generated
+    # supported by the adapter used for executing the generated
     # proxy cmdlets.
     if(($metadataXML -ne $null) -and ($metadataXML.Edmx -ne $null))
     {
@@ -363,10 +363,10 @@ function VerifyMetaData
         $callerPSCmdlet.ThrowTerminatingError($errorRecord)
     }
     
-    # All the generated proxy cmdlets would have the following paramters added.
-    # The ODataAdpter has the default implementation on how to handle the 
+    # All the generated proxy cmdlets would have the following parameters added.
+    # The ODataAdapter has the default implementation on how to handle the 
     # scenario when these parameters are used during proxy invocations.
-    # The default implementaion can be overridden using adapter derivation model. 
+    # The default implementation can be overridden using adapter derivation model. 
     $reservedProperties = @("Filter", "IncludeTotalResponseCount", "OrderBy", "Select", "Skip", "Top", "ConnectionUri", "CertificateThumbprint", "Credential")
     $validEntitySets = @()
     $sessionCommands = Get-Command -All
@@ -492,8 +492,8 @@ function VerifyMetaData
 # GenerateClientSideProxyModule is a helper function used 
 # to generate a PowerShell module that serves as a client
 # side proxy for interacting with the server side 
-# OData endpoint. The proxy module conatins proxy cmdlets
-# implemneted in CDXML modules and they are exposed 
+# OData endpoint. The proxy module contains proxy cmdlets
+# implemented in CDXML modules and they are exposed 
 # through module manifest as nested modules.
 # One CDXML module is created for each EntitySet 
 # described in the metadata. Each CDXML module contains
@@ -528,11 +528,11 @@ function GenerateClientSideProxyModule
 
     # This function performs the following set of tasks 
     # while creating the client side proxy module:
-    # 1. If the server side endpoint exposes comlex types,
+    # 1. If the server side endpoint exposes complex types,
     #    the client side proxy complex types are created
-    #    as C# class in ComplexTypeDefinations.psm1 
-    # 2. Creates proxy cmdlets for CRUD opreations.
-    # 3. Creates proxy cmdlets for Serice action opreations.
+    #    as C# class in ComplexTypeDefinitions.psm1 
+    # 2. Creates proxy cmdlets for CRUD operations.
+    # 3. Creates proxy cmdlets for Service action operations.
     # 4. Creates module manifest.
 
     Write-Verbose ($LocalizedData.VerboseSavingModule -f $outputModule)
@@ -1169,7 +1169,7 @@ function GenerateServiceActionProxyCmdlet
 # to generate a wrapper module manifest file. The
 # generated module manifest is persisted to the disk at
 # the specified OutPutModule path. When the module 
-# manifest is imported, the following comands will 
+# manifest is imported, the following commands will 
 # be imported:
 # 1. Get, Set, New & Remove proxy cmdlets.
 # 2. If the server side Odata endpoint exposes complex
@@ -1466,11 +1466,11 @@ function GetEntitySetForEntityType
 #########################################################
 # ProcessStreamHelper is a helper function that performs 
 # the following utility tasks:
-# 1. Writes verobose messsages to the stream.
+# 1. Writes verbose messages to the stream.
 # 2. Writes FileInfo objects for the proxy modules 
 #    saved to the disk. This is done to keep the user 
 #    experience in consistent with Export-PSSession.
-# 3. Updates progess bar.
+# 3. Updates progress bar.
 #########################################################
 function ProcessStreamHelper 
 {
@@ -1660,8 +1660,8 @@ function AddParametersCDXML
 }
 
 #########################################################
-# GenerateComplexTypeDefination is a helper function used 
-# to generate comlplex type defination from the metadata.
+# GenerateComplexTypeDefinition is a helper function used 
+# to generate complex type definition from the metadata.
 #########################################################
 function GenerateComplexTypeDefination 
 {
@@ -1779,7 +1779,7 @@ using System.Management.Automation;
      return $complexTypeMapping
 }
 
-# Creating a single instace of CSharpCodeProvider that would be used 
+# Creating a single instance of CSharpCodeProvider that would be used 
 # for Identifier validation in the ValidateComplexTypeIdentifier helper method.
 $cSharpCodeProvider = [Microsoft.CSharp.CSharpCodeProvider]::new()
 

--- a/src/Modules/Windows-Full/Microsoft.PowerShell.ODataUtils/Microsoft.PowerShell.ODataUtilsHelper.ps1
+++ b/src/Modules/Windows-Full/Microsoft.PowerShell.ODataUtils/Microsoft.PowerShell.ODataUtilsHelper.ps1
@@ -283,7 +283,7 @@ function GetMetaData
     {
         $uri = [System.Uri]::new($metadataUri)
 
-        # By default, proxy generation is supported on sercured Uri (i.e., https).
+        # By default, proxy generation is supported on secured Uri (i.e., https).
         # However if the user trusts the unsecure http uri, then they can override
         # the security check by specifying -AllowSecureConnection parameter during
         # proxy generation. 

--- a/src/Modules/Windows-Full/Microsoft.PowerShell.ODataUtils/Microsoft.PowerShell.ODataV4Adapter.ps1
+++ b/src/Modules/Windows-Full/Microsoft.PowerShell.ODataUtils/Microsoft.PowerShell.ODataV4Adapter.ps1
@@ -60,7 +60,7 @@ function ExportODataEndpointProxy
     VerifyMetadata $GlobalMetadata $AllowClobber.IsPresent $PSCmdlet $ProgressBarStatus
 
     # Get Uri Resource path key format. It can be either 'EmbeddedKey' or 'SeparateKey'. 
-    # If not provided, deault value will be set to 'EmbeddedKey'.
+    # If not provided, default value will be set to 'EmbeddedKey'.
     $UriResourcePathKeyFormat = 'EmbeddedKey'
     if ($CustomData -and $CustomData.ContainsKey("UriResourcePathKeyFormat"))
     {
@@ -159,7 +159,7 @@ function NormalizeNamespace
     {
         if ($NormalizedNamespaces.ContainsKey($MetadataNamespace))
         {
-            # It's possible we've already attemted to normalize that namespace. In that case we'll update normalized name.
+            # It's possible we've already attempted to normalize that namespace. In that case we'll update normalized name.
             $NormalizedNamespaces[$MetadataNamespace] = NormalizeNamespaceHelper $NormalizedNamespaces[$MetadataNamespace] $doesNamespaceContainsInvalidChars $DoesNamespaceConflictsWithClassName
         }
         else
@@ -214,7 +214,7 @@ function NormalizeNamespaceCollisionWithClassName
 
 #########################################################
 # This helper method is used by functions, 
-# writing directly to CDXML files or to .Net namespace/class definitions CompplexTypes file
+# writing directly to CDXML files or to .Net namespace/class definitions ComplexTypes file
 #########################################################
 function GetNamespace
 {
@@ -266,7 +266,7 @@ function NormalizeNamespaceHelper
 
     # For example, following namespace: Service.1.0.0
     # Will change to: Service_1_0_0
-    # Ns postfix in Namespace name will allow to diffirintiate between this namespace 
+    # Ns postfix in Namespace name will allow to differentiate between this namespace 
     # and a colliding type name from different namespace
     $updatedNs = $Namespace
     if ($DoesNamespaceContainsInvalidChars)
@@ -1774,7 +1774,7 @@ function SaveCDXMLInstanceCmdlets
 }
 
 # Helper Method
-# Returns true if navigation property of $AssociatedType has coresponding EntitySet or Singleton
+# Returns true if navigation property of $AssociatedType has corresponding EntitySet or Singleton
 # If yes, then it should become an associated parameter in CDXML
 function ShouldBeAssociatedParameter
 {
@@ -2292,7 +2292,7 @@ function SaveServiceActionsCDXML
 # to generate a wrapper module manifest file. The
 # generated module manifest is persisted to the disk at
 # the specified OutputModule path. When the module 
-# manifest is imported, the following comands will 
+# manifest is imported, the following commands will 
 # be imported:
 # 1. Get, Set, New & Remove proxy cmdlets for entity 
 #    sets and singletons.
@@ -2350,8 +2350,8 @@ function GenerateModuleManifest
 }
 
 #########################################################
-# This is a helper function used to generate comlplex 
-# type defination from the metadata.
+# This is a helper function used to generate complex 
+# type definition from the metadata.
 #########################################################
 function GenerateComplexTypeDefinition 
 {
@@ -2376,7 +2376,7 @@ using System.ComponentModel;
 
 "@
     # We are currently generating classes for EntityType & ComplexType 
-    # defination exposed in the metadata.
+    # definition exposed in the metadata.
     
     $complexTypeMapping = @{}
 

--- a/src/Schemas/PSMaml/Maml_HTML_Style.xsl
+++ b/src/Schemas/PSMaml/Maml_HTML_Style.xsl
@@ -163,7 +163,7 @@
 				<xsl:with-param name='attributeName'>charoff</xsl:with-param>
 			</xsl:call-template>
 			
-			<!-- handle verical alignment -->
+			<!-- handle vertical alignment -->
 			<xsl:variable name='valign' select='ancestor-or-self::*[@valign][1]/@valign'/>
 			<xsl:attribute name='valign'>
 				<xsl:choose>
@@ -206,9 +206,9 @@
 	
 	<!-- If the context node is an entry or entrytbl, searches for the value of an
 	     inherited attribute by following the normal inheritance path.  If a
-	     value is found, calls tranformInheritedAttribute with attributeName
+	     value is found, calls transformInheritedAttribute with attributeName
 	     passes as is and attributeValue set to the found value; otherwise, calls
-	     tranformInheritedAttribute with attributeValue set to the empty string.
+	     transformInheritedAttribute with attributeValue set to the empty string.
 	     
 	     Parameter attributeName is the name of the attribute found.
      -->

--- a/src/Schemas/PSMaml/ManagedDeveloper.xsd
+++ b/src/Schemas/PSMaml/ManagedDeveloper.xsd
@@ -9,7 +9,7 @@
         </documentation>
 		<documentation>
             The schema is broken into three main areas: end user, developer and
-            IT Pro. These areas adequaltely categorize Microsoft
+            IT Pro. These areas adequately categorize Microsoft
             documentation.
         </documentation>
 		<documentation>

--- a/src/Schemas/PSMaml/ManagedDeveloperStructure.xsd
+++ b/src/Schemas/PSMaml/ManagedDeveloperStructure.xsd
@@ -9,7 +9,7 @@
         </documentation>
 		<documentation>
             The schema is broken into three main areas: end user, developer and
-            IT Pro. These areas adequaltely categorize Microsoft
+            IT Pro. These areas adequately categorize Microsoft
             documentation.
         </documentation>
 		<documentation>

--- a/src/System.Management.Automation/CoreCLR/CorePsExtensions.cs
+++ b/src/System.Management.Automation/CoreCLR/CorePsExtensions.cs
@@ -1032,7 +1032,7 @@ namespace System.Management.Automation
 
         /// <summary>
         /// The API set 'api-ms-win-shell-shellfolders-l1-1-0.dll' was removed from NanoServer, so we cannot depend on 'SHGetFolderPathW'
-        /// to get the special folder paths. Instead, we need to rely on the baisc environment variables to get the special folder paths.
+        /// to get the special folder paths. Instead, we need to rely on the basic environment variables to get the special folder paths.
         /// </summary>
         /// <returns>
         /// The path to the specified system special folder, if that folder physically exists on your computer.

--- a/src/System.Management.Automation/CoreCLR/CorePsPlatform.cs
+++ b/src/System.Management.Automation/CoreCLR/CorePsPlatform.cs
@@ -241,7 +241,7 @@ namespace System.Management.Automation
             switch (dirpath)
             {
                 case Platform.XDG_Type.CONFIG:
-                    //the user has set XDG_CONFIG_HOME corrresponding to profile path
+                    //the user has set XDG_CONFIG_HOME corresponding to profile path
                     if (String.IsNullOrEmpty(xdgconfighome))
                     {
                         //xdg values have not been set

--- a/src/System.Management.Automation/DscSupport/CimDSCParser.cs
+++ b/src/System.Management.Automation/DscSupport/CimDSCParser.cs
@@ -498,7 +498,7 @@ namespace Microsoft.PowerShell.DesiredStateConfiguration.Internal
             StringComparer.OrdinalIgnoreCase);
 
         //a collection to hold current importing script based resource file
-        //this prevent circular importing case when the script resource exising in the same module with resources it import-dscresource
+        //this prevent circular importing case when the script resource existing in the same module with resources it import-dscresource
         private static readonly HashSet<string> s_currentImportingScriptFiles = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
         /// <summary>
@@ -1179,7 +1179,7 @@ namespace Microsoft.PowerShell.DesiredStateConfiguration.Internal
         }
 
         /// <summary>
-        /// A routine that validates a string contining MOF instances against the
+        /// A routine that validates a string containing MOF instances against the
         /// current set of cached classes.
         /// </summary>
         /// <param name="instanceText"></param>
@@ -1748,7 +1748,7 @@ namespace Microsoft.PowerShell.DesiredStateConfiguration.Internal
 
                 if (LanguagePrimitives.TryConvertTo(moduleName, out moduleSpecifications))
                 {
-                    // if resourceNames are specifed then we can not specify multiple modules name 
+                    // if resourceNames are specified then we can not specify multiple modules name 
                     if (moduleSpecifications != null && moduleSpecifications.Length > 1 && resourceNames != null)
                     {
                         errorList.Add(new ParseError(moduleNameBindingResult.Value.Extent,
@@ -1756,7 +1756,7 @@ namespace Microsoft.PowerShell.DesiredStateConfiguration.Internal
                                                      string.Format(CultureInfo.CurrentCulture, ParserStrings.ImportDscResourceMultipleModulesNotSupportedWithName)));
                     }
 
-                    // if moduleversion is specifed then we can not specify multiple modules name 
+                    // if moduleversion is specified then we can not specify multiple modules name 
                     if (moduleSpecifications != null && moduleSpecifications.Length > 1 && moduleVersion != null)
                     {
                         errorList.Add(new ParseError(moduleNameBindingResult.Value.Extent,
@@ -1764,7 +1764,7 @@ namespace Microsoft.PowerShell.DesiredStateConfiguration.Internal
                                                      string.Format(CultureInfo.CurrentCulture, ParserStrings.ImportDscResourceNeedParams)));
                     }
 
-                    // if moduleversion is specifed then we can not specify another version in modulespecification object of ModuleName  
+                    // if moduleversion is specified then we can not specify another version in modulespecification object of ModuleName  
                     if (moduleSpecifications != null && (moduleSpecifications[0].Version != null || moduleSpecifications[0].MaximumVersion != null) && moduleVersion != null)
                     {
                         errorList.Add(new ParseError(moduleNameBindingResult.Value.Extent,
@@ -1870,7 +1870,7 @@ namespace Microsoft.PowerShell.DesiredStateConfiguration.Internal
                     {
                         if (mandatoryPropertiesNames.Remove(presentName) && mandatoryPropertiesNames.Count == 0)
                         {
-                            // optimization, once all mandotory properties are specified, we can safely exit.
+                            // optimization, once all mandatory properties are specified, we can safely exit.
                             return null;
                         }
                     }
@@ -3167,7 +3167,7 @@ namespace Microsoft.PowerShell.DesiredStateConfiguration.Internal
                             if (classes != null)
                             {
                                 //
-                                // search if class'es friendly name is the given resourceName
+                                // search if class's friendly name is the given resourceName
                                 //
                                 foreach (var c in classes)
                                 {
@@ -3581,7 +3581,7 @@ namespace Microsoft.PowerShell.DesiredStateConfiguration.Internal
         }
 
         /// <summary>
-        /// The scriptblock that implementes the CIM keyword functionality.
+        /// The scriptblock that implements the CIM keyword functionality.
         /// </summary>
         private static ScriptBlock CimKeywordImlementationFunction
         {
@@ -3708,11 +3708,11 @@ namespace Microsoft.PowerShell.DesiredStateConfiguration.Internal
         }
         else
         {
-# If there are prerequsite resources, validate that the references are well-formed strings
+# If there are prerequisite resources, validate that the references are well-formed strings
 # This routine also adds the resource to the global node resources table.
             Test-DependsOn
 
-# Check if PsDscRunCredetial is being specified as Arguments to Configuration
+# Check if PsDscRunCredential is being specified as Arguments to Configuration
         if($PsDscRunAsCredential -ne $null)
         {
 # Check if resource is also trying to set the value for RunAsCred

--- a/src/System.Management.Automation/cimSupport/cmdletization/QueryBuilder.cs
+++ b/src/System.Management.Automation/cimSupport/cmdletization/QueryBuilder.cs
@@ -17,7 +17,7 @@ namespace Microsoft.PowerShell.Cmdletization
         /// - When a wildcard is specified, then no errors are reported (i.e. Get-Process -Name noSuchProcess*)
         /// - When no wildcard is specified, then errors are reported (i.e. Get-Process -Name noSuchProcess)
         /// 
-        /// Note that the following conventions are adpoted:
+        /// Note that the following conventions are adopted:
         /// - Min/max queries 
         ///   (<see cref="QueryBuilder.FilterByMinPropertyValue(string,object,BehaviorOnNoMatch)"/> and 
         ///    <see cref="QueryBuilder.FilterByMaxPropertyValue(string,object,BehaviorOnNoMatch)"/>) 

--- a/src/System.Management.Automation/cimSupport/cmdletization/xml/CoreCLR/cmdlets-over-objects.xmlSerializer.autogen.cs
+++ b/src/System.Management.Automation/cimSupport/cmdletization/xml/CoreCLR/cmdlets-over-objects.xmlSerializer.autogen.cs
@@ -162,7 +162,7 @@ namespace Microsoft.PowerShell.Cmdletization.Xml
             {
                 // XmlSerializationReader implementation is:
                 //    return checkDeserializeAdvances ? countingReader.AdvanceCount : 0;
-                // and checkDeserializeAdvances is set in the static constrcutor:
+                // and checkDeserializeAdvances is set in the static constructor:
                 //    XmlSerializerSection configSection = ConfigurationManager.GetSection(ConfigurationStrings.XmlSerializerSectionPath) as XmlSerializerSection;
                 //    checkDeserializeAdvances = (configSection == null) ? false : configSection.CheckDeserializeAdvances;
                 // When XmlSerializationReader is used in powershell, there is no configuration file defined for it, so 'checkDeserializeAdvances' will actually

--- a/src/System.Management.Automation/commands/utility/FormatAndOutput/common/BaseFormattingCommand.cs
+++ b/src/System.Management.Automation/commands/utility/FormatAndOutput/common/BaseFormattingCommand.cs
@@ -132,7 +132,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                     break;
                 default:
                     {
-                        // do not eumerate at all (CoreOnly)
+                        // do not enumerate at all (CoreOnly)
                         ProcessObject(so);
                     }
                     break;
@@ -421,7 +421,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         /// <summary>
         /// compute the group transition, given an input object
         /// </summary>
-        /// <param name="so">object receoved from the input pipeline</param>
+        /// <param name="so">object received from the input pipeline</param>
         /// <returns>GroupTransition enumeration</returns>
         private GroupTransition ComputeGroupTransition(PSObject so)
         {
@@ -691,7 +691,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         /// <summary>
         /// Positional parameter for properties, property sets and table sets
         /// specified on the command line.
-        /// The paramater is optional, since the defaults
+        /// The parameter is optional, since the defaults
         /// will be determined using property sets, etc.
         /// </summary>
         [Parameter(Position = 0)]

--- a/src/System.Management.Automation/commands/utility/FormatAndOutput/common/BaseOutputtingCommand.cs
+++ b/src/System.Management.Automation/commands/utility/FormatAndOutput/common/BaseOutputtingCommand.cs
@@ -275,7 +275,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             }
             else if (o is FormatStartData)
             {
-                // when encountering FormatStartDate out of sequemce,
+                // when encountering FormatStartDate out of sequence,
                 // pretend that the previous formatting directives were properly closed
                 if (_currentFormattingState == FormattingState.InsideGroup)
                 {
@@ -318,7 +318,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
 
         private void ValidateCurrentFormattingState(FormattingState expectedFormattingState, object obj)
         {
-            // chec if we are in the expected formatting state
+            // check if we are in the expected formatting state
             if (_currentFormattingState != expectedFormattingState)
             {
                 // we are not in the expected state, some message is out of sequence,
@@ -839,7 +839,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             internal virtual void Initialize() { }
 
             /// <summary>
-            /// called when a group of data is started, overrided will do
+            /// called when a group of data is started, overridden will do
             /// things such as headers, etc...
             /// </summary>
             internal virtual void GroupStart() { }
@@ -1124,7 +1124,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 // set the hard wider default, to be used if no other info is available
                 int itemsPerRow = 2;
 
-                // get the header info and the wiew hint
+                // get the header info and the view hint
                 WideFormattingHint hint = this.InnerCommand.RetrieveFormattingHint() as WideFormattingHint;
 
                 // give a preference to the hint, if there

--- a/src/System.Management.Automation/commands/utility/FormatAndOutput/common/ComplexWriter.cs
+++ b/src/System.Management.Automation/commands/utility/FormatAndOutput/common/ComplexWriter.cs
@@ -17,7 +17,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
     internal sealed class ComplexWriter
     {
         /// <summary>
-        /// initalization method to be called before any other operation
+        /// initialization method to be called before any other operation
         /// </summary>
         /// <param name="lineOutput">LineOutput interfaces to write to</param>
         /// <param name="numberOfTextColumns">number of columns used to write out</param>
@@ -46,13 +46,13 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         /// <param name="formatValueList">list of FormatValue tokens to interpret</param>
         internal void WriteObject(List<FormatValue> formatValueList)
         {
-            // we always start with no identation
+            // we always start with no indentation
             _indentationManager.Clear();
 
             foreach (FormatEntry fe in formatValueList)
             {
                 // operate on each directive inside the list,
-                // carrying the identation from invocation to invocation
+                // carrying the indentation from invocation to invocation
                 GenerateFormatEntryDisplay(fe, 0);
             }
             // make sure that, if we have pending text in the buffer it gets flushed
@@ -129,7 +129,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
 
             // VALIDITY CHECKS:
 
-            // check the useful ("active") witdth
+            // check the useful ("active") width
             int usefulWidth = _textColumns - rightIndentation - leftIndentation;
             if (usefulWidth <= 0)
             {
@@ -216,7 +216,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         private LineOutput _lo;
 
         /// <summary>
-        /// nomber of columns for the output device
+        /// number of columns for the output device
         /// </summary>
         private int _textColumns;
 
@@ -459,11 +459,11 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                         }
                         else
                         {
-                            // of the given lenght, add it to the accumulator
+                            // of the given length, add it to the accumulator
                             accumulator.AddLine(lines[k].Substring(offset, charactersToAdd));
                         }
 
-                        // increase the offest by the # of characters added
+                        // increase the offset by the # of characters added
                         offset += charactersToAdd;
                     }
                     else

--- a/src/System.Management.Automation/commands/utility/FormatAndOutput/common/DisplayDatabase/FormatTable.cs
+++ b/src/System.Management.Automation/commands/utility/FormatAndOutput/common/DisplayDatabase/FormatTable.cs
@@ -73,7 +73,7 @@ namespace System.Management.Automation.Runspaces
         }
 
         /// <summary>
-        /// This constructor takes a colletion of errors occurred during construction
+        /// This constructor takes a collection of errors occurred during construction
         /// time.
         /// </summary>
         /// <param name="loadErrors">

--- a/src/System.Management.Automation/commands/utility/FormatAndOutput/common/DisplayDatabase/XmlLoaderBase.cs
+++ b/src/System.Management.Automation/commands/utility/FormatAndOutput/common/DisplayDatabase/XmlLoaderBase.cs
@@ -22,7 +22,7 @@ using Microsoft.PowerShell.CoreClr.Stubs;
     It provides the capability of:
     * logging errors, warnings and traces to a file or in memory
     * managing the XML dom traversal using an add hoc stack frame management scheme
-    * validating common error condotions (e.g. missing node or unknown node)
+    * validating common error conditions (e.g. missing node or unknown node)
 */
 
 namespace Microsoft.PowerShell.Commands.Internal.Format
@@ -247,7 +247,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         }
 
         /// <summary>
-        /// get the list of logg entries
+        /// get the list of log entries
         /// </summary>
         /// <value>list of entries logged during a load</value>
         internal List<XmlLoaderLoggerEntry> LogEntries

--- a/src/System.Management.Automation/commands/utility/FormatAndOutput/common/DisplayDatabase/displayDescriptionData.cs
+++ b/src/System.Management.Automation/commands/utility/FormatAndOutput/common/DisplayDatabase/displayDescriptionData.cs
@@ -290,7 +290,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         internal ComplexControlItemDefinition itemDefinition = new ComplexControlItemDefinition();
 
         /// <summary>
-        /// frame info assocated with this frame definition
+        /// frame info associated with this frame definition
         /// </summary>
         internal FrameInfoDefinition frameInfoDefinition = new FrameInfoDefinition();
     }
@@ -491,7 +491,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         internal ControlBase control = null;
 
         /// <summary>
-        /// alternative (and simpified) representation for the control
+        /// alternative (and simplified) representation for the control
         /// RULE: if the control object is null, use this one
         /// </summary>
         internal TextToken labelTextToken = null;

--- a/src/System.Management.Automation/commands/utility/FormatAndOutput/common/DisplayDatabase/displayDescriptionData_List.cs
+++ b/src/System.Management.Automation/commands/utility/FormatAndOutput/common/DisplayDatabase/displayDescriptionData_List.cs
@@ -336,7 +336,7 @@ namespace System.Management.Automation
 
         /// <summary>
         /// Public constructor for ListControlEntryItem
-        /// Lable and Entry could be null
+        /// Label and Entry could be null
         /// </summary>
         /// <param name="label"></param>
         /// <param name="entry"></param>

--- a/src/System.Management.Automation/commands/utility/FormatAndOutput/common/DisplayDatabase/displayDescriptionData_Table.cs
+++ b/src/System.Management.Automation/commands/utility/FormatAndOutput/common/DisplayDatabase/displayDescriptionData_Table.cs
@@ -173,7 +173,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
     internal sealed class TableRowItemDefinition
     {
         /// <summary>
-        /// optional aligment to override the default one at the header level
+        /// optional alignment to override the default one at the header level
         /// </summary>
         internal int alignment = TextAlignment.Undefined;
 

--- a/src/System.Management.Automation/commands/utility/FormatAndOutput/common/DisplayDatabase/displayResourceManagerCache.cs
+++ b/src/System.Management.Automation/commands/utility/FormatAndOutput/common/DisplayDatabase/displayResourceManagerCache.cs
@@ -121,7 +121,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         private Assembly LoadAssemblyFromResourceReference(StringResourceReference resourceReference, out bool foundInGac)
         {
             // NOTE: we keep the function signature as and the calling code is able do deal
-            // with dynamically loaded assemblies. If this functinality is implemented, this
+            // with dynamically loaded assemblies. If this functionality is implemented, this
             // method will have to be changed accordingly
             foundInGac = false; // it always be false, since we return already loaded assemblies
             return _assemblyNameResolver.ResolveAssemblyName(resourceReference.assemblyName);

--- a/src/System.Management.Automation/commands/utility/FormatAndOutput/common/DisplayDatabase/typeDataManager.cs
+++ b/src/System.Management.Automation/commands/utility/FormatAndOutput/common/DisplayDatabase/typeDataManager.cs
@@ -533,7 +533,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         /// <summary>
         /// helper to to add any pre-load intrinsics to the db
         /// </summary>
-        /// <param name="db">db being iniitalized</param>
+        /// <param name="db">db being initialized</param>
         private static void AddPreLoadInstrinsics(TypeInfoDataBase db)
         {
             // NOTE: nothing to add for the time being. Add here if needed.
@@ -542,7 +542,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         /// <summary>
         /// helper to to add any post-load intrinsics to the db
         /// </summary>
-        /// <param name="db">db being iniitalized</param>
+        /// <param name="db">db being initialized</param>
         private static void AddPostLoadInstrinsics(TypeInfoDataBase db)
         {
             // add entry for the output of update-formatdata

--- a/src/System.Management.Automation/commands/utility/FormatAndOutput/common/DisplayDatabase/typeDataQuery.cs
+++ b/src/System.Management.Automation/commands/utility/FormatAndOutput/common/DisplayDatabase/typeDataQuery.cs
@@ -595,7 +595,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                     if (tgr == null)
                         continue;
 
-                    // find the type group definition the rererence points to
+                    // find the type group definition the reference points to
                     TypeGroupDefinition tgd = FindGroupDefinition(db, tgr.name);
 
                     if (tgd == null)

--- a/src/System.Management.Automation/commands/utility/FormatAndOutput/common/DisplayDatabase/typeDataXmlLoader.cs
+++ b/src/System.Management.Automation/commands/utility/FormatAndOutput/common/DisplayDatabase/typeDataXmlLoader.cs
@@ -67,7 +67,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             internal const string EnumerableExpansionNode = "EnumerableExpansion";
             internal const string ExpandNode = "Expand";
 
-            // entries indentifying the various control types definitions
+            // entries identifying the various control types definitions
             internal const string ControlNode = "Control";
             internal const string ComplexControlNameNode = "CustomControlName";
 
@@ -81,7 +81,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
 
             internal const string ViewNode = "View";
 
-            // entries indentifying the various control types
+            // entries identifying the various control types
             internal const string TableControlNode = "TableControl";
             internal const string ListControlNode = "ListControl";
             internal const string WideControlNode = "WideControl";
@@ -554,7 +554,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             if (tableBody.header.columnHeaderDefinitionList.Count != 0)
             {
                 // CHECK: if there are headers in the list, their number has to match
-                // the default row definition intem count
+                // the default row definition item count
                 if (tableBody.header.columnHeaderDefinitionList.Count !=
                     tableBody.defaultDefinition.rowItemDefinitionList.Count)
                 {
@@ -586,7 +586,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 TableColumnHeaderDefinition chd = new TableColumnHeaderDefinition();
 
                 // Contains:
-                //   Label     --- Lable     cardinality 0..1
+                //   Label     --- Label     cardinality 0..1
                 //   Width     --- Width     cardinality 0..1
                 //   Alignment --- Alignment cardinality 0..1
                 if (!String.IsNullOrEmpty(header.Label))
@@ -914,7 +914,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         #region Load WideControl
 
         /// <summary>
-        /// Load the WideControl into the WideContolBody
+        /// Load the WideControl into the WideControlBody
         /// </summary>
         /// <param name="wide"></param>
         /// <param name="viewIndex"></param>

--- a/src/System.Management.Automation/commands/utility/FormatAndOutput/common/DisplayDatabase/typeDataXmlLoader_Table.cs
+++ b/src/System.Management.Automation/commands/utility/FormatAndOutput/common/DisplayDatabase/typeDataXmlLoader_Table.cs
@@ -107,7 +107,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 if (tableBody.header.columnHeaderDefinitionList.Count != 0)
                 {
                     // CHECK: if there are headers in the list, their number has to match
-                    // the default row definition intem count
+                    // the default row definition item count
                     if (tableBody.header.columnHeaderDefinitionList.Count !=
                         tableBody.defaultDefinition.rowItemDefinitionList.Count)
                     {

--- a/src/System.Management.Automation/commands/utility/FormatAndOutput/common/FormatGroupManager.cs
+++ b/src/System.Management.Automation/commands/utility/FormatAndOutput/common/FormatGroupManager.cs
@@ -17,10 +17,10 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
     internal sealed class GroupingInfoManager
     {
         /// <summary>
-        /// Initalize with the grouping property data
+        /// Initialize with the grouping property data
         /// </summary>
-        /// <param name="groupingExpression">name of the grouping porperty</param>
-        /// <param name="displayLabel">dispaly name of the property</param>
+        /// <param name="groupingExpression">name of the grouping property</param>
+        /// <param name="displayLabel">display name of the property</param>
         internal void Initialize(MshExpression groupingExpression, string displayLabel)
         {
             _groupingKeyExpression = groupingExpression;

--- a/src/System.Management.Automation/commands/utility/FormatAndOutput/common/FormatMsgCtxManager.cs
+++ b/src/System.Management.Automation/commands/utility/FormatAndOutput/common/FormatMsgCtxManager.cs
@@ -10,11 +10,11 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
     /// INTERNAL IMPLEMENTATION CLASS
     /// 
     /// It manages the finite state machine for the sequence of formatting messages.
-    /// It achieves this by maintaning a stack of OutputContext-derived objects.
+    /// It achieves this by maintaining a stack of OutputContext-derived objects.
     /// A predefined set of events allows the host of this class to process the information
     /// as it comes trough the finite state machine (push model)
     /// 
-    /// IMPORTANT: The code using this class will have to provide ALL the callabacks.
+    /// IMPORTANT: The code using this class will have to provide ALL the callbacks.
     /// </summary>
     internal class FormatMessagesContextManager
     {

--- a/src/System.Management.Automation/commands/utility/FormatAndOutput/common/FormatViewGenerator.cs
+++ b/src/System.Management.Automation/commands/utility/FormatAndOutput/common/FormatViewGenerator.cs
@@ -95,7 +95,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             // first check if there is an override from the command line
             if (parameters != null && parameters.groupByParameter != null)
             {
-                // get the epxpression to use
+                // get the expression to use
                 MshExpression groupingKeyExpression = parameters.groupByParameter.GetEntry(FormatParameterDefinitionKeys.ExpressionEntryKey) as MshExpression;
 
                 // set the label

--- a/src/System.Management.Automation/commands/utility/FormatAndOutput/common/FormatViewGenerator_Complex.cs
+++ b/src/System.Management.Automation/commands/utility/FormatAndOutput/common/FormatViewGenerator_Complex.cs
@@ -759,7 +759,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         private ComplexSpecificParameters _complexSpecificParameters;
 
         /// <summary>
-        /// identation added to each level in the recursion
+        /// indentation added to each level in the recursion
         /// </summary>
         private int _indentationStep = 2;
 

--- a/src/System.Management.Automation/commands/utility/FormatAndOutput/common/FormatViewGenerator_Table.cs
+++ b/src/System.Management.Automation/commands/utility/FormatAndOutput/common/FormatViewGenerator_Table.cs
@@ -404,7 +404,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 return tableBody.defaultDefinition.rowItemDefinitionList;
             }
 
-            // the overriding row definition takes the precendence
+            // the overriding row definition takes the precedence
             if (matchingRowDefinition.multiLine)
                 multiLine = matchingRowDefinition.multiLine;
 
@@ -439,7 +439,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             {
                 FormatPropertyField fpf = GenerateFormatPropertyField(rowItem.formatTokenList, so, enumerationLimit);
 
-                // get the aligment from the row entry
+                // get the alignment from the row entry
                 // NOTE: if it's not set, the alignment sent with the header will prevail
                 fpf.alignment = rowItem.alignment;
 

--- a/src/System.Management.Automation/commands/utility/FormatAndOutput/common/FormatViewGenerator_Wide.cs
+++ b/src/System.Management.Automation/commands/utility/FormatAndOutput/common/FormatViewGenerator_Wide.cs
@@ -83,7 +83,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             WideViewEntry wve = new WideViewEntry();
             wve.formatPropertyField = GenerateFormatPropertyField(activeWideControlEntryDefinition.formatTokenList, so, enumerationLimit);
 
-            //wve.aligment = activeWideViewEntryDefinition.alignment;
+            //wve.alignment = activeWideViewEntryDefinition.alignment;
 
             return wve;
         }

--- a/src/System.Management.Automation/commands/utility/FormatAndOutput/common/FormattingObjects.cs
+++ b/src/System.Management.Automation/commands/utility/FormatAndOutput/common/FormattingObjects.cs
@@ -18,7 +18,7 @@ Copyright (c) Microsoft Corporation.  All rights reserved.
 // representation that mig have been introduced by serialization.
 // 
 // There is also the need to preserve type information across serialization
-// boudaries, therefore the objects provide a GUID based machanism to
+// boundaries, therefore the objects provide a GUID based machanism to
 // preserve the information.
 //
 
@@ -205,7 +205,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         /// Advisory, the outputter can decide otherwise
         /// 
         /// A zero value signifies let the outputter get the
-        /// best fit on the screen (possibily blocking until the end)
+        /// best fit on the screen (possibly blocking until the end)
         /// </summary>
         public int columns = 0;
     }

--- a/src/System.Management.Automation/commands/utility/FormatAndOutput/common/FormattingObjectsDeserializer.cs
+++ b/src/System.Management.Automation/commands/utility/FormatAndOutput/common/FormattingObjectsDeserializer.cs
@@ -260,7 +260,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         /// <summary>
         /// Deserialization of string without TAB expansion (RAW)
         /// </summary>
-        /// <param name="so">object whose the property belogs to</param>
+        /// <param name="so">object whose the property belongs to</param>
         /// <param name="property">name of the string property</param>
         /// <returns>string out of the MsObject</returns>
         internal string DeserializeStringMemberVariableRaw(PSObject so, string property)
@@ -271,7 +271,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         /// <summary>
         /// Deserialization of string performing TAB expansion
         /// </summary>
-        /// <param name="so">object whose the property belogs to</param>
+        /// <param name="so">object whose the property belongs to</param>
         /// <param name="property">name of the string property</param>
         /// <returns>string out of the MsObject</returns>
         internal string DeserializeStringMemberVariable(PSObject so, string property)

--- a/src/System.Management.Automation/commands/utility/FormatAndOutput/common/ILineOutput.cs
+++ b/src/System.Management.Automation/commands/utility/FormatAndOutput/common/ILineOutput.cs
@@ -138,7 +138,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
     internal abstract class LineOutput
     {
         /// <summary>
-        /// whether the device requres full buffering of formatting
+        /// whether the device requires full buffering of formatting
         /// objects before any processing
         /// </summary>
         internal virtual bool RequiresBuffering { get { return false; } }
@@ -207,7 +207,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             get
             {
                 CheckStopProcessing();
-                // just return the default singelton implementation
+                // just return the default singleton implementation
                 return _displayCellsDefault;
             }
         }
@@ -223,7 +223,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
     /// <summary>
     /// helper class to provide line breaking (based on device width) 
     /// and embedded newline processing
-    /// It needs to be provided with two callabacks for line processing
+    /// It needs to be provided with two callbacks for line processing
     /// </summary>
     internal class WriteLineHelper
     {

--- a/src/System.Management.Automation/commands/utility/FormatAndOutput/common/OutputManager.cs
+++ b/src/System.Management.Automation/commands/utility/FormatAndOutput/common/OutputManager.cs
@@ -316,7 +316,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                     return ce;
             }
 
-            // falied any match: return the default handler
+            // failed any match: return the default handler
             return _defaultCommandEntry;
         }
 

--- a/src/System.Management.Automation/commands/utility/FormatAndOutput/common/TableWriter.cs
+++ b/src/System.Management.Automation/commands/utility/FormatAndOutput/common/TableWriter.cs
@@ -10,7 +10,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
     internal class TableWriter
     {
         /// <summary>
-        /// Information about each column boudaries
+        /// Information about each column boundaries
         /// </summary>
         private class ColumnInfo
         {
@@ -69,7 +69,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
 
 
         /// <summary>
-        /// Initalize the table specifying the width of each column
+        /// Initialize the table specifying the width of each column
         /// </summary>
         /// <param name="leftMarginIndent">left margin indentation</param>
         /// <param name="screenColumns">number of character columns on the screen</param>
@@ -167,7 +167,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                         count = labelDisplayCells;
                 }
                 // NOTE: we can do this because "-" is a single cell character
-                // on all devices. If changed to some other character, this assuption
+                // on all devices. If changed to some other character, this assumption
                 // would be invalidated
                 breakLine[k] = new string('-', count);
             }
@@ -179,7 +179,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             if (_disabled)
                 return;
 
-            // build the current row aligment settings
+            // build the current row alignment settings
             int cols = _si.columnInfo.Length;
             int[] currentAlignment = new int[cols];
 
@@ -264,7 +264,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 }
             }
 
-            // now we processed all the rows colums and we need to find the cell that occupies the most
+            // now we processed all the rows columns and we need to find the cell that occupies the most
             // rows
             int screenRows = 0;
             for (int k = 0; k < scArray.Length; k++)
@@ -273,7 +273,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                     screenRows = scArray[k].Count;
             }
 
-            // add padding for the colums that are shorter
+            // add padding for the columns that are shorter
             for (int col = 0; col < scArray.Length; col++)
             {
                 int paddingBlanks = _si.columnInfo[validColumnArray[col]].width;

--- a/src/System.Management.Automation/commands/utility/FormatAndOutput/common/Utilities/MshObjectUtil.cs
+++ b/src/System.Management.Automation/commands/utility/FormatAndOutput/common/Utilities/MshObjectUtil.cs
@@ -271,7 +271,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
 
         /// <summary>
         /// helper to convert an PSObject into a string
-        /// It takes into account eumerations (use display name)
+        /// It takes into account enumerations (use display name)
         /// </summary>
         /// <param name="so">shell object to process</param>
         /// <param name="expressionFactory">expression factory to create MshExpression</param>

--- a/src/System.Management.Automation/commands/utility/FormatAndOutput/common/Utilities/MshParameter.cs
+++ b/src/System.Management.Automation/commands/utility/FormatAndOutput/common/Utilities/MshParameter.cs
@@ -12,7 +12,7 @@ using System.Diagnostics.CodeAnalysis;
 
 #if CORECLR 
 // Used for 'IsAssignableFrom' which is not available under 'Type' in CoreClR but provided 
-// as an extenstion method in 'System.Reflection.TypeExtensions'
+// as an extension method in 'System.Reflection.TypeExtensions'
 using System.Reflection;
 #endif
 

--- a/src/System.Management.Automation/commands/utility/FormatAndOutput/out-console/ConsoleLineOutput.cs
+++ b/src/System.Management.Automation/commands/utility/FormatAndOutput/out-console/ConsoleLineOutput.cs
@@ -374,12 +374,12 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         /// </summary>
         private void LineWrittenEvent()
         {
-            // check to avoid reeentrancy from the prompt handler
-            // writing during the PropmtUser() call
+            // check to avoid reentrancy from the prompt handler
+            // writing during the PromptUser() call
             if (_disableLineWrittenEvent)
                 return;
 
-            // if there is no promting, we are done
+            // if there is no prompting, we are done
             if (_prompt == null)
                 return;
 
@@ -420,7 +420,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         /// <summary>
         /// check if we need to put out a prompt
         /// </summary>
-        /// <value>true if we need to promp</value>
+        /// <value>true if we need to prompt</value>
         private bool NeedToPrompt
         {
             get
@@ -471,10 +471,10 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             }
 
             /// <summary>
-            /// detemine how many rows the prompt should take.
+            /// determine how many rows the prompt should take.
             /// </summary>
-            /// <param name="cols">current number of colums on the screen</param>
-            /// <param name="displayCells">string manipupation helper</param>
+            /// <param name="cols">current number of columns on the screen</param>
+            /// <param name="displayCells">string manipulation helper</param>
             /// <returns></returns>
             internal int ComputePromptLines(DisplayCells displayCells, int cols)
             {
@@ -574,7 +574,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
 
         /// <summary>
         /// handler to prompt the user for page breaks
-        /// if this handler is not null, we have promting
+        /// if this handler is not null, we have prompting
         /// </summary>
         private PromptHandler _prompt = null;
 
@@ -584,7 +584,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         private long _linesWritten = 0;
 
         /// <summary>
-        /// flag to avoid renetrancy on promting
+        /// flag to avoid reentrancy on prompting
         /// </summary>
         private bool _disableLineWrittenEvent = false;
 

--- a/src/System.Management.Automation/commands/utility/FormatAndOutput/out-console/OutConsole.cs
+++ b/src/System.Management.Automation/commands/utility/FormatAndOutput/out-console/OutConsole.cs
@@ -31,14 +31,14 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         protected override void ProcessRecord()
         {
-            // explicitely overriden:
+            // explicitely overridden:
             // do not do any processing
         }
     }
 
     /// <summary>
     /// implementation for the out-default command
-    /// this command it impicitely inject by the
+    /// this command it implicitly inject by the
     /// powershell.exe host at the end of the pipeline as the
     /// default sink (display to console screen)
     /// </summary>
@@ -47,7 +47,7 @@ namespace Microsoft.PowerShell.Commands
     {
         /// <summary>
         /// Determines whether objects should be sent to API consumers.
-        /// This command is automatically added to the pipeline when PowerShell is transcripting and
+        /// This command is automatically added to the pipeline when PowerShell is transcribing and
         /// invoked via API. This ensures that the objects pass through the formatting and output
         /// system, but can still make it to the API consumer.
         /// </summary>

--- a/src/System.Management.Automation/commands/utility/FormatAndOutput/out-textInterface/OutTextInterface.cs
+++ b/src/System.Management.Automation/commands/utility/FormatAndOutput/out-textInterface/OutTextInterface.cs
@@ -19,7 +19,7 @@ namespace Microsoft.PowerShell.Commands
     public class OutLineOutputCommand : FrontEndCommandBase
     {
         /// <summary>
-        /// command line switch for ILineOutput comunication channel
+        /// command line switch for ILineOutput communication channel
         /// </summary>
         /// <value></value>
         [Parameter(Mandatory = true, Position = 0)]

--- a/src/System.Management.Automation/engine/Modules/GetModuleCommand.cs
+++ b/src/System.Management.Automation/engine/Modules/GetModuleCommand.cs
@@ -62,7 +62,7 @@ namespace Microsoft.PowerShell.Commands
         public ModuleSpecification[] FullyQualifiedName { get; set; }
 
         /// <summary>
-        /// If specified, all loaded modules should be returne, otherwise only the visible
+        /// If specified, all loaded modules should be returned, otherwise only the visible
         /// modules should be returned.
         /// </summary>
         [Parameter(ParameterSetName = ParameterSet_Loaded)]
@@ -426,7 +426,7 @@ namespace Microsoft.PowerShell.Commands
         }
 
         /// <summary>
-        /// Determine whether a module info matches a given module specification table and specified PSEditon value.
+        /// Determine whether a module info matches a given module specification table and specified PSEdition value.
         /// </summary>
         /// <param name="moduleInfo"></param>
         /// <param name="moduleSpecTable"></param>

--- a/src/System.Management.Automation/engine/Modules/ImportModuleCommand.cs
+++ b/src/System.Management.Automation/engine/Modules/ImportModuleCommand.cs
@@ -112,7 +112,7 @@ namespace Microsoft.PowerShell.Commands
                 if (value == null)
                     return;
                 _functionImportList = value;
-                // Create the list of patterns to match at patameter bind time
+                // Create the list of patterns to match at parameter bind time
                 // so errors will be reported before loading the module...
                 BaseFunctionPatterns = new List<WildcardPattern>();
                 foreach (string pattern in _functionImportList)
@@ -138,7 +138,7 @@ namespace Microsoft.PowerShell.Commands
                     return;
 
                 _cmdletImportList = value;
-                // Create the list of patterns to match at patameter bind time
+                // Create the list of patterns to match at parameter bind time
                 // so errors will be reported before loading the module...
                 BaseCmdletPatterns = new List<WildcardPattern>();
                 foreach (string pattern in _cmdletImportList)
@@ -1430,7 +1430,7 @@ namespace Microsoft.PowerShell.Commands
 
                     //
                     // import the module 
-                    // (from memory - this avoids the authenticode singature problems 
+                    // (from memory - this avoids the authenticode signature problems 
                     // that would be introduced by rewriting the contents of the manifest)
                     //
                     moduleInfo = LoadModuleManifest(
@@ -1483,7 +1483,7 @@ namespace Microsoft.PowerShell.Commands
                     }
 
                     //
-                    // store the default sesion 
+                    // store the default session 
                     //
                     Dbg.Assert(moduleInfo.ModuleType == ModuleType.Manifest, "Remote discovery should always produce a 'manifest' module");
                     Dbg.Assert(moduleInfo.NestedModules != null, "Remote discovery should always produce a 'manifest' module with nested modules entry");
@@ -1523,7 +1523,7 @@ namespace Microsoft.PowerShell.Commands
                     moduleInfo.OnRemove = onRemoveScriptBlock;
 
                     //
-                    // Some procesing common for local and remote modules
+                    // Some processing common for local and remote modules
                     //
                     AddModuleToModuleTables(
                         this.Context,

--- a/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
@@ -170,25 +170,25 @@ namespace Microsoft.PowerShell.Commands
 
         /// <summary>
         /// The minimum version number to check the module against. Used the underlying property
-        /// for derived cmdlet paramters.
+        /// for derived cmdlet parameters.
         /// </summary>
         internal Version BaseMinimumVersion { get; set; }
 
         /// <summary>
         /// The maximum version number to check the module against. Used the underlying property
-        /// for derived cmdlet paramters.
+        /// for derived cmdlet parameters.
         /// </summary>
         internal Version BaseMaximumVersion { get; set; }
 
         /// <summary>
         /// The version number to check the module against. Used the underlying property
-        /// for derived cmdlet paramters.
+        /// for derived cmdlet parameters.
         /// </summary>
         internal Version BaseRequiredVersion { get; set; }
 
         /// <summary>
         /// The Guid to check the module against. Used the underlying property
-        /// for derived cmdlet paramters.
+        /// for derived cmdlet parameters.
         /// </summary>
         internal Guid? BaseGuid { get; set; }
 
@@ -433,7 +433,7 @@ namespace Microsoft.PowerShell.Commands
         }
 
         /// <summary>
-        /// Extra variables that are allowed to be referenced in moudle manifest file
+        /// Extra variables that are allowed to be referenced in module manifest file
         /// </summary>
         private static readonly string[] s_extraAllowedVariables = new string[] { "PSScriptRoot", "PSEdition" };
 
@@ -515,7 +515,7 @@ namespace Microsoft.PowerShell.Commands
             }
 
             // MSFT:873446 Create a case insensitive comparer based hashtable to help
-            // with case-insenstive comparision of keys.
+            // with case-insensitive comparison of keys.
             data = new Hashtable(data, StringComparer.OrdinalIgnoreCase);
             if (validMembers != null && !ValidateManifestHash(data, validMembers, moduleManifestPath, manifestProcessingFlags))
             {
@@ -960,7 +960,7 @@ namespace Microsoft.PowerShell.Commands
                         }
                         else
                         {
-                            // Given path is a directory, we first check if it is end with moudle version.
+                            // Given path is a directory, we first check if it is end with module version.
                             Version version;
                             if (Version.TryParse(moduleName, out version))
                             {
@@ -1134,7 +1134,7 @@ namespace Microsoft.PowerShell.Commands
             }
             else
             {
-                // If first convertion fails, try to convert * to maximum version
+                // If first conversion fails, try to convert * to maximum version
                 string maxRange = "999999999";
                 if (stringVersion[stringVersion.Length - 1] == '*')
                 {
@@ -1487,7 +1487,7 @@ namespace Microsoft.PowerShell.Commands
             // Workflows specified in NestedModules from the manifest
             List<string> workflowsToProcess = new List<string>();
 
-            // Workflows specified in ReduiredAssemblies
+            // Workflows specified in RequiredAssemblies
             List<string> dependentWorkflows = new List<string>();
 
             string moduleToProcess = null;
@@ -1873,7 +1873,7 @@ namespace Microsoft.PowerShell.Commands
                 }
             }
 
-            // Test the required procesor architecture
+            // Test the required processor architecture
             ProcessorArchitecture requiredProcesorArchitecture;
             if (
                 !GetScalarFromData(data, moduleManifestPath, "ProcessorArchitecture", manifestProcessingFlags,
@@ -2378,7 +2378,7 @@ namespace Microsoft.PowerShell.Commands
                 !GetListOfFilesFromData(data, moduleManifestPath, "FileList", manifestProcessingFlags, moduleBase, ""
                     /*extension*/,
                     false
-                    /* don't check file existance - don't want to change current behavior without feature team discussion */,
+                    /* don't check file existence - don't want to change current behavior without feature team discussion */,
                     out fileList))
             {
                 containedErrors = true;
@@ -2981,7 +2981,7 @@ namespace Microsoft.PowerShell.Commands
                             ModuleIntrinsics.GetModuleName(moduleManifestPath));
                     throw workflowModuleNotSupported;
 #else
-                    // Depending on current execution policy, check the signature of Module manfiest file if required.
+                    // Depending on current execution policy, check the signature of Module manifest file if required.
                     // Reusing already created ScriptInfo object to avoid race condition when modulemanifest was not signed during first check and signed before this step.
                     //
                     scriptInfo.ValidateScriptInfo(Host);
@@ -3395,7 +3395,7 @@ namespace Microsoft.PowerShell.Commands
                 }
 
                 // If there are types/formats entries in the ModuleToProcess use them
-                // only if there are no entries from the manifst. The manifest entries
+                // only if there are no entries from the manifest. The manifest entries
                 // completely override the module's entries.
                 if (manifestInfo.ExportedTypeFiles.Count > 0)
                 {
@@ -4476,7 +4476,7 @@ namespace Microsoft.PowerShell.Commands
                     error = new ErrorRecord(mm, "Modules_InvalidManifest", ErrorCategory.ResourceUnavailable, mo.Path);
                     return true;
                 }
-                else // Go for the recusrive check for the RequiredModules of current module
+                else // Go for the recursive check for the RequiredModules of current module
                 {
                     // Add required Modules of m to the list
                     Collection<PSModuleInfo> availableModules = GetModuleIfAvailable(moduleSpecification);
@@ -5013,7 +5013,7 @@ namespace Microsoft.PowerShell.Commands
             {
                 try
                 {
-                    filePaths = context.SessionState.Path.GetResolvedProviderPathFromPSPath(filePath, true /* allowNonExistantPaths */, out provider);
+                    filePaths = context.SessionState.Path.GetResolvedProviderPathFromPSPath(filePath, true /* allowNonExistentPaths */, out provider);
                 }
                 catch (Exception e)
                 {
@@ -5052,7 +5052,7 @@ namespace Microsoft.PowerShell.Commands
             {
                 try
                 {
-                    filePaths = context.SessionState.Path.GetResolvedProviderPathFromPSPath(filePath, true /* allowNonExistantPaths */, out provider);
+                    filePaths = context.SessionState.Path.GetResolvedProviderPathFromPSPath(filePath, true /* allowNonExistentPaths */, out provider);
                 }
                 catch (Exception e)
                 {
@@ -5381,7 +5381,7 @@ namespace Microsoft.PowerShell.Commands
                     }
 
                     this.RemoveTypesAndFormatting(module.ExportedFormatFiles, module.ExportedTypeFiles);
-                    // reseting the help caches. This is needed as the help content cached is cached in process.
+                    // resetting the help caches. This is needed as the help content cached is cached in process.
                     // When a module is removed there is no need to cache the help content for the commands in
                     // the module. The HelpSystem is not designed to track per module help content...so resetting
                     // all of the cache. HelpSystem knows how to build this cache back when needed.
@@ -6854,7 +6854,7 @@ namespace Microsoft.PowerShell.Commands
             }
             else
             {
-                // Avoid trying to import a PowerShell assembly as Snapin as it results in PSArgementException
+                // Avoid trying to import a PowerShell assembly as Snapin as it results in PSArgumentException
                 if ((moduleName != null) && Utils.IsPowerShellAssembly(moduleName))
                 {
                     trySnapInName = false;

--- a/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
@@ -185,7 +185,7 @@ namespace System.Management.Automation
                     ast = ast.Parent;
                 }
 
-                // The variables set in the interpretted case get set by InvokeWithPipe in the compiled case.
+                // The variables set in the interpreted case get set by InvokeWithPipe in the compiled case.
                 Diagnostics.Assert(_context.SessionState.Internal.CurrentScope.LocalsTuple == null,
                                     "No locals tuple should have been created yet.");
 
@@ -862,7 +862,7 @@ namespace System.Management.Automation
             else // The running powershell is Full PS or inbox Core PS
             {
                 // If there is no personal path key, then if the env variable doesn't match the system variable,
-                // the user modified it somewhere, else prepend the default personel module path
+                // the user modified it somewhere, else prepend the default personal module path
                 if (hklmMachineModulePath != null) // EVT.Machine exists
                 {
                     if (hkcuUserModulePath == null) // EVT.User does Not exist
@@ -1328,7 +1328,7 @@ namespace System.Management.Automation
     }
 
     /// <summary>
-    /// Used by modules to provide a hooko to the engine for cleanup on removal
+    /// Used by modules to provide a hook to the engine for cleanup on removal
     /// w.r.t. compiled assembly being removed.
     /// </summary>
     public interface IModuleAssemblyCleanup

--- a/src/System.Management.Automation/engine/Modules/ModuleSpecification.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleSpecification.cs
@@ -82,7 +82,7 @@ namespace Microsoft.PowerShell.Commands
         /// Initialize moduleSpecification from hashtable. Return exception object, if hashtable cannot be converted.
         /// Return null, in the success case.
         /// </summary>
-        /// <param name="moduleSpecification">object to initalize</param>
+        /// <param name="moduleSpecification">object to initialize</param>
         /// <param name="hashtable">contains info about object to initialize.</param>
         /// <returns></returns>
         internal static Exception ModuleSpecificationInitHelper(ModuleSpecification moduleSpecification, Hashtable hashtable)
@@ -124,7 +124,7 @@ namespace Microsoft.PowerShell.Commands
                 }
             }
             // catch all exceptions here, we are going to report them via return value.
-            // Example of catched exception: one of convertions to Version failed.
+            // Example of catched exception: one of conversions to Version failed.
             catch (Exception e)
             {
                 return e;

--- a/src/System.Management.Automation/engine/Modules/NewModuleCommand.cs
+++ b/src/System.Management.Automation/engine/Modules/NewModuleCommand.cs
@@ -63,7 +63,7 @@ namespace Microsoft.PowerShell.Commands
                     return;
 
                 _functionImportList = value;
-                // Create the list of patterns to match at patameter bind time
+                // Create the list of patterns to match at parameter bind time
                 // so errors will be reported before loading the module...
                 BaseFunctionPatterns = new List<WildcardPattern>();
                 foreach (string pattern in _functionImportList)
@@ -89,7 +89,7 @@ namespace Microsoft.PowerShell.Commands
                     return;
 
                 _cmdletImportList = value;
-                // Create the list of patterns to match at patameter bind time
+                // Create the list of patterns to match at parameter bind time
                 // so errors will be reported before loading the module...
                 BaseCmdletPatterns = new List<WildcardPattern>();
                 foreach (string pattern in _cmdletImportList)

--- a/src/System.Management.Automation/engine/Modules/NewModuleManifestCommand.cs
+++ b/src/System.Management.Automation/engine/Modules/NewModuleManifestCommand.cs
@@ -683,7 +683,7 @@ namespace Microsoft.PowerShell.Commands
         ///// <summary>
         ///// Takes a collection of file names and returns the collection
         ///// quoted.  It does not expand wildcard to actual files (as QuoteFiles does).
-        ///// It throws an error when the entered filename is different than the alllowedExtension.
+        ///// It throws an error when the entered filename is different than the allowedExtension.
         ///// If any file name falls outside the directory tree basPath a warning is issued.
         ///// </summary>
         ///// <param name="basePath">This is the path which will be used to determine whether a warning is to be displayed.</param>
@@ -833,7 +833,7 @@ namespace Microsoft.PowerShell.Commands
         }
 
         /// <summary>
-        /// Generate the module manfest...
+        /// Generate the module manifest...
         /// </summary>
         protected override void EndProcessing()
         {
@@ -864,7 +864,7 @@ namespace Microsoft.PowerShell.Commands
             }
 
             // By default, we want to generate a module manifest the encourages the best practice of explicitly specifying
-            // the commands exported (even if it's an empty array.) Unforunately, changing the default breaks automation
+            // the commands exported (even if it's an empty array.) Unfortunately, changing the default breaks automation
             // (however unlikely, this cmdlet isn't really meant for automation). Instead of trying to detect interactive
             // use (which is quite hard), we infer interactive use if none of RootModule/NestedModules/RequiredModules is
             // specified - because the manifest needs to be edited to actually be of use in those cases.

--- a/src/System.Management.Automation/engine/Modules/PSModuleInfo.cs
+++ b/src/System.Management.Automation/engine/Modules/PSModuleInfo.cs
@@ -255,7 +255,7 @@ namespace System.Management.Automation
 
         /// <summary>
         /// Get the module base directory for this module. For modules loaded via a module
-        /// manifest, this will be the directory containting the manifest file rather than
+        /// manifest, this will be the directory containing the manifest file rather than
         /// the directory containing the actual module file. This is particularly useful
         /// when loading a GAC'ed assembly.
         /// </summary>
@@ -735,7 +735,7 @@ namespace System.Management.Automation
         /// <summary>
         /// Gets the aggregated list of visible commands exported from the module. If there are two
         /// commands of different types exported with the same name (e.g. alias 'foo' and cmdlet 'foo') the
-        /// combined dictionary will only contain the highest precidence cmdlet (e.g. the alias 'foo' since
+        /// combined dictionary will only contain the highest precedence cmdlet (e.g. the alias 'foo' since
         /// aliases shadow cmdlets.
         /// </summary>
         public Dictionary<string, CommandInfo> ExportedCommands

--- a/src/System.Management.Automation/engine/Modules/RemoveModuleCommand.cs
+++ b/src/System.Management.Automation/engine/Modules/RemoveModuleCommand.cs
@@ -57,7 +57,7 @@ namespace Microsoft.PowerShell.Commands
         private PSModuleInfo[] _moduleInfo = Utils.EmptyArray<PSModuleInfo>();
 
         /// <summary>
-        /// If provided, this paramter will allow readonly modules to be removed.
+        /// If provided, this parameter will allow readonly modules to be removed.
         /// </summary>
         [Parameter]
         public SwitchParameter Force
@@ -69,7 +69,7 @@ namespace Microsoft.PowerShell.Commands
         private int _numberRemoved = 0;  // Maintains a count of the number of modules removed...
 
         /// <summary>
-        /// Remove the specified modules. Modules can be specifed either through a ModuleInfo or a name.
+        /// Remove the specified modules. Modules can be specified either through a ModuleInfo or a name.
         /// </summary>
         protected override void ProcessRecord()
         {

--- a/src/System.Management.Automation/engine/Modules/ScriptAnalysis.cs
+++ b/src/System.Management.Automation/engine/Modules/ScriptAnalysis.cs
@@ -52,7 +52,7 @@ namespace System.Management.Automation
             ParseError[] errors;
             var moduleAst = (new Parser()).Parse(path, scriptContent, null, out errors, ParseMode.ModuleAnalysis);
 
-            // Don't bother analyzing if there are syntax errors (we don't do semenatic analysis which would
+            // Don't bother analyzing if there are syntax errors (we don't do semantic analysis which would
             // detect other errors that we also might choose to ignore, but it's slower.)
             if (errors.Length > 0)
                 return null;

--- a/src/System.Management.Automation/engine/Modules/TestModuleManifestCommand.cs
+++ b/src/System.Management.Automation/engine/Modules/TestModuleManifestCommand.cs
@@ -116,7 +116,7 @@ namespace Microsoft.PowerShell.Commands
 
                     if (module != null)
                     {
-                        //Validtate file existence
+                        //Validate file existence
                         if (module.RequiredAssemblies != null)
                         {
                             foreach (string requiredAssembliespath in module.RequiredAssemblies)

--- a/src/libpsl-native/src/createhardlink.cpp
+++ b/src/libpsl-native/src/createhardlink.cpp
@@ -40,7 +40,7 @@
 //! - ERROR_BAD_PATH_NAME: pathname is too long, or contains invalid characters
 //!
 //! @retval 1 if creation is successful
-//! @retval 0 if createion failed
+//! @retval 0 if creation failed
 //!
 
 int32_t CreateHardLink(const char *newlink, const char *target)

--- a/src/libpsl-native/src/followsymlink.cpp
+++ b/src/libpsl-native/src/followsymlink.cpp
@@ -30,7 +30,7 @@
 //! - ERROR_INVALID_NAME: file provided is not a symbolic link
 //! - ERROR_INVALID_FUNCTION: incorrect function
 //! - ERROR_BAD_PATH_NAME: pathname is too long
-//! - ERROR_OUTOFMEMORY insufficient kernal memory
+//! - ERROR_OUTOFMEMORY insufficient kernel memory
 //!
 //! @retval target path, or NULL if unsuccessful
 //!

--- a/src/libpsl-native/src/getfullyqualifiedname.cpp
+++ b/src/libpsl-native/src/getfullyqualifiedname.cpp
@@ -9,7 +9,7 @@
 #include "getcomputername.h"
 #include "getfullyqualifiedname.h"
 
-//! @brief GetFullyQualifiedName retrieves the fully qualifed dns name of the host
+//! @brief GetFullyQualifiedName retrieves the fully qualified dns name of the host
 //!
 //! @exception errno Passes these errors via errno to GetLastError:
 //! - ERROR_INVALID_FUNCTION: getlogin_r() returned an unrecognized error code (from GetComputerName)

--- a/src/libpsl-native/src/getlinkcount.cpp
+++ b/src/libpsl-native/src/getlinkcount.cpp
@@ -42,7 +42,7 @@
 //! - ERROR_BAD_PATH_NAME: pathname is too long, or contains invalid characters
 //!
 //! @retval 1 If the function succeeds, and the variable pointed to by buffer contains 
-//! infomation about the files
+//! information about the files
 //! @retval 0 If the function fails, the return value is zero. To get
 //! extended error information, call GetLastError.
 //!

--- a/src/powershell-native/nativemsh/pwrshcommon/NativeMsh.h
+++ b/src/powershell-native/nativemsh/pwrshcommon/NativeMsh.h
@@ -5,7 +5,7 @@
 //
 //  File:      NativeMsh.h
 //
-//  Contents:  common code requred to start powershell (exe and plugin)
+//  Contents:  common code required to start powershell (exe and plugin)
 //
 // ----------------------------------------------------------------------
 

--- a/src/powershell-native/nativemsh/pwrshcommon/pwrshcommon.cpp
+++ b/src/powershell-native/nativemsh/pwrshcommon/pwrshcommon.cpp
@@ -57,7 +57,7 @@ namespace NativeMsh
                 break;
             }
             WCHAR * pwchIntEnd = NULL;
-            // this should never cause overflow because VerifyInteger gaurantees pwchMinorVersion
+            // this should never cause overflow because VerifyInteger guarantees pwchMinorVersion
             // has less than g_MAX_NUMBER_OF_DIGITS_IN_VERSION which is 10.
             unsigned long ulTempResult = wcstoul(pwchStart, &pwchIntEnd, 10);
             // Make sure the whole string is an integer and fits an int 

--- a/src/powershell-native/nativemsh/pwrshexe/MainEntry.cpp
+++ b/src/powershell-native/nativemsh/pwrshexe/MainEntry.cpp
@@ -1483,7 +1483,7 @@ HRESULT AddPowerShellTasksToList(ICustomDestinationList *pCustDestList, STARTUPI
 
 /*********************************************************************
 * FileExists is a helper function used to check if the file path 
-* provided as arguement to this function exists or not.
+* provided as argument to this function exists or not.
 *********************************************************************/
 BOOL FileExists(LPCWSTR  fileName)
 {
@@ -1586,7 +1586,7 @@ int __cdecl
     // Change the thread user interface to a language that the
     // windows console can display. This is important as starting
     // from windows vista and later, the OS support thread user
-    // interface lanaguage separate from thread locale.
+    // interface language separate from thread locale.
     // Setting this will enable OS resource loader to load correct
     // resource that can display properly in a console window.
     // Note: If the language identifier is 0, the function always 
@@ -1723,7 +1723,7 @@ int __cdecl
             pwrshExeOutput->DisplayMessage(false, g_NONSTANDARD_CLR_VERSION, wszRuntimeVersion);
         }
 
-        // On downlevel setups, verify that the CLR was present when PowerShell was intalled.
+        // On downlevel setups, verify that the CLR was present when PowerShell was installed.
         // If it wasn't, then PowerShell is in a bad state and needs to be installed after the
         // CLR.
         exitCode = ValidateDownlevelSetupHadClrWhenInstalled(

--- a/src/powershell-native/nativemsh/pwrshplugin/entrypoints.cpp
+++ b/src/powershell-native/nativemsh/pwrshplugin/entrypoints.cpp
@@ -30,7 +30,7 @@ LPCWSTR g_MAIN_BINARY_NAME = L"pwrshplugin.dll";
 // gets the error message from the resources section of the current module.
 // the caller should free pwszErrorMessage using LocalFree().
 // returns: If the function succeeds the return value is the number of CHARs stored int the output
-// buffer, excluding the terminating null character. If the function failes the return value is zero.
+// buffer, excluding the terminating null character. If the function fails the return value is zero.
 #pragma prefast(push)
 #pragma prefast (disable: 28196)
 DWORD GetFormattedErrorMessage(__deref_out PWSTR * pwszErrorMessage, DWORD dwMessageId, va_list* arguments)
@@ -181,7 +181,7 @@ unsigned int ConstructPowerShellVersion(int iPSMajorVersion,
 static PwrshCommon sPwrshCommon;
 
 // Gets the CLR Version for a given PowerShell Version. PowerShell Version is
-// supplied with 2 paramaters iPSMajorVersion (PowerShell major version) and
+// supplied with 2 parameters iPSMajorVersion (PowerShell major version) and
 // iPSMinorVersion (PowerShell minor version). The CLR version is returned through
 // pwszRuntimeVersion and pRuntimeVersionLength represents the size of pwszRuntimeVersion.
 // returns: 0 on success, non-zero on failure.

--- a/src/powershell-native/nativemsh/pwrshplugin/pwrshheaders.h
+++ b/src/powershell-native/nativemsh/pwrshplugin/pwrshheaders.h
@@ -10,7 +10,7 @@
 #pragma once
 
 // Gets the CLR Version for a given PowerShell Version. PowerShell Version is
-// supplied with 2 paramaters iPSMajorVersion (PowerShell major version) and
+// supplied with 2 parameters iPSMajorVersion (PowerShell major version) and
 // iPSMinorVersion (PowerShell minor version). The CLR version is returned through
 // pwszRuntimeVersion and pRuntimeVersionLength represents the size of pwszRuntimeVersion.
 // returns: 0 on success, non-zero on failure.

--- a/src/powershell-native/nativemsh/pwrshplugin/pwrshplugin.h
+++ b/src/powershell-native/nativemsh/pwrshplugin/pwrshplugin.h
@@ -93,7 +93,7 @@ private:
     bool isCSInitSucceeded; 
 
     // Abstraction of the differences between CLR hosting environments with
-    // repsect to the interface with pspluginwkr.
+    // respect to the interface with pspluginwkr.
     IPowerShellClrHost* powerShellClrHost;
 
     // Default no-op implementation used for the output functions.
@@ -180,7 +180,7 @@ public:
             {
                 if (!singletonInstance.bIsPluginLoaded)
                 {
-                    // process extra info initializies the pwrshplugin
+                    // process extra info initializes the pwrshplugin
                     // by initializing the CLR version and obtaining access
                     // pointers for the plugin worker or for System.Management.Automation.dll.
                     singletonInstance.ProcessExtraInfo(extraInfo, NULL);
@@ -668,7 +668,7 @@ private:
         wchar_t* wszMonadVersion = NULL;    // Allocated via ConstructPowerShellVersion || GetRegistryInfo
         wchar_t* wszTempCLRVersion = NULL;  // Allocated via GetRegistryInfo
         wchar_t* wszTempAppBase = NULL;     // Allocated via GetRegistryInfo
-        PWSTR wszMgdPlugInFileName = NULL;  // Allocted in CreateMgdPluginFileName
+        PWSTR wszMgdPlugInFileName = NULL;  // Allocated in CreateMgdPluginFileName
         unsigned int exitCode = EXIT_CODE_SUCCESS;
         PlugInException* pErrorMsg = NULL;
 


### PR DESCRIPTION
 The complete change series (see my spelling branch) was ~180 directories, ~850 words, ~1000 files, ~3400 changes. There's no good way to review such a thing, there are only different ways to slice it.

Nothing here should impact the build, however, there are a lot of files. In order to make it possible for me to exclude things which would have, I selectively included changes on a per-directory basis.

This means there are 34 commits, each of which should be fairly easy to review independently.

It is possible for me to squash them if requested, but I'd really like to avoid doing that until someone is absolutely confident they're about ready to accept it, otherwise merging, rebasing, and reviewing are all painful.

Also, if you really want each of the 34 changesets to be distinct PRs, I can do that, but it's approaching the limit of my work tolerance (I still have to produce changesets for comments in the src/System.Management.Automation directory, and then changesets for all the non-comments).

This is PR 4 of N:

The following is a list of some spelling fixes which have been made to the impacted files. It is not necessarily a complete list of changed words -- if a word is misspelled in code or resource strings the quick tool I used to list what's changed might say "that's still present" and not have highlighted it.
- baseclass
- blankspaces
- cachemetadata
- commandline
- defaultcredential
- erroraction
- IDisposable
- IEnumerable's
- IFormattable's
- JQuery
- lifecycle
- parameterset
- persistable
- Refactor
- Thu
- unsubscribe
