### PR TITLE
Fix multi-line input w/ redirected stdin

### DIFF
--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterface.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterface.cs
@@ -1557,6 +1557,7 @@ namespace Microsoft.PowerShell
             if (initialContent != null)
             {
                 sb.Append(initialContent);
+                sb.Append('\n');
             }
 
             while (true)
@@ -1579,7 +1580,11 @@ namespace Microsoft.PowerShell
                         if (!NoPrompt) Console.Out.Write('\n');
                         Console.In.Read();
                     }
-                    sb.Append('\n');
+                    break;
+                }
+
+                if (c == '\n')
+                {
                     break;
                 }
 
@@ -1590,12 +1595,6 @@ namespace Microsoft.PowerShell
                 else
                 {
                     sb.Append(c);
-                }
-
-
-                if (c == '\n')
-                {
-                    break;
                 }
             }
 

--- a/test/powershell/Host/ConsoleHost.Tests.ps1
+++ b/test/powershell/Host/ConsoleHost.Tests.ps1
@@ -263,8 +263,23 @@ Describe "ConsoleHost unit tests" -tags "Feature" {
             $si = NewProcessStartInfo "-noprofile -" -RedirectStdIn
             $process = RunPowerShell $si
             $process.StandardInput.Write("1+1`n")
+            $process.StandardOutput.ReadLine() | Should Be "2"
+
+            # Multi-line input
+            $process.StandardInput.Write("if (1)`n{`n    42`n}`n`n")
+            $process.StandardOutput.ReadLine() | Should Be "42"
+            $process.StandardInput.Write(@"
+function foo
+{
+    'in foo'
+}
+
+foo
+
+"@)
+            $process.StandardOutput.ReadLine() | Should Be "in foo"
+
             $process.StandardInput.Close()
-            $process.StandardOutput.ReadToEnd() | Should Be "2${nl}"
             EnsureChildHasExited $process
         }
 


### PR DESCRIPTION
The input loop reading from stdin did not handle multi-line input correctly
because it was adding a newline character where none was expected.

The fix was to not include the final newline character to accept input,
just like Console.ReadLine or PSReadline would.

Fixes #2068.
