### PR TITLE
Spelling comments

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Computer.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Computer.cs
@@ -6281,7 +6281,7 @@ $result
         private const string MatchFormat = "{0}:{1}";
 
         /// <summary>
-        /// The HasSuceeded which shows the operation was success or not
+        /// The HasSucceeded which shows the operation was success or not
         /// </summary>
         public bool HasSucceeded { get; set; }
 

--- a/src/Microsoft.PowerShell.PackageManagement/Cmdlets/CmdletBase.cs
+++ b/src/Microsoft.PowerShell.PackageManagement/Cmdlets/CmdletBase.cs
@@ -179,7 +179,7 @@ namespace Microsoft.PowerShell.PackageManagement.Cmdlets {
                     }
                 }
 
-                return Constants.DefaultTimeout; // in a non-invokcation, always default to one hour
+                return Constants.DefaultTimeout; // in a non-invocation, always default to one hour
             }
         }
 
@@ -191,7 +191,7 @@ namespace Microsoft.PowerShell.PackageManagement.Cmdlets {
                         return t;
                     }
                 }
-                return Constants.DefaultResponsiveness; // in a non-invokcation, always default to one hour
+                return Constants.DefaultResponsiveness; // in a non-invocation, always default to one hour
             }
         }
 

--- a/src/Microsoft.WSMan.Management/ConfigProvider.cs
+++ b/src/Microsoft.WSMan.Management/ConfigProvider.cs
@@ -33,7 +33,7 @@ namespace Microsoft.WSMan.Management
         private PSObject objPluginNames = null;
 
         /// <summary>
-        /// Determinies if Set-Item user input type validateion is required or not.
+        /// Determines if Set-Item user input type validation is required or not.
         /// It is True by default, Clear-Item will set it to false so that it can 
         /// pass Empty String as value for Set-Item.
         /// </summary>
@@ -42,7 +42,7 @@ namespace Microsoft.WSMan.Management
         WSManHelper helper = new WSManHelper();
 
         /// <summary>
-        /// Object contains the cache of the enumarate results for the cmdlet to execute.
+        /// Object contains the cache of the enumerate results for the cmdlet to execute.
         /// </summary>
         Dictionary<string, XmlDocument> enumarateMapping = new Dictionary<string, XmlDocument>();
 
@@ -196,7 +196,7 @@ namespace Microsoft.WSMan.Management
         }
 
         /// <summary>
-        /// Adds the requird drive
+        /// Adds the required drive
         /// </summary>
         /// <returns></returns>
         protected override Collection<PSDriveInfo> InitializeDefaultDrives()
@@ -208,7 +208,7 @@ namespace Microsoft.WSMan.Management
         }
 
         /// <summary>
-        /// Removes the requird drive
+        /// Removes the required drive
         /// </summary>
         /// <returns></returns>
         protected override PSDriveInfo RemoveDrive(PSDriveInfo drive)
@@ -223,9 +223,9 @@ namespace Microsoft.WSMan.Management
         #region ItemCmdletProvider
 
         /// <summary>
-        /// Get a Child Name. This methos is called from MakePath method.
+        /// Get a Child Name. This method is called from MakePath method.
         /// This Method helps in getting the correct case of particular element in the provider path.
-        /// XML is case senstive but Powershell is not. 
+        /// XML is case sensitive but Powershell is not. 
         /// </summary>
         /// <param name="path"></param>
         /// <returns></returns>
@@ -391,7 +391,7 @@ namespace Microsoft.WSMan.Management
                 /* 
                 WsMan Config Can be divided in to Four Fixed Regions to Check Whether it has Child Items.
                 
-                 * 1. Branch in to Listerners (winrm/config/listener)
+                 * 1. Branch in to Listeners (winrm/config/listener)
                  * 2. Branch in to CertMapping (winrm/config/service/certmapping)
                  * 3. Branch in to Plugin (winrm/config/plugin) - Plugin is subdivided in Resources,Security & InitParams
                  * 4. Rest all the branches like Client, Shell(WinRS) ,Service
@@ -1314,7 +1314,7 @@ namespace Microsoft.WSMan.Management
         }
 
         /// <summary>
-        /// This commad is used to clear the value of a item.
+        /// This command is used to clear the value of a item.
         /// </summary>
         /// <param name="path"></param>
         protected override void ClearItem(string path)
@@ -1366,7 +1366,7 @@ namespace Microsoft.WSMan.Management
         }
 
         /// <summary>
-        /// This method gives the names of child items. this is used for Tab compeletion.
+        /// This method gives the names of child items. this is used for Tab completion.
         /// </summary>
         /// <param name="path"></param>
         /// <param name="returnContainers"></param>
@@ -1427,7 +1427,7 @@ namespace Microsoft.WSMan.Management
                 /* 
                 WsMan Config Can be divided in to Four Fixed Regions to Check Whether Item is Container
                 
-                 * 1. Branch in to Listerners (winrm/config/listener)
+                 * 1. Branch in to Listeners (winrm/config/listener)
                  * 2. Branch in to CertMapping (winrm/config/service/certmapping)
                  * 3. Branch in to Plugin (winrm/config/plugin) - Plugin is subdivided in Resources,Security & InitParams
                  * 4. Rest all the branches like Client, Shell(WinRS) ,Service
@@ -3016,7 +3016,7 @@ namespace Microsoft.WSMan.Management
                 if (!prop.Value.ToString().Equals(WSManStringLiterals.ContainerChildValue))
                 {
                     // This path is used by WriteItemObject to construct PSPath.
-                    // PSPath is a provider quailified path and we dont need to specify
+                    // PSPath is a provider qualified path and we dont need to specify
                     // provider root in this path..So I am trying to eliminate provider root
                     // in this case.
                     string pathToUse = WSManStringLiterals.rootpath.Equals(path, StringComparison.OrdinalIgnoreCase) ?
@@ -3027,7 +3027,7 @@ namespace Microsoft.WSMan.Management
                 else
                 {
                     // This path is used by WriteItemObject to construct PSPath.
-                    // PSPath is a provider quailified path and we dont need to specify
+                    // PSPath is a provider qualified path and we dont need to specify
                     // provider root in this path..So I am trying to eliminate provider root
                     // in this case.
                     string pathToUse = WSManStringLiterals.rootpath.Equals(path, StringComparison.OrdinalIgnoreCase) ?
@@ -3292,13 +3292,13 @@ namespace Microsoft.WSMan.Management
         /// Given wsman config path, gets the value of the leaf present.
         /// If path is not valid or not present throws an exception.
         /// 
-        /// Currently this supports only retreiving Rescource_XXXX dir contents.
+        /// Currently this supports only retrieving Resource_XXXX dir contents.
         /// if you need support at other levels implement them.
         /// Example resource dir: WSMan:\localhost\Plugin\someplugin\Resources\Resource_XXXXXXX
         /// </summary>
         /// <param name="path"></param>
         /// <returns>
-        /// A PSObject representing the contents of the path if successfull,
+        /// A PSObject representing the contents of the path if successful,
         /// Otherwise null.
         /// </returns>
         /// <exception cref="ArgumentException">
@@ -3381,7 +3381,7 @@ namespace Microsoft.WSMan.Management
                     }
                     else
                     {
-                        // Currently this supports only retreiving Rescource_XXXX dir contents.
+                        // Currently this supports only retrieving Resource_XXXX dir contents.
                         // if you need support at other levels implement them.
                         // Example resource dir: WSMan:\localhost\Plugin\someplugin\Resources\Resource_67830040
                         string filter = uri + "?Name=" + currentpluginname;
@@ -3695,7 +3695,7 @@ namespace Microsoft.WSMan.Management
         }
 
         /// <summary>
-        /// Removes a Listerner or ClientCertificate object. Used by Remove-Item cmdlets.
+        /// Removes a Listener or ClientCertificate object. Used by Remove-Item cmdlets.
         /// </summary>
         /// <param name="sessionobj"></param>
         /// <param name="WsManUri"></param>
@@ -4409,7 +4409,7 @@ namespace Microsoft.WSMan.Management
                     {
                         PluginNames.Properties.Add(new PSNoteProperty(e.Attributes[i].Value, WSManStringLiterals.ContainerChildValue));
 
-                        // If the path contains \plugin and splitLength is greater than 3 then splitLenght[2] will be plugin Name.
+                        // If the path contains \plugin and splitLength is greater than 3 then splitLength[2] will be plugin Name.
                         if (splitPath.Length >= 3 && splitPath[2].Equals(e.Attributes[i].Value, StringComparison.OrdinalIgnoreCase))
                         {
                             CurrentPluginName = e.Attributes[i].Value;
@@ -4575,7 +4575,7 @@ namespace Microsoft.WSMan.Management
                         && attribute.Key.ToString().Equals("Port", StringComparison.OrdinalIgnoreCase))
                     {
                         // we add the Port number when generating the name in order 
-                        // be distinguish compatiblity listeners which might have the same
+                        // be distinguish compatibility listeners which might have the same
                         // real key (address and port) as a real listener
                         sbHashKey.Append(attribute.Key.ToString());
                         sbHashKey.Append(WSManStringLiterals.Equalto);
@@ -5460,7 +5460,7 @@ namespace Microsoft.WSMan.Management
 
         /// <summary>
         /// The following is the definition of the input parameter "UseSSL".
-        /// Uses the Secure Sockets Layer (SSL) protocol to establish a connnection to 
+        /// Uses the Secure Sockets Layer (SSL) protocol to establish a connection to 
         /// the remote computer. If SSL is not available on the port specified by the 
         /// Port parameter, the command fails.
         /// </summary>
@@ -5599,7 +5599,7 @@ namespace Microsoft.WSMan.Management
         private PSCredential runAsCredentials;
 
         /// <summary>
-        /// Parameter for Plugin Host Process configuration (Shared or Saperate).
+        /// Parameter for Plugin Host Process configuration (Shared or Separate).
         /// </summary>
         [Parameter()]
         public SwitchParameter UseSharedProcess
@@ -5810,7 +5810,7 @@ namespace Microsoft.WSMan.Management
 #region Listener Dynamic Parameters
 
     /// <summary>
-    /// Listener Dyanamic parameters
+    /// Listener Dynamic parameters
     /// Path - WsMan:\Localhost\Listener>
     /// </summary>
     public class WSManProvidersListenerParameters
@@ -6091,15 +6091,15 @@ namespace Microsoft.WSMan.Management
         /// </summary>
         internal const string containerService = "Service";
         /// <summary>
-        /// Auth Container - Under Client,Serive
+        /// Auth Container - Under Client,Service
         /// </summary>
         internal const string containerAuth = "Auth";
         /// <summary>
-        /// DefaultPorts Container - Under Client,Serive
+        /// DefaultPorts Container - Under Client,Service
         /// </summary>
         internal const string containerDefaultPorts = "DefaultPorts";
         /// <summary>
-        /// TrustedHosts Container - Under Client,Serive
+        /// TrustedHosts Container - Under Client,Service
         /// </summary>
         internal const string containerTrustedHosts = "TrustedHosts";
         /// <summary>
@@ -6177,7 +6177,7 @@ namespace Microsoft.WSMan.Management
         internal const string ConfigRunAsUserName = "RunAsUser";
 
         /// <summary>
-        /// Name of the configuration which represents if HostProcess is shared or saperate.
+        /// Name of the configuration which represents if HostProcess is shared or separate.
         /// </summary>
         internal const string ConfigUseSharedProcess = "UseSharedProcess";
 
@@ -6371,7 +6371,7 @@ $_ | Start-WSManServiceD15A7957836142a18627D7E1D342DD82 -force $args[0] -caption
 
 
 
-#endregion "WsMan Outpu tObjects"
+#endregion "WsMan Output Objects"
 
 
 }

--- a/src/Microsoft.WSMan.Management/CredSSP.cs
+++ b/src/Microsoft.WSMan.Management/CredSSP.cs
@@ -423,7 +423,7 @@ namespace Microsoft.WSMan.Management
     /// an application to delegate the user's credentials from the client to the 
     /// server, hence allowing the user to perform management operations that access 
     /// a second hop.
-    /// This cmdlt performs the following:
+    /// This cmdlet performs the following:
     /// 
     /// On the client:
     /// 1. Enables WSMan local configuration on client to enable CredSSP
@@ -547,7 +547,7 @@ namespace Microsoft.WSMan.Management
                 return dyanmicParameters;
             }
 
-            // Construct attributes for the DelegateComputer paramter
+            // Construct attributes for the DelegateComputer parameter
             Collection<Attribute> delegateComputerAttributeCollection = new Collection<Attribute>();
             ParameterAttribute paramAttribute = new ParameterAttribute();
             paramAttribute.Mandatory = true;
@@ -848,7 +848,7 @@ namespace Microsoft.WSMan.Management
     /// enables an application to delegate the user's credentials from the client to 
     /// the server, hence allowing the user to perform management operations that 
     /// access a second hop.
-    /// This cmdlt performs the following:
+    /// This cmdlet performs the following:
     /// 1. Gets the configuration for WSMan policy on client to enable/disable 
     /// CredSSP
     /// 2. Gets the configuration information for the CredSSP policy 

--- a/src/Microsoft.WSMan.Management/CurrentConfigurations.cs
+++ b/src/Microsoft.WSMan.Management/CurrentConfigurations.cs
@@ -41,7 +41,7 @@ namespace Microsoft.WSMan.Management
         private XmlDocument rootDocument;
 
         /// <summary>
-        /// Holds the referance to the current document element.
+        /// Holds the reference to the current document element.
         /// </summary>
         private XmlElement documentElement;
 
@@ -89,7 +89,7 @@ namespace Microsoft.WSMan.Management
 
         /// <summary>
         /// Refresh the CurrentConfiguration. This method calls GET operation for the given 
-        /// URI on the server and update the current configuraition. It also intialize some
+        /// URI on the server and update the current configuration. It also initialize some
         /// of required class members.
         /// </summary>
         /// <param name="responseOfGet">Plugin configuration.</param>
@@ -115,7 +115,7 @@ namespace Microsoft.WSMan.Management
         /// Issues a PUT request with the ResourceUri provided.
         /// </summary>
         /// <param name="resourceUri">Resource URI to use.</param>
-        /// <returns>Fales, if operation is not succesful.</returns>
+        /// <returns>False, if operation is not succesful.</returns>
         public void PutConfiguraitonOnServer(string resourceUri)
         {
             if (String.IsNullOrEmpty(resourceUri))

--- a/src/Microsoft.WSMan.Management/Interop.cs
+++ b/src/Microsoft.WSMan.Management/Interop.cs
@@ -153,7 +153,7 @@ namespace Microsoft.WSMan.Management
         /// </summary>
         Digest = 0x2,
         /// <summary>
-        /// Use negotiate authentication for a remote operation (may use kerboros or ntlm)
+        /// Use negotiate authentication for a remote operation (may use kerberos or ntlm)
         /// </summary>
         Negotiate = 0x4,
         /// <summary>

--- a/src/Microsoft.WSMan.Management/InvokeWSManAction.cs
+++ b/src/Microsoft.WSMan.Management/InvokeWSManAction.cs
@@ -178,7 +178,7 @@ namespace Microsoft.WSMan.Management
 
         /// <summary>
         /// The following is the definition of the input parameter "UseSSL".
-        /// Uses the Secure Sockets Layer (SSL) protocol to establish a connnection to 
+        /// Uses the Secure Sockets Layer (SSL) protocol to establish a connection to 
         /// the remote computer. If SSL is not available on the port specified by the 
         /// Port parameter, the command fails.
         /// </summary>

--- a/src/Microsoft.WSMan.Management/NewWSManSession.cs
+++ b/src/Microsoft.WSMan.Management/NewWSManSession.cs
@@ -180,7 +180,7 @@ namespace Microsoft.WSMan.Management
         /// <summary>
         /// The following is the definition of the input parameter "UnEncrypted".
         /// Specifies that no encryption will be used when doing remote operations over 
-        /// http. Unencrypted traffix is not allowed by default and must be enabled in 
+        /// http. Unencrypted traffic is not allowed by default and must be enabled in 
         /// the local configuration
         /// </summary>
         [Parameter]

--- a/src/Microsoft.WSMan.Management/PingWSMan.cs
+++ b/src/Microsoft.WSMan.Management/PingWSMan.cs
@@ -98,7 +98,7 @@ namespace Microsoft.WSMan.Management
 
         /// <summary>
         /// The following is the definition of the input parameter "UseSSL".
-        /// Uses the Secure Sockets Layer (SSL) protocol to establish a connnection to 
+        /// Uses the Secure Sockets Layer (SSL) protocol to establish a connection to 
         /// the remote computer. If SSL is not available on the port specified by the 
         /// Port parameter, the command fails.
         /// </summary>

--- a/src/Microsoft.WSMan.Management/WSManConnections.cs
+++ b/src/Microsoft.WSMan.Management/WSManConnections.cs
@@ -214,7 +214,7 @@ namespace Microsoft.WSMan.Management
 
         /// <summary>
         /// The following is the definition of the input parameter "UseSSL".
-        /// Uses the Secure Sockets Layer (SSL) protocol to establish a connnection to 
+        /// Uses the Secure Sockets Layer (SSL) protocol to establish a connection to 
         /// the remote computer. If SSL is not available on the port specified by the 
         /// Port parameter, the command fails.
         /// </summary>

--- a/src/Microsoft.WSMan.Management/WSManInstance.cs
+++ b/src/Microsoft.WSMan.Management/WSManInstance.cs
@@ -341,7 +341,7 @@ namespace Microsoft.WSMan.Management
 
         /// <summary>
         /// The following is the definition of the input parameter "UseSSL".
-        /// Uses the Secure Sockets Layer (SSL) protocol to establish a connnection to 
+        /// Uses the Secure Sockets Layer (SSL) protocol to establish a connection to 
         /// the remote computer. If SSL is not available on the port specified by the 
         /// Port parameter, the command fails.
         /// </summary>
@@ -371,7 +371,7 @@ namespace Microsoft.WSMan.Management
             string[] Split = filter.Trim().Split(new Char[] { '=', ';' });
             if ((Split.Length)%2 != 0)
             {
-                //missmatched property name/value pair
+                //mismatched property name/value pair
                 return null;
             }
             filter = "<wsman:SelectorSet xmlns:wsman='http://schemas.dmtf.org/wbem/wsman/1/wsman.xsd'>";
@@ -787,7 +787,7 @@ namespace Microsoft.WSMan.Management
 
         /// <summary>
         /// The following is the definition of the input parameter "UseSSL".
-        /// Uses the Secure Sockets Layer (SSL) protocol to establish a connnection to 
+        /// Uses the Secure Sockets Layer (SSL) protocol to establish a connection to 
         /// the remote computer. If SSL is not available on the port specified by the 
         /// Port parameter, the command fails.
         /// </summary>
@@ -1097,7 +1097,7 @@ namespace Microsoft.WSMan.Management
 
         /// <summary>
         /// The following is the definition of the input parameter "UseSSL".
-        /// Uses the Secure Sockets Layer (SSL) protocol to establish a connnection to 
+        /// Uses the Secure Sockets Layer (SSL) protocol to establish a connection to 
         /// the remote computer. If SSL is not available on the port specified by the 
         /// Port parameter, the command fails.
         /// </summary>
@@ -1360,7 +1360,7 @@ namespace Microsoft.WSMan.Management
 
         /// <summary>
         /// The following is the definition of the input parameter "UseSSL".
-        /// Uses the Secure Sockets Layer (SSL) protocol to establish a connnection to 
+        /// Uses the Secure Sockets Layer (SSL) protocol to establish a connection to 
         /// the remote computer. If SSL is not available on the port specified by the 
         /// Port parameter, the command fails.
         /// </summary>

--- a/src/Microsoft.WSMan.Management/WsManHelper.cs
+++ b/src/Microsoft.WSMan.Management/WsManHelper.cs
@@ -203,7 +203,7 @@ namespace Microsoft.WSMan.Management
 
 
         /// <summary>
-        /// add a session to dictioanry
+        /// add a session to dictionary
         /// </summary>
         /// <param name="key">connection string</param>
         /// <param name="value">session object</param>
@@ -408,7 +408,7 @@ namespace Microsoft.WSMan.Management
                     string parameters = null, nilns = null;
                     string xmlns = GetXmlNs(resourceUri.ResourceUri);
 
-                    //if valueset is given, i.e hastable
+                    //if valueset is given, i.e hashtable
                     if (valueset != null)
                     {
                         foreach (DictionaryEntry entry in valueset)
@@ -619,7 +619,7 @@ namespace Microsoft.WSMan.Management
         /// Used to resolve authentication from the parameters chosen by the user.
         /// User has the following options:
         /// 1. AuthMechanism + Credential
-        /// 2. CertiticateThumbPrint
+        /// 2. CertificateThumbPrint
         /// 
         /// All the above are mutually exclusive.
         /// </summary>
@@ -982,7 +982,7 @@ namespace Microsoft.WSMan.Management
         /// Verifies all the registry keys are set as expected. In case of failure .. try ecery second for 60 seconds before returning false.
         /// </summary>
         /// <param name="AllowFreshCredentialsValueShouldBePresent">True if trying to Enable CredSSP.</param>
-        /// <param name="DelegateComputer">Names of the degate computer.</param>
+        /// <param name="DelegateComputer">Names of the delegate computer.</param>
         /// <param name="applicationname">Name of the application.</param>
         /// <returns>True if valid.</returns>
         internal bool ValidateCreadSSPRegistryRetry(bool AllowFreshCredentialsValueShouldBePresent, string[] DelegateComputer, string applicationname)

--- a/src/Schemas/PSMaml/command.xsd
+++ b/src/Schemas/PSMaml/command.xsd
@@ -29,7 +29,7 @@
 					name : moved to commandDetails
 					verb : moved to commandDetails
 					noun : moved to commandDetails
-					? Synposis : mapped to commandDetails.CommandDescription
+					? Synopsis : mapped to commandDetails.CommandDescription
 				-->
 				<!-- [gxie] items added:
 					keywords
@@ -102,7 +102,7 @@
 						<sequence>
 							<element name="synonym" type="maml:textType" maxOccurs="unbounded"/>
 						</sequence>
-						<!-- [gxie] ? what is usage of contentIdentficationsSharingAndConditionGroup-->
+						<!-- [gxie] ? what is usage of contentIdentificationSharingAndConditionGroup-->
 						<attributeGroup ref="maml:contentIdentificationSharingAndConditionGroup"/>
 					</complexType>
 				</element>

--- a/src/System.Management.Automation/engine/AliasInfo.cs
+++ b/src/System.Management.Automation/engine/AliasInfo.cs
@@ -108,7 +108,7 @@ namespace System.Management.Automation
             get
             {
                 // Need to lookup the referenced command every time
-                // to ensure we get the lastest session state information
+                // to ensure we get the latest session state information
 
                 CommandInfo referencedCommand = null;
 
@@ -186,7 +186,7 @@ namespace System.Management.Automation
                     if (result == null)
                     {
                         // Since we couldn't resolve the command that the alias
-                        // points to, remember the defintion so that we can
+                        // points to, remember the definition so that we can
                         // provide better error reporting.
 
                         UnresolvedCommandName = commandNameToResolve;

--- a/src/System.Management.Automation/engine/Attributes.cs
+++ b/src/System.Management.Automation/engine/Attributes.cs
@@ -582,7 +582,7 @@ namespace System.Management.Automation
         }
 
         /// <summary>
-        /// Initiailizes a new instance of the AliasAttribute class
+        /// Initializes a new instance of the AliasAttribute class
         /// </summary>
         /// <param name="aliasNames">The name for this alias</param>
         /// <exception cref="ArgumentException">for invalid arguments</exception>
@@ -604,7 +604,7 @@ namespace System.Management.Automation
     public sealed class ParameterAttribute : ParsingBaseAttribute
     {
         /// <summary>
-        /// ParameterSetName refering to all ParameterSets
+        /// ParameterSetName referring to all ParameterSets
         /// </summary>
         public const string AllParameterSets = "__AllParameterSets";
 
@@ -690,7 +690,7 @@ namespace System.Management.Automation
         }
 
         /// <summary>
-        /// Gets and sets the base name of the resource for a help message. When this field is speicifed, 
+        /// Gets and sets the base name of the resource for a help message. When this field is specified, 
         /// HelpMessageResourceId must also be specified.
         /// </summary>
         /// <exception cref="ArgumentException">for a null or empty value when setting</exception>
@@ -711,7 +711,7 @@ namespace System.Management.Automation
         }
 
         /// <summary>
-        /// Gets and sets the Id of the resource for a help message. When this field is speicifed,
+        /// Gets and sets the Id of the resource for a help message. When this field is specified,
         /// HelpMessageBaseName must also be specified.
         /// </summary>
         /// <exception cref="ArgumentException">for a null or empty value when setting</exception>
@@ -989,7 +989,7 @@ namespace System.Management.Automation
         /// <param name="maxRange">Maximum value of the range allowed. </param>
         /// <exception cref="ArgumentNullException">for invalid arguments</exception>
         /// <exception cref="ValidationMetadataException">
-        /// if maxRange has a differnet type than minRange
+        /// if maxRange has a different type than minRange
         /// if maxRange is smaller than minRange
         /// if maxRange, minRange are not IComparable
         /// </exception>
@@ -1241,7 +1241,7 @@ namespace System.Management.Automation
         /// </param>
         /// <exception cref="ValidationMetadataException">
         /// if the element is none of ICollection, IEnumerable, IList, IEnumerator
-        /// if the element's lenght is not between MinLength and MAxLEngth
+        /// if the element's length is not between MinLength and MAxLEngth
         /// </exception>
         protected override void Validate(object arguments, EngineIntrinsics engineIntrinsics)
         {

--- a/src/System.Management.Automation/engine/COM/ComAdapter.cs
+++ b/src/System.Management.Automation/engine/COM/ComAdapter.cs
@@ -170,7 +170,7 @@ namespace System.Management.Automation
         /// </summary>
         /// <param name="property">PSProperty coming from a previous call to DoGetProperty</param>
         /// <param name="setValue">value to set the property with</param>
-        ///  <param name="convertIfPossible">instructs the adapter to convert before setting, if the adapter suports conversion</param>
+        ///  <param name="convertIfPossible">instructs the adapter to convert before setting, if the adapter supports conversion</param>
         protected override void PropertySet(PSProperty property, object setValue, bool convertIfPossible)
         {
             ComProperty prop = (ComProperty)property.adapterData;

--- a/src/System.Management.Automation/engine/COM/ComTypeInfo.cs
+++ b/src/System.Management.Automation/engine/COM/ComTypeInfo.cs
@@ -258,7 +258,7 @@ namespace System.Management.Automation
         /// <returns>ITypeInfo reference to the Dispatch interface </returns>
         internal static COM.ITypeInfo GetDispatchTypeInfoFromCoClassTypeInfo(COM.ITypeInfo typeinfo)
         {
-            //Get the number of interfaces implmented by this CoClass.
+            //Get the number of interfaces implemented by this CoClass.
             COM.TYPEATTR typeattr = GetTypeAttr(typeinfo);
             int count = typeattr.cImplTypes;
             int href;

--- a/src/System.Management.Automation/engine/COM/ComUtil.cs
+++ b/src/System.Management.Automation/engine/COM/ComUtil.cs
@@ -30,7 +30,7 @@ namespace System.Management.Automation
         /// </summary>
         /// <param name="typeinfo">ITypeInfo interface of the object</param>
         /// <param name="funcdesc">FuncDesc which defines the method</param>
-        /// <param name="isPropertyPut">True if this is a property put; these properties take their return type from their first paramenter</param>
+        /// <param name="isPropertyPut">True if this is a property put; these properties take their return type from their first parameter</param>
         /// <returns>signature of the method</returns>
         internal static string GetMethodSignatureFromFuncDesc(COM.ITypeInfo typeinfo, COM.FUNCDESC funcdesc, bool isPropertyPut)
         {

--- a/src/System.Management.Automation/engine/CmdletParameterBinderController.cs
+++ b/src/System.Management.Automation/engine/CmdletParameterBinderController.cs
@@ -323,7 +323,7 @@ namespace System.Management.Automation
 
             foreach (MergedCompiledCommandParameter parameter in UnboundParameters)
             {
-                // If a prarameter doesn't take pipeline input at all, we can skip it
+                // If a parameter doesn't take pipeline input at all, we can skip it
                 if (!parameter.Parameter.IsPipelineParameterInSomeParameterSet)
                 {
                     continue;
@@ -363,7 +363,7 @@ namespace System.Management.Automation
         }
 
         /// <summary>
-        /// Apply the binding for the defualt parameter defined by the user 
+        /// Apply the binding for the default parameter defined by the user 
         /// </summary>
         /// <param name="bindingStage">
         /// Dictate which binding stage this default binding happens
@@ -413,7 +413,7 @@ namespace System.Management.Automation
         /// <param name="validParameterSetFlag">validParameterSetFlag</param>
         /// <param name="defaultParameterValues">default value pairs</param>
         /// <returns>
-        /// true if there is at least one default parameter bound scucessfully
+        /// true if there is at least one default parameter bound successfully
         /// false if there is no default parameter bound successfully
         /// </returns>
         private bool BindDefaultParameters(uint validParameterSetFlag, Dictionary<MergedCompiledCommandParameter, object> defaultParameterValues)
@@ -554,7 +554,7 @@ namespace System.Management.Automation
                     continue;
                 }
 
-                // check if this param's set confilcts with other possible params.
+                // check if this param's set conflicts with other possible params.
                 if (param.Parameter.ParameterSetFlags != 0)
                 {
                     possibleParameterFlag &= param.Parameter.ParameterSetFlags;
@@ -876,7 +876,7 @@ namespace System.Management.Automation
         /// Verify if all arguments from the command line are bound.
         /// </summary>
         /// <param name="originalBindingException">
-        /// Previous binding exceptions that possiblly causes the failure
+        /// Previous binding exceptions that possibly causes the failure
         /// </param>
         private void VerifyArgumentsProcessed(ParameterBindingException originalBindingException)
         {
@@ -2037,7 +2037,7 @@ namespace System.Management.Automation
                         //
                         // We ignore those parameter sets that contain unbound mandatory parameters, but leave
                         // all other parameter sets remain valid. The other parameter sets contains the default
-                        // parameter set and have one characeristic: NONE of them contain unbound mandatory parameters
+                        // parameter set and have one characteristic: NONE of them contain unbound mandatory parameters
                         //
                         // Comparing to the old algorithm, we keep more possible parameter sets here, but
                         // we need to prioritize the default parameter set for pipeline binding, so as NOT to
@@ -2932,7 +2932,7 @@ namespace System.Management.Automation
         } // AtLeastOneValidParameterSetTakesPipelineInput
 
         /// <summary>
-        /// Checks for unbound mandatory paramters. If any are found, an exception is thrown.
+        /// Checks for unbound mandatory parameters. If any are found, an exception is thrown.
         /// </summary>
         /// 
         /// <param name="missingMandatoryParameters">
@@ -2953,7 +2953,7 @@ namespace System.Management.Automation
         }
 
         /// <summary>
-        /// Checks for unbound mandatory paramters. If any are found and promptForMandatory is true,
+        /// Checks for unbound mandatory parameters. If any are found and promptForMandatory is true,
         /// the user will be prompted for the missing mandatory parameters.
         /// </summary>
         /// 
@@ -3358,7 +3358,7 @@ namespace System.Management.Automation
             {
                 // Reset the default values
                 // This prevents the last pipeline object from being bound during EndProcessing
-                // if it failed some post binding varification step.
+                // if it failed some post binding verification step.
                 this.RestoreDefaultParameterValues(ParametersBoundThroughPipelineInput);
 
                 // Let the parameter binding errors propagate out
@@ -3374,7 +3374,7 @@ namespace System.Management.Automation
             {
                 // Reset the default values
                 // This prevents the last pipeline object from being bound during EndProcessing
-                // if it failed some post binding varification step.
+                // if it failed some post binding verification step.
                 this.RestoreDefaultParameterValues(ParametersBoundThroughPipelineInput);
 
                 throw;
@@ -3384,7 +3384,7 @@ namespace System.Management.Automation
             {
                 // Reset the default values
                 // This prevents the last pipeline object from being bound during EndProcessing
-                // if it failed some post binding varification step.
+                // if it failed some post binding verification step.
                 this.RestoreDefaultParameterValues(ParametersBoundThroughPipelineInput);
             }
             return result;
@@ -4229,7 +4229,7 @@ namespace System.Management.Automation
         private class DelayedScriptBlockArgument
         {
             // Remember the parameter binder so we know when to invoke the script block
-            // and when to use the evaluted argument.
+            // and when to use the evaluated argument.
             internal CmdletParameterBinderController _parameterBinder;
             internal CommandParameterInternal _argument;
             internal Collection<PSObject> _evaluatedArgument;
@@ -4756,7 +4756,7 @@ namespace System.Management.Automation
         /// When the name is not enclosed by quotes, the index returned should be the index of the separator;
         /// 
         /// For parameterName:
-        /// When the name is enclosed by quotes, the index returned should be the index of the seocnd quote plus 1 (the length of the key if the key is in a valid format);
+        /// When the name is enclosed by quotes, the index returned should be the index of the second quote plus 1 (the length of the key if the key is in a valid format);
         /// When the name is not enclosed by quotes, the index returned should be the length of the key.
         /// 
         /// </returns>

--- a/src/System.Management.Automation/engine/CodeMethods.cs
+++ b/src/System.Management.Automation/engine/CodeMethods.cs
@@ -14,7 +14,7 @@ using Dbg = System.Management.Automation.Diagnostics;
 namespace Microsoft.PowerShell
 {
     /// <summary>
-    /// Contains auxilliary ToString CodeMethod implementations for some types
+    /// Contains auxiliary ToString CodeMethod implementations for some types
     /// </summary>
     public static partial class ToStringCodeMethods
     {

--- a/src/System.Management.Automation/engine/CommandBase.cs
+++ b/src/System.Management.Automation/engine/CommandBase.cs
@@ -237,12 +237,12 @@ namespace System.Management.Automation.Internal
 
         /// <summary>
         /// IDisposable implementation
-        /// When the command is complete, release the associated memmbers
+        /// When the command is complete, release the associated members
         /// </summary>
         /// <remarks>
         /// Using InternalDispose instead of Dispose pattern because this
         /// interface was shipped in PowerShell V1 and 3rd cmdlets indirectly
-        /// derive from this inerface. If we depend on Dispose() and 3rd
+        /// derive from this interface. If we depend on Dispose() and 3rd
         /// party cmdlets do not call base.Dispose (which is the case), we 
         /// will still end up having this leak.
         /// </remarks>
@@ -393,7 +393,7 @@ namespace System.Management.Automation
         } // Events
 
         /// <summary>
-        /// Repostiory for jobs 
+        /// Repository for jobs 
         /// </summary>
         public JobRepository JobRepository
         {

--- a/src/System.Management.Automation/engine/CommandDiscovery.cs
+++ b/src/System.Management.Automation/engine/CommandDiscovery.cs
@@ -1271,7 +1271,7 @@ namespace System.Management.Automation
 
                         cleanupModuleAnalysisAppDomain = context.TakeResponsibilityForModuleAnalysisAppDomain();
 
-                        // Get the available module files, prefering modules from $PSHOME so that user modules don't
+                        // Get the available module files, preferring modules from $PSHOME so that user modules don't
                         // override system modules during auto-loading
                         if (etwEnabled) CommandDiscoveryEventSource.Log.SearchingForModuleFilesStart();
                         var defaultAvailableModuleFiles = ModuleUtils.GetDefaultAvailableModuleFiles(true, true, context);

--- a/src/System.Management.Automation/engine/CommandFactory.cs
+++ b/src/System.Management.Automation/engine/CommandFactory.cs
@@ -51,9 +51,9 @@ namespace System.Management.Automation
         #region public_methods
 
         /// <summary>
-        /// Creates a command object corresponing to specified name. The command processor will use global scope.
+        /// Creates a command object corresponding to specified name. The command processor will use global scope.
         /// </summary>
-        /// <param name="commandName">Creates a command object corresponing to specified name.</param>
+        /// <param name="commandName">Creates a command object corresponding to specified name.</param>
         /// <param name="commandOrigin"> Location where the command was dispatched from. </param>
         /// <returns>Created command processor object.</returns>
         /// <exception cref="InvalidOperationException">
@@ -65,9 +65,9 @@ namespace System.Management.Automation
         }
 
         /// <summary>
-        /// Creates a command object corresponing to specified name.
+        /// Creates a command object corresponding to specified name.
         /// </summary>
-        /// <param name="commandName">Creates a command object corresponing to specified name.</param>
+        /// <param name="commandName">Creates a command object corresponding to specified name.</param>
         /// <param name="commandOrigin"> Location where the command was dispatched from. </param>
         /// <param name="useLocalScope"> 
         /// True if command processor should use local scope to execute the command,
@@ -84,9 +84,9 @@ namespace System.Management.Automation
         }
 
         /// <summary>
-        /// Creates a command object corresponing to specified name.
+        /// Creates a command object corresponding to specified name.
         /// </summary>
-        /// <param name="commandName">Creates a command object corresponing to specified name.</param>
+        /// <param name="commandName">Creates a command object corresponding to specified name.</param>
         /// <param name="executionContext">Execution Context.</param>
         /// <param name="commandOrigin"> Location where the command was dispatched from. </param>
         /// <returns>Created command processor object.</returns>

--- a/src/System.Management.Automation/engine/CommandInfo.cs
+++ b/src/System.Management.Automation/engine/CommandInfo.cs
@@ -557,7 +557,7 @@ namespace System.Management.Automation
                 }
                 catch (ParameterBindingException)
                 {
-                    // Ignore the binding exception if no arugment is specified
+                    // Ignore the binding exception if no argument is specified
                     if (processor.arguments.Count > 0)
                     {
                         throw;

--- a/src/System.Management.Automation/engine/CommandMetadata.cs
+++ b/src/System.Management.Automation/engine/CommandMetadata.cs
@@ -35,7 +35,7 @@ namespace System.Management.Automation
         RemoteServer = 0x1,
 
         /// <summary>
-        /// Session with <see cref="WorkflowServer"/> capabibilities can be made available on 
+        /// Session with <see cref="WorkflowServer"/> capabilities can be made available on 
         /// a server that wants to provide workflow hosting capabilities in the
         /// specified end points. All jobs commands as well as commands for
         /// implicit remoting and interactive remoting will be made available
@@ -57,7 +57,7 @@ namespace System.Management.Automation
         #region Public Constructor
 
         /// <summary>
-        /// Constructs a CommandMetada object for the given CLS complaint type
+        /// Constructs a CommandMetadata object for the given CLS complaint type
         /// <paramref name="commandType"/>.
         /// </summary>
         /// <param name="commandType">
@@ -294,7 +294,7 @@ namespace System.Management.Automation
         #region ctor
 
         /// <summary>
-        /// Gets the metdata for the specified cmdlet from the cache or creates
+        /// Gets the metadata for the specified cmdlet from the cache or creates
         /// a new instance if its not in the cache.
         /// </summary>
         /// 
@@ -586,7 +586,7 @@ namespace System.Management.Automation
                     }
                     else if (this.CommandType != null)
                     {
-                        // Construct compiled parameter metada from this
+                        // Construct compiled parameter metadata from this
                         InternalParameterMetadata parameterMetadata = InternalParameterMetadata.Get(this.CommandType, null, false);
                         MergedCommandParameterMetadata mergedCommandParameterMetadata =
                             MergeParameterMetadata(null, parameterMetadata, _shouldGenerateCommonParameters);

--- a/src/System.Management.Automation/engine/CommandPathSearch.cs
+++ b/src/System.Management.Automation/engine/CommandPathSearch.cs
@@ -34,7 +34,7 @@ namespace System.Management.Automation
         /// </param>
         /// 
         /// <param name="context">
-        /// The exection context for the current engine instance.
+        /// The execution context for the current engine instance.
         /// </param>
         internal CommandPathSearch(
             IEnumerable<string> patterns,
@@ -568,7 +568,7 @@ namespace System.Management.Automation
         private bool _justReset;
 
         /// <summary>
-        /// If not null, called with the enumerated files for futher processing
+        /// If not null, called with the enumerated files for further processing
         /// </summary>
         private Func<string[], IEnumerable<string>> _postProcessEnumeratedFiles;
 

--- a/src/System.Management.Automation/engine/CommandProcessorBase.cs
+++ b/src/System.Management.Automation/engine/CommandProcessorBase.cs
@@ -78,7 +78,7 @@ namespace System.Management.Automation
         /// </summary>
         /// <remarks> 
         /// Script command processor created from a script file is special
-        /// in following two perspect, 
+        /// in following two perspectives, 
         /// 
         ///     1. New scope created needs to be a 'script' scope in the 
         ///        sense that it needs to handle $script: variables. 
@@ -172,7 +172,7 @@ namespace System.Management.Automation
             // This goes both ways:
             //    - Can't dot something from a more permissive mode, since that would probably expose
             //      functions that were never designed to handle untrusted data.
-            //    - Can't dot something from a less permissive mode, since that might introduce tained
+            //    - Can't dot something from a less permissive mode, since that might introduce tainted
             //      data into the current scope.
             if ((scriptBlock.LanguageMode.HasValue) &&
                 (scriptBlock.LanguageMode != languageMode) &&
@@ -228,7 +228,7 @@ namespace System.Management.Automation
         }
 
         /// <summary>
-        /// Creates a command procesor for "get-help [helpTarget]"
+        /// Creates a command processor for "get-help [helpTarget]"
         /// </summary>
         /// <param name="context">context for the command processor</param>
         /// <param name="helpTarget">help target</param>
@@ -895,7 +895,7 @@ namespace System.Management.Automation
             }
             catch (Exception)
             {
-                // this method shoud not throw exceptions; warn about any violations on checked builds and re-throw
+                // this method should not throw exceptions; warn about any violations on checked builds and re-throw
                 Diagnostics.Assert(false, "This method should not throw exceptions!");
                 throw;
             }

--- a/src/System.Management.Automation/engine/CommandSearcher.cs
+++ b/src/System.Management.Automation/engine/CommandSearcher.cs
@@ -1483,7 +1483,7 @@ namespace System.Management.Automation
         private CommandPathSearch _pathSearcher;
 
         /// <summary>
-        /// Thge execution context instance for the current engine...
+        /// The execution context instance for the current engine...
         /// </summary>
         private ExecutionContext _context;
 

--- a/src/System.Management.Automation/engine/CompiledCommandParameter.cs
+++ b/src/System.Management.Automation/engine/CompiledCommandParameter.cs
@@ -71,7 +71,7 @@ namespace System.Management.Automation
                 }
             }
 
-            // If this is a PSCredential type and they haven't added any argument transformation attributues,
+            // If this is a PSCredential type and they haven't added any argument transformation attributes,
             // add one for credential transformation
             if ((this.Type == typeof(PSCredential)) && argTransformationAttributes == null)
             {

--- a/src/System.Management.Automation/engine/CoreAdapter.cs
+++ b/src/System.Management.Automation/engine/CoreAdapter.cs
@@ -33,7 +33,7 @@ namespace System.Management.Automation
     /// This is the place to look every time you create a new Adapter. Consider if you 
     /// should implement each of the virtual methods here.
     /// The base class deals with errors and performs additional operations before and after
-    /// calling the drived virtual methods.
+    /// calling the derived virtual methods.
     /// </summary>
     internal abstract class Adapter
     {
@@ -119,7 +119,7 @@ namespace System.Management.Automation
         /// </summary>
         /// <param name="property">PSProperty coming from a previous call to GetMember</param>
         /// <param name="setValue">value to set the property with</param>
-        /// <param name="convertIfPossible">instructs the adapter to convert before setting, if the adapter suports conversion</param>
+        /// <param name="convertIfPossible">instructs the adapter to convert before setting, if the adapter supports conversion</param>
         protected abstract void PropertySet(PSProperty property, object setValue, bool convertIfPossible);
 
         /// <summary>
@@ -1214,7 +1214,7 @@ namespace System.Management.Automation
         }
 
         /// <summary>
-        /// Return the best method out of overlaoded methods.
+        /// Return the best method out of overloaded methods.
         /// The best has the smallest type distance between the method's parameters and the given arguments.
         /// </summary>
         /// <param name="methods">different overloads for a method</param>
@@ -1670,7 +1670,7 @@ namespace System.Management.Automation
         }
 
         /// <summary>
-        /// Auxilliary method in MethodInvoke to set newArguments[index] with the propper value
+        /// Auxiliary method in MethodInvoke to set newArguments[index] with the propper value
         /// </summary>
         /// <param name="methodName">used for the MethodException that might be thrown</param>
         /// <param name="arguments">the complete array of arguments</param>
@@ -2317,7 +2317,7 @@ namespace System.Management.Automation
     /// </summary>
     internal class DotNetAdapter : Adapter
     {
-        #region auxilliary methods and classes
+        #region auxiliary methods and classes
 
         private const BindingFlags instanceBindingFlags = (BindingFlags.FlattenHierarchy | BindingFlags.Public |
                                                               BindingFlags.IgnoreCase | BindingFlags.Instance);
@@ -2422,7 +2422,7 @@ namespace System.Management.Automation
                 {
                     PropertyInfo property = properties[i];
                     // Properties can have different return types. If they do
-                    // we pretent it is System.Object
+                    // we pretend it is System.Object
                     if (property.PropertyType != this.propertyType)
                     {
                         this.propertyType = typeof(object);
@@ -3541,7 +3541,7 @@ namespace System.Management.Automation
             return entry.isStatic;
         }
 
-        #endregion auxilliary methods and classes
+        #endregion auxiliary methods and classes
 
         #region virtual
 
@@ -3688,7 +3688,7 @@ namespace System.Management.Automation
         /// </summary>
         /// <param name="property">PSProperty coming from a previous call to GetMember</param>
         /// <param name="setValue">value to set the property with</param>
-        /// <param name="convertIfPossible">instructs the adapter to convert before setting, if the adapter suports conversion</param>
+        /// <param name="convertIfPossible">instructs the adapter to convert before setting, if the adapter supports conversion</param>
         protected override void PropertySet(PSProperty property, object setValue, bool convertIfPossible)
         {
             PropertyCacheEntry adapterData = (PropertyCacheEntry)property.adapterData;
@@ -3770,7 +3770,7 @@ namespace System.Management.Automation
 
         #region method
 
-        #region auxilliary to method calling
+        #region auxiliary to method calling
 
         /// <summary>
         /// Calls constructor using the arguments and catching the appropriate exception
@@ -3912,7 +3912,7 @@ namespace System.Management.Automation
         /// <param name="target">object to call the method on</param>
         /// <param name="methodInformation">method information corresponding to methods</param>
         /// <param name="invocationConstraints">invocation constraints</param>
-        /// <param name="arguments">arguiments of the call </param>
+        /// <param name="arguments">arguments of the call </param>
         /// <returns>the return of the method</returns>
         /// <exception cref="MethodInvocationException">if the method throws an exception</exception>
         /// <exception cref="MethodException">if we could not find a method for the given arguments</exception>
@@ -4088,7 +4088,7 @@ namespace System.Management.Automation
             return builder.ToString();
         }
 
-        #endregion auxilliary to method calling
+        #endregion auxiliary to method calling
 
         /// <summary>
         /// Called after a non null return from GetMember to try to call
@@ -4277,7 +4277,7 @@ namespace System.Management.Automation
                 return property as T;
             }
 
-            // In order to not break v1..base dotnet adpater should not return methods
+            // In order to not break v1..base dotnet adapter should not return methods
             // when accessed with T as PSMethod.. accessing method with PSMemberInfo
             // is ok as property always gets precedence over methods and duplicates
             // are ignored.
@@ -4372,7 +4372,7 @@ namespace System.Management.Automation
         /// </summary>
         /// <param name="property">PSProperty coming from a previous call to GetMember</param>
         /// <param name="setValue">value to set the property with</param>
-        /// <param name="convertIfPossible">instructs the adapter to convert before setting, if the adapter suports conversion</param>
+        /// <param name="convertIfPossible">instructs the adapter to convert before setting, if the adapter supports conversion</param>
         protected override void PropertySet(PSProperty property, object setValue, bool convertIfPossible)
         {
             Diagnostics.Assert(false, "redirection adapter is not called for properties");
@@ -4908,7 +4908,7 @@ namespace System.Management.Automation
         /// </summary>
         /// <param name="property">PSProperty coming from a previous call to DoGetProperty</param>
         /// <param name="setValue">value to set the property with</param>
-        /// <param name="convertIfPossible">instructs the adapter to convert before setting, if the adapter suports conversion</param>
+        /// <param name="convertIfPossible">instructs the adapter to convert before setting, if the adapter supports conversion</param>
         protected override void PropertySet(PSProperty property, object setValue, bool convertIfPossible)
         {
             string valueString = setValue as string;
@@ -4996,7 +4996,7 @@ namespace System.Management.Automation
 
 
         /// <summary>
-        /// Auxilliary in GetProperty to perform case sensitive and case insensitve searches
+        /// Auxiliary in GetProperty to perform case sensitive and case insensitive searches
         /// in the child nodes
         /// </summary>
         /// <param name="obj">XmlNode to extract property from</param>

--- a/src/System.Management.Automation/engine/Credential.cs
+++ b/src/System.Management.Automation/engine/Credential.cs
@@ -81,7 +81,7 @@ namespace System.Management.Automation
     }
 
     /// <summary>
-    /// Declare a delegate which returns the encryption key and initialization vector for symmetric encryption algorithem.
+    /// Declare a delegate which returns the encryption key and initialization vector for symmetric encryption algorithm.
     /// </summary>
     /// <param name="context">The streaming context, which contains the searilization context.</param>
     /// <param name="key">Symmetric encryption key.</param>

--- a/src/System.Management.Automation/engine/DataStoreAdapter.cs
+++ b/src/System.Management.Automation/engine/DataStoreAdapter.cs
@@ -196,7 +196,7 @@ namespace System.Management.Automation
 
         /// <summary>
         /// Gets or sets the Persist Switch parameter.
-        /// If this switch parmter is set then the created PSDrive
+        /// If this switch parameter is set then the created PSDrive
         /// would be persisted across PowerShell sessions.
         /// </summary>
         internal bool Persist { get; } = false;
@@ -208,7 +208,7 @@ namespace System.Management.Automation
 
         /// <summary>
         /// Gets or sets the UNC path of the drive. This property would be populated only
-        /// if the cereated PSDrive is targeting a network drive or else this property
+        /// if the created PSDrive is targeting a network drive or else this property
         /// would be null.
         /// </summary>
         public string DisplayRoot { get; internal set; } = null;
@@ -412,7 +412,7 @@ namespace System.Management.Automation
         /// If null, the current user credential is used.
         /// </param>
         /// <param name="displayRoot">
-        /// The network path of the drive. This field would be populted only if PSDriveInfo
+        /// The network path of the drive. This field would be populated only if PSDriveInfo
         /// is targeting the network drive or else this filed is null for local drives.
         /// </param>
         /// 

--- a/src/System.Management.Automation/engine/DataStoreAdapterProvider.cs
+++ b/src/System.Management.Automation/engine/DataStoreAdapterProvider.cs
@@ -146,7 +146,7 @@ namespace System.Management.Automation
         public String Description { get; set; }
 
         /// <summary>
-        /// Gets the capabilies that are implemented by the provider.
+        /// Gets the capabilities that are implemented by the provider.
         /// </summary>
         public Provider.ProviderCapabilities Capabilities
         {
@@ -172,7 +172,7 @@ namespace System.Management.Automation
                     catch (Exception e) // Catch-all OK, 3rd party callout
                     {
                         CommandProcessorBase.CheckForSevereException(e);
-                        // Assume no capabilites for now
+                        // Assume no capabilities for now
                     }
                 }
                 return _capabilities;
@@ -623,7 +623,7 @@ namespace System.Management.Automation
             // Possible solutions are to not cache the provider instance, or to maintain
             // a CmdletProviderContext stack in ProviderBase.  Each method invocation pushes
             // the current context and the last action of the method pops back to the
-            // previos context.
+            // previous context.
 #if USE_TLS
             // Next see if we already have an instance in thread local storage
 

--- a/src/System.Management.Automation/engine/DefaultCommandRuntime.cs
+++ b/src/System.Management.Automation/engine/DefaultCommandRuntime.cs
@@ -42,7 +42,7 @@ namespace System.Management.Automation
 
         /// <summary>
         /// Default implementation of WriteError - if the error record contains
-        /// an exceptin then that exception will be thrown. If not, then an
+        /// an exception then that exception will be thrown. If not, then an
         /// InvalidOperationException will be constructed and thrown.
         /// </summary>
         /// <param name="errorRecord">Error record instance to process</param>

--- a/src/System.Management.Automation/engine/DscResourceInfo.cs
+++ b/src/System.Management.Automation/engine/DscResourceInfo.cs
@@ -72,7 +72,7 @@ namespace System.Management.Automation
         public string FriendlyName { get; set; }
 
         /// <summary>
-        /// Gets or sets of the file which implements the resource. For the reosurces which are defined using 
+        /// Gets or sets of the file which implements the resource. For the resources which are defined using 
         /// MOF file, this will be path to a module which resides in the same folder where schema.mof file is present.
         /// For composite resources, this will be the module which implements the resource
         /// </summary>

--- a/src/System.Management.Automation/engine/EnumExpressionEvaluator.cs
+++ b/src/System.Management.Automation/engine/EnumExpressionEvaluator.cs
@@ -51,8 +51,8 @@ namespace System.Management.Automation
         }
 
         /// <summary>
-        /// Construct the tree from an object collection when arguments are comma seperated.
-        /// If valid, all elements are OR seperated.
+        /// Construct the tree from an object collection when arguments are comma separated.
+        /// If valid, all elements are OR separated.
         /// </summary>
         /// <param name="expression">
         /// The array of specified flag attribute subexpression strings.

--- a/src/System.Management.Automation/engine/ErrorPackage.cs
+++ b/src/System.Management.Automation/engine/ErrorPackage.cs
@@ -1093,7 +1093,7 @@ namespace System.Management.Automation
         private string _serializedFullyQualifiedErrorId = null;
 
         /// <summary>
-        /// Message overidee for CategoryInfo.GetMessage method
+        /// Message overridee for CategoryInfo.GetMessage method
         /// </summary>
         internal string _serializedErrorCategoryMessageOverride = null;
 
@@ -1634,7 +1634,7 @@ namespace System.Management.Automation
         private ReadOnlyCollection<int> _pipelineIterationInfo = Utils.EmptyReadOnlyCollection<int>();
 
         /// <summary>
-        /// Whether to serizalize the InvocationInfo during remote calls
+        /// Whether to serialize the InvocationInfo during remote calls
         /// </summary>
         internal bool SerializeExtendedInfo
         {

--- a/src/System.Management.Automation/engine/EventManager.cs
+++ b/src/System.Management.Automation/engine/EventManager.cs
@@ -991,7 +991,7 @@ namespace System.Management.Automation
                     // invocation to the current runspace, we took dependency on eventing infrastructure and
                     // this required ensuring the event and associated action be processed in the current thread
                     // synchronously. The below while loop was added for that (win8: 530495). However, fix for
-                    // 530495 resulted in hang for icm | % { icm } case and dynamic event/subscriptions senarios.
+                    // 530495 resulted in hang for icm | % { icm } case and dynamic event/subscriptions scenarios.
                     // To overcome that, changed "processSynchronously" parameter to "processInCurrentThread" and added
                     // a new parameter "waitForCompletionWhenInCurrentThread" to trigger blocking for ScriptBlock
                     // case.

--- a/src/System.Management.Automation/engine/ExecutionContext.cs
+++ b/src/System.Management.Automation/engine/ExecutionContext.cs
@@ -237,7 +237,7 @@ namespace System.Management.Automation
 
         /// <summary>
         /// The AppDomain currently being used for module analysis.  It should only be created if needed,
-        /// but various callers need to take responsbility for unloading the domain via
+        /// but various callers need to take responsibility for unloading the domain via
         /// the TakeResponsibilityForModuleAnalysisAppDomain.
         /// </summary>
         internal AppDomain AppDomainForModuleAnalysis { get; set; }
@@ -334,7 +334,7 @@ namespace System.Management.Automation
         }
 
         /// <summary>
-        /// Get/set constraints for this execution environemnt
+        /// Get/set constraints for this execution environment
         /// </summary>
         internal PSLanguageMode LanguageMode
         {
@@ -792,7 +792,7 @@ namespace System.Management.Automation
             if (arraylist.Count > 0)
             {
                 // There may be exceptions stored directly in which case
-                // the direc comparison will catch them...
+                // the direct comparison will catch them...
                 if (arraylist[0] == obj)
                     return;
                 // otherwise check the exception members of the error records...
@@ -802,7 +802,7 @@ namespace System.Management.Automation
                     return;
             }
 
-            // 1045384-2004/12/14-JonN impementing $MaximumErrorCount
+            // 1045384-2004/12/14-JonN implementing $MaximumErrorCount
             object maxcountobj = EngineSessionState.CurrentScope.ErrorCapacity.FastValue;
             if (null != maxcountobj)
             {
@@ -1238,7 +1238,7 @@ namespace System.Management.Automation
         private TypeInfoDataBaseManager _formatDBManager;
 
         /// <summary>
-        /// Gets the TransactionManager instance that controlls transactions in the current
+        /// Gets the TransactionManager instance that controls transactions in the current
         /// instance.
         /// </summary>
         internal PSTransactionManager TransactionManager
@@ -1382,7 +1382,7 @@ namespace System.Management.Automation
                 catch (FileLoadException fileLoadException)
                 {
                     error = fileLoadException;
-                    // this is a legitamate error on CoreCLR for a newly emited with Add-Type assemblies
+                    // this is a legitimate error on CoreCLR for a newly emited with Add-Type assemblies
                     // they cannot be loaded by name, but we are only interested in importing them by path
                 }
                 catch (BadImageFormatException badImage)
@@ -1663,7 +1663,7 @@ namespace System.Management.Automation
                 // we only want to set the event handler once for the entire app domain...
                 lock (lockObject)
                 {
-                    // Need to check again inside the lock due to possibliity of a race condition...
+                    // Need to check again inside the lock due to possibility of a race condition...
                     if (!_assemblyEventHandlerSet)
                     {
                         AppDomain currentAppDomain = AppDomain.CurrentDomain;

--- a/src/System.Management.Automation/engine/ExternalScriptInfo.cs
+++ b/src/System.Management.Automation/engine/ExternalScriptInfo.cs
@@ -60,7 +60,7 @@ namespace System.Management.Automation
 
             Diagnostics.Assert(IO.Path.IsPathRooted(path), "Caller makes sure that 'path' is already resolved.");
 
-            // Path might contian short-name syntax such as 'DOCUME~1'. Use Path.GetFullPath to expand the short name
+            // Path might contain short-name syntax such as 'DOCUME~1'. Use Path.GetFullPath to expand the short name
             _path = IO.Path.GetFullPath(path);
             CommonInitialization();
         }
@@ -90,7 +90,7 @@ namespace System.Management.Automation
 
             Diagnostics.Assert(IO.Path.IsPathRooted(path), "Caller makes sure that 'path' is already resolved.");
 
-            // Path might contian short-name syntax such as 'DOCUME~1'. Use Path.GetFullPath to expand the short name
+            // Path might contain short-name syntax such as 'DOCUME~1'. Use Path.GetFullPath to expand the short name
             _path = IO.Path.GetFullPath(path);
             CommonInitialization();
         }
@@ -110,7 +110,7 @@ namespace System.Management.Automation
         /// </summary>
         private void CommonInitialization()
         {
-            // Assume external scripts are untrusted by defult (for Get-Command, etc)
+            // Assume external scripts are untrusted by default (for Get-Command, etc)
             // until we've actually parsed their script block.
             if (SystemPolicy.GetSystemLockdownPolicy() != SystemEnforcementMode.None)
             {

--- a/src/System.Management.Automation/engine/ExtraAdapter.cs
+++ b/src/System.Management.Automation/engine/ExtraAdapter.cs
@@ -114,7 +114,7 @@ namespace System.Management.Automation
         /// </summary>
         /// <param name="property">PSProperty coming from a previous call to DoGetProperty</param>
         /// <param name="setValue">value to set the property with</param>
-        /// <param name="convertIfPossible">instructs the adapter to convert before setting, if the adapter suports conversion</param>
+        /// <param name="convertIfPossible">instructs the adapter to convert before setting, if the adapter supports conversion</param>
         protected override void PropertySet(PSProperty property, object setValue, bool convertIfPossible)
         {
             DataRow dataRow = (DataRow)property.baseObject;
@@ -220,7 +220,7 @@ namespace System.Management.Automation
         /// </summary>
         /// <param name="property">PSProperty coming from a previous call to DoGetProperty</param>
         /// <param name="setValue">value to set the property with</param>
-        /// <param name="convertIfPossible">instructs the adapter to convert before setting, if the adapter suports conversion</param>
+        /// <param name="convertIfPossible">instructs the adapter to convert before setting, if the adapter supports conversion</param>
         protected override void PropertySet(PSProperty property, object setValue, bool convertIfPossible)
         {
             DataRowView dataRowView = (DataRowView)property.baseObject;
@@ -314,7 +314,7 @@ namespace System.Management.Automation
                     // Adapter engine resolve's members in the following steps:
                     //  1. Extended members -> 2. Adapted members -> 3. Dotnet members
                     // We cannot say from DirectoryEntryAdapter if a method with name "memberName"
-                    // is available. So check if a DotNet proeperty with the same name is available
+                    // is available. So check if a DotNet property with the same name is available
                     // If yes, return null from the adapted view and let adapter engine
                     // take care of DotNet member resolution. If not, assume memberName method
                     // is available on native adsi object.
@@ -400,7 +400,7 @@ namespace System.Management.Automation
         /// </summary>
         /// <param name="property">PSProperty coming from a previous call to GetMember</param>
         /// <param name="setValue">value to set the property with</param>
-        /// <param name="convertIfPossible">instructs the adapter to convert before setting, if the adapter suports conversion</param>
+        /// <param name="convertIfPossible">instructs the adapter to convert before setting, if the adapter supports conversion</param>
         protected override void PropertySet(PSProperty property, object setValue, bool convertIfPossible)
         {
             PropertyValueCollection values = property.adapterData as PropertyValueCollection;
@@ -539,7 +539,7 @@ namespace System.Management.Automation
             // First try to invoke method on the native adsi object. If the method
             // call fails, try to invoke dotnet method with same name, if one available.
             // This will ensure dotnet methods are exposed for DE objects.
-            // The problem is in GetMemeber<T>(), DE adapter cannot check if a requested
+            // The problem is in GetMember<T>(), DE adapter cannot check if a requested
             // method is available as it doesn't have access to native adsi object's
             // method metadata. So GetMember<T> returns PSMethod assuming a method
             // is available. This behavior will never give a chance to dotnet adapter

--- a/src/System.Management.Automation/engine/FunctionInfo.cs
+++ b/src/System.Management.Automation/engine/FunctionInfo.cs
@@ -16,7 +16,7 @@ namespace System.Management.Automation
         #region ctor
 
         /// <summary>
-        /// Creates an instance of the FunctonInfo class with the specified name and ScriptBlock
+        /// Creates an instance of the FunctionInfo class with the specified name and ScriptBlock
         /// </summary>
         /// 
         /// <param name="name">
@@ -40,7 +40,7 @@ namespace System.Management.Automation
         } // FunctionInfo ctor
 
         /// <summary>
-        /// Creates an instance of the FunctonInfo class with the specified name and ScriptBlock
+        /// Creates an instance of the FunctionInfo class with the specified name and ScriptBlock
         /// </summary>
         /// 
         /// <param name="name">
@@ -79,7 +79,7 @@ namespace System.Management.Automation
         } // FunctionInfo ctor
 
         /// <summary>
-        /// Creates an instance of the FunctonInfo class with the specified name and ScriptBlock
+        /// Creates an instance of the FunctionInfo class with the specified name and ScriptBlock
         /// </summary>
         /// 
         /// <param name="name">
@@ -107,7 +107,7 @@ namespace System.Management.Automation
         } // FunctionInfo ctor
 
         /// <summary>
-        /// Creates an instance of the FunctonInfo class with the specified name and ScriptBlock
+        /// Creates an instance of the FunctionInfo class with the specified name and ScriptBlock
         /// </summary>
         /// 
         /// <param name="name">

--- a/src/System.Management.Automation/engine/GetCommandCommand.cs
+++ b/src/System.Management.Automation/engine/GetCommandCommand.cs
@@ -531,7 +531,7 @@ namespace Microsoft.PowerShell.Commands
 
             _timer.Stop();
 
-            // We want telemtry on commands people look for but don't exist - this should give us an idea
+            // We want telementry on commands people look for but don't exist - this should give us an idea
             // what sort of commands people expect but either don't exist, or maybe should be installed by default.
             // The StartsWith is to avoid logging telemetry when suggestion mode checks the
             // current directory for scripts/exes in the current directory and '.' is not in the path.

--- a/src/System.Management.Automation/engine/InformationRecord.cs
+++ b/src/System.Management.Automation/engine/InformationRecord.cs
@@ -100,7 +100,7 @@ namespace System.Management.Automation
         public DateTime TimeGenerated { get; set; }
 
         /// <summary>
-        /// The tags assocaited with this informational record (if any)
+        /// The tags associated with this informational record (if any)
         /// </summary>
         [DataMember]
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2227:CollectionPropertiesShouldBeReadOnly")]

--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -144,7 +144,7 @@ namespace System.Management.Automation.Runspaces
 
     /// <summary>
     /// Command class so that all the commands can derive off this one.
-    /// Adds the flexibility of adding addditional derived class,
+    /// Adds the flexibility of adding additional derived class,
     /// such as ProxyCommand for Exchange.
     /// Derived classes - Alias, Application, Cmdlet, Function, Script.
     /// </summary>
@@ -404,7 +404,7 @@ namespace System.Management.Automation.Runspaces
 
         /// <summary>
         /// Create a named entry for the assembly to load, specifying
-        /// just the nanme
+        /// just the name
         /// </summary>
         /// <param name="name">The name of the assembly to load</param>
         public SessionStateAssemblyEntry(string name)
@@ -555,7 +555,7 @@ namespace System.Management.Automation.Runspaces
         }
 
         /// <summary>
-        /// Create a session state command entry instance with the specified visiblity.
+        /// Create a session state command entry instance with the specified visibility.
         /// </summary>
         /// <param name="path">The path to the script</param>
         /// <param name="visibility">Visibility of the script.</param>
@@ -591,7 +591,7 @@ namespace System.Management.Automation.Runspaces
         /// <summary>
         ///  Define an alias entry to add to the initial session state
         /// </summary>
-        /// <param name="name">Name of the aliase</param>
+        /// <param name="name">Name of the alias</param>
         /// <param name="definition">The name of the command it resolves to</param>
         public SessionStateAliasEntry(string name, string definition)
             : base(name, SessionStateEntryVisibility.Public)
@@ -603,9 +603,9 @@ namespace System.Management.Automation.Runspaces
         /// <summary>
         ///  Define an alias entry to add to the initial session state
         /// </summary>
-        /// <param name="name">Name of the aliase</param>
+        /// <param name="name">Name of the alias</param>
         /// <param name="definition">The name of the command it resolves to</param>
-        /// <param name="description">A descripion of the purpose of the alias.</param>
+        /// <param name="description">A description of the purpose of the alias.</param>
         public SessionStateAliasEntry(string name, string definition, string description)
             : base(name, SessionStateEntryVisibility.Public)
         {
@@ -617,10 +617,10 @@ namespace System.Management.Automation.Runspaces
         /// <summary>
         ///  Define an alias entry to add to the initial session state
         /// </summary>
-        /// <param name="name">Name of the aliase</param>
+        /// <param name="name">Name of the alias</param>
         /// <param name="definition">The name of the command it resolves to</param>
-        /// <param name="description">A descripion of the purpose of the alias.</param>
-        /// <param name="options">Options defining the scope visiblity, readonly and constant</param>
+        /// <param name="description">A description of the purpose of the alias.</param>
+        /// <param name="options">Options defining the scope visibility, readonly and constant</param>
         public SessionStateAliasEntry(string name, string definition, string description, ScopedItemOptions options)
             : base(name, SessionStateEntryVisibility.Public)
         {
@@ -633,10 +633,10 @@ namespace System.Management.Automation.Runspaces
         /// <summary>
         ///  Define an alias entry to add to the initial session state
         /// </summary>
-        /// <param name="name">Name of the aliase</param>
+        /// <param name="name">Name of the alias</param>
         /// <param name="definition">The name of the command it resolves to</param>
-        /// <param name="description">A descripion of the purpose of the alias.</param>
-        /// <param name="options">Options defining the scope visiblity, readonly and constant</param>
+        /// <param name="description">A description of the purpose of the alias.</param>
+        /// <param name="options">Options defining the scope visibility, readonly and constant</param>
         /// <param name="visibility"></param>
         internal SessionStateAliasEntry(string name, string definition, string description,
             ScopedItemOptions options, SessionStateEntryVisibility visibility)
@@ -669,7 +669,7 @@ namespace System.Management.Automation.Runspaces
         public string Description { get; } = String.Empty;
 
         /// <summary>
-        /// Options controling scope visiblity and setability for this entry.
+        /// Options controling scope visibility and setability for this entry.
         /// </summary>
         public ScopedItemOptions Options { get; } = ScopedItemOptions.None;
     }
@@ -696,7 +696,7 @@ namespace System.Management.Automation.Runspaces
         /// "*", then any path is permitted.
         /// </summary>
         /// <param name="path">The full path to the application</param>
-        /// <param name="visibility">Sets the external visibilty of the path.</param>
+        /// <param name="visibility">Sets the external visibility of the path.</param>
         internal SessionStateApplicationEntry(string path, SessionStateEntryVisibility visibility)
             : base(path, visibility)
         {
@@ -823,7 +823,7 @@ namespace System.Management.Automation.Runspaces
         internal ScriptBlock ScriptBlock { get; set; }
 
         /// <summary>
-        /// Options controling scope visiblity and setability for this entry.
+        /// Options controling scope visibility and setability for this entry.
         /// </summary>
         public ScopedItemOptions Options { get; } = ScopedItemOptions.None;
 
@@ -918,7 +918,7 @@ namespace System.Management.Automation.Runspaces
         internal WorkflowInfo WorkflowInfo { get; set; }
 
         /// <summary>
-        /// Options controling scope visiblity and setability for this entry.
+        /// Options controling scope visibility and setability for this entry.
         /// </summary>
         public ScopedItemOptions Options { get; } = ScopedItemOptions.None;
 
@@ -1521,7 +1521,7 @@ namespace System.Management.Automation.Runspaces
             allowedCommands.Add("Measure-Object"); // used to have nice progress bars when import/export-pssession is running
             // required by interactive remoting
             allowedCommands.Add("Out-Default"); // appended to every command line
-            allowedCommands.Add("Exit-PSSession"); // used by the user to exit the sesion
+            allowedCommands.Add("Exit-PSSession"); // used by the user to exit the session
 
             // We don't remove these entries so that they can be called by commands in the runspace.
             // Setting them to 'Private' ensures that the user can't call them.
@@ -2255,7 +2255,7 @@ namespace System.Management.Automation.Runspaces
 
         /// <summary>
         /// Specifies the authorization manager to be used for this session state instance.
-        /// If no authorization manager is specified, then the default authroization manager
+        /// If no authorization manager is specified, then the default authorization manager
         /// for PowerShell will be used which checks the ExecutionPolicy before running a command.
         /// </summary>
         public virtual AuthorizationManager AuthorizationManager { get; set; } = new Microsoft.PowerShell.PSAuthorizationManager(Utils.DefaultPowerShellShellID);
@@ -2289,7 +2289,7 @@ namespace System.Management.Automation.Runspaces
         /// Add a list of modules to import when the runspace is created.
         /// </summary>
         /// <param name="modules">
-        /// The modules, whose specificiations are specified by <paramref name="modules"/>,
+        /// The modules, whose specifications are specified by <paramref name="modules"/>,
         /// to add.
         /// </param>
         public void ImportPSModule(IEnumerable<ModuleSpecification> modules)
@@ -2394,7 +2394,7 @@ namespace System.Management.Automation.Runspaces
 
         /// <summary>
         /// If set to true, disables any updates to format table. This includes disabling
-        /// format table updates throught Update-FormatData, Import-Module etc.
+        /// format table updates through Update-FormatData, Import-Module etc.
         /// All the disabling happens silently ie., the user will not get any exception.
         /// By default, this is set to False.
         /// </summary>
@@ -2528,7 +2528,7 @@ namespace System.Management.Automation.Runspaces
 
                 // If the initial session state made some commands private by way of
                 // VisibleCmdlets / etc., then change the default command visibility for
-                // the sesssion state so that newly imported modules aren't exposed accidentally.
+                // the session state so that newly imported modules aren't exposed accidentally.
                 if (DefaultCommandVisibility == SessionStateEntryVisibility.Private)
                 {
                     ss.DefaultCommandVisibility = SessionStateEntryVisibility.Private;
@@ -3148,7 +3148,7 @@ namespace System.Management.Automation.Runspaces
 
         private string MakeUserNamePath()
         {
-            // Use the user name passsed to initial session state if avaiable, or
+            // Use the user name passed to initial session state if available, or
             // otherwise use the current user name.
             var userName = (!string.IsNullOrEmpty(this.UserDriveUserName)) ?
                 this.UserDriveUserName :
@@ -5142,7 +5142,7 @@ end
                         "Stop-Service",    "", ScopedItemOptions.ReadOnly | ScopedItemOptions.AllScope),
                     new SessionStateAliasEntry("sv",
                         "Set-Variable",    "", ScopedItemOptions.ReadOnly | ScopedItemOptions.AllScope),
-// Porting note: #if !UNIX is used to disable alises for cmdlets which conflict with Linux / OS X
+// Porting note: #if !UNIX is used to disable aliases for cmdlets which conflict with Linux / OS X
 #if !UNIX
                     // ac is a native command on OS X
                     new SessionStateAliasEntry("ac",
@@ -5163,7 +5163,7 @@ end
                         "Tee-Object",      "", ScopedItemOptions.ReadOnly | ScopedItemOptions.AllScope),
                     new SessionStateAliasEntry("write",
                         "Write-Output",    "", ScopedItemOptions.ReadOnly | ScopedItemOptions.AllScope),
-                    // These were traqnsferred from the "transferred from the profile" section
+                    // These were transferred from the "transferred from the profile" section
                     new SessionStateAliasEntry("cat",
                         "Get-Content",     "", ScopedItemOptions.AllScope),
                     new SessionStateAliasEntry("cp",

--- a/src/System.Management.Automation/engine/InternalCommands.cs
+++ b/src/System.Management.Automation/engine/InternalCommands.cs
@@ -173,7 +173,7 @@ namespace Microsoft.PowerShell.Commands
             // Win8: 176403: ScriptCmdlets sets the global WhatIf and Confirm preferences
             // This effects the new W8 foreach-object cmdlet with -whatif and -confirm
             // implemented. -whatif and -confirm needed only for PropertyAndMethodSet
-            // parmaeter set. So erring out in cases where these are used with ScriptBlockSet.
+            // parameter set. So erring out in cases where these are used with ScriptBlockSet.
             // Not using MshCommandRuntime, as those variables will be affected by ScriptCmdlet
             // infrastructure (wherein ScriptCmdlet modifies the global preferences).
             Dictionary<string, object> psBoundParameters = this.MyInvocation.BoundParameters;
@@ -210,7 +210,7 @@ namespace Microsoft.PowerShell.Commands
             _end = _scripts.Count;
             _start = _scripts.Count > 1 ? 1 : 0;
 
-            // and set the end script if it wasn't explicilty set with a named parameter.
+            // and set the end script if it wasn't explicitly set with a named parameter.
             if (!_setEndScript)
             {
                 if (_scripts.Count > 2)
@@ -338,7 +338,7 @@ namespace Microsoft.PowerShell.Commands
 
                             if (members.Count > 1)
                             {
-                                // write error record: property method ambigious
+                                // write error record: property method ambiguous
                                 StringBuilder possibleMatches = new StringBuilder();
                                 foreach (PSMemberInfo item in members)
                                 {
@@ -505,7 +505,7 @@ namespace Microsoft.PowerShell.Commands
             Dbg.Assert(methods != null, "The return value of Members.Match should never be null.");
             if (methods.Count > 1)
             {
-                // write error record: method ambigious
+                // write error record: method ambiguous
                 StringBuilder possibleMatches = new StringBuilder();
                 foreach (PSMemberInfo item in methods)
                 {
@@ -1495,7 +1495,7 @@ namespace Microsoft.PowerShell.Commands
                                                        "ValueNotSpecifiedForWhereObject", null));
                 }
 
-                // The binary operation needs to be specified if the user specifies both the -Propery and -Value
+                // The binary operation needs to be specified if the user specifies both the -Property and -Value
                 if (!_valueNotSpecified && (_binaryOperator == TokenKind.Ieq && _forceBooleanEvaluation))
                 {
                     // The -Property and -Value are specified explicitly by the user but the binary operation is not

--- a/src/System.Management.Automation/engine/InvocationInfo.cs
+++ b/src/System.Management.Automation/engine/InvocationInfo.cs
@@ -21,7 +21,7 @@ namespace System.Management.Automation
         #region Constructors
 
         /// <summary>
-        /// Contructor for InvocationInfo object when the associated command object is present. 
+        /// Constructor for InvocationInfo object when the associated command object is present. 
         /// </summary>
         /// <param name="command"></param>
         internal InvocationInfo(InternalCommand command)

--- a/src/System.Management.Automation/engine/ItemCmdletProviderInterfaces.cs
+++ b/src/System.Management.Automation/engine/ItemCmdletProviderInterfaces.cs
@@ -283,7 +283,7 @@ namespace System.Management.Automation
             // Parameter validation is done in the session state object
 
             return _sessionState.GetItemDynamicParameters(path, context);
-        } // GetItemDynamicParamters
+        } // GetItemDynamicParameters
 
         #endregion GetItem
 
@@ -2505,7 +2505,7 @@ namespace System.Management.Automation
         CopyTargetContainer,
 
         /// <summary>
-        /// The children of the source contianer are copied.
+        /// The children of the source container are copied.
         /// </summary>
         CopyChildrenOfTargetContainer
     }

--- a/src/System.Management.Automation/engine/LanguagePrimitives.cs
+++ b/src/System.Management.Automation/engine/LanguagePrimitives.cs
@@ -94,7 +94,7 @@ namespace System.Management.Automation
         /// </summary>
         /// <param name="sourceValue">value supposedly *not* of the types supported by this converted to be converted to the <paramref name="destinationType"/> parameter</param>
         /// <param name="destinationType">one of the types supported by this converter to which the <paramref name="sourceValue"/> parameter should be converted to</param>
-        /// <param name="formatProvider">The format provider to use like in IFormatable's ToString</param>
+        /// <param name="formatProvider">The format provider to use like in IFormattable's ToString</param>
         /// <param name="ignoreCase">true if case should be ignored</param>
         /// <returns>the <paramref name="sourceValue"/> parameter converted to the <paramref name="destinationType"/> parameter using formatProvider and ignoreCase</returns>
         /// <exception cref="InvalidCastException">if no conversion was possible</exception>
@@ -105,7 +105,7 @@ namespace System.Management.Automation
         /// </summary>
         /// <param name="sourceValue">value supposedly *not* of the types supported by this converted to be converted to the <paramref name="destinationType"/> parameter</param>
         /// <param name="destinationType">one of the types supported by this converter to which the <paramref name="sourceValue"/> parameter should be converted to</param>
-        /// <param name="formatProvider">The format provider to use like in IFormatable's ToString</param>
+        /// <param name="formatProvider">The format provider to use like in IFormattable's ToString</param>
         /// <param name="ignoreCase">true if case should be ignored</param>
         /// <returns>the <paramref name="sourceValue"/> parameter converted to the <paramref name="destinationType"/> parameter using formatProvider and ignoreCase</returns>
         /// <exception cref="InvalidCastException">if no conversion was possible</exception>
@@ -138,7 +138,7 @@ namespace System.Management.Automation
         /// </summary>
         /// <param name="sourceValue">value supposedly from one of the types supported by this converter to be converted to the <paramref name="destinationType"/> parameter</param>
         /// <param name="destinationType">type to convert the <paramref name="sourceValue"/> parameter, supposedly not one of the types supported by the converter</param>
-        /// <param name="formatProvider">The format provider to use like in IFormatable's ToString</param>
+        /// <param name="formatProvider">The format provider to use like in IFormattable's ToString</param>
         /// <param name="ignoreCase">true if case should be ignored</param>
         /// <returns>sourceValue converted to the <paramref name="destinationType"/> parameter using formatProvider and ignoreCase</returns>
         /// <exception cref="InvalidCastException">if no conversion was possible</exception>
@@ -149,7 +149,7 @@ namespace System.Management.Automation
         /// </summary>
         /// <param name="sourceValue">value supposedly from one of the types supported by this converter to be converted to the <paramref name="destinationType"/> parameter</param>
         /// <param name="destinationType">type to convert the <paramref name="sourceValue"/> parameter, supposedly not one of the types supported by the converter</param>
-        /// <param name="formatProvider">The format provider to use like in IFormatable's ToString</param>
+        /// <param name="formatProvider">The format provider to use like in IFormattable's ToString</param>
         /// <param name="ignoreCase">true if case should be ignored</param>
         /// <returns>sourceValue converted to the <paramref name="destinationType"/> parameter using formatProvider and ignoreCase</returns>
         /// <exception cref="InvalidCastException">if no conversion was possible</exception>
@@ -934,7 +934,7 @@ namespace System.Management.Automation
                 case 1:
                     // A possible implementation would be just 
                     // return IsTrue(objectArray[0]);
-                    // but since we don't want this to recurse indefinately
+                    // but since we don't want this to recurse indefinitely
                     // we explicitly check the case where it would recurse
                     // and deal with it.
                     IList firstElement = objectArray[0] as IList;
@@ -965,7 +965,7 @@ namespace System.Management.Automation
         }
 
         /// <summary>
-        /// Auxilliary for the cases where we want a new PSObject or null
+        /// Auxiliary for the cases where we want a new PSObject or null
         /// </summary>
         internal static PSObject AsPSObjectOrNull(object obj)
         {
@@ -1305,7 +1305,7 @@ namespace System.Management.Automation
                     // This assumption holds for System.Collections.Generic.Dictionary<TKey,TValue>.
 
                     // If we did not make this assumption, we would be forced to generate code
-                    // to call the generic indexer directly, somewhat analgous to what we do
+                    // to call the generic indexer directly, somewhat analogous to what we do
                     // in GetEnumeratorFromIEnumeratorT.
 
                     Type[] genericArguments = i.GetGenericArguments();
@@ -1447,7 +1447,7 @@ namespace System.Management.Automation
         /// If the string to convert is null or empty then the function returns "[object]" as the default typeless type.
         /// </summary>
         /// <param name="typeName">The typename string to convert.</param>
-        /// <returns>The equivalent PowerShell representatin of that type.</returns>
+        /// <returns>The equivalent PowerShell representation of that type.</returns>
         public static string ConvertTypeNameToPSTypeName(string typeName)
         {
             if (string.IsNullOrWhiteSpace(typeName))
@@ -1557,7 +1557,7 @@ namespace System.Management.Automation
         ///                                                 string representation of valueToConvert.
         ///     - to ADSI                               -   returns DirectoryEntry  represented by the
         ///                                                 string representation of valueToConvert.
-        ///     - to ADSISearcher                       -   return DirectorySearcher representd by the
+        ///     - to ADSISearcher                       -   return DirectorySearcher represented by the
         ///                                                 string representation of valueToConvert.
         /// 
         /// If none of the cases above is true, the following is considered in order:
@@ -1644,7 +1644,7 @@ namespace System.Management.Automation
         /// <param name="resultType">type to convert psobject.</param>
         /// <param name="recursion">Indicates if inner properties have to be recursively converted.</param>
         /// <param name="formatProvider">To be used in custom type conversions, to call parse and to call Convert.ChangeType</param>
-        /// <param name="ignoreUnknownMembers">Indiacates if Unknown members in the psobject have to be ignored if the corresponding members in resultType do not exist.</param>
+        /// <param name="ignoreUnknownMembers">Indicates if Unknown members in the psobject have to be ignored if the corresponding members in resultType do not exist.</param>
         /// <returns>converted value.</returns>
         public static object ConvertPSObjectToType(PSObject valueToConvert, Type resultType, bool recursion, IFormatProvider formatProvider, bool ignoreUnknownMembers)
         {
@@ -1658,7 +1658,7 @@ namespace System.Management.Automation
         }
 
         /// <summary>
-        /// Generic convertto that simplifies workfing with workflow.
+        /// Generic convertto that simplifies working with workflow.
         /// </summary>
         /// <typeparam name="T">The type of object to return</typeparam>
         /// <param name="valueToConvert"></param>
@@ -1831,7 +1831,7 @@ namespace System.Management.Automation
                             }
 
                             // we know the value is not negative, so this conversion
-                            // always succede
+                            // always succeed
                             allValues |= Convert.ToUInt64(value, CultureInfo.CurrentCulture);
                         }
                     }
@@ -2121,9 +2121,9 @@ namespace System.Management.Automation
         /// <summary>
         /// There might be many cast operators in a Type A that take Type A. Each operator will have a 
         /// different return type. Because of that we cannot call GetMethod since it would cause a 
-        /// AmbiguousMatchException. This auxilliar method calls GetMember to find the right method
+        /// AmbiguousMatchException. This auxiliary method calls GetMember to find the right method
         /// </summary>
-        /// <param name="methodName">Either op_Excplicit or op_Implicit, at the moment</param>
+        /// <param name="methodName">Either op_Explicit or op_Implicit, at the moment</param>
         /// <param name="targetType">the type to look for an operator</param>
         /// <param name="originalType">Type of the only parameter the operator method should have</param>
         /// <param name="resultType">Return type of the operator method</param>
@@ -2472,7 +2472,7 @@ namespace System.Management.Automation
 
         /// backupTypeTable:
         /// Used by Remoting Rehydration Logic. While Deserializing a remote object, 
-        /// LocalPipeline.ExecutionCotextFromTLS() might return null..In which case this
+        /// LocalPipeline.ExecutionContextFromTLS() might return null..In which case this
         /// TypeTable will be used to do the conversion.
         private static bool IsCustomTypeConversion(object valueToConvert,
                                                    Type resultType,
@@ -2741,7 +2741,7 @@ namespace System.Management.Automation
         }
 
         /// <summary>
-        /// We need to add this built-in converter because in FullCLR, Syste.Uri has a TypeConverter attribute
+        /// We need to add this built-in converter because in FullCLR, System.Uri has a TypeConverter attribute
         /// declared: [TypeConverter(typeof(UriTypeConverter))], so the conversion from 'string' to 'Uri' is
         /// actually taken care of by 'UriTypeConverter'. However, the type 'UriTypeConverter' is not available
         /// in CoreCLR, and thus the conversion from 'string' to 'Uri' would show a different behavior.
@@ -4547,7 +4547,7 @@ namespace System.Management.Automation
         /// <param name="formatProvider">governing conversion of types</param>
         /// <param name="backupTypeTable">
         /// Used by Remoting Rehydration Logic. While Deserializing a remote object, 
-        /// LocalPipeline.ExecutionCotextFromTLS() might return null..In which case this
+        /// LocalPipeline.ExecutionContextFromTLS() might return null..In which case this
         /// TypeTable will be used to do the conversion.
         /// </param>
         /// <returns>the value converted</returns>

--- a/src/System.Management.Automation/engine/ManagementObjectAdapter.cs
+++ b/src/System.Management.Automation/engine/ManagementObjectAdapter.cs
@@ -349,7 +349,7 @@ namespace System.Management.Automation
         /// </summary>
         /// <param name="property">PSProperty coming from a previous call to DoGetProperty</param>
         /// <param name="setValue">value to set the property with</param>
-        /// <param name="convertIfPossible">instructs the adapter to convert before setting, if the adapter suports conversion</param>
+        /// <param name="convertIfPossible">instructs the adapter to convert before setting, if the adapter supports conversion</param>
         protected override void PropertySet(PSProperty property, object setValue, bool convertIfPossible)
         {
             ManagementBaseObject mObj = property.baseObject as ManagementBaseObject;
@@ -452,7 +452,7 @@ namespace System.Management.Automation
                 try
                 {
                     // try to populate method table..if there is any exception
-                    // generati.ng the method metadata..suppress the exception
+                    // generating the method metadata..suppress the exception
                     // but dont store the info in the cache. This is to allow
                     // for method look up again in future (after the wmi object
                     // is fixed)
@@ -511,7 +511,7 @@ namespace System.Management.Automation
         /// <summary>
         /// Constructs a ManagementClass object from the supplied mgmtBaseObject.
         /// ManagementObject has scope, options, path which need to be carried over to the ManagementClass for
-        /// retreiveing method/property/parameter metadata
+        /// retrieving method/property/parameter metadata
         /// </summary>
         /// <param name="mgmtBaseObject"></param>
         /// <returns></returns>
@@ -724,7 +724,7 @@ namespace System.Management.Automation
                 // and also null ints to 0. But WMI providers do not like these
                 // conversions. So dont convert input arguments if they are null.
                 // We could have done this in the base adapter but the change would be
-                // costly for other adpaters which dont mind the conversion.
+                // costly for other adapters which dont mind the conversion.
                 if ((i < arguments.Length) && (arguments[i] == null))
                 {
                     verifiedArguments[i] = null;
@@ -753,7 +753,7 @@ namespace System.Management.Automation
 
             foreach (PropertyData data in parameters.Properties)
             {
-                // parameter postion..
+                // parameter position..
                 int location = -1;
                 WMIParameterInformation pInfo = new WMIParameterInformation(data.Name, GetDotNetType(data));
 
@@ -928,7 +928,7 @@ namespace System.Management.Automation
     /// <summary>
     /// Deals with ManagementClass objects.
     /// Adapts only static methods and SystemProperties of a 
-    /// ManagemetnClass object.
+    /// ManagementClass object.
     /// </summary>
     internal class ManagementClassApdapter : BaseWMIAdapter
     {
@@ -961,7 +961,7 @@ namespace System.Management.Automation
         }
 
         /// <summary>
-        /// Invokes method reperesented by <paramref name="mdata"/> using supplied arguments.
+        /// Invokes method represented by <paramref name="mdata"/> using supplied arguments.
         /// </summary>
         /// <param name="wmiObject">ManagementObject on which the method is invoked.</param>
         /// <param name="methodName">Method data.</param>
@@ -1118,7 +1118,7 @@ namespace System.Management.Automation
         }
 
         /// <summary>
-        /// Invokes method reperesented by <paramref name="mdata"/> using supplied arguments.
+        /// Invokes method represented by <paramref name="mdata"/> using supplied arguments.
         /// </summary>
         /// <param name="obj">ManagementObject on which the method is invoked.</param>
         /// <param name="methodName">Method data.</param>

--- a/src/System.Management.Automation/engine/MergedCommandParameterMetadata.cs
+++ b/src/System.Management.Automation/engine/MergedCommandParameterMetadata.cs
@@ -60,7 +60,7 @@ namespace System.Management.Automation
         } // ReplaceMetadata
 
         /// <summary>
-        /// Merges the specified metdata with the other metadata already defined
+        /// Merges the specified metadata with the other metadata already defined
         /// in this object.
         /// </summary>
         /// 
@@ -625,7 +625,7 @@ namespace System.Management.Automation
         /// <summary>
         /// Gets a dictionary of the compiled parameter metadata for this Type. 
         /// The dictionary keys are the names of the parameters and
-        /// the values are the compiled parameter metdata.
+        /// the values are the compiled parameter metadata.
         /// </summary>
         internal IDictionary<string, MergedCompiledCommandParameter> BindableParameters { get { return _bindableParameters; } }
         private IDictionary<string, MergedCompiledCommandParameter> _bindableParameters =

--- a/src/System.Management.Automation/engine/MshCommandRuntime.cs
+++ b/src/System.Management.Automation/engine/MshCommandRuntime.cs
@@ -785,7 +785,7 @@ namespace System.Management.Automation
                             if (foregroundColor.HasValue || backgroundColor.HasValue)
                             {
                                 // It is possible for either one or the other to be empty if run from a 
-                                // non-interative host, but only one was specified in Write-Host.
+                                // non-interactive host, but only one was specified in Write-Host.
                                 // So fill them with defaults if they are empty.
                                 if (!foregroundColor.HasValue)
                                 {
@@ -825,7 +825,7 @@ namespace System.Management.Automation
                     }
                     else
                     {
-                        // Only transcribe informational messages here. Transcripton of PSHost-targeted messages is done in the InternalUI.Write* methods.
+                        // Only transcribe informational messages here. Transcription of PSHost-targeted messages is done in the InternalUI.Write* methods.
                         CBhost.InternalUI.TranscribeResult(StringUtil.Format(InternalHostUserInterfaceStrings.InformationFormatString, record.ToString()));
                     }
                 }

--- a/src/System.Management.Automation/engine/MshMemberInfo.cs
+++ b/src/System.Management.Automation/engine/MshMemberInfo.cs
@@ -43,7 +43,7 @@ namespace System.Management.Automation
         /// </summary>
         Property = 4,
         /// <summary>
-        /// A prorperty defined by a Name-Value pair
+        /// A property defined by a Name-Value pair
         /// </summary>
         NoteProperty = 8,
         /// <summary>
@@ -462,7 +462,7 @@ namespace System.Management.Automation
         /// When 
         ///     the alias has not been added to an PSObject or
         ///     the alias has a cycle or
-        ///     an aliased member is not presen
+        ///     an aliased member is not present
         /// </exception>
         public override bool IsSettable
         {
@@ -761,7 +761,7 @@ namespace System.Management.Automation
         /// </summary>
         /// <param name="name">name of the property</param>
         /// <param name="getterCodeReference">This should be a public static non void method taking one PSObject parameter.</param>
-        /// <exception cref="ArgumentException">if namme is null or empty or getterCodeReference is null</exception>
+        /// <exception cref="ArgumentException">if name is null or empty or getterCodeReference is null</exception>
         /// <exception cref="ExtendedTypeSystemException">if getterCodeReference doesn't have the right format.</exception>
         public PSCodeProperty(string name, MethodInfo getterCodeReference)
         {
@@ -1010,7 +1010,7 @@ namespace System.Management.Automation
         }
 
         /// <summary>
-        /// Constructs this proprerty
+        /// Constructs this property
         /// </summary>
         /// <param name="name">name of the property</param>
         /// <param name="adapter">adapter used in DoGetProperty</param>
@@ -1246,7 +1246,7 @@ namespace System.Management.Automation
         internal object noteValue;
 
         /// <summary>
-        /// Initiializes a new instance of the PSNoteProperty class.
+        /// Initializes a new instance of the PSNoteProperty class.
         /// </summary>
         /// <param name="name">name of the property</param>
         /// <param name="value">value of the property</param>
@@ -1413,7 +1413,7 @@ namespace System.Management.Automation
         internal PSVariable _variable;
 
         /// <summary>
-        /// Initiializes a new instance of the PSVariableProperty class. This is
+        /// Initializes a new instance of the PSVariableProperty class. This is
         /// a subclass of the NoteProperty that wraps a variable instead of a simple value.
         /// </summary>
         /// <param name="variable">The variable to wrap</param>
@@ -2687,7 +2687,7 @@ namespace System.Management.Automation
         internal object baseObject;
 
         /// <summary>
-        /// Constructs this parameterized proprerty
+        /// Constructs this parameterized property
         /// </summary>
         /// <param name="name">name of the property</param>
         /// <param name="adapter">adapter used in DoGetMethod</param>
@@ -3501,7 +3501,7 @@ namespace System.Management.Automation
 
     #endregion PSMemberInfo
 
-    #region Member collection classes and its auxilliary classes
+    #region Member collection classes and its auxiliary classes
 
     /// <summary>
     /// /// This class is used in PSMemberInfoInternalCollection and ReadOnlyPSMemberInfoCollection
@@ -4812,7 +4812,7 @@ namespace System.Management.Automation
         }
     }
 
-    #endregion Member collection classes and its auxilliary classes
+    #endregion Member collection classes and its auxiliary classes
 }
 
 #pragma warning restore 56503

--- a/src/System.Management.Automation/engine/MshObject.cs
+++ b/src/System.Management.Automation/engine/MshObject.cs
@@ -206,7 +206,7 @@ namespace System.Management.Automation
         private static Collection<CollectionEntry<PSPropertyInfo>> s_propertyCollection = GetPropertyCollection(PSMemberViewTypes.All);
 
         /// <summary>
-        /// A collection of delegates to get Extended/Adapated/Dotnet members based on the 
+        /// A collection of delegates to get Extended/Adapted/Dotnet members based on the 
         /// <paramref name="viewType"/>
         /// </summary>
         /// <param name="viewType">
@@ -219,7 +219,7 @@ namespace System.Management.Automation
         }
 
         /// <summary>
-        /// A collection of delegates to get Extended/Adapated/Dotnet members based on the 
+        /// A collection of delegates to get Extended/Adapted/Dotnet members based on the 
         /// <paramref name="viewType"/>
         /// </summary>
         /// <param name="viewType">
@@ -293,7 +293,7 @@ namespace System.Management.Automation
         }
 
         /// <summary>
-        /// A collection of delegates to get Extended/Adapated/Dotnet properties based on the 
+        /// A collection of delegates to get Extended/Adapted/Dotnet properties based on the 
         /// <paramref name="viewType"/>
         /// </summary>
         /// <param name="viewType">
@@ -307,7 +307,7 @@ namespace System.Management.Automation
         }
 
         /// <summary>
-        /// A collection of delegates to get Extended/Adapated/Dotnet properties based on the 
+        /// A collection of delegates to get Extended/Adapted/Dotnet properties based on the 
         /// <paramref name="viewType"/>
         /// </summary>
         /// <param name="viewType">
@@ -632,7 +632,7 @@ namespace System.Management.Automation
 
         /// <summary>
         /// This is the adapter set that will contain the adapter of the baseObject 
-        /// and the ultimate .net member lookup adater.
+        /// and the ultimate .net member lookup adapter.
         /// See <see cref="PSObject.AdapterSet"/> for explanation.
         /// </summary>
         private AdapterSet InternalAdapterSet
@@ -1207,7 +1207,7 @@ namespace System.Management.Automation
         /// enumerating and if that fails we call obj.ToString.
         /// If this is an PSObject, we look for a brokered ToString. 
         /// If it is not present, and the BaseObject is null we try listing the properties.
-        /// If the BaseObject is not null we try enumerationg. If that fails we try the BaseObject's ToString.
+        /// If the BaseObject is not null we try enumerating. If that fails we try the BaseObject's ToString.
         /// </param>
         /// <returns>A string representation of the object</returns>
         /// <exception cref="ExtendedTypeSystemException">
@@ -1239,7 +1239,7 @@ namespace System.Management.Automation
         /// enumerating and if that fails we call obj.ToString.
         /// If this is an PSObject, we look for a brokered ToString. 
         /// If it is not present, and the BaseObject is null we try listing the properties.
-        /// If the BaseObject is not null we try enumerationg. If that fails we try the BaseObject's ToString.
+        /// If the BaseObject is not null we try enumerating. If that fails we try the BaseObject's ToString.
         /// </param>
         /// <param name="separator">The separator between elements, if this is an enumeration</param>
         /// <param name="format">the format to be passed to ToString</param>
@@ -1521,8 +1521,8 @@ namespace System.Management.Automation
         /// CodeMethod or ScriptMethod will be used, if available. Enumerations items are
         /// concatenated using $ofs.
         /// </summary>
-        /// <param name="format">repassed to baseObject's IFormatable if present</param>
-        /// <param name="formatProvider">repassed to baseObject's IFormatable if present</param>
+        /// <param name="format">repassed to baseObject's IFormattable if present</param>
+        /// <param name="formatProvider">repassed to baseObject's IFormattable if present</param>
         /// <returns>the string representation for baseObject</returns>
         /// <exception cref="ExtendedTypeSystemException">if an exception was thrown by the BaseObject's ToString</exception>
         public string ToString(string format, IFormatProvider formatProvider)
@@ -1648,11 +1648,11 @@ namespace System.Management.Automation
         ///     Greater than zero This instance is greater than obj.
         /// </returns>
         /// <exception cref="ExtendedTypeSystemException"> If <paramref name="obj"/> has a different type
-        /// than this intance's BaseObject or if the BaseObject does not implement IComparable.
+        /// than this instance's BaseObject or if the BaseObject does not implement IComparable.
         /// </exception>
         public int CompareTo(object obj)
         {
-            // This ReferenceEqulas is not just an optimization. 
+            // This ReferenceEquals is not just an optimization. 
             // It is necessary so that mshObject.Equals(mshObject) returns 0. 
             // Please see the comments inside the Equals implementation.
             if (Object.ReferenceEquals(this, obj))
@@ -1691,7 +1691,7 @@ namespace System.Management.Automation
             }
 
             // The above check validates if we are comparing with the same object references
-            // This check "shortcuts" the comparision if the first object is a CustomObject
+            // This check "shortcuts" the comparison if the first object is a CustomObject
             // since 2 custom objects are not equal.
             if (Object.ReferenceEquals(this.BaseObject, PSCustomObject.SelfInstance))
             {
@@ -1748,7 +1748,7 @@ namespace System.Management.Automation
         /// The name of the member set for adapted members
         /// </summary>
         /// <remarks>
-        /// This needs to be Lower cased as it saves some comparision time elsewhere.
+        /// This needs to be Lower cased as it saves some comparison time elsewhere.
         /// </remarks>
         public const string AdaptedMemberSetName = "psadapted";
 
@@ -1756,7 +1756,7 @@ namespace System.Management.Automation
         /// The name of the member set for extended members
         /// </summary>
         /// <remarks>
-        /// This needs to be Lower cased as it saves some comparision time elsewhere.
+        /// This needs to be Lower cased as it saves some comparison time elsewhere.
         /// </remarks>
         public const string ExtendedMemberSetName = "psextended";
 
@@ -1764,7 +1764,7 @@ namespace System.Management.Automation
         /// The name of the member set for the BaseObject's members
         /// </summary>
         /// <remarks>
-        /// This needs to be Lower cased as it saves some comparision time elsewhere.
+        /// This needs to be Lower cased as it saves some comparison time elsewhere.
         /// </remarks>
         public const string BaseObjectMemberSetName = "psbase";
 
@@ -1773,7 +1773,7 @@ namespace System.Management.Automation
         /// The PSObject's properties
         /// </summary>
         /// <remarks>
-        /// This needs to be Lower cased as it saves some comparision time elsewhere.
+        /// This needs to be Lower cased as it saves some comparison time elsewhere.
         /// </remarks>
         internal const string PSObjectMemberSetName = "psobject";
 
@@ -1781,7 +1781,7 @@ namespace System.Management.Automation
         /// a shortcut to .PSObject.TypeNames
         /// </summary>
         /// <remarks>
-        /// This needs to be Lower cased as it saves some comparision time elsewhere.
+        /// This needs to be Lower cased as it saves some comparison time elsewhere.
         /// </remarks>
         internal const string PSTypeNames = "pstypenames";
 
@@ -1817,7 +1817,7 @@ namespace System.Management.Automation
         }
 
         /// <summary>
-        /// Used in the serialization dupplicate entry hashtable to detect when an PSObject has been serialized
+        /// Used in the serialization duplicate entry hashtable to detect when an PSObject has been serialized
         /// </summary>
         /// <returns>The System.Object implementation of GetHashCode</returns>
         internal int GetReferenceHashCode()
@@ -1836,7 +1836,7 @@ namespace System.Management.Automation
         /// true to make this PSObject as the owner of the memberset.
         /// </param>
         /// <param name="ownerObject">
-        /// PSObject to be used while replicating the owner for PSMemeberSet
+        /// PSObject to be used while replicating the owner for PSMemberSet
         /// </param>
         /// <returns></returns>
         internal static object GetNoteSettingValue(PSMemberSet settings, string noteName,
@@ -2147,7 +2147,7 @@ namespace System.Management.Automation
         /// 3. This will fix v1.0 ADSI adapter where most of the complaints were about
         ///    discovering original .net members.
         /// 
-        /// Use of this class will allow us to customize the utlitmate .net member lookup.
+        /// Use of this class will allow us to customize the ultimate .net member lookup.
         /// For example, XML adapter already exposes .net methods. 
         /// Using this class you can choose exact .net adapter to support .net
         /// member lookup and avoid lookup duplication.
@@ -2159,7 +2159,7 @@ namespace System.Management.Automation
         {
             #region Private Data
 
-            // orginal adapter like Xml, ManagementClass, DirectoryEntry etc.
+            // original adapter like Xml, ManagementClass, DirectoryEntry etc.
             // .net adapter
 
             #endregion
@@ -2407,7 +2407,7 @@ namespace System.Management.Automation
 namespace Microsoft.PowerShell
 {
     /// <summary>
-    /// Contains auxilliary ToString CodeMethod implementations for some types
+    /// Contains auxiliary ToString CodeMethod implementations for some types
     /// </summary>
     public static partial class ToStringCodeMethods
     {
@@ -2464,7 +2464,7 @@ namespace Microsoft.PowerShell
                     {
                         if (typeinfo.IsNested)
                         {
-                            // For nested types, we should return OutterType+InnerType. For example,
+                            // For nested types, we should return OuterType+InnerType. For example,
                             //  System.Environment+SpecialFolder ->  Environment+SpecialFolder
                             string fullName = type.ToString();
                             result = type.Namespace == null

--- a/src/System.Management.Automation/engine/MshObjectTypeDescriptor.cs
+++ b/src/System.Management.Automation/engine/MshObjectTypeDescriptor.cs
@@ -520,7 +520,7 @@ namespace System.Management.Automation
 
             if (defaultProperty != null)
             {
-                // There is a defaultPropery, but let's check if it is actually one of the properties we are
+                // There is a defaultProperty, but let's check if it is actually one of the properties we are
                 // returning in GetProperties
                 foreach (PropertyDescriptor descriptor in properties)
                 {
@@ -562,7 +562,7 @@ namespace System.Management.Automation
             return this.Instance;
         }
 
-        #region Overides Forwarded To BaseObject
+        #region Overrides Forwarded To BaseObject
 
         #region ReadMe
         // This region contains methods implemented like:
@@ -725,9 +725,9 @@ namespace System.Management.Automation
             // It would be nice to throw an exception for the case 2) instructing the user to use 
             // an ArrayList, but since we have case 1) and maybe others we haven't found we return
             // an PSObjectTypeDescriptor(null). PSObjectTypeDescriptor's GetProperties 
-            // checks for null instance and returns an empty property colection. 
+            // checks for null instance and returns an empty property collection. 
             // All other overrides also check for null and return some default result.
-            // Case 1), which is using a PropertyGrid seems to be unafected by these results returned
+            // Case 1), which is using a PropertyGrid seems to be unaffected by these results returned
             // by PSObjectTypeDescriptor overrides when the Instance is null, so we must conclude
             // that the TypeDescriptor returned by that call where instance is null is not used
             // for anything meaningful. That null instance PSObjectTypeDescriptor is only one

--- a/src/System.Management.Automation/engine/MshSnapinQualifiedName.cs
+++ b/src/System.Management.Automation/engine/MshSnapinQualifiedName.cs
@@ -7,7 +7,7 @@ using Dbg = System.Management.Automation.Diagnostics;
 namespace System.Management.Automation
 {
     /// <summary>
-    /// A class respresenting a name that is qualified by the PSSnapin name
+    /// A class representing a name that is qualified by the PSSnapin name
     /// </summary>
     internal class PSSnapinQualifiedName
     {

--- a/src/System.Management.Automation/engine/NativeCommandParameterBinder.cs
+++ b/src/System.Management.Automation/engine/NativeCommandParameterBinder.cs
@@ -190,7 +190,7 @@ namespace System.Management.Automation
                         // actually have quotes in different places, but the Win32 command line=>argv parser
                         // erases those differences.
                         //
-                        // We need to check quotes that the win32 arugment parser checks which is currently 
+                        // We need to check quotes that the win32 argument parser checks which is currently 
                         // just the normal double quotes, no other special quotes.  Also note that mismatched
                         // quotes are supported.
 

--- a/src/System.Management.Automation/engine/NativeCommandProcessor.cs
+++ b/src/System.Management.Automation/engine/NativeCommandProcessor.cs
@@ -660,7 +660,7 @@ namespace System.Management.Automation
         #region Process cleanup with Child Process cleanup
 
         /// <summary>
-        /// Utility routine to kill a process, discarding non-critial exceptions.
+        /// Utility routine to kill a process, discarding non-critical exceptions.
         /// This utility makes two passes at killing a process. In the first pass,
         /// if the process handle is invalid (as seems to be the case with an ntvdm)
         /// then we try to get a fresh handle based on the original process id.
@@ -745,8 +745,8 @@ namespace System.Management.Automation
             {
                 try
                 {
-                    // note that we have tried to retrived parent id once.
-                    // retreiving parent id might throw exceptions..so
+                    // note that we have tried to retrieved parent id once.
+                    // retrieving parent id might throw exceptions..so
                     // setting this to -1 so that we dont try again to
                     // get the parent id.
                     _parentId = -1;
@@ -1085,7 +1085,7 @@ namespace System.Management.Automation
                 // compare the command name to avoid breaking change.
                 if (String.Equals(outputProcessor.CommandInfo.Name, "Out-Default", StringComparison.OrdinalIgnoreCase))
                 {
-                    // Verify that this isn't an Out-Default added for transcripting
+                    // Verify that this isn't an Out-Default added for transcribing
                     if (!outputProcessor.Command.MyInvocation.BoundParameters.ContainsKey("Transcript"))
                     {
                         return true;
@@ -1113,7 +1113,7 @@ namespace System.Management.Automation
             // redirecting anything. This is a bit tricky as we always run redirected so
             // we have to see if the redirection is actually being done at the topmost level or not.
 
-            // If we're eligable to be running standalone, that is, without redirection
+            // If we're eligible to be running standalone, that is, without redirection
             // use our pipeline position to determine if we really want to redirect
             // input and error or not. If we're first in the pipeline, then we don't
             // redirect input. If we're last in the pipeline, we don't redirect output.
@@ -1121,7 +1121,7 @@ namespace System.Management.Automation
             if (this.Command.MyInvocation.PipelinePosition == this.Command.MyInvocation.PipelineLength)
             {
                 // If the output pipe is the default outputter, for example, calling the native command from command-line host,
-                // then we're possiblly running standalone.
+                // then we're possibly running standalone.
                 //
                 // If the downstream cmdlet is explicitly Out-Default, for example: 
                 //    $powershell.AddScript('ipconfig.exe') 
@@ -1140,7 +1140,7 @@ namespace System.Management.Automation
             if (CommandRuntime.ErrorMergeTo != MshCommandRuntime.MergeDataStream.Output)
             {
                 // If the error output pipe is the default outputter, for example, calling the native command from command-line host,
-                // then we're possiblly running standalone.
+                // then we're possibly running standalone.
                 //
                 // If the downstream cmdlet is explicitly Out-Default, for example: 
                 //    $powershell.AddScript('ipconfig.exe') 
@@ -1697,7 +1697,7 @@ namespace System.Management.Automation
     /// and processes them appropriately.
     /// </summary>
     /// <remarks>
-    /// This class is not thread safe. It is assumed that NativeCommnadProcessor
+    /// This class is not thread safe. It is assumed that NativeCommandProcessor
     /// class will synchronize access to this class between different threads.
     /// </remarks>
     internal class ProcessStreamReader
@@ -2204,7 +2204,7 @@ namespace System.Management.Automation
 
         /// <summary>
         /// Initializes a new instance of the RemoteException 
-        /// with a specified error message, serialzed Exception and 
+        /// with a specified error message, serialized Exception and 
         /// serialized InvocationInfo
         /// </summary>
         /// <param name="message">The message that describes the error. </param>

--- a/src/System.Management.Automation/engine/PSVersionInfo.cs
+++ b/src/System.Management.Automation/engine/PSVersionInfo.cs
@@ -31,7 +31,7 @@ namespace System.Management.Automation
         /// 
         /// This is why we hard code the PowerShell version here. 
         /// 
-        /// For each later relase of PowerShell, this constant needs to 
+        /// For each later release of PowerShell, this constant needs to 
         /// be updated to reflect the right version. 
         /// </remarks>
         private static Version s_psV1Version = new Version(1, 0);

--- a/src/System.Management.Automation/engine/ParameterBinderController.cs
+++ b/src/System.Management.Automation/engine/ParameterBinderController.cs
@@ -489,7 +489,7 @@ namespace System.Management.Automation
         /// </param>
         /// 
         /// <param name="flags">
-        /// Flags for type coercion and valiation of the arguments.
+        /// Flags for type coercion and validation of the arguments.
         /// </param>
         /// 
         /// <returns>
@@ -1139,7 +1139,7 @@ namespace System.Management.Automation
 
         /// <summary>
         /// If the parameter binder might use the value more than once, this it can save the value to avoid
-        /// re-evalauting complicated expressions.
+        /// re-evaluating complicated expressions.
         /// </summary>
         protected virtual void SaveDefaultScriptParameterValue(string name, object value)
         {

--- a/src/System.Management.Automation/engine/ParameterSetInfo.cs
+++ b/src/System.Management.Automation/engine/ParameterSetInfo.cs
@@ -82,7 +82,7 @@ namespace System.Management.Automation
         public string Name { get; private set; }
 
         /// <summary>
-        /// Gets whether the parameer set is the default parameter set.
+        /// Gets whether the parameter set is the default parameter set.
         /// </summary>
         public bool IsDefault { get; private set; }
 
@@ -129,7 +129,7 @@ namespace System.Management.Automation
 
         /// <summary>
         /// GenerateParameters parameters in display order 
-        /// ie., Postional followed by
+        /// ie., Positional followed by
         ///      Named Mandatory (in alpha numeric) followed by
         ///      Named (in alpha numeric).
         /// 

--- a/src/System.Management.Automation/engine/ParameterSetSpecificMetadata.cs
+++ b/src/System.Management.Automation/engine/ParameterSetSpecificMetadata.cs
@@ -150,7 +150,7 @@ namespace System.Management.Automation
 
         /// <summary>
         /// If HelpMessageBaseName and HelpMessageResourceId are set, the help info is
-        /// loaded from the resouce indicated by HelpMessageBaseName and HelpMessageResourceId.
+        /// loaded from the resource indicated by HelpMessageBaseName and HelpMessageResourceId.
         /// If that fails and HelpMessage is set, the help info is set to HelpMessage; otherwise,
         /// the exception that is thrown when loading the resource is thrown.
         /// If both HelpMessageBaseName and HelpMessageResourceId are not set, the help info is

--- a/src/System.Management.Automation/engine/PropertyAccessor.cs
+++ b/src/System.Management.Automation/engine/PropertyAccessor.cs
@@ -44,7 +44,7 @@ namespace System.Management.Automation
 #endif
         }
         /// <summary>
-        /// The instance of the ConfigPropertyAccessor to use to iteract with properties.
+        /// The instance of the ConfigPropertyAccessor to use to interact with properties.
         /// Derived classes should not be directly instantiated.
         /// </summary>
         internal static readonly ConfigPropertyAccessor Instance;
@@ -131,7 +131,7 @@ namespace System.Management.Automation
         /// <summary>
         /// Lock used to enable multiple concurrent readers and singular write locks within a
         /// single process.
-        /// TODO: This solution only works for IO from a single process. A more robust solution is needed to enable ReaderWriterLockSlim behavior between proceses.
+        /// TODO: This solution only works for IO from a single process. A more robust solution is needed to enable ReaderWriterLockSlim behavior between processes.
         /// </summary>
         private ReaderWriterLockSlim fileLock = new ReaderWriterLockSlim();
 
@@ -696,7 +696,7 @@ namespace System.Management.Automation
         }
 
         /// <summary>
-        /// Reads a DWORD from the Registry. Excpetions are intentionally allowed to pass through to 
+        /// Reads a DWORD from the Registry. Exceptions are intentionally allowed to pass through to 
         /// the caller because different classes and methods within the code base handle Registry 
         /// exceptions differently. Some suppress exceptions and others pass them to the user.
         /// </summary>
@@ -730,7 +730,7 @@ namespace System.Management.Automation
         }
 
         /// <summary>
-        /// Excpetions are intentionally allowed to pass through to 
+        /// Exceptions are intentionally allowed to pass through to 
         /// the caller because different classes and methods within the code base handle Registry 
         /// exceptions differently. Some suppress exceptions and others pass them to the user.
         /// </summary>
@@ -750,7 +750,7 @@ namespace System.Management.Automation
         }
 
         /// <summary>
-        /// Excpetions are intentionally allowed to pass through to 
+        /// Exceptions are intentionally allowed to pass through to 
         /// the caller because different classes and methods within the code base handle Registry 
         /// exceptions differently. Some suppress exceptions and others pass them to the user.
         /// </summary>
@@ -787,7 +787,7 @@ namespace System.Management.Automation
         }
 
         /// <summary>
-        /// Excpetions are intentionally allowed to pass through to 
+        /// Exceptions are intentionally allowed to pass through to 
         /// the caller because different classes and methods within the code base handle Registry 
         /// exceptions differently. Some suppress exceptions and others pass them to the user.
         /// </summary>

--- a/src/System.Management.Automation/engine/SerializationStrings.cs
+++ b/src/System.Management.Automation/engine/SerializationStrings.cs
@@ -34,7 +34,7 @@ namespace System.Management.Automation
         /// </summary>
         internal const string TypeNamesTag = "TN";
         /// <summary>
-        /// Tag for type item in typeanmes
+        /// Tag for type item in typenames
         /// </summary>
         internal const string TypeNamesItemTag = "T";
         /// <summary>
@@ -77,12 +77,12 @@ namespace System.Management.Automation
         internal const string DictionaryEntryTag = "En";
 
         /// <summary>
-        /// Value of name attribute for dictionary key part in dictnary entry
+        /// Value of name attribute for dictionary key part in dictionary entry
         /// </summary>
         internal const string DictionaryKey = "Key";
 
         /// <summary>
-        /// Value of name attribute for dictionary value part in dictnary entry
+        /// Value of name attribute for dictionary value part in dictionary entry
         /// </summary>
         internal const string DictionaryValue = "Value";
 

--- a/src/System.Management.Automation/engine/SessionState.cs
+++ b/src/System.Management.Automation/engine/SessionState.cs
@@ -188,7 +188,7 @@ namespace System.Management.Automation
         internal Dictionary<string, PSModuleInfo> ModuleTable { get; } = new Dictionary<string, PSModuleInfo>(StringComparer.OrdinalIgnoreCase);
 
         /// <summary>
-        /// Get/set constraints for this execution environemnt
+        /// Get/set constraints for this execution environment
         /// </summary>
         internal PSLanguageMode LanguageMode
         {
@@ -230,7 +230,7 @@ namespace System.Management.Automation
         }
 
         /// <summary>
-        /// The list of appications that are allowed to be run. If the name "*"
+        /// The list of applications that are allowed to be run. If the name "*"
         /// is in the list, then all applications can be run. (This is the default.)
         /// </summary>
         public List<string> Applications { get; } = new List<string>(new string[] { "*" });

--- a/src/System.Management.Automation/engine/SessionStateAliasAPIs.cs
+++ b/src/System.Management.Automation/engine/SessionStateAliasAPIs.cs
@@ -459,7 +459,7 @@ namespace System.Management.Automation
         /// </param>
         /// 
         /// <param name="origin">
-        /// Specifies the origin of the comannd setting the alias.
+        /// Specifies the origin of the command setting the alias.
         /// </param>
         /// 
         /// <returns>
@@ -670,7 +670,7 @@ namespace System.Management.Automation
         } // RemoveAlias
 
         /// <summary>
-        /// Gets the alises by command name (used by metadata-driven help)
+        /// Gets the aliases by command name (used by metadata-driven help)
         /// </summary>
         /// <param name="command"></param>
         /// <returns></returns>

--- a/src/System.Management.Automation/engine/SessionStateContainer.cs
+++ b/src/System.Management.Automation/engine/SessionStateContainer.cs
@@ -3701,7 +3701,7 @@ namespace System.Management.Automation
 
                     // Don't support 'New-Item -Type Directory' on the Function provider
                     // if the runspace has ever been in constrained language mode, as the mkdir
-                    // funciton can be abused
+                    // function can be abused
                     if (context.ExecutionContext.HasRunspaceEverUsedConstrainedLanguageMode &&
                         (providerInstance is Microsoft.PowerShell.Commands.FunctionProvider) &&
                         (String.Equals(type, "Directory", StringComparison.OrdinalIgnoreCase)))

--- a/src/System.Management.Automation/engine/SessionStateDriveAPIs.cs
+++ b/src/System.Management.Automation/engine/SessionStateDriveAPIs.cs
@@ -938,7 +938,7 @@ namespace System.Management.Automation
 
         /// <summary>
         /// If a VHD is mounted to a drive prior to the PowerShell session being launched, 
-        /// then such a drive has to be validated for its existance before performing 
+        /// then such a drive has to be validated for its existence before performing 
         /// any operations on that drive to make sure that the drive is not unmounted.
         /// </summary>
         /// <param name="drive"></param>
@@ -956,7 +956,7 @@ namespace System.Management.Automation
             // A VHD mounted drive gets detected  with a DriveType of DriveType.Fixed
             // when the VHD is mounted, however if the drive is unmounted, such a
             // stale drive is no longer valid and gets detected with DriveType.NoRootDirectory.
-            // We would hit this situaltion in the following scenario:
+            // We would hit this situation in the following scenario:
             //  1. Launch Powershell session 'A' and mount the VHD.
             //  2. Launch different powershell session 'B'.
             //  3. Unmount the VHD in session 'A'. 

--- a/src/System.Management.Automation/engine/SessionStateFunctionAPIs.cs
+++ b/src/System.Management.Automation/engine/SessionStateFunctionAPIs.cs
@@ -894,7 +894,7 @@ namespace System.Management.Automation
         /// Removes a function from the function table 
         /// if the function was imported from the given module.
         /// 
-        /// BUGBUG: This is only used by the implict remoting functions...
+        /// BUGBUG: This is only used by the implicit remoting functions...
         /// </summary>
         /// 
         /// <param name="name">

--- a/src/System.Management.Automation/engine/SessionStateProviderAPIs.cs
+++ b/src/System.Management.Automation/engine/SessionStateProviderAPIs.cs
@@ -110,7 +110,7 @@ namespace System.Management.Automation
         }
 
         /// <summary>
-        /// Internal method used by RunspaceConfig for updatting providers.
+        /// Internal method used by RunspaceConfig for updating providers.
         /// </summary>
         /// <param name="providerConfig"></param>
         private ProviderInfo AddProvider(ProviderConfigurationEntry providerConfig)

--- a/src/System.Management.Automation/engine/SessionStatePublic.cs
+++ b/src/System.Management.Automation/engine/SessionStatePublic.cs
@@ -128,7 +128,7 @@ namespace System.Management.Automation
         }
 
         /// <summary>
-        /// Get/set constraints for this execution environemnt
+        /// Get/set constraints for this execution environment
         /// </summary>
         public PSLanguageMode LanguageMode
         {
@@ -154,7 +154,7 @@ namespace System.Management.Automation
         }
 
         /// <summary>
-        /// Public proxy for the list of appications that are allowed to be run. If the name "*"
+        /// Public proxy for the list of applications that are allowed to be run. If the name "*"
         /// is in the list, then all applications can be run. (This is the default.)
         /// </summary>
         public List<string> Applications
@@ -187,7 +187,7 @@ namespace System.Management.Automation
         }
 
         /// <summary>
-        /// Utility to check the visiblity of an object based on the current
+        /// Utility to check the visibility of an object based on the current
         /// command origin. If the object implements IHasSessionStateEntryVisibility
         /// then the check will be made. If the check fails, then an exception will be thrown...
         /// </summary>
@@ -359,7 +359,7 @@ namespace System.Management.Automation
     } // SessionStatePublic
 
     /// <summary>
-    /// This enum defines the visiblity of execution environment elements...
+    /// This enum defines the visibility of execution environment elements...
     /// </summary>
     public enum SessionStateEntryVisibility
     {
@@ -386,7 +386,7 @@ namespace System.Management.Automation
     public enum PSLanguageMode
     {
         /// <summary>
-        /// All PowerShell langugage elements are available
+        /// All PowerShell language elements are available
         /// </summary>
         FullLanguage = 0,
 

--- a/src/System.Management.Automation/engine/SessionStateScope.cs
+++ b/src/System.Management.Automation/engine/SessionStateScope.cs
@@ -1948,7 +1948,7 @@ namespace System.Management.Automation
         {
             get
             {
-                // this is kind of our own lazy initization logic here.
+                // this is kind of our own lazy initialization logic here.
                 if (_typeResolutionState == null)
                 {
                     if (this.Parent != null)
@@ -2349,7 +2349,7 @@ namespace System.Management.Automation
         private Dictionary<string, List<string>> _commandsToAliasesCache = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
 
         /// <summary>
-        /// Gets the alises by command name (used by metadata-driven help)
+        /// Gets the aliases by command name (used by metadata-driven help)
         /// </summary>
         /// <param name="command"></param>
         /// <returns></returns>

--- a/src/System.Management.Automation/engine/SessionStateSecurityDescriptorInterface.cs
+++ b/src/System.Management.Automation/engine/SessionStateSecurityDescriptorInterface.cs
@@ -76,7 +76,7 @@ namespace System.Management.Automation
         /// </param>
         /// 
         /// <returns>
-        /// The security descriptor for the item at the sepecified path.
+        /// The security descriptor for the item at the specified path.
         /// </returns>
         /// 
         internal Collection<PSObject> GetSecurityDescriptor(string path,
@@ -115,7 +115,7 @@ namespace System.Management.Automation
         /// </param>
         /// 
         /// <returns>
-        /// Nothing. The security descriptor for the item at the sepecified path is
+        /// Nothing. The security descriptor for the item at the specified path is
         /// written to the context.
         /// </returns>
         /// 
@@ -219,7 +219,7 @@ namespace System.Management.Automation
         /// </param>
         /// 
         /// <returns>
-        /// The security descriptor that was set on the item at the sepecified path.
+        /// The security descriptor that was set on the item at the specified path.
         /// </returns>
         /// 
         internal Collection<PSObject> SetSecurityDescriptor(string path, ObjectSecurity securityDescriptor)
@@ -263,7 +263,7 @@ namespace System.Management.Automation
         /// </param>
         /// 
         /// <returns>
-        /// Nothing. The security descriptor that was set on the item at the sepecified path
+        /// Nothing. The security descriptor that was set on the item at the specified path
         /// is written to the context.
         /// </returns>
         /// 
@@ -416,7 +416,7 @@ namespace System.Management.Automation
         /// </param>
         /// 
         /// <returns>
-        /// Nothing. The security descriptor for the item at the sepecified path is
+        /// Nothing. The security descriptor for the item at the specified path is
         /// written to the context.
         /// </returns>
         /// 
@@ -538,7 +538,7 @@ namespace System.Management.Automation
         /// </param>
         /// 
         /// <returns>
-        /// Nothing. The security descriptor for the item at the sepecified type is
+        /// Nothing. The security descriptor for the item at the specified type is
         /// written to the context.
         /// </returns>
         /// 
@@ -570,7 +570,7 @@ namespace System.Management.Automation
         /// </param>
         /// 
         /// <returns>
-        /// Nothing. The security descriptor for the item at the sepecified type is
+        /// Nothing. The security descriptor for the item at the specified type is
         /// written to the context.
         /// </returns>
         /// 

--- a/src/System.Management.Automation/engine/SessionStateStrings.cs
+++ b/src/System.Management.Automation/engine/SessionStateStrings.cs
@@ -77,7 +77,7 @@ namespace System.Management.Automation
 
         /// <summary>
         /// When prefixing a variable "script" makes the variable
-        /// global to the scipt but not global to the entire session.
+        /// global to the script but not global to the entire session.
         /// </summary>
         internal const string Script = "SCRIPT";
 

--- a/src/System.Management.Automation/engine/SessionStateVariableAPIs.cs
+++ b/src/System.Management.Automation/engine/SessionStateVariableAPIs.cs
@@ -1162,7 +1162,7 @@ namespace System.Management.Automation
         }
 
         /// <summary>
-        /// Set a variable useing a pre-parsed variablePath object instead of a string.
+        /// Set a variable using a pre-parsed variablePath object instead of a string.
         /// </summary>
         /// 
         /// <param name="variablePath">
@@ -1226,7 +1226,7 @@ namespace System.Management.Automation
         }
 
         /// <summary>
-        /// Set a variable useing a pre-parsed variablePath object instead of a string.
+        /// Set a variable using a pre-parsed variablePath object instead of a string.
         /// </summary>
         /// 
         /// <param name="variablePath">

--- a/src/System.Management.Automation/engine/ThirdPartyAdapter.cs
+++ b/src/System.Management.Automation/engine/ThirdPartyAdapter.cs
@@ -284,7 +284,7 @@ namespace System.Management.Automation
     public abstract class PSPropertyAdapter
     {
         /// <summary>
-        /// Returns the type hiercharchy for the given object
+        /// Returns the type hierarchy for the given object
         /// </summary>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1720:IdentifiersShouldNotContainTypeNames", MessageId = "object")]
         public virtual Collection<string> GetTypeNameHierarchy(object baseObject)

--- a/src/System.Management.Automation/engine/TransactionManager.cs
+++ b/src/System.Management.Automation/engine/TransactionManager.cs
@@ -408,7 +408,7 @@ namespace System.Management.Automation.Internal
         }
 
         /// <summary>
-        /// Creates a new Transaction that should be managed idependently of
+        /// Creates a new Transaction that should be managed independently of
         /// any parent transactions.
         /// </summary>
         ///
@@ -418,7 +418,7 @@ namespace System.Management.Automation.Internal
         }
 
         /// <summary>
-        /// Creates a new Transaction that should be managed idependently of
+        /// Creates a new Transaction that should be managed independently of
         /// any parent transactions.
         /// </summary>
         ///

--- a/src/System.Management.Automation/engine/TypeMetadata.cs
+++ b/src/System.Management.Automation/engine/TypeMetadata.cs
@@ -467,7 +467,7 @@ namespace System.Management.Automation
 
         /// <summary>
         /// An internal constructor which constructs a ParameterMetadata object
-        /// from compiled commmand parameter metadata. ParameterMetadata
+        /// from compiled command parameter metadata. ParameterMetadata
         /// is a proxy written on top of CompiledCommandParameter
         /// </summary>
         /// <param name="cmdParameterMD">
@@ -1089,7 +1089,7 @@ namespace System.Management.Automation
         /// </param>
         /// 
         /// <returns>
-        /// An instance of the TypeMetdata for the specified runtime-defined parameters. The metadata 
+        /// An instance of the TypeMetadata for the specified runtime-defined parameters. The metadata 
         /// is always constructed on demand and never cached.
         /// </returns>
         /// 
@@ -1131,7 +1131,7 @@ namespace System.Management.Automation
         /// </param>
         /// 
         /// <returns>
-        /// An instance of the TypeMetdata for the specified type. The metadata may get
+        /// An instance of the TypeMetadata for the specified type. The metadata may get
         /// constructed on-demand or may be retrieved from the cache.
         /// </returns>
         /// 
@@ -1248,7 +1248,7 @@ namespace System.Management.Automation
         /// <summary>
         /// Gets a dictionary of the compiled parameter metadata for this Type. 
         /// The dictionary keys are the names of the parameters (or aliases) and
-        /// the values are the compiled parameter metdata.
+        /// the values are the compiled parameter metadata.
         /// </summary>
         /// 
         internal Dictionary<string, CompiledCommandParameter> BindableParameters { get; }

--- a/src/System.Management.Automation/engine/TypeTable.cs
+++ b/src/System.Management.Automation/engine/TypeTable.cs
@@ -1564,7 +1564,7 @@ namespace System.Management.Automation.Runspaces
         }
 
         /// <summary>
-        /// This constructor takes a colletion of errors occurred during construction
+        /// This constructor takes a collection of errors occurred during construction
         /// time.
         /// </summary>
         /// <param name="loadErrors">
@@ -4225,7 +4225,7 @@ namespace System.Management.Automation.Runspaces
 
             ConcurrentBag<string> errors = new ConcurrentBag<string>();
 
-            // Always clear the consolidate memebrs - they need to be recalculated
+            // Always clear the consolidate members - they need to be recalculated
             // anytime the types are updated...
             ClearConsolidatedMembers();
 
@@ -4252,7 +4252,7 @@ namespace System.Management.Automation.Runspaces
             TypeData typeData = new TypeData(typeName);
             ConcurrentBag<string> errors = new ConcurrentBag<string>();
 
-            // Always clear the consolidate memebrs - they need to be recalculated
+            // Always clear the consolidate members - they need to be recalculated
             // anytime the types are updated...
             ClearConsolidatedMembers();
 
@@ -4275,7 +4275,7 @@ namespace System.Management.Automation.Runspaces
         /// Host passed to <paramref name="authorizationManager"/>.  Can be null if no interactive questions should be asked.
         /// </param>
         /// <exception cref="InvalidOperationException">
-        /// 1. The TypeTable cannot be updated becasue the TypeTable might have 
+        /// 1. The TypeTable cannot be updated because the TypeTable might have 
         /// been created outside of the Runspace.
         /// </exception>
         internal void Update(
@@ -4322,7 +4322,7 @@ namespace System.Management.Automation.Runspaces
         /// </param>
         /// <param name="failToLoadFile">Indicate if the file cannot be loaded due to the security reason</param>
         /// <exception cref="InvalidOperationException">
-        /// 1. The TypeTable cannot be updated becasue the TypeTable might have 
+        /// 1. The TypeTable cannot be updated because the TypeTable might have 
         /// been created outside of the Runspace.
         /// </exception>
         internal void Update(
@@ -4350,7 +4350,7 @@ namespace System.Management.Automation.Runspaces
         /// </param>
         /// <param name="failToLoadFile">Indicate if the file cannot be loaded due to security reason</param>
         /// <exception cref="InvalidOperationException">
-        /// 1. The TypeTable cannot be updated becasue the TypeTable might have 
+        /// 1. The TypeTable cannot be updated because the TypeTable might have 
         /// been created outside of the Runspace.
         /// </exception>
         internal void Update(

--- a/src/System.Management.Automation/engine/Types_Ps1Xml.generated.cs
+++ b/src/System.Management.Automation/engine/Types_Ps1Xml.generated.cs
@@ -1102,7 +1102,7 @@ namespace System.Management.Automation.Runspaces
           {
           if ($psversiontable.psversion.Major -lt 3)
           {
-          # ok to cast CommandTypes enum to HelpCategory because string/indentifier for
+          # ok to cast CommandTypes enum to HelpCategory because string/identifier for
           # cmdlet,function,filter,alias,externalscript is identical.
           # it is ok to fail for other enum values (i.e. for Application)
           $commandName = $this.Name

--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -95,7 +95,7 @@ namespace System.Management.Automation
             }
             //
             // we use AES algorithm which supports key
-            // lenghts of 128, 192 and 256 bits.
+            // lengths of 128, 192 and 256 bits.
             // We throw ArgumentException if the key is
             // of any other length
             //
@@ -943,7 +943,7 @@ namespace System.Management.Automation
             // Porting note: only Windows supports the SecurityPrincipal API of .NET. Due to
             // advanced privilege models, the correct approach on Unix is to assume the user has
             // permissions, attempt the task, and error gracefully if the task fails due to
-            // permissions. To fit into PowerShell's existing model of pre-emptively checking
+            // permissions. To fit into PowerShell's existing model of preemptively checking
             // permissions (which cannot be assumed on Unix), we "assume" the user is an
             // administrator by returning true, thus nullifying this check on Unix.
 #if UNIX

--- a/src/System.Management.Automation/engine/VariableAttributeCollection.cs
+++ b/src/System.Management.Automation/engine/VariableAttributeCollection.cs
@@ -17,7 +17,7 @@ namespace System.Management.Automation
         /// <summary>
         /// Constructs a variable attribute collection attached to
         /// the specified variable. Whenever the attributes change
-        /// the variable value is varified against the attribute.
+        /// the variable value is verified against the attribute.
         /// </summary>
         /// 
         /// <param name="variable">

--- a/src/System.Management.Automation/engine/VariableInterfaces.cs
+++ b/src/System.Management.Automation/engine/VariableInterfaces.cs
@@ -75,7 +75,7 @@ namespace System.Management.Automation
 
             // Null is returned whenever the requested variable is String.Empty.
             // As per Powershell V1 implementation:
-            // 1. If the requested varible exists in the session scope, the variable value is returned.
+            // 1. If the requested variable exists in the session scope, the variable value is returned.
             // 2. If the requested variable is not null and does not exist in the session scope, then a null value is returned to the pipeline.
             // 3. If the requested variable is null then an NewArgumentNullException is thrown.
             // PowerShell V3 has the similar experience.

--- a/src/System.Management.Automation/engine/debugger/debugger.cs
+++ b/src/System.Management.Automation/engine/debugger/debugger.cs
@@ -296,7 +296,7 @@ namespace System.Management.Automation
         Ignore = 1,
 
         /// <summary>
-        /// Wait on unhandled breakpoint events until a handler is avaialable.
+        /// Wait on unhandled breakpoint events until a handler is available.
         /// </summary>
         Wait
     }
@@ -594,7 +594,7 @@ namespace System.Management.Automation
         /// </summary>
         /// <param name="command">Command string</param>
         /// <param name="output">Output collection</param>
-        /// <returns>DebuggerCommand containing information on whether and how the command was procssed.</returns>
+        /// <returns>DebuggerCommand containing information on whether and how the command was processed.</returns>
         internal virtual DebuggerCommand InternalProcessCommand(string command, IList<PSObject> output)
         {
             throw new PSNotImplementedException();
@@ -1330,7 +1330,7 @@ namespace System.Management.Automation
         #region enabling/disabling breakpoints
 
         /// <summary>
-        /// Implmentation of Enable-PSBreakpoint cmdlet.
+        /// Implementation of Enable-PSBreakpoint cmdlet.
         /// </summary>
         internal void EnableBreakpoint(Breakpoint bp)
         {
@@ -2337,7 +2337,7 @@ namespace System.Management.Automation
         /// </summary>
         /// <param name="command">Command string</param>
         /// <param name="output">output</param>
-        /// <returns>DebuggerCommand containing information on whether and how the command was procssed.</returns>
+        /// <returns>DebuggerCommand containing information on whether and how the command was processed.</returns>
         internal override DebuggerCommand InternalProcessCommand(string command, IList<PSObject> output)
         {
             if (!DebuggerStopped)
@@ -3818,7 +3818,7 @@ namespace System.Management.Automation
         /// <summary>
         /// Process debugger or PowerShell command/script.
         /// </summary>
-        /// <param name="command">PowreShell command</param>
+        /// <param name="command">PowerShell command</param>
         /// <param name="output">Output collection</param>
         /// <returns>DebuggerCommandResults</returns>
         public override DebuggerCommandResults ProcessCommand(PSCommand command, PSDataCollection<PSObject> output)
@@ -4313,7 +4313,7 @@ namespace System.Management.Automation
             if (parentStackFrame == null) { return null; }
 
             // Attempt to find parent script file create script block with Ast to 
-            // find correct line and offset adjustements.
+            // find correct line and offset adjustments.
             if ((_parentScriptBlockAst == null) &&
                 !string.IsNullOrEmpty(parentStackFrame.ScriptName) &&
                 System.IO.File.Exists(parentStackFrame.ScriptName))

--- a/src/System.Management.Automation/engine/hostifaces/AsyncResult.cs
+++ b/src/System.Management.Automation/engine/hostifaces/AsyncResult.cs
@@ -32,7 +32,7 @@ namespace System.Management.Automation.Runspaces
         /// Constructor
         /// </summary>
         /// <param name="ownerId">
-        /// Instace Id of the object creating this instance
+        /// Instance Id of the object creating this instance
         /// </param>
         /// <param name="callback">
         /// A AsyncCallback to call once the async operation completes.

--- a/src/System.Management.Automation/engine/hostifaces/Command.cs
+++ b/src/System.Management.Automation/engine/hostifaces/Command.cs
@@ -272,7 +272,7 @@ namespace System.Management.Automation.Runspaces
         internal PipelineResultTypes[] MergeInstructions { get; set; } = new PipelineResultTypes[MaxMergeType];
 
         /// <summary>
-        /// Merges this commands resutls
+        /// Merges this commands results
         /// </summary>
         /// 
         /// <param name="myResult">
@@ -874,7 +874,7 @@ namespace System.Management.Automation.Runspaces
         }
 
         /// <summary>
-        /// Gets the string represenation of the command collection to be used for history.
+        /// Gets the string representation of the command collection to be used for history.
         /// </summary>
         /// <returns>
         /// string representing the command(s)

--- a/src/System.Management.Automation/engine/hostifaces/Connection.cs
+++ b/src/System.Management.Automation/engine/hostifaces/Connection.cs
@@ -419,7 +419,7 @@ namespace System.Management.Automation.Runspaces
     public enum RunspaceCapability
     {
         /// <summary>
-        /// No additional capabilites beyond a default runspace.
+        /// No additional capabilities beyond a default runspace.
         /// </summary>
         Default = 0x0,
 
@@ -674,7 +674,7 @@ namespace System.Management.Automation.Runspaces
         }
 
         /// <summary>
-        /// Get unqiue id for this instance of runspace. It is primarily used 
+        /// Get unique id for this instance of runspace. It is primarily used 
         /// for logging purposes
         /// </summary>
         public Guid InstanceId { get;
@@ -1394,7 +1394,7 @@ namespace System.Management.Automation.Runspaces
         /// </summary>
         /// <param name="command">A valid command string</param>
         /// <returns>
-        /// A pipline pre-filled with a <see cref="Command"/> object for specified command parameter.
+        /// A pipeline pre-filled with a <see cref="Command"/> object for specified command parameter.
         /// </returns>
         /// <exception cref="ArgumentNullException">
         /// command is null
@@ -1407,7 +1407,7 @@ namespace System.Management.Automation.Runspaces
         /// <param name="command">A valid command string</param>
         /// <param name="addToHistory">if true command is added to history</param>
         /// <returns>
-        /// A pipline pre-filled with a <see cref="Command"/> object for specified command parameter.
+        /// A pipeline pre-filled with a <see cref="Command"/> object for specified command parameter.
         /// </returns>
         /// <exception cref="ArgumentNullException">
         /// command is null
@@ -1430,7 +1430,7 @@ namespace System.Management.Automation.Runspaces
         /// <param name="command">A valid command string</param>
         /// <param name="addToHistory">if true command is added to history</param>
         /// <returns>
-        /// A pipline pre-filled with Command specified in commandString.
+        /// A pipeline pre-filled with Command specified in commandString.
         /// </returns>
         /// <exception cref="ArgumentNullException">
         /// command is null

--- a/src/System.Management.Automation/engine/hostifaces/ConnectionBase.cs
+++ b/src/System.Management.Automation/engine/hostifaces/ConnectionBase.cs
@@ -279,7 +279,7 @@ namespace System.Management.Automation.Runspaces
             OpenHelper(syncCall);
             if (etwEnabled) RunspaceEventSource.Log.OpenRunspaceStop();
 
-            // We report startup telemtry when opening the runspace - because this is the first time
+            // We report startup telementry when opening the runspace - because this is the first time
             // we are really using PowerShell. This isn't the cleanest place though, because
             // sometimes there are many runspaces created - the callee ensures telemetry is only
             // reported once. Note that if the host implements IHostProvidesTelemetryData, we rely
@@ -541,11 +541,11 @@ namespace System.Management.Automation.Runspaces
         }
 
         /// <summary>
-        /// Createa a pipeline froma command string
+        /// Create a pipeline from a command string
         /// </summary>
         /// <param name="command">A valid command string</param>
         /// <returns>
-        /// A pipline pre-filled with Commands specified in commandString.
+        /// A pipeline pre-filled with Commands specified in commandString.
         /// </returns>
         /// <exception cref="ArgumentNullException">
         /// command is null
@@ -566,7 +566,7 @@ namespace System.Management.Automation.Runspaces
         /// <param name="command">A valid command string</param>
         /// <param name="addToHistory">if true command is added to history</param>
         /// <returns>
-        /// A pipline pre-filled with Commands specified in commandString.
+        /// A pipeline pre-filled with Commands specified in commandString.
         /// </returns>
         /// <exception cref="ArgumentNullException">
         /// command is null
@@ -600,7 +600,7 @@ namespace System.Management.Automation.Runspaces
         /// <param name="command">A valid command string</param>
         /// <param name="addToHistory">if true command is added to history</param>
         /// <returns>
-        /// A pipline pre-filled with Commands specified in commandString.
+        /// A pipeline pre-filled with Commands specified in commandString.
         /// </returns>
         /// <exception cref="ArgumentNullException">
         /// command is null
@@ -623,7 +623,7 @@ namespace System.Management.Automation.Runspaces
         /// <param name="addToHistory">if true command is added to history</param>
         /// <param name="isNested">True for nested pipeline</param>
         /// <returns>
-        /// A pipline pre-filled with Commands specified in commandString.
+        /// A pipeline pre-filled with Commands specified in commandString.
         /// </returns>
         protected abstract Pipeline CoreCreatePipeline(string command, bool addToHistory, bool isNested);
 
@@ -866,7 +866,7 @@ namespace System.Management.Automation.Runspaces
                     throw e;
                 }
 
-                //Add the pipeline to list of Excuting pipeline.
+                //Add the pipeline to list of Executing pipeline.
                 //Note:_runningPipelines is always accessed with the lock so
                 //there is no need to create a synchronized version of list
                 RunningPipelines.Add(pipeline);
@@ -892,7 +892,7 @@ namespace System.Management.Automation.Runspaces
                 Dbg.Assert(RunspaceState != RunspaceState.BeforeOpen,
                              "Runspace should not be before open when pipeline is running");
 
-                //Remove the pipeline to list of Excuting pipeline.
+                //Remove the pipeline to list of Executing pipeline.
                 //Note:_runningPipelines is always accessed with the lock so
                 //there is no need to create a synchronized version of list
                 RunningPipelines.Remove(pipeline);
@@ -1529,7 +1529,7 @@ namespace System.Management.Automation.Runspaces
 
         /// <summary>
         /// Protected methods to be implemented by derived class.
-        /// This does the acutal work of setting variable.
+        /// This does the actual work of setting variable.
         /// </summary>
         /// <param name="name">Name of the variable to set</param>
         /// <param name="value">The value to set it to</param>

--- a/src/System.Management.Automation/engine/hostifaces/ConnectionFactory.cs
+++ b/src/System.Management.Automation/engine/hostifaces/ConnectionFactory.cs
@@ -480,7 +480,7 @@ namespace System.Management.Automation.Runspaces
 
         /// <summary>
         /// Creates a RunspacePool 
-        /// on the specified remote runspace compuer.
+        /// on the specified remote runspace computer.
         /// <paramref name="maxRunspaces"/>
         /// limits the number of Runspaces that can exist in this
         /// pool. The minimum pool size is set to 
@@ -498,10 +498,10 @@ namespace System.Management.Automation.Runspaces
         /// The TypeTable to use while deserializing/serializing remote objects.
         /// TypeTable has the following information used by serializer:
         ///   1. SerializationMethod
-        ///   2. SerailizationDepth
+        ///   2. SerializationDepth
         ///   3. SpecificSerializationProperties
-        /// TypeTable has the following inforamtion used by deserializer:
-        ///   1. TargetTypeForDeserializaiton
+        /// TypeTable has the following information used by deserializer:
+        ///   1. TargetTypeForDeserialization
         ///   2. TypeConverter
         /// 
         /// If <paramref name="typeTable"/> is null no custom serialization/deserialization
@@ -527,7 +527,7 @@ namespace System.Management.Automation.Runspaces
 
         /// <summary>
         /// Creates a RunspacePool 
-        /// on the specified remote runspace compuer.
+        /// on the specified remote runspace computer.
         /// <paramref name="maxRunspaces"/>
         /// limits the number of Runspaces that can exist in this
         /// pool. The minimum pool size is set to 
@@ -545,10 +545,10 @@ namespace System.Management.Automation.Runspaces
         /// The TypeTable to use while deserializing/serializing remote objects.
         /// TypeTable has the following information used by serializer:
         ///   1. SerializationMethod
-        ///   2. SerailizationDepth
+        ///   2. SerializationDepth
         ///   3. SpecificSerializationProperties
-        /// TypeTable has the following inforamtion used by deserializer:
-        ///   1. TargetTypeForDeserializaiton
+        /// TypeTable has the following information used by deserializer:
+        ///   1. TargetTypeForDeserialization
         ///   2. TypeConverter
         /// 
         /// If <paramref name="typeTable"/> is null no custom serialization/deserialization
@@ -600,10 +600,10 @@ namespace System.Management.Automation.Runspaces
         /// The TypeTable to use while deserializing/serializing remote objects.
         /// TypeTable has the following information used by serializer:
         ///   1. SerializationMethod
-        ///   2. SerailizationDepth
+        ///   2. SerializationDepth
         ///   3. SpecificSerializationProperties
-        /// TypeTable has the following inforamtion used by deserializer:
-        ///   1. TargetTypeForDeserializaiton
+        /// TypeTable has the following information used by deserializer:
+        ///   1. TargetTypeForDeserialization
         ///   2. TypeConverter
         /// </param>
         /// <param name="host"></param>
@@ -621,10 +621,10 @@ namespace System.Management.Automation.Runspaces
         /// The TypeTable to use while deserializing/serializing remote objects.
         /// TypeTable has the following information used by serializer:
         ///   1. SerializationMethod
-        ///   2. SerailizationDepth
+        ///   2. SerializationDepth
         ///   3. SpecificSerializationProperties
-        /// TypeTable has the following inforamtion used by deserializer:
-        ///   1. TargetTypeForDeserializaiton
+        /// TypeTable has the following information used by deserializer:
+        ///   1. TargetTypeForDeserialization
         ///   2. TypeConverter
         /// </param>
         /// <param name="host"></param>
@@ -647,10 +647,10 @@ namespace System.Management.Automation.Runspaces
         /// The TypeTable to use while deserializing/serializing remote objects.
         /// TypeTable has the following information used by serializer:
         ///   1. SerializationMethod
-        ///   2. SerailizationDepth
+        ///   2. SerializationDepth
         ///   3. SpecificSerializationProperties
-        /// TypeTable has the following inforamtion used by deserializer:
-        ///   1. TargetTypeForDeserializaiton
+        /// TypeTable has the following information used by deserializer:
+        ///   1. TargetTypeForDeserialization
         ///   2. TypeConverter
         /// </param>
         /// <param name="applicationArguments">

--- a/src/System.Management.Automation/engine/hostifaces/History.cs
+++ b/src/System.Management.Automation/engine/hostifaces/History.cs
@@ -86,7 +86,7 @@ namespace Microsoft.PowerShell.Commands
         }
 
         /// <summary>
-        /// Execution status of assoicated pipeline
+        /// Execution status of associated pipeline
         /// </summary>
         /// <value></value>
         public PipelineState ExecutionStatus
@@ -245,7 +245,7 @@ namespace Microsoft.PowerShell.Commands
         #region ICloneable Members
 
         /// <summary>
-        /// Retuns a clone of this object
+        /// Returns a clone of this object
         /// </summary>
         /// <returns></returns>
         public HistoryInfo Clone()
@@ -326,7 +326,7 @@ namespace Microsoft.PowerShell.Commands
         }
 
         /// <summary>
-        /// Udpate the history entry corresponding to id.
+        /// Update the history entry corresponding to id.
         /// </summary>
         /// <param name="id">id of history entry to be updated</param>
         /// <param name="status">status to be updated</param>
@@ -497,7 +497,7 @@ namespace Microsoft.PowerShell.Commands
                     long index, SmallestID = 0;
                     //if we change the defaulthistory size and when no of entries exceed the size, then 
                     //we need to get the smallest entry in the buffer when we want to clear the oldest entry
-                    //eg if size is 5 and then the enrties can be 7,6,1,2,3
+                    //eg if size is 5 and then the entries can be 7,6,1,2,3
                     if (_capacity != DefaultHistorySize)
                         SmallestID = SmallestIDinBuffer();
                     if (!newest.IsPresent)
@@ -585,7 +585,7 @@ namespace Microsoft.PowerShell.Commands
                 }
                 List<HistoryInfo> cmdlist = new List<HistoryInfo>();
                 long SmallestID = 1;
-                //if buffersize is changes,Get the smallest entry thts not cleared in the buffer
+                //if buffersize is changes,Get the smallest entry that's not cleared in the buffer
                 if (_capacity != DefaultHistorySize)
                     SmallestID = SmallestIDinBuffer();
                 if (count != 0)
@@ -613,7 +613,7 @@ namespace Microsoft.PowerShell.Commands
                         long id = _countEntriesAdded;
                         for (long i = 0; i <= count - 1;)
                         {
-                            //if buffersize is changed,we have to loop from max enttry to min entry thats not cleraed
+                            //if buffersize is changed,we have to loop from max entry to min entry thats not cleared
                             if (_capacity != DefaultHistorySize)
                             {
                                 if (_countEntriesAdded > _capacity)
@@ -1056,7 +1056,7 @@ namespace Microsoft.PowerShell.Commands
             }
             else
             {
-                // The defualt value for _count is the size of the history buffer.
+                // The default value for _count is the size of the history buffer.
                 if (!_countParameterSpecified)
                 {
                     _count = history.Buffercapacity();
@@ -1508,7 +1508,7 @@ namespace Microsoft.PowerShell.Commands
         /// mshObject to be converted to HistoryInfo.
         /// </param>
         /// <returns>
-        /// HistoryInfo object if coversion is successful else null.
+        /// HistoryInfo object if conversion is successful else null.
         /// </returns>
 #pragma warning disable 0162
         private
@@ -1991,7 +1991,7 @@ namespace Microsoft.PowerShell.Commands
 
 
         /// <summary>
-        /// Clears the session history based on the input parametera
+        /// Clears the session history based on the input parameter
         /// <param name="id" >id of the entry to be cleared</param>
         /// <param name="count" > count of entries to be cleared</param>
         /// <param name="cmdline" >cmdline string to be cleared</param>

--- a/src/System.Management.Automation/engine/hostifaces/HostUtilities.cs
+++ b/src/System.Management.Automation/engine/hostifaces/HostUtilities.cs
@@ -79,8 +79,8 @@ namespace System.Management.Automation
         /// </summary>
         /// <param name="allUsersAllHosts">The profile file name for all users and all hosts.</param>
         /// <param name="allUsersCurrentHost">The profile file name for all users and current host.</param>
-        /// <param name="currentUserAllHosts">The profile file name for cuurrent user and all hosts.</param>
-        /// <param name="currentUserCurrentHost">The profile  name for cuurrent user and current host.</param>
+        /// <param name="currentUserAllHosts">The profile file name for current user and all hosts.</param>
+        /// <param name="currentUserCurrentHost">The profile  name for current user and current host.</param>
         /// <returns>A PSObject whose base object is currentUserCurrentHost and with notes for the other 4 parameters.</returns>
         internal static PSObject GetDollarProfile(string allUsersAllHosts, string allUsersCurrentHost, string currentUserAllHosts, string currentUserCurrentHost)
         {

--- a/src/System.Management.Automation/engine/hostifaces/InternalHost.cs
+++ b/src/System.Management.Automation/engine/hostifaces/InternalHost.cs
@@ -128,7 +128,7 @@ namespace System.Management.Automation.Internal.Host
         /// <value></value>
         /// <exception cref="NotImplementedException">
         /// 
-        ///  when the external host's InstaceId is a zero Guid.
+        ///  when the external host's InstanceId is a zero Guid.
         /// 
         /// </exception>
         public override System.Guid InstanceId

--- a/src/System.Management.Automation/engine/hostifaces/InternalHostUserInterface.cs
+++ b/src/System.Management.Automation/engine/hostifaces/InternalHostUserInterface.cs
@@ -424,7 +424,7 @@ namespace System.Management.Automation.Internal.Host
         /// </exception>
         /// <exception cref="ArgumentException">
         /// 
-        /// If the debug preference is not a valid ActionPrefernce value.
+        /// If the debug preference is not a valid ActionPreference value.
         /// 
         /// </exception>
 
@@ -482,11 +482,11 @@ namespace System.Management.Automation.Internal.Host
         /// </summary>
         /// <param name="informationalBuffers">
         /// Buffers to which Debug, Verbose, Warning, Progress, Information messages
-        /// will be writtern to.
+        /// will be written to.
         /// </param>
         /// <remarks>
         /// This method is not thread safe. Caller should make sure of the
-        /// assosciated risks. 
+        /// associated risks. 
         /// </remarks>
         internal void SetInformationalMessageBuffers(PSInformationalBuffers informationalBuffers)
         {
@@ -910,7 +910,7 @@ namespace System.Management.Automation.Internal.Host
         /// Presents a dialog allowing the user to choose options from a set of options.
         /// </summary>
         /// <param name="caption">
-        /// Caption to preceed or title the prompt.  E.g. "Parameters for get-foo (instance 1 of 2)"
+        /// Caption to precede or title the prompt.  E.g. "Parameters for get-foo (instance 1 of 2)"
         /// </param>
         /// <param name="message">
         /// A message that describes what the choice is for.

--- a/src/System.Management.Automation/engine/hostifaces/LocalConnection.cs
+++ b/src/System.Management.Automation/engine/hostifaces/LocalConnection.cs
@@ -529,7 +529,7 @@ namespace System.Management.Automation.Runspaces
                     }
                     else
                     {
-                        // For wahtever reason, cache is corrupted. Hence override the cache content.
+                        // For whatever reason, cache is corrupted. Hence override the cache content.
                         if (enable)
                         {
                             debugPreferenceCache = new Hashtable();
@@ -604,7 +604,7 @@ namespace System.Management.Automation.Runspaces
         /// Open the runspace
         /// </summary>
         /// <param name="syncCall">
-        /// paramter which control if Open is done synchronously or asynchronously
+        /// parameter which control if Open is done synchronously or asynchronously
         /// </param>
         protected override void OpenHelper(bool syncCall)
         {
@@ -796,7 +796,7 @@ namespace System.Management.Automation.Runspaces
         /// Returns the thread that must be used to execute pipelines when CreateThreadOptions is ReuseThread
         /// </summary>
         /// <remarks>
-        /// The pipeline calls this function after ensuring there is a single thread in the pipeline, so no locking is neccesary
+        /// The pipeline calls this function after ensuring there is a single thread in the pipeline, so no locking is necessary
         /// </remarks>
         internal PipelineThread GetPipelineThread()
         {

--- a/src/System.Management.Automation/engine/hostifaces/LocalPipeline.cs
+++ b/src/System.Management.Automation/engine/hostifaces/LocalPipeline.cs
@@ -170,7 +170,7 @@ namespace System.Management.Automation.Runspaces
                         }
                         else
                         {
-                            apartmentState = this.LocalRunspace.ApartmentState; // use the Runspace apartmet state
+                            apartmentState = this.LocalRunspace.ApartmentState; // use the Runspace apartment state
                         }
 
                         if (apartmentState != ApartmentState.Unknown)
@@ -821,7 +821,7 @@ namespace System.Management.Automation.Runspaces
         private PipelineStopper _stopper;
 
         /// <summary>
-        /// Gets PipelineStopper object which maitains stack of PipelineProcessor
+        /// Gets PipelineStopper object which maintains stack of PipelineProcessor
         /// for this pipeline
         /// </summary>
         /// <value></value>
@@ -1081,7 +1081,7 @@ namespace System.Management.Automation.Runspaces
         internal
         void AddHistoryEntryFromAddHistoryCmdlet()
         {
-            //This method can be called by mulitple times during a single
+            //This method can be called by multiple times during a single
             //pipeline execution. For ex: a script can execute add-history
             //command multiple times. However we should add entry only 
             //once.
@@ -1129,7 +1129,7 @@ namespace System.Management.Automation.Runspaces
         /// </summary>
         /// <returns>
         /// ExecutionContext, if it available in TLS
-        /// Null, if ExecutionContext is not availalbe in TLS
+        /// Null, if ExecutionContext is not available in TLS
         /// </returns>
         internal static System.Management.Automation.ExecutionContext GetExecutionContextFromTLS()
         {
@@ -1437,7 +1437,7 @@ namespace System.Management.Automation.Runspaces
                     {
                         _stack.Peek().ExecutionFailed = true;
                     }
-                    // If this is the last pipeline processor on the stack, then propigate it's execution status
+                    // If this is the last pipeline processor on the stack, then propagate it's execution status
                     if (_stack.Count == 1 && _localPipeline != null)
                     {
                         _localPipeline.SetHadErrors(oldPipe.ExecutionFailed);
@@ -1460,7 +1460,7 @@ namespace System.Management.Automation.Runspaces
                 copyStack = _stack.ToArray();
             }
 
-            // Propigate error from the toplevel operation through to enclosing the LocalPipeline.
+            // Propagate error from the toplevel operation through to enclosing the LocalPipeline.
             if (copyStack.Length > 0)
             {
                 PipelineProcessor topLevel = copyStack[copyStack.Length - 1];

--- a/src/System.Management.Automation/engine/hostifaces/MshHost.cs
+++ b/src/System.Management.Automation/engine/hostifaces/MshHost.cs
@@ -238,9 +238,9 @@ namespace System.Management.Automation.Host
         /// If the UI property returns null, the engine should not call this method.
         /// 
         /// 
-        /// <!--Was: ExecuteSubShell.  "subshell" inplies a new child engine, which is not the case here.  This is called during the 
+        /// <!--Was: ExecuteSubShell.  "subshell" implies a new child engine, which is not the case here.  This is called during the 
         /// interruption of a pipeline to allow nested pipeline(s) to be run as a way to the user to suspend execution while he
-        /// evalautes other commands.  It does not create a truly new engine instance with new session state.-->
+        /// evaluates other commands.  It does not create a truly new engine instance with new session state.-->
         /// 
         /// </remarks>
         /// <seealso cref="System.Management.Automation.Host.PSHost.ExitNestedPrompt"/>
@@ -258,7 +258,7 @@ namespace System.Management.Automation.Host
         /// </summary>
         /// <remarks>
         /// 
-        /// Typicalled called by the engine in response to some user action that resumes a suspended pipeline, such as with the
+        /// Typically called by the engine in response to some user action that resumes a suspended pipeline, such as with the
         /// 'continue-command' intrinsic cmdlet. Before calling this method, the engine should clear out the loop-specific 
         /// variables that were set when the loop was created.
         /// 
@@ -291,7 +291,7 @@ namespace System.Management.Automation.Host
         /// 
         /// If the host is using an in-process Runspace, then the BaseObject property can be a non-null value  a live object. 
         /// No guarantees are made as to the app domain or thread that the BaseObject is accessed if it is accessed in the 
-        /// runspace. No guarantees of threadsafety or re-entrancy are made.  The object set in the BaseObject property of
+        /// runspace. No guarantees of threadsafety or reentrancy are made.  The object set in the BaseObject property of
         /// the value returned by this method is responsible for ensuring its own threadsafety and re-entrance safety.
         /// Note that thread(s) accessing that object may not necessarily be the same from one access to the next.
         /// 
@@ -364,7 +364,7 @@ namespace System.Management.Automation.Host
         /// <summary>
         /// Used by hosting applications to notify PowerShell engine that it is
         /// being hosted in a console based application and the Pipeline execution
-        /// thread should call SetThreadUILanguage(0). This propery is currently
+        /// thread should call SetThreadUILanguage(0). This property is currently
         /// used by ConsoleHost only and in future releases we may consider 
         /// exposing this publicly.
         /// </summary>

--- a/src/System.Management.Automation/engine/hostifaces/MshHostRawUserInterface.cs
+++ b/src/System.Management.Automation/engine/hostifaces/MshHostRawUserInterface.cs
@@ -880,7 +880,7 @@ namespace System.Management.Automation.Host
 
         /// <summary>
         /// 
-        /// Gets and sets the bottom of the rectanngle
+        /// Gets and sets the bottom of the rectangle
         /// 
         /// </summary>
 
@@ -909,7 +909,7 @@ namespace System.Management.Automation.Host
         /// </param>
         /// <param name="bottom">
         /// 
-        /// The bottom of the rectanngle
+        /// The bottom of the rectangle
         /// 
         /// </param>
         /// <exception cref="ArgumentException">
@@ -2145,7 +2145,7 @@ namespace System.Management.Automation.Host
         /// equal to the largest number of cells a string in <paramref name="contents"/> takes. The
         /// foreground and background colors of the cells are initialized to
         /// <paramref name="foregroundColor"/> and <paramref name="backgroundColor"/>, respectively.
-        /// The resuling array is suitable for use with <see cref="PSHostRawUserInterface.SetBufferContents(Rectangle, BufferCell)"/>
+        /// The resulting array is suitable for use with <see cref="PSHostRawUserInterface.SetBufferContents(Rectangle, BufferCell)"/>
         /// and <see cref="PSHostRawUserInterface.SetBufferContents(Coordinates, BufferCell[,])"/>.
         /// 
         /// </remark>

--- a/src/System.Management.Automation/engine/hostifaces/MshHostUserInterface.cs
+++ b/src/System.Management.Automation/engine/hostifaces/MshHostUserInterface.cs
@@ -237,7 +237,7 @@ namespace System.Management.Automation.Host
         // 
         // Ideally, this would be associated with the host instance, but remoting recycles host instances
         // for each command that gets invoked (so that it can keep track of the order of commands and their
-        // output.) Therefore, we store this transcripton data in the runspace. However, the
+        // output.) Therefore, we store this transcription data in the runspace. However, the
         // Runspace.DefaultRunspace property isn't always available (i.e.: when the pipeline is being set up),
         // so we have to cache it the first time it becomes available.
         private TranscriptionData TranscriptionData
@@ -721,7 +721,7 @@ namespace System.Management.Automation.Host
         /// Constructs a 'dialog' where the user is presented with a number of fields for which to supply values.
         /// </summary>
         /// <param name="caption">
-        /// Caption to preceed or title the prompt.  E.g. "Parameters for get-foo (instance 1 of 2)"
+        /// Caption to precede or title the prompt.  E.g. "Parameters for get-foo (instance 1 of 2)"
         /// </param>
         /// <param name="message">
         /// A text description of the set of fields to be prompt.
@@ -733,7 +733,7 @@ namespace System.Management.Automation.Host
         /// A Dictionary object with results of prompting.  The keys are the field names from the FieldDescriptions, the values
         /// are objects representing the values of the corresponding fields as collected from the user. To the extent possible, 
         /// the host should return values of the type(s) identified in the FieldDescription.  When that is not possible (for 
-        /// example, the type is not avaiable to the host), the host should return the value as a string.
+        /// example, the type is not available to the host), the host should return the value as a string.
         /// </returns>
         /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.ReadLine"/>
         /// <seealso cref="System.Management.Automation.Host.PSHostUserInterface.ReadLineAsSecureString"/>
@@ -815,7 +815,7 @@ namespace System.Management.Automation.Host
         /// Presents a dialog allowing the user to choose an option from a set of options.
         /// </summary>
         /// <param name="caption">
-        /// Caption to preceed or title the prompt.  E.g. "Parameters for get-foo (instance 1 of 2)"
+        /// Caption to precede or title the prompt.  E.g. "Parameters for get-foo (instance 1 of 2)"
         /// </param>
         /// <param name="message">
         /// A message that describes what the choice is for.
@@ -1145,7 +1145,7 @@ namespace System.Management.Automation.Host
         /// Presents a dialog allowing the user to choose options from a set of options.
         /// </summary>
         /// <param name="caption">
-        /// Caption to preceed or title the prompt.  E.g. "Parameters for get-foo (instance 1 of 2)"
+        /// Caption to precede or title the prompt.  E.g. "Parameters for get-foo (instance 1 of 2)"
         /// </param>
         /// <param name="message">
         /// A message that describes what the choice is for.

--- a/src/System.Management.Automation/engine/hostifaces/NativeCultureResolver.cs
+++ b/src/System.Management.Automation/engine/hostifaces/NativeCultureResolver.cs
@@ -1,7 +1,7 @@
 /********************************************************************++
 Copyright (c) Microsoft Corporation.  All rights reserved.
  
-Descripton: 
+Description: 
  
 Windows Vista and later support non-traditional UI fallback ie., a 
 user on an Arabic machine can choose either French or English(US) as
@@ -61,8 +61,8 @@ namespace Microsoft.PowerShell
         {
             get
             {
-                // First traverse the parent heirarchy as established by CLR.
-                // This is required because there is difference in the parent heirarchy
+                // First traverse the parent hierarchy as established by CLR.
+                // This is required because there is difference in the parent hierarchy
                 // between CLR and Windows for Chinese. Ex: Native windows has
                 // zh-CN->zh-Hans->neutral whereas CLR has zh-CN->zh-CHS->zh-Hans->neutral
                 if ((null != base.Parent) && (!string.IsNullOrEmpty(base.Parent.Name)))
@@ -120,7 +120,7 @@ namespace Microsoft.PowerShell
                         {
                             string parentCulture = base.Parent.Name;
                             // remove the parentCulture from the m_fallbacks list.
-                            // ie., remove duplicates from the parent heirarchy.
+                            // ie., remove duplicates from the parent hierarchy.
                             string[] fallbacksForTheParent = null;
                             if (null != _fallbacks)
                             {
@@ -135,7 +135,7 @@ namespace Microsoft.PowerShell
                                     }
                                 }
 
-                                // There is atlease 1 duplicate in m_fallbacks which was not added to
+                                // There is atleast 1 duplicate in m_fallbacks which was not added to
                                 // fallbacksForTheParent array. Resize the array to take care of  this.
                                 if (_fallbacks.Length != currentIndex)
                                 {
@@ -290,7 +290,7 @@ namespace Microsoft.PowerShell
                     // filter out languages that console cannot display..
                     // Sometimes GetConsoleFallbackUICulture returns neutral cultures
                     // like "en" on "ar-SA". However neutral culture cannot be 
-                    // asssigned as CurrentCulture. CreateSpecificCulture fixes
+                    // assigned as CurrentCulture. CreateSpecificCulture fixes
                     // this problem.
                     returnValue = CultureInfo.CreateSpecificCulture(
                         returnValue.GetConsoleFallbackUICulture().Name);
@@ -352,7 +352,7 @@ namespace Microsoft.PowerShell
         /// the UI languages a user has chosen.
         /// </summary>
         /// <returns>
-        /// List of ThredPreferredUILanguages.
+        /// List of ThreadPreferredUILanguages.
         /// </returns>
         /// <remarks>
         /// This method will work only on Vista and later.
@@ -367,7 +367,7 @@ namespace Microsoft.PowerShell
             if (filterOutNonConsoleCultures)
             {
                 // Filter out languages that do not support console.
-                // The third paramter should be null otherwise this API will not 
+                // The third parameter should be null otherwise this API will not 
                 // set Console CodePage filter.
                 // The MSDN documentation does not call this out explicitly. Opened
                 // Bug 950 (Windows Developer Content) to track this.
@@ -451,7 +451,7 @@ namespace Microsoft.PowerShell
         /// <returns>
         /// Returns the size of the buffer containing the locale name, including 
         /// the terminating null character, if successful. The function returns 0 
-        /// if it does not succeed. To get extended error information, the applciation
+        /// if it does not succeed. To get extended error information, the application
         /// can call GetLastError. Possible returns from GetLastError
         /// include ERR_INSUFFICIENT_BUFFER.
         /// </returns>

--- a/src/System.Management.Automation/engine/hostifaces/PSDataCollection.cs
+++ b/src/System.Management.Automation/engine/hostifaces/PSDataCollection.cs
@@ -316,7 +316,7 @@ namespace System.Management.Automation
         /// as the data buffer.
         /// </summary>
         /// <param name="listToUse">
-        /// buffer wherer the elements are stored
+        /// buffer where the elements are stored
         /// </param>
         /// <remarks>
         /// Using this constructor will make the data buffer a wrapper on
@@ -534,7 +534,7 @@ namespace System.Management.Automation
                     {
                         _isOpen = false;
                         raiseEvents = true;
-                        // release any threads to notify an event. Enumertor
+                        // release any threads to notify an event. Enumerator
                         // blocks on this syncObject.
                         Monitor.PulseAll(SyncObject);
 
@@ -1363,7 +1363,7 @@ namespace System.Management.Automation
                         _readWaitHandle.Reset();
                     }
                 }
-                // release any threads to notify an event. Enumertor
+                // release any threads to notify an event. Enumerator
                 // blocks on this syncObject.
                 Monitor.PulseAll(SyncObject);
 
@@ -1525,7 +1525,7 @@ namespace System.Management.Automation
                 {
                     InsertItem(psInstanceId, _data.Count, (T)o);
 
-                    // set raise events if atlease one item is
+                    // set raise events if atleast one item is
                     // added.
                     raiseEvents = true;
                 }
@@ -1568,7 +1568,7 @@ namespace System.Management.Automation
                     _readWaitHandle.Set();
                 }
 
-                // release any threads to notify refCount is 0. Enumertor
+                // release any threads to notify refCount is 0. Enumerator
                 // blocks on this syncObject and it needs to be notified
                 // when the count becomes 0. 
                 Monitor.PulseAll(SyncObject);
@@ -1576,7 +1576,7 @@ namespace System.Management.Automation
         }
 
         /// <summary>
-        /// Returns the index of first occurece of <paramref name="item"/>
+        /// Returns the index of first occurrence of <paramref name="item"/>
         /// in the buffer. 
         /// This method is not thread safe.
         /// </summary>
@@ -1822,7 +1822,7 @@ namespace System.Management.Automation
 
     /// <summary>
     /// Enumerator for PSDataCollection. This enumerator blocks until 
-    /// either all the PowerShell operations are compeleted or the
+    /// either all the PowerShell operations are completed or the
     /// PSDataCollection is closed.
     /// </summary>
     /// <typeparam name="W"></typeparam>
@@ -2006,7 +2006,7 @@ namespace System.Management.Automation
         /// </summary>
         /// <param name="psInstanceId">
         /// Guid of Powershell instance creating this buffers.
-        /// Whenver an item is added to one of the buffers, this id is
+        /// Whenever an item is added to one of the buffers, this id is
         /// used to notify the buffer about the PowerShell instance adding
         /// this data.
         /// </param>

--- a/src/System.Management.Automation/engine/hostifaces/Pipeline.cs
+++ b/src/System.Management.Automation/engine/hostifaces/Pipeline.cs
@@ -115,7 +115,7 @@ namespace System.Management.Automation.Runspaces
         }
 
         /// <summary>
-        /// State of pipleine when exception was thrown.
+        /// State of pipeline when exception was thrown.
         /// </summary>
         [NonSerialized]
         private PipelineState _currentState = 0;
@@ -397,7 +397,7 @@ namespace System.Management.Automation.Runspaces
 
         /// <summary>
         /// True if pipeline execution encountered and error.
-        /// It will alwys be true if _reason is non-null
+        /// It will always be true if _reason is non-null
         /// since an exception occurred. For other error types,
         /// It has to be set manually.
         /// </summary>
@@ -413,7 +413,7 @@ namespace System.Management.Automation.Runspaces
         }
 
         /// <summary>
-        /// gets the unique identifier for this pipeline. This indentifier is unique with in
+        /// gets the unique identifier for this pipeline. This identifier is unique with in
         /// the scope of Runspace.
         /// </summary>
         public long InstanceId { get; }
@@ -444,7 +444,7 @@ namespace System.Management.Automation.Runspaces
         /// On V1, the global error output pipe is redirected to the command's error output pipe only when 
         /// it has already been redirected. The command-line host achieves this redirection by merging the
         /// error output into the output pipe so it checks $ErrorActionPreference all right. However, when 
-        /// the Pipeline class is used programatically the global error output pipe is not set and the first
+        /// the Pipeline class is used programmatically the global error output pipe is not set and the first
         /// error terminates the pipeline.
         /// 
         /// This flag is used to force the redirection. By default it is false to maintain compatibility with
@@ -500,7 +500,7 @@ namespace System.Management.Automation.Runspaces
         /// <exception cref="System.Security.SecurityException">
         /// A CLR security violation occurred.  Typically, this happens
         /// because the current CLR permissions do not allow adequate
-        /// reflextion access to a cmdlet assembly.
+        /// reflection access to a cmdlet assembly.
         /// </exception>
         /// <exception cref="ThreadAbortException">
         /// The thread in which the pipeline was executing was aborted.
@@ -571,7 +571,7 @@ namespace System.Management.Automation.Runspaces
         /// <exception cref="System.Security.SecurityException">
         /// A CLR security violation occurred.  Typically, this happens
         /// because the current CLR permissions do not allow adequate
-        /// reflextion access to a cmdlet assembly.
+        /// reflection access to a cmdlet assembly.
         /// </exception>
         /// <exception cref="ThreadAbortException">
         /// The thread in which the pipeline was executing was aborted.

--- a/src/System.Management.Automation/engine/hostifaces/PowerShell.cs
+++ b/src/System.Management.Automation/engine/hostifaces/PowerShell.cs
@@ -529,7 +529,7 @@ namespace System.Management.Automation
         /// Constructor
         /// </summary>
         /// <param name="ownerId">
-        /// Instace Id of the Powershell object creating this instance
+        /// Instance Id of the Powershell object creating this instance
         /// </param>
         /// <param name="callback">
         /// Callback to call when the async operation completes.
@@ -567,7 +567,7 @@ namespace System.Management.Automation
     /// <code>
     ///    Powershell.Create("get-process").Invoke();
     /// </code>
-    /// The above statetement creates a local runspace using default
+    /// The above statement creates a local runspace using default
     /// configuration, executes the command and then closes the runspace.
     /// 
     /// Using RunspacePool property, the caller can provide the runspace
@@ -1672,7 +1672,7 @@ namespace System.Management.Automation
         internal bool RedirectShellErrorOutputPipe { get; set; } = true;
 
         /// <summary>
-        /// Get unqiue id for this instance of runspace pool. It is primarily used 
+        /// Get unique id for this instance of runspace pool. It is primarily used 
         /// for logging purposes.
         /// </summary>
         public Guid InstanceId { get; private set; }
@@ -1710,7 +1710,7 @@ namespace System.Management.Automation
         }
 
         /// <summary>
-        /// Access to the EndInvoke AysncResult object.  Used by remote
+        /// Access to the EndInvoke AsyncResult object.  Used by remote
         /// debugging to invoke debugger commands on command thread.
         /// </summary>
         internal AsyncResult EndInvokeAsyncResult
@@ -1720,7 +1720,7 @@ namespace System.Management.Automation
         }
 
         /// <summary>
-        /// Event rasied when PowerShell Execution State Changes.
+        /// Event raised when PowerShell Execution State Changes.
         /// </summary>
         public event EventHandler<PSInvocationStateChangedEventArgs> InvocationStateChanged;
 
@@ -2212,7 +2212,7 @@ namespace System.Management.Automation
         /// <exception cref="System.Security.SecurityException">
         /// A CLR security violation occurred.  Typically, this happens
         /// because the current CLR permissions do not allow adequate
-        /// reflextion access to a cmdlet assembly.
+        /// reflection access to a cmdlet assembly.
         /// </exception>
         /// <exception cref="ThreadAbortException">
         /// The thread in which the command was executing was aborted.
@@ -2274,7 +2274,7 @@ namespace System.Management.Automation
         /// <exception cref="System.Security.SecurityException">
         /// A CLR security violation occurred.  Typically, this happens
         /// because the current CLR permissions do not allow adequate
-        /// reflextion access to a cmdlet assembly.
+        /// reflection access to a cmdlet assembly.
         /// </exception>
         /// <exception cref="ThreadAbortException">
         /// The thread in which the command was executing was aborted.
@@ -2339,7 +2339,7 @@ namespace System.Management.Automation
         /// <exception cref="System.Security.SecurityException">
         /// A CLR security violation occurred.  Typically, this happens
         /// because the current CLR permissions do not allow adequate
-        /// reflextion access to a cmdlet assembly.
+        /// reflection access to a cmdlet assembly.
         /// </exception>
         /// <exception cref="ThreadAbortException">
         /// The thread in which the command was executing was aborted.
@@ -2401,7 +2401,7 @@ namespace System.Management.Automation
         /// <exception cref="System.Security.SecurityException">
         /// A CLR security violation occurred.  Typically, this happens
         /// because the current CLR permissions do not allow adequate
-        /// reflextion access to a cmdlet assembly.
+        /// reflection access to a cmdlet assembly.
         /// </exception>
         /// <exception cref="ThreadAbortException">
         /// The thread in which the command was executing was aborted.
@@ -2467,7 +2467,7 @@ namespace System.Management.Automation
         /// <exception cref="System.Security.SecurityException">
         /// A CLR security violation occurred.  Typically, this happens
         /// because the current CLR permissions do not allow adequate
-        /// reflextion access to a cmdlet assembly.
+        /// reflection access to a cmdlet assembly.
         /// </exception>
         /// <exception cref="ThreadAbortException">
         /// The thread in which the command was executing was aborted.
@@ -2534,7 +2534,7 @@ namespace System.Management.Automation
         /// <exception cref="System.Security.SecurityException">
         /// A CLR security violation occurred.  Typically, this happens
         /// because the current CLR permissions do not allow adequate
-        /// reflextion access to a cmdlet assembly.
+        /// reflection access to a cmdlet assembly.
         /// </exception>
         /// <exception cref="ThreadAbortException">
         /// The thread in which the command was executing was aborted.
@@ -2604,7 +2604,7 @@ namespace System.Management.Automation
         /// <exception cref="System.Security.SecurityException">
         /// A CLR security violation occurred.  Typically, this happens
         /// because the current CLR permissions do not allow adequate
-        /// reflextion access to a cmdlet assembly.
+        /// reflection access to a cmdlet assembly.
         /// </exception>
         /// <exception cref="ThreadAbortException">
         /// The thread in which the command was executing was aborted.
@@ -2670,7 +2670,7 @@ namespace System.Management.Automation
         /// <exception cref="System.Security.SecurityException">
         /// A CLR security violation occurred.  Typically, this happens
         /// because the current CLR permissions do not allow adequate
-        /// reflextion access to a cmdlet assembly.
+        /// reflection access to a cmdlet assembly.
         /// </exception>
         /// <exception cref="ThreadAbortException">
         /// The thread in which the command was executing was aborted.
@@ -2744,7 +2744,7 @@ namespace System.Management.Automation
         /// <exception cref="System.Security.SecurityException">
         /// A CLR security violation occurred.  Typically, this happens
         /// because the current CLR permissions do not allow adequate
-        /// reflextion access to a cmdlet assembly.
+        /// reflection access to a cmdlet assembly.
         /// </exception>
         /// <exception cref="ThreadAbortException">
         /// The thread in which the command was executing was aborted.
@@ -4161,7 +4161,7 @@ namespace System.Management.Automation
         /// <exception cref="System.Security.SecurityException">
         /// A CLR security violation occurred.  Typically, this happens
         /// because the current CLR permissions do not allow adequate
-        /// reflextion access to a cmdlet assembly.
+        /// reflection access to a cmdlet assembly.
         /// </exception>
         /// <exception cref="ThreadAbortException">
         /// The thread in which the command was executing was aborted.
@@ -4271,7 +4271,7 @@ namespace System.Management.Automation
                         "Nested PowerShell can only work on a Runspace");
 
 
-                    // Peform work on the current thread. Nested Pipeline
+                    // Perform work on the current thread. Nested Pipeline
                     // should be invoked from the same thread that the parent
                     // pipeline is executing in.
                     _worker.ConstructPipelineAndDoWork(rsToUse, true);
@@ -4415,7 +4415,7 @@ namespace System.Management.Automation
                                 throw;
                             }
 
-                            // Ignore the exception if neccessary.
+                            // Ignore the exception if necessary.
                             if ((null != settings) && settings.ErrorActionPreference == ActionPreference.Ignore)
                             {
                                 continue;
@@ -5179,7 +5179,7 @@ namespace System.Management.Automation
             /// <summary>
             /// This method gets called from a ThreadPool thread.
             /// This method gets called from a RunspacePool thread when a
-            /// Runsapce is available.
+            /// Runspace is available.
             /// </summary>
             /// <param name="asyncResult">
             /// AsyncResult object which monitors the asyncOperation.

--- a/src/System.Management.Automation/engine/hostifaces/PowerShellProcessInstance.cs
+++ b/src/System.Management.Automation/engine/hostifaces/PowerShellProcessInstance.cs
@@ -140,7 +140,7 @@ namespace System.Management.Automation.Runspaces
         {
             get
             {
-                // When process is exited, there is some delay in receiving ProcesExited event and HasExited property on process object.
+                // When process is exited, there is some delay in receiving ProcessExited event and HasExited property on process object.
                 // Using HasExited property on started process object to determine if powershell process has exited. 
                 //                
                 return _processExited || (_started && Process != null && Process.HasExited);

--- a/src/System.Management.Automation/engine/hostifaces/RunspacePool.cs
+++ b/src/System.Management.Automation/engine/hostifaces/RunspacePool.cs
@@ -355,7 +355,7 @@ namespace System.Management.Automation.Runspaces
     public enum RunspacePoolCapability
     {
         /// <summary>
-        /// No additional capabilites beyond a default runspace.
+        /// No additional capabilities beyond a default runspace.
         /// </summary>
         Default = 0x0,
 
@@ -384,7 +384,7 @@ namespace System.Management.Automation.Runspaces
         /// Constructor
         /// </summary>
         /// <param name="ownerId">
-        /// Instace Id of the pool creating this instance
+        /// Instance Id of the pool creating this instance
         /// </param>
         /// <param name="callback">
         /// Callback to call when the async operation completes.
@@ -433,7 +433,7 @@ namespace System.Management.Automation.Runspaces
         /// Constructor
         /// </summary>
         /// <param name="ownerId">
-        /// Instace Id of the pool creating this instance
+        /// Instance Id of the pool creating this instance
         /// </param>
         /// <param name="callback">
         /// Callback to call when the async operation completes.
@@ -649,7 +649,7 @@ namespace System.Management.Automation.Runspaces
             PSHost host,
             TypeTable typeTable)
         {
-            // Disconnect-Connect semantics are currently only suppored in WSMan transport.
+            // Disconnect-Connect semantics are currently only supported in WSMan transport.
             if (!(connectionInfo is WSManConnectionInfo))
             {
                 throw new NotSupportedException();
@@ -666,7 +666,7 @@ namespace System.Management.Automation.Runspaces
         #region Public Properties
 
         /// <summary>
-        /// Get unqiue id for this instance of runspace pool. It is primarily used 
+        /// Get unique id for this instance of runspace pool. It is primarily used 
         /// for logging purposes.
         /// </summary>
         public Guid InstanceId
@@ -689,7 +689,7 @@ namespace System.Management.Automation.Runspaces
         }
 
         /// <summary>
-        /// Gets State of the current runpsace pool.
+        /// Gets State of the current runspace pool.
         /// </summary>
         public RunspacePoolStateInfo RunspacePoolStateInfo
         {
@@ -859,7 +859,7 @@ namespace System.Management.Automation.Runspaces
         }
 
         /// <summary>
-        /// Event rasied when a new Runspace is created by the pool.
+        /// Event raised when a new Runspace is created by the pool.
         /// </summary>
         internal event EventHandler<RunspaceCreatedEventArgs> RunspaceCreated
         {
@@ -1331,7 +1331,7 @@ namespace System.Management.Automation.Runspaces
         }
 
         /// <summary>
-        /// Waits for the pending asynchronous BegineGetRunspace to complete. 
+        /// Waits for the pending asynchronous BeginGetRunspace to complete. 
         /// </summary>
         /// <param name="asyncResult">
         /// </param>

--- a/src/System.Management.Automation/engine/hostifaces/RunspacePoolInternal.cs
+++ b/src/System.Management.Automation/engine/hostifaces/RunspacePoolInternal.cs
@@ -201,7 +201,7 @@ namespace System.Management.Automation.Runspaces.Internal
         #region Public Properties
 
         /// <summary>
-        /// Get unqiue id for this instance of runspace pool. It is primarily used 
+        /// Get unique id for this instance of runspace pool. It is primarily used 
         /// for logging purposes.
         /// </summary>
         public Guid InstanceId
@@ -224,7 +224,7 @@ namespace System.Management.Automation.Runspaces.Internal
         }
 
         /// <summary>
-        /// Gets State of the current runpsace pool.
+        /// Gets State of the current runspace pool.
         /// </summary>
         public RunspacePoolStateInfo RunspacePoolStateInfo
         {
@@ -340,7 +340,7 @@ namespace System.Management.Automation.Runspaces.Internal
         public event EventHandler<PSEventArgs> ForwardEvent;
 
         /// <summary>
-        /// Event rasied when a new Runspace is created by the pool.
+        /// Event raised when a new Runspace is created by the pool.
         /// </summary>
         internal event EventHandler<RunspaceCreatedEventArgs> RunspaceCreated;
 
@@ -937,7 +937,7 @@ namespace System.Management.Automation.Runspaces.Internal
         }
 
         /// <summary>
-        /// Waits for the pending asynchronous BegineGetRunspace to complete. 
+        /// Waits for the pending asynchronous BeginGetRunspace to complete. 
         /// </summary>
         /// <param name="asyncResult">
         /// </param>

--- a/src/System.Management.Automation/engine/hostifaces/pipelinebase.cs
+++ b/src/System.Management.Automation/engine/hostifaces/pipelinebase.cs
@@ -389,7 +389,7 @@ namespace System.Management.Automation.Runspaces
             if (SyncInvokeCall)
             {
                 //Raise the pipeline completion events. These events are set in
-                //pipeline execution thread. However for Synchornous execution
+                //pipeline execution thread. However for Synchronous execution
                 //we raise the event in the main thread.
                 RaisePipelineStateEvents();
             }
@@ -526,7 +526,7 @@ namespace System.Management.Automation.Runspaces
                 RunspaceBase.DoConcurrentCheckAndAddToRunningPipelines(this, syncCall);
 
                 //Note: Set PipelineState to Running only after adding pipeline to list
-                //of pipelines in exectuion. AddForExecution checks that runspace is in
+                //of pipelines in execution. AddForExecution checks that runspace is in
                 //state where pipeline can be run.
                 //StartPipelineExecution raises this event. See Windows Bug 1160481 for
                 //more details.
@@ -591,7 +591,7 @@ namespace System.Management.Automation.Runspaces
         /// In case of LocalPipeline, this is the thread of execution
         /// of LocalPipeline. In case of RemotePipeline, this is thread
         /// on which EnterNestedPrompt is called.
-        /// RemotePipeline proxy should set it on at the begining of 
+        /// RemotePipeline proxy should set it on at the beginning of 
         /// EnterNestedPrompt and clear it on return.
         /// </summary>
         internal Thread NestedPipelineExecutionThread { get; set; }
@@ -604,7 +604,7 @@ namespace System.Management.Automation.Runspaces
         /// <param name="syncCall">True if method is called from Invoke, false
         /// if called from InvokeAsync</param>
         /// <param name="syncObject">The sync object on which the lock is acquired</param>
-        /// <param name="isInLock">True if the method is invoked in a critical secion</param>
+        /// <param name="isInLock">True if the method is invoked in a critical section</param>
         /// <exception cref="InvalidOperationException">
         /// 1) A pipeline is already executing. Pipeline cannot execute 
         /// concurrently.
@@ -871,7 +871,7 @@ namespace System.Management.Automation.Runspaces
 
                     // this is shipped as part of V1. So disabling the warning here.
 #pragma warning disable 56500
-                    //Exception rasied in the eventhandler are not error in pipeline.
+                    //Exception raised in the eventhandler are not error in pipeline.
                     //silently ignore them.
                     if (stateChanged != null)
                     {

--- a/src/System.Management.Automation/engine/interpreter/BranchLabel.cs
+++ b/src/System.Management.Automation/engine/interpreter/BranchLabel.cs
@@ -48,7 +48,7 @@ namespace System.Management.Automation.Interpreter
         internal int _stackDepth = UnknownDepth;
         internal int _continuationStackDepth = UnknownDepth;
 
-        // Offsets of forward branching instructions targetting this label 
+        // Offsets of forward branching instructions targeting this label 
         // that need to be updated after we emit the label.
         private List<int> _forwardBranchFixups;
 

--- a/src/System.Management.Automation/engine/interpreter/CallInstruction.Generated.cs
+++ b/src/System.Management.Automation/engine/interpreter/CallInstruction.Generated.cs
@@ -80,7 +80,7 @@ namespace System.Management.Automation.Interpreter {
 
         /// <summary>
         /// Fast creation works if we have a known primitive types for the entire
-        /// method siganture.  If we have any non-primitive types then FastCreate
+        /// method signature.  If we have any non-primitive types then FastCreate
         /// falls back to SlowCreate which works for all types.
         /// 
         /// Fast creation is fast because it avoids using reflection (MakeGenericType

--- a/src/System.Management.Automation/engine/interpreter/ControlFlowInstructions.cs
+++ b/src/System.Management.Automation/engine/interpreter/ControlFlowInstructions.cs
@@ -376,7 +376,7 @@ namespace System.Management.Automation.Interpreter
                 // rethrow if there is no catch blocks defined for this try block
                 if (!_tryHandler.IsCatchBlockExist) { throw; }
 
-                // Search for the best handler in the TryCatchFianlly block. If no suitable handler is found, rethrow
+                // Search for the best handler in the TryCatchFinally block. If no suitable handler is found, rethrow
                 ExceptionHandler exHandler;
                 frame.InstructionIndex += _tryHandler.GotoHandler(frame, exception, out exHandler);
                 if (exHandler == null) { throw; }
@@ -484,7 +484,7 @@ namespace System.Management.Automation.Interpreter
         {
             // If _pendingContinuation == -1 then we were getting into the finally block because an exception was thrown
             //      in this case we need to set the stack depth
-            // Else we were getting into this finnaly block from a 'Goto' jump, and the stack depth is alreayd set properly
+            // Else we were getting into this finally block from a 'Goto' jump, and the stack depth is already set properly
             if (!frame.IsJumpHappened())
             {
                 frame.SetStackDepth(GetLabel(frame).StackDepth);

--- a/src/System.Management.Automation/engine/interpreter/InstructionFactory.cs
+++ b/src/System.Management.Automation/engine/interpreter/InstructionFactory.cs
@@ -18,7 +18,7 @@ using BigInt = System.Numerics.BigInteger;
 #endif
 
 #if CORECLR
-// Used for 'GetField' which is not available under 'Type' in CoreClR but provided as an extenstion method in 'System.Reflection.TypeExtensions'
+// Used for 'GetField' which is not available under 'Type' in CoreClR but provided as an extension method in 'System.Reflection.TypeExtensions'
 using System.Reflection;
 #endif
 

--- a/src/System.Management.Automation/engine/interpreter/LabelInfo.cs
+++ b/src/System.Management.Automation/engine/interpreter/LabelInfo.cs
@@ -147,7 +147,7 @@ namespace System.Management.Automation.Interpreter
                 }
             }
 
-            // Valdiate that we aren't jumping into a catch or an expression
+            // Validate that we aren't jumping into a catch or an expression
             for (LabelScopeInfo j = def; j != common; j = j.Parent)
             {
                 if (!j.CanJumpInto)

--- a/src/System.Management.Automation/engine/interpreter/LightCompiler.cs
+++ b/src/System.Management.Automation/engine/interpreter/LightCompiler.cs
@@ -177,7 +177,7 @@ namespace System.Management.Automation.Interpreter
     }
 
     /// <summary>
-    /// The re-throw instrcution will throw this exception
+    /// The re-throw instruction will throw this exception
     /// </summary>
     internal sealed class RethrowException : SystemException
     {
@@ -282,7 +282,7 @@ namespace System.Management.Automation.Interpreter
 
         private readonly Stack<ParameterExpression> _exceptionForRethrowStack = new Stack<ParameterExpression>();
 
-        // Set to true to force compiliation of this lambda.
+        // Set to true to force compilation of this lambda.
         // This disables the interpreter for this lambda. We still need to
         // walk it, however, to resolve variables closed over from the parent
         // lambdas (because they may be interpreted).
@@ -1249,7 +1249,7 @@ namespace System.Management.Automation.Interpreter
                     return true;
                 case ExpressionType.Switch:
                     PushLabelBlock(LabelScopeKind.Switch);
-                    // Define labels inside of the switch cases so theyare in
+                    // Define labels inside of the switch cases so they are in
                     // scope for the whole switch. This allows "goto case" and
                     // "goto default" to be considered as local jumps.
                     var @switch = (SwitchExpression)node;

--- a/src/System.Management.Automation/engine/interpreter/LightLambdaClosureVisitor.cs
+++ b/src/System.Management.Automation/engine/interpreter/LightLambdaClosureVisitor.cs
@@ -245,7 +245,7 @@ namespace System.Management.Automation.Interpreter
         #region MergedRuntimeVariables
 
         /// <summary>
-        /// Provides a list of variables, supporing read/write of the values
+        /// Provides a list of variables, supporting read/write of the values
         /// </summary>
         private sealed class MergedRuntimeVariables : IRuntimeVariables
         {

--- a/src/System.Management.Automation/engine/lang/interface/PSParser.cs
+++ b/src/System.Management.Automation/engine/lang/interface/PSParser.cs
@@ -55,7 +55,7 @@ namespace System.Management.Automation
     //  3. Parsing Logic
     //  
     //  Script parsing is done through instances of PSParser object. Each PSParser object 
-    //  wraps an interal Parser object. It is PSParser object's responsibility to 
+    //  wraps an internal Parser object. It is PSParser object's responsibility to 
     //      a. setup local runspace and retrieve internal Parser object from it. 
     //      b. call internal parser for actual parsing
     //      c. translate parsing result from internal Token and RuntimeException type
@@ -144,7 +144,7 @@ namespace System.Management.Automation
         /// collection, there are some scenarios where resource limits will result
         /// in an exception being thrown by this API. This allows the caller to
         /// distinguish between a successful parse with errors and a failed parse.
-        /// All exceptions thrown will be derived from System.Mnagement.Automation.RuntimeException
+        /// All exceptions thrown will be derived from System.Management.Automation.RuntimeException
         /// but may contain an inner exception that describes the real issue.
         /// </exception>
         public static Collection<PSToken> Tokenize(string script, out Collection<PSParseError> errors)
@@ -171,7 +171,7 @@ namespace System.Management.Automation
         /// collection, there are some scenarios where resource limits will result
         /// in an exception being thrown by this API. This allows the caller to
         /// distinguish between a successful parse with errors and a failed parse.
-        /// All exceptions thrown will be derived from System.Mnagement.Automation.RuntimeException
+        /// All exceptions thrown will be derived from System.Management.Automation.RuntimeException
         /// but may contain an inner exception that describes the real issue.
         /// </exception>
         public static Collection<PSToken> Tokenize(object[] script, out Collection<PSParseError> errors)

--- a/src/System.Management.Automation/engine/lang/interface/PSToken.cs
+++ b/src/System.Management.Automation/engine/lang/interface/PSToken.cs
@@ -168,7 +168,7 @@ namespace System.Management.Automation
             /*               Equals */ PSTokenType.Operator,
             /*           PlusEquals */ PSTokenType.Operator,
             /*          MinusEquals */ PSTokenType.Operator,
-            /*        MultipyEquals */ PSTokenType.Operator,
+            /*       MultiplyEquals */ PSTokenType.Operator,
             /*         DivideEquals */ PSTokenType.Operator,
             /*      RemainderEquals */ PSTokenType.Operator,
             /*          Redirection */ PSTokenType.Operator,

--- a/src/System.Management.Automation/engine/lang/parserutils.cs
+++ b/src/System.Management.Automation/engine/lang/parserutils.cs
@@ -73,7 +73,7 @@ namespace System.Management.Automation
             return (c == '{' || c == '}');
         }
         /// <summary>
-        /// Canonicalize the quote charater - map all of the aliases for " or '
+        /// Canonicalize the quote character - map all of the aliases for " or '
         /// into their ascii equivalent.
         /// </summary>
         /// <param name="c">The character to map</param>
@@ -270,7 +270,7 @@ namespace System.Management.Automation
     public enum SplitOptions
     {
         /// <summary>
-        /// Use simple string comparison when evaluting the delimiter.
+        /// Use simple string comparison when evaluating the delimiter.
         /// Cannot be used with RegexMatch.
         /// </summary>
         SimpleMatch = 0x01,
@@ -280,7 +280,7 @@ namespace System.Management.Automation
         /// </summary>
         RegexMatch = 0x02,
         /// <summary>
-        /// CultureInvariant: Ignores cultural differences in language when evaluting the delimiter.
+        /// CultureInvariant: Ignores cultural differences in language when evaluating the delimiter.
         /// Valid only with RegexMatch.
         /// </summary>
         CultureInvariant = 0x04,
@@ -1330,7 +1330,7 @@ namespace System.Management.Automation
 
         /// <summary>
         /// Launch a method on an object. This will handle .NET native methods, COM 
-        /// methods and ScriptBlock notes. Native methods currently take precidence over notes...
+        /// methods and ScriptBlock notes. Native methods currently take precedence over notes...
         /// </summary>
         /// <param name="errorPosition">The position to use for error reporting.</param>
         /// <param name="target">The object to call the method on. It shouldn't be an msh object</param>
@@ -1338,7 +1338,7 @@ namespace System.Management.Automation
         /// <param name="invocationConstraints">Invocation constraints</param>
         /// <param name="paramArray">The arguments to pass to the method.</param>
         /// <param name="callStatic">Set to true if you want to call a static method.</param>
-        /// <param name="valueToSet">If not automation null, then this must be a settable propery</param>
+        /// <param name="valueToSet">If not automation null, then this must be a settable property</param>
         /// <exception cref="RuntimeException">Wraps the exception returned from the method call</exception>
         /// <exception cref="SessionStateOverflowException">The maximum scope depth would be exceeded</exception>
         /// <exception cref="FlowControlException">Internal exception from a flow control statement</exception>        

--- a/src/System.Management.Automation/engine/lang/scriptblock.cs
+++ b/src/System.Management.Automation/engine/lang/scriptblock.cs
@@ -769,7 +769,7 @@ namespace System.Management.Automation
 
         internal object InvokeAsDelegateHelper(object dollarUnder, object dollarThis, object[] args)
         {
-            // Retrive context and current runspace to ensure that we throw exception, if this is non-default runspace.
+            // Retrieve context and current runspace to ensure that we throw exception, if this is non-default runspace.
             ExecutionContext context = GetContextFromTLS();
             RunspaceBase runspace = (RunspaceBase)context.CurrentRunspace;
 
@@ -1295,7 +1295,7 @@ namespace System.Management.Automation
         /// <summary>
         /// Recommended constructor for the class
         /// </summary>
-        /// <param name="errorId">String that uniquelly identifies each thrown Exception</param>
+        /// <param name="errorId">String that uniquely identifies each thrown Exception</param>
         /// <param name="innerException">The inner exception</param>
         /// <param name="message">The error message</param>
         /// <param name="arguments">Arguments to the resource string</param>

--- a/src/System.Management.Automation/engine/parser/Compiler.cs
+++ b/src/System.Management.Automation/engine/parser/Compiler.cs
@@ -1857,7 +1857,7 @@ namespace System.Management.Automation.Language
             exprs.Add(Expression.Call(oldPipe, CachedReflectionInfo.Pipe_SetVariableListForTemporaryPipe, s_getCurrentPipe));
             if (generateRedirectExprs != null)
             {
-                // Add merge redirection expressions if delgate is provided.
+                // Add merge redirection expressions if delegate is provided.
                 generateRedirectExprs(exprs, finallyExprs);
             }
             exprs.Add(Compile(ast));
@@ -2427,7 +2427,7 @@ namespace System.Management.Automation.Language
             exprs.Add(Expression.Assign(LocalVariablesParameter,
                                         Expression.Field(_functionContext, CachedReflectionInfo.FunctionContext__localsTuple).Cast(this.LocalVariablesTupleType)));
 
-            // Compiling a single expression (a default argument, or an locally evalutated argument in a ScriptBlock=>PowerShell conversion)
+            // Compiling a single expression (a default argument, or an locally evaluated argument in a ScriptBlock=>PowerShell conversion)
             // does not support debugging, so skip calling EnterScriptFunction.
             if (!_compilingSingleExpression)
             {
@@ -2647,7 +2647,7 @@ namespace System.Management.Automation.Language
                     //     "Should continue here"
                     // In this example, the trap just continues, but we want to continue after the 'if' statement, not after
                     // the 'throw' statement.
-                    // We push null onto the active trap handlers to let ExceptionHandlingOps.CheckActionPrefence know it
+                    // We push null onto the active trap handlers to let ExceptionHandlingOps.CheckActionPreference know it
                     // shouldn't process traps (but should still query the user if appropriate), and just rethrow so we can
                     // unwind to the block with the trap.
 
@@ -3040,7 +3040,7 @@ namespace System.Management.Automation.Language
 
                 // The redirections are passed as a CommandRedirection[][] - one dimension for each command in the pipe,
                 // one dimension because each command may have multiple redirections.  Here we create the array for
-                // each command in the pipe, either a compile time constant or created at runtime if necesary.
+                // each command in the pipe, either a compile time constant or created at runtime if necessary.
                 Expression redirectionExpr;
                 if (commandRedirections.Any(r => r is Expression))
                 {
@@ -3093,7 +3093,7 @@ namespace System.Management.Automation.Language
                 return null;
             }
 
-            // Most redirections will be instannces of CommandRedirection, but non-constant filenames
+            // Most redirections will be instances of CommandRedirection, but non-constant filenames
             // will generated a Linq.Expression, so we store objects.
             object[] compiledRedirections = new object[count];
             for (int i = 0; i < count; ++i)
@@ -3233,7 +3233,7 @@ namespace System.Management.Automation.Language
                 exprs.Add(Compile(subExpr.SubExpression));
                 if (resultList != null)
                 {
-                    // If there is no resultList, we wrote our results of the subexperssion directly to the pipe
+                    // If there is no resultList, we wrote our results of the subexpression directly to the pipe
                     // instead of being collected to be written here.
                     result = Expression.Call(CachedReflectionInfo.PipelineOps_PipelineResult, resultList);
                 }
@@ -3871,7 +3871,7 @@ namespace System.Management.Automation.Language
             if (dataStatementAst.CommandsAllowed.Count > 0)
             {
                 // If CommandsAllowed was specified, we need to check the language mode - the data section runs
-                // in restriced language mode and we don't want to allow disallowed commands to run if we were in
+                // in restricted language mode and we don't want to allow disallowed commands to run if we were in
                 // constrained language mode.
                 exprs.Add(
                     Expression.Call(

--- a/src/System.Management.Automation/engine/parser/ConstantValues.cs
+++ b/src/System.Management.Automation/engine/parser/ConstantValues.cs
@@ -252,7 +252,7 @@ namespace System.Management.Automation.Language
         {
             // A script block expression is a constant when we're generating metadata, but when
             // we're generating code, we need to create new script blocks so we can't use a constant.
-            // Also - we have no way to desribe a script block when generating .Net metadata, so
+            // Also - we have no way to describe a script block when generating .Net metadata, so
             // we must disallow script blocks as attribute arguments on/inside a class.
             return CheckingAttributeArgument && !CheckingClassAttributeArguments;
         }

--- a/src/System.Management.Automation/engine/parser/Parser.cs
+++ b/src/System.Management.Automation/engine/parser/Parser.cs
@@ -32,7 +32,7 @@ namespace System.Management.Automation.Language
 
     /// <summary>
     /// The parser that parses PowerShell script and returns a <see cref="ScriptBlockAst"/>, tokens, and error messages
-    /// if the script cannot be parsed successfullly.
+    /// if the script cannot be parsed successfully.
     /// </summary>
     public sealed class Parser
     {
@@ -4126,7 +4126,7 @@ namespace System.Management.Automation.Language
                 {
                     // Incompleted input like:
                     // class foo { $private: }
-                    // Error message already emmited by tokenizer ScanVariable
+                    // Error message already emitted by tokenizer ScanVariable
 
                     RecordErrorAsts(attributeList, ref astsOnError);
                     RecordErrorAsts(typeConstraint, ref astsOnError);

--- a/src/System.Management.Automation/engine/parser/Position.cs
+++ b/src/System.Management.Automation/engine/parser/Position.cs
@@ -106,7 +106,7 @@ namespace System.Management.Automation.Language
     }
 
     /// <summary>
-    /// A few utilty functions for script positions.
+    /// A few utility functions for script positions.
     /// </summary>
     internal static class PositionUtilities
     {
@@ -116,7 +116,7 @@ namespace System.Management.Automation.Language
         public static IScriptPosition EmptyPosition { get; } = new EmptyScriptPosition();
 
         /// <summary>
-        /// Return a unique extent repesenting an empty or missing extent.
+        /// Return a unique extent representing an empty or missing extent.
         /// </summary>
         public static IScriptExtent EmptyExtent { get; } = new EmptyScriptExtent();
 

--- a/src/System.Management.Automation/engine/parser/PreOrderVisitor.cs
+++ b/src/System.Management.Automation/engine/parser/PreOrderVisitor.cs
@@ -29,7 +29,7 @@ namespace System.Management.Automation.Language
     }
 
     /// <summary>
-    /// AstVisitor is used for basic scenarios requiring traveral of the nodes in an Ast.
+    /// AstVisitor is used for basic scenarios requiring traversal of the nodes in an Ast.
     /// An implementation of AstVisitor does not explicitly traverse the Ast, instead,
     /// the engine traverses all nodes in the Ast and calls the appropriate method on each node.
     /// </summary>

--- a/src/System.Management.Automation/engine/parser/SemanticChecks.cs
+++ b/src/System.Management.Automation/engine/parser/SemanticChecks.cs
@@ -1173,7 +1173,7 @@ namespace System.Management.Automation.Language
         public override AstVisitAction VisitConfigurationDefinition(ConfigurationDefinitionAst configurationDefinitionAst)
         {
             //
-            // Check if the ScirptBlockAst contains NamedBlockAst other than the End block
+            // Check if the ScriptBlockAst contains NamedBlockAst other than the End block
             //
             ScriptBlockAst configBody = configurationDefinitionAst.Body.ScriptBlock;
             if (configBody.BeginBlock != null || configBody.ProcessBlock != null || configBody.DynamicParamBlock != null)
@@ -1447,7 +1447,7 @@ namespace System.Management.Automation.Language
         /// </summary>
         /// <param name="parser"></param>
         /// <param name="functionMemberAst">The function member AST</param>
-        /// <param name="hasGet">True if it is a Get method with qualified return type and signaure; otherwise, false. </param>
+        /// <param name="hasGet">True if it is a Get method with qualified return type and signature; otherwise, false. </param>
         private static void CheckGet(Parser parser, FunctionMemberAst functionMemberAst, ref bool hasGet)
         {
             if (hasGet)
@@ -1484,7 +1484,7 @@ namespace System.Management.Automation.Language
         /// Check if it is a Test method with correct return type and signature
         /// </summary>
         /// <param name="functionMemberAst">The function member AST</param>
-        /// <param name="hasTest">True if it is a Test method with qualified return type and signaure; otherwise, false.</param>
+        /// <param name="hasTest">True if it is a Test method with qualified return type and signature; otherwise, false.</param>
         private static void CheckTest(FunctionMemberAst functionMemberAst, ref bool hasTest)
         {
             if (hasTest) return;
@@ -1497,7 +1497,7 @@ namespace System.Management.Automation.Language
         /// Check if it is a Set method with correct return type and signature
         /// </summary>
         /// <param name="functionMemberAst">The function member AST</param>
-        /// <param name="hasSet">True if it is a Set method with qualified return type and signaure; otherwise, false.</param>
+        /// <param name="hasSet">True if it is a Set method with qualified return type and signature; otherwise, false.</param>
         private static void CheckSet(FunctionMemberAst functionMemberAst, ref bool hasSet)
         {
             if (hasSet) return;

--- a/src/System.Management.Automation/engine/parser/SymbolResolver.cs
+++ b/src/System.Management.Automation/engine/parser/SymbolResolver.cs
@@ -70,7 +70,7 @@ namespace System.Management.Automation.Language
                 {
                     // Duplicate members are an error, but we catch that later after all types
                     // have been resolved.  We could report errors for properties here, but
-                    // we couldn't compare methods becaues overloads can't be compared until types
+                    // we couldn't compare methods because overloads can't be compared until types
                     // are resolved.
                     if (!_variableTable.ContainsKey(propertyMember.Name))
                     {
@@ -423,7 +423,7 @@ namespace System.Management.Automation.Language
 
         /// <summary>
         /// Resolves using module to a collection of PSModuleInfos. Doesn't throw.
-        /// PSModuleInfo objects are retunred in the right order: i.e. if multiply verions of the module
+        /// PSModuleInfo objects are returned in the right order: i.e. if multiply versions of the module
         /// is presented on the system and user didn't specify version, we will return all of them, but newer one would go first.
         /// </summary>
         /// <param name="usingStatementAst">using statement</param>

--- a/src/System.Management.Automation/engine/parser/TypeResolver.cs
+++ b/src/System.Management.Automation/engine/parser/TypeResolver.cs
@@ -49,7 +49,7 @@ namespace System.Management.Automation.Language
         }
 
         /// <summary>
-        /// Inherited from InvalidCastException, because it happens in [string] -> [Type] convertion.
+        /// Inherited from InvalidCastException, because it happens in [string] -> [Type] conversion.
         /// </summary>
         internal class AmbiguousTypeException : InvalidCastException
         {
@@ -202,7 +202,7 @@ namespace System.Management.Automation.Language
             try
             {
                 // We shouldn't really bother looking for the type in System namespace, but
-                // we've always done that.  We explictily are not supporting arbitrary
+                // we've always done that.  We explicitly are not supporting arbitrary
                 // 'using namespace' here because there is little value, if you need the assembly
                 // qualifier, it's best to just fully specify the type.
                 var result = Type.GetType(typeName.FullName, false, true) ??
@@ -266,14 +266,14 @@ namespace System.Management.Automation.Language
             //             Consider this code
             //                  Add-Type 'public class Q {}' # ok
             //                  Add-Type 'public class Q { }' # get error about the same name
-            //                  [Q] # we would get error about ambigious type, because we added assembly with duplicated type
+            //                  [Q] # we would get error about ambiguous type, because we added assembly with duplicated type
             //                      # before we can report TYPE_ALREADY_EXISTS error.
             //      
             //                  Add-Type 'public class Q2 {}' # ok
             //                  [Q2] # caching Q2 type
             //                  Add-Type 'public class Q2 { }' # get error about the same name
-            //                  [Q2] # we don't get an error about ambigious type, because it's cached already
-            //          2) NuGet (VS Package Management console) uses MEF extensability model. 
+            //                  [Q2] # we don't get an error about ambiguous type, because it's cached already
+            //          2) NuGet (VS Package Management console) uses MEF extensibility model. 
             //             Different assemblies includes same interface (i.e. NuGet.VisualStudio.IVsPackageInstallerServices), 
             //             where they include only methods that they are interested in the interface declaration (result interfaces are different!).
             //             Then, at runtime VS provides an instance. Everything work as far as instance has compatible API.
@@ -751,14 +751,14 @@ namespace System.Management.Automation
 
     /// <summary>
     /// A class to view and modify the type accelerators used by the PowerShell engine.  Builtin
-    /// type accelerators are read only, but user defined type accerators may be added.
+    /// type accelerators are read only, but user defined type accelerators may be added.
     /// </summary>
     internal static class TypeAccelerators
     {
         // builtins are not exposed publicly in a direct manner so they can't be changed at all
         internal static Dictionary<string, Type> builtinTypeAccelerators = new Dictionary<string, Type>(64, StringComparer.OrdinalIgnoreCase);
 
-        // users can add to user added accelerators (but not currently remove any.)  Keeping a seperate
+        // users can add to user added accelerators (but not currently remove any.)  Keeping a separate
         // list allows us to add removing in the future w/o worrying about breaking the builtins.
         internal static Dictionary<string, Type> userTypeAccelerators = new Dictionary<string, Type>(64, StringComparer.OrdinalIgnoreCase);
 
@@ -847,7 +847,7 @@ namespace System.Management.Automation
         /// to the dictionary will not affect PowerShell scripts in any way.  Use
         /// <see cref="TypeAccelerators.Add"/> and
         /// <see cref="TypeAccelerators.Remove"/> to
-        /// affect the type resolutin in PowerShell scripts.
+        /// affect the type resolution in PowerShell scripts.
         /// </remarks>
         public static Dictionary<string, Type> Get
         {

--- a/src/System.Management.Automation/engine/parser/VariableAnalysis.cs
+++ b/src/System.Management.Automation/engine/parser/VariableAnalysis.cs
@@ -1615,7 +1615,7 @@ namespace System.Management.Automation.Language
                 // left operand is always evaluated, visit it's expression in the current block.
                 binaryExpressionAst.Left.Accept(this);
 
-                // The right operand is condtionally evaluated.  We aren't generating any code here, just
+                // The right operand is conditionally evaluated.  We aren't generating any code here, just
                 // modeling the flow graph, so we just visit the right operand in a new block, and have
                 // both the current and new blocks both flow to a post-expression block.
                 var targetBlock = new Block();

--- a/src/System.Management.Automation/engine/parser/ast.cs
+++ b/src/System.Management.Automation/engine/parser/ast.cs
@@ -506,7 +506,7 @@ namespace System.Management.Automation.Language
         public Token Kind { get; private set; }
 
         /// <summary>
-        /// The flags specifid and their value. The value is null if it's not specified.
+        /// The flags specified and their value. The value is null if it's not specified.
         /// e.g. switch -regex -file c:\demo.txt  --->   regex -- null
         ///                                              file  -- { c:\demo.txt }
         /// </summary>
@@ -749,7 +749,7 @@ namespace System.Management.Automation.Language
         public ReadOnlyCollection<PSSnapInSpecification> RequiresPSSnapIns { get; internal set; }
 
         /// <summary>
-        /// The aseemblies this script requires, specified like:
+        /// The assemblies this script requires, specified like:
         ///     <code>#requires -Assembly path\to\foo.dll</code>
         ///     <code>#requires -Assembly "System.Management.Automation, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35"</code>
         /// If no assemblies are required, this property is an empty collection.
@@ -757,7 +757,7 @@ namespace System.Management.Automation.Language
         public ReadOnlyCollection<string> RequiredAssemblies { get; internal set; }
 
         /// <summary>
-        /// Specifies if this script requires elevated privelges, specified like:
+        /// Specifies if this script requires elevated privileges, specified like:
         ///     <code>#requires -RunAsAdministrator</code>
         /// If nothing is specified, this property is false.
         /// </summary>
@@ -1206,7 +1206,7 @@ namespace System.Management.Automation.Language
                                "Caller makes sure the section is within the ScriptBlockAst");
 
             List<VariableExpressionAst> usingVars = usingVariablesTuple.Item1; // A list of using variables
-            string newParams = usingVariablesTuple.Item2; // The new parameters are seperated by the comma
+            string newParams = usingVariablesTuple.Item2; // The new parameters are separated by the comma
 
             // astElements contains
             //  -- UsingVariable
@@ -1943,7 +1943,7 @@ namespace System.Management.Automation.Language
     public abstract class AttributeBaseAst : Ast
     {
         /// <summary>
-        /// Initiale the common fields for an attribute.
+        /// Initialize the common fields for an attribute.
         /// </summary>
         /// <param name="extent">The extent of the attribute, from the opening '[' to the closing ']'.</param>
         /// <param name="typeName">The type named by the attribute.</param>
@@ -2268,7 +2268,7 @@ namespace System.Management.Automation.Language
         /// A parameter name cannot be a using variable, but its default value could contain any number of UsingExpressions, for example:
         ///     function bar ($x = (Get-X @using:defaultSettings.Parameters)) { ... }
         /// This method goes through the ParameterAst text and replace each $using variable with its new synthetic name (remove the $using prefix).
-        /// This method is used when we call Invoke-Command targetting a PSv2 remote machine. In that case, we might need to call this method
+        /// This method is used when we call Invoke-Command targeting a PSv2 remote machine. In that case, we might need to call this method
         /// to process the script block text, since $using prefix cannot be recognized by PSv2.
         /// </summary>
         /// <param name="orderedUsingVar">A sorted enumerator of using variable asts, ascendingly sorted based on StartOffSet</param>
@@ -2661,7 +2661,7 @@ namespace System.Management.Automation.Language
             // REVIEW: should old visitors completely skip the attributes and
             // bodies of methods, or should they get a chance to see them.  If
             // we want to skip them, the code below needs to move up into the
-            // above test 'vistitor2 != null'.
+            // above test 'visitor2 != null'.
             if (action == AstVisitAction.Continue)
             {
                 for (int index = 0; index < Attributes.Count; index++)
@@ -4098,7 +4098,7 @@ namespace System.Management.Automation.Language
     public abstract class LabeledStatementAst : StatementAst
     {
         /// <summary>
-        /// Initialize the properties commmon to labeled statements.
+        /// Initialize the properties common to labeled statements.
         /// </summary>
         /// <param name="extent">The extent of the statement.</param>
         /// <param name="label">The optionally null label for the statement.</param>
@@ -4363,7 +4363,7 @@ namespace System.Management.Automation.Language
         public PipelineBaseAst Initializer { get; private set; }
 
         /// <summary>
-        /// The ast for the iteration experssion of a for statement, or null if none was specified.
+        /// The ast for the iteration expression of a for statement, or null if none was specified.
         /// </summary>
         public PipelineBaseAst Iterator { get; private set; }
 
@@ -4679,7 +4679,7 @@ namespace System.Management.Automation.Language
 
         /// <summary>
         /// A possibly empty collection of conditions and statement blocks representing the cases of the switch statement.
-        /// If the colleciton is empty, the default clause is not null.
+        /// If the collection is empty, the default clause is not null.
         /// </summary>
         [SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures")]
         public ReadOnlyCollection<SwitchClause> Clauses { get; private set; }
@@ -5435,7 +5435,7 @@ namespace System.Management.Automation.Language
     #region Pipelines
 
     /// <summary>
-    /// An abstract base class for statements that include command invocations, pipelines, expressions, and assignements.
+    /// An abstract base class for statements that include command invocations, pipelines, expressions, and assignments.
     /// Any statement that does not begin with a keyword is derives from PipelineBastAst.
     /// </summary>
     public abstract class PipelineBaseAst : StatementAst
@@ -5462,7 +5462,7 @@ namespace System.Management.Automation.Language
     }
 
     /// <summary>
-    /// The ast that repesents a PowerShell pipeline, e.g. <c>gci -re . *.cs | select-string Foo</c> or <c> 65..90 | % { [char]$_ }</c>.
+    /// The ast that represents a PowerShell pipeline, e.g. <c>gci -re . *.cs | select-string Foo</c> or <c> 65..90 | % { [char]$_ }</c>.
     /// A pipeline must have at least 1 command.  The first command may be an expression or a command invocation.
     /// </summary>
     public class PipelineAst : PipelineBaseAst
@@ -5808,7 +5808,7 @@ namespace System.Management.Automation.Language
         }
 
         /// <summary>
-        /// If this command was synthesiszed out of a dynamic keyword, this property will point to the DynamicKeyword
+        /// If this command was synthesized out of a dynamic keyword, this property will point to the DynamicKeyword
         /// data structure that was used to create this command.
         /// </summary>
         public DynamicKeyword DefiningKeyword { get; set; }
@@ -6290,7 +6290,7 @@ namespace System.Management.Automation.Language
     public class AssignmentStatementAst : PipelineBaseAst
     {
         /// <summary>
-        /// Construct an assignement statement.
+        /// Construct an assignment statement.
         /// </summary>
         /// <param name="extent">The extent of the assignment statement.</param>
         /// <param name="left">The value being assigned.</param>
@@ -6564,7 +6564,7 @@ namespace System.Management.Automation.Language
         internal List<DynamicKeyword> DefinedKeywords { get; set; }
 
         /// <summary>
-        /// Generate ast that definies a function for this <see cref="ConfigurationDefinitionAst"/> object
+        /// Generate ast that defines a function for this <see cref="ConfigurationDefinitionAst"/> object
         /// </summary>
         /// <returns>
         /// The <see cref="PipelineAst"/> that defines a function for this <see cref="ConfigurationDefinitionAst"/> object
@@ -6627,7 +6627,7 @@ namespace System.Management.Automation.Language
             cea.Add(new CommandParameterAst(LCurlyToken.Extent, "InstanceName", new VariableExpressionAst(LCurlyToken.Extent, "InstanceName", false), LCurlyToken.Extent));
 
             //
-            // copy the configuration paramter to the new function parameter
+            // copy the configuration parameter to the new function parameter
             // the new set-item created function will have below parameters
             //    [cmdletbinding()]
             //    param(
@@ -7062,13 +7062,13 @@ namespace System.Management.Automation.Language
             //
             // The second type, where the DirectCall flag is set to true, simply calls the command directly.
             // In the original source, the keyword body will be a property collection where the allowed properties
-            // in the collection corresond to the parameters on the actual called function.
+            // in the collection correspond to the parameters on the actual called function.
             //
             var cea = new Collection<CommandElementAst>();
 
             //
             // First add the name of the command to call. If a module name has been provided
-            // then use the module-quilified form of the command name..
+            // then use the module-qualified form of the command name..
             //
             if (string.IsNullOrEmpty(Keyword.ImplementingModule))
             {
@@ -7225,7 +7225,7 @@ namespace System.Management.Automation.Language
                         LCurly.Extent));
 
                 //
-                // Add the -SourceMetadata parametere
+                // Add the -SourceMetadata parameter
                 //
                 string sourceMetadata = FunctionName.Extent.File
                                         + "::" + FunctionName.Extent.StartLineNumber
@@ -7874,7 +7874,7 @@ namespace System.Management.Automation.Language
         /// <param name="expression">The expression before the member access operator '.' or '::'.</param>
         /// <param name="member">The name or expression naming the member to access.</param>
         /// <param name="static">True if the '::' operator was used, false if '.' is used.
-        /// True if the member access is for a static member, using '::', false if accessing a member on an instace using '.'.
+        /// True if the member access is for a static member, using '::', false if accessing a member on an instance using '.'.
         /// </param>
         /// <exception cref="PSArgumentNullException">
         /// If <paramref name="extent"/>, <paramref name="expression"/>, or <paramref name="member"/> is null.
@@ -8164,7 +8164,7 @@ namespace System.Management.Automation.Language
         /// <param name="method">The method to invoke.</param>
         /// <param name="arguments">The arguments to pass to the method.</param>
         /// <param name="static">
-        /// True if the invocation is for a static method, using '::', false if invoking a method on an instace using '.'.
+        /// True if the invocation is for a static method, using '::', false if invoking a method on an instance using '.'.
         /// </param>
         /// <exception cref="PSArgumentNullException">
         /// If <paramref name="extent"/> is null.
@@ -9302,7 +9302,7 @@ namespace System.Management.Automation.Language
         }
 
         /// <summary>
-        /// Construct a variable reference with an exising VariablePath (rather than construct a new one.)
+        /// Construct a variable reference with an existing VariablePath (rather than construct a new one.)
         /// </summary>
         /// <exception cref="PSArgumentNullException">
         /// If <paramref name="extent"/> or <paramref name="variablePath"/> is null.
@@ -9417,7 +9417,7 @@ namespace System.Management.Automation.Language
                                 {
                                     // Assume (because we're looking at $_ and we're inside a script block that is an
                                     // argument to some command) that the type we're getting is actually unrolled.
-                                    // This might not be right in all cases, but with our simple analysis, it'r
+                                    // This might not be right in all cases, but with our simple analysis, it's
                                     // right more often than it's wrong.
                                     if (result.Type.IsArray)
                                     {
@@ -9950,7 +9950,7 @@ namespace System.Management.Automation.Language
     }
 
     /// <summary>
-    /// The ast that repesents a double quoted string (here string or normal string) and can have nested variable
+    /// The ast that represents a double quoted string (here string or normal string) and can have nested variable
     /// references or sub-expressions, e.g. <c>"Name: $name`nAge: $([DateTime]::Now.Year - $dob.Year)"</c>.
     /// </summary>
     public class ExpandableStringExpressionAst : ExpressionAst
@@ -10333,7 +10333,7 @@ namespace System.Management.Automation.Language
             yield return new PSTypeName(typeof(Hashtable));
         }
 
-        // Indicates that this ast was consructed as part of a schematized object instead of just a plain hash literal.
+        // Indicates that this ast was constructed as part of a schematized object instead of just a plain hash literal.
         internal bool IsSchemaElement { get; set; }
 
 

--- a/src/System.Management.Automation/engine/parser/token.cs
+++ b/src/System.Management.Automation/engine/parser/token.cs
@@ -212,7 +212,7 @@ namespace System.Management.Automation.Language
         /// <summary>The subtraction assignment operator '-='.</summary>
         MinusEquals = 44,
 
-        /// <summary>The multiplcation assignment operator '*='.</summary>
+        /// <summary>The multiplication assignment operator '*='.</summary>
         MultiplyEquals = 45,
 
         /// <summary>The division assignment operator '/='.</summary>
@@ -598,7 +598,7 @@ namespace System.Management.Automation.Language
 
         /// <summary>
         /// The precedence of comparison operators including: '-eq', '-ne', '-ge', '-gt', '-lt', '-le', '-like', '-notlike',
-        /// '-match', '-notmatch', '-replace', '-containts', '-notcontains', '-in', '-notin', '-split', '-join', '-is', '-isnot', '-as',
+        /// '-match', '-notmatch', '-replace', '-contains', '-notcontains', '-in', '-notin', '-split', '-join', '-is', '-isnot', '-as',
         /// and all of the case sensitive variants of these operators, if they exists.
         /// </summary>
         BinaryPrecedenceComparison = 3,
@@ -792,7 +792,7 @@ namespace System.Management.Automation.Language
             /*               Equals */ TokenFlags.AssignmentOperator,
             /*           PlusEquals */ TokenFlags.AssignmentOperator,
             /*          MinusEquals */ TokenFlags.AssignmentOperator,
-            /*        MultipyEquals */ TokenFlags.AssignmentOperator,
+            /*       MultiplyEquals */ TokenFlags.AssignmentOperator,
             /*         DivideEquals */ TokenFlags.AssignmentOperator,
             /*      RemainderEquals */ TokenFlags.AssignmentOperator,
             /*          Redirection */ TokenFlags.DisallowedInRestrictedMode,
@@ -990,7 +990,7 @@ namespace System.Management.Automation.Language
             /*               Equals */ "=",
             /*           PlusEquals */ "+=",
             /*          MinusEquals */ "-=",
-            /*        MultipyEquals */ "*=",
+            /*       MultiplyEquals */ "*=",
             /*         DivideEquals */ "/=",
             /*      RemainderEquals */ "%=",
             /*          Redirection */ "redirection",

--- a/src/System.Management.Automation/engine/parser/tokenizer.cs
+++ b/src/System.Management.Automation/engine/parser/tokenizer.cs
@@ -188,7 +188,7 @@ namespace System.Management.Automation.Language
 
         /// <summary>
         /// Remove a single entry from the dynamic keyword collection
-        /// and clean up any assoicated data.
+        /// and clean up any associated data.
         /// </summary>
         /// <param name="name"></param>
         public static void RemoveKeyword(string name)
@@ -306,7 +306,7 @@ namespace System.Management.Automation.Language
         public bool MetaStatement { get; set; }
 
         /// <summary>
-        /// Indicate that the keyword is reservce for future use by powershell
+        /// Indicate that the keyword is reserved for future use by powershell
         /// </summary>
         public bool IsReservedKeyword { get; set; }
 
@@ -1497,7 +1497,7 @@ namespace System.Management.Automation.Language
                     }
                     else
                     {
-                        // Otherwise, the edit distance is the minumum
+                        // Otherwise, the edit distance is the minimum
                         // of doing an addition of a character, a deletion
                         // of a character, or a substitution of a character
                         distanceMap[row, column] = Math.Min(
@@ -2115,7 +2115,7 @@ namespace System.Management.Automation.Language
 
         private bool ScanAfterHereStringHeader(string header)
         {
-            // On entry, we've see the header.  We allow whitepace and require a newline before the actual string starts
+            // On entry, we've see the header.  We allow whitespace and require a newline before the actual string starts
             int headerOffset = _currentIndex - 2;
 
             char c;
@@ -3394,7 +3394,7 @@ namespace System.Management.Automation.Language
         internal Token GetLBracket()
         {
             // We know we want a '[' token or no token.  We are in a context where we expect an attribute/type constraint
-            // and allow any whitespace/commments before the '[', but nothing else (the caller has already skipped newlines
+            // and allow any whitespace/comments before the '[', but nothing else (the caller has already skipped newlines
             // if appropriate.)  This is handled specially because in command mode, a generic token may begin with '[', but
             // we don't want anything more than the '['.
 

--- a/src/System.Management.Automation/engine/pipeline.cs
+++ b/src/System.Management.Automation/engine/pipeline.cs
@@ -349,7 +349,7 @@ namespace System.Management.Automation.Internal
 
                 commandProcessor.AddedToPipelineAlready = true;
             }
-            // 2003/08/11-JonN Subseqent commands must have predecessor
+            // 2003/08/11-JonN Subsequent commands must have predecessor
             else if (readFromCommand > _commands.Count || readFromCommand <= 0)
             {
                 // "invalid command number"
@@ -1002,7 +1002,7 @@ namespace System.Management.Automation.Internal
                 // Generate new Activity Id for the thread
                 Guid pipelineActivityId = EtwActivity.CreateActivityId();
 
-                // commandProcess.PieplineActivityId = new Activity id
+                // commandProcess.PipelineActivityId = new Activity id
                 EtwActivity.SetActivityId(pipelineActivityId);
                 commandProcessor.PipelineActivityId = pipelineActivityId;
 

--- a/src/System.Management.Automation/engine/regex.cs
+++ b/src/System.Management.Automation/engine/regex.cs
@@ -431,7 +431,7 @@ namespace System.Management.Automation
 
         /// <summary>
         /// Constructs an instance of the WildcardPatternException object taking
-        /// a message parameter to use in cnstructing the exception.
+        /// a message parameter to use in constructing the exception.
         /// </summary>
         /// <param name="message">The string to use as the exception message</param>
         public WildcardPatternException(string message) : base(message)

--- a/src/System.Management.Automation/engine/remoting/client/ClientRemotePowerShell.cs
+++ b/src/System.Management.Automation/engine/remoting/client/ClientRemotePowerShell.cs
@@ -610,7 +610,7 @@ namespace System.Management.Automation.Runspaces.Internal
         /// PSRP layer.
         /// </summary>
         /// <param name="sender">Sender of this event, unused.</param>
-        /// <param name="e">Event arugments.</param>
+        /// <param name="e">Event arguments.</param>
         private void HandleConnectCompleted(object sender, RemoteDataEventArgs<Exception> e)
         {
             // After initial connect/reconnect set state to "Running".  Later events

--- a/src/System.Management.Automation/engine/remoting/client/Job.cs
+++ b/src/System.Management.Automation/engine/remoting/client/Job.cs
@@ -570,7 +570,7 @@ namespace System.Management.Automation
         /// <summary>
         /// Wait Handle which is signaled when job is finished.
         /// This is set when state of the job is set to Completed,
-        /// Stopped or Failied.
+        /// Stopped or Failed.
         /// </summary>
         public WaitHandle Finished
         {
@@ -1408,7 +1408,7 @@ namespace System.Management.Automation
                 }
 
 #pragma warning disable 56500
-                //Exception rasied in the eventhandler are not error in job.
+                //Exception raised in the eventhandler are not error in job.
                 //silently ignore them.
                 try
                 {
@@ -1778,7 +1778,7 @@ namespace System.Management.Automation
                         int throttleLimit, string name)
             : base(remoteCommand, name)
         {
-            // Create chiild jobs for each object in the list
+            // Create child jobs for each object in the list
             for (int i = 0; i < remoteRunspaceInfos.Length; i++)
             {
                 ExecutionCmdletHelperRunspace helper = (ExecutionCmdletHelperRunspace)runspaceHelpers[i];
@@ -2661,7 +2661,7 @@ namespace System.Management.Automation
             }
             else
             {
-                // Will have to raise OpertionComplete from here,
+                // Will have to raise OperationComplete from here,
                 // else ThrottleManager will have
                 SendStopComplete();
             }
@@ -4081,7 +4081,7 @@ namespace System.Management.Automation
 
     /// <summary>
     /// This job is used for running as a job the results from multiple
-    /// pipelines. This is used in synchronouse Invoke-Expression execution
+    /// pipelines. This is used in synchronous Invoke-Expression execution
     /// </summary>
     /// <remarks>
     /// TODO: I am not sure whether to change this internal to just InvokeExpressionSyncJob.

--- a/src/System.Management.Automation/engine/remoting/client/Job2.cs
+++ b/src/System.Management.Automation/engine/remoting/client/Job2.cs
@@ -45,7 +45,7 @@ namespace System.Management.Automation
     /// <remarks>The following are some of the notes about
     /// why the asynchronous operations are provided this way
     /// in this class. There are two possible options in which
-    /// asynchornous support can be provided:
+    /// asynchronous support can be provided:
     ///     1. Classical pattern (Begin and End)
     ///     2. Event based pattern
     ///     
@@ -212,7 +212,7 @@ namespace System.Management.Automation
         /// start a job. The job will be started with the parameters
         /// specified in StartParameters
         /// </summary>
-        /// <remarks>It is redudant to have a method named StartJob
+        /// <remarks>It is redundant to have a method named StartJob
         /// on a job class. However, this is done so as to avoid
         /// an FxCop violation "CA1716:IdentifiersShouldNotMatchKeywords"
         /// Stop and Resume are reserved keyworks in C# and hence cannot
@@ -257,7 +257,7 @@ namespace System.Management.Automation
         }
 
         /// <summary>
-        /// Method which can be exteded or called by derived 
+        /// Method which can be extended or called by derived 
         /// classes to raise the event when suspending a 
         /// job is completed
         /// </summary>
@@ -801,7 +801,7 @@ namespace System.Management.Automation
                 catch (Exception e)
                 {
                     // These exceptions are thrown by third party code. Adding them here to the collection
-                    // of execution errors to present consistant behavior of the object.
+                    // of execution errors to present consistent behavior of the object.
 
                     ExecutionError.Add(new ErrorRecord(e, "ContainerParentJobStartError",
                                                        ErrorCategory.InvalidResult, child));
@@ -985,7 +985,7 @@ namespace System.Management.Automation
                 catch (Exception e)
                 {
                     // These exceptions are thrown by third party code. Adding them here to the collection
-                    // of execution errors to present consistant behavior of the object.
+                    // of execution errors to present consistent behavior of the object.
 
                     ExecutionError.Add(new ErrorRecord(e, "ContainerParentJobResumeError",
                                                        ErrorCategory.InvalidResult, child));
@@ -1221,7 +1221,7 @@ namespace System.Management.Automation
                 catch (Exception e)
                 {
                     // These exceptions are thrown by third party code. Adding them here to the collection
-                    // of execution errors to present consistant behavior of the object.
+                    // of execution errors to present consistent behavior of the object.
 
                     ExecutionError.Add(new ErrorRecord(e, "ContainerParentJobUnblockError",
                         ErrorCategory.InvalidResult, child));
@@ -1390,7 +1390,7 @@ namespace System.Management.Automation
                 catch (Exception e)
                 {
                     // These exceptions are thrown by third party code. Adding them here to the collection
-                    // of execution errors to present consistant behavior of the object.
+                    // of execution errors to present consistent behavior of the object.
 
                     ExecutionError.Add(new ErrorRecord(e, "ContainerParentJobSuspendError",
                                                        ErrorCategory.InvalidResult, child));
@@ -1563,7 +1563,7 @@ namespace System.Management.Automation
                 catch (Exception e)
                 {
                     // These exceptions are thrown by third party code. Adding them here to the collection
-                    // of execution errors to present consistant behavior of the object.
+                    // of execution errors to present consistent behavior of the object.
 
                     ExecutionError.Add(new ErrorRecord(e, "ContainerParentJobStopError",
                                                        ErrorCategory.InvalidResult, child));

--- a/src/System.Management.Automation/engine/remoting/client/JobManager.cs
+++ b/src/System.Management.Automation/engine/remoting/client/JobManager.cs
@@ -181,7 +181,7 @@ namespace System.Management.Automation
         /// <summary>
         /// Creates a new job of the appropriate type given by JobDefinition passed in.
         /// </summary>
-        /// <param name="definition">JobDefiniton defining the command.</param>
+        /// <param name="definition">JobDefinition defining the command.</param>
         /// <returns>Job2 object of the appropriate type specified by the definition.</returns>
         /// <exception cref="InvalidOperationException">If JobSourceAdapter type specified
         /// in definition is not registered.</exception>

--- a/src/System.Management.Automation/engine/remoting/client/JobSourceAdapter.cs
+++ b/src/System.Management.Automation/engine/remoting/client/JobSourceAdapter.cs
@@ -50,7 +50,7 @@ namespace System.Management.Automation
         private string _moduleName;
 
         /// <summary>
-        /// Module name for the module contianing
+        /// Module name for the module containing
         /// the source adapter implementation.
         /// </summary>
         public string ModuleName
@@ -169,7 +169,7 @@ namespace System.Management.Automation
     /// be passed to a job so that the job can be
     /// instantiated without having to specify
     /// the parameters explicitly. Helps in 
-    /// passivating job parameters to disk
+    /// passing job parameters to disk
     /// </summary>
     /// <remarks>This class is not required if
     /// CommandParameterCollection adds a public

--- a/src/System.Management.Automation/engine/remoting/client/PSProxyJob.cs
+++ b/src/System.Management.Automation/engine/remoting/client/PSProxyJob.cs
@@ -1128,7 +1128,7 @@ namespace System.Management.Automation
                         }
                         catch (Exception e)
                         {
-                            // Trasfer exception via event arguments.
+                            // Transfer exception via event arguments.
                             OnStopJobCompleted(new AsyncCompletedEventArgs(e, false, null));
                         }
                         break;
@@ -1792,7 +1792,7 @@ namespace System.Management.Automation
                                                                       ChildJobs.Count,
                                                                       out computedJobState))
                 return;
-            if (computedJobState == JobState.Suspending) return; // Ignor for proxy job
+            if (computedJobState == JobState.Suspending) return; // Ignore for proxy job
 
             _tracer.WriteMessage(ClassNameTrace, "HandleChildProxyJobStateChanged", Guid.Empty, this,
                                  "storing job state to {0}", computedJobState.ToString());

--- a/src/System.Management.Automation/engine/remoting/client/PowerShellStreams.cs
+++ b/src/System.Management.Automation/engine/remoting/client/PowerShellStreams.cs
@@ -55,7 +55,7 @@ namespace System.Management.Automation
         private bool _disposed;
 
         /// <summary>
-        /// Private object for thread-safe exection.
+        /// Private object for thread-safe execution.
         /// </summary>
         private readonly object _syncLock = new object();
 
@@ -98,7 +98,7 @@ namespace System.Management.Automation
         }
 
         /// <summary>
-        /// Disope implementation.
+        /// Dispose implementation.
         /// </summary>
         public void Dispose()
         {

--- a/src/System.Management.Automation/engine/remoting/client/RemoteRunspacePoolInternal.cs
+++ b/src/System.Management.Automation/engine/remoting/client/RemoteRunspacePoolInternal.cs
@@ -41,10 +41,10 @@ namespace System.Management.Automation.Runspaces.Internal
         /// The TypeTable to use while deserializing/serializing remote objects.
         /// TypeTable has the following information used by serializer:
         ///   1. SerializationMethod
-        ///   2. SerailizationDepth
+        ///   2. SerializationDepth
         ///   3. SpecificSerializationProperties
-        /// TypeTable has the following inforamtion used by deserializer:
-        ///   1. TargetTypeForDeserializaiton
+        /// TypeTable has the following information used by deserializer:
+        ///   1. TargetTypeForDeserialization
         ///   2. TypeConverter
         /// </param>
         /// <param name="host">Host associated with this runspacepool</param>
@@ -134,7 +134,7 @@ namespace System.Management.Automation.Runspaces.Internal
             this.instanceId = instanceId;
 
             // This indicates that this is a disconnected remote runspace pool and min/max values
-            // are currently unkown. These values will be updated once the object is connected.
+            // are currently unknown. These values will be updated once the object is connected.
             this.minPoolSz = -1;
             this.maxPoolSz = -1;
 
@@ -261,7 +261,7 @@ namespace System.Management.Automation.Runspaces.Internal
                     // same way it is set for runspaces.
                     availability = (AvailableForConnection) ?
                             RunspacePoolAvailability.None :     // Disconnected runspacepool available for connection.
-                            RunspacePoolAvailability.Busy;      // Disconnected runspacepool unavailble for connection.
+                            RunspacePoolAvailability.Busy;      // Disconnected runspacepool unavailable for connection.
                 }
                 else
                 {
@@ -518,7 +518,7 @@ namespace System.Management.Automation.Runspaces.Internal
 
             if (raiseEvents)
             {
-                // Private application data is senter after (post) connect.  We need
+                // Private application data is sent after (post) connect.  We need
                 // to wait for application data before raising the state change
                 // Connecting -> Opened event.
                 ThreadPool.QueueUserWorkItem(WaitAndRaiseConnectEventsProc, info);
@@ -695,7 +695,7 @@ namespace System.Management.Automation.Runspaces.Internal
         internal event EventHandler<RemoteDataEventArgs<RemoteHostCall>> HostCallReceived;
 
         /// <summary>
-        /// EventHandler used to report connecion URI redirections to the application
+        /// EventHandler used to report connection URI redirections to the application
         /// </summary>
         internal event EventHandler<RemoteDataEventArgs<Uri>> URIRedirectionReported;
 

--- a/src/System.Management.Automation/engine/remoting/client/RemotingErrorRecord.cs
+++ b/src/System.Management.Automation/engine/remoting/client/RemotingErrorRecord.cs
@@ -363,7 +363,7 @@ namespace System.Management.Automation.Remoting
         }
 
         /// <summary>
-        /// Overriden ToString() method
+        /// Overridden ToString() method
         /// </summary>
         /// <returns>returns the computername</returns>
         public override string ToString()

--- a/src/System.Management.Automation/engine/remoting/client/RemotingProtocol2.cs
+++ b/src/System.Management.Automation/engine/remoting/client/RemotingProtocol2.cs
@@ -359,7 +359,7 @@ namespace System.Management.Automation.Internal
         /// Event raised when RunspacePoolInitInfo is received. This is the first runspace pool message expected
         /// after connecting to an existing remote runspace pool. RemoteRunspacePoolInternal should use this 
         /// notification to set the state of a reconstructed runspace to "Opened State" and use the
-        /// minRusnpace and MaxRunspaces information to set its state
+        /// minRunspace and MaxRunspaces information to set its state
         /// </summary>
         internal event EventHandler<RemoteDataEventArgs<RunspacePoolInitInfo>> RSPoolInitInfoReceived;
 
@@ -400,7 +400,7 @@ namespace System.Management.Automation.Internal
         internal event EventHandler<RemoteDataEventArgs<PSObject>> SetMaxMinRunspacesResponseRecieved;
 
         /// <summary>
-        /// EventHandler used to report connecion URI redirections to the application
+        /// EventHandler used to report connection URI redirections to the application
         /// </summary>
         internal event EventHandler<RemoteDataEventArgs<Uri>> URIRedirectionReported;
 
@@ -490,7 +490,7 @@ namespace System.Management.Automation.Internal
 
                 lock (_syncObject)
                 {
-                    //We are doing this check because Establised event 
+                    //We are doing this check because Established event 
                     //is raised more than once
                     if (_createRunspaceCalled)
                     {
@@ -1024,7 +1024,7 @@ namespace System.Management.Automation.Internal
         /// <summary>
         /// Event that is raised when a remote connection is successfully closed. The event is raised
         /// from a WSMan transport thread. Since this thread can hold on to a HTTP
-        /// connection, the event handler should compelete processing as fast as possible.
+        /// connection, the event handler should complete processing as fast as possible.
         /// Importantly the event handler should not generate any call that results in a
         /// user request like host.ReadLine().
         /// 
@@ -1174,7 +1174,7 @@ namespace System.Management.Automation.Internal
             {
                 // its possible that in client input data is written in a thread
                 // other than the current thread. Since we want to write input
-                // to the server in the order in which it was recieved, this
+                // to the server in the order in which it was received, this
                 // operation of writing to the server need to be synced
                 // Also we need to ensure that all the data currently available
                 // for enumeration are written out before any newly added data
@@ -1351,7 +1351,7 @@ namespace System.Management.Automation.Internal
         }
 
         /// <summary>
-        /// Closes tranport manager.
+        /// Closes transport manager.
         /// </summary>
         internal void CloseConnectionAsync(Exception sessionCloseReason)
         {
@@ -1411,7 +1411,7 @@ namespace System.Management.Automation.Internal
         /// This does not ensure that the corresponding session/runspacepool is in connected stated
         /// Its the caller responsiblity to ensure that this is the case
         /// At the protocols layers, this logic is delegated to the transport layer.
-        /// WSMan tranport ensures that WinRS commands cannot be reconnected when the parent shell is not in connected state
+        /// WSMan transport ensures that WinRS commands cannot be reconnected when the parent shell is not in connected state
         /// </summary>
         internal void ReconnectAsync()
         {

--- a/src/System.Management.Automation/engine/remoting/client/RunspaceRef.cs
+++ b/src/System.Management.Automation/engine/remoting/client/RunspaceRef.cs
@@ -135,7 +135,7 @@ namespace System.Management.Automation.Remoting
         }
 
         /// <summary>
-        /// Creates the PSCommand when the runspace is not overriden
+        /// Creates the PSCommand when the runspace is not overridden
         /// </summary>
         private PSCommand CreatePsCommandNotOverriden(string line, bool isScript, bool? useNewScope)
         {

--- a/src/System.Management.Automation/engine/remoting/client/clientremotesession.cs
+++ b/src/System.Management.Automation/engine/remoting/client/clientremotesession.cs
@@ -43,7 +43,7 @@ namespace System.Management.Automation.Remoting
         internal RemoteSessionCapability ServerCapability { get; set; }
 
         /// <summary>
-        /// This is the shellName which indentifies the PowerShell configuration to launch
+        /// This is the shellName which identifies the PowerShell configuration to launch
         /// on remote machine.        
         /// </summary>
         internal string ShellName { get; set; }
@@ -75,7 +75,7 @@ namespace System.Management.Automation.Remoting
 
         /// <summary>
         /// Close the connection to the remote computer in an asynchronous manner.
-        /// Client side user can register an event handler with ConnectionClosed to minitor
+        /// Client side user can register an event handler with ConnectionClosed to monitor
         /// the connection state.
         /// </summary>
         public abstract void CloseAsync();
@@ -108,7 +108,7 @@ namespace System.Management.Automation.Remoting
         #region URI Redirection
 
         /// <summary>
-        /// Deleagate used to report connecion URI redirections to the application
+        /// Delegate used to report connection URI redirections to the application
         /// </summary>
         /// <param name="newURI">
         /// New URI to which the connection is being redirected to.
@@ -239,7 +239,7 @@ namespace System.Management.Automation.Remoting
         /// </summary>
         public override void CreateAsync()
         {
-            //Raise a CreateSession event in StateMachine. This start the process of connection and negotition to a new remote session
+            //Raise a CreateSession event in StateMachine. This start the process of connection and negotiation to a new remote session
             RemoteSessionStateMachineEventArgs startArg = new RemoteSessionStateMachineEventArgs(RemoteSessionEvent.CreateSession);
             SessionDataStructureHandler.StateMachine.RaiseEvent(startArg);
         }
@@ -249,7 +249,7 @@ namespace System.Management.Automation.Remoting
         /// </summary>
         public override void ConnectAsync()
         {
-            //Raise the connectsession event in statemachine. This start the process of connection and negotition to an existing remote session
+            //Raise the connectsession event in statemachine. This start the process of connection and negotiation to an existing remote session
             RemoteSessionStateMachineEventArgs startArg = new RemoteSessionStateMachineEventArgs(RemoteSessionEvent.ConnectSession);
             SessionDataStructureHandler.StateMachine.RaiseEvent(startArg);
         }
@@ -267,7 +267,7 @@ namespace System.Management.Automation.Remoting
         }
 
         /// <summary>
-        /// Temporaritly suspends connection to a connected remote session
+        /// Temporarily suspends connection to a connected remote session
         /// </summary>
         public override void DisconnectAsync()
         {
@@ -487,7 +487,7 @@ namespace System.Management.Automation.Remoting
         /// Verifies the negotiation packet received from the server
         /// </summary>
         /// <param name="serverRemoteSessionCapability">
-        /// Capablities of remote session
+        /// Capabilities of remote session
         /// </param>
         /// <returns> 
         /// The method returns true if the capability negotiation is successful.
@@ -567,7 +567,7 @@ namespace System.Management.Automation.Remoting
             return true;
         }
 
-        #endregion negotioation
+        #endregion negotiation
 
         internal override RemotingDestination MySelf { get; }
 

--- a/src/System.Management.Automation/engine/remoting/client/clientremotesessionprotocolstatemachine.cs
+++ b/src/System.Management.Automation/engine/remoting/client/clientremotesessionprotocolstatemachine.cs
@@ -577,7 +577,7 @@ namespace System.Management.Automation.Remoting
         #region Event Handlers
 
         /// <summary>
-        /// This is the handler for CreateSession event of the FSM. This is the begining of everything
+        /// This is the handler for CreateSession event of the FSM. This is the beginning of everything
         /// else. From this moment on, the FSM will proceeds step by step to eventually reach
         /// Established state or Closed state.
         /// </summary>
@@ -612,7 +612,7 @@ namespace System.Management.Automation.Remoting
 
 
         /// <summary>
-        /// This is the handler for ConnectSession event of the FSM. This is the begining of everything
+        /// This is the handler for ConnectSession event of the FSM. This is the beginning of everything
         /// else. From this moment on, the FSM will proceeds step by step to eventually reach
         /// Established state or Closed state.
         /// </summary>
@@ -633,7 +633,7 @@ namespace System.Management.Automation.Remoting
 
                 if (State == RemoteSessionState.Idle)
                 {
-                    //We need to send negotiotion and connect algorithm related info 
+                    //We need to send negotiation and connect algorithm related info 
                     //Change state to let other DSHandlers add appropriate messages to be piggybacked on transport's Create payload
                     RemoteSessionStateMachineEventArgs sendingArg = new RemoteSessionStateMachineEventArgs(RemoteSessionEvent.NegotiationSendingOnConnect);
                     RaiseEvent(sendingArg);

--- a/src/System.Management.Automation/engine/remoting/client/remotepipeline.cs
+++ b/src/System.Management.Automation/engine/remoting/client/remotepipeline.cs
@@ -636,7 +636,7 @@ namespace System.Management.Automation
         /// <summary>
         /// Disposes the pipeline
         /// </summary>
-        /// <param name="disposing">true, when called on Dipose()</param>       
+        /// <param name="disposing">true, when called on Dispose()</param>       
         protected override void Dispose(bool disposing)
         {
             try
@@ -786,7 +786,7 @@ namespace System.Management.Automation
             // using the copyStateInfo here as this piece of code is 
             // outside of lock and _pipelineStateInfo might get changed
             // by two threads running concurrently..so its value is 
-            // not gauranteed to be the same for this entire method call.
+            // not guaranteed to be the same for this entire method call.
             // copyStateInfo is a local variable.
             if (copyStateInfo.State == PipelineState.Completed ||
                 copyStateInfo.State == PipelineState.Failed ||
@@ -835,7 +835,7 @@ namespace System.Management.Automation
                         _runspace.RaiseAvailabilityChangedEvent(queueItem.NewRunspaceAvailability);
                     }
 
-                    //Exception rasied in the eventhandler are not error in pipeline.
+                    //Exception raised in the eventhandler are not error in pipeline.
                     //silently ignore them.
                     if (stateChanged != null)
                     {

--- a/src/System.Management.Automation/engine/remoting/client/remoterunspace.cs
+++ b/src/System.Management.Automation/engine/remoting/client/remoterunspace.cs
@@ -113,10 +113,10 @@ namespace System.Management.Automation
         /// The TypeTable to use while deserializing/serializing remote objects.
         /// TypeTable has the following information used by serializer:
         ///   1. SerializationMethod
-        ///   2. SerailizationDepth
+        ///   2. SerializationDepth
         ///   3. SpecificSerializationProperties
-        /// TypeTable has the following inforamtion used by deserializer:
-        ///   1. TargetTypeForDeserializaiton
+        /// TypeTable has the following information used by deserializer:
+        ///   1. TargetTypeForDeserialization
         ///   2. TypeConverter
         /// </param>
         /// <param name="connectionInfo">connection information which identifies
@@ -176,7 +176,7 @@ namespace System.Management.Automation
             SetRunspaceState(RunspaceState.Disconnected, null);
 
             // Normal Availability for a disconnected runspace is "None", which means it can be connected.
-            // However, we can also have disconnected runspace objects that are *not* avaialable for 
+            // However, we can also have disconnected runspace objects that are *not* available for 
             // connection and in this case the Availability is set to "Busy".
             _runspaceAvailability = RunspacePool.RemoteRunspacePoolInternal.AvailableForConnection ?
                 Runspaces.RunspaceAvailability.None : Runspaces.RunspaceAvailability.Busy;
@@ -703,7 +703,7 @@ namespace System.Management.Automation
         /// accidental dependencies on prior runspace state.
         /// </summary>
         /// <exception cref="PSInvalidOperationException">
-        /// Thrown when runspace is not in proper state or avaialablity or if the
+        /// Thrown when runspace is not in proper state or availability or if the
         /// reset operation fails in the remote session.
         /// </exception>
         public override void ResetRunspaceState()
@@ -1037,11 +1037,11 @@ namespace System.Management.Automation
 
 
         /// <summary>
-        /// Createa a pipeline froma command string
+        /// Create a pipeline from a command string
         /// </summary>
         /// <param name="command">A valid command string</param>
         /// <returns>
-        /// A pipline pre-filled with Commands specified in commandString.
+        /// A pipeline pre-filled with Commands specified in commandString.
         /// </returns>
         /// <exception cref="ArgumentNullException">
         /// command is null
@@ -1062,7 +1062,7 @@ namespace System.Management.Automation
         /// <param name="command">A valid command string</param>
         /// <param name="addToHistory">if true command is added to history</param>
         /// <returns>
-        /// A pipline pre-filled with Commands specified in commandString.
+        /// A pipeline pre-filled with Commands specified in commandString.
         /// </returns>
         /// <exception cref="ArgumentNullException">
         /// command is null
@@ -1098,7 +1098,7 @@ namespace System.Management.Automation
         /// <param name="command">A valid command string</param>
         /// <param name="addToHistory">if true command is added to history</param>
         /// <returns>
-        /// A pipline pre-filled with Commands specified in commandString.
+        /// A pipeline pre-filled with Commands specified in commandString.
         /// </returns>
         /// <exception cref="PSNotSupportedException">Not supported in remoting
         /// scenarios</exception>
@@ -1156,7 +1156,7 @@ namespace System.Management.Automation
                     throw e;
                 }
 
-                //Add the pipeline to list of Excuting pipeline.
+                //Add the pipeline to list of Executing pipeline.
                 //Note:_runningPipelines is always accessed with the lock so
                 //there is no need to create a synchronized version of list
                 _runningPipelines.Add(pipeline);
@@ -1181,7 +1181,7 @@ namespace System.Management.Automation
                 Dbg.Assert(_runspaceStateInfo.State != RunspaceState.BeforeOpen,
                              "Runspace should not be before open when pipeline is running");
 
-                //Remove the pipeline to list of Excuting pipeline.
+                //Remove the pipeline to list of Executing pipeline.
                 //Note:_runningPipelines is always accessed with the lock so
                 //there is no need to create a synchronized version of list
                 _runningPipelines.Remove(pipeline);
@@ -1255,7 +1255,7 @@ namespace System.Management.Automation
                             UpdateDisconnectExpiresOn();
 
                             // Application private data containing server debug state is updated on
-                            // a *reconstruct* connect operation when _applicatPrivateData is null.  
+                            // a *reconstruct* connect operation when _applicationPrivateData is null.  
                             // Pass new information to the debugger.
                             if (_applicationPrivateData == null)
                             {
@@ -1719,7 +1719,7 @@ namespace System.Management.Automation
 
         /// <summary>
         /// Keeps track of the current invoke command executing 
-        /// within the current local pipline
+        /// within the current local pipeline
         /// </summary>
         /// <param name="invokeCommand">reference to invoke command
         /// which is currently being processed</param>
@@ -1770,7 +1770,7 @@ namespace System.Management.Automation
         internal RunspacePool RunspacePool { get; }
 
         /// <summary>
-        /// EventHandler used to report connecion URI redirections to the application
+        /// EventHandler used to report connection URI redirections to the application
         /// </summary>
         internal event EventHandler<RemoteDataEventArgs<Uri>> URIRedirectionReported;
 

--- a/src/System.Management.Automation/engine/remoting/client/remotingprotocolimplementation.cs
+++ b/src/System.Management.Automation/engine/remoting/client/remotingprotocolimplementation.cs
@@ -135,7 +135,7 @@ namespace System.Management.Automation.Remoting
         private void HandleConnectComplete(object sender, EventArgs args)
         {
             //No-OP. Once the negotiation messages are exchanged and the session gets into established state,
-            //it will take care of spawning the receieve operation on the connected session
+            //it will take care of spawning the receive operation on the connected session
             // There is however a caveat. 
             // A rouge remote server if it does not send the required negotiation data in the Connect Response,
             // then the state machine can never get into the established state and the runspace can never get into a opened state
@@ -309,7 +309,7 @@ namespace System.Management.Automation.Remoting
             }
 
             // Close the transport manager only after powershell's close their transports
-            // Powershell's close their transport using the ConnectionStateChaged event notification.
+            // Powershell's close their transport using the ConnectionStateChanged event notification.
             if (arg.SessionStateInfo.State == RemoteSessionState.ClosingConnection)
             {
                 CloseConnectionAsync();
@@ -535,7 +535,7 @@ namespace System.Management.Automation.Remoting
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="dataArg">
-        /// arg which contains the data recevied from input queue
+        /// arg which contains the data received from input queue
         /// </param>
         internal void DispatchInputQueueData(object sender, RemoteDataEventArgs dataArg)
         {
@@ -575,7 +575,7 @@ namespace System.Management.Automation.Remoting
                     //Non Session messages do not change the state of the statemachine. 
                     //However instead of forwarding them to Runspace/pipeline here, an
                     //event is raised in state machine which verified that state is
-                    //suitable for accpeting these messages. if state is suitable statemachine
+                    //suitable for accepting these messages. if state is suitable statemachine
                     //will call DoMessageForwading which will forward the messages appropriately
                     RemoteSessionStateMachineEventArgs msgRcvArg = new RemoteSessionStateMachineEventArgs(RemoteSessionEvent.MessageReceived, null);
                     if (StateMachine.CanByPassRaiseEvent(msgRcvArg))
@@ -600,10 +600,10 @@ namespace System.Management.Automation.Remoting
 
         /// <summary>
         /// This processes the object received from transport which are 
-        /// targetted for session
+        /// targeted for session
         /// </summary>
         /// <param name="arg">
-        /// argument containg the data object
+        /// argument contains the data object
         /// </param>
         private void ProcessSessionMessages(RemoteDataEventArgs arg)
         {
@@ -671,7 +671,7 @@ namespace System.Management.Automation.Remoting
 
         /// <summary>
         /// This processes the object received from transport which are 
-        /// not targetted for session
+        /// not targeted for session
         /// </summary>
         /// <param name="rcvdData">
         /// received data.

--- a/src/System.Management.Automation/engine/remoting/commands/ConnectPSSession.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/ConnectPSSession.cs
@@ -973,7 +973,7 @@ namespace Microsoft.PowerShell.Commands
             if (ParameterSetName != ConnectPSSessionCommand.ConnectionUriParameterSet &&
                 ParameterSetName != ConnectPSSessionCommand.ConnectionUriGuidParameterSet)
             {
-                // uri redirection is supported only with URI parmeter set
+                // uri redirection is supported only with URI parameter set
                 connectionInfo.MaximumConnectionRedirectionCount = 0;
             }
 

--- a/src/System.Management.Automation/engine/remoting/commands/CustomShellCommands.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/CustomShellCommands.cs
@@ -38,7 +38,7 @@ namespace Microsoft.PowerShell.Commands
 {
     #region Register-PSSessionConfiguration cmdlet
     /// <summary>
-    /// Class implemeting Register-PSSessionConfiguration
+    /// Class implementing Register-PSSessionConfiguration
     /// </summary>
     [Cmdlet(VerbsLifecycle.Register, RemotingConstants.PSSessionConfigurationNoun,
         DefaultParameterSetName = PSSessionConfigurationCommandBase.NameParameterSetName,
@@ -1364,7 +1364,7 @@ else
         /// Checks if the current thread is running elevated. If not, throws an error.
         /// </summary>
         /// <exception cref="InvalidOperationException">
-        /// 1. Acess is denied. You need to run this cmdlet from an elevated process.
+        /// 1. Access is denied. You need to run this cmdlet from an elevated process.
         /// </exception>
         internal static void ThrowIfNotAdministrator()
         {
@@ -1641,7 +1641,7 @@ else
             sb.Append(prologue);
 
             //
-            // Convert to condtional ACE
+            // Convert to conditional ACE
             // Beginning (Regular) ACE has exactly 6 required fields and one (optional) field.
             // We only manipulate ACEs that we create and we currently do not use the optional resource field,
             // so we always expect a beginning ACE with exactly 6 fields.
@@ -1764,13 +1764,13 @@ else
         private const string MemberOfFormat = "Member_of {{SID({0})}}";
 
         /// <summary>
-        /// Parse RequiredGroups configruation and build conditional ACE string.
+        /// Parse RequiredGroups configuration and build conditional ACE string.
         /// </summary>
         /// <param name="configTable"></param>
         /// <returns></returns>
         // RequiredGroups:  @{ And = @{ Or = '2FA_GROUP_1', '2FA_GROUP_2' }, @{ Or = 'TRUSTEDHOSTS_1', 'TRUSTEDHOSTS_2' } }
-        // User ACE:        (XA;;GA;;;S-1-5-21-2127438184-1604012920-1882527527;CondionalPart)
-        // CondionalPart:   ((Member_of {SID(2FA_GROUP_1)} || Member_of {SID(2FA_GROUP_2)}) && (Member_of {SID(TRUSTEDHOSTS_1)} || Member_of {TRUSTEDHOSTS_2}))
+        // User ACE:        (XA;;GA;;;S-1-5-21-2127438184-1604012920-1882527527;ConditionalPart)
+        // ConditionalPart:   ((Member_of {SID(2FA_GROUP_1)} || Member_of {SID(2FA_GROUP_2)}) && (Member_of {SID(TRUSTEDHOSTS_1)} || Member_of {TRUSTEDHOSTS_2}))
         //         where:   2FA_GROUP_1, 2FA_GROUP_2, TRUSTEDHOSTS_1, TRUSTEDHOSTS_2 are resolved SIDs of the group names.
         // (https://msdn.microsoft.com/en-us/library/windows/desktop/dd981030(v=vs.85).aspx)
         internal static string CreateConditionalACEFromConfig(
@@ -2040,7 +2040,7 @@ else
         /// <summary>
         /// This parameter should be specified with AssemblyName. This supplies
         /// the type to load to get the InitialSessionState. The type should
-        /// be derivided from <see cref="PSSessionConfiguration"/>.
+        /// be derived from <see cref="PSSessionConfiguration"/>.
         /// </summary>
         [Parameter(Position = 2, Mandatory = true, ParameterSetName = PSSessionConfigurationCommandBase.AssemblyNameParameterSetName)]
         public string ConfigurationTypeName
@@ -2446,7 +2446,7 @@ else
     #region Unregister-PSSessionConfiguration cmdlet
 
     /// <summary>
-    /// Class implemeting Unregister-PSSessionConfiguration
+    /// Class implementing Unregister-PSSessionConfiguration
     /// </summary>
     [Cmdlet(VerbsLifecycle.Unregister, RemotingConstants.PSSessionConfigurationNoun,
         SupportsShouldProcess = true, ConfirmImpact = ConfirmImpact.Low, HelpUri = "http://go.microsoft.com/fwlink/?LinkID=144308")]
@@ -2668,7 +2668,7 @@ else
     #region Get-PSSessionConfiguration cmdlet
 
     /// <summary>
-    /// Class implemeting Get-PSSessionConfiguration
+    /// Class implementing Get-PSSessionConfiguration
     /// </summary>
     [Cmdlet(VerbsCommon.Get, RemotingConstants.PSSessionConfigurationNoun, HelpUri = "http://go.microsoft.com/fwlink/?LinkID=144304")]
     [OutputType("Microsoft.PowerShell.Commands.PSSessionConfigurationCommands#PSSessionConfiguration")]
@@ -2904,7 +2904,7 @@ $args[0] | foreach {{
     #region Set-PSSessionConfiguration cmdlet
 
     /// <summary>
-    /// Class implemeting Set-PSSessionConfiguration
+    /// Class implementing Set-PSSessionConfiguration
     /// </summary>
     [Cmdlet(VerbsCommon.Set, RemotingConstants.PSSessionConfigurationNoun,
        DefaultParameterSetName = PSSessionConfigurationCommandBase.NameParameterSetName,
@@ -3958,7 +3958,7 @@ Set-PSSessionConfiguration $args[0] $args[1] $args[2] $args[3] $args[4] $args[5]
                                     }
                                 }
                                 // if ModulesToImport doesn't exist in the pssessionConfigurationData, we don't need to do anything.
-                                // in this case, if the current config is of type workfolw, it's not a valid config.
+                                // in this case, if the current config is of type workflow, it's not a valid config.
                             }
                             else
                             {
@@ -4786,7 +4786,7 @@ param(
             if ($pa -eq ""x86"")
             {{
                 # on 64-bit platforms, wow64 bit process has the correct architecture
-                # available in processor_architew6432 varialbe
+                # available in processor_architew6432 variable
                 $pa = $env:PROCESSOR_ARCHITEW6432
             }}
             if ((($pa -eq ""amd64"")) -and (test-path $env:windir\syswow64\pwrshplugin.dll))
@@ -5191,7 +5191,7 @@ Disable-PSRemoting -force:$args[0] -queryForSet $args[1] -captionForSet $args[2]
         #region Cmdlet Override
 
         /// <summary>
-        /// Check for prerequisites and eleveation mode
+        /// Check for prerequisites and elevation mode
         /// </summary>
         protected override void BeginProcessing()
         {

--- a/src/System.Management.Automation/engine/remoting/commands/GetJob.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/GetJob.cs
@@ -104,7 +104,7 @@ namespace Microsoft.PowerShell.Commands
         #region Overrides
 
         /// <summary>
-        /// Extract resutl objects corresponding to the specified 
+        /// Extract result objects corresponding to the specified 
         /// names or expressions
         /// </summary>
         protected override void ProcessRecord()

--- a/src/System.Management.Automation/engine/remoting/commands/InvokeCommandCommand.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/InvokeCommandCommand.cs
@@ -573,7 +573,7 @@ namespace Microsoft.PowerShell.Commands
         }
 
         /// <summary>
-        /// The AllowRediraction parameter enables the implicit redirection functionality
+        /// The AllowRedirection parameter enables the implicit redirection functionality
         /// </summary>
         [Parameter(ParameterSetName = InvokeCommandCommand.UriParameterSet)]
         [Parameter(ParameterSetName = InvokeCommandCommand.FilePathUriParameterSet)]
@@ -882,7 +882,7 @@ namespace Microsoft.PowerShell.Commands
                                     // be using protocol version 2.2. Otherwise, we skip this and assume the old behavior.
                                     if (version >= RemotingConstants.ProtocolVersionWin8RTM)
                                     {
-                                        // Supress collection behavior
+                                        // Suppress collection behavior
                                         _needToCollect = false;
                                         _needToStartSteppablePipelineOnServer = true;
                                         break;
@@ -1948,7 +1948,7 @@ namespace Microsoft.PowerShell.Commands
                     }
                 }
             }
-        } // Dipose
+        } // Dispose
 
         #endregion IDisposable Overrides
     }

--- a/src/System.Management.Automation/engine/remoting/commands/NewPSSessionConfigurationFile.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/NewPSSessionConfigurationFile.cs
@@ -285,7 +285,7 @@ namespace Microsoft.PowerShell.Commands
         private IDictionary _requiredGroups;
 
         /// <summary>
-        /// Languange mode
+        /// Language mode
         /// </summary>
         [Parameter()]
         public PSLanguageMode LanguageMode
@@ -446,7 +446,7 @@ namespace Microsoft.PowerShell.Commands
         private string[] _visibleProviders = Utils.EmptyArray<string>();
 
         /// <summary>
-        /// A list of alises
+        /// A list of aliases
         /// </summary>
         [Parameter()]
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays")]
@@ -1309,7 +1309,7 @@ namespace Microsoft.PowerShell.Commands
         private string[] _scriptsToProcess = Utils.EmptyArray<string>();
 
         /// <summary>
-        /// A list of alises
+        /// A list of aliases
         /// </summary>
         [Parameter()]
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays")]

--- a/src/System.Management.Automation/engine/remoting/commands/NewPSSessionOptionCommand.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/NewPSSessionOptionCommand.cs
@@ -164,7 +164,7 @@ namespace System.Management.Automation.Remoting
 
         /// <summary>
         /// Specifies that no encryption will be used when doing remote operations over 
-        /// http. Unencrypted traffix is not allowed by default and must be enabled in 
+        /// http. Unencrypted traffic is not allowed by default and must be enabled in 
         /// the local configuration
         /// </summary>
         public bool NoEncryption { get; set; }
@@ -525,7 +525,7 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// The following is the definition of the input parameter "UnEncrypted".
         /// Specifies that no encryption will be used when doing remote operations over 
-        /// http. Unencrypted traffix is not allowed by default and must be enabled in 
+        /// http. Unencrypted traffic is not allowed by default and must be enabled in 
         /// the local configuration
         /// </summary>
         [Parameter]

--- a/src/System.Management.Automation/engine/remoting/commands/PSRemotingCmdlet.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/PSRemotingCmdlet.cs
@@ -110,7 +110,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         /// <param name="resourceString">resource String which holds the message
         /// </param>
-        /// <returns>Error message loaded from appropriate resouce cache</returns>
+        /// <returns>Error message loaded from appropriate resource cache</returns>
         internal String GetMessage(string resourceString)
         {
             String message = GetMessage(resourceString, null);
@@ -603,7 +603,7 @@ namespace Microsoft.PowerShell.Commands
         public virtual Uri[] ConnectionUri { get; set; }
 
         /// <summary>
-        /// The AllowRediraction parameter enables the implicit redirection functionality
+        /// The AllowRedirection parameter enables the implicit redirection functionality
         /// </summary>
         [Parameter(ParameterSetName = PSRemotingBaseCmdlet.UriParameterSet)]
         public virtual SwitchParameter AllowRedirection
@@ -723,7 +723,7 @@ namespace Microsoft.PowerShell.Commands
         /// Used to resolve authentication from the parameters chosen by the user.
         /// User has the following options:
         /// 1. AuthMechanism + Credential
-        /// 2. CertiticateThumbPrint
+        /// 2. CertificateThumbPrint
         /// 
         /// All the above are mutually exclusive.
         /// </summary>
@@ -814,7 +814,7 @@ namespace Microsoft.PowerShell.Commands
 
             if (!ParameterSetName.Equals(PSRemotingBaseCmdlet.UriParameterSet, StringComparison.OrdinalIgnoreCase))
             {
-                // uri redirection is supported only with URI parmeter set
+                // uri redirection is supported only with URI parameter set
                 connectionInfo.MaximumConnectionRedirectionCount = 0;
             }
 
@@ -2834,11 +2834,11 @@ namespace Microsoft.PowerShell.Commands
         }
 
         /// <summary>
-        /// Write the maching runspace objects down the pipeline, or add to the list.
+        /// Write the matching runspace objects down the pipeline, or add to the list.
         /// </summary>
-        /// <param name="matchingRunspaceInfos">The maching runspaces</param>
+        /// <param name="matchingRunspaceInfos">The matching runspaces</param>
         /// <param name="writeobject">if true write the object down the pipeline. Otherwise, add to the list</param>
-        /// <param name="matches">The list we add the maching runspaces to</param>        
+        /// <param name="matches">The list we add the matching runspaces to</param>        
         private void WriteOrAddMatches(List<PSSession> matchingRunspaceInfos,
             bool writeobject,
             ref Dictionary<Guid, PSSession> matches)
@@ -3015,7 +3015,7 @@ namespace Microsoft.PowerShell.Commands
             }
             else
             {
-                // will have to raise OpertionComplete from here,
+                // will have to raise OperationComplete from here,
                 // else ThrottleManager will have
                 RaiseOperationCompleteEvent();
             }
@@ -3237,7 +3237,7 @@ namespace Microsoft.PowerShell.Commands
                     break;
                 case RunspaceState.Closed:
                     {
-                        // raise a OpertionComplete event with
+                        // raise a OperationComplete event with
                         // StopComplete message 
                         if (stateEventArgs.RunspaceStateInfo.Reason != null)
                         {

--- a/src/System.Management.Automation/engine/remoting/commands/ReceiveJob.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/ReceiveJob.cs
@@ -22,7 +22,7 @@ using System.Management.Automation.Internal;
 namespace Microsoft.PowerShell.Commands
 {
     /// <summary>
-    /// Cmdlet used for receiveing results from job object. 
+    /// Cmdlet used for receiving results from job object. 
     /// This cmdlet is intended to have a slightly different behavior
     /// in the following two cases:
     ///          1. The job object to receive results from is a PSRemotingJob

--- a/src/System.Management.Automation/engine/remoting/commands/ReceivePSSession.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/ReceivePSSession.cs
@@ -23,7 +23,7 @@ namespace Microsoft.PowerShell.Commands
     ///    until the running command completes and all output data is received on 
     ///    the client.
     /// b) To a job object.  This is the asynchronous mode of the cmdlet which will
-    ///    return immmediately providing the job object that is collecting the 
+    ///    return immediately providing the job object that is collecting the 
     ///    running command output data.
     ///    
     /// The running command becomes disconnected when the associated runspace is 
@@ -408,7 +408,7 @@ namespace Microsoft.PowerShell.Commands
         /// in a job object that is returned (OutTarget.Job).
         /// </summary>
         /// <param name="name">Name of session to find.</param>
-        /// <param name="instanceId">Instnace Id of session to find.</param>
+        /// <param name="instanceId">Instance Id of session to find.</param>
         private void QueryForAndConnectCommands(string name, Guid instanceId)
         {
             WSManConnectionInfo connectionInfo = GetConnectionObject();
@@ -601,7 +601,7 @@ namespace Microsoft.PowerShell.Commands
             if (ParameterSetName != ReceivePSSessionCommand.ConnectionUriInstanceIdParameterSet &&
                 ParameterSetName != ReceivePSSessionCommand.ConnectionUriSessionNameParameterSet)
             {
-                // uri redirection is supported only with URI parmeter set
+                // uri redirection is supported only with URI parameter set
                 connectionInfo.MaximumConnectionRedirectionCount = 0;
             }
 
@@ -1313,7 +1313,7 @@ namespace Microsoft.PowerShell.Commands
         Host = 1,
 
         /// <summary>
-        /// Asyncronous mode.  Receive-PSSession ouput data goes to returned job object.
+        /// Asynchronous mode.  Receive-PSSession ouput data goes to returned job object.
         /// </summary>
         Job = 2
     }

--- a/src/System.Management.Automation/engine/remoting/commands/RemoveJob.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/RemoveJob.cs
@@ -48,7 +48,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         /// 
         /// <param name="writeobject">if true, method writes the object instead of returning it
-        /// in list (an empty list is retuened). </param>
+        /// in list (an empty list is returned). </param>
         /// <param name="writeErrorOnNoMatch">write error if no match is found</param>
         /// <param name="checkIfJobCanBeRemoved">check if this job can be removed</param>
         /// <param name="recurse">recurse and check in child jobs</param>
@@ -181,7 +181,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         /// 
         /// <param name="writeobject">if true, method writes the object instead of returning it
-        /// in list (an empty list is retuened). </param>
+        /// in list (an empty list is returned). </param>
         /// <param name="writeErrorOnNoMatch">write error if no match is found</param>
         /// <param name="checkIfJobCanBeRemoved">check if this job can be removed</param>
         /// <param name="recurse">look in all child jobs</param>
@@ -297,7 +297,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         /// 
         /// <param name="writeobject">if true, method writes the object instead of returning it
-        /// in list (an empty list is retuened). </param>
+        /// in list (an empty list is returned). </param>
         /// <param name="writeErrorOnNoMatch">write error if no match is found</param>
         /// <param name="checkIfJobCanBeRemoved">check if this job can be removed</param>
         /// <param name="recurse">look in child jobs as well</param>
@@ -401,7 +401,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         /// 
         /// <param name="writeobject">if true, method writes the object instead of returning it
-        /// in list (an empty list is retuened). </param>
+        /// in list (an empty list is returned). </param>
         /// <returns>list of matching jobs</returns>
         internal List<Job> FindJobsMatchingByCommand(
             bool writeobject)
@@ -431,7 +431,7 @@ namespace Microsoft.PowerShell.Commands
                     WildcardPattern commandPattern = WildcardPattern.Get(command, WildcardOptions.IgnoreCase);
                     string jobCommand = job.Command.Trim();
                     // Win8: 469830
-                    // Win7 code does not have commandPattern.IsMatch. We added wildcard support for Command parmaeterset
+                    // Win7 code does not have commandPattern.IsMatch. We added wildcard support for Command parameterset
                     // in Win8 which breaks scenarios where the actual command has wildcards.)
                     if (jobCommand.Equals(command.Trim(), StringComparison.OrdinalIgnoreCase) || commandPattern.IsMatch(jobCommand))
                     {
@@ -454,7 +454,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         /// 
         /// <param name="writeobject">if true, method writes the object instead of returning it
-        /// in list (an empty list is retuened). </param>
+        /// in list (an empty list is returned). </param>
         /// <returns>list of matching jobs</returns>
         internal List<Job> FindJobsMatchingByState(
             bool writeobject)
@@ -550,7 +550,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         /// <param name="jobs"></param>
         /// <param name="writeobject">if true, method writes the object instead of returning it
-        /// in list (an empty list is retuened). </param>
+        /// in list (an empty list is returned). </param>
         /// <param name="checkIfJobCanBeRemoved">if true, only jobs which can be removed will be checked</param>
         /// <returns></returns>
         internal List<Job> CopyJobsToList(Job[] jobs, bool writeobject, bool checkIfJobCanBeRemoved)
@@ -884,7 +884,7 @@ namespace Microsoft.PowerShell.Commands
                 if (!job.IsFinishedState(job.JobStateInfo.State))
                 {
                     // if it is a Job2, then async is supported
-                    // stop the job asynchornously
+                    // stop the job asynchronously
                     if (job2 != null)
                     {
                         _cleanUpActions.Add(job2, HandleStopJobCompleted);

--- a/src/System.Management.Automation/engine/remoting/commands/ResumeJob.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/ResumeJob.cs
@@ -120,7 +120,7 @@ namespace Microsoft.PowerShell.Commands
 
             _allJobsToResume.AddRange(jobsToResume);
 
-            // Blue: 151804 When resuming a single suspended workfllow job, Resume-job cmdlet doesn't wait for the job to be in running state
+            // Blue: 151804 When resuming a single suspended workflow job, Resume-job cmdlet doesn't wait for the job to be in running state
             // Setting Wait to true so that this cmdlet will wait for the running job state.
             if (_allJobsToResume.Count == 1)
                 Wait = true;

--- a/src/System.Management.Automation/engine/remoting/commands/StartJob.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/StartJob.cs
@@ -31,7 +31,7 @@ namespace Microsoft.PowerShell.Commands
         private const string DefinitionNameParameterSet = "DefinitionName";
 
         /// <summary>
-        /// JobDefintion Name.
+        /// JobDefinition Name.
         /// </summary>
         [Parameter(Position = 0, Mandatory = true,
                    ParameterSetName = StartJobCommand.DefinitionNameParameterSet)]
@@ -671,7 +671,7 @@ namespace Microsoft.PowerShell.Commands
             {
                 CloseAllInputStreams();
             }
-        } // Dipose
+        } // Dispose
 
         #endregion IDisposable Overrides
     }

--- a/src/System.Management.Automation/engine/remoting/commands/StopJob.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/StopJob.cs
@@ -14,7 +14,7 @@ using System.Threading;
 namespace Microsoft.PowerShell.Commands
 {
     /// <summary>
-    /// This cmdlet stops the asynchronously invoked remote operaitons.
+    /// This cmdlet stops the asynchronously invoked remote operations.
     /// </summary>
     [Cmdlet(VerbsLifecycle.Stop, "Job", SupportsShouldProcess = true, DefaultParameterSetName = JobCmdletBase.SessionIdParameterSet,
         HelpUri = "http://go.microsoft.com/fwlink/?LinkID=113413")]
@@ -141,7 +141,7 @@ namespace Microsoft.PowerShell.Commands
                 {
                     Job2 job2 = job as Job2;
                     // if it is a Job2, then async is supported
-                    // stop the job asynchornously
+                    // stop the job asynchronously
                     if (job2 != null)
                     {
                         _cleanUpActions.Add(job2, HandleStopJobCompleted);

--- a/src/System.Management.Automation/engine/remoting/commands/SuspendJob.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/SuspendJob.cs
@@ -201,7 +201,7 @@ namespace Microsoft.PowerShell.Commands
                         }
                     }
 
-                    // there could be possiblility that the job gets completed befor or after the 
+                    // there could be possibility that the job gets completed before or after the 
                     // subscribing to nowait_job2_statechanged event so checking it again.
                     if (!_wait && (job2.IsFinishedState(job2.JobStateInfo.State) || job2.JobStateInfo.State == JobState.Suspending || job2.JobStateInfo.State == JobState.Suspended))
                     {
@@ -262,7 +262,7 @@ namespace Microsoft.PowerShell.Commands
                 }
                 else
                 {
-                    // there could be a possiblity of race condiftion where this fucntion is getting called twice
+                    // there could be a possibility of race condition where this function is getting called twice
                     // so if job doesn't present in the _pendingJobs then just return
                     return;
                 }

--- a/src/System.Management.Automation/engine/remoting/commands/WaitJob.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/WaitJob.cs
@@ -73,7 +73,7 @@ namespace Microsoft.PowerShell.Commands
         public override string[] Command { get; set; }
         #endregion Parameters
 
-        #region Coordinating how different events (timeout, stopprocesing, job finished, job blocked) affect what happens in EndProcessing
+        #region Coordinating how different events (timeout, stopprocessing, job finished, job blocked) affect what happens in EndProcessing
 
         private readonly object _endProcessingActionLock = new object();
         private Action _endProcessingAction;
@@ -103,7 +103,7 @@ namespace Microsoft.PowerShell.Commands
                 endProcessingAction = _endProcessingAction;
             }
 
-            // Inovke action outside lock.
+            // Invoke action outside lock.
             if (endProcessingAction != null)
             {
                 endProcessingAction();
@@ -117,7 +117,7 @@ namespace Microsoft.PowerShell.Commands
 
         #endregion
 
-        #region Support for triggering EndProcesing when jobs are finished or blocked
+        #region Support for triggering EndProcessing when jobs are finished or blocked
 
         private readonly HashSet<Job> _finishedJobs = new HashSet<Job>();
         private readonly HashSet<Job> _blockedJobs = new HashSet<Job>();

--- a/src/System.Management.Automation/engine/remoting/commands/getrunspacecommand.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/getrunspacecommand.cs
@@ -109,7 +109,7 @@ namespace Microsoft.PowerShell.Commands
         /// this is not set as well, then Microsoft.PowerShell is used.
         ///
         /// For VM/Container sessions:
-        /// If this parameter is not speficied then all sessions that match other filters are returned.
+        /// If this parameter is not specified then all sessions that match other filters are returned.
         /// </summary>
         [Parameter(ValueFromPipelineByPropertyName = true,
                            ParameterSetName = GetPSSessionCommand.ComputerNameParameterSet)]
@@ -134,7 +134,7 @@ namespace Microsoft.PowerShell.Commands
         public String ConfigurationName { get; set; }
 
         /// <summary>
-        /// The AllowRediraction parameter enables the implicit redirection functionality.
+        /// The AllowRedirection parameter enables the implicit redirection functionality.
         /// </summary>
         [Parameter(ParameterSetName = GetPSSessionCommand.ConnectionUriParameterSet)]
         [Parameter(ParameterSetName = GetPSSessionCommand.ConnectionUriInstanceIdParameterSet)]
@@ -483,7 +483,7 @@ namespace Microsoft.PowerShell.Commands
             if (ParameterSetName != GetPSSessionCommand.ConnectionUriParameterSet &&
                 ParameterSetName != GetPSSessionCommand.ConnectionUriInstanceIdParameterSet)
             {
-                // uri redirection is supported only with URI parmeter set
+                // uri redirection is supported only with URI parameter set
                 connectionInfo.MaximumConnectionRedirectionCount = 0;
             }
 

--- a/src/System.Management.Automation/engine/remoting/commands/newrunspacecommand.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/newrunspacecommand.cs
@@ -325,7 +325,7 @@ namespace Microsoft.PowerShell.Commands
         /// </remarks>
         protected override void StopProcessing()
         {
-            // close the outputStream so that futher writes to the outputStream
+            // close the outputStream so that further writes to the outputStream
             // are not possible
             _stream.ObjectWriter.Close();
 
@@ -603,7 +603,7 @@ namespace Microsoft.PowerShell.Commands
         {
             List<RemoteRunspace> remoteRunspaces = new List<RemoteRunspace>();
 
-            // validate the runspaces specfied before processing them.
+            // validate the runspaces specified before processing them.
             // The function will result in terminating errors, if any
             // validation failure is encountered
             ValidateRemoteRunspacesSpecified();
@@ -1300,7 +1300,7 @@ namespace Microsoft.PowerShell.Commands
         /// Handler for handling runspace state changed events. This method will be
         /// registered in the StartOperation and StopOperation methods. This handler
         /// will in turn invoke the OperationComplete event for all events that are 
-        /// necesary - Opened, Closed, Disconnected, Broken. It will ignore all other state 
+        /// necessary - Opened, Closed, Disconnected, Broken. It will ignore all other state 
         /// changes.
         /// </summary>
         /// <remarks>

--- a/src/System.Management.Automation/engine/remoting/commands/removerunspacecommand.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/removerunspacecommand.cs
@@ -88,7 +88,7 @@ namespace Microsoft.PowerShell.Commands
         #region Overrides
 
         /// <summary>
-        /// Do the follwing actions:
+        /// Do the following actions:
         ///     1. If runspace is in opened state,
         ///             a. stop any execution in process in the runspace
         ///             b. close the runspace

--- a/src/System.Management.Automation/engine/remoting/common/PSSessionConfigurationTypeOption.cs
+++ b/src/System.Management.Automation/engine/remoting/common/PSSessionConfigurationTypeOption.cs
@@ -105,7 +105,7 @@ namespace System.Management.Automation
         }
 
         /// <summary>
-        /// Clone from IClonable
+        /// Clone from ICloneable
         /// </summary>
         public object Clone()
         {

--- a/src/System.Management.Automation/engine/remoting/common/RemoteSessionHyperVSocket.cs
+++ b/src/System.Management.Automation/engine/remoting/common/RemoteSessionHyperVSocket.cs
@@ -483,7 +483,7 @@ namespace System.Management.Automation.Remoting
 
         /// <summary>
         /// Connect to Hyper-V socket server.  This is a blocking call until a 
-        /// connection occurs or the timeout time has ellapsed.
+        /// connection occurs or the timeout time has elapsed.
         /// </summary>
         /// <param name="networkCredential">The credential used for authentication</param>
         /// <param name="configurationName">The configuration name of the PS session</param>
@@ -566,8 +566,8 @@ namespace System.Management.Automation.Remoting
                     //
                     // There are 3 cases for the responseString received above.
                     // - "FAIL": credential is invalid
-                    // - "PASS": credentail is valid, but PowerShell Direct in VM does not support configuration (Server 2016 TP4 and before)
-                    // - "CONF": credentail is valid, and PowerShell Direct in VM supports configuration (Server 2016 TP5 and later)
+                    // - "PASS": credential is valid, but PowerShell Direct in VM does not support configuration (Server 2016 TP4 and before)
+                    // - "CONF": credential is valid, and PowerShell Direct in VM supports configuration (Server 2016 TP5 and later)
                     //
 
                     //

--- a/src/System.Management.Automation/engine/remoting/common/RemoteSessionNamedPipe.cs
+++ b/src/System.Management.Automation/engine/remoting/common/RemoteSessionNamedPipe.cs
@@ -264,7 +264,7 @@ namespace System.Management.Automation.Remoting
         #region Properties
 
         /// <summary>
-        /// Exception reson for listener end event.  Can be null
+        /// Exception reason for listener end event.  Can be null
         /// which indicates listener thread end is not due to an error.
         /// </summary>
         public Exception Reason
@@ -503,7 +503,7 @@ namespace System.Management.Automation.Remoting
             s_syncObject = new object();
 
             // All PowerShell instances will start with the named pipe
-            // and listner created and running.
+            // and listener created and running.
             if (Platform.IsWindows)
             {
                 IPCNamedPipeServerEnabled = true;
@@ -962,7 +962,7 @@ namespace System.Management.Automation.Remoting
 
         /// <summary>
         /// Connect to named pipe server.  This is a blocking call until a 
-        /// connection occurs or the timeout time has ellapsed.
+        /// connection occurs or the timeout time has elapsed.
         /// </summary>
         /// <param name="timeout">Connection attempt timeout in milliseconds</param>
         public void Connect(

--- a/src/System.Management.Automation/engine/remoting/common/RunspaceConnectionInfo.cs
+++ b/src/System.Management.Automation/engine/remoting/common/RunspaceConnectionInfo.cs
@@ -545,7 +545,7 @@ namespace System.Management.Automation.Runspaces
         }
 
         /// <summary>
-        /// AuthenticationMaechanism converted to WSManAuthenticationMechanism type.
+        /// AuthenticationMechanism converted to WSManAuthenticationMechanism type.
         /// This is internal.
         /// </summary>
         internal WSManAuthenticationMechanism WSManAuthenticationMechanism { get; private set; } = WSManAuthenticationMechanism.WSMAN_FLAG_DEFAULT_AUTHENTICATION;
@@ -709,7 +709,7 @@ namespace System.Management.Automation.Runspaces
 
         /// <summary>
         /// Specifies that no encryption will be used when doing remote operations over 
-        /// http. Unencrypted traffix is not allowed by default and must be enabled in 
+        /// http. Unencrypted traffic is not allowed by default and must be enabled in 
         /// the local configuration
         /// </summary>
         public bool NoEncryption { get; set; }
@@ -925,7 +925,7 @@ namespace System.Management.Automation.Runspaces
         /// default server life time and default open
         /// timeout
         /// </summary>
-        /// <param name="uri">uri of remote runspae</param>
+        /// <param name="uri">uri of remote runspace</param>
         /// <exception cref="ArgumentException">When an
         /// uri representing an invalid path is specified</exception>
         public WSManConnectionInfo(Uri uri)
@@ -1089,7 +1089,7 @@ namespace System.Management.Automation.Runspaces
 
         /// <summary>
         /// Converts <paramref name="rsCI"/> to a WSManConnectionInfo. If conversion succeeds extracts
-        /// the propery..otherwise returns default value
+        /// the property..otherwise returns default value
         /// </summary>
         /// <param name="rsCI"></param>
         /// <param name="property"></param>
@@ -1246,7 +1246,7 @@ namespace System.Management.Automation.Runspaces
         /// Used to resolve authentication from the parameters chosen by the user.
         /// User has the following options:
         /// 1. AuthMechanism + Credential
-        /// 2. CertiticateThumbPrint
+        /// 2. CertificateThumbPrint
         /// 
         /// All the above are mutually exclusive.
         /// </summary>
@@ -1603,7 +1603,7 @@ namespace System.Management.Automation.Runspaces
         /// ThumbPrint of a certificate used for connecting to a remote machine.
         /// When this is specified, you dont need to supply credential and authentication
         /// mechanism.
-        /// Will always be empty to signfy that this is not supported.
+        /// Will always be empty to signify that this is not supported.
         /// </summary>
         public override string CertificateThumbprint
         {
@@ -2056,7 +2056,7 @@ namespace System.Management.Automation.Runspaces
         /// <summary>
         /// Create a process through native Win32 APIs and return StdIn, StdOut, StdError reader/writers
         /// This needs to be done via Win32 APIs because managed code creates anonymous synchronous pipes 
-        /// for redirected StdIn/Out and SSH (and PSRP) require asynchrous (overlapped) pipes, which must
+        /// for redirected StdIn/Out and SSH (and PSRP) require asynchronous (overlapped) pipes, which must
         /// be through named pipes.  Managed code for named pipes is unreliable and so this is done via
         /// P-Invoking native APIs.
         /// </summary>
@@ -2362,7 +2362,7 @@ namespace System.Management.Automation.Runspaces
         /// ThumbPrint of a certificate used for connecting to a remote machine.
         /// When this is specified, you dont need to supply credential and authentication
         /// mechanism.
-        /// Will always be null to signfy that this is not supported.
+        /// Will always be null to signify that this is not supported.
         /// </summary>
         public override string CertificateThumbprint
         {
@@ -2483,7 +2483,7 @@ namespace System.Management.Automation.Runspaces
         /// ThumbPrint of a certificate used for connecting to a remote machine.
         /// When this is specified, you dont need to supply credential and authentication
         /// mechanism.
-        /// Will always be null to signfy that this is not supported.
+        /// Will always be null to signify that this is not supported.
         /// </summary>
         public override string CertificateThumbprint
         {

--- a/src/System.Management.Automation/engine/remoting/common/WireDataFormat/EncodeAndDecode.cs
+++ b/src/System.Management.Automation/engine/remoting/common/WireDataFormat/EncodeAndDecode.cs
@@ -856,7 +856,7 @@ namespace System.Management.Automation
 
         /// <summary>
         /// This method generates a Remoting data structure handler message for 
-        /// that contains a repsonse to SetMaxRunspaces or SetMinRunspaces
+        /// that contains a response to SetMaxRunspaces or SetMinRunspaces
         /// </summary>
         /// <param name="clientRunspacePoolId">id of the clientRunspacePool</param>
         /// <param name="callId">call id of the call at client</param>
@@ -896,7 +896,7 @@ namespace System.Management.Automation
         /// --------------------------------------------------------------------------
         /// | D |    TI     |  RPID  |   PID   |      Data     |        Type          |
         /// ---------------------------------------------------------------------------
-        /// | S | Runspace  | CRPID  |    0    |     null      |GetAvailalbeRunspaces |
+        /// | S | Runspace  | CRPID  |    0    |     null      |GetAvailableRunspaces |
         /// |   |   Pool    |        |         |               |                      |
         /// --------------------------------------------------------------------------
         internal static RemoteDataObject GenerateGetAvailableRunspaces(Guid clientRunspacePoolId,
@@ -914,13 +914,13 @@ namespace System.Management.Automation
 
         /// <summary>
         /// This method generates a remoting data structure handler message for
-        /// transfering a roles public key to the other side
+        /// transferring a roles public key to the other side
         /// </summary>
         /// <param name="runspacePoolId">runspace pool id</param>
         /// <param name="publicKey">public key to send across</param>
         /// <param name="destination">destination that this message is
-        /// targetted to</param>
-        /// <returns>data strucutre message</returns>
+        /// targeted to</param>
+        /// <returns>data structure message</returns>
         /// The message format is as under for this message
         /// --------------------------------------------------------------------------
         /// | D |    TI     |  RPID  |   PID   |      Data     |        Type          |
@@ -946,7 +946,7 @@ namespace System.Management.Automation
         /// requesting a public key from the client to the server
         /// </summary>
         /// <param name="runspacePoolId">runspace pool id</param>
-        /// <returns>data strucutre message</returns>
+        /// <returns>data structure message</returns>
         /// The message format is as under for this message
         /// --------------------------------------------------------------------------
         /// | D |    TI     |  RPID  |   PID   |      Data     |        Type          |
@@ -969,7 +969,7 @@ namespace System.Management.Automation
         /// </summary>
         /// <param name="runspacePoolId">runspace pool id</param>
         /// <param name="encryptedSessionKey">encrypted session key</param>
-        /// <returns>data strucutre message</returns>
+        /// <returns>data structure message</returns>
         /// The message format is as under for this message
         /// --------------------------------------------------------------------------
         /// | D |    TI     |  RPID  |   PID   |      Data     |        Type          |
@@ -1312,7 +1312,7 @@ namespace System.Management.Automation
         /// --------------------------------------------------------------------------------------
         /// | D |    TI     |  RPID  |   PID   |   Action   |      Data     |        Type         |
         /// --------------------------------------------------------------------------------------
-        /// | S |PowerShell | CRPID  |   CPID  |    Data    |  intput data  |   PowerShellInput   |
+        /// | S |PowerShell | CRPID  |   CPID  |    Data    |  input data   |   PowerShellInput   |
         /// |   |           |        |         |            |               |                     |
         /// --------------------------------------------------------------------------------------
         internal static RemoteDataObject GeneratePowerShellInput(object data, Guid clientRemoteRunspacePoolId,
@@ -1998,7 +1998,7 @@ namespace System.Management.Automation
         }
 
         /// <summary>
-        /// Generates RunspacePoolInitInfo object from a recevied PSObject
+        /// Generates RunspacePoolInitInfo object from a received PSObject
         /// </summary>
         /// <param name="dataAsPSObject">data object to decode</param>
         /// <returns>RunspacePoolInitInfo generated</returns>
@@ -2049,7 +2049,7 @@ namespace System.Management.Automation
         }
 
         /// <summary>
-        /// Gets the exception if any from the serializaed state info object
+        /// Gets the exception if any from the serialized state info object
         /// </summary>
         /// <param name="stateInfo"></param>
         /// <returns></returns>

--- a/src/System.Management.Automation/engine/remoting/common/WireDataFormat/RemoteHost.cs
+++ b/src/System.Management.Automation/engine/remoting/common/WireDataFormat/RemoteHost.cs
@@ -417,7 +417,7 @@ namespace System.Management.Automation.Remoting
             // check if the incoming call is GetBufferContents
             // if so do the following:
             //      (a) Specify a warning message that the server is 
-            //          attemping to read the screen buffer contents 
+            //          attempting to read the screen buffer contents 
             //          on screen and it has been blocked
             //      (b) Modify the message so that call is not executed
             else if (MethodId == RemoteHostMethodId.GetBufferContents)

--- a/src/System.Management.Automation/engine/remoting/common/WireDataFormat/RemoteHostEncoder.cs
+++ b/src/System.Management.Automation/engine/remoting/common/WireDataFormat/RemoteHostEncoder.cs
@@ -483,8 +483,8 @@ namespace System.Management.Automation.Remoting
             }
             else if (obj is PSObject && IsGenericIEnumerableOfInt(type))
             {
-                // we cannot create an instance of interface type like IEnumberable
-                // Since a Collection implements IEnumberable, falling back to use 
+                // we cannot create an instance of interface type like IEnumerable
+                // Since a Collection implements IEnumerable, falling back to use 
                 // that.
                 return DecodeCollection((PSObject)obj, typeof(Collection<int>));
             }

--- a/src/System.Management.Automation/engine/remoting/common/WireDataFormat/RemotingDataObject.cs
+++ b/src/System.Management.Automation/engine/remoting/common/WireDataFormat/RemotingDataObject.cs
@@ -129,11 +129,11 @@ namespace System.Management.Automation.Remoting
 
 
         /// <summary>
-        /// Creates a RemoteDataObject by deserialzing <paramref name="data"/>.
+        /// Creates a RemoteDataObject by deserializing <paramref name="data"/>.
         /// </summary>
         /// <param name="serializedDataStream"></param>
         /// <param name="defragmentor">
-        /// Defragmetor used to deserialize an object.
+        /// Defragmentor used to deserialize an object.
         /// </param>
         /// <returns></returns>
         internal static RemoteDataObject<T> CreateFrom(Stream serializedDataStream, Fragmentor defragmentor)
@@ -170,7 +170,7 @@ namespace System.Management.Automation.Remoting
         #region Serialize / Deserialize
 
         /// <summary>
-        /// Seriliazes the object into the stream specified. The serialization mechanism uses
+        /// Serializes the object into the stream specified. The serialization mechanism uses
         /// UTF8 encoding to encode data.
         /// </summary>
         /// <param name="streamToWriteTo"></param>
@@ -193,7 +193,7 @@ namespace System.Management.Automation.Remoting
 
         /// <summary>
         /// Serializes only the header portion of the object. ie., runspaceId,
-        /// powerShellId, destinaion and dataType.
+        /// powerShellId, destination and dataType.
         /// </summary>
         /// <param name="streamToWriteTo">
         /// place where the serialized data is stored into.

--- a/src/System.Management.Automation/engine/remoting/common/fragmentor.cs
+++ b/src/System.Management.Automation/engine/remoting/common/fragmentor.cs
@@ -17,7 +17,7 @@ namespace System.Management.Automation.Remoting
     /// <summary>
     /// This class is used to hold a fragment of remoting PSObject for transporting to remote computer.
     /// 
-    /// A large remoting PSObject will be broken into fragments. Each fragment has a ObjectId and a FragementId.
+    /// A large remoting PSObject will be broken into fragments. Each fragment has a ObjectId and a FragmentId.
     /// The first fragment has a StartFragment marker. The last fragment also an EndFragment marker. 
     /// These fragments can be reassembled on the receiving
     /// end by sequencing the fragment ids.
@@ -271,7 +271,7 @@ namespace System.Management.Automation.Remoting
         /// If fragmentBytes is null.
         /// </exception>
         /// <exception cref="ArgumentException">
-        /// If startIndex is negative or fragmentBytes is not large enought to hold the entire header of
+        /// If startIndex is negative or fragmentBytes is not large enough to hold the entire header of
         /// a binary encoded FragmentedRemoteObject.
         /// </exception>
         internal static long GetObjectId(byte[] fragmentBytes, int startIndex)
@@ -305,7 +305,7 @@ namespace System.Management.Automation.Remoting
         /// If fragmentBytes is null.
         /// </exception>
         /// <exception cref="ArgumentException">
-        /// If startIndex is negative or fragmentBytes is not large enought to hold the entire header of
+        /// If startIndex is negative or fragmentBytes is not large enough to hold the entire header of
         /// a binary encoded FragmentedRemoteObject.
         /// </exception>
         internal static long GetFragmentId(byte[] fragmentBytes, int startIndex)
@@ -340,7 +340,7 @@ namespace System.Management.Automation.Remoting
         /// If fragmentBytes is null.
         /// </exception>
         /// <exception cref="ArgumentException">
-        /// If startIndex is negative or fragmentBytes is not large enought to hold the entire header of
+        /// If startIndex is negative or fragmentBytes is not large enough to hold the entire header of
         /// a binary encoded FragmentedRemoteObject.
         /// </exception>
         internal static bool GetIsStartFragment(byte[] fragmentBytes, int startIndex)
@@ -369,7 +369,7 @@ namespace System.Management.Automation.Remoting
         /// If fragmentBytes is null.
         /// </exception>
         /// <exception cref="ArgumentException">
-        /// If startIndex is negative or fragmentBytes is not large enought to hold the entire header of
+        /// If startIndex is negative or fragmentBytes is not large enough to hold the entire header of
         /// a binary encoded FragmentedRemoteObject.
         /// </exception>
         internal static bool GetIsEndFragment(byte[] fragmentBytes, int startIndex)
@@ -398,7 +398,7 @@ namespace System.Management.Automation.Remoting
         /// If fragmentBytes is null.
         /// </exception>
         /// <exception cref="ArgumentException">
-        /// If startIndex is negative or fragmentBytes is not large enought to hold the entire header of
+        /// If startIndex is negative or fragmentBytes is not large enough to hold the entire header of
         /// a binary encoded FragmentedRemoteObject.
         /// </exception>
         internal static int GetBlobLength(byte[] fragmentBytes, int startIndex)
@@ -613,7 +613,7 @@ namespace System.Management.Automation.Remoting
         /// <summary>
         /// Returns a byte[] which holds data of fragment size (or) serialized data of
         /// one object, which ever is greater. If data is not currently available, then
-        /// the callback is registerd and called whenever the data is available.
+        /// the callback is registered and called whenever the data is available.
         /// </summary>
         /// <param name="callback">
         /// callback to call once the data becomes available.
@@ -955,7 +955,7 @@ namespace System.Management.Automation.Remoting
     /// <summary>
     /// This class performs the fragmentation as well as defragmentation operations of large objects to be sent 
     /// to the other side. A large remoting PSObject will be broken into fragments. Each fragment has a ObjectId 
-    /// and a FragementId. The last fragment also has an end of fragment marker. These fragments can be reassembled 
+    /// and a FragmentId. The last fragment also has an end of fragment marker. These fragments can be reassembled 
     /// on the receiving end by sequencing the fragment ids.
     /// </summary>
     internal class Fragmentor
@@ -1005,7 +1005,7 @@ namespace System.Management.Automation.Remoting
         /// The object to be fragmented. Caller should make sure this is not null.
         /// </param>
         /// <param name="dataToBeSent">
-        /// Caller specified dataToStore to which the fragements are added 
+        /// Caller specified dataToStore to which the fragments are added 
         /// one-by-one
         /// </param>
         internal void Fragment<T>(RemoteDataObject<T> obj, SerializedDataStream dataToBeSent)

--- a/src/System.Management.Automation/engine/remoting/common/misc.cs
+++ b/src/System.Management.Automation/engine/remoting/common/misc.cs
@@ -145,7 +145,7 @@ namespace System.Management.Automation
         NegotiationReceived = 7,
 
         /// <summary>
-        /// Used by server to wait for negotation from client.
+        /// Used by server to wait for negotiation from client.
         /// </summary>
         NegotiationPending = 8,
 
@@ -181,9 +181,9 @@ namespace System.Management.Automation
         /// <summary>
         /// for Server - Have sent a request to the remote end to 
         /// send a public key 
-        /// for Cleint - have received a PK request from server
+        /// for Client - have received a PK request from server
         /// </summary>
-        /// <remarks>Applicable to both cleint and server</remarks>
+        /// <remarks>Applicable to both client and server</remarks>
         EstablishedAndKeyRequested = 14,
 
         /// <summary>
@@ -392,7 +392,7 @@ namespace System.Management.Automation
 
         /// <summary>
         /// In the presence of ambient remoting, the command assumes
-        /// all responsibility for targetting the remote computer;
+        /// all responsibility for targeting the remote computer;
         /// PowerShell Remoting is not supported.
         /// </summary>
         OwnedByCommand

--- a/src/System.Management.Automation/engine/remoting/common/remotesession.cs
+++ b/src/System.Management.Automation/engine/remoting/common/remotesession.cs
@@ -7,7 +7,7 @@ using System.Management.Automation.Remoting;
 namespace System.Management.Automation
 {
     /// <summary>
-    /// This abstract class is designed to provide InstandId and self identification for
+    /// This abstract class is designed to provide InstanceId and self identification for
     /// client and server remote session classes.
     /// </summary>
     internal abstract class RemoteSession

--- a/src/System.Management.Automation/engine/remoting/common/remotingexceptions.cs
+++ b/src/System.Management.Automation/engine/remoting/common/remotingexceptions.cs
@@ -241,7 +241,7 @@ namespace System.Management.Automation.Remoting
         PSDefaultSessionOptionDescription = 1002,
         PSSenderInfoDescription = 1004,
 
-        // IPC for Backgroud jobs related errors: 2000
+        // IPC for Background jobs related errors: 2000
         IPCUnknownNodeType = 2001,
         IPCInsufficientDataforElement = 2002,
         IPCWrongAttributeCountForDataElement = 2003,
@@ -296,7 +296,7 @@ namespace System.Management.Automation.Remoting
         #region Constructors
 
         /// <summary>
-        /// Default construtor.
+        /// Default constructor.
         /// </summary>
         public PSRemotingDataStructureException()
             : base(PSRemotingErrorInvariants.FormatResourceString(RemotingErrorIdStrings.DefaultRemotingExceptionMessage, typeof(PSRemotingDataStructureException).FullName))
@@ -350,7 +350,7 @@ namespace System.Management.Automation.Remoting
         /// This constuctor takes an inner exception and an error id.
         /// </summary>
         /// <param name="innerException">
-        /// Inner excetion.
+        /// Inner exception.
         /// </param>
         /// <param name="resourceString">
         /// The resource string in the base resource file.
@@ -460,7 +460,7 @@ namespace System.Management.Automation.Remoting
         /// This constuctor takes an inner exception and an error id.
         /// </summary>
         /// <param name="innerException">
-        /// Inner excetion.
+        /// Inner exception.
         /// </param>
         /// <param name="resourceString">
         /// The resource string in the base resource file.
@@ -602,7 +602,7 @@ namespace System.Management.Automation.Remoting
         /// This constuctor takes an inner exception and an error id.
         /// </summary>
         /// <param name="innerException">
-        /// Inner excetion.
+        /// Inner exception.
         /// </param>
         /// <param name="resourceString">
         /// The resource string in the base resource file.

--- a/src/System.Management.Automation/engine/remoting/common/throttlemanager.cs
+++ b/src/System.Management.Automation/engine/remoting/common/throttlemanager.cs
@@ -64,10 +64,10 @@ namespace System.Management.Automation.Remoting
     internal abstract class IThrottleOperation
     {
         /// <summary>
-        /// This method should handle the actual operation whcih need to be
+        /// This method should handle the actual operation which need to be
         /// controlled and performed. Examples of this can be Opening remote
         /// runspace, invoking expression in a remote runspace, etc. Once 
-        /// an event is successfully recieved as a result of this function,
+        /// an event is successfully received as a result of this function,
         /// the handler has to ensure that it raises an OperationComplete
         /// event with StartComplete or StopComplete for the throttle manager
         /// to handle
@@ -80,7 +80,7 @@ namespace System.Management.Automation.Remoting
         /// remote runspaces, the user might hit ctrl-C. In which case, the 
         /// pending runspaces to be opened will actually be signalled through
         /// this method to stop operation and return back. This method also
-        /// needs to be asynchronous. Once an event is successfully recieved
+        /// needs to be asynchronous. Once an event is successfully received
         /// as a result of this function, the handler has to ensure that it
         /// raises an OperationComplete event with StopComplete for the 
         /// throttle manager to handle. It is important that this function
@@ -91,7 +91,7 @@ namespace System.Management.Automation.Remoting
 
         /// <summary>
         /// Event which will be triggered when the operation is complete. It is
-        /// assumed that all the operations perfomed by StartOperation and 
+        /// assumed that all the operations performed by StartOperation and 
         /// StopOperation are asynchronous. The submitter of operations may 
         /// subscribe to this event to know when it's complete (or it can handle 
         /// the synchronization with its scheduler) and the throttle 
@@ -107,7 +107,7 @@ namespace System.Management.Automation.Remoting
         /// In the initial implementation of ThrottleManager stopping 
         /// individual operations was not supported. When the support 
         /// for stopping individual operations was added, there was 
-        /// the following problem - if an opertaion is not there in 
+        /// the following problem - if an operation is not there in 
         /// the pending queue and in the startOperationQueue as well, 
         /// then the following two scenarios are possible
         ///      (a) Operation was started and start completed
@@ -139,7 +139,7 @@ namespace System.Management.Automation.Remoting
     /// <summary>
     /// Class which handles the throttling operations. This class is singleton and therefore
     /// when used either across cmdlets or at the infrastructure level it will ensure that
-    /// there aren't more operations by way of accumalation than what is intended by design.
+    /// there aren't more operations by way of accumulation than what is intended by design.
     /// 
     /// This class contains a queue of items, each of which has the 
     /// <see cref="System.Management.Automation.Remoting.IThrottleOperation">
@@ -600,7 +600,7 @@ namespace System.Management.Automation.Remoting
         /// <summary>
         /// Dispose method of IDisposable. Any cmdlet that uses
         /// the throttle manager needs to call this method from its
-        /// Dipose method
+        /// Dispose method
         /// </summary>
         public void Dispose()
         {

--- a/src/System.Management.Automation/engine/remoting/fanin/BaseTransportManager.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/BaseTransportManager.cs
@@ -191,14 +191,14 @@ namespace System.Management.Automation.Remoting
         /// <summary>
         /// Event that is raised when a remote object is available. The event is raised
         /// from a WSMan transport thread. Since this thread can hold on to a HTTP
-        /// connection, the event handler should compelete processing as fast as possible.
+        /// connection, the event handler should complete processing as fast as possible.
         /// Importantly the event handler should not generate any call that results in a
         /// user request like host.ReadLine().
         /// </summary>
         internal event EventHandler<RemoteDataEventArgs> DataReceived;
 
         /// <summary>
-        /// Listen to this event to observe the PowerShell guid of the process'ed object.
+        /// Listen to this event to observe the PowerShell guid of the processed object.
         /// </summary>
         public event EventHandler PowerShellGuidObserver;
 
@@ -228,7 +228,7 @@ namespace System.Management.Automation.Remoting
         /// This may be null..in which case type rehydration does not happen.
         /// At construction time we may not have typetable (server runspace
         /// is created only when a request from the client)..so this is
-        /// a property on the base tranpsort manager to allow for setting at
+        /// a property on the base transport manager to allow for setting at
         /// a later time.
         /// </summary>
         internal TypeTable TypeTable
@@ -453,7 +453,7 @@ namespace System.Management.Automation.Remoting.Client
         /// Event that is raised when a create operation on transport has been successfully completed
         /// The event is raised
         /// from a WSMan transport thread. Since this thread can hold on to a HTTP
-        /// connection, the event handler should compelete processing as fast as possible.
+        /// connection, the event handler should complete processing as fast as possible.
         /// Importantly the event handler should not generate any call that results in a
         /// user request like host.ReadLine().
         /// 
@@ -464,7 +464,7 @@ namespace System.Management.Automation.Remoting.Client
         /// <summary>
         /// Event that is raised when a remote connection is successfully closed. The event is raised
         /// from a WSMan transport thread. Since this thread can hold on to a HTTP
-        /// connection, the event handler should compelete processing as fast as possible.
+        /// connection, the event handler should complete processing as fast as possible.
         /// Importantly the event handler should not generate any call that results in a
         /// user request like host.ReadLine().
         /// 
@@ -477,7 +477,7 @@ namespace System.Management.Automation.Remoting.Client
         internal event EventHandler<EventArgs> CloseCompleted;
 
         /// <summary>
-        /// Indicated successfull completion of a connect operation on transport
+        /// Indicated successful completion of a connect operation on transport
         /// 
         /// Errors are reported through WSManTransportErrorOccured
         /// event.
@@ -485,7 +485,7 @@ namespace System.Management.Automation.Remoting.Client
         internal event EventHandler<EventArgs> ConnectCompleted;
 
         /// <summary>
-        /// Indicated successfull completion of a disconnect operation on transport
+        /// Indicated successful completion of a disconnect operation on transport
         /// 
         /// Errors are reported through WSManTransportErrorOccured
         /// event.
@@ -493,7 +493,7 @@ namespace System.Management.Automation.Remoting.Client
         internal event EventHandler<EventArgs> DisconnectCompleted;
 
         /// <summary>
-        /// Indicated successfull completion of a reconnect operation on transport
+        /// Indicated successful completion of a reconnect operation on transport
         /// 
         /// Errors are reported through WSManTransportErrorOccured
         /// event.
@@ -524,7 +524,7 @@ namespace System.Management.Automation.Remoting.Client
         #region Properties
 
         /// <summary>
-        /// Gets the data collection which is used by this tranport manager to send
+        /// Gets the data collection which is used by this transport manager to send
         /// data to the server.
         /// </summary>
         internal PrioritySendDataCollection DataToBeSentCollection
@@ -927,7 +927,7 @@ namespace System.Management.Automation.Remoting.Client
         internal class CallbackNotificationInformation
         {
             // only one of the following 2 should be present..
-            // anyway transportException takes precendence over remoteObject.
+            // anyway transportException takes precedence over remoteObject.
             internal RemoteDataObject<PSObject> remoteObject;
             internal TransportErrorOccuredEventArgs transportError;
             // Used by ServicePendingCallbacks to give the control to derived classes for
@@ -937,7 +937,7 @@ namespace System.Management.Automation.Remoting.Client
 
         #endregion
 
-        #region Abstract / Virtural methods
+        #region Abstract / Virtual methods
 
         internal abstract void CreateAsync();
 
@@ -996,7 +996,7 @@ namespace System.Management.Automation.Remoting.Client
 
                 try
                 {
-                    // looks like Dispose is not called for this tranpsort manager
+                    // looks like Dispose is not called for this transport manager
                     // try closing the transport manager.
                     CloseAsync();
                 }
@@ -1252,8 +1252,8 @@ namespace System.Management.Automation.Remoting.Server
         #region Helper Methods
 
         /// <summary>
-        /// Sends an object from the server end. The object is fragmented and each fragement is sent
-        /// separately. The call blocks until all the fragements are sent to the client. If there
+        /// Sends an object from the server end. The object is fragmented and each fragment is sent
+        /// separately. The call blocks until all the fragments are sent to the client. If there
         /// is a failure sending any of the fragments WSManTransportErrorOccured event is raised.
         /// </summary>
         /// <typeparam name="T"></typeparam>
@@ -1266,16 +1266,16 @@ namespace System.Management.Automation.Remoting.Server
         /// </param>
         internal void SendDataToClient<T>(RemoteDataObject<T> data, bool flush, bool reportPending = false)
         {
-            // make sure only one data packet can be sent in its entirity at any 
+            // make sure only one data packet can be sent in its entirety at any 
             // given point of time using this transport manager.
             lock (_syncObject)
             {
                 // Win8: 491001 Icm -computername $env:COMPUTERNAME {Get-NetIpInterface} fails with Unexpected ObjectId
-                // This is because the output object has some extentded script properties. Getter of one of the
-                // script proprties is calling write-progress. Write-Progress in turn results in a progress record
+                // This is because the output object has some extended script properties. Getter of one of the
+                // script properties is calling write-progress. Write-Progress in turn results in a progress record
                 // being sent to client. This breaks the fragmentation rule when the original object (without progress)
                 // does not fit in fragmented packet.
-                // ******************** repro using powershll *********************************
+                // ******************** repro using powershell *********************************
                 //  icm . {
                 //        $a = new-object psobject
                 //        $a.pstypenames.Insert(0, "Microsoft.PowerShell.Test.Bug491001")
@@ -1286,12 +1286,12 @@ namespace System.Management.Automation.Remoting.Server
                 //   }
                 // 1. The value of "name" property is huge 50kb and cannot fit in one fragment (with fragment size 32kb)   
                 // 2. The value of "Verbose" is actually writing a progress record
-                // 3. The value of "zname" proprty is also huge
-                // 4. Notice the ascending order of propery names. This is because seralizer seralizes properties in sort order
+                // 3. The value of "zname" property is also huge
+                // 4. Notice the ascending order of property names. This is because serializer serializes properties in sort order
                 // ******************** End of repro ******************************************
-                // To fix the issue, I am creating a Queue and enqueuing the data objects if we are already serializaing another data object
-                // Notice this is in lock() above. An object is serialized in its entirity in one thread. So, in my example above "name",
-                // "verbose","zname" properties are serialized in one thread. So lock() estenially protects from serialing other objects
+                // To fix the issue, I am creating a Queue and enqueuing the data objects if we are already serializing another data object
+                // Notice this is in lock() above. An object is serialized in its entirety in one thread. So, in my example above "name",
+                // "verbose","zname" properties are serialized in one thread. So lock() essentially protects from serializing other objects
                 // and not this (parent)object.
                 RemoteDataObject dataToBeSent = RemoteDataObject.CreateFrom(data.Destination, data.DataType,
                                                                             data.RunspacePoolId, data.PowerShellId,
@@ -1362,8 +1362,8 @@ namespace System.Management.Automation.Remoting.Server
         }
 
         /// <summary>
-        /// Sends an object to the server end. The object is fragmented and each fragement is sent
-        /// separately. The call blocks until all the fragements are sent to the client. If there
+        /// Sends an object to the server end. The object is fragmented and each fragment is sent
+        /// separately. The call blocks until all the fragments are sent to the client. If there
         /// is a failure sending any of the fragments WSManTransportErrorOccured event is raised.
         /// </summary>
         /// <param name="psObjectData"></param>

--- a/src/System.Management.Automation/engine/remoting/fanin/InitialSessionStateProvider.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/InitialSessionStateProvider.cs
@@ -332,7 +332,7 @@ namespace System.Management.Automation.Remoting
             {
             }
 
-            // if we are here, that means we are unble to load the type specified
+            // if we are here, that means we are unable to load the type specified
             // in the config xml.. notify the same.
             throw PSTraceSource.NewArgumentException("typeToLoad", RemotingErrorIdStrings.UnableToLoadType,
                     EndPointConfigurationTypeName, ConfigurationDataFromXML.INITPARAMETERSTOKEN);
@@ -340,7 +340,7 @@ namespace System.Management.Automation.Remoting
     }
 
     /// <summary>
-    /// InitialSessionStateProvider is used by 3rd parties to provide shell configurtion
+    /// InitialSessionStateProvider is used by 3rd parties to provide shell configuration
     /// on the remote server.
     /// </summary>
     public abstract class PSSessionConfiguration : IDisposable
@@ -356,7 +356,7 @@ namespace System.Management.Automation.Remoting
         #region public interfaces
 
         /// <summary>
-        /// Derived classes must override this to supply an InitialSesionState
+        /// Derived classes must override this to supply an InitialSessionState
         /// to be used to construct a Runspace for the user
         /// </summary>
         /// <param name="senderInfo">
@@ -426,7 +426,7 @@ namespace System.Management.Automation.Remoting
         #region IDisposable Overrides
 
         /// <summary>
-        /// Disose this configuration object. This will be called when a Runspace/RunspacePool
+        /// Dispose this configuration object. This will be called when a Runspace/RunspacePool
         /// created using InitialSessionState from this object is Closed.
         /// </summary>
         public void Dispose()
@@ -587,7 +587,7 @@ namespace System.Management.Automation.Remoting
                 {
                 }
 
-                // if we are here, that means we are unble to load the type specified
+                // if we are here, that means we are unable to load the type specified
                 // in the config xml.. notify the same.
                 throw PSTraceSource.NewArgumentException("typeToLoad", RemotingErrorIdStrings.UnableToLoadType,
                         typeToLoad, ConfigurationDataFromXML.INITPARAMETERSTOKEN);
@@ -601,7 +601,7 @@ namespace System.Management.Automation.Remoting
         /// <summary>
         /// Sets the application's current working directory to <paramref name="applicationBase"/> and 
         /// loads the assembly <paramref name="assemblyName"/>. Once the assembly is loaded, the application's
-        /// current working directory is set back to the orginal value.
+        /// current working directory is set back to the original value.
         /// </summary>
         /// <param name="applicationBase"></param>
         /// <param name="assemblyName"></param>
@@ -654,7 +654,7 @@ namespace System.Management.Automation.Remoting
                 }
             }
 
-            // Even if there is erro changing current working directory..try to load the assembly
+            // Even if there is error changing current working directory..try to load the assembly
             // This is to allow assembly loading from GAC
             Assembly result = null;
             try
@@ -2068,7 +2068,7 @@ namespace System.Management.Automation.Remoting
                                     // Win8: 627752 Cannot load microsoft.powershell.core module as part of DISC
                                     // Convert Microsoft.PowerShell.Core module -> Microsoft.PowerShell.Core snapin.
                                     // Doing this Import only in SessionType.Empty case, because other cases already do this.
-                                    // In V3, Micorosft.PowerShell.Core module is not installed externally.
+                                    // In V3, Microsoft.PowerShell.Core module is not installed externally.
                                     iss.ImportCorePSSnapIn();
                                 }
                                 // silently ignore Microsoft.PowerShell.Core for other cases ie., SessionType.RestrictedRemoteServer && SessionType.Default
@@ -2316,7 +2316,7 @@ namespace System.Management.Automation.Remoting
                 }
             }
 
-            // Now apply visibilty logic
+            // Now apply visibility logic
             if (cmdletVisibilityApplied || functionVisiblityApplied || aliasVisibilityApplied || providerVisibiltyApplied)
             {
                 if (sessionType == SessionType.Default)
@@ -2758,7 +2758,7 @@ namespace System.Management.Automation.Remoting
         }
 
         /// <summary>
-        /// Attempts to get a hastable array from an object
+        /// Attempts to get a hashtable array from an object
         /// </summary>
         /// <param name="hashObj"></param>
         /// <returns></returns>
@@ -2802,7 +2802,7 @@ namespace System.Management.Automation.Remoting
         }
 
         /// <summary>
-        /// Attemps to get a string array from a hashtable
+        /// Attempts to get a string array from a hashtable
         /// </summary>
         /// <param name="hashObj"></param>
         /// <returns></returns>

--- a/src/System.Management.Automation/engine/remoting/fanin/OutOfProcTransportManager.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/OutOfProcTransportManager.cs
@@ -483,7 +483,7 @@ namespace System.Management.Automation.Remoting.Client
             _dataProcessingCallbacks.CloseAckPacketReceived += new OutOfProcessUtils.CloseAckPacketReceived(OnCloseAckReceived);
 
             dataToBeSent.Fragmentor = base.Fragmentor;
-            // session transport manager can recieve unlimited data..however each object is limited
+            // session transport manager can receive unlimited data..however each object is limited
             // by maxRecvdObjectSize. this is to allow clients to use a session for an unlimited time..
             // also the messages that can be sent to a session are limited and very controlled.
             // However a command transport manager can be restricted to receive only a fixed amount of data
@@ -708,7 +708,7 @@ namespace System.Management.Automation.Remoting.Client
                 }
 
                 // dont let the writer write new data as the process is exited.
-                // Not asssigning null to stdInWriter to fix the race condition between OnExited() and CloseAsync() methods.
+                // Not assigning null to stdInWriter to fix the race condition between OnExited() and CloseAsync() methods.
                 // 
                 stdInWriter.StopWriting();
             }
@@ -1044,7 +1044,7 @@ namespace System.Management.Automation.Remoting.Client
                 return;
             }
 
-            // Send one fragement
+            // Send one fragment
             SendOneItem();
         }
 
@@ -2242,7 +2242,7 @@ namespace System.Management.Automation.Remoting.Server
 
             lock (_syncObject)
             {
-                // the dictinoary is cleared by ServerPowershellDataStructure handler
+                // the dictionary is cleared by ServerPowershellDataStructure handler
                 // once the clean up is complete for the transport manager
                 Dbg.Assert(!_cmdTransportManagers.ContainsKey(powerShellCmdId), "key already exists");
                 _cmdTransportManagers.Add(powerShellCmdId, cmdTM);

--- a/src/System.Management.Automation/engine/remoting/fanin/PSPrincipal.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/PSPrincipal.cs
@@ -276,7 +276,7 @@ namespace System.Management.Automation.Remoting
 
         /// <summary>
         /// Gets the type of authentication used.
-        /// For a WSMan service autheticated user this will be one of the following:
+        /// For a WSMan service authenticated user this will be one of the following:
         ///  WSMAN_DEFAULT_AUTHENTICATION
         ///  WSMAN_NO_AUTHENTICATION 
         ///  WSMAN_AUTH_DIGEST           
@@ -306,11 +306,11 @@ namespace System.Management.Automation.Remoting
         #region Public Constructor
 
         /// <summary>
-        /// Constructor used to construt a PSIdentity object
+        /// Constructor used to construct a PSIdentity object
         /// </summary>
         /// <param name="authType">
         /// Type of authentication used to authenticate this user.
-        /// For a WSMan service autheticated user this will be one of the following:
+        /// For a WSMan service authenticated user this will be one of the following:
         ///  WSMAN_DEFAULT_AUTHENTICATION
         ///  WSMAN_NO_AUTHENTICATION 
         ///  WSMAN_AUTH_DIGEST           
@@ -327,7 +327,7 @@ namespace System.Management.Automation.Remoting
         /// Name of the user
         /// </param>
         /// <param name="cert">
-        /// Certificate details if Certifiate authentication is used.
+        /// Certificate details if Certificate authentication is used.
         /// </param>
         public PSIdentity(string authType, bool isAuthenticated, string userName, PSCertificateDetails cert)
         {
@@ -367,7 +367,7 @@ namespace System.Management.Automation.Remoting
         #region Constructor
 
         /// <summary>
-        /// Constructor used to construt a PSCertificateDetails object
+        /// Constructor used to construct a PSCertificateDetails object
         /// </summary>
         /// <param name="subject">
         /// Subject of the certificate.

--- a/src/System.Management.Automation/engine/remoting/fanin/PriorityCollection.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/PriorityCollection.cs
@@ -22,7 +22,7 @@ namespace System.Management.Automation.Remoting
         Default = 0,
 
         /// <summary>
-        /// PromptReponse may be sent with or without priority considerations.
+        /// PromptResponse may be sent with or without priority considerations.
         /// Large data objects will be fragmented so that each fragmented piece can
         /// fit into one message.
         /// </summary>
@@ -62,7 +62,7 @@ namespace System.Management.Automation.Remoting
         /// Callback that is called once a fragmented data is available to send.
         /// </summary>
         /// <param name="data">
-        /// Fragemented object that can be sent to the remote end.
+        /// Fragmented object that can be sent to the remote end.
         /// </param>
         /// <param name="priorityType">
         /// Priority stream to which <paramref name="data"/> belongs to.
@@ -124,7 +124,7 @@ namespace System.Management.Automation.Remoting
             Dbg.Assert(null != _dataToBeSent, "Serialized streams are not initialized");
 
             // make sure the only one object is fragmented and added to the collection
-            // at any give time. This way the order of fragmenets is maintained
+            // at any give time. This way the order of fragment is maintained
             // in the SendDataCollection(s).
             lock (_syncObjects[(int)priority])
             {
@@ -172,7 +172,7 @@ namespace System.Management.Automation.Remoting
         /// synchronized way.
         /// 
         /// While getting a fragment the following algorithm is used:
-        /// 1. If this is the first time or if the last fragement read is an EndFragment,
+        /// 1. If this is the first time or if the last fragment read is an EndFragment,
         ///    then a new set of fragments is chosen based on the implicit priority.
         ///    PromptResponse is higher in priority order than default.
         /// 2. If last fragment read is not an EndFragment, then next fragment is chosen from
@@ -189,7 +189,7 @@ namespace System.Management.Automation.Remoting
         /// is undefined.
         /// </param>
         /// <returns>
-        /// A FragementRemoteObject if available, otherwise null.
+        /// A FragmentRemoteObject if available, otherwise null.
         /// </returns>
         internal byte[] ReadOrRegisterCallback(OnDataAvailableCallback callback,
             out DataPriorityType priorityType)
@@ -284,16 +284,16 @@ namespace System.Management.Automation.Remoting
         private MemoryStream _pendingDataStream;
         // the idea is to maintain 1 whole object.
         // 1 whole object may contain any number of fragments. blob from
-        // each fragement is written to this stream.
+        // each fragment is written to this stream.
         private MemoryStream _dataToProcessStream;
         private long _currentObjectId;
         private long _currentFrgId;
-        // max deseriazlied object size in bytes
+        // max deserialized object size in bytes
         private Nullable<int> _maxReceivedObjectSize;
         private int _totalReceivedObjectSizeSoFar;
         private bool _isCreateByClientTM;
 
-        // this indicates if any off sync fragments canbe ignored
+        // this indicates if any off sync fragments can be ignored
         // this gets reset (to false) upon receiving the next "start" fragment along the stream
         private bool _canIgnoreOffSyncFragments = false;
 
@@ -375,7 +375,7 @@ namespace System.Management.Automation.Remoting
 
         /// <summary>
         /// Prepares the collection for a stream connect
-        ///     When reconneting from same client, its possible that fragment stream get interrupted if server is dropping data
+        ///     When reconnecting from same client, its possible that fragment stream get interrupted if server is dropping data
         ///     When connecting from a new client, its possible to get trailing fragments of a previously partially transmitted object
         ///     Logic based on this flag, ensures such offsync/trailing fragments get ignored until the next full object starts flowing
         /// </summary>
@@ -401,7 +401,7 @@ namespace System.Management.Automation.Remoting
         /// Defragmented Object if any, otherwise null.
         /// </returns>
         /// <exception cref="PSRemotingTransportException">
-        /// 1. Fragmet Ids not in sequence
+        /// 1. Fragment Ids not in sequence
         /// 2. Object Ids does not match
         /// 3. The current deserialized object size of the received data exceeded 
         /// allowed maximum object size. The current deserialized object size is {0}.
@@ -518,7 +518,7 @@ namespace System.Management.Automation.Remoting
                         }
                     }
 
-                    // appears like stream doesn't have individual postion marker for read and write
+                    // appears like stream doesn't have individual position marker for read and write
                     // since we are going to read from now...
                     _pendingDataStream.Seek(0, SeekOrigin.Begin);
 
@@ -612,7 +612,7 @@ namespace System.Management.Automation.Remoting
                     {
                         try
                         {
-                            // appears like stream doesn't individual postion marker for read and write
+                            // appears like stream doesn't individual position marker for read and write
                             // since we are going to read from now..i am resetting position to 0.
                             _dataToProcessStream.Seek(0, SeekOrigin.Begin);
                             RemoteDataObject<PSObject> remoteObject = RemoteDataObject<PSObject>.CreateFrom(_dataToProcessStream, _defragmentor);
@@ -726,7 +726,7 @@ namespace System.Management.Automation.Remoting
         #region Constructor
 
         /// <summary>
-        /// Construct a priority recieve data collection
+        /// Construct a priority receive data collection
         /// </summary>
         /// <param name="defragmentor">Defragmentor used to deserialize an object.</param>
         /// <param name="createdByClientTM">
@@ -811,7 +811,7 @@ namespace System.Management.Automation.Remoting
         /// Data to process.
         /// </param>
         /// <param name="priorityType">
-        /// Priorty stream this data belongs to.
+        /// Priority stream this data belongs to.
         /// </param>
         /// <param name="callback">
         /// Callback to call once a complete deserialized object is available.
@@ -820,7 +820,7 @@ namespace System.Management.Automation.Remoting
         /// Defragmented Object if any, otherwise null.
         /// </returns>
         /// <exception cref="PSRemotingTransportException">
-        /// 1. Fragmet Ids not in sequence
+        /// 1. Fragment Ids not in sequence
         /// 2. Object Ids does not match
         /// 3. The current deserialized object size of the received data exceeded 
         /// allowed maximum object size. The current deserialized object size is {0}.

--- a/src/System.Management.Automation/engine/remoting/fanin/WSManNativeAPI.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/WSManNativeAPI.cs
@@ -238,7 +238,7 @@ namespace System.Management.Automation.Remoting.Client
             /// </summary>
             WSMAN_FLAG_AUTH_DIGEST = 0x2,
             /// <summary>
-            /// Use negotiate authentication for a remote operation (may use kerboros or ntlm)
+            /// Use negotiate authentication for a remote operation (may use kerberos or ntlm)
             /// </summary>
             WSMAN_FLAG_AUTH_NEGOTIATE = 0x4,
             /// <summary>
@@ -355,7 +355,7 @@ namespace System.Management.Automation.Remoting.Client
             }
 
             /// <summary>
-            /// gets a structure represenation (used for marshalling)
+            /// gets a structure representation (used for marshalling)
             /// </summary>
             internal WSManUserNameCredentialStruct CredentialStruct
             {
@@ -508,7 +508,7 @@ namespace System.Management.Automation.Remoting.Client
             /// </summary>
             WSMAN_OPTION_UNENCRYPTED_MESSAGES = 20,
             /// <summary>
-            /// int - 1 Send all network packets for remote operatons in UTF16; 0 - default is UTF8
+            /// int - 1 Send all network packets for remote operations in UTF16; 0 - default is UTF8
             /// </summary>
             WSMAN_OPTION_UTF16 = 21,
             /// <summary>
@@ -607,7 +607,7 @@ namespace System.Management.Automation.Remoting.Client
 
         #region WSManData
         /// <summary>
-        /// types of suppored WSMan data.
+        /// types of supported WSMan data.
         /// PowerShell uses only Text and DWORD (in some places).
         /// </summary>
         internal enum WSManDataType : uint
@@ -712,7 +712,7 @@ namespace System.Management.Automation.Remoting.Client
             }
 
             /// <summary>
-            /// Gets the buffer lenfth of data.
+            /// Gets the buffer length of data.
             /// </summary>
             internal int BufferLength
             {
@@ -748,7 +748,7 @@ namespace System.Management.Automation.Remoting.Client
             }
 
             /// <summary>
-            /// implict IntPtr conversion
+            /// implicit IntPtr conversion
             /// </summary>
             /// <param name="data"></param>
             /// <returns></returns>
@@ -1085,7 +1085,7 @@ namespace System.Management.Automation.Remoting.Client
         }
 
         /// <summary>
-        /// Option set struct used to pass optional infromation
+        /// Option set struct used to pass optional information
         /// with WSManCreateShellEx
         /// </summary>
         internal struct WSManOptionSet : IDisposable
@@ -1899,7 +1899,7 @@ namespace System.Management.Automation.Remoting.Client
             }
         }
         /// <summary>
-        /// Used in the shell compeletion function delegate to refer to the data.
+        /// Used in the shell completion function delegate to refer to the data.
         /// </summary>
         internal class WSManReceiveDataResult
         {
@@ -1916,7 +1916,7 @@ namespace System.Management.Automation.Remoting.Client
             /// Constructs a WSManReceiveDataResult from the unmanaged pointer.
             /// This involves copying data from unmanaged memory to managed heap.
             /// Currently PowerShell supports only text data on the wire, so this
-            /// method asserst if the data is not text.
+            /// method asserts if the data is not text.
             /// </summary>
             /// <param name="unmanagedData">
             /// Pointer to unmanaged data.
@@ -2104,7 +2104,7 @@ namespace System.Management.Automation.Remoting.Client
             }
 
             /// <summary>
-            /// Managed represenation of WSMAN_SENDER_DETAILS
+            /// Managed representation of WSMAN_SENDER_DETAILS
             /// </summary>
             [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
             private struct WSManSenderDetailsInternal
@@ -2324,7 +2324,7 @@ namespace System.Management.Automation.Remoting.Client
         /// <summary>
         /// This API deinitializes the Winrm client stack; all operations will 
         /// finish before this API will return; this is a sync call;
-        /// it is highly recommended that all operations are explictly cancelled 
+        /// it is highly recommended that all operations are explicitly cancelled 
         /// and all sessions are closed before calling this API
         /// Returns non zero error code upon failure.
         /// </summary>
@@ -2494,7 +2494,7 @@ namespace System.Management.Automation.Remoting.Client
         /// callback to notify when the create operation completes.
         /// </param>
         /// <param name="shellOperationHandle">
-        /// An out parameter referening a WSMan shell operation handle
+        /// An out parameter referencing a WSMan shell operation handle
         /// for this shell.
         /// </param>
         /// <returns></returns>
@@ -2596,7 +2596,7 @@ namespace System.Management.Automation.Remoting.Client
         /// callback to notify when the operation completes.
         /// </param>
         /// <param name="commandOperationHandle">
-        /// An out parameter referening a WSMan shell operation handle
+        /// An out parameter referencing a WSMan shell operation handle
         /// for this command.
         /// </param>
         [DllImport(WSManNativeApi.WSManClientApiDll, EntryPoint = "WSManRunShellCommandEx", SetLastError = false, CharSet = CharSet.Unicode)]
@@ -2643,7 +2643,7 @@ namespace System.Management.Automation.Remoting.Client
         /// <param name="flags"> </param>
         /// <param name="desiredStreamSet"></param>
         /// <param name="asyncCallback">
-        /// callback which receives the data asynchronoulsy.
+        /// callback which receives the data asynchronously.
         /// </param>
         /// <param name="receiveOperationHandle">
         /// handle to use to cancel the operation.

--- a/src/System.Management.Automation/engine/remoting/fanin/WSManPlugin.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/WSManPlugin.cs
@@ -135,7 +135,7 @@ namespace System.Management.Automation.Remoting
 
         /// <summary>
         /// Enables dependency injection after the static constructor is called.
-        /// This may be overridden in unit tests to enable different behavoir.
+        /// This may be overridden in unit tests to enable different behavior.
         /// It is static because static instances of this class use the facade. Otherwise,
         /// it would be passed in via a parameterized constructor.
         /// </summary>
@@ -159,7 +159,7 @@ namespace System.Management.Automation.Remoting
         static WSManPluginInstance()
         {
             // NOTE - the order is important here:
-            // because handler from WindowsErrorReporting is going to terminate the proces
+            // because handler from WindowsErrorReporting is going to terminate the process
             // we want it to fire last
 
 #if !CORECLR
@@ -312,7 +312,7 @@ namespace System.Management.Automation.Remoting
                     return;
                 }
 
-                // Create a shell session wrapper to track and service future interacations.
+                // Create a shell session wrapper to track and service future interactions.
                 mgdShellSession = new WSManPluginShellSession(requestDetails, serverTransportMgr, remoteShellSession, context);
                 AddToActiveShellSessions(mgdShellSession);
                 mgdShellSession.SessionClosed += new EventHandler<EventArgs>(HandleShellSessionClosed);
@@ -791,7 +791,7 @@ namespace System.Management.Automation.Remoting
                 return;
             }
 
-            // this connect is on a commad
+            // this connect is on a command
             WSManPluginCommandSession mgdCmdSession = mgdShellSession.GetCommandSession(commandContext);
             if (null == mgdCmdSession)
             {
@@ -1471,7 +1471,7 @@ namespace System.Management.Automation.Remoting
         /// Sets thread properties like UI Culture, Culture etc..This is needed as code is transitioning from
         /// unmanaged heap to managed heap...and thread properties are not set correctly during this 
         /// transition.
-        /// Currently WSMan provider supplies only UI Culture related data..so only UI Cutlure is set.
+        /// Currently WSMan provider supplies only UI Culture related data..so only UI Culture is set.
         /// </summary>
         /// <param name="requestDetails"></param>
         internal static void SetThreadProperties(

--- a/src/System.Management.Automation/engine/remoting/fanin/WSManPluginFacade.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/WSManPluginFacade.cs
@@ -22,7 +22,7 @@ namespace System.Management.Automation.Remoting
     // cases if GCRoot is used, CLR will pick up the first AppDomain in the list
     // to get the managed handle. Delegates are not just function pointers, they
     // also contain a reference to the AppDomain that created it. However the catch
-    // is that delegates must be marshelled into their respective unmanaged function
+    // is that delegates must be marshalled into their respective unmanaged function
     // pointers (otherwise we end up storing the delegate into a GCRoot).
 
     /// <summary>

--- a/src/System.Management.Automation/engine/remoting/fanin/WSManPluginShellSession.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/WSManPluginShellSession.cs
@@ -39,7 +39,7 @@ namespace System.Management.Automation.Remoting
         // request context passed by WSMan while sending Plugin data.
         internal WSManNativeApi.WSManPluginRequest sendRequestDetails;
         internal WSManPluginOperationShutdownContext shutDownContext;
-        // tracker used in conjunction with WSMan API to identigy a particular
+        // tracker used in conjunction with WSMan API to identify a particular
         // shell context.
         internal RegisteredWaitHandle registeredShutDownWaitHandle;
         internal WSManPluginServerTransportManager transportMgr;
@@ -72,7 +72,7 @@ namespace System.Management.Automation.Remoting
             // Dispose of unmanaged resources.
             Dispose(true);
             // This object will be cleaned up by the Dispose method. 
-            // Therefore, you should call GC.SupressFinalize to 
+            // Therefore, you should call GC.SuppressFinalize to 
             // take this object off the finalization queue 
             // and prevent finalization code for this object 
             // from executing a second time.
@@ -323,7 +323,7 @@ namespace System.Management.Automation.Remoting
             Close(reasonForClose);
         }
 
-        // handle prepare from tranport by reporting context to WSMan.
+        // handle prepare from transport by reporting context to WSMan.
         internal void HandlePrepareFromTransportManager(Object sender, EventArgs eventArgs)
         {
             ReportContext();
@@ -481,7 +481,7 @@ namespace System.Management.Automation.Remoting
                                     WSManNativeApi.PS_XML_NAMESPACE,
                                     Convert.ToBase64String(outputData));
 
-                    //TODO: curretly using OperationComplete to report back the responseXml. This will need to change to use WSManReportObject
+                    //TODO: currently using OperationComplete to report back the responseXml. This will need to change to use WSManReportObject
                     //that is currently internal.
                     WSManPluginInstance.ReportOperationComplete(requestDetails, WSManPluginErrorCodes.NoError, responseData);
                 }
@@ -641,7 +641,7 @@ namespace System.Management.Automation.Remoting
             while (cmdSessionEnumerator.MoveNext())
             {
                 WSManPluginCommandSession cmdSession = cmdSessionEnumerator.Current;
-                // we are not interested in session closed events anymore as we are intiating the close
+                // we are not interested in session closed events anymore as we are initiating the close
                 // anyway/
                 cmdSession.SessionClosed -= new EventHandler<EventArgs>(this.HandleCommandSessionClosed);
                 cmdSession.Close(reasonForClose);
@@ -712,7 +712,7 @@ namespace System.Management.Automation.Remoting
             if (!isRcvOp)
             {
                 // Initiate close on the active command sessions and then clear the internal
-                // Command Sesison dictionary
+                // Command Session dictionary
                 CloseAndClearCommandSessions(reasonForClose);
                 // raise session closed event and let dependent code to release resources.
                 // null check is not performed here because the handler will take care of this.

--- a/src/System.Management.Automation/engine/remoting/fanin/WSManPluginTransportManager.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/WSManPluginTransportManager.cs
@@ -391,7 +391,7 @@ namespace System.Management.Automation.Remoting
         private WSManPluginServerTransportManager _serverTransportMgr;
         private System.Guid _cmdId;
 
-        // Create Cmd Transport Manager for this sessn trnsprt manager
+        // Create Cmd Transport Manager for this sessn transport manager
         internal WSManPluginCommandTransportManager(WSManPluginServerTransportManager srvrTransportMgr)
             : base(srvrTransportMgr.Fragmentor.FragmentSize, srvrTransportMgr.CryptoHelper)
         {

--- a/src/System.Management.Automation/engine/remoting/fanin/WSManTransportManager.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/WSManTransportManager.cs
@@ -122,8 +122,8 @@ namespace System.Management.Automation.Remoting.Client
             PSRemotingTransportException e;
 
             //For the first two special error conditions, it is remotely possible that the wsmanSessionTM is null when the failures are returned 
-            //as part of command TM operations (could be returned becuase of RC retries under the hood)
-            //Not worth to handle these cases seperately as there are very corner scenarios, but need to make sure wsmanSessionTM is not referenced
+            //as part of command TM operations (could be returned because of RC retries under the hood)
+            //Not worth to handle these cases separately as there are very corner scenarios, but need to make sure wsmanSessionTM is not referenced
 
 
             // Destination server is reporting that URI redirect is required for this user.
@@ -576,7 +576,7 @@ namespace System.Management.Automation.Remoting.Client
             dataToBeSent.Fragmentor = base.Fragmentor;
             _sessionName = sessionName;
 
-            // session transport manager can recieve unlimited data..however each object is limited
+            // session transport manager can receive unlimited data..however each object is limited
             // by maxRecvdObjectSize. this is to allow clients to use a session for an unlimited time..
             // also the messages that can be sent to a session are limited and very controlled.
             // However a command transport manager can be restricted to receive only a fixed amount of data
@@ -931,7 +931,7 @@ namespace System.Management.Automation.Remoting.Client
                     _openContent = new WSManNativeApi.WSManData_ManToUn(base64EncodedDataInXml);
                 }
 
-                //THERE SHOULD BE NO ADDITIONAL DATA. If there is, it means we are not able to push all initial negotaion related data
+                //THERE SHOULD BE NO ADDITIONAL DATA. If there is, it means we are not able to push all initial negotiation related data
                 // as part of Connect SOAP. The connect algorithm is based on this assumption. So bail out.
                 additionalData = dataToBeSent.ReadOrRegisterCallback(null, out additionalDataType);
                 if (additionalData != null)
@@ -973,7 +973,7 @@ namespace System.Management.Automation.Remoting.Client
                 WSManNativeApi.WSManConnectShellEx(_wsManSessionHandle,
                     flags,
                     ConnectionInfo.ShellUri,
-                    RunspacePoolInstanceId.ToString().ToUpperInvariant(),  //wsman is case sensetive wrt shellId. so consistently using upper case
+                    RunspacePoolInstanceId.ToString().ToUpperInvariant(),  //wsman is case sensitive wrt shellId. so consistently using upper case
                     IntPtr.Zero,
                     _openContent,
                     _connectSessionCallback,
@@ -1067,7 +1067,7 @@ namespace System.Management.Automation.Remoting.Client
                 uIdleTimeout,
                 _sessionName);
 
-            // additional content with create shell call. Piggy back first fragement from
+            // additional content with create shell call. Piggy back first fragment from
             // the dataToBeSent buffer.
             if (null == _openContent)
             {
@@ -3035,7 +3035,7 @@ namespace System.Management.Automation.Remoting.Client
                 }
 
                 // WSMan API do not allow a signal/input/receive be sent until RunShellCommand is
-                // successfull (ie., callback is received)..so note that a signal is to be sent
+                // successful (ie., callback is received)..so note that a signal is to be sent
                 // here and return.
                 if (!_isCreateCallbackReceived)
                 {
@@ -3315,7 +3315,7 @@ namespace System.Management.Automation.Remoting.Client
                 }
             }
 
-            // Send remaing cmd / parameter fragments.
+            // Send remaining cmd / parameter fragments.
             lock (cmdTM.syncObject)
             {
                 cmdTM._isCreateCallbackReceived = true;
@@ -3350,7 +3350,7 @@ namespace System.Management.Automation.Remoting.Client
                 cmdTM.SendOneItem();
 
                 // WSMan API does not allow a signal/input/receive be sent until RunShellCommand is
-                // successfull (ie., callback is received)
+                // successful (ie., callback is received)
                 if (cmdTM._isStopSignalPending)
                 {
                     cmdTM.SendStopSignal();
@@ -3802,7 +3802,7 @@ namespace System.Management.Automation.Remoting.Client
             if (serializedPipeline.Length > 0)
             {
                 data = serializedPipeline.ReadOrRegisterCallback(null);
-                // if there are no command / parameter fragements need to be sent
+                // if there are no command / parameter fragments need to be sent
                 // start receiving data. Reason: Command will start its execution
                 // once command string + parameters are sent.
                 if (serializedPipeline.Length == 0)
@@ -3925,7 +3925,7 @@ namespace System.Management.Automation.Remoting.Client
                 }
 
                 receiveDataInitiated = true;
-                // recive callback
+                // receive callback
                 _receivedFromRemote = new WSManNativeApi.WSManShellAsync(new IntPtr(_cmdContextId), s_cmdReceiveCallback);
                 WSManNativeApi.WSManReceiveShellOutputEx(_wsManShellOperationHandle,
                     _wsManCmdOperationHandle, startInDisconnectedMode ? (int)WSManNativeApi.WSManShellFlag.WSMAN_FLAG_RECEIVE_DELAY_OUTPUT_STREAM : 0,

--- a/src/System.Management.Automation/engine/remoting/server/OutOfProcServerMediator.cs
+++ b/src/System.Management.Automation/engine/remoting/server/OutOfProcServerMediator.cs
@@ -342,7 +342,7 @@ namespace System.Management.Automation.Remoting.Server
                         lock (_syncObject)
                         {
                             // give a chance to runspace/pipelines to close (as it looks like the client died
-                            // interminently)
+                            // intermittently)
                             sessionTM.Close(null);
                             sessionTM = null;
                         }

--- a/src/System.Management.Automation/engine/remoting/server/ServerPowerShellDriver.cs
+++ b/src/System.Management.Automation/engine/remoting/server/ServerPowerShellDriver.cs
@@ -718,7 +718,7 @@ namespace System.Management.Automation
         /// <remarks>This method should be called before
         /// sending the state information. The client will 
         /// remove the association between a powershell and
-        /// runspace pool if it recieves any of the terminal
+        /// runspace pool if it receives any of the terminal
         /// states. Hence all the remaining data should be
         /// sent before this happens. Else the data will be
         /// discarded</remarks>

--- a/src/System.Management.Automation/engine/remoting/server/ServerRemoteHost.cs
+++ b/src/System.Management.Automation/engine/remoting/server/ServerRemoteHost.cs
@@ -398,7 +398,7 @@ namespace System.Management.Automation.Remoting
         #region Properties
 
         /// <summary>
-        /// Server Debuger
+        /// Server Debugger
         /// </summary>
         internal Debugger ServerDebugger
         {

--- a/src/System.Management.Automation/engine/remoting/server/ServerRemotingProtocol2.cs
+++ b/src/System.Management.Automation/engine/remoting/server/ServerRemotingProtocol2.cs
@@ -503,7 +503,7 @@ namespace System.Management.Automation
                 // no need to listen for closing events as we are initiating the close
                 _transportManager.Closing -= HandleTransportClosing;
                 // if terminal state is reached close the transport manager instead of letting
-                // the client intiate the close.
+                // the client initiate the close.
                 _transportManager.Close(null);
             }
         }
@@ -589,7 +589,7 @@ namespace System.Management.Automation
         /// <summary>
         /// called when session is connected from a new client
         /// calls into observers of this event. 
-        /// observers include corrensponding driver that shutsdown
+        /// observers include corresponding driver that shutdown
         /// input stream is present
         /// </summary>
         internal void ProcessConnect()

--- a/src/System.Management.Automation/engine/remoting/server/ServerRunspacePoolDriver.cs
+++ b/src/System.Management.Automation/engine/remoting/server/ServerRunspacePoolDriver.cs
@@ -304,7 +304,7 @@ namespace System.Management.Automation
         }
 
         /// <summary>
-        /// Send applicaiton private data to client
+        /// Send application private data to client
         /// will be called during runspace creation 
         /// and each time a new client connects to the server session
         /// </summary>
@@ -2366,7 +2366,7 @@ namespace System.Management.Automation
         }
 
         /// <summary>
-        /// Blocks DebugerStop event thread until exit debug mode is 
+        /// Blocks DebuggerStop event thread until exit debug mode is 
         /// received from the client.
         /// </summary>
         private void OnEnterDebugMode(ManualResetEventSlim debugModeCompletedEvent)

--- a/src/System.Management.Automation/engine/remoting/server/serverremotesession.cs
+++ b/src/System.Management.Automation/engine/remoting/server/serverremotesession.cs
@@ -53,7 +53,7 @@ namespace System.Management.Automation.Remoting
         internal RemoteSessionCapability ServerCapability { get; set; }
 
         /// <summary>
-        /// True if negotiation from client is succeeded...in which case ClienCapability
+        /// True if negotiation from client is succeeded...in which case ClientCapability
         /// is the capability that server agreed with.
         /// </summary>
         internal bool IsNegotiationSucceeded { get; set; }
@@ -102,7 +102,7 @@ namespace System.Management.Automation.Remoting
         #region Constructors
 
         /// <summary>
-        /// This constructor inistantiates a ServerRemoteSession object and 
+        /// This constructor instantiates a ServerRemoteSession object and 
         /// a ServerRemoteSessionDataStructureHandler object.
         /// </summary>
         /// <param name="senderInfo">
@@ -150,11 +150,11 @@ namespace System.Management.Automation.Remoting
             transportManager.Closing += HandleResourceClosing;
 
             // update the quotas from sessionState..start with default size..and
-            // when Custom Session Configuration is loaded (during runsapce creation) update this.
+            // when Custom Session Configuration is loaded (during runspace creation) update this.
             transportManager.ReceivedDataCollection.MaximumReceivedObjectSize =
                 BaseTransportManager.MaximumReceivedObjectSize;
 
-            // session transport manager can recieve unlimited data..however each object is limited
+            // session transport manager can receive unlimited data..however each object is limited
             // by maxRecvdObjectSize. this is to allow clients to use a session for an unlimited time..
             // also the messages that can be sent to a session are limited and very controlled.
             // However a command transport manager can be restricted to receive only a fixed amount of data
@@ -168,7 +168,7 @@ namespace System.Management.Automation.Remoting
 #region Creation Factory
 
         /// <summary>
-        /// Creates a server remote session for the supplied <paramref name="configuratioinProviderId"/>
+        /// Creates a server remote session for the supplied <paramref name="configurationProviderId"/>
         /// and <paramref name="transportManager"/>.
         /// </summary>
         /// <param name="senderInfo"></param>
@@ -464,13 +464,13 @@ namespace System.Management.Automation.Remoting
 
         /// <summary>
         /// This property returns the ServerRemoteSessionContext object created inside
-        /// this object's contructor.
+        /// this object's constructor.
         /// </summary>
         internal ServerRemoteSessionContext Context { get; }
 
         /// <summary>
         /// This property returns the ServerRemoteSessionDataStructureHandler object created inside
-        /// this object's contructor.
+        /// this object's constructor.
         /// </summary>
         internal ServerRemoteSessionDataStructureHandler SessionDataStructureHandler { get; }
 
@@ -493,15 +493,15 @@ namespace System.Management.Automation.Remoting
         /// ExecutesConnect. expects client capability and connect_runspacepool PSRP 
         /// messages in connectData. 
         /// If negotiation is successful and max and min runspaces in connect_runspacepool
-        /// match the assiciated runspace pool parameters, it builds up server capability
+        /// match the associated runspace pool parameters, it builds up server capability
         /// and runspace_initinfo in connectResponseData.
-        /// This is a version of Connect that executes the whole connect alogirithm in one single
+        /// This is a version of Connect that executes the whole connect algorithm in one single
         /// hop. 
         /// This algorithm is being executed synchronously without associating with state machine. 
         /// </summary>
         /// <param name="connectData"></param>
         /// <param name="connectResponseData"></param>
-        /// The operation is being outside the statemachine becuase of multiple reasons assiciated with design simplicity
+        /// The operation is being outside the statemachine because of multiple reasons associated with design simplicity
         /// - Support automatic disconnect and let wsman server stack take care of connection state
         /// - The response data should not travel in transports output stream but as part of connect response
         /// - We want this operation to be synchronous
@@ -520,7 +520,7 @@ namespace System.Management.Automation.Remoting
             }
 
             //TODO: Follow up on comment from Krishna regarding having the serialization/deserialization separate for this 
-            // operation. This could be integrated as helper functions in fragmenter/serializer components
+            // operation. This could be integrated as helper functions in fragmentor/serializer components
             long fragmentId = FragmentedRemoteObject.GetFragmentId(connectData, 0);
             bool sFlag = FragmentedRemoteObject.GetIsStartFragment(connectData, 0);
             bool eFlag = FragmentedRemoteObject.GetIsEndFragment(connectData, 0);
@@ -664,7 +664,7 @@ namespace System.Management.Automation.Remoting
 
             //we currently dont support adjusting runspace count on a connect operation.
             //there is a potential race here where in the runspace pool driver is still yet to process a queued
-            //setMax or setMinrunspacees request. 
+            //setMax or setMinrunspaces request. 
             //TODO: resolve this race.. probably by letting the runspace pool consume all messages before we execute this.
             if (clientRequestedRunspaceCount
                 && (_runspacePoolDriver.RunspacePool.GetMaxRunspaces() != clientRequestedMaxRunspaces)
@@ -674,7 +674,7 @@ namespace System.Management.Automation.Remoting
             }
 
             // all client messages are validated
-            // now build up the server capabilites and connect response messages to be piggybacked on connect response
+            // now build up the server capabilities and connect response messages to be piggybacked on connect response
             RemoteDataObject capability = RemotingEncoder.GenerateServerSessionCapability(Context.ServerCapability, _runspacePoolDriver.InstanceId);
             RemoteDataObject runspacepoolInitData = RemotingEncoder.GenerateRunspacePoolInitData(_runspacePoolDriver.InstanceId,
                                                                                                _runspacePoolDriver.RunspacePool.GetMaxRunspaces(),
@@ -682,7 +682,7 @@ namespace System.Management.Automation.Remoting
 
             //having this stream operating separately will result in out of sync fragment Ids. but this is still OK
             //as this is executed only when connecting from a new client that does not have any previous fragments context.
-            //no problem even if fragment Ids in this respose and the sessiontransport stream clash (interfere) and its guaranteed
+            //no problem even if fragment Ids in this response and the sessiontransport stream clash (interfere) and its guaranteed
             // that the fragments in connect response are always complete (enclose a complete object).
             SerializedDataStream stream = new SerializedDataStream(4 * 1024);//Each message with fragment headers cannot cross 4k
             stream.Enter();
@@ -697,8 +697,8 @@ namespace System.Management.Automation.Remoting
             //we are done
             connectResponseData = outbuffer;
 
-            //enque a connect event in state machine to let session do any other post-connect operation
-            // Do this outside of the sychronous connect operation, as otherwise connect can easily get deadlocked
+            //enqueue a connect event in state machine to let session do any other post-connect operation
+            // Do this outside of the synchronous connect operation, as otherwise connect can easily get deadlocked
             ThreadPool.QueueUserWorkItem(new WaitCallback(
                 delegate (object state)
                 {
@@ -947,7 +947,7 @@ namespace System.Management.Automation.Remoting
         }
 
         /// <summary>
-        /// Handle session closing event to close runspace pool drivers this sesion is hosting.
+        /// Handle session closing event to close runspace pool drivers this session is hosting.
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="eventArgs"></param>

--- a/src/System.Management.Automation/engine/remoting/server/serverremotesessionstatemachine.cs
+++ b/src/System.Management.Automation/engine/remoting/server/serverremotesessionstatemachine.cs
@@ -276,7 +276,7 @@ namespace System.Management.Automation.Remoting
         #region Event Handlers
 
         /// <summary>
-        /// This is the handler for Start event of the FSM. This is the begining of everything
+        /// This is the handler for Start event of the FSM. This is the beginning of everything
         /// else. From this moment on, the FSM will proceeds step by step to eventually reach
         /// Established state or Closed state.
         /// </summary>

--- a/src/System.Management.Automation/engine/remoting/server/serverremotingprotocolimplementation.cs
+++ b/src/System.Management.Automation/engine/remoting/server/serverremotingprotocolimplementation.cs
@@ -60,7 +60,7 @@ namespace System.Management.Automation.Remoting
         }
 
         /// <summary>
-        /// This method sends the server side capability negotitation packet to the client. 
+        /// This method sends the server side capability negotiation packet to the client. 
         /// </summary>
         internal override void SendNegotiationAsync()
         {

--- a/src/System.Management.Automation/engine/serialization.cs
+++ b/src/System.Management.Automation/engine/serialization.cs
@@ -241,7 +241,7 @@ namespace System.Management.Automation
         /// <summary>
         /// Used by Remoting infrastructure. This TypeTable instance
         /// will be used by Serializer if ExecutionContext is not
-        /// avaliable (to get the ExecutionContext's TypeTable)
+        /// available (to get the ExecutionContext's TypeTable)
         /// </summary>
         internal TypeTable TypeTable
         {
@@ -517,7 +517,7 @@ namespace System.Management.Automation
         /// <summary>
         /// Used by Remoting infrastructure. This TypeTable instance
         /// will be used by Deserializer if ExecutionContext is not
-        /// avaliable (to get the ExecutionContext's TypeTable)
+        /// available (to get the ExecutionContext's TypeTable)
         /// </summary>
         internal TypeTable TypeTable
         {
@@ -806,7 +806,7 @@ namespace System.Management.Automation
 
         /// Used by Remoting infrastructure. This TypeTable instance
         /// will be used by Serializer if ExecutionContext is not
-        /// avaliable (to get the ExecutionContext's TypeTable)
+        /// available (to get the ExecutionContext's TypeTable)
         private TypeTable _typeTable;
 
         /// <summary>
@@ -843,7 +843,7 @@ namespace System.Management.Automation
         /// <summary>
         /// Used by Remoting infrastructure. This TypeTable instance
         /// will be used by Serializer if ExecutionContext is not
-        /// avaliable (to get the ExecutionContext's TypeTable)
+        /// available (to get the ExecutionContext's TypeTable)
         /// </summary>
         internal TypeTable TypeTable
         {
@@ -1039,7 +1039,7 @@ namespace System.Management.Automation
 
         /// <summary>
         /// Handles primitive known type by first converting it to a PSObject.In W8, extended
-        /// property data is stored external to PSObject. By coverting to PSObject, we will
+        /// property data is stored external to PSObject. By converting to PSObject, we will
         /// be able to retrieve and serialize the extended properties. This is tracked by
         /// Win8: 414042
         /// </summary>
@@ -1243,7 +1243,7 @@ namespace System.Management.Automation
 
             if (depth != 0)
             {
-                // An object which is orignially enumerable becomes an PSObject with ArrayList on deserialization. 
+                // An object which is original enumerable becomes an PSObject with ArrayList on deserialization. 
                 // So on roundtrip it will show up as List.
                 // We serialize properties of enumerable and on deserialization mark the object as Deserialized. 
                 // So if object is marked deserialized, we should write properties.
@@ -2929,7 +2929,7 @@ namespace System.Management.Automation
 
         /// Used by Remoting infrastructure. This TypeTable instance
         /// will be used by Serializer if ExecutionContext is not
-        /// avaliable (to get the ExecutionContext's TypeTable)
+        /// available (to get the ExecutionContext's TypeTable)
         private TypeTable _typeTable;
 
         /// <summary>
@@ -2997,7 +2997,7 @@ namespace System.Management.Automation
         /// <summary>
         /// Used by Remoting infrastructure. This TypeTable instance
         /// will be used by Deserializer if ExecutionContext is not
-        /// avaliable (to get the ExecutionContext's TypeTable)
+        /// available (to get the ExecutionContext's TypeTable)
         /// </summary>
         internal TypeTable TypeTable
         {
@@ -3038,7 +3038,7 @@ namespace System.Management.Automation
             //Versioning Note:Future version of serialization can add new known types.
             //This version will ignore those known types, if they are base object.
             //It is expected that future version will still put information in base
-            //and adpater properties which this serializer can read and use. 
+            //and adapter properties which this serializer can read and use. 
             //For example, assume the version 2 serialization engine supports a new known 
             //type IPAddress. The version 1 deserializer doesn't know IPAddress as known 
             //type and it must retrieve it as an PSObject. The version 2 serializer 
@@ -3046,17 +3046,17 @@ namespace System.Management.Automation
             //<PSObject Version=1.2 Was=Deserialized.IPAddress >
             //  <TypeNames>...</TypeNames>
             //  <BaseObject>
-            //      <IPAddress>120.23.35.53</IPAdddress>
+            //      <IPAddress>120.23.35.53</IPAddress>
             //  </BaseObject>
             //  <Properties>
             //      <string name=Address>120.23.34.53</string>
             //      <string name=class>A</string>
             //  </Properties>
             //</PSObject>
-            // In above example, V1 serializer will ingore <IPAdresss> element and read
+            // In above example, V1 serializer will ignore <IPAddress> element and read
             // properties from <Properties>
             // V2 serializer can read <IPAddress> tag and ignore properties.
-            // Read serializion note doc for information.
+            // Read serialization note doc for information.
 
             //Now validate the major version number is 1
             if (_version.Major != 1)
@@ -3624,7 +3624,7 @@ namespace System.Management.Automation
                     }
                     else
                     {
-                        //We have an unknwon tag
+                        //We have an unknown tag
                         s_trace.WriteLine("Unknwon tag {0} encountered", _reader.LocalName);
                         if (UnknownTagsAllowed)
                         {
@@ -5595,7 +5595,7 @@ namespace System.Management.Automation
                 {
                     // collected object doesn't have a hash code
                     // return an arbitrary hashcode here and fall back on Equal method for comparison
-                    return RuntimeHelpers.GetHashCode(obj); // RuntimeHelpers.GetHashCode(null) returns 0 - this would cause many hashtable colisions for WeakReferences to dead objects
+                    return RuntimeHelpers.GetHashCode(obj); // RuntimeHelpers.GetHashCode(null) returns 0 - this would cause many hashtable collisions for WeakReferences to dead objects
                 }
                 else
                 {
@@ -6602,7 +6602,7 @@ namespace Microsoft.PowerShell
         /// </summary>
         /// <param name="sourceValue">The value to convert from</param>
         /// <param name="destinationType">The type to convert to</param>
-        /// <param name="formatProvider">The format provider to use like in IFormatable's ToString</param>
+        /// <param name="formatProvider">The format provider to use like in IFormattable's ToString</param>
         /// <param name="ignoreCase">true if case should be ignored</param>
         /// <returns>the <paramref name="sourceValue"/> parameter converted to the <paramref name="destinationType"/> parameter using formatProvider and ignoreCase</returns>
         /// <exception cref="InvalidCastException">if no conversion was possible</exception>
@@ -6690,7 +6690,7 @@ namespace Microsoft.PowerShell
         /// </summary>
         /// <param name="sourceValue">The value to convert from</param>
         /// <param name="destinationType">The type to convert to</param>
-        /// <param name="formatProvider">The format provider to use like in IFormatable's ToString</param>
+        /// <param name="formatProvider">The format provider to use like in IFormattable's ToString</param>
         /// <param name="ignoreCase">true if case should be ignored</param>
         /// <returns>sourceValue converted to the <paramref name="destinationType"/> parameter using formatProvider and ignoreCase</returns>
         /// <exception cref="InvalidCastException">if no conversion was possible</exception>
@@ -7209,7 +7209,7 @@ namespace Microsoft.PowerShell
         /// of the DebuggerStopEventArgs type.
         /// </summary>
         /// <param name="instance">InvocationInfo instance.</param>
-        /// <returns>PSObject containing seralized InvocationInfo.</returns>
+        /// <returns>PSObject containing serialized InvocationInfo.</returns>
         public static PSObject GetInvocationInfo(PSObject instance)
         {
             if (instance == null)
@@ -7400,7 +7400,7 @@ namespace Microsoft.PowerShell
         private static PSControl RehydratePSControl(PSObject deserializedControl)
         {
             // Earlier versions of PowerShell did not have all of the possible properties in a control, so we must
-            // use MisingPropertyOk to allow for connections to those older endpoints.
+            // use MissingPropertyOk to allow for connections to those older endpoints.
             PSControl result;
             if (Deserializer.IsDeserializedInstanceOfType(deserializedControl, typeof(TableControl)))
             {

--- a/src/System.Management.Automation/help/AliasHelpProvider.cs
+++ b/src/System.Management.Automation/help/AliasHelpProvider.cs
@@ -126,14 +126,14 @@ namespace System.Management.Automation
         /// <remarks>
         /// This will, 
         ///     a. use _sessionState object to get a list of alias that match the target.
-        ///     b. for each alias, retrive help info as in ExactMatchHelp.
+        ///     b. for each alias, retrieve help info as in ExactMatchHelp.
         /// </remarks>
         /// <param name="helpRequest">help request object</param>   
         /// <param name="searchOnlyContent">
         /// If true, searches for pattern in the help content. Individual 
         /// provider can decide which content to search in.
         /// 
-        /// If false, seraches for pattern in the command names.
+        /// If false, searches for pattern in the command names.
         /// </param> 
         /// <returns>a IEnumerable of helpinfo object</returns>
         internal override IEnumerable<HelpInfo> SearchHelp(HelpRequest helpRequest, bool searchOnlyContent)

--- a/src/System.Management.Automation/help/BaseCommandHelpInfo.cs
+++ b/src/System.Management.Automation/help/BaseCommandHelpInfo.cs
@@ -371,7 +371,7 @@ namespace System.Management.Automation
         }
 
         /// <summary>
-        /// Returs help information for a parameter(s) identified by pattern
+        /// Returns help information for a parameter(s) identified by pattern
         /// </summary>
         /// <param name="pattern">pattern to search for parameters</param>
         /// <returns>A collection of parameters that match pattern</returns>        

--- a/src/System.Management.Automation/help/CabinetAPI.cs
+++ b/src/System.Management.Automation/help/CabinetAPI.cs
@@ -22,7 +22,7 @@ namespace System.Management.Automation.Internal
 
         #region IDisposable Interface
         //
-        // This is a special case of the IDisposable pattern becaue the resource
+        // This is a special case of the IDisposable pattern because the resource
         // to be disposed is managed by the derived class. The implementation here
         // enables derived classes to handle it cleanly.
         //

--- a/src/System.Management.Automation/help/CabinetNativeApi.cs
+++ b/src/System.Management.Automation/help/CabinetNativeApi.cs
@@ -196,7 +196,7 @@ namespace System.Management.Automation.Internal
 
     internal static class CabinetNativeApi
     {
-        #region Delegates and function defintions
+        #region Delegates and function definitions
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
         internal delegate IntPtr FdiAllocDelegate(int size);
@@ -617,7 +617,7 @@ namespace System.Management.Automation.Internal
 
         #endregion
 
-        #region PInvoke Defintions
+        #region PInvoke Definitions
 
         /// <summary>
         /// Creates an FDI context

--- a/src/System.Management.Automation/help/CommandHelpProvider.cs
+++ b/src/System.Management.Automation/help/CommandHelpProvider.cs
@@ -261,7 +261,7 @@ namespace System.Management.Automation
                 if (sb != null)
                 {
                     helpFile = null;
-                    // serachOnlyContent == true means get-help is looking into the content, in this case we dont
+                    // searchOnlyContent == true means get-help is looking into the content, in this case we dont
                     // want to download the content from the remote machine. Reason: In Exchange scenario there
                     // are ~700 proxy commands, downloading help for all the commands and searching in that
                     // content takes a lot of time (in the order of 30 minutes) for their scenarios.
@@ -401,8 +401,8 @@ namespace System.Management.Automation
         /// </summary>
         /// 
         /// <remarks>
-        /// ExactMatchHelp is overrided instead of DoExactMatchHelp to make sure 
-        /// all help item retrival will go through command discovery. Because each 
+        /// ExactMatchHelp is overridden instead of DoExactMatchHelp to make sure 
+        /// all help item retrieval will go through command discovery. Because each 
         /// help file can contain multiple help items for different commands. Directly
         /// retrieve help cache can result in a invalid command to contain valid
         /// help item. Forcing each ExactMatchHelp to go through command discovery 
@@ -591,7 +591,7 @@ namespace System.Management.Automation
                     if (String.IsNullOrEmpty(location))
                     {
                         // If the help file could not be found, then it is possible that the actual assembly name is something like
-                        // <Name>.ni.dll, e.g., MyAsembly.ni.dll, so let’s try to find the original help file in the cmdlet metadata.
+                        // <Name>.ni.dll, e.g., MyAssembly.ni.dll, so let’s try to find the original help file in the cmdlet metadata.
                         location = GetHelpFile(helpFile, cmdletInfo);
                     }
                 }
@@ -794,14 +794,14 @@ namespace System.Management.Automation
             HelpInfo result = GetFromCommandCache(helpFileIdentifier, commandInfo.Name, commandInfo.HelpCategory);
             if (null == result)
             {
-                // check if the command is prefixed and try retreiving help by removing the prefix
+                // check if the command is prefixed and try retrieving help by removing the prefix
                 if ((commandInfo.Module != null) && (!string.IsNullOrEmpty(commandInfo.Prefix)))
                 {
                     MamlCommandHelpInfo newMamlHelpInfo = GetFromCommandCacheByRemovingPrefix(helpFileIdentifier, commandInfo);
                     if (null != newMamlHelpInfo)
                     {
                         // caching the changed help content under the prefixed name for faster
-                        // retreival later.
+                        // retrieval later.
                         AddToCommandCache(helpFileIdentifier, commandInfo.Name, newMamlHelpInfo);
                         return newMamlHelpInfo;
                     }
@@ -824,7 +824,7 @@ namespace System.Management.Automation
             HelpInfo result = GetFromCommandCache(cmdletInfo.ModuleName, cmdletInfo.Name, cmdletInfo.HelpCategory);
             if (result == null)
             {
-                // check if the command is prefixed and try retreiving help by removing the prefix
+                // check if the command is prefixed and try retrieving help by removing the prefix
                 if ((cmdletInfo.Module != null) && (!string.IsNullOrEmpty(cmdletInfo.Prefix)))
                 {
                     MamlCommandHelpInfo newMamlHelpInfo = GetFromCommandCacheByRemovingPrefix(cmdletInfo.ModuleName, cmdletInfo);
@@ -845,7 +845,7 @@ namespace System.Management.Automation
                         }
 
                         // caching the changed help content under the prefixed name for faster
-                        // retreival later.
+                        // retrieval later.
                         AddToCommandCache(cmdletInfo.ModuleName, cmdletInfo.Name, newMamlHelpInfo);
                         return newMamlHelpInfo;
                     }
@@ -862,7 +862,7 @@ namespace System.Management.Automation
         /// original command name (without prefix) as the key.
         /// 
         /// This method retrieves the help content by suppressing the prefix and then making a copy
-        /// of the help contnet + change the name and then returns the copied help content.
+        /// of the help content + change the name and then returns the copied help content.
         /// </summary>
         /// <param name="helpIdentifier"></param>
         /// <param name="cmdInfo"></param>
@@ -882,7 +882,7 @@ namespace System.Management.Automation
             if (null != originalHelpInfo)
             {
                 result = originalHelpInfo.Copy();
-                // command's name can be changed using -Prefix while importing module.To give better user expereience for
+                // command's name can be changed using -Prefix while importing module.To give better user experience for
                 // get-help (on par with get-command), it was decided to use the prefixed command name
                 // for the help content.
                 if (result.FullHelp.Properties["Name"] != null)
@@ -982,7 +982,7 @@ namespace System.Management.Automation
         /// <param name="helpRequest">help request object</param>
         /// <param name="searchOnlyContent">
         /// If true, searches for pattern in the help content of all cmdlets.
-        /// Otherwise, seraches for pattern in the cmdlet names.
+        /// Otherwise, searches for pattern in the cmdlet names.
         /// </param>
         /// <returns></returns>
         internal override IEnumerable<HelpInfo> SearchHelp(HelpRequest helpRequest, bool searchOnlyContent)

--- a/src/System.Management.Automation/help/DefaultCommandHelpObjectBuilder.cs
+++ b/src/System.Management.Automation/help/DefaultCommandHelpObjectBuilder.cs
@@ -235,7 +235,7 @@ namespace System.Management.Automation.Help
 
                 Collection<CommandParameterInfo> parameters = new Collection<CommandParameterInfo>();
                 // GenerateParameters parameters in display order 
-                // ie., Postional followed by
+                // ie., Positional followed by
                 //      Named Mandatory (in alpha numeric) followed by
                 //      Named (in alpha numeric)
                 parameterSet.GenerateParametersInDisplayOrder(commonWorkflow,
@@ -256,7 +256,7 @@ namespace System.Management.Automation.Help
         /// <param name="obj">HelpInfo object</param>
         /// <param name="parameters">
         /// a collection of parameters in display order 
-        /// ie., Postional followed by
+        /// ie., Positional followed by
         ///      Named Mandatory (in alpha numeric) followed by
         ///      Named (in alpha numeric)
         /// </param>

--- a/src/System.Management.Automation/help/HelpCommands.cs
+++ b/src/System.Management.Automation/help/HelpCommands.cs
@@ -201,7 +201,7 @@ namespace Microsoft.PowerShell.Commands
 
         private bool _showWindow;
         /// <summary>
-        /// Gets and sets a value indicatuing whether the help should be displayed in a separate window
+        /// Gets and sets a value indicating whether the help should be displayed in a separate window
         /// </summary>
         [Parameter(ParameterSetName = "ShowWindow", Mandatory = true)]
         public SwitchParameter ShowWindow
@@ -397,7 +397,7 @@ namespace Microsoft.PowerShell.Commands
         /// Change <paramref name="originalHelpObject"/> as per user request.
         /// 
         /// This method creates a new type to the existing typenames 
-        /// depending on Detailed,Full,Example parameteres and adds this 
+        /// depending on Detailed,Full,Example parameters and adds this 
         /// new type(s) to the top of the list.
         /// </summary>
         /// <param name="originalHelpObject">Full help object to transform.</param>
@@ -456,7 +456,7 @@ namespace Microsoft.PowerShell.Commands
         }
 
         /// <summary>
-        /// Gets the paramater info for patterns identified Parameter property.
+        /// Gets the parameter info for patterns identified Parameter property.
         /// Writes the parameter info(s) to the output stream. An error is thrown
         /// if a parameter with a given pattern is not found.
         /// </summary>

--- a/src/System.Management.Automation/help/HelpCommentsParser.cs
+++ b/src/System.Management.Automation/help/HelpCommentsParser.cs
@@ -1140,7 +1140,7 @@ namespace System.Management.Automation
                 }
 
                 // comment block is behind function definition
-                // we don't suport it for configuration delaration as this style is rarely used
+                // we don't support it for configuration declaration as this style is rarely used
                 if (funcDefnAst != null)
                 {
                     startTokenIndex =

--- a/src/System.Management.Automation/help/HelpErrorTracer.cs
+++ b/src/System.Management.Automation/help/HelpErrorTracer.cs
@@ -44,10 +44,10 @@ namespace System.Management.Automation
         /// TraceFrame instance exists in a scope governed by using statement. It is possible
         /// that a new TraceFrame instance will be created in the scope of another TraceFrame
         /// instance. The scopes of various live TraceFrame instances form a stack which is 
-        /// similiar to call stacks of normal C# functions. This is why we call this class
+        /// similar to call stacks of normal C# functions. This is why we call this class
         /// a "TraceFrame"
         /// 
-        /// TraceFrame itself implements IDisposable interface to guarrentee a chance to 
+        /// TraceFrame itself implements IDisposable interface to guarantee a chance to 
         /// write errors into system error pool when execution gets out of its scope. During
         /// disposal time, errorRecords accumulated will be written to system error pool 
         /// together with error context information collected at instance creation.

--- a/src/System.Management.Automation/help/HelpFileHelpInfo.cs
+++ b/src/System.Management.Automation/help/HelpFileHelpInfo.cs
@@ -18,7 +18,7 @@ namespace System.Management.Automation
         /// Constructor for HelpFileHelpInfo
         /// </summary>
         /// <remarks>
-        /// This is made private intentally so that the only way to create object of this type
+        /// This is made private intentionally so that the only way to create object of this type
         /// is through 
         ///     GetHelpInfo(string name, string text, string filename)
         /// </remarks>

--- a/src/System.Management.Automation/help/HelpInfo.cs
+++ b/src/System.Management.Automation/help/HelpInfo.cs
@@ -100,7 +100,7 @@ namespace System.Management.Automation
 
         /// <summary>
         /// Target object in forward-help-provider that should process this HelpInfo.
-        /// This will serve as auxilliary information to be passed to forward help provider.
+        /// This will serve as auxiliary information to be passed to forward help provider.
         /// 
         /// In the case of AliasHelpInfo, for example, it needs to be forwarded to 
         /// CommandHelpProvider to fill in detailed helpInfo. In that case, ForwardHelpCategory
@@ -140,7 +140,7 @@ namespace System.Management.Automation
         }
 
         /// <summary>
-        /// Returs help information for a parameter(s) identified by pattern
+        /// Returns help information for a parameter(s) identified by pattern
         /// </summary>
         /// <param name="pattern">pattern to search for parameters</param>
         /// <returns>A collection of parameters that match pattern</returns>

--- a/src/System.Management.Automation/help/HelpProvider.cs
+++ b/src/System.Management.Automation/help/HelpProvider.cs
@@ -143,7 +143,7 @@ namespace System.Management.Automation
         /// Retrieve help info that exactly match the target.
         /// </summary>
         /// <param name="helpRequest">help request object</param>
-        /// <returns>List of HelpInfo objects retrived</returns>
+        /// <returns>List of HelpInfo objects retrieved</returns>
         internal abstract IEnumerable<HelpInfo> ExactMatchHelp(HelpRequest helpRequest);
 
         /// <summary>
@@ -154,7 +154,7 @@ namespace System.Management.Automation
         /// If true, searches for pattern in the help content. Individual 
         /// provider can decide which content to search in.
         /// 
-        /// If false, seraches for pattern in the command names.
+        /// If false, searches for pattern in the command names.
         /// </param>       
         /// <returns>a collection of help info objects</returns>
         internal abstract IEnumerable<HelpInfo> SearchHelp(HelpRequest helpRequest, bool searchOnlyContent);

--- a/src/System.Management.Automation/help/HelpProviderWithCache.cs
+++ b/src/System.Management.Automation/help/HelpProviderWithCache.cs
@@ -93,8 +93,8 @@ namespace System.Management.Automation
         /// </summary>
         /// <remarks>
         /// Derived class can choose to either override ExactMatchHelp method to DoExactMatchHelp method.
-        /// If ExactMatchHelp is overriden, initial cache checking will be disabled by default.
-        /// If DoExactMatchHelp is overriden, cache check will be done first in ExactMatchHelp before the 
+        /// If ExactMatchHelp is overridden, initial cache checking will be disabled by default.
+        /// If DoExactMatchHelp is overridden, cache check will be done first in ExactMatchHelp before the 
         /// logic in DoExactMatchHelp is in place.
         /// </remarks>
         /// <param name="helpRequest">help request object</param>
@@ -110,7 +110,7 @@ namespace System.Management.Automation
         /// If true, searches for pattern in the help content. Individual 
         /// provider can decide which content to search in.
         /// 
-        /// If false, seraches for pattern in the command names.
+        /// If false, searches for pattern in the command names.
         /// </param> 
         /// <returns>a collection of help info objects</returns>
         internal override IEnumerable<HelpInfo> SearchHelp(HelpRequest helpRequest, bool searchOnlyContent)

--- a/src/System.Management.Automation/help/HelpProviderWithFullCache.cs
+++ b/src/System.Management.Automation/help/HelpProviderWithFullCache.cs
@@ -64,7 +64,7 @@ namespace System.Management.Automation
         /// If true, searches for pattern in the help content. Individual 
         /// provider can decide which content to search in.
         /// 
-        /// If false, seraches for pattern in the command names.
+        /// If false, searches for pattern in the command names.
         /// </param> 
         /// <returns>a collection of help info objects</returns> 
         internal sealed override IEnumerable<HelpInfo> SearchHelp(HelpRequest helpRequest, bool searchOnlyContent)

--- a/src/System.Management.Automation/help/HelpSystem.cs
+++ b/src/System.Management.Automation/help/HelpSystem.cs
@@ -17,7 +17,7 @@ namespace System.Management.Automation
     /// <summary>
     /// Monad help is an architecture made up of three layers: 
     ///     1. At the top is get-help commandlet from where help functionality is accessed. 
-    ///     2. At the middel is the help system which collects help objects based on user's request. 
+    ///     2. At the middle is the help system which collects help objects based on user's request. 
     ///     3. At the bottom are different help providers which provide help contents for different kinds of information requested.
     /// 
     /// Class HelpSystem implements the middle layer of Monad Help.
@@ -48,7 +48,7 @@ namespace System.Management.Automation
     /// Help Api:
     ///     Help Api is the function to be called by get-help commandlet. 
     /// 
-    ///     Following information needs to be provided in Help Api paramters, 
+    ///     Following information needs to be provided in Help Api parameters, 
     ///         1. search target: (which can be one or multiple strings)
     ///         2. help type: limit the type of help to be searched.
     ///         3. included fields: the fields to be included in the help info
@@ -145,7 +145,7 @@ namespace System.Management.Automation
             InitializeHelpProviders();
         }
 
-        #endregion Initalization
+        #endregion Initialization
 
         #region Help API
 
@@ -290,7 +290,7 @@ namespace System.Management.Automation
         /// <summary>
         /// Get help based on the target, help type, etc
         /// 
-        /// Help eninge retrieve help based on following schemes,
+        /// Help engine retrieve help based on following schemes,
         /// 
         ///     1. if help target is empty, get default help
         ///     2. if help target is not a search pattern, try to retrieve exact help
@@ -411,7 +411,7 @@ namespace System.Management.Automation
         /// <param name="helpInfo"></param>
         /// <param name="helpRequest">Help request object</param>        
         /// <returns>Never returns null.</returns>
-        /// <remarks>helpInfos is not null or emtpy.</remarks>
+        /// <remarks>helpInfos is not null or empty.</remarks>
         private IEnumerable<HelpInfo> ForwardHelp(HelpInfo helpInfo, HelpRequest helpRequest)
         {
             Collection<HelpInfo> result = new Collection<HelpInfo>();

--- a/src/System.Management.Automation/help/MUIFileSearcher.cs
+++ b/src/System.Management.Automation/help/MUIFileSearcher.cs
@@ -43,7 +43,7 @@ namespace System.Management.Automation
         ///     1. a file name
         ///     2. a search pattern
         /// It can also include a path, in that case, 
-        ///     1. the path will be searched first for the existense of the files.
+        ///     1. the path will be searched first for the existence of the files.
         /// </summary>
         internal string Target { get; } = null;
 

--- a/src/System.Management.Automation/help/MamlCommandHelpInfo.cs
+++ b/src/System.Management.Automation/help/MamlCommandHelpInfo.cs
@@ -163,7 +163,7 @@ namespace System.Management.Automation
         //       particular component, role and functionality using parameters like
         //       -component, -role, -functionality.
         //    3. At runtime, help engine will match against component/role/functionality
-        //       criteria before returing help results.
+        //       criteria before returning help results.
         //
 
         private string _component = null;
@@ -276,7 +276,7 @@ namespace System.Management.Automation
         /// <summary>
         /// Merge the provider specific help with current command help. 
         /// 
-        /// The cmdletHelp and dynamicParameterHelp is normally retrived from ProviderHelpProvider.
+        /// The cmdletHelp and dynamicParameterHelp is normally retrieved from ProviderHelpProvider.
         /// </summary>
         /// <remarks>
         /// A new MamlCommandHelpInfo is created to avoid polluting the provider help cache.
@@ -292,7 +292,7 @@ namespace System.Management.Automation
             MamlCommandHelpInfo result = (MamlCommandHelpInfo)this.MemberwiseClone();
 
             // We will need to use a deep clone of _fullHelpObject
-            // to avoid _fullHelpObject being get tarminated. 
+            // to avoid _fullHelpObject being get terminated. 
             result._fullHelpObject = this._fullHelpObject.Copy();
 
             if (cmdletHelp != null)
@@ -333,7 +333,7 @@ namespace System.Management.Automation
 
         /// <summary>
         /// Given a PSObject, this method will traverse through the objects properties,
-        /// extracts content from properities that are of type System.String, appends them
+        /// extracts content from properties that are of type System.String, appends them
         /// together and returns.
         /// </summary>
         /// <param name="psObject"></param>

--- a/src/System.Management.Automation/help/MamlNode.cs
+++ b/src/System.Management.Automation/help/MamlNode.cs
@@ -17,7 +17,7 @@ namespace System.Management.Automation
     /// etc, which needs to be taken care of during display. As a result, xml node in Maml schema can't be 
     /// converted into PSObject directly with XmlNodeAdapter. 
     /// 
-    /// MamlNode class provides logic in converting formatting tags into the format accetable by monad format
+    /// MamlNode class provides logic in converting formatting tags into the format acceptable by monad format
     /// and output engine. 
     /// 
     /// Following three kinds of formating tags are supported per our agreement with Maml team, 
@@ -61,10 +61,10 @@ namespace System.Management.Automation
     ///             <tag>*</tag>
     ///             <text>text for list item 2</text>
     ///         </textItem>
-    ///     3. definitionList => a list of defintionTextItem's
+    ///     3. definitionList => a list of definitionTextItem's
     ///         <definitionListItem>
     ///             <term>definition term here</term>
-    ///             <definition>defintion text here</definition>
+    ///             <definition>definition text here</definition>
     ///         </definitionListItem>
     /// </summary>
     /// 
@@ -380,7 +380,7 @@ namespace System.Management.Automation
         /// "attrib1" will be lost. This seems to be OK with current practice of authoring 
         /// monad command help. 
         /// </summary>
-        /// <param name="properties">property hastable</param>
+        /// <param name="properties">property hashtable</param>
         /// <param name="name">property name</param>
         /// <param name="mshObject">property value</param>
         private static void AddProperty(Hashtable properties, string name, PSObject mshObject)
@@ -805,7 +805,7 @@ namespace System.Management.Automation
         /// two properties,
         ///        a. tag=" 1. " or " 2. "
         ///        b. text="text for list item 1" or "text for list item 2"
-        /// In the case of unordered list, similiar PSObject will created with type to be "MamlUnorderedListText" and tag="*"
+        /// In the case of unordered list, similar PSObject will created with type to be "MamlUnorderedListText" and tag="*"
         /// 
         /// </summary>
         /// <param name="xmlNode"></param>
@@ -977,16 +977,16 @@ namespace System.Management.Automation
         /// Convert an definitionListItem node into an PSObject
         /// 
         /// For example
-        ///        <defintionListItem>
+        ///        <definitionListItem>
         ///            <term>
         ///                term text
         ///            </term>
         ///            <definition>
         ///                <para>
-        ///                    definiton text
+        ///                    definition text
         ///                </para>
         ///            </definition>
-        ///        </defintionListItem>
+        ///        </definitionListItem>
         /// In this case, an PSObject of type "definitionListText" will be created with following 
         /// properties
         ///        a. term="term text"
@@ -1185,7 +1185,7 @@ namespace System.Management.Automation
         }
 
         /// <summary>
-        /// Get mininum indentation of a paragraph
+        /// Get minimum indentation of a paragraph
         /// </summary>
         /// <param name="lines"></param>
         /// <returns></returns>
@@ -1208,7 +1208,7 @@ namespace System.Management.Automation
         }
 
         /// <summary>
-        /// Get indetation of a line, i.e., number of spaces
+        /// Get indentation of a line, i.e., number of spaces
         /// at the beginning of the line.
         /// </summary>
         /// <param name="line"></param>

--- a/src/System.Management.Automation/help/MamlUtil.cs
+++ b/src/System.Management.Automation/help/MamlUtil.cs
@@ -188,7 +188,7 @@ namespace System.Management.Automation
         }
 
         /// <summary>
-        /// Get propery info.
+        /// Get property info.
         /// </summary>
         internal static PSPropertyInfo GetProperyInfo(PSObject psObject, string[] path)
         {

--- a/src/System.Management.Automation/help/PSClassHelpProvider.cs
+++ b/src/System.Management.Automation/help/PSClassHelpProvider.cs
@@ -126,7 +126,7 @@ namespace System.Management.Automation
         /// <summary>
         /// Get the help in for the PS Class Info.        /// 
         /// </summary>
-        /// <param name="searcher">Searcher for PS Classses.</param>
+        /// <param name="searcher">Searcher for PS Classes.</param>
         /// <returns>Next HelpInfo object.</returns>
         private IEnumerable<HelpInfo> GetHelpInfo(PSClassSearcher searcher)
         {

--- a/src/System.Management.Automation/help/ProviderContext.cs
+++ b/src/System.Management.Automation/help/ProviderContext.cs
@@ -112,7 +112,7 @@ namespace System.Management.Automation
                 throw new ItemNotFoundException(_requestedPath, "PathNotFound", SessionStateStrings.PathNotFound);
             }
 
-            // ok we have path and valid provider that supplys content..intialize the provider
+            // ok we have path and valid provider that supplys content..initialize the provider
             // and get the help content for the path.
             cmdletProvider.Start(providerInfo, cmdletProviderContext);
             // There should be exactly one resolved path.

--- a/src/System.Management.Automation/help/ProviderHelpInfo.cs
+++ b/src/System.Management.Automation/help/ProviderHelpInfo.cs
@@ -263,7 +263,7 @@ namespace System.Management.Automation
         private Hashtable _dynamicParameterHelps;
 
         /// <summary>
-        /// Return the provider-specific dynamic paramter help based on input parameter name
+        /// Return the provider-specific dynamic parameter help based on input parameter name
         /// </summary>
         /// <param name="parameters">an array of parameters to retrieve help</param>
         /// <returns>an array of mshObject that contains the parameter help</returns>

--- a/src/System.Management.Automation/help/ProviderHelpProvider.cs
+++ b/src/System.Management.Automation/help/ProviderHelpProvider.cs
@@ -264,7 +264,7 @@ namespace System.Management.Automation
         /// If true, searches for pattern in the help content. Individual 
         /// provider can decide which content to search in.
         /// 
-        /// If false, seraches for pattern in the command names.
+        /// If false, searches for pattern in the command names.
         /// </param>        
         /// <returns></returns>
         internal override IEnumerable<HelpInfo> SearchHelp(HelpRequest helpRequest, bool searchOnlyContent)

--- a/src/System.Management.Automation/help/RemoteHelpInfo.cs
+++ b/src/System.Management.Automation/help/RemoteHelpInfo.cs
@@ -52,7 +52,7 @@ namespace System.Management.Automation
                 _deserializedRemoteHelp = helpResults[0];
                 _deserializedRemoteHelp.Methods.Remove("ToString");
                 // Win8: bug9457: Remote proxy command's name can be changed locally using -Prefix
-                // parameter of the Import-PSSession cmdlet. To give better user expereience for
+                // parameter of the Import-PSSession cmdlet. To give better user experience for
                 // get-help (on par with get-command), it was decided to use the local command name
                 // for the help content.
                 PSPropertyInfo nameInfo = _deserializedRemoteHelp.Properties["Name"];

--- a/src/System.Management.Automation/help/SaveHelpCommand.cs
+++ b/src/System.Management.Automation/help/SaveHelpCommand.cs
@@ -16,7 +16,7 @@ using System.Diagnostics;
 namespace Microsoft.PowerShell.Commands
 {
     /// <summary>
-    /// This class implements the Save-Help cmdleto
+    /// This class implements the Save-Help cmdlet
     /// </summary>
     [Cmdlet(VerbsData.Save, "Help", DefaultParameterSetName = SaveHelpCommand.PathParameterSetName,
         HelpUri = "http://go.microsoft.com/fwlink/?LinkID=210612")]

--- a/src/System.Management.Automation/help/UpdatableHelpCommandBase.cs
+++ b/src/System.Management.Automation/help/UpdatableHelpCommandBase.cs
@@ -799,7 +799,7 @@ namespace Microsoft.PowerShell.Commands
         #region Logging
 
         /// <summary>
-        /// Loggs a command message
+        /// Logs a command message
         /// </summary>
         /// <param name="message">message to log</param>
         internal void LogMessage(string message)

--- a/src/System.Management.Automation/help/UpdatableHelpSystem.cs
+++ b/src/System.Management.Automation/help/UpdatableHelpSystem.cs
@@ -869,7 +869,7 @@ namespace System.Management.Automation.Help
         }
 
         /// <summary>
-        /// Downloads the help cotent
+        /// Downloads the help content
         /// </summary>
         /// <param name="commandType">command type</param>
         /// <param name="path">destination path</param>
@@ -1267,7 +1267,7 @@ namespace System.Management.Automation.Help
 
             string cabDir = Path.GetDirectoryName(srcPath);
 
-            // Cabinet API doens't handle the trailing back slash
+            // Cabinet API doesn't handle the trailing back slash
             if (!cabDir.EndsWith("\\", StringComparison.Ordinal))
             {
                 cabDir += "\\";

--- a/src/System.Management.Automation/logging/LogContext.cs
+++ b/src/System.Management.Automation/logging/LogContext.cs
@@ -72,7 +72,7 @@ namespace System.Management.Automation
         /// <summary>
         /// Type of the command, which can be Alias, CommandLet, Script, Application, etc.
         /// 
-        /// The value of this property is a usually coversion of CommandTypes enum into a string.
+        /// The value of this property is a usually conversion of CommandTypes enum into a string.
         /// </summary>
         /// <value></value>
         internal string CommandType { get; set; } = "";

--- a/src/System.Management.Automation/logging/MshLog.cs
+++ b/src/System.Management.Automation/logging/MshLog.cs
@@ -32,7 +32,7 @@ namespace System.Management.Automation
     /// 
     /// Msh Log Engine provides features in following areas, 
     ///   1. Loading and managing logging providers. Based on some "Provider Catalog", engine will try to 
-    ///      load providers. First provider that is sucessfully loaded will be used for low level logging.
+    ///      load providers. First provider that is successfully loaded will be used for low level logging.
     ///      If no providers can be loaded, a dummy provider will be used, which will essentially do nothing.
     ///   2. Implementation of logging api functions. These api functions is implemented by calling corresponding 
     ///      functions in provider interface. 
@@ -222,7 +222,7 @@ namespace System.Management.Automation
         /// LogEngineHealthEvent: Log an engine health event. If engine state is changed, a engine 
         /// lifecycle event will be logged also.
         /// 
-        /// This is the basic form of EngineHealthEvent logging api, in which all paramters are provided.
+        /// This is the basic form of EngineHealthEvent logging api, in which all parameters are provided.
         /// 
         /// Variant form of this function is defined below, which will make parameters additionalInfo 
         /// and newEngineState optional.
@@ -382,7 +382,7 @@ namespace System.Management.Automation
         /// <summary>
         /// LogEngineLifecycleEvent: Log an engine lifecycle event. 
         /// 
-        /// This is the basic form of EngineLifecycleEvent logging api, in which all paramters are provided.
+        /// This is the basic form of EngineLifecycleEvent logging api, in which all parameters are provided.
         /// 
         /// Variant form of this function is defined below, which will make parameter additionalInfo 
         /// optional.
@@ -473,7 +473,7 @@ namespace System.Management.Automation
         #region Command Lifecycle Event Logging Api
 
         /// <summary>
-        /// LogCommandLifecycleEvent: Log a command lifecyle event.
+        /// LogCommandLifecycleEvent: Log a command lifecycle event.
         /// 
         /// This is the only form of CommandLifecycleEvent logging api.
         /// </summary>
@@ -513,7 +513,7 @@ namespace System.Management.Automation
         }
 
         /// <summary>
-        /// LogCommandLifecycleEvent: Log a command lifecyle event.
+        /// LogCommandLifecycleEvent: Log a command lifecycle event.
         /// 
         /// This is a form of CommandLifecycleEvent which takes a commandName instead
         /// of invocationInfo. It is likely that invocationInfo is not available if 
@@ -665,7 +665,7 @@ namespace System.Management.Automation
         #region Provider Lifecycle Event Logging Api
 
         /// <summary>
-        /// LogProviderLifecycleEvent: Log a provider lifecyle event.
+        /// LogProviderLifecycleEvent: Log a provider lifecycle event.
         /// 
         /// This is the only form of ProviderLifecycleEvent logging api.
         /// </summary>

--- a/src/System.Management.Automation/logging/eventlog/EventLogLogProvider.cs
+++ b/src/System.Management.Automation/logging/eventlog/EventLogLogProvider.cs
@@ -184,7 +184,7 @@ namespace System.Management.Automation
         private const int _invalidEventId = -1;
 
         /// <summary>
-        /// Get engine lifecyle event id based on engine state
+        /// Get engine lifecycle event id based on engine state
         /// </summary>
         /// <param name="engineState"></param>
         /// <returns></returns>

--- a/src/System.Management.Automation/minishell/api/RunspaceConfiguration.cs
+++ b/src/System.Management.Automation/minishell/api/RunspaceConfiguration.cs
@@ -125,7 +125,7 @@ namespace System.Management.Automation.Runspaces
         /// <!--
         /// This is a RunspaceConfiguration factory function which will create an instance
         /// of default RunspaceConfiguration-derived type, whose name is decided by an 
-        /// assemly attribute in mini-shell.
+        /// assembly attribute in mini-shell.
         /// -->
         internal static RunspaceConfiguration Create()
         {
@@ -153,7 +153,7 @@ namespace System.Management.Automation.Runspaces
         /// <!--
         /// This is a RunspaceConfiguration factory function which will create an instance
         /// of default RunspaceConfiguration-derived type, whose name is decided by an 
-        /// assemly attribute in the assembly specified.
+        /// assembly attribute in the assembly specified.
         /// -->
         public static RunspaceConfiguration Create(string assemblyName)
         {

--- a/src/System.Management.Automation/minishell/api/RunspaceConfigurationAttributeException.cs
+++ b/src/System.Management.Automation/minishell/api/RunspaceConfigurationAttributeException.cs
@@ -176,7 +176,7 @@ namespace System.Management.Automation.Runspaces
         }
 
         /// <summary>
-        /// Get object data from serizliation information.
+        /// Get object data from serialization information.
         /// </summary>
         /// <param name="info"> Serialization information </param>
         /// <param name="context"> Streaming context </param>

--- a/src/System.Management.Automation/minishell/api/RunspaceConfigurationEntryCollection.cs
+++ b/src/System.Management.Automation/minishell/api/RunspaceConfigurationEntryCollection.cs
@@ -21,7 +21,7 @@ namespace System.Management.Automation.Runspaces
     /// Runspace configuration entry collection is used for handling following 
     /// problems for runspace configuration entries. 
     /// 
-    ///     1. synhronization. Since multiple runspaces may be sharing the same
+    ///     1. synchronization. Since multiple runspaces may be sharing the same
     ///        runspace configuration, it is essential all the entry collections
     ///        (cmdlets, providers, assemblies, types, formats) are thread-safe. 
     ///     2. prepending/appending. Data for types and formats are order 

--- a/src/System.Management.Automation/minishell/api/RunspaceConfigurationTypeAttribute.cs
+++ b/src/System.Management.Automation/minishell/api/RunspaceConfigurationTypeAttribute.cs
@@ -9,7 +9,7 @@ namespace System.Management.Automation.Runspaces
     /// </summary>
     /// <!--
     /// This is an assembly attribute for the mini-shell assembly to tell 
-    /// the type name for MiniShellConguration derived class.
+    /// the type name for MiniShellConfiguration derived class.
     /// -->
     [AttributeUsage(AttributeTargets.Assembly)]
 #if CORECLR

--- a/src/System.Management.Automation/minishell/api/RunspaceConfigurationTypeException.cs
+++ b/src/System.Management.Automation/minishell/api/RunspaceConfigurationTypeException.cs
@@ -168,7 +168,7 @@ namespace System.Management.Automation.Runspaces
         }
 
         /// <summary>
-        /// Get object data from serizliation information.
+        /// Get object data from serialization information.
         /// </summary>
         /// <param name="info"> Serialization information </param>
         /// <param name="context"> Streaming context </param>

--- a/src/System.Management.Automation/namespaces/ContainerProviderBase.cs
+++ b/src/System.Management.Automation/namespaces/ContainerProviderBase.cs
@@ -19,7 +19,7 @@ namespace System.Management.Automation.Provider
     /// the use of a set of core commands against the objects that the provider
     /// gives access to. By deriving from this class users can take advantage of
     /// all the features of the <see cref="ItemCmdletProvider"/> as well as
-    /// globbing and the following commands when targetting this provider:
+    /// globbing and the following commands when targeting this provider:
     ///     get-childitem
     ///     rename-item
     ///     new-item
@@ -100,7 +100,7 @@ namespace System.Management.Automation.Provider
         /// parsing attributes similar to a cmdlet class or a 
         /// <see cref="System.Management.Automation.RuntimeDefinedParameterDictionary"/>.
         /// 
-        /// The default implemenation returns null. (no additional parameters)
+        /// The default implementation returns null. (no additional parameters)
         /// </returns>
         /// 
         internal object GetChildItemsDynamicParameters(
@@ -181,7 +181,7 @@ namespace System.Management.Automation.Provider
         /// </returns>
         /// 
         /// <remarks>
-        /// Providers override this method if they support a native filteing syntax that
+        /// Providers override this method if they support a native filtering syntax that
         /// can offer performance improvements over wildcard matching done by the PowerShell
         /// engine.
         /// If the provider can handle a portion (or all) of the PowerShell wildcard with
@@ -229,7 +229,7 @@ namespace System.Management.Automation.Provider
         /// parsing attributes similar to a cmdlet class or a 
         /// <see cref="System.Management.Automation.RuntimeDefinedParameterDictionary"/>.
         /// 
-        /// The default implemenation returns null. (no additional parameters)
+        /// The default implementation returns null. (no additional parameters)
         /// </returns>
         /// 
         internal object GetChildNamesDynamicParameters(
@@ -701,7 +701,7 @@ namespace System.Management.Automation.Provider
         /// parsing attributes similar to a cmdlet class or a 
         /// <see cref="System.Management.Automation.RuntimeDefinedParameterDictionary"/>.
         /// 
-        /// The default implemenation returns null. (no additional parameters)
+        /// The default implementation returns null. (no additional parameters)
         /// </returns>
         protected virtual object GetChildItemsDynamicParameters(string path, bool recurse)
         {
@@ -785,7 +785,7 @@ namespace System.Management.Automation.Provider
         /// </returns>
         /// 
         /// <remarks>
-        /// Providers override this method if they support a native filteing syntax that
+        /// Providers override this method if they support a native filtering syntax that
         /// can offer performance improvements over wildcard matching done by the PowerShell
         /// engine.
         /// If the provider can handle a portion (or all) of the PowerShell wildcard with
@@ -830,7 +830,7 @@ namespace System.Management.Automation.Provider
         /// parsing attributes similar to a cmdlet class or a 
         /// <see cref="System.Management.Automation.RuntimeDefinedParameterDictionary"/>.
         /// 
-        /// The default implemenation returns null. (no additional parameters)
+        /// The default implementation returns null. (no additional parameters)
         /// </returns>
         protected virtual object GetChildNamesDynamicParameters(string path)
         {
@@ -908,7 +908,7 @@ namespace System.Management.Automation.Provider
         /// parsing attributes similar to a cmdlet class or a 
         /// <see cref="System.Management.Automation.RuntimeDefinedParameterDictionary"/>.
         /// 
-        /// The default implemenation returns null. (no additional parameters)
+        /// The default implementation returns null. (no additional parameters)
         /// </returns>
         protected virtual object RenameItemDynamicParameters(string path, string newName)
         {
@@ -995,7 +995,7 @@ namespace System.Management.Automation.Provider
         /// parsing attributes similar to a cmdlet class or a 
         /// <see cref="System.Management.Automation.RuntimeDefinedParameterDictionary"/>.
         /// 
-        /// The default implemenation returns null. (no additional parameters)
+        /// The default implementation returns null. (no additional parameters)
         /// </returns>
         protected virtual object NewItemDynamicParameters(
             string path,
@@ -1077,7 +1077,7 @@ namespace System.Management.Automation.Provider
         /// parsing attributes similar to a cmdlet class or a 
         /// <see cref="System.Management.Automation.RuntimeDefinedParameterDictionary"/>.
         /// 
-        /// The default implemenation returns null. (no additional parameters)
+        /// The default implementation returns null. (no additional parameters)
         /// </returns>
         protected virtual object RemoveItemDynamicParameters(
             string path,
@@ -1205,7 +1205,7 @@ namespace System.Management.Automation.Provider
         /// parsing attributes similar to a cmdlet class or a 
         /// <see cref="System.Management.Automation.RuntimeDefinedParameterDictionary"/>.
         /// 
-        /// The default implemenation returns null. (no additional parameters)
+        /// The default implementation returns null. (no additional parameters)
         /// </returns>
         protected virtual object CopyItemDynamicParameters(
             string path,

--- a/src/System.Management.Automation/namespaces/CoreCommandContext.cs
+++ b/src/System.Management.Automation/namespaces/CoreCommandContext.cs
@@ -15,7 +15,7 @@ namespace System.Management.Automation
     /// This allows the providers to be called in a variety of situations.
     /// The most common will be from the core cmdlets themselves but they
     /// can also be called programmatically either by having the results
-    /// accumulated or by providing delgates for the various streams.
+    /// accumulated or by providing delegates for the various streams.
     /// 
     /// NOTE:  USER Feedback mechanism are only enabled for the CoreCmdlet
     /// case.  This is because we have not seen a use-case for them in the

--- a/src/System.Management.Automation/namespaces/DriveProviderBase.cs
+++ b/src/System.Management.Automation/namespaces/DriveProviderBase.cs
@@ -186,7 +186,7 @@ namespace System.Management.Automation.Provider
         /// parsing attributes similar to a cmdlet class or a 
         /// <see cref="System.Management.Automation.RuntimeDefinedParameterDictionary"/>.
         /// 
-        /// The default implemenation returns null. (no additional parameters)
+        /// The default implementation returns null. (no additional parameters)
         /// </returns>
         protected virtual object NewDriveDynamicParameters()
         {

--- a/src/System.Management.Automation/namespaces/FileSystemContentStream.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemContentStream.cs
@@ -24,7 +24,7 @@ namespace Microsoft.PowerShell.Commands
     /// 
     /// <remarks>
     /// Note, this class does no specific error handling. All errors are allowed to
-    /// propogate to the caller so that they can be written to the error pipeline
+    /// propagate to the caller so that they can be written to the error pipeline
     /// if necessary.
     /// </remarks>
     /// 
@@ -556,7 +556,7 @@ namespace Microsoft.PowerShell.Commands
                             // If the delimiter is at the end of the file, we need to read one more
                             // to get to the right position. For example:
                             //      ua123ua456ua -- -Tail 1
-                            // If we read backward only once, we get 'ua', and cannot get to the rigth position
+                            // If we read backward only once, we get 'ua', and cannot get to the right position
                             // So we read one more time, get 'ua456ua', and then we can get the right position
                             lastDelimiterMatch = (string)blocks[0];
                             if (currentBlock == 0 && lastDelimiterMatch.Equals(actualDelimiter, StringComparison.Ordinal))
@@ -643,7 +643,7 @@ namespace Microsoft.PowerShell.Commands
             // dealing with a "find the substring" algorithm, but with
             // the additional restriction that we cannot read past the
             // end of the delimiter.  If we read past the end of the delimiter,
-            // then we'll eat up bytes that we nede from the filestream.
+            // then we'll eat up bytes that we need from the filestream.
             // The solution is a modified Boyer-Moore string search algorithm.
             // This version retains the sub-linear search performance (via the 
             // lookup tables,) but offloads much of the dirty work to the
@@ -1469,7 +1469,7 @@ namespace Microsoft.PowerShell.Commands
                 // The BufferSize will be a multiple of 4, so we can just read toRead number of bytes
                 // if the current file is encoded by any of these formatting
 
-                // If IsSignleByteCharacterSet() reutrns true, we are sure that the given encoding is OEM 
+                // If IsSingleByteCharacterSet() returns true, we are sure that the given encoding is OEM 
                 // or Default, and it is SBCS(single byte character set) code page -- one byte per character
                 _currentPosition = _stream.Position;
                 _byteCount = _stream.Read(_byteBuff, 0, toRead);

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -484,7 +484,7 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// MapNetworkDrive facilitates to map the newly created PS Drive to a network share.
         /// </summary>
-        /// <param name="drive">The PSDrive infor that would be used to create a new PS drive.</param>
+        /// <param name="drive">The PSDrive info that would be used to create a new PS drive.</param>
         private void MapNetworkDrive(PSDriveInfo drive)
         {
             // Porting note: mapped network drives are only supported on Windows
@@ -509,7 +509,7 @@ namespace Microsoft.PowerShell.Commands
                 const int RESOURCEDISPLAYTYPE_GENERIC = 0x00000000;
                 const int RESOURCEUSAGE_CONNECTABLE = 0x00000001;
 
-                // By deafult the connection is not persisted.
+                // By default the connection is not persisted.
                 int CONNECT_TYPE = CONNECT_NOPERSIST;
 
                 string driveName = null;
@@ -572,7 +572,7 @@ namespace Microsoft.PowerShell.Commands
                 }
                 finally
                 {
-                    // Clear the passward in the memory.
+                    // Clear the password in the memory.
                     if (passwd != null)
                     {
                         Array.Clear(passwd, 0, passwd.Length - 1);
@@ -694,7 +694,7 @@ namespace Microsoft.PowerShell.Commands
                 // By default buffer size is set to 300 which would generally be sufficient in most of the cases.
                 int bufferSize = 300;
 #if DEBUG
-                // In Debug mode buffer size is initially set to 3 and if additial buffer is required, the 
+                // In Debug mode buffer size is initially set to 3 and if additional buffer is required, the 
                 // required buffer size is allocated and the WNetGetConnection API is executed with the newly 
                 // allocated buffer size.
                 bufferSize = 3;
@@ -749,7 +749,7 @@ namespace Microsoft.PowerShell.Commands
             string associatedPath = null;
             if (!string.IsNullOrEmpty(driveName) && driveName.Length == 1)
             {
-                // By default buffer size is set to 300 which would generatlly be sufficient in most of the cases.
+                // By default buffer size is set to 300 which would generally be sufficient in most of the cases.
                 int bufferSize = 300;
                 var pathInfo = new StringBuilder(bufferSize);
                 driveName += ':';
@@ -1237,7 +1237,7 @@ namespace Microsoft.PowerShell.Commands
             }
 
             bool filterHidden = false;           // "Hidden" is specified somewhere in the expression
-            bool switchFilterHidden = false;     // "Hidden" is specified somewhere in the paramters
+            bool switchFilterHidden = false;     // "Hidden" is specified somewhere in the parameters
 
             if (null != evaluator)
             {
@@ -1248,7 +1248,7 @@ namespace Microsoft.PowerShell.Commands
                 switchFilterHidden = switchEvaluator.ExistsInExpression(FileAttributes.Hidden);
             }
 
-            // if "Hidden" is specified in the attribute filter dynamic paramters
+            // if "Hidden" is specified in the attribute filter dynamic parameters
             // also return the object
             if (exists && !directory && (!hidden || Force || showHidden || filterHidden || switchFilterHidden))
             {
@@ -1274,7 +1274,7 @@ namespace Microsoft.PowerShell.Commands
                         directoryObj.FullName,
                         StringComparison.OrdinalIgnoreCase) == 0;
 
-                // if "Hidden" is specified in the attribute filter dynamic paramters
+                // if "Hidden" is specified in the attribute filter dynamic parameters
                 // also return the object
                 if (exists && (isRootPath || !hidden || Force || showHidden || filterHidden || switchFilterHidden))
                 {
@@ -1531,7 +1531,7 @@ namespace Microsoft.PowerShell.Commands
                     bool attributeFilter = true;
                     bool switchAttributeFilter = true;
                     bool filterHidden = false;           // "Hidden" is specified somewhere in the expression
-                    bool switchFilterHidden = false;     // "Hidden" is specified somewhere in the paramters
+                    bool switchFilterHidden = false;     // "Hidden" is specified somewhere in the parameters
 
                     if (null != evaluator)
                     {
@@ -1540,7 +1540,7 @@ namespace Microsoft.PowerShell.Commands
                     }
                     if (null != switchEvaluator)
                     {
-                        switchAttributeFilter = switchEvaluator.Evaluate(fileInfo.Attributes);  // switch paramters
+                        switchAttributeFilter = switchEvaluator.Evaluate(fileInfo.Attributes);  // switch parameters
                         switchFilterHidden = switchEvaluator.ExistsInExpression(FileAttributes.Hidden);
                     }
 
@@ -1661,7 +1661,7 @@ namespace Microsoft.PowerShell.Commands
                         }
                         if (null != switchEvaluator)
                         {
-                            switchAttributeFilter = switchEvaluator.Evaluate(filesystemInfo.Attributes);  // switch paramters
+                            switchAttributeFilter = switchEvaluator.Evaluate(filesystemInfo.Attributes);  // switch parameters
                             switchFilterHidden = switchEvaluator.ExistsInExpression(FileAttributes.Hidden);
                         }
 
@@ -1758,7 +1758,7 @@ namespace Microsoft.PowerShell.Commands
 
         /// <summary>
         /// Create an enum expression evaluator for user-specified attribute filtering
-        /// switch paramters. 
+        /// switch parameters. 
         /// </summary>
         /// <returns>
         /// If any attribute filtering switch parameters are set,
@@ -3269,7 +3269,7 @@ namespace Microsoft.PowerShell.Commands
         /// parsing attributes similar to a cmdlet class or a 
         /// <see cref="System.Management.Automation.RuntimeDefinedParameterDictionary"/>.
         /// 
-        /// The default implemenation returns null. (no additional parameters)
+        /// The default implementation returns null. (no additional parameters)
         /// </returns>
         protected override object ItemExistsDynamicParameters(string path)
         {
@@ -4117,7 +4117,7 @@ namespace Microsoft.PowerShell.Commands
             {
                 bool result = PerformCopyFileFromRemoteSession(sourceFileFullName, destinationFile, destinationPath, force, ps, fileSize, false, null);
 
-                // Copying the file from the remote session completed sucessfully
+                // Copying the file from the remote session completed successfully
                 if (result)
                 {
                     // Check if the remote source file has any alternate data streams
@@ -4610,7 +4610,7 @@ namespace Microsoft.PowerShell.Commands
 
             bool targetSupportsAlternateStreams = RemoteTargetSupportsAlternateStreams(ps, remoteFilePath);
 
-            // Once the file is copied sucessfully, check if the file has any alternate data streams
+            // Once the file is copied successfully, check if the file has any alternate data streams
             if (result && targetSupportsAlternateStreams)
             {
                 foreach (AlternateStreamData stream in AlternateDataStreamUtilities.GetStreams(file.FullName))
@@ -4737,7 +4737,7 @@ namespace Microsoft.PowerShell.Commands
                 // Since UNC paths must have "\\server\share" as the base of
                 // the path, you cannot get a parent path higher than this.
                 // So this looks for the path separator between server\share and
-                // ensures that it is in a position where it is preceeded by
+                // ensures that it is in a position where it is preceded by
                 // "\\s" at a minimum.
 
                 int indexOfLastPathSeparator = parentPath.LastIndexOf('\\');
@@ -5058,9 +5058,9 @@ namespace Microsoft.PowerShell.Commands
         /// is encouraged that the provider actually use the path to lookup in its store
         /// and create a relative path that matches the casing, and standardized path syntax.
         /// 
-        /// Note, the base class implemenation uses GetParentPath, GetChildName, and MakePath
+        /// Note, the base class implementation uses GetParentPath, GetChildName, and MakePath
         /// to normalize the path and then make it relative to basePath. All string comparisons
-        /// are done using StringComparison.InvariantCultureIngoreCase.
+        /// are done using StringComparison.InvariantCultureIgnoreCase.
         /// </remarks>
         /// 
         private string NormalizeRelativePathHelper(string path, string basePath)
@@ -5291,7 +5291,7 @@ namespace Microsoft.PowerShell.Commands
         /// 
         /// <returns>
         /// A stack containing the tokenized path with leaf elements on the bottom
-        /// of the stack and the most ancestoral parent at the top.
+        /// of the stack and the most ancestral parent at the top.
         /// </returns>
         /// 
         private Stack<string> TokenizePathToStack(string path, string basePath)
@@ -5344,7 +5344,7 @@ namespace Microsoft.PowerShell.Commands
         } // TokenizePathToStack
 
         /// <summary>
-        /// Given the tokenized path, the relative pathing elements are removed.
+        /// Given the tokenized path, the relative path elements are removed.
         /// </summary>
         /// 
         /// <param name="basepath">
@@ -5353,13 +5353,13 @@ namespace Microsoft.PowerShell.Commands
         /// 
         /// <param name="tokenizedPathStack">
         /// A stack containing path elements where the leaf most element is at
-        /// the bottom of the stack and the most ancestoral parent is on the top.
+        /// the bottom of the stack and the most ancestral parent is on the top.
         /// Generally this stack comes from TokenizePathToStack().
         /// </param>
         /// 
         /// <returns>
         /// A stack in reverse order with the path elements normalized and all relative
-        /// pathing tokens removed.
+        /// path tokens removed.
         /// </returns>
         /// 
         private Stack<string> NormalizeThePath(string basepath, Stack<string> tokenizedPathStack)
@@ -6115,7 +6115,7 @@ namespace Microsoft.PowerShell.Commands
         } // GetProperty
 
         /// <summary>
-        /// Gets the dynamic propery parameters required by the get-itemproperty cmdlet.
+        /// Gets the dynamic property parameters required by the get-itemproperty cmdlet.
         /// This feature is not required by the File System provider.
         /// </summary>
         /// 
@@ -6317,7 +6317,7 @@ namespace Microsoft.PowerShell.Commands
         } // SetProperty
 
         /// <summary>
-        /// Gets the dynamic propery parameters required by the set-itemproperty cmdlet.
+        /// Gets the dynamic property parameters required by the set-itemproperty cmdlet.
         /// This feature is not required by the File System provider.
         /// </summary>
         /// 
@@ -6450,7 +6450,7 @@ namespace Microsoft.PowerShell.Commands
         } // ClearProperty
 
         /// <summary>
-        /// Gets the dynamic propery parameters required by the clear-itemproperty cmdlet.
+        /// Gets the dynamic property parameters required by the clear-itemproperty cmdlet.
         /// This feature is not required by the File System provider.
         /// </summary>
         /// 
@@ -6622,7 +6622,7 @@ namespace Microsoft.PowerShell.Commands
         } // GetContentReader
 
         /// <summary>
-        /// Gets the dynamic propery parameters required by the get-content cmdlet.
+        /// Gets the dynamic property parameters required by the get-content cmdlet.
         /// </summary>
         /// 
         /// <param name="path">
@@ -6744,7 +6744,7 @@ namespace Microsoft.PowerShell.Commands
         } // GetContentWriter
 
         /// <summary>
-        /// Gets the dynamic propery parameters required by the set-content and
+        /// Gets the dynamic property parameters required by the set-content and
         /// add-content cmdlets.
         /// </summary>
         /// 
@@ -6894,7 +6894,7 @@ namespace Microsoft.PowerShell.Commands
                         FileStream fileStream = new FileStream(path, FileMode.Truncate, FileAccess.Write, FileShare.Write);
                         fileStream.Dispose();
 
-                        //For filesystem once content is cleare
+                        //For filesystem once content is cleared
                         WriteItemObject("", path, false);
                     }
                     catch (UnauthorizedAccessException failure)
@@ -6915,7 +6915,7 @@ namespace Microsoft.PowerShell.Commands
         } // ClearContent
 
         /// <summary>
-        /// Gets the dynamic propery parameters required by the clear-content cmdlet.
+        /// Gets the dynamic property parameters required by the clear-content cmdlet.
         /// </summary>
         /// 
         /// <param name="path">
@@ -7054,20 +7054,20 @@ namespace Microsoft.PowerShell.Commands
             /// <summary>
             /// WNetAddConnection2 API makes a connection to a network resource 
             /// and can redirect a local device to the network resource.
-            /// This API simulates the "new Use" funcationality used to connect to 
+            /// This API simulates the "new Use" functionality used to connect to 
             /// network resource.
             /// </summary>
             /// <param name="netResource">
             /// The The netResource structure contains information 
             /// about a network resource.</param>
             /// <param name="password">
-            /// The passward used to get connected to network resource.
+            /// The password used to get connected to network resource.
             /// </param>
             /// <param name="username">
             /// The username used to get connected to network resource.
             /// </param>
             /// <param name="flags">
-            /// The flags paramter is used to indicate if the created network 
+            /// The flags parameter is used to indicate if the created network 
             /// resource has to be persisted or not.
             /// </param>
             /// <returns>If connection is established to the network resource 
@@ -7211,7 +7211,7 @@ namespace Microsoft.PowerShell.Commands
             /// </summary>
             /// <param name="name">Path of the symbolic link.</param>
             /// <param name="destination">Path of the target of the symbolic link.</param>
-            /// <param name="destinationType">0 for destionation as file and 1 for destination as directory.</param>
+            /// <param name="destinationType">0 for destination as file and 1 for destination as directory.</param>
             /// <returns>1 on successful creation.</returns>
             [DllImport(PinvokeDllNames.CreateSymbolicLinkDllName, CharSet = CharSet.Unicode, SetLastError = true)]
             internal static extern int CreateSymbolicLink(string name, string destination, int destinationType);
@@ -8299,7 +8299,7 @@ namespace Microsoft.PowerShell.Commands
 
                 if (reparseDataBuffer.ReparseTag == IO_REPARSE_TAG_MOUNT_POINT)
                 {
-                    //Since this is a junction we need to unmarshall to the correct structure.
+                    //Since this is a junction we need to unmarshal to the correct structure.
                     REPARSE_DATA_BUFFER_MOUNTPOINT reparseDataBufferMountPoint = ClrFacade.PtrToStructure<REPARSE_DATA_BUFFER_MOUNTPOINT>(outBuffer);
 
                     targetDir = Encoding.Unicode.GetString(reparseDataBufferMountPoint.PathBuffer, reparseDataBufferMountPoint.SubstituteNameOffset, reparseDataBufferMountPoint.SubstituteNameLength);
@@ -8898,7 +8898,7 @@ namespace System.Management.Automation.Internal
             return $op
         }}
 
-        # Retuns a hashtable with the following members:
+        # Returns a hashtable with the following members:
         #    BytesWritten - number of bytes written to an alternate file stream
         #
         function PSCopyFileAlternateStreamToRemoteSession

--- a/src/System.Management.Automation/namespaces/IContentProvider.cs
+++ b/src/System.Management.Automation/namespaces/IContentProvider.cs
@@ -67,7 +67,7 @@ namespace System.Management.Automation.Provider
         /// parsing attributes similar to a cmdlet class or a 
         /// <see cref="System.Management.Automation.RuntimeDefinedParameterDictionary"/>.
         /// 
-        /// The default implemenation returns null. (no additional parameters)
+        /// The default implementation returns null. (no additional parameters)
         /// </returns>
         object GetContentReaderDynamicParameters(string path);
 
@@ -113,7 +113,7 @@ namespace System.Management.Automation.Provider
         /// parsing attributes similar to a cmdlet class or a 
         /// <see cref="System.Management.Automation.RuntimeDefinedParameterDictionary"/>.
         /// 
-        /// The default implemenation returns null. (no additional parameters)
+        /// The default implementation returns null. (no additional parameters)
         /// </returns>
         object GetContentWriterDynamicParameters(string path);
 
@@ -154,7 +154,7 @@ namespace System.Management.Automation.Provider
         /// parsing attributes similar to a cmdlet class or a 
         /// <see cref="System.Management.Automation.RuntimeDefinedParameterDictionary"/>.
         /// 
-        /// The default implemenation returns null. (no additional parameters)
+        /// The default implementation returns null. (no additional parameters)
         /// </returns>
         object ClearContentDynamicParameters(string path);
     } // IContentCmdletProvider

--- a/src/System.Management.Automation/namespaces/IContentReader.cs
+++ b/src/System.Management.Automation/namespaces/IContentReader.cs
@@ -53,7 +53,7 @@ namespace System.Management.Automation.Provider
         /// </param>
         /// 
         /// <remarks>
-        /// The implemenation of this method moves the content reader <paramref name="offset"/> 
+        /// The implementation of this method moves the content reader <paramref name="offset"/> 
         /// number of blocks from the specified <paramref name="origin"/>. See <see cref="IContentReader.Read"/>
         /// for a description of what a block is.
         /// </remarks>

--- a/src/System.Management.Automation/namespaces/IContentWriter.cs
+++ b/src/System.Management.Automation/namespaces/IContentWriter.cs
@@ -54,7 +54,7 @@ namespace System.Management.Automation.Provider
         /// </param>
         /// 
         /// <remarks>
-        /// The implemenation of this method moves the content writer <paramref name="offset"/> 
+        /// The implementation of this method moves the content writer <paramref name="offset"/> 
         /// number of blocks from the specified <paramref name="origin"/>. See <see cref="System.Management.Automation.Provider.IContentWriter.Write(IList)"/>
         /// for a description of what a block is.
         /// </remarks>

--- a/src/System.Management.Automation/namespaces/IDynamicPropertyProvider.cs
+++ b/src/System.Management.Automation/namespaces/IDynamicPropertyProvider.cs
@@ -98,7 +98,7 @@ namespace System.Management.Automation.Provider
         /// parsing attributes similar to a cmdlet class or a 
         /// <see cref="System.Management.Automation.RuntimeDefinedParameterDictionary"/>.
         /// 
-        /// The default implemenation returns null. (no additional parameters)
+        /// The default implementation returns null. (no additional parameters)
         /// </returns>
         object NewPropertyDynamicParameters(
             string path,
@@ -157,7 +157,7 @@ namespace System.Management.Automation.Provider
         /// parsing attributes similar to a cmdlet class or a 
         /// <see cref="System.Management.Automation.RuntimeDefinedParameterDictionary"/>.
         /// 
-        /// The default implemenation returns null. (no additional parameters)
+        /// The default implementation returns null. (no additional parameters)
         /// </returns>
         object RemovePropertyDynamicParameters(
             string path,
@@ -224,7 +224,7 @@ namespace System.Management.Automation.Provider
         /// parsing attributes similar to a cmdlet class or a 
         /// <see cref="System.Management.Automation.RuntimeDefinedParameterDictionary"/>.
         /// 
-        /// The default implemenation returns null. (no additional parameters)
+        /// The default implementation returns null. (no additional parameters)
         /// </returns>
         object RenamePropertyDynamicParameters(
             string path,
@@ -301,7 +301,7 @@ namespace System.Management.Automation.Provider
         /// parsing attributes similar to a cmdlet class or a 
         /// <see cref="System.Management.Automation.RuntimeDefinedParameterDictionary"/>.
         /// 
-        /// The default implemenation returns null. (no additional parameters)
+        /// The default implementation returns null. (no additional parameters)
         /// </returns>
         object CopyPropertyDynamicParameters(
             string sourcePath,
@@ -378,7 +378,7 @@ namespace System.Management.Automation.Provider
         /// parsing attributes similar to a cmdlet class or a 
         /// <see cref="System.Management.Automation.RuntimeDefinedParameterDictionary"/>.
         /// 
-        /// The default implemenation returns null. (no additional parameters)
+        /// The default implementation returns null. (no additional parameters)
         /// </returns>
         object MovePropertyDynamicParameters(
             string sourcePath,

--- a/src/System.Management.Automation/namespaces/IPermissionProvider.cs
+++ b/src/System.Management.Automation/namespaces/IPermissionProvider.cs
@@ -40,7 +40,7 @@ namespace System.Management.Automation.Provider
         /// 
         /// <returns>
         /// Nothing.   Write the security descriptor to the context's pipeline for 
-        /// the item specifed by the path using the WriteSecurityDescriptorObject 
+        /// the item specified by the path using the WriteSecurityDescriptorObject 
         /// method.  
         /// </returns>
         void GetSecurityDescriptor(
@@ -63,7 +63,7 @@ namespace System.Management.Automation.Provider
         /// <returns>
         /// Nothing.   After setting the security descriptor to the value passed in,
         /// write the new security descriptor to the context's pipeline for the 
-        /// item specifed by the path using the WriteSecurityDescriptorObject method.
+        /// item specified by the path using the WriteSecurityDescriptorObject method.
         /// </returns>
         /// 
         void SetSecurityDescriptor(

--- a/src/System.Management.Automation/namespaces/IPropertiesProvider.cs
+++ b/src/System.Management.Automation/namespaces/IPropertiesProvider.cs
@@ -86,7 +86,7 @@ namespace System.Management.Automation.Provider
         /// parsing attributes similar to a cmdlet class or a 
         /// <see cref="System.Management.Automation.RuntimeDefinedParameterDictionary"/>.
         /// 
-        /// The default implemenation returns null. (no additional parameters)
+        /// The default implementation returns null. (no additional parameters)
         /// </returns>
         object GetPropertyDynamicParameters(
             string path,
@@ -152,7 +152,7 @@ namespace System.Management.Automation.Provider
         /// parsing attributes similar to a cmdlet class or a 
         /// <see cref="System.Management.Automation.RuntimeDefinedParameterDictionary"/>.
         /// 
-        /// The default implemenation returns null. (no additional parameters)
+        /// The default implementation returns null. (no additional parameters)
         /// </returns>
         object SetPropertyDynamicParameters(
             string path,
@@ -213,7 +213,7 @@ namespace System.Management.Automation.Provider
         /// parsing attributes similar to a cmdlet class or a 
         /// <see cref="System.Management.Automation.RuntimeDefinedParameterDictionary"/>.
         /// 
-        /// The default implemenation returns null. (no additional parameters)
+        /// The default implementation returns null. (no additional parameters)
         /// </returns>
         object ClearPropertyDynamicParameters(
             string path,

--- a/src/System.Management.Automation/namespaces/ItemProviderBase.cs
+++ b/src/System.Management.Automation/namespaces/ItemProviderBase.cs
@@ -71,7 +71,7 @@ namespace System.Management.Automation.Provider
         /// parsing attributes similar to a cmdlet class or a 
         /// <see cref="System.Management.Automation.RuntimeDefinedParameterDictionary"/>.
         /// 
-        /// The default implemenation returns null. (no additional parameters)
+        /// The default implementation returns null. (no additional parameters)
         /// </returns>
         /// 
         internal object GetItemDynamicParameters(string path, CmdletProviderContext context)
@@ -139,7 +139,7 @@ namespace System.Management.Automation.Provider
         /// parsing attributes similar to a cmdlet class or a 
         /// <see cref="System.Management.Automation.RuntimeDefinedParameterDictionary"/>.
         /// 
-        /// The default implemenation returns null. (no additional parameters)
+        /// The default implementation returns null. (no additional parameters)
         /// </returns>
         /// 
         internal object SetItemDynamicParameters(
@@ -197,7 +197,7 @@ namespace System.Management.Automation.Provider
         /// parsing attributes similar to a cmdlet class or a 
         /// <see cref="System.Management.Automation.RuntimeDefinedParameterDictionary"/>.
         /// 
-        /// The default implemenation returns null. (no additional parameters)
+        /// The default implementation returns null. (no additional parameters)
         /// </returns>
         /// 
         internal object ClearItemDynamicParameters(
@@ -255,7 +255,7 @@ namespace System.Management.Automation.Provider
         /// parsing attributes similar to a cmdlet class or a 
         /// <see cref="System.Management.Automation.RuntimeDefinedParameterDictionary"/>.
         /// 
-        /// The default implemenation returns null. (no additional parameters)
+        /// The default implementation returns null. (no additional parameters)
         /// </returns>
         /// 
         internal object InvokeDefaultActionDynamicParameters(
@@ -325,7 +325,7 @@ namespace System.Management.Automation.Provider
         /// parsing attributes similar to a cmdlet class or a 
         /// <see cref="System.Management.Automation.RuntimeDefinedParameterDictionary"/>.
         /// 
-        /// The default implemenation returns null. (no additional parameters)
+        /// The default implementation returns null. (no additional parameters)
         /// </returns>
         /// 
         internal object ItemExistsDynamicParameters(
@@ -356,7 +356,7 @@ namespace System.Management.Automation.Provider
         /// </returns>
         /// 
         /// <remarks>
-        /// This test should not verify the existance of the item at the path. It should
+        /// This test should not verify the existence of the item at the path. It should
         /// only perform syntactic and semantic validation of the path.  For instance, for
         /// the file system provider, that path should be canonicalized, syntactically verified,
         /// and ensure that the path does not refer to a device.
@@ -455,7 +455,7 @@ namespace System.Management.Automation.Provider
         /// parsing attributes similar to a cmdlet class or a 
         /// <see cref="System.Management.Automation.RuntimeDefinedParameterDictionary"/>.
         /// 
-        /// The default implemenation returns null. (no additional parameters)
+        /// The default implementation returns null. (no additional parameters)
         /// </returns>
         protected virtual object GetItemDynamicParameters(string path)
         {
@@ -526,7 +526,7 @@ namespace System.Management.Automation.Provider
         /// parsing attributes similar to a cmdlet class or a 
         /// <see cref="System.Management.Automation.RuntimeDefinedParameterDictionary"/>.
         /// 
-        /// The default implemenation returns null. (no additional parameters)
+        /// The default implementation returns null. (no additional parameters)
         /// </returns>
         protected virtual object SetItemDynamicParameters(string path, object value)
         {
@@ -588,7 +588,7 @@ namespace System.Management.Automation.Provider
         /// parsing attributes similar to a cmdlet class or a 
         /// <see cref="System.Management.Automation.RuntimeDefinedParameterDictionary"/>.
         /// 
-        /// The default implemenation returns null. (no additional parameters)
+        /// The default implementation returns null. (no additional parameters)
         /// </returns>
         protected virtual object ClearItemDynamicParameters(string path)
         {
@@ -611,7 +611,7 @@ namespace System.Management.Automation.Provider
         /// </returns>
         /// 
         /// <remarks>
-        /// The default implemenation does nothing.
+        /// The default implementation does nothing.
         /// 
         /// Providers override this method to give the user the ability to invoke provider objects using
         /// the invoke-item cmdlet. Think of the invocation as a double click in the Windows Shell. This
@@ -651,7 +651,7 @@ namespace System.Management.Automation.Provider
         /// parsing attributes similar to a cmdlet class or a 
         /// <see cref="System.Management.Automation.RuntimeDefinedParameterDictionary"/>.
         /// 
-        /// The default implemenation returns null. (no additional parameters)
+        /// The default implementation returns null. (no additional parameters)
         /// </returns>
         protected virtual object InvokeDefaultActionDynamicParameters(string path)
         {
@@ -685,7 +685,7 @@ namespace System.Management.Automation.Provider
         /// of ExpandWildcards, Filter, Include, or Exclude should ensure that the path passed meets those
         /// requirements by accessing the appropriate property from the base class.
         /// 
-        /// The implemenation of this method should take into account any form of access to the object that may
+        /// The implementation of this method should take into account any form of access to the object that may
         /// make it visible to the user.  For instance, if a user has write access to a file in the file system 
         /// provider bug not read access, the file still exists and the method should return true.  Sometimes this
         /// may require checking the parent to see if the child can be enumerated.
@@ -717,7 +717,7 @@ namespace System.Management.Automation.Provider
         /// parsing attributes similar to a cmdlet class or a 
         /// <see cref="System.Management.Automation.RuntimeDefinedParameterDictionary"/>.
         /// 
-        /// The default implemenation returns null. (no additional parameters)
+        /// The default implementation returns null. (no additional parameters)
         /// </returns>
         protected virtual object ItemExistsDynamicParameters(string path)
         {
@@ -742,7 +742,7 @@ namespace System.Management.Automation.Provider
         /// </returns>
         /// 
         /// <remarks>
-        /// This test should not verify the existance of the item at the path. It should
+        /// This test should not verify the existence of the item at the path. It should
         /// only perform syntactic and semantic validation of the path.  For instance, for
         /// the file system provider, that path should be canonicalized, syntactically verified,
         /// and ensure that the path does not refer to a device.

--- a/src/System.Management.Automation/namespaces/LocationGlobber.cs
+++ b/src/System.Management.Automation/namespaces/LocationGlobber.cs
@@ -1053,7 +1053,7 @@ namespace System.Management.Automation
         /// </param>
         /// 
         /// <returns>
-        /// A provider specifc path that the Msh path represents.
+        /// A provider specific path that the Msh path represents.
         /// </returns>
         /// 
         /// <exception cref="ArgumentNullException">
@@ -1114,7 +1114,7 @@ namespace System.Management.Automation
         /// </param>
         /// 
         /// <returns>
-        /// A provider specifc path that the Msh path represents.
+        /// A provider specific path that the Msh path represents.
         /// </returns>
         /// 
         /// <exception cref="ArgumentNullException">
@@ -1198,7 +1198,7 @@ namespace System.Management.Automation
         /// </param>
         /// 
         /// <returns>
-        /// A provider specifc path that the Msh path represents.
+        /// A provider specific path that the Msh path represents.
         /// </returns>
         /// 
         /// <exception cref="ArgumentNullException">
@@ -1330,7 +1330,7 @@ namespace System.Management.Automation
         /// Returns a provider specific path for given PowerShell path.
         /// </summary>
         /// <param name="path">Path to resolve</param>
-        /// <param name="context">Cmdlet contet</param>
+        /// <param name="context">Cmdlet context</param>
         /// <param name="isTrusted">When true bypass trust check</param>
         /// <param name="provider">Provider</param>
         /// <param name="drive">Drive</param>
@@ -1794,7 +1794,7 @@ namespace System.Management.Automation
         private SessionState _sessionState;
 
         /// <summary>
-        /// Removs the back tick "`" from any of the glob characters in the path.
+        /// Removes the back tick "`" from any of the glob characters in the path.
         /// </summary>
         /// 
         /// <param name="path">
@@ -2009,7 +2009,7 @@ namespace System.Management.Automation
 
                 // This will resolve $GLOBAL, and $LOCAL as needed.
                 // This throws DriveNotFoundException if a drive of the specified
-                // name does not exist. Just let the exception propogate out.
+                // name does not exist. Just let the exception propagate out.
                 try
                 {
                     workingDriveForPath = _sessionState.Drive.Get(driveName);

--- a/src/System.Management.Automation/namespaces/NavigationProviderBase.cs
+++ b/src/System.Management.Automation/namespaces/NavigationProviderBase.cs
@@ -582,9 +582,9 @@ namespace System.Management.Automation.Provider
         /// is encouraged that the provider actually use the path to lookup in its store
         /// and create a relative path that matches the casing, and standardized path syntax.
         /// 
-        /// Note, the base class implemenation uses GetParentPath, GetChildName, and MakePath
+        /// Note, the base class implementation uses GetParentPath, GetChildName, and MakePath
         /// to normalize the path and then make it relative to basePath. All string comparisons
-        /// are done using StringComparison.InvariantCultureIngoreCase.
+        /// are done using StringComparison.InvariantCultureIgnoreCase.
         /// </remarks>
         protected virtual string NormalizeRelativePath(
             string path,
@@ -952,7 +952,7 @@ namespace System.Management.Automation.Provider
         /// parsing attributes similar to a cmdlet class or a 
         /// <see cref="System.Management.Automation.RuntimeDefinedParameterDictionary"/>.
         /// 
-        /// The default implemenation returns null. (no additional parameters)
+        /// The default implementation returns null. (no additional parameters)
         /// </returns>
         protected virtual object MoveItemDynamicParameters(
             string path,
@@ -1047,7 +1047,7 @@ namespace System.Management.Automation.Provider
         /// 
         /// <returns>
         /// A stack containing the tokenized path with leaf elements on the bottom
-        /// of the stack and the most ancestoral parent at the top.
+        /// of the stack and the most ancestral parent at the top.
         /// </returns>
         /// 
         private Stack<string> TokenizePathToStack(string path, string basePath)
@@ -1087,12 +1087,12 @@ namespace System.Management.Automation.Provider
         } // TokenizePathToStack
 
         /// <summary>
-        /// Given the tokenized path, the relative pathing elements are removed.
+        /// Given the tokenized path, the relative path elements are removed.
         /// </summary>
         /// 
         /// <param name="tokenizedPathStack">
         /// A stack containing path elements where the leaf most element is at
-        /// the bottom of the stack and the most ancestoral parent is on the top.
+        /// the bottom of the stack and the most ancestral parent is on the top.
         /// Generally this stack comes from TokenizePathToStack().
         /// </param>
         /// 
@@ -1110,7 +1110,7 @@ namespace System.Management.Automation.Provider
         /// 
         /// <returns>
         /// A stack in reverse order with the path elements normalized and all relative
-        /// pathing tokens removed.
+        /// path tokens removed.
         /// </returns>
         /// 
         private static Stack<string> NormalizeThePath(

--- a/src/System.Management.Automation/namespaces/ProviderBase.cs
+++ b/src/System.Management.Automation/namespaces/ProviderBase.cs
@@ -110,7 +110,7 @@ namespace System.Management.Automation.Provider
 
         /// <summary>
         /// Checks whether the filter of the provider is set. 
-        /// Can be overriden by derived class when additional filters are defined.
+        /// Can be overridden by derived class when additional filters are defined.
         /// </summary>
         /// <returns>
         /// Whether the filter of the provider is set. 
@@ -226,7 +226,7 @@ namespace System.Management.Automation.Provider
             Context = cmdletProviderContext;
 
             return StartDynamicParameters();
-        } // StartDynamicParmaters
+        } // StartDynamicParameter
 
         /// <summary>
         /// Called when the provider is being removed. It sets the context
@@ -1713,7 +1713,7 @@ namespace System.Management.Automation.Provider
         /// parsing attributes similar to a cmdlet class or a 
         /// <see cref="System.Management.Automation.RuntimeDefinedParameterDictionary"/>.
         /// 
-        /// The default implemenation returns null. (no additional parameters)
+        /// The default implementation returns null. (no additional parameters)
         /// </returns>
         protected virtual object StartDynamicParameters()
         {

--- a/src/System.Management.Automation/namespaces/ProviderBaseSecurity.cs
+++ b/src/System.Management.Automation/namespaces/ProviderBaseSecurity.cs
@@ -34,7 +34,7 @@ namespace System.Management.Automation.Provider
         /// 
         /// <returns>
         /// Nothing. An instance of an object that represents the security descriptor
-        /// for the item specifed by the path should be written to the context.
+        /// for the item specified by the path should be written to the context.
         /// </returns>
         /// 
         internal void GetSecurityDescriptor(

--- a/src/System.Management.Automation/namespaces/ProviderDeclarationAttribute.cs
+++ b/src/System.Management.Automation/namespaces/ProviderDeclarationAttribute.cs
@@ -119,7 +119,7 @@ namespace System.Management.Automation.Provider
         ///
         /// <remarks>
         /// When this attribute is specified a provider specific filter can be passed from
-        /// the Core Commands to the provider. This filter string is not interpretted in any
+        /// the Core Commands to the provider. This filter string is not interpreted in any
         /// way by the Monad engine.
         /// </remarks>
         Filter = 0x4,

--- a/src/System.Management.Automation/namespaces/RegistryProvider.cs
+++ b/src/System.Management.Automation/namespaces/RegistryProvider.cs
@@ -1109,7 +1109,7 @@ namespace Microsoft.PowerShell.Commands
         /// </param>
         ///
         /// <param name="recurse">
-        /// Ignored. All removes are recursive becuase the
+        /// Ignored. All removes are recursive because the
         /// registry provider does not support filters.
         /// </param>
         protected override void RemoveItem(
@@ -3519,7 +3519,7 @@ namespace Microsoft.PowerShell.Commands
 
             // If the main path existed, we must do a semantic analysis
             // to find the parent -- since path elements may contain
-            // path delemiters. We only need to do this comparison
+            // path delimiters. We only need to do this comparison
             // if the base implementation returns something in our namespace.
             if (!String.Equals(parentPath, root, StringComparison.OrdinalIgnoreCase))
             {
@@ -4048,7 +4048,7 @@ namespace Microsoft.PowerShell.Commands
 
             switch (valueKind)
             {
-                // NOTICE: we assume that an unkown type is treated as
+                // NOTICE: we assume that an unknown type is treated as
                 // the same as a binary blob
                 case RegistryValueKind.Binary:
                 case RegistryValueKind.Unknown:
@@ -4877,7 +4877,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         /// <param name="key">RegistryKey containing property</param>
         /// <param name="valueName">Property for which RegistryValueKind is requested</param>
-        /// <returns>RegistryValueKind of the property. If the property does not exit,returns RegsitryValueKind.Unknown</returns>
+        /// <returns>RegistryValueKind of the property. If the property does not exit,returns RegistryValueKind.Unknown</returns>
         private static RegistryValueKind GetValueKindForProperty(IRegistryWrapper key, string valueName)
         {
             try
@@ -4995,7 +4995,7 @@ namespace Microsoft.PowerShell.Commands
         /// 
         /// <param name="kind"> output for the RegistryValueKind for the string</param>
         /// <returns>
-        /// true if the conversion succeded
+        /// true if the conversion succeeded
         /// </returns>
         private bool ParseKind(string type, out RegistryValueKind kind)
         {

--- a/src/System.Management.Automation/namespaces/SafeTransactionHandle.cs
+++ b/src/System.Management.Automation/namespaces/SafeTransactionHandle.cs
@@ -41,7 +41,7 @@ namespace Microsoft.PowerShell.Commands.Internal
                 throw new InvalidOperationException(RegistryProviderStrings.InvalidOperation_NeedTransaction);
             }
 
-            // MSDTC is not avaliable on WinPE machine.
+            // MSDTC is not available on WinPE machine.
             // CommitableTransaction will use DTC APIs under the covers to get KTM transaction manager interface. 
             // KTM is kernel Transaction Manager to handle file, registry etc and MSDTC provides an integration support 
             // with KTM to handle transaction across kernel resources and MSDTC resources like SQL, MSMQ etc. 

--- a/src/System.Management.Automation/namespaces/TransactedRegistryKey.cs
+++ b/src/System.Management.Automation/namespaces/TransactedRegistryKey.cs
@@ -854,7 +854,7 @@ namespace Microsoft.PowerShell.Commands.Internal
             // Return null if we didn't find the key.
             if (ret == Win32Native.ERROR_ACCESS_DENIED || ret == Win32Native.ERROR_BAD_IMPERSONATION_LEVEL)
             {
-                // We need to throw SecurityException here for compatiblity reason,
+                // We need to throw SecurityException here for compatibility reason,
                 // although UnauthorizedAccessException will make more sense.
                 throw new SecurityException(RegistryProviderStrings.Security_RegistryPermission);
             }
@@ -1907,7 +1907,7 @@ namespace Microsoft.PowerShell.Commands.Internal
         {
             if (_checkMode == RegistryKeyPermissionCheck.Default)
             {
-                // only need to check for default mode (dynamice check)
+                // only need to check for default mode (dynamic check)
                 new RegistryPermission(RegistryPermissionAccess.Read, _keyName + "\\" + valueName).Demand();
             }
         }
@@ -1918,7 +1918,7 @@ namespace Microsoft.PowerShell.Commands.Internal
         {
             if (_checkMode == RegistryKeyPermissionCheck.Default)
             {
-                // only need to check for default mode (dynamice check)                
+                // only need to check for default mode (dynamic check)                
                 new RegistryPermission(RegistryPermissionAccess.Read, _keyName + "\\.").Demand();
             }
         }
@@ -2037,7 +2037,7 @@ namespace Microsoft.PowerShell.Commands.Internal
         {
             if (0 != (rights & ~((int)RegistryRights.FullControl)))
             {
-                // We need to throw SecurityException here for compatiblity reason,
+                // We need to throw SecurityException here for compatibility reason,
                 // although UnauthorizedAccessException will make more sense.
                 throw new SecurityException(RegistryProviderStrings.Security_RegistryPermission);
             }

--- a/src/System.Management.Automation/security/CatalogHelper.cs
+++ b/src/System.Management.Automation/security/CatalogHelper.cs
@@ -103,7 +103,7 @@ namespace System.Management.Automation
             }
             // One Windows 7 this API sent version information as decimal 1 not hex (0X100 = 256)
             // so we are checking for that value as well. Reason we are not checking for version 2 above in
-            // this scenario because catalog verion 2 is not supported on win7. 
+            // this scenario because catalog version 2 is not supported on win7. 
             else if ((catalogInfo.dwPublicVersion == catalogVersion1) || (catalogInfo.dwPublicVersion == 1))
             {
                 catalogVersion = 1;
@@ -152,14 +152,14 @@ namespace System.Management.Automation
         }
 
         /// <summary>
-        /// Generate the Catalog Defintion File representing files and folders 
+        /// Generate the Catalog Definition File representing files and folders 
         /// </summary>
         /// 
         /// <param name="Path"> Path of expected output .cdf file </param>        
         ///          
         /// <param name="catalogFilePath"> Path of the output catalog file </param>        
         /// 
-        /// <param name="cdfFilePath"> Path of the catalog definiton file </param>        
+        /// <param name="cdfFilePath"> Path of the catalog definition file </param>        
         /// 
         /// <param name="catalogVersion"> Version of catalog</param>
         ///  
@@ -213,7 +213,7 @@ namespace System.Management.Automation
         /// <param name="relativePaths"> working set of relative paths of all files. </param>   
         /// <param name="cdfHeaderContent"> content to be added in CatalogHeader section of cdf File</param>   
         /// <param name="cdfFilesContent"> content to be added in CatalogFiles section of cdf File </param>   
-        /// <param name="catAttributeCount"> indictaing the current no of catalog header level attributes </param>   
+        /// <param name="catAttributeCount"> indicating the current no of catalog header level attributes </param>   
         /// <returns> void </returns>
         internal static void ProcessFileToBeAddedInCatalogDefinitionFile(FileInfo fileToHash, DirectoryInfo dirInfo, ref HashSet<string> relativePaths, ref string cdfHeaderContent, ref string cdfFilesContent, ref int catAttributeCount)
         {
@@ -252,7 +252,7 @@ namespace System.Management.Automation
             }
         }
         /// <summary>
-        /// Generate the Catalog file for Input Catalog Defintion File 
+        /// Generate the Catalog file for Input Catalog Definition File 
         /// </summary>
         ///
         /// <param name="cdfFilePath"> Path to the Input .cdf file </param>        
@@ -346,7 +346,7 @@ namespace System.Management.Automation
 
             if (!String.IsNullOrEmpty(hashAlgorithm))
             {
-                // Generate Path for Catalog Defintion File 
+                // Generate Path for Catalog Definition File 
                 string cdfFilePath = System.IO.Path.Combine(System.IO.Path.GetTempPath(), System.IO.Path.GetRandomFileName());
                 cdfFilePath = cdfFilePath + ".cdf";
                 try
@@ -355,8 +355,8 @@ namespace System.Management.Automation
 
                     if (!File.Exists(cdfFilePath))
                     {
-                        // If we are not able to generate catalog defintion file we can not continue generating catalog 
-                        // throw PSTraceSource.NewInvalidOperationException("catalog", CatalogStrings.CatalogDefintionFileNotGenerated);                    
+                        // If we are not able to generate catalog definition file we can not continue generating catalog 
+                        // throw PSTraceSource.NewInvalidOperationException("catalog", CatalogStrings.CatalogDefinitionFileNotGenerated);                    
                         ErrorRecord errorRecord = new ErrorRecord(new InvalidOperationException(CatalogStrings.CatalogDefintionFileNotGenerated), "CatalogDefintionFileNotGenerated", ErrorCategory.InvalidOperation, null);
                         _cmdlet.ThrowTerminatingError(errorRecord);
                     }

--- a/src/System.Management.Automation/security/SecurityManager.cs
+++ b/src/System.Management.Automation/security/SecurityManager.cs
@@ -53,7 +53,7 @@ namespace Microsoft.PowerShell
     ///    run or not.  This is the default setting.
     /// Unrestricted - No files must be signed.  If a file originates from the
     ///    internet, Monad provides a warning prompt to alert the user.  To
-    ///    supress this warning message, right-click on the file in File Explorer,
+    ///    suppress this warning message, right-click on the file in File Explorer,
     ///    select "Properties," and then "Unblock."
     /// Bypass - No files must be signed, and internet origin is not verified
     /// 

--- a/src/System.Management.Automation/security/SecuritySupport.cs
+++ b/src/System.Management.Automation/security/SecuritySupport.cs
@@ -37,7 +37,7 @@ namespace Microsoft.PowerShell
     {
         /// Unrestricted - No files must be signed.  If a file originates from the
         ///    internet, Monad provides a warning prompt to alert the user.  To
-        ///    supress this warning message, right-click on the file in File Explorer,
+        ///    suppress this warning message, right-click on the file in File Explorer,
         ///    select "Properties," and then "Unblock."
         Unrestricted = 0,
 
@@ -642,7 +642,7 @@ namespace System.Management.Automation.Internal
 
         /// <summary>
         /// check to see if the specified cert is suitable to be
-        /// used as an encryption cert for PKI encyryption. Note
+        /// used as an encryption cert for PKI encryption. Note
         /// that this cert doesn't require the private key.
         /// </summary>
         ///

--- a/src/System.Management.Automation/security/wldpNativeMethods.cs
+++ b/src/System.Management.Automation/security/wldpNativeMethods.cs
@@ -105,7 +105,7 @@ namespace System.Management.Automation.Security
             MessageId = "System.Runtime.InteropServices.SafeHandle.DangerousGetHandle")]
         private static SystemEnforcementMode GetWldpPolicy(string path, SafeHandle handle)
         {
-            // If the WLDP assembly is missing (such as windows 7 or down OS), return default/None to skip WLDP valification
+            // If the WLDP assembly is missing (such as windows 7 or down OS), return default/None to skip WLDP validation
             if (s_hadMissingWldpAssembly || !IO.File.Exists(IO.Path.Combine(Environment.SystemDirectory, "wldp.dll")))
             {
                 s_hadMissingWldpAssembly = true;

--- a/src/System.Management.Automation/singleshell/config/MshConsoleInfo.cs
+++ b/src/System.Management.Automation/singleshell/config/MshConsoleInfo.cs
@@ -21,7 +21,7 @@ namespace System.Management.Automation.Runspaces
     /// 2. Data values for the content represented by Console file. Later this data
     /// is used by other components ( MshConsoleInfo ) to construct Monad Types ( like
     /// PSSnapInInfo ).
-    /// 3. Owns responsibilty to read/write Files.
+    /// 3. Owns responsibility to read/write Files.
     /// 
     /// Risk:
     /// File Acces related security issues.
@@ -419,7 +419,7 @@ namespace System.Management.Automation.Runspaces
             IsDirty = false;
             Filename = null;
 
-            // Intialize list of mshsnapins..
+            // Initialize list of mshsnapins..
             _defaultPSSnapIns = new Collection<PSSnapInInfo>();
             _externalPSSnapIns = new Collection<PSSnapInInfo>();
         }
@@ -451,7 +451,7 @@ namespace System.Management.Automation.Runspaces
             catch (PSArgumentException ae)
             {
                 string message = ConsoleInfoErrorStrings.CannotLoadDefaults;
-                // If we were unalbe to load default mshsnapins throw PSSnapInException
+                // If we were unable to load default mshsnapins throw PSSnapInException
 
                 s_mshsnapinTracer.TraceError(message);
 
@@ -460,7 +460,7 @@ namespace System.Management.Automation.Runspaces
             catch (System.Security.SecurityException se)
             {
                 string message = ConsoleInfoErrorStrings.CannotLoadDefaults;
-                // If we were unalbe to load default mshsnapins throw PSSnapInException
+                // If we were unable to load default mshsnapins throw PSSnapInException
 
                 s_mshsnapinTracer.TraceError(message);
 
@@ -814,7 +814,7 @@ namespace System.Management.Automation.Runspaces
         /// </exception>
         private Collection<PSSnapInInfo> Load(string path, out PSConsoleLoadException cle)
         {
-            // Intialize the out parameter..
+            // Initialize the out parameter..
             cle = null;
 
             s_mshsnapinTracer.WriteLine("Load mshsnapins from console file {0}", path);
@@ -933,7 +933,7 @@ namespace System.Management.Automation.Runspaces
 
 
         /// <summary>
-        /// Constructs a new list of mshsnapins from defualt mshsnapins and external mshsnapins.
+        /// Constructs a new list of mshsnapins from default mshsnapins and external mshsnapins.
         /// </summary>
         /// <returns>A list of mshsnapins represented by the current console file</returns>
         private Collection<PSSnapInInfo> MergeDefaultExternalMshSnapins()

--- a/src/System.Management.Automation/singleshell/config/MshConsoleLoadException.cs
+++ b/src/System.Management.Automation/singleshell/config/MshConsoleLoadException.cs
@@ -31,7 +31,7 @@ namespace System.Management.Automation.Runspaces
     public class PSConsoleLoadException : SystemException, IContainsErrorRecord
     {
         /// <summary>
-        /// Intiate an instance of PSConsoleLoadException.
+        /// Initiate an instance of PSConsoleLoadException.
         /// </summary>
         /// <param name="consoleInfo">Console info object for the exception</param>
         /// <param name="exceptions">A collection of PSSnapInExceptions.</param>
@@ -159,7 +159,7 @@ namespace System.Management.Automation.Runspaces
         }
 
         /// <summary>
-        /// Get object data from serizliation information.
+        /// Get object data from serialization information.
         /// </summary>
         /// <param name="info"> Serialization information </param>
         /// <param name="context"> Streaming context </param>

--- a/src/System.Management.Automation/singleshell/config/MshSnapinInfo.cs
+++ b/src/System.Management.Automation/singleshell/config/MshSnapinInfo.cs
@@ -227,7 +227,7 @@ namespace System.Management.Automation
         public bool IsDefault { get; }
 
         /// <summary>
-        /// Retuns applicationbase for mshsnapin
+        /// Returns applicationbase for mshsnapin
         /// </summary>
         public string ApplicationBase { get; }
 
@@ -630,7 +630,7 @@ namespace System.Management.Automation
                 {
                     mshsnapins.Add(ReadOne(mshsnapinRoot, id));
                 }
-                //If we cannot read some mshsnapins, we should contiune
+                //If we cannot read some mshsnapins, we should continue
                 catch (SecurityException)
                 {
                 }
@@ -906,7 +906,7 @@ namespace System.Management.Automation
                 string.Format(CultureInfo.CurrentCulture, "{0} is null", RegistryStrings.MonadEngine_MonadVersion));
 
             // Get version number in x.x.x.x format
-            // This information is available from the exeucting assembly
+            // This information is available from the executing assembly
             //
             // PROBLEM: The following code assumes all assemblies have the same version,
             // culture, publickeytoken...This will break the scenarios where only one of

--- a/src/System.Management.Automation/singleshell/config/MshSnapinLoadException.cs
+++ b/src/System.Management.Automation/singleshell/config/MshSnapinLoadException.cs
@@ -189,7 +189,7 @@ namespace System.Management.Automation.Runspaces
         }
 
         /// <summary>
-        /// Get object data from serizliation information.
+        /// Get object data from serialization information.
         /// </summary>
         /// <param name="info"> Serialization information </param>
         /// <param name="context"> Streaming context </param>

--- a/src/System.Management.Automation/singleshell/config/RegistryStringResourceIndirect.cs
+++ b/src/System.Management.Automation/singleshell/config/RegistryStringResourceIndirect.cs
@@ -414,7 +414,7 @@ namespace System.Management.Automation
         /// </summary>
         /// 
         /// <param name="assemblyName">
-        /// The FullName of the assembly to load. This takes precendence over the modulePath and
+        /// The FullName of the assembly to load. This takes precedence over the modulePath and
         /// will be passed to as a parameter to the ReflectionOnlyLoad.
         /// </param>
         /// 

--- a/src/System.Management.Automation/singleshell/config/RunspaceConfigForSingleShell.cs
+++ b/src/System.Management.Automation/singleshell/config/RunspaceConfigForSingleShell.cs
@@ -15,7 +15,7 @@ namespace System.Management.Automation.Runspaces
     /// Runspace config for single shell are a special kind of runspace
     /// configuration that is generated for single shells. 
     /// 
-    /// This class needs to handle the standard managment of 
+    /// This class needs to handle the standard management of 
     /// 
     ///     1. consoleInfo: each instance of this class will have 
     ///        a consoleInfo object. 

--- a/src/System.Management.Automation/singleshell/installer/CustomMshSnapin.cs
+++ b/src/System.Management.Automation/singleshell/installer/CustomMshSnapin.cs
@@ -33,7 +33,7 @@ namespace System.Management.Automation
     /// Developers should derive from this class to implement their own 
     /// custom mshsnapins. 
     /// 
-    /// Derived mshsnapins should be denotated with [RunInstaller] attribute
+    /// Derived mshsnapins should be denoted with [RunInstaller] attribute
     /// so that installutil.exe can directly install the mshsnapin into registry. 
     /// </remarks>
     public abstract class CustomPSSnapIn : PSSnapInInstaller

--- a/src/System.Management.Automation/singleshell/installer/MshInstaller.cs
+++ b/src/System.Management.Automation/singleshell/installer/MshInstaller.cs
@@ -35,7 +35,7 @@ namespace System.Management.Automation
     ///     1. accessing system registry
     ///     2. support of additional command line parameters. 
     ///     3. writing registry files
-    ///     4. automatically extract informaton like vender, version, etc.
+    ///     4. automatically extract information like vender, version, etc.
     /// 
     /// Different monad component will derive from this class. Two common
     /// components that need install include, 

--- a/src/System.Management.Automation/singleshell/installer/MshSnapin.cs
+++ b/src/System.Management.Automation/singleshell/installer/MshSnapin.cs
@@ -28,7 +28,7 @@ namespace System.Management.Automation
     /// Developers should derive from this class when implementing their own 
     /// mshsnapins. 
     /// 
-    /// Derived mshsnapins should be denotated with [RunInstaller] attribute
+    /// Derived mshsnapins should be denoted with [RunInstaller] attribute
     /// so that installutil.exe can directly install the mshsnapin into registry. 
     /// </remarks>
     public abstract class PSSnapIn : PSSnapInInstaller

--- a/src/System.Management.Automation/singleshell/installer/MshSnapinInstaller.cs
+++ b/src/System.Management.Automation/singleshell/installer/MshSnapinInstaller.cs
@@ -30,7 +30,7 @@ namespace System.Management.Automation
     /// Here, the information about registry content is provided. 
     /// 
     /// The reason of not calling this class MshSnapinInstaller is to "hide" the details 
-    /// that MshSnapin class is actually doing installion. It is also more intuitive
+    /// that MshSnapin class is actually doing installation. It is also more intuitive
     /// since people deriving from this class will think there are really 
     /// implementing a class for mshsnapin. 
     /// 

--- a/src/System.Management.Automation/utils/ClrFacade.cs
+++ b/src/System.Management.Automation/utils/ClrFacade.cs
@@ -38,7 +38,7 @@ namespace System.Management.Automation
     {
         /// <summary>
         /// We need it to avoid calling lookups inside dynamic assemblies with PS Types, so we exclude it from GetAssemblies().
-        /// We use this convention for names to achive it.
+        /// We use this convention for names to archive it.
         /// </summary>
         internal static readonly char FIRST_CHAR_PSASSEMBLY_MARK = (char)0x29f9;
 
@@ -326,7 +326,7 @@ namespace System.Management.Automation
         }
 
         /// <summary>
-        /// Load assemlby from byte stream.
+        /// Load assembly from byte stream.
         /// </summary>
         internal static Assembly LoadFrom(Stream assembly)
         {
@@ -602,7 +602,7 @@ namespace System.Management.Automation
         /// 
         /// In CORECLR, there are two peculiarities with its implementation that affect our own:
         /// 1. Structures cannot be instantiated using GetConstructor, so they must be filtered out.
-        /// 2. Classes must have a default constructor implemented for GetContructor to work.
+        /// 2. Classes must have a default constructor implemented for GetConstructor to work.
         /// 
         /// See RemoteHostEncoder.IsEncodingAllowedForClassOrStruct for a list of the required types.
         /// </summary>

--- a/src/System.Management.Automation/utils/CryptoUtils.cs
+++ b/src/System.Management.Automation/utils/CryptoUtils.cs
@@ -371,7 +371,7 @@ namespace System.Management.Automation.Internal
         /// Constructor with inner exception
         /// </summary>
         /// <param name="message">error message</param>
-        /// <param name="innerException">innter exception</param>
+        /// <param name="innerException">inner exception</param>
         /// <remarks>This constructor is currently not called 
         /// explicitly from crypto utils</remarks>
         public PSCryptoException(string message, Exception innerException) :
@@ -512,7 +512,7 @@ namespace System.Management.Automation.Internal
         }
 
         /// <summary>
-        /// Generates an AEX-256 sessin key if one is not already generated
+        /// Generates an AEX-256 session key if one is not already generated
         /// </summary>
         internal void GenerateSessionKey()
         {
@@ -860,7 +860,7 @@ namespace System.Management.Automation.Internal
         #region IDisposable
 
         /// <summary>
-        /// Dipose resources
+        /// Dispose resources
         /// </summary>
         public void Dispose()
         {

--- a/src/System.Management.Automation/utils/GraphicalHostReflectionWrapper.cs
+++ b/src/System.Management.Automation/utils/GraphicalHostReflectionWrapper.cs
@@ -21,7 +21,7 @@ namespace System.Management.Automation.Internal
     /// Microsoft.PowerShell.GraphicalHost.dll contains:
     ///    1) out-gridview window implementation (the actual cmdlet is in Microsoft.PowerShell.Commands.Utility.dll)
     ///    2) show-command window implementation (the actual cmdlet is in Microsoft.PowerShell.Commands.Utility.dll)
-    ///    3) the help window used in the System.Management.Automation.dll's get-help cmdslet when -ShowWindow is specified
+    ///    3) the help window used in the System.Management.Automation.dll's get-help cmdlet when -ShowWindow is specified
     /// </summary>
     internal class GraphicalHostReflectionWrapper
     {

--- a/src/System.Management.Automation/utils/IObjectWriter.cs
+++ b/src/System.Management.Automation/utils/IObjectWriter.cs
@@ -107,7 +107,7 @@ namespace System.Management.Automation.Runspaces
         /// If enumerateCollection is true, and <paramref name="obj"/>
         /// is an enumeration according to LanguagePrimitives.GetEnumerable,
         /// the objects in the enumeration will be unrolled and
-        /// written seperately.  Otherwise, <paramref name="obj"/>
+        /// written separately.  Otherwise, <paramref name="obj"/>
         /// will be written as a single object.
         /// </param>
         /// <returns>The number of objects written</returns>

--- a/src/System.Management.Automation/utils/MshTraceSource.cs
+++ b/src/System.Management.Automation/utils/MshTraceSource.cs
@@ -24,7 +24,7 @@ namespace System.Management.Automation
     /// 
     /// The PSTraceSource class is derived from Switch to provide granular
     /// control over the tracing in a program.  An instance of PSTraceSource
-    /// is created for each category of tracing such that seperate flags
+    /// is created for each category of tracing such that separate flags
     /// (filters) can be set. Each flag enables one or more method for tracing.
     /// 
     /// For instance, the Exception flag will enable tracing on these methods:

--- a/src/System.Management.Automation/utils/ObjectStream.cs
+++ b/src/System.Management.Automation/utils/ObjectStream.cs
@@ -280,7 +280,7 @@ namespace System.Management.Automation.Internal
         /// If enumerateCollection is true, and <paramref name="obj"/>
         /// is an enumeration according to LanguagePrimitives.GetEnumerable,
         /// the objects in the enumeration will be unrolled and
-        /// written seperately.  Otherwise, <paramref name="obj"/>
+        /// written separately.  Otherwise, <paramref name="obj"/>
         /// will be written as a single object.
         /// </param>
         /// <returns>The number of objects written</returns>
@@ -520,7 +520,7 @@ namespace System.Management.Automation.Internal
         /// Default constructor
         /// </summary>
         /// <remarks>
-        /// Constructs a stream with a miximum size of Int32.Max
+        /// Constructs a stream with a maximum size of Int32.Max
         /// </remarks>
         internal ObjectStream()
             : this(Int32.MaxValue)
@@ -1293,7 +1293,7 @@ namespace System.Management.Automation.Internal
         /// If enumerateCollection is true, and <paramref name="obj"/>
         /// is an enumeration according to LanguagePrimitives.GetEnumerable,
         /// the objects in the enumeration will be unrolled and
-        /// written seperately.  Otherwise, <paramref name="obj"/>
+        /// written separately.  Otherwise, <paramref name="obj"/>
         /// will be written as a single object.
         /// </param>
         /// <returns>The number of objects written</returns>
@@ -1342,7 +1342,7 @@ namespace System.Management.Automation.Internal
                 foreach (object o in enumerable)
                 {
                     // 879023-2003/10/28-JonN
-                    //  Outputting stops when recieving a AutomationNull.Value
+                    //  Outputting stops when receiving a AutomationNull.Value
                     // 2003/10/28-JonN There is a window where another
                     //  thread could modify the array to contain
                     //  AutomationNull.Value, but I'm not going to deal with it.
@@ -1833,7 +1833,7 @@ namespace System.Management.Automation.Internal
             {
                 foreach (object o in enumerable)
                 {
-                    //  Outputting stops when recieving a AutomationNull.Value
+                    //  Outputting stops when receiving a AutomationNull.Value
                     //  There is a window where another thread could modify the 
                     //  array to contain AutomationNull.Value, 
                     //  but I'm not going to deal with it.

--- a/src/System.Management.Automation/utils/ObjectWriter.cs
+++ b/src/System.Management.Automation/utils/ObjectWriter.cs
@@ -156,7 +156,7 @@ namespace System.Management.Automation.Internal
         /// If enumerateCollection is true, and <paramref name="obj"/>
         /// is an enumeration according to LanguagePrimitives.GetEnumerable,
         /// the objects in the enumeration will be unrolled and
-        /// written seperately.  Otherwise, <paramref name="obj"/>
+        /// written separately.  Otherwise, <paramref name="obj"/>
         /// will be written as a single object.
         /// </param>
         /// <returns>The number of objects written</returns>

--- a/src/System.Management.Automation/utils/PathUtils.cs
+++ b/src/System.Management.Automation/utils/PathUtils.cs
@@ -23,7 +23,7 @@ namespace System.Management.Automation
         /// </summary>
         /// <param name="cmdlet">cmdlet that is opening the file (used mainly for error reporting)</param>
         /// <param name="filePath">path to the file (as specified on the command line - this method will resolve the path)</param>
-        /// <param name="encoding">encoding (this method will convert the command line strin to an Encoding instance)</param>
+        /// <param name="encoding">encoding (this method will convert the command line string to an Encoding instance)</param>
         /// <param name="defaultEncoding">if <c>true</c>, then we will use default .NET encoding instead of the encoding specified in <paramref name="encoding"/> parameter</param>
         /// <param name="Append"></param>
         /// <param name="Force"></param>
@@ -57,7 +57,7 @@ namespace System.Management.Automation
         /// </summary>
         /// <param name="cmdlet">cmdlet that is opening the file (used mainly for error reporting)</param>
         /// <param name="filePath">path to the file (as specified on the command line - this method will resolve the path)</param>
-        /// <param name="resolvedEncoding">encoding (this method will convert the command line strin to an Encoding instance)</param>
+        /// <param name="resolvedEncoding">encoding (this method will convert the command line string to an Encoding instance)</param>
         /// <param name="defaultEncoding">if <c>true</c>, then we will use default .NET encoding instead of the encoding specified in <paramref name="encoding"/> parameter</param>
         /// <param name="Append"></param>
         /// <param name="Force"></param>
@@ -453,7 +453,7 @@ namespace System.Management.Automation
         internal const string OEM = "oem";
 
         /// <summary>
-        /// retrieve the encoding paramater from the command line
+        /// retrieve the encoding parameter from the command line
         /// it throws if the encoding does not match the known ones
         /// </summary>
         /// <returns>a System.Text.Encoding object (null if no encoding specified)</returns>

--- a/src/System.Management.Automation/utils/PowerShellETWTracer.cs
+++ b/src/System.Management.Automation/utils/PowerShellETWTracer.cs
@@ -350,7 +350,7 @@ namespace System.Management.Automation.Tracing
         Exception = 0xB002,
 
         /// <summary>
-        /// PoweShellObject
+        /// PowerShellObject
         /// </summary>
         PowerShellObject = 0xB003,
 
@@ -940,7 +940,7 @@ namespace System.Management.Automation.Tracing
         private bool disposed;
 
         /// <summary>
-        /// Consturctor
+        /// Constructor
         /// </summary>
         internal PowerShellTraceSource(PowerShellTraceTask task, PowerShellTraceKeywords keywords)
         {

--- a/src/System.Management.Automation/utils/PsUtils.cs
+++ b/src/System.Management.Automation/utils/PsUtils.cs
@@ -145,10 +145,10 @@ namespace System.Management.Automation
             }
         }
 
-#if !CORECLR // .NET Frmework Version is not applicable to CoreCLR
+#if !CORECLR // .NET Framework Version is not applicable to CoreCLR
         /// <summary>
-        /// Detects the installation of Frmework Versions 1.1, 2.0, 3.0 and 3.5 and 4.0 through
-        /// the official registry instalation keys.
+        /// Detects the installation of Framework Versions 1.1, 2.0, 3.0 and 3.5 and 4.0 through
+        /// the official registry installation keys.
         /// </summary>
         internal static class FrameworkRegistryInstallation
         {
@@ -586,7 +586,7 @@ namespace System.Management.Automation
             }
 #else
             // Important:
-            // this functiona has a clone in Workflow.ServiceCore in admin\monad\src\m3p\product\ServiceCore\WorkflowCore\WorkflowRuntimeCompilation.cs
+            // this function has a clone in Workflow.ServiceCore in admin\monad\src\m3p\product\ServiceCore\WorkflowCore\WorkflowRuntimeCompilation.cs
             // if you are making any changes specific to this function then update the clone as well.
 
             var sysInfo = new NativeMethods.SYSTEM_INFO();
@@ -682,7 +682,7 @@ namespace System.Management.Automation
         /// 
         /// This method is used when handling a script block that contains $using for Invoke-Command.
         /// 
-        /// When run Invoke-Command targetting a machine that runs PSv3 or above, we pass a dictionary
+        /// When run Invoke-Command targeting a machine that runs PSv3 or above, we pass a dictionary
         /// to the remote end that contains the key of each UsingExpressionAst and its value. This method
         /// is used to generate the key.
         /// </summary>

--- a/src/System.Management.Automation/utils/SessionStateExceptions.cs
+++ b/src/System.Management.Automation/utils/SessionStateExceptions.cs
@@ -683,7 +683,7 @@ namespace System.Management.Automation
     /// SessionStateUnauthorizedAccessException occurs when
     /// a change to a session state object cannot be completed
     /// because the object is read-only or constant, or because
-    /// an object which is declard constant cannot be removed
+    /// an object which is declared constant cannot be removed
     /// or made non-constant.
     /// </summary>
     [Serializable]

--- a/src/System.Management.Automation/utils/StructuredTraceSource.cs
+++ b/src/System.Management.Automation/utils/StructuredTraceSource.cs
@@ -36,7 +36,7 @@ namespace System.Management.Automation
         /// Constructors will be traced
         /// </summary>
         /// <!--
-        /// The TraceConstrutor methods are enabled
+        /// The TraceConstructor methods are enabled
         /// -->
         Constructor = 0x00000001,
 
@@ -221,7 +221,7 @@ namespace System.Management.Automation
     /// <!--
     /// The StructuredTraceSource class is derived from TraceSource to provide granular
     /// control over the tracing in a program.  An instance of StructuredTraceSource
-    /// is created for each category of tracing such that seperate flags
+    /// is created for each category of tracing such that separate flags
     /// (filters) can be set. Each flag enables one or more method for tracing.
     /// 
     /// For instance, the Exception flag will enable tracing on these methods:

--- a/src/System.Management.Automation/utils/Verbs.cs
+++ b/src/System.Management.Automation/utils/Verbs.cs
@@ -452,7 +452,7 @@ namespace System.Management.Automation
     public static class VerbsDiagnostic
     {
         /// <summary>
-        /// Interatively interact with a resource or activity for the purpose finding a flaw or better understanding of what is occurring.
+        /// Iteratively interact with a resource or activity for the purpose finding a flaw or better understanding of what is occurring.
         /// </summary>
         public const string Debug = "Debug";
 
@@ -509,7 +509,7 @@ namespace System.Management.Automation
         public const string Receive = "Receive";
 
         /// <summary>
-        /// Associate subsequent activies with a resource
+        /// Associate subsequent activities with a resource
         /// </summary>
         public const string Connect = "Connect";
 

--- a/src/System.Management.Automation/utils/WindowsErrorReporting.cs
+++ b/src/System.Management.Automation/utils/WindowsErrorReporting.cs
@@ -653,7 +653,7 @@ namespace System.Management.Automation
         /// to a defined exception. If the HRESULT maps to a defined exception, ThrowExceptionForHR
         /// creates an instance of the exception and throws it. Otherwise, it creates an instance 
         /// of System.Runtime.InteropServices.COMException, initializes the error code field with 
-        /// the HRESULT, and throws that exception. When this method is invoked, it attemps to
+        /// the HRESULT, and throws that exception. When this method is invoked, it attempts to
         /// retrieve extra information regarding the error by using the unmanaged GetErrorInfo
         /// function.
         /// </exception>
@@ -772,7 +772,7 @@ namespace System.Management.Automation
         /// to a defined exception. If the HRESULT maps to a defined exception, ThrowExceptionForHR
         /// creates an instance of the exception and throws it. Otherwise, it creates an instance 
         /// of System.Runtime.InteropServices.COMException, initializes the error code field with 
-        /// the HRESULT, and throws that exception. When this method is invoked, it attemps to
+        /// the HRESULT, and throws that exception. When this method is invoked, it attempts to
         /// retrieve extra information regarding the error by using the unmanaged GetErrorInfo
         /// function.
         /// </exception>
@@ -813,7 +813,7 @@ namespace System.Management.Automation
         /// to a defined exception. If the HRESULT maps to a defined exception, ThrowExceptionForHR
         /// creates an instance of the exception and throws it. Otherwise, it creates an instance 
         /// of System.Runtime.InteropServices.COMException, initializes the error code field with 
-        /// the HRESULT, and throws that exception. When this method is invoked, it attemps to
+        /// the HRESULT, and throws that exception. When this method is invoked, it attempts to
         /// retrieve extra information regarding the error by using the unmanaged GetErrorInfo
         /// function.
         /// </exception>
@@ -932,7 +932,7 @@ namespace System.Management.Automation
             }
             finally
             {
-                // FailFast if something went wrong and SubmitReport didn't terminate the proces
+                // FailFast if something went wrong and SubmitReport didn't terminate the process
                 // (or simply if not registered)
                 Environment.FailFast((null != exception) ? exception.Message : string.Empty);
             }

--- a/src/System.Management.Automation/utils/assert.cs
+++ b/src/System.Management.Automation/utils/assert.cs
@@ -6,7 +6,7 @@ Copyright (c) Microsoft Corporation.  All rights reserved.
 // defined here to call Diagnostics.Assert when only ASSERTIONS_TRACE is defined
 // Any #if DEBUG is pointless (always true) in this file because of this declaration.
 // The presence of the define will cause the System.Diagnostics.Debug.Asser calls
-// allways to be compiled in for this file. What can be compiled out are the calls to
+// always to be compiled in for this file. What can be compiled out are the calls to
 // System.Management.Automation.Diagnostics.Assert in other files when neither DEBUG
 // nor ASSERTIONS_TRACE is defined.
 #define DEBUG
@@ -115,7 +115,7 @@ namespace System.Management.Automation
         /// Basic assertion with logical condition and message
         /// </summary>
         /// <param name="condition">
-        /// logical condtion that should be true for program to proceed
+        /// logical condition that should be true for program to proceed
         /// </param>
         /// <param name="whyThisShouldNeverHappen">
         /// Message to explain why condition should always be true
@@ -144,7 +144,7 @@ namespace System.Management.Automation
         /// Basic assertion with logical condition, message and detailed message
         /// </summary>
         /// <param name="condition">
-        /// logical condtion that should be true for program to proceed
+        /// logical condition that should be true for program to proceed
         /// </param>
         /// <param name="whyThisShouldNeverHappen">
         /// Message to explain why condition should always be true

--- a/src/System.Management.Automation/utils/perfCounters/CounterSetInstanceBase.cs
+++ b/src/System.Management.Automation/utils/perfCounters/CounterSetInstanceBase.cs
@@ -131,7 +131,7 @@ namespace System.Management.Automation.PerformanceData
         /// <summary>
         /// If isNumerator is true, then updates the numerator component
         /// of target counter 'counterName' by a value given by 'stepAmount'. 
-        /// Otherwise, updaqtes the denominator component by 'stepAmount'.
+        /// Otherwise, updates the denominator component by 'stepAmount'.
         /// </summary>
         public abstract bool UpdateCounterByValue(
             string counterName,
@@ -328,7 +328,7 @@ namespace System.Management.Automation.PerformanceData
         {
             this.Dispose(true);
             // This object will be cleaned up by the Dispose method.
-            // Therefore, you should call GC.SupressFinalize to
+            // Therefore, you should call GC.SuppressFinalize to
             // take this object off the finalization queue
             // and prevent finalization code for this object
             // from executing a second time.

--- a/src/System.Management.Automation/utils/perfCounters/CounterSetRegistrarBase.cs
+++ b/src/System.Management.Automation/utils/perfCounters/CounterSetRegistrarBase.cs
@@ -8,7 +8,7 @@ using System.Diagnostics.CodeAnalysis;
 namespace System.Management.Automation.PerformanceData
 {
     /// <summary>
-    /// A struct that encapuslates the information pertaining to a given counter
+    /// A struct that encapsulates the information pertaining to a given counter
     /// like name,type and id.
     /// </summary>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1815:OverrideEqualsAndOperatorEqualsOnValueTypes")]

--- a/src/System.Management.Automation/utils/perfCounters/PSPerfCountersMgr.cs
+++ b/src/System.Management.Automation/utils/perfCounters/PSPerfCountersMgr.cs
@@ -14,7 +14,7 @@ namespace System.Management.Automation.PerformanceData
     /// <summary>
     /// Powershell Performance Counters Manager class shall provide a mechanism
     /// for components using SYstem.Management.Automation assembly to register
-    /// performance counters with Performance Counters susbsystem.
+    /// performance counters with Performance Counters subsystem.
     /// </summary>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
     public class PSPerfCountersMgr
@@ -37,7 +37,7 @@ namespace System.Management.Automation.PerformanceData
 
         #endregion
 
-        #region Desctructor
+        #region Destructor
 
         /// <summary>
         /// Destructor which will trigger the cleanup of internal data structures and

--- a/src/System.Management.Automation/utils/tracing/EtwActivity.cs
+++ b/src/System.Management.Automation/utils/tracing/EtwActivity.cs
@@ -64,7 +64,7 @@ namespace System.Management.Automation.Tracing
             private set;
         }
 
-        /// <summary> Gets whether the event is sucessfully written </summary>
+        /// <summary> Gets whether the event is successfully written </summary>
         public bool Success
         {
             get;
@@ -83,7 +83,7 @@ namespace System.Management.Automation.Tracing
         /// Creates a new instance of EtwEventArgs class.
         /// </summary>
         /// <param name="descriptor">Event descriptor</param>
-        /// <param name="success">Indicate whether the event is sucessfully written</param>
+        /// <param name="success">Indicate whether the event is successfully written</param>
         /// <param name="payload">Event payload</param>
         public EtwEventArgs(EventDescriptor descriptor, bool success, object[] payload)
         {
@@ -110,7 +110,7 @@ namespace System.Management.Automation.Tracing
             private AsyncCallback asyncCallback;
 
             /// <summary>
-            /// parantActivityId
+            /// parentActivityId
             /// </summary>
             protected readonly Guid parentActivityId;
             private readonly EtwActivity tracer;

--- a/src/System.Management.Automation/utils/tracing/EtwActivityReverterMethodInvoker.cs
+++ b/src/System.Management.Automation/utils/tracing/EtwActivityReverterMethodInvoker.cs
@@ -33,7 +33,7 @@ namespace System.Management.Automation.Tracing
 
 #endregion
 
-#region Instsance Access
+#region Instance Access
 
         public Delegate Invoker
         {


### PR DESCRIPTION
Nothing here should impact the build, however, there are a lot of files. In order to make it possible for me to exclude things which would have, I selectively included changes on a per-directory basis.

This means there are 23 commits, each of which should be fairly easy to review independently.

This is PR 5 of N:

The following is a list of some spelling fixes which have been made to the impacted files. It is not necessarily a complete list of changed words -- if a word is misspelled in code or resource strings the quick tool I used to list what's changed might say "that's still present" and not have highlighted it.
- atleast
- Defragmentor
- deserialization
- deserialized
- deserializing
- fragmentor
- ICloneable
- IEnumerable
- iformattable
- kerberos
- lifecycle
- Microsoft
- Minrunspaces
- overridee
- parameterset
- stopprocessing
- telementry
- typenames
- unmarshal
