### PR TITLE
Clone 1000 commits on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ branches:
     - master
     - /^test.*$/
 
+git:
+  depth: 1000
+
 os:
   - linux
 sudo: required


### PR DESCRIPTION
The previous failure we saw was because the most recent annotated tag did not exist in the previous 50 commits. In my experience we've gone about ~300 commits between tags, so I believe 1000 to be safe, but know 100 will not be.

We should continue to use `git describe` because it encodes both the most recent version and the exact commit past it where it's built.

Resolves #2029.

Finding out right now from Travis CI if it's possible to completely disable shallow cloning.
