### PR TITLE
Made AppVeyor and TravisCI use similar code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ gen
 
 # OS X
 .DS_Store
+
+# TestsResults
+TestsResults*.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,5 @@
 language: cpp
 
-branches:
-  only:
-    - master
-    - /^test.*$/
-
 git:
   depth: 1000
 

--- a/build.psm1
+++ b/build.psm1
@@ -278,7 +278,7 @@ function Start-PSBuild {
 cmd.exe /C cd /d "$currentLocation" "&" "$($vcVarsPath)\vcvarsall.bat" "$NativeHostArch" "&" mc.exe -o -d -c -U "$($_.FullName)" -h "$nativeResourcesFolder" -r "$nativeResourcesFolder"
 "@
                     log "  Executing mc.exe Command: $command"
-                    Start-NativeExecution { Invoke-Expression -Command:$command }
+                    Start-NativeExecution { Invoke-Expression -Command:$command 2>&1 }
                 }
             }
 

--- a/build.psm1
+++ b/build.psm1
@@ -551,30 +551,32 @@ function Start-PSPester {
     [CmdletBinding()]param(
         [string]$OutputFormat = "NUnitXml",
         [string]$OutputFile = "pester-tests.xml",
-        [switch]$DisableExit,
         [string[]]$ExcludeTag = "Slow",
         [string[]]$Tag = "CI",
-        [string]$Path = "$PSScriptRoot/test/powershell"
+        [string]$Path = "$PSScriptRoot/test/powershell",
+        [switch]$ThrowOnFailure,
+        [switch]$FullCLR,
+        [string]$binDir = (Split-Path (New-PSOptions -FullCLR:$FullCLR).Output) 
     )
-
-    $powershell = Get-PSOutput
 
     # All concatenated commands/arguments are suffixed with the delimiter (space)
     $Command = ""
+    $powershell = Join-Path $binDir 'powershell'
 
     # Windows needs the execution policy adjusted
     if ($IsWindows) {
         $Command += "Set-ExecutionPolicy -Scope Process Unrestricted; "
     }
+    $startParams = @{binDir=$binDir}
 
-    $PesterModule = [IO.Path]::Combine((Split-Path $powershell), "Modules", "Pester")
-    $Command += "Import-Module '$PesterModule'; "
+    $PesterModule = [IO.Path]::Combine($binDir, "Modules", "Pester")
+    if(!$FullCLR)
+    {
+        $Command += "Import-Module '$PesterModule'; "
+    }
     $Command += "Invoke-Pester "
 
     $Command += "-OutputFormat ${OutputFormat} -OutputFile ${OutputFile} "
-    if (!$DisableExit) {
-        $Command += "-EnableExit "
-    }
     if ($ExcludeTag -and ($ExcludeTag -ne "")) {
         $Command += "-ExcludeTag @('" + (${ExcludeTag} -join "','") + "') "
     }
@@ -585,17 +587,46 @@ function Start-PSPester {
     $Command += "'" + $Path + "'"
         
     Write-Verbose $Command
-    # To ensure proper testing, the module path must not be inherited by the spawned process
-    try {
-        $originalModulePath = $env:PSMODULEPATH
-        $env:PSMODULEPATH = ""
-        & $powershell -noprofile -c $Command
-    } finally {
-        $env:PSMODULEPATH = $originalModulePath
-    }
 
-    if ($LASTEXITCODE -ne 0) {
-        throw "$LASTEXITCODE Pester tests failed"
+    # To ensure proper testing, the module path must not be inherited by the spawned process
+    if($FullCLR)
+    {
+        Start-DevPowerShell -binDir $binDir -FullCLR -NoNewWindow -ArgumentList '-noprofile', '-noninteractive' -Command $command
+    }
+    else {
+        try {
+            $originalModulePath = $env:PSMODULEPATH
+            
+            & $powershell -noprofile -c $Command
+        } finally {
+            $env:PSMODULEPATH = $originalModulePath
+        }        
+    }
+    if($ThrowOnFailure)
+    {
+        Test-PSPesterResults -TestResultsFile $OutputFile
+    }
+}
+
+#
+# Read the test result file and
+# Throw if a test failed 
+function Test-PSPesterResults
+{
+    param(
+        [string]$TestResultsFile = "pester-tests.xml",
+        [string] $TestArea = 'test/powershell'
+    )
+
+    if(!(Test-Path $TestResultsFile))
+    {
+        throw "Test result file '$testResultsFile' not found for $TestArea."
+    } 
+
+    $x = [xml](Get-Content -raw $testResultsFile)
+    if ([int]$x.'test-results'.failures -gt 0)
+    {
+        throw "$($x.'test-results'.failures) tests in $TestArea failed"
     }
 }
 
@@ -1213,9 +1244,13 @@ function Start-DevPowerShell {
 
         Start-Process @startProcessArgs
     } finally {
-        ri env:DEVPATH
+        if($env:DevPath)
+        {
+            Remove-Item env:DEVPATH
+        }
+        
         if ($ZapDisable) {
-            ri env:COMPLUS_ZapDisable
+            Remove-Item env:COMPLUS_ZapDisable
         }
     }
 }

--- a/tools/appveyor.psm1
+++ b/tools/appveyor.psm1
@@ -9,7 +9,7 @@ function Invoke-AppVeyorFull
 {
     Invoke-AppVeyorInstall
     Invoke-AppVeyorBuild
-    Invoke-AppVeyorTest
+    Invoke-AppVeyorTest -ErrorAction Continue
     Invoke-AppveyorFinish
 }
 
@@ -86,6 +86,8 @@ function Update-AppVeyorTestResults
 # Implement AppVeyor 'Test_script'
 function Invoke-AppVeyorTest 
 {
+    [CmdletBinding()]
+    param()
     #
     # CoreCLR
     $env:CoreOutput = Split-Path -Parent (Get-PSOutput -Options (New-PSOptions -Publish -Configuration $buildConfiguration))
@@ -96,7 +98,8 @@ function Invoke-AppVeyorTest
         throw "CoreCLR PowerShell.exe was not built"
     }
     
-    & ("$env:CoreOutput\powershell.exe") -noprofile -noninteractive -c "Set-ExecutionPolicy -Scope Process Unrestricted; Invoke-Pester test/powershell -Tag 'CI' -ExcludeTag 'Slow' -OutputFormat NUnitXml -OutputFile $testResultsFile"
+    Start-PSPester -bindir $env:CoreOutput -outputFile $testResultsFile
+    Write-Host -Foreground Green 'Upload CoreCLR test results'
     Update-AppVeyorTestResults -resultsFile $testResultsFile
     
     #
@@ -104,26 +107,17 @@ function Invoke-AppVeyorTest
     $env:FullOutput = Split-Path -Parent (Get-PSOutput -Options (New-PSOptions -FullCLR))
     Write-Host -Foreground Green 'Run FullCLR tests'
     $testResultsFileFullCLR = "$pwd\TestsResults.FullCLR.xml"
-    Start-DevPowerShell -FullCLR -NoNewWindow -ArgumentList '-noprofile', '-noninteractive' -Command "Set-ExecutionPolicy -Scope Process Unrestricted; Invoke-Pester test/fullCLR -ExcludeTag 'Slow' -OutputFormat NUnitXml -OutputFile $testResultsFileFullCLR"
+    Start-PSPester -FullCLR -bindir $env:FullOutput -outputFile $testResultsFileFullCLR -Tag $null -path 'test/fullCLR'
+
+    Write-Host -Foreground Green 'Upload FullCLR test results'
     Update-AppVeyorTestResults -resultsFile $testResultsFileFullCLR
  
 
     #
     # Fail the build, if tests failed
-    Write-Host -Foreground Green 'Upload CoreCLR test results'
-    $x = [xml](cat -raw $testResultsFile)
-    if ([int]$x.'test-results'.failures -gt 0)
-    {
-        throw "$($x.'test-results'.failures) tests in test/powershell failed"
-    }
+    Test-PSPesterResults -TestResultsFile $testResultsFile
 
-    Write-Host -Foreground Green 'Upload FullCLR test results'
-    $x = [xml](cat -raw $testResultsFileFullCLR)
-
-    if ([int]$x.'test-results'.failures -gt 0)
-    {
-        throw "$($x.'test-results'.failures) tests in test/fullCLR failed"
-    }
+    Test-PSPesterResults -TestResultsFile $testResultsFileFullCLR
 }
 
 # Implements AppVeyor 'on_finish' step

--- a/tools/travis.sh
+++ b/tools/travis.sh
@@ -2,7 +2,7 @@ set -x
 ulimit -n 4096
 # Only build packages for branches, not pull requests
 if [[ "$TRAVIS_PULL_REQUEST" == "false" ]]; then
-    powershell -c "Import-Module ./build.psm1; Start-PSBootstrap -Package; Start-PSBuild -CrossGen; Start-PSPackage; Start-PSPester; Start-PSxUnit"
+    powershell -c "Import-Module ./build.psm1; Start-PSBootstrap -Package; Start-PSBuild -CrossGen; Start-PSPackage; Start-PSPester -ThrowOnFailure; Test-PSPesterResults; Start-PSxUnit"
 else
-    powershell -c "Import-Module ./build.psm1; Start-PSBootstrap; Start-PSBuild -CrossGen; Start-PSPester; Start-PSxUnit"
+    powershell -c "Import-Module ./build.psm1; Start-PSBootstrap; Start-PSBuild -CrossGen; Start-PSPester -ThrowOnFailure; Start-PSxUnit"
 fi


### PR DESCRIPTION
redirect mc messages to stderr which occur even on success to stdout
Removed travis-ci branch restriction now that we are using forks ( makes it easier to use your own instance of travis-ci)

Address a portion of #1646 

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/powershell/2128)

<!-- Reviewable:end -->
