### PR TITLE
Path fix for git submodule update

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -665,9 +665,11 @@ function Start-PSBootstrap {
     try {
         # Update googletest submodule for linux native cmake
         if ($IsLinux -or $IsOSX) {
+            Push-Location $PSScriptRoot
             $Submodule = "$PSScriptRoot/src/libpsl-native/test/googletest"
             Remove-Item -Path $Submodule -Recurse -Force -ErrorAction SilentlyContinue
             git submodule update --init -- $submodule
+            Pop-Location
         }
 
         # Install ours and .NET's dependencies


### PR DESCRIPTION
When updating the googletest submodule for cmake, the path should be the base script directory or the update with fail.
