### PR TITLE
Spelling debug

### DIFF
--- a/src/System.Management.Automation/singleshell/Commands/ConsoleCommands.cs
+++ b/src/System.Management.Automation/singleshell/Commands/ConsoleCommands.cs
@@ -248,7 +248,7 @@ namespace Microsoft.PowerShell.Commands
             catch (ArgumentException ae)
             {
                 ThrowError(resolvedPath,
-                    "InvalidCharacetersInPath", ae, ErrorCategory.InvalidArgument);
+                    "InvalidCharactersInPath", ae, ErrorCategory.InvalidArgument);
             }
 
             // looks like saving succeeded.

--- a/src/System.Management.Automation/utils/PSTelemetryMethods.cs
+++ b/src/System.Management.Automation/utils/PSTelemetryMethods.cs
@@ -196,12 +196,12 @@ namespace Microsoft.PowerShell.Telemetry.Internal
             System.Management.Automation.Host.TranscriptionData transcriptionData)
         {
             bool isConstrained = (iss != null) && (iss.DefaultCommandVisibility != SessionStateEntryVisibility.Public) && (iss.LanguageMode != PSLanguageMode.FullLanguage);
-            bool isTranscripting = (transcriptionData != null) && (transcriptionData.SystemTranscript != null);
+            bool isTranscribing = (transcriptionData != null) && (transcriptionData.SystemTranscript != null);
 
             TelemetryWrapper.TraceMessage("PSNewLocalSession", new
             {
                 Constrained = isConstrained,
-                Transcripting = isTranscripting
+                Transcribing = isTranscribing
             });
         }
 


### PR DESCRIPTION
While these changes technically impact the build, they should be debug only changes that only impact debugging failure cases. There are also only a handful of them which should make review easy.

These can definitely be squashed together. I'm slowly peeling them out from other categories...

The ErrorRecord commit might need to be dropped. Essentially that's changing an "Error ID" which might be considered a public API (I don't know).
