### PR TITLE
Corrected Powershell profiles location and added test for the same.

### DIFF
--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
@@ -1724,8 +1724,11 @@ namespace Microsoft.PowerShell
                 if (_configuration != null)
                     shellId = _configuration.ShellId;
                 else
+#if CORECLR                
+                    shellId = Platform.IsInbox ?  "Microsoft.PowerShell" : "PowerShell";
+#else
                     shellId = "Microsoft.PowerShell"; // TODO: what will happen for custom shells built using Make-Shell.exe
-
+#endif
                 // If the system lockdown policy says "Enforce", do so. Do this after types / formatting, default functions, etc
                 // are loaded so that they are trusted. (Validation of their signatures is done in F&O)
                 if (SystemPolicy.GetSystemLockdownPolicy() == SystemEnforcementMode.Enforce)

--- a/test/powershell/Host/Base-Directory.Tests.ps1
+++ b/test/powershell/Host/Base-Directory.Tests.ps1
@@ -2,13 +2,15 @@ Describe "Configuration file locations" -tags "CI","Slow" {
 
     BeforeAll {
         $powershell = Join-Path -Path $PsHome -ChildPath "powershell"
-        $profileName = "Microsoft.PowerShell_profile.ps1"
+        $profileName = "PowerShell_profile.ps1"
     }
 
     Context "Default configuration file locations" {
 
         BeforeAll {
 
+            $profileNameAllHosts = "profile.ps1"
+            $profileNameCurrentHost = "Powershell_Profile.ps1"
             if ($IsWindows) {
                 $ProductName = "WindowsPowerShell"
                 if ($IsCoreCLR -and ($PSHOME -notlike "*Windows\System32\WindowsPowerShell\v1.0"))
@@ -17,12 +19,18 @@ Describe "Configuration file locations" -tags "CI","Slow" {
                 }
                 $expectedCache    = [IO.Path]::Combine($env:LOCALAPPDATA, "Microsoft", "Windows", "PowerShell", "StartupProfileData-NonInteractive")
                 $expectedModule   = [IO.Path]::Combine($env:USERPROFILE, "Documents", $ProductName, "Modules")
-                $expectedProfile  = [io.path]::Combine($env:USERPROFILE, "Documents", $ProductName, $profileName)
+                $expectedProfileAllUserAllHosts  = [io.path]::Combine($PSHOME, $profileNameAllHosts)
+                $expectedProfileAllUserCurrentHost  = [io.path]::Combine($PSHOME, $profileNameCurrentHost)
+                $expectedProfileCurrentUserAllHosts  = [io.path]::Combine($env:USERPROFILE, "Documents", $ProductName, $profileNameAllHosts)
+                $expectedProfileCurrentUserCurrentHost  = [io.path]::Combine($env:USERPROFILE, "Documents", $ProductName, $profileNameCurrentHost)
                 $expectedReadline = [IO.Path]::Combine($env:AppData, "Microsoft", "Windows", "PowerShell", "PSReadline", "ConsoleHost_history.txt")
             } else {
                 $expectedCache    = [IO.Path]::Combine($env:HOME, ".cache", "powershell", "StartupProfileData-NonInteractive")
                 $expectedModule   = [IO.Path]::Combine($env:HOME, ".local", "share", "powershell", "Modules")
-                $expectedProfile  = [io.path]::Combine($env:HOME,".config","powershell",$profileName)
+                $expectedProfileAllUserAllHosts  = [io.path]::Combine($PSHOME, $profileNameAllHosts)
+                $expectedProfileAllUserCurrentHost  = [io.path]::Combine($PSHOME, $profileNameCurrentHost)
+                $expectedProfileCurrentUserAllHosts  = [io.path]::Combine($env:HOME,".config","powershell",$profileNameAllHosts)
+                $expectedProfileCurrentUserCurrentHost  = [io.path]::Combine($env:HOME,".config","powershell",$profileNameCurrentHost)
                 $expectedReadline = [IO.Path]::Combine($env:HOME, ".local", "share", "powershell", "PSReadLine", "ConsoleHost_history.txt")
             }
 
@@ -37,8 +45,12 @@ Describe "Configuration file locations" -tags "CI","Slow" {
             $env:PSMODULEPATH = $original_PSMODULEPATH
         }
 
-        It @ItArgs "Profile location should be correct" {
-            & $powershell -noprofile `$PROFILE | Should Be $expectedProfile
+        It @ItArgs "Profiles location should be correct" {
+            & $powershell -noprofile `$PROFILE | Should Be $expectedProfileCurrentUserCurrentHost
+            & $powershell -noprofile `$PROFILE.AllUsersAllHosts | Should Be $expectedProfileAllUserAllHosts
+            & $powershell -noprofile `$PROFILE.AllUsersCurrentHost | Should Be $expectedProfileAllUserCurrentHost
+            & $powershell -noprofile `$PROFILE.CurrentUserAllHosts | Should Be $expectedProfileCurrentUserAllHosts
+            & $powershell -noprofile `$PROFILE.CurrentUserCurrentHost | Should Be $expectedProfileCurrentUserCurrentHost
         }
 
         It @ItArgs "PSMODULEPATH should contain the correct path" {


### PR DESCRIPTION
Resolve #1190 
For windows :
AllUsersAllHosts = $PSHome\profile.ps1
AllUsersCurrentHost = $PSHome\PowerShell_profile.ps1
CurrentUserAllHosts = ~\Documents\PowerShell\profile.ps1
CurrentUserCurrentHost = ~\Documents\PowerShell\PowerShell_profile.ps1

For Linux :
AllUsersAllHosts = $PSHOME/profile.ps1
AAllUsersCurrentHost = $PSHOME/PowerShell_profile.ps1
PCurrentUserCurrentHost =
/home/user/.config/powershell/PowerShell_profile.ps1
$CurrentUserAllHosts = /home/user/.config/powershell/profile.ps1
