### PR TITLE
Provide an unsupported message for 'Verb' parameter (#1691)

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
@@ -1855,7 +1855,6 @@ namespace Microsoft.PowerShell.Commands
         }
         private string _redirectstandardoutput;
 
-#if !CORECLR
         /// <summary>
         /// Verb
         /// </summary>
@@ -1867,7 +1866,7 @@ namespace Microsoft.PowerShell.Commands
         [ValidateNotNullOrEmpty]
         public string Verb { get; set; }
 
-
+#if !CORECLR
         /// <summary>
         /// Window style of the process window
         /// </summary>
@@ -1922,6 +1921,14 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         protected override void BeginProcessing()
         {
+#if CORECLR
+            if(this.ParameterSetName.Equals("UseShellExecute"))
+            {
+                String errorMessage = StringUtil.Format(ProcessResources.ParameterNotSupportedOnPSEdition, "-Verb", "Start-Process");
+                ErrorRecord er =  new ErrorRecord(new NotSupportedException(errorMessage), "NotSupportedException", ErrorCategory.NotImplemented, null);
+                ThrowTerminatingError(er);
+            }
+#endif
             //create an instance of the ProcessStartInfo Class
             ProcessStartInfo startInfo = new ProcessStartInfo();
             string message = String.Empty;

--- a/src/Microsoft.PowerShell.Commands.Management/resources/ProcessResources.resx
+++ b/src/Microsoft.PowerShell.Commands.Management/resources/ProcessResources.resx
@@ -222,4 +222,7 @@
   <data name="ParameterNotSupported" xml:space="preserve">
     <value>The parameter '{0}' is not supported for the cmdlet '{1}' on this edition of Windows.</value>
   </data>
+  <data name="ParameterNotSupportedOnPSEdition" xml:space="preserve">
+    <value>The parameter '{0}' is not supported for the cmdlet '{1}' on this edition of PowerShell.</value>
+  </data>
 </root>

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Start-Process.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Start-Process.Tests.ps1
@@ -69,5 +69,17 @@ Describe "Start-Process" -Tags @("CI","SLOW") {
 	$dirEntry.Length | Should BeGreaterThan 0
     }
 
+    It "Should give an error when Verb parameter is used" -Skip:(-not $IsCoreClr) {
+        try 
+        {
+            Start-Process -Verb runas -FilePath $pingCommand -ArgumentList $pingParam
+            throw "No Exception!"
+        }
+        catch
+        {
+            $_.FullyQualifiedErrorId | Should be "NotSupportedException,Microsoft.PowerShell.Commands.StartProcessCommand"
+            $_.Exception.Message | Should match '-Verb'
+        }
+    }
     Remove-Item -Path $tempFile -Force
 }


### PR DESCRIPTION
Resolving #1691
Add the 'Verb' parameter to Powershell core and add an unsupported message
for the same.
