### PR TITLE
Merge TFS 8193011: Constrained language mode doesn't allow CIM cmdlets

### DIFF
--- a/src/System.Management.Automation/engine/CommandProcessorBase.cs
+++ b/src/System.Management.Automation/engine/CommandProcessorBase.cs
@@ -169,24 +169,38 @@ namespace System.Management.Automation
             InvocationInfo invocationInfo)
         {
             // If we are in a constrained language mode (Core or Restricted), block it.
-            // This goes both ways:
+            // We are currently restricting in one direction:
             //    - Can't dot something from a more permissive mode, since that would probably expose
             //      functions that were never designed to handle untrusted data.
-            //    - Can't dot something from a less permissive mode, since that might introduce tainted
-            //      data into the current scope.
             if ((scriptBlock.LanguageMode.HasValue) &&
                 (scriptBlock.LanguageMode != languageMode) &&
                 ((languageMode == PSLanguageMode.RestrictedLanguage) ||
                 (languageMode == PSLanguageMode.ConstrainedLanguage)))
             {
-                ErrorRecord errorRecord = new ErrorRecord(
+                // Finally check if script block is really just PowerShell commands plus parameters.
+                // If so then it is safe to dot source across language mode boundaries.
+                bool isSafeToDotSource = false;
+                try
+                {
+                    scriptBlock.GetPowerShell();
+                    isSafeToDotSource = true;
+                }
+                catch (Exception e)
+                {
+                    CheckForSevereException(e);
+                }
+
+                if (!isSafeToDotSource)
+                {
+                    ErrorRecord errorRecord = new ErrorRecord(
                     new NotSupportedException(
                         DiscoveryExceptions.DotSourceNotSupported),
                         "DotSourceNotSupported",
                         ErrorCategory.InvalidOperation,
                         null);
-                errorRecord.SetInvocationInfo(invocationInfo);
-                throw new CmdletInvocationException(errorRecord);
+                    errorRecord.SetInvocationInfo(invocationInfo);
+                    throw new CmdletInvocationException(errorRecord);
+                }
             }
         }
 

--- a/src/System.Management.Automation/engine/CommandProcessorBase.cs
+++ b/src/System.Management.Automation/engine/CommandProcessorBase.cs
@@ -172,6 +172,8 @@ namespace System.Management.Automation
             // We are currently restricting in one direction:
             //    - Can't dot something from a more permissive mode, since that would probably expose
             //      functions that were never designed to handle untrusted data.
+            // This function won't be called for NoLanguage mode so the only direction checked is trusted 
+            // (FullLanguage mode) script running in a constrained/restricted session.
             if ((scriptBlock.LanguageMode.HasValue) &&
                 (scriptBlock.LanguageMode != languageMode) &&
                 ((languageMode == PSLanguageMode.RestrictedLanguage) ||

--- a/src/System.Management.Automation/engine/parser/TypeResolver.cs
+++ b/src/System.Management.Automation/engine/parser/TypeResolver.cs
@@ -12,9 +12,12 @@ using System.Linq;
 using System.Management.Automation.Language;
 using System.Management.Automation.Runspaces;
 using System.Net;
+using System.Net.NetworkInformation;
 using System.Numerics;
 using System.Reflection;
 using System.Security;
+using System.Security.AccessControl;
+using System.Security.Cryptography.X509Certificates;
 using System.Text.RegularExpressions;
 using System.Xml;
 using Microsoft.Management.Infrastructure;
@@ -677,10 +680,13 @@ namespace System.Management.Automation
                     { typeof(Microsoft.Management.Infrastructure.CimType), new[] { "cimtype" } },
                     { typeof(CimConverter),                                new[] { "cimconverter" } },
                     { typeof(ModuleSpecification),                         null },
+                    { typeof(IPEndPoint),                                  new[] { "IPEndpoint" } },
                     { typeof(NullString),                                  new[] { "NullString" } },
                     { typeof(OutputTypeAttribute),                         new[] { "OutputType" } },
                     { typeof(Object[]),                                    null },
+                    { typeof(ObjectSecurity),                              new[] { "ObjectSecurity" } },
                     { typeof(ParameterAttribute),                          new[] { "Parameter" } },
+                    { typeof(PhysicalAddress),                             new[] { "PhysicalAddress" } },
                     { typeof(PSCredential),                                new[] { "pscredential" } },
                     { typeof(PSDefaultValueAttribute),                     new[] { "PSDefaultValue" } },
                     { typeof(PSListModifier),                              new[] { "pslistmodifier" } },
@@ -716,9 +722,13 @@ namespace System.Management.Automation
                     { typeof(void),                                        new[] { "void" } },
                     { typeof(IPAddress),                                   new[] { "ipaddress" } },
                     { typeof(DscLocalConfigurationManagerAttribute),       new[] {"DscLocalConfigurationManager"}},
+                    { typeof(WildcardPattern),                             new[] { "WildcardPattern" } },
+                    { typeof(X509Certificate),                             new[] { "X509Certificate" } },
+                    { typeof(X500DistinguishedName),                       new[] { "X500DistinguishedName" } },
                     { typeof(XmlDocument),                                 new[] { "xml" } },
+                    { typeof(CimSession),                                  new[] { "CimSession" } },
 #if !CORECLR
-                    // Following types not int CoreCLR
+                    // Following types not in CoreCLR
                     { typeof(DirectoryEntry),                              new[] { "adsi" } },
                     { typeof(DirectorySearcher),                           new[] { "adsisearcher" } },
                     { typeof(ManagementClass),                             new[] { "wmiclass" } },


### PR DESCRIPTION
Some CIM needed types were not included in the PowerShell core types white list preventing the CimCmdlets module commands from running in a ConstrainedLanguage PowerShell.

Fix is to add the missing types to the white list.  Fix also includes modifying the dot source check to allow script that only implements PowerShell commands, which allows the CimCmdlets module to load in ConstrainedLanguage mode.
