### PR TITLE
Merge TFS 2064268: ConstrainedLanguage PowerShell should not block nested cmdlet invocation via runspace

### DIFF
--- a/src/System.Management.Automation/engine/AutomationEngine.cs
+++ b/src/System.Management.Automation/engine/AutomationEngine.cs
@@ -93,8 +93,6 @@ namespace System.Management.Automation
             }
 
             InitialSessionState.SetSessionStateDrive(Context, true);
-
-            InitialSessionState.CreateQuestionVariable(Context);
         }
 
         /// <summary>

--- a/src/System.Management.Automation/engine/SessionState.cs
+++ b/src/System.Management.Automation/engine/SessionState.cs
@@ -352,7 +352,7 @@ namespace System.Management.Automation
             this.GlobalScope.SetVariable(v.Name, v, false, true, this, CommandOrigin.Internal, fastPath: true);
 
             // $?
-            v = new QuestionMarkVariable(this._context);
+            v = new QuestionMarkVariable(this.ExecutionContext);
             this.GlobalScope.SetVariableForce(v, this);
 
             // $ShellId - if there is no runspace config, use the default string

--- a/src/System.Management.Automation/engine/SessionState.cs
+++ b/src/System.Management.Automation/engine/SessionState.cs
@@ -351,6 +351,10 @@ namespace System.Management.Automation
             v = new PSUICultureVariable();
             this.GlobalScope.SetVariable(v.Name, v, false, true, this, CommandOrigin.Internal, fastPath: true);
 
+            // $?
+            v = new QuestionMarkVariable(this._context);
+            this.GlobalScope.SetVariableForce(v, this);
+
             // $ShellId - if there is no runspace config, use the default string
             string shellId = ExecutionContext.ShellID;
 

--- a/src/System.Management.Automation/engine/SessionStateScope.cs
+++ b/src/System.Management.Automation/engine/SessionStateScope.cs
@@ -630,6 +630,24 @@ namespace System.Management.Automation
         } // SetVariable
 
         /// <summary>
+        /// Sets a variable to scope without any checks.
+        /// This is intended to be used only for global scope.
+        /// </summary>
+        /// <param name="variableToSet">PSVariable to set</param>
+        /// <param name="sessionState">SessionState for variable</param>
+        /// <returns></returns>
+        internal void SetVariableForce(PSVariable variableToSet, SessionStateInternal sessionState)
+        {
+            if (Parent != null)
+            {
+                throw new NotImplementedException("SetVariableForce");
+            }
+
+            variableToSet.SessionState = sessionState;
+            GetPrivateVariables()[variableToSet.Name] = variableToSet;
+        }
+
+        /// <summary>
         /// Sets a variable to the given value.
         /// </summary>
         ///


### PR DESCRIPTION
Runspace creation in trusted script running under ConstrainedLanugage mode was failing with an unneeded security check.  The security check occurred during the creation of the Question built-in variable and is unneeded because it is being created/set in a trusted context.

Fix is to create the built-in question variable at the same location and in the same way that other built-in variables are created.
