### PR TITLE
Use lowercase name for package folders

### DIFF
--- a/src/TypeCatalogParser/Main.cs
+++ b/src/TypeCatalogParser/Main.cs
@@ -34,7 +34,7 @@ namespace TypeCatalogParser
                                          // Get the real reference assemblies
                                          from y in x.CompileTimeAssemblies where y.Path.EndsWith(".dll")
                                          // Construct the path to the assemblies
-                                         select $"{context.PackagesDirectory}/{x.Name}/{x.Version}/{y.Path};");
+                                         select $"{context.PackagesDirectory}/{x.Name.ToLower()}/{x.Version}/{y.Path};");
 
             Console.WriteLine($"List of reference assemblies written to {outputPath}");
         }


### PR DESCRIPTION
.NET CLI build 3546 started placing packages in:

```
~/.nuget/packages/microsoft.codeanalysis.common
```

instead of:

```
~/.nuget/packages/Microsoft.CodeAnalysis.Common
```

Where the previous (capitalized) version corresponded directly to the
package's name. Now they are all lower-cased.
