### PR TITLE
Remove incorrect logic from GetFullyQualifiedName()

### DIFF
--- a/src/libpsl-native/src/getfullyqualifiedname.cpp
+++ b/src/libpsl-native/src/getfullyqualifiedname.cpp
@@ -30,11 +30,6 @@ char *GetFullyQualifiedName()
         return NULL;
     }
 
-    if (strchr(computerName, '.') != NULL)
-    {
-        return computerName;
-    }
-
     struct addrinfo hints, *info;
 
     memset(&hints, 0, sizeof hints);


### PR DESCRIPTION
I think this logic was originally added with the assumption that any hostname with a dot in it was an FQDN. I believe this is incorrect. The hostname is the hostname regardless of included dots, and getting the FQDN amounts to always querying for the canonical name.

@daxian-dbw I think this is the rest of the fix for the bug we ran into on launch day. The current was still buggy for me when I had a machine whose _hostname_ was `localhost.localdomain`.
