### PR TITLE
Fix test-locale.cpp to report value of failing locale setting

### DIFF
--- a/Dockerfile_build
+++ b/Dockerfile_build
@@ -1,0 +1,19 @@
+FROM ubuntu:16.04
+
+RUN apt-get update && apt-get install -y curl  libunwind8 libicu55 libcurl3
+RUN curl -LO https://github.com/PowerShell/PowerShell/releases/download/v6.0.0-alpha.9/powershell_6.0.0-alpha.9-1ubuntu1.16.04.1_amd64.deb
+RUN dpkg -i powershell_6.0.0-alpha.9-1ubuntu1.16.04.1_amd64.deb
+
+Entrypoint [ "powershell" ]
+
+RUN apt-get update && apt-get install -y git sudo apt-transport-https
+ADD . /usr/src/powershell
+WORKDIR /usr/src/powershell
+
+RUN locale-gen en_US.UTF-8  
+ENV LANG en_US.UTF-8  
+ENV LANGUAGE en_US:en  
+ENV LC_ALL en_US.UTF-8  
+
+RUN powershell -command 'import-module ./build.psm1; Start-PSBootstrap'
+RUN powershell -command 'Import-Module ./build.psm1; Start-PSBuild'

--- a/Dockerfile_build
+++ b/Dockerfile_build
@@ -10,10 +10,10 @@ RUN apt-get update && apt-get install -y git sudo apt-transport-https
 ADD . /usr/src/powershell
 WORKDIR /usr/src/powershell
 
-RUN locale-gen en_US.UTF-8  
-ENV LANG en_US.UTF-8  
-ENV LANGUAGE en_US:en  
-ENV LC_ALL en_US.UTF-8  
+RUN locale-gen en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
 
 RUN powershell -command 'import-module ./build.psm1; Start-PSBootstrap'
 RUN powershell -command 'Import-Module ./build.psm1; Start-PSBuild'

--- a/src/libpsl-native/test/test-locale.cpp
+++ b/src/libpsl-native/test/test-locale.cpp
@@ -15,7 +15,7 @@ class LocaleTest : public ::testing::Test
 
 TEST_F(LocaleTest, Success)
 {
-    setlocale (LC_ALL, "");
-    ASSERT_FALSE (nl_langinfo(CODESET) == NULL);
-    ASSERT_TRUE(nl_langinfo(CODESET) == std::string("UTF-8"));
+    setlocale(LC_ALL, "");
+    ASSERT_FALSE(nl_langinfo(CODESET) == NULL);
+    ASSERT_STREQ(nl_langinfo(CODESET), "UTF-8");
 }


### PR DESCRIPTION
Changed test in src/libpsl-native/test/test-locale.cpp from ASSERT_TRUE to ASSERT_STREQ to provide detail of the failing test value.

Output from failing test before:

```
1: [----------] 1 test from LocaleTest
1: [ RUN      ] LocaleTest.Success
1: /usr/src/powershell/src/libpsl-native/test/test-locale.cpp:20: Failure
1: Value of: nl_langinfo(CODESET) == std::string("UTF-8")
1:   Actual: false
1: Expected: true
1: [  FAILED  ] LocaleTest.Success (1 ms)
1: [----------] 1 test from LocaleTest (2 ms total)
```

Output from failing test after:

```
1: [----------] 1 test from LocaleTest
1: [ RUN      ] LocaleTest.Success
1: /usr/src/powershell/src/libpsl-native/test/test-locale.cpp:20: Failure
1: Value of: "UTF-8"
1: Expected: nl_langinfo(CODESET)
1: Which is: "ANSI_X3.4-1968"
1: [  FAILED  ] LocaleTest.Success (0 ms)
1: [----------] 1 test from LocaleTest (0 ms total)
```
