### PR TITLE
Fix test-locale.cpp to report failing value

### DIFF
--- a/src/libpsl-native/test/test-locale.cpp
+++ b/src/libpsl-native/test/test-locale.cpp
@@ -15,7 +15,7 @@ class LocaleTest : public ::testing::Test
 
 TEST_F(LocaleTest, Success)
 {
-    setlocale (LC_ALL, "");
-    ASSERT_FALSE (nl_langinfo(CODESET) == NULL);
-    ASSERT_TRUE(nl_langinfo(CODESET) == std::string("UTF-8"));
+    setlocale(LC_ALL, "");
+    ASSERT_FALSE(nl_langinfo(CODESET) == NULL);
+    ASSERT_STREQ(nl_langinfo(CODESET), "UTF-8");
 }


### PR DESCRIPTION
Changed test in src/libpsl-native/test/test-locale.cpp from ASSERT_TRUE to ASSERT_STREQ to provide detail of the failing test value.

Also adjusted adjacent whitspace formatting for consistency. 

Output from failing test before:

```
1: [----------] 1 test from LocaleTest
1: [ RUN      ] LocaleTest.Success
1: /usr/src/powershell/src/libpsl-native/test/test-locale.cpp:20: Failure
1: Value of: nl_langinfo(CODESET) == std::string("UTF-8")
1:   Actual: false
1: Expected: true
1: [  FAILED  ] LocaleTest.Success (1 ms)
1: [----------] 1 test from LocaleTest (2 ms total)
```

Output from failing test after:

```
1: [----------] 1 test from LocaleTest
1: [ RUN      ] LocaleTest.Success
1: /usr/src/powershell/src/libpsl-native/test/test-locale.cpp:20: Failure
1: Value of: "UTF-8"
1: Expected: nl_langinfo(CODESET)
1: Which is: "ANSI_X3.4-1968"
1: [  FAILED  ] LocaleTest.Success (0 ms)
1: [----------] 1 test from LocaleTest (0 ms total)
```
