### PR TITLE
grammar: TransactedRegistry stub in System.Management.Automation CoreCLR

### DIFF
--- a/src/System.Management.Automation/CoreCLR/CorePsStub.cs
+++ b/src/System.Management.Automation/CoreCLR/CorePsStub.cs
@@ -1153,61 +1153,61 @@ namespace Microsoft.PowerShell.Commands.Internal
 
         public void SetValue(string name, object value)
         {
-            throw new NotImplementedException("SetValue(string name, obj value) is not implemented. TransactedRegistry related APIs should not be hitten.");
+            throw new NotImplementedException("SetValue(string name, obj value) is not implemented. TransactedRegistry related APIs should not be used.");
         }
 
         public void SetValue(string name, object value, RegistryValueKind valueKind)
         {
-            throw new NotImplementedException("SetValue(string name, obj value, RegistryValueKind valueKind) is not implemented. TransactedRegistry related APIs should not be hitten.");
+            throw new NotImplementedException("SetValue(string name, obj value, RegistryValueKind valueKind) is not implemented. TransactedRegistry related APIs should not be used.");
         }
         public string[] GetValueNames()
         {
-            throw new NotImplementedException("GetValueNames() is not implemented. TransactedRegistry related APIs should not be hitten.");
+            throw new NotImplementedException("GetValueNames() is not implemented. TransactedRegistry related APIs should not be used.");
         }
 
         public void DeleteValue(string name)
         {
-            throw new NotImplementedException("DeleteValue(string name) is not implemented. TransactedRegistry related APIs should not be hitten.");
+            throw new NotImplementedException("DeleteValue(string name) is not implemented. TransactedRegistry related APIs should not be used.");
         }
 
         public string[] GetSubKeyNames()
         {
-            throw new NotImplementedException("GetSubKeyNames() is not implemented. TransactedRegistry related APIs should not be hitten.");
+            throw new NotImplementedException("GetSubKeyNames() is not implemented. TransactedRegistry related APIs should not be used.");
         }
 
         public TransactedRegistryKey CreateSubKey(string subkey)
         {
-            throw new NotImplementedException("CreateSubKey(string subkey) is not implemented. TransactedRegistry related APIs should not be hitten.");
+            throw new NotImplementedException("CreateSubKey(string subkey) is not implemented. TransactedRegistry related APIs should not be used.");
         }
 
         public TransactedRegistryKey OpenSubKey(string name, bool writable)
         {
-            throw new NotImplementedException("OpenSubKey(string name, bool writeable) is not implemented. TransactedRegistry related APIs should not be hitten.");
+            throw new NotImplementedException("OpenSubKey(string name, bool writeable) is not implemented. TransactedRegistry related APIs should not be used.");
         }
 
         public void DeleteSubKeyTree(string subkey)
         {
-            throw new NotImplementedException("DeleteSubKeyTree(string subkey) is not implemented. TransactedRegistry related APIs should not be hitten.");
+            throw new NotImplementedException("DeleteSubKeyTree(string subkey) is not implemented. TransactedRegistry related APIs should not be used.");
         }
 
         public object GetValue(string name)
         {
-            throw new NotImplementedException("GetValue(string name) is not implemented. TransactedRegistry related APIs should not be hitten.");
+            throw new NotImplementedException("GetValue(string name) is not implemented. TransactedRegistry related APIs should not be used.");
         }
 
         public object GetValue(string name, object defaultValue, RegistryValueOptions options)
         {
-            throw new NotImplementedException("GetValue(string name, object defaultValue, RegistryValueOptions options) is not implemented. TransactedRegistry related APIs should not be hitten.");
+            throw new NotImplementedException("GetValue(string name, object defaultValue, RegistryValueOptions options) is not implemented. TransactedRegistry related APIs should not be used.");
         }
 
         public RegistryValueKind GetValueKind(string name)
         {
-            throw new NotImplementedException("GetValueKind(string name) is not implemented. TransactedRegistry related APIs should not be hitten.");
+            throw new NotImplementedException("GetValueKind(string name) is not implemented. TransactedRegistry related APIs should not be used.");
         }
 
         public void Close()
         {
-            throw new NotImplementedException("Close() is not implemented. TransactedRegistry related APIs should not be hitten.");
+            throw new NotImplementedException("Close() is not implemented. TransactedRegistry related APIs should not be used.");
         }
 
         public abstract string Name { get; }
@@ -1215,12 +1215,12 @@ namespace Microsoft.PowerShell.Commands.Internal
 
         public void SetAccessControl(ObjectSecurity securityDescriptor)
         {
-            throw new NotImplementedException("SetAccessControl(ObjectSecurity securityDescriptor) is not implemented. TransactedRegistry related APIs should not be hitten.");
+            throw new NotImplementedException("SetAccessControl(ObjectSecurity securityDescriptor) is not implemented. TransactedRegistry related APIs should not be used.");
         }
 
         public ObjectSecurity GetAccessControl(AccessControlSections includeSections)
         {
-            throw new NotImplementedException("GetAccessControl(AccessControlSections includeSections) is not implemented. TransactedRegistry related APIs should not be hitten.");
+            throw new NotImplementedException("GetAccessControl(AccessControlSections includeSections) is not implemented. TransactedRegistry related APIs should not be used.");
         }
     }
 


### PR DESCRIPTION
PowerShell has some stubs to enable code to almost sort of work with things.
Some of the stubs try to say "Do not use me".

This commit corrects the grammar of the message.

Previously the message tried to apply a past tense form to `hit`,
but the past tense of `hit` is `hit`, and while breakpoints can
be hit, it's better to talk to the user about what should be done/
should not be done.

split from #2154
