### PR TITLE
Fix for Linux remote script debugging hang

### DIFF
--- a/src/Microsoft.PowerShell.PSReadLine/ReadLine.cs
+++ b/src/Microsoft.PowerShell.PSReadLine/ReadLine.cs
@@ -882,8 +882,8 @@ namespace Microsoft.PowerShell
             _singleton.Render();
         }
 
-        private const string s_PromptCommand = "prompt";
-        private const string s_DefaultPrompt = "PS>";
+        private const string PromptCommand = "prompt";
+        private const string DefaultPrompt = "PS>";
 
         /// <summary>
         /// Gets the current prompt as possibly defined by the user through the
@@ -901,16 +901,12 @@ namespace Microsoft.PowerShell
                 // This handles remote runspace debugging and nested debugger scenarios.
                 PSDataCollection<PSObject> results = new PSDataCollection<PSObject>();
                 var command = new PSCommand();
-                command.AddCommand(s_PromptCommand);
+                command.AddCommand(PromptCommand);
                 _singleton._runspace.Debugger.ProcessCommand(
                     command,
                     results);
 
-                newPrompt = (results.Count == 1) ? (results[0].BaseObject as string) : s_DefaultPrompt;
-                if (newPrompt == null)
-                {
-                    newPrompt = s_DefaultPrompt;
-                }
+                newPrompt = (results.Count == 1) ? (results[0].BaseObject as string) : DefaultPrompt;
             }
             else
             {
@@ -926,10 +922,15 @@ namespace Microsoft.PowerShell
                 }
                 using (ps)
                 {
-                    ps.AddCommand(s_PromptCommand);
+                    ps.AddCommand(PromptCommand);
                     var result = ps.Invoke<string>();
-                    newPrompt = result.Count == 1 ? result[0] : s_DefaultPrompt;
+                    newPrompt = result.Count == 1 ? result[0] : DefaultPrompt;
                 }
+            }
+
+            if (string.IsNullOrEmpty(newPrompt))
+            {
+                newPrompt = DefaultPrompt;
             }
 
             if (runspaceIsRemote)
@@ -940,6 +941,7 @@ namespace Microsoft.PowerShell
                     newPrompt = string.Format(CultureInfo.InvariantCulture, "[{0}]: {1}", connectionInfo.ComputerName, newPrompt);
                 }
             }
+
             return newPrompt;
         }
 

--- a/src/Microsoft.PowerShell.PSReadLine/ReadLine.cs
+++ b/src/Microsoft.PowerShell.PSReadLine/ReadLine.cs
@@ -4,7 +4,6 @@ Copyright (c) Microsoft Corporation.  All rights reserved.
 
 using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;

--- a/src/System.Management.Automation/engine/hostifaces/HostUtilities.cs
+++ b/src/System.Management.Automation/engine/hostifaces/HostUtilities.cs
@@ -872,7 +872,12 @@ namespace System.Management.Automation
         ///   1. Local runspace.  If the local runspace is busy it will invoke as a nested command.
         ///   2. Remote runspace.
         ///   3. Runspace that is stopped in the debugger at a breakpoint.
+        ///   
         /// Error and information streams are ignored and only the command result output is returned.
+        /// 
+        /// This method is NOT thread safe.  It does not support running commands from different threads on the 
+        /// provided runspace.  It assumes the thread invoking this method is the same that runs all other 
+        /// commands on the provided runspace.
         /// </summary>
         /// <param name="runspace">Runspace to invoke the command on</param>
         /// <param name="command">Command to invoke</param>

--- a/src/System.Management.Automation/engine/hostifaces/HostUtilities.cs
+++ b/src/System.Management.Automation/engine/hostifaces/HostUtilities.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.PowerShell.Commands;
 using System.Management.Automation.Host;
@@ -863,6 +864,60 @@ namespace System.Management.Automation
 
         #region Public Access
 
+        #region Runspace Invoke
+
+        /// <summary>
+        /// Helper method to invoke a PSCommand on a given runspace.  This method correctly invokes the command for 
+        /// these runspace cases:
+        ///   1. Local runspace.  If the local runspace is busy it will invoke as a nested command.
+        ///   2. Remote runspace.
+        ///   3. Runspace that is stopped in the debugger at a breakpoint.
+        /// Error and information streams are ignored and only the command result output is returned.
+        /// </summary>
+        /// <param name="runspace">Runspace to invoke the command on</param>
+        /// <param name="command">Command to invoke</param>
+        /// <returns>Collection of command output result objects</returns>
+        public static Collection<PSObject> InvokeOnRunspace(PSCommand command, Runspace runspace)
+        {
+            if (command == null)
+            {
+                throw new PSArgumentNullException("command");
+            }
+
+            if (runspace == null)
+            {
+                throw new PSArgumentNullException("runspace");
+            }
+
+            if ((runspace.Debugger != null) && runspace.Debugger.InBreakpoint)
+            {
+                // Use the Debugger API to run the command when a runspace is stopped in the debugger.
+                PSDataCollection<PSObject> output = new PSDataCollection<PSObject>();
+                runspace.Debugger.ProcessCommand(
+                    command,
+                    output);
+
+                return new Collection<PSObject>(output);
+            }
+
+            // Otherwise run command directly in runspace.
+            PowerShell ps = PowerShell.Create();
+            ps.Runspace = runspace;
+            ps.IsRunspaceOwner = false;
+            if (runspace.ConnectionInfo == null)
+            {
+                // Local runspace.  Make a nested PowerShell object as needed.
+                ps.SetIsNested(runspace.GetCurrentlyRunningPipeline() != null);
+            }
+            using (ps)
+            {
+                ps.Commands = command;
+                return ps.Invoke<PSObject>();
+            }
+        }
+
+        #endregion
+
         #region PSEdit Support
 
         /// <summary>
@@ -878,10 +933,10 @@ namespace System.Management.Automation
                 dir $file -File | foreach {
                     $filePathName = $_.FullName
 
-# Get file contents
+                    # Get file contents
                     $contentBytes = Get-Content -Path $filePathName -Raw -Encoding Byte
 
-# Notify client for file open.
+                    # Notify client for file open.
                     New-Event -SourceIdentifier PSISERemoteSessionOpenFile -EventArguments @($filePathName, $contentBytes) > $null
                 }
             }

--- a/test/powershell/Host/HostUtilities.Tests.ps1
+++ b/test/powershell/Host/HostUtilities.Tests.ps1
@@ -1,7 +1,9 @@
 ﻿Describe "InvokeOnRunspace method argument error handling" -tags "Feature" {
 
-    $command = [System.Management.Automation.PSCommand]::new()
-    $localRunspace = $host.Runspace
+    BeforeAll {
+        $command = [System.Management.Automation.PSCommand]::new()
+        $localRunspace = $host.Runspace
+    }
 
     It "Null argument exception should be thrown for null PSCommand argument" {
 

--- a/test/powershell/Host/HostUtilities.Tests.ps1
+++ b/test/powershell/Host/HostUtilities.Tests.ps1
@@ -1,46 +1,45 @@
-﻿Describe "InvokeOnRunspace method argument error handling" -tags "CI" {
+﻿Describe "InvokeOnRunspace method argument error handling" -tags "Feature" {
 
     $command = [System.Management.Automation.PSCommand]::new()
     $localRunspace = $host.Runspace
 
-    $ex = $null
-    try
-    {
-        [System.Management.Automation.HostUtilities]::InvokeOnRunspace($null, $localRunspace)
-    }
-    catch [System.Management.Automation.PSArgumentNullException]
-    {
-        $ex = $_
-    }
-
     It "Null argument exception should be thrown for null PSCommand argument" {
-        $ex | Should Not Be $null
-    }
 
-    $ex = $null
-    try
-    {
-        [System.Management.Automation.HostUtilities]::InvokeOnRunspace($command, $null)
-    }
-    catch [System.Management.Automation.PSArgumentNullException]
-    {
-        $ex = $_
+        try
+        {
+            [System.Management.Automation.HostUtilities]::InvokeOnRunspace($null, $localRunspace)
+            throw "InvokeOnRunspace method did not throw expected PSArgumentNullException exception"
+        }
+        catch
+        {
+            $_.FullyQualifiedErrorId | Should Be "PSArgumentNullException"
+        }
     }
 
     It "Null argument exception should be thrown for null Runspace argument" {
-        $ex | Should Not Be $null
+
+        try
+        {
+            [System.Management.Automation.HostUtilities]::InvokeOnRunspace($command, $null)
+            throw "InvokeOnRunspace method did not throw expected PSArgumentNullException exception"
+        }
+        catch
+        {
+            $_.FullyQualifiedErrorId | Should Be "PSArgumentNullException"
+        }
     }
 }
 
 Describe "InvokeOnRunspace method as nested command" -tags "Feature" {
 
-    $command = [System.Management.Automation.PSCommand]::new()
-    $command.AddScript('"Hello!"')
-    $currentRunspace = $host.Runspace
-
-    $results = [System.Management.Automation.HostUtilities]::InvokeOnRunspace($command, $currentRunspace)
-
     It "Method should successfully invoke command as nested on busy runspace" {
+
+        $command = [System.Management.Automation.PSCommand]::new()
+        $command.AddScript('"Hello!"')
+        $currentRunspace = $host.Runspace
+
+        $results = [System.Management.Automation.HostUtilities]::InvokeOnRunspace($command, $currentRunspace)
+
         $results[0] | Should Be "Hello!"
     }
 }
@@ -57,12 +56,13 @@ Describe "InvokeOnRunspace method on remote runspace" -tags "Feature" {
         $remoteRunspace.Dispose();
     }
 
-    $command = [System.Management.Automation.PSCommand]::new()
-    $command.AddScript('"Hello!"')
-
-    $results = [System.Management.Automation.HostUtilities]::InvokeOnRunspace($command, $remoteRunspace)
-
     It "Method should successfully invoke command on remote runspace" {
+
+        $command = [System.Management.Automation.PSCommand]::new()
+        $command.AddScript('"Hello!"')
+
+        $results = [System.Management.Automation.HostUtilities]::InvokeOnRunspace($command, $remoteRunspace)
+
         $results[0] | Should Be "Hello!"
     }
 }

--- a/test/powershell/Host/HostUtilities.Tests.ps1
+++ b/test/powershell/Host/HostUtilities.Tests.ps1
@@ -1,0 +1,68 @@
+﻿Describe "InvokeOnRunspace method argument error handling" -tags "CI" {
+
+    $command = [System.Management.Automation.PSCommand]::new()
+    $localRunspace = $host.Runspace
+
+    $ex = $null
+    try
+    {
+        [System.Management.Automation.HostUtilities]::InvokeOnRunspace($null, $localRunspace)
+    }
+    catch [System.Management.Automation.PSArgumentNullException]
+    {
+        $ex = $_
+    }
+
+    It "Null argument exception should be thrown for null PSCommand argument" {
+        $ex | Should Not Be $null
+    }
+
+    $ex = $null
+    try
+    {
+        [System.Management.Automation.HostUtilities]::InvokeOnRunspace($command, $null)
+    }
+    catch [System.Management.Automation.PSArgumentNullException]
+    {
+        $ex = $_
+    }
+
+    It "Null argument exception should be thrown for null Runspace argument" {
+        $ex | Should Not Be $null
+    }
+}
+
+Describe "InvokeOnRunspace method as nested command" -tags "Feature" {
+
+    $command = [System.Management.Automation.PSCommand]::new()
+    $command.AddScript('"Hello!"')
+    $currentRunspace = $host.Runspace
+
+    $results = [System.Management.Automation.HostUtilities]::InvokeOnRunspace($command, $currentRunspace)
+
+    It "Method should successfully invoke command as nested on busy runspace" {
+        $results[0] | Should Be "Hello!"
+    }
+}
+
+Describe "InvokeOnRunspace method on remote runspace" -tags "Feature" {
+    
+    BeforeAll {
+        $wc = [System.Management.Automation.Runspaces.WSManConnectionInfo]::new()
+        $remoteRunspace = [runspacefactory]::CreateRunspace($host, $wc)
+        $remoteRunspace.Open()
+    }
+
+    AfterAll {
+        $remoteRunspace.Dispose();
+    }
+
+    $command = [System.Management.Automation.PSCommand]::new()
+    $command.AddScript('"Hello!"')
+
+    $results = [System.Management.Automation.HostUtilities]::InvokeOnRunspace($command, $remoteRunspace)
+
+    It "Method should successfully invoke command on remote runspace" {
+        $results[0] | Should Be "Hello!"
+    }
+}


### PR DESCRIPTION
This is a fix for issue #1531 (Linux -> Windows remote debugging does not work).

Trying to remote debug a script from a Linux client would result in a hang.  The hang was in the PSReadLine GetPrompt() method because it tried to run the "prompt" function in a remote session that was stopped in the debugger, with the result that the "prompt" command was queued on the remote session for when the debugger stop is released.

Commands should always be run through the Debugger API when a runspace is in debug stop mode.  The fix is to provide a new public helper method that invokes a command correctly on a runspace depending on its current state, and update PSReadLine to use the new helper method.  The new method is intended to help other console host implementations that need to run commands on a its runspace for user display.
