### PR TITLE
Minor improvements to SSH remoting cmdlets

### DIFF
--- a/src/System.Management.Automation/engine/remoting/commands/InvokeCommandCommand.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/InvokeCommandCommand.cs
@@ -693,11 +693,11 @@ namespace Microsoft.PowerShell.Commands
         [Parameter(ParameterSetName = InvokeCommandCommand.SSHHostParameterSet)]
         [Parameter(ParameterSetName = InvokeCommandCommand.FilePathSSHHostParameterSet)]
         [ValidateNotNullOrEmpty()]
-        public override string KeyPath
+        public override string KeyFilePath
         {
-            get { return base.KeyPath; }
+            get { return base.KeyFilePath; }
 
-            set { base.KeyPath = value; }
+            set { base.KeyFilePath = value; }
         }
 
         #endregion

--- a/src/System.Management.Automation/engine/remoting/commands/PSRemotingCmdlet.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/PSRemotingCmdlet.cs
@@ -683,7 +683,7 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// SSH Target Host Name
         /// </summary>
-        [Parameter(ParameterSetName = PSRemotingBaseCmdlet.SSHHostParameterSet)]
+        [Parameter(ParameterSetName = PSRemotingBaseCmdlet.SSHHostParameterSet, Mandatory = true)]
         [ValidateNotNullOrEmpty()]
         public virtual string HostName
         {
@@ -694,7 +694,7 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// SSH User Name
         /// </summary>
-        [Parameter(ParameterSetName = PSRemotingBaseCmdlet.SSHHostParameterSet)]
+        [Parameter(ParameterSetName = PSRemotingBaseCmdlet.SSHHostParameterSet, Mandatory = true)]
         [ValidateNotNullOrEmpty()]
         public virtual string UserName
         {
@@ -703,15 +703,22 @@ namespace Microsoft.PowerShell.Commands
         }
 
         /// <summary>
-        /// SSH Key Path
+        /// SSH Key File Path
         /// </summary>
         [Parameter(ParameterSetName = PSRemotingBaseCmdlet.SSHHostParameterSet)]
         [ValidateNotNullOrEmpty()]
-        public virtual string KeyPath
+        public virtual string KeyFilePath
         {
-            get;
-            set;
+            get { return _keyFilePath; }
+
+            set
+            {
+                // Resolve the key file path.
+                PathResolver resolver = new PathResolver();
+                _keyFilePath = resolver.ResolveProviderAndPath(value, true, this, false, RemotingErrorIdStrings.FilePathNotFromFileSystemProvider);
+            }
         }
+        private string _keyFilePath;
 
         #endregion
 
@@ -1166,7 +1173,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         protected void CreateHelpersForSpecifiedHostNames()
         {
-            var sshConnectionInfo = new SSHConnectionInfo(this.UserName, this.HostName, this.KeyPath);
+            var sshConnectionInfo = new SSHConnectionInfo(this.UserName, this.HostName, this.KeyFilePath);
             var typeTable = TypeTable.LoadDefaultTypeFiles();
             var remoteRunspace = RunspaceFactory.CreateRunspace(sshConnectionInfo, this.Host, typeTable) as RemoteRunspace;
             var pipeline = CreatePipeline(remoteRunspace);

--- a/src/System.Management.Automation/engine/remoting/commands/PSRemotingCmdlet.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/PSRemotingCmdlet.cs
@@ -864,9 +864,10 @@ namespace Microsoft.PowerShell.Commands
             base.BeginProcessing();
 
             // Validate KeyFilePath parameter.
-            if (ParameterSetName == PSRemotingBaseCmdlet.SSHHostParameterSet)
+            if ((ParameterSetName == PSRemotingBaseCmdlet.SSHHostParameterSet) &&
+                (this.KeyFilePath != null))
             {
-                // Resolve the key file path.
+                // Resolve the key file path when set.
                 this.KeyFilePath = PathResolver.ResolveProviderAndPath(this.KeyFilePath, true, this, false, RemotingErrorIdStrings.FilePathNotFromFileSystemProvider);
             }
 

--- a/src/System.Management.Automation/engine/remoting/commands/PushRunspaceCommand.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/PushRunspaceCommand.cs
@@ -1248,7 +1248,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         private RemoteRunspace GetRunspaceForSSHSession()
         {
-            var sshConnectionInfo = new SSHConnectionInfo(this.UserName, this.HostName, this.KeyPath);
+            var sshConnectionInfo = new SSHConnectionInfo(this.UserName, this.HostName, this.KeyFilePath);
             var typeTable = TypeTable.LoadDefaultTypeFiles();
             var remoteRunspace = RunspaceFactory.CreateRunspace(sshConnectionInfo, this.Host, typeTable) as RemoteRunspace;
             remoteRunspace.Open();

--- a/src/System.Management.Automation/engine/remoting/commands/newrunspacecommand.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/newrunspacecommand.cs
@@ -1065,7 +1065,7 @@ namespace Microsoft.PowerShell.Commands
             var sshConnectionInfo = new SSHConnectionInfo(
                 this.UserName,
                 this.HostName,
-                this.KeyPath);
+                this.KeyFilePath);
             var typeTable = TypeTable.LoadDefaultTypeFiles();
             remoteRunspaces.Add(RunspaceFactory.CreateRunspace(sshConnectionInfo, this.Host, typeTable) as RemoteRunspace);
 

--- a/src/System.Management.Automation/engine/remoting/fanin/OutOfProcTransportManager.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/OutOfProcTransportManager.cs
@@ -1524,13 +1524,20 @@ namespace System.Management.Automation.Remoting.Client
                 while (true)
                 {
                     string error = reader.ReadLine();
-                    if (!string.IsNullOrEmpty(error) && (error.IndexOf("WARNING:", StringComparison.OrdinalIgnoreCase) < 0))
+                    if (!string.IsNullOrEmpty(error) && (error.IndexOf("WARNING:", StringComparison.OrdinalIgnoreCase) > -1))
+                    {
+                        // Handle as interactive warning message.
+                        Console.WriteLine(error);
+                    }
+                    else
                     {
                         // Any SSH client error results in a broken session.
                         PSRemotingTransportException psrte = new PSRemotingTransportException(
                             PSRemotingErrorId.IPCServerProcessReportedError,
                             RemotingErrorIdStrings.IPCServerProcessReportedError,
-                            error);
+                            string.IsNullOrEmpty(error) ?
+                                RemotingErrorIdStrings.SSHClientEndNoErrorMessage
+                                : StringUtil.Format(RemotingErrorIdStrings.SSHClientEndWithErrorMessage, error));
                         RaiseErrorHandler(new TransportErrorOccuredEventArgs(psrte, TransportMethodEnum.CloseShellOperationEx));
                         CloseConnection();
                     }

--- a/src/System.Management.Automation/resources/RemotingErrorIdStrings.resx
+++ b/src/System.Management.Automation/resources/RemotingErrorIdStrings.resx
@@ -1610,6 +1610,15 @@ All WinRM sessions connected to Windows PowerShell session configurations, such 
   -The domain or computer name was not included with the specified credential, for example: DOMAIN\UserName or COMPUTER\UserName.</value>
   </data>
   <data name="CannotStartSSHClient" xml:space="preserve">
-    <value>An error occurred when starting the SSH.exe client needed for the remoting connection.</value>
+    <value>Failed to start the SSH client process needed for the remoting connection with error: {0}.</value>
+  </data>
+  <data name="KeyFileNotFound" xml:space="preserve">
+    <value>The specified key file {0} was not found.</value>
+  </data>
+  <data name="SSHClientEndWithErrorMessage" xml:space="preserve">
+    <value>The SSH client session has ended with error message: {0}</value>
+  </data>
+  <data name="SSHClientEndNoErrorMessage" xml:space="preserve">
+    <value>The SSH client session has ended with no error message.</value>
   </data>
 </root>

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/RemotingCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/RemotingCmdlets.Tests.ps1
@@ -1,50 +1,41 @@
 Describe "SSH Remoting Cmdlet Tests" -Tags "Feature" {
 
-    Context "Enter-PSSession Cmdlet" {
+    It "Enter-PSSession HostName parameter set should throw error for invalid key path" {
 
-        It "HostName parameter set should throw error for invalid key path" {
-
-            try
-            {
-                Enter-PSSession -HostName localhost -UserName User -KeyFilePath NoKeyFile
-                throw "Enter-PSSession did not throw expected PathNotFound exception."
-            }
-            catch
-            {
-                $_.FullyQualifiedErrorId | Should Match "PathNotFound"
-            }
+        try
+        {
+            Enter-PSSession -HostName localhost -UserName User -KeyFilePath NoKeyFile
+            throw "Enter-PSSession did not throw expected PathNotFound exception."
+        }
+        catch
+        {
+            $_.FullyQualifiedErrorId | Should Be "PathNotFound,Microsoft.PowerShell.Commands.EnterPSSessionCommand"
         }
     }
 
-    Context "New-PSSession Cmdlet" {
+    It "New-PSSession HostName parameter set should throw error for invalid key path" {
 
-        It "HostName parameter set should throw error for invalid key path" {
-
-            try
-            {
-                Enter-PSSession -HostName localhost -UserName User -KeyFilePath NoKeyFile
-                throw "New-PSSession did not throw expected PathNotFound exception."
-            }
-            catch
-            {
-                $_.FullyQualifiedErrorId | Should Match "PathNotFound"
-            }
+        try
+        {
+            New-PSSession -HostName localhost -UserName User -KeyFilePath NoKeyFile
+            throw "New-PSSession did not throw expected PathNotFound exception."
+        }
+        catch
+        {
+            $_.FullyQualifiedErrorId | Should Be "PathNotFound,Microsoft.PowerShell.Commands.NewPSSessionCommand"
         }
     }
 
-    Context "Invoke-Command Cmdlet" {
+    It "Invoke-Command HostName parameter set should throw error for invalid key path" {
 
-        It "Invoke-Command HostName parameter set should throw error for invalid key path" {
-
-            try
-            {
-                Enter-PSSession -HostName localhost -UserName User -KeyFilePath NoKeyFile
-                throw "Invoke-Command did not throw expected PathNotFound exception."
-            }
-            catch
-            {
-                $_.FullyQualifiedErrorId | Should Match "PathNotFound"
-            }
+        try
+        {
+            Invoke-Command -HostName localhost -UserName User -KeyFilePath NoKeyFile -ScriptBlock {1}
+            throw "Invoke-Command did not throw expected PathNotFound exception."
+        }
+        catch
+        {
+            $_.FullyQualifiedErrorId | Should Be "PathNotFound,Microsoft.PowerShell.Commands.InvokeCommandCommand"
         }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/RemotingCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/RemotingCmdlets.Tests.ps1
@@ -1,0 +1,50 @@
+Describe "SSH Remoting Cmdlet Tests" -Tags "Feature" {
+
+    Context "Enter-PSSession Cmdlet" {
+
+        It "HostName parameter set should throw error for invalid key path" {
+
+            try
+            {
+                Enter-PSSession -HostName localhost -UserName User -KeyFilePath NoKeyFile
+                throw "Enter-PSSession did not throw expected PathNotFound exception."
+            }
+            catch
+            {
+                $_.FullyQualifiedErrorId | Should Match "PathNotFound"
+            }
+        }
+    }
+
+    Context "New-PSSession Cmdlet" {
+
+        It "HostName parameter set should throw error for invalid key path" {
+
+            try
+            {
+                Enter-PSSession -HostName localhost -UserName User -KeyFilePath NoKeyFile
+                throw "New-PSSession did not throw expected PathNotFound exception."
+            }
+            catch
+            {
+                $_.FullyQualifiedErrorId | Should Match "PathNotFound"
+            }
+        }
+    }
+
+    Context "Invoke-Command Cmdlet" {
+
+        It "Invoke-Command HostName parameter set should throw error for invalid key path" {
+
+            try
+            {
+                Enter-PSSession -HostName localhost -UserName User -KeyFilePath NoKeyFile
+                throw "Invoke-Command did not throw expected PathNotFound exception."
+            }
+            catch
+            {
+                $_.FullyQualifiedErrorId | Should Match "PathNotFound"
+            }
+        }
+    }
+}

--- a/test/powershell/engine/Remoting/SSHRemotingAPI.Tests.ps1
+++ b/test/powershell/engine/Remoting/SSHRemotingAPI.Tests.ps1
@@ -1,0 +1,65 @@
+Describe "SSH Remoting API Tests" -Tags "Feature" {
+
+    Context "SSHConnectionInfo Class Tests" {
+
+        It "SSHConnectionInfo constructor should throw null argument exception for null UserName parameter" {
+
+            try
+            {
+                [System.Management.Automation.Runspaces.SSHConnectionInfo]::new(
+                    [System.Management.Automation.Internal.AutomationNull]::Value,
+                    "localhost",
+                    [System.Management.Automation.Internal.AutomationNull]::Value)
+
+                throw "SSHConnectionInfo constructor did not throw expected PSArgumentNullException exception"
+            }
+            catch
+            {
+                $_.FullyQualifiedErrorId | Should Match "PSArgumentNullException"
+            }
+        }
+
+        It "SSHConnectionInfo constructor should throw null argument exception for null HostName parameter" {
+
+            try
+            {
+                [System.Management.Automation.Runspaces.SSHConnectionInfo]::new(
+                    "UserName",
+                    [System.Management.Automation.Internal.AutomationNull]::Value,
+                    [System.Management.Automation.Internal.AutomationNull]::Value)
+
+                throw "SSHConnectionInfo constructor did not throw expected PSArgumentNullException exception"
+            }
+            catch
+            {
+                $_.FullyQualifiedErrorId | Should Match "PSArgumentNullException"
+            }
+        }
+
+        It "SSHConnectionInfo should throw file not found exception for invalid key file path" {
+
+            try
+            {
+                $sshConnectionInfo = [System.Management.Automation.Runspaces.SSHConnectionInfo]::new(
+                    "UserName",
+                    "localhost",
+                    "NoValidKeyFilePath")
+
+                $rs = [runspacefactory]::CreateRunspace($sshConnectionInfo)
+                $rs.Open()
+
+                throw "SSHConnectionInfo did not throw expected FileNotFoundException exception"
+            }
+            catch
+            {
+                $expectedFileNotFoundExecption = $null
+                if (($_.Exception -ne $null) -and ($_.Exception.InnerException -ne $null))
+                {
+                    $expectedFileNotFoundExecption = $_.Exception.InnerException.InnerException
+                }
+
+                ($expectedFileNotFoundExecption.GetType().FullName) | Should Be "System.IO.FileNotFoundException"
+            }
+        }
+    }
+}


### PR DESCRIPTION
This change contains some minor improvements to the SSH remoting.  This includes cmdlets parameter name change but keep in mind that SSH remoting is still in alpha stage and that the cmdlet parameter sets are likely to change in the future.  I'll be submitting an RFC for proposed final parameter sets in the (hopefully) near future, but in the mean this is meant to fix some of the current issues.
1. The KeyPath parameter name has been changed to KeyFilePath to be more descriptive.
2. HostName and UserName cmdlet parameters are now marked "mandatory".
3. Added path resolution to handle partial key file paths.
4. Added key path file existence check before starting ssh client.
5. SSH client warning messages are now written to host.
6. Improved SSH client error messages.
7. Added some tests for SSH cmdlets and remoting API.
