### PR TITLE
Spelling public

### DIFF
--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CimCommandBase.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CimCommandBase.cs
@@ -379,7 +379,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
                 }
                 if (nameset.Count == 0)
                 {
-                    throw new PSArgumentException(Strings.UnableToResolvePareameterSetName);
+                    throw new PSArgumentException(Strings.UnableToResolveParameterSetName);
                 }
                 else
                 {
@@ -433,7 +433,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
                 {
                     if (boundParameterSetName != null)
                     {
-                        throw new PSArgumentException(Strings.UnableToResolvePareameterSetName);
+                        throw new PSArgumentException(Strings.UnableToResolveParameterSetName);
                     }
                     boundParameterSetName = parameterSetName;
                 }
@@ -445,7 +445,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
                 // throw if there are > 1 parameter set
                 if (noMandatoryParameterSet.Count > 1)
                 {
-                    throw new PSArgumentException(Strings.UnableToResolvePareameterSetName);
+                    throw new PSArgumentException(Strings.UnableToResolveParameterSetName);
                 }
                 else if (noMandatoryParameterSet.Count == 1)
                 {
@@ -462,7 +462,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
             // throw if still can not find the parameter set name
             if (boundParameterSetName == null)
             {
-                throw new PSArgumentException(Strings.UnableToResolvePareameterSetName);
+                throw new PSArgumentException(Strings.UnableToResolveParameterSetName);
             }
             return boundParameterSetName;
         }

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CimIndicationWatcher.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CimIndicationWatcher.cs
@@ -208,7 +208,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
             string theNameSpace,
             string theQueryDialect,
             string theQueryExpression,
-            UInt32 theOpreationTimeout)
+            UInt32 theOperationTimeout)
         {
             enableRaisingEvents = false;
             status = Status.Default;
@@ -220,7 +220,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
             this.nameSpace = theNameSpace;
             this.queryDialect = ConstValue.GetQueryDialectWithDefault(theQueryDialect);
             this.queryExpression = theQueryExpression;
-            this.operationTimeout = theOpreationTimeout;
+            this.operationTimeout = theOperationTimeout;
             this.computerName = theComputerName;
         }
 

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CimRegisterCimIndication.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CimRegisterCimIndication.cs
@@ -135,17 +135,17 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         /// <param name="nameSpace"></param>
         /// <param name="queryDialect"></param>
         /// <param name="queryExpression"></param>
-        /// <param name="opreationTimeout"></param>
+        /// <param name="operationTimeout"></param>
         public void RegisterCimIndication(
             string computerName,
             string nameSpace,
             string queryDialect,
             string queryExpression,
-            UInt32 opreationTimeout)
+            UInt32 operationTimeout)
         {
             DebugHelper.WriteLogEx("queryDialect = '{0}'; queryExpression = '{1}'", 0, queryDialect, queryExpression);
             this.TargetComputerName = computerName;
-            CimSessionProxy proxy = CreateSessionProxy(computerName, opreationTimeout);
+            CimSessionProxy proxy = CreateSessionProxy(computerName, operationTimeout);
             proxy.SubscribeAsync(nameSpace, queryDialect, queryExpression);
             WaitForAckMessage();
         }
@@ -157,14 +157,14 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         /// <param name="nameSpace"></param>
         /// <param name="queryDialect"></param>
         /// <param name="queryExpression"></param>
-        /// <param name="opreationTimeout"></param>
+        /// <param name="operationTimeout"></param>
         /// <exception cref="ArgumentNullException">throw if cimSession is null</exception>
         public void RegisterCimIndication(
             CimSession cimSession,
             string nameSpace,
             string queryDialect,
             string queryExpression,
-            UInt32 opreationTimeout)
+            UInt32 operationTimeout)
         {
             DebugHelper.WriteLogEx("queryDialect = '{0}'; queryExpression = '{1}'", 0, queryDialect, queryExpression);
             if (cimSession == null)
@@ -172,7 +172,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
                 throw new ArgumentNullException(String.Format(CultureInfo.CurrentUICulture, Strings.NullArgument, @"cimSession"));
             }
             this.TargetComputerName = cimSession.ComputerName;
-            CimSessionProxy proxy = CreateSessionProxy(cimSession, opreationTimeout);
+            CimSessionProxy proxy = CreateSessionProxy(cimSession, operationTimeout);
             proxy.SubscribeAsync(nameSpace, queryDialect, queryExpression);
             WaitForAckMessage();
         }

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/resources/Microsoft.Management.Infrastructure.CimCmdlets.Strings.resx
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/resources/Microsoft.Management.Infrastructure.CimCmdlets.Strings.resx
@@ -221,7 +221,7 @@
     <value>Unable to add property '{0}' to input object '{1}'. The class schema does not contain the property.</value>
     <comment>{0} stand for property name, {1} stand for cim instance path.</comment>
   </data>
-  <data name="UnableToResolvePareameterSetName" xml:space="preserve">
+  <data name="UnableToResolveParameterSetName" xml:space="preserve">
     <value>Unable to resolve the parameter set name.</value>
     <comment>N/A</comment>
   </data>

--- a/src/Microsoft.PackageManagement.MetaProvider.PowerShell/resources/Microsoft.PackageManagement.MetaProvider.PowerShell.Resources.Messages.resx
+++ b/src/Microsoft.PackageManagement.MetaProvider.PowerShell/resources/Microsoft.PackageManagement.MetaProvider.PowerShell.Resources.Messages.resx
@@ -148,7 +148,7 @@
     <value>PowerShell Script '{0}' Function '{1}' returns null.</value>
     <comment>{0} script name, {1} function name</comment>
   </data>
-  <data name="ProvideNameMismatch" xml:space="preserve">
+  <data name="ProviderNameMismatch" xml:space="preserve">
     <value>Unable to find provider '{0}'. Please check if the ProviderName is set to '{1}' in '{2}'. </value>
     <comment>{0} provider name, {1} provider path, {2} provider name</comment>
   </data>

--- a/src/Microsoft.PackageManagement.NuGetProvider/NuGetExtensions.cs
+++ b/src/Microsoft.PackageManagement.NuGetProvider/NuGetExtensions.cs
@@ -20,7 +20,7 @@ namespace Microsoft.PackageManagement.NuGetProvider
             var newSearchTerm = string.Format(CultureInfo.InvariantCulture, NuGetConstant.SearchTerm, searchTerm, allowPrereleaseVersions ? "true" : "false");
 
             // Make the uri query string
-            return PathUtility.UriCombine(baseUrl, String.Concat((allVersions ? NuGetConstant.SearchFilterAllersions : NuGetConstant.SearchFilter), newSearchTerm));
+            return PathUtility.UriCombine(baseUrl, String.Concat((allVersions ? NuGetConstant.SearchFilterAllVersions : NuGetConstant.SearchFilter), newSearchTerm));
         }
 
         internal static string InsertSkipAndTop(this string query)

--- a/src/Microsoft.PackageManagement.NuGetProvider/NugetLightConstant.cs
+++ b/src/Microsoft.PackageManagement.NuGetProvider/NugetLightConstant.cs
@@ -48,7 +48,7 @@ namespace Microsoft.PackageManagement.NuGetProvider
         /// <summary>
         /// Represents a method that the V2 web service supports to search packages with filtering
         /// </summary>
-        public static readonly string SearchFilterAllersions = "Search()?$orderby=DownloadCount%20desc,Id";
+        public static readonly string SearchFilterAllVersions = "Search()?$orderby=DownloadCount%20desc,Id";
 
         /// <summary>
         /// Represents a method that the V2 web service supports to search packages with filtering. The result returned is already

--- a/src/Microsoft.PackageManagement.NuGetProvider/nugetlightprovider.cs
+++ b/src/Microsoft.PackageManagement.NuGetProvider/nugetlightprovider.cs
@@ -126,7 +126,7 @@ namespace Microsoft.PackageManagement.NuGetProvider
 
             if (category == null)
             {
-                request.Warning(Resources.Messages.UnkownCategory, PackageProviderName, "GetDynamicOptions", category);
+                request.Warning(Resources.Messages.UnknownCategory, PackageProviderName, "GetDynamicOptions", category);
                 return;
             }
 
@@ -155,7 +155,7 @@ namespace Microsoft.PackageManagement.NuGetProvider
                     request.YieldDynamicOption("AllowPrereleaseVersions", Constants.OptionType.Switch, false);
                     break;
                 default:
-                    request.Warning(Resources.Messages.UnkownCategory, PackageProviderName, "GetDynamicOptions", category);
+                    request.Warning(Resources.Messages.UnknownCategory, PackageProviderName, "GetDynamicOptions", category);
                     break;
             }
         }

--- a/src/Microsoft.PackageManagement.NuGetProvider/resources/Microsoft.PackageManagement.NuGetProvider.Resources.Messages.resx
+++ b/src/Microsoft.PackageManagement.NuGetProvider/resources/Microsoft.PackageManagement.NuGetProvider.Resources.Messages.resx
@@ -312,7 +312,7 @@
   <data name="UninstalledPackage" xml:space="preserve">
     <value>Uninstalled '{0}' package.</value>
   </data>
-  <data name="UnkownCategory" xml:space="preserve">
+  <data name="UnknownCategory" xml:space="preserve">
     <value>Unknown category for '{0}'::'{1}': '{2}'</value>
   </data>
   <data name="Unzipping" xml:space="preserve">

--- a/src/Microsoft.PackageManagement.PackageSourceListProvider/PackageList/PackageListParser.cs
+++ b/src/Microsoft.PackageManagement.PackageSourceListProvider/PackageList/PackageListParser.cs
@@ -255,7 +255,7 @@ namespace Microsoft.PackageManagement.PackageSourceListProvider
     public class OSRequirement
     {
         public List<string> architecture { get; set; }
-        public string minimunVersion { get; set; }
+        public string minimumVersion { get; set; }
         public List<string> installationOption { get; set; }
     }
 

--- a/src/Microsoft.PackageManagement.PackageSourceListProvider/PackageList/PackageListParser.cs
+++ b/src/Microsoft.PackageManagement.PackageSourceListProvider/PackageList/PackageListParser.cs
@@ -342,7 +342,7 @@ namespace Microsoft.PackageManagement.PackageSourceListProvider
                     // check whether source is http instead of https
                     if (!Uri.TryCreate(value, UriKind.Absolute, out uri))
                     {
-                        throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Resources.Messages.UnsuportedUriFormat, Constants.ProviderName, value));
+                        throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Resources.Messages.UnsupportedUriFormat, Constants.ProviderName, value));
                     }
 
                     if (!uri.IsFile)

--- a/src/Microsoft.PackageManagement.PackageSourceListProvider/PackageList/PackageListProvider.cs
+++ b/src/Microsoft.PackageManagement.PackageSourceListProvider/PackageList/PackageListProvider.cs
@@ -879,11 +879,11 @@ namespace Microsoft.PackageManagement.PackageSourceListProvider
             {
                 if (userSpecifiedProvider != null && userSpecifiedProvider.IndexOf(Constants.ProviderName, StringComparison.OrdinalIgnoreCase) > -1)
                 {
-                    request.WriteError(ErrorCategory.InvalidOperation, Constants.ProviderName, Resources.Messages.MininumVersonCheck, Constants.ProviderName, RequiredPackageManagementVersion, _currentPackageManagementVersion);
+                    request.WriteError(ErrorCategory.InvalidOperation, Constants.ProviderName, Resources.Messages.MinimumVersionCheck, Constants.ProviderName, RequiredPackageManagementVersion, _currentPackageManagementVersion);
                 }
                 else
                 {
-                    request.Verbose(Resources.Messages.MininumVersonCheck, Constants.ProviderName, RequiredPackageManagementVersion, _currentPackageManagementVersion);
+                    request.Verbose(Resources.Messages.MinimumVersionCheck, Constants.ProviderName, RequiredPackageManagementVersion, _currentPackageManagementVersion);
                 }
             }
 

--- a/src/Microsoft.PackageManagement.PackageSourceListProvider/PackageList/PowerShellArtifactInstaller.cs
+++ b/src/Microsoft.PackageManagement.PackageSourceListProvider/PackageList/PowerShellArtifactInstaller.cs
@@ -87,7 +87,7 @@ namespace Microsoft.PackageManagement.PackageSourceListProvider
           
             if (installing == null || !installing.Any())
             {
-                request.Verbose(Resources.Messages.NumberOfPackagesRecevied, 0, provider.Name, "InstallPackage");
+                request.Verbose(Resources.Messages.NumberOfPackagesReceived, 0, provider.Name, "InstallPackage");
                 request.Warning(Resources.Messages.FailToInstallPackage, Constants.ProviderName, packages[0].Name);
                 return;
             }
@@ -114,7 +114,7 @@ namespace Microsoft.PackageManagement.PackageSourceListProvider
                 packagesReceived++;
             }
 
-            request.Verbose(Resources.Messages.NumberOfPackagesRecevied, packagesReceived, provider.Name, "install-package");
+            request.Verbose(Resources.Messages.NumberOfPackagesReceived, packagesReceived, provider.Name, "install-package");
         }
 
         internal static void GeInstalledPowershellArtifacts(PackageJson package, string requiredVersion, string minimumVersion, string maximumVersion, Dictionary<string, SoftwareIdentity> fastPackReftable, PackageSourceListRequest request)
@@ -136,7 +136,7 @@ namespace Microsoft.PackageManagement.PackageSourceListProvider
 
             if (packagesInstalled == null || !packagesInstalled.Any())
             {
-                request.Verbose(Resources.Messages.NumberOfPackagesRecevied, 0, provider.Name, "GetInstalledPackages");
+                request.Verbose(Resources.Messages.NumberOfPackagesReceived, 0, provider.Name, "GetInstalledPackages");
                 return;
             }          
             

--- a/src/Microsoft.PackageManagement.PackageSourceListProvider/PackageList/WebDownloader.cs
+++ b/src/Microsoft.PackageManagement.PackageSourceListProvider/PackageList/WebDownloader.cs
@@ -194,7 +194,7 @@ namespace Microsoft.PackageManagement.PackageSourceListProvider
 
                 if (!Uri.TryCreate(queryUrl, UriKind.Absolute, out uri))
                 {
-                    request.Error(Internal.ErrorCategory.InvalidOperation, Resources.Messages.UnsuportedUriFormat, Constants.ProviderName, queryUrl);
+                    request.Error(Internal.ErrorCategory.InvalidOperation, Resources.Messages.UnsupportedUriFormat, Constants.ProviderName, queryUrl);
                     return null;
                 }
 
@@ -287,7 +287,7 @@ namespace Microsoft.PackageManagement.PackageSourceListProvider
                     }
                     else
                     {
-                        request.Verbose(Resources.Messages.HashValidationSuccessfull);
+                        request.Verbose(Resources.Messages.HashValidationSuccessful);
                     }
                 }
             }

--- a/src/Microsoft.PackageManagement.PackageSourceListProvider/resources/Microsoft.PackageManagement.PackageSourceListProvider.Resources.Messages.resx
+++ b/src/Microsoft.PackageManagement.PackageSourceListProvider/resources/Microsoft.PackageManagement.PackageSourceListProvider.Resources.Messages.resx
@@ -273,7 +273,7 @@
   <data name="UninstalledPackage" xml:space="preserve">
     <value>Uninstalled '{0}' package.</value>
   </data>
-  <data name="UnkownCategory" xml:space="preserve">
+  <data name="UnknownCategory" xml:space="preserve">
     <value>Unknown category for '{0}'::'{1}': '{2}'</value>
   </data>
   <data name="UriSchemeNotSupported" xml:space="preserve">

--- a/src/Microsoft.PackageManagement.PackageSourceListProvider/resources/Microsoft.PackageManagement.PackageSourceListProvider.Resources.Messages.resx
+++ b/src/Microsoft.PackageManagement.PackageSourceListProvider/resources/Microsoft.PackageManagement.PackageSourceListProvider.Resources.Messages.resx
@@ -347,10 +347,10 @@
   <data name="InstallingPackage" xml:space="preserve">
     <value>Installing a package from '{0}'</value>
   </data>
-  <data name="MininumVersonCheck" xml:space="preserve">
+  <data name="MinimumVersionCheck" xml:space="preserve">
     <value>Provider '{0}' is not used to perform this operation because it requires a minimum version of the PackageManagement module to be '{1}', but the current version of the PackageManagement module is '{2}'.</value>
   </data>
-  <data name="NumberOfPackagesRecevied" xml:space="preserve">
+  <data name="NumberOfPackagesReceived" xml:space="preserve">
     <value>'{0}' packages returned by the provider '{1}' for the '{2}' operation.</value>
   </data>
   <data name="RetryingDownload" xml:space="preserve">
@@ -371,7 +371,7 @@
   <data name="UnknownMediaType" xml:space="preserve">
     <value>Package '{0}' with Source '{1}' has unknown media type '{2}'.</value>
   </data>
-  <data name="UnsuportedUriFormat" xml:space="preserve">
+  <data name="UnsupportedUriFormat" xml:space="preserve">
     <value>The provider '{0}' does not support the Uri format: '{1}'.</value>
   </data>
   <data name="UnsupportedPackageSource" xml:space="preserve">
@@ -411,7 +411,7 @@
   <data name="HashNotSpecified" xml:space="preserve">
     <value>Invalid hash for package '{0}'. Please correct the values in json file or use -SkipHashValidation switch to skip Hash validation.</value>
   </data>
-  <data name="HashValidationSuccessfull" xml:space="preserve">
+  <data name="HashValidationSuccessful" xml:space="preserve">
     <value>Hash validation was successful.</value>
   </data>
   <data name="HashVerificationFailed" xml:space="preserve">

--- a/src/Microsoft.PackageManagement/Utility/Collections/PathEqualityComparer.cs
+++ b/src/Microsoft.PackageManagement/Utility/Collections/PathEqualityComparer.cs
@@ -25,7 +25,7 @@ namespace Microsoft.PackageManagement.Internal.Utility.Collections {
             _option = option;
         }
 
-        [SuppressMessage("Microsoft.Globalization", "CA1309:UseOrginalStringComparison")]
+        [SuppressMessage("Microsoft.Globalization", "CA1309:UseOrdinalStringComparison")]
         public bool Equals(string x, string y) {
 #if !CORECLR
             return string.Compare(ComparePath(x), ComparePath(y), StringComparison.InvariantCultureIgnoreCase) == 0;

--- a/src/Microsoft.PackageManagement/Utility/Platform/NativeMethods.cs
+++ b/src/Microsoft.PackageManagement/Utility/Platform/NativeMethods.cs
@@ -119,7 +119,7 @@ namespace Microsoft.PackageManagement.Internal.Utility.Platform {
         public static ResourceType GroupCursor = new ResourceType(12);
         public static ResourceType GroupIcon = new ResourceType(14);
         public static ResourceType Version = new ResourceType(16);
-        public static ResourceType DialogInclud = new ResourceType(17);
+        public static ResourceType DialogInclude = new ResourceType(17);
         public static ResourceType PlugPlay = new ResourceType(19);
         public static ResourceType Vxd = new ResourceType(20);
         public static ResourceType AniCursor = new ResourceType(21);

--- a/src/Microsoft.PackageManagement/Utility/Plugin/DynamicTypeExtensions.cs
+++ b/src/Microsoft.PackageManagement/Utility/Plugin/DynamicTypeExtensions.cs
@@ -63,7 +63,7 @@ namespace Microsoft.PackageManagement.Internal.Utility.Plugin
             il.LoadThis();
             il.LoadField(implementedMethodsField);
             il.LoadArgument(1);
-            il.CallVirutal(typeof(HashSet<string>).GetMethod("Contains"));
+            il.CallVirtual(typeof(HashSet<string>).GetMethod("Contains"));
             il.Return();
         }
 
@@ -112,7 +112,7 @@ namespace Microsoft.PackageManagement.Internal.Utility.Plugin
             }
 
             // call the actual method implementation
-            il.CallVirutal(instanceMethod);
+            il.CallVirtual(instanceMethod);
 
             if (hasReturn)
             {
@@ -206,7 +206,7 @@ namespace Microsoft.PackageManagement.Internal.Utility.Plugin
             {
                 il.LoadArgument(i + 1);
             }
-            il.CallVirutal(delegateType.GetMethod("Invoke"));
+            il.CallVirtual(delegateType.GetMethod("Invoke"));
             il.Return();
         }
 

--- a/src/Microsoft.PackageManagement/Utility/Plugin/FluentIlExtensions.cs
+++ b/src/Microsoft.PackageManagement/Utility/Plugin/FluentIlExtensions.cs
@@ -102,7 +102,7 @@ namespace Microsoft.PackageManagement.Internal.Utility.Plugin {
             il.Emit(OpCodes.Brfalse_S, label);
         }
 
-        public static void CallVirutal(this ILGenerator il, MethodInfo methodInfo) {
+        public static void CallVirtual(this ILGenerator il, MethodInfo methodInfo) {
             il.Emit(OpCodes.Callvirt, methodInfo);
         }
 

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Computer.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Computer.cs
@@ -275,7 +275,7 @@ namespace Microsoft.PowerShell.Commands
 
             if ((_transportProtocol == TransportProtocol.DCOM) && haveWsmanAuthenticationParam)
             {
-                string errMsg = StringUtil.Format(ComputerResources.StopCommandWSManAuthProtcolConflict, ComputerResources.StopCommandParamMessage);
+                string errMsg = StringUtil.Format(ComputerResources.StopCommandWSManAuthProtocolConflict, ComputerResources.StopCommandParamMessage);
                 ThrowTerminatingError(
                     new ErrorRecord(
                         new PSArgumentException(errMsg),
@@ -286,7 +286,7 @@ namespace Microsoft.PowerShell.Commands
 
             if ((_transportProtocol == TransportProtocol.WSMan) && (haveDcomAuthenticationParam || haveDcomImpersonation))
             {
-                string errMsg = StringUtil.Format(ComputerResources.StopCommandAuthProtcolConflict, ComputerResources.StopCommandParamMessage);
+                string errMsg = StringUtil.Format(ComputerResources.StopCommandAuthProtocolConflict, ComputerResources.StopCommandParamMessage);
                 ThrowTerminatingError(
                     new ErrorRecord(
                         new PSArgumentException(errMsg),
@@ -1481,7 +1481,7 @@ namespace Microsoft.PowerShell.Commands
                     if (restoreStatus.Equals(0))
                         WriteObject(ComputerResources.RestoreFailed);
                     else if (restoreStatus.Equals(1))
-                        WriteObject(ComputerResources.RestoreSuceess);
+                        WriteObject(ComputerResources.RestoreSuccess);
                     else if (restoreStatus.Equals(2))
                         WriteObject(ComputerResources.RestoreInterrupted);
                 }
@@ -1533,7 +1533,7 @@ namespace Microsoft.PowerShell.Commands
                         {
                             foreach (int id in sequenceList.Keys)
                             {
-                                string message = StringUtil.Format(ComputerResources.NoResorePoint, id);
+                                string message = StringUtil.Format(ComputerResources.NoRestorePoint, id);
                                 ArgumentException e = new ArgumentException(message);
                                 ErrorRecord errorrecord = new ErrorRecord(e, "NoResorePoint", ErrorCategory.InvalidArgument, null);
                                 WriteError(errorrecord);
@@ -3368,7 +3368,7 @@ $result
 
             if ((_transportProtocol == TransportProtocol.DCOM) && haveWsmanAuthenticationParam)
             {
-                string errMsg = StringUtil.Format(ComputerResources.StopCommandWSManAuthProtcolConflict, ComputerResources.StopCommandParamMessage);
+                string errMsg = StringUtil.Format(ComputerResources.StopCommandWSManAuthProtocolConflict, ComputerResources.StopCommandParamMessage);
                 ThrowTerminatingError(
                     new ErrorRecord(
                         new PSArgumentException(errMsg),
@@ -3379,7 +3379,7 @@ $result
 
             if ((_transportProtocol == TransportProtocol.WSMan) && (haveDcomAuthenticationParam || haveDcomImpersonation))
             {
-                string errMsg = StringUtil.Format(ComputerResources.StopCommandAuthProtcolConflict, ComputerResources.StopCommandParamMessage);
+                string errMsg = StringUtil.Format(ComputerResources.StopCommandAuthProtocolConflict, ComputerResources.StopCommandParamMessage);
                 ThrowTerminatingError(
                     new ErrorRecord(
                         new PSArgumentException(errMsg),

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/GetComputerInfoCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/GetComputerInfoCommand.cs
@@ -820,7 +820,7 @@ namespace Microsoft.PowerShell.Commands
 
                 if (otherInfo != null)
                 {
-                    output.CsPhyicallyInstalledMemory = otherInfo.physicallyInstalledMemory;
+                    output.CsPhysicallyInstalledMemory = otherInfo.physicallyInstalledMemory;
                 }
             }
 
@@ -2749,7 +2749,7 @@ namespace Microsoft.PowerShell.Commands
         /// Size of physically installed memory, as reported by the Windows API
         /// function GetPhysicallyInstalledSystemMemory
         /// </summary>
-        public UInt64? CsPhyicallyInstalledMemory { get; internal set; }
+        public UInt64? CsPhysicallyInstalledMemory { get; internal set; }
 
         /// <summary>
         /// Name of a user that is logged on currently.
@@ -3427,7 +3427,7 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Availability status is Not Installed
         /// </summary>
-        NotIntalled = 11,
+        NotInstalled = 11,
 
         /// <summary>
         /// Availability status is Install Error

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
@@ -653,11 +653,11 @@ namespace Microsoft.PowerShell.Commands
                     }
                     catch (InvalidOperationException exception)
                     {
-                        WriteNonTerminatingError(process, exception, ProcessResources.CouldnotEnumerateModuleFileVer, "CouldnotEnumerateModuleFileVer", ErrorCategory.PermissionDenied);
+                        WriteNonTerminatingError(process, exception, ProcessResources.CouldNotEnumerateModuleFileVer, "CouldNotEnumerateModuleFileVer", ErrorCategory.PermissionDenied);
                     }
                     catch (ArgumentException exception)
                     {
-                        WriteNonTerminatingError(process, exception, ProcessResources.CouldnotEnumerateModuleFileVer, "CouldnotEnumerateModuleFileVer", ErrorCategory.PermissionDenied);
+                        WriteNonTerminatingError(process, exception, ProcessResources.CouldNotEnumerateModuleFileVer, "CouldNotEnumerateModuleFileVer", ErrorCategory.PermissionDenied);
                     }
                     catch (Win32Exception exception)
                     {
@@ -669,18 +669,18 @@ namespace Microsoft.PowerShell.Commands
                             }
                             else
                             {
-                                WriteNonTerminatingError(process, exception, ProcessResources.CouldnotEnumerateModuleFileVer, "CouldnotEnumerateModuleFileVer", ErrorCategory.PermissionDenied);
+                                WriteNonTerminatingError(process, exception, ProcessResources.CouldNotEnumerateModuleFileVer, "CouldNotEnumerateModuleFileVer", ErrorCategory.PermissionDenied);
                             }
                         }
                         catch (Win32Exception ex)
                         {
-                            WriteNonTerminatingError(process, ex, ProcessResources.CouldnotEnumerateModuleFileVer, "CouldnotEnumerateModuleFileVer", ErrorCategory.PermissionDenied);
+                            WriteNonTerminatingError(process, ex, ProcessResources.CouldNotEnumerateModuleFileVer, "CouldNotEnumerateModuleFileVer", ErrorCategory.PermissionDenied);
                         }
                     }
                     catch (Exception exception)
                     {
                         CommandsCommon.CheckForSevereException(this, exception);
-                        WriteNonTerminatingError(process, exception, ProcessResources.CouldnotEnumerateModuleFileVer, "CouldnotEnumerateModuleFileVer", ErrorCategory.PermissionDenied);
+                        WriteNonTerminatingError(process, exception, ProcessResources.CouldNotEnumerateModuleFileVer, "CouldNotEnumerateModuleFileVer", ErrorCategory.PermissionDenied);
                     }
                 }
                 else if (Module.IsPresent)
@@ -700,18 +700,18 @@ namespace Microsoft.PowerShell.Commands
                             }
                             else
                             {
-                                WriteNonTerminatingError(process, exception, ProcessResources.CouldnotEnumerateModules, "CouldnotEnumerateModules", ErrorCategory.PermissionDenied);
+                                WriteNonTerminatingError(process, exception, ProcessResources.CouldNotEnumerateModules, "CouldNotEnumerateModules", ErrorCategory.PermissionDenied);
                             }
                         }
                         catch (Win32Exception ex)
                         {
-                            WriteNonTerminatingError(process, ex, ProcessResources.CouldnotEnumerateModules, "CouldnotEnumerateModules", ErrorCategory.PermissionDenied);
+                            WriteNonTerminatingError(process, ex, ProcessResources.CouldNotEnumerateModules, "CouldNotEnumerateModules", ErrorCategory.PermissionDenied);
                         }
                     }
                     catch (Exception exception)
                     {
                         CommandsCommon.CheckForSevereException(this, exception);
-                        WriteNonTerminatingError(process, exception, ProcessResources.CouldnotEnumerateModules, "CouldnotEnumerateModules", ErrorCategory.PermissionDenied);
+                        WriteNonTerminatingError(process, exception, ProcessResources.CouldNotEnumerateModules, "CouldNotEnumerateModules", ErrorCategory.PermissionDenied);
                     }
                 }
                 else if (FileVersionInfo.IsPresent)
@@ -723,11 +723,11 @@ namespace Microsoft.PowerShell.Commands
                     }
                     catch (InvalidOperationException exception)
                     {
-                        WriteNonTerminatingError(process, exception, ProcessResources.CouldnotEnumerateFileVer, "CouldnotEnumerateFileVer", ErrorCategory.PermissionDenied);
+                        WriteNonTerminatingError(process, exception, ProcessResources.CouldNotEnumerateFileVer, "CouldNotEnumerateFileVer", ErrorCategory.PermissionDenied);
                     }
                     catch (ArgumentException exception)
                     {
-                        WriteNonTerminatingError(process, exception, ProcessResources.CouldnotEnumerateFileVer, "CouldnotEnumerateFileVer", ErrorCategory.PermissionDenied);
+                        WriteNonTerminatingError(process, exception, ProcessResources.CouldNotEnumerateFileVer, "CouldNotEnumerateFileVer", ErrorCategory.PermissionDenied);
                     }
                     catch (Win32Exception exception)
                     {
@@ -739,18 +739,18 @@ namespace Microsoft.PowerShell.Commands
                             }
                             else
                             {
-                                WriteNonTerminatingError(process, exception, ProcessResources.CouldnotEnumerateFileVer, "CouldnotEnumerateFileVer", ErrorCategory.PermissionDenied);
+                                WriteNonTerminatingError(process, exception, ProcessResources.CouldNotEnumerateFileVer, "CouldNotEnumerateFileVer", ErrorCategory.PermissionDenied);
                             }
                         }
                         catch (Win32Exception ex)
                         {
-                            WriteNonTerminatingError(process, ex, ProcessResources.CouldnotEnumerateFileVer, "CouldnotEnumerateFileVer", ErrorCategory.PermissionDenied);
+                            WriteNonTerminatingError(process, ex, ProcessResources.CouldNotEnumerateFileVer, "CouldNotEnumerateFileVer", ErrorCategory.PermissionDenied);
                         }
                     }
                     catch (Exception exception)
                     {
                         CommandsCommon.CheckForSevereException(this, exception);
-                        WriteNonTerminatingError(process, exception, ProcessResources.CouldnotEnumerateFileVer, "CouldnotEnumerateFileVer", ErrorCategory.PermissionDenied);
+                        WriteNonTerminatingError(process, exception, ProcessResources.CouldNotEnumerateFileVer, "CouldNotEnumerateFileVer", ErrorCategory.PermissionDenied);
                     }
                 }
                 else

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/TimeZoneCommands.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/TimeZoneCommands.cs
@@ -722,7 +722,7 @@ namespace Microsoft.PowerShell.Commands
             /// PInvoke AdjustTokenPrivilege API
             /// </summary>
             /// <param name="TokenHandle"></param>
-            /// <param name="DisableAllPrivilegs"></param>
+            /// <param name="DisableAllPrivileges"></param>
             /// <param name="NewState"></param>
             /// <param name="BufferLength"></param>
             /// <param name="PreviousState"></param>
@@ -730,7 +730,7 @@ namespace Microsoft.PowerShell.Commands
             /// <returns></returns>
             [DllImport(AdjustTokenPrivilegesApiDllName, SetLastError = true, CharSet = CharSet.Unicode, BestFitMapping = false)]
             [return: MarshalAs(UnmanagedType.Bool)]
-            public static extern bool AdjustTokenPrivileges(IntPtr TokenHandle, bool DisableAllPrivilegs,
+            public static extern bool AdjustTokenPrivileges(IntPtr TokenHandle, bool DisableAllPrivileges,
                 ref TOKEN_PRIVILEGES NewState, int BufferLength, IntPtr PreviousState, IntPtr ReturnLength);
 
             /// <summary>

--- a/src/Microsoft.PowerShell.Commands.Management/resources/CmdletizationResources.resx
+++ b/src/Microsoft.PowerShell.Commands.Management/resources/CmdletizationResources.resx
@@ -120,7 +120,7 @@
   <data name="CimJob_InvalidClassName" xml:space="preserve">
     <value>Cannot find the {0} class on the {1} CIM server.  Verify the value of the ClassName xml attribute in Cmdlet Definition XML and retry. Valid class name example: ROOT\cimv2\Win32_Process.</value>
     <comment>{StrContains="ClassName"} {StrContains="ROOT\cimv2\Win32_Process"}
-{0} is a placeholder for a name of a (potentially misspelled) CIM class.  Example: "Win32_Proccess".
+{0} is a placeholder for a name of a (potentially misspelled) CIM class.  Example: "Win32_Process".
 {1} is a placeholder for a server name.  Example: "localhost".</comment>
   </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />

--- a/src/Microsoft.PowerShell.Commands.Management/resources/ComputerResources.resx
+++ b/src/Microsoft.PowerShell.Commands.Management/resources/ComputerResources.resx
@@ -144,13 +144,13 @@
   <data name="RestoreFailed" xml:space="preserve">
     <value>The last attempt to restore the computer failed.</value>
   </data>
-  <data name="RestoreSuceess" xml:space="preserve">
+  <data name="RestoreSuccess" xml:space="preserve">
     <value>The computer has been restored to the specified restore point.</value>
   </data>
   <data name="RestoreInterrupted" xml:space="preserve">
     <value>The last attempt to restore the computer was interrupted.</value>
   </data>
-  <data name="NoResorePoint" xml:space="preserve">
+  <data name="NoRestorePoint" xml:space="preserve">
     <value>The command cannot locate the "{0}" restore point. Verify the "{0}" sequence number, and then try the command again.</value>
   </data>
   <data name="NoPingResult" xml:space="preserve">
@@ -399,7 +399,7 @@
   <data name="RenameCommandWsmanAuthParamConflict" xml:space="preserve">
     <value>Parameter WsmanAuthentication cannot be specified with the DCOM protocol. Parameter WSManAuthentication is valid only when the WSMan protocol is used.</value>
   </data>
-  <data name="StopCommandAuthProtcolConflict" xml:space="preserve">
+  <data name="StopCommandAuthProtocolConflict" xml:space="preserve">
     <value>Parameters DcomAuthentication and Impersonation cannot be specified with the WSMan protocol. {0}</value>
   </data>
   <data name="StopCommandParamMessage" xml:space="preserve">
@@ -408,7 +408,7 @@
   <data name="StopCommandParamWSManAuthConflict" xml:space="preserve">
     <value>Parameter WsmanAuthentication cannot be specified with DcomAuthentication or Impersonation parameters. {0}</value>
   </data>
-  <data name="StopCommandWSManAuthProtcolConflict" xml:space="preserve">
+  <data name="StopCommandWSManAuthProtocolConflict" xml:space="preserve">
     <value>Parameter WsmanAuthentication cannot be specified with the DCOM protocol. {0}</value>
   </data>
   <data name="InvalidParameterDCOMNotSupported" xml:space="preserve">

--- a/src/Microsoft.PowerShell.Commands.Management/resources/ProcessResources.resx
+++ b/src/Microsoft.PowerShell.Commands.Management/resources/ProcessResources.resx
@@ -132,13 +132,13 @@
   <data name="ProcessNameForConfirmation" xml:space="preserve">
     <value>{0} ({1})</value>
   </data>
-  <data name="CouldnotEnumerateModules" xml:space="preserve">
+  <data name="CouldNotEnumerateModules" xml:space="preserve">
     <value>Cannot enumerate the modules of the "{0}" process.</value>
   </data>
-  <data name="CouldnotEnumerateFileVer" xml:space="preserve">
+  <data name="CouldNotEnumerateFileVer" xml:space="preserve">
     <value>Cannot enumerate the file version information of the "{0}" process.</value>
   </data>
-  <data name="CouldnotEnumerateModuleFileVer" xml:space="preserve">
+  <data name="CouldNotEnumerateModuleFileVer" xml:space="preserve">
     <value>Cannot enumerate the modules and the file version information of the "{0}" process.</value>
   </data>
   <data name="ConfirmStopProcess" xml:space="preserve">

--- a/src/Microsoft.PowerShell.GraphicalHost/HelpWindow/HelpParagraphBuilder.cs
+++ b/src/Microsoft.PowerShell.GraphicalHost/HelpWindow/HelpParagraphBuilder.cs
@@ -106,17 +106,17 @@ namespace Microsoft.Management.UI.Internal
             switch (category)
             {
                 case HelpCategory.Class:
-                    this.AddDescription(HelpWindowSettings.Default.HelpSynopsysDisplayed, HelpWindowResources.SynopsisTitle, "Introduction");
+                    this.AddDescription(HelpWindowSettings.Default.HelpSynopsisDisplayed, HelpWindowResources.SynopsisTitle, "Introduction");
                     this.AddMembers(HelpWindowSettings.Default.HelpParametersDisplayed, HelpWindowResources.PropertiesTitle);
                     this.AddMembers(HelpWindowSettings.Default.HelpParametersDisplayed, HelpWindowResources.MethodsTitle);
                     break;
                 case HelpCategory.DscResource:
-                    this.AddStringSection(HelpWindowSettings.Default.HelpSynopsysDisplayed, "Synopsis", HelpWindowResources.SynopsisTitle);
+                    this.AddStringSection(HelpWindowSettings.Default.HelpSynopsisDisplayed, "Synopsis", HelpWindowResources.SynopsisTitle);
                     this.AddDescription(HelpWindowSettings.Default.HelpDescriptionDisplayed, HelpWindowResources.DescriptionTitle, "Description");
                     this.AddParameters(HelpWindowSettings.Default.HelpParametersDisplayed, HelpWindowResources.PropertiesTitle, "Properties", HelpCategory.DscResource);
                     break;
                 default:
-                    this.AddStringSection(HelpWindowSettings.Default.HelpSynopsysDisplayed, "Synopsis", HelpWindowResources.SynopsisTitle);
+                    this.AddStringSection(HelpWindowSettings.Default.HelpSynopsisDisplayed, "Synopsis", HelpWindowResources.SynopsisTitle);
                     this.AddDescription(HelpWindowSettings.Default.HelpDescriptionDisplayed, HelpWindowResources.DescriptionTitle, "Description");
                     this.AddParameters(HelpWindowSettings.Default.HelpParametersDisplayed, HelpWindowResources.ParametersTitle, "Parameters", HelpCategory.Default);
                     this.AddSyntax(HelpWindowSettings.Default.HelpSyntaxDisplayed, HelpWindowResources.SyntaxTitle);

--- a/src/Microsoft.PowerShell.GraphicalHost/HelpWindow/HelpWindowSettings.Designer.cs
+++ b/src/Microsoft.PowerShell.GraphicalHost/HelpWindow/HelpWindowSettings.Designer.cs
@@ -68,12 +68,12 @@ namespace Microsoft.Management.UI.Internal {
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("True")]
-        public bool HelpSynopsysDisplayed {
+        public bool HelpSynopsisDisplayed {
             get {
-                return ((bool)(this["HelpSynopsysDisplayed"]));
+                return ((bool)(this["HelpSynopsisDisplayed"]));
             }
             set {
-                this["HelpSynopsysDisplayed"] = value;
+                this["HelpSynopsisDisplayed"] = value;
             }
         }
         

--- a/src/Microsoft.PowerShell.GraphicalHost/HelpWindow/SettingsDialog.xaml.cs
+++ b/src/Microsoft.PowerShell.GraphicalHost/HelpWindow/SettingsDialog.xaml.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Management.UI
             this.Parameters.IsChecked = HelpWindowSettings.Default.HelpParametersDisplayed;
             this.RelatedLinks.IsChecked = HelpWindowSettings.Default.HelpRelatedLinksDisplayed;
             this.Remarks.IsChecked = HelpWindowSettings.Default.HelpRemarksDisplayed;
-            this.Synopsys.IsChecked = HelpWindowSettings.Default.HelpSynopsysDisplayed;
+            this.Synopsis.IsChecked = HelpWindowSettings.Default.HelpSynopsisDisplayed;
             this.Syntax.IsChecked = HelpWindowSettings.Default.HelpSyntaxDisplayed;
             this.CaseSensitive.IsChecked = HelpWindowSettings.Default.HelpSearchMatchCase;
             this.WholeWord.IsChecked = HelpWindowSettings.Default.HelpSearchWholeWord;
@@ -52,7 +52,7 @@ namespace Microsoft.Management.UI
             HelpWindowSettings.Default.HelpParametersDisplayed = this.Parameters.IsChecked == true;
             HelpWindowSettings.Default.HelpRelatedLinksDisplayed = this.RelatedLinks.IsChecked == true;
             HelpWindowSettings.Default.HelpRemarksDisplayed = this.Remarks.IsChecked == true;
-            HelpWindowSettings.Default.HelpSynopsysDisplayed = this.Synopsys.IsChecked == true;
+            HelpWindowSettings.Default.HelpSynopsisDisplayed = this.Synopsis.IsChecked == true;
             HelpWindowSettings.Default.HelpSyntaxDisplayed = this.Syntax.IsChecked == true;
             HelpWindowSettings.Default.HelpSearchMatchCase = this.CaseSensitive.IsChecked == true;
             HelpWindowSettings.Default.HelpSearchWholeWord = this.WholeWord.IsChecked == true;

--- a/src/Microsoft.PowerShell.GraphicalHost/xamls/SettingsDialog.xaml
+++ b/src/Microsoft.PowerShell.GraphicalHost/xamls/SettingsDialog.xaml
@@ -23,7 +23,7 @@
                     <RowDefinition Height="Auto"></RowDefinition>
                     <RowDefinition Height="Auto"></RowDefinition>
                 </Grid.RowDefinitions>
-                <CheckBox x:Name="Synopsys" Margin="5" Grid.Row="0" Grid.Column="0" Content="{x:Static this:HelpWindowResources.SynopsisTitle}"></CheckBox>
+                <CheckBox x:Name="Synopsis" Margin="5" Grid.Row="0" Grid.Column="0" Content="{x:Static this:HelpWindowResources.SynopsisTitle}"></CheckBox>
                 <CheckBox x:Name="Syntax" Margin="5" Grid.Row="1" Grid.Column="0" Content="{x:Static this:HelpWindowResources.SyntaxTitle}"></CheckBox>
                 <CheckBox x:Name="Description" Margin="5" Grid.Row="2" Grid.Column="0" Content="{x:Static this:HelpWindowResources.DescriptionTitle}"></CheckBox>
                 <CheckBox x:Name="Parameters" Margin="5" Grid.Row="3" Grid.Column="0" Content="{x:Static this:HelpWindowResources.ParametersTitle}"></CheckBox>

--- a/src/Microsoft.PowerShell.Workflow.ServiceCore/ServiceCore/WorkflowCore/ImportWorkflowCommand.cs
+++ b/src/Microsoft.PowerShell.Workflow.ServiceCore/ServiceCore/WorkflowCore/ImportWorkflowCommand.cs
@@ -723,7 +723,7 @@ namespace Microsoft.PowerShell.Commands
         {
             get
             {
-                return Resources.AsJobandJobNameNotAllowed;
+                return Resources.AsJobAndJobNameNotAllowed;
             }
         }
 

--- a/src/Microsoft.PowerShell.Workflow.ServiceCore/resources/Resources.resx
+++ b/src/Microsoft.PowerShell.Workflow.ServiceCore/resources/Resources.resx
@@ -236,7 +236,7 @@
   <data name="ExitReason" xml:space="preserve">
     <value>Workflow complete.</value>
   </data>
-  <data name="RemovingWrokflowInstance" xml:space="preserve">
+  <data name="RemovingWorkflowInstance" xml:space="preserve">
     <value>Removing workflow instance from the table.</value>
   </data>
   <data name="ElapsedTimeReached" xml:space="preserve">
@@ -278,7 +278,7 @@ Method: {3}</value>
   <data name="ErrorWhileValidatingWorkflow" xml:space="preserve">
     <value>An exception has occurred while validating the workflow.</value>
   </data>
-  <data name="AsJobandJobNameNotAllowed" xml:space="preserve">
+  <data name="AsJobAndJobNameNotAllowed" xml:space="preserve">
     <value>The argument to -PSParameterCollection can not contain AsJob, JobName, InputObject or PSParameterCollection as entries. Remove the extra entries and try again.</value>
     <comment>PSParameterCollection, AsJob, JobName, InputObject should not be localized. These are the names of parameters.</comment>
   </data>

--- a/src/Schemas/PSMaml/command.xsd
+++ b/src/Schemas/PSMaml/command.xsd
@@ -137,7 +137,7 @@
 						<sequence>
 							<element ref="maml:name"/>
 							<element ref="maml:commandSyntaxParameter" minOccurs="0" maxOccurs="unbounded"/>
-							<element name="commmandSyntaxParameterGroup" minOccurs="0" maxOccurs="unbounded">
+							<element name="commandSyntaxParameterGroup" minOccurs="0" maxOccurs="unbounded">
 								<complexType>
 									<sequence>
 										<element ref="maml:commandSyntaxParameter" maxOccurs="unbounded"/>

--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -4930,7 +4930,7 @@ end
             new SessionStateVariableEntry(
                 FormatEnumerationLimit,
                 DefaultFormatEnumerationLimit,
-                RunspaceInit.FormatEnunmerationLimitDescription
+                RunspaceInit.FormatEnumerationLimitDescription
                 ),
 
              //variable for PSEmailServer

--- a/src/System.Management.Automation/engine/Modules/ModuleSpecification.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleSpecification.cs
@@ -157,7 +157,7 @@ namespace Microsoft.PowerShell.Commands
 
             if (moduleSpecification.RequiredVersion != null && moduleSpecification.MaximumVersion != null)
             {
-                message = StringUtil.Format(SessionStateStrings.GetContent_TailAndHeadCannotCoexist, "MaxiumVersion", "RequiredVersion");
+                message = StringUtil.Format(SessionStateStrings.GetContent_TailAndHeadCannotCoexist, "MaximumVersion", "RequiredVersion");
                 return new ArgumentException(message);
             }
             return null;

--- a/src/System.Management.Automation/engine/parser/SemanticChecks.cs
+++ b/src/System.Management.Automation/engine/parser/SemanticChecks.cs
@@ -469,7 +469,7 @@ namespace System.Management.Automation.Language
             if ((forEachStatementAst.ThrottleLimit != null) &&
                 ((forEachStatementAst.Flags & ForEachFlags.Parallel) != ForEachFlags.Parallel))
             {
-                _parser.ReportError(forEachStatementAst.Extent, () => ParserStrings.ThrottleLimitRequresParallelFlag);
+                _parser.ReportError(forEachStatementAst.Extent, () => ParserStrings.ThrottleLimitRequiresParallelFlag);
             }
 
             return AstVisitAction.Continue;

--- a/src/System.Management.Automation/engine/remoting/commands/NewPSSessionOptionCommand.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/NewPSSessionOptionCommand.cs
@@ -112,7 +112,7 @@ namespace System.Management.Automation.Remoting
                         _proxyAuthentication = value;
                         break;
                     default:
-                        string message = PSRemotingErrorInvariants.FormatResourceString(RemotingErrorIdStrings.ProxyAmbiguosAuthentication,
+                        string message = PSRemotingErrorInvariants.FormatResourceString(RemotingErrorIdStrings.ProxyAmbiguousAuthentication,
                             value,
                             AuthenticationMechanism.Basic.ToString(),
                             AuthenticationMechanism.Negotiate.ToString(),

--- a/src/System.Management.Automation/engine/remoting/commands/PSRemotingCmdlet.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/PSRemotingCmdlet.cs
@@ -735,7 +735,7 @@ namespace Microsoft.PowerShell.Commands
             if ((credential != null) && (thumbprint != null))
             {
                 String message = PSRemotingErrorInvariants.FormatResourceString(
-                    RemotingErrorIdStrings.NewRunspaceAmbiguosAuthentication,
+                    RemotingErrorIdStrings.NewRunspaceAmbiguousAuthentication,
                         "CertificateThumbPrint", "Credential");
 
                 throw new InvalidOperationException(message);
@@ -744,7 +744,7 @@ namespace Microsoft.PowerShell.Commands
             if ((authentication != AuthenticationMechanism.Default) && (thumbprint != null))
             {
                 String message = PSRemotingErrorInvariants.FormatResourceString(
-                    RemotingErrorIdStrings.NewRunspaceAmbiguosAuthentication,
+                    RemotingErrorIdStrings.NewRunspaceAmbiguousAuthentication,
                         "CertificateThumbPrint", authentication.ToString());
 
                 throw new InvalidOperationException(message);
@@ -754,7 +754,7 @@ namespace Microsoft.PowerShell.Commands
                 (credential != null))
             {
                 string message = PSRemotingErrorInvariants.FormatResourceString(
-                    RemotingErrorIdStrings.NewRunspaceAmbiguosAuthentication,
+                    RemotingErrorIdStrings.NewRunspaceAmbiguousAuthentication,
                     "Credential", authentication.ToString());
                 throw new InvalidOperationException(message);
             }

--- a/src/System.Management.Automation/engine/remoting/common/RunspaceConnectionInfo.cs
+++ b/src/System.Management.Automation/engine/remoting/common/RunspaceConnectionInfo.cs
@@ -654,7 +654,7 @@ namespace System.Management.Automation.Runspaces
                         _proxyAuthentication = value;
                         break;
                     default:
-                        string message = PSRemotingErrorInvariants.FormatResourceString(RemotingErrorIdStrings.ProxyAmbiguosAuthentication,
+                        string message = PSRemotingErrorInvariants.FormatResourceString(RemotingErrorIdStrings.ProxyAmbiguousAuthentication,
                             value,
                             AuthenticationMechanism.Basic.ToString(),
                             AuthenticationMechanism.Negotiate.ToString(),
@@ -1258,7 +1258,7 @@ namespace System.Management.Automation.Runspaces
             if ((WSManAuthenticationMechanism != WSManAuthenticationMechanism.WSMAN_FLAG_DEFAULT_AUTHENTICATION)
                 && (_thumbPrint != null))
             {
-                throw PSTraceSource.NewInvalidOperationException(RemotingErrorIdStrings.NewRunspaceAmbiguosAuthentication,
+                throw PSTraceSource.NewInvalidOperationException(RemotingErrorIdStrings.NewRunspaceAmbiguousAuthentication,
                       "CertificateThumbPrint", this.AuthenticationMechanism.ToString());
             }
         }

--- a/src/System.Management.Automation/engine/remoting/common/remotingexceptions.cs
+++ b/src/System.Management.Automation/engine/remoting/common/remotingexceptions.cs
@@ -67,7 +67,7 @@ namespace System.Management.Automation.Remoting
         MissingIsStartFragment = 409,
         MissingProperty = 410,
         ObjectIdsNotMatching = 411,
-        FragmetIdsNotInSequence = 412,
+        FragmentIdsNotInSequence = 412,
         ObjectIsTooBig = 413,
         MissingIsEndFragment = 414,
         DeserializedObjectIsNull = 415,
@@ -193,7 +193,7 @@ namespace System.Management.Automation.Remoting
         RemoteRunspaceNotAvailableForSpecifiedSessionId = 920,
         ItemNotFoundInRepository = 921,
         CannotRemoveJob = 922,
-        NewRunspaceAmbiguosAuthentication = 923,
+        NewRunspaceAmbiguousAuthentication = 923,
         WildCardErrorFilePathParameter = 924,
         FilePathNotFromFileSystemProvider = 925,
         FilePathShouldPS1Extension = 926,
@@ -204,7 +204,7 @@ namespace System.Management.Automation.Remoting
         URIRedirectionReported = 930,
         NoMoreInputWrites = 931,
         InvalidComputerName = 932,
-        ProxyAmbiguosAuthentication = 933,
+        ProxyAmbiguousAuthentication = 933,
         ProxyCredentialWithoutAccess = 934,
 
         // Start-PSSession related error codes.

--- a/src/System.Management.Automation/engine/remoting/fanin/PriorityCollection.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/PriorityCollection.cs
@@ -592,7 +592,7 @@ namespace System.Management.Automation.Remoting
                             ResetReceiveData();
                             if (!_canIgnoreOffSyncFragments)
                             {
-                                PSRemotingTransportException e = new PSRemotingTransportException(RemotingErrorIdStrings.FragmetIdsNotInSequence);
+                                PSRemotingTransportException e = new PSRemotingTransportException(RemotingErrorIdStrings.FragmentIdsNotInSequence);
                                 throw e;
                             }
                             else

--- a/src/System.Management.Automation/resources/CatalogStrings.resx
+++ b/src/System.Management.Automation/resources/CatalogStrings.resx
@@ -117,7 +117,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="CatalogDefintionFileNotGenerated" xml:space="preserve">
+  <data name="CatalogDefinitionFileNotGenerated" xml:space="preserve">
     <value>Unable to generate catalog definition file.</value>
   </data>
   <data name="AddFileToCatalog" xml:space="preserve">
@@ -126,7 +126,7 @@
   <data name="SkipValidationOfCatalogFile" xml:space="preserve">
     <value>Skipping validating file {0} from catalog. </value>
   </data>
-  <data name="FoundFileHashInCatlogItem" xml:space="preserve">
+  <data name="FoundFileHashInCatalogItem" xml:space="preserve">
     <value>Found file {0} in the catalog with hash of {1}. </value>
   </data>
   <data name="FoundDuplicateFilesRelativePath" xml:space="preserve">

--- a/src/System.Management.Automation/resources/ConsoleInfoErrorStrings.resx
+++ b/src/System.Management.Automation/resources/ConsoleInfoErrorStrings.resx
@@ -216,7 +216,7 @@
   <data name="PromptForExportConsole" xml:space="preserve">
     <value>Cannot export a console file because no console file has been specified. Do you want to continue with the export operation?</value>
   </data>
-  <data name="ConsoleCannotbeConvertedToString" xml:space="preserve">
+  <data name="ConsoleCannotBeConvertedToString" xml:space="preserve">
     <value>Cannot save the file because the file name format is not valid. Specify a file name using the command: export-console -path.</value>
   </data>
   <data name="FileNameNotResolved" xml:space="preserve">

--- a/src/System.Management.Automation/resources/ParserStrings.resx
+++ b/src/System.Management.Automation/resources/ParserStrings.resx
@@ -991,7 +991,7 @@ Possible matches are</value>
     <value>The ThrottleLimit parameter of the foreach statement is missing a value. Supply a throttle limit to the parameter.</value>
     <comment>'ThrottleLimit' must not be localized.</comment>
   </data>
-  <data name="ThrottleLimitRequresParallelFlag" xml:space="preserve">
+  <data name="ThrottleLimitRequiresParallelFlag" xml:space="preserve">
     <value>The ThrottleLimit parameter is only supported on foreach statements that use the Parallel parameter.</value>
     <comment>'ThrottleLimit' and 'Parallel' must not be localized.</comment>
   </data>

--- a/src/System.Management.Automation/resources/RemotingErrorIdStrings.resx
+++ b/src/System.Management.Automation/resources/RemotingErrorIdStrings.resx
@@ -227,7 +227,7 @@
   <data name="ObjectIdCannotBeLessThanZero" xml:space="preserve">
     <value>ObjectId cannot be less than or equal to 0. This can happen if the fragments are not properly constructed by the remote computer, or the data has been changed by unauthorized users.</value>
   </data>
-  <data name="FragmetIdsNotInSequence" xml:space="preserve">
+  <data name="FragmentIdsNotInSequence" xml:space="preserve">
     <value>The FragmentIDs of the same object must be in sequence, incrementally changing by 1. This can happen if the fragments are not properly constructed by the remote computer. The data might also have been corrupted or changed.</value>
   </data>
   <data name="ObjectIsTooBig" xml:space="preserve">
@@ -542,7 +542,7 @@
   <data name="StopPSJobWhatIfTarget" xml:space="preserve">
     <value>Remote Command: {0}, associated with the job that has an ID of "{1}".</value>
   </data>
-  <data name="NewRunspaceAmbiguosAuthentication" xml:space="preserve">
+  <data name="NewRunspaceAmbiguousAuthentication" xml:space="preserve">
     <value>A {0} cannot be specified when {1} is specified.</value>
   </data>
   <data name="WildCardErrorFilePathParameter" xml:space="preserve">
@@ -602,7 +602,7 @@
   <data name="CSCDoubleParameterOutOfRange" xml:space="preserve">
     <value>{0} is not a valid value for the parameter {1}. The value must be greater than or equal to 0.</value>
   </data>
-  <data name="ProxyAmbiguosAuthentication" xml:space="preserve">
+  <data name="ProxyAmbiguousAuthentication" xml:space="preserve">
     <value>{0} cannot be specified as a proxy authentication mechanism. Only {1},{2} or {3} are supported for proxy authentication.</value>
   </data>
   <data name="ProxyCredentialWithoutAccess" xml:space="preserve">

--- a/src/System.Management.Automation/resources/RunspaceInit.resx
+++ b/src/System.Management.Automation/resources/RunspaceInit.resx
@@ -183,7 +183,7 @@
   <data name="WhatIfPreferenceDescription" xml:space="preserve">
     <value>If true, WhatIf is considered to be enabled for all commands.</value>
   </data>
-  <data name="FormatEnunmerationLimitDescription" xml:space="preserve">
+  <data name="FormatEnumerationLimitDescription" xml:space="preserve">
     <value>Dictates the limit of enumeration on formatting IEnumerable objects</value>
   </data>
   <data name="ReportErrorShowStackTraceDescription" xml:space="preserve">

--- a/src/System.Management.Automation/resources/SessionStateStrings.resx
+++ b/src/System.Management.Automation/resources/SessionStateStrings.resx
@@ -297,7 +297,7 @@
   <data name="ProviderStartException" xml:space="preserve">
     <value>Attempting to perform the Start operation on the '{0}' provider failed. {1}</value>
   </data>
-  <data name="StartDynamicParmatersProviderException" xml:space="preserve">
+  <data name="StartDynamicParameterProviderException" xml:space="preserve">
     <value>Attempting to perform the StartDynamicParameters operation on the '{0}' provider failed for the path '{1}'. {2}</value>
   </data>
   <data name="InitializeDefaultDrivesException" xml:space="preserve">

--- a/src/System.Management.Automation/security/CatalogHelper.cs
+++ b/src/System.Management.Automation/security/CatalogHelper.cs
@@ -357,7 +357,7 @@ namespace System.Management.Automation
                     {
                         // If we are not able to generate catalog definition file we can not continue generating catalog 
                         // throw PSTraceSource.NewInvalidOperationException("catalog", CatalogStrings.CatalogDefinitionFileNotGenerated);                    
-                        ErrorRecord errorRecord = new ErrorRecord(new InvalidOperationException(CatalogStrings.CatalogDefintionFileNotGenerated), "CatalogDefintionFileNotGenerated", ErrorCategory.InvalidOperation, null);
+                        ErrorRecord errorRecord = new ErrorRecord(new InvalidOperationException(CatalogStrings.CatalogDefinitionFileNotGenerated), "CatalogDefinitionFileNotGenerated", ErrorCategory.InvalidOperation, null);
                         _cmdlet.ThrowTerminatingError(errorRecord);
                     }
 
@@ -586,7 +586,7 @@ namespace System.Management.Automation
         internal static void ProcessCatalogFile(string relativePath, string fileHash, WildcardPattern[] excludedPatterns, ref Dictionary<String, String> catalogHashes)
         {
             // Found the attribute we are looking for 
-            _cmdlet.WriteVerbose(StringUtil.Format(CatalogStrings.FoundFileHashInCatlogItem, relativePath, fileHash));
+            _cmdlet.WriteVerbose(StringUtil.Format(CatalogStrings.FoundFileHashInCatalogItem, relativePath, fileHash));
 
             // Only add the file for validation if it does not meet exclusion criteria 
             if (!CheckExcludedCriteria((new FileInfo(relativePath)).Name, excludedPatterns))

--- a/src/System.Management.Automation/singleshell/Commands/ConsoleCommands.cs
+++ b/src/System.Management.Automation/singleshell/Commands/ConsoleCommands.cs
@@ -556,7 +556,7 @@ namespace Microsoft.PowerShell.Commands
                 return consoleValue;
             }
 
-            throw PSTraceSource.NewArgumentException("fileName", ConsoleInfoErrorStrings.ConsoleCannotbeConvertedToString);
+            throw PSTraceSource.NewArgumentException("fileName", ConsoleInfoErrorStrings.ConsoleCannotBeConvertedToString);
         }
 
         /// <summary>

--- a/src/System.Management.Automation/utils/WindowsErrorReporting.cs
+++ b/src/System.Management.Automation/utils/WindowsErrorReporting.cs
@@ -172,7 +172,7 @@ namespace System.Management.Automation
             /// <summary>
             /// Spawn another process to submit the report and return from this function call immediately. Note that the contents of the pSubmitResult parameter are undefined and there is no way to query when the reporting completes or the completion status.
             /// </summary>
-            OutOfProcesAsync = 1024,
+            OutOfProcessAsync = 1024,
 
             BypassDataThrottling = 2048,
             ArchiveParametersOnly = 4096,
@@ -440,7 +440,7 @@ namespace System.Management.Automation
             /// <param name="dumpType">The type of dump to be generated.</param>
             /// <param name="exceptionParam">A pointer to a MINIDUMP_EXCEPTION_INFORMATION structure describing the client exception that caused the minidump to be generated. If the value of this parameter is NULL, no exception information is included in the minidump file.</param>
             /// <param name="userStreamParam">A pointer to a MINIDUMP_USER_STREAM_INFORMATION structure. If the value of this parameter is NULL, no user-defined information is included in the minidump file.</param>
-            /// <param name="callackParam">A pointer to a MINIDUMP_CALLBACK_INFORMATION structure that specifies a callback routine which is to receive extended minidump information. If the value of this parameter is NULL, no callbacks are performed.</param>
+            /// <param name="callbackParam">A pointer to a MINIDUMP_CALLBACK_INFORMATION structure that specifies a callback routine which is to receive extended minidump information. If the value of this parameter is NULL, no callbacks are performed.</param>
             /// <returns></returns>
             [DllImport("DbgHelp.dll", SetLastError = true)]
             internal static extern bool MiniDumpWriteDump(
@@ -450,7 +450,7 @@ namespace System.Management.Automation
                 MiniDumpType dumpType,
                 IntPtr exceptionParam,
                 IntPtr userStreamParam,
-                IntPtr callackParam);
+                IntPtr callbackParam);
         }
 
         #endregion Native methods


### PR DESCRIPTION
These changes are almost entirely composed of changes to public APIs, either classes, methods, or resource identifiers. They're split by directory.

These can definitely be squashed together. Or changes can be split out/dropped if necessary.
