### PR TITLE
Improve ModulePath calculation and refactor related method names

### DIFF
--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -2823,7 +2823,7 @@ namespace System.Management.Automation.Runspaces
             // If a user has any module with the same name as that of the core module( or nested module inside the core module)
             // in his module path, then that will get loaded instead of the actual nested module (from the GAC - in our case)
             // Hence, searching only from the system module path while loading the core modules
-            ProcessImportModule(initializedRunspace, CoreModulesToImport, ModuleIntrinsics.GetSystemwideModulePath(), publicCommands);
+            ProcessImportModule(initializedRunspace, CoreModulesToImport, ModuleIntrinsics.GetPSHomeModulePath(), publicCommands);
 
             // Win8:328748 - functions defined in global scope end up in a module
             // Since we import the core modules, EngineSessionState's module is set to the last imported module. So, if a function is defined in global scope, it ends up in that module.

--- a/test/powershell/enginecore/ModulePath.Tests.ps1
+++ b/test/powershell/enginecore/ModulePath.Tests.ps1
@@ -20,6 +20,15 @@ Describe "SxS Module Path Basic Tests" -tags "CI" {
             $expectedSharedPath = [System.Management.Automation.Platform]::SelectProductNameForDirectory("SHARED_MODULES")
         }
         $expectedSystemPath = Join-Path -Path $PSHOME -ChildPath 'Modules'
+
+        ## Setup a fake PSHome
+        $fakePSHome = Join-Path -Path $TestDrive -ChildPath 'FakePSHome'
+        $fakePSHomeModuleDir = Join-Path -Path $fakePSHome -ChildPath 'Modules'
+        $fakePowerShell = Join-Path -Path $fakePSHome -ChildPath (Split-Path -Path $powershell -Leaf)
+        $fakePSDepsFile = Join-Path -Path $fakePSHome -ChildPath "powershell.deps.json"
+
+        New-Item -Path $fakePSHome -ItemType Directory > $null
+        New-Item -Path $fakePSHomeModuleDir -ItemType Directory > $null
     }
 
     BeforeEach {
@@ -30,6 +39,7 @@ Describe "SxS Module Path Basic Tests" -tags "CI" {
         $env:PSMODULEPATH = $originalModulePath
     }
 
+
     It "validate sxs module path" {
 
         $env:PSMODULEPATH = ""
@@ -38,8 +48,49 @@ Describe "SxS Module Path Basic Tests" -tags "CI" {
         $paths = $defaultModulePath -split [System.IO.Path]::PathSeparator
 
         $paths.Count | Should Be 3
-        $paths[0] | Should Be $expectedUserPath
-        $paths[1] | Should Be $expectedSharedPath
-        $paths[2] | Should Be $expectedSystemPath
+        $paths[0].TrimEnd([System.IO.Path]::DirectorySeparatorChar) | Should Be $expectedUserPath
+        $paths[1].TrimEnd([System.IO.Path]::DirectorySeparatorChar) | Should Be $expectedSharedPath
+        $paths[2].TrimEnd([System.IO.Path]::DirectorySeparatorChar) | Should Be $expectedSystemPath
+    }
+
+
+    It "ignore pshome module path derived from a different powershell core instance" -Skip:(!$IsCoreCLR) {
+
+        ## Create 'powershell' and 'powershell.deps.json' in the fake PSHome folder,
+        ## so that the module path calculation logic would believe it's real.
+        New-Item -Path $fakePowerShell -ItemType File -Force > $null
+        New-Item -Path $fakePSDepsFile -ItemType File -Force > $null
+
+        try {
+
+            ## PSHome module path derived from another powershell core instance should be ignored
+            $env:PSMODULEPATH = $fakePSHomeModuleDir
+            $newModulePath = & $powershell -nopro -c '$env:PSMODULEPATH'
+            $paths = $newModulePath -split [System.IO.Path]::PathSeparator
+
+            $paths.Count | Should Be 3
+            $paths[0] | Should Be $expectedUserPath
+            $paths[1] | Should Be $expectedSharedPath
+            $paths[2] | Should Be $expectedSystemPath
+
+        } finally {
+
+            ## Remove 'powershell' and 'powershell.deps.json' from the fake PSHome folder
+            Remove-Item -Path $fakePowerShell -Force -ErrorAction SilentlyContinue
+            Remove-Item -Path $fakePSDepsFile -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    It "keep non-pshome module path derived from powershell core instance parent" -Skip:(!$IsCoreCLR) {
+
+        ## non-pshome module path derived from another powershell core instance should be preserved
+        $customeModules = Join-Path -Path $TestDrive -ChildPath 'CustomModules'
+        $env:PSMODULEPATH = $fakePSHomeModuleDir, $customeModules -join ([System.IO.Path]::PathSeparator)
+        $newModulePath = & $powershell -nopro -c '$env:PSMODULEPATH'
+        $paths = $newModulePath -split [System.IO.Path]::PathSeparator
+
+        $paths.Count | Should Be 5
+        $paths -contains $fakePSHomeModuleDir | Should Be $true
+        $paths -contains $customeModules | Should Be $true
     }
 }


### PR DESCRIPTION
Resolving #1744

The PR include following changes:
1. Refactor method names related to module path calculation.
2. Improve the logic that detects if a module path is PSHome module path derived from a different powershell core instance.
3. Add more sxs module path tests.
