### PR TITLE
correct links in test-guidelines.md (issue #1665)

### DIFF
--- a/docs/testing-guidelines/WritingPesterTests.md
+++ b/docs/testing-guidelines/WritingPesterTests.md
@@ -197,5 +197,65 @@ Passed: 1 Failed: 0 Skipped: 0 Pending: 0
 The DESCRIBE BeforeAll block is executed before any other code even though it was at the bottom of the Describe block, so if state is set elsewhere in the describe BLOCK, that state will not be visible (as the code will not yet been run). Notice, too, that the BEFOREALL block in Context is executed before any other code in that block.
 Generally, you should have code reside in one of the code block elements of `[Before|After][All|Each]`, especially if those block rely on state set by free code elsewhere in the block.
 
+## Skipping tests in bulk
+Sometimes it is beneficial to skip all the tests in a particular `Describe` block. For example, tests which are not applicable to a platform could be skipped, and they would be reported as skipped. The following is an example of how this may be done:
+```
+Describe "Should not run these tests on non-Windows platforms" {
+    BeforeAll {
+        $originalDefaultParameterValues = $PSDefaultParameterValues.Clone()
+        if ( ! $IsWindows ) {
+            $PSDefaultParameterValues["it:skip"] = $true
+        }
+    }
+    AfterAll {
+        $global:PSDefaultParameterValues = $originalDefaultParameterValues
+    }
+    Context "Block 1" {
+        It "This block 1 test 1" {
+            1 | should be 1
+        }
+        It "This is block 1 test 2" {
+            1 | should be 1
+        }
+    }
+    Context "Block 2" {
+        It "This block 2 test 1" {
+            2 | should be 1
+        }
+        It "This is block 2 test 2" {
+            2 | should be 1
+        }
+    }
+}  
+```
+Here is the output when run on a Linux distribution:
+```
+Describing Should not run these tests on non-Windows platforms
+   Context Block 1
+    [!] This block 1 test 1 691ms
+    [!] This is block 1 test 2 114ms
+   Context Block 2
+    [!] This block 2 test 1 73ms
+    [!] This is block 2 test 2 6ms
+```
+and here is the output when run on a Windows distribution:
+```
+Describing Should not run these tests on non-Windows platforms
+   Context Block 1
+    [+] This block 1 test 1 86ms
+    [+] This is block 1 test 2 33ms
+   Context Block 2
+    [-] This block 2 test 1 52ms
+      Expected: {1}
+      But was:  {2}
+      22:             2 | should be 1
+      at <ScriptBlock>, <No file>: line 22
+    [-] This is block 2 test 2 77ms
+      Expected: {1}
+      But was:  {2}
+      25:             2 | should be 1
+      at <ScriptBlock>, <No file>: line 25
+```
 
+this technique uses the `$PSDefaultParameterValues` feature of PowerShell to temporarily set the It block parameter `-skip` to true (or in the case of Windows, it is not set at all)
 

--- a/docs/testing-guidelines/testing-guidelines.md
+++ b/docs/testing-guidelines/testing-guidelines.md
@@ -8,9 +8,7 @@ Having all of those tests available for the initial release of PowerShell was no
 we believe will provide us the ability to catch regressions in the areas which have had the largest changes for PowerShell. 
 It is our intent to continue to release more and more of our tests until we have the coverage we need.
 
-For creating new tests, please review the 
-[documents](https://github.com/PowerShell/PowerShell/tree/master/docs/testing-guidelines) on how to
-create tests for PowerShell.
+For creating new tests, please review the [documents](https://github.com/PowerShell/PowerShell/tree/master/docs/testing-guidelines) on how to create tests for PowerShell. There is a best practices document for [writing Pester tests](https://github.com/PowerShell/PowerShell/tree/master/docs/testing-guidelines/WritingPesterTests.md) and a list of [Pester Do's and Don'ts](https://github.com/PowerShell/PowerShell/tree/master/docs/testing-guidelines/PesterDoAndDont.md). When adding new tests, place them in the directories as [outlined below](#Test-Layout).
 
 ## CI System
 
@@ -60,7 +58,14 @@ Substantial changes were required, to get Pester executing on non-Windows system
 These changes are not yet in the official Pester code base. 
 Some features of Pester may not be available or may have incorrect behavior. 
 Please make sure to create issues in [PowerShell/PowerShell](https://github.com/PowerShell/PowerShell/issues) (not Pester) for anything that you find.
+#### Test Tags
+The Pester framework allows `Describe` blocks to be tagged, and our CI system relies on those tags to invoke our tests. One of the following tags must be used:
+* `CI` - this tag indicates that the tests in the `Describe` block will be executed as part of the CI/PR process
+* `Feature` - tests with this tag will not be executed as part of the CI/PR process, but they will be executed on a daily basis as part of a `cron` driven build. They indicate that the test will be validating more behavior, or will be using remote network resources (ex: package management tests)
+* `Scenario` - this tag indicates a larger scale test interacting with multiple areas of functionality and/or remote resources, these tests are also run daily.
 
+Additionally, the tag:
+* `SLOW` indicates that the test takes a somewhat longer time to execute (97% of our `CI` tests take 100ms or less), a test which takes longer than 1 second should be considered as a candidate for being tagged `Slow`
 ### xUnit
 For those tests which are not easily run via Pester, we have decided to use [xUnit](https://xunit.github.io/) as the test framework. 
 Currently, we have a minuscule number of tests which are run by using xUnit.


### PR DESCRIPTION
added specific links for PesterDoAndDont and WritingPesterTests
added new section in WritingPesterTests.md on bulk skipping tests
