### PR TITLE
Separate tests on Windows CI to Admin-Required and Non-Admin-Required

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -653,8 +653,8 @@ function Start-PSPester {
     if ($Unelevate)
     {
         $outputBufferFilePath = [System.IO.Path]::GetTempFileName()
-        $Command += "Start-Transcript -Force -Path $outputBufferFilePath;"
     }
+    
     $Command += "Invoke-Pester "
 
     $Command += "-OutputFormat ${OutputFormat} -OutputFile ${OutputFile} "
@@ -668,7 +668,7 @@ function Start-PSPester {
     $Command += "'" + $Path + "'"
     if ($Unelevate)
     {
-        $Command += "; Stop-Transcript; '__UNELEVATED_TESTS_THE_END__' >> $outputBufferFilePath"
+        $Command += " *> $outputBufferFilePath; '__UNELEVATED_TESTS_THE_END__' >> $outputBufferFilePath"
     }
 
     Write-Verbose $Command

--- a/build.psm1
+++ b/build.psm1
@@ -621,14 +621,14 @@ function Start-PSPester {
             throw '-Unelevate cannot be applied because the current user is not Administrator'
         }
 
-        if (-not $PSBoundParameters.ContainsKey('RequireAdminOnWindows'))
+        if (-not $PSBoundParameters.ContainsKey('ExcludeTag'))
         {
             $ExcludeTag += 'RequireAdminOnWindows'
         }
     }
     elseif ($IsWindows -and (-not $IsAdmin))
     {
-        if (-not $PSBoundParameters.ContainsKey('RequireAdminOnWindows'))
+        if (-not $PSBoundParameters.ContainsKey('ExcludeTag'))
         {
             $ExcludeTag += 'RequireAdminOnWindows'
         }

--- a/build.psm1
+++ b/build.psm1
@@ -537,7 +537,7 @@ function Get-PesterTag {
         foreach( $describe in $des) {
             $elements = $describe.CommandElements
             $lineno = $elements[0].Extent.StartLineNumber
-            $foundTag = $false
+            $foundPriorityTags = @()
             for ( $i = 0; $i -lt $elements.Count; $i++) {
                 if ( $elements[$i].extent.text -match "^-t" ) {
                     $vAst = $elements[$i+1]
@@ -550,7 +550,7 @@ function Get-PesterTag {
                             # These are valid tags also, but they are not the priority tags
                         }
                         elseif (@('CI', 'FEATURE', 'SCENARIO') -contains $_) {
-                            $foundTag = $true
+                            $foundPriorityTags += $_
                         }
                         else {
                             $warnings += "${fullname} includes improper tag '$_', line '$lineno'"
@@ -560,8 +560,11 @@ function Get-PesterTag {
                     }
                 }
             }
-            if ( ! $foundTag ) {
-                $warnings += "${fullname} does not include -Tag in Describe, line '$lineno'"
+            if ( $foundPriorityTags.Count -eq 0 ) {
+                $warnings += "${fullname}:$lineno does not include -Tag in Describe"
+            }
+            elseif ( $foundPriorityTags.Count -gt 1 ) {
+                $warnings += "${fullname}:$lineno includes more then one scope -Tag: $foundPriorityTags"
             }
         }
     }

--- a/docs/testing-guidelines/WritingPesterTests.md
+++ b/docs/testing-guidelines/WritingPesterTests.md
@@ -82,6 +82,15 @@ Provides logical grouping of It blocks within a single Describe block. Any Mocks
 #### It
 The  It  block is intended to be used inside of a  Describe  or  Context  Block. If you are familiar with the AAA pattern (Arrange-Act-Assert), the body of the  It  block is the appropriate location for an assert. The convention is to assert a single expectation for each  It  block. The code inside of the  It  block should throw a terminating error if the expectation of the test is not met and thus cause the test to fail. The name of the  It  block should expressively state the expectation of the test.
 
+### Admin privileges in tests
+Tests that require admin privileges **on windows** should be additionally marked with 'RequireAdminOnWindows' Pester tag.
+In the AppVeyor CI, we run two different passes:
+
+- The pass with exclusion of tests with 'RequireAdminOnWindows' tag
+- The pass where we run only 'RequireAdminOnWindows' tests
+
+In each case, tests are executed with appropriate privileges.
+
 ### Selected Features
 
 #### Test Drive

--- a/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalGroup.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalGroup.Tests.ps1
@@ -53,7 +53,7 @@ try {
         }
     }
 
-    Describe "Validate simple New-LocalGroup" -Tags "CI" {
+    Describe "Validate simple New-LocalGroup" -Tags @('CI', 'RequireAdminOnWindows') {
 
         AfterEach {
             if ($IsNotSkipped) {
@@ -69,7 +69,7 @@ try {
         }
     }
 
-    Describe "Validate New-LocalGroup cmdlet" -Tags "Feature" {
+    Describe "Validate New-LocalGroup cmdlet" -Tags @('Feature', 'RequireAdminOnWindows') {
 
         AfterEach {
             if ($IsNotSkipped) {
@@ -224,7 +224,7 @@ try {
         }
     }
 
-    Describe "Validate simple Get-LocalGroup" -Tags "CI" {
+    Describe "Validate simple Get-LocalGroup" -Tags @('CI', 'RequireAdminOnWindows') {
 
         BeforeAll {
             if ($IsNotSkipped) {
@@ -247,7 +247,7 @@ try {
         }
     }
 
-    Describe "Validate Get-LocalGroup cmdlet" -Tags "Feature" {
+    Describe "Validate Get-LocalGroup cmdlet" -Tags @('Feature', 'RequireAdminOnWindows') {
        
         BeforeAll {
             if ($IsNotSkipped) {
@@ -365,7 +365,7 @@ try {
         }
     }
 
-    Describe "Validate simple Set-LocalGroup" -Tags "CI" {
+    Describe "Validate simple Set-LocalGroup" -Tags @('CI', 'RequireAdminOnWindows') {
 
         BeforeAll {
             if ($IsNotSkipped) {
@@ -394,7 +394,7 @@ try {
         }
     }
 
-    Describe "Validate Set-LocalGroup cmdlet" -Tags "Feature" {
+    Describe "Validate Set-LocalGroup cmdlet" -Tags @('Feature', 'RequireAdminOnWindows') {
 
         BeforeAll {
             if ($IsNotSkipped) {
@@ -468,7 +468,7 @@ try {
         }
     }
 
-    Describe "Validate simple Rename-LocalGroup" -Tags "CI" {
+    Describe "Validate simple Rename-LocalGroup" -Tags @('CI', 'RequireAdminOnWindows') {
 
         BeforeAll {
             if ($IsNotSkipped) {
@@ -505,7 +505,7 @@ try {
         }
     }
 
-    Describe "Validate Rename-LocalGroup cmdlet" -Tags "Feature" {
+    Describe "Validate Rename-LocalGroup cmdlet" -Tags @('Feature', 'RequireAdminOnWindows') {
 
         BeforeAll {
             if ($IsNotSkipped) {
@@ -678,7 +678,7 @@ try {
         }
     }
 
-    Describe "Validate simple Remove-LocalGroup" -Tags "CI" {
+    Describe "Validate simple Remove-LocalGroup" -Tags @('CI', 'RequireAdminOnWindows') {
 
         BeforeAll {
             if ($IsNotSkipped) {
@@ -716,7 +716,7 @@ try {
         }
     }
 
-    Describe "Validate Remove-LocalGroup cmdlet" -Tags "Feature" {
+    Describe "Validate Remove-LocalGroup cmdlet" -Tags @('Feature', 'RequireAdminOnWindows') {
 
         BeforeAll {
             if ($IsNotSkipped) {

--- a/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalGroupMember.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalGroupMember.Tests.ps1
@@ -68,7 +68,7 @@ try {
         }
     }
 
-    Describe "Validate simple Add-LocalGroupMember" -Tags "CI" {
+    Describe "Validate simple Add-LocalGroupMember" -Tags @('CI', 'RequireAdminOnWindows') {
 
         BeforeEach {
             if ($IsNotSkipped) {
@@ -93,7 +93,7 @@ try {
         }
     }
 
-    Describe "Validate Add-LocalGroupMember cmdlet" -Tags "Feature" {
+    Describe "Validate Add-LocalGroupMember cmdlet" -Tags @('Feature', 'RequireAdminOnWindows') {
 
         BeforeAll {
             $OptDomainPrefix="(.+\\)?"
@@ -241,7 +241,7 @@ try {
         }
     }
 
-    Describe "Validate simple Get-LocalGroupMember" -Tags "CI" {
+    Describe "Validate simple Get-LocalGroupMember" -Tags @('CI', 'RequireAdminOnWindows') {
 
         BeforeEach {
             if ($IsNotSkipped) {
@@ -273,7 +273,7 @@ try {
         }
     }
 
-    Describe "Validate Get-LocalGroupMember cmdlet" -Tags "Feature" {
+    Describe "Validate Get-LocalGroupMember cmdlet" -Tags @('Feature', 'RequireAdminOnWindows') {
 
         BeforeAll {
             $OptDomainPrefix="(.+\\)?"
@@ -407,7 +407,7 @@ try {
         #TODO: 10.A valid user attempts to get membership from a group to which they don't have access
     }
 
-    Describe "Validate simple Remove-LocalGroupMember" -Tags "CI" {
+    Describe "Validate simple Remove-LocalGroupMember" -Tags @('CI', 'RequireAdminOnWindows') {
 
         BeforeEach {
             if ($IsNotSkipped) {
@@ -434,7 +434,7 @@ try {
         }
     }
 
-    Describe "Validate Remove-LocalGroupMember cmdlet" -Tags "Feature" {
+    Describe "Validate Remove-LocalGroupMember cmdlet" -Tags @('Feature', 'RequireAdminOnWindows') {
 
         BeforeEach {
             if ($IsNotSkipped) {

--- a/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalUser.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalUser.Tests.ps1
@@ -44,7 +44,7 @@ try {
     $IsNotSkipped = ($IsWindows -eq $true);
     $PSDefaultParameterValues["it:skip"] = !$IsNotSkipped
 
-    Describe "Verify Expected LocalUser Cmdlets are present" -Tags "CI" {
+    Describe "Verify Expected LocalUser Cmdlets are present" -Tags 'CI' {
 
         It "Test command presence" {
             $result = Get-Command -Module Microsoft.PowerShell.LocalAccounts | % Name
@@ -59,7 +59,7 @@ try {
         }
     }
 
-    Describe "Verify Expected LocalUser Aliases are present" -Tags "CI" {
+    Describe "Verify Expected LocalUser Aliases are present" -Tags @('CI', 'RequireAdminOnWindows') {
 
         It "Test command presence" {
             $result = get-alias | % { if ($_.Source -eq "Microsoft.PowerShell.LocalAccounts") {$_}}
@@ -82,7 +82,7 @@ try {
         }
     }
 
-    Describe "Validate simple New-LocalUser" -Tags "CI" {
+    Describe "Validate simple New-LocalUser" -Tags @('CI', 'RequireAdminOnWindows') {
 
         AfterEach {
             if ($IsNotSkipped) {
@@ -101,7 +101,7 @@ try {
         }
     }
 
-    Describe "Validate New-LocalUser cmdlet" -Tags "Feature" {
+    Describe "Validate New-LocalUser cmdlet" -Tags @('Feature', 'RequireAdminOnWindows') {
 
         AfterEach {
             if ($IsNotSkipped) {
@@ -385,7 +385,7 @@ try {
         }
     }
 
-    Describe "Validate simple Get-LocalUser" -Tags "CI" {
+    Describe "Validate simple Get-LocalUser" -Tags @('CI', 'RequireAdminOnWindows') {
 
         BeforeAll {
             if ($IsNotSkipped) {
@@ -409,7 +409,7 @@ try {
         }
     }
 
-    Describe "Validate Get-LocalUser cmdlet" -Tags "Feature" {
+    Describe "Validate Get-LocalUser cmdlet" -Tags @('Feature', 'RequireAdminOnWindows') {
 
         BeforeAll {
             if ($IsNotSkipped) {
@@ -554,7 +554,7 @@ try {
         }
     }
 
-    Describe "Validate simple Set-LocalUser" -Tags "CI" {
+    Describe "Validate simple Set-LocalUser" -Tags @('CI', 'RequireAdminOnWindows') {
 
         BeforeAll {
             if ($IsNotSkipped) {
@@ -584,7 +584,7 @@ try {
         }
     }
 
-    Describe "Validate Set-LocalUser cmdlet" -Tags "Feature" {
+    Describe "Validate Set-LocalUser cmdlet" -Tags @('Feature', 'RequireAdminOnWindows') {
 
         BeforeAll {
             if ($IsNotSkipped) {
@@ -803,7 +803,7 @@ try {
         }
     }
 
-    Describe "Validate simple Rename-LocalUser" -Tags "CI" {
+    Describe "Validate simple Rename-LocalUser" -Tags @('CI', 'RequireAdminOnWindows') {
 
         BeforeAll {
             if ($IsNotSkipped) {
@@ -833,7 +833,7 @@ try {
         }
     }
 
-    Describe "Validate Rename-LocalUser cmdlet" -Tags "Feature" {
+    Describe "Validate Rename-LocalUser cmdlet" -Tags @('Feature', 'RequireAdminOnWindows') {
 
         BeforeAll {
             if ($IsNotSkipped) {
@@ -984,7 +984,7 @@ try {
         }
     }
 
-    Describe "Validate simple Remove-LocalUser" -Tags "CI" {
+    Describe "Validate simple Remove-LocalUser" -Tags @('CI', 'RequireAdminOnWindows') {
 
         BeforeAll {
             if ($IsNotSkipped) {
@@ -1023,7 +1023,7 @@ try {
         }
     }
 
-    Describe "Validate Remove-LocalUser cmdlet" -Tags "Feature" {
+    Describe "Validate Remove-LocalUser cmdlet" -Tags @('Feature', 'RequireAdminOnWindows') {
 
         BeforeAll {
             if ($IsNotSkipped) {
@@ -1197,7 +1197,7 @@ try {
         }
     }
 
-    Describe "Validate simple Enable-LocalUser" -Tags "CI" {
+    Describe "Validate simple Enable-LocalUser" -Tags @('CI', 'RequireAdminOnWindows') {
 
         BeforeAll {
             if ($IsNotSkipped) {
@@ -1227,7 +1227,7 @@ try {
         }
     }
 
-    Describe "Validate Enable-LocalUser cmdlet" -Tags "Feature" {
+    Describe "Validate Enable-LocalUser cmdlet" -Tags @('Feature', 'RequireAdminOnWindows') {
 
         BeforeAll {
             if ($IsNotSkipped) {
@@ -1368,7 +1368,7 @@ try {
         }
     }
 
-    Describe "Validate simple Disable-LocalUser" -Tags "CI" {
+    Describe "Validate simple Disable-LocalUser" -Tags @('CI', 'RequireAdminOnWindows') {
 
         BeforeAll {
             if ($IsNotSkipped) {
@@ -1398,7 +1398,7 @@ try {
         }
     }
 
-    Describe "Validate Disable-LocalUser cmdlet" -Tags "Feature" {
+    Describe "Validate Disable-LocalUser cmdlet" -Tags @('Feature', 'RequireAdminOnWindows') {
 
         BeforeAll {
             if ($IsNotSkipped) {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Process.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Process.Tests.ps1
@@ -1,8 +1,10 @@
-Describe "Get-Process" -Tags "CI" {
+Describe "Get-Process for admin" -Tags @('CI', 'RequireAdminOnWindows') {
     It "Should support -IncludeUserName" {
         (Get-Process powershell -IncludeUserName | Select-Object -First 1).UserName | Should Match $env:USERNAME
     }
+}
 
+Describe "Get-Process" -Tags "CI" {
     # These tests are no good, please replace!
     It "Should return a type of Object[] for Get-Process cmdlet" -Pending:$IsOSX {
         (Get-Process).GetType().BaseType | Should Be 'array'

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/New-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/New-Item.Tests.ps1
@@ -104,6 +104,36 @@ Describe "New-Item" -Tags "CI" {
         Test-Path $FullyQualifiedFile | Should Be $false
     }
 
+    It "Should create a hard link of a file without error" {
+        New-Item -Name $testfile -Path $tmpDirectory -ItemType file
+        Test-Path $FullyQualifiedFile | Should Be $true
+
+        New-Item -ItemType HardLink -Target $FullyQualifiedFile -Name $testlink -Path $tmpDirectory
+        Test-Path $FullyQualifiedLink | Should Be $true
+
+        $fileInfo = Get-ChildItem $FullyQualifiedLink
+        $fileInfo.Target | Should Be $null
+        $fileInfo.LinkType | Should Be "HardLink"
+    }
+}
+
+# More precisely these tests require SeCreateSymbolicLinkPrivilege.
+# You can see list of priveledges with `whoami /priv`.
+# In the default windows setup, Admin user has this priveledge, but regular users don't.
+
+Describe "New-Item with links" -Tags @('CI', 'RequireAdminOnWindows') {
+    $tmpDirectory         = $TestDrive
+    $testfile             = "testfile.txt"
+    $testfolder           = "newDirectory"
+    $testlink             = "testlink"
+    $FullyQualifiedFile   = Join-Path -Path $tmpDirectory -ChildPath $testfile
+    $FullyQualifiedFolder = Join-Path -Path $tmpDirectory -ChildPath $testfolder
+    $FullyQualifiedLink   = Join-Path -Path $tmpDirectory -ChildPath $testlink
+    
+    BeforeEach {
+        Clean-State
+    }
+
     It "Should create a symbolic link of a file without error" {
         New-Item -Name $testfile -Path $tmpDirectory -ItemType file
         Test-Path $FullyQualifiedFile | Should Be $true
@@ -141,17 +171,4 @@ Describe "New-Item" -Tags "CI" {
         # Remove the link explicitly to avoid broken symlink issue
         Remove-Item $FullyQualifiedLink -Force
     }
-
-    It "Should create a hard link of a file without error" {
-        New-Item -Name $testfile -Path $tmpDirectory -ItemType file
-        Test-Path $FullyQualifiedFile | Should Be $true
-
-        New-Item -ItemType HardLink -Target $FullyQualifiedFile -Name $testlink -Path $tmpDirectory
-        Test-Path $FullyQualifiedLink | Should Be $true
-
-        $fileInfo = Get-ChildItem $FullyQualifiedLink
-        $fileInfo.Target | Should Be $null
-        $fileInfo.LinkType | Should Be "HardLink"
-    }
-
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Registry.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Registry.Tests.ps1
@@ -1,4 +1,4 @@
-Describe "Validate Registry Provider" -Tags "CI" {
+Describe "Validate Registry Provider" -Tags @('CI', 'RequireAdminOnWindows') {
     BeforeAll {
         $registryBase = "HKLM:\software\Microsoft\PowerShell\3\"
         $testKey = "TestKeyThatWillNotConflict"

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/TimeZone.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/TimeZone.Tests.ps1
@@ -118,7 +118,7 @@ Describe "Get-Timezone test cases" -Tags "CI" {
     }
 }
 
-Describe "Set-Timezone test case: call by single Id" -Tags "CI" {
+Describe "Set-Timezone test case: call by single Id" -Tags @('CI', 'RequireAdminOnWindows') {
     $originalTimeZoneId
     BeforeAll {
         $originalTimeZoneId = (Get-TimeZone).Id
@@ -145,7 +145,7 @@ Describe "Set-Timezone test case: call by single Id" -Tags "CI" {
     }
 }
 
-Describe "Set-Timezone test cases" -Tags "Feature" {
+Describe "Set-Timezone test cases" -Tags @('Feature', 'RequireAdminOnWindows') {
     $originalTimeZoneId
     BeforeAll {
         $originalTimeZoneId = (Get-TimeZone).Id

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/ExecutionPolicy.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/ExecutionPolicy.Tests.ps1
@@ -911,73 +911,78 @@ ZoneId=$FileType
         }
     }
 
+    function VerfiyBlockedSetExecutionPolicy
+    {
+        param(
+            [string]
+            $policyScope
+        )
+        try {
+            Set-ExecutionPolicy -Scope $policyScope -ExecutionPolicy Restricted
+        }
+        catch {
+            $_.FullyQualifiedErrorId | Should Be "CantSetGroupPolicy,Microsoft.PowerShell.Commands.SetExecutionPolicyCommand"
+        }
+    }
+
+    function RestoreExecutionPolicy
+    {
+        param($originalPolicies)
+
+        foreach ($scopedPolicy in $originalPolicies)
+        {
+            if (($scopedPolicy.Scope -eq "Process") -or
+                ($scopedPolicy.Scope -eq "CurrentUser"))
+            {
+                try {
+                    Set-ExecutionPolicy -Scope $scopedPolicy.Scope -ExecutionPolicy $scopedPolicy.ExecutionPolicy -Force
+                }
+                catch {
+                    if ($_.FullyQualifiedErrorId -ne "ExecutionPolicyOverride,Microsoft.PowerShell.Commands.SetExecutionPolicyCommand")
+                    {
+                        # Re-throw unrecognized exceptions. Otherwise, swallow 
+                        # the exception that warns about overridden policies
+                        throw $_
+                    }
+                }
+            }
+            elseif($scopedPolicy.Scope -eq "LocalMachine")
+            {
+                try {
+                    Set-ExecutionPolicy -Scope $scopedPolicy.Scope -ExecutionPolicy $scopedPolicy.ExecutionPolicy -Force
+                }
+                catch {
+                    if ($_.FullyQualifiedErrorId -eq "System.UnauthorizedAccessException,Microsoft.PowerShell.Commands.SetExecutionPolicyCommand")
+                    {
+                        # Do nothing. Depending on the ownership of the file, 
+                        # regular users may or may not be able to set its 
+                        # value. 
+                        #
+                        # When targetting the Registry, regular users cannot
+                        # modify this value.
+                    }
+                    elseif ($_.FullyQualifiedErrorId -ne "ExecutionPolicyOverride,Microsoft.PowerShell.Commands.SetExecutionPolicyCommand")
+                    {
+                        # Re-throw unrecognized exceptions. Otherwise, swallow 
+                        # the exception that warns about overridden policies
+                        throw $_
+                    }
+                }
+            }
+        }
+    }
+
     Describe "Validate Set-ExecutionPolicy -Scope" -Tags "CI" {
 
         BeforeAll {
             if ($IsNotSkipped) {
                 $originalPolicies = Get-ExecutionPolicy -list
-
-                # Calls Set-ExecutionPolicy with a known-bad Scope and expects failure.
-                # It is defined here so that it will be available at It scope.
-                function VerfiyBlockedSetExecutionPolicy
-                {
-                    param(
-                        [string]
-                        $policyScope
-                    )
-                    try {
-                        Set-ExecutionPolicy -Scope $policyScope -ExecutionPolicy Restricted
-                    }
-                    catch {
-                        $_.FullyQualifiedErrorId | Should Be "CantSetGroupPolicy,Microsoft.PowerShell.Commands.SetExecutionPolicyCommand"
-                    }
-                }
             }
         }
 
         AfterAll {
             if ($IsNotSkipped) {
-                foreach ($scopedPolicy in $originalPolicies)
-                {
-                    if (($scopedPolicy.Scope -eq "Process") -or
-                        ($scopedPolicy.Scope -eq "CurrentUser"))
-                    {
-                        try {
-                            Set-ExecutionPolicy -Scope $scopedPolicy.Scope -ExecutionPolicy $scopedPolicy.ExecutionPolicy -Force
-                        }
-                        catch {
-                            if ($_.FullyQualifiedErrorId -ne "ExecutionPolicyOverride,Microsoft.PowerShell.Commands.SetExecutionPolicyCommand")
-                            {
-                                # Re-throw unrecognized exceptions. Otherwise, swallow 
-                                # the exception that warns about overridden policies
-                                throw $_
-                            }
-                        }
-                    }
-                    elseif($scopedPolicy.Scope -eq "LocalMachine")
-                    {
-                        try {
-                            Set-ExecutionPolicy -Scope $scopedPolicy.Scope -ExecutionPolicy $scopedPolicy.ExecutionPolicy -Force
-                        }
-                        catch {
-                            if ($_.FullyQualifiedErrorId -eq "System.UnauthorizedAccessException,Microsoft.PowerShell.Commands.SetExecutionPolicyCommand")
-                            {
-                                # Do nothing. Depending on the ownership of the file, 
-                                # regular users may or may not be able to set its 
-                                # value. 
-                                #
-                                # When targetting the Registry, regular users cannot
-                                # modify this value.
-                            }
-                            elseif ($_.FullyQualifiedErrorId -ne "ExecutionPolicyOverride,Microsoft.PowerShell.Commands.SetExecutionPolicyCommand")
-                            {
-                                # Re-throw unrecognized exceptions. Otherwise, swallow 
-                                # the exception that warns about overridden policies
-                                throw $_
-                            }
-                        }
-                    }
-                }
+                RestoreExecutionPolicy $originalPolicies
             }
         }
 
@@ -998,8 +1003,24 @@ ZoneId=$FileType
             Set-ExecutionPolicy -Scope CurrentUser -ExecutionPolicy ByPass
             Get-ExecutionPolicy -Scope CurrentUser | Should Be "ByPass"
         }
+    }
 
-        # This test requires Administrator privileges on Windows.
+    Describe "Validate Set-ExecutionPolicy -Scope (Admin)" -Tags @('CI', 'RequireAdminOnWindows') {
+
+        BeforeAll {
+            if ($IsNotSkipped)
+            {
+                $originalPolicies = Get-ExecutionPolicy -list
+            }
+        }
+
+        AfterAll {
+            if ($IsNotSkipped)
+            {
+                RestoreExecutionPolicy $originalPolicies
+            }
+        }
+
         It "-Scope LocalMachine is Settable" {
             Set-ExecutionPolicy -Scope LocalMachine -ExecutionPolicy ByPass
             Get-ExecutionPolicy -Scope LocalMachine | Should Be "ByPass"

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/ExecutionPolicy.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/ExecutionPolicy.Tests.ps1
@@ -1021,7 +1021,25 @@ ZoneId=$FileType
             }
         }
 
-        It "-Scope LocalMachine is Settable" {
+        It '-Scope LocalMachine is Settable, but overridden' {
+            # setup
+            Set-ExecutionPolicy -Scope Process -ExecutionPolicy Undefined
+            Set-ExecutionPolicy -Scope CurrentUser -ExecutionPolicy Restricted
+            $errorId = $null
+            try
+            {
+                Set-ExecutionPolicy -Scope LocalMachine -ExecutionPolicy ByPass
+            }
+            catch [System.Security.SecurityException] {
+                $errorId = $_.FullyQualifiedErrorId
+            }
+
+            $errorId | Should Be 'ExecutionPolicyOverride,Microsoft.PowerShell.Commands.SetExecutionPolicyCommand'
+            Get-ExecutionPolicy -Scope LocalMachine | Should Be "ByPass"
+        }
+
+        It '-Scope LocalMachine is Settable' {
+            Set-ExecutionPolicy -Scope CurrentUser -ExecutionPolicy Undefined
             Set-ExecutionPolicy -Scope LocalMachine -ExecutionPolicy ByPass
             Get-ExecutionPolicy -Scope LocalMachine | Should Be "ByPass"
         }

--- a/test/powershell/Modules/PackageManagement/Install-PackageProvider.Tests.ps1
+++ b/test/powershell/Modules/PackageManagement/Install-PackageProvider.Tests.ps1
@@ -260,7 +260,7 @@ Describe "Install-Save-Package with multiple sources" -Tags "Feature" {
 
     It "install-package with array of sources, Expect succeed" {
 
-        $x= install-package jquery -force -Source @('foooobarrrr', 'https://www.nuget.org/api/v2')  -ProviderName @('PowershellGet', 'NuGet')    
+        $x= install-package -Scope CurrentUser jquery -force -Source @('foooobarrrr', 'https://www.nuget.org/api/v2')  -ProviderName @('PowershellGet', 'NuGet')
                 
         $x | ?{ $_.name -eq "jquery" } | should not BeNullOrEmpty
         #$x | ?{ $_.Source -eq "https://www.nuget.org/api/v2" } | should not BeNullOrEmpty

--- a/test/powershell/Modules/PowerShellGet/PowerShellGet.Tests.ps1
+++ b/test/powershell/Modules/PowerShellGet/PowerShellGet.Tests.ps1
@@ -76,29 +76,21 @@ else
 
 #endregion
 
+function Remove-InstalledModules
+{
+    Get-InstalledModule -Name $ContosoServer -AllVersions -ErrorAction SilentlyContinue | Uninstall-Module -Force
+}
+
 Describe "PowerShellGet - Module tests" -tags "Feature" {
 
     BeforeEach {
-        Get-InstalledModule -Name $ContosoServer -AllVersions -ErrorAction SilentlyContinue | Uninstall-Module -Force
+        Remove-InstalledModules
     }
 
     It "Should find a module correctly" {
         $psgetModuleInfo = Find-Module -Name $ContosoServer -Repository $RepositoryName
         $psgetModuleInfo.Name | Should Be $ContosoServer
         $psgetModuleInfo.Repository | Should Be $RepositoryName
-    }
-
-    It "Should install a module correctly to the required location with default AllUsers scope" {
-        Install-Module -Name $ContosoServer -Repository $RepositoryName
-        $installedModuleInfo = Get-InstalledModule -Name $ContosoServer
-
-        $installedModuleInfo | Should Not Be $null        
-        $installedModuleInfo.Name | Should Be $ContosoServer
-        $installedModuleInfo.InstalledLocation.StartsWith($script:programFilesModulesPath, [System.StringComparison]::OrdinalIgnoreCase) | Should Be $true
-
-        $module = Get-Module $ContosoServer -ListAvailable
-        $module.Name | Should be $ContosoServer
-        $module.ModuleBase | Should Be $installedModuleInfo.InstalledLocation
     }
 
     It "Should install a module correctly to the required location with CurrentUser scope" {
@@ -115,29 +107,49 @@ Describe "PowerShellGet - Module tests" -tags "Feature" {
     }
 
     AfterAll {
-        Get-InstalledModule -Name $ContosoServer -AllVersions -ErrorAction SilentlyContinue | Uninstall-Module -Force
+        Remove-InstalledModules
     }
+}
+
+Describe "PowerShellGet - Module tests (Admin)" -tags @('Feature', 'RequireAdminOnWindows') {
+
+    BeforeEach {
+        Remove-InstalledModules
+    }
+
+    It "Should install a module correctly to the required location with default AllUsers scope" {
+        Install-Module -Name $ContosoServer -Repository $RepositoryName
+        $installedModuleInfo = Get-InstalledModule -Name $ContosoServer
+
+        $installedModuleInfo | Should Not Be $null
+        $installedModuleInfo.Name | Should Be $ContosoServer
+        $installedModuleInfo.InstalledLocation.StartsWith($script:programFilesModulesPath, [System.StringComparison]::OrdinalIgnoreCase) | Should Be $true
+
+        $module = Get-Module $ContosoServer -ListAvailable
+        $module.Name | Should be $ContosoServer
+        $module.ModuleBase | Should Be $installedModuleInfo.InstalledLocation
+    }
+
+    AfterAll {
+        Remove-InstalledModules
+    }
+}
+
+function Remove-InstalledScripts
+{
+    Get-InstalledScript -Name $FabrikamServerScript -ErrorAction SilentlyContinue | Uninstall-Script -Force
 }
 
 Describe "PowerShellGet - Script tests" -tags "Feature" {
 
     BeforeEach {
-        Get-InstalledScript -Name $FabrikamServerScript -ErrorAction SilentlyContinue | Uninstall-Script -Force
+        Remove-InstalledScripts
     }
 
     It "Should find a script correctly" {
         $psgetScriptInfo = Find-Script -Name $FabrikamServerScript -Repository $RepositoryName
         $psgetScriptInfo.Name | Should Be $FabrikamServerScript
         $psgetScriptInfo.Repository | Should Be $RepositoryName
-    }
-
-    It "Should install a script correctly to the required location with default AllUsers scope" {
-        Install-Script -Name $FabrikamServerScript -Repository $RepositoryName -NoPathUpdate
-        $installedScriptInfo = Get-InstalledScript -Name $FabrikamServerScript
-
-        $installedScriptInfo | Should Not Be $null
-        $installedScriptInfo.Name | Should Be $FabrikamServerScript
-        $installedScriptInfo.InstalledLocation.StartsWith($script:ProgramFilesScriptsPath, [System.StringComparison]::OrdinalIgnoreCase) | Should Be $true
     }
 
     It "Should install a script correctly to the required location with CurrentUser scope" {
@@ -150,7 +162,27 @@ Describe "PowerShellGet - Script tests" -tags "Feature" {
     }
 
     AfterAll {
-        Get-InstalledScript -Name $FabrikamServerScript -ErrorAction SilentlyContinue | Uninstall-Script -Force
+        Remove-InstalledScripts
+    }
+}
+
+Describe "PowerShellGet - Script tests (Admin)" -tags @('Feature', 'RequireAdminOnWindows') {
+
+    BeforeEach {
+        Remove-InstalledScripts
+    }
+
+    It "Should install a script correctly to the required location with default AllUsers scope" {
+        Install-Script -Name $FabrikamServerScript -Repository $RepositoryName -NoPathUpdate
+        $installedScriptInfo = Get-InstalledScript -Name $FabrikamServerScript
+
+        $installedScriptInfo | Should Not Be $null
+        $installedScriptInfo.Name | Should Be $FabrikamServerScript
+        $installedScriptInfo.InstalledLocation.StartsWith($script:ProgramFilesScriptsPath, [System.StringComparison]::OrdinalIgnoreCase) | Should Be $true
+    }
+
+    AfterAll {
+        Remove-InstalledScripts
     }
 }
 

--- a/test/powershell/engine/HelpSystem.Tests.ps1
+++ b/test/powershell/engine/HelpSystem.Tests.ps1
@@ -65,17 +65,17 @@ function RunTestCase
     }
 }
 
-Describe "Validate that get-help <cmdletName> works" -Tags "CI" {
+Describe "Validate that get-help <cmdletName> works" -Tags @('CI', 'RequireAdminOnWindows') {
 
     RunTestCase -tag "CI"
 }
 
-Describe "Validate Get-Help for all cmdlets in 'Microsoft.PowerShell.Core'" -Tags "Feature" {
+Describe "Validate Get-Help for all cmdlets in 'Microsoft.PowerShell.Core'" -Tags @('Feature', 'RequireAdminOnWindows') {
 
     RunTestCase -tag "Feature"
 }
 
-Describe "Validate that Get-Help returns provider-specific help" -Tags "CI" {
+Describe "Validate that Get-Help returns provider-specific help" -Tags @('CI', 'RequireAdminOnWindows') {
     BeforeAll {
         $namespaces = @{
             command = 'http://schemas.microsoft.com/maml/dev/command/2004/10'


### PR DESCRIPTION
Fixes #1486 
- Add 'RequireAdminOnWindows' tag to some tests suites
- Change install scope for Install-PackageProvider.Tests.ps1
  This helps avoid problem when run as non-elevated user.
- Restructure PowerShellGet.Tests.ps1 to enable 'RequireAdminOnWindows' tagging
- Add Start-PSPester -Unelevated
  That will enable running tests without Admin in CI
- Make Invoke-AppVeyorTest run elevated and non-elevated tests separately

Before merging, we would need to update documentation:
- [ ] About using `Start-PSPester -Unelevate`
- [x] About Tags that are used in our Pester tests (add `RequireAdminOnWindows`)
