### PR TITLE
Change "message" in Get-Credential to mandatory

### DIFF
--- a/src/Microsoft.PowerShell.Security/security/CredentialCommands.cs
+++ b/src/Microsoft.PowerShell.Security/security/CredentialCommands.cs
@@ -54,7 +54,7 @@ namespace Microsoft.PowerShell.Commands
         /// Gets and sets the user supplied message providing description about which script/function is 
         /// requesting the PSCredential from the user.
         /// </summary>
-        [Parameter(Mandatory = false, ParameterSetName = messageSet)]
+        [Parameter(Mandatory = true, ParameterSetName = messageSet)]
         [ValidateNotNullOrEmpty]
         public string Message
         {

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/GetCredential.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/GetCredential.Tests.ps1
@@ -46,7 +46,7 @@ Describe "Get-Credential Test" -tag "CI" {
         }
         catch
         {
-            $_.FullyQualifiedErrorId | Should Be "ParameterArgumentValidationErrorNullNotAllowed,Microsoft.PowerShell.Commands.GetCredentialCommand"
+            $_.FullyQualifiedErrorId | Should Be "ParameterArgumentValidationError,Microsoft.PowerShell.Commands.GetCredentialCommand"
         }
         # when Message is empty            
         try 
@@ -56,7 +56,7 @@ Describe "Get-Credential Test" -tag "CI" {
         }
         catch
         {
-            $_.FullyQualifiedErrorId | Should Be "ParameterArgumentValidationErrorEmptyStringNotAllowed,Microsoft.PowerShell.Commands.GetCredentialCommand"
+            $_.FullyQualifiedErrorId | Should Be "ParameterArgumentValidationError,Microsoft.PowerShell.Commands.GetCredentialCommand"
         }
     }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/GetCredential.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/GetCredential.Tests.ps1
@@ -29,22 +29,6 @@ Describe "Get-Credential Test" -tag "CI" {
         $netcred.Password | Should be "this is a test"
         $th.ui.Streams.Prompt[-1] | Should Match "Credential:[^:]+:Foo" 
     }
-    It "Get-Credential with title, produces a credential object" {
-        $cred = $ps.AddScript("Get-Credential -UserName Joe -Title CustomTitle").Invoke() | Select-Object -First 1
-        $cred.gettype().FullName | Should Be "System.Management.Automation.PSCredential"
-        $netcred = $cred.GetNetworkCredential()
-        $netcred.UserName | Should be "Joe"
-        $netcred.Password | Should be "this is a test"
-        $th.ui.Streams.Prompt[-1] | should be "Credential:CustomTitle:"
-    }
-    It "Get-Credential with only username, produces a credential object" {
-        $cred = $ps.AddScript("Get-Credential -UserName Joe").Invoke() | Select-Object -First 1
-        $cred.gettype().FullName | Should Be "System.Management.Automation.PSCredential"
-        $netcred = $cred.GetNetworkCredential()
-        $netcred.UserName | Should be "Joe"
-        $netcred.Password | Should be "this is a test"
-        $th.ui.Streams.Prompt[-1] | Should Match "Credential:[^:]+:"
-    }
     It "Get-Credential with title and message, produces a credential object" {
         $cred = $ps.AddScript("Get-Credential -UserName Joe -Message Foo -Title CustomTitle").Invoke() | Select-Object -First 1
         $cred.gettype().FullName | Should Be "System.Management.Automation.PSCredential"
@@ -53,4 +37,27 @@ Describe "Get-Credential Test" -tag "CI" {
         $netcred.Password | Should be "this is a test"
         $th.ui.Streams.Prompt[-1] | should be "Credential:CustomTitle:Foo"
     }
+    It "Mandatory parameters should not be null nor empty" {
+        # when Message is null 
+        try 
+        {
+            Get-Credential -Message $null 
+            Throw "Execution OK"
+        }
+        catch
+        {
+            $_.FullyQualifiedErrorId | Should Be "ParameterArgumentValidationErrorNullNotAllowed,Microsoft.PowerShell.Commands.GetCredentialCommand"
+        }
+        # when Message is empty            
+        try 
+        {
+            Get-Credential -Message "" 
+            Throw "Execution OK"
+        }
+        catch
+        {
+            $_.FullyQualifiedErrorId | Should Be "ParameterArgumentValidationErrorEmptyStringNotAllowed,Microsoft.PowerShell.Commands.GetCredentialCommand"
+        }
+    }
+
 }


### PR DESCRIPTION
Revert change from PR #1904 
1. Set "message" to optional is not best practice, from https://msdn.microsoft.com/en-us/library/dd878348%28v=vs.85%29.aspx :
   •Each parameter set must have at least one unique parameter. If possible, make this parameter a mandatory parameter.
   Set both "message" and "title" to optional open a way to "anonymous" request of credential. That is bad. This provokes writing bad code.
2. Set "message" to optional also breaks backward compatibility: script running in version 6 will not work in the previous versions if "message" is empty.
