### PR TITLE
Fix $? assignment to not crash powershell

### DIFF
--- a/test/powershell/Language/Parser/LanguageAndParser.TestFollowup.Tests.ps1
+++ b/test/powershell/Language/Parser/LanguageAndParser.TestFollowup.Tests.ps1
@@ -140,6 +140,11 @@ Describe "Assign automatic variables" -Tags "CI" {
       & { [string]$PSScriptRoot = 'abc'; $PSScriptRoot } | Should Be abc
       & { [string]$PSCommandPath = 'abc'; $PSCommandPath } | Should Be abc
     }
+
+    It "Assign `$? w/o type constraint" {
+        { & { $? = 1 } } | Should Throw
+        { . { $? = 1 } } | Should Throw
+    }
 }
 
 Describe "Attribute error position" -Tags "CI" {

--- a/test/powershell/Language/Parser/LanguageAndParser.TestFollowup.Tests.ps1
+++ b/test/powershell/Language/Parser/LanguageAndParser.TestFollowup.Tests.ps1
@@ -131,14 +131,14 @@ Describe "Assign automatic variables" -Tags "CI" {
     }
 
     It "Assign auto w/ correct type constraint" {
-      & { [object]$_ = 1; $_ } | Should Be 1
-      & { [object[]]$args = 1; $args } | Should Be 1
-      & { [object]$this = 1; $this } | Should Be 1
-      & { [object]$input = 1; $input } | Should Be 1
-      # Can't test PSCmdlet or PSBoundParameters, they use an internal type
-      & { [System.Management.Automation.InvocationInfo]$myInvocation = $myInvocation; $myInvocation.Line } | Should Match Automation.InvocationInfo
-      & { [string]$PSScriptRoot = 'abc'; $PSScriptRoot } | Should Be abc
-      & { [string]$PSCommandPath = 'abc'; $PSCommandPath } | Should Be abc
+        & { [object]$_ = 1; $_ } | Should Be 1
+        & { [object[]]$args = 1; $args } | Should Be 1
+        & { [object]$this = 1; $this } | Should Be 1
+        & { [object]$input = 1; $input } | Should Be 1
+        # Can't test PSCmdlet or PSBoundParameters, they use an internal type
+        & { [System.Management.Automation.InvocationInfo]$myInvocation = $myInvocation; $myInvocation.Line } | Should Match Automation.InvocationInfo
+        & { [string]$PSScriptRoot = 'abc'; $PSScriptRoot } | Should Be abc
+        & { [string]$PSCommandPath = 'abc'; $PSCommandPath } | Should Be abc
     }
 
     It "Assign `$? w/o type constraint" {


### PR DESCRIPTION
Fix #2243 

There is another fix for this bug, which is to remove `|| (details.LocalTupleIndex == ForceDynamic && details.Automatic)` at

```
var orderedLocals = (from details in _variables.Values
                     where (details.LocalTupleIndex >= 0 || (details.LocalTupleIndex == ForceDynamic && details.Automatic))
```

I think it's OK to do so because the real automatic variable would have LocalTupleIndex set to be `ForceDynamic` only if there is type conversion or attributes associated with an assignment of the automatic variable, such as `[datetime]$pscmdlet=1` or `[ValidateNotNullOrEmpty]$PSCmdlet =1`. In that case, we will throw parsing error in semantic check at https://github.com/PowerShell/PowerShell/blob/master/src/System.Management.Automation/engine/parser/SemanticChecks.cs#L739

cc @lzybkr 
