### PR TITLE
Fix Get-Credential to not prompt twice when no parameter is specified

### DIFF
--- a/src/Microsoft.PowerShell.Security/resources/UtilsStrings.resx
+++ b/src/Microsoft.PowerShell.Security/resources/UtilsStrings.resx
@@ -151,6 +151,9 @@
     <value>Central Access Policy identifier or name is not valid. If specifying an identifier, it must begin with S-1-17. If specifying a name, the policy must be applied on the target machine.</value>
   </data>
   <data name="PromptForCredential_DefaultCaption" xml:space="preserve">
-    <value>Windows PowerShell credential request.</value>
+    <value>Windows PowerShell credential request</value>
+  </data>
+  <data name="PromptForCredential_DefaultMessage" xml:space="preserve">
+    <value>Enter your credentials.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Security/security/CredentialCommands.cs
+++ b/src/Microsoft.PowerShell.Security/security/CredentialCommands.cs
@@ -34,21 +34,10 @@ namespace Microsoft.PowerShell.Commands
         /// the instance.
         /// </summary>
         ///
-        [Parameter(Position = 0, Mandatory = true, ParameterSetName = credentialSet)]
+        [Parameter(Position = 0, ParameterSetName = credentialSet)]
+        [ValidateNotNull]
         [Credential()]
-        public PSCredential Credential
-        {
-            get
-            {
-                return _cred;
-            }
-
-            set
-            {
-                _cred = value;
-            }
-        }
-        private PSCredential _cred;
+        public PSCredential Credential { get; set; }
 
         /// <summary>
         /// Gets and sets the user supplied message providing description about which script/function is 
@@ -61,7 +50,7 @@ namespace Microsoft.PowerShell.Commands
             get { return _message; }
             set { _message = value; }
         }
-        private string _message = null;
+        private string _message = UtilsStrings.PromptForCredential_DefaultMessage;
 
         /// <summary>
         /// Gets and sets the user supplied username to be used while creating the PSCredential.
@@ -99,6 +88,12 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         protected override void BeginProcessing()
         {
+            if (Credential != null)
+            {
+                WriteObject(Credential);
+                return;
+            }
+
             try
             {
                 Credential = this.Host.UI.PromptForCredential(_title, _message, _userName, string.Empty);

--- a/test/powershell/Common/TestHostCS.psm1
+++ b/test/powershell/Common/TestHostCS.psm1
@@ -112,7 +112,8 @@ namespace TestHost
         public string ReadLineData = "This is readline data";
         public int PromptedChoice = 0;
         public string StringForSecureString = "TEST";
-        public string promptResponse = "this is a prompt response";
+        public string UserNameForCredential = "Admin";
+        public object promptResponse = "this is a prompt response";
 
         public Streams Streams = new Streams();
         public override PSHostRawUserInterface RawUI
@@ -122,11 +123,15 @@ namespace TestHost
 
         public override Dictionary<string, PSObject> Prompt(string caption, string message, Collection<FieldDescription> descriptions)
         {
-            string s = String.Empty;
-            if ( descriptions[0] != null ) { s = descriptions[0].Name; }
+            if (descriptions == null || descriptions[0] == null)
+            {
+                throw new ArgumentException("descriptions");
+            }
+
+            string s = descriptions[0].Name;
             Streams.Prompt.Add(caption + ":" + message + ":" + s);
             Dictionary<string, PSObject> d = new Dictionary<string, PSObject>();
-            d.Add(descriptions[0].ToString(), new PSObject(promptResponse));
+            d.Add(s, new PSObject(promptResponse));
             return d;
         }
 
@@ -140,14 +145,16 @@ namespace TestHost
         {
             Streams.Prompt.Add("Credential:" + caption + ":" + message);
             SecureString ss = ReadLineAsSecureString();
-            return new PSCredential(userName, ss);
+            string userNameToUse = string.IsNullOrEmpty(userName) ? UserNameForCredential : userName;
+            return new PSCredential(userNameToUse, ss);
         }
 
         public override PSCredential PromptForCredential(string caption, string message, string userName, string targetName, PSCredentialTypes allowedCredentialTypes, PSCredentialUIOptions options)
         {
             Streams.Prompt.Add("Credential:" + caption + ":" + message);
             SecureString ss = ReadLineAsSecureString();
-            return new PSCredential(userName, ss);
+            string userNameToUse = string.IsNullOrEmpty(userName) ? UserNameForCredential : userName;
+            return new PSCredential(userNameToUse, ss);
         }
 
         public override string ReadLine()

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/GetCredential.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/GetCredential.Tests.ps1
@@ -10,6 +10,7 @@ Describe "Get-Credential Test" -tag "CI" {
     BeforeAll {
         $th = New-TestHost
         $th.UI.StringForSecureString = "This is a test"
+        $th.UI.UserNameForCredential = "John"
         $rs = [runspacefactory]::Createrunspace($th)
         $rs.open()
         $ps = [powershell]::Create()
@@ -20,6 +21,9 @@ Describe "Get-Credential Test" -tag "CI" {
         $rs.Close()
         $rs.Dispose()
         $ps.Dispose()
+    }
+    AfterEach {
+        $ps.Commands.Clear()
     }
     It "Get-Credential with message, produces a credential object" {
         $cred = $ps.AddScript("Get-Credential -UserName Joe -Message Foo").Invoke() | Select-Object -First 1
@@ -35,7 +39,7 @@ Describe "Get-Credential Test" -tag "CI" {
         $netcred = $cred.GetNetworkCredential()
         $netcred.UserName | Should be "Joe"
         $netcred.Password | Should be "this is a test"
-        $th.ui.Streams.Prompt[-1] | should be "Credential:CustomTitle:"
+        $th.ui.Streams.Prompt[-1] | should Match "Credential:CustomTitle:[^:]+"
     }
     It "Get-Credential with only username, produces a credential object" {
         $cred = $ps.AddScript("Get-Credential -UserName Joe").Invoke() | Select-Object -First 1
@@ -43,7 +47,7 @@ Describe "Get-Credential Test" -tag "CI" {
         $netcred = $cred.GetNetworkCredential()
         $netcred.UserName | Should be "Joe"
         $netcred.Password | Should be "this is a test"
-        $th.ui.Streams.Prompt[-1] | Should Match "Credential:[^:]+:"
+        $th.ui.Streams.Prompt[-1] | Should Match "Credential:[^:]+:[^:]+"
     }
     It "Get-Credential with title and message, produces a credential object" {
         $cred = $ps.AddScript("Get-Credential -UserName Joe -Message Foo -Title CustomTitle").Invoke() | Select-Object -First 1
@@ -52,5 +56,55 @@ Describe "Get-Credential Test" -tag "CI" {
         $netcred.UserName | Should be "Joe"
         $netcred.Password | Should be "this is a test"
         $th.ui.Streams.Prompt[-1] | should be "Credential:CustomTitle:Foo"
+    }
+    It "Get-Credential without parameters" {
+        $cred = $ps.AddScript("Get-Credential").Invoke() | Select-Object -First 1
+        $cred.gettype().FullName | Should Be "System.Management.Automation.PSCredential"
+        $netcred = $cred.GetNetworkCredential()
+        $netcred.UserName | Should be "John"
+        $netcred.Password | Should be "This is a test"
+        $th.ui.Streams.Prompt[-1] | Should Match "Credential:[^:]+:[^:]+"
+    }
+    It "Get-Credential `$null" {
+        $cred = $ps.AddScript("Get-Credential `$null").Invoke() | Select-Object -First 1
+        $cred.gettype().FullName | Should Be "System.Management.Automation.PSCredential"
+        $netcred = $cred.GetNetworkCredential()
+        $netcred.UserName | Should be "John"
+        $netcred.Password | Should be "This is a test"
+        $th.ui.Streams.Prompt[-1] | Should Match "Credential:[^:]+:[^:]+"
+    }
+    It "Get-Credential -Credential `$null" {
+        $cred = $ps.AddScript("Get-Credential -Credential `$null").Invoke() | Select-Object -First 1
+        $cred.gettype().FullName | Should Be "System.Management.Automation.PSCredential"
+        $netcred = $cred.GetNetworkCredential()
+        $netcred.UserName | Should be "John"
+        $netcred.Password | Should be "This is a test"
+        $th.ui.Streams.Prompt[-1] | Should Match "Credential:[^:]+:[^:]+"
+    }
+    it "Get-Credential Joe" {
+        $cred = $ps.AddScript("Get-Credential Joe").Invoke() | Select-Object -First 1
+        $cred.gettype().FullName | Should Be "System.Management.Automation.PSCredential"
+        $netcred = $cred.GetNetworkCredential()
+        $netcred.UserName | Should be "Joe"
+        $netcred.Password | Should be "This is a test"
+        $th.ui.Streams.Prompt[-1] | Should Match "Credential:[^:]+:[^:]+"
+    }
+    it "Get-Credential -Credential Joe" {
+        $cred = $ps.AddScript("Get-Credential Joe").Invoke() | Select-Object -First 1
+        $cred.gettype().FullName | Should Be "System.Management.Automation.PSCredential"
+        $netcred = $cred.GetNetworkCredential()
+        $netcred.UserName | Should be "Joe"
+        $netcred.Password | Should be "This is a test"
+        $th.ui.Streams.Prompt[-1] | Should Match "Credential:[^:]+:[^:]+"
+    }
+    it "Get-Credential `$credential" {
+        $password = ConvertTo-SecureString -String "CredTest" -AsPlainText -Force
+        $credential = [pscredential]::new("John", $password)
+
+        $cred = Get-Credential $credential
+        $cred.gettype().FullName | Should Be "System.Management.Automation.PSCredential"
+        $netcred = $cred.GetNetworkCredential()
+        $netcred.UserName | Should be "John"
+        $netcred.Password | Should be "CredTest"
     }
 }


### PR DESCRIPTION
Fix #2306 
