### PR TITLE
Fix binary operator tab completion

### DIFF
--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -825,7 +825,9 @@ namespace System.Management.Automation
 
         private static string GetOperatorDescription(string op)
         {
-            return ResourceManagerCache.GetResourceString(typeof(CompletionCompleters).GetTypeInfo().Assembly, "TabCompletionStrings", op + "OperatorDescription");
+            return ResourceManagerCache.GetResourceString(typeof(CompletionCompleters).GetTypeInfo().Assembly,
+                                                          "System.Management.Automation.resources.TabCompletionStrings",
+                                                          op + "OperatorDescription");
         }
 
         #endregion Command Parameters

--- a/test/powershell/Host/TabCompletion/BugFix.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/BugFix.Tests.ps1
@@ -1,9 +1,24 @@
-Describe "Issue#682 - [system.manage<tab>] should work" -Tags "CI" {
+Describe "Tab completion bug fix" -Tags "CI" {
     
-    It "[system.manage<tab>" {
+    It "Issue#682 - '[system.manage<tab>' should work" {
         $result = TabExpansion2 -inputScript "[system.manage" -cursorColumn "[system.manage".Length
         $result | Should Not BeNullOrEmpty
         $result.CompletionMatches.Count | Should Be 1
         $result.CompletionMatches[0].CompletionText | Should Be "System.Management"
+    }
+
+    It "Issue#1350 - '1 -sp<tab>' should work" {
+        $result = TabExpansion2 -inputScript "1 -sp" -cursorColumn "1 -sp".Length
+        $result | Should Not BeNullOrEmpty
+        $result.CompletionMatches.Count | Should Be 1
+        $result.CompletionMatches[0].CompletionText | Should Be "-split"
+    }
+
+    It "Issue#1350 - '1 -a<tab>' should work" {
+        $result = TabExpansion2 -inputScript "1 -a" -cursorColumn "1 -a".Length
+        $result | Should Not BeNullOrEmpty
+        $result.CompletionMatches.Count | Should Be 2
+        $result.CompletionMatches[0].CompletionText | Should Be "-and"
+        $result.CompletionMatches[1].CompletionText | Should Be "-as"
     }
 }


### PR DESCRIPTION
Fix #1350 

.NET CLI add the prefix '<project-name>.resources.' to the actual .resx file name when embedding the resource to the assembly, so we need to use `System.Management.Automation.resources.TabCompletionStrings` instead of `TabCompletionStrings` to get the tool tips for operators.
