### PR TITLE
Ignore macOS failures on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,11 @@ sudo: required
 dist: trusty
 osx_image: xcode7.3
 
+matrix:
+  allow_failures:
+    - os: osx
+  fast_finish: true
+
 addons:
   artifacts:
     paths: $(ls powershell*{deb,pkg} | tr "\n" ":")


### PR DESCRIPTION
Since the Travis CI OS X infrastructure is incredibly unstable, we need to let the builds run on a best effort basis, but not report failure and not hang a result until it's finished.

With this setup, the Linux build dictates the success, completely ignoring OS X.
