### PR TITLE
Remove bundler v1.13.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,8 @@ install:
   - pushd tools
   - ./download.sh
   - popd
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then rvm use 2.2.1; fi # Default 2.0.0 Ruby is buggy
+  # Default 2.0.0 Ruby is buggy
+  # Default bundler version is buggy
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then rvm use 2.2.1; gem uninstall bundler -v1.13.1; fi
 
 script: ./tools/travis.sh


### PR DESCRIPTION
The new version of bundler is buggy and causing installation of fpm to fail, which causes builds to fail.

This fixes the build: https://travis-ci.org/andschwa/PowerShell/jobs/162320709
