### PR TITLE
Fix host remote test InvokeOnRunspace to work with AppVeyor

### DIFF
--- a/test/powershell/Host/HostUtilities.Tests.ps1
+++ b/test/powershell/Host/HostUtilities.Tests.ps1
@@ -23,7 +23,7 @@
     return $remoteRunspace
 }
 
-Describe "InvokeOnRunspace method argument error handling" -tags "Feature" {
+Describe "InvokeOnRunspace method argument error handling" -tags "CI" {
 
     BeforeAll {
         $command = [System.Management.Automation.PSCommand]::new()
@@ -57,7 +57,7 @@ Describe "InvokeOnRunspace method argument error handling" -tags "Feature" {
     }
 }
 
-Describe "InvokeOnRunspace method as nested command" -tags "Feature" {
+Describe "InvokeOnRunspace method as nested command" -tags "CI" {
 
     It "Method should successfully invoke command as nested on busy runspace" {
 
@@ -71,13 +71,12 @@ Describe "InvokeOnRunspace method as nested command" -tags "Feature" {
     }
 }
 
-Describe "InvokeOnRunspace method on remote runspace" -tags "Feature" {
+Describe "InvokeOnRunspace method on remote runspace" -tags "CI" {
     
     BeforeAll {
-        $script:skipTest = $true
-        It "Get remote runspace for test" -Skip:(!$IsWindows) {
+
+        It "Configures remote runspace for tests"  -Skip:(!$IsWindows) {
             $script:remoteRunspace = Get-RemoteRunspace
-            $script:skipTest = $false
         }
     }
 
@@ -88,7 +87,7 @@ Describe "InvokeOnRunspace method on remote runspace" -tags "Feature" {
         }
     }
 
-    It "Method should successfully invoke command on remote runspace" -Skip:$script:skipTest {
+    It "Method should successfully invoke command on remote runspace" -Skip:(!$IsWindows) {
 
         $command = [System.Management.Automation.PSCommand]::new()
         $command.AddScript('"Hello!"')

--- a/test/powershell/Host/HostUtilities.Tests.ps1
+++ b/test/powershell/Host/HostUtilities.Tests.ps1
@@ -55,9 +55,20 @@ Describe "InvokeOnRunspace method on remote runspace" -tags "CI" {
             $wc = [System.Management.Automation.Runspaces.WSManConnectionInfo]::new()
 
             # Use AppVeyor credentials if running in AppVeyor, rather than implicit credentials.
-            if ($global:AppveyorRemoteCredential)
+			try
+			{
+				$appveyorRemoteCredential = Import-Clixml -Path "$env:TEMP\AppVeyorRemoteCred.xml"
+			}
+			catch { }
+            if ($appveyorRemoteCredential)
             {
-                $wc.Credential = $global:AppveyorRemoteCredential
+                Write-Verbose "Using global AppVeyor credential";
+                $wc.Credential = $appveyorRemoteCredential
+            }
+            else
+            {
+                Write-Verbose "Using implicit credentials"
+				throw "Should not use implict credentials in AppVeyor"
             }
 
             $script:remoteRunspace = [runspacefactory]::CreateRunspace($host, $wc)

--- a/test/powershell/Host/HostUtilities.Tests.ps1
+++ b/test/powershell/Host/HostUtilities.Tests.ps1
@@ -50,6 +50,14 @@ Describe "InvokeOnRunspace method on remote runspace" -tags "Feature" {
     
     BeforeAll {
         $wc = [System.Management.Automation.Runspaces.WSManConnectionInfo]::new()
+
+        # Use AppVeyor credentials if running in AppVeyor, rather than implicit credentials.
+        if ($global:AppveyorCredential)
+        {
+            $wc.ComputerName = '127.0.0.1'
+            $wc.Credential = $global:AppveyorCredential
+        }
+
         $remoteRunspace = [runspacefactory]::CreateRunspace($host, $wc)
         $remoteRunspace.Open()
     }

--- a/test/powershell/Host/HostUtilities.Tests.ps1
+++ b/test/powershell/Host/HostUtilities.Tests.ps1
@@ -75,7 +75,7 @@ Describe "InvokeOnRunspace method on remote runspace" -tags "CI" {
     
     BeforeAll {
 
-        It "Configures remote runspace for tests"  -Skip:(!$IsWindows) {
+        if ($IsWindows) {
             $script:remoteRunspace = Get-RemoteRunspace
         }
     }

--- a/test/powershell/Host/HostUtilities.Tests.ps1
+++ b/test/powershell/Host/HostUtilities.Tests.ps1
@@ -23,7 +23,7 @@
     return $remoteRunspace
 }
 
-Describe "InvokeOnRunspace method argument error handling" -tags "CI" {
+Describe "InvokeOnRunspace method argument error handling" -tags "Feature" {
 
     BeforeAll {
         $command = [System.Management.Automation.PSCommand]::new()
@@ -57,7 +57,7 @@ Describe "InvokeOnRunspace method argument error handling" -tags "CI" {
     }
 }
 
-Describe "InvokeOnRunspace method as nested command" -tags "CI" {
+Describe "InvokeOnRunspace method as nested command" -tags "Feature" {
 
     It "Method should successfully invoke command as nested on busy runspace" {
 
@@ -71,7 +71,7 @@ Describe "InvokeOnRunspace method as nested command" -tags "CI" {
     }
 }
 
-Describe "InvokeOnRunspace method on remote runspace" -tags "CI" {
+Describe "InvokeOnRunspace method on remote runspace" -tags "Feature" {
     
     BeforeAll {
         $script:skipTest = $true

--- a/test/powershell/Host/HostUtilities.Tests.ps1
+++ b/test/powershell/Host/HostUtilities.Tests.ps1
@@ -23,7 +23,7 @@
     return $remoteRunspace
 }
 
-Describe "InvokeOnRunspace method argument error handling" -tags "CI" {
+Describe "InvokeOnRunspace method argument error handling" -tags "Feature" {
 
     BeforeAll {
         $command = [System.Management.Automation.PSCommand]::new()
@@ -57,7 +57,7 @@ Describe "InvokeOnRunspace method argument error handling" -tags "CI" {
     }
 }
 
-Describe "InvokeOnRunspace method as nested command" -tags "CI" {
+Describe "InvokeOnRunspace method as nested command" -tags "Feature" {
 
     It "Method should successfully invoke command as nested on busy runspace" {
 
@@ -71,7 +71,7 @@ Describe "InvokeOnRunspace method as nested command" -tags "CI" {
     }
 }
 
-Describe "InvokeOnRunspace method on remote runspace" -tags "CI" {
+Describe "InvokeOnRunspace method on remote runspace" -tags "Feature" {
     
     BeforeAll {
 

--- a/tools/appveyor.psm1
+++ b/tools/appveyor.psm1
@@ -181,7 +181,7 @@ function Invoke-AppVeyorInstall
         Update-AppveyorBuild -message $buildName
     }
 
-    if ($APPVEYOR)
+    if ($env:APPVEYOR)
     {
         #
         # Generate new credential for appveyor (only) remoting tests.

--- a/tools/appveyor.psm1
+++ b/tools/appveyor.psm1
@@ -108,6 +108,20 @@ function Invoke-AppVeyorInstall
         Update-AppveyorBuild -message $buildName
     }
 
+    # Generate credentials for appveyor remoting tests.
+    $randomObj = [System.Random]::new()
+    $password = ""
+    1..(Get-Random -Minimum 15 -Maximum 126) | ForEach { $password = $password + [char]$randomObj.next(45,126) }
+
+    # Update user with new password
+    $objUser = [ADSI]("WinNT://$($env:computername)/appveyor")
+    $objUser.SetPassword($password)
+
+    # Save credentials globally for tests.
+    $ss = ConvertTo-SecureString -String $password -AsPlainText -Force
+    $global:AppveyorCredential = [PSCredential]::new('appveyor', $ss)
+
+
     Set-BuildVariable -Name TestPassed -Value False
     Start-PSBootstrap -Force
 }

--- a/tools/appveyor.psm1
+++ b/tools/appveyor.psm1
@@ -198,8 +198,8 @@ function Invoke-AppVeyorInstall
 
     # Provide credentials globally for remote tests.
     $ss = ConvertTo-SecureString -String $password -AsPlainText -Force
-    $global:AppveyorRemoteCredential = [PSCredential]::new($userName, $ss)
-
+    $appveyorRemoteCredential = [PSCredential]::new("$env:COMPUTERNAME\$userName", $ss)
+	$appveyorRemoteCredential | Export-Clixml -Path "$env:TEMP\AppVeyorRemoteCred.xml" -Force
 
     # Check that LocalAccountTokenFilterPolicy policy is set, since it is needed for remoting
     # using above local admin account.

--- a/tools/appveyor.psm1
+++ b/tools/appveyor.psm1
@@ -210,7 +210,8 @@ function Invoke-AppVeyorInstall
     catch { }
     if (!$haveLocalAccountTokenFilterPolicy)
     {
-        Write-Warning "LocalAccountTokenFilterPolicy not set.  Remoting tests will fail!"
+        Write-Warning "Setting the LocalAccountTokenFilterPolicy for remoting tests"
+		Set-ItemProperty -Path HKLM:SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System -Name LocalAccountTokenFilterPolicy -Value 1
     }
 
     Set-BuildVariable -Name TestPassed -Value False

--- a/tools/appveyor.psm1
+++ b/tools/appveyor.psm1
@@ -184,6 +184,7 @@ function Invoke-AppVeyorInstall
     #
     # Generate new credential for appveyor remoting tests.
     #
+    Write-Verbose "Creating account for remoting tests in AppVeyor."
 
     # Password
     $randomObj = [System.Random]::new()
@@ -202,6 +203,7 @@ function Invoke-AppVeyorInstall
 
     # Check that LocalAccountTokenFilterPolicy policy is set, since it is needed for remoting
     # using above local admin account.
+    Write-Verbose "Checking for LocalAccountTokenFilterPolicy in AppVeyor."
     $haveLocalAccountTokenFilterPolicy = $false
     try
     {
@@ -210,8 +212,8 @@ function Invoke-AppVeyorInstall
     catch { }
     if (!$haveLocalAccountTokenFilterPolicy)
     {
-        Write-Warning "Setting the LocalAccountTokenFilterPolicy for remoting tests"
-		Set-ItemProperty -Path HKLM:SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System -Name LocalAccountTokenFilterPolicy -Value 1
+        Write-Verbose "Setting the LocalAccountTokenFilterPolicy for remoting tests"
+        Set-ItemProperty -Path HKLM:SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System -Name LocalAccountTokenFilterPolicy -Value 1
     }
 
     Set-BuildVariable -Name TestPassed -Value False

--- a/tools/appveyor.psm1
+++ b/tools/appveyor.psm1
@@ -1,7 +1,80 @@
 $ErrorActionPreference = 'Stop'
 $repoRoot = Join-Path $PSScriptRoot '..'
+$script:administratorsGroupSID = "S-1-5-32-544"
+$script:usersGroupSID = "S-1-5-32-545"
 
 Import-Module (Join-Path $repoRoot 'build.psm1')
+
+function New-LocalUser
+{
+  <#
+    .SYNOPSIS
+        Creates a local user with the specified username and password
+    .DESCRIPTION
+    .EXAMPLE
+    .PARAMETER
+        username Username of the user which will be created
+    .PARAMETER
+        password Password of the user which will be created
+    .OUTPUTS
+    .NOTES
+  #>
+  param(
+    [Parameter(Mandatory=$true)]
+    [string] $username,
+
+    [Parameter(Mandatory=$true)]
+    [string] $password
+
+  )
+
+  $LocalComputer = [ADSI] "WinNT://$env:computername";
+  $user = $LocalComputer.Create('user', $username);
+  $user.SetPassword($password) | out-null;
+  $user.SetInfo() | out-null;
+}
+
+<#
+  Converts SID to NT Account Name
+#>
+function ConvertTo-NtAccount
+{
+  param(
+    [Parameter(Mandatory=$true)]
+    [string] $sid
+  )
+	(new-object System.Security.Principal.SecurityIdentifier($sid)).translate([System.Security.Principal.NTAccount]).Value
+}
+
+<#
+  Add a user to a local security group
+#>
+function Add-UserToGroup
+{
+  param(
+    [Parameter(Mandatory=$true)]
+    [string] $username,
+
+    [Parameter(Mandatory=$true, ParameterSetName = "SID")]
+    [string] $groupSid,
+
+    [Parameter(Mandatory=$true, ParameterSetName = "Name")]
+    [string] $group
+  )
+
+  $userAD = [ADSI] "WinNT://$env:computername/${username},user"
+
+  if($PsCmdlet.ParameterSetName -eq "SID")
+  {
+    $ntAccount=ConvertTo-NtAccount $groupSid
+    $group =$ntAccount.Split("\\")[1]
+  }
+
+  $groupAD = [ADSI] "WinNT://$env:computername/${group},group"
+
+  $groupAD.Add($userAD.AdsPath);
+}
+
 
 # tests if we should run a daily build
 # returns true if the build is scheduled 
@@ -108,19 +181,37 @@ function Invoke-AppVeyorInstall
         Update-AppveyorBuild -message $buildName
     }
 
-    # Generate credentials for appveyor remoting tests.
+    #
+    # Generate new credential for appveyor remoting tests.
+    #
+
+    # Password
     $randomObj = [System.Random]::new()
     $password = ""
     1..(Get-Random -Minimum 15 -Maximum 126) | ForEach { $password = $password + [char]$randomObj.next(45,126) }
 
-    # Update user with new password
-    $objUser = [ADSI]("WinNT://$($env:computername)/appveyor")
-    $objUser.SetPassword($password)
+    # Account
+    $userName = 'appVeyorRemote'
+    New-LocalUser -username $userName -password $password
+    Add-UserToGroup -username $userName -groupSid $script:administratorsGroupSID
 
-    # Save credentials globally for tests.
+    # Provide credentials globally for remote tests.
     $ss = ConvertTo-SecureString -String $password -AsPlainText -Force
-    $global:AppveyorCredential = [PSCredential]::new('appveyor', $ss)
+    $global:AppveyorRemoteCredential = [PSCredential]::new($userName, $ss)
 
+
+    # Check that LocalAccountTokenFilterPolicy policy is set, since it is needed for remoting
+    # using above local admin account.
+    $haveLocalAccountTokenFilterPolicy = $false
+    try
+    {
+        $haveLocalAccountTokenFilterPolicy = ((Get-ItemPropertyValue -Path HKLM:SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System -Name LocalAccountTokenFilterPolicy) -eq 1)
+    }
+    catch { }
+    if (!$haveLocalAccountTokenFilterPolicy)
+    {
+        Write-Warning "LocalAccountTokenFilterPolicy not set.  Remoting tests will fail!"
+    }
 
     Set-BuildVariable -Name TestPassed -Value False
     Start-PSBootstrap -Force


### PR DESCRIPTION
This change fixes the "InvokeOnRunspace method on remote runspace" test that fails on AppVeyor due to its reliance on implicit credentials.  This fix uses the same code as Remotely AppVeyor uses to create explicit credentials for use in remoting connections.
