### PR TITLE
Fix CategoryInfo.Activity so that it has the specified value

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/write.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/write.cs
@@ -382,7 +382,10 @@ namespace Microsoft.PowerShell.Commands
             {
                 errorRecord.SetInvocationInfo(myInvocation);
                 errorRecord.PreserveInvocationInfoOnce = true;
-                errorRecord.CategoryInfo.Activity = "Write-Error";
+                if (!String.IsNullOrEmpty(CategoryActivity))
+                    errorRecord.CategoryInfo.Activity = CategoryActivity;
+                else
+                    errorRecord.CategoryInfo.Activity = "Write-Error";
             }
 
             WriteError(errorRecord);

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Error.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Error.Tests.ps1
@@ -30,8 +30,7 @@ Describe "Write-Error DRT Unit Tests" -Tags "CI" {
         $e.InvocationInfo.MyCommand.Name | Should BeNullOrEmpty     
     }
 
-    #Blocked by issue #846
-    It "Should be works with all parameters" -Pending { 
+    It "Should be works with all parameters" {
         $exception = New-Object -TypeName System.ArgumentNullException -ArgumentList paramname 
         $e = Write-Error -Message myerrortext -Exception $exception -ErrorId myerrorid -Category syntaxerror -TargetObject TargetObject -CategoryActivity myactivity -CategoryReason myreason -CategoryTargetName mytargetname -CategoryTargetType mytargettype -RecommendedAction myrecommendedaction 2>&1
         $e | Should Not BeNullOrEmpty
@@ -69,8 +68,7 @@ Describe "Write-Error DRT Unit Tests" -Tags "CI" {
         $e.InvocationInfo.MyCommand.Name | Should BeNullOrEmpty  
     }
 
-    #Blocked by issue #846
-    It "Should be works with all parameters" -Pending {
+    It "Should be works with all parameters" {
         $e = write-error -Activity fooAct -Reason fooReason -TargetName fooTargetName -TargetType fooTargetType -Message fooMessage 2>&1
         $e.CategoryInfo.Activity | Should Be 'fooAct'
         $e.CategoryInfo.Reason | Should Be 'fooReason'


### PR DESCRIPTION
Fixes #846 CategoryInfo.Activity of Write-Error does not honor the value for
'activity' but uses the hard-coded string 'write-error'. The change sets
the value if specified by Write-Error cmdlet or set 'write-error'.
