### PR TITLE
Fix Get-WinEvent -FilterHashtable to work with named event data field

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Diagnostics/GetEventCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Diagnostics/GetEventCommand.cs
@@ -1304,9 +1304,9 @@ namespace Microsoft.PowerShell.Commands
         private string HandleEventIdHashValue(Object value)
         {
             string ret = "";
-            if (value is Array)
+            Array idsArray = value as Array;
+            if (idsArray != null)
             {
-                Array idsArray = (Array)(value);
                 ret += "(";
                 for (int i = 0; i < idsArray.Length; i++)
                 {
@@ -1333,10 +1333,9 @@ namespace Microsoft.PowerShell.Commands
         private string HandleLevelHashValue(Object value)
         {
             string ret = "";
-
-            if (value is Array)
+            Array levelsArray = value as Array;
+            if (levelsArray != null)
             {
-                Array levelsArray = (Array)(value);
                 ret += "(";
                 for (int i = 0; i < levelsArray.Length; i++)
                 {
@@ -1365,9 +1364,10 @@ namespace Microsoft.PowerShell.Commands
             Int64 keywordsMask = 0;
             Int64 keywordLong = 0;
 
-            if (value is Array)
+            Array keywordArray = value as Array;
+            if (keywordArray != null)
             {
-                foreach (Object keyword in (Array)value)
+                foreach (Object keyword in keywordArray)
                 {
                     if (KeywordStringToInt64(keyword.ToString(), ref keywordLong))
                     {
@@ -1519,9 +1519,9 @@ namespace Microsoft.PowerShell.Commands
         private string HandleDataHashValue(Object value)
         {
             string ret = "";
-            if (value is Array)
+            Array dataArray = value as Array;
+            if (dataArray != null)
             {
-                Array dataArray = (Array)(value);
                 ret += "(";
                 for (int i = 0; i < dataArray.Length; i++)
                 {
@@ -1806,15 +1806,19 @@ namespace Microsoft.PowerShell.Commands
                         Exception exc = new Exception(string.Format(CultureInfo.InvariantCulture, msg, key));
                         ThrowTerminatingError(new ErrorRecord(exc, "NullNotAllowedInHashtable", ErrorCategory.InvalidArgument, key));
                     }
-                    else if (value is Array)
+                    else
                     {
-                        foreach (Object elt in (Array)value)
+                        Array eltArray = value as Array;
+                        if (eltArray != null)
                         {
-                            if (elt == null)
+                            foreach (Object elt in eltArray)
                             {
-                                string msg = _resourceMgr.GetString("NullNotAllowedInHashtable");
-                                Exception exc = new Exception(string.Format(CultureInfo.InvariantCulture, msg, key));
-                                ThrowTerminatingError(new ErrorRecord(exc, "NullNotAllowedInHashtable", ErrorCategory.InvalidArgument, key));
+                                if (elt == null)
+                                {
+                                    string msg = _resourceMgr.GetString("NullNotAllowedInHashtable");
+                                    Exception exc = new Exception(string.Format(CultureInfo.InvariantCulture, msg, key));
+                                    ThrowTerminatingError(new ErrorRecord(exc, "NullNotAllowedInHashtable", ErrorCategory.InvalidArgument, key));
+                                }
                             }
                         }
                     }

--- a/src/Microsoft.PowerShell.Commands.Diagnostics/GetEventCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Diagnostics/GetEventCommand.cs
@@ -360,6 +360,7 @@ namespace Microsoft.PowerShell.Commands
         private const string propOpen = "[";
         private const string propClose = "]";
         private const string filePrefix = "file://";
+        private const string NamedDataTemplate = "((EventData[Data[@Name='{0}']='{1}']) or (UserData/*/{0}='{1}'))";
 
         //
         // Other private members and constants
@@ -1549,14 +1550,14 @@ namespace Microsoft.PowerShell.Commands
         private string HandleNamedDataHashValue(String key, Object value)
         {
             string ret = "";
-            if (value is Array)
+            Array dataArray = value as Array;
+            if (dataArray != null)
             {
-                Array dataArray = (Array)(value);
                 ret += "(";
                 for (int i = 0; i < dataArray.Length; i++)
                 {
                     ret += string.Format(CultureInfo.InvariantCulture,
-                                         "((EventData[Data[@Name='{0}']='{1}']) or (UserData/*/{0}='{1}'))",
+                                         NamedDataTemplate,
                                          key, dataArray.GetValue(i).ToString());
                     if (i < (dataArray.Length - 1))
                     {
@@ -1568,7 +1569,7 @@ namespace Microsoft.PowerShell.Commands
             else
             {
                 ret += string.Format(CultureInfo.InvariantCulture,
-                                         "((EventData[Data[@Name='{0}']='{1}']) or (UserData/*/{0}='{1}'))",
+                                         NamedDataTemplate,
                                          key, value);
             }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/Get-WinEvent.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/Get-WinEvent.Tests.ps1
@@ -85,7 +85,6 @@ Describe 'Get-WinEvent' -Tags "CI" {
             @($results).Count | Should be 1
             $results.RecordId | should be 10
         }
-        <#
         It 'Get-WinEvent can retrieve events with UserData queries using FilterHashtable' {
             # this relies on apriori knowledge about the log file
             # the provided log file has been edited to remove MS PII, so we must use -ea silentlycontinue
@@ -95,7 +94,6 @@ Describe 'Get-WinEvent' -Tags "CI" {
             @($results).Count | Should be 1
             $results.RecordId | should be 10
         }
-        #>
         It 'Get-WinEvent can retrieve events with UserData queries using FilterXPath' {
             # this relies on apriori knowledge about the log file
             # the provided log file has been edited to remove MS PII, so we must use -ea silentlycontinue

--- a/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/Get-WinEvent.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/Get-WinEvent.Tests.ps1
@@ -108,7 +108,7 @@ Describe 'Get-WinEvent' -Tags "CI" {
             # this relies on apriori knowledge about the log file
             # the provided log file has been edited to remove MS PII, so we must use -ea silentlycontinue
             $eventLogFile = [io.path]::Combine($PSScriptRoot, "assets", "Saved-Events.evtx")
-            $filter = @{ path = "$eventLogFile"; ; PackageAware="Not package aware"; DriverName = "Remote Desktop Easy Print", "Microsoft enhanced Point and Print compatibility driver" } 
+            $filter = @{ path = "$eventLogFile"; PackageAware="Not package aware"; DriverName = "Remote Desktop Easy Print", "Microsoft enhanced Point and Print compatibility driver" } 
             $results = Get-WinEvent -filterHashtable $filter -ea silentlycontinue
             @($results).Count | Should be 2
             ($results.RecordId -contains 9) | should be $true

--- a/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/Get-WinEvent.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/Get-WinEvent.Tests.ps1
@@ -85,7 +85,7 @@ Describe 'Get-WinEvent' -Tags "CI" {
             @($results).Count | Should be 1
             $results.RecordId | should be 10
         }
-        It 'Get-WinEvent can retrieve events with UserData queries using FilterHashtable' {
+        It 'Get-WinEvent can retrieve events with UserData queries using FilterHashtable (one value)' {
             # this relies on apriori knowledge about the log file
             # the provided log file has been edited to remove MS PII, so we must use -ea silentlycontinue
             $eventLogFile = [io.path]::Combine($PSScriptRoot, "assets", "Saved-Events.evtx")
@@ -93,6 +93,26 @@ Describe 'Get-WinEvent' -Tags "CI" {
             $results = Get-WinEvent -filterHashtable $filter -ea silentlycontinue
             @($results).Count | Should be 1
             $results.RecordId | should be 10
+        }
+        It 'Get-WinEvent can retrieve events with UserData queries using FilterHashtable (array of values)' {
+            # this relies on apriori knowledge about the log file
+            # the provided log file has been edited to remove MS PII, so we must use -ea silentlycontinue
+            $eventLogFile = [io.path]::Combine($PSScriptRoot, "assets", "Saved-Events.evtx")
+            $filter = @{ path = "$eventLogFile"; DriverName = "Remote Desktop Easy Print", "Microsoft enhanced Point and Print compatibility driver" } 
+            $results = Get-WinEvent -filterHashtable $filter -ea silentlycontinue
+            @($results).Count | Should be 2
+            ($results.RecordId -contains 9) | should be $true
+            ($results.RecordId -contains 11) | should be $true
+        }
+        It 'Get-WinEvent can retrieve events with UserData queries using FilterHashtable (multiple named params)' {
+            # this relies on apriori knowledge about the log file
+            # the provided log file has been edited to remove MS PII, so we must use -ea silentlycontinue
+            $eventLogFile = [io.path]::Combine($PSScriptRoot, "assets", "Saved-Events.evtx")
+            $filter = @{ path = "$eventLogFile"; ; PackageAware="Not package aware"; DriverName = "Remote Desktop Easy Print", "Microsoft enhanced Point and Print compatibility driver" } 
+            $results = Get-WinEvent -filterHashtable $filter -ea silentlycontinue
+            @($results).Count | Should be 2
+            ($results.RecordId -contains 9) | should be $true
+            ($results.RecordId -contains 11) | should be $true
         }
         It 'Get-WinEvent can retrieve events with UserData queries using FilterXPath' {
             # this relies on apriori knowledge about the log file


### PR DESCRIPTION
Now FilterHashtable parameter in Get-WinEvent for named data field:
1. generates a valid query, ex. @{Logname="System";Param="a"}
2. generates a valid query for multiple values, ex.
@{Logname="System";Param="a","b"}

Now I need help in creating tests #2368

Close #2327 
