### PR TITLE
Add archive with test content to AppVeyor artifacts for daily builds.

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -370,6 +370,19 @@ cmd.exe /C cd /d "$location" "&" "$($vcVarsPath)\vcvarsall.bat" "$NativeHostArch
     }
 }
 
+function Compress-TestContent {
+    [CmdletBinding()]
+    param(
+        $Destination
+    )
+
+    $powerShellTestRoot =  Join-Path $PSScriptRoot 'test\powershell'    
+    Add-Type -AssemblyName System.IO.Compression.FileSystem
+
+    $resolvedPath = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($Destination)
+    [System.IO.Compression.ZipFile]::CreateFromDirectory($powerShellTestRoot, $resolvedPath)    
+}
+
 function New-PSOptions {
     [CmdletBinding()]
     param(

--- a/tools/appveyor.psm1
+++ b/tools/appveyor.psm1
@@ -248,6 +248,14 @@ function Invoke-AppveyorFinish
         $artifacts.Add($zipFilePath)
         $artifacts.Add($zipFileFullPath)
 
+        # Create archive for test content
+        if(Test-DailyBuild) 
+        {
+            $zipTestContentPath = Join-Path $pwd 'tests.zip' 
+            Compress-TestContent -Destination $zipTestContentPath
+            $artifacts.Add($zipTestContentPath)
+        }
+
         if ($env:APPVEYOR_REPO_TAG_NAME)
         {
             # ignore the first part of semver, use the preview part


### PR DESCRIPTION
The change adds Compress-TestContent cmdlet to build.psm1 so that it can
compress the powershell test content. This is done only for daily builds.
