### PR TITLE
Nuget test failures

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -370,6 +370,19 @@ cmd.exe /C cd /d "$location" "&" "$($vcVarsPath)\vcvarsall.bat" "$NativeHostArch
     }
 }
 
+function Compress-TestContent {
+    [CmdletBinding()]
+    param(
+        $Destination
+    )
+
+    $powerShellTestRoot =  Join-Path $PSScriptRoot 'test\powershell'    
+    Add-Type -AssemblyName System.IO.Compression.FileSystem
+
+    $resolvedPath = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($Destination)
+    [System.IO.Compression.ZipFile]::CreateFromDirectory($powerShellTestRoot, $resolvedPath)    
+}
+
 function New-PSOptions {
     [CmdletBinding()]
     param(

--- a/test/powershell/Modules/PackageManagement/Nuget.Tests.ps1
+++ b/test/powershell/Modules/PackageManagement/Nuget.Tests.ps1
@@ -18,7 +18,9 @@
 
 $source = "http://www.nuget.org/api/v2/"
 $sourceWithoutSlash = "http://www.nuget.org/api/v2"
-$fwlink = "https://go.microsoft.com/fwlink/?LinkID=623861&clcid=0x409"
+## Filed a bug for HttpClient for https redirections. https://github.com/dotnet/corefx/issues/12171
+## Changing the fwlink to http.
+$fwlink = "http://go.microsoft.com/fwlink/?LinkID=623861&clcid=0x409"
 $longName = "THISISOVER255CHARACTERSTHISISOVER255CHARACTERSTHISISOVER255CHARACTERSTHISISOVER255CHARACTERSTHISISOVER255CHARACTERSTHISISOVER255CHARACTERSTHISISOVER255CHARACTERSTHISISOVER255CHARACTERSTHISISOVER255CHARACTERSTHISISOVER255CHARACTERSTHISISOVER255CHARACTERSTHISISOVER255CHARACTERS";
 $workingMaximumVersions = {"2.0", "2.5", "3.0"};
 $packageNames = @("Azurecontrib", "AWSSDK", "TestLib");

--- a/tools/appveyor.psm1
+++ b/tools/appveyor.psm1
@@ -248,6 +248,14 @@ function Invoke-AppveyorFinish
         $artifacts.Add($zipFilePath)
         $artifacts.Add($zipFileFullPath)
 
+        # Create archive for test content
+        if(Test-DailyBuild) 
+        {
+            $zipTestContentPath = Join-Path $pwd 'tests.zip' 
+            Compress-TestContent -Destination $zipTestContentPath
+            $artifacts.Add($zipTestContentPath)
+        }
+
         if ($env:APPVEYOR_REPO_TAG_NAME)
         {
             # ignore the first part of semver, use the preview part


### PR DESCRIPTION
The fix changes the fwlink from https to http due to httpclient.getasync issue filed at: https://github.com/dotnet/corefx/issues/12171

This change unblocks daily builds.
