### PR TITLE
Add PS_DAILY_BUILD variable check in Test-DailyBuild

### DIFF
--- a/tools/appveyor.psm1
+++ b/tools/appveyor.psm1
@@ -8,14 +8,11 @@ Import-Module (Join-Path $repoRoot 'build.psm1')
 # or is a pushed tag
 Function Test-DailyBuild
 {
-    if($env:APPVEYOR_SCHEDULED_BUILD -eq 'True')
+    if(($env:PS_DAILY_BUILD -eq 'True') -or ($env:APPVEYOR_SCHEDULED_BUILD -eq 'True') -or ($env:APPVEYOR_REPO_TAG_NAME))
     {
         return $true
     }
-    if($env:APPVEYOR_REPO_TAG_NAME)
-    {
-        return $true
-    }
+
     return $false
 }
 


### PR DESCRIPTION
The PS_DAILY_BUILD variable is set in the Appveyor environment in the
PowerShell [Daily] project. When this is set we want to have full daily
build.
