### PR TITLE
Add RequireAdminOnWindows tag for install-package tests

### DIFF
--- a/test/powershell/Modules/PackageManagement/Nuget.Tests.ps1
+++ b/test/powershell/Modules/PackageManagement/Nuget.Tests.ps1
@@ -819,7 +819,7 @@ Describe "install-package with Whatif" -Tags "Feature" {
     }
 }
 
-Describe "install-package with Scope" -tags "Feature" {
+Describe "install-package with Scope" -tags @('Feature', 'RequireAdminOnWindows') {
 
      it "EXPECTED Success: Get and Install-Package without Scope without destination" {
             


### PR DESCRIPTION
Add the tag RequireAdminOnWindows tags so that these tests do not fail on
daily builds.
