### PR TITLE
Allow Start-PSBuild -Output to take absolute path

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -197,7 +197,7 @@ function Start-PSBuild {
         $Arguments += "build"
     }
     if ($Output) {
-        $Arguments += "--output", (Join-Path $PSScriptRoot $Output)
+        $Arguments += "--output", $Output
     }
     elseif ($SMAOnly) {
         $Arguments += "--output", (Split-Path $script:Options.Output)
@@ -490,9 +490,7 @@ function New-PSOptions {
     }
 
     # Build the Output path
-    if ($Output) {
-        $Output = Join-Path $PSScriptRoot $Output
-    } else {
+    if (!$Output) {
         $Output = [IO.Path]::Combine($Top, "bin", $Configuration, $Framework, $Runtime)
 
         # Publish injects the publish directory


### PR DESCRIPTION
There was no point to using Join-Path here, but it made it impossible to specify absolute paths (or any path outside of the PowerShell repo).

/cc @vors @daxian-dbw 
