### PR TITLE
Fix bytewise operators to work on enum types with 'System.Byte' as the underlying type

### DIFF
--- a/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
+++ b/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
@@ -2940,13 +2940,15 @@ namespace System.Management.Automation.Language
 
                 if (numericTarget != null && numericArg != null)
                 {
-                    var expr = exprGenerator(numericTarget.Expression.Cast(target.LimitType).Cast(opType),
-                        numericArg.Expression.Cast(numericArg.LimitType).Cast(opType)).Cast(typeof(object));
+                    var expr = exprGenerator(numericTarget.Expression.Cast(numericTarget.LimitType).Cast(opType),
+                                             numericArg.Expression.Cast(numericArg.LimitType).Cast(opType));
 
                     if (target.LimitType.GetTypeInfo().IsEnum)
                     {
-                        expr = expr.Cast(target.LimitType).Cast(typeof(object));
+                        expr = expr.Cast(target.LimitType);
                     }
+
+                    expr = expr.Cast(typeof(object));
                     return new DynamicMetaObject(expr, numericTarget.CombineRestrictions(numericArg));
                 }
             }

--- a/test/powershell/Language/Operators/ComparisonOperator.Tests.ps1
+++ b/test/powershell/Language/Operators/ComparisonOperator.Tests.ps1
@@ -69,3 +69,43 @@ Describe "ComparisonOperator" -tag "CI" {
 	 "Hello world" -notlike "Hello*"       | Should Be $false
     }
 }
+
+
+Describe "Bytewise Operator" -tag "CI" {
+
+    It "Test -bor on enum with [byte] as underlying type" {
+        $result = [System.Security.AccessControl.AceFlags]::ObjectInherit -bxor `
+                  [System.Security.AccessControl.AceFlags]::ContainerInherit
+        $result.ToString() | Should Be "ObjectInherit, ContainerInherit"
+    }
+
+    It "Test -bor on enum with [int] as underlying type" {
+        $result = [System.Management.Automation.CommandTypes]::Alias -bor `
+                  [System.Management.Automation.CommandTypes]::Application
+        $result.ToString() | Should Be "Alias, Application"
+    }
+
+    It "Test -band on enum with [byte] as underlying type" {
+        $result = [System.Security.AccessControl.AceFlags]::ObjectInherit -band `
+                  [System.Security.AccessControl.AceFlags]::ContainerInherit
+        $result.ToString() | Should Be "None"
+    }
+
+    It "Test -band on enum with [int] as underlying type" {
+        $result = [System.Management.Automation.CommandTypes]::Alias -band `
+                  [System.Management.Automation.CommandTypes]::All
+        $result.ToString() | Should Be "Alias"
+    }
+
+    It "Test -bxor on enum with [byte] as underlying type" {
+        $result = [System.Security.AccessControl.AceFlags]::ObjectInherit -bxor `
+                  [System.Security.AccessControl.AceFlags]::ContainerInherit
+        $result.ToString() | Should Be "ObjectInherit, ContainerInherit"
+    }
+
+    It "Test -bxor on enum with [int] as underlying type" {
+        $result = [System.Management.Automation.CommandTypes]::Alias -bxor `
+                  [System.Management.Automation.CommandTypes]::Application
+        $result.ToString() | Should Be "Alias, Application"
+    }
+}


### PR DESCRIPTION
Fix #2310

This is because we were casting the result expression to an object before casting it to the enum type.
If the target enum type has `System.Int32` as underlying type, then the cast of `(int-enum)(object)(int)` works in C#.
But if the target enum type has `System.Byte` as underlying type, then the cast of `(byte-enum)(object)(int)` fails in C# with error "Specified cast is not valid" in FullCLR, and "Unable to cast object of type 'System.Int32' to type" in CoreCLR.

The fix is to cast the expression to the enum type before casting it to object.
