### PR TITLE
Fix VS Code debug output

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -9,7 +9,7 @@
     "tasks": [
         {
             "taskName": "build",
-            "args": [ "Import-Module ${workspaceRoot}/build.psm1; Start-PSBuild -Output debug" ],
+            "args": [ "Import-Module ${workspaceRoot}/build.psm1; Start-PSBuild -Output ${workspaceRoot}/debug" ],
             "isBuildCommand": true,
             "problemMatcher": "$msCompile"
         }


### PR DESCRIPTION
Resolves #2422.

Sorry, I don't use VS Code much (can't take Emacs from me!). I've updated the default configuration to provide an absolute path, since the build script `cd`s into the directory of the `project.json` to build.
