### PR TITLE
Fix try/catch to choose the more specific exception handler

### DIFF
--- a/src/System.Management.Automation/engine/parser/Compiler.cs
+++ b/src/System.Management.Automation/engine/parser/Compiler.cs
@@ -4544,9 +4544,8 @@ namespace System.Management.Automation.Language
                     else
                     {
                         cases.Add(Expression.SwitchCase(catchBody,
-                                                        Enumerable.Range(handlerTypeIndex,
-                                                                         handlerTypeIndex + c.CatchTypes.Count).Select(
-                                                                             ExpressionCache.Constant)));
+                                                        Enumerable.Range(handlerTypeIndex, c.CatchTypes.Count).Select(
+                                                            ExpressionCache.Constant)));
                         handlerTypeIndex += c.CatchTypes.Count;
                     }
                 }

--- a/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
+++ b/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
@@ -1262,6 +1262,25 @@ namespace System.Management.Automation
         internal class CatchAll { }
 
         /// <summary>
+        /// Represent a handler search result
+        /// </summary>
+        private class HandlerSearchResult
+        {
+            internal HandlerSearchResult()
+            {
+                Handler = -1;
+                Rank = int.MaxValue;
+                ExceptionToPass = null;
+                ErrorRecordToPass = null;
+            }
+
+            internal int Handler;
+            internal int Rank;
+            internal Exception ExceptionToPass;
+            internal ErrorRecord ErrorRecordToPass;
+        }
+
+        /// <summary>
         /// Rank the exception types based on how specific they are.
         /// Smaller ranking number indicates more specific exception type.
         /// </summary>
@@ -1301,79 +1320,114 @@ namespace System.Management.Automation
             return ranks;
         }
 
+        /// <summary>
+        /// Search for handler by the exception type and process the found result.
+        /// </summary>
+        private static void FindAndProcessHandler(Type[] types, int[] ranks,
+                                                  HandlerSearchResult current,
+                                                  Exception exception,
+                                                  ErrorRecord errorRecord)
+        {
+            Diagnostics.Assert(current != null, "Caller makes sure 'current' is not null.");
+            int handler = FindMatchingHandlerByType(exception.GetType(), types);
+
+            // If no handler was found, return without changing the current result.
+            if (handler == -1) { return; }
+
+            // New handler was found.
+            //  - If new-rank is less than current-rank -- meaning the new handler is more specific,
+            //    then we update the current result with it.
+            //  - If new-rank is more than current-rank -- meaning the new handler is less specific,
+            //    then we do NOT change the current result.
+            //  - If new-rank is equal to current-rank, we do NOT change the current result UNLESS the
+            //    current handler is catch-all. (This is to keep the original behavior -- prefer to use
+            //    the later found exception as the exception-to-pass-in if all exceptions result in the
+            //    catch-all handler.
+            int rank = ranks[handler];
+            if (rank < current.Rank ||
+                (rank == current.Rank && types[current.Handler].Equals(typeof(CatchAll)))
+               )
+            {
+                current.Handler = handler;
+                current.Rank = rank;
+                current.ExceptionToPass = exception;
+                current.ErrorRecordToPass = errorRecord;
+            }
+        }
+
+        /// <summary>
+        /// Find the matching handler for the caught exception
+        /// </summary>
         internal static int FindMatchingHandler(MutableTuple tuple, RuntimeException rte, Type[] types, ExecutionContext context)
         {
-            Exception exceptionToPass = null;
-            ErrorRecord errorRecordToPass = null;
-            int handler = -1;
             bool continueToSearch = false;
+            int[] ranks = RankExceptionTypes(types);
+            var current = new HandlerSearchResult();
 
             do {
                 // Always assume no need to repeat the search for another interation
                 continueToSearch = false;
                 // The 'ErrorRecord' of the current RuntimeException would be passed to $_
-                errorRecordToPass = rte.ErrorRecord;
-                
+                ErrorRecord errorRecordToPass = rte.ErrorRecord;
+
                 Exception inner = rte.InnerException;
                 if (inner != null)
                 {
-                    handler = FindMatchingHandlerByType(inner.GetType(), types);
-                    exceptionToPass = inner;
+                    FindAndProcessHandler(types, ranks, current, inner, errorRecordToPass);
                 }
 
-                // If no handler was found, or if the handler we found was the catch all handler,
-                // then look again, this time using the outer exception.  If we found the catch all,
-                // there may be a handler that catches outer but not inner.  Furthermore, rethrow
-                // should throw the original exception from a catchall, not the inner.
-                if (handler == -1 || types[handler].Equals(typeof(CatchAll)))
+                // If no handler was found (rank = int.MaxValue), or if the handler we found was not
+                // the most specific one, then look again, this time using the outer exception.
+                // If we found a handler, but not one of the most specific ones (rank != 0), there may
+                // be a more specific handler that catches outer but not inner exception.
+                if (current.Rank > 0)
                 {
-                    handler = FindMatchingHandlerByType(rte.GetType(), types);
-                    exceptionToPass = rte;
+                    FindAndProcessHandler(types, ranks, current, rte, errorRecordToPass);
                 }
 
-                // If we still didn't find a specific handler, we'll try unwrapping a few other of our exceptions:
-                //     ActionPreferenceStopException - to cover -ea stop
+                // If we still didn't find one of the most specific handlers (rank != 0), we'll try unwrapping a few other of our exceptions:
+                //     ActionPreferenceStopException - to cover '-ea stop'
                 //         try { gci nosuchfile -ea stop } catch [System.Management.Automation.ItemNotFoundException] { 'caught' }
                 //     CmdletInvocationException - to cover cmdlets like Invoke-Expression
-                //
-                if ((handler == -1 || types[handler].Equals(typeof(CatchAll))))
+                if (current.Rank > 0)
                 {
                     var apse = rte as ActionPreferenceStopException;
                     if (apse != null)
                     {
-                        exceptionToPass = apse.ErrorRecord.Exception;
-                        
-                        // If it's also a RuntimeException, then we need to repeat the search using it
+                        var exceptionToPass = apse.ErrorRecord.Exception;
+
+                        // If it's again a RuntimeException, we repeat the search using it
                         rte = exceptionToPass as RuntimeException;
                         if (rte != null)
                         {
                             continueToSearch = true;
-                            continue;
                         }
                         else if (exceptionToPass != null)
                         {
-                            handler = FindMatchingHandlerByType(exceptionToPass.GetType(), types);
+                            FindAndProcessHandler(types, ranks, current, exceptionToPass, errorRecordToPass);
                         }
                     }
                     else if (rte is CmdletInvocationException && inner != null)
                     {
-                        exceptionToPass = inner.InnerException;
-                        if (exceptionToPass != null)
+                        if (inner.InnerException != null)
                         {
-                            handler = FindMatchingHandlerByType(exceptionToPass.GetType(), types);
+                            FindAndProcessHandler(types, ranks, current, inner.InnerException, errorRecordToPass);
                         }
                     }
                 }
             } while (continueToSearch);
 
-            if (handler != -1)
+            if (current.Handler != -1)
             {
-                var errorRecord = new ErrorRecord(errorRecordToPass, exceptionToPass);
+                var errorRecord = new ErrorRecord(current.ErrorRecordToPass, current.ExceptionToPass);
                 tuple.SetAutomaticVariable(AutomaticVariable.Underbar, errorRecord, context);
             }
-            return handler;
+            return current.Handler;
         }
 
+        /// <summary>
+        /// Find the matching handler by the exception type
+        /// </summary>
         private static int FindMatchingHandlerByType(Type exceptionType, Type[] types)
         {
             int i;

--- a/test/powershell/Language/Scripting/Trap.Tests.ps1
+++ b/test/powershell/Language/Scripting/Trap.Tests.ps1
@@ -8,21 +8,21 @@ Describe "Test trap" -Tags "CI" {
         }
 
         It "Line after exception should NOT be continued and both inner and outter traps should be triggered" {
-            $a = . {trap {"outter trap"; continue;}; . {trap {"inner trap"; break;}; "hello"; throw "exception"; "world"}}
+            $a = . {trap {"outer trap"; continue;}; . {trap {"inner trap"; break;}; "hello"; throw "exception"; "world"}}
             $a.Length | Should Be 3
-            $a -join "," | Should Be "hello,inner trap,outter trap"
+            $a -join "," | Should Be "hello,inner trap,outer trap"
         }
 
         It "Line after exception should be invoked after continue" {
-            $a = . {trap {"outter trap"; continue;} "hello"; throw "exception"; "world"}
+            $a = . {trap {"outer trap"; continue;} "hello"; throw "exception"; "world"}
             $a.Length | Should Be 3
-            $a -join "," | Should Be "hello,outter trap,world"
+            $a -join "," | Should Be "hello,outer trap,world"
         }
 
         It "Line after exception should NOT be invoked and inner trap should not be triggered" {
-            $a = . {trap {"outter trap"; continue;}; . {trap [system.Argumentexception] {"inner trap"; continue;}; "hello"; throw "exception"; "world"}}
+            $a = . {trap {"outer trap"; continue;}; . {trap [system.Argumentexception] {"inner trap"; continue;}; "hello"; throw "exception"; "world"}}
             $a.Length | Should Be 2
-            $a -join "," | Should Be "hello,outter trap"
+            $a -join "," | Should Be "hello,outer trap"
         }
     }
 }

--- a/test/powershell/Language/Scripting/Trap.Tests.ps1
+++ b/test/powershell/Language/Scripting/Trap.Tests.ps1
@@ -1,28 +1,24 @@
-#  <Test>
-#    <TestType>DRT</TestType>
-#    <summary>Exception handling</summary>
-#  </Test>
 
-. "$($args[0])\..\asserts.ps1"
+Describe "Test trap" -Tags "CI" {
+    Context "Line after exception should not be invoked" {
+        It "line after exception should not be invoked" {
+            $a = . {trap {"trapped"; continue;}; . {"hello"; throw "exception"; "world"}}
+            $a.Length | Should Be 2
+        }
 
-#############################################################
-#
-# Line after exception should not be invoked.
-#
-#############################################################
+        It "line after exception should not be invoked" {
+            $a = . {trap {"outside trapped"; continue;}; . {trap {break;}; "hello"; throw "exception"; "world"}}
+            $a.Length | Should Be 2
+        }
 
-$a = . {trap {"trapped"; continue;}; . {"hello"; throw "exception"; "world"}}
+        It "line after exception should be invoked after continue" {
+            $a = . {trap {"outside trapped"; continue;} "hello"; throw "exception"; "world"}
+            $a.Length | Should Be 3
+        }
 
-Assert ($a.Length -eq 2) "line after exception should not be invoked"
-
-$a = . {trap {"outside trapped"; continue;}; . {trap {break;}; "hello"; throw "exception"; "world"}}
-
-Assert ($a.Length -eq 2) "line after exception should not be invoked"
-
-$a = . {trap {"outside trapped"; continue;} "hello"; throw "exception"; "world"}
-
-Assert ($a.Length -eq 3) "line after exception should be invoked after continue"
-
-$a = . {trap {"outside trapped"; continue;}; . {trap [system.Argumentexception] {continue;}; "hello"; throw "exception"; "world"}}
-
-Assert ($a.Length -eq 2) "line after exception should not be invoked"
+        It "line after exception should not be invoked" {
+            $a = . {trap {"outside trapped"; continue;}; . {trap [system.Argumentexception] {continue;}; "hello"; throw "exception"; "world"}}
+            $a.Length | Should Be 2
+        }
+    }
+}

--- a/test/powershell/Language/Scripting/Trap.Tests.ps1
+++ b/test/powershell/Language/Scripting/Trap.Tests.ps1
@@ -1,0 +1,28 @@
+#  <Test>
+#    <TestType>DRT</TestType>
+#    <summary>Exception handling</summary>
+#  </Test>
+
+. "$($args[0])\..\asserts.ps1"
+
+#############################################################
+#
+# Line after exception should not be invoked.
+#
+#############################################################
+
+$a = . {trap {"trapped"; continue;}; . {"hello"; throw "exception"; "world"}}
+
+Assert ($a.Length -eq 2) "line after exception should not be invoked"
+
+$a = . {trap {"outside trapped"; continue;}; . {trap {break;}; "hello"; throw "exception"; "world"}}
+
+Assert ($a.Length -eq 2) "line after exception should not be invoked"
+
+$a = . {trap {"outside trapped"; continue;} "hello"; throw "exception"; "world"}
+
+Assert ($a.Length -eq 3) "line after exception should be invoked after continue"
+
+$a = . {trap {"outside trapped"; continue;}; . {trap [system.Argumentexception] {continue;}; "hello"; throw "exception"; "world"}}
+
+Assert ($a.Length -eq 2) "line after exception should not be invoked"

--- a/test/powershell/Language/Scripting/TryCatch.Tests.ps1
+++ b/test/powershell/Language/Scripting/TryCatch.Tests.ps1
@@ -1,16 +1,3 @@
-#  <Test>
-#    <TestType>DRT</TestType>
-#    <summary>Exception handling (try/catch/finally)</summary>
-#  </Test>
-
-param($path = $null)
-
-if ($path -eq $null)
-{
-    $path = split-path $MyInvocation.InvocationName
-}
-
-. "$path\..\asserts.ps1"
 
 #############################################################
 #
@@ -18,543 +5,582 @@ if ($path -eq $null)
 #
 #############################################################
 
-try
-{
-}
-catch
-{
-}
+Describe "Test try/catch" -Tags "CI" {
 
-try
-{
-}
-catch
-[int]
-{
-}
-
-try
-{
-}
-catch
-[int]
-,
-[char]
-{
-}
-
-try
-{
-}
-finally
-{
-}
-
-try
-{
-}
-catch
-{
-}
-finally
-{
-}
-
-try
-{
-}
-catch
-[int]
-{
-}
-finally
-{
-}
-
-try
-{
-}
-catch
-[int]
-,
-[char]
-{
-}
-finally
-{
-}
-
-
-#############################################################
-#
-# Basic exception handling
-#
-#############################################################
-
-$a = . { try { 1; throw "exception"; "test failed" } catch { 2 } }
-AssertArraysEqual $a (1,2) "Simple throw and catch"
-
-$a = . { try { 1 } finally { 2 } }
-AssertArraysEqual $a (1,2) "Simple try finally"
-
-$a = . { try { 1; throw "exception"; "test failed" } catch { 2 } finally { 3 } }
-AssertArraysEqual $a (1..3) "Simple try, throw, catch, and finally"
-
-
-#############################################################
-#
-# Mix traps with try/catch
-#
-#############################################################
-
-$a = . { trap { "test failed" } try { 1; throw "exception"; "test failed" } catch { 2 } }
-AssertArraysEqual $a (1,2) "Trap shouldn't catch exception"
-
-$a = . { try { 1; throw "exception"; trap { 2; return }; "test failed" } catch { "test failed" } }
-AssertArraysEqual $a (1,2) "Trap should catch exception"
-
-
-#############################################################
-#
-# Catch by type
-#
-#############################################################
-
-$a = . { try { 1; $a = 0; 1/$a; "test failed" } catch [DivideByZeroException] { 2 } }
-AssertArraysEqual $a (1,2) "Catch by type #1"
-
-$a = . { try { 1; $a = 0; 1/$a; "test failed" } catch [DivideByZeroException] { 2 } catch [Exception] { "test failed" } }
-AssertArraysEqual $a (1,2) "Catch by type #2"
-
-$a = . { try { 1; $a = 0; 1/$a; "test failed" } catch [DivideByZeroException] { 2 } catch { "test failed" } }
-AssertArraysEqual $a (1,2) "Catch by type #3"
-
-$a = . { try { 1; $a = 0; 1/$a; "test failed" } catch [DivideByZeroException],[StackOverflowException] { 2 } }
-AssertArraysEqual $a (1,2) "Catch by type #3"
-
-#############################################################
-#
-# Control flow in try
-#    exit not tested
-#    throw tested elsewhere
-#
-#############################################################
-
-$a = . {
-  foreach ($i in (1..3)) {
-    try {
-      if ($i -eq 2) {
-        break
-      }
-      $i
-    } catch {
-      "test failed"
-    } finally {
-      "finally: $i"
-    }
-  }
-}
-AssertArraysEqual $a (1, "finally: 1", "finally: 2") "break in try"
-
-$a = . {
-  foreach ($i in (1..3)) {
-    try {
-      if ($i -eq 2) {
-        continue
-      }
-      $i
-    } catch {
-      "test failed"
-    } finally {
-      "finally: $i"
-    }
-  }
-}
-AssertArraysEqual $a (1, "finally: 1", "finally: 2", 3, "finally: 3") "continue in try"
-
-$a = . {
-  function foo($i) {
-    try {
-      if ($i -eq 2) {
-        return "return: $i"
-      }
-      $i
-    } catch {
-      "test failed"
-    } finally {
-      "finally: $i"
-    }
-  }
-  foo 1
-  foo 2
-}
-
-# Disabled - Compiled script has differing (but better) behavior
-#AssertArraysEqual $a (1, "finally: 1", "finally: 2", "return: 2") "return in try"
-
-$a = . {
-    foreach ($i in (1..3)) {
-        try { #1
-            try { #2
-                if ($i -eq 2) {
-                    continue
-                }
-                $i
-            } catch {
-                "test failed: catch#2"
-            } finally {
-                "finally#2: $i"
+    BeforeAll {
+        function AssertArraysEqual ($result, $expected)
+        {
+            $result.Count | Should Be $expected.Count
+            for ($i = 0; $i -lt $result.Count; $i++) {
+                $result[$i] | Should Be $expected[$i]
             }
-        } catch {
-            "test failed: catch#1"
-        } finally {
-            "finally#1: $i"
         }
     }
-}
-AssertArraysEqual $a (1, "finally#2: 1", "finally#1: 1", "finally#2: 2", "finally#1: 2", 3, "finally#2: 3", "finally#1: 3")
+    
+    It "Test simple parsing, ensure newlines allowed everywhere" {
+        {
+            try
+            {
+            }
+            catch
+            {
+            }
 
+            try
+            {
+            }
+            catch
+            [int]
+            {
+            }
 
-$a = . {
-    foreach ($i in (1..3)) {
-        try { #1
-            try { #2
-                if ($i -eq 2) {
+            try
+            {
+            }
+            catch
+            [int]
+            ,
+            [char]
+            {
+            }
+
+            try
+            {
+            }
+            finally
+            {
+            }
+
+            try
+            {
+            }
+            catch
+            {
+            }
+            finally
+            {
+            }
+
+            try
+            {
+            }
+            catch
+            [int]
+            {
+            }
+            finally
+            {
+            }
+
+            try
+            {
+            }
+            catch
+            [int]
+            ,
+            [char]
+            {
+            }
+            finally
+            {
+            }
+        } | Should Not Throw
+    }
+
+    Context "Basic exception handling" {
+        It "Simple throw and catch" {
+            $a = . { try { 1; throw "exception"; "test failed" } catch { 2 } }
+            AssertArraysEqual $a (1, 2)
+        }
+
+        It "Simple try finally" {
+            $a = . { try { 1 } finally { 2 } }
+            AssertArraysEqual $a (1,2)
+        }
+
+        It "Simple try, throw, catch, and finally" {
+            $a = . { try { 1; throw "exception"; "test failed" } catch { 2 } finally { 3 } }
+            AssertArraysEqual $a (1..3)
+        }
+    }
+
+    Context "Mix traps with try/catch" {
+        It "Trap shouldn't catch exception" {
+            $a = . { trap { "test failed" } try { 1; throw "exception"; "test failed" } catch { 2 } }
+            AssertArraysEqual $a (1,2)
+        }
+
+        It "Trap should catch exception" {
+            $a = . { try { 1; throw "exception"; trap { 2; return }; "test failed" } catch { "test failed" } }
+            AssertArraysEqual $a (1,2)
+        }
+    }
+
+    Context "Catch by type" {
+        It "Catch by type #1" {
+            $a = . { try { 1; $a = 0; 1/$a; "test failed" } catch [DivideByZeroException] { 2 } }
+            AssertArraysEqual $a (1,2)
+        }
+
+        It "Catch by type #2" {
+            $a = . { try { 1; $a = 0; 1/$a; "test failed" } catch [DivideByZeroException] { 2 } catch [Exception] { "test failed" } }
+            AssertArraysEqual $a (1,2)
+        }
+
+        It "Catch by type #3" {
+            $a = . { try { 1; $a = 0; 1/$a; "test failed" } catch [DivideByZeroException] { 2 } catch { "test failed" } }
+            AssertArraysEqual $a (1,2)
+        }
+
+        It "Catch by type #4" {
+            $a = . { try { 1; $a = 0; 1/$a; "test failed" } catch [DivideByZeroException],[ArgumentNullException] { 2 } }
+            AssertArraysEqual $a (1,2)
+        }
+    }
+
+    Context "Control flow in try [exit not tested and throw tested elsewhere]" {
+        It "break in try" {
+            $a = . {
+              foreach ($i in (1..3)) {
+                try {
+                  if ($i -eq 2) {
                     break
+                  }
+                  $i
+                } catch {
+                  "test failed"
+                } finally {
+                  "finally: $i"
                 }
-                $i
-            } catch {
-                "test failed: catch#2"
-            } finally {
-                "finally#2: $i"
+              }
             }
-        } catch {
-            "test failed: catch#1"
-        } finally {
-            "finally#1: $i"
+            AssertArraysEqual $a (1, "finally: 1", "finally: 2")
         }
-    }
-}
-AssertArraysEqual $a (1, "finally#2: 1", "finally#1: 1", "finally#2: 2", "finally#1: 2")
 
-
-#############################################################
-#
-# Control flow in catch
-#    exit not tested
-#    throw tested elsewhere
-#
-#############################################################
-$a = . {
-  try {
-    throw 1
-  } catch {
-    foreach ($i in (1..3)) {
-      if ($i -eq 2) {
-        break
-      }
-      $i
-    }
-  } finally {
-    "finally"
-  }
-}
-AssertArraysEqual $a (1, "finally") "break in catch"
-
-$a = . {
-  foreach ($i in (1..3)) {
-    try {
-      throw 1
-    } catch {
-      if ($i -eq 2) {
-        break
-      }
-      $i
-    } finally {
-      "finally $i"
-    }
-  }
-}
-AssertArraysEqual $a (1, "finally 1", "finally 2") "break in catch"
-
-$a = . {
-  try {
-    throw 1
-  } catch {
-    foreach ($i in (1..3)) {
-      if ($i -eq 2) {
-        continue
-      }
-      $i
-    }
-  } finally {
-    "finally"
-  }
-}
-AssertArraysEqual $a (1, 3, "finally") "continue in catch"
-
-$a = . {
-  foreach ($i in (1..3)) {
-    try {
-    throw 1
-    } catch {
-      if ($i -eq 2) {
-        continue
-      }
-      $i
-    } finally {
-      "finally $i"
-    }
-  }
-}
-AssertArraysEqual $a (1, "finally 1", "finally 2", 3, "finally 3") "continue in catch"
-
-$a = . {
-    foreach ($i in (1..3)) {
-        try { #1
-            try { #2
-                throw 1
-            } catch {
-                if ($i -eq 2) {
+        It "continue in try" {
+            $a = . {
+              foreach ($i in (1..3)) {
+                try {
+                  if ($i -eq 2) {
                     continue
+                  }
+                  $i
+                } catch {
+                  "test failed"
+                } finally {
+                  "finally: $i"
                 }
-                $i
-            } finally {
-                "finally#2: $i"
+              }
             }
-        } catch {
-            "test failed: catch#1"
-        } finally {
-            "finally#1: $i"
+            AssertArraysEqual $a (1, "finally: 1", "finally: 2", 3, "finally: 3")
+        }
+
+        # Disabled - Compiled script has differing (but better) behavior
+        It "return in try" -Skip:$true {
+            $a = . {
+              function foo($i) {
+                try {
+                  if ($i -eq 2) {
+                    return "return: $i"
+                  }
+                  $i
+                } catch {
+                  "test failed"
+                } finally {
+                  "finally: $i"
+                }
+              }
+              foo 1
+              foo 2
+            }
+
+            AssertArraysEqual $a (1, "finally: 1", "finally: 2", "return: 2")
+        }
+
+        It "continue in nested try within foreach loop" {
+            $a = . {
+                foreach ($i in (1..3)) {
+                    try { #1
+                        try { #2
+                            if ($i -eq 2) {
+                                continue
+                            }
+                            $i
+                        } catch {
+                            "test failed: catch#2"
+                        } finally {
+                            "finally#2: $i"
+                        }
+                    } catch {
+                        "test failed: catch#1"
+                    } finally {
+                        "finally#1: $i"
+                    }
+                }
+            }
+            AssertArraysEqual $a (1, "finally#2: 1", "finally#1: 1", "finally#2: 2", "finally#1: 2", 3, "finally#2: 3", "finally#1: 3")
+        }
+
+        It "break in nested try within foreach loop" {
+            $a = . {
+                foreach ($i in (1..3)) {
+                    try { #1
+                        try { #2
+                            if ($i -eq 2) {
+                                break
+                            }
+                            $i
+                        } catch {
+                            "test failed: catch#2"
+                        } finally {
+                            "finally#2: $i"
+                        }
+                    } catch {
+                        "test failed: catch#1"
+                    } finally {
+                        "finally#1: $i"
+                    }
+                }
+            }
+            AssertArraysEqual $a (1, "finally#2: 1", "finally#1: 1", "finally#2: 2", "finally#1: 2")
         }
     }
-}
-AssertArraysEqual $a (1, "finally#2: 1", "finally#1: 1", "finally#2: 2", "finally#1: 2", 3, "finally#2: 3", "finally#1: 3")
 
-
-$a = . {
-    foreach ($i in (1..3)) {
-        try { #1
-            try { #2
+    Context "Control flow in catch [exit not tested and throw tested elsewhere]" {
+        It "break in catch without loop" {
+            $a = . {
+              try {
                 throw 1
-            } catch {
-                if ($i -eq 2) {
+              } catch {
+                foreach ($i in (1..3)) {
+                  if ($i -eq 2) {
                     break
+                  }
+                  $i
                 }
-                $i
-            } finally {
-                "finally#2: $i"
+              } finally {
+                "finally"
+              }
             }
-        } catch {
-            "test failed: catch#1"
-        } finally {
-            "finally#1: $i"
+            AssertArraysEqual $a (1, "finally")
+        }
+
+        It "break in catch within foreach loop" {
+            $a = . {
+              foreach ($i in (1..3)) {
+                try {
+                  throw 1
+                } catch {
+                  if ($i -eq 2) {
+                    break
+                  }
+                  $i
+                } finally {
+                  "finally $i"
+                }
+              }
+            }
+            AssertArraysEqual $a (1, "finally 1", "finally 2")
+        }
+
+        It "continue in catch without loop" {
+            $a = . {
+              try {
+                throw 1
+              } catch {
+                foreach ($i in (1..3)) {
+                  if ($i -eq 2) {
+                    continue
+                  }
+                  $i
+                }
+              } finally {
+                "finally"
+              }
+            }
+            AssertArraysEqual $a (1, 3, "finally")
+        }
+
+        It "continue in catch within foreach loop" {
+            $a = . {
+              foreach ($i in (1..3)) {
+                try {
+                throw 1
+                } catch {
+                  if ($i -eq 2) {
+                    continue
+                  }
+                  $i
+                } finally {
+                  "finally $i"
+                }
+              }
+            }
+            AssertArraysEqual $a (1, "finally 1", "finally 2", 3, "finally 3")
+        }
+
+        It "continue in nested catch within foreach loop" {
+            $a = . {
+                foreach ($i in (1..3)) {
+                    try { #1
+                        try { #2
+                            throw 1
+                        } catch {
+                            if ($i -eq 2) {
+                                continue
+                            }
+                            $i
+                        } finally {
+                            "finally#2: $i"
+                        }
+                    } catch {
+                        "test failed: catch#1"
+                    } finally {
+                        "finally#1: $i"
+                    }
+                }
+            }
+            AssertArraysEqual $a (1, "finally#2: 1", "finally#1: 1", "finally#2: 2", "finally#1: 2", 3, "finally#2: 3", "finally#1: 3")
+        }
+
+        It "break in nested catch within foreach loop" {
+            $a = . {
+                foreach ($i in (1..3)) {
+                    try { #1
+                        try { #2
+                            throw 1
+                        } catch {
+                            if ($i -eq 2) {
+                                break
+                            }
+                            $i
+                        } finally {
+                            "finally#2: $i"
+                        }
+                    } catch {
+                        "test failed: catch#1"
+                    } finally {
+                        "finally#1: $i"
+                    }
+                }
+            }
+            AssertArraysEqual $a (1, "finally#2: 1", "finally#1: 1", "finally#2: 2", "finally#1: 2")
+        }
+
+        # Disabled - Compiled script has differing (but better) behavior
+        It "return in catch without loop" -Skip:$true {
+            $a = . {
+              function foo {
+                try {
+                  throw 1
+                } catch {
+                  foreach ($i in (1..3)) {
+                    if ($i -eq 2) {
+                      return "returned"
+                    }
+                    $i
+                  }
+                } finally {
+                  "finally"
+                }
+              }
+              foo
+            }
+
+            AssertArraysEqual $a (1, "finally", "returned") "return in catch"
+        }
+
+        # Disabled - Compiled script has differing (but better) behavior
+        It "return in catch within foreach loop" -Skip:$true {
+            $a = . {
+              function foo {
+                foreach ($i in (1..3)) {
+                  try {
+                    throw 1
+                  } catch {
+                    if ($i -eq 2) {
+                      return "returned"
+                    }
+                    $i
+                  } finally {
+                     "finally $i"
+                  }
+                }
+              }
+              foo
+            }
+            
+            AssertArraysEqual $a (1, "finally 1", "finally 2", "returned")
+        }
+    }
+
+    Context "Control flow in finally, normal execution" {
+        It "break in finally normal execution" {
+            $a = . {
+              try {
+                "try"
+              } catch {
+              } finally {
+                "finally"
+                foreach ($i in (1..3)) {
+                  if ($i -eq 2) {
+                    break
+                  }
+                  $i
+                }
+              }
+            }
+            
+            AssertArraysEqual $a ("try", "finally", 1)
+        }
+
+        It "continue in finally normal execution" {
+            $a = . {
+              try {
+                "try"
+              } catch {
+              } finally {
+                "finally"
+                foreach ($i in (1..3)) {
+                  if ($i -eq 2) {
+                    continue
+                  }
+                  $i
+                }
+              }
+            }
+            
+            AssertArraysEqual $a ("try", "finally", 1, 3)
+        }
+    }
+
+    Context "Control flow in finally, abnormal execution" {
+        It "break in finally normal execution" {
+            $a = . {
+              try {
+                "try"
+                throw 1
+              } catch {
+                "catch"
+              } finally {
+                "finally"
+                foreach ($i in (1..3)) {
+                  if ($i -eq 2) {
+                    break
+                  }
+                  $i
+                }
+              }
+            }
+
+            AssertArraysEqual $a ("try", "catch", "finally", 1)
+        }
+
+        It "continue in finally normal execution" {
+            $a = . {
+              try {
+                "try"
+                throw 1
+              } catch {
+                "catch"
+              } finally {
+                "finally"
+                foreach ($i in (1..3)) {
+                  if ($i -eq 2) {
+                    continue
+                  }
+                  $i
+                }
+              }
+            }
+
+            AssertArraysEqual $a ("try", "catch", "finally", 1, 3)
+        }
+    }
+
+    Context "Exception object" {
+        It "ErrorRecord object is set correctly" {
+            $a = . {
+              try {
+                throw 42
+              } catch {
+                $_
+              }
+            }
+
+            [int]$a.ToString() | Should Be 42
+        }
+    }
+
+    It "Nested try/catch" {
+        $a = . {
+          try {
+            "outer try"
+            try {
+              "inner try"
+              $a = 0
+              1 / $a
+            }
+            catch [OutOfMemoryException] {
+              "test failed"
+            }
+            finally {
+              "inner finally"
+            }
+          }
+          catch [DivideByZeroException] {
+            "caught"
+          }
+          finally {
+            "outer finally"
+          }
+        }
+
+        AssertArraysEqual $a ("outer try", "inner try", "inner finally", "caught", "outer finally")
+    }
+
+    Context "Rethrow" {
+        It "rethrow flow up" {
+            $a = . {
+              try {
+                try {
+                  $a = 0
+                  1 / $a
+                } catch {
+                  "inner catch"
+                  $ex_inner = $_
+                  throw
+                }
+              } catch {
+                "outer catch"
+                $ex_outer = $_
+              }
+            }
+
+            AssertArraysEqual $a ("inner catch", "outer catch")
+            ($ex_inner.Exception -eq $ex_outer.Exception) | Should Be $true
+        }
+
+        It "throw; outside catch threw wrong object" {
+            $a = . {
+              function foo {
+                trap [system.management.automation.runtimeexception] {      
+                  return "test passed"
+                }
+                trap {
+                  return "test failed"
+                }
+                throw
+              }
+              try {
+                $a = 0
+                1 / $a
+              } catch {
+                foo
+              }
+            }
+
+            ($a -eq "test passed") | Should Be $true
         }
     }
 }
-AssertArraysEqual $a (1, "finally#2: 1", "finally#1: 1", "finally#2: 2", "finally#1: 2")
-
-
-$a = . {
-  function foo {
-    try {
-      throw 1
-    } catch {
-      foreach ($i in (1..3)) {
-        if ($i -eq 2) {
-          return "returned"
-        }
-        $i
-      }
-    } finally {
-      "finally"
-    }
-  }
-  foo
-}
-
-# Disabled - Compiled script has differing (but better) behavior
-#AssertArraysEqual $a (1, "finally", "returned") "return in catch"
-
-$a = . {
-  function foo {
-    foreach ($i in (1..3)) {
-      try {
-        throw 1
-      } catch {
-        if ($i -eq 2) {
-          return "returned"
-        }
-        $i
-      } finally {
-         "finally $i"
-      }
-    }
-  }
-  foo
-}
-# Disabled - Compiled script has differing (but better) behavior
-#AssertArraysEqual $a (1, "finally 1", "finally 2", "returned") "return in catch"
-
-#############################################################
-#
-# Control flow in finally, normal execution
-#
-#############################################################
-$a = . {
-  try {
-    "try"
-  } catch {
-  } finally {
-    "finally"
-    foreach ($i in (1..3)) {
-      if ($i -eq 2) {
-        break
-      }
-      $i
-    }
-  }
-}
-AssertArraysEqual $a ("try", "finally", 1) "break in finally normal execution"
-
-$a = . {
-  try {
-    "try"
-  } catch {
-  } finally {
-    "finally"
-    foreach ($i in (1..3)) {
-      if ($i -eq 2) {
-        continue
-      }
-      $i
-    }
-  }
-}
-AssertArraysEqual $a ("try", "finally", 1, 3) "continue in finally normal execution"
-
-#############################################################
-#
-# Control flow in finally, abnormal execution
-#
-#############################################################
-$a = . {
-  try {
-    "try"
-    throw 1
-  } catch {
-    "catch"
-  } finally {
-    "finally"
-    foreach ($i in (1..3)) {
-      if ($i -eq 2) {
-        break
-      }
-      $i
-    }
-  }
-}
-AssertArraysEqual $a ("try", "catch", "finally", 1) "break in finally normal execution"
-
-$a = . {
-  try {
-    "try"
-    throw 1
-  } catch {
-    "catch"
-  } finally {
-    "finally"
-    foreach ($i in (1..3)) {
-      if ($i -eq 2) {
-        continue
-      }
-      $i
-    }
-  }
-}
-AssertArraysEqual $a ("try", "catch", "finally", 1, 3) "continue in finally normal execution"
-
-#############################################################
-#
-# Exception object
-#
-#############################################################
-$a = . {
-  try {
-    throw 42
-  } catch {
-    $_
-  }
-}
-Assert ([int]$a.ToString() -eq 42) "ErrorRecord object is set correctly"
-
-#############################################################
-#
-# Nested tries
-#
-#############################################################
-$a = . {
-  try {
-    "outer try"
-    try {
-      "inner try"
-      $a = 0
-      1 / $a
-    }
-    catch [OutOfMemoryException] {
-      "test failed"
-    }
-    finally {
-      "inner finally"
-    }
-  }
-  catch [DivideByZeroException] {
-    "caught"
-  }
-  finally {
-    "outer finally"
-  }
-}
-AssertArraysEqual $a ("outer try", "inner try", "inner finally", "caught", "outer finally") "Nested try/catch"
-
-#############################################################
-#
-# Rethrow
-#
-#############################################################
-$a = . {
-  try {
-    try {
-      $a = 0
-      1 / $a
-    } catch {
-      "inner catch"
-      $ex_inner = $_
-      throw
-    }
-  } catch {
-    "outer catch"
-    $ex_outer = $_
-  }
-}  
-AssertArraysEqual $a ("inner catch", "outer catch") "rethrow flow"
-Assert ($ex_inner.Exception -eq $ex_outer.Exception) "rethrow correct object"
-
-$a = . {
-  function foo {
-    trap [system.management.automation.runtimeexception] {      
-      return "test passed"
-    }
-    trap {
-      return "test failed"
-    }
-    throw
-  }
-  try {
-    $a = 0
-    1 / $a
-  } catch {
-    foo
-  }
-}
-Assert ($a -eq "test passed") "throw; outside catch threw wrong object"

--- a/test/powershell/Language/Scripting/TryCatch.Tests.ps1
+++ b/test/powershell/Language/Scripting/TryCatch.Tests.ps1
@@ -1,0 +1,560 @@
+#  <Test>
+#    <TestType>DRT</TestType>
+#    <summary>Exception handling (try/catch/finally)</summary>
+#  </Test>
+
+param($path = $null)
+
+if ($path -eq $null)
+{
+    $path = split-path $MyInvocation.InvocationName
+}
+
+. "$path\..\asserts.ps1"
+
+#############################################################
+#
+# Test simple parsing, ensure newlines allowed everywhere
+#
+#############################################################
+
+try
+{
+}
+catch
+{
+}
+
+try
+{
+}
+catch
+[int]
+{
+}
+
+try
+{
+}
+catch
+[int]
+,
+[char]
+{
+}
+
+try
+{
+}
+finally
+{
+}
+
+try
+{
+}
+catch
+{
+}
+finally
+{
+}
+
+try
+{
+}
+catch
+[int]
+{
+}
+finally
+{
+}
+
+try
+{
+}
+catch
+[int]
+,
+[char]
+{
+}
+finally
+{
+}
+
+
+#############################################################
+#
+# Basic exception handling
+#
+#############################################################
+
+$a = . { try { 1; throw "exception"; "test failed" } catch { 2 } }
+AssertArraysEqual $a (1,2) "Simple throw and catch"
+
+$a = . { try { 1 } finally { 2 } }
+AssertArraysEqual $a (1,2) "Simple try finally"
+
+$a = . { try { 1; throw "exception"; "test failed" } catch { 2 } finally { 3 } }
+AssertArraysEqual $a (1..3) "Simple try, throw, catch, and finally"
+
+
+#############################################################
+#
+# Mix traps with try/catch
+#
+#############################################################
+
+$a = . { trap { "test failed" } try { 1; throw "exception"; "test failed" } catch { 2 } }
+AssertArraysEqual $a (1,2) "Trap shouldn't catch exception"
+
+$a = . { try { 1; throw "exception"; trap { 2; return }; "test failed" } catch { "test failed" } }
+AssertArraysEqual $a (1,2) "Trap should catch exception"
+
+
+#############################################################
+#
+# Catch by type
+#
+#############################################################
+
+$a = . { try { 1; $a = 0; 1/$a; "test failed" } catch [DivideByZeroException] { 2 } }
+AssertArraysEqual $a (1,2) "Catch by type #1"
+
+$a = . { try { 1; $a = 0; 1/$a; "test failed" } catch [DivideByZeroException] { 2 } catch [Exception] { "test failed" } }
+AssertArraysEqual $a (1,2) "Catch by type #2"
+
+$a = . { try { 1; $a = 0; 1/$a; "test failed" } catch [DivideByZeroException] { 2 } catch { "test failed" } }
+AssertArraysEqual $a (1,2) "Catch by type #3"
+
+$a = . { try { 1; $a = 0; 1/$a; "test failed" } catch [DivideByZeroException],[StackOverflowException] { 2 } }
+AssertArraysEqual $a (1,2) "Catch by type #3"
+
+#############################################################
+#
+# Control flow in try
+#    exit not tested
+#    throw tested elsewhere
+#
+#############################################################
+
+$a = . {
+  foreach ($i in (1..3)) {
+    try {
+      if ($i -eq 2) {
+        break
+      }
+      $i
+    } catch {
+      "test failed"
+    } finally {
+      "finally: $i"
+    }
+  }
+}
+AssertArraysEqual $a (1, "finally: 1", "finally: 2") "break in try"
+
+$a = . {
+  foreach ($i in (1..3)) {
+    try {
+      if ($i -eq 2) {
+        continue
+      }
+      $i
+    } catch {
+      "test failed"
+    } finally {
+      "finally: $i"
+    }
+  }
+}
+AssertArraysEqual $a (1, "finally: 1", "finally: 2", 3, "finally: 3") "continue in try"
+
+$a = . {
+  function foo($i) {
+    try {
+      if ($i -eq 2) {
+        return "return: $i"
+      }
+      $i
+    } catch {
+      "test failed"
+    } finally {
+      "finally: $i"
+    }
+  }
+  foo 1
+  foo 2
+}
+
+# Disabled - Compiled script has differing (but better) behavior
+#AssertArraysEqual $a (1, "finally: 1", "finally: 2", "return: 2") "return in try"
+
+$a = . {
+    foreach ($i in (1..3)) {
+        try { #1
+            try { #2
+                if ($i -eq 2) {
+                    continue
+                }
+                $i
+            } catch {
+                "test failed: catch#2"
+            } finally {
+                "finally#2: $i"
+            }
+        } catch {
+            "test failed: catch#1"
+        } finally {
+            "finally#1: $i"
+        }
+    }
+}
+AssertArraysEqual $a (1, "finally#2: 1", "finally#1: 1", "finally#2: 2", "finally#1: 2", 3, "finally#2: 3", "finally#1: 3")
+
+
+$a = . {
+    foreach ($i in (1..3)) {
+        try { #1
+            try { #2
+                if ($i -eq 2) {
+                    break
+                }
+                $i
+            } catch {
+                "test failed: catch#2"
+            } finally {
+                "finally#2: $i"
+            }
+        } catch {
+            "test failed: catch#1"
+        } finally {
+            "finally#1: $i"
+        }
+    }
+}
+AssertArraysEqual $a (1, "finally#2: 1", "finally#1: 1", "finally#2: 2", "finally#1: 2")
+
+
+#############################################################
+#
+# Control flow in catch
+#    exit not tested
+#    throw tested elsewhere
+#
+#############################################################
+$a = . {
+  try {
+    throw 1
+  } catch {
+    foreach ($i in (1..3)) {
+      if ($i -eq 2) {
+        break
+      }
+      $i
+    }
+  } finally {
+    "finally"
+  }
+}
+AssertArraysEqual $a (1, "finally") "break in catch"
+
+$a = . {
+  foreach ($i in (1..3)) {
+    try {
+      throw 1
+    } catch {
+      if ($i -eq 2) {
+        break
+      }
+      $i
+    } finally {
+      "finally $i"
+    }
+  }
+}
+AssertArraysEqual $a (1, "finally 1", "finally 2") "break in catch"
+
+$a = . {
+  try {
+    throw 1
+  } catch {
+    foreach ($i in (1..3)) {
+      if ($i -eq 2) {
+        continue
+      }
+      $i
+    }
+  } finally {
+    "finally"
+  }
+}
+AssertArraysEqual $a (1, 3, "finally") "continue in catch"
+
+$a = . {
+  foreach ($i in (1..3)) {
+    try {
+    throw 1
+    } catch {
+      if ($i -eq 2) {
+        continue
+      }
+      $i
+    } finally {
+      "finally $i"
+    }
+  }
+}
+AssertArraysEqual $a (1, "finally 1", "finally 2", 3, "finally 3") "continue in catch"
+
+$a = . {
+    foreach ($i in (1..3)) {
+        try { #1
+            try { #2
+                throw 1
+            } catch {
+                if ($i -eq 2) {
+                    continue
+                }
+                $i
+            } finally {
+                "finally#2: $i"
+            }
+        } catch {
+            "test failed: catch#1"
+        } finally {
+            "finally#1: $i"
+        }
+    }
+}
+AssertArraysEqual $a (1, "finally#2: 1", "finally#1: 1", "finally#2: 2", "finally#1: 2", 3, "finally#2: 3", "finally#1: 3")
+
+
+$a = . {
+    foreach ($i in (1..3)) {
+        try { #1
+            try { #2
+                throw 1
+            } catch {
+                if ($i -eq 2) {
+                    break
+                }
+                $i
+            } finally {
+                "finally#2: $i"
+            }
+        } catch {
+            "test failed: catch#1"
+        } finally {
+            "finally#1: $i"
+        }
+    }
+}
+AssertArraysEqual $a (1, "finally#2: 1", "finally#1: 1", "finally#2: 2", "finally#1: 2")
+
+
+$a = . {
+  function foo {
+    try {
+      throw 1
+    } catch {
+      foreach ($i in (1..3)) {
+        if ($i -eq 2) {
+          return "returned"
+        }
+        $i
+      }
+    } finally {
+      "finally"
+    }
+  }
+  foo
+}
+
+# Disabled - Compiled script has differing (but better) behavior
+#AssertArraysEqual $a (1, "finally", "returned") "return in catch"
+
+$a = . {
+  function foo {
+    foreach ($i in (1..3)) {
+      try {
+        throw 1
+      } catch {
+        if ($i -eq 2) {
+          return "returned"
+        }
+        $i
+      } finally {
+         "finally $i"
+      }
+    }
+  }
+  foo
+}
+# Disabled - Compiled script has differing (but better) behavior
+#AssertArraysEqual $a (1, "finally 1", "finally 2", "returned") "return in catch"
+
+#############################################################
+#
+# Control flow in finally, normal execution
+#
+#############################################################
+$a = . {
+  try {
+    "try"
+  } catch {
+  } finally {
+    "finally"
+    foreach ($i in (1..3)) {
+      if ($i -eq 2) {
+        break
+      }
+      $i
+    }
+  }
+}
+AssertArraysEqual $a ("try", "finally", 1) "break in finally normal execution"
+
+$a = . {
+  try {
+    "try"
+  } catch {
+  } finally {
+    "finally"
+    foreach ($i in (1..3)) {
+      if ($i -eq 2) {
+        continue
+      }
+      $i
+    }
+  }
+}
+AssertArraysEqual $a ("try", "finally", 1, 3) "continue in finally normal execution"
+
+#############################################################
+#
+# Control flow in finally, abnormal execution
+#
+#############################################################
+$a = . {
+  try {
+    "try"
+    throw 1
+  } catch {
+    "catch"
+  } finally {
+    "finally"
+    foreach ($i in (1..3)) {
+      if ($i -eq 2) {
+        break
+      }
+      $i
+    }
+  }
+}
+AssertArraysEqual $a ("try", "catch", "finally", 1) "break in finally normal execution"
+
+$a = . {
+  try {
+    "try"
+    throw 1
+  } catch {
+    "catch"
+  } finally {
+    "finally"
+    foreach ($i in (1..3)) {
+      if ($i -eq 2) {
+        continue
+      }
+      $i
+    }
+  }
+}
+AssertArraysEqual $a ("try", "catch", "finally", 1, 3) "continue in finally normal execution"
+
+#############################################################
+#
+# Exception object
+#
+#############################################################
+$a = . {
+  try {
+    throw 42
+  } catch {
+    $_
+  }
+}
+Assert ([int]$a.ToString() -eq 42) "ErrorRecord object is set correctly"
+
+#############################################################
+#
+# Nested tries
+#
+#############################################################
+$a = . {
+  try {
+    "outer try"
+    try {
+      "inner try"
+      $a = 0
+      1 / $a
+    }
+    catch [OutOfMemoryException] {
+      "test failed"
+    }
+    finally {
+      "inner finally"
+    }
+  }
+  catch [DivideByZeroException] {
+    "caught"
+  }
+  finally {
+    "outer finally"
+  }
+}
+AssertArraysEqual $a ("outer try", "inner try", "inner finally", "caught", "outer finally") "Nested try/catch"
+
+#############################################################
+#
+# Rethrow
+#
+#############################################################
+$a = . {
+  try {
+    try {
+      $a = 0
+      1 / $a
+    } catch {
+      "inner catch"
+      $ex_inner = $_
+      throw
+    }
+  } catch {
+    "outer catch"
+    $ex_outer = $_
+  }
+}  
+AssertArraysEqual $a ("inner catch", "outer catch") "rethrow flow"
+Assert ($ex_inner.Exception -eq $ex_outer.Exception) "rethrow correct object"
+
+$a = . {
+  function foo {
+    trap [system.management.automation.runtimeexception] {      
+      return "test passed"
+    }
+    trap {
+      return "test failed"
+    }
+    throw
+  }
+  try {
+    $a = 0
+    1 / $a
+  } catch {
+    foo
+  }
+}
+Assert ($a -eq "test passed") "throw; outside catch threw wrong object"

--- a/test/powershell/Language/Scripting/TryCatch.Tests.ps1
+++ b/test/powershell/Language/Scripting/TryCatch.Tests.ps1
@@ -18,73 +18,73 @@ Describe "Test try/catch" -Tags "CI" {
     }
     
     It "Test simple parsing, ensure newlines allowed everywhere" {
+        try
         {
-            try
-            {
-            }
-            catch
-            {
-            }
+        }
+        catch
+        {
+        }
 
-            try
-            {
-            }
-            catch
-            [int]
-            {
-            }
+        try
+        {
+        }
+        catch
+        [int]
+        {
+        }
 
-            try
-            {
-            }
-            catch
-            [int]
-            ,
-            [char]
-            {
-            }
+        try
+        {
+        }
+        catch
+        [int]
+        ,
+        [char]
+        {
+        }
 
-            try
-            {
-            }
-            finally
-            {
-            }
+        try
+        {
+        }
+        finally
+        {
+        }
 
-            try
-            {
-            }
-            catch
-            {
-            }
-            finally
-            {
-            }
+        try
+        {
+        }
+        catch
+        {
+        }
+        finally
+        {
+        }
 
-            try
-            {
-            }
-            catch
-            [int]
-            {
-            }
-            finally
-            {
-            }
+        try
+        {
+        }
+        catch
+        [int]
+        {
+        }
+        finally
+        {
+        }
 
-            try
-            {
-            }
-            catch
-            [int]
-            ,
-            [char]
-            {
-            }
-            finally
-            {
-            }
-        } | Should Not Throw
+        try
+        {
+        }
+        catch
+        [int]
+        ,
+        [char]
+        {
+        }
+        finally
+        {
+        }
+
+        $true | Should Be $true # we only verify that there is no parsing error. This line contains a dummy Should to make pester happy.
     }
 
     Context "Basic exception handling" {
@@ -136,6 +136,11 @@ Describe "Test try/catch" -Tags "CI" {
             $a = . { try { 1; $a = 0; 1/$a; "test failed" } catch [DivideByZeroException],[ArgumentNullException] { 2 } }
             AssertArraysEqual $a (1,2)
         }
+
+        It "Catch by type #5" {
+            $a = . { try { 1; throw ([ArgumentNullException]::new("bad")) } catch [DivideByZeroException],[ArgumentNullException] { 2 } }
+            AssertArraysEqual $a (1,2)
+        }
     }
 
     Context "Control flow in try [exit not tested and throw tested elsewhere]" {
@@ -176,7 +181,7 @@ Describe "Test try/catch" -Tags "CI" {
         }
 
         # Disabled - Compiled script has differing (but better) behavior
-        It "return in try" -Skip:$true {
+        It "return in try" -Pending {
             $a = . {
               function foo($i) {
                 try {
@@ -368,7 +373,7 @@ Describe "Test try/catch" -Tags "CI" {
         }
 
         # Disabled - Compiled script has differing (but better) behavior
-        It "return in catch without loop" -Skip:$true {
+        It "return in catch without loop" -Pending {
             $a = . {
               function foo {
                 try {
@@ -391,7 +396,7 @@ Describe "Test try/catch" -Tags "CI" {
         }
 
         # Disabled - Compiled script has differing (but better) behavior
-        It "return in catch within foreach loop" -Skip:$true {
+        It "return in catch within foreach loop" -Pending {
             $a = . {
               function foo {
                 foreach ($i in (1..3)) {

--- a/test/powershell/Language/map.json
+++ b/test/powershell/Language/map.json
@@ -61,4 +61,6 @@
     "monad/tests/monad/DRT/utscripts/Language/I18n.Test_fallback.psd1":"Scripting/I18n.Test_fallback.psd1",
     "monad/tests/monad/DRT/utscripts/Language/scriptHelp.ps1":"Scripting/ScriptHelp.Tests.ps1",
     "monad/tests/monad/DRT/utscripts/Language/scriptHelp.xml":"Scripting/ScriptHelp.Tests.xml",
+    "monad/tests/monad/DRT/utscripts/Language/trycatch.ps1":"Scripting/TryCatch.Tests.ps1",
+    "monad/tests/monad/DRT/utscripts/Language/trap.ps1":"Scripting/Trap.Tests.ps1"
 }


### PR DESCRIPTION
Fix #2293

**Idea behind the Fix**
~~After selecting a handler, for both try/catch and trap{}, we set `$_` with [`new ErrorRecord(rte.ErrorRecord, exceptionToPass)`](https://github.com/PowerShell/PowerShell/blob/master/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs#L1297). The `exceptionToPass` will be adopted only if [`(rte.ErrorRecord.Exception is ParentContainsErrorRecordException) == true`](https://github.com/PowerShell/PowerShell/blob/master/src/System.Management.Automation/engine/ErrorPackage.cs#L1401). So basically `$_.Exception` will always be `rte.ErrorRecord.Exception` unless it's a `ParentContainsErrorRecordException` instance. So we should just select the handler based on `rte.ErrorRecord.Exception` if it's not `ParentContainsErrorRecordException`. When it is `ParentContainsErrorRecordException`, then we go through the original code path to determine what exception to pass to user.~~

The old fix would cause unacceptable breaking changes (see the discussion below). The following is the new fix:

First rank the given exception types -- a smaller rank indicates a more specific exception type, for example, `rank == 0` means the corresponding exception type is not derived by another other given exception types, while `rank == 1` means the corresponding exception type is derived by another exception type in the given types. `CatchAll` is considered to be derived by any other exception type. 

Then during the search, we try all existing searching methods in the same existing order, as long as we haven't found a handler whose exception type's rank is 0.
When a new handler is found, we use the following algorithm to decide whether to replace the current handler (the handler that was found before the new handler):
 - If new-rank is less than current-rank -- meaning the new handler is more specific, then we update the current result with it.
-  If new-rank is more than current-rank -- meaning the new handler is less specific, then we do NOT change the current result.
- If new-rank is equal to current-rank, we do NOT change the current result UNLESS the current handler is catch-all. (This is to keep the original behavior -- prefer to use the later found exception as the exception-to-pass-in if all exceptions result in the catch-all handler.

**With the Fix**

``` powershell
PS D:\> try {
>>     Get-ChildItem c:\xyzzy -ea Stop
>> } catch [System.Management.Automation.ItemNotFoundException] {
>>     "ItemNotFoundException caught"
>> } catch [System.Exception] {
>>     "System.Exception caught"
>> }
ItemNotFoundException caught
PS D:\>
PS D:\> try {
>>     Get-ChildItem c:\xyzzy -ea Stop
>> } catch [System.Management.Automation.ItemNotFoundException] {
>>     "ItemNotFoundException caught"
>> } catch [System.Management.Automation.RuntimeException] {
>>     "RuntimeException caught"
>> }
ItemNotFoundException caught
```

**Task**
- [x] Refine the fix
- [x] Run our legacy tests to find potential regressions (ran the Github nightly build tests)
- [x] Add tests
