### PR TITLE
Set-Content on Unix system not working with created PSDrives with the FileSystem provider

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/ContentCommandBase.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/ContentCommandBase.cs
@@ -684,6 +684,10 @@ namespace Microsoft.PowerShell.Commands
                                 currentCommandContext,
                                 out provider,
                                 out drive);
+#if UNIX
+                        // we need to pass null for non-Windows as we have a single rooted filesystem
+                        drive = null;
+#endif
 
                         PathInfo pathInfo =
                             new PathInfo(

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Content.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Content.Tests.ps1
@@ -1,51 +1,77 @@
 Describe "Set-Content cmdlet tests" -Tags "CI" {
-  $file1 = "file1.txt"
-  Setup -File "$file1" -Content $file1
-  Context "Set-Content should actually set content" {
-    It "should set-Content of testdrive:\$file1" {
-      $result=set-content -path testdrive:\$file1 -value "ExpectedContent" -passthru 
-      $result| Should be "ExpectedContent"
+    BeforeAll {
+        $file1 = "file1.txt"
+        Setup -File "$file1" -Content $file1
+        # if the registry doesn't exist, don't run those tests
+        $skipRegistry = ! (test-path hklm:/)
     }
-    It "should return expected string from testdrive:\$file1" {
-      $result = get-content -path testdrive:\$file1
-      $result | Should BeExactly "ExpectedContent"
+    Context "Set-Content should actually set content" {
+        It "should set-Content of testdrive:\$file1" {
+            $result=set-content -path testdrive:\$file1 -value "ExpectedContent" -passthru 
+            $result| Should be "ExpectedContent"
+        }
+
+        It "should return expected string from testdrive:\$file1" {
+            $result = get-content -path testdrive:\$file1
+            $result | Should BeExactly "ExpectedContent"
+        }
+
+
+        It "should Set-Content to testdrive:\dynamicfile.txt with dynamic parameters" {
+            $result=set-content -path testdrive:\dynamicfile.txt -value "ExpectedContent" -passthru
+            $result| Should BeExactly "ExpectedContent"
+        }
+
+        It "should return expected string from testdrive:\dynamicfile.txt" {
+            $result = get-content -path testdrive:\dynamicfile.txt
+            $result | Should BeExactly "ExpectedContent"
+        }
+
+        It "should remove existing content from testdrive:\$file1 when the -Value is `$null" {
+            $AsItWas=get-content testdrive:\$file1
+            $AsItWas |Should BeExactly "ExpectedContent"
+            set-content -path testdrive:\$file1 -value $null -ea stop
+            $AsItIs=get-content testdrive:\$file1
+            $AsItIs| Should Not Be $AsItWas
+        }
+
+        It "should throw 'ParameterArgumentValidationErrorNullNotAllowed' when -Path is `$null" {
+            try {
+                set-content -path $null -value "ShouldNotWorkBecausePathIsNull" -ea stop
+                Throw "Previous statement unexpectedly succeeded..."
+            } 
+            catch {
+                $_.FullyQualifiedErrorId | Should Be "ParameterArgumentValidationErrorNullNotAllowed,Microsoft.PowerShell.Commands.SetContentCommand"
+            }
+        }
+
+        It "should throw 'ParameterArgumentValidationErrorNullNotAllowed' when -Path is `$()" {
+            try {
+                set-content -path $() -value "ShouldNotWorkBecausePathIsInvalid" -ea stop
+                Throw "Previous statement unexpectedly succeeded..."
+            } 
+            catch {
+                $_.FullyQualifiedErrorId | Should Be "ParameterArgumentValidationErrorNullNotAllowed,Microsoft.PowerShell.Commands.SetContentCommand"
+            }
+        }
+
+        It "should throw 'PSNotSupportedException' when you set-content to an unsupported provider" -skip:$skipRegistry {
+            try {
+                set-content -path HKLM:\\software\\microsoft -value "ShouldNotWorkBecausePathIsUnsupported" -ea stop
+                Throw "Previous statement unexpectedly succeeded..."
+            } 
+            catch {
+                $_.FullyQualifiedErrorId | Should Be "NotSupported,Microsoft.PowerShell.Commands.SetContentCommand"
+            }
+        }
+        #[BugId(BugDatabase.WindowsOutOfBandReleases, 9058182)]
+
+        It "should be able to pass multiple [string]`$objects to Set-Content through the pipeline to output a dynamic Path file" {
+            "hello","world"|set-content testdrive:\dynamicfile2.txt
+            $result=get-content testdrive:\dynamicfile2.txt
+            $result.length |Should be 2
+            $result[0]     |Should be "hello"
+            $result[1]     |Should be "world"
+        }
     }
-    It "should Set-Content to testdrive:\dynamicfile.txt with dynamic parameters" -Pending:($IsLinux -Or $IsOSX) {#https://github.com/PowerShell/PowerShell/issues/891
-      $result=set-content -path testdrive:\dynamicfile.txt -value "ExpectedContent" -passthru
-      $result| Should BeExactly "ExpectedContent"
-    }
-    It "should return expected string from testdrive:\dynamicfile.txt" -Pending:($IsLinux -Or $IsOSX) {#https://github.com/PowerShell/PowerShell/issues/891
-      $result = get-content -path testdrive:\dynamicfile.txt
-      $result | Should BeExactly "ExpectedContent"
-    }
-    It "should remove existing content from testdrive:\$file1 when the -Value is `$null" {
-      $AsItWas=get-content testdrive:\$file1
-      $AsItWas |Should BeExactly "ExpectedContent"
-      {set-content -path testdrive:\$file1 -value $null -ea stop} | Should Not Throw
-      $AsItIs=get-content testdrive:\$file1
-      $AsItIs| Should Not Be $AsItWas
-    }
-    It "should throw 'ParameterArgumentValidationErrorNullNotAllowed' when -Path is `$null" {
-      Try {set-content -path $null -value "ShouldNotWorkBecausePathIsNull" -ea stop; Throw "Previous statement unexpectedly succeeded..."
-      } Catch {$_.FullyQualifiedErrorId | Should Be "ParameterArgumentValidationErrorNullNotAllowed,Microsoft.PowerShell.Commands.SetContentCommand"}
-    }
-    #[BugId(BugDatabase.WindowsOutOfBandReleases, 903880)]
-    It "should throw 'ParameterArgumentValidationErrorNullNotAllowed' when -Path is `$()" {
-      Try {set-content -path $() -value "ShouldNotWorkBecausePathIsInvalid" -ea stop; Throw "Previous statement unexpectedly succeeded..."
-      } Catch {$_.FullyQualifiedErrorId | Should Be "ParameterArgumentValidationErrorNullNotAllowed,Microsoft.PowerShell.Commands.SetContentCommand"}
-    }
-    #[BugId(BugDatabase.WindowsOutOfBandReleases, 906022)]
-    It "should throw 'PSNotSupportedException' when you set-content to an unsupported provider" -Skip:($IsLinux -Or $IsOSX) {
-      Try {set-content -path HKLM:\\software\\microsoft -value "ShouldNotWorkBecausePathIsUnsupported" -ea stop; Throw "Previous statement unexpectedly succeeded..."
-      } Catch {$_.FullyQualifiedErrorId | Should Be "NotSupported,Microsoft.PowerShell.Commands.SetContentCommand"}
-    }
-    #[BugId(BugDatabase.WindowsOutOfBandReleases, 9058182)]
-    It "should be able to pass multiple [string]`$objects to Set-Content through the pipeline to output a dynamic Path file" -Pending:($IsLinux -Or $IsOSX) {#https://github.com/PowerShell/PowerShell/issues/891
-      "hello","world"|set-content testdrive:\dynamicfile2.txt
-      $result=get-content testdrive:\dynamicfile2.txt
-      $result.length |Should be 2
-      $result[0]     |Should be "hello"
-      $result[1]     |Should be "world"
-    }
-  }
 }


### PR DESCRIPTION
Also activate the tests which were marked as skipped for those tests

Anything that went against the single rooted drive was fine, but

``` powershell
new-psdrive -name TEMP -root /tmp -psprovider filesystem`
set-content TEMP:/file
```

would fail
