### PR TITLE
Add Invoke-Item deterministic Windows tests

### DIFF
--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Invoke-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Invoke-Item.Tests.ps1
@@ -43,33 +43,27 @@ Describe "Invoke-Item on non-Windows" -Tags "CI" {
         EnsureChildHasExited $process
         $process.ExitCode | Should Be 0
     }
-
-<#
-    It "Should throw not supported on Windows with .NET Core" -Skip:($IsLinux -or $IsOSX -or !$IsCoreCLR) {
-        { Invoke-Item $testfile }| Should Throw "Operation is not supported on this platform."
-    }
-#>
 }
 
 Describe "Invoke-Item tests on Windows" -Tags "CI","RequireAdminOnWindows" {
     BeforeAll {
-        $testfilename = "testfile.!!testext!!"
-        $testfilepath = Join-Path $TestDrive $testfilename
-        $renamedtestfilename = "renamedtestfile.!!testext!!"
-        $renamedtestfilepath = Join-Path $TestDrive $renamedtestfilename
-        remove-item $testfilepath -ErrorAction SilentlyContinue
-        remove-item $renamedtestfilepath -ErrorAction SilentlyContinue
-        new-item $testfilepath | Out-Null
-        if ( $IsWindows -and -not ($IsWindows -and $IsCoreCLR) ) {
-            cmd.exe /c assoc .!!testext!!=!!testext!!.FileType
-            cmd.exe /c ftype !!testext!!.FileType=cmd.exe /c rename $testfilepath $renamedtestfilename
+        if ($IsWindows) {
+            $testfilename = "testfile.!!testext!!"
+            $testfilepath = Join-Path $TestDrive $testfilename
+            $renamedtestfilename = "renamedtestfile.!!testext!!"
+            $renamedtestfilepath = Join-Path $TestDrive $renamedtestfilename
+            remove-item $testfilepath -ErrorAction SilentlyContinue
+            remove-item $renamedtestfilepath -ErrorAction SilentlyContinue
+            new-item $testfilepath | Out-Null
+            cmd.exe /c assoc .!!testext!!=!!testext!!.FileType | Out-Null
+            cmd.exe /c ftype !!testext!!.FileType=cmd.exe /c rename $testfilepath $renamedtestfilename | Out-Null
         }
     }
 
     AfterAll {
-        remove-item $testfilepath -ErrorAction SilentlyContinue
-        remove-item $renamedtestfilepath -ErrorAction SilentlyContinue
-        if ( $IsWindows -and -not ($IsWindows -and $IsCoreCLR) ) {
+        if ($IsWindows) {
+            remove-item $testfilepath -ErrorAction SilentlyContinue
+            remove-item $renamedtestfilepath -ErrorAction SilentlyContinue
             cmd.exe /c assoc !!testext!!=
             cmd.exe /c ftype !!testext!!.FileType=
         }
@@ -78,17 +72,17 @@ Describe "Invoke-Item tests on Windows" -Tags "CI","RequireAdminOnWindows" {
     It "Should invoke a file without error on Windows w/o .NET Core" -Skip:(-not $IsWindows -or ($IsWindows -and $IsCoreCLR)) {
         invoke-item $testfilepath
         # Waiting subprocess start and rename file
-        $startTime = [Datetime]::Now
-        $result = $true
-        while (-not (test-path $renamedtestfilepath))
         {
-          Start-Sleep -Milliseconds  100
-          if (([Datetime]::Now - $startTime) -ge [timespan]"00:00:05") { $result = $false; break;}
-        }
-        $result | Should Be $true
+            $startTime = [Datetime]::Now
+            while (-not (test-path $renamedtestfilepath))
+            {
+                Start-Sleep -Milliseconds  100
+                if (([Datetime]::Now - $startTime) -ge [timespan]"00:00:05") { throw "Timeout exception" }
+            }
+        } | Should Not throw
     }
 
     It "Should throw 'not supported' on Windows with .NET Core" -Skip:(-not ($IsWindows -and $IsCoreCLR)) {
-        { Invoke-Item $testfilepath }| Should Throw "Operation is not supported on this platform."
+        { Invoke-Item $testfilepath } | Should Throw "Operation is not supported on this platform."
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Invoke-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Invoke-Item.Tests.ps1
@@ -1,6 +1,6 @@
 using namespace System.Diagnostics
 
-Describe "Invoke-Item" -Tags "CI" {
+Describe "Invoke-Item on non-Windows" -Tags "CI" {
 
     function NewProcessStartInfo([string]$CommandLine, [switch]$RedirectStdIn)
     {
@@ -37,14 +37,52 @@ Describe "Invoke-Item" -Tags "CI" {
         $testfile = Join-Path $TestDrive testfile.txt
     }
 
-    It "Should invoke a text file without error" -Skip:($IsWindows -and $IsCoreCLR) {
+    It "Should invoke a text file without error on non-Windows" -Skip:($IsWindows) {
         $debugfn = NewProcessStartInfo "-noprofile ""``Invoke-Item $testfile`n" -RedirectStdIn
         $process = RunPowerShell $debugfn
         EnsureChildHasExited $process
         $process.ExitCode | Should Be 0
     }
 
+<#
     It "Should throw not supported on Windows with .NET Core" -Skip:($IsLinux -or $IsOSX -or !$IsCoreCLR) {
         { Invoke-Item $testfile }| Should Throw "Operation is not supported on this platform."
+    }
+#>
+}
+
+Describe "Invoke-Item deterministic tests on Windows" -Tags "CI","RequireAdminOnWindows" {
+    BeforeAll {
+        $testfilename = "testfile.!!testext!!"
+        $testfilepath = Join-Path $TestDrive $testfilename
+        $renamedtestfilename = "renamedtestfile.!!testext!!"
+        $renamedtestfilepath = Join-Path $TestDrive $renamedtestfilename
+        remove-item $testfilepath -ErrorAction SilentlyContinue
+        remove-item $renamedtestfilepath -ErrorAction SilentlyContinue
+        new-item $testfilepath | Out-Null
+
+    }
+
+    AfterAll {
+        remove-item $testfilepath -ErrorAction SilentlyContinue
+        remove-item $renamedtestfilepath -ErrorAction SilentlyContinue
+
+    }
+
+    It "Should invoke a file without error on Windows w/o .NET Core" -Skip:(-not $IsWindows -or ($IsWindows -and $IsCoreCLR)) {
+        cmd.exe /c assoc .!!testext!!=!!testext!!.FileType
+        cmd.exe /c ftype !!testext!!.FileType=cmd.exe /c rename $testfilepath $renamedtestfilename
+        invoke-item $testfilepath
+        $PSVersionTable | Out-File c:\1\1.txt
+        # Wiaiting subprocess start and rename file
+        Start-Sleep -Milliseconds 500
+        test-path $renamedtestfilepath | Should Be $true
+
+        cmd.exe /c assoc !!testext!!=
+        cmd.exe /c ftype !!testext!!.FileType=
+    }
+
+    It "Should throw 'not supported' on Windows with .NET Core" -Skip:(-not ($IsWindows -and $IsCoreCLR)) {
+        { Invoke-Item $testfilepath }| Should Throw "Operation is not supported on this platform."
     }
 }


### PR DESCRIPTION
1. Fix "close text file" (problem was only in FullCLR).
2. Add test which really check on Windows that invoke-item do.
3. Split Windows and non-Windows tests.

Close #1568

(In fact, non-Windows test verifies nothing. This requires a separate fix. )
