### PR TITLE
Added -Top and -Bottom aliases for -First and -Last

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/select-object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/select-object.cs
@@ -129,6 +129,7 @@ namespace Microsoft.PowerShell.Commands
         // NTRAID#Windows Out Of Band Releases-927878-2006/03/02
         // Allow zero
         [ValidateRange(0, int.MaxValue)]
+        [Alias("Bottom")]
         public int Last
         {
             get { return _last; }
@@ -144,6 +145,7 @@ namespace Microsoft.PowerShell.Commands
         // NTRAID#Windows Out Of Band Releases-927878-2006/03/02
         // Allow zero
         [ValidateRange(0, int.MaxValue)]
+        [Alias("Top")]
         public int First
         {
             get { return _first; }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-Object.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-Object.Tests.ps1
@@ -50,6 +50,28 @@ Describe "Select-Object" -Tags "CI" {
 	}
     }
 
+    It "Should return correct object with Top parameter alias" {
+	$result = $dirObject | Select-Object -Top $TestLength
+
+	$result.Length | Should Be $TestLength
+
+	for ($i=0; $i -lt $TestLength; $i++)
+	{
+	    $result[$i].Name | Should Be $dirObject[$i].Name
+	}
+    }
+
+    It "Should return correct object with Bottom parameter alias" {
+	$result = $dirObject | Select-Object -Bottom $TestLength
+
+	$result.Length | Should Be $TestLength
+
+	for ($i=0; $i -lt $TestLength; $i++)
+	{
+	    $result[$i].Name | Should Be $dirObject[$dirObject.Length - $TestLength + $i].Name
+	}
+    }
+
     It "Should work correctly with Unique parameter" {
 	$result   = ("a","b","c","a","a","a" | Select-Object -Unique).Length
 	$expected = 3


### PR DESCRIPTION
If you watch recorded demos of introductory PowerShell sessions delivered by people like @jpsnover, they inevitably show the famous select top 10 processes pipeline. When they do, they invoke something like this (with or without aliases, etc.):

```
Get-Process | sort WorkingSet64 -desc | select -first 10
```

As they are entering that line, they very often (almost always) say top 10 as they type "-first 10". It's a small thing, but it's how the mind works. We want the top 10 processes, and technically, in the output, we're getting the top 10 since they are output vertically. I've always felt this would be better if the -First parameter of Select-Object had a -Top alias and the -Last parameter of Select-Object had a -Bottom alias. Such a change would allow for this instead:

```
gps | sort WorkingSet64 -desc | select -top 10
```

Now that PowerShell is open source, I decided to add them, see what you think. New parameter aliases are defined and new Pester tests are included for verification.
