### PR TITLE
Skipping New-PSRoleCapabilityFile and Get-PSSessionCapability on help…

### DIFF
--- a/test/powershell/engine/HelpSystem.Tests.ps1
+++ b/test/powershell/engine/HelpSystem.Tests.ps1
@@ -41,7 +41,9 @@ function RunTestCase
     $cmdletsToSkip = @(
         "Get-PSHostProcessInfo",
         "Out-Default",
-        "Register-ArgumentCompleter"
+        "Register-ArgumentCompleter",
+        "New-PSRoleCapabilityFile",
+        "Get-PSSessionCapability"
     )
 
     foreach ($cmdletName in $cmdlets)


### PR DESCRIPTION
Skipping Get-PSSessionCapability and New-PSRoleCapabilityFile on help system tests since there is no help content for these two cmldets. See issue #2460.
