### PR TITLE
Added tests to close code coverage in CIM area

### DIFF
--- a/test/powershell/Modules/CimCmdlets/CimInstance.Tests.ps1
+++ b/test/powershell/Modules/CimCmdlets/CimInstance.Tests.ps1
@@ -1,0 +1,41 @@
+Try {
+    if ( ! $IsWindows ) {
+        $PSDefaultParameterValues["it:pending"] = $true
+    }
+    Describe "CimInstance cmdlet tests" {
+        BeforeAll {
+            if ( ! $IsWindows ) { return }
+            $instance = get-ciminstance cim_computersystem
+        }
+        It "CimClass property should not be null" {
+            # we can't use equals here as on windows cimclassname
+            # is win32_computersystem, but that's not likely to be the
+            # case on non-Windows systems
+            $instance.cimClass.CimClassName | should match _computersystem
+        }
+        It "Property access should be case insensitive" {
+            foreach($property in $instance.psobject.properties.name) {
+                $pUpper = $property.ToUpper()
+                $pLower = $property.ToLower()
+                [string]$pLowerValue = $pinstance.$pLower -join ","
+                [string]$pUpperValue = $pinstance.$pUpper -join ","
+                $pLowerValue | should be $pUpperValue
+            }
+        }
+        It "GetCimSessionInstanceId method invocation should return data" {
+           $instance.GetCimSessionInstanceId() | Should BeOfType "Guid"
+        }
+        It "should produce an error for a non-existing classname" {
+            try {
+                get-ciminstance -classname thisnameshouldnotexist -ea stop
+                throw "expected error did not occur"
+            }
+            catch {
+                $_.FullyQualifiedErrorId | should be "HRESULT 0x80041010,Microsoft.Management.Infrastructure.CimCmdlets.GetCimInstanceCommand"
+            }
+        }        
+    }
+}
+finally {
+    $PSDefaultParameterValues.Remove("it:pending")
+}

--- a/test/powershell/Modules/CimCmdlets/CimInstance.Tests.ps1
+++ b/test/powershell/Modules/CimCmdlets/CimInstance.Tests.ps1
@@ -2,7 +2,7 @@ Try {
     if ( ! $IsWindows ) {
         $PSDefaultParameterValues["it:pending"] = $true
     }
-    Describe "CimInstance cmdlet tests" {
+    Describe "CimInstance cmdlet tests" -Tag @("CI") {
         BeforeAll {
             if ( ! $IsWindows ) { return }
             $instance = get-ciminstance cim_computersystem

--- a/test/powershell/Modules/CimCmdlets/CimInstance.Tests.ps1
+++ b/test/powershell/Modules/CimCmdlets/CimInstance.Tests.ps1
@@ -1,6 +1,6 @@
 Try {
     if ( ! $IsWindows ) {
-        $PSDefaultParameterValues["it:pending"] = $true
+        $PSDefaultParameterValues['it:pending'] = $true
     }
     Describe "CimInstance cmdlet tests" -Tag @("CI") {
         BeforeAll {
@@ -33,9 +33,9 @@ Try {
             catch {
                 $_.FullyQualifiedErrorId | should be "HRESULT 0x80041010,Microsoft.Management.Infrastructure.CimCmdlets.GetCimInstanceCommand"
             }
-        }        
+        }
     }
 }
 finally {
-    $PSDefaultParameterValues.Remove("it:pending")
+    $PSDefaultParameterValues.Remove('it:pending')
 }

--- a/test/powershell/Modules/CimCmdlets/CimSession.Tests.ps1
+++ b/test/powershell/Modules/CimCmdlets/CimSession.Tests.ps1
@@ -32,7 +32,7 @@ try {
         It "A cim session can be removed" {
             $sessionName = [guid]::NewGuid()
             $session = New-CimSession -ComputerName . -name $sessionName
-            $sessiosn += $session
+            $sessions += $session
             $session.Name | Should be $sessionName
             $session | Remove-CimSession
             Get-CimSession $session.Id -ErrorAction SilentlyContinue | should BeNullOrEmpty

--- a/test/powershell/Modules/CimCmdlets/CimSession.Tests.ps1
+++ b/test/powershell/Modules/CimCmdlets/CimSession.Tests.ps1
@@ -3,7 +3,7 @@ try {
         $global:PSDefaultParameterValues['it:pending'] = $true
         $script:SkipTests = $true
     }
-    Describe "New-CimSession" {
+    Describe "New-CimSession" -Tag @("CI") {
         BeforeAll {
             $sessions = @()
         }

--- a/test/powershell/Modules/CimCmdlets/CimSession.Tests.ps1
+++ b/test/powershell/Modules/CimCmdlets/CimSession.Tests.ps1
@@ -1,7 +1,6 @@
 try {
     if ( ! $IsWindows ) {
-        $global:PSDefaultParameterValues['it:pending'] = $true
-        $script:SkipTests = $true
+        $PSDefaultParameterValues['it:pending'] = $true
     }
     Describe "New-CimSession" -Tag @("CI") {
         BeforeAll {
@@ -18,14 +17,14 @@ try {
         It "A cim session can be created" {
             $sessionName = [guid]::NewGuid()
             $session = New-CimSession -ComputerName . -name $sessionName
-            $sessions += $session 
+            $sessions += $session
             $session.Name | Should be $sessionName
             $session.InstanceId  | should BeOfType "System.Guid"
         }
         It "A Cim session can be retrieved" {
             $sessionName = [guid]::NewGuid()
             $session = New-CimSession -ComputerName . -name $sessionName
-            $sessions += $session 
+            $sessions += $session
             (get-cimsession -Name $sessionName).InstanceId | should be $session.InstanceId
             (get-cimsession -Id $session.Id).InstanceId | should be $session.InstanceId
             (get-cimsession -InstanceId $session.InstanceId).InstanceId | should be $session.InstanceId
@@ -41,5 +40,5 @@ try {
     }
 }
 finally {
-    $global:PSDefaultParameterValues.remove("it:pending")
+    $PSDefaultParameterValues.remove('it:pending')
 }

--- a/test/powershell/Modules/CimCmdlets/CimSession.Tests.ps1
+++ b/test/powershell/Modules/CimCmdlets/CimSession.Tests.ps1
@@ -1,0 +1,45 @@
+try {
+    if ( ! $IsWindows ) {
+        $global:PSDefaultParameterValues['it:pending'] = $true
+        $script:SkipTests = $true
+    }
+    Describe "New-CimSession" {
+        BeforeAll {
+            $sessions = @()
+        }
+        AfterEach {
+            try {
+                $sessions | remove-cimsession
+            }
+            finally {
+                $sessions = @()
+            }
+        }
+        It "A cim session can be created" {
+            $sessionName = [guid]::NewGuid()
+            $session = New-CimSession -ComputerName . -name $sessionName
+            $sessions += $session 
+            $session.Name | Should be $sessionName
+            $session.InstanceId  | should BeOfType "System.Guid"
+        }
+        It "A Cim session can be retrieved" {
+            $sessionName = [guid]::NewGuid()
+            $session = New-CimSession -ComputerName . -name $sessionName
+            $sessions += $session 
+            (get-cimsession -Name $sessionName).InstanceId | should be $session.InstanceId
+            (get-cimsession -Id $session.Id).InstanceId | should be $session.InstanceId
+            (get-cimsession -InstanceId $session.InstanceId).InstanceId | should be $session.InstanceId
+        }
+        It "A cim session can be removed" {
+            $sessionName = [guid]::NewGuid()
+            $session = New-CimSession -ComputerName . -name $sessionName
+            $sessiosn += $session
+            $session.Name | Should be $sessionName
+            $session | Remove-CimSession
+            Get-CimSession $session.Id -ErrorAction SilentlyContinue | should BeNullOrEmpty
+        }
+    }
+}
+finally {
+    $global:PSDefaultParameterValues.remove("it:pending")
+}

--- a/test/powershell/Modules/CimCmdlets/Get-CimClass.Tests.ps1
+++ b/test/powershell/Modules/CimCmdlets/Get-CimClass.Tests.ps1
@@ -1,6 +1,39 @@
 Describe 'Get-CimClass' -tags "CI" {
-    # Get-CimClass works only on windows
-    It 'can get CIM_Error CIM class' -Skip:(-not $IsWindows) {
-        Get-CimClass -ClassName CIM_Error | Should Not Be $null
+    BeforeAll {
+        if ( ! $IsWindows ) {
+            $PSDefaultParameterValues['it:pending'] = $true
+        }
     }
+    AfterAll {
+        $PSDefaultParameterValues.Remove('it:pending')
+    }
+    # Get-CimClass works only on windows right now
+    It 'can get CIM_Error CIM class' {
+        Get-CimClass -ClassName CIM_Error | Should Not BeNullOrEmpty
+    }
+    It 'can get class when namespace is specified' {
+        Get-CimClass -ClassName CIM_OperatingSystem -Namespace root/cimv2 | Should Not BeNullOrEmpty
+    }
+    It 'can retrieve a class when a method is provided' {
+        Get-CimClass -MethodName Reboot | Should Not BeNullOrEmpty
+    }
+    It 'produces an error when a non-existent class is used' {
+        try {
+            Get-CimClass -ClassName thisclasstypedoesnotexist -ea stop
+            throw "Expected error did not occur"
+        }
+        catch {
+            $_.FullyQualifiedErrorId | should be "HRESULT 0x80041002,Microsoft.Management.Infrastructure.CimCmdlets.GetCimClassCommand"
+        }
+    }
+    It 'produces an error when an improper namespace is used' {
+        try {
+            Get-CimClass -ClassName CIM_OperatingSystem -Namespace badnamespace -ea stop
+            throw "Expected error did not occur"
+        }
+        catch {
+            $_.FullyQualifiedErrorId | should be "HRESULT 0x8004100e,Microsoft.Management.Infrastructure.CimCmdlets.GetCimClassCommand"
+        }
+    }
+
 }            

--- a/test/powershell/Modules/CimCmdlets/Get-CimClass.Tests.ps1
+++ b/test/powershell/Modules/CimCmdlets/Get-CimClass.Tests.ps1
@@ -1,39 +1,44 @@
-Describe 'Get-CimClass' -tags "CI" {
-    BeforeAll {
-        if ( ! $IsWindows ) {
-            $PSDefaultParameterValues['it:pending'] = $true
-        }
-    }
-    AfterAll {
-        $PSDefaultParameterValues.Remove('it:pending')
-    }
+try {
     # Get-CimClass works only on windows right now
-    It 'can get CIM_Error CIM class' {
-        Get-CimClass -ClassName CIM_Error | Should Not BeNullOrEmpty
+    if ( ! $IsWindows ) {
+        $PSDefaultParameterValues['it:pending'] = $true
     }
-    It 'can get class when namespace is specified' {
-        Get-CimClass -ClassName CIM_OperatingSystem -Namespace root/cimv2 | Should Not BeNullOrEmpty
-    }
-    It 'can retrieve a class when a method is provided' {
-        Get-CimClass -MethodName Reboot | Should Not BeNullOrEmpty
-    }
-    It 'produces an error when a non-existent class is used' {
-        try {
-            Get-CimClass -ClassName thisclasstypedoesnotexist -ea stop
-            throw "Expected error did not occur"
+
+    Describe 'Get-CimClass' -tags "CI" {
+        It 'can get CIM_Error CIM class' {
+            Get-CimClass -ClassName CIM_Error | Should Not BeNullOrEmpty
         }
-        catch {
-            $_.FullyQualifiedErrorId | should be "HRESULT 0x80041002,Microsoft.Management.Infrastructure.CimCmdlets.GetCimClassCommand"
+        It 'can get class when namespace is specified' {
+            Get-CimClass -ClassName CIM_OperatingSystem -Namespace root/cimv2 | Should Not BeNullOrEmpty
         }
-    }
-    It 'produces an error when an improper namespace is used' {
-        try {
-            Get-CimClass -ClassName CIM_OperatingSystem -Namespace badnamespace -ea stop
-            throw "Expected error did not occur"
+
+        It 'produces an error when a non-existent class is used' {
+            try {
+                Get-CimClass -ClassName thisclasstypedoesnotexist -ea stop
+                throw "Expected error did not occur"
+            }
+            catch {
+                $_.FullyQualifiedErrorId | should be "HRESULT 0x80041002,Microsoft.Management.Infrastructure.CimCmdlets.GetCimClassCommand"
+            }
         }
-        catch {
-            $_.FullyQualifiedErrorId | should be "HRESULT 0x8004100e,Microsoft.Management.Infrastructure.CimCmdlets.GetCimClassCommand"
+        It 'produces an error when an improper namespace is used' {
+            try {
+                Get-CimClass -ClassName CIM_OperatingSystem -Namespace badnamespace -ea stop
+                throw "Expected error did not occur"
+            }
+            catch {
+                $_.FullyQualifiedErrorId | should be "HRESULT 0x8004100e,Microsoft.Management.Infrastructure.CimCmdlets.GetCimClassCommand"
+            }
         }
     }
 
-}            
+    # feature tests
+    Describe 'Get-CimClass' -tags @("Feature") {
+        It 'can retrieve a class when a method is provided' {
+            Get-CimClass -MethodName Reboot | Should Not BeNullOrEmpty
+        }
+    }
+}
+finally {
+    $PSDefaultParameterValues.Remove('it:pending')
+}

--- a/test/powershell/engine/ETS/CimAdapter.Tests.ps1
+++ b/test/powershell/engine/ETS/CimAdapter.Tests.ps1
@@ -1,0 +1,83 @@
+function getIndex
+{
+	param([string[]]$strings,[string]$pattern)
+	for ($i = 0; $i -lt $strings.Count; $i++) {
+		if ($strings[$i] -like $pattern) {
+			return $i
+		}
+	}
+	return -1
+}
+
+Describe "CIM Objects are adapted properly" {
+    BeforeAll {
+        if ( ! $IsWindows ) {
+            $PSDefaultParameterValues["it:pending"] = $true
+            return
+        }
+        $p = get-ciminstance win32_process |Select-object -first 1
+
+        $indexOf_namespaceQualified_Win32Process            = getIndex $p.PSTypeNames "*root?cimv2?Win32_Process"
+        $indexOf_namespaceQualified_CimProcess              = getIndex $p.PSTypeNames "*root?cimv2?CIM_Process"
+        $indexOf_namespaceQualified_CimLogicalElement       = getIndex $p.PSTypeNames "*root?cimv2?CIM_LogicalElement"
+        $indexOf_namespaceQualified_CimManagedSystemElement = getIndex $p.PSTypeNames "*root?cimv2?CIM_ManagedSystemElement"
+
+        $indexOf_className_Win32Process            = getIndex $p.PSTypeNames "*#Win32_Process"
+        $indexOf_className_CimProcess              = getIndex $p.PSTypeNames "*#CIM_Process"
+        $indexOf_className_CimLogicalElement       = getIndex $p.PSTypeNames "*#CIM_LogicalElement"
+        $indexOf_className_CimManagedSystemElement = getIndex $p.PSTypeNames "*#CIM_ManagedSystemElement"
+    }
+    AfterAll {
+            $PSDefaultParameterValues.Remove("it:pending")        
+    }
+
+    It "Namespace-qualified Win32_Process is present" -skip:(!$IsWindows) {
+        $indexOf_namespaceQualified_Win32Process |Should not Be (-1)
+    }
+    It "Namespace-qualified CIM_Process is present" {
+        $indexOf_namespaceQualified_CimProcess |Should not Be (-1)
+    }
+    It "Namespace-qualified CIM_LogicalElement is present" {
+        $indexOf_namespaceQualified_CimLogicalElement |Should not Be (-1)
+    }
+    It "Namespace-qualified CIM_ManagedSystemElement is present" {
+        $indexOf_namespaceQualified_CimManagedSystemElement |Should not Be (-1)
+    }
+
+    It "Classname of Win32_Process is present" -skip:(!$IsWindows) {
+        $indexOf_className_Win32Process |Should not Be (-1)
+    }
+    It "Classname of CIM_Process is present" {
+        $indexOf_className_CimProcess |Should not Be (-1)
+    }
+    It "Classname of CIM_LogicalElement is present" {
+        $indexOf_className_CimLogicalElement |Should not Be (-1)
+    }
+    It "Classname of CIM_ManagedSystemElement is present" {
+        $indexOf_className_CimManagedSystemElement |Should not Be (-1)
+    }
+
+    It "Win32_Process comes after CIM_Process (namespace qualified)" -skip:(!$IsWindows) {
+        $indexOf_namespaceQualified_Win32Process |should belessthan $indexOf_namespaceQualified_CimProcess
+    }
+    It "CIM_Process comes after CIM_LogicalElement (namespace qualified)" {
+        $indexOf_namespaceQualified_CimProcess |should belessthan $indexOf_namespaceQualified_CimLogicalElement
+    }
+    It "CIM_LogicalElement comes after CIM_ManagedSystemElement (namespace qualified)" {
+        $indexOf_namespaceQualified_CimLogicalElement |should belessthan $indexOf_namespaceQualified_CimManagedSystemElement
+    }
+
+    It "Win32_Process comes after CIM_Process (classname only)" -skip:(!$IsWindows) {
+        $indexOf_className_Win32Process |should belessthan $indexOf_className_CimProcess
+    }
+    It "CIM_Process comes after CIM_LogicalElement (classname only)" {
+        $indexOf_className_CimProcess |should belessthan $indexOf_className_CimLogicalElement
+    }
+    It "CIM_LogicalElement comes after CIM_ManagedSystemElement (classname only)" {
+        $indexOf_className_CimLogicalElement |should belessthan $indexOf_className_CimManagedSystemElement
+    }
+
+    It "Namespace qualified PSTypenames comes after class-only PSTypeNames" -skip:(!$IsWindows) {
+        $indexOf_namespaceQualified_CimManagedSystemElement |should belessthan $indexOf_className_Win32Process
+    }
+}

--- a/test/powershell/engine/ETS/CimAdapter.Tests.ps1
+++ b/test/powershell/engine/ETS/CimAdapter.Tests.ps1
@@ -9,7 +9,7 @@ function getIndex
 	return -1
 }
 
-Describe "CIM Objects are adapted properly" {
+Describe "CIM Objects are adapted properly" -Tag @("CI") {
     BeforeAll {
         if ( ! $IsWindows ) {
             $PSDefaultParameterValues["it:pending"] = $true

--- a/test/powershell/engine/ETS/CimAdapter.Tests.ps1
+++ b/test/powershell/engine/ETS/CimAdapter.Tests.ps1
@@ -9,75 +9,82 @@ function getIndex
 	return -1
 }
 
-Describe "CIM Objects are adapted properly" -Tag @("CI") {
-    BeforeAll {
-        if ( ! $IsWindows ) {
-            $PSDefaultParameterValues["it:pending"] = $true
-            return
+try {
+    if ( ! $IsWindows ) {
+        $PSDefaultParameterValues["it:pending"] = $true
+    }
+    Describe "CIM Objects are adapted properly" -Tag @("CI") {
+        BeforeAll {
+            if ( ! $IsWindows ) {
+                return
+            }
+            $p = get-ciminstance win32_process |Select-object -first 1
+
+            $indexOf_namespaceQualified_Win32Process            = getIndex $p.PSTypeNames "*root?cimv2?Win32_Process"
+            $indexOf_namespaceQualified_CimProcess              = getIndex $p.PSTypeNames "*root?cimv2?CIM_Process"
+            $indexOf_namespaceQualified_CimLogicalElement       = getIndex $p.PSTypeNames "*root?cimv2?CIM_LogicalElement"
+            $indexOf_namespaceQualified_CimManagedSystemElement = getIndex $p.PSTypeNames "*root?cimv2?CIM_ManagedSystemElement"
+
+            $indexOf_className_Win32Process            = getIndex $p.PSTypeNames "*#Win32_Process"
+            $indexOf_className_CimProcess              = getIndex $p.PSTypeNames "*#CIM_Process"
+            $indexOf_className_CimLogicalElement       = getIndex $p.PSTypeNames "*#CIM_LogicalElement"
+            $indexOf_className_CimManagedSystemElement = getIndex $p.PSTypeNames "*#CIM_ManagedSystemElement"
         }
-        $p = get-ciminstance win32_process |Select-object -first 1
+        AfterAll {
+            $PSDefaultParameterValues.Remove("it:pending")
+        }
 
-        $indexOf_namespaceQualified_Win32Process            = getIndex $p.PSTypeNames "*root?cimv2?Win32_Process"
-        $indexOf_namespaceQualified_CimProcess              = getIndex $p.PSTypeNames "*root?cimv2?CIM_Process"
-        $indexOf_namespaceQualified_CimLogicalElement       = getIndex $p.PSTypeNames "*root?cimv2?CIM_LogicalElement"
-        $indexOf_namespaceQualified_CimManagedSystemElement = getIndex $p.PSTypeNames "*root?cimv2?CIM_ManagedSystemElement"
+        It "Namespace-qualified Win32_Process is present" -skip:(!$IsWindows) {
+            $indexOf_namespaceQualified_Win32Process |Should not Be (-1)
+        }
+        It "Namespace-qualified CIM_Process is present" {
+            $indexOf_namespaceQualified_CimProcess |Should not Be (-1)
+        }
+        It "Namespace-qualified CIM_LogicalElement is present" {
+            $indexOf_namespaceQualified_CimLogicalElement |Should not Be (-1)
+        }
+        It "Namespace-qualified CIM_ManagedSystemElement is present" {
+            $indexOf_namespaceQualified_CimManagedSystemElement |Should not Be (-1)
+        }
 
-        $indexOf_className_Win32Process            = getIndex $p.PSTypeNames "*#Win32_Process"
-        $indexOf_className_CimProcess              = getIndex $p.PSTypeNames "*#CIM_Process"
-        $indexOf_className_CimLogicalElement       = getIndex $p.PSTypeNames "*#CIM_LogicalElement"
-        $indexOf_className_CimManagedSystemElement = getIndex $p.PSTypeNames "*#CIM_ManagedSystemElement"
-    }
-    AfterAll {
-            $PSDefaultParameterValues.Remove("it:pending")        
-    }
+        It "Classname of Win32_Process is present" -skip:(!$IsWindows) {
+            $indexOf_className_Win32Process |Should not Be (-1)
+        }
+        It "Classname of CIM_Process is present" {
+            $indexOf_className_CimProcess |Should not Be (-1)
+        }
+        It "Classname of CIM_LogicalElement is present" {
+            $indexOf_className_CimLogicalElement |Should not Be (-1)
+        }
+        It "Classname of CIM_ManagedSystemElement is present" {
+            $indexOf_className_CimManagedSystemElement |Should not Be (-1)
+        }
 
-    It "Namespace-qualified Win32_Process is present" -skip:(!$IsWindows) {
-        $indexOf_namespaceQualified_Win32Process |Should not Be (-1)
-    }
-    It "Namespace-qualified CIM_Process is present" {
-        $indexOf_namespaceQualified_CimProcess |Should not Be (-1)
-    }
-    It "Namespace-qualified CIM_LogicalElement is present" {
-        $indexOf_namespaceQualified_CimLogicalElement |Should not Be (-1)
-    }
-    It "Namespace-qualified CIM_ManagedSystemElement is present" {
-        $indexOf_namespaceQualified_CimManagedSystemElement |Should not Be (-1)
-    }
+        It "Win32_Process comes after CIM_Process (namespace qualified)" -skip:(!$IsWindows) {
+            $indexOf_namespaceQualified_Win32Process |should belessthan $indexOf_namespaceQualified_CimProcess
+        }
+        It "CIM_Process comes after CIM_LogicalElement (namespace qualified)" {
+            $indexOf_namespaceQualified_CimProcess |should belessthan $indexOf_namespaceQualified_CimLogicalElement
+        }
+        It "CIM_LogicalElement comes after CIM_ManagedSystemElement (namespace qualified)" {
+            $indexOf_namespaceQualified_CimLogicalElement |should belessthan $indexOf_namespaceQualified_CimManagedSystemElement
+        }
 
-    It "Classname of Win32_Process is present" -skip:(!$IsWindows) {
-        $indexOf_className_Win32Process |Should not Be (-1)
-    }
-    It "Classname of CIM_Process is present" {
-        $indexOf_className_CimProcess |Should not Be (-1)
-    }
-    It "Classname of CIM_LogicalElement is present" {
-        $indexOf_className_CimLogicalElement |Should not Be (-1)
-    }
-    It "Classname of CIM_ManagedSystemElement is present" {
-        $indexOf_className_CimManagedSystemElement |Should not Be (-1)
-    }
+        It "Win32_Process comes after CIM_Process (classname only)" -skip:(!$IsWindows) {
+            $indexOf_className_Win32Process |should belessthan $indexOf_className_CimProcess
+        }
+        It "CIM_Process comes after CIM_LogicalElement (classname only)" {
+            $indexOf_className_CimProcess |should belessthan $indexOf_className_CimLogicalElement
+        }
+        It "CIM_LogicalElement comes after CIM_ManagedSystemElement (classname only)" {
+            $indexOf_className_CimLogicalElement |should belessthan $indexOf_className_CimManagedSystemElement
+        }
 
-    It "Win32_Process comes after CIM_Process (namespace qualified)" -skip:(!$IsWindows) {
-        $indexOf_namespaceQualified_Win32Process |should belessthan $indexOf_namespaceQualified_CimProcess
+        It "Namespace qualified PSTypenames comes after class-only PSTypeNames" -skip:(!$IsWindows) {
+            $indexOf_namespaceQualified_CimManagedSystemElement |should belessthan $indexOf_className_Win32Process
+        }
     }
-    It "CIM_Process comes after CIM_LogicalElement (namespace qualified)" {
-        $indexOf_namespaceQualified_CimProcess |should belessthan $indexOf_namespaceQualified_CimLogicalElement
-    }
-    It "CIM_LogicalElement comes after CIM_ManagedSystemElement (namespace qualified)" {
-        $indexOf_namespaceQualified_CimLogicalElement |should belessthan $indexOf_namespaceQualified_CimManagedSystemElement
-    }
-
-    It "Win32_Process comes after CIM_Process (classname only)" -skip:(!$IsWindows) {
-        $indexOf_className_Win32Process |should belessthan $indexOf_className_CimProcess
-    }
-    It "CIM_Process comes after CIM_LogicalElement (classname only)" {
-        $indexOf_className_CimProcess |should belessthan $indexOf_className_CimLogicalElement
-    }
-    It "CIM_LogicalElement comes after CIM_ManagedSystemElement (classname only)" {
-        $indexOf_className_CimLogicalElement |should belessthan $indexOf_className_CimManagedSystemElement
-    }
-
-    It "Namespace qualified PSTypenames comes after class-only PSTypeNames" -skip:(!$IsWindows) {
-        $indexOf_namespaceQualified_CimManagedSystemElement |should belessthan $indexOf_className_Win32Process
-    }
+}
+finally {
+    $PSDefaultParameterValues.Remove("it:pending")
 }

--- a/test/powershell/engine/Remoting/SessionOption.Tests.ps1
+++ b/test/powershell/engine/Remoting/SessionOption.Tests.ps1
@@ -1,0 +1,55 @@
+try {
+    $defaultParameterValues = $PSDefaultParameterValues.Clone()
+    if ( ! $IsWindows ) {
+        $PSDefaultParameterValues['it:skip'] = $true
+    }
+    Describe " WSMan SessionOption object" {
+        It "The SessionOption type exists" {
+            "Microsoft.WSMan.Management.SessionOption" -as "Type" | Should Not BeNullOrEmpty
+        }
+        It "The SessionOption type can be created" {
+            $result = [Microsoft.WSMan.Management.SessionOption]::new()
+            $result | should BeOfType "Microsoft.WSMan.Management.SessionOption"
+        }
+        It "The SessionOption type has the proper properties when created with the default constructor" {
+            $result = [Microsoft.WSMan.Management.SessionOption]::new()
+            $result.SkipCACheck         | should be $False
+            $result.SkipCNCheck         | should be $False
+            $result.SkipRevocationCheck | should be $False
+            $result.UseEncryption       | should be $True
+            $result.UseUtf16            | should be $False
+            $result.ProxyAuthentication | should be 0
+            $result.SPNPort             | should be 0
+            $result.OperationTimeout    | should be 0
+            $result.ProxyCredential     | should BeNullOrEmpty
+            $result.ProxyAccessType     | should be ProxyIEConfig
+        }
+        It "The values of SessionOption may be set" {
+            $result = [Microsoft.WSMan.Management.SessionOption]::new()
+            $result.SkipCACheck = $true
+            $result.SkipCNCheck = $true 
+            $result.SkipRevocationCheck = $true
+            $result.UseUtf16 = $True
+            $result.UseEncryption = $false
+            $result.ProxyAuthentication = "Negotiate"
+            $result.SPNPort = 10
+            $result.OperationTimeout = 10
+            $result.ProxyAccessType = "ProxyAutoDetect"
+            $result.ProxyCredential = [System.Net.NetworkCredential]::new("user","pass")
+            
+            $result.SkipCACheck         | should be $true
+            $result.SkipCNCheck         | should be $true
+            $result.SkipRevocationCheck | should be $true
+            $result.UseEncryption       | should be $False
+            $result.UseUtf16            | should be $True
+            $result.ProxyAuthentication | should be "Negotiate"
+            $result.SPNPort             | should be 10
+            $result.OperationTimeout    | should be 10
+            $result.ProxyCredential     | should Not BeNullOrEmpty
+            $result.ProxyAccessType     | should be "ProxyAutoDetect"
+        }
+    }
+}
+finally {
+    $global:PSDefaultParameterValues = $defaultParameterValues
+}

--- a/test/powershell/engine/Remoting/SessionOption.Tests.ps1
+++ b/test/powershell/engine/Remoting/SessionOption.Tests.ps1
@@ -3,7 +3,7 @@ try {
     if ( ! $IsWindows ) {
         $PSDefaultParameterValues['it:skip'] = $true
     }
-    Describe " WSMan SessionOption object" {
+    Describe " WSMan SessionOption object" -Tag @("CI") {
         It "The SessionOption type exists" {
             "Microsoft.WSMan.Management.SessionOption" -as "Type" | Should Not BeNullOrEmpty
         }

--- a/test/powershell/engine/Remoting/SessionOption.Tests.ps1
+++ b/test/powershell/engine/Remoting/SessionOption.Tests.ps1
@@ -1,5 +1,4 @@
 try {
-    $defaultParameterValues = $PSDefaultParameterValues.Clone()
     if ( ! $IsWindows ) {
         $PSDefaultParameterValues['it:skip'] = $true
     }
@@ -27,7 +26,7 @@ try {
         It "The values of SessionOption may be set" {
             $result = [Microsoft.WSMan.Management.SessionOption]::new()
             $result.SkipCACheck = $true
-            $result.SkipCNCheck = $true 
+            $result.SkipCNCheck = $true
             $result.SkipRevocationCheck = $true
             $result.UseUtf16 = $True
             $result.UseEncryption = $false
@@ -36,7 +35,7 @@ try {
             $result.OperationTimeout = 10
             $result.ProxyAccessType = "ProxyAutoDetect"
             $result.ProxyCredential = [System.Net.NetworkCredential]::new("user","pass")
-            
+
             $result.SkipCACheck         | should be $true
             $result.SkipCNCheck         | should be $true
             $result.SkipRevocationCheck | should be $true
@@ -51,5 +50,5 @@ try {
     }
 }
 finally {
-    $global:PSDefaultParameterValues = $defaultParameterValues
+    $PSDefaultParameterValues.remove("it:skip")
 }


### PR DESCRIPTION
Using our code coverage report to close some test gaps

Added CimAdapter.Tests for adaptation layer (code cribbed from BVT tests)
Added SessionOption.Tests.ps1 (Code cribbed from BVT tests)
Modified CimClass tests by adding more tests
Added CimSession.Tests for basic tests of New-CimSession cmdlet
Added CimInstance.Tests for basic tests of Get-CimInstance
