### PR TITLE
Fixing HashMap to PSCustomObject object conversion (#2295)

### DIFF
--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -5698,7 +5698,7 @@ namespace System.Management.Automation
 
             internal override CompletionResult GetCompletionResult(string keyMatched, string prefix, string suffix, string namespaceToRemove)
             {
-                string completion = ToStringCodeMethods.Type(Type);
+                string completion = ToStringCodeMethods.Type(Type, false, keyMatched);
 
                 // If the completion included a namespace and ToStringCodeMethods.Type found
                 // an accelerator, then just use the type's FullName instead because the user

--- a/src/System.Management.Automation/engine/MshObject.cs
+++ b/src/System.Management.Automation/engine/MshObject.cs
@@ -2415,7 +2415,7 @@ namespace Microsoft.PowerShell
             sb.Append(']');
         }
 
-        internal static string Type(Type type, bool dropNamespaces = false)
+        internal static string Type(Type type, bool dropNamespaces = false, string key = null)
         {
             if (type == null)
                 return String.Empty;
@@ -2450,9 +2450,13 @@ namespace Microsoft.PowerShell
             }
             else
             {
-                result = TypeAccelerators.FindBuiltinAccelerator(type);
+                result = TypeAccelerators.FindBuiltinAccelerator(type, key);
                 if (result == null)
                 {
+                    if (type == typeof(PSCustomObject))
+                    {
+                        return type.Name;
+                    }
                     if (dropNamespaces)
                     {
                         if (typeinfo.IsNested)

--- a/src/System.Management.Automation/engine/parser/TypeResolver.cs
+++ b/src/System.Management.Automation/engine/parser/TypeResolver.cs
@@ -804,7 +804,7 @@ namespace System.Management.Automation
             builtinTypeAccelerators.Add("psvariableproperty", typeof(PSVariableProperty));
         }
 
-        internal static string FindBuiltinAccelerator(Type type,string expectedKey=null)
+        internal static string FindBuiltinAccelerator(Type type, string expectedKey = null)
         {
             // Taking attributes as special case. In this case, we only want to return the
             // accelerator.

--- a/src/System.Management.Automation/engine/parser/TypeResolver.cs
+++ b/src/System.Management.Automation/engine/parser/TypeResolver.cs
@@ -804,18 +804,31 @@ namespace System.Management.Automation
             builtinTypeAccelerators.Add("psvariableproperty", typeof(PSVariableProperty));
         }
 
-        internal static string FindBuiltinAccelerator(Type type)
+        internal static string FindBuiltinAccelerator(Type type,string expectedKey=null)
         {
-            foreach (KeyValuePair<string, Type> entry in builtinTypeAccelerators)
+            // Taking attributes as special case. In this case, we only want to return the
+            // accelerator.
+            if (null == expectedKey || typeof(Attribute).IsAssignableFrom(type))
             {
-                if (entry.Value == type)
+                foreach (KeyValuePair<string, Type> entry in builtinTypeAccelerators)
                 {
-                    return entry.Key;
+                    if (entry.Value == type)
+                    {
+                        return entry.Key;
+                    }
+                }
+            }
+            else
+            {
+                Type resultType = null;
+                builtinTypeAccelerators.TryGetValue(expectedKey, out resultType);
+                if (null != resultType && resultType == type)
+                {
+                    return expectedKey;
                 }
             }
             return null;
         }
-
         /// <summary>
         /// Add a type accelerator.
         /// </summary>

--- a/test/powershell/Host/TabCompletion/BugFix.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/BugFix.Tests.ps1
@@ -21,4 +21,10 @@ Describe "Tab completion bug fix" -Tags "CI" {
         $result.CompletionMatches[0].CompletionText | Should Be "-and"
         $result.CompletionMatches[1].CompletionText | Should Be "-as"
     }
+    It "Issue#2295 - '[pscu<tab>' should expand to [pscustomobject]" {
+        $result = TabExpansion2 -inputScript "[pscu" -cursorColumn "[pscu".Length
+        $result | Should Not BeNullOrEmpty
+        $result.CompletionMatches.Count | Should Be 1
+        $result.CompletionMatches[0].CompletionText | Should Be "pscustomobject"
+    }
 }

--- a/test/powershell/Language/Scripting/HashtableToPSCustomObjectConversion.Tests.ps1
+++ b/test/powershell/Language/Scripting/HashtableToPSCustomObjectConversion.Tests.ps1
@@ -20,6 +20,14 @@
         @{ Name = 'Hashtable(Stored in a variable) conversion to  PSCustomObject succeeds (Insertion Order is not retained)';
            Cmd = "`$ht = @{one=1;two=2};[pscustomobject]`$ht";
            ExpectedType = 'System.Management.automation.psobject'
+        },
+        @{ Name = 'New-Object cmdlet should accept `$null as Property argument for pscustomobject';
+           Cmd = "new-object pscustomobject -property `$null";
+           ExpectedType = 'System.Management.automation.psobject'
+        },
+	   @{ Name = 'New-Object cmdlet should accept empty hashtable as property argument for pscustomobject';
+           Cmd = "`$ht = @{};new-object pscustomobject -property `$ht";
+           ExpectedType = 'System.Management.automation.psobject'
         }
     )
 
@@ -128,6 +136,22 @@
 	    $obj = [PSCustomObject] @{pstypename = 'System.Object'}
 	    $obj.PSTypeNames.Count | Should Be 3
 	    $obj.PSTypeNames[0] | Should Be 'System.Object'
+    }
+    It "new-object should fail to create object for System.Management.Automation.PSCustomObject" {
+
+        $errorObj = $null
+        $obj = $null
+		$ht = @{one=1;two=2}
+        try
+        {
+            $obj = New-Object System.Management.Automation.PSCustomObject -property $ht
+        }
+        catch
+        {
+            $errorObj = $_
+        }
+        $obj | should be $null
+        $errorObj.FullyQualifiedErrorId | should be "CannotFindAppropriateCtor,Microsoft.PowerShell.Commands.NewObjectCommand"
     }
 }
 


### PR DESCRIPTION
Fixing following issues :
1. HashMap to PSCustomObject Conversion fails if full name of PSCustomObject type is specified.
2. [pscu] expands to [System.Management.Automation.PSCustomObject] whereas [pso] expands to [PSObject].
3. [PSCustomObject].FullName returned System.Management.Automation.PSObject instead of System.Management.Automation.PSCustomObject.

After the fix, these 3 should not happen.
