### PR TITLE
Fixing the plugin install directory to reflect the current version

### DIFF
--- a/src/powershell-native/Install-PowerShellRemoting.ps1
+++ b/src/powershell-native/Install-PowerShellRemoting.ps1
@@ -142,7 +142,7 @@ else
     Write-Verbose "Using PowerShell Version: $targetPsVersion" -Verbose
 }
 
-$pluginBasePath = Join-Path "$env:WINDIR\System32\PowerShell" $powerShellVersion
+$pluginBasePath = Join-Path "$env:WINDIR\System32\PowerShell" $targetPsVersion
 
 $resolvedPluginAbsolutePath = ""
 if (! (Test-Path $pluginBasePath))


### PR DESCRIPTION
Fixes the plugin DLL destination path error:

``` powershell
PS C:\Program Files\PowerShell> .\6.0.0.11\Install-PowerShellRemoting.ps1
VERBOSE: Using PowerShell Version: 6.0.0-alpha.11
VERBOSE: Performing the operation "Copy File" on target "Item: C:\Program Files\PowerShell\6.0.0.11\pwrshplugin.dll
Destination: C:\WINDOWS\System32\PowerShell\6.0.0-alpha.8\pwrshplugin.dll".
The operation completed successfully.
```

To be:

``` powershell
PS C:\Program Files\PowerShell> .\6.0.0.11\Install-PowerShellRemoting.ps1
VERBOSE: Using PowerShell Version: 6.0.0-alpha.11
VERBOSE: Performing the operation "Copy File" on target "Item: C:\Program Files\PowerShell\6.0.0.11\pwrshplugin.dll
Destination: C:\WINDOWS\System32\PowerShell\6.0.0-alpha.11\pwrshplugin.dll".
The operation completed successfully.
```

Now the destination path directory is properly versioned.
