### PR TITLE
Fix Get-Alias Name parameter allows Null value

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetAliasCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetAliasCommand.cs
@@ -26,6 +26,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         /// 
         [Parameter(ParameterSetName = "Default", Position = 0, ValueFromPipeline = true, ValueFromPipelineByPropertyName = true)]
+        [ValidateNotNullOrEmpty()]
         public string[] Name
         {
             get { return _names; }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Alias.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Alias.Tests.ps1
@@ -221,15 +221,23 @@ Describe "Get-Alias null tests" -Tags "CI" {
   Context 'Check null or empty value to the -Name parameter' {
     It 'Should throw if <value> is passed to -Name parameter' -TestCases $testCases {
       param($data)
-      try {Get-Alias -Name $data }
-      catch [System.Management.Automation.ParameterBindingException] {$_.Exception.ErrorId | Should Be 'ParameterArgumentValidationError'}
+      try 
+      {
+          Get-Alias -Name $data
+          throw "No Exception!"
+      }
+      catch { $_.FullyQualifiedErrorId | Should Be 'ParameterArgumentValidationError,Microsoft.PowerShell.Commands.GetAliasCommand' }
     }
   }
   Context 'Check null or empty value to the -Name parameter via pipeline' {
     It 'Should throw if <value> is passed through pipeline to -Name parameter' -TestCases $testCases {
       param($data)
-      try {$data | Get-Alias -ErrorAction Stop}
-      catch [System.Management.Automation.ParameterBindingException] {$_.Exception.ErrorId | Should Be 'ParameterArgumentValidationError'}
+      try 
+      {
+          $data | Get-Alias -ErrorAction Stop
+          throw "No Exception!"
+      }
+      catch { $_.FullyQualifiedErrorId | Should Be 'ParameterArgumentValidationError,Microsoft.PowerShell.Commands.GetAliasCommand' }
     }
   }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Alias.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Alias.Tests.ps1
@@ -211,3 +211,25 @@ Describe "Get-Alias" -Tags "CI" {
         }
     }
 }
+
+Describe "Get-Alias null tests" -Tags "CI" {
+
+  $testCases = 
+    @{ data = $null; value = 'null' },
+    @{ data = [String]::Empty; value = 'empty string' }
+
+  Context 'Check null or empty value to the -Name parameter' {
+    It 'Should throw if <value> is passed to -Name parameter' -TestCases $testCases {
+      param($data)
+      try {Get-Alias -Name $data }
+      catch [System.Management.Automation.ParameterBindingException] {$_.Exception.ErrorId | Should Be 'ParameterArgumentValidationError'}
+    }
+  }
+  Context 'Check null or empty value to the -Name parameter via pipeline' {
+    It 'Should throw if <value> is passed through pipeline to -Name parameter' -TestCases $testCases {
+      param($data)
+      try {$data | Get-Alias -ErrorAction Stop}
+      catch [System.Management.Automation.ParameterBindingException] {$_.Exception.ErrorId | Should Be 'ParameterArgumentValidationError'}
+    }
+  }
+}


### PR DESCRIPTION
1. Add [ValidateNotNullOrEmpty()] to Name parameter
2. Add tests

Close #2544 
