### PR TITLE
Guard against ReflectionTypeLoadException in InitializeTypeCache

### DIFF
--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -5860,7 +5860,17 @@ namespace System.Management.Automation
             #region Process_LoadedAssemblies
 
             var assembliesExcludingPSGenerated = ClrFacade.GetAssemblies();
-            var allPublicTypes = assembliesExcludingPSGenerated.SelectMany(assembly => assembly.GetTypes().Where(TypeResolver.IsPublic));
+            var allPublicTypes = assembliesExcludingPSGenerated.SelectMany(assembly =>
+            {
+                try
+                {
+                    return assembly.GetTypes().Where(TypeResolver.IsPublic);
+                }
+                catch (ReflectionTypeLoadException)
+                {
+                }
+                return Type.EmptyTypes;
+            });
 
             foreach (var type in allPublicTypes)
             {


### PR DESCRIPTION
Tab completion sometimes becomes completely inoperative due to a failure to populate the type cache for command completion. This can happen when the shell has loaded assemblies that require binding redirection for certain types, but doesn't itself use those types. 

For example, when trying to use completion with the SharePoint administrative mini-shell, the snap-in for SharePoint loads some server-side assemblies from SharePoint. Some of the Types in these assemblies require binding redirection to newer versions of their dependencies - in my case, there is an assembly reference to v10 of sql analysis services, but a binding redirect to v12; this is normally handled by SharePoint's Web.config. The snap-in doesn't use these types, but since InitializeTypeCache scans the entire assembly, it triggers dependency resolution. In the PowerShell context, there are no binding redirections in play, so attempts to load the Types fail with a `ReflectionTypeLoadException` and the entire `InitializeTypeCache` call is aborted, leaving an empty cache, and no working tab completion.
