### PR TITLE
Adding a callback prior to string-to-scriptblock conversions.

### DIFF
--- a/src/System.Management.Automation/engine/MshCmdlet.cs
+++ b/src/System.Management.Automation/engine/MshCmdlet.cs
@@ -359,6 +359,12 @@ namespace System.Management.Automation
         public System.EventHandler<CommandLookupEventArgs> PostCommandLookupAction { get; set; }
 
         /// <summary>
+        /// This event handler is called before a string is converted into a ScriptBlock. It
+        /// should have a single string parameter that is the string being converted.
+        /// </summary>
+        public static System.EventHandler<DynamicScriptBlockCreationEventArgs> PreDynamicScriptBlockCreationAction { get; set; }
+
+        /// <summary>
         /// Returns the CmdletInfo object that corresponds to the name argument
         /// </summary>
         /// <param name="commandName">The name of the cmdlet to look for</param>

--- a/src/System.Management.Automation/engine/lang/scriptblock.cs
+++ b/src/System.Management.Automation/engine/lang/scriptblock.cs
@@ -97,6 +97,13 @@ namespace System.Management.Automation
         /// <param name="script">The string to compile.</param>
         internal static ScriptBlock Create(ExecutionContext context, string script)
         {
+            EventHandler<DynamicScriptBlockCreationEventArgs> preDynamicScriptBlockCreationEvent = CommandInvocationIntrinsics.PreDynamicScriptBlockCreationAction;
+
+            if (preDynamicScriptBlockCreationEvent != null)
+            {
+                preDynamicScriptBlockCreationEvent.Invoke(null, new DynamicScriptBlockCreationEventArgs(script));
+            }
+
             ScriptBlock sb = Create(context.Engine.EngineParser, null, script);
             if (context.EngineSessionState != null && context.EngineSessionState.Module != null)
             {
@@ -112,6 +119,13 @@ namespace System.Management.Automation
         /// <param name="script">The string to compile.</param>
         public static ScriptBlock Create(string script)
         {
+            EventHandler<DynamicScriptBlockCreationEventArgs> preDynamicScriptBlockCreationEvent = CommandInvocationIntrinsics.PreDynamicScriptBlockCreationAction;
+
+            if (preDynamicScriptBlockCreationEvent != null)
+            {
+                preDynamicScriptBlockCreationEvent.Invoke(null, new DynamicScriptBlockCreationEventArgs(script));
+            }
+
             return Create(new Language.Parser(), null, script);
         }
 

--- a/src/vs-csproj/System.Management.Automation.csproj
+++ b/src/vs-csproj/System.Management.Automation.csproj
@@ -2329,6 +2329,7 @@
     <Compile Include="..\System.Management.Automation\utils\WindowsErrorReporting.cs">
       <Link>utils\WindowsErrorReporting.cs</Link>
     </Compile>
+    <Compile Include="engine\DynamicScriptBlockCreationEventArgs.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\System.Management.Automation\map.json">

--- a/src/vs-csproj/engine/DynamicScriptBlockCreationEventArgs.cs
+++ b/src/vs-csproj/engine/DynamicScriptBlockCreationEventArgs.cs
@@ -1,0 +1,22 @@
+﻿namespace System.Management.Automation
+{
+    /// <summary>
+    /// EventArgs for the DynamicScriptBlockCreationEvent event
+    /// </summary>
+    public class DynamicScriptBlockCreationEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Constructor for event args object
+        /// </summary>
+        /// <param name="script">The string to compile</param>
+        internal DynamicScriptBlockCreationEventArgs(string script)
+        {
+            Script = script;
+        }
+
+        /// <summary>
+        /// The string to compile
+        /// </summary>
+        public string Script { get; }
+    }
+}

--- a/test/powershell/Language/Scripting/PreDynamicScriptBlockCreationAction.Tests.ps1
+++ b/test/powershell/Language/Scripting/PreDynamicScriptBlockCreationAction.Tests.ps1
@@ -1,0 +1,30 @@
+Describe "Tests for PreDynamicScriptBlockCreationAction" -Tags "CI" {
+    It 'No action' { 
+        iex "`$true" | Should Be $true
+        [ScriptBlock]::Create("`$true") | Should Be $true
+    }
+
+    It "Action" {
+        [System.Management.Automation.CommandInvocationIntrinsics]::PreDynamicScriptBlockCreationAction = {
+            param($source, [System.Management.Automation.DynamicScriptBlockCreationEventArgs]$eventArgs)
+            throw $eventArgs.Script
+        }
+
+        $guid = [System.Guid]::NewGuid().ToString()
+
+        try
+        {
+            iex $guid
+            Throw "Execution shouldn't reach here"
+        }
+        catch
+        {
+            $_.Exception.Message | Should Be $guid
+        }
+    }
+
+    It "Action removed" {
+        [System.Management.Automation.CommandInvocationIntrinsics]::PreDynamicScriptBlockCreationAction = $null
+        iex "`$true" | Should Be $true
+    }
+}


### PR DESCRIPTION
This allows runspace operators (for example) to look for or prevent PowerShell injection by calling a custom piece of code prior to the conversion happening.

It's unclear whether or not this change requires an update to the documentation. I couldn't, for example, find where PreCommandLookupAction (similar to this) is covered. This change may also warrant a note in the changelog.
