### PR TITLE
Fix Resolve-Path -LiteralPath.

### DIFF
--- a/src/System.Management.Automation/namespaces/LocationGlobber.cs
+++ b/src/System.Management.Automation/namespaces/LocationGlobber.cs
@@ -3339,8 +3339,11 @@ namespace System.Management.Automation
                 }
                 else
                 {
-                    if (path.StartsWith(StringLiterals.DefaultPathSeparatorString, StringComparison.Ordinal) || 
-                        path.StartsWith(StringLiterals.AlternatePathSeparatorString, StringComparison.Ordinal)) 
+                    // Check if the path begins with "\" or "/" (UNC Path or Path in Unix).
+                    // Ignore if the path resolves to a drive path, this will happen when path is equal to "\" or "/".
+                    // Drive path still need formatting, so treat them as relative.
+                    if (path.Length > 1 && (path.StartsWith(StringLiterals.DefaultPathSeparatorString, StringComparison.Ordinal) || 
+                        path.StartsWith(StringLiterals.AlternatePathSeparatorString, StringComparison.Ordinal)))
                     {
                         treatAsRelative = false;
                     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Resolve-Path.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Resolve-Path.Tests.ps1
@@ -15,4 +15,12 @@ Describe "Resolve-Path returns proper path" -Tag "CI" {
             $_.fullyqualifiederrorid | should be "PathNotFound,Microsoft.PowerShell.Commands.ResolvePathCommand"
         }
     }
+    It "Resolve-Path -Path should return correct drive path" {
+        $result = Resolve-Path -Path "TestDrive:\\\\\"
+        ($result.Path.TrimEnd('/\')) | Should Be "TestDrive:"
+    }
+    It "Resolve-Path -LiteralPath should return correct drive path" {
+        $result = Resolve-Path -LiteralPath "TestDrive:\\\\\"
+        ($result.Path.TrimEnd('/\')) | Should Be "TestDrive:"
+    }
 }


### PR DESCRIPTION
Resolving #2570.

Ignore drive paths in the check. If the input is a drive path, then "\" is passed as the path to GetDriveQualifiedPath with drive info. Since, the path here starts with "\", treatAsRelative is set to false
which prevents further formatting of this path. The check is only valid for PSDrives with root path equals to UNC paths or the paths in unix.