### PR TITLE
Fix blocking of the pipeline when running windows exes

### DIFF
--- a/src/System.Management.Automation/engine/NativeCommandProcessor.cs
+++ b/src/System.Management.Automation/engine/NativeCommandProcessor.cs
@@ -842,9 +842,12 @@ namespace System.Management.Automation
         [ArchitectureSensitive]
         private static bool IsWindowsApplication(string fileName)
         {
-#if CORECLR
+#if UNIX
             return false;
 #else
+            if (Platform.IsNanoServer)
+                return false;
+
             SHFILEINFO shinfo = new SHFILEINFO();
             IntPtr type = SHGetFileInfo(fileName, 0, ref shinfo, (uint)Marshal.SizeOf(shinfo), SHGFI_EXETYPE);
 
@@ -1223,7 +1226,7 @@ namespace System.Management.Automation
             return false;
         }
 
-#if !CORECLR // Shell doesn't exist on OneCore, so documents cannot be associated with applications.
+#if !UNIX // Shell doesn't exist on OneCore, so documents cannot be associated with applications.
         #region Interop for FindExecutable...
 
         // Constant used to determine the buffer size for a path
@@ -1258,7 +1261,11 @@ namespace System.Management.Automation
                 // If we got an index-out-of-range exception here, it's because
                 // of a buffer overrun error so we fail fast instead of
                 // continuing to run in an possibly unstable environment....
+#if CORECLR
+                System.Environment.FailFast(e.Message);
+#else
                 WindowsErrorReporting.FailFast(e);
+#endif
             }
 
             // If FindExecutable returns a result >= 32, then it succeeded

--- a/test/powershell/Language/Scripting/NativeExecution/NativeCommandProcessor.Tests.ps1
+++ b/test/powershell/Language/Scripting/NativeExecution/NativeCommandProcessor.Tests.ps1
@@ -51,7 +51,7 @@ Describe "Native Command Processor" -tags "Feature" {
         $count | Should Be 0
     }
 
-    It "Should not block running Windows executables" -Skip:(!$IsWindows -and !(Get-Command notepad.exe)) {
+    It "Should not block running Windows executables" -Skip:(!$IsWindows -or !(Get-Command notepad.exe)) {
         function FindNewNotepad
         {
             Get-Process -Name notepad -ErrorAction Ignore | Where-Object { $_.Id -notin $dontKill }


### PR DESCRIPTION
Code in the NativeCommandProcessor was guarded under `CORECLR` when it should have been `UNIX`.

Fixes #1254.