### PR TITLE
Performance improvements to security checks when group policies are in effect for ExecutionPolicy

### DIFF
--- a/src/System.Management.Automation/utils/PsUtils.cs
+++ b/src/System.Management.Automation/utils/PsUtils.cs
@@ -86,112 +86,42 @@ namespace System.Management.Automation
             return mainModule;
         }
 
-        // Cache of the current process' parentId 
+        // Cache of the current process' parentId
         private static int? s_currentParentProcessId;
         private static readonly int s_currentProcessId = Process.GetCurrentProcess().Id;
 
         /// <summary>
-<<<<<<< HEAD
         /// Retrieve the parent process of a process.
         ///
         /// Previously this code used WMI, but WMI is causing a CPU spike whenever the query gets called as it results in
-        /// tzres.dll and tzres.mui.dll being loaded into every process to conver the time information to local format.
-        /// For perf reasons, we result to P/Invoke.
+        /// tzres.dll and tzres.mui.dll being loaded into every process to convert the time information to local format.
+        /// For perf reasons, we resort to P/Invoke.
         /// </summary>
         ///
         /// <param name="current">The process we want to find the
         /// parent of</param>
         internal static Process GetParentProcess(Process current)
         {
-=======
-        /// Gets the parent process id for the specified process
-        /// </summary>        
-        /// <remarks>
-        /// Caching is used for the current process
-        /// </remarks>
-        /// <param name="processId">the id of the process whose parent id should be retreived</param>
-        /// <returns>0 on failure, else a parent process id. Note that the parent process id may have been recycled</returns>
-        internal static int GetParentProcessId(int processId)
-        {            
->>>>>>> Caching the parent id of the current process
-            int parentPid = 0;
+            var processId = current.Id;
 
             // This is a common query (parent id for the current process)
             // Use cached value if available
-            if (processId == s_currentProcessId && s_currentParentProcessId.HasValue)
-            {
-                return s_currentParentProcessId.Value;
-            }
-
-            parentPid = GetParentProcessIdNative(processId);
+            var parentProcessId = processId == s_currentProcessId && s_currentParentProcessId.HasValue ?
+                 s_currentParentProcessId.Value :
+                 Microsoft.PowerShell.ProcessCodeMethods.GetParentPid(current);
 
             // cache the current process parent pid if it hasn't been done yet
             if (processId == s_currentProcessId && !s_currentParentProcessId.HasValue)
             {
-                s_currentParentProcessId = parentPid;
+                s_currentParentProcessId = parentProcessId;
             }
-            return parentPid;
-        }
 
-        /// <summary>
-        /// Helper function to get the parent process id from the win32 Toolhelp apis
-        /// </summary>
-        /// <remarks>
-        /// This could potentially be replaced with calls to NTQueryInformationProcess
-        /// </remarks>
-        /// <param name="processId">The child process id to get the parent from</param>
-        /// <returns></returns>
-        private static int GetParentProcessIdNative(int processId)
-        {            
-            int parentPid = 0;
-#if !UNIX
-            PlatformInvokes.PROCESSENTRY32 pe32 = new PlatformInvokes.PROCESSENTRY32 { };
-            pe32.dwSize = (uint)ClrFacade.SizeOf<PlatformInvokes.PROCESSENTRY32>();
-
-            using (PlatformInvokes.SafeSnapshotHandle hSnapshot = PlatformInvokes.CreateToolhelp32Snapshot(PlatformInvokes.SnapshotFlags.Process, (uint)processId))
-            {
-                if (!PlatformInvokes.Process32First(hSnapshot, ref pe32))
-                {
-                    int errno = Marshal.GetLastWin32Error();
-                    if (errno == PlatformInvokes.ERROR_NO_MORE_FILES)
-                    {
-                        return 0;
-                    }
-                }
-                do
-                {
-                    if (pe32.th32ProcessID == (uint) processId)
-                    {
-                        parentPid = (int)pe32.th32ParentProcessID;
-                        break;
-                    }
-                } while (PlatformInvokes.Process32Next(hSnapshot, ref pe32));
-            }
-#endif
-            return parentPid;
-        }
-
-        /// <summary>
-        /// Retrieve the parent process of a process.
-        /// 
-        /// Previously this code used WMI, but WMI is causing a CPU spike whenever the query gets called as it results in 
-        /// tzres.dll and tzres.mui.dll being loaded into every process to conver the time information to local format.
-        /// For perf reasons, we result to P/Invoke.
-        /// </summary>
-        ///
-        /// <param name="current">The process we want to find the
-        /// parent of</param>
-        internal static Process GetParentProcess(Process current)
-        {
-            
-            int parentPid = GetParentProcessId(current.Id);
-
-            if (parentPid == 0)
+            if (parentProcessId == 0)
                 return null;
 
             try
             {
-                Process returnProcess = Process.GetProcessById(parentPid);
+                Process returnProcess = Process.GetProcessById(parentProcessId);
 
                 // Ensure the process started before the current
                 // process, as it could have gone away and had the


### PR DESCRIPTION
Fixes #2578 
When group policies are in effect for execution policy, a check is made to determine if the current process has been launched by gpscript.exe, and in that case, ignore the execution policy.
This is expensive to determine, is done over and over again, and has resulted in very long load times for scripts and modules.

One of the things that is checked (in an expensive way) is the parent id of the current process. That never changes, and is now cached.

The other change is to check once if we are launched by gpscript.exe or not and save that value.
This results in speedups in the order of a magnitude for module loads.