### PR TITLE
Fix Start-PSBootstrap install_name_tool call on macOS

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -885,7 +885,7 @@ function Install-Dotnet {
             # This is the library shipped with .NET Core
             # This is allowed to fail as the user may have installed other versions of dotnet
             Write-Warning ".NET Core links the incorrect OpenSSL, correcting .NET CLI libraries..."
-            find $env:HOME/.dotnet -name System.Security.Cryptography.Native.dylib | % { sudo install_name_tool -add_rpath /usr/local/opt/openssl/lib }
+            find $env:HOME/.dotnet -name System.Security.Cryptography.Native.dylib | % { sudo install_name_tool -add_rpath /usr/local/opt/openssl/lib $_ }
         }
     } elseif ($IsWindows) {
         Remove-Item -ErrorAction SilentlyContinue -Recurse -Force ~\AppData\Local\Microsoft\dotnet


### PR DESCRIPTION
This is left-over from #2541
Failure: https://travis-ci.org/PowerShell/PowerShell/jobs/172763810

One line was misformatted
cc @daxian-dbw 

