### PR TITLE
Update Select-Object to imply '-Property *' only if ExcludeProperty is specified and not empty

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/select-object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/select-object.cs
@@ -336,10 +336,10 @@ namespace Microsoft.PowerShell.Commands
                 _expandMshParameterList = processor.ProcessParameters(new string[] { ExpandProperty }, invocationContext);
             }
 
-            if (ExcludeProperty != null)
+            if (ExcludeProperty != null && ExcludeProperty.Length > 0)
             {
                 _exclusionFilter = new MshExpressionFilter(ExcludeProperty);
-                // ExcludeProperty implies -Property * for better UX
+                // Non-empty ExcludeProperty implies '-Property *' for better UX
                 if ((Property == null) || (Property.Length == 0))
                 {
                     Property = new Object[]{"*"};

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-Object.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-Object.Tests.ps1
@@ -295,4 +295,12 @@ Describe "Select-Object with Property = '*'" -Tags "CI" {
 		$p = Get-Process -Id $pid | Select-Object -Property Process* -ExcludeProperty ProcessorAffinity -ExpandProperty Modules
 		$p[0].psobject.Properties.Item("ProcessorAffinity") | Should Be $null
     }
+
+    It "'Select-Object -ExpandProperty' implies '*' only if '-ExpandProperty' is specified and not empty" {
+        $p = Get-Process -Id $PID | Select-Object -ExcludeProperty @()
+        $p.GetType().FullName | Should Be "System.Diagnostics.Process"
+
+        $p = Get-Process -Id $PID | Select-Object -Property * -ExcludeProperty @()
+        $p.GetType().FullName | Should Be "System.Management.Automation.PSCustomObject"
+    }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-Object.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-Object.Tests.ps1
@@ -296,11 +296,15 @@ Describe "Select-Object with Property = '*'" -Tags "CI" {
 		$p[0].psobject.Properties.Item("ProcessorAffinity") | Should Be $null
     }
 
-    It "'Select-Object -ExpandProperty' implies '*' only if '-ExpandProperty' is specified and not empty" {
+    It "'Select-Object -ExcludeProperty' implies '-Property *' only if '-ExcludeProperty' is specified and not empty" {
         $p = Get-Process -Id $PID | Select-Object -ExcludeProperty @()
         $p.GetType().FullName | Should Be "System.Diagnostics.Process"
 
         $p = Get-Process -Id $PID | Select-Object -Property * -ExcludeProperty @()
         $p.GetType().FullName | Should Be "System.Management.Automation.PSCustomObject"
+
+        ## No property from the input Process object should be attached to the expanded ProcessModule objects.
+        ## Therefore, no error should be thrown.
+        $null = Get-Process -Id $PID | Select-Object -ExcludeProperty @() -ExpandProperty Modules
     }
 }


### PR DESCRIPTION
Update Select-Object to imply '-Property *' only if ExcludeProperty is specified and not empty

I make this change because I remember uses like the following when I was analyzing `Select-Object -ExcludeProperty`:
```powershell
$propertiesToExclude = @()
# logic to add properties to be excluded under some circumstances.
... | Select-Object -ExcludeProperty $propertiesToExclude -ExpandProperty <property>
```
If `$propertiesToExclude` turns out to be empty, `Select-Object` shouldn't assume `-Property *` in this case.

/cc @iSazonov can you please review this PR?