### PR TITLE
Update project version to 6.0.0 to match our release version

### DIFF
--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/project.json
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/project.json
@@ -1,6 +1,6 @@
 {
     "name" : "Microsoft.Management.Infrastructure.CimCmdlets",
-    "version" : "1.0.0-*",
+    "version" : "6.0.0-*",
 
     "buildOptions": {
         "keyFile": "../signing/visualstudiopublic.snk",
@@ -10,7 +10,7 @@
     },
 
     "dependencies": {
-        "System.Management.Automation": "1.0.0-*"
+        "System.Management.Automation": "6.0.0-*"
     },
 
     "frameworks": {

--- a/src/Microsoft.PackageManagement.ArchiverProviders/project.json
+++ b/src/Microsoft.PackageManagement.ArchiverProviders/project.json
@@ -1,6 +1,6 @@
 {
     "name": "Microsoft.PackageManagement.ArchiverProviders",
-    "version": "1.0.0-*",
+    "version": "6.0.0-*",
 
     "buildOptions": {
         "warningsAsErrors": true
@@ -15,8 +15,8 @@
     },
 
     "dependencies": {
-        "System.Management.Automation": "1.0.0-*",
-        "Microsoft.PackageManagement": "1.0.0-*"
+        "System.Management.Automation": "6.0.0-*",
+        "Microsoft.PackageManagement": "6.0.0-*"
     },
 
     "frameworks": {

--- a/src/Microsoft.PackageManagement.CoreProviders/project.json
+++ b/src/Microsoft.PackageManagement.CoreProviders/project.json
@@ -1,6 +1,6 @@
 {
     "name": "Microsoft.PackageManagement.CoreProviders",
-    "version": "1.0.0-*",
+    "version": "6.0.0-*",
 
     "buildOptions": {
         "warningsAsErrors": true
@@ -15,8 +15,8 @@
     },
 
     "dependencies": {
-        "System.Management.Automation": "1.0.0-*",
-        "Microsoft.PackageManagement": "1.0.0-*"
+        "System.Management.Automation": "6.0.0-*",
+        "Microsoft.PackageManagement": "6.0.0-*"
     },
 
     "frameworks": {

--- a/src/Microsoft.PackageManagement.MetaProvider.PowerShell/project.json
+++ b/src/Microsoft.PackageManagement.MetaProvider.PowerShell/project.json
@@ -1,6 +1,6 @@
 {
     "name": "Microsoft.PackageManagement.MetaProvider.PowerShell",
-    "version": "1.0.0-*",
+    "version": "6.0.0-*",
 
     "buildOptions": {
         "warningsAsErrors": true
@@ -15,8 +15,8 @@
     },
 
     "dependencies": {
-        "System.Management.Automation": "1.0.0-*",
-        "Microsoft.PackageManagement": "1.0.0-*"
+        "System.Management.Automation": "6.0.0-*",
+        "Microsoft.PackageManagement": "6.0.0-*"
     },
 
     "frameworks": {

--- a/src/Microsoft.PackageManagement.MsiProvider/project.json
+++ b/src/Microsoft.PackageManagement.MsiProvider/project.json
@@ -1,45 +1,45 @@
 {
-	"name": "Microsoft.PackageManagement.MsiProvider",
-	"version": "1.0.0-*",
+    "name": "Microsoft.PackageManagement.MsiProvider",
+    "version": "6.0.0-*",
 
-	"buildOptions": {
-		"warningsAsErrors": true
-	},
+    "buildOptions": {
+        "warningsAsErrors": true
+    },
 
-	"configurations": {
-		"Linux": {
-			"buildOptions": {
-				"define": ["UNIX"]
-			}
-		}
-	},
+    "configurations": {
+        "Linux": {
+            "buildOptions": {
+                "define": ["UNIX"]
+            }
+        }
+    },
 
-	"dependencies": {
-		"System.Management.Automation": "1.0.0-*",
-    "Microsoft.PackageManagement": "1.0.0-*",
-    "Microsoft.PackageManagement.ArchiverProviders":  "1.0.0-*"
-	},
+    "dependencies": {
+        "System.Management.Automation": "6.0.0-*",
+        "Microsoft.PackageManagement": "6.0.0-*",
+        "Microsoft.PackageManagement.ArchiverProviders":  "6.0.0-*"
+    },
 
-	"frameworks": {
-		"net451": {
-			"frameworkAssemblies": {
-				"System.Runtime": "",
-				"System.Xml": "",
-				"System.Xml.Linq": "",
-				"System.Numerics": "",
-				"System.Data": "",
-				"System.DirectoryServices": "",
-				"System.Security": "",
-				"System.Transactions": "",
-				"System.Runtime.Serialization": "",
-				"System.Management": "",
-				"System.Configuration": "",
-				"System.Configuration.Install": "",
-				"System.Net": "",
-				"System.Net.Http": "",
-				"System.IO.Compression": "",
-				"System.IO.Compression.FileSystem": ""
-			}
-		}
-	}
+    "frameworks": {
+        "net451": {
+            "frameworkAssemblies": {
+                "System.Runtime": "",
+                "System.Xml": "",
+                "System.Xml.Linq": "",
+                "System.Numerics": "",
+                "System.Data": "",
+                "System.DirectoryServices": "",
+                "System.Security": "",
+                "System.Transactions": "",
+                "System.Runtime.Serialization": "",
+                "System.Management": "",
+                "System.Configuration": "",
+                "System.Configuration.Install": "",
+                "System.Net": "",
+                "System.Net.Http": "",
+                "System.IO.Compression": "",
+                "System.IO.Compression.FileSystem": ""
+            }
+        }
+    }
 }

--- a/src/Microsoft.PackageManagement.MsuProvider/project.json
+++ b/src/Microsoft.PackageManagement.MsuProvider/project.json
@@ -1,45 +1,45 @@
 {
-	"name": "Microsoft.PackageManagement.MsuProvider",
-	"version": "1.0.0-*",
+    "name": "Microsoft.PackageManagement.MsuProvider",
+    "version": "6.0.0-*",
 
-	"buildOptions": {
-		"warningsAsErrors": true
-	},
+    "buildOptions": {
+        "warningsAsErrors": true
+    },
 
-	"configurations": {
-		"Linux": {
-			"buildOptions": {
-				"define": ["UNIX"]
-			}
-		}
-	},
+    "configurations": {
+        "Linux": {
+            "buildOptions": {
+                "define": ["UNIX"]
+            }
+        }
+    },
 
-	"dependencies": {
-		"System.Management.Automation": "1.0.0-*",
-    "Microsoft.PackageManagement": "1.0.0-*",
-    "Microsoft.PackageManagement.ArchiverProviders":  "1.0.0-*"
-	},
+    "dependencies": {
+        "System.Management.Automation": "6.0.0-*",
+        "Microsoft.PackageManagement": "6.0.0-*",
+        "Microsoft.PackageManagement.ArchiverProviders":  "6.0.0-*"
+    },
 
-	"frameworks": {
-		"net451": {
-			"frameworkAssemblies": {
-				"System.Runtime": "",
-				"System.Xml": "",
-				"System.Xml.Linq": "",
-				"System.Numerics": "",
-				"System.Data": "",
-				"System.DirectoryServices": "",
-				"System.Security": "",
-				"System.Transactions": "",
-				"System.Runtime.Serialization": "",
-				"System.Management": "",
-				"System.Configuration": "",
-				"System.Configuration.Install": "",
-				"System.Net": "",
-				"System.Net.Http": "",
-				"System.IO.Compression": "",
-				"System.IO.Compression.FileSystem": ""
-			}
-		}
-	}
+    "frameworks": {
+        "net451": {
+            "frameworkAssemblies": {
+                "System.Runtime": "",
+                "System.Xml": "",
+                "System.Xml.Linq": "",
+                "System.Numerics": "",
+                "System.Data": "",
+                "System.DirectoryServices": "",
+                "System.Security": "",
+                "System.Transactions": "",
+                "System.Runtime.Serialization": "",
+                "System.Management": "",
+                "System.Configuration": "",
+                "System.Configuration.Install": "",
+                "System.Net": "",
+                "System.Net.Http": "",
+                "System.IO.Compression": "",
+                "System.IO.Compression.FileSystem": ""
+            }
+        }
+    }
 }

--- a/src/Microsoft.PackageManagement.NuGetProvider/project.json
+++ b/src/Microsoft.PackageManagement.NuGetProvider/project.json
@@ -1,6 +1,6 @@
 {
     "name": "Microsoft.PackageManagement.NuGetProvider",
-    "version": "1.0.0-*",
+    "version": "6.0.0-*",
 
     "buildOptions": {
         "warningsAsErrors": true
@@ -15,7 +15,7 @@
     },
 
     "dependencies": {
-        "System.Management.Automation": "1.0.0-*"
+        "System.Management.Automation": "6.0.0-*"
     },
 
     "frameworks": {

--- a/src/Microsoft.PackageManagement.PackageSourceListProvider/project.json
+++ b/src/Microsoft.PackageManagement.PackageSourceListProvider/project.json
@@ -1,6 +1,6 @@
 {
     "name": "Microsoft.PackageManagement.PackageSourceListProvider",
-    "version": "1.0.0-*",
+    "version": "6.0.0-*",
 
     "buildOptions": {
         "warningsAsErrors": true
@@ -15,8 +15,8 @@
     },
 
     "dependencies": {
-        "System.Management.Automation": "1.0.0-*",
-        "Microsoft.PackageManagement":  "1.0.0-*"
+        "System.Management.Automation": "6.0.0-*",
+        "Microsoft.PackageManagement":  "6.0.0-*"
     },
 
     "frameworks": {

--- a/src/Microsoft.PackageManagement/project.json
+++ b/src/Microsoft.PackageManagement/project.json
@@ -1,6 +1,6 @@
 {
     "name": "Microsoft.PackageManagement",
-    "version": "1.0.0-*",
+    "version": "6.0.0-*",
 
     "buildOptions": {
         "warningsAsErrors": true
@@ -15,7 +15,7 @@
     },
 
     "dependencies": {
-        "System.Management.Automation": "1.0.0-*"
+        "System.Management.Automation": "6.0.0-*"
     },
 
     "frameworks": {

--- a/src/Microsoft.PowerShell.Activities/project.json
+++ b/src/Microsoft.PowerShell.Activities/project.json
@@ -1,6 +1,6 @@
 {
     "name": "Microsoft.PowerShell.Activities",
-    "version": "1.0.0-*",
+    "version": "6.0.0-*",
 
     "buildOptions": {
         "nowarn": [ "CS1570" ],
@@ -22,7 +22,7 @@
     },
 
     "dependencies": {
-        "Microsoft.PowerShell.Utility.Activities": "1.0.0-*" 
+        "Microsoft.PowerShell.Utility.Activities": "6.0.0-*" 
     },
 
     "frameworks": {

--- a/src/Microsoft.PowerShell.Commands.Diagnostics/project.json
+++ b/src/Microsoft.PowerShell.Commands.Diagnostics/project.json
@@ -1,6 +1,6 @@
 {
     "name": "Microsoft.PowerShell.Commands.Diagnostics",
-    "version": "1.0.0-*",
+    "version": "6.0.0-*",
     "buildOptions": {
         "nowarn": [ "CS1591" ],
         "xmlDoc": true,
@@ -11,7 +11,7 @@
     },
 
     "dependencies": {
-        "System.Management.Automation": "1.0.0-*"
+        "System.Management.Automation": "6.0.0-*"
     },
 
     "frameworks": {

--- a/src/Microsoft.PowerShell.Commands.Management/project.json
+++ b/src/Microsoft.PowerShell.Commands.Management/project.json
@@ -1,6 +1,6 @@
 {
     "name": "Microsoft.PowerShell.Commands.Management",
-    "version": "1.0.0-*",
+    "version": "6.0.0-*",
 
     "buildOptions": {
         "nowarn": [ "CS1570" ],
@@ -21,7 +21,7 @@
     },
 
     "dependencies": {
-        "Microsoft.PowerShell.Security": "1.0.0-*"
+        "Microsoft.PowerShell.Security": "6.0.0-*"
     },
 
     "frameworks": {
@@ -91,7 +91,7 @@
                 "System.Web.Services": ""
             },
             "dependencies": {
-                "Microsoft.WSMan.Management": "1.0.0-*"
+                "Microsoft.WSMan.Management": "6.0.0-*"
             },
             "buildOptions": {
                 "compile": {

--- a/src/Microsoft.PowerShell.Commands.Utility/project.json
+++ b/src/Microsoft.PowerShell.Commands.Utility/project.json
@@ -1,6 +1,6 @@
 {
     "name": "Microsoft.PowerShell.Commands.Utility",
-    "version": "1.0.0-*",
+    "version": "6.0.0-*",
 
     "buildOptions": {
         "nowarn": [ "CS1570" ],
@@ -21,7 +21,7 @@
     },
 
     "dependencies": {
-        "System.Management.Automation": "1.0.0-*"
+        "System.Management.Automation": "6.0.0-*"
     },
 
     "frameworks": {

--- a/src/Microsoft.PowerShell.ConsoleHost/project.json
+++ b/src/Microsoft.PowerShell.ConsoleHost/project.json
@@ -1,6 +1,6 @@
 {
     "name": "Microsoft.PowerShell.ConsoleHost",
-    "version": "1.0.0-*",
+    "version": "6.0.0-*",
     "description": "PowerShell Host",
 
     "buildOptions": {
@@ -22,7 +22,7 @@
     },
 
     "dependencies": {
-        "System.Management.Automation": "1.0.0-*"
+        "System.Management.Automation": "6.0.0-*"
     },
 
     "frameworks": {

--- a/src/Microsoft.PowerShell.Core.Activities/project.json
+++ b/src/Microsoft.PowerShell.Core.Activities/project.json
@@ -1,6 +1,6 @@
 {
     "name": "Microsoft.PowerShell.Core.Activities",
-    "version": "1.0.0-*",
+    "version": "6.0.0-*",
 
     "buildOptions": {
         "xmlDoc": true,
@@ -11,7 +11,7 @@
     },
 
     "dependencies": {
-        "Microsoft.PowerShell.Workflow.ServiceCore": "1.0.0-*"
+        "Microsoft.PowerShell.Workflow.ServiceCore": "6.0.0-*"
     },
 
     "frameworks": {

--- a/src/Microsoft.PowerShell.CoreCLR.AssemblyLoadContext/project.json
+++ b/src/Microsoft.PowerShell.CoreCLR.AssemblyLoadContext/project.json
@@ -1,6 +1,6 @@
 {
     "name": "Microsoft.PowerShell.CoreCLR.AssemblyLoadContext",
-    "version": "1.0.0-*",
+    "version": "6.0.0-*",
 
     "buildOptions": {
         "xmlDoc": true,

--- a/src/Microsoft.PowerShell.CoreCLR.Eventing/project.json
+++ b/src/Microsoft.PowerShell.CoreCLR.Eventing/project.json
@@ -1,6 +1,6 @@
 {
     "name": "Microsoft.PowerShell.CoreCLR.Eventing",
-    "version": "1.0.0-*",
+    "version": "6.0.0-*",
 
     "buildOptions": {
         "nowarn": [ "CS1591" ],

--- a/src/Microsoft.PowerShell.Diagnostics.Activities/project.json
+++ b/src/Microsoft.PowerShell.Diagnostics.Activities/project.json
@@ -1,6 +1,6 @@
 {
     "name": "Microsoft.PowerShell.Diagnostics.Activities",
-    "version": "1.0.0-*",
+    "version": "6.0.0-*",
 
     "buildOptions": {
         "xmlDoc": true,
@@ -11,8 +11,8 @@
     },
 
     "dependencies": {
-        "Microsoft.PowerShell.Workflow.ServiceCore": "1.0.0-*",
-        "Microsoft.PowerShell.Commands.Diagnostics": "1.0.0-*"
+        "Microsoft.PowerShell.Workflow.ServiceCore": "6.0.0-*",
+        "Microsoft.PowerShell.Commands.Diagnostics": "6.0.0-*"
     },
 
     "frameworks": {

--- a/src/Microsoft.PowerShell.GraphicalHost/AssemblyInfo.cs
+++ b/src/Microsoft.PowerShell.GraphicalHost/AssemblyInfo.cs
@@ -1,2 +1,11 @@
+using System.Reflection;
+using System.Resources;
 using System.Runtime.CompilerServices;
+
+[assembly: AssemblyFileVersionAttribute("3.0.0.0")]
+[assembly: AssemblyVersion("3.0.0.0")]
+
+[assembly: AssemblyCulture("")]
+[assembly: NeutralResourcesLanguage("en-US")]
+
 [assembly: InternalsVisibleTo(@"Microsoft.PowerShell.GPowerShell"+@",PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]

--- a/src/Microsoft.PowerShell.GraphicalHost/project.json
+++ b/src/Microsoft.PowerShell.GraphicalHost/project.json
@@ -1,6 +1,6 @@
 {
     "name": "Microsoft.PowerShell.GraphicalHost",
-    "version": "1.0.0-*",
+    "version": "6.0.0-*",
 
     "buildOptions": {
         "nowarn": [ "CS1570" ],
@@ -12,8 +12,8 @@
     },
 
     "dependencies": {
-        "System.Management.Automation": "1.0.0-*",
-        "Microsoft.PowerShell.Commands.Utility": "1.0.0-*"
+        "System.Management.Automation": "6.0.0-*",
+        "Microsoft.PowerShell.Commands.Utility": "6.0.0-*"
     },
 
     "frameworks": {

--- a/src/Microsoft.PowerShell.LocalAccounts/LocalAccounts/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.PowerShell.LocalAccounts/LocalAccounts/Properties/AssemblyInfo.cs
@@ -1,7 +1,14 @@
 ﻿using System.Reflection;
+using System.Resources;
 
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("LocalAccounts")]
 [assembly: AssemblyDescription("PowerShell cmdlet for local accounts.")]
+
+[assembly: AssemblyFileVersionAttribute("3.0.0.0")]
+[assembly: AssemblyVersion("3.0.0.0")]
+
+[assembly: AssemblyCulture("")]
+[assembly: NeutralResourcesLanguage("en-US")]

--- a/src/Microsoft.PowerShell.LocalAccounts/project.json
+++ b/src/Microsoft.PowerShell.LocalAccounts/project.json
@@ -1,6 +1,6 @@
 {
     "name": "Microsoft.PowerShell.LocalAccounts",
-    "version": "1.0.0-*",
+    "version": "6.0.0-*",
 
     "buildOptions": {
         "xmlDoc": true,
@@ -11,7 +11,7 @@
     },
 
     "dependencies": {
-        "System.Management.Automation": "1.0.0-*"
+        "System.Management.Automation": "6.0.0-*"
     },
 
     "frameworks": {

--- a/src/Microsoft.PowerShell.Management.Activities/project.json
+++ b/src/Microsoft.PowerShell.Management.Activities/project.json
@@ -1,6 +1,6 @@
 {
     "name": "Microsoft.PowerShell.Management.Activities",
-    "version": "1.0.0-*",
+    "version": "6.0.0-*",
 
     "buildOptions": {
         "xmlDoc": true,
@@ -11,7 +11,7 @@
     },
 
     "dependencies": {
-        "Microsoft.PowerShell.Activities": "1.0.0-*"
+        "Microsoft.PowerShell.Activities": "6.0.0-*"
     },
 
     "frameworks": {

--- a/src/Microsoft.PowerShell.PSReadLine/project.json
+++ b/src/Microsoft.PowerShell.PSReadLine/project.json
@@ -1,6 +1,6 @@
 {
     "name": "Microsoft.PowerShell.PSReadLine",
-    "version": "1.0.0-*",
+    "version": "6.0.0-*",
 
     "buildOptions": {
         "xmlDoc": true,
@@ -19,7 +19,7 @@
     },
 
     "dependencies": {
-        "System.Management.Automation": "1.0.0-*"
+        "System.Management.Automation": "6.0.0-*"
     },
 
     "frameworks": {

--- a/src/Microsoft.PowerShell.PackageManagement/project.json
+++ b/src/Microsoft.PowerShell.PackageManagement/project.json
@@ -1,6 +1,6 @@
 {
     "name": "Microsoft.PowerShell.PackageManagement",
-    "version": "1.0.0-*",
+    "version": "6.0.0-*",
 
     "buildOptions": {
         "warningsAsErrors": true
@@ -15,12 +15,12 @@
     },
 
     "dependencies": {
-        "System.Management.Automation": "1.0.0-*",
-        "Microsoft.PackageManagement": "1.0.0-*",
-        "Microsoft.PackageManagement.NuGetProvider": "1.0.0-*",
-        "Microsoft.PackageManagement.CoreProviders": "1.0.0-*",
-        "Microsoft.PackageManagement.MetaProvider.PowerShell": "1.0.0-*",
-        "Microsoft.PackageManagement.ArchiverProviders": "1.0.0-*"
+        "System.Management.Automation": "6.0.0-*",
+        "Microsoft.PackageManagement": "6.0.0-*",
+        "Microsoft.PackageManagement.NuGetProvider": "6.0.0-*",
+        "Microsoft.PackageManagement.CoreProviders": "6.0.0-*",
+        "Microsoft.PackageManagement.MetaProvider.PowerShell": "6.0.0-*",
+        "Microsoft.PackageManagement.ArchiverProviders": "6.0.0-*"
     },
 
     "frameworks": {
@@ -44,8 +44,8 @@
                 "System.IO.Compression.FileSystem": ""
             },
             "dependencies": {
-                "Microsoft.PackageManagement.MsiProvider": "1.0.0-*",
-                "Microsoft.PackageManagement.MsuProvider": "1.0.0-*"
+                "Microsoft.PackageManagement.MsiProvider": "6.0.0-*",
+                "Microsoft.PackageManagement.MsuProvider": "6.0.0-*"
             }
         },
 

--- a/src/Microsoft.PowerShell.SDK/project.json
+++ b/src/Microsoft.PowerShell.SDK/project.json
@@ -1,14 +1,14 @@
 {
     "name": "Microsoft.PowerShell.SDK",
-    "version": "1.0.0-*",
+    "version": "6.0.0-*",
     "description": "PowerShell SDK metapackage",
 
     "dependencies": {
-        "Microsoft.PowerShell.Commands.Management" : "1.0.0-*",
-        "Microsoft.PowerShell.Commands.Utility" : "1.0.0-*",
-        "Microsoft.PowerShell.ConsoleHost" : "1.0.0-*",
-        "Microsoft.PowerShell.Security" : "1.0.0-*",
-        "System.Management.Automation" : "1.0.0-*"
+        "Microsoft.PowerShell.Commands.Management" : "6.0.0-*",
+        "Microsoft.PowerShell.Commands.Utility" : "6.0.0-*",
+        "Microsoft.PowerShell.ConsoleHost" : "6.0.0-*",
+        "Microsoft.PowerShell.Security" : "6.0.0-*",
+        "System.Management.Automation" : "6.0.0-*"
     },
 
     "frameworks": {

--- a/src/Microsoft.PowerShell.ScheduledJob/project.json
+++ b/src/Microsoft.PowerShell.ScheduledJob/project.json
@@ -1,6 +1,6 @@
 {
     "name": "Microsoft.PowerShell.ScheduledJob",
-    "version": "1.0.0-*",
+    "version": "6.0.0-*",
 
     "buildOptions": {
         "xmlDoc": true,
@@ -11,7 +11,7 @@
     },
 
     "dependencies": {
-        "System.Management.Automation": "1.0.0-*",
+        "System.Management.Automation": "6.0.0-*",
         "Microsoft.PowerShell.ScheduledJob.Interop": "1.0.0-*"
     },
 

--- a/src/Microsoft.PowerShell.Security.Activities/project.json
+++ b/src/Microsoft.PowerShell.Security.Activities/project.json
@@ -1,6 +1,6 @@
 {
     "name": "Microsoft.PowerShell.Security.Activities",
-    "version": "1.0.0-*",
+    "version": "6.0.0-*",
 
     "buildOptions": {
         "xmlDoc": true,
@@ -11,7 +11,7 @@
     },
 
     "dependencies": {
-        "Microsoft.PowerShell.Activities": "1.0.0-*"
+        "Microsoft.PowerShell.Activities": "6.0.0-*"
     },
 
     "frameworks": {

--- a/src/Microsoft.PowerShell.Security/project.json
+++ b/src/Microsoft.PowerShell.Security/project.json
@@ -1,6 +1,6 @@
 {
     "name": "Microsoft.PowerShell.Security",
-    "version": "1.0.0-*",
+    "version": "6.0.0-*",
 
     "buildOptions": {
         "nowarn": [ "CS1570" ],
@@ -21,7 +21,7 @@
     },
 
     "dependencies": {
-        "System.Management.Automation": "1.0.0-*"
+        "System.Management.Automation": "6.0.0-*"
     },
 
     "frameworks": {

--- a/src/Microsoft.PowerShell.Utility.Activities/project.json
+++ b/src/Microsoft.PowerShell.Utility.Activities/project.json
@@ -1,6 +1,6 @@
 {
     "name": "Microsoft.PowerShell.Utility.Activities",
-    "version": "1.0.0-*",
+    "version": "6.0.0-*",
 
     "buildOptions": {
         "xmlDoc": true,
@@ -11,8 +11,8 @@
     },
 
     "dependencies": {
-        "Microsoft.PowerShell.Workflow.ServiceCore": "1.0.0-*",
-        "Microsoft.PowerShell.Commands.Utility": "1.0.0-*"
+        "Microsoft.PowerShell.Workflow.ServiceCore": "6.0.0-*",
+        "Microsoft.PowerShell.Commands.Utility": "6.0.0-*"
     },
 
     "frameworks": {

--- a/src/Microsoft.PowerShell.Workflow.ServiceCore/project.json
+++ b/src/Microsoft.PowerShell.Workflow.ServiceCore/project.json
@@ -1,6 +1,6 @@
 {
     "name": "Microsoft.PowerShell.Workflow.ServiceCore",
-    "version": "1.0.0-*",
+    "version": "6.0.0-*",
 
     "buildOptions": {
         "nowarn": [ "CS1570" ],
@@ -13,8 +13,8 @@
     },
 
     "dependencies": {
-        "Microsoft.PowerShell.Commands.Management": "1.0.0-*",
-        "Microsoft.Management.Infrastructure.CimCmdlets": "1.0.0-*"
+        "Microsoft.PowerShell.Commands.Management": "6.0.0-*",
+        "Microsoft.Management.Infrastructure.CimCmdlets": "6.0.0-*"
     },
 
     "frameworks": {

--- a/src/Microsoft.WSMan.Management.Activities/project.json
+++ b/src/Microsoft.WSMan.Management.Activities/project.json
@@ -1,6 +1,6 @@
 {
     "name": "Microsoft.WSMan.Management.Activities",
-    "version": "1.0.0-*",
+    "version": "6.0.0-*",
 
     "buildOptions": {
         "keyFile": "../signing/visualstudiopublic.snk",
@@ -10,7 +10,7 @@
     },
 
     "dependencies": {
-        "Microsoft.PowerShell.Workflow.ServiceCore": "1.0.0-*"
+        "Microsoft.PowerShell.Workflow.ServiceCore": "6.0.0-*"
     },
 
     "frameworks": {

--- a/src/Microsoft.WSMan.Management/project.json
+++ b/src/Microsoft.WSMan.Management/project.json
@@ -1,6 +1,6 @@
 {
     "name": "Microsoft.WSMan.Management",
-    "version": "1.0.0-*",
+    "version": "6.0.0-*",
 
     "buildOptions": {
         "keyFile": "../signing/visualstudiopublic.snk",
@@ -10,8 +10,8 @@
     },
 
     "dependencies": {
-        "System.Management.Automation": "1.0.0-*",
-        "Microsoft.WSMan.Runtime": "1.0.0-*"
+        "System.Management.Automation": "6.0.0-*",
+        "Microsoft.WSMan.Runtime": "6.0.0-*"
     },
 
     "frameworks": {

--- a/src/Microsoft.WSMan.Runtime/project.json
+++ b/src/Microsoft.WSMan.Runtime/project.json
@@ -1,6 +1,6 @@
 {
     "name": "Microsoft.WSMan.Runtime",
-    "version": "1.0.0-*",
+    "version": "6.0.0-*",
 
     "buildOptions": {
         "keyFile": "../signing/visualstudiopublic.snk",

--- a/src/System.Management.Automation/project.json
+++ b/src/System.Management.Automation/project.json
@@ -1,6 +1,6 @@
 {
     "name": "System.Management.Automation",
-    "version": "1.0.0-*",
+    "version": "6.0.0-*",
 
     "buildOptions": {
         "nowarn": [ "CS1570", "CS1734" ],
@@ -140,8 +140,8 @@
                 }
             },
             "dependencies": {
-                "Microsoft.PowerShell.CoreCLR.AssemblyLoadContext": "1.0.0-*",
-                "Microsoft.PowerShell.CoreCLR.Eventing": "1.0.0-*",
+                "Microsoft.PowerShell.CoreCLR.AssemblyLoadContext": "6.0.0-*",
+                "Microsoft.PowerShell.CoreCLR.Eventing": "6.0.0-*",
 
                 "Microsoft.CSharp": "4.3.0-preview1-24530-04",
                 "Microsoft.Win32.Registry.AccessControl": "4.3.0-preview1-24530-04",

--- a/src/powershell-unix/project.json
+++ b/src/powershell-unix/project.json
@@ -1,6 +1,6 @@
 {
     "name": "powershell",
-    "version": "1.0.0-*",
+    "version": "6.0.0-*",
     "description": "PowerShell top-level project with .NET CLI host",
 
     "buildOptions": {
@@ -53,11 +53,11 @@
     },
 
     "dependencies": {
-        "Microsoft.PowerShell.SDK": "1.0.0-*",
-        "Microsoft.PowerShell.PSReadLine": "1.0.0-*",
+        "Microsoft.PowerShell.SDK": "6.0.0-*",
+        "Microsoft.PowerShell.PSReadLine": "6.0.0-*",
         "libmi": "1.0.0-alpha01",
         "PSDesiredStateConfiguration": "1.0.0-alpha01",
-        "Microsoft.PowerShell.PackageManagement": "1.0.0-*",
+        "Microsoft.PowerShell.PackageManagement": "6.0.0-*",
         "PowerShellHelpFiles": "1.0.0-alpha01"
     },
 

--- a/src/powershell-win-core/project.json
+++ b/src/powershell-win-core/project.json
@@ -1,6 +1,6 @@
 {
     "name": "powershell",
-    "version": "1.0.0-*",
+    "version": "6.0.0-*",
     "description": "PowerShell top-level project with .NET CLI PowerShell app",
 
     "buildOptions": {
@@ -55,13 +55,13 @@
     },
 
     "dependencies": {
-        "Microsoft.PowerShell.SDK": "1.0.0-*",
-        "Microsoft.PowerShell.PSReadLine": "1.0.0-*",
-        "Microsoft.PowerShell.Commands.Diagnostics": "1.0.0-*",
-        "Microsoft.PowerShell.LocalAccounts": "1.0.0-*",
-        "Microsoft.PowerShell.PackageManagement": "1.0.0-*",
-        "Microsoft.Management.Infrastructure.CimCmdlets": "1.0.0-*",
-        "Microsoft.WSMan.Management": "1.0.0-*",
+        "Microsoft.PowerShell.SDK": "6.0.0-*",
+        "Microsoft.PowerShell.PSReadLine": "6.0.0-*",
+        "Microsoft.PowerShell.Commands.Diagnostics": "6.0.0-*",
+        "Microsoft.PowerShell.LocalAccounts": "6.0.0-*",
+        "Microsoft.PowerShell.PackageManagement": "6.0.0-*",
+        "Microsoft.Management.Infrastructure.CimCmdlets": "6.0.0-*",
+        "Microsoft.WSMan.Management": "6.0.0-*",
         "PSDesiredStateConfiguration": "1.0.0-alpha01"
     },
 

--- a/src/powershell-win-full/project.json
+++ b/src/powershell-win-full/project.json
@@ -1,6 +1,6 @@
 {
     "name": "powershell",
-    "version": "1.0.0-*",
+    "version": "6.0.0-*",
     "description": "PowerShell top-level project for FullCLR package with native host",
 
     "publishOptions": {
@@ -26,22 +26,22 @@
     },
 
     "dependencies": {
-        "Microsoft.PowerShell.SDK": "1.0.0-*",
-        "Microsoft.Management.Infrastructure.CimCmdlets": "1.0.0-*",
-        "Microsoft.PowerShell.Activities": "1.0.0-*",
-        "Microsoft.PowerShell.Commands.Diagnostics": "1.0.0-*",
-        "Microsoft.PowerShell.Core.Activities": "1.0.0-*",
-        "Microsoft.PowerShell.Diagnostics.Activities": "1.0.0-*",
-        "Microsoft.PowerShell.GraphicalHost": "1.0.0-*",
-        "Microsoft.PowerShell.LocalAccounts": "1.0.0-*",
-        "Microsoft.PowerShell.Management.Activities": "1.0.0-*",
-        "Microsoft.PowerShell.PackageManagement": "1.0.0-*",
-        "Microsoft.PowerShell.PSReadLine": "1.0.0-*",
-        "Microsoft.PowerShell.ScheduledJob": "1.0.0-*",
-        "Microsoft.PowerShell.Security.Activities": "1.0.0-*",
-        "Microsoft.PowerShell.Utility.Activities": "1.0.0-*",
-        "Microsoft.PowerShell.Workflow.ServiceCore": "1.0.0-*",
-        "Microsoft.WSMan.Management.Activities": "1.0.0-*"
+        "Microsoft.PowerShell.SDK": "6.0.0-*",
+        "Microsoft.Management.Infrastructure.CimCmdlets": "6.0.0-*",
+        "Microsoft.PowerShell.Activities": "6.0.0-*",
+        "Microsoft.PowerShell.Commands.Diagnostics": "6.0.0-*",
+        "Microsoft.PowerShell.Core.Activities": "6.0.0-*",
+        "Microsoft.PowerShell.Diagnostics.Activities": "6.0.0-*",
+        "Microsoft.PowerShell.GraphicalHost": "6.0.0-*",
+        "Microsoft.PowerShell.LocalAccounts": "6.0.0-*",
+        "Microsoft.PowerShell.Management.Activities": "6.0.0-*",
+        "Microsoft.PowerShell.PackageManagement": "6.0.0-*",
+        "Microsoft.PowerShell.PSReadLine": "6.0.0-*",
+        "Microsoft.PowerShell.ScheduledJob": "6.0.0-*",
+        "Microsoft.PowerShell.Security.Activities": "6.0.0-*",
+        "Microsoft.PowerShell.Utility.Activities": "6.0.0-*",
+        "Microsoft.PowerShell.Workflow.ServiceCore": "6.0.0-*",
+        "Microsoft.WSMan.Management.Activities": "6.0.0-*"
     },
 
     "frameworks": {


### PR DESCRIPTION
And also 	Add `AssemblyVersion` attribute to 'GraphicalHost' and 'LocalAccounts' projects so that they are of version 3.0.0.0 (same as the inbox ones) and not affected by the version number defined in `project.json`.

This is part of the work to address #2354. After updating the version number in project.json files, the nuget packages we produce will be labelled with `6.0.0` instead of `1.0.0`.

No `AssemblyVersion` attribute is added to "PackageManagement" related projects because they probably will be pull out of powershell/powershell repository soon. /cc @jianyunt