### PR TITLE
Make Out-Null fast

### DIFF
--- a/test/powershell/Language/Parser/RedirectionOperator.Tests.ps1
+++ b/test/powershell/Language/Parser/RedirectionOperator.Tests.ps1
@@ -81,5 +81,14 @@ Describe "Redirection operator now supports encoding changes" -Tags "CI" {
 
         }
     }
+}
 
+Describe "File redirection mixed with Out-Null" -Tags CI {
+    It "File redirection before Out-Null should work" {
+        "some text" > $TestDrive\out.txt | Out-Null
+        Get-Content $TestDrive\out.txt | Should Be "some text"
+
+        echo "some more text" > $TestDrive\out.txt | Out-Null
+        Get-Content $TestDrive\out.txt | Should Be "some more text"
+    }
 }


### PR DESCRIPTION
People use Out-Null despite much faster alternatives:

    $null = Do-Stuff
    [void] = Do-Stuff
    Do-Stuff > $null

This change makes Out-Null work in roughly the same say as the above.

The optimization is to detect that we're calling the built-in Out-Null
cmdlet when invoking a pipeline from script (the change won't have any
effect in the PowerShell api). If we detect Out-Null, we rewrite the
pipe to look similar to `Do-Stuff > $null`.