### PR TITLE
Wire up proper ConsoleHostRawUserInterface.LengthInBufferCells for Unix

### DIFF
--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleControl.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleControl.cs
@@ -16,7 +16,6 @@ Copyright (c) Microsoft Corporation.  All rights reserved.
 
 using System;
 using System.Text;
-using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 using System.Management.Automation;
 using System.Management.Automation.Host;
@@ -27,7 +26,6 @@ using System.Globalization;
 using System.Diagnostics;
 using Microsoft.Win32.SafeHandles;
 
-using Dbg = System.Management.Automation.Diagnostics;
 using ConsoleHandle = Microsoft.Win32.SafeHandles.SafeFileHandle;
 
 using WORD = System.UInt16;
@@ -36,6 +34,11 @@ using DWORD = System.UInt32;
 using NakedWin32Handle = System.IntPtr;
 using HWND = System.IntPtr;
 using HDC = System.IntPtr;
+
+#endif
+
+using System.Diagnostics.CodeAnalysis;
+using Dbg = System.Management.Automation.Diagnostics;
 
 namespace Microsoft.PowerShell
 {
@@ -48,6 +51,7 @@ namespace Microsoft.PowerShell
 
     internal static class ConsoleControl
     {
+#if !UNIX
 #region structs
 
         internal enum InputRecordEventTypes : ushort
@@ -2812,8 +2816,9 @@ namespace Microsoft.PowerShell
             }
         }
 
-
+#endif
 #region Dealing with CJK
+#if !UNIX
 
         /// <summary>
         /// From IsConsoleFullWidth in \windows\core\ntcon\server\dbcs.c
@@ -3035,6 +3040,7 @@ namespace Microsoft.PowerShell
             }
         }
 
+#endif
 
         // Return the length of a VT100 control sequence character in str starting
         // at the given offset.
@@ -3101,6 +3107,9 @@ namespace Microsoft.PowerShell
                 }
             }
 
+#if UNIX
+            return str.Length - offset - escapeSequenceAdjustment;
+#else
             uint codePage = NativeMethods.GetConsoleOutputCP();
             if (!IsAvailableFarEastCodePage(codePage))
             {
@@ -3129,8 +3138,10 @@ namespace Microsoft.PowerShell
                     NativeMethods.ReleaseDC(hwnd, hDC);
                 }
             }
+#endif
         }
 
+#if !UNIX
 
         /// <summary>
         /// Check if the output buffer code page is Japanese, Simplified Chinese, Korean, or Traditional Chinese
@@ -3146,7 +3157,10 @@ namespace Microsoft.PowerShell
                 codePage == 950;  // Traditional Chinese
         }
 
+#endif
 #endregion Dealing with CJK
+
+#if !UNIX
 
 #region Cursor
 
@@ -3606,6 +3620,6 @@ namespace Microsoft.PowerShell
 
         [TraceSourceAttribute("ConsoleControl", "Console control methods")]
         private static PSTraceSource tracer = PSTraceSource.GetTracer("ConsoleControl", "Console control methods");
+#endif
     }
 }   // namespace 
-#endif

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostRawUserInterface.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostRawUserInterface.cs
@@ -1832,6 +1832,35 @@ namespace Microsoft.PowerShell
         {
             throw new NotImplementedException("The method or operation is not implemented.");
         }
+
+        /// <summary>
+        /// See base class
+        /// </summary>
+        /// <param name="s"></param>
+        /// <returns></returns>
+
+        public override
+        int LengthInBufferCells(string s)
+        {
+            return this.LengthInBufferCells(s, 0);
+        }
+
+        /// <summary>
+        /// See base class
+        /// </summary>
+        /// <param name="s"></param>
+        /// <param name="offset"></param>
+        /// <returns></returns>
+
+        public override
+        int LengthInBufferCells(string s, int offset)
+        {
+            if (s == null)
+            {
+                throw PSTraceSource.NewArgumentNullException("str");
+            }
+            return ConsoleControl.LengthInBufferCells(s, offset, _parent.SupportsVirtualTerminal);
+        }
     }
 }
 #endif

--- a/test/powershell/Host/ConsoleHost.Tests.ps1
+++ b/test/powershell/Host/ConsoleHost.Tests.ps1
@@ -330,4 +330,17 @@ foo
             }
         }
     }
+
+    Context "String escape sequences" {
+        It "Should properly calculate buffer cell width" {
+            $esc = [char]0x1b
+            $host.UI.RawUI.LengthInBufferCells("abc") | Should Be 3
+            $host.UI.RawUI.LengthInBufferCells("$esc[31mabc") | Should Be 3
+            $host.UI.RawUI.LengthInBufferCells("$esc[31mabc$esc[0m") | Should Be 3
+
+            $host.UI.RawUI.LengthInBufferCells("${esc} [31mabc") | Should Be 9
+            $host.UI.RawUI.LengthInBufferCells("${esc}abc") | Should Be 4
+            $host.UI.RawUI.LengthInBufferCells("[31mabc") | Should Be 7
+        }
+    }
 }


### PR DESCRIPTION
Fixes issue https://github.com/PowerShell/PowerShell/issues/2502

This allows for Unix console host to properly calculate display width for
strings containing escape sequences (e.g. ANSI color), rather than
falling back to naive string.Length.

Before:
![image](https://cloud.githubusercontent.com/assets/5943573/20034454/e900c44a-a37b-11e6-93d3-4a5e6fe7998f.png)

After:
![image](https://cloud.githubusercontent.com/assets/5943573/20034456/f7b9eac0-a37b-11e6-9c27-6139778c9d51.png)

Following general pattern I see elsewhere, I just went with minimal set of `#if / #else / #endif` to include this small piece of `ConsoleControl` that has shared logic. If bigger refactor to, e.g. `SharedConsoleControl/WinConsoleControl/UnixConsoleControl`, is preferred I could do that.

Would be happy to add tests if someone points me in the right direction, but following roadblocks currently:

  - Docs on how to run tests are [out of date/wrong](https://github.com/PowerShell/PowerShell/issues/2070)
  - Tons of failures on Mac when running `Invoke-Pester`, not sure if that's known or env issue
  - I couldn't find any existing tests specifically covering table column calculations
  - Adding to `Format-Table` tests with a check of `Out-String` doesn't work, since that doesn't go through the host APIs