### PR TITLE
Fix PackageManagement issue in the latest Alpah12 on Linux

### DIFF
--- a/src/Microsoft.PackageManagement/Implementation/PackageManagementService.cs
+++ b/src/Microsoft.PackageManagement/Implementation/PackageManagementService.cs
@@ -1037,10 +1037,15 @@ namespace Microsoft.PackageManagement.Internal.Implementation {
                 throw new ArgumentNullException("request");
             }
 
+            var providerAssemblies = Enumerable.Empty<string>();
+
+#if !CORECLR
             //looks like registry needs to be here for supporting .msi packages
-            var providerAssemblies = (_initialized ? Enumerable.Empty<string>() : _defaultProviders)
+             providerAssemblies = (_initialized ? Enumerable.Empty<string>() : _defaultProviders)
                 .Concat(GetProvidersFromRegistry(Registry.LocalMachine, "SOFTWARE\\MICROSOFT\\PACKAGEMANAGEMENT"))
                 .Concat(GetProvidersFromRegistry(Registry.CurrentUser, "SOFTWARE\\MICROSOFT\\PACKAGEMANAGEMENT"));
+
+#endif
 
 #if !COMMUNITY_BUILD
             // todo: these should just be strong-named references. for now, just load them from the same directory.

--- a/src/Microsoft.PackageManagement/Implementation/PackageManagementService.cs
+++ b/src/Microsoft.PackageManagement/Implementation/PackageManagementService.cs
@@ -1037,14 +1037,14 @@ namespace Microsoft.PackageManagement.Internal.Implementation {
                 throw new ArgumentNullException("request");
             }
 
+#if CORECLR
             var providerAssemblies = Enumerable.Empty<string>();
 
-#if !CORECLR
+#else
             //looks like registry needs to be here for supporting .msi packages
-             providerAssemblies = (_initialized ? Enumerable.Empty<string>() : _defaultProviders)
+            var providerAssemblies = (_initialized ? Enumerable.Empty<string>() : _defaultProviders)
                 .Concat(GetProvidersFromRegistry(Registry.LocalMachine, "SOFTWARE\\MICROSOFT\\PACKAGEMANAGEMENT"))
                 .Concat(GetProvidersFromRegistry(Registry.CurrentUser, "SOFTWARE\\MICROSOFT\\PACKAGEMANAGEMENT"));
-
 #endif
 
 #if !COMMUNITY_BUILD


### PR DESCRIPTION
Registry.LocalMachine throws on non-Windows platform which broke OneGet on Linux in the Alpha12 build.
The fix is to exclude Registry. related on non-Windows.

Fixed Issue https://github.com/PowerShell/PowerShell/issues/2664