### PR TITLE
Fix WebRequest failure to handle missing ContentType in response header

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/ContentHelper.CoreClr.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/ContentHelper.CoreClr.cs
@@ -14,13 +14,26 @@ namespace Microsoft.PowerShell.Commands
     {
         internal static Encoding GetEncoding(HttpResponseMessage response)
         {
-            string charSet = response.Content.Headers.ContentType.CharSet;
+                
+            //ContentType may not exist in response header.
+            string charSet = null;
+            if ( response.Content.Headers.ContentType != null)
+            { 
+                charSet = response.Content.Headers.ContentType.CharSet;
+            }
             return GetEncodingOrDefault(charSet);
         }
 
         internal static string GetContentType(HttpResponseMessage response)
         {
-            return response.Content.Headers.ContentType.MediaType;
+            
+            //ContentType may not exist in response header.  Return null if not.
+            string contentType = null;
+            if ( response.Content.Headers.ContentType != null)
+            { 
+                contentType = response.Content.Headers.ContentType.MediaType;
+            }
+            return contentType;
         }
 
         internal static StringBuilder GetRawContentHeader(HttpResponseMessage response)

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/ContentHelper.CoreClr.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/ContentHelper.CoreClr.cs
@@ -16,11 +16,7 @@ namespace Microsoft.PowerShell.Commands
         {
                 
             //ContentType may not exist in response header.
-            string charSet = null;
-            if ( response.Content.Headers.ContentType != null)
-            { 
-                charSet = response.Content.Headers.ContentType.CharSet;
-            }
+            string charSet = response.Content.Headers.ContentType?.CharSet;
             return GetEncodingOrDefault(charSet);
         }
 
@@ -28,11 +24,7 @@ namespace Microsoft.PowerShell.Commands
         {
             
             //ContentType may not exist in response header.  Return null if not.
-            string contentType = null;
-            if ( response.Content.Headers.ContentType != null)
-            { 
-                contentType = response.Content.Headers.ContentType.MediaType;
-            }
+            string contentType = response.Content.Headers.ContentType?.MediaType;
             return contentType;
         }
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/ContentHelper.CoreClr.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/ContentHelper.CoreClr.cs
@@ -15,7 +15,7 @@ namespace Microsoft.PowerShell.Commands
         internal static Encoding GetEncoding(HttpResponseMessage response)
         {
                 
-            //ContentType may not exist in response header.
+            // ContentType may not exist in response header.
             string charSet = response.Content.Headers.ContentType?.CharSet;
             return GetEncodingOrDefault(charSet);
         }
@@ -23,7 +23,7 @@ namespace Microsoft.PowerShell.Commands
         internal static string GetContentType(HttpResponseMessage response)
         {
             
-            //ContentType may not exist in response header.  Return null if not.
+            // ContentType may not exist in response header.  Return null if not.
             string contentType = response.Content.Headers.ContentType?.MediaType;
             return contentType;
         }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/ContentHelper.CoreClr.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/ContentHelper.CoreClr.cs
@@ -14,7 +14,6 @@ namespace Microsoft.PowerShell.Commands
     {
         internal static Encoding GetEncoding(HttpResponseMessage response)
         {
-                
             // ContentType may not exist in response header.
             string charSet = response.Content.Headers.ContentType?.CharSet;
             return GetEncodingOrDefault(charSet);
@@ -22,10 +21,8 @@ namespace Microsoft.PowerShell.Commands
 
         internal static string GetContentType(HttpResponseMessage response)
         {
-            
             // ContentType may not exist in response header.  Return null if not.
-            string contentType = response.Content.Headers.ContentType?.MediaType;
-            return contentType;
+            return response.Content.Headers.ContentType?.MediaType;
         }
 
         internal static StringBuilder GetRawContentHeader(HttpResponseMessage response)

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebRequestPSCmdlet.CoreClr.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebRequestPSCmdlet.CoreClr.cs
@@ -350,7 +350,7 @@ namespace Microsoft.PowerShell.Commands
 
                     HttpResponseMessage response = GetResponse(client, request);
                     response.EnsureSuccessStatusCode();
-                    
+
                     string contentType = ContentHelper.GetContentType(response);
                     string respVerboseMsg = string.Format(CultureInfo.CurrentCulture,
                         "received {0}-byte response of content type {1}",

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebRequestPSCmdlet.CoreClr.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebRequestPSCmdlet.CoreClr.cs
@@ -350,19 +350,8 @@ namespace Microsoft.PowerShell.Commands
 
                     HttpResponseMessage response = GetResponse(client, request);
                     response.EnsureSuccessStatusCode();
-
-                    //It is possible for a response to not include Content-Type in the reponse
-                    //header in which case GetContentType will throw a nullReference exception.
-                    //Try to get the ContentType, otherwise catch the resulting exception.
-                    string contentType = null;
-                    try 
-                    { 
-                        contentType = ContentHelper.GetContentType(response);
-                    }
-                    catch (NullReferenceException) 
-                    {
-                    }
-
+                    
+                    string contentType = ContentHelper.GetContentType(response);
                     string respVerboseMsg = string.Format(CultureInfo.CurrentCulture,
                         "received {0}-byte response of content type {1}",
                         response.Content.Headers.ContentLength,

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebRequestPSCmdlet.CoreClr.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebRequestPSCmdlet.CoreClr.cs
@@ -351,15 +351,16 @@ namespace Microsoft.PowerShell.Commands
                     HttpResponseMessage response = GetResponse(client, request);
                     response.EnsureSuccessStatusCode();
 
-                    //added try/catch due to possible lack of content type in the response header.
-                    //seems the only reason we are getting it here is for a log message?
+                    //It is possible for a response to not include Content-Type in the reponse
+                    //header in which case GetContentType will throw a nullReference exception.
+                    //Try to get the ContentType, otherwise catch the resulting exception.
                     string contentType = null;
                     try 
                     { 
                         contentType = ContentHelper.GetContentType(response);
                     }
-                    catch {
-                        contentType = null;
+                    catch (NullReferenceException) 
+                    {
                     }
 
                     string respVerboseMsg = string.Format(CultureInfo.CurrentCulture,

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebRequestPSCmdlet.CoreClr.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebRequestPSCmdlet.CoreClr.cs
@@ -353,11 +353,10 @@ namespace Microsoft.PowerShell.Commands
 
                     //added try/catch due to possible lack of content type in the response header.
                     //seems the only reason we are getting it here is for a log message?
-
                     string contentType = null;
                     try 
                     { 
-                        ContentHelper.GetContentType(response);
+                        contentType = ContentHelper.GetContentType(response);
                     }
                     catch {
                         contentType = null;

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebRequestPSCmdlet.CoreClr.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebRequestPSCmdlet.CoreClr.cs
@@ -351,7 +351,18 @@ namespace Microsoft.PowerShell.Commands
                     HttpResponseMessage response = GetResponse(client, request);
                     response.EnsureSuccessStatusCode();
 
-                    string contentType = ContentHelper.GetContentType(response);
+                    //added try/catch due to possible lack of content type in the response header.
+                    //seems the only reason we are getting it here is for a log message?
+
+                    string contentType = null;
+                    try 
+                    { 
+                        ContentHelper.GetContentType(response);
+                    }
+                    catch {
+                        contentType = null;
+                    }
+
                     string respVerboseMsg = string.Format(CultureInfo.CurrentCulture,
                         "received {0}-byte response of content type {1}",
                         response.Content.Headers.ContentLength,

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebResponseHelper.CoreClr.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebResponseHelper.CoreClr.cs
@@ -46,7 +46,6 @@ namespace Microsoft.PowerShell.Commands
             }
             catch 
             {
-
                 contentType = null;
             }
             return ContentHelper.IsText(contentType);

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebResponseHelper.CoreClr.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebResponseHelper.CoreClr.cs
@@ -38,8 +38,7 @@ namespace Microsoft.PowerShell.Commands
 
         internal static bool IsText(HttpResponseMessage response)
         {
-
-            // ContentType may not exist in response header.  Return null if not.
+            // ContentType may not exist in response header.
             string contentType = response.Content.Headers.ContentType?.MediaType;
             return ContentHelper.IsText(contentType);
         }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebResponseHelper.CoreClr.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebResponseHelper.CoreClr.cs
@@ -39,7 +39,7 @@ namespace Microsoft.PowerShell.Commands
         internal static bool IsText(HttpResponseMessage response)
         {
 
-            //ContentType may not exist in response header.  Return null if not.
+            // ContentType may not exist in response header.  Return null if not.
             string contentType = response.Content.Headers.ContentType?.MediaType;
             return ContentHelper.IsText(contentType);
         }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebResponseHelper.CoreClr.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebResponseHelper.CoreClr.cs
@@ -38,7 +38,17 @@ namespace Microsoft.PowerShell.Commands
 
         internal static bool IsText(HttpResponseMessage response)
         {
-            string contentType = response.Content.Headers.ContentType.MediaType;
+
+            //catching exception in the event that the contenttype is not defined in the response Headers
+            string contentType = null;
+            try { 
+                contentType = response.Content.Headers.ContentType.MediaType;
+            }
+            catch 
+            {
+
+                contentType = null;
+            }
             return ContentHelper.IsText(contentType);
         }
     }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebResponseHelper.CoreClr.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebResponseHelper.CoreClr.cs
@@ -4,6 +4,7 @@
 Copyright (c) Microsoft Corporation.  All rights reserved.
 --********************************************************************/
 
+using System;
 using System.Net.Http;
 using System.Globalization;
 
@@ -44,9 +45,8 @@ namespace Microsoft.PowerShell.Commands
             try { 
                 contentType = response.Content.Headers.ContentType.MediaType;
             }
-            catch 
+            catch (NullReferenceException) 
             {
-                contentType = null;
             }
             return ContentHelper.IsText(contentType);
         }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebResponseHelper.CoreClr.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebResponseHelper.CoreClr.cs
@@ -40,13 +40,11 @@ namespace Microsoft.PowerShell.Commands
         internal static bool IsText(HttpResponseMessage response)
         {
 
-            //catching exception in the event that the contenttype is not defined in the response Headers
+            //ContentType may not exist in response header.  Return null if not.
             string contentType = null;
-            try { 
+            if ( response.Content.Headers.ContentType != null)
+            { 
                 contentType = response.Content.Headers.ContentType.MediaType;
-            }
-            catch (NullReferenceException) 
-            {
             }
             return ContentHelper.IsText(contentType);
         }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebResponseHelper.CoreClr.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebResponseHelper.CoreClr.cs
@@ -40,11 +40,7 @@ namespace Microsoft.PowerShell.Commands
         {
 
             //ContentType may not exist in response header.  Return null if not.
-            string contentType = null;
-            if ( response.Content.Headers.ContentType != null)
-            { 
-                contentType = response.Content.Headers.ContentType.MediaType;
-            }
+            string contentType = response.Content.Headers.ContentType?.MediaType;
             return ContentHelper.IsText(contentType);
         }
     }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebResponseHelper.CoreClr.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebResponseHelper.CoreClr.cs
@@ -4,7 +4,6 @@
 Copyright (c) Microsoft Corporation.  All rights reserved.
 --********************************************************************/
 
-using System;
 using System.Net.Http;
 using System.Globalization;
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -391,6 +391,14 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
         $result = ExecuteWebCommand -command $command
         $result.Error | Should BeNullOrEmpty
     }
+    It "Validate Invoke-WebRequest handles missing Content-Type in response header" {
+
+        #Validate that exception is not thrown when response headers are missing Content-Type.
+        $command = "Invoke-WebRequest -Uri 'http://httpbin.org/response-headers?Content-Type='"
+        $result = ExecuteWebCommand -command $command
+        $result.Error | Should BeNullOrEmpty
+
+    }
 
 }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -628,4 +628,11 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
         $result.Error | Should BeNullOrEmpty
     }
 
+    It "Validate Invoke-RestMethod handles missing Content-Type in response header" {
+
+        #Validate that exception is not thrown when response headers are missing Content-Type.
+        $command = "Invoke-RestMethod -Uri 'http://httpbin.org/response-headers?Content-Type='"
+        $result = ExecuteWebCommand -command $command
+        $result.Error | Should BeNullOrEmpty
+    }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -391,15 +391,14 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
         $result = ExecuteWebCommand -command $command
         $result.Error | Should BeNullOrEmpty
     }
+    
     It "Validate Invoke-WebRequest handles missing Content-Type in response header" {
 
         #Validate that exception is not thrown when response headers are missing Content-Type.
         $command = "Invoke-WebRequest -Uri 'http://httpbin.org/response-headers?Content-Type='"
         $result = ExecuteWebCommand -command $command
         $result.Error | Should BeNullOrEmpty
-
     }
-
 }
 
 Describe "Invoke-RestMethod tests" -Tags "Feature" {


### PR DESCRIPTION
If a response to invoke-webrequest does not set the content type in the
response header, an object not set exception is thrown in
WebResponseHelper.CoreClr.cs.  Updated to set contenttype = null.