### PR TITLE
Speed up Write-Host

### DIFF
--- a/src/System.Management.Automation/engine/InformationRecord.cs
+++ b/src/System.Management.Automation/engine/InformationRecord.cs
@@ -5,6 +5,7 @@ Copyright (c) Microsoft Corporation.  All rights reserved.
 using Dbg = System.Management.Automation.Diagnostics;
 using System.Runtime.Serialization;
 using System.Collections.Generic;
+using System.Management.Automation.Language;
 
 #if CORECLR
 using Environment = System.Management.Automation.Environment;
@@ -41,15 +42,6 @@ namespace System.Management.Automation
             this.Source = source;
 
             this.TimeGenerated = DateTime.Now;
-            this.Tags = new List<string>();
-            // domain\user on Windows, just user on Unix
-#if UNIX
-            this.User = Platform.Unix.UserName;
-#else
-            this.User = System.Security.Principal.WindowsIdentity.GetCurrent().Name;
-#endif
-            this.Computer = PsUtils.GetHostName();
-            this.ProcessId = (uint)System.Diagnostics.Process.GetCurrentProcess().Id;
             this.NativeThreadId = PsUtils.GetNativeThreadId();
             this.ManagedThreadId = (uint)System.Threading.Thread.CurrentThread.ManagedThreadId;
         }
@@ -104,25 +96,64 @@ namespace System.Management.Automation
         /// </summary>
         [DataMember]
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2227:CollectionPropertiesShouldBeReadOnly")]
-        public List<string> Tags { get; internal set; }
+        public List<string> Tags
+        {
+            get { return _tags ?? (_tags = new List<string>()); }
+            internal set { _tags = value; }
+        }
+        private List<string> _tags;
 
         /// <summary>
         /// The user that generated this informational record
         /// </summary>
         [DataMember]
-        public string User { get; set; }
+        public string User
+        {
+            get
+            {
+                if (this._user == null)
+                {
+                    // domain\user on Windows, just user on Unix
+#if UNIX
+                    this._user = Platform.Unix.UserName;
+#else
+                    this._user = System.Security.Principal.WindowsIdentity.GetCurrent().Name;
+#endif
+                }
+                return _user;
+            }
+            set { _user = value; }
+        }
+        private string _user;
 
         /// <summary>
         /// The computer that generated this informational record
         /// </summary>
         [DataMember]
-        public string Computer { get; set; }
+        public string Computer
+        {
+            get { return this._computerName ?? (this._computerName = PsUtils.GetHostName()); }
+            set { this._computerName = value; }
+        }
+        private string _computerName;
 
         /// <summary>
         /// The process that generated this informational record
         /// </summary>
         [DataMember]
-        public uint ProcessId { get; set; }
+        public uint ProcessId
+        {
+            get
+            {
+                if (!this._processId.HasValue)
+                {
+                    this._processId = (uint) System.Diagnostics.Process.GetCurrentProcess().Id;
+                }
+                return this._processId.Value;
+            }
+            set { _processId = value; }
+        }
+        private uint? _processId;
 
         /// <summary>
         /// The native thread that generated this informational record

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Stream.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Stream.Tests.ps1
@@ -75,6 +75,18 @@ Describe "Stream writer tests" -Tags "CI" {
            $result = Write-Information "Test Message" *>&1
            $result.GetType().Fullname | Should be "System.Management.Automation.InformationRecord"
            $result.NativeThreadId | Should Not Be 0
+           $result.ProcessId | Should Be $pid
+           if ($IsWindows)
+           {
+               # Use Match instead of Be so we can avoid dealing with a potential domain name
+               $result.Computer | Should Match ".*${env:COMPUTERNAME}"
+               $result.User | Should Match ".*${env:USERNAME}"
+           }
+           else
+           {
+               $result.Computer | Should Be $(uname -n)
+               $result.User | Should Be $(whoami)
+           }
            "$result" | Should be "Test Message"
        }
     }


### PR DESCRIPTION
Write-Host is creating an InformationRecord.

As part of the initialization of InformationRecord, we were initializing the ComputerName property.

This is apparently expensive, so I deferred initializing the value until the first time the property is accessed, which is uncommon, but will happen during remoting (because all properties are serialized).

In my local runs, CI tests ran much faster, 254s with the change, 305s without. A similar improvement is seen in calling Write-Host repeatedly - 2.2s for 4000 calls with the change, 47s without.