### PR TITLE
ensure *nix platforms add an initial / rooted drive

### DIFF
--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -936,12 +936,15 @@ namespace Microsoft.PowerShell.Commands
                         }
 
 #if UNIX
-                        // Porting notes: On platforms with single root filesystems, only
-                        // add the filesystem with the root "/" to the initial drive list,
+                        // Porting notes: On platforms with single root filesystems, ensure
+                        // that we add a filesystem with the root "/" to the initial drive list,
                         // otherwise path handling will not work correctly because there
                         // is no : available to separate the filesystems from each other
-                        if (root != StringLiterals.DefaultPathSeparatorString)
-                            continue;
+                        if (root != StringLiterals.DefaultPathSeparatorString
+                            && newDriveName == StringLiterals.DefaultPathSeparatorString)
+                        {
+                            root = StringLiterals.DefaultPathSeparatorString;
+                        }
 #endif
 
                         // Porting notes: On non-windows platforms .net can report two


### PR DESCRIPTION
This is certainly an edge case but I am working in a docker container that has no `/` mount point:
```
[181][default:/src:0]# cat /proc/mounts
tmpfs /dev tmpfs rw,nosuid,mode=755 0 0
devpts /dev/pts devpts rw,relatime,gid=5,mode=620,ptmxmode=000 0 0
proc /proc proc rw,relatime 0 0
sysfs /sys sysfs rw,relatime 0 0
tmpfs /run tmpfs rw,relatime 0 0
tmpfs /var/run/docker.sock tmpfs rw,nodev,relatime,size=201160k,mode=755 0 0
//10.0.75.1/C /src cifs rw,relatime,vers=3.02,sec=ntlmssp,cache=strict,username=matt,domain=ULTRAWROCK,uid=0,noforceuid,gid=0,noforcegid,addr=10.0.75.1,file_mode=0755,dir_mode=0755,iocharset=utf8,nounix,serverino,mapposix,nobrl,mfsymlinks,noperm,rsize=1048576,wsize=1048576,actimeo=1 0 0
```
This results in an "automounted" PS Drive named `/` but with a `Root` of `/dev` which causes `Get-Location`, `$pwd` and auto module loading to fail.

This ensures that a `/` dirive is added during the file system provider drive initialization and rooted to `/`.
