### PR TITLE
Write-Information accept objects from the pipeline

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/write.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/write.cs
@@ -171,13 +171,13 @@ namespace Microsoft.PowerShell.Commands
     /// This class implements Write-Information command
     /// 
     /// </summary>
-    [Cmdlet("Write", "Information", HelpUri = "https://go.microsoft.com/fwlink/?LinkId=525909", RemotingCapability = RemotingCapability.None)]
+    [Cmdlet(VerbsCommunications.Write, "Information", HelpUri = "https://go.microsoft.com/fwlink/?LinkId=525909", RemotingCapability = RemotingCapability.None)]
     public sealed class WriteInformationCommand : PSCmdlet
     {
         /// <summary>
         /// Object to be sent to the Information stream.
         /// </summary>
-        [Parameter(Position = 0, Mandatory = true)]
+        [Parameter(Position = 0, Mandatory = true, ValueFromPipeline = true)]
         [Alias("Msg")]
         public Object MessageData { get; set; }
 
@@ -206,10 +206,18 @@ namespace Microsoft.PowerShell.Commands
                     }
                 }
             }
+        }
 
+        /// <summary>
+        /// This method implements the ProcessRecord method for Write-Information command
+        /// </summary>
+        protected override void ProcessRecord()
+        {
             WriteInformation(MessageData, Tags);
         }
+
     }//WriteInformationCommand
+
     #endregion WriteInformationCommand
 
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Stream.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Stream.Tests.ps1
@@ -71,10 +71,6 @@ Describe "Stream writer tests" -Tags "CI" {
 
     Context "Write-Information cmdlet" {
         BeforeAll {
-            $rs = [runspacefactory]::Createrunspace()
-            $rs.open()
-            $ps = [powershell]::Create()
-            $ps.Runspace = $rs
             $ps = [powershell]::Create()
         }
 
@@ -83,8 +79,6 @@ Describe "Stream writer tests" -Tags "CI" {
         }
 
         AfterAll {
-            $rs.Close()
-            $rs.Dispose()
             $ps.Dispose()
         }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Stream.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Stream.Tests.ps1
@@ -76,6 +76,7 @@ Describe "Stream writer tests" -Tags "CI" {
 
         BeforeEach {
             $ps.Commands.Clear()
+            $ps.Streams.ClearStreams()
         }
 
         AfterAll {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Stream.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Stream.Tests.ps1
@@ -70,6 +70,24 @@ Describe "Stream writer tests" -Tags "CI" {
     }
 
     Context "Write-Information cmdlet" {
+        BeforeAll {
+            $rs = [runspacefactory]::Createrunspace()
+            $rs.open()
+            $ps = [powershell]::Create()
+            $ps.Runspace = $rs
+            $ps = [powershell]::Create()
+        }
+
+        BeforeEach {
+            $ps.Commands.Clear()
+        }
+
+        AfterAll {
+            $rs.Close()
+            $rs.Dispose()
+            $ps.Dispose()
+        }
+
        It "Write-Information outputs an information object" {
            # redirect the streams is sufficient
            $result = Write-Information "Test Message" *>&1
@@ -88,6 +106,14 @@ Describe "Stream writer tests" -Tags "CI" {
                $result.User | Should Be $(whoami)
            }
            "$result" | Should be "Test Message"
+       }
+
+       It "Write-Information accept objects from pipe" {
+            $ps.AddScript("'teststring',12345 | Write-Information -InformationAction Continue").Invoke()
+            $result = $ps.Streams.Information
+            $result.Count | Should be 2
+            $result[0].MessageData | Should be "teststring"
+            $result[1].MessageData | Should be "12345"
        }
     }
 }


### PR DESCRIPTION
Close #2559

- [x] Now Write-Information accept objects from the pipeline.
- [x] Add test

At the moment there are no tests for Write-Information (and for Write-Warning too).
@JamesWTruher could you please help?