### PR TITLE
Adding ValidateNotNullOrEmpty attribute to parameters listed in #2672

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/GetWMIObjectCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/GetWMIObjectCommand.cs
@@ -28,6 +28,7 @@ namespace Microsoft.PowerShell.Commands
         [Alias("ClassName")]
         [Parameter(Position = 0, Mandatory = true, ParameterSetName = "query")]
         [Parameter(Position = 1, ParameterSetName = "list")]
+        [ValidateNotNullOrEmpty()]
         public string Class { get; set; }
 
         /// <summary>
@@ -40,6 +41,7 @@ namespace Microsoft.PowerShell.Commands
         /// The WMI properties to retrieve
         /// </summary>
         [Parameter(Position = 1, ParameterSetName = "query")]
+        [ValidateNotNullOrEmpty()]
         public string[] Property
         {
             get { return (string[])_property.Clone(); }

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Navigation.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Navigation.cs
@@ -4747,6 +4747,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         ///
         [Parameter(Position = 0, ValueFromPipelineByPropertyName = true)]
+        [ValidateNotNullOrEmpty()]
         public string[] PSProvider
         {
             get { return _provider; }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/EnableDisableRunspaceDebugCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/EnableDisableRunspaceDebugCommand.cs
@@ -132,6 +132,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         [Parameter(Position = 0,
                    ParameterSetName = CommonRunspaceCommandBase.RunspaceNameParameterSet)]
+        [ValidateNotNullOrEmpty()]
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays")]
         public string[] RunspaceName
         {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Get-PSBreakpoint.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Get-PSBreakpoint.cs
@@ -41,7 +41,7 @@ namespace Microsoft.PowerShell.Commands
         [Parameter(ParameterSetName = "Variable")]
         [Parameter(ParameterSetName = "Command")]
         [Parameter(ParameterSetName = "Type")]
-        [ValidateNotNull]
+        [ValidateNotNullOrEmpty()]
         public string[] Script
         {
             get

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetEventCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetEventCommand.cs
@@ -21,6 +21,7 @@ namespace Microsoft.PowerShell.Commands
         /// An identifier for this event subscription
         /// </summary>
         [Parameter(Position = 0, ValueFromPipelineByPropertyName = true, ParameterSetName = "BySource")]
+        [ValidateNotNullOrEmpty()]
         public string SourceIdentifier
         {
             get

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetEventSubscriberCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetEventSubscriberCommand.cs
@@ -21,6 +21,7 @@ namespace Microsoft.PowerShell.Commands
         /// An identifier for this event subscription
         /// </summary>
         [Parameter(Position = 0, ValueFromPipelineByPropertyName = true, ParameterSetName = "BySource")]
+        [ValidateNotNullOrEmpty()]
         public string SourceIdentifier
         {
             get

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetRunspaceCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetRunspaceCommand.cs
@@ -34,6 +34,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         [Parameter(Position = 0,
                    ParameterSetName = GetRunspaceCommand.NameParameterSet)]
+        [ValidateNotNullOrEmpty()]
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays")]
         public string[] Name
         {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Var.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Var.cs
@@ -258,7 +258,7 @@ namespace Microsoft.PowerShell.Commands
         /// Name of the PSVariable
         /// </summary>
         [Parameter(Position = 0, ValueFromPipeline = true, ValueFromPipelineByPropertyName = true)]
-        [ValidateNotNull]
+        [ValidateNotNullOrEmpty()]
         public string[] Name
         {
             get

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/trace/GetTracerCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/trace/GetTracerCommand.cs
@@ -22,6 +22,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         /// <value></value>
         [Parameter(Position = 0, ValueFromPipeline = true, ValueFromPipelineByPropertyName = true)]
+        [ValidateNotNullOrEmpty()]
         public string[] Name
         {
             get

--- a/src/Microsoft.PowerShell.Security/security/CredentialCommands.cs
+++ b/src/Microsoft.PowerShell.Security/security/CredentialCommands.cs
@@ -56,6 +56,7 @@ namespace Microsoft.PowerShell.Commands
         /// Gets and sets the user supplied username to be used while creating the PSCredential.
         /// </summary>
         [Parameter(Position = 0, Mandatory = false, ParameterSetName = messageSet)]
+        [ValidateNotNullOrEmpty()]
         public string UserName
         {
             get { return _userName; }

--- a/src/System.Management.Automation/engine/remoting/commands/CustomShellCommands.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/CustomShellCommands.cs
@@ -2824,6 +2824,7 @@ $args[0] | foreach {{
         /// </summary>
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays")]
         [Parameter(Position = 0, Mandatory = false)]
+        [ValidateNotNullOrEmpty()]
         public string[] Name { get; set; }
 
         /// <summary>

--- a/src/System.Management.Automation/help/HelpCommands.cs
+++ b/src/System.Management.Automation/help/HelpCommands.cs
@@ -51,6 +51,7 @@ namespace Microsoft.PowerShell.Commands
         /// Target to search for help
         /// </summary>
         [Parameter(Position = 0, ValueFromPipelineByPropertyName = true)]
+        [ValidateNotNullOrEmpty()]
         public string Name { get; set; } = "";
 
         /// <summary>

--- a/src/System.Management.Automation/singleshell/Commands/MshSnapinCommands.cs
+++ b/src/System.Management.Automation/singleshell/Commands/MshSnapinCommands.cs
@@ -712,6 +712,7 @@ namespace Microsoft.PowerShell.Commands
         /// Name(s) of PSSnapIn(s).
         /// </summary>
         [Parameter(Position = 0, Mandatory = false)]
+        [ValidateNotNullOrEmpty()]
         public string[] Name
         {
             get


### PR DESCRIPTION
Do changes to parameter metadata require tests?  If so, should they be located with the tests for each individual command, or would it be sufficient to write a single `It` block with `-TestCases` to hit all of the affected commands in this issue / PR?