### PR TITLE
Jameswtruher/dailytravis

### DIFF
--- a/tools/travis.sh
+++ b/tools/travis.sh
@@ -1,7 +1,10 @@
 set -x
 ulimit -n 4096
+# do this for our daily build test run
+if [[ "$TRAVIS_DAILY_BUILD" == "true" ]]; then
+    powershell -c "Import-Module ./build.psm1; Start-PSBootstrap; Start-PSBuild -CrossGen; Start-PSPester -Tag @('CI','Feature','Scenario') -ExcludeTag RequireAdminOnWindows; Start-PSxUnit"
 # Only build packages for branches, not pull requests
-if [[ "$TRAVIS_PULL_REQUEST" == "false" ]]; then
+elif [[ "$TRAVIS_PULL_REQUEST" == "false" ]]; then
     powershell -c "Import-Module ./build.psm1; Start-PSBootstrap -Package; Start-PSBuild -CrossGen; Start-PSPackage; Start-PSPester -ThrowOnFailure; Test-PSPesterResults; Start-PSxUnit"
 else
     powershell -c "Import-Module ./build.psm1; Start-PSBootstrap; Start-PSBuild -CrossGen; Start-PSPester -ThrowOnFailure; Start-PSxUnit"

--- a/tools/travis.sh
+++ b/tools/travis.sh
@@ -1,7 +1,7 @@
 set -x
 ulimit -n 4096
 # do this for our daily build test run
-if [[ "$TRAVIS_DAILY_BUILD" == "true" ]]; then
+if [[ "$TRAVIS_EVENT_TYPE" == "cron" ]]; then
     powershell -c "Import-Module ./build.psm1; Start-PSBootstrap; Start-PSBuild -CrossGen; Start-PSPester -Tag @('CI','Feature','Scenario') -ExcludeTag RequireAdminOnWindows; Start-PSxUnit"
 # Only build packages for branches, not pull requests
 elif [[ "$TRAVIS_PULL_REQUEST" == "false" ]]; then


### PR DESCRIPTION
It looks like using cron on travis-ci will enable us to create daily builds. However, travis-ci doesn't allow for cron jobs to be run at any particular time. Also, it does not appear that it is possible to label these builds, so they will just appear in the same stream as other builds.

The tests are not marked as throwonfailure for the execution of the pester tests because I want to be sure that we always upload our artifacts.

After this change is merged, we can create the cron job (which is now enabled for us in travis-ci)