### PR TITLE
Add WithTopLevelBinderFlags call hack to Add-Type

### DIFF
--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Add-Type.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Add-Type.Tests.ps1
@@ -16,4 +16,17 @@ public class AttributeTest$guid {}
     It "Can load TPA assembly System.Runtime.Serialization.Primitives.dll" {
         Add-Type -AssemblyName 'System.Runtime.Serialization.Primitives' -PassThru | Should Not Be $null
     }
+
+    It "Can use Console class" {
+        # For more context, see https://github.com/PowerShell/PowerShell/issues/1616
+        Add-Type -ReferencedAssemblies System.Console -TypeDefinition @"
+using System;
+public static class ConsoleUser$guid {
+    public static void Test() {
+        Console.BackgroundColor = Console.BackgroundColor;
+    }
+}
+"@ -PassThru | Should Not Be $null
+    }
+
 }


### PR DESCRIPTION
We want to workaround CoreFX bug.
https://github.com/dotnet/corefx/issues/5540
They are exporting the same public type from both assemblies.

There is a workaround: an internal Roslyn API that allows compiling such
cases.

~~This API will become public at some point, this work is tracked in
https://github.com/dotnet/roslyn/issues/5855~~

Fix #1616