### PR TITLE
Updates behavior of split-path when working with UNC roots. 

### DIFF
--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -4735,24 +4735,11 @@ namespace Microsoft.PowerShell.Commands
         protected override string GetParentPath(string path, string root)
         {
             string parentPath = base.GetParentPath(path, root);
-            if (IsUNCPath(path))
-            {
-                // Since UNC paths must have "\\server\share" as the base of
-                // the path, you cannot get a parent path higher than this.
-                // So this looks for the path separator between server\share and
-                // ensures that it is in a position where it is preceded by
-                // "\\s" at a minimum.
-
-                int indexOfLastPathSeparator = parentPath.LastIndexOf('\\');
-                if (indexOfLastPathSeparator < 3)
-                {
-                    parentPath = String.Empty;
-                }
-            }
-            else
+            if (!IsUNCPath(path))
             {
                 parentPath = EnsureDriveIsRooted(parentPath);
             }
+            
             return parentPath;
         } // GetParentPath
 
@@ -5530,24 +5517,7 @@ namespace Microsoft.PowerShell.Commands
             }
             else
             {
-                if (IsUNCPath(path))
-                {
-                    // For UNC paths we need to ensure that "\\server\share" is
-                    // maintained as a single unit. There is no child for "\\server\share"
-
-                    if (IsUNCRoot(path))
-                    {
-                        result = String.Empty;
-                    }
-                    else
-                    {
-                        result = path.Substring(separatorIndex + 1);
-                    }
-                }
-                else
-                {
-                    result = path.Substring(separatorIndex + 1);
-                }
+                 result = path.Substring(separatorIndex + 1);
             }
 
             return result;

--- a/test/powershell/Provider/FileSystemProvider.tests.ps1
+++ b/test/powershell/Provider/FileSystemProvider.tests.ps1
@@ -1,0 +1,39 @@
+﻿Describe "SplitPath Tests" -tags "CI" {
+    It 'Splits a multilevel path' {
+        Split-Path -Path 'C:\Temp\folder1' | Should be 'C:\temp'
+    }
+
+    It 'Returns a multilevel path child' {
+        Split-Path -Path 'C:\Temp\folder1' -Leaf | Should be 'folder1'
+    }
+   
+    It 'Splits a single level path' {
+        Split-Path -Path 'C:\Temp' | Should be 'C:\'
+    }
+
+    It 'Returns a single level child' {
+        Split-Path -Path 'C:\Temp' -Leaf | Should be 'temp'
+    }
+
+    It 'Splits a multilevel unc path' {
+        Split-Path -Path '\\server1\share1\folder' | Should be '\\server1\share1'
+    }
+
+    It 'Returns a multilevel unc path child' {
+        Split-Path -Path '\\server1\share1\folder' -Leaf | Should be 'folder'
+    }
+
+    It 'Splits a unc path' {
+        Split-Path -Path '\\server1\share1' | Should be '\\server1'
+    }
+
+    It 'Returns a unc path child' {
+        Split-Path -Path '\\server1\share1' -Leaf | Should be 'share1'
+    }
+
+    It 'Does not split a drive leter'{
+        Split-Path -Path 'C:\' | Should be ''
+    }
+   
+} 
+


### PR DESCRIPTION
Currently splitting a UNC root on windows will return a empty string. 

Please reference:
https://github.com/PowerShell/PowerShell/issues/2301