### PR TITLE
Adding -Extension and -LeafBase switches to Split-Path

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/ParsePathCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/ParsePathCommand.cs
@@ -15,13 +15,13 @@ namespace Microsoft.PowerShell.Commands
     /// A command to resolve MSH paths containing glob characters to
     /// MSH paths that match the glob strings.
     /// </summary>
-    [Cmdlet(VerbsCommon.Split, "Path", DefaultParameterSetName = "ParentSet", SupportsTransactions = true, HelpUri = "https://go.microsoft.com/fwlink/?LinkID=113404")]
-    [OutputType(typeof(string), ParameterSetName = new string[] { SplitPathCommand.leafSet,
-                                                                  SplitPathCommand.noQualifierSet,
-                                                                  SplitPathCommand.parentSet,
-                                                                  SplitPathCommand.qualifierSet,
-                                                                  SplitPathCommand.literalPathSet})]
-    [OutputType(typeof(bool), ParameterSetName = new string[] { SplitPathCommand.isAbsoluteSet })]
+    [Cmdlet("Split", "Path", DefaultParameterSetName = "ParentSet", SupportsTransactions = true, HelpUri = "https://go.microsoft.com/fwlink/?LinkID=113404")]
+    [OutputType(typeof(string), ParameterSetName = new string[] { leafSet,
+                                                                  noQualifierSet,
+                                                                  parentSet,
+                                                                  qualifierSet,
+                                                                  literalPathSet})]
+    [OutputType(typeof(bool), ParameterSetName = new string[] { isAbsoluteSet })]
     public class SplitPathCommand : CoreCommandWithCredentialsBase
     {
         #region Parameters
@@ -64,18 +64,7 @@ namespace Microsoft.PowerShell.Commands
         [Parameter(Position = 0, ParameterSetName = qualifierSet, Mandatory = true, ValueFromPipeline = true, ValueFromPipelineByPropertyName = true)]
         [Parameter(Position = 0, ParameterSetName = noQualifierSet, Mandatory = true, ValueFromPipeline = true, ValueFromPipelineByPropertyName = true)]
         [Parameter(Position = 0, ParameterSetName = isAbsoluteSet, Mandatory = true, ValueFromPipeline = true, ValueFromPipelineByPropertyName = true)]
-        public string[] Path
-        {
-            get
-            {
-                return _paths;
-            } // get
-
-            set
-            {
-                _paths = value;
-            } // set
-        } // Path
+        public string[] Path { get; set; }
 
         /// <summary>
         /// Gets or sets the literal path parameter to the command
@@ -86,13 +75,13 @@ namespace Microsoft.PowerShell.Commands
         {
             get
             {
-                return _paths;
+                return Path;
             } // get
 
             set
             {
                 base.SuppressWildcardExpansion = true;
-                _paths = value;
+                Path = value;
             } // set
         } // LiteralPath
 
@@ -107,18 +96,7 @@ namespace Microsoft.PowerShell.Commands
         /// </value>
         ///
         [Parameter(Position = 1, ValueFromPipelineByPropertyName = true, ParameterSetName = qualifierSet, Mandatory = false)]
-        public SwitchParameter Qualifier
-        {
-            get
-            {
-                return _qualifier;
-            } // get
-
-            set
-            {
-                _qualifier = value;
-            } //set
-        } // Qualifier
+        public SwitchParameter Qualifier { get; set; }
 
         /// <summary>
         /// Determines if the qualifier should be returned
@@ -131,19 +109,7 @@ namespace Microsoft.PowerShell.Commands
         /// </value>
         ///
         [Parameter(ParameterSetName = noQualifierSet, Mandatory = false, ValueFromPipelineByPropertyName = true)]
-        public SwitchParameter NoQualifier
-        {
-            get
-            {
-                return _noqualifier;
-            } // get
-
-            set
-            {
-                _noqualifier = value;
-            } //set
-        } // NoQualifier
-
+        public SwitchParameter NoQualifier { get; set; }
 
         /// <summary>
         /// Determines if the parent path should be returned
@@ -154,18 +120,7 @@ namespace Microsoft.PowerShell.Commands
         /// </value>
         ///
         [Parameter(ParameterSetName = parentSet, Mandatory = false, ValueFromPipelineByPropertyName = true)]
-        public SwitchParameter Parent
-        {
-            get
-            {
-                return _parent;
-            } // get
-
-            set
-            {
-                _parent = value;
-            } //set
-        } // Parent
+        public SwitchParameter Parent { get; set; } = true;
 
         /// <summary>
         /// Determines if the leaf name should be returned
@@ -176,98 +131,26 @@ namespace Microsoft.PowerShell.Commands
         /// </value>
         ///
         [Parameter(ParameterSetName = leafSet, Mandatory = false, ValueFromPipelineByPropertyName = true)]
-        public SwitchParameter Leaf
-        {
-            get
-            {
-                return _leaf;
-            } // get
+        public SwitchParameter Leaf { get; set; }
 
-            set
-            {
-                _leaf = value;
-            } //set
-        } // Leaf
 
         /// <summary>
         /// Determines if the path should be resolved before being parsed.
         /// </summary>
         /// <value></value>
         [Parameter]
-        public SwitchParameter Resolve
-        {
-            get
-            {
-                return _resolve;
-            } // get
-
-            set
-            {
-                _resolve = value;
-            } //set
-        } // Resolve
+        public SwitchParameter Resolve { get; set; }
 
         /// <summary>
         /// Determines if the path is an absolute path.
         /// </summary>
-        ///
         [Parameter(ParameterSetName = isAbsoluteSet)]
-        public SwitchParameter IsAbsolute
-        {
-            get
-            {
-                return _isAbsolute;
-            } // get
+        public SwitchParameter IsAbsolute { get; set; }
 
-            set
-            {
-                _isAbsolute = value;
-            } //set
-        }
         #endregion Parameters
 
         #region parameter data
 
-        /// <summary>
-        /// The path to resolve
-        /// </summary>
-        private string[] _paths;
-
-        /// <summary>
-        /// Determines if the qualifier of the path should be returned.
-        /// The qualifier is either the drive name or provider name that
-        /// is qualifying the path.
-        /// </summary>
-        private bool _qualifier;
-
-        /// <summary>
-        /// Determines if the qualifier of the path should be returned.
-        /// If false, the qualifier will be returned. If true, it will
-        /// be stripped from the path.
-        /// The qualifier is either the drive name or provider name that
-        /// is qualifying the path.
-        /// </summary>
-        private bool _noqualifier;
-
-        /// <summary>
-        /// Determines if the parent path of the specified path should be returned.
-        /// </summary>
-        private bool _parent = true;
-
-        /// <summary>
-        /// Determines if the leaf name of the specified path should be returned.
-        /// </summary>
-        private bool _leaf;
-
-        /// <summary>
-        /// Determines if the path(s) should be resolved before being parsed.
-        /// </summary>
-        private bool _resolve;
-
-        /// <summary>
-        /// Determines if the path(s) are absolute paths.
-        /// </summary>
-        private bool _isAbsolute;
 
         #endregion parameter data
 
@@ -281,15 +164,15 @@ namespace Microsoft.PowerShell.Commands
         {
             StringCollection pathsToParse = new StringCollection();
 
-            if (_resolve)
+            if (Resolve)
             {
                 CmdletProviderContext currentContext = CmdletProviderContext;
 
-                foreach (string path in _paths)
+                foreach (string path in Path)
                 {
                     // resolve the paths and then parse each one.
 
-                    Collection<PathInfo> resolvedPaths = null;
+                    Collection<PathInfo> resolvedPaths;
 
                     try
                     {
@@ -387,7 +270,7 @@ namespace Microsoft.PowerShell.Commands
                 switch (ParameterSetName)
                 {
                     case isAbsoluteSet:
-                        string ignored = null;
+                        string ignored;
                         bool isPathAbsolute =
                             SessionState.Path.IsPSAbsolute(pathsToParse[index], out ignored);
 
@@ -436,10 +319,6 @@ namespace Microsoft.PowerShell.Commands
 
                     case parentSet:
                     case literalPathSet:
-                        bool pathStartsWithRoot =
-                            pathsToParse[index].StartsWith("\\", StringComparison.CurrentCulture) ||
-                            pathsToParse[index].StartsWith("/", StringComparison.CurrentCulture);
-
                         try
                         {
                             result =

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
@@ -518,6 +518,7 @@ Describe "Extended FileSystem Path/Location Cmdlet Provider Tests" -Tags "Featur
         $level1_0 = "Level1_0"
         $level2_0 = "Level2_0"
         $level2_1 = "Level2_1"
+        $fileExt = ".ext"
         $root = Join-Path "TestDrive:" "" #adds correct / or \
         $level1_0Full = Join-Path $root $level1_0
         $level2_0Full = Join-Path $level1_0Full $level2_0
@@ -576,6 +577,22 @@ Describe "Extended FileSystem Path/Location Cmdlet Provider Tests" -Tags "Featur
         It "Validate Leaf" {
             $result = Split-Path -Path $level1_0Full -Leaf
             $result | Should Be $level1_0
+        }
+        
+        It 'Validate LeafBase' {
+            $result = Split-Path -Path "$level2_1Full$fileExt" -LeafBase
+            $result | Should Be $level2_1
+        }
+
+        It 'Validate LeafBase is not over-zealous' {
+            
+            $result = Split-Path -Path "$level2_1Full$fileExt$fileExt" -LeafBase
+            $result | Should Be "$level2_1$fileExt"
+        }
+
+        It 'Validate LeafBase' {
+            $result = Split-Path -Path "$level2_1Full$fileExt" -Extension
+            $result | Should Be $fileExt
         }
 
         It "Validate NoQualifier" {


### PR DESCRIPTION
Fixes #2700 

Extension and LeafBase are specializations of Leaf, and uses System.IO.Path.GetExtension
and System.IO.Path.GetFilenameWithoutExtension to extract parts from the Leaf

Tests added in test\powershell\Modules\Microsoft.PowerShell.Management\FileSystem.Tests.ps1