### PR TITLE
Fix ambiguous tab completion for some cmdlets (lzybkr/PSReadLine#430)

### DIFF
--- a/src/System.Management.Automation/engine/Modules/AnalysisCache.cs
+++ b/src/System.Management.Automation/engine/Modules/AnalysisCache.cs
@@ -97,6 +97,29 @@ namespace System.Management.Automation
             return result;
         }
 
+        internal static List<PSModuleInfo> GetNestedModules(string modulePath)
+        {
+            List<PSModuleInfo> result = new List<PSModuleInfo>();
+            var extension = Path.GetExtension(modulePath);
+            if (extension.Equals(StringLiterals.PowerShellDataFileExtension, StringComparison.OrdinalIgnoreCase))
+            {
+                var moduleManifestProperties = PsUtils.GetModuleManifestProperties(modulePath, PsUtils.FastModuleManifestAnalysisPropertyNames);
+                if (moduleManifestProperties != null)
+                {
+                    object[] nestedModules = moduleManifestProperties["NestedModules"] as object[];
+                    if (null != nestedModules)
+                    {
+                        foreach (string nestedModuleName in nestedModules)
+                        {
+                            PSModuleInfo module = new PSModuleInfo(nestedModuleName, null, null, null);
+                            result.Add(module);
+                        }
+                    }
+                }
+            }           
+            return result;
+        }
+
         private static ConcurrentDictionary<string, CommandTypes> AnalyzeManifestModule(string modulePath, ExecutionContext context, DateTime lastWriteTime, bool etwEnabled)
         {
             ConcurrentDictionary<string, CommandTypes> result = null;

--- a/src/System.Management.Automation/engine/Modules/ModuleUtils.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleUtils.cs
@@ -362,7 +362,15 @@ namespace System.Management.Automation.Internal
                             PSModuleInfo psModule = modules[0];
                             tempModuleInfo = new PSModuleInfo(psModule.Name, psModule.Path, null, null);
                             tempModuleInfo.SetModuleBase(psModule.ModuleBase);
-
+                            // Also add information for nested modules.
+                            // Need this information to check for duplicate commands in tab completion.
+                            if (null != psModule.NestedModules)
+                            {
+                                foreach (PSModuleInfo nestedModule in psModule.NestedModules)
+                                {
+                                    tempModuleInfo.AddNestedModule(nestedModule);
+                                }
+                            }
                             foreach (var entry in psModule.ExportedCommands)
                             {
                                 if (commandPattern.IsMatch(entry.Value.Name))
@@ -419,7 +427,13 @@ namespace System.Management.Automation.Internal
                         tempModuleInfo.SetVersion(ModuleIntrinsics.GetManifestModuleVersion(modulePath));
                         tempModuleInfo.SetGuid(ModuleIntrinsics.GetManifestGuid(modulePath));
                     }
-
+                    // Also add information for nested modules.
+                    // Need this information to check for duplicate commands in tab completion.
+                    List<PSModuleInfo> nestedModules = AnalysisCache.GetNestedModules(modulePath);
+                    foreach (PSModuleInfo nestedModule in nestedModules)
+                    {
+                        tempModuleInfo.AddNestedModule(nestedModule);
+                    }
                     foreach (var pair in exportedCommands)
                     {
                         var commandName = pair.Key;

--- a/test/powershell/Host/TabCompletion/BugFix.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/BugFix.Tests.ps1
@@ -21,4 +21,12 @@ Describe "Tab completion bug fix" -Tags "CI" {
         $result.CompletionMatches[0].CompletionText | Should Be "-and"
         $result.CompletionMatches[1].CompletionText | Should Be "-as"
     }
+
+    It "Issue#430 - Tab completion should give unique results for commands" {
+        $result = TabExpansion2 -inputScript "get-psreadline" -cursorColumn "get-psreadline".Length
+        $result | Should Not BeNullOrEmpty
+        $result.CompletionMatches.Count | Should Be 2
+        $result.CompletionMatches[0].CompletionText | Should Be "Get-PSReadlineKeyHandler"
+        $result.CompletionMatches[1].CompletionText | Should Be "Get-PSReadlineOption"
+    }
 }


### PR DESCRIPTION
Resolving lzybkr/PSReadLine#430.

This happens because module prefix is used when comparing 2 cmdlets.
For example: Microsoft.PowerShell.PSReadLine.dll\Get-PSReadlineOption
and PSReadLine\Get-PSReadlineOption are treated as different cmdlets.