### PR TITLE
Make Get-Process <id> work as well as Get-Process <name>

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
@@ -15,6 +15,7 @@ using System.Management.Automation;
 using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using System.IO;
+using System.Linq;
 using System.Runtime.InteropServices;
 using System.Security;
 using System.Security.Principal;
@@ -201,17 +202,29 @@ namespace Microsoft.PowerShell.Commands
                     found = true;
                     AddIdempotent(process);
                 }
+
                 if (!found &&
                     !WildcardPattern.ContainsWildcardCharacters(pattern))
                 {
-                    WriteNonTerminatingError(
-                        pattern,
-                        0,
-                        pattern,
-                        null,
-                        ProcessResources.NoProcessFoundForGivenName,
-                        "NoProcessFoundForGivenName",
-                        ErrorCategory.ObjectNotFound);
+                    int processIdCandidate;
+                    if (int.TryParse(pattern, out processIdCandidate) && processIdCandidate > 0)
+                    {
+                        var process = AllProcesses.FirstOrDefault(p => p.Id == processIdCandidate);
+                        if (process != null)
+                        {
+                            AddIdempotent(process);
+                        }
+                    }
+                    else {
+                        WriteNonTerminatingError(
+                            pattern,
+                            0,
+                            pattern,
+                            null,
+                            ProcessResources.NoProcessFoundForGivenName,
+                            "NoProcessFoundForGivenName",
+                            ErrorCategory.ObjectNotFound);
+                    }
                 }
             }
         } // MatchingProcessesByProcessName


### PR DESCRIPTION
Fixes #2722 

At the end of RetrieveMatchingProcessesByProcessName,
a check is added to see if the pattern is a positive integer.
In that case an attempt is made to match it to a process id.