### PR TITLE
Adding errormessage property to ValidatePatternAttribute 

### DIFF
--- a/src/System.Management.Automation/engine/Attributes.cs
+++ b/src/System.Management.Automation/engine/Attributes.cs
@@ -1114,7 +1114,13 @@ namespace System.Management.Automation
         public RegexOptions Options { set; get; } = RegexOptions.IgnoreCase;
 
         /// <summary>
-        /// Gets or sets the custom error message that is displayed to the user
+        /// Gets or sets the custom error message pattern that is displayed to the user.
+        /// 
+        /// The text representation of the object being validated and the validating regex is passed as
+        /// the first and second formatting parameters to the ErrorMessage formatting pattern.
+        /// <example>
+        /// [ValidatePattern("\s+", ErrorMessage="The text '{0}' did not pass validation of regex '{1}'")]
+        /// </example>
         /// </summary>
         public string ErrorMessage { get; set; }
 
@@ -1170,7 +1176,14 @@ namespace System.Management.Automation
     public sealed class ValidateScriptAttribute : ValidateEnumeratedArgumentsAttribute
     {
         /// <summary>
-        /// Gets or sets the custom error message that is displayed to the user
+        /// Gets or sets the custom error message that is displayed to the user.
+        /// 
+        /// The item being validated and the validating scriptblock is passed as the first and second
+        /// formatting argument.
+        /// 
+        /// <example>
+        /// [ValidateScript("$_ % 2", ErrorMessage = "The item '{0}' did not pass validation of script '{1}'")]
+        /// </example>
         /// </summary>
         public string ErrorMessage { get; set; }
 
@@ -1350,6 +1363,13 @@ namespace System.Management.Automation
 
         /// <summary>
         /// Gets or sets the custom error message that is displayed to the user
+        /// 
+        /// The item being validated and a text representation of the validation set
+        /// is passed as the first and second formatting argument to the ErrorMessage formatting pattern.
+        /// 
+        /// <example>
+        /// [ValidateSet("A","B","C", ErrorMessage="The item '{0}' is not part of the set '{1}'.")
+        /// </example>
         /// </summary>
         public string ErrorMessage { get; set; }
 

--- a/src/System.Management.Automation/engine/Attributes.cs
+++ b/src/System.Management.Automation/engine/Attributes.cs
@@ -1114,6 +1114,11 @@ namespace System.Management.Automation
         public RegexOptions Options { set; get; } = RegexOptions.IgnoreCase;
 
         /// <summary>
+        /// Gets or sets the custom error message that is displayed to the user
+        /// </summary>
+        public string ErrorMessage { get; set; }
+
+        /// <summary>
         /// Validates that each parameter argument matches the RegexPattern
         /// </summary>
         /// <param name="element">object to validate</param>
@@ -1136,8 +1141,9 @@ namespace System.Management.Automation
             Match match = regex.Match(objectString);
             if (!match.Success)
             {
+                var errorMessageFormat = String.IsNullOrEmpty(ErrorMessage) ? Metadata.ValidatePatternFailure : ErrorMessage;
                 throw new ValidationMetadataException("ValidatePatternFailure",
-                        null, Metadata.ValidatePatternFailure,
+                        null, errorMessageFormat,
                         objectString, RegexPattern);
             }
         }
@@ -1163,6 +1169,11 @@ namespace System.Management.Automation
     /// </summary>
     public sealed class ValidateScriptAttribute : ValidateEnumeratedArgumentsAttribute
     {
+        /// <summary>
+        /// Gets or sets the custom error message that is displayed to the user
+        /// </summary>
+        public string ErrorMessage { get; set; }
+
         /// <summary>
         /// Gets the scriptblock to be used in the validation
         /// </summary>
@@ -1193,8 +1204,9 @@ namespace System.Management.Automation
 
             if (!LanguagePrimitives.IsTrue(result))
             {
+                var errorMessageFormat = String.IsNullOrEmpty(ErrorMessage) ? Metadata.ValidateScriptFailure : ErrorMessage;
                 throw new ValidationMetadataException("ValidateScriptFailure",
-                        null, Metadata.ValidateScriptFailure,
+                        null, errorMessageFormat,
                         element, ScriptBlock);
             }
         }
@@ -1337,6 +1349,11 @@ namespace System.Management.Automation
         private string[] _validValues;
 
         /// <summary>
+        /// Gets or sets the custom error message that is displayed to the user
+        /// </summary>
+        public string ErrorMessage { get; set; }
+
+        /// <summary>
         /// Gets a flag specifying if we should ignore the case when performing string comparison. The
         /// default is true.
         /// </summary>
@@ -1386,8 +1403,10 @@ namespace System.Management.Automation
                     return;
                 }
             }
+
+            var errorMessageFormat = String.IsNullOrEmpty(ErrorMessage) ? Metadata.ValidateSetFailure : ErrorMessage;
             throw new ValidationMetadataException("ValidateSetFailure", null,
-                Metadata.ValidateSetFailure,
+                errorMessageFormat,
                 element.ToString(), SetAsString());
         }
 

--- a/src/System.Management.Automation/engine/parser/Compiler.cs
+++ b/src/System.Management.Automation/engine/parser/Compiler.cs
@@ -1313,6 +1313,10 @@ namespace System.Management.Automation.Language
                 {
                     result.IgnoreCase = s_attrArgToBoolConverter.Target(s_attrArgToBoolConverter, argValue);
                 }
+                else if (argumentName.Equals("ErrorMessage", StringComparison.OrdinalIgnoreCase))
+                {
+                    result.ErrorMessage = argValue.ToString();
+                }
                 else
                 {
                     throw InterpreterError.NewInterpreterException(namedArg, typeof(RuntimeException), namedArg.Extent,

--- a/test/powershell/Language/Scripting/ParameterBinding.Tests.ps1
+++ b/test/powershell/Language/Scripting/ParameterBinding.Tests.ps1
@@ -415,6 +415,62 @@ Describe "Tests for parameter binding" -Tags "CI" {
 
             { get-fooh } | Should not throw
         }
+
+        It "ValidateScript can use custom ErrorMessage" {
+            function get-fooi {
+                [CmdletBinding()]
+                param([ValidateScript({$_ -gt 2}, ErrorMessage = "Item '{0}' failed '{1}' validation")] $p)
+                $p
+            }
+            $errMsg = ''
+            try
+            {
+                get-fooi -p 2
+            }
+            catch
+            {
+                $errMsg = $_.Exception.Message
+            }
+            $errMsg | Should Be "Cannot validate argument on parameter 'p'. Item '2' failed '`$_ -gt 2' validation"
+        }
+
+        It "ValidatePattern can use custom ErrorMessage" {
+            function get-fooj
+            {
+                [CmdletBinding()]
+                param([ValidatePattern("\s+", ErrorMessage = "Item '{0}' failed '{1}' regex")] $p)
+                $p
+            }
+            $errMsg = ''
+            try
+            {
+                get-fooj -p 2
+            }
+            catch
+            {
+                $errMsg = $_.Exception.Message
+            }
+            $errMsg | Should Be "Cannot validate argument on parameter 'p'. Item '2' failed '\s+' regex"
+        }
+
+        It "ValidateSet can use custom ErrorMessage" {
+            function get-fook
+            {
+                param([ValidateSet('A', 'B', 'C', IgnoreCase=$false, ErrorMessage="Item '{0}' is not in '{1}'")] $p)
+            }
+            $errMsg = ''
+            try
+            {
+                get-fook -p 2
+            }
+            catch
+            {
+                $errMsg = $_.Exception.Message
+            }
+            $set = 'A','B','C' -join [Globalization.CultureInfo]::CurrentUICulture.TextInfo.ListSeparator
+            $errMsg | Should Be "Cannot validate argument on parameter 'p'. Item '2' is not in '$set'"
+        }
+
     }
 
     #known issue 2069


### PR DESCRIPTION
Fixes #2719 

Adding an ErrorMessage property to ValidatePatternAttribute so a message that
is meaningful to the user can be displayed, instead of a regular expression that
probably even the person who wrote will have a hard time understanding.