### PR TITLE
Fix the indicator for redirecting standard input

### DIFF
--- a/src/System.Management.Automation/engine/NativeCommandProcessor.cs
+++ b/src/System.Management.Automation/engine/NativeCommandProcessor.cs
@@ -1186,7 +1186,7 @@ namespace System.Management.Automation
         /// <param name="redirectInput"></param>
         private void CalculateIORedirection(out bool redirectOutput, out bool redirectError, out bool redirectInput)
         {
-            redirectInput = this.Command.MyInvocation.PipelinePosition > 0;
+            redirectInput = this.Command.MyInvocation.ExpectingInput;
             redirectOutput = true;
             redirectError = true;
 

--- a/src/System.Management.Automation/engine/pipeline.cs
+++ b/src/System.Management.Automation/engine/pipeline.cs
@@ -1026,8 +1026,8 @@ namespace System.Management.Automation.Internal
                 myInfo.PipelinePosition = i + 1;
                 myInfo.PipelineLength = _commands.Count;
                 myInfo.PipelineIterationInfo = pipelineIterationInfo;
-                commandProcessor.DoPrepare(psDefaultParameterValues);
                 myInfo.ExpectingInput = commandProcessor.IsPipelineInputExpected();
+                commandProcessor.DoPrepare(psDefaultParameterValues);
             }
 
             // Clear ErrorVariable as appropriate

--- a/test/powershell/Language/Scripting/NativeExecution/NativeLinuxCommands.Tests.ps1
+++ b/test/powershell/Language/Scripting/NativeExecution/NativeLinuxCommands.Tests.ps1
@@ -15,6 +15,18 @@ Describe "NativeLinuxCommands" -tags "CI" {
     It "Should find Application touch" -Skip:$IsWindows {
         (get-command touch).CommandType | Should Be Application
     }
+
+    It "Should not redirect standard input if native command is the first command in pipeline (1)" -Skip:$IsWindows {
+        stty | ForEach-Object -Begin { $out = @() } -Process { $out += $_ }
+        $out.Length > 0 | Should Be $true
+        $out[0] -like "speed * baud; line =*" | Should Be $true
+    }
+
+    It "Should not redirect standard input if native command is the first command in pipeline (2)" -Skip:$IsWindows {
+        $out = stty
+        $out.Length > 0 | Should Be $true
+        $out[0] -like "speed * baud; line =*" | Should Be $true
+    }
 }
 
 Describe "Scripts with extensions" -tags "CI" {

--- a/test/powershell/Language/Scripting/NativeExecution/NativeLinuxCommands.Tests.ps1
+++ b/test/powershell/Language/Scripting/NativeExecution/NativeLinuxCommands.Tests.ps1
@@ -18,13 +18,13 @@ Describe "NativeLinuxCommands" -tags "CI" {
 
     It "Should not redirect standard input if native command is the first command in pipeline (1)" -Skip:$IsWindows {
         stty | ForEach-Object -Begin { $out = @() } -Process { $out += $_ }
-        $out.Length > 0 | Should Be $true
+        $out.Length -gt 0 | Should Be $true
         $out[0] -like "speed * baud; line =*" | Should Be $true
     }
 
     It "Should not redirect standard input if native command is the first command in pipeline (2)" -Skip:$IsWindows {
         $out = stty
-        $out.Length > 0 | Should Be $true
+        $out.Length -gt 0 | Should Be $true
         $out[0] -like "speed * baud; line =*" | Should Be $true
     }
 }


### PR DESCRIPTION
Fix #2745 
`PipelinePosition` starts from 1, ~~so the indicator for redirecting standard input should be `PipelinePosition > 1`.~~

When there is input to a native command like `1,2,3 | <native>`, the native command is still marked as position 1 in the pipeline because the input doesn't take up pipeline position. So we cannot simply using `PipelinePosition` to decide whether standard input needs to be redirected.

The new fix swaps the running order of the following code in `PipelineProcessor.Start`, so as to make sure `ExpectingInput` is set before calling `DoPrepare`. Then in `NativeCommandProcessor.Prepare` we can use `MyInvocation.ExpectingInput` to check whether to redirect standard input.
```
commandProcessor.DoPrepare(psDefaultParameterValues);
myInfo.ExpectingInput = commandProcessor.IsPipelineInputExpected();
```