### PR TITLE
Fixed failing PackageManagement related tests in daily-builds.

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -395,12 +395,13 @@ cmd.exe /C cd /d "$location" "&" "$($vcVarsPath)\vcvarsall.bat" "$NativeHostArch
 
     if($PSModuleRestore)
     {
-        # downloading the PackageManagement module
+        # Downloading the PowerShellGet and PackageManagement modules.
         # $Options.Output is pointing to something like "...\src\powershell-win-core\bin\Debug\netcoreapp1.0\win10-x64\publish\powershell.exe", 
         # so we need to get its parent directory
         $publishPath = Split-Path $Options.Output -Parent
-        log "Restore PowerShell modules to $publishPath"
-        Restore-PSModule -Name @('PackageManagement','PowerShellGet') -Destination (Join-Path -Path $publishPath -ChildPath "Modules")
+        log "Restore PowerShell modules to $publishPath"    
+        # PowerShellGet depends on PackageManagement module, so PackageManagement module will be installed with the PowerShellGet module.
+        Restore-PSModule -Name @('PowerShellGet') -Destination (Join-Path -Path $publishPath -ChildPath "Modules")
     }
 }
 
@@ -2622,7 +2623,7 @@ function Restore-PSModule
         }
     }
 
-    log ("Name='{0}', Destination='{1}', Repository='{2}'" -f $Name, $Destination, $RepositoryName)
+    log ("Name='{0}', Destination='{1}', Repository='{2}'" -f ($Name -join ','), $Destination, $RepositoryName)
 
     $Name | ForEach-Object {
 
@@ -2638,8 +2639,13 @@ function Restore-PSModule
         }
 
         # pull down the module
-        log "running save-module $Name"
+        log "running save-module $_"
         PowerShellGet\Save-Module @command -Force -Verbose
+        
+        # Remove PSGetModuleInfo.xml file
+        Find-Module -Name $_ -Repository $RepositoryName -IncludeDependencies | ForEach-Object {
+            Get-ChildItem -Path (Join-Path -Path $Destination -ChildPath $_.Name) -Recurse -Depth 2 -File -Include 'PSGetModuleInfo.xml' -Attributes h,a,r | Remove-Item -Force
+        }
     }
 
     # Clean up

--- a/test/powershell/Modules/PackageManagement/PackageManagement.Tests.ps1
+++ b/test/powershell/Modules/PackageManagement/PackageManagement.Tests.ps1
@@ -40,7 +40,7 @@ Describe "PackageManagement Acceptance Test" -Tags "Feature" {
     }
 
      It "install-packageprovider, Expect succeed" {
-        $ipp = (install-PackageProvider -name gistprovider -force -source $InternalSource).name 
+        $ipp = (install-PackageProvider -name gistprovider -force -source $InternalSource -Scope CurrentUser).name 
         $ipp -contains "gistprovider" | should be $true      
     }
        
@@ -51,7 +51,7 @@ Describe "PackageManagement Acceptance Test" -Tags "Feature" {
 	}
 
     it "Install-package"  {
-        $i = install-Package -ProviderName NuGet -Name jquery -force -source Nugettest
+        $i = install-Package -ProviderName NuGet -Name jquery -force -source Nugettest -Scope CurrentUser 
         $i.Name -contains "jquery" | should be $true
 	}
 

--- a/test/powershell/engine/Help/UpdatableHelpSystem.Tests.ps1
+++ b/test/powershell/engine/Help/UpdatableHelpSystem.Tests.ps1
@@ -103,14 +103,14 @@ $testCases = @{
         HelpFiles            = "Microsoft.PowerShell.PackageManagement.dll-help.xml"
         HelpInfoFiles        = "PackageManagement_4ae9fd46-338a-459c-8186-07f910774cb8_HelpInfo.xml"
         CompressedFiles      = "PackageManagement_4ae9fd46-338a-459c-8186-07f910774cb8_en-US_helpcontent$extension"
-        HelpInstallationPath = "$pshome\Modules\PackageManagement\en-US"
+        HelpInstallationPath = "$pshome\Modules\PackageManagement\*\en-US"
     }
 
     "PowershellGet" = @{
         HelpFiles            = "PSGet.psm1-help.xml"
         HelpInfoFiles        = "PowershellGet_1d73a601-4a6c-43c5-ba3f-619b18bbb404_HelpInfo.xml"
         CompressedFiles      = "PowershellGet_1d73a601-4a6c-43c5-ba3f-619b18bbb404_en-US_helpcontent$extension"
-        HelpInstallationPath = "$pshome\Modules\PowershellGet\en-US"
+        HelpInstallationPath = "$pshome\Modules\PowershellGet\*\en-US"
     }
 
     "PSReadline" = @{


### PR DESCRIPTION
- Fixed failing PackageManagement related tests in daily-builds
- Updated Restore-PSModule function to delete the PSGetModuleInfo.xml so that this file will not be included in the PowerShell release.
- Since PackageManagement module gets installed with PowerShellGet module, removed PackageManagement module name in Restore-PSModule command invocation.