### PR TITLE
Moved publishing of code coverage artifacts to test_script phase

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,5 +20,8 @@ build_script:
 test_script:
   - ps: Invoke-AppveyorTest
 
+after_test:
+  - ps: Invoke-AppVeyorAfterTest
+
 on_finish: 
   - ps: Invoke-AppveyorFinish

--- a/tools/appveyor.psm1
+++ b/tools/appveyor.psm1
@@ -326,9 +326,12 @@ function Invoke-AppVeyorTest
     Write-Host -Foreground Green 'Upload FullCLR test results'
     Update-AppVeyorTestResults -resultsFile $testResultsFileFullCLR
 
-    ## CodeCoverage
+    ## Publish code coverage build, tests and OpenCover module to artifacts, so webhook has the information.
+    ## Build webhook is called after 'after_test' phase, hence we need to do this here and not in AppveyorFinish. 
     $env:CodeCoverageOutput = Split-Path -Parent (Get-PSOutput -Options (New-PSOptions -Configuration CodeCoverage))
- 
+    $codeCoverageArtifacts = Compress-CoverageArtifacts
+    $codeCoverageArtifacts | % { Update-AppVeyorTestResults -resultsFile $_ }
+
     #
     # Fail the build, if tests failed
     @(
@@ -340,6 +343,32 @@ function Invoke-AppVeyorTest
     }
 
     Set-BuildVariable -Name TestPassed -Value True
+}
+
+function Compress-CoverageArtifacts
+{
+    # Create archive for test content, OpenCover module and CodeCoverage build
+    if(Test-DailyBuild)
+    {
+        $artifacts = @()
+
+        $zipTestContentPath = Join-Path $pwd 'tests.zip'
+        Compress-TestContent -Destination $zipTestContentPath
+        $artifacts.Add($zipTestContentPath)
+
+        Add-Type -AssemblyName System.IO.Compression.FileSystem
+        $resolvedPath = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath((Join-Path $PSScriptRoot '..\test\tools\OpenCover'))
+        $zipOpenCoverPath = Join-Path $pwd 'OpenCover.zip'
+        [System.IO.Compression.ZipFile]::CreateFromDirectory($resolvedPath, $zipOpenCoverPath) 
+        $artifacts.Add($zipOpenCoverPath)
+
+        $zipCodeCoveragePath = Join-Path $pwd "$name.CodeCoverage.zip"
+        Write-Verbose "Zipping ${env:CodeCoverageOutput} into $zipCodeCoveragePath" -verbose
+        [System.IO.Compression.ZipFile]::CreateFromDirectory($env:CodeCoverageOutput, $zipCodeCoveragePath)
+        $artifacts.Add($zipCodeCoveragePath)
+    }
+
+    return $artifacts
 }
 
 # Implements AppVeyor 'on_finish' step
@@ -372,25 +401,6 @@ function Invoke-AppveyorFinish
 
         $artifacts.Add($zipFilePath)
         $artifacts.Add($zipFileFullPath)
-
-        # Create archive for test content, OpenCover module and CodeCoverage build
-        if(Test-DailyBuild) 
-        {
-            $zipTestContentPath = Join-Path $pwd 'tests.zip' 
-            Compress-TestContent -Destination $zipTestContentPath
-            $artifacts.Add($zipTestContentPath)
-
-            Add-Type -AssemblyName System.IO.Compression.FileSystem
-            $resolvedPath = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath((Join-Path $PSScriptRoot '..\test\tools\OpenCover'))
-            $zipOpenCoverPath = Join-Path $pwd 'OpenCover.zip'
-            [System.IO.Compression.ZipFile]::CreateFromDirectory($resolvedPath, $zipOpenCoverPath) 
-            $artifacts.Add($zipOpenCoverPath)
-
-            $zipCodeCoveragePath = Join-Path $pwd "$name.CodeCoverage.zip"
-            Write-Verbose "Zipping ${env:CodeCoverageOutput} into $zipCodeCoveragePath" -verbose
-            [System.IO.Compression.ZipFile]::CreateFromDirectory($env:CodeCoverageOutput, $zipCodeCoveragePath)
-            $artifacts.Add($zipCodeCoveragePath)
-        }
 
         if ($env:APPVEYOR_REPO_TAG_NAME)
         {

--- a/tools/appveyor.psm1
+++ b/tools/appveyor.psm1
@@ -326,11 +326,14 @@ function Invoke-AppVeyorTest
     Write-Host -Foreground Green 'Upload FullCLR test results'
     Update-AppVeyorTestResults -resultsFile $testResultsFileFullCLR
 
-    ## Publish code coverage build, tests and OpenCover module to artifacts, so webhook has the information.
-    ## Build webhook is called after 'after_test' phase, hence we need to do this here and not in AppveyorFinish. 
-    $env:CodeCoverageOutput = Split-Path -Parent (Get-PSOutput -Options (New-PSOptions -Configuration CodeCoverage))
-    $codeCoverageArtifacts = Compress-CoverageArtifacts
-    $codeCoverageArtifacts | % { Update-AppVeyorTestResults -resultsFile $_ }
+    if(Test-DailyBuild)
+    {
+        ## Publish code coverage build, tests and OpenCover module to artifacts, so webhook has the information.
+        ## Build webhook is called after 'after_test' phase, hence we need to do this here and not in AppveyorFinish. 
+        $env:CodeCoverageOutput = Split-Path -Parent (Get-PSOutput -Options (New-PSOptions -Configuration CodeCoverage))
+        $codeCoverageArtifacts = Compress-CoverageArtifacts
+        $codeCoverageArtifacts | % { Update-AppVeyorTestResults -resultsFile $_ }
+    }
 
     #
     # Fail the build, if tests failed


### PR DESCRIPTION
The webhook for build completion is called after the test_script phase
hence we needed to publish code coverage artifacts before that. Moved the
logic for compression and publish the artifacts after running tests.