### PR TITLE
Prettify ConvertTo-Json Output #2736

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/NewTemporaryFileCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/NewTemporaryFileCommand.cs
@@ -1,0 +1,47 @@
+
+/********************************************************************++
+Copyright (c) Microsoft Corporation.  All rights reserved.
+--********************************************************************/
+
+using System;
+using System.IO;
+using System.Management.Automation;
+
+namespace Microsoft.PowerShell.Commands
+{
+    /// <summary>
+    /// The implementation of the "New-TemporaryFile" cmdlet
+    /// </summary>    
+    [Cmdlet(VerbsCommon.New, "TemporaryFile", SupportsShouldProcess = true, HelpUri = "https://go.microsoft.com/fwlink/?LinkId=526726")]
+    [OutputType(typeof(System.IO.FileInfo))]
+    public class NewTemporaryFileCommand : Cmdlet
+    {      
+        /// <summary>
+        /// returns a TemporaryFile
+        /// </summary>
+        protected override void BeginProcessing()
+        {
+            string filePath = null;
+            if (ShouldProcess(System.Environment.GetEnvironmentVariable("TEMP")))
+            {
+                try
+                {
+                    filePath = Path.GetTempFileName();                
+                }
+                catch (Exception e)
+                {
+                    ErrorRecord errorRecord = new ErrorRecord(
+                        e,
+                        "NewTemporaryFileWriteError",
+                        ErrorCategory.WriteError,
+                        System.Environment.GetEnvironmentVariable("TEMP")
+                    );
+                    WriteError(errorRecord);
+                    return;
+                }
+            FileInfo file = new FileInfo(filePath);
+            WriteObject(file);
+            }
+        }
+    }
+}

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/ConvertToJsonCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/ConvertToJsonCommand.cs
@@ -296,7 +296,7 @@ namespace Microsoft.PowerShell.Commands
             bool headChar = true;
             bool beforeQuote = true;
             int newSpaceCount = 0;
-            const int spaceCountAfterQuoteMark = 2;
+            const int spaceCountAfterQuoteMark = 1;
 
             for (int i = index; i < json.Length; i++)
             {
@@ -327,7 +327,7 @@ namespace Microsoft.PowerShell.Commands
                         int end = ConvertQuotedString(json, i + 1, result);
                         if (beforeQuote)
                         {
-                            newSpaceCount += (end - i + 1);
+                            newSpaceCount = 0;
                         }
                         i = end;
                         headChar = false;
@@ -335,7 +335,6 @@ namespace Microsoft.PowerShell.Commands
                     case ':':
                         result.Append(json[i]);
                         AddSpaces(spaceCountAfterQuoteMark, result);
-                        newSpaceCount += 3;
                         headChar = false;
                         beforeQuote = false;
                         break;
@@ -373,7 +372,7 @@ namespace Microsoft.PowerShell.Commands
         /// <param name="result"></param>
         private void AddIndentations(int numberOfTabsToReturn, StringBuilder result)
         {
-            int realNumber = numberOfTabsToReturn * 4;
+            int realNumber = numberOfTabsToReturn * 2;
             for (int i = 0; i < realNumber; i++)
             {
                 result.Append(' ');

--- a/src/Modules/Shared/Microsoft.PowerShell.Utility/Microsoft.PowerShell.Utility.psm1
+++ b/src/Modules/Shared/Microsoft.PowerShell.Utility/Microsoft.PowerShell.Utility.psm1
@@ -141,38 +141,6 @@ function Get-FileHash
     }
 }
 
-<# This cmdlet is used to create a new temporary file in $env:temp #>
-function New-TemporaryFile
-{
-    [CmdletBinding(
-        HelpURI='https://go.microsoft.com/fwlink/?LinkId=526726',
-        SupportsShouldProcess=$true)]
-    [OutputType([System.IO.FileInfo])]
-    Param()
-
-    Begin
-    {
-        try
-        {
-            if($PSCmdlet.ShouldProcess($env:TEMP))
-            {
-                $tempFilePath = [System.IO.Path]::GetTempFileName()            
-            }
-        }
-        catch
-        {
-            $errorRecord = [System.Management.Automation.ErrorRecord]::new($_.Exception,"NewTemporaryFileWriteError", "WriteError", $env:TEMP)
-            Write-Error -ErrorRecord $errorRecord
-            return
-        } 
-
-        if($tempFilePath)
-        {
-            Get-Item $tempFilePath
-        }
-    }    
-}
-
 <# This cmdlet is used to generate a new guid #>
 function New-Guid
 {
@@ -419,7 +387,7 @@ function Format-Hex
                     # 170..180 | format-hex
                     #           Path:
                     #           00 01 02 03 04 05 06 07 08 09 0A 0B 0C 0D 0E 0F
-                    #00000000   AA AB AC AD AE AF B0 B1 B2 B3 B4                 ª«¬­®¯°±²³´
+                    #00000000   AA AB AC AD AE AF B0 B1 B2 B3 B4                 ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
                     #
                     # any integer padding is likely to be more confusing than this
                     # fairly compact representation.
@@ -432,9 +400,9 @@ function Format-Hex
                     # 
                     #            00 01 02 03 04 05 06 07 08 09 0A 0B 0C 0D 0E 0F
                     # 
-                    # 00000000   AA 00 00 00 AB 00 00 00 AC 00 00 00 AD 00 00 00  ª...«...¬...­...
-                    # 00000010   AE 00 00 00 AF 00 00 00 B0 00 00 00 B1 00 00 00  ®...¯...°...±...
-                    # 00000020   B2 00 00 00 B3 00 00 00 B4 00 00 00              ²...³...´...
+                    # 00000000   AA 00 00 00 AB 00 00 00 AC 00 00 00 AD 00 00 00  ï¿½...ï¿½...ï¿½...ï¿½...
+                    # 00000010   AE 00 00 00 AF 00 00 00 B0 00 00 00 B1 00 00 00  ï¿½...ï¿½...ï¿½...ï¿½...
+                    # 00000020   B2 00 00 00 B3 00 00 00 B4 00 00 00              ï¿½...ï¿½...ï¿½...
                     #
                     # this provides a representation of the piped numbers which includes all
                     # of the bytes which are in an int32

--- a/src/Modules/Windows-Core/Microsoft.PowerShell.Utility/Microsoft.PowerShell.Utility.psd1
+++ b/src/Modules/Windows-Core/Microsoft.PowerShell.Utility/Microsoft.PowerShell.Utility.psd1
@@ -19,11 +19,11 @@ CmdletsToExport= "Format-List", "Format-Custom", "Format-Table", "Format-Wide",
     "Group-Object", "Sort-Object", "Get-Variable", "New-Variable", "Set-Variable", "Remove-Variable",
     "Clear-Variable", "Export-Clixml", "Import-Clixml", "ConvertTo-Xml", "Select-Xml", "Write-Debug",
     "Write-Verbose", "Write-Warning", "Write-Error", "Write-Information", "Write-Output", "Set-PSBreakpoint",
-    "Get-PSBreakpoint", "Remove-PSBreakpoint", "Enable-PSBreakpoint", "Disable-PSBreakpoint", "Get-PSCallStack",
+    "Get-PSBreakpoint", "Remove-PSBreakpoint", "New-TemporaryFile", "Enable-PSBreakpoint", "Disable-PSBreakpoint", "Get-PSCallStack",
     "Get-TraceSource", "Set-TraceSource", "Trace-Command",
     "Unblock-File", "Get-Runspace", "Debug-Runspace", "Enable-RunspaceDebug", "Disable-RunspaceDebug",
     "Get-RunspaceDebug", "Wait-Debugger" , "Get-Uptime"
-FunctionsToExport= "Get-FileHash", "New-TemporaryFile", "New-Guid", "Format-Hex", "Import-PowerShellDataFile",
+FunctionsToExport= "Get-FileHash", "New-Guid", "Format-Hex", "Import-PowerShellDataFile",
     "ConvertFrom-SddlString"
 AliasesToExport= "fhx"
 NestedModules="Microsoft.PowerShell.Commands.Utility.dll","Microsoft.PowerShell.Utility.psm1"

--- a/src/Modules/Windows-Full/Microsoft.PowerShell.Utility/Microsoft.PowerShell.Utility.psd1
+++ b/src/Modules/Windows-Full/Microsoft.PowerShell.Utility/Microsoft.PowerShell.Utility.psd1
@@ -2,7 +2,7 @@
 GUID="1DA87E53-152B-403E-98DC-74D7B4D63D59"
 Author="Microsoft Corporation"
 CompanyName="Microsoft Corporation"
-Copyright="© Microsoft Corporation. All rights reserved."
+Copyright="ï¿½ Microsoft Corporation. All rights reserved."
 ModuleVersion="3.1.0.0"
 PowerShellVersion="3.0"
 CLRVersion="4.0"
@@ -22,10 +22,10 @@ CmdletsToExport= "Format-List", "Format-Custom", "Format-Table", "Format-Wide",
     "Clear-Variable", "Export-Clixml", "Import-Clixml", "ConvertTo-Xml", "Select-Xml", "Write-Debug",
     "Write-Verbose", "Write-Warning", "Write-Error", "Write-Information", "Write-Output", "Set-PSBreakpoint", "Get-PSBreakpoint",
     "Remove-PSBreakpoint", "Enable-PSBreakpoint", "Disable-PSBreakpoint", "Get-PSCallStack",
-    "Send-MailMessage", "Get-TraceSource", "Set-TraceSource", "Trace-Command", "Show-Command", "Unblock-File",
+    "Send-MailMessage", "Get-TraceSource", "New-TemporaryFile", "Set-TraceSource", "Trace-Command", "Show-Command", "Unblock-File",
     "Get-Runspace", "Debug-Runspace", "Enable-RunspaceDebug", "Disable-RunspaceDebug", "Get-RunspaceDebug", "Wait-Debugger",
     "ConvertFrom-String", "Convert-String" , "Get-Uptime"
-FunctionsToExport= "Get-FileHash", "New-TemporaryFile", "New-Guid", "Format-Hex", "Import-PowerShellDataFile",
+FunctionsToExport= "Get-FileHash", "New-Guid", "Format-Hex", "Import-PowerShellDataFile",
     "ConvertFrom-SddlString"
 AliasesToExport= "CFS", "fhx"
 NestedModules="Microsoft.PowerShell.Commands.Utility.dll","Microsoft.PowerShell.Utility.psm1"

--- a/src/vs-csproj/Microsoft.PowerShell.Commands.Utility.csproj
+++ b/src/vs-csproj/Microsoft.PowerShell.Commands.Utility.csproj
@@ -226,6 +226,9 @@
     <Compile Include="..\Microsoft.PowerShell.Commands.Utility\commands\utility\neweventcommand.cs">
       <Link>commands\utility\neweventcommand.cs</Link>
     </Compile>
+    <Compile Include="..\Microsoft.PowerShell.Commands.Utility\commands\utility\newtemporaryfilecommand.cs">
+      <Link>commands\utility\newtemporaryfilecommand.cs</Link>
+    </Compile>
     <Compile Include="..\Microsoft.PowerShell.Commands.Utility\commands\utility\NewTimeSpanCommand.cs">
       <Link>commands\utility\NewTimeSpanCommand.cs</Link>
     </Compile>


### PR DESCRIPTION
Change indentation settings to match standards.

These changes appear to work with the example given in the issue as well as with nested dictionaries/arrays. 

Validated with the following test object:

@{
  foo = @{
    first = 'a'
    second = 'bbbbbbbb'
  }
  barbarbarbar = @{
    first = 'a'
    second = 'bbbbbbbb'
    NestedArray = @(
        'Test3'
        'Test4'
        'Test5'
        3
        4
    )
    NestedObject = @{
        MoreObject = 'AnotherObject'
        TestBool = $true
    }
  }
  array = @(
    'Thing1'
    'Thing2'
  )
  dan = 15
} | ConvertTo-Json

Compares similarly to when formatted through web based jsonformatter/lint tools.