### PR TITLE
Add back '-Configuration $buildConfiguration' since $buildConfiguration is set in appveyor.yml

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,6 @@ nuget:
 
 install:
   - git submodule update --init
-  - ps: $buildConfiguration = 'Release'
   - ps: Import-Module .\tools\Appveyor.psm1
   - ps: Invoke-AppveyorInstall
 

--- a/tools/appveyor.psm1
+++ b/tools/appveyor.psm1
@@ -164,7 +164,7 @@ function Invoke-AppVeyorBuild
       }
 
       Start-PSBuild -FullCLR -PSModuleRestore
-      Start-PSBuild -CrossGen -PSModuleRestore
+      Start-PSBuild -CrossGen -PSModuleRestore -Configuration 'Release'
 }
 
 # Implements the AppVeyor 'install' step
@@ -285,7 +285,7 @@ function Invoke-AppVeyorTest
     #
     # CoreCLR
     
-    $env:CoreOutput = Split-Path -Parent (Get-PSOutput -Options (New-PSOptions -Publish))
+    $env:CoreOutput = Split-Path -Parent (Get-PSOutput -Options (New-PSOptions -Publish -Configuration 'Release'))
     Write-Host -Foreground Green 'Run CoreCLR tests'
     $testResultsNonAdminFile = "$pwd\TestsResultsNonAdmin.xml"
     $testResultsAdminFile = "$pwd\TestsResultsAdmin.xml"


### PR DESCRIPTION
`-Configuration $buildConfiguration` was removed in commit https://github.com/PowerShell/PowerShell/commit/41f8c9c7df657ad6a338cf2fb3500e6d9f699070 because it was believed that `$buildConfiguration` was not set anywhere and thus should be removed.

However, it's actually being set to 'Release' in `appveyor.yml` before importing `Appveyor.psm1`. After removing `-Configuration $buildConfiguration` our appveyor CIs are running tests on 'Debug' builds.

This PR is to revert back the changes in that commit.