### PR TITLE
Assigned all ArrayList.Add() to $null

### DIFF
--- a/tools/appveyor.psm1
+++ b/tools/appveyor.psm1
@@ -436,7 +436,7 @@ function Invoke-AppveyorFinish
         }
 
         $nugetArtifacts = Get-ChildItem .\nuget-artifacts -ErrorAction SilentlyContinue | ForEach-Object { $_.FullName }
-        $null = $artifacts.AddRange($nugetArtifacts)
+        $artifacts.AddRange($nugetArtifacts)
 
         $pushedAllArtifacts = $true
         $artifacts | ForEach-Object { 

--- a/tools/appveyor.psm1
+++ b/tools/appveyor.psm1
@@ -435,7 +435,11 @@ function Invoke-AppveyorFinish
             Publish-NuGetFeed -OutputPath .\nuget-artifacts -VersionSuffix $preReleaseVersion
         }
 
-        $artifacts += (Get-ChildItem .\nuget-artifacts -ErrorAction SilentlyContinue | ForEach-Object {$_.FullName})
+        $nugetArtifacts = Get-ChildItem .\nuget-artifacts -ErrorAction SilentlyContinue
+        foreach($artifact in $nugetArtifacts)
+        {
+            $null = $artifacts.Add($artifact.FullName)
+        }
 
         $pushedAllArtifacts = $true
         $artifacts | ForEach-Object { 

--- a/tools/appveyor.psm1
+++ b/tools/appveyor.psm1
@@ -435,11 +435,8 @@ function Invoke-AppveyorFinish
             Publish-NuGetFeed -OutputPath .\nuget-artifacts -VersionSuffix $preReleaseVersion
         }
 
-        $nugetArtifacts = Get-ChildItem .\nuget-artifacts -ErrorAction SilentlyContinue
-        foreach($artifact in $nugetArtifacts)
-        {
-            $null = $artifacts.Add($artifact.FullName)
-        }
+        $nugetArtifacts = Get-ChildItem .\nuget-artifacts -ErrorAction SilentlyContinue | ForEach-Object { $_.FullName }
+        $null = $artifacts.AddRange($nugetArtifacts)
 
         $pushedAllArtifacts = $true
         $artifacts | ForEach-Object { 

--- a/tools/appveyor.psm1
+++ b/tools/appveyor.psm1
@@ -366,18 +366,18 @@ function Compress-CoverageArtifacts
 
     $zipTestContentPath = Join-Path $pwd 'tests.zip'
     Compress-TestContent -Destination $zipTestContentPath
-    $artifacts.Add($zipTestContentPath)
+    $null = $artifacts.Add($zipTestContentPath)
 
     Add-Type -AssemblyName System.IO.Compression.FileSystem
     $resolvedPath = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath((Join-Path $PSScriptRoot '..\test\tools\OpenCover'))
     $zipOpenCoverPath = Join-Path $pwd 'OpenCover.zip'
     [System.IO.Compression.ZipFile]::CreateFromDirectory($resolvedPath, $zipOpenCoverPath) 
-    $artifacts.Add($zipOpenCoverPath)
+    $null = $artifacts.Add($zipOpenCoverPath)
 
     $zipCodeCoveragePath = Join-Path $pwd "$name.CodeCoverage.zip"
     Write-Verbose "Zipping ${CodeCoverageOutput} into $zipCodeCoveragePath" -verbose
     [System.IO.Compression.ZipFile]::CreateFromDirectory($CodeCoverageOutput, $zipCodeCoveragePath)
-    $artifacts.Add($zipCodeCoveragePath)
+    $null = $artifacts.Add($zipCodeCoveragePath)
 
     return $artifacts
 }
@@ -407,11 +407,11 @@ function Invoke-AppveyorFinish
 
         $artifacts = New-Object System.Collections.ArrayList
         foreach ($package in $packages) {
-            $artifacts.Add($package)
+            $null = $artifacts.Add($package)
         }
 
-        $artifacts.Add($zipFilePath)
-        $artifacts.Add($zipFileFullPath)
+        $null = $artifacts.Add($zipFilePath)
+        $null = $artifacts.Add($zipFileFullPath)
 
         if ($env:APPVEYOR_REPO_TAG_NAME)
         {


### PR DESCRIPTION
ArrayList.Add() returns the array list size after the add. This causes the
value to be thrown on the pipeline. Assigning them to $null as we do not
need to know the size after addition. This causes errors and unnecessary
output on the AppVeyor console.