### PR TITLE
Added -erroraction silentlycontinue for import-module

### DIFF
--- a/test/tools/OpenCover/OpenCover.psm1
+++ b/test/tools/OpenCover/OpenCover.psm1
@@ -353,7 +353,8 @@ function Install-OpenCover
         throw "Download failed: $packageUrl"
     }
     
-    import-module Microsoft.PowerShell.Archive
+    ## We add ErrorAction as we do not have this module on PS v4 and below. Calling import-module will throw an error otherwise.
+    import-module Microsoft.PowerShell.Archive -ErrorAction SilentlyContinue
 
     if ((Get-Command Expand-Archive -ErrorAction Ignore) -ne $null) {
         Expand-Archive -Path $tempPath -DestinationPath "$TargetDirectory/OpenCover"


### PR DESCRIPTION
If the module is not available it throws an error. To make sure OpenCover
works on PSv4 and below, -erroraction silentlycontinue was added.