### PR TITLE
modify Start-PSPester to accept -Quiet to eliminate Pester output

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -667,7 +667,8 @@ function Start-PSPester {
         [string]$binDir = (Split-Path (New-PSOptions -FullCLR:$FullCLR).Output),
         [string]$powershell = (Join-Path $binDir 'powershell'),
         [string]$Pester = ([IO.Path]::Combine($binDir, "Modules", "Pester")),
-        [switch]$Unelevate
+        [switch]$Unelevate,
+        [switch]$Quiet
     )
 
     # we need to do few checks and if user didn't provide $ExcludeTag explicitly, we should alternate the default
@@ -725,6 +726,11 @@ function Start-PSPester {
     }
     if ($Tag) {
         $Command += "-Tag @('" + (${Tag} -join "','") + "') "
+    }
+    # sometimes we need to eliminate Pester output, especially when we're
+    # doing a daily build as the log file is too large
+    if ( $Quiet ) {
+        $Command += "-Quiet "
     }
 
     $Command += "'" + $Path + "'"

--- a/tools/travis.ps1
+++ b/tools/travis.ps1
@@ -17,6 +17,13 @@ $pesterParam = @{ 'binDir' = $output }
 if ($isFullBuild) {
     $pesterParam['Tag'] = @('CI','Feature','Scenario')
     $pesterParam['ExcludeTag'] = @()
+    # cron jobs create log files which include the stdout of Pester
+    # which creates too much data for travis to put in the log file
+    # and the job is then cancelled. Add Quiet to reduce the log size
+    # the xunit log created by pester is what is important
+    if ( $env:TRAVIS_EVENT_TYPE -eq 'cron' ) {
+        $pesterParam['Quiet'] = $true
+    }
 } else {
     $pesterParam['Tag'] = @('CI')
     $pesterParam['ThrowOnFailure'] = $true


### PR DESCRIPTION
also modify travis.ps1 to include -Quiet for Pester args to reduce
stdout log size which should hopefully allow daily builds to run
without being cancelled due to too much output