### PR TITLE
Added -publish to codecoverage package generation and fixed package name

### DIFF
--- a/tools/appveyor.psm1
+++ b/tools/appveyor.psm1
@@ -160,7 +160,7 @@ function Invoke-AppVeyorBuild
 
       if(Test-DailyBuild)
       {
-          Start-PSBuild -Configuration 'CodeCoverage' -PSModuleRestore
+          Start-PSBuild -Configuration 'CodeCoverage' -PSModuleRestore -Publish
       }
 
       Start-PSBuild -FullCLR -PSModuleRestore
@@ -373,6 +373,12 @@ function Compress-CoverageArtifacts
     $zipOpenCoverPath = Join-Path $pwd 'OpenCover.zip'
     [System.IO.Compression.ZipFile]::CreateFromDirectory($resolvedPath, $zipOpenCoverPath) 
     $null = $artifacts.Add($zipOpenCoverPath)
+
+    $name = git describe
+
+    # Remove 'v' from version, prepend 'PowerShell' - to be consistent with other package names
+    $name = $name -replace 'v',''
+    $name = 'PowerShell_' + $name
 
     $zipCodeCoveragePath = Join-Path $pwd "$name.CodeCoverage.zip"
     Write-Verbose "Zipping ${CodeCoverageOutput} into $zipCodeCoveragePath" -verbose

--- a/tools/appveyor.psm1
+++ b/tools/appveyor.psm1
@@ -374,18 +374,22 @@ function Compress-CoverageArtifacts
     [System.IO.Compression.ZipFile]::CreateFromDirectory($resolvedPath, $zipOpenCoverPath) 
     $null = $artifacts.Add($zipOpenCoverPath)
 
-    $name = git describe
-
-    # Remove 'v' from version, prepend 'PowerShell' - to be consistent with other package names
-    $name = $name -replace 'v',''
-    $name = 'PowerShell_' + $name
-
+    $name = Get-PackageName
     $zipCodeCoveragePath = Join-Path $pwd "$name.CodeCoverage.zip"
     Write-Verbose "Zipping ${CodeCoverageOutput} into $zipCodeCoveragePath" -verbose
     [System.IO.Compression.ZipFile]::CreateFromDirectory($CodeCoverageOutput, $zipCodeCoveragePath)
     $null = $artifacts.Add($zipCodeCoveragePath)
 
     return $artifacts
+}
+
+function Get-PackageName
+{
+    $name = git describe
+    # Remove 'v' from version, prepend 'PowerShell' - to be consistent with other package names
+    $name = $name -replace 'v',''
+    $name = 'PowerShell_' + $name
+    return $name
 }
 
 # Implements AppVeyor 'on_finish' step
@@ -395,12 +399,7 @@ function Invoke-AppveyorFinish
         # Build packages
         $packages = Start-PSPackage
 
-        # Creating project artifact
-        $name = git describe
-
-        # Remove 'v' from version, append 'PowerShell' - to be consistent with other package names
-        $name = $name -replace 'v',''
-        $name = 'PowerShell_' + $name
+        $name = Get-PackageName
 
         $zipFilePath = Join-Path $pwd "$name.zip"
         $zipFileFullPath = Join-Path $pwd "$name.FullCLR.zip"


### PR DESCRIPTION
 Added -Publish to Start-PSBuild used by CodeCoverage configuration so that
 .netcore dependencies are also included in the package. This makes the
 package usable on systems that do not have .netcore in path.

 Fixed the name of the coverage package by making it consistent with other
 package names.
