### PR TITLE
Fix the CI build break

### DIFF
--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterfaceProgress.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterfaceProgress.cs
@@ -7,7 +7,6 @@ Copyright (c) Microsoft Corporation.  All rights reserved.
 using System;
 using System.Management.Automation;
 using Dbg = System.Management.Automation.Diagnostics;
-using System.Threading;
 
 
 namespace Microsoft.PowerShell
@@ -29,12 +28,6 @@ namespace Microsoft.PowerShell
             // destroy the data structures representing outstanding progress records
             // take down and destroy the progress display
 
-            if (_progPaneUpdateTimer != null)
-            {
-                // Stop update 'ProgressPane' and destroy timer
-                _progPaneUpdateTimer.Dispose();
-                _progPaneUpdateTimer = null;
-            }
             if (_progPane != null)
             {
                 Dbg.Assert(_pendingProgress != null, "How can you have a progress pane and no backing data structure?");
@@ -71,41 +64,11 @@ namespace Microsoft.PowerShell
 
             if (_progPane == null)
             {
-                // This is the first time we've received a progress record.
-                // Create a progress pane,
-                // then show it,
-                // then create and start timer to update it.
+                // This is the first time we've received a progress record. Create a progress pane, then show it.
 
                 _progPane = new ProgressPane(this);
-
-                if (_progPaneUpdateTimer == null && _progPane != null)
-                {
-                    _progPane.Show(_pendingProgress);
-                    _progPaneUpdateTimer = new Timer( new TimerCallback(ProgressPaneUpdateTimerElapsed), null, UpdateTimerThreshold, Timeout.Infinite);
-                }
             }
-        }
-
-
-
-        /// <summary>
-        ///
-        /// TimerCallback for _progPaneUpdateTimer to update 'ProgressPane' and restart the timer.
-        ///
-        /// </summary>
-
-        private
-        void
-        ProgressPaneUpdateTimerElapsed(object sender)
-        {
-            if (_progPane != null)
-            {
-                _progPane.Show(_pendingProgress);
-            }
-            if (_progPaneUpdateTimer != null)
-            {
-                _progPaneUpdateTimer.Change(UpdateTimerThreshold, Timeout.Infinite);
-            }
+            _progPane.Show(_pendingProgress);
         }
 
 
@@ -205,9 +168,6 @@ namespace Microsoft.PowerShell
 
         private ProgressPane _progPane = null;
         private PendingProgress _pendingProgress = null;
-        // The timer update 'ProgressPane' every 'UpdateTimerThreshold' milliseconds
-        private Timer _progPaneUpdateTimer;
-        private const int UpdateTimerThreshold = 100;
     }
 }   // namespace 
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Start-Sleep.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Start-Sleep.Tests.ps1
@@ -12,7 +12,7 @@ Describe "Start-Sleep DRT Unit Tests" -Tags "CI" {
         Start-Sleep -Milliseconds 1000
         $dtEnd = [DateTime]::Now
         $milliseconds = (New-TimeSpan -Start $dtStart -End $dtEnd).TotalMilliseconds
-        $milliseconds | Should BeGreaterThan 1000
+        $milliseconds -ge 1000 | Should Be $true
     }
 
 }

--- a/test/powershell/engine/Help/UpdatableHelpSystem.Tests.ps1
+++ b/test/powershell/engine/Help/UpdatableHelpSystem.Tests.ps1
@@ -158,7 +158,8 @@ function RunUpdateHelpTests
 {
     param (
         [string]$tag = "CI",
-        [switch]$useSourcePath
+        [switch]$useSourcePath,
+        [switch]$Pending
     )
 
     foreach ($moduleName in $modulesInBox)
@@ -166,7 +167,7 @@ function RunUpdateHelpTests
         if ($powershellCoreModules -contains $moduleName)
         {
 
-            It "Validate Update-Help for module '$moduleName'" {
+            It "Validate Update-Help for module '$moduleName'" -Pending:$Pending {
 
                 # If the help file is already installed, delete it.
                 Get-ChildItem $testCases[$moduleName].HelpInstallationPath -Include @("about_*.txt","*help.xml") -Recurse -ea SilentlyContinue |
@@ -209,7 +210,8 @@ function RunUpdateHelpTests
 function RunSaveHelpTests
 {
     param (
-        [string]$tag = "CI"
+        [string]$tag = "CI",
+        [switch]$Pending
     )
 
     foreach ($moduleName in $modulesInBox)
@@ -221,7 +223,7 @@ function RunSaveHelpTests
                 $saveHelpFolder = Join-Path $TestDrive (Get-Random).ToString()
                 New-Item  $saveHelpFolder -Force -ItemType Directory
 
-                It "Validate Save-Help for the '$moduleName' module" {
+                It "Validate Save-Help for the '$moduleName' module" -Pending:$Pending {
 
                     if ((Get-UICulture).Name -ne "en-Us")
                     {
@@ -266,7 +268,7 @@ function ValidateSaveHelp
 
 Describe "Validate Update-Help from the Web for one PowerShell Core module." -Tags @('CI', 'RequireAdminOnWindows') {
 
-    RunUpdateHelpTests -tag "CI"
+    RunUpdateHelpTests -tag "CI" -Pending
 }
 
 Describe "Validate Update-Help from the Web for all PowerShell Core modules." -Tags @('Feature', 'RequireAdminOnWindows') {
@@ -285,7 +287,7 @@ Describe "Validate Update-Help -SourcePath for all PowerShell Core modules." -Ta
 }
 
 Describe "Validate 'Save-Help -DestinationPath for one PowerShell Core modules." -Tags @('CI', 'RequireAdminOnWindows') {
-    RunSaveHelpTests -tag "CI"
+    RunSaveHelpTests -tag "CI" -Pending
 }
 
 Describe "Validate 'Save-Help -DestinationPath for all PowerShell Core modules." -Tags @('Feature', 'RequireAdminOnWindows') {


### PR DESCRIPTION
There are two fixes:
1. Revert timer changes in `ConsoleHostUserInterfaceProgress.cs` to avoid race conditions. Fix #2800 and #2756. Re-open issue #2138
2. Skip `Update-Help` and `Save-Help` tests in CI builds since the HelpInfo URIs for powershell modules are broken. Address #2807, but need to keep the issue open to track reverting this test change once the URIs are fixed.

@SteveL-MSFT @Francisco-Gamino, can you please review this PR?