### PR TITLE
Wrapping a call to Registry so that Invoke-WebRequest does not fail on non-text responses

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/ContentHelper.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/ContentHelper.Common.cs
@@ -3,6 +3,7 @@ Copyright (c) Microsoft Corporation.  All rights reserved.
 --********************************************************************/
 
 using System;
+using System.Management.Automation;
 using System.Text;
 using Microsoft.Win32;
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/ContentHelper.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/ContentHelper.Common.cs
@@ -87,8 +87,8 @@ namespace Microsoft.PowerShell.Commands
             || CheckIsXml(contentType)
             || CheckIsJson(contentType);
 
-            #if !CORECLR // Registry access not supported on CoreCLR
-            if (!isText)
+            // Further content type analysis is available on Windows
+            if (Platform.IsWindows && !isText)
             {
                 // Media types registered with Windows as having a perceived type of text, are text
                 using (RegistryKey contentTypeKey = Registry.ClassesRoot.OpenSubKey(@"MIME\Database\Content Type\" + contentType))
@@ -110,7 +110,6 @@ namespace Microsoft.PowerShell.Commands
                     }
                 }
             }
-            #endif
 
             return (isText);
         }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/ContentHelper.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/ContentHelper.Common.cs
@@ -87,6 +87,7 @@ namespace Microsoft.PowerShell.Commands
             || CheckIsXml(contentType)
             || CheckIsJson(contentType);
 
+            #if !CORECLR // Registry access not supported on CoreCLR
             if (!isText)
             {
                 // Media types registered with Windows as having a perceived type of text, are text
@@ -109,6 +110,7 @@ namespace Microsoft.PowerShell.Commands
                     }
                 }
             }
+            #endif
 
             return (isText);
         }
@@ -135,7 +137,7 @@ namespace Microsoft.PowerShell.Commands
             // the correct type for JSON content, as specified in RFC 4627
             bool isJson = contentType.Equals("application/json", StringComparison.OrdinalIgnoreCase);
 
-            // add in these other "javascript" related types that 
+            // add in these other "javascript" related types that
             // sometimes get sent down as the mime type for JSON content
             isJson |= contentType.Equals("text/json", StringComparison.OrdinalIgnoreCase)
             || contentType.Equals("application/x-javascript", StringComparison.OrdinalIgnoreCase)


### PR DESCRIPTION
A small bug where content types from an Invoke-WebRequest that are not text-based fall through to a registry check.  Wrapping that check (which is additive) with a #if !CORECLR.  I can't find any tests that test out that specific behavior, or I would be happy to extend them.  I'm also happy to add a new test, just not sure if that is desired.