### PR TITLE
Added check for empty $nugetArtifacts

### DIFF
--- a/tools/appveyor.psm1
+++ b/tools/appveyor.psm1
@@ -441,7 +441,11 @@ function Invoke-AppveyorFinish
         }
 
         $nugetArtifacts = Get-ChildItem .\nuget-artifacts -ErrorAction SilentlyContinue | ForEach-Object { $_.FullName }
-        $artifacts.AddRange($nugetArtifacts)
+
+        if($nugetArtifacts)
+        {
+            $artifacts.AddRange($nugetArtifacts)
+        }
 
         $pushedAllArtifacts = $true
         $artifacts | ForEach-Object { 


### PR DESCRIPTION
When the build fails there are no $nugetArtifacts, so AddRange fails