### PR TITLE
Empty key name converting to PSObject

### DIFF
--- a/src/System.Management.Automation/commands/utility/FormatAndOutput/common/Utilities/Mshexpression.cs
+++ b/src/System.Management.Automation/commands/utility/FormatAndOutput/common/Utilities/Mshexpression.cs
@@ -52,7 +52,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         /// <exception cref="ArgumentNullException"></exception>
         internal MshExpression(string s, bool isResolved)
         {
-            if (string.IsNullOrEmpty(s))
+            if (s == null)
             {
                 throw PSTraceSource.NewArgumentNullException("s");
             }

--- a/src/System.Management.Automation/engine/MshMemberInfo.cs
+++ b/src/System.Management.Automation/engine/MshMemberInfo.cs
@@ -1253,7 +1253,7 @@ namespace System.Management.Automation
         /// <exception cref="ArgumentException">for an empty or null name</exception>
         public PSNoteProperty(string name, object value)
         {
-            if (String.IsNullOrEmpty(name))
+            if (name == null)
             {
                 throw PSTraceSource.NewArgumentException("name");
             }
@@ -3915,7 +3915,7 @@ namespace System.Management.Automation
         {
             get
             {
-                if (String.IsNullOrEmpty(name))
+                if (name == null)
                 {
                     throw PSTraceSource.NewArgumentException("name");
                 }
@@ -4469,7 +4469,7 @@ namespace System.Management.Automation
             {
                 using (PSObject.memberResolution.TraceScope("Lookup"))
                 {
-                    if (String.IsNullOrEmpty(name))
+                    if (name == null)
                     {
                         throw PSTraceSource.NewArgumentException("name");
                     }

--- a/src/System.Management.Automation/engine/MshMemberInfo.cs
+++ b/src/System.Management.Automation/engine/MshMemberInfo.cs
@@ -1250,7 +1250,7 @@ namespace System.Management.Automation
         /// </summary>
         /// <param name="name">name of the property</param>
         /// <param name="value">value of the property</param>
-        /// <exception cref="ArgumentException">for an empty or null name</exception>
+        /// <exception cref="ArgumentException">for a null name</exception>
         public PSNoteProperty(string name, object value)
         {
             if (name == null)


### PR DESCRIPTION
In issue #1755 we determined that you could not create a PSObject with a
key name of an empty string. This is supported in JSON and in
Hashtables.

Simple change was to lower evaluations of name field from
'IsNullOrEmpty' to '== null'.

Simple test to confirm is:
[pscustomobject]@{'' = 'Test'}

Simple JSON to test which results in ths same error:
'{"": "Test"}' | ConvertFrom-Json

After these changes, both of these cases work and I am able to
succesfully Convert project.lock.json from JSON and back to JSON with no
data loss.

There are many references to the areas of code I have updated and I do not believe I can foresee all consequences however I have ran the full test suite locally and have not found any indication these changes are harmful, while I have confirmed that it addresses the issue we are seeing.

I would also at least like to submit the above two cases as tests for this issue, but I am uncertain where those tests should go.