### PR TITLE
Improve a progress pane performance (one thread)

### DIFF
--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterface.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterface.cs
@@ -1390,10 +1390,9 @@ namespace Microsoft.PowerShell
                 }
                 else
                 {
-                    lock (_instanceLock)
-                    {
-                        HandleIncomingProgressRecord(sourceId, record);
-                    }
+                    // lock (_instanceLock) is moved into HandleIncomingProgressRecord
+                    // to exclude unneeded locks
+                    HandleIncomingProgressRecord(sourceId, record);
                 }
             }
         }

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterface.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterface.cs
@@ -1390,9 +1390,10 @@ namespace Microsoft.PowerShell
                 }
                 else
                 {
-                    // lock (_instanceLock) is moved into HandleIncomingProgressRecord
-                    // to exclude unneeded locks
-                    HandleIncomingProgressRecord(sourceId, record);
+                    lock (_instanceLock)
+                    {
+                        HandleIncomingProgressRecord(sourceId, record);
+                    }
                 }
             }
         }

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterfaceProgress.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterfaceProgress.cs
@@ -90,17 +90,13 @@ namespace Microsoft.PowerShell
                 }
             }
 
-            if (progPaneUpdateFlag)
+            if (progPaneUpdateFlag || record.RecordType == ProgressRecordType.Completed)
             {
-                // Update the progress pane only when the timer set up the flag
-                // as a result, we do not block WriteProgress and whole script
-                // and eliminate unnecessary console locks and updates
-                lock (_instanceLock)
-                {
-                    _pendingProgress?.Update(sourceId, record);
-                    _progPane?.Show(_pendingProgress);
-                    progPaneUpdateFlag = false;
-                }
+                // Update the progress pane only when the timer set up the update flag or WriteProgress is completed.
+                // As a result, we do not block WriteProgress and whole script and eliminate unnecessary console locks and updates.
+                _pendingProgress.Update(sourceId, record);
+                _progPane.Show(_pendingProgress);
+                progPaneUpdateFlag = false;
             }
         }
 

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterfaceProgress.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterfaceProgress.cs
@@ -35,7 +35,10 @@ namespace Microsoft.PowerShell
                 _progPaneUpdateTimer.Dispose();
                 _progPaneUpdateTimer = null;
             }
-            progPaneUpdateFlag = false;
+            // We don't reset 'progPaneUpdateFlag = false' here
+            // because `HandleIncomingProgressRecord` will be init 'progPaneUpdateFlag' in any way.
+            // (Also the timer callback can still set it to 'true' accidentally)
+
 
             if (_progPane != null)
             {
@@ -79,7 +82,7 @@ namespace Microsoft.PowerShell
 
                 _progPane = new ProgressPane(this);
 
-                if (_progPaneUpdateTimer == null && _progPane != null)
+                if (_progPaneUpdateTimer == null)
                 {
                     // Show a progress pane at the first time we've received a progress record
                     progPaneUpdateFlag = true;


### PR DESCRIPTION
Close #2138
(Reference #2800)

1. All updates left in one thread. (The use of multiple threads was the main problem previous PR #2640)

2. The timer is only used to set up a update flag. (According to my tests calling Datetime.Now() and verifing the time delta creates a much larger delay)

3. The timer interval is set to 200 ms. I test intervals from 50 ms to 2000 ms. I don't see any differences on the screen with 100 ms and 200 ms. So I chose the more cost-effective option. @lzybkr What do you think about this?

4. Removed unnecessary locks and updates. `WriteProgress` is executed as quickly as possible, as a result the entire script executes significantly faster.

5. Performance tests:

```powershell
Measure-Command { 1..1e4 | % { Write-Progress "..." -PercentComplete ($_*100/1e4)} }
```
After:
```
Days              : 0
Hours             : 0
Minutes           : 0
Seconds           : 1
Milliseconds      : 26
Ticks             : 10269198
TotalDays         : 1.18856458333333E-05
TotalHours        : 0.0002852555
TotalMinutes      : 0.01711533
TotalSeconds      : 1.0269198
TotalMilliseconds : 1026.9198
```
Before:
```
Days              : 0
Hours             : 0
Minutes           : 0
Seconds           : 30
Milliseconds      : 697
Ticks             : 306978612
TotalDays         : 0.000355299319444444
TotalHours        : 0.00852718366666667
TotalMinutes      : 0.51163102
TotalSeconds      : 30.6978612
TotalMilliseconds : 30697.8612
```

6. The two problems are not addressed this PR:
6.1 `Hung`  or  `Freeze`  of a progress pane. If Write-Progress is not called very frequently user sees that the pane freeze.
6.2 If Write-Progress frequently updates a progress pane and the script make output to console the user sees that the display flickers. The following script illustrates this:
```powershell
1..1e4 | % { $_;Write-Progress "..." -PercentComplete ($_*100/1e4)}
```