### PR TITLE
Add ErrorAction Stop to DeviceGuard function

### DIFF
--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ComputerInfo.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ComputerInfo.Tests.ps1
@@ -340,7 +340,7 @@ public static extern int LCIDToLocaleName(uint localeID, System.Text.StringBuild
         $returnValue = $null
         try
         {
-            $returnValue = Get-CimClassPropVal Win32_DeviceGuard $propertyName -namespace 'root\Microsoft\Windows\DeviceGuard'
+            $returnValue = Get-CimClassPropVal Win32_DeviceGuard $propertyName -namespace 'root\Microsoft\Windows\DeviceGuard' -ErrorAction Stop
         }
         catch
         {
@@ -1187,7 +1187,7 @@ try {
 
     Describe "Tests for Get-ComputerInfo: Ensure Type returned" -tags "CI", "RequireAdminOnWindows" {
 
-        It "Verfiy type returned by Get-ComputerInfo" {
+        It "Verify type returned by Get-ComputerInfo" {
             $computerInfo = Get-ComputerInfo
             $computerInfo.GetType().Name | Should Be "ComputerInfo"
         } 


### PR DESCRIPTION
A non-terminating error is thrown when the namespace does not exist by
Get-CimInstance. The namespace is not present on OS versions below Windows
10. It is not caught in the try-catch unless ErrorAction Stop is added.

Also fixed a typo in test name.