### PR TITLE
Disable help content test for Microsoft.Powershell.Archive module

### DIFF
--- a/test/powershell/engine/Help/UpdatableHelpSystem.Tests.ps1
+++ b/test/powershell/engine/Help/UpdatableHelpSystem.Tests.ps1
@@ -3,7 +3,11 @@
 # This is the list of PowerShell Core modules for which we test update-help
 $powershellCoreModules = @(
     "CimCmdlets"
+    <#
+    This scenario is broken due to issue # https://github.com/PowerShell/platyPS/issues/241
+    Re-enable when issue is fixed.
     "Microsoft.PowerShell.Archive"
+    #>
     "Microsoft.PowerShell.Host"
     "Microsoft.PowerShell.Core"
     "Microsoft.PowerShell.Diagnostics"
@@ -36,12 +40,16 @@ $testCases = @{
         HelpInstallationPath = "$pshome\Modules\CimCmdlets\en-US"
     }
 
+<#
+    This scenario is broken due to issue # https://github.com/PowerShell/platyPS/issues/241 
+    Re-enable when issue is fixed.
     "Microsoft.PowerShell.Archive" = @{
         HelpFiles            = "Microsoft.PowerShell.Archive.psm1-help.xml"
         HelpInfoFiles        = "Microsoft.PowerShell.Archive_eb74e8da-9ae2-482a-a648-e96550fb8733_HelpInfo.xml"
         CompressedFiles      = "Microsoft.PowerShell.Archive_eb74e8da-9ae2-482a-a648-e96550fb8733_en-US_HelpContent$extension"
         HelpInstallationPath = "$pshome\Modules\Microsoft.PowerShell.Archive\en-US"
     }
+#>
 
     "Microsoft.PowerShell.Core" = @{
         HelpFiles            = "System.Management.Automation.dll-help.xml"


### PR DESCRIPTION
The published help content filename is missing '.psm1', but the help still
works. The bug is in PlatyPS and needs to be fixed to re-enable this test.