### PR TITLE
Jameswtruher/travisdaily2

### DIFF
--- a/test/powershell/Modules/PackageManagement/PackageManagement.Tests.ps1
+++ b/test/powershell/Modules/PackageManagement/PackageManagement.Tests.ps1
@@ -18,7 +18,7 @@ $InternalSource = 'OneGetTestSource'
 
 
 Describe "PackageManagement Acceptance Test" -Tags "Feature" {
- 
+
  BeforeAll{
     Register-PackageSource -Name Nugettest -provider NuGet -Location https://www.nuget.org/api/v2 -force
     Register-PackageSource -Name $InternalSource -Location $InternalGallery -ProviderName 'PowerShellGet' -Trusted -ErrorAction SilentlyContinue
@@ -29,25 +29,25 @@ Describe "PackageManagement Acceptance Test" -Tags "Feature" {
      $ProgressPreference = $SavedProgressPreference
  }
     It "get-packageprovider" {
-       
+
         $gpp = Get-PackageProvider
-        
+
         $gpp | ?{ $_.name -eq "NuGet" } | should not BeNullOrEmpty
-   
-        $gpp | ?{ $_.name -eq "PowerShellGet" } | should not BeNullOrEmpty   
+
+        $gpp | ?{ $_.name -eq "PowerShellGet" } | should not BeNullOrEmpty
     }
 
 
     It "find-packageprovider PowerShellGet" {
-        $fpp = (Find-PackageProvider -Name "PowerShellGet" -force).name 
+        $fpp = (Find-PackageProvider -Name "PowerShellGet" -force).name
         $fpp -contains "PowerShellGet" | should be $true
     }
 
      It "install-packageprovider, Expect succeed" {
-        $ipp = (install-PackageProvider -name gistprovider -force -source $InternalSource -Scope CurrentUser).name 
-        $ipp -contains "gistprovider" | should be $true      
+        $ipp = (install-PackageProvider -name gistprovider -force -source $InternalSource -Scope CurrentUser).name
+        $ipp -contains "gistprovider" | should be $true
     }
-       
+
 
     it "Find-package"  {
         $f = Find-Package -ProviderName NuGet -Name jquery -source Nugettest
@@ -55,7 +55,7 @@ Describe "PackageManagement Acceptance Test" -Tags "Feature" {
 	}
 
     it "Install-package"  {
-        $i = install-Package -ProviderName NuGet -Name jquery -force -source Nugettest -Scope CurrentUser 
+        $i = install-Package -ProviderName NuGet -Name jquery -force -source Nugettest -Scope CurrentUser
         $i.Name -contains "jquery" | should be $true
 	}
 

--- a/test/powershell/Modules/PackageManagement/PackageManagement.Tests.ps1
+++ b/test/powershell/Modules/PackageManagement/PackageManagement.Tests.ps1
@@ -22,7 +22,11 @@ Describe "PackageManagement Acceptance Test" -Tags "Feature" {
  BeforeAll{
     Register-PackageSource -Name Nugettest -provider NuGet -Location https://www.nuget.org/api/v2 -force
     Register-PackageSource -Name $InternalSource -Location $InternalGallery -ProviderName 'PowerShellGet' -Trusted -ErrorAction SilentlyContinue
-
+    $SavedProgressPreference = $ProgressPreference
+    $ProgressPreference = "SilentlyContinue"
+ }
+ AfterAll {
+     $ProgressPreference = $SavedProgressPreference
  }
     It "get-packageprovider" {
        

--- a/test/powershell/engine/Help/HelpSystem.OnlineHelp.Tests.ps1
+++ b/test/powershell/engine/Help/HelpSystem.OnlineHelp.Tests.ps1
@@ -26,7 +26,7 @@
 
         # Disable the test hook
         [system.management.automation.internal.internaltesthooks]::SetTestHook('BypassOnlineHelpRetrieval', $false)
-        $ProgressPreference = $SavedProgressPreference 
+        $ProgressPreference = $SavedProgressPreference
     }
 
     foreach ($filePath in @("$PSScriptRoot\assets\HelpURI\V2Cmdlets.csv", "$PSScriptRoot\assets\HelpURI\V3Cmdlets.csv"))

--- a/test/powershell/engine/Help/HelpSystem.OnlineHelp.Tests.ps1
+++ b/test/powershell/engine/Help/HelpSystem.OnlineHelp.Tests.ps1
@@ -8,6 +8,8 @@
     # (when calling get-help -online) might not matched the one in the csv file.
 
     BeforeAll {
+        $SavedProgressPreference = $ProgressPreference
+        $ProgressPreference = "SilentlyContinue"
 
         # Enable the test hook
         [system.management.automation.internal.internaltesthooks]::SetTestHook('BypassOnlineHelpRetrieval', $true)
@@ -24,6 +26,7 @@
 
         # Disable the test hook
         [system.management.automation.internal.internaltesthooks]::SetTestHook('BypassOnlineHelpRetrieval', $false)
+        $ProgressPreference = $SavedProgressPreference 
     }
 
     foreach ($filePath in @("$PSScriptRoot\assets\HelpURI\V2Cmdlets.csv", "$PSScriptRoot\assets\HelpURI\V3Cmdlets.csv"))

--- a/test/powershell/engine/Help/HelpSystem.Tests.ps1
+++ b/test/powershell/engine/Help/HelpSystem.Tests.ps1
@@ -63,11 +63,24 @@ function RunTestCase
 }
 
 Describe "Validate that get-help <cmdletName> works" -Tags @('CI', 'RequireAdminOnWindows') {
-
+    BeforeAll {
+        $SavedProgressPreference = $ProgressPreference
+        $ProgressPreference = "SilentlyContinue"
+    }
+    AfterAll {
+        $ProgressPreference = $SavedProgressPreference 
+    }
     RunTestCase -tag "CI"
 }
 
 Describe "Validate Get-Help for all cmdlets in 'Microsoft.PowerShell.Core'" -Tags @('Feature', 'RequireAdminOnWindows') {
+    BeforeAll {
+        $SavedProgressPreference = $ProgressPreference
+        $ProgressPreference = "SilentlyContinue"
+    }
+    AfterAll {
+        $ProgressPreference = $SavedProgressPreference 
+    }
 
     RunTestCase -tag "Feature"
 }
@@ -79,7 +92,12 @@ Describe "Validate that Get-Help returns provider-specific help" -Tags @('CI', '
             dev     = 'http://schemas.microsoft.com/maml/dev/2004/10'
             maml    = 'http://schemas.microsoft.com/maml/2004/10'
             msh     = 'http://msh'
+        $SavedProgressPreference = $ProgressPreference
+        $ProgressPreference = "SilentlyContinue"
         }
+    AfterAll {
+        $ProgressPreference = $SavedProgressPreference 
+    }
 
         # Currently these test cases are verified only on Windows, because
         # - WSMan:\ and Cert:\ providers are not yet supported on non-Windows platforms.

--- a/test/powershell/engine/Help/HelpSystem.Tests.ps1
+++ b/test/powershell/engine/Help/HelpSystem.Tests.ps1
@@ -68,7 +68,7 @@ Describe "Validate that get-help <cmdletName> works" -Tags @('CI', 'RequireAdmin
         $ProgressPreference = "SilentlyContinue"
     }
     AfterAll {
-        $ProgressPreference = $SavedProgressPreference 
+        $ProgressPreference = $SavedProgressPreference
     }
     RunTestCase -tag "CI"
 }
@@ -79,7 +79,7 @@ Describe "Validate Get-Help for all cmdlets in 'Microsoft.PowerShell.Core'" -Tag
         $ProgressPreference = "SilentlyContinue"
     }
     AfterAll {
-        $ProgressPreference = $SavedProgressPreference 
+        $ProgressPreference = $SavedProgressPreference
     }
 
     RunTestCase -tag "Feature"
@@ -87,17 +87,15 @@ Describe "Validate Get-Help for all cmdlets in 'Microsoft.PowerShell.Core'" -Tag
 
 Describe "Validate that Get-Help returns provider-specific help" -Tags @('CI', 'RequireAdminOnWindows') {
     BeforeAll {
+        $SavedProgressPreference = $ProgressPreference
+        $ProgressPreference = "SilentlyContinue"
+
         $namespaces = @{
             command = 'http://schemas.microsoft.com/maml/dev/command/2004/10'
             dev     = 'http://schemas.microsoft.com/maml/dev/2004/10'
             maml    = 'http://schemas.microsoft.com/maml/2004/10'
             msh     = 'http://msh'
-        $SavedProgressPreference = $ProgressPreference
-        $ProgressPreference = "SilentlyContinue"
         }
-    AfterAll {
-        $ProgressPreference = $SavedProgressPreference 
-    }
 
         # Currently these test cases are verified only on Windows, because
         # - WSMan:\ and Cert:\ providers are not yet supported on non-Windows platforms.
@@ -137,6 +135,9 @@ Describe "Validate that Get-Help returns provider-specific help" -Tags @('CI', '
         UpdateHelpFromLocalContentPath -ModuleName 'Microsoft.PowerShell.Core' -Tag 'CI'
     }
 
+    AfterAll {
+        $ProgressPreference = $SavedProgressPreference
+    }
     It -Skip:(-not $IsWindows) "shows contextual help when Get-Help is invoked for provider-specific path (Get-Help -Name <verb>-<noun> -Path <path>)" -TestCases $testCases {
         param($helpFile, $path, $helpContext, $verb, $noun)
 

--- a/test/powershell/engine/Help/UpdatableHelpSystem.Tests.ps1
+++ b/test/powershell/engine/Help/UpdatableHelpSystem.Tests.ps1
@@ -275,29 +275,71 @@ function ValidateSaveHelp
 }
 
 Describe "Validate Update-Help from the Web for one PowerShell Core module." -Tags @('CI', 'RequireAdminOnWindows') {
+    BeforeAll {
+        $SavedProgressPreference = $ProgressPreference
+        $ProgressPreference = "SilentlyContinue"
+    }
+    AfterAll {
+        $ProgressPreference = $SavedProgressPreference 
+    }
 
     RunUpdateHelpTests -tag "CI" -Pending
 }
 
 Describe "Validate Update-Help from the Web for all PowerShell Core modules." -Tags @('Feature', 'RequireAdminOnWindows') {
+    BeforeAll {
+        $SavedProgressPreference = $ProgressPreference
+        $ProgressPreference = "SilentlyContinue"
+    }
+    AfterAll {
+        $ProgressPreference = $SavedProgressPreference 
+    }
 
     RunUpdateHelpTests -tag "Feature"
 }
 
 Describe "Validate Update-Help -SourcePath for one PowerShell Core module." -Tags @('CI', 'RequireAdminOnWindows') {
+    BeforeAll {
+        $SavedProgressPreference = $ProgressPreference
+        $ProgressPreference = "SilentlyContinue"
+    }
+    AfterAll {
+        $ProgressPreference = $SavedProgressPreference 
+    }
 
     RunUpdateHelpTests -tag "CI" -useSourcePath
 }
 
 Describe "Validate Update-Help -SourcePath for all PowerShell Core modules." -Tags @('Feature', 'RequireAdminOnWindows') {
+    BeforeAll {
+        $SavedProgressPreference = $ProgressPreference
+        $ProgressPreference = "SilentlyContinue"
+    }
+    AfterAll {
+        $ProgressPreference = $SavedProgressPreference 
+    }
 
     RunUpdateHelpTests -tag "Feature" -useSourcePath
 }
 
 Describe "Validate 'Save-Help -DestinationPath for one PowerShell Core modules." -Tags @('CI', 'RequireAdminOnWindows') {
+    BeforeAll {
+        $SavedProgressPreference = $ProgressPreference
+        $ProgressPreference = "SilentlyContinue"
+    }
+    AfterAll {
+        $ProgressPreference = $SavedProgressPreference 
+    }
     RunSaveHelpTests -tag "CI" -Pending
 }
 
 Describe "Validate 'Save-Help -DestinationPath for all PowerShell Core modules." -Tags @('Feature', 'RequireAdminOnWindows') {
+    BeforeAll {
+        $SavedProgressPreference = $ProgressPreference
+        $ProgressPreference = "SilentlyContinue"
+    }
+    AfterAll {
+        $ProgressPreference = $SavedProgressPreference 
+    }
     RunSaveHelpTests -tag "Feature"
 }

--- a/test/powershell/engine/Help/UpdatableHelpSystem.Tests.ps1
+++ b/test/powershell/engine/Help/UpdatableHelpSystem.Tests.ps1
@@ -41,7 +41,7 @@ $testCases = @{
     }
 
 <#
-    This scenario is broken due to issue # https://github.com/PowerShell/platyPS/issues/241 
+    This scenario is broken due to issue # https://github.com/PowerShell/platyPS/issues/241
     Re-enable when issue is fixed.
     "Microsoft.PowerShell.Archive" = @{
         HelpFiles            = "Microsoft.PowerShell.Archive.psm1-help.xml"
@@ -141,7 +141,7 @@ function GetFiles
         [ValidateNotNullOrEmpty()]
         [string]$path
     )
-                            
+
     Get-ChildItem $path -Include $fileType -Recurse -ea SilentlyContinue | Select-Object -ExpandProperty FullName
 }
 
@@ -280,7 +280,7 @@ Describe "Validate Update-Help from the Web for one PowerShell Core module." -Ta
         $ProgressPreference = "SilentlyContinue"
     }
     AfterAll {
-        $ProgressPreference = $SavedProgressPreference 
+        $ProgressPreference = $SavedProgressPreference
     }
 
     RunUpdateHelpTests -tag "CI" -Pending
@@ -292,7 +292,7 @@ Describe "Validate Update-Help from the Web for all PowerShell Core modules." -T
         $ProgressPreference = "SilentlyContinue"
     }
     AfterAll {
-        $ProgressPreference = $SavedProgressPreference 
+        $ProgressPreference = $SavedProgressPreference
     }
 
     RunUpdateHelpTests -tag "Feature"
@@ -304,7 +304,7 @@ Describe "Validate Update-Help -SourcePath for one PowerShell Core module." -Tag
         $ProgressPreference = "SilentlyContinue"
     }
     AfterAll {
-        $ProgressPreference = $SavedProgressPreference 
+        $ProgressPreference = $SavedProgressPreference
     }
 
     RunUpdateHelpTests -tag "CI" -useSourcePath
@@ -316,7 +316,7 @@ Describe "Validate Update-Help -SourcePath for all PowerShell Core modules." -Ta
         $ProgressPreference = "SilentlyContinue"
     }
     AfterAll {
-        $ProgressPreference = $SavedProgressPreference 
+        $ProgressPreference = $SavedProgressPreference
     }
 
     RunUpdateHelpTests -tag "Feature" -useSourcePath
@@ -328,7 +328,7 @@ Describe "Validate 'Save-Help -DestinationPath for one PowerShell Core modules."
         $ProgressPreference = "SilentlyContinue"
     }
     AfterAll {
-        $ProgressPreference = $SavedProgressPreference 
+        $ProgressPreference = $SavedProgressPreference
     }
     RunSaveHelpTests -tag "CI" -Pending
 }
@@ -339,7 +339,7 @@ Describe "Validate 'Save-Help -DestinationPath for all PowerShell Core modules."
         $ProgressPreference = "SilentlyContinue"
     }
     AfterAll {
-        $ProgressPreference = $SavedProgressPreference 
+        $ProgressPreference = $SavedProgressPreference
     }
     RunSaveHelpTests -tag "Feature"
 }


### PR DESCRIPTION
continued attempts to reduce output size so we can get a daily build in travis-ci

this sets progress preference on the help and package management tests to SilentlyContinue to reduce output. This is done for all test execution, including dev and CI