### PR TITLE
Depend on the NuGet package 'libpsrpclient' to enable client-side PSRP on Linux and OSX

### DIFF
--- a/src/powershell-unix/project.json
+++ b/src/powershell-unix/project.json
@@ -79,7 +79,7 @@
     "dependencies": {
         "Microsoft.PowerShell.SDK": "6.0.0-*",
         "Microsoft.PowerShell.PSReadLine": "6.0.0-*",
-        "libmi": "1.0.0-alpha01",
+        "libpsrpclient": "1.0.0-*",
         "PSDesiredStateConfiguration": "1.0.0-alpha01",
         "PowerShellHelpFiles": "1.0.0-alpha01"
     },

--- a/test/powershell/engine/Remoting/RemoteSession.Basic.Tests.ps1
+++ b/test/powershell/engine/Remoting/RemoteSession.Basic.Tests.ps1
@@ -1,0 +1,11 @@
+
+Describe "New-PSSession basic test" -Tag @("CI") {
+    It "New-PSSession should not crash powershell" {
+        try {
+            New-PSSession -ComputerName nonexistcomputer -Authentication Basic
+            throw "New-PSSession should throw"
+        } catch {
+            $_.FullyQualifiedErrorId | Should Be "InvalidOperation,Microsoft.PowerShell.Commands.NewPSSessionCommand"
+        }
+    }
+}


### PR DESCRIPTION
libpsrpclient.1.0.0-alpha01.nupkg and libmi.1.0.0-alpha02.nupkg are published to powershell-core. They need to be included in powershell to enable client-side PSRP on Linux/OS X.
libpsrpclient depends on libmi (`libmi (>= 1.0.0-alpha02)`), so libmi will be pulled from feed and published as well during the build.