### PR TITLE
Fixing 'InFile parameter of Invoke-WebRequest doesn't work' and adding aliases (iwr for invoke-webrequest and irm for invoke-restmethod) to the web cmdlets.

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebRequestPSCmdlet.CoreClr.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebRequestPSCmdlet.CoreClr.cs
@@ -280,10 +280,7 @@ namespace Microsoft.PowerShell.Commands
                 try
                 {
                     // open the input file
-                    using (FileStream fs = new FileStream(InFile, FileMode.Open))
-                    {
-                        SetRequestContent(request, fs);
-                    }
+                    SetRequestContent(request, new FileStream(InFile, FileMode.Open));
                 }
                 catch (UnauthorizedAccessException)
                 {
@@ -331,55 +328,57 @@ namespace Microsoft.PowerShell.Commands
                 // Set cmdlet context for write progress
                 ValidateParameters();
                 PrepareSession();
-                HttpClient client = GetHttpClient();
-                HttpRequestMessage request = GetRequest(Uri);
-                FillRequestStream(request);
 
-                try
+                using (HttpClient client = GetHttpClient())
+                using (HttpRequestMessage request = GetRequest(Uri))
                 {
-                    long requestContentLength = 0;
-                    if (request.Content != null)
-                        requestContentLength = request.Content.Headers.ContentLength.Value;
-
-                    string reqVerboseMsg = String.Format(CultureInfo.CurrentCulture,
-                        "{0} {1} with {2}-byte payload",
-                        request.Method,
-                        request.RequestUri,
-                        requestContentLength);
-                    WriteVerbose(reqVerboseMsg);
-
-                    HttpResponseMessage response = GetResponse(client, request);
-                    response.EnsureSuccessStatusCode();
-
-                    string contentType = ContentHelper.GetContentType(response);
-                    string respVerboseMsg = string.Format(CultureInfo.CurrentCulture,
-                        "received {0}-byte response of content type {1}",
-                        response.Content.Headers.ContentLength,
-                        contentType);
-                    WriteVerbose(respVerboseMsg);
-                    ProcessResponse(response);
-                    UpdateSession(response);
-
-                    // If we hit our maximum redirection count, generate an error.
-                    // Errors with redirection counts of greater than 0 are handled automatically by .NET, but are
-                    // impossible to detect programmatically when we hit this limit. By handling this ourselves
-                    // (and still writing out the result), users can debug actual HTTP redirect problems.
-                    if (WebSession.MaximumRedirection == 0) // Indicate "HttpClientHandler.AllowAutoRedirect == false"
+                    FillRequestStream(request);
+                    try
                     {
-                        if (response.StatusCode == HttpStatusCode.Found ||
-                            response.StatusCode == HttpStatusCode.Moved ||
-                            response.StatusCode == HttpStatusCode.MovedPermanently)
+                        long requestContentLength = 0;
+                        if (request.Content != null)
+                            requestContentLength = request.Content.Headers.ContentLength.Value;
+
+                        string reqVerboseMsg = String.Format(CultureInfo.CurrentCulture,
+                            "{0} {1} with {2}-byte payload",
+                            request.Method,
+                            request.RequestUri,
+                            requestContentLength);
+                        WriteVerbose(reqVerboseMsg);
+
+                        HttpResponseMessage response = GetResponse(client, request);
+                        response.EnsureSuccessStatusCode();
+
+                        string contentType = ContentHelper.GetContentType(response);
+                        string respVerboseMsg = string.Format(CultureInfo.CurrentCulture,
+                            "received {0}-byte response of content type {1}",
+                            response.Content.Headers.ContentLength,
+                            contentType);
+                        WriteVerbose(respVerboseMsg);
+                        ProcessResponse(response);
+                        UpdateSession(response);
+
+                        // If we hit our maximum redirection count, generate an error.
+                        // Errors with redirection counts of greater than 0 are handled automatically by .NET, but are
+                        // impossible to detect programmatically when we hit this limit. By handling this ourselves
+                        // (and still writing out the result), users can debug actual HTTP redirect problems.
+                        if (WebSession.MaximumRedirection == 0) // Indicate "HttpClientHandler.AllowAutoRedirect == false"
                         {
-                            ErrorRecord er = new ErrorRecord(new InvalidOperationException(), "MaximumRedirectExceeded", ErrorCategory.InvalidOperation, request);
-                            er.ErrorDetails = new ErrorDetails(WebCmdletStrings.MaximumRedirectionCountExceeded);
-                            WriteError(er);
+                            if (response.StatusCode == HttpStatusCode.Found ||
+                                response.StatusCode == HttpStatusCode.Moved ||
+                                response.StatusCode == HttpStatusCode.MovedPermanently)
+                            {
+                                ErrorRecord er = new ErrorRecord(new InvalidOperationException(), "MaximumRedirectExceeded", ErrorCategory.InvalidOperation, request);
+                                er.ErrorDetails = new ErrorDetails(WebCmdletStrings.MaximumRedirectionCountExceeded);
+                                WriteError(er);
+                            }
                         }
                     }
-                }
-                catch (HttpRequestException ex)
-                {
-                    ErrorRecord er = new ErrorRecord(ex, "WebCmdletWebResponseException", ErrorCategory.InvalidOperation, request);
-                    ThrowTerminatingError(er);
+                    catch (HttpRequestException ex)
+                    {
+                        ErrorRecord er = new ErrorRecord(ex, "WebCmdletWebResponseException", ErrorCategory.InvalidOperation, request);
+                        ThrowTerminatingError(er);
+                    }
                 }
             }
             catch (CryptographicException ex)

--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -5108,6 +5108,11 @@ end
                         "Stop-Service",    "", ScopedItemOptions.ReadOnly | ScopedItemOptions.AllScope),
                     new SessionStateAliasEntry("sv",
                         "Set-Variable",    "", ScopedItemOptions.ReadOnly | ScopedItemOptions.AllScope),
+                    // Web cmdlets aliases
+                     new SessionStateAliasEntry("irm",
+                        "Invoke-RestMethod",   "", ScopedItemOptions.ReadOnly | ScopedItemOptions.AllScope),
+                    new SessionStateAliasEntry("iwr",
+                        "Invoke-WebRequest",   "", ScopedItemOptions.ReadOnly | ScopedItemOptions.AllScope),
 // Porting note: #if !UNIX is used to disable aliases for cmdlets which conflict with Linux / OS X
 #if !UNIX
                     // ac is a native command on OS X
@@ -5175,10 +5180,6 @@ end
                         "Get-PSSnapIn",   "", ScopedItemOptions.ReadOnly | ScopedItemOptions.AllScope),
                     new SessionStateAliasEntry("gwmi",
                         "Get-WmiObject",   "", ScopedItemOptions.ReadOnly | ScopedItemOptions.AllScope),
-                    new SessionStateAliasEntry("irm",
-                        "Invoke-RestMethod",   "", ScopedItemOptions.ReadOnly | ScopedItemOptions.AllScope),
-                    new SessionStateAliasEntry("iwr",
-                        "Invoke-WebRequest",   "", ScopedItemOptions.ReadOnly | ScopedItemOptions.AllScope),
                     new SessionStateAliasEntry("iwmi",
                         "Invoke-WMIMethod",     "", ScopedItemOptions.ReadOnly | ScopedItemOptions.AllScope),
                     new SessionStateAliasEntry("ogv",

--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -5109,7 +5109,7 @@ end
                     new SessionStateAliasEntry("sv",
                         "Set-Variable",    "", ScopedItemOptions.ReadOnly | ScopedItemOptions.AllScope),
                     // Web cmdlets aliases
-                     new SessionStateAliasEntry("irm",
+                    new SessionStateAliasEntry("irm",
                         "Invoke-RestMethod",   "", ScopedItemOptions.ReadOnly | ScopedItemOptions.AllScope),
                     new SessionStateAliasEntry("iwr",
                         "Invoke-WebRequest",   "", ScopedItemOptions.ReadOnly | ScopedItemOptions.AllScope),

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -643,3 +643,85 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
         $result.Error | Should BeNullOrEmpty
     }
 }
+
+Describe "Validate Invoke-WebRequest and Invoke-RestMethod -InFile" -Tags "Feature" {
+
+    Context "InFile parameter negative tests" {
+
+        $testCases = @(
+#region INVOKE-WEBREQUEST
+            @{
+                Name = 'Validate error for Invoke-WebRequest -InFile ""'
+                ScriptBlock = {Invoke-WebRequest -Uri http://httpbin.org/post -Method Post -InFile ""}
+                ExpectedFullyQualifiedErrorId = 'WebCmdletInFileNotFilePathException,Microsoft.PowerShell.Commands.InvokeWebRequestCommand'
+            }
+
+            @{
+                Name = 'Validate error for Invoke-WebRequest -InFile'
+                ScriptBlock = {Invoke-WebRequest -Uri http://httpbin.org/post -Method Post -InFile}
+                ExpectedFullyQualifiedErrorId = 'MissingArgument,Microsoft.PowerShell.Commands.InvokeWebRequestCommand'
+            }
+
+            @{
+                Name = "Validate error for Invoke-WebRequest -InFile  $TestDrive\content.txt"
+                ScriptBlock = {Invoke-WebRequest -Uri http://httpbin.org/post -Method Post -InFile  $TestDrive\content.txt}
+                ExpectedFullyQualifiedErrorId = 'PathNotFound,Microsoft.PowerShell.Commands.InvokeWebRequestCommand'
+            }
+#endregion
+
+#region INVOKE-RESTMETHOD
+            @{
+                Name = "Validate error for Invoke-RestMethod -InFile ''"
+                ScriptBlock = {Invoke-RestMethod -Uri http://httpbin.org/post -Method Post -InFile ''}
+                ExpectedFullyQualifiedErrorId = 'WebCmdletInFileNotFilePathException,Microsoft.PowerShell.Commands.InvokeRestMethodCommand'
+            }
+
+            @{
+                Name = "Validate error for Invoke-RestMethod -InFile <null>"
+                ScriptBlock = {Invoke-RestMethod -Uri http://httpbin.org/post -Method Post -InFile}
+                ExpectedFullyQualifiedErrorId = 'MissingArgument,Microsoft.PowerShell.Commands.InvokeRestMethodCommand'
+            }
+
+            @{
+                Name = "Validate error for Invoke-RestMethod -InFile  $TestDrive\content.txt"
+                ScriptBlock = {Invoke-RestMethod -Uri http://httpbin.org/post -Method Post -InFile $TestDrive\content.txt}
+                ExpectedFullyQualifiedErrorId = 'PathNotFound,Microsoft.PowerShell.Commands.InvokeRestMethodCommand'
+            }
+#endregion
+        )
+
+        It "<Name>" -TestCases $testCases {
+            param ($scriptblock, $expectedFullyQualifiedErrorId)
+
+            try
+            {
+                & $scriptblock
+                throw "No Exception!"
+            }
+            catch
+            {
+                $_.FullyQualifiedErrorId | should be $ExpectedFullyQualifiedErrorId
+            }
+        }
+    }
+
+    Context "InFile parameter positive tests" {
+
+        BeforeAll {
+            $filePath = Join-Path $TestDrive test.txt
+            New-Item -Path $filePath -Value "hello" -ItemType File -Force
+        }
+
+        It "Invoke-WebRequest -InFile" {
+            $result = Invoke-WebRequest -InFile $filePath  -Uri http://httpbin.org/post -Method Post
+            $content = $result.Content | ConvertFrom-Json
+            $content.form | Should Match "hello"
+        }
+
+        It "Invoke-RestMethod -InFile" {
+            $result = Invoke-RestMethod -InFile $filePath  -Uri http://httpbin.org/post -Method Post
+            $result.form | Should Match "hello"
+        }
+    }
+}
+


### PR DESCRIPTION
Fixing 'InFile parameter of Invoke-WebRequest doesn't work' #2754 

For Invoke-WebRequest/RestMethod InFile, we use a filestream to read the file as we populate the HttpRequestMessage. However, by the time we actual do the request, the file stream has already been disposed, and an exception is thrown. To work around this issue, a possible option is to use File.ReadAllBytes(filepath). However, with this approach, the file will be locked while is being read. In this current fix, I am creating a class member _fileStream to be used to read the file. Then, once we are done reading the file and making the request, we dispose the resource in the main finally block.
Also, I have added tests for both Invoke-WebRequest and Invoke-RestMethod using the -InFile parameter. These new tests cover both positive and negative test cases.

Fixing 'Missing command alias: iwr ' #1778
Added aliases 'iwr' for Invoke-WebRequest and 'irm' for Invoke-RestMethod. This PR includes the code changes as well as new tests.
