### PR TITLE
Fix OpenCover.console.exe parameter ordering issue.

### DIFF
--- a/test/tools/OpenCover/OpenCover.psm1
+++ b/test/tools/OpenCover/OpenCover.psm1
@@ -413,7 +413,7 @@ function Invoke-OpenCover
 
     $targetArgString = $targetArgs -join " "
     # the order seems to be important. Always keep -targetargs as the last parameter.
-    $openCoverArgs = "-target:$target","-register:user","-output:${outputLog}","-nodefaultfilters","-oldstyle","-hideskipped:all","-targetargs:""$targetArgString"""
+    $openCoverArgs = "-target:$target","-register:user","-output:${outputLog}","-nodefaultfilters","-oldstyle","-hideskipped:all","-targetargs:`"$targetArgString`""
 
     if ( $PSCmdlet.ShouldProcess("$OpenCoverBin $openCoverArgs")  )
     {

--- a/test/tools/OpenCover/OpenCover.psm1
+++ b/test/tools/OpenCover/OpenCover.psm1
@@ -412,8 +412,8 @@ function Invoke-OpenCover
     }
 
     $targetArgString = $targetArgs -join " "
-    # the order seems to be important
-    $openCoverArgs = "-target:$target","-targetargs:""$targetArgString""","-register:user","-output:${outputLog}","-nodefaultfilters","-oldstyle","-hideskipped:all"
+    # the order seems to be important. Always keep -targetargs as the last parameter.
+    $openCoverArgs = "-target:$target","-register:user","-output:${outputLog}","-nodefaultfilters","-oldstyle","-hideskipped:all","-targetargs:""$targetArgString"""
 
     if ( $PSCmdlet.ShouldProcess("$OpenCoverBin $openCoverArgs")  )
     {


### PR DESCRIPTION
The targetargs parameter needs to be at the end, otherwise everything
after that is considered as part of targetargs.