### PR TITLE
Fix for group policy cache bug

### DIFF
--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -650,23 +650,22 @@ namespace System.Management.Automation
 #else
             lock (s_cachedGroupPolicySettings)
             {
-                // Return cached information, if we have it
-                Dictionary<string, object> settings;
-                if ((s_cachedGroupPolicySettings.TryGetValue(settingName, out settings)) &&
-                    !InternalTestHooks.BypassGroupPolicyCaching)
-                {
-                    return settings;
-                }
-
+                Dictionary<string, object> settings = null;
                 if (!String.Equals(".", settingName, StringComparison.OrdinalIgnoreCase))
                 {
                     groupPolicyBase += "\\" + settingName;
                 }
 
-                settings = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
-
                 foreach (RegistryKey searchKey in preferenceOrder)
                 {
+                    // Return cached information, if we have it
+                    string uniqueSettingName = searchKey.Name + "\\" + groupPolicyBase;
+                    if (!InternalTestHooks.BypassGroupPolicyCaching &&
+                        (s_cachedGroupPolicySettings.TryGetValue(uniqueSettingName, out settings)))
+                    {
+                        return settings;
+                    }
+
                     try
                     {
                         // Look up the machine-wide group policy
@@ -674,6 +673,8 @@ namespace System.Management.Automation
                         {
                             if (key != null)
                             {
+                                settings = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
+
                                 foreach (string subkeyName in key.GetValueNames())
                                 {
                                     // A null or empty subkey name string corresponds to a (Default) key.
@@ -698,6 +699,12 @@ namespace System.Management.Automation
                                     }
                                 }
 
+                                // No group policy settings, then return null
+                                if (settings.Count == 0)
+                                {
+                                    settings = null;
+                                }
+
                                 break;
                             }
                         }
@@ -706,18 +713,12 @@ namespace System.Management.Automation
                     {
                         // User doesn't have access to open group policy key
                     }
-                }
 
-                // No group policy settings, then return null
-                if (settings.Count == 0)
-                {
-                    settings = null;
-                }
-
-                // Cache the data
-                if (!InternalTestHooks.BypassGroupPolicyCaching)
-                {
-                    s_cachedGroupPolicySettings[settingName] = settings;
+                    // Cache the data
+                    if (!InternalTestHooks.BypassGroupPolicyCaching)
+                    {
+                        s_cachedGroupPolicySettings[uniqueSettingName] = settings;
+                    }
                 }
 
                 return settings;

--- a/test/powershell/engine/ExecutionPolicy.GroupPolicy.Tests.ps1
+++ b/test/powershell/engine/ExecutionPolicy.GroupPolicy.Tests.ps1
@@ -7,7 +7,11 @@ Describe "User group policy execution policy should work" -Tags 'Feature' {
 
     BeforeAll {
 
-        if (!$IsWindows) { return }
+        $originalDefaultParameterValues = $PSDefaultParameterValues.Clone()
+        if (!$IsWindows)
+        {
+            $PSDefaultParameterValues["it:skip"] = $true
+        }
 
         # Add User group policy execution policy RemoteSigned
         $regHKCUKey = "HKCU:\SOFTWARE\Policies\Microsoft\Windows\PowerShell"
@@ -21,13 +25,13 @@ Describe "User group policy execution policy should work" -Tags 'Feature' {
 
     AfterAll {
 
-        if (!$IsWindows) { return }
+        $global:PSDefaultParameterValues = $originalDefaultParameterValues
 
         # Remove User group policy
         Remove-Item $regHKCUKey -Force -ErrorAction SilentlyContinue
     }
 
-    It "Sets User GroupPolicy ExecutionPolicy to RemoteSigned" -Skip:(!$IsWindows) {
+    It "Sets User GroupPolicy ExecutionPolicy to RemoteSigned" {
 
         $command = @'
         return Get-ExecutionPolicy -List | ? { ($_.Scope -eq 'UserPolicy') -and ($_.ExecutionPolicy -eq 'RemoteSigned') }

--- a/test/powershell/engine/ExecutionPolicy.GroupPolicy.Tests.ps1
+++ b/test/powershell/engine/ExecutionPolicy.GroupPolicy.Tests.ps1
@@ -7,10 +7,11 @@ Describe "User group policy execution policy should work" -Tags 'Feature' {
 
     BeforeAll {
 
-        $originalDefaultParameterValues = $PSDefaultParameterValues.Clone()
         if (!$IsWindows)
         {
+            $originalDefaultParameterValues = $PSDefaultParameterValues.Clone()
             $PSDefaultParameterValues["it:skip"] = $true
+            return
         }
 
         # Add User group policy execution policy RemoteSigned
@@ -25,7 +26,11 @@ Describe "User group policy execution policy should work" -Tags 'Feature' {
 
     AfterAll {
 
-        $global:PSDefaultParameterValues = $originalDefaultParameterValues
+        if (!$IsWindows) 
+        { 
+            $global:PSDefaultParameterValues = $originalDefaultParameterValues
+            return 
+        }
 
         # Remove User group policy
         Remove-Item $regHKCUKey -Force -ErrorAction SilentlyContinue

--- a/test/powershell/engine/ExecutionPolicy.GroupPolicy.Tests.ps1
+++ b/test/powershell/engine/ExecutionPolicy.GroupPolicy.Tests.ps1
@@ -15,6 +15,8 @@ Describe "User group policy execution policy should work" -Tags 'Feature' {
         New-Item -Path $regHKCUKey -Force
         Set-ItemProperty -Path $regHKCUKey -Name "EnableScripts" -Value 1
         Set-ItemProperty -Path $regHKCUKey -Name "ExecutionPolicy" -Value "RemoteSigned"
+
+        $powershell = Join-Path -Path $PSHOME -ChildPath "powershell"
     }
 
     AfterAll {
@@ -31,8 +33,7 @@ Describe "User group policy execution policy should work" -Tags 'Feature' {
         return Get-ExecutionPolicy -List | ? { ($_.Scope -eq 'UserPolicy') -and ($_.ExecutionPolicy -eq 'RemoteSigned') }
 '@
 
-        $psPath = Join-Path -Path $PSHOME -ChildPath "powershell.exe"
-        $results = & $psPath -c $command
+        $results = & $powershell -c $command -noprofile
         $results -join "," | Should Not BeNullOrEmpty
     }
 }

--- a/test/powershell/engine/ExecutionPolicy.GroupPolicy.Tests.ps1
+++ b/test/powershell/engine/ExecutionPolicy.GroupPolicy.Tests.ps1
@@ -1,0 +1,38 @@
+﻿##
+## PowerShell ExecutionPolicy GroupPolicy tests
+## These are Windows only tests
+##
+
+Describe "User group policy execution policy should work" -Tags 'Feature' {
+
+    BeforeAll {
+
+        if (!$IsWindows) { return }
+
+        # Add User group policy execution policy RemoteSigned
+        $regHKCUKey = "HKCU:\SOFTWARE\Policies\Microsoft\Windows\PowerShell"
+        Remove-Item $regHKCUKey -Force -ErrorAction SilentlyContinue
+        New-Item -Path $regHKCUKey -Force
+        Set-ItemProperty -Path $regHKCUKey -Name "EnableScripts" -Value 1
+        Set-ItemProperty -Path $regHKCUKey -Name "ExecutionPolicy" -Value "RemoteSigned"
+    }
+
+    AfterAll {
+
+        if (!$IsWindows) { return }
+
+        # Remove User group policy
+        Remove-Item $regHKCUKey -Force -ErrorAction SilentlyContinue
+    }
+
+    It "Sets User GroupPolicy ExecutionPolicy to RemoteSigned" -Skip:(!$IsWindows) {
+
+        $command = @'
+        return Get-ExecutionPolicy -List | ? { ($_.Scope -eq 'UserPolicy') -and ($_.ExecutionPolicy -eq 'RemoteSigned') }
+'@
+
+        $psPath = Join-Path -Path $PSHOME -ChildPath "powershell.exe"
+        $results = & $psPath -c $command
+        $results -join "," | Should Not BeNullOrEmpty
+    }
+}


### PR DESCRIPTION
The group policy settings cache was not using a unique enough name, with the result that GPO MachinePolicy ExecutionPolicy setting would be substituted for the UserPolicy setting.  

The fix is to use a unique name so that the two GPO settings are distinct in the cache.