### PR TITLE
Invoke-RestMethod cmdlet error if the response is neither JSON nor XML

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/InvokeRestMethodCommand.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/InvokeRestMethodCommand.Common.cs
@@ -6,9 +6,6 @@ using System;
 using System.Management.Automation;
 using System.IO;
 using System.Xml;
-#if CORECLR
-using Newtonsoft.Json;
-#endif
 
 namespace Microsoft.PowerShell.Commands
 {
@@ -147,14 +144,6 @@ namespace Microsoft.PowerShell.Commands
                 exRef = ex;
                 obj = null;
             }
-#if CORECLR
-            // we use another serializer for CORECLR implementation
-            catch (JsonException ex)
-            {
-                exRef = ex;
-                obj = null;
-            }
-#endif
             return (null != obj);
         }
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/InvokeRestMethodCommand.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/InvokeRestMethodCommand.Common.cs
@@ -6,6 +6,9 @@ using System;
 using System.Management.Automation;
 using System.IO;
 using System.Xml;
+#if CORECLR
+using Newtonsoft.Json;
+#endif
 
 namespace Microsoft.PowerShell.Commands
 {
@@ -144,6 +147,14 @@ namespace Microsoft.PowerShell.Commands
                 exRef = ex;
                 obj = null;
             }
+#if CORECLR
+            // we use another serializer for CORECLR implementation
+            catch (JsonException ex)
+            {
+                exRef = ex;
+                obj = null;
+            }
+#endif
             return (null != obj);
         }
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/ConvertFromJsonCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/ConvertFromJsonCommand.cs
@@ -92,12 +92,7 @@ namespace Microsoft.PowerShell.Commands
                         // The first input string does not represent a complete Json Syntax. 
                         // Hence consider the the entire input as a single Json content.
                     }
-#if CORECLR
-                    catch (Newtonsoft.Json.JsonSerializationException)
-                    {
-                        // we use another serializer for CORECLR implementation
-                    }
-#endif
+
                     if (successfullyConverted)
                     {
                         for (int index = 1; index < _inputObjectBuffer.Count; index++)

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/JsonObject.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/JsonObject.cs
@@ -44,20 +44,29 @@ namespace Microsoft.PowerShell.Commands
             }
             error = null;
 #if CORECLR
-            object obj = JsonConvert.DeserializeObject(input, new JsonSerializerSettings() { TypeNameHandling = TypeNameHandling.None, MaxDepth = 1024 });
-
-            // JObject is a IDictionary
-            if (obj is JObject)
+            object obj = null;
+            try
             {
-                var dictionary = obj as JObject;
-                obj = PopulateFromJDictionary(dictionary, out error);
+                obj = JsonConvert.DeserializeObject(input, new JsonSerializerSettings() { TypeNameHandling = TypeNameHandling.None, MaxDepth = 1024 });
+
+                // JObject is a IDictionary
+                if (obj is JObject)
+                {
+                    var dictionary = obj as JObject;
+                    obj = PopulateFromJDictionary(dictionary, out error);
+                }
+
+                // JArray is a collection
+                else if (obj is JArray)
+                {
+                    var list = obj as JArray;
+                    obj = PopulateFromJArray(list, out error);
+                }
             }
-
-            // JArray is a collection
-            else if (obj is JArray)
+            catch (JsonException je)
             {
-                var list = obj as JArray;
-                obj = PopulateFromJArray(list, out error);
+                // the same as JavaScriptSerializer does
+                throw new ArgumentException("input", je);
             }
 #else
             //In ConvertTo-Json, to serialize an object with a given depth, we set the RecursionLimit to depth + 2, see JavaScriptSerializer constructor in ConvertToJsonCommand.cs.

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/JsonObject.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/JsonObject.cs
@@ -67,8 +67,9 @@ namespace Microsoft.PowerShell.Commands
             }
             catch (JsonException je)
             {
+                var msg = string.Format(CultureInfo.CurrentCulture, WebCmdletStrings.JsonDeserializationFailed, je.Message);
                 // the same as JavaScriptSerializer does
-                throw new ArgumentException("input", je);
+                throw new ArgumentException(msg, je);
             }
 #else
             //In ConvertTo-Json, to serialize an object with a given depth, we set the RecursionLimit to depth + 2, see JavaScriptSerializer constructor in ConvertToJsonCommand.cs.

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/JsonObject.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/JsonObject.cs
@@ -50,17 +50,19 @@ namespace Microsoft.PowerShell.Commands
                 obj = JsonConvert.DeserializeObject(input, new JsonSerializerSettings() { TypeNameHandling = TypeNameHandling.None, MaxDepth = 1024 });
 
                 // JObject is a IDictionary
-                if (obj is JObject)
+                var dictionary = obj as JObject;
+                if (dictionary != null)
                 {
-                    var dictionary = obj as JObject;
                     obj = PopulateFromJDictionary(dictionary, out error);
                 }
-
-                // JArray is a collection
-                else if (obj is JArray)
+                else
                 {
+                    // JArray is a collection
                     var list = obj as JArray;
-                    obj = PopulateFromJArray(list, out error);
+                    if (list != null)
+                    {
+                        obj = PopulateFromJArray(list, out error);
+                    }
                 }
             }
             catch (JsonException je)

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/JsonObject.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/JsonObject.cs
@@ -44,20 +44,32 @@ namespace Microsoft.PowerShell.Commands
             }
             error = null;
 #if CORECLR
-            object obj = JsonConvert.DeserializeObject(input, new JsonSerializerSettings() { TypeNameHandling = TypeNameHandling.None, MaxDepth = 1024 });
-
-            // JObject is a IDictionary
-            if (obj is JObject)
+            object obj = null;
+            try
             {
-                var dictionary = obj as JObject;
-                obj = PopulateFromJDictionary(dictionary, out error);
+                obj = JsonConvert.DeserializeObject(input, new JsonSerializerSettings() { TypeNameHandling = TypeNameHandling.None, MaxDepth = 1024 });
+
+                // JObject is a IDictionary
+                if (obj is JObject)
+                {
+                    var dictionary = obj as JObject;
+                    obj = PopulateFromJDictionary(dictionary, out error);
+                }
+
+                // JArray is a collection
+                else if (obj is JArray)
+                {
+                    var list = obj as JArray;
+                    obj = PopulateFromJArray(list, out error);
+                }
             }
-
-            // JArray is a collection
-            else if (obj is JArray)
+            catch (JsonException ex)
             {
-                var list = obj as JArray;
-                obj = PopulateFromJArray(list, out error);
+                error = new ErrorRecord(
+                new InvalidOperationException(ex.Message),
+                "JsonStringInBadFormat",
+                ErrorCategory.InvalidOperation,
+                null);
             }
 #else
             //In ConvertTo-Json, to serialize an object with a given depth, we set the RecursionLimit to depth + 2, see JavaScriptSerializer constructor in ConvertToJsonCommand.cs.

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/WebCmdletStrings.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/WebCmdletStrings.resx
@@ -207,4 +207,7 @@
   <data name="ReachedMaximumDepthAllowed" xml:space="preserve">
     <value>The maximum depth allowed for serialization is {0}.</value>
   </data>
+  <data name="JsonDeserializationFailed" xml:space="preserve">
+    <value>Conversion from JSON failed with error: {0}</value>
+  </data>
 </root>

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/JsonObject.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/JsonObject.Tests.ps1
@@ -6,7 +6,7 @@
             [Parameter(ValueFromPipeline = $true)]
             $InputObject,
             [Parameter(Position = 0)]
-            $expectedException
+            $ExpectedException
         )
 
         try
@@ -15,17 +15,17 @@
             throw "Should throw exception"
         } catch
         {
-            $_.FullyQualifiedErrorId | should be $expectedException
+            $_.FullyQualifiedErrorId | should be $ExpectedException
         }
     }
 
     $validStrings = @(
-        @{ str = "" }
-        @{ str = "  " }
-        @{ str = "{a:1}" }
+        @{ name = "empty"; str = "" }
+        @{ name = "spaces"; str = "  " }
+        @{ name = "object"; str = "{a:1}" }
     )
 
-    It 'no error for valid string' -TestCase $validStrings {
+    It 'no error for valid string - <name>' -TestCase $validStrings {
         param ($str)
         $errRecord = $null
         [Microsoft.PowerShell.Commands.JsonObject]::ConvertFromJson($str, [ref]$errRecord)
@@ -33,11 +33,11 @@
     }
 
     $invalidStrings = @(
-        @{ str = "plaintext" }
-        @{ str = "{a:1" }
+        @{ name = "plain text"; str = "plaintext" }
+        @{ name = "part"; str = '{"a" :' }
     )
 
-    It 'throw ArgumentException for invalid string' -TestCase $invalidStrings  {
+    It 'throw ArgumentException for invalid string - <name>' -TestCase $invalidStrings  {
         param ($str)
         $errRecord = $null
         { [Microsoft.PowerShell.Commands.JsonObject]::ConvertFromJson($str, [ref]$errRecord) } | ShouldThrow 'ArgumentException'

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/JsonObject.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/JsonObject.Tests.ps1
@@ -1,0 +1,53 @@
+﻿# Unit tests for JsonObject
+Describe 'JsonObject' -tags "CI" {
+
+    function ShouldThrow
+    {
+        param (
+            [Parameter(ValueFromPipeline = $true)]
+            $InputObject,
+            [Parameter(Position = 0)]
+            $expectedException
+        )
+
+        try
+        {
+            & $InputObject
+        }
+        catch
+        {
+            $ex = $_.Exception.InnerException
+        }
+
+        $ex | Should Not BeNullOrEmpty
+        $ex.GetType() | Should Be $expectedException
+    }
+
+    It 'empty string' {
+        $errRecord = $null
+        [Microsoft.PowerShell.Commands.JsonObject]::ConvertFromJson("", [ref]$errRecord)
+        $errRecord | Should BeNullOrEmpty
+    }
+
+    It 'whitespace' {
+        $errRecord = $null
+        [Microsoft.PowerShell.Commands.JsonObject]::ConvertFromJson("   ", [ref]$errRecord)
+        $errRecord | Should BeNullOrEmpty
+    }
+
+    It 'plain text' {
+        $errRecord = $null
+        { [Microsoft.PowerShell.Commands.JsonObject]::ConvertFromJson("plaintext", [ref]$errRecord) } | ShouldThrow 'System.ArgumentException'
+    }
+
+    It 'object' {
+        $errRecord = $null
+        [Microsoft.PowerShell.Commands.JsonObject]::ConvertFromJson("{a:1}", [ref]$errRecord)
+        $errRecord | Should BeNullOrEmpty
+    }
+
+    It 'part' {
+        $errRecord = $null
+        { [Microsoft.PowerShell.Commands.JsonObject]::ConvertFromJson("{a:1", [ref]$errRecord) } | ShouldThrow 'System.ArgumentException'
+    }
+}

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/JsonObject.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/JsonObject.Tests.ps1
@@ -1,5 +1,4 @@
-﻿# Unit tests for JsonObject
-Describe 'JsonObject' -tags "CI" {
+﻿Describe 'Unit tests for JsonObject' -tags "CI" {
 
     function ShouldThrow
     {
@@ -13,41 +12,34 @@ Describe 'JsonObject' -tags "CI" {
         try
         {
             & $InputObject
-        }
-        catch
+            throw "Should throw exception"
+        } catch
         {
-            $ex = $_.Exception.InnerException
+            $_.FullyQualifiedErrorId | should be $expectedException
         }
-
-        $ex | Should Not BeNullOrEmpty
-        $ex.GetType() | Should Be $expectedException
     }
 
-    It 'empty string' {
+    $validStrings = @(
+        @{ str = "" }
+        @{ str = "  " }
+        @{ str = "{a:1}" }
+    )
+
+    It 'no error for valid string' -TestCase $validStrings {
+        param ($str)
         $errRecord = $null
-        [Microsoft.PowerShell.Commands.JsonObject]::ConvertFromJson("", [ref]$errRecord)
+        [Microsoft.PowerShell.Commands.JsonObject]::ConvertFromJson($str, [ref]$errRecord)
         $errRecord | Should BeNullOrEmpty
     }
 
-    It 'whitespace' {
-        $errRecord = $null
-        [Microsoft.PowerShell.Commands.JsonObject]::ConvertFromJson("   ", [ref]$errRecord)
-        $errRecord | Should BeNullOrEmpty
-    }
+    $invalidStrings = @(
+        @{ str = "plaintext" }
+        @{ str = "{a:1" }
+    )
 
-    It 'plain text' {
+    It 'throw ArgumentException for invalid string' -TestCase $invalidStrings  {
+        param ($str)
         $errRecord = $null
-        { [Microsoft.PowerShell.Commands.JsonObject]::ConvertFromJson("plaintext", [ref]$errRecord) } | ShouldThrow 'System.ArgumentException'
-    }
-
-    It 'object' {
-        $errRecord = $null
-        [Microsoft.PowerShell.Commands.JsonObject]::ConvertFromJson("{a:1}", [ref]$errRecord)
-        $errRecord | Should BeNullOrEmpty
-    }
-
-    It 'part' {
-        $errRecord = $null
-        { [Microsoft.PowerShell.Commands.JsonObject]::ConvertFromJson("{a:1", [ref]$errRecord) } | ShouldThrow 'System.ArgumentException'
+        { [Microsoft.PowerShell.Commands.JsonObject]::ConvertFromJson($str, [ref]$errRecord) } | ShouldThrow 'ArgumentException'
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/JsonObject.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/JsonObject.Tests.ps1
@@ -13,7 +13,8 @@
         {
             & $InputObject
             throw "Should throw exception"
-        } catch
+        }
+        catch
         {
             $_.FullyQualifiedErrorId | should be $ExpectedException
         }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -635,4 +635,11 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
         $result = ExecuteWebCommand -command $command
         $result.Error | Should BeNullOrEmpty
     }
+
+    It "Invoke-RestMethod supports request that returns page containing UTF-8 data." {
+
+        $command = "Invoke-RestMethod -Uri 'http://httpbin.org/encoding/utf8'"
+        $result = ExecuteWebCommand -command $command
+        $result.Error | Should BeNullOrEmpty
+    }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -636,7 +636,7 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
         $result.Error | Should BeNullOrEmpty
     }
 
-    It "Invoke-RestMethod supports request that returns response that is neither XML nor JSON." {
+    It "Invoke-RestMethod supports request that returns plain text response." {
 
         $command = "Invoke-RestMethod -Uri 'http://httpbin.org/encoding/utf8'"
         $result = ExecuteWebCommand -command $command

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -636,7 +636,7 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
         $result.Error | Should BeNullOrEmpty
     }
 
-    It "Invoke-RestMethod supports request that returns page containing UTF-8 data." {
+    It "Invoke-RestMethod supports request that returns response that is neither XML nor JSON." {
 
         $command = "Invoke-RestMethod -Uri 'http://httpbin.org/encoding/utf8'"
         $result = ExecuteWebCommand -command $command


### PR DESCRIPTION
This pull request fixes the Invoke-RestMethod cmdlet behavior if the response is neither XML nor JSON, e.g. just a plain text from a webservice.

**Before the change:**
```
PS> Invoke-RestMethod http://httpbin.org/encoding/utf8
Invoke-RestMethod : Unexpected character encountered while parsing value: <. Path '', line 0, position 0.
At line:1 char:1
+ Invoke-RestMethod http://httpbin.org/encoding/utf8
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  + CategoryInfo : NotSpecified: (:) [Invoke-RestMethod], JsonReaderException
  + FullyQualifiedErrorId : Newtonsoft.Json.JsonReaderException,Microsoft.PowerShell.Commands.InvokeRestMethodComman
  d
```
**After the change:**
```
PS> Invoke-RestMethod http://httpbin.org/encoding/utf8
<h1>Unicode Demo</h1>
...
```