### PR TITLE
Change package name to CodeCoverage.zip from Powershell_6.0.0...

### DIFF
--- a/tools/appveyor.psm1
+++ b/tools/appveyor.psm1
@@ -374,8 +374,7 @@ function Compress-CoverageArtifacts
     [System.IO.Compression.ZipFile]::CreateFromDirectory($resolvedPath, $zipOpenCoverPath) 
     $null = $artifacts.Add($zipOpenCoverPath)
 
-    $name = Get-PackageName
-    $zipCodeCoveragePath = Join-Path $pwd "$name.CodeCoverage.zip"
+    $zipCodeCoveragePath = Join-Path $pwd "CodeCoverage.zip"
     Write-Verbose "Zipping ${CodeCoverageOutput} into $zipCodeCoveragePath" -verbose
     [System.IO.Compression.ZipFile]::CreateFromDirectory($CodeCoverageOutput, $zipCodeCoveragePath)
     $null = $artifacts.Add($zipCodeCoveragePath)


### PR DESCRIPTION
Changed the package name from the standard Powershell_6.0.0-xx-gxxxxxxx to
CodeCoverage.zip so that it is easier to download the latest package from
the AppVeyor permalink for last successful build.