### PR TITLE
Skip PSSession test on Linux to avoid NullReferenceException

### DIFF
--- a/test/powershell/engine/Remoting/RemoteSession.Basic.Tests.ps1
+++ b/test/powershell/engine/Remoting/RemoteSession.Basic.Tests.ps1
@@ -1,11 +1,14 @@
-
 Describe "New-PSSession basic test" -Tag @("CI") {
+    if ( ! $IsWindows ) {
+        $PSDefaultParameterValues['it:skip'] = $true
+    }
     It "New-PSSession should not crash powershell" {
         try {
-            New-PSSession -ComputerName nonexistcomputer -Authentication Basic
-            throw "New-PSSession should throw"
+    	New-PSSession -ComputerName nonexistcomputer -Authentication Basic
+    	throw "New-PSSession should throw"
         } catch {
-            $_.FullyQualifiedErrorId | Should Be "InvalidOperation,Microsoft.PowerShell.Commands.NewPSSessionCommand"
+    	$_.FullyQualifiedErrorId | Should Be "InvalidOperation,Microsoft.PowerShell.Commands.NewPSSessionCommand"
         }
     }
+    $PSDefaultParameterValues.remove('it:skip')
 }

--- a/test/powershell/engine/Remoting/RemoteSession.Basic.Tests.ps1
+++ b/test/powershell/engine/Remoting/RemoteSession.Basic.Tests.ps1
@@ -4,10 +4,10 @@ Describe "New-PSSession basic test" -Tag @("CI") {
     }
     It "New-PSSession should not crash powershell" {
         try {
-    	New-PSSession -ComputerName nonexistcomputer -Authentication Basic
-    	throw "New-PSSession should throw"
+    	    New-PSSession -ComputerName nonexistcomputer -Authentication Basic
+    	    throw "New-PSSession should throw"
         } catch {
-    	$_.FullyQualifiedErrorId | Should Be "InvalidOperation,Microsoft.PowerShell.Commands.NewPSSessionCommand"
+    	    $_.FullyQualifiedErrorId | Should Be "InvalidOperation,Microsoft.PowerShell.Commands.NewPSSessionCommand"
         }
     }
     $PSDefaultParameterValues.remove('it:skip')


### PR DESCRIPTION
Since [#942](https://github.com/PowerShell/PowerShell/issues/942), `New-PSSession` causes a `NullReferenceException` due to dependency on PSRP. A test in the `Start-PSPester` suite invokes this unconditionally, crashing the test suite on Linux builds.

This adds a condition to skip the test on non-Windows builds of PowerShell, just like in [SessionOption.Tests](https://github.com/PowerShell/PowerShell/blob/master/test/powershell/engine/Remoting/SessionOption.Tests.ps1). The other natural alternative is to encase the test in a `try` block to count it as "failed" until PSRP is supported.