### PR TITLE
PowerShell transcripts should include the configuration name in the transcript header

### DIFF
--- a/src/System.Management.Automation/engine/hostifaces/MshHostUserInterface.cs
+++ b/src/System.Management.Automation/engine/hostifaces/MshHostUserInterface.cs
@@ -453,7 +453,11 @@ namespace System.Management.Automation.Host
                     psVersionInfo.AppendLine(versionKey + ": " + valueString);
                 }
             }
-
+            string psConfigurationName = string.Empty;
+            if (senderInfo != null && !string.IsNullOrEmpty(senderInfo.ConfigurationName))
+            {
+                psConfigurationName = senderInfo.ConfigurationName;
+            }
             // Transcribe the transcript header
             string format = InternalHostUserInterfaceStrings.TranscriptPrologue;
             string line =
@@ -463,6 +467,7 @@ namespace System.Management.Automation.Host
                     DateTime.Now,
                     username,
                     runAsUser,
+                    psConfigurationName,
                     Environment.MachineName,
                     Environment.OSVersion.VersionString,
                     String.Join(" ", Environment.GetCommandLineArgs()),

--- a/src/System.Management.Automation/engine/remoting/fanin/PSPrincipal.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/PSPrincipal.cs
@@ -162,6 +162,11 @@ namespace System.Management.Automation.Remoting
             internal set { _applicationArguments = value; }
         }
 
+        /// <summary>
+        /// "ConfigurationName" from the sever remote session
+        /// </summary>
+        public string ConfigurationName { get; internal set; }
+
         #endregion
     }
 

--- a/src/System.Management.Automation/engine/remoting/server/serverremotesession.cs
+++ b/src/System.Management.Automation/engine/remoting/server/serverremotesession.cs
@@ -206,7 +206,9 @@ namespace System.Management.Automation.Remoting
             {
                 throw PSTraceSource.NewInvalidOperationException("RemotingErrorIdStrings.NonExistentInitialSessionStateProvider", configurationProviderId);
             }
-
+            string shellPrefix = System.Management.Automation.Remoting.Client.WSManNativeApi.ResourceURIPrefix;
+            int index = configurationProviderId.IndexOf(shellPrefix, StringComparison.OrdinalIgnoreCase);
+            senderInfo.ConfigurationName = (index == 0) ? configurationProviderId.Substring(shellPrefix.Length) : string.Empty;
             ServerRemoteSession result = new ServerRemoteSession(senderInfo,
                 configurationProviderId,
                 initializationParameters,

--- a/src/System.Management.Automation/resources/InternalHostUserInterfaceStrings.resx
+++ b/src/System.Management.Automation/resources/InternalHostUserInterfaceStrings.resx
@@ -201,10 +201,11 @@ Windows PowerShell transcript start
 Start time: {0:yyyyMMddHHmmss}
 Username: {1}
 RunAs User: {2}
-Machine: {3} ({4})
-Host Application: {5}
-Process ID: {6}
-{7}
+Configuration Name: {3}
+Machine: {4} ({5})
+Host Application: {6}
+Process ID: {7}
+{8}
 **********************</value>
   </data>
   <data name="TranscriptEpilogue" xml:space="preserve">

--- a/test/powershell/engine/Remoting/RemoteSession.Basic.Tests.ps1
+++ b/test/powershell/engine/Remoting/RemoteSession.Basic.Tests.ps1
@@ -9,3 +9,26 @@ Describe "New-PSSession basic test" -Tag @("CI") {
         }
     }
 }
+
+Describe "JEA session Transcprit script test" -Tag @("Feature", 'RequireAdminOnWindows') {
+    It "Configuration name should be in the transcript header" {
+        [string] $RoleCapDirectory = (New-Item -Path "$TestDrive\RoleCapability" -ItemType Directory -Force).FullName
+        [string] $PSSessionConfigFile = "$RoleCapDirectory\TestConfig.pssc"
+        [string] $transScriptFile = "$RoleCapDirectory\*.txt"
+        try
+        {
+            New-PSSessionConfigurationFile -Path $PSSessionConfigFile -TranscriptDirectory $RoleCapDirectory -SessionType RestrictedRemoteServer
+            Register-PSSessionConfiguration -Name JEA -Path $PSSessionConfigFile -Force -ErrorAction SilentlyContinue 
+            $scriptBlock = {Enter-PSSession -ComputerName Localhost -ConfigurationName JEA; Exit-PSSession}
+            & $scriptBlock
+            $headerFile = Get-ChildItem $transScriptFile | Sort-Object LastWriteTime | Select-Object -Last 1
+            $header = Get-Content $headerFile | Out-String
+            $header | Should BeLike "Configuration Name: JEA"
+        }
+        finally
+        {
+            Unregister-PSSessionConfiguration -Name JEA -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+}


### PR DESCRIPTION
Steps to reproduce
```powershell
New-PSSessionConfigurationFile -Path .\myJeaConfig.pssc -TranscriptDirectory 'C:\temp\transcripts' -SessionType RestrictedRemoteServer
Register-PSSessionConfiguration -Name JEA -Path .\myJeaconfig.pssc
Enter-PSSession -ComputerName Localhost -ConfigurationName JEA

exit
```
Expected behavior

PowerShell transcripts currently do not log the configuration name the user used to connect to and manage the machine. For JEA scenarios, this means an auditor trying to understand how someone was able to do a certain command will not know through which endpoint the user entered and was assigned those privileges.

Suggestion is to add a new line to the transcript header similar to the following:

ConfigurationName: MyJEA

[…]
RunAs User: WinRM Virtual Users\WinRM VA_10_PRIV_priv.demo
Configuration Name: JEA
Machine: DC (Microsoft Windows NT 10.0.14393.0)
[…]

Actual behavior

[…]
RunAs User: WinRM Virtual Users\WinRM VA_10_PRIV_priv.demo
Machine: DC (Microsoft Windows NT 10.0.14393.0)
[…]

Environment data
```
Name Value

PSVersion 5.1.14993.1000
PSEdition Desktop
PSCompatibleVersions {1.0, 2.0, 3.0, 4.0...}
BuildVersion 10.0.14993.1000
CLRVersion 4.0.30319.42000
WSManStackVersion 3.0
PSRemotingProtocolVersion 2.3
SerializationVersion 1.1.0.1
```