### PR TITLE
Wrong expected exception assertion in tests

### DIFF
--- a/test/powershell/Modules/Microsoft.PowerShell.Core/TestGetCommand.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/TestGetCommand.Tests.ps1
@@ -243,7 +243,8 @@
     It "Throw an Exception when set testtorun to 'returnduplicateparameter'" { 
         try
         {       
-            Get-Command testgetcommand-dynamicparametersdcr -testtorun returnduplicateparameter -ErrorAction SilentlyContinue
+            Get-Command testgetcommand-dynamicparametersdcr -testtorun returnduplicateparameter -ErrorAction Stop
+            throw "No Exception!"
         }
         catch
         {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/TimeZone.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/TimeZone.Tests.ps1
@@ -155,9 +155,15 @@ Describe "Set-Timezone test cases" -Tags @('Feature', 'RequireAdminOnWindows') {
     }
 
     It "Call Set-TimeZone with invalid Id" {
-        $exception = $null
-        try { Set-TimeZone -Id "zzInvalidID" } catch { $exception = $_ }
-        $exception.FullyQualifiedErrorID | Should Be "TimeZoneNotFound,Microsoft.PowerShell.Commands.SetTimeZoneCommand"
+        try
+        {
+            Set-TimeZone -Id "zzInvalidID"
+            throw "No Exception!"
+        }
+        catch
+        {
+            $_.FullyQualifiedErrorID | Should Be "TimeZoneNotFound,Microsoft.PowerShell.Commands.SetTimeZoneCommand"
+        }
     }
 
     It "Call Set-TimeZone by Name" {
@@ -178,9 +184,15 @@ Describe "Set-Timezone test cases" -Tags @('Feature', 'RequireAdminOnWindows') {
     }
 
     It "Call Set-TimeZone with invalid Name" {
-        $exception = $null
-        try { Set-TimeZone -Name "zzINVALID_Name" } catch { $exception = $_ }
-        $exception.FullyQualifiedErrorID | Should Be "TimeZoneNotFound,Microsoft.PowerShell.Commands.SetTimeZoneCommand"
+        try
+        {
+            Set-TimeZone -Name "zzINVALID_Name"
+            throw "No Exception!"
+        }
+        catch
+        {
+            $_.FullyQualifiedErrorID | Should Be "TimeZoneNotFound,Microsoft.PowerShell.Commands.SetTimeZoneCommand"
+        }
     }
 
     It "Verify that alias 'stz' exists" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/ExecutionPolicy.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/ExecutionPolicy.Tests.ps1
@@ -919,6 +919,7 @@ ZoneId=$FileType
         )
         try {
             Set-ExecutionPolicy -Scope $policyScope -ExecutionPolicy Restricted
+            throw "No Exception!"
         }
         catch {
             $_.FullyQualifiedErrorId | Should Be "CantSetGroupPolicy,Microsoft.PowerShell.Commands.SetExecutionPolicyCommand"

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/SecureString.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/SecureString.Tests.ps1
@@ -14,6 +14,7 @@ Describe "SecureString conversion tests" -Tags "CI" {
     It "using null arguments to ConvertFrom-SecureString produces an exception" {
         try {
             ConvertFrom-SecureString -secureString $null -key $null
+            throw "No Exception!"
         }
         catch {
             $_.FullyQualifiedErrorId | should be "ParameterArgumentValidationErrorNullNotAllowed,Microsoft.PowerShell.Commands.ConvertFromSecureStringCommand"

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Export-Alias.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Export-Alias.Tests.ps1
@@ -103,6 +103,7 @@ Describe "Export-Alias DRT Unit Tests" -Tags "CI" {
 		
 		try{
 			Export-Alias $fulltestpath abcd02
+			throw "No Exception!"
 		}
 		catch{
 			$_.FullyQualifiedErrorId | Should be "FileOpenFailure,Microsoft.PowerShell.Commands.ExportAliasCommand"

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-Wide.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-Wide.Tests.ps1
@@ -27,6 +27,7 @@ Describe "Format-Wide" -Tags "CI" {
         try
 		{
 			Format-Wide -InputObject $(Get-ChildItem) -Property CreationTime -View aoeu
+			throw "No Exception!"
 		}
 		catch
 		{

--- a/test/powershell/engine/ParameterBinding/ParameterBinding.Tests.ps1
+++ b/test/powershell/engine/ParameterBinding/ParameterBinding.Tests.ps1
@@ -15,6 +15,7 @@
         try
         {
             test-PositionalBinding1 1
+            throw "No Exception!"
         }
         catch
         {
@@ -64,6 +65,7 @@
         try
         {
             test-allownullattributes -Parameter2 1 -Parameter3 $null -ShowMe 1
+            throw "No Exception!"
         }
         catch
         {
@@ -89,6 +91,7 @@
         try
         {
             test-namedwithboolishargument -Parameter2 -Parameter1
+            throw "No Exception!"
         }
         catch
         {
@@ -148,6 +151,7 @@
         try
         {
             test-singleintparameter -Parameter1 'dookie'
+            throw "No Exception!"
         }
         catch
         {
@@ -266,6 +270,7 @@
         try
         {
             test-nameconflicts6 -Parameter2 1
+            throw "No Exception!"
         }
         catch
         {


### PR DESCRIPTION
Hello, this is a follow-up pull request to [the comment I left](https://github.com/PowerShell/PowerShell/pull/2862#discussion_r92483509) about expected exception assertions in the current tests. 

To put it briefly, there were two problems I found:
1. It was forgotten to throw an exception (and calibrate the test too;)) if no exception was thrown.
```
try
{
    Do-SomethingThatThrowsException
    # no throw "No Exception!" or something
}
catch
{
    $_.FullyQualifiedErrorId | should be "SomeErrorId"
}
```
As a result, in the case of no exception, the test would not become red. This command shows you lots mistakes like this:
```
grep -Hn -B 4 -ir "FullyQualifiedErrorId.*should" --include *Test*.ps1 --group-separator=$'\n\n---------------------------------\n\n'
```
```
powershell/engine/ParameterBinding/ParameterBinding.Tests.ps1-17- test-PositionalBinding1 1
powershell/engine/ParameterBinding/ParameterBinding.Tests.ps1-18- }
powershell/engine/ParameterBinding/ParameterBinding.Tests.ps1-19- catch
powershell/engine/ParameterBinding/ParameterBinding.Tests.ps1-20- {
powershell/engine/ParameterBinding/ParameterBinding.Tests.ps1:21: $_.FullyQualifiedErrorId | should be "AmbiguousPositionalParameterNoName,test-PositionalBinding1"

---------------------------------

powershell/engine/ParameterBinding/ParameterBinding.Tests.ps1-66- test-allownullattributes -Parameter2 1 -Parameter3 $null -ShowMe 1
powershell/engine/ParameterBinding/ParameterBinding.Tests.ps1-67- }
powershell/engine/ParameterBinding/ParameterBinding.Tests.ps1-68- catch
powershell/engine/ParameterBinding/ParameterBinding.Tests.ps1-69- {
powershell/engine/ParameterBinding/ParameterBinding.Tests.ps1:70: $_.FullyQualifiedErrorId | should be "ParameterArgumentValidationErrorEmptyStringNotAllowed,test-allownullattributes"

---------------------------------

powershell/engine/ParameterBinding/ParameterBinding.Tests.ps1-91- test-namedwithboolishargument -Parameter2 -Parameter1
powershell/engine/ParameterBinding/ParameterBinding.Tests.ps1-92- }
powershell/engine/ParameterBinding/ParameterBinding.Tests.ps1-93- catch
powershell/engine/ParameterBinding/ParameterBinding.Tests.ps1-94- {
powershell/engine/ParameterBinding/ParameterBinding.Tests.ps1:95: $_.FullyQualifiedErrorId | should be "MissingArgument,test-namedwithboolishargument"

---------------------------------

powershell/engine/ParameterBinding/ParameterBinding.Tests.ps1-150- test-singleintparameter -Parameter1 'dookie'
powershell/engine/ParameterBinding/ParameterBinding.Tests.ps1-151- }
powershell/engine/ParameterBinding/ParameterBinding.Tests.ps1-152- catch
powershell/engine/ParameterBinding/ParameterBinding.Tests.ps1-153- {
powershell/engine/ParameterBinding/ParameterBinding.Tests.ps1:154: $_.FullyQualifiedErrorId | should be "ParameterArgumentTransformationError,test-singleintparameter"

---------------------------------

powershell/engine/ParameterBinding/ParameterBinding.Tests.ps1-268- test-nameconflicts6 -Parameter2 1
powershell/engine/ParameterBinding/ParameterBinding.Tests.ps1-269- }
powershell/engine/ParameterBinding/ParameterBinding.Tests.ps1-270- catch
powershell/engine/ParameterBinding/ParameterBinding.Tests.ps1-271- {
powershell/engine/ParameterBinding/ParameterBinding.Tests.ps1:272: $_.FullyQualifiedErrorId | should be "ParameterNameConflictsWithAlias"

---------------------------------
powershell/Modules/Microsoft.PowerShell.Core/TestGetCommand.Tests.ps1-246- Get-Command testgetcommand-dynamicparametersdcr -testtorun returnduplicateparameter -ErrorAction SilentlyContinue
powershell/Modules/Microsoft.PowerShell.Core/TestGetCommand.Tests.ps1-247- }
powershell/Modules/Microsoft.PowerShell.Core/TestGetCommand.Tests.ps1-248- catch
powershell/Modules/Microsoft.PowerShell.Core/TestGetCommand.Tests.ps1-249- {
powershell/Modules/Microsoft.PowerShell.Core/TestGetCommand.Tests.ps1:250: $_.FullyQualifiedErrorId | Should Be "GetCommandMetadataError,Microsoft.PowerShell.Commands.GetCommandCommand"

---------------------------------

powershell/Modules/Microsoft.PowerShell.Security/ExecutionPolicy.Tests.ps1-920- try {
powershell/Modules/Microsoft.PowerShell.Security/ExecutionPolicy.Tests.ps1-921- Set-ExecutionPolicy -Scope $policyScope -ExecutionPolicy Restricted
powershell/Modules/Microsoft.PowerShell.Security/ExecutionPolicy.Tests.ps1-922- }
powershell/Modules/Microsoft.PowerShell.Security/ExecutionPolicy.Tests.ps1-923- catch {
powershell/Modules/Microsoft.PowerShell.Security/ExecutionPolicy.Tests.ps1:924: $_.FullyQualifiedErrorId | Should Be "CantSetGroupPolicy,Microsoft.PowerShell.Commands.SetExecutionPolicyCommand"

---------------------------------

powershell/Modules/Microsoft.PowerShell.Security/SecureString.Tests.ps1-15- try {
powershell/Modules/Microsoft.PowerShell.Security/SecureString.Tests.ps1-16- ConvertFrom-SecureString -secureString $null -key $null
powershell/Modules/Microsoft.PowerShell.Security/SecureString.Tests.ps1-17- }
powershell/Modules/Microsoft.PowerShell.Security/SecureString.Tests.ps1-18- catch {
powershell/Modules/Microsoft.PowerShell.Security/SecureString.Tests.ps1:19: $_.FullyQualifiedErrorId | should be "ParameterArgumentValidationErrorNullNotAllowed,Microsoft.PowerShell.Commands.ConvertFromSecureStringCommand"

---------------------------------

powershell/Modules/Microsoft.PowerShell.Utility/Export-Alias.Tests.ps1-104- try{
powershell/Modules/Microsoft.PowerShell.Utility/Export-Alias.Tests.ps1-105- Export-Alias $fulltestpath abcd02
powershell/Modules/Microsoft.PowerShell.Utility/Export-Alias.Tests.ps1-106- }
powershell/Modules/Microsoft.PowerShell.Utility/Export-Alias.Tests.ps1-107- catch{
powershell/Modules/Microsoft.PowerShell.Utility/Export-Alias.Tests.ps1:108: $_.FullyQualifiedErrorId | Should be "FileOpenFailure,Microsoft.PowerShell.Commands.ExportAliasCommand"

---------------------------------

powershell/Modules/Microsoft.PowerShell.Utility/Format-Wide.Tests.ps1-29- Format-Wide -InputObject $(Get-ChildItem) -Property CreationTime -View aoeu
powershell/Modules/Microsoft.PowerShell.Utility/Format-Wide.Tests.ps1-30- }
powershell/Modules/Microsoft.PowerShell.Utility/Format-Wide.Tests.ps1-31- catch
powershell/Modules/Microsoft.PowerShell.Utility/Format-Wide.Tests.ps1-32- {
powershell/Modules/Microsoft.PowerShell.Utility/Format-Wide.Tests.ps1:33: $_.FullyQualifiedErrorId | Should be "FormatCannotSpecifyViewAndProperty,Microsoft.PowerShell.Commands.FormatWideCommand"
```

2. Unclear error reporting if no exception was thrown (Expected: {SomeException}, But was: {})
```
powershell/Modules/Microsoft.PowerShell.Management/TimeZone.Tests.ps1-156-
powershell/Modules/Microsoft.PowerShell.Management/TimeZone.Tests.ps1-157- It "Call Set-TimeZone with invalid Id" {
powershell/Modules/Microsoft.PowerShell.Management/TimeZone.Tests.ps1-158- $exception = $null
powershell/Modules/Microsoft.PowerShell.Management/TimeZone.Tests.ps1-159- try { Set-TimeZone -Id "zzInvalidID" } catch { $exception = $_ }
powershell/Modules/Microsoft.PowerShell.Management/TimeZone.Tests.ps1:160: $exception.FullyQualifiedErrorID | Should Be "TimeZoneNotFound,Microsoft.PowerShell.Commands.SetTimeZoneCommand"

---------------------------------

powershell/Modules/Microsoft.PowerShell.Management/TimeZone.Tests.ps1-179-
powershell/Modules/Microsoft.PowerShell.Management/TimeZone.Tests.ps1-180- It "Call Set-TimeZone with invalid Name" {
powershell/Modules/Microsoft.PowerShell.Management/TimeZone.Tests.ps1-181- $exception = $null
powershell/Modules/Microsoft.PowerShell.Management/TimeZone.Tests.ps1-182- try { Set-TimeZone -Name "zzINVALID_Name" } catch { $exception = $_ }
powershell/Modules/Microsoft.PowerShell.Management/TimeZone.Tests.ps1:183: $exception.FullyQualifiedErrorID | Should Be "TimeZoneNotFound,Microsoft.PowerShell.Commands.SetTimeZoneCommand"
```

P.S. We can also discuss how to prevent oversights like this in the future except for careful code-review, like using static code analysis or common fixtures