### PR TITLE
Default to outputting help via cat

### DIFF
--- a/docker/release/centos7/Dockerfile
+++ b/docker/release/centos7/Dockerfile
@@ -25,6 +25,7 @@ RUN yum install -y \
         which \
         curl \
         git \
+        less \
     && yum clean all
 
 # Install PowerShell package and clean up

--- a/docker/release/ubuntu14.04/Dockerfile
+++ b/docker/release/ubuntu14.04/Dockerfile
@@ -25,6 +25,7 @@ RUN apt-get update \
         zlib1g \
         curl \
         git \
+        less \
     && rm -rf /var/lib/apt/lists/*
 
 # Install PowerShell package and clean up

--- a/docker/release/ubuntu16.04/Dockerfile
+++ b/docker/release/ubuntu16.04/Dockerfile
@@ -25,6 +25,7 @@ RUN apt-get update \
         zlib1g \
         curl \
         git \
+        less \
     && rm -rf /var/lib/apt/lists/*
 
 # Install PowerShell package and clean up

--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -5339,12 +5339,17 @@ $OutputEncoding = if ($IsWindows -and $IsCoreCLR) {
 }
 
 # Respect PAGER, use more on Windows, and use less on Linux
-if (Test-Path env:PAGER) {
-    $moreCommand = (Get-Command -CommandType Application $env:PAGER | Select-Object -First 1).Definition
-} elseif ($IsWindows) {
-    $moreCommand = (Get-Command -CommandType Application more | Select-Object -First 1).Definition
-} else {
-    $moreCommand = (Get-Command -CommandType Application less | Select-Object -First 1).Definition
+Try {
+  if (Test-Path env:PAGER) {
+      $moreCommand = (Get-Command -CommandType Application $env:PAGER -ErrorAction Stop | Select-Object -First 1).Definition
+  } elseif ($IsWindows) {
+      $moreCommand = (Get-Command -CommandType Application more -ErrorAction Stop | Select-Object -First 1).Definition
+  } else {
+      $moreCommand = (Get-Command -CommandType Application less -ErrorAction Stop | Select-Object -First 1).Definition
+  }
+}
+Catch {
+  $moreCommand = (Get-Command -CommandType Application cat | Select-Object -First 1).Definition
 }
 
 if($paths) {


### PR DESCRIPTION
Fixes #2809 

Wrap selection of $moreCommand in Try, Catch block, and default to `cat` where `less` is not found.

In addition, add the less package to the Docker images so it works anyway.