### PR TITLE
Fix here string '`$a=@`"`n'`"'`n`"@'

### DIFF
--- a/src/System.Management.Automation/engine/parser/tokenizer.cs
+++ b/src/System.Management.Automation/engine/parser/tokenizer.cs
@@ -2609,6 +2609,8 @@ namespace System.Management.Automation.Language
                         case '.':
                         case '[':
                             // Something like $a.b or $a[1].
+                        case '=':
+                            // Something like $a=
                             UngetChar();
                             scanning = false;
                             break;

--- a/test/powershell/Language/Parser/Parser.Tests.ps1
+++ b/test/powershell/Language/Parser/Parser.Tests.ps1
@@ -825,4 +825,9 @@ Describe "ParserTests (admin\monad\tests\monad\src\engine\core\ParserTests.cs)" 
             $_.FullyQualifiedErrorId | should be "ParseException"
         }
     }
+
+    It "A here string should not throw on '@`"``n'`"'``n`"@'" {
+        # Issue #2780
+        { ExecuteCommand "@`"`n'`"'`n`"@" } | Should Not Throw
+    }
 } 

--- a/test/powershell/Language/Parser/Parser.Tests.ps1
+++ b/test/powershell/Language/Parser/Parser.Tests.ps1
@@ -826,8 +826,8 @@ Describe "ParserTests (admin\monad\tests\monad\src\engine\core\ParserTests.cs)" 
         }
     }
 
-    It "A here string should not throw on '@`"``n'`"'``n`"@'" {
+    It "A here string should not throw on '`$herestr=@`"``n'`"'``n`"@'" {
         # Issue #2780
-        { ExecuteCommand "@`"`n'`"'`n`"@" } | Should Not Throw
+        { ExecuteCommand "`$herestr=@`"`n'`"'`n`"@" } | Should Not Throw
     }
 } 


### PR DESCRIPTION
Close #2780 

1. Fix tokenizer
The tokenizer do multiple scans the script line to get tokens. Before
the fix the tokenizer on the first pass examined that string as
double-quoted (Expandable) string not as here string, figured the
average double quotation mark as a closing and then starting with the
single quotation mark continued processing the line as single-quoted
string which had no closing single quotation mark.
The fix stop the first scan pass after getting '=' (assume
assignment-expression '$a=' for next pass).
2. Add test.