### PR TITLE
Remove errors in counter tests on non-Windows

### DIFF
--- a/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/CounterTestHelperFunctions.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/CounterTestHelperFunctions.ps1
@@ -278,14 +278,3 @@ function CompareCounterSets
         }
     }
 }
-
-function SkipCounterTests
-{
-    if ([System.Management.Automation.Platform]::IsLinux -or
-        [System.Management.Automation.Platform]::IsOSX)
-    {
-        return $true
-    }
-
-    return $false
-}

--- a/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/Export-Counter.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/Export-Counter.Tests.ps1
@@ -9,7 +9,7 @@ $cmdletName = "Export-Counter"
 $rootFilename = "exportedCounters"
 $filePath = $null
 
-if ( ! $(SkipCounterTests) ) {
+if ( $isWindows ) {
 
     $counterNames = @(
         (TranslateCounterPath "\Memory\Available Bytes")
@@ -36,7 +36,7 @@ function CheckExportResults
 # Run a test case
 function RunTest($testCase)
 {
-    It "$($testCase.Name)" -Skip:$(SkipCounterTests) {
+    It "$($testCase.Name)" {
         $getCounterParams = ""
         if ($testCase.ContainsKey("GetCounterParams"))
         {
@@ -121,19 +121,30 @@ function RunTest($testCase)
 Describe "CI tests for Export-Counter cmdlet" -Tags "CI" {
 
     BeforeAll {
+        if ( ! $IsWindows )
+        {
+            $origDefaults = $PSDefaultParameterValues.Clone()
+            $PSDefaultParameterValues['it:skip'] = $true
+        }
         $script:outputDirectory = $testDrive
+    }
+
+    AfterAll {
+        if ( ! $IsWindows ){
+            $global:PSDefaultParameterValues = $origDefaults
+        }
     }
 
     $testCases = @(
         @{
             Name = "Can export BLG format"
             FileFormat = "blg"
-            GetCounterParams = "-MaxSamples 5"
+            GetCounterParams = "-MaxSamples 2"
             Script = { CheckExportResults }
         }
         @{
             Name = "Exports BLG format by default"
-            GetCounterParams = "-MaxSamples 5"
+            GetCounterParams = "-MaxSamples 2"
             Script = { CheckExportResults }
         }
     )
@@ -147,7 +158,18 @@ Describe "CI tests for Export-Counter cmdlet" -Tags "CI" {
 Describe "Feature tests for Export-Counter cmdlet" -Tags "Feature" {
 
     BeforeAll {
+        if ( ! $IsWindows )
+        {
+            $origDefaults = $PSDefaultParameterValues.Clone()
+            $PSDefaultParameterValues['it:skip'] = $true
+        }
         $script:outputDirectory = $testDrive
+    }
+
+    AfterAll {
+        if ( ! $IsWindows ){
+            $global:PSDefaultParameterValues = $origDefaults
+        }
     }
 
     Context "Validate incorrect parameter usage" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/Export-Counter.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/Export-Counter.Tests.ps1
@@ -8,14 +8,19 @@ $cmdletName = "Export-Counter"
 
 $rootFilename = "exportedCounters"
 $filePath = $null
-$counterNames = @(
-    (TranslateCounterPath "\Memory\Available Bytes")
-    (TranslateCounterPath "\Processor(*)\% Processor Time")
-    (TranslateCounterPath "\Processor(_Total)\% Processor Time")
-    (TranslateCounterPath "\PhysicalDisk(_Total)\Current Disk Queue Length")
-    (TranslateCounterPath "\PhysicalDisk(_Total)\Disk Bytes/sec")
-    (TranslateCounterPath "\PhysicalDisk(_Total)\Disk Read Bytes/sec")
-)
+
+if ( ! $(SkipCounterTests) ) {
+
+    $counterNames = @(
+        (TranslateCounterPath "\Memory\Available Bytes")
+        (TranslateCounterPath "\Processor(*)\% Processor Time")
+        (TranslateCounterPath "\Processor(_Total)\% Processor Time")
+        (TranslateCounterPath "\PhysicalDisk(_Total)\Current Disk Queue Length")
+        (TranslateCounterPath "\PhysicalDisk(_Total)\Disk Bytes/sec")
+        (TranslateCounterPath "\PhysicalDisk(_Total)\Disk Read Bytes/sec")
+    )
+}
+
 $counterValues = $null
 
 # Test the results of Export-Counter by importing the exported

--- a/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/Get-Counter.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/Get-Counter.Tests.ps1
@@ -7,11 +7,15 @@ $cmdletName = "Get-Counter"
 . "$PSScriptRoot/CounterTestHelperFunctions.ps1"
 
 $badName = "bad-name-DAD288C0-72F8-47D3-8C54-C69481B528DF"
-$counterPaths = @{
-    MemoryBytes = TranslateCounterPath "\Memory\Available Bytes"
-    TotalDiskRead = TranslateCounterPath "\PhysicalDisk(_Total)\Disk Read Bytes/sec"
-    Unknown = TranslateCounterPath "\Memory\$badName"
-    Bad = $badName
+
+if ( ! $(SkipCounterTests) ) {
+
+    $counterPaths = @{
+        MemoryBytes = TranslateCounterPath "\Memory\Available Bytes"
+        TotalDiskRead = TranslateCounterPath "\PhysicalDisk(_Total)\Disk Read Bytes/sec"
+        Unknown = TranslateCounterPath "\Memory\$badName"
+        Bad = $badName
+    }
 }
 
 $nonEnglishCulture = (-not (Get-Culture).Name.StartsWith("en-", [StringComparison]::InvariantCultureIgnoreCase))

--- a/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/Get-Counter.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/Get-Counter.Tests.ps1
@@ -8,7 +8,7 @@ $cmdletName = "Get-Counter"
 
 $badName = "bad-name-DAD288C0-72F8-47D3-8C54-C69481B528DF"
 
-if ( ! $(SkipCounterTests) ) {
+if ( $isWindows ) {
 
     $counterPaths = @{
         MemoryBytes = TranslateCounterPath "\Memory\Available Bytes"
@@ -22,7 +22,7 @@ $nonEnglishCulture = (-not (Get-Culture).Name.StartsWith("en-", [StringCompariso
 
 function ValidateParameters($testCase)
 {
-    It "$($testCase.Name)" -Skip:$(SkipCounterTests) {
+    It "$($testCase.Name)" {
 
         # build up a command
         $counterParam = ""
@@ -49,13 +49,27 @@ function ValidateParameters($testCase)
 
 Describe "CI Tests for Get-Counter cmdlet" -Tags "CI" {
 
-    It "Get-Counter with no parameters returns data for a default set of counters" -Skip:$(SkipCounterTests) {
+    BeforeAll {
+        if ( ! $IsWindows )
+        {
+            $origDefaults = $PSDefaultParameterValues.Clone()
+            $PSDefaultParameterValues['it:skip'] = $true
+        }
+    }
+
+    AfterAll {
+        if ( ! $IsWindows ){
+            $global:PSDefaultParameterValues = $origDefaults
+        }
+    }
+
+    It "Get-Counter with no parameters returns data for a default set of counters" {
         $counterData = Get-Counter
         # At the very least we should get processor and memory
         $counterData.CounterSamples.Length | should BeGreaterThan 1
     }
 
-    It "Can retrieve the specified counter" -Skip:$(SkipCounterTests) {
+    It "Can retrieve the specified counter" {
         $counterPath = $counterPaths.MemoryBytes
         $counterData = Get-Counter -Counter $counterPath
         $counterData.Length | Should Be 1
@@ -65,6 +79,20 @@ Describe "CI Tests for Get-Counter cmdlet" -Tags "CI" {
 }
 
 Describe "Feature tests for Get-Counter cmdlet" -Tags "Feature" {
+
+    BeforeAll {
+        if ( ! $IsWindows )
+        {
+            $origDefaults = $PSDefaultParameterValues.Clone()
+            $PSDefaultParameterValues['it:skip'] = $true
+        }
+    }
+
+    AfterAll {
+        if ( ! $IsWindows ){
+            $global:PSDefaultParameterValues = $origDefaults
+        }
+    }
 
     Context "Validate incorrect parameter usage" {
         $parameterTestCases = @(
@@ -171,14 +199,14 @@ Describe "Feature tests for Get-Counter cmdlet" -Tags "Feature" {
 
     Context "Get-Counter CounterSet tests" {
 
-        It "Can retrieve the specified number of counter samples" -Skip:$(SkipCounterTests) {
+        It "Can retrieve the specified number of counter samples" {
             $counterPath = $counterPaths.MemoryBytes
             $counterCount = 5
             $counterData = Get-Counter -Counter $counterPath -MaxSamples $counterCount
             $counterData.Length | Should Be $counterCount
         }
 
-        It "Can specify the sample interval" -Skip:$(SkipCounterTests) {
+        It "Can specify the sample interval" {
             $counterPath = TranslateCounterPath "\PhysicalDisk(*)\Current Disk Queue Length"
             $counterCount = 5
             $sampleInterval = 2
@@ -189,7 +217,7 @@ Describe "Feature tests for Get-Counter cmdlet" -Tags "Feature" {
             ($endTime - $startTime).TotalSeconds | Should Not BeLessThan ($counterCount * $sampleInterval)
         }
 
-        It "Can process array of counter names" -Skip:$(SkipCounterTests) {
+        It "Can process array of counter names" {
             $counterPaths = @((TranslateCounterPath "\PhysicalDisk(_Total)\Disk Read Bytes/sec"),
                               (TranslateCounterPath "\Memory\Available bytes"))
             $counterData = Get-Counter -Counter $counterPaths
@@ -198,14 +226,14 @@ Describe "Feature tests for Get-Counter cmdlet" -Tags "Feature" {
     }
 
     Context "Get-Counter ListSet tests" {
-        It "Can retrieve specified counter set" -Skip:$(SkipCounterTests) {
+        It "Can retrieve specified counter set" {
             $counterSetName = "Memory"
             $counterSet = Get-Counter -ListSet $counterSetName
             $counterSet.Length | Should Be 1
             $counterSet.CounterSetName | Should Be $counterSetName
         }
 
-        It "Can process an array of counter set names" -Skip:$(SkipCounterTests) {
+        It "Can process an array of counter set names" {
             $counterSetNames = @("Memory", "Processor")
             $counterSets = Get-Counter -ListSet $counterSetNames
             $counterSets.Length | Should Be 2

--- a/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/Import-Counter.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/Import-Counter.Tests.ps1
@@ -7,18 +7,21 @@ $cmdletName = "Import-Counter"
 
 . "$PSScriptRoot/CounterTestHelperFunctions.ps1"
 
-$counterPaths = @(
-    (TranslateCounterPath "\Memory\Available Bytes")
-    (TranslateCounterPath "\processor(*)\% Processor time")
-    (TranslateCounterPath "\Processor(_Total)\% Processor Time")
-    (TranslateCounterPath "\PhysicalDisk(_Total)\Current Disk Queue Length")
-    (TranslateCounterPath "\PhysicalDisk(_Total)\Disk Bytes/sec")
-    (TranslateCounterPath "\PhysicalDisk(_Total)\Disk Read Bytes/sec")
-)
-$setNames = @{
-    Memory = (TranslateCounterName "memory")
-    PhysicalDisk = (TranslateCounterName "physicaldisk")
-    Processor = (TranslateCounterName "processor")
+if ( ! $(SkipCounterTests) ) {
+
+    $counterPaths = @(
+        (TranslateCounterPath "\Memory\Available Bytes")
+        (TranslateCounterPath "\processor(*)\% Processor time")
+        (TranslateCounterPath "\Processor(_Total)\% Processor Time")
+        (TranslateCounterPath "\PhysicalDisk(_Total)\Current Disk Queue Length")
+        (TranslateCounterPath "\PhysicalDisk(_Total)\Disk Bytes/sec")
+        (TranslateCounterPath "\PhysicalDisk(_Total)\Disk Read Bytes/sec")
+    )
+    $setNames = @{
+        Memory = (TranslateCounterName "memory")
+        PhysicalDisk = (TranslateCounterName "physicaldisk")
+        Processor = (TranslateCounterName "processor")
+    }
 }
 
 $badSamplesBlgPath = Join-Path $PSScriptRoot "assets" "BadCounterSamples.blg"

--- a/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/Import-Counter.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/Import-Counter.Tests.ps1
@@ -7,7 +7,7 @@ $cmdletName = "Import-Counter"
 
 . "$PSScriptRoot/CounterTestHelperFunctions.ps1"
 
-if ( ! $(SkipCounterTests) ) {
+if ( $isWindows ) {
 
     $counterPaths = @(
         (TranslateCounterPath "\Memory\Available Bytes")
@@ -91,7 +91,7 @@ function ConstructCommand($testCase)
 # Run a test that is expected to succeed
 function RunTest($testCase)
 {
-    $skipTest = $testCase.SkipTest -or (SkipCounterTests)
+    $skipTest = $testCase.SkipTest -or ( ! $isWindows )
 
     It "$($testCase.Name)" -Skip:$skipTest {
 
@@ -113,7 +113,6 @@ function RunTest($testCase)
         }
 
         $cmd = ConstructCommand $testCase
-        Write-Host "Command to run: $cmd"
         $cmd = $cmd + " -ErrorAction SilentlyContinue -ErrorVariable errVar"
 
         $errVar = $null
@@ -224,7 +223,18 @@ function RunExpectedFailureTest($testCase)
 Describe "CI tests for Import-Counter cmdlet" -Tags "CI" {
 
     BeforeAll {
-        SetScriptVars $testDrive 0 $false
+        if ( ! $IsWindows )
+        {
+            $origDefaults = $PSDefaultParameterValues.Clone()
+            $PSDefaultParameterValues['it:skip'] = $true
+            SetScriptVars $testDrive 0 $false
+        }
+    }
+
+    AfterAll {
+        if ( ! $IsWindows ){
+            $global:PSDefaultParameterValues = $origDefaults
+        }
     }
 
     $performatTestCases = @(
@@ -256,13 +266,21 @@ Describe "CI tests for Import-Counter cmdlet" -Tags "CI" {
 Describe "Feature tests for Import-Counter cmdlet" -Tags "Feature" {
 
     BeforeAll {
-        SetScriptVars $testDrive 25 $true
+        if ( ! $IsWindows )
+        {
+            $origDefaults = $PSDefaultParameterValues.Clone()
+            $PSDefaultParameterValues['it:skip'] = $true
+            SetScriptVars $testDrive 25 $true
+        }
     }
 
     AfterAll {
-        Remove-Item $script:blgPath -Force -ErrorAction SilentlyContinue
-        Remove-Item $script:csvPath -Force -ErrorAction SilentlyContinue
-        Remove-Item $script:tsvPath -Force -ErrorAction SilentlyContinue
+        if ( ! $IsWindows ){
+            $global:PSDefaultParameterValues = $origDefaults
+            Remove-Item $script:blgPath -Force -ErrorAction SilentlyContinue
+            Remove-Item $script:csvPath -Force -ErrorAction SilentlyContinue
+            Remove-Item $script:tsvPath -Force -ErrorAction SilentlyContinue
+        }
     }
 
     Context "Validate incorrect usage" {


### PR DESCRIPTION
Errors in Travis CI log is `Get-ItemProperty : Cannot find a provider with the name 'Registry'.`
(Get-Counter, Import-Counter and Export-Counter is only Windows cmdlets.)
