### PR TITLE
Code coverage automation script

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -75,6 +75,7 @@ nunit
 exe
 init
 labeled
+toolset
  - demos/Azure/README.md
 alpha.12
 AzureRM.NetCore.Preview
@@ -725,3 +726,15 @@ shebang
  - CHANGELOG.md
 v6.0.0
 alpha.13
+ - test/tools/CodeCoverageAutomation/README.md
+Start-CodeCoverageRun
+Coveralls.io.
+v5.0
+v6.0.
+CodeCoverage.zip
+OpenCover.zip
+tests.zip
+Coveralls.net
+powershell.version
+csmacnz
+Coveralls.exe

--- a/test/tools/CodeCoverageAutomation/README.md
+++ b/test/tools/CodeCoverageAutomation/README.md
@@ -1,0 +1,23 @@
+# Code Coverage Automation
+
+The script Start-CodeCoverageRun.ps1 automates the execution of tests and uploading the results to Coveralls.io.
+
+The script is self contained and can be executed on any Windows system which supports Powershell v5.0 or above. It has not been tested on Powershell v6.0.
+
+## Execution
+
+The virtual machine hosting the script, has a scheduled task to start the tests at 5 am PDT. 
+
+The script follows the steps below:
+
+1. Download the code coverage binaries package from AppVeyor nightly builds artifacts (CodeCoverage.zip). 
+2. Download the OpenCover powershell module from AppVeyor nightly builds artifacts. (OpenCover.zip)
+3. Download the tests from AppVeyor nightly builds artifacts (tests.zip) 
+4. Download Coveralls.net from 'https://github.com/csMACnz/coveralls.net/releases/download/0.7.0/coveralls.net.0.7.0.nupkg'
+5. Invoke 'Install-OpenCover' to install OpenCover toolset.
+6. Invoke 'Invoke-OpenCover' to execute tests.
+7. Get git commit ID from powershell.version file from the downloaded daily build package.
+8. Using the commit ID get commiter info like, message, author and email using the github REST API.
+9. Invoke 'csmacnz.Coveralls.exe' to upload the coverage results to Coveralls.net
+
+The uploaded coverage data can be viewed at: https://coveralls.io/github/PowerShell/PowerShell

--- a/test/tools/CodeCoverageAutomation/README.md
+++ b/test/tools/CodeCoverageAutomation/README.md
@@ -17,7 +17,7 @@ The script follows the steps below:
 5. Invoke 'Install-OpenCover' to install OpenCover toolset.
 6. Invoke 'Invoke-OpenCover' to execute tests.
 7. Get git commit ID from powershell.version file from the downloaded daily build package.
-8. Using the commit ID get commiter info like, message, author and email using the github REST API.
+8. Using the commit ID get committer info like, message, author and email using the github REST API.
 9. Invoke 'csmacnz.Coveralls.exe' to upload the coverage results to Coveralls.net
 
 The uploaded coverage data can be viewed at: https://coveralls.io/github/PowerShell/PowerShell

--- a/test/tools/CodeCoverageAutomation/README.md
+++ b/test/tools/CodeCoverageAutomation/README.md
@@ -6,7 +6,7 @@ The script is self contained and can be executed on any Windows system which sup
 
 ## Execution
 
-The virtual machine hosting the script, has a scheduled task to start the tests at 5 am PDT. 
+The virtual machine hosting the script has a scheduled task to start the tests at 5 am PDT. 
 
 The script follows the steps below:
 
@@ -16,7 +16,7 @@ The script follows the steps below:
 4. Download Coveralls.net from 'https://github.com/csMACnz/coveralls.net/releases/download/0.7.0/coveralls.net.0.7.0.nupkg'
 5. Invoke 'Install-OpenCover' to install OpenCover toolset.
 6. Invoke 'Invoke-OpenCover' to execute tests.
-7. Get git commit ID from powershell.version file from the downloaded daily build package.
+7. Invoke powershell to get the git commit ID of the downloaded daily build package.
 8. Using the commit ID get committer info like, message, author and email using the github REST API.
 9. Invoke 'csmacnz.Coveralls.exe' to upload the coverage results to Coveralls.net
 

--- a/test/tools/CodeCoverageAutomation/Start-CodeCoverageRun.ps1
+++ b/test/tools/CodeCoverageAutomation/Start-CodeCoverageRun.ps1
@@ -49,9 +49,9 @@ try
 
     Write-LogPassThru -Message "Starting expansion."
 
-    Expand-Archive -path "$outputBaseFolder\PSCodeCoverage.zip" -destinationpath "$psBinPath"
-    Expand-Archive -path "$outputBaseFolder\tests.zip" -destinationpath $testPath
-    Expand-Archive -path "$outputBaseFolder\OpenCover.zip" -destinationpath $openCoverPath
+    Expand-Archive -path "$outputBaseFolder\PSCodeCoverage.zip" -destinationpath "$psBinPath" -Force
+    Expand-Archive -path "$outputBaseFolder\tests.zip" -destinationpath $testPath -Force
+    Expand-Archive -path "$outputBaseFolder\OpenCover.zip" -destinationpath $openCoverPath -Force
 
     ## Download Coveralls.net uploader
     $coverallsToolsUrl = 'https://github.com/csMACnz/coveralls.net/releases/download/0.7.0/coveralls.net.0.7.0.nupkg'
@@ -59,7 +59,7 @@ try
 
     ## Saving the nupkg as zip so we can expand it.
     Invoke-WebRequest $coverallsToolsUrl -outfile "$outputBaseFolder\coveralls.zip"
-    Expand-Archive -Path "$outputBaseFolder\coveralls.zip" -DestinationPath $coverallsPath
+    Expand-Archive -Path "$outputBaseFolder\coveralls.zip" -DestinationPath $coverallsPath -Force
 
     Write-LogPassThru -Message "Expansion complete."
 
@@ -89,7 +89,7 @@ try
 
     Write-LogPassThru -Message "Test run done."
 
-    $gitCommitId = & "$psBinPath\publish\powershell.exe" -noprofile -command $PSVersiontable.GitCommitId  
+    $gitCommitId = & "$psBinPath\publish\powershell.exe" -noprofile -command { $PSVersiontable.GitCommitId }
     $commitId = $gitCommitId.substring($gitCommitId.LastIndexOf('-g') + 2)
 
     Write-LogPassThru -Message $commitId

--- a/test/tools/CodeCoverageAutomation/Start-CodeCoverageRun.ps1
+++ b/test/tools/CodeCoverageAutomation/Start-CodeCoverageRun.ps1
@@ -116,6 +116,8 @@ try
     Write-LogPassThru -Message $coverallsParams
 
     & $coverallsExe """$coverallsParams"""
+
+    Write-LogPassThru -Message "Upload complete."
 }
 catch
 {

--- a/test/tools/CodeCoverageAutomation/Start-CodeCoverageRun.ps1
+++ b/test/tools/CodeCoverageAutomation/Start-CodeCoverageRun.ps1
@@ -77,7 +77,7 @@ try
                          PowerShellExeDirectory = "$psBinPath\publish"
                         }
 
-    Write-LogPassThru -Message $openCoverParams
+    $openCoverParams | Out-String | Write-LogPassThru
     Write-LogPassThru -Message "Starting test run."
 
     Invoke-OpenCover @openCoverParams

--- a/test/tools/CodeCoverageAutomation/Start-CodeCoverageRun.ps1
+++ b/test/tools/CodeCoverageAutomation/Start-CodeCoverageRun.ps1
@@ -1,0 +1,109 @@
+﻿$codeCoverageZip = 'https://ci.appveyor.com/api/projects/PowerShell/powershell-f975h/artifacts/CodeCoverage.zip'
+$testContentZip = 'https://ci.appveyor.com/api/projects/PowerShell/powershell-f975h/artifacts/tests.zip'
+$openCoverZip = 'https://ci.appveyor.com/api/projects/PowerShell/powershell-f975h/artifacts/OpenCover.zip'
+
+
+New-Item "$PSScriptRoot\logs.txt"  -Force
+"codeCoverageZip: $codeCoverageZip" | Tee-Object -FilePath "$PSScriptRoot\logs.txt" -Append
+"testcontentZip: $testContentZip" | Tee-Object -FilePath "$PSScriptRoot\logs.txt" -Append
+"openCoverZip: $openCoverZip" | Tee-Object -FilePath "$PSScriptRoot\logs.txt" -Append
+
+$outputBaseFolder = "$env:Temp\CC"
+$null = New-Item -ItemType Directory -Path $outputBaseFolder -Force
+
+$openCoverPath = "$outputBaseFolder\OpenCover"
+$testPath = "$outputBaseFolder\tests"
+$psBinPath = "$outputBaseFolder\PSCodeCoverage"
+$openCoverTargetDirectory = "$outputBaseFolder\OpenCoverToolset"
+$outputLog = "$outputBaseFolder\CodeCoverageOutput.xml"
+$psCodeZip = "$outputBaseFolder\PSCode.zip"
+$psCodePath = "$outputBaseFolder\PSCode"
+
+try
+{
+    "Starting downloads." | Tee-Object -FilePath "$PSScriptRoot\logs.txt" -Append
+
+    Invoke-WebRequest -uri $codeCoverageZip -outfile "$outputBaseFolder\PSCodeCoverage.zip"
+    Invoke-WebRequest $testContentZip -outfile "$outputBaseFolder\tests.zip"
+    Invoke-WebRequest $openCoverZip -outfile "$outputBaseFolder\OpenCover.zip"
+
+    "Downloads complete." | Tee-Object -FilePath "$PSScriptRoot\logs.txt" -Append
+
+    "Starting expansion." | Tee-Object -FilePath "$PSScriptRoot\logs.txt" -Append
+
+    Expand-Archive -path "$outputBaseFolder\PSCodeCoverage.zip" -destinationpath "$psBinPath"
+    Expand-Archive -path "$outputBaseFolder\tests.zip" -destinationpath $testPath
+    Expand-Archive -path "$outputBaseFolder\OpenCover.zip" -destinationpath $openCoverPath
+
+    ## Download Coveralls.net uploader
+    $coverallsToolsUrl = 'https://github.com/csMACnz/coveralls.net/releases/download/0.7.0/coveralls.net.0.7.0.nupkg'
+    $coverallsPath = "$outputBaseFolder\coveralls"
+
+    ## Saving the nupkg as zip so we can expand it.
+    Invoke-WebRequest $coverallsToolsUrl -outfile "$outputBaseFolder\coveralls.zip"
+    Expand-Archive -Path "$outputBaseFolder\coveralls.zip" -DestinationPath $coverallsPath
+
+    "Expansion complete." | Tee-Object -FilePath "$PSScriptRoot\logs.txt" -Append
+
+    Import-Module "$openCoverPath\OpenCover" -force
+    Install-OpenCover -TargetDirectory $openCoverTargetDirectory -force
+    "OpenCover installed." | Tee-Object -FilePath "$PSScriptRoot\logs.txt" -Append
+
+    "TestDirectory : $testPath" | Tee-Object -FilePath "$PSScriptRoot\logs.txt" -Append
+    "openCoverPath : $openCoverTargetDirectory\OpenCover" | Tee-Object -FilePath "$PSScriptRoot\logs.txt" -Append
+    "psbinpath : $psBinPath" | Tee-Object -FilePath "$PSScriptRoot\logs.txt" -Append
+
+    $openCoverParams = @{outputlog = $outputLog;
+                         TestDirectory = $testPath;
+                         OpenCoverPath = "$openCoverTargetDirectory\OpenCover";
+                         PowerShellExeDirectory = "$psBinPath\publish"
+                        }
+
+    $openCoverParams | Tee-Object -FilePath "$PSScriptRoot\logs.txt" -Append
+
+    "Starting test run." | Tee-Object -FilePath "$PSScriptRoot\logs.txt" -Append
+
+    Invoke-OpenCover @openCoverParams
+
+    if(Test-Path $outputLog)
+    {
+        get-childitem $outputLog | Tee-Object -FilePath "$PSScriptRoot\logs.txt" -Append
+    }
+
+    "Test run done.!!" | Tee-Object -FilePath "$PSScriptRoot\logs.txt" -Append
+
+    $powershellVersionString = (Get-Content "$psBinPath\publish\powershell.version")
+    $commitId = $powershellVersionString.Substring($powershellVersionString.LastIndexOf('-g') + 2)
+    $commitId | Add-Content -Path "$PSScriptRoot\logs.txt"
+
+    $coverallsPath = "$outputBaseFolder\coveralls"
+    $coverallsToken = 'SaRLabTUDNqaO2JT9uuYcR78a7kia044D'
+
+    $commitInfo = Invoke-RestMethod -Method Get "https://api.github.com/repos/powershell/powershell/git/commits/$commitId"
+    $message = ($commitInfo.message).replace("`n", " ")
+    $author = $commitInfo.author.name
+    $email = $commitInfo.author.email
+
+    $coverallsExe = Join-Path $coverallsPath "tools\csmacnz.Coveralls.exe"
+    $coverallsParams = @("--opencover",
+                        "-i $outputLog",
+                        "--repoToken $coverallsToken",
+                        "--commitId $commitId",
+                        "--commitBranch master",
+                        "--commitAuthor `"$author`"",
+                        "--commitEmail $email",
+                        "--commitMessage `"$message`""
+                        )
+
+    $coverallsParams | Add-Content -Path "$PSScriptRoot\logs.txt"
+
+    & $coverallsExe """$coverallsParams"""
+}
+catch
+{
+    $_
+}
+finally
+{
+    Remove-Item -recurse -force -path $outputBaseFolder
+}


### PR DESCRIPTION
This script downloads the latest nightly build package and executes the
tests on it. It also downloads all necessary tools and then uploads the
results to Coveralls.io. The badge for coverage is posted on README.md