### PR TITLE
Treat unbound command parameters as command arguments

### DIFF
--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -566,10 +566,11 @@ namespace System.Management.Automation
 
             PseudoBindingInfo pseudoBinding = new PseudoParameterBinder()
                                                 .DoPseudoParameterBinding(commandAst, null, parameterAst, PseudoParameterBinder.BindingType.ParameterCompletion);
-            // The command cannot be found or it's not a cmdlet, not a script cmdlet, not a function
+            // The command cannot be found or it's not a cmdlet, not a script cmdlet, not a function.
+            // Try completing as if it the parameter is a command argument for native command completion.
             if (pseudoBinding == null)
             {
-                return result;
+                return CompleteCommandArgument(context);
             }
 
             switch (pseudoBinding.InfoType)

--- a/test/powershell/Language/Parser/ExtensibleCompletion.Tests.ps1
+++ b/test/powershell/Language/Parser/ExtensibleCompletion.Tests.ps1
@@ -229,6 +229,38 @@ Describe "Test extensible completion of native commands" -Tags "CI" {
     } | Get-CompletionTestCaseData | Test-Completions
 }
 
+Describe "Test completion of parameters for native commands" -Tags "CI" {
+    Register-ArgumentCompleter -Native -CommandName foo -ScriptBlock {
+        Param($wordToComplete)
+
+        @("-dir", "-verbose", "-help", "-version") |
+        Where-Object {
+            $_ -match "$wordToComplete*"
+        } |
+        ForEach-Object {
+            [CompletionResult]::new($_, $_, [CompletionResultType]::ParameterName, $_)
+        }
+    }
+
+    @{
+        ExpectedResults = @(
+            @{CompletionText = "-version"; ResultType = "ParameterName"}
+            @{CompletionText = "-verbose"; ResultType = "ParameterName"}
+            @{CompletionText = "-dir"; ResultType = "ParameterName"}
+            @{CompletionText = "-help"; ResultType = "ParameterName"}
+        )
+        TestInput = 'foo -'
+    } | Get-CompletionTestCaseData | Test-Completions
+
+    @{
+        ExpectedResults = @(
+            @{CompletionText = "-version"; ResultType = "ParameterName"}
+            @{CompletionText = "-verbose"; ResultType = "ParameterName"}
+        )
+        TestInput = 'foo -v'
+    } | Get-CompletionTestCaseData | Test-Completions
+}
+
 Describe "Test extensible completion of using namespace" -Tags "CI" {
     @{
         ExpectedResults = @(


### PR DESCRIPTION
This addresses some of the problems reported in Issue #2912. It fixes native tab completion for tokens that begin with a single "Dash" (defined by CharTraits.IsDash), but it does not fix native tab completion for the '--' token.