### PR TITLE
Add support for escape char ESC via `e. 

### DIFF
--- a/src/System.Management.Automation/engine/parser/tokenizer.cs
+++ b/src/System.Management.Automation/engine/parser/tokenizer.cs
@@ -1236,6 +1236,7 @@ namespace System.Management.Automation.Language
                 case '0': return '\0';
                 case 'a': return '\a';
                 case 'b': return '\b';
+                case 'e': return '\u001b';
                 case 'f': return '\f';
                 case 'n': return '\n';
                 case 'r': return '\r';

--- a/test/powershell/Language/Parser/Parser.Tests.ps1
+++ b/test/powershell/Language/Parser/Parser.Tests.ps1
@@ -8,10 +8,10 @@ Describe "ParserTests (admin\monad\tests\monad\src\engine\core\ParserTests.cs)" 
 			param (
 			[Parameter(Position = 0)]
 			[string] $Property1 = "unset",
-			
+
 			[Parameter(Position = 1)]
 			[string] $Property2 = "unset",
-			
+
 			[Parameter(Position = 2)]
 			[string] $Property3 = "unset",
 
@@ -21,55 +21,55 @@ Describe "ParserTests (admin\monad\tests\monad\src\engine\core\ParserTests.cs)" 
 			)
 
 			BEGIN {}
-			
+
 			PROCESS {
 				if ( ! $ReturnType ) {
 					$ReturnType = "default"
 				}
-				
+
 				switch ( $ReturnType )
 				{
-					"default" { 
+					"default" {
 						$result = "$Property1;$Property2;$Property3"
 						break
 					}
-					"array" { 
+					"array" {
 						$result = 1,2,3
 						break
 					}
-					"object" { 
+					"object" {
 						$result = new-object psobject
 						break
 					}
-					"nestedobject" { 
+					"nestedobject" {
 						$result = [pscustomobject]@{Name="John";Person=[pscustomobject]@{Name="John";Age=30}}
 						break
 					}
-					"struct" { 
+					"struct" {
 						$result = [pscustomobject]@{Name="John";Age=30}
 						break
 					}
-					"mshobject" { 
+					"mshobject" {
 						$result = new-object psobject
 						break
 					}
-					"nulltostring" { 
+					"nulltostring" {
 						$result = $null
 						break
 					}
-					default { 
+					default {
 						throw ([invalidoperationexception]::new("ReturnType parameter wasn't of any Expected value!"))
-						break 
+						break
 					}
 				}
 				return $result
 			}
-	
+
 			END {}
 		}
 '@
 		$functionDefinition>$functionDefinitionFile
-		
+
         $PowerShell = [powershell]::Create()
         function ExecuteCommand {
             param ([string]$command)
@@ -128,24 +128,24 @@ Describe "ParserTests (admin\monad\tests\monad\src\engine\core\ParserTests.cs)" 
 			Remove-Item $testfolder1
 		}
     }
-	
+
 	AfterAll {
 		if(Test-Path $functionDefinitionFile)
 		{
 			Remove-Item $functionDefinitionFile
 		}
 	}
-	
+
 	It "Throws a syntax error when parsing a string without a closing quote. (line 164)" {
 		try {
-            ExecuteCommand '"This is a test' 
+            ExecuteCommand '"This is a test'
             throw "Execution OK"
         }
         catch {
             $_.FullyQualifiedErrorId | Should be "IncompleteParseException"
         }
 	}
-	
+
 	It "Throws an error if an open parenthesis is not closed (line 176)" {
         try {
             ExecuteCommand "("
@@ -155,7 +155,7 @@ Describe "ParserTests (admin\monad\tests\monad\src\engine\core\ParserTests.cs)" 
             $_.FullyQualifiedErrorId | should be "IncompleteParseException"
         }
     }
-	
+
     It "Throws an exception if the the first statement starts with an empty pipe element (line 188)" {
         try {
             ExecuteCommand "| get-location"
@@ -165,13 +165,13 @@ Describe "ParserTests (admin\monad\tests\monad\src\engine\core\ParserTests.cs)" 
             $_.FullyQualifiedErrorId | should be "ParseException"
         }
     }
-	
+
 	It "Throws an CommandNotFoundException exception if using a label in front of an if statement is not allowed. (line 225)"{
         ExecuteCommand ":foo if ($x -eq 3) { 1 }"
 		$PowerShell.HadErrors | should be $true
         $PowerShell.Streams.Error.FullyQualifiedErrorId | should be "CommandNotFoundException"
     }
-	
+
 	It "Pipe an expression into a value expression. (line 237)" {
         try {
             ExecuteCommand "testcmd-parserbvt | 3"
@@ -180,7 +180,7 @@ Describe "ParserTests (admin\monad\tests\monad\src\engine\core\ParserTests.cs)" 
         catch {
             $_.FullyQualifiedErrorId | should be "ParseException"
         }
-		
+
 		try {
             ExecuteCommand "testcmd-parserbvt | $(1 + 1)"
             throw "Execution OK"
@@ -188,7 +188,7 @@ Describe "ParserTests (admin\monad\tests\monad\src\engine\core\ParserTests.cs)" 
         catch {
             $_.FullyQualifiedErrorId | should be "ParseException"
         }
-		
+
 		try {
             ExecuteCommand "testcmd-parserbvt | 'abc'"
             throw "Execution OK"
@@ -209,67 +209,72 @@ Describe "ParserTests (admin\monad\tests\monad\src\engine\core\ParserTests.cs)" 
             }
         }
     }
-	
+
 	It "Throws an incomplete parse exception when a comma follows an expression (line 247)" {
         try {
-            ExecuteCommand "(1+ 1)," 
+            ExecuteCommand "(1+ 1),"
             throw "Execution OK"
         }
         catch {
             $_.FullyQualifiedErrorId | Should be "IncompleteParseException"
         }
     }
-	
-		
+
+
 	It "Test that invoke has a higher precedence for a script than for an executable. (line 279)" {
 		"1">$testfile
         $result = ExecuteCommand ". $testfile"
 		$result | should be 1
     }
-	
+
 	It "This test will check that a path is correctly interpreted when using '..' and '.'  (line 364)" {
         $result = ExecuteCommand "set-location $TestDrive; get-childitem dir1\.\.\.\..\dir1\.\dir2\..\..\dir1\.\dir2"
 		$result.Count | should be 2
 		$result[0].Name | should be "testdirfile1.txt"
 		$result[1].Name | should be "testdirfile2.txt"
     }
-	
+
 	It "This test will check that the parser can handle a mix of forward slashes and back slashes in the path (line 417)" {
         $result = ExecuteCommand "get-childitem $TestDrive/dir1/./.\.\../dir1/.\dir2\../..\dir1\.\dir2"
 		$result.Count | should be 2
 		$result[0].Name | should be "testdirfile1.txt"
 		$result[1].Name | should be "testdirfile2.txt"
     }
-	
+
 	It "This test checks that the asterisk globs as expected. (line 545)" {
         $result = ExecuteCommand "get-childitem $TestDrive/dir1\dir2\*.txt"
 		$result.Count | should be 2
 		$result[0].Name | should be "testdirfile1.txt"
 		$result[1].Name | should be "testdirfile2.txt"
     }
-	
+
 	It "This test checks that we can use a range for globbing: [1-2] (line 557)" {
         $result = ExecuteCommand "get-childitem $TestDrive/dir1\dir2\testdirfile[1-2].txt"
 		$result.Count | should be 2
 		$result[0].Name | should be "testdirfile1.txt"
 		$result[1].Name | should be "testdirfile2.txt"
     }
-	
+
 	It "This test will check that escaping the $ sigil inside single quotes simply returns the $ character. (line 583)" {
         $result = ExecuteCommand "'`$'"
 		$result | should be "`$"
     }
-	
+
 	It "Test that escaping a space just returns that space. (line 593)" {
         $result = ExecuteCommand '"foo` bar"'
 		$result | should be "foo bar"
     }
-	
+
+    It "Test that escaping the character 'e' returns the ESC character (0x1b)." {
+        $result = ExecuteCommand '"`e"'
+        $result | should be ([char]0x1b)
+    }
+
 	It "Test that escaping any character with no special meaning just returns that char. (line 602)" {
         $result = ExecuteCommand '"fo`obar"'
 		$result | should be "foobar"
     }
-	
+
 	Context "Test that we support all of the C# escape sequences. We use the ` instead of \. (line 613)" {
 		# the first two sequences are tricky, because we need to provide something to
 		# execute without causing an incomplete parse error
@@ -293,26 +298,26 @@ Describe "ParserTests (admin\monad\tests\monad\src\engine\core\ParserTests.cs)" 
 		}
     }
 
-	
+
 	It "This test checks that array substitution occurs inside double quotes. (line 646)" {
         $result = ExecuteCommand '$MyArray = "a","b";"Hello $MyArray"'
 		$result | should be "Hello a b"
     }
-	
+
 	It "This tests declaring an array in nested variable tables. (line 761)" {
         $result = ExecuteCommand "`$Variable:vtbl1:vtbl2:b=@(5,6);`$Variable:vtbl1:vtbl2:b"
 		$result.Count | should be 2
 		$result[0] | should be 5
 		$result[1] | should be 6
     }
-	
+
 	It "Test a simple multiple assignment. (line 773)" {
         $result = ExecuteCommand '$one,$two = 1,2,3; "One = $one"; "Two = $two"'
 		$result.Count | should be 2
 		$result[0] | should be "One = 1"
 		$result[1] | should be "Two = 2 3"
     }
-	
+
 	It "Tests script, global and local scopes from a function inside a script. (line 824)" {
 		"`$var = 'script';function func { `$var; `$var = 'local'; `$local:var; `$script:var; `$global:var };func;`$var;">$testfile
 		ExecuteCommand "`$var = 'global'"
@@ -324,10 +329,10 @@ Describe "ParserTests (admin\monad\tests\monad\src\engine\core\ParserTests.cs)" 
 		$result[3] | should be "global"
 		$result[4] | should be "script"
     }
-	
+
 	It "Use break inside of a loop that is inside another loop. (line 945)" {
-		$commands = " while (1) { 1; while(1) { 2; break; 3; }; 4; break; 5;  } ", 
-                " for (;;) { 1; for(;;) { 2; break; 3; }; 4; break; 5; } ", 
+		$commands = " while (1) { 1; while(1) { 2; break; 3; }; 4; break; 5;  } ",
+                " for (;;) { 1; for(;;) { 2; break; 3; }; 4; break; 5; } ",
                 " foreach(`$a in 1,2,3) { 1; foreach( `$b in 1,2,3 ) { 2; break; 3; }; 4; break; 5; } "
 		$results = "1", "2", "4"
         $i = 0
@@ -337,10 +342,10 @@ Describe "ParserTests (admin\monad\tests\monad\src\engine\core\ParserTests.cs)" 
 			$result | should be $results
 		}
     }
-	
+
 	It "Use break in two loops with same label. (line 967)" {
-		$commands = " :foo while (1) { 1; :foo while(1) { 2; break foo; 3; }; 4; break; 5;  } ", 
-                " :foo for (;;) { 1; :foo for(;;) { 2; break foo; 3; }; 4; break; 5; } ", 
+		$commands = " :foo while (1) { 1; :foo while(1) { 2; break foo; 3; }; 4; break; 5;  } ",
+                " :foo for (;;) { 1; :foo for(;;) { 2; break foo; 3; }; 4; break; 5; } ",
                 " :foo foreach(`$a in 1,2,3) { 1; :foo foreach( `$b in 1,2,3 ) { 2; break foo; 3; }; 4; break; 5; } "
 		$results = "1", "2", "4"
         $i = 0
@@ -350,10 +355,10 @@ Describe "ParserTests (admin\monad\tests\monad\src\engine\core\ParserTests.cs)" 
 			$result | should be $results
 		}
     }
-	
+
 	It "Try continue inside of different loop statements. (line 1039)" {
-		$commands = " `$a = 0; while (`$a -lt 2) { `$a; `$a += 1; continue; 2; } ", 
-                " for (`$a = 0;`$a -lt 2; `$a += 1) { 9; continue; 3; } ", 
+		$commands = " `$a = 0; while (`$a -lt 2) { `$a; `$a += 1; continue; 2; } ",
+                " for (`$a = 0;`$a -lt 2; `$a += 1) { 9; continue; 3; } ",
                 " foreach(`$a in 0,1) { `$a; continue; 2; } "
 		$result = ExecuteCommand $commands[0]
 		$result | should be "0", "1"
@@ -362,10 +367,10 @@ Describe "ParserTests (admin\monad\tests\monad\src\engine\core\ParserTests.cs)" 
 		$result = ExecuteCommand $commands[2]
 		$result | should be "0", "1"
     }
-	
+
 	It "Use a label to continue an inner loop. (line 1059)" {
-		$commands = " `$x = 0; while (`$x -lt 1) { `$x += 1; `$x; `$a = 0; :foo while(`$a -lt 2) { `$a += 1; `$a; continue foo; 3; }; 4; continue; 5;  } ", 
-                " for (`$x = 0;`$x -lt 1;`$x += 1) { 1; :foo for(`$a = 0; `$a -lt 2; `$a += 1) { `$a; continue foo; 3; }; 4; continue; 5; } ", 
+		$commands = " `$x = 0; while (`$x -lt 1) { `$x += 1; `$x; `$a = 0; :foo while(`$a -lt 2) { `$a += 1; `$a; continue foo; 3; }; 4; continue; 5;  } ",
+                " for (`$x = 0;`$x -lt 1;`$x += 1) { 1; :foo for(`$a = 0; `$a -lt 2; `$a += 1) { `$a; continue foo; 3; }; 4; continue; 5; } ",
                 " foreach(`$a in 1) { 1; :foo foreach( `$b in 1,2 ) { `$b; continue foo; 3; }; 4; continue; 5; } "
 		$result = ExecuteCommand $commands[0]
 		$result | should be "1", "1", "2", "4"
@@ -374,10 +379,10 @@ Describe "ParserTests (admin\monad\tests\monad\src\engine\core\ParserTests.cs)" 
 		$result = ExecuteCommand $commands[2]
 		$result | should be "1", "1", "2", "4"
     }
-	
+
 	It "Use continue with a label on a nested loop. (line 1059)" {
-		$commands = " `$x = 0; :foo while (`$x -lt 2) { `$x; `$x += 1; :bar while(1) { 2; continue foo; 3; }; 4; continue; 5;  } ", 
-                " :foo for (`$x = 0;`$x -lt 2;`$x += 1) { 1; :bar for(;;) { 2; continue foo; 3; }; 4; continue; 5; } ", 
+		$commands = " `$x = 0; :foo while (`$x -lt 2) { `$x; `$x += 1; :bar while(1) { 2; continue foo; 3; }; 4; continue; 5;  } ",
+                " :foo for (`$x = 0;`$x -lt 2;`$x += 1) { 1; :bar for(;;) { 2; continue foo; 3; }; 4; continue; 5; } ",
                 " :foo foreach(`$a in 1,2) { 1; :bar foreach( `$b in 1,2,3 ) { 2; continue foo; 3; }; 4; continue; 5; } "
 		$result = ExecuteCommand $commands[0]
 		$result | should be "0", "2", "1", "2"
@@ -386,136 +391,136 @@ Describe "ParserTests (admin\monad\tests\monad\src\engine\core\ParserTests.cs)" 
 		$result = ExecuteCommand $commands[2]
 		$result | should be "1", "2", "1", "2"
     }
-	
+
 	It "This test will check that it is a syntax error to use if without a code block. (line 1141)" {
         try {
-            ExecuteCommand 'if ("true")' 
+            ExecuteCommand 'if ("true")'
             throw "Execution OK"
         }
         catch {
             $_.FullyQualifiedErrorId | Should be "IncompleteParseException"
         }
     }
-	
+
 	It "This test will check that it is a syntax error if the if condition is not complete. (line 1150)" {
         try {
-            ExecuteCommand 'if (' 
+            ExecuteCommand 'if ('
             throw "Execution OK"
         }
         catch {
             $_.FullyQualifiedErrorId | Should be "IncompleteParseException"
         }
     }
-	
+
 	It "This test will check that it is a syntax error to have an if condition without parentheses. (line 1159)" {
         try {
-            ExecuteCommand 'if "true" { 1} else {2}' 
+            ExecuteCommand 'if "true" { 1} else {2}'
             throw "Execution OK"
         }
         catch {
             $_.FullyQualifiedErrorId | Should be "ParseException"
         }
     }
-	
+
 	It "This test will check that the parser throws a syntax error when the if condition is missing the closing parentheses. (line 1168)" {
         try {
-            ExecuteCommand 'if ("true"  { 1};' 
+            ExecuteCommand 'if ("true"  { 1};'
             throw "Execution OK"
         }
         catch {
             $_.FullyQualifiedErrorId | Should be "ParseException"
         }
     }
-	
+
 	It "This test will check that it is a syntax error to have an else keyword without the corresponding code block. (line 1177)" {
         try {
-            ExecuteCommand 'if ("true") {1} else' 
+            ExecuteCommand 'if ("true") {1} else'
             throw "Execution OK"
         }
         catch {
             $_.FullyQualifiedErrorId | Should be "IncompleteParseException"
         }
     }
-	
+
 	It "This test will check that the parser throws a syntax error when a foreach loop is not complete. (line 1238)" {
         try {
-            ExecuteCommand '$count=0;$files = $(get-childitem / -filter *.txt );foreach ($i ;$count' 
+            ExecuteCommand '$count=0;$files = $(get-childitem / -filter *.txt );foreach ($i ;$count'
             throw "Execution OK"
         }
         catch {
             $_.FullyQualifiedErrorId | Should be "ParseException"
         }
     }
-	
+
 	It "This test will check that the parser throws a syntax error if the foreach loop is not complete. (line 1248)" {
         try {
-            ExecuteCommand '$count=0;$files = $(get-childitem / -filter *.txt );foreach ($i in ;$count' 
+            ExecuteCommand '$count=0;$files = $(get-childitem / -filter *.txt );foreach ($i in ;$count'
             throw "Execution OK"
         }
         catch {
             $_.FullyQualifiedErrorId | Should be "ParseException"
         }
     }
-	
+
 	It "This will test that the parser throws a syntax error if the foreach loop is missing a closing parentheses. (line 1258)" {
         try {
-            ExecuteCommand '$count=0;$files = $(get-childitem / -filter *.txt );foreach ($i in $files ;$count' 
+            ExecuteCommand '$count=0;$files = $(get-childitem / -filter *.txt );foreach ($i in $files ;$count'
             throw "Execution OK"
         }
         catch {
             $_.FullyQualifiedErrorId | Should be "ParseException"
         }
     }
-	
+
 	It "Test that if an exception is thrown from the try block it will be caught in the appropropriate catch block and that the finally block will run regardless of whether an exception is thrown. (line 1317)" {
         $result = ExecuteCommand 'try { try { throw (new-object System.ArgumentException) } catch [System.DivideByZeroException] { } finally { "Finally" } } catch { $_.Exception.GetType().FullName }'
 		$result | should be "Finally", "System.ArgumentException"
     }
-	
+
 	It "Test that null can be passed to a method that expects a reference type. (line 1439)" {
         $result = ExecuteCommand '$test = "String";$test.CompareTo($())'
 		$result | should be 1
     }
-	
+
 	It "Tests that command expansion operators can be used as a parameter to an object method. (line 1507)" {
         $result = ExecuteCommand '$test = "String";$test.SubString($("hello" | foreach-object { $_.length - 2 } ))'
 		$result | should be "ing"
     }
-	
+
 	It "Test that & can be used as a parameter as long as it is quoted. (line 1606)" {
         $result = ExecuteCommand 'testcmd-parserbvt `&get-childitem'
 		$result | should be "&get-childitem;unset;unset"
 		$result = ExecuteCommand 'testcmd-parserbvt `&*'
 		$result | should be "&*;unset;unset"
     }
-	
+
 	It "Run a command with parameters. (line 1621)" {
         $result = ExecuteCommand 'testcmd-parserBVT -Property1 set'
 		$result | should be "set;unset;unset"
     }
-	
+
 	It "Test that typing a number at the command line will return that number. (line 1630)" {
         $result = ExecuteCommand '3'
 		$result | should be "3"
-		$result.gettype() |should be ([int]) 
+		$result.gettype() |should be ([int])
     }
-	
+
 	It "This test will check that an msh script can be run without invoking. (line 1641)" {
         "1">$testfile
         $result = ExecuteCommand ". $testfile"
 		$result | should be 1
     }
-	
+
 	It "Test that an alias is resolved before a function. (line 1657)" {
         $result = ExecuteCommand 'set-alias parserInvokeTest testcmd-parserBVT;function parserInvokeTest { 3 };parserInvokeTest'
 		$result | should be "unset;unset;unset"
     }
-	
+
 	It "Test that functions are resolved before cmdlets. (line 1678)"{
         $result = ExecuteCommand 'function testcmd-parserBVT { 3 };testcmd-parserBVT'
 		$result | should be "3"
     }
-	
+
 	It "Check that a command that uses shell execute can be run from the command line and that no exception is thrown. (line 1702)" {
 		if ( $IsLinux -or $IsOSX ) {
             # because we execute on *nix based on executable bit, and the file name doesn't matter
@@ -528,7 +533,7 @@ Describe "ParserTests (admin\monad\tests\monad\src\engine\core\ParserTests.cs)" 
         }
         { ExecuteCommand "$shellfile" } | Should Not Throw
     }
-	
+
 	Context "Boolean Tests (starting at line 1723 to line 1772)" {
         $testData = @(
             @{ Script = '"False"'; Expected = $true }
@@ -546,7 +551,7 @@ Describe "ParserTests (admin\monad\tests\monad\src\engine\core\ParserTests.cs)" 
             ExecuteCommand $Script | Should be $Expected
         }
     }
-	
+
 	Context "Comparison operator Tests (starting at line 1785 to line 1842)" {
         $testData = @(
 			@{ Script = 'if (1 -and 1) { $true } else { $false }'; Expected = $true }
@@ -586,7 +591,7 @@ Describe "ParserTests (admin\monad\tests\monad\src\engine\core\ParserTests.cs)" 
             ExecuteCommand $Script | Should be $Expected
         }
     }
-	
+
     Context "Arithmetic and String Comparison Tests (starting at line 1848 to line 1943)" {
         $testData = @(
             @{ Script = '$a=10; if( !$a -eq 10) { $a=1 } else {$a=2};$a'; Expected = 2 }
@@ -617,7 +622,7 @@ Describe "ParserTests (admin\monad\tests\monad\src\engine\core\ParserTests.cs)" 
             ExecuteCommand $Script | Should be $Expected
         }
     }
-	
+
 	Context "Comparison Operators with Arrays Tests (starting at line 2015 to line 2178)" {
         $testData = @(
             @{ Script = "@(3) -eq 3"; Expected = "3" }
@@ -632,24 +637,24 @@ Describe "ParserTests (admin\monad\tests\monad\src\engine\core\ParserTests.cs)" 
             ExecuteCommand $Script | Should be $Expected
         }
     }
-	
+
 	It "A simple test for trapping a specific exception. Expected Result: The exception is caught and ignored. (line 2265)" {
         { ExecuteCommand "trap [InvalidCastException] { continue;  }; [int] 'abc'" } | Should Not Throw
     }
-	
+
 	It "Test that assign to input var and use then execute a script block with piped input. (line 2297)"{
         $result = ExecuteCommand '$input = 1,2,3;4,-5,6 | & { $input }'
-		 $result -join "" | should be (4,-5,6 -join "") 
+		 $result -join "" | should be (4,-5,6 -join "")
     }
-	
+
 	It "Test that pipe objects into a script and use arguments. (line 2313)"{
 		"`$input; `$args;">$testfile
         $result = ExecuteCommand "1,2,3 | $testfile"
-		$result -join "" | should be (1, 2, 3 -join "") 
+		$result -join "" | should be (1, 2, 3 -join "")
 		$result = ExecuteCommand "$testfile 4 -5 6 -blah -- foo -bar"
 		$result | should be "4", "-5", "6", "-blah", "foo", "-bar"
     }
-	
+
 	Context "Numerical Notations Tests (starting at line 2374 to line 2452)" {
         $testData = @(
 			#Test various numbers using the standard notation.
@@ -691,12 +696,12 @@ Describe "ParserTests (admin\monad\tests\monad\src\engine\core\ParserTests.cs)" 
             ExecuteCommand $Script | Should be $Expected
         }
     }
-	
+
 	It "This is a simple test of the concatenation of two arrays. (line 2460)"{
         $result = ExecuteCommand '1,2,3 + 4,5,6'
-		$result -join "" | should be (1, 2, 3, 4, 5, 6 -join "") 
+		$result -join "" | should be (1, 2, 3, 4, 5, 6 -join "")
     }
-	
+
 	It "Test that an incomplete parse exception is thrown if the array is unfinished. (line 2473)"{
 		try {
             ExecuteCommand '1,2,'
@@ -706,7 +711,7 @@ Describe "ParserTests (admin\monad\tests\monad\src\engine\core\ParserTests.cs)" 
             $_.FullyQualifiedErrorId | Should be "IncompleteParseException"
         }
     }
-	
+
 	It "Test that the unary comma is not valid in cmdlet parameters. (line 2482)"{
 		try {
             ExecuteCommand 'write-output 2,,1'
@@ -716,7 +721,7 @@ Describe "ParserTests (admin\monad\tests\monad\src\engine\core\ParserTests.cs)" 
             $_.FullyQualifiedErrorId | Should be "ParseException"
         }
     }
-	
+
 	It 'Test that "$var:" will expand to nothing inside a string. (line 2551)'{
 		try {
             ExecuteCommand '"$var:"'
@@ -726,18 +731,18 @@ Describe "ParserTests (admin\monad\tests\monad\src\engine\core\ParserTests.cs)" 
             $_.FullyQualifiedErrorId | Should be "ParseException"
         }
     }
-	
+
 	It "Tests the assignment to a read-only property (line 2593)"{
 		$result = ExecuteCommand '$A=$(testcmd-parserBVT -returntype array); $A.rank =5;$A.rank'
         $result | Should be "1"
     }
-	
+
 	It 'Tests accessing using null as index. (line 2648)'{
 		ExecuteCommand '$A=$(testcmd-parserBVT -returntype array); $A[$NONEXISTING_VARIABLE];'
         $PowerShell.HadErrors | should be $true
         $PowerShell.Streams.Error.FullyQualifiedErrorId | should be "NullArrayIndex"
     }
-	
+
 	It 'Tests the parser response to ArrayName[. (line 2678)'{
 		try {
             ExecuteCommand '$A=$(testcmd-parserBVT -returntype array); $A[ ;'
@@ -747,7 +752,7 @@ Describe "ParserTests (admin\monad\tests\monad\src\engine\core\ParserTests.cs)" 
             $_.FullyQualifiedErrorId | Should be "ParseException"
         }
     }
-	
+
 	It 'Tests the parser response to ArrayName[]. (line 2687)'{
 		try {
             ExecuteCommand '$A=$(testcmd-parserBVT -returntype array); $A[] ;'
@@ -757,7 +762,7 @@ Describe "ParserTests (admin\monad\tests\monad\src\engine\core\ParserTests.cs)" 
             $_.FullyQualifiedErrorId | Should be "ParseException"
         }
     }
-	
+
 	#Issue#1430
 	It "Tests function scopes in a script. (line 2800)" -Pending{
 		" function global:func { 'global' }; " +
@@ -766,11 +771,11 @@ Describe "ParserTests (admin\monad\tests\monad\src\engine\core\ParserTests.cs)" 
                 " script:func; " +
                 " global:func; ">$testfile
         $result = ExecuteCommand "function func { 'notcalled' };. $testfile"
-		$result -join "" | should be ("default", "default", "global" -join "") 
+		$result -join "" | should be ("default", "default", "global" -join "")
 		$result = ExecuteCommand "func"
 		$result | should be "global"
     }
-	
+
 	It 'Test piping arguments to a script block. The objects should be accessible from "$input". (line 2870)'{
 		ExecuteCommand '$script = { $input; };$results = @(0,0),-1 | &$script'
 		$result = ExecuteCommand '$results[0][0]'
@@ -780,29 +785,29 @@ Describe "ParserTests (admin\monad\tests\monad\src\engine\core\ParserTests.cs)" 
 		$result = ExecuteCommand '$results[1]'
         $result | Should be "-1"
     }
-	
+
 	It 'Test piping null into a scriptblock. The script block should not be passed anything. (line 2903)'{
 		$result = ExecuteCommand '$() | &{ $count = 0; foreach ($i in $input) { $count++ }; $count }'
         $result | Should be "1"
 		$result = ExecuteCommand '$() | &{ $input }'
         $result | Should BeNullOrEmpty
     }
-	
+
 	It 'Test that types in System.dll are found automatically. (line 2951)'{
 		$result = ExecuteCommand '[   System.IO.FileInfo]'
         $result | Should be "System.IO.FileInfo"
     }
-		
+
 	Context "Mathematical Operations Tests (starting at line 2975 to line 3036)" {
         $testData = @(
             @{ Script = '$a=6; $a -= 2;$a'; Expected = 4 }
 			@{ Script = "20 %
 			6"; Expected = "2" }
-			@{ Script = "(20 % 
-			6 * 
-			4  + 
-			2 ) / 
-			2 - 
+			@{ Script = "(20 %
+			6 *
+			4  +
+			2 ) /
+			2 -
 			3"; Expected = "2" }
         )
         It "<Script> should return <Expected>" -TestCases $testData {
@@ -810,12 +815,12 @@ Describe "ParserTests (admin\monad\tests\monad\src\engine\core\ParserTests.cs)" 
             ExecuteCommand $Script | Should be $Expected
         }
     }
-	
+
 	It 'This test will call a cmdlet that returns an array and assigns it to a variable.  Then it will concatenate this array with itself and check that what results is an array of double the size of the original. (line 3148)'{
 		$result = ExecuteCommand '$list=$(testcmd-parserBVT -ReturnType "array"); $list = $list + $list;$list.length'
         $result | Should be 6
     }
-	
+
     It "A here string must have one line (line 3266)" {
         try {
             ExecuteCommand "@`"`"@"
@@ -825,4 +830,4 @@ Describe "ParserTests (admin\monad\tests\monad\src\engine\core\ParserTests.cs)" 
             $_.FullyQualifiedErrorId | should be "ParseException"
         }
     }
-} 
+}

--- a/test/powershell/Language/Parser/Parser.Tests.ps1
+++ b/test/powershell/Language/Parser/Parser.Tests.ps1
@@ -274,7 +274,7 @@ Describe "ParserTests (admin\monad\tests\monad\src\engine\core\ParserTests.cs)" 
         $result = ExecuteCommand '"fo`obar"'
 		$result | should be "foobar"
     }
-
+	
 	Context "Test that we support all of the C# escape sequences. We use the ` instead of \. (line 613)" {
 		# the first two sequences are tricky, because we need to provide something to
 		# execute without causing an incomplete parse error

--- a/test/powershell/Language/Parser/Parser.Tests.ps1
+++ b/test/powershell/Language/Parser/Parser.Tests.ps1
@@ -8,10 +8,10 @@ Describe "ParserTests (admin\monad\tests\monad\src\engine\core\ParserTests.cs)" 
 			param (
 			[Parameter(Position = 0)]
 			[string] $Property1 = "unset",
-
+			
 			[Parameter(Position = 1)]
 			[string] $Property2 = "unset",
-
+			
 			[Parameter(Position = 2)]
 			[string] $Property3 = "unset",
 
@@ -21,55 +21,55 @@ Describe "ParserTests (admin\monad\tests\monad\src\engine\core\ParserTests.cs)" 
 			)
 
 			BEGIN {}
-
+			
 			PROCESS {
 				if ( ! $ReturnType ) {
 					$ReturnType = "default"
 				}
-
+				
 				switch ( $ReturnType )
 				{
-					"default" {
+					"default" { 
 						$result = "$Property1;$Property2;$Property3"
 						break
 					}
-					"array" {
+					"array" { 
 						$result = 1,2,3
 						break
 					}
-					"object" {
+					"object" { 
 						$result = new-object psobject
 						break
 					}
-					"nestedobject" {
+					"nestedobject" { 
 						$result = [pscustomobject]@{Name="John";Person=[pscustomobject]@{Name="John";Age=30}}
 						break
 					}
-					"struct" {
+					"struct" { 
 						$result = [pscustomobject]@{Name="John";Age=30}
 						break
 					}
-					"mshobject" {
+					"mshobject" { 
 						$result = new-object psobject
 						break
 					}
-					"nulltostring" {
+					"nulltostring" { 
 						$result = $null
 						break
 					}
-					default {
+					default { 
 						throw ([invalidoperationexception]::new("ReturnType parameter wasn't of any Expected value!"))
-						break
+						break 
 					}
 				}
 				return $result
 			}
-
+	
 			END {}
 		}
 '@
 		$functionDefinition>$functionDefinitionFile
-
+		
         $PowerShell = [powershell]::Create()
         function ExecuteCommand {
             param ([string]$command)
@@ -128,24 +128,24 @@ Describe "ParserTests (admin\monad\tests\monad\src\engine\core\ParserTests.cs)" 
 			Remove-Item $testfolder1
 		}
     }
-
+	
 	AfterAll {
 		if(Test-Path $functionDefinitionFile)
 		{
 			Remove-Item $functionDefinitionFile
 		}
 	}
-
+	
 	It "Throws a syntax error when parsing a string without a closing quote. (line 164)" {
 		try {
-            ExecuteCommand '"This is a test'
+            ExecuteCommand '"This is a test' 
             throw "Execution OK"
         }
         catch {
             $_.FullyQualifiedErrorId | Should be "IncompleteParseException"
         }
 	}
-
+	
 	It "Throws an error if an open parenthesis is not closed (line 176)" {
         try {
             ExecuteCommand "("
@@ -155,7 +155,7 @@ Describe "ParserTests (admin\monad\tests\monad\src\engine\core\ParserTests.cs)" 
             $_.FullyQualifiedErrorId | should be "IncompleteParseException"
         }
     }
-
+	
     It "Throws an exception if the the first statement starts with an empty pipe element (line 188)" {
         try {
             ExecuteCommand "| get-location"
@@ -165,13 +165,13 @@ Describe "ParserTests (admin\monad\tests\monad\src\engine\core\ParserTests.cs)" 
             $_.FullyQualifiedErrorId | should be "ParseException"
         }
     }
-
+	
 	It "Throws an CommandNotFoundException exception if using a label in front of an if statement is not allowed. (line 225)"{
         ExecuteCommand ":foo if ($x -eq 3) { 1 }"
 		$PowerShell.HadErrors | should be $true
         $PowerShell.Streams.Error.FullyQualifiedErrorId | should be "CommandNotFoundException"
     }
-
+	
 	It "Pipe an expression into a value expression. (line 237)" {
         try {
             ExecuteCommand "testcmd-parserbvt | 3"
@@ -180,7 +180,7 @@ Describe "ParserTests (admin\monad\tests\monad\src\engine\core\ParserTests.cs)" 
         catch {
             $_.FullyQualifiedErrorId | should be "ParseException"
         }
-
+		
 		try {
             ExecuteCommand "testcmd-parserbvt | $(1 + 1)"
             throw "Execution OK"
@@ -188,7 +188,7 @@ Describe "ParserTests (admin\monad\tests\monad\src\engine\core\ParserTests.cs)" 
         catch {
             $_.FullyQualifiedErrorId | should be "ParseException"
         }
-
+		
 		try {
             ExecuteCommand "testcmd-parserbvt | 'abc'"
             throw "Execution OK"
@@ -209,67 +209,67 @@ Describe "ParserTests (admin\monad\tests\monad\src\engine\core\ParserTests.cs)" 
             }
         }
     }
-
+	
 	It "Throws an incomplete parse exception when a comma follows an expression (line 247)" {
         try {
-            ExecuteCommand "(1+ 1),"
+            ExecuteCommand "(1+ 1)," 
             throw "Execution OK"
         }
         catch {
             $_.FullyQualifiedErrorId | Should be "IncompleteParseException"
         }
     }
-
-
+	
+		
 	It "Test that invoke has a higher precedence for a script than for an executable. (line 279)" {
 		"1">$testfile
         $result = ExecuteCommand ". $testfile"
 		$result | should be 1
     }
-
+	
 	It "This test will check that a path is correctly interpreted when using '..' and '.'  (line 364)" {
         $result = ExecuteCommand "set-location $TestDrive; get-childitem dir1\.\.\.\..\dir1\.\dir2\..\..\dir1\.\dir2"
 		$result.Count | should be 2
 		$result[0].Name | should be "testdirfile1.txt"
 		$result[1].Name | should be "testdirfile2.txt"
     }
-
+	
 	It "This test will check that the parser can handle a mix of forward slashes and back slashes in the path (line 417)" {
         $result = ExecuteCommand "get-childitem $TestDrive/dir1/./.\.\../dir1/.\dir2\../..\dir1\.\dir2"
 		$result.Count | should be 2
 		$result[0].Name | should be "testdirfile1.txt"
 		$result[1].Name | should be "testdirfile2.txt"
     }
-
+	
 	It "This test checks that the asterisk globs as expected. (line 545)" {
         $result = ExecuteCommand "get-childitem $TestDrive/dir1\dir2\*.txt"
 		$result.Count | should be 2
 		$result[0].Name | should be "testdirfile1.txt"
 		$result[1].Name | should be "testdirfile2.txt"
     }
-
+	
 	It "This test checks that we can use a range for globbing: [1-2] (line 557)" {
         $result = ExecuteCommand "get-childitem $TestDrive/dir1\dir2\testdirfile[1-2].txt"
 		$result.Count | should be 2
 		$result[0].Name | should be "testdirfile1.txt"
 		$result[1].Name | should be "testdirfile2.txt"
     }
-
+	
 	It "This test will check that escaping the $ sigil inside single quotes simply returns the $ character. (line 583)" {
         $result = ExecuteCommand "'`$'"
 		$result | should be "`$"
     }
-
+	
 	It "Test that escaping a space just returns that space. (line 593)" {
         $result = ExecuteCommand '"foo` bar"'
 		$result | should be "foo bar"
     }
-
+	
     It "Test that escaping the character 'e' returns the ESC character (0x1b)." {
         $result = ExecuteCommand '"`e"'
         $result | should be ([char]0x1b)
     }
-
+	
 	It "Test that escaping any character with no special meaning just returns that char. (line 602)" {
         $result = ExecuteCommand '"fo`obar"'
 		$result | should be "foobar"
@@ -298,26 +298,26 @@ Describe "ParserTests (admin\monad\tests\monad\src\engine\core\ParserTests.cs)" 
 		}
     }
 
-
+	
 	It "This test checks that array substitution occurs inside double quotes. (line 646)" {
         $result = ExecuteCommand '$MyArray = "a","b";"Hello $MyArray"'
 		$result | should be "Hello a b"
     }
-
+	
 	It "This tests declaring an array in nested variable tables. (line 761)" {
         $result = ExecuteCommand "`$Variable:vtbl1:vtbl2:b=@(5,6);`$Variable:vtbl1:vtbl2:b"
 		$result.Count | should be 2
 		$result[0] | should be 5
 		$result[1] | should be 6
     }
-
+	
 	It "Test a simple multiple assignment. (line 773)" {
         $result = ExecuteCommand '$one,$two = 1,2,3; "One = $one"; "Two = $two"'
 		$result.Count | should be 2
 		$result[0] | should be "One = 1"
 		$result[1] | should be "Two = 2 3"
     }
-
+	
 	It "Tests script, global and local scopes from a function inside a script. (line 824)" {
 		"`$var = 'script';function func { `$var; `$var = 'local'; `$local:var; `$script:var; `$global:var };func;`$var;">$testfile
 		ExecuteCommand "`$var = 'global'"
@@ -329,10 +329,10 @@ Describe "ParserTests (admin\monad\tests\monad\src\engine\core\ParserTests.cs)" 
 		$result[3] | should be "global"
 		$result[4] | should be "script"
     }
-
+	
 	It "Use break inside of a loop that is inside another loop. (line 945)" {
-		$commands = " while (1) { 1; while(1) { 2; break; 3; }; 4; break; 5;  } ",
-                " for (;;) { 1; for(;;) { 2; break; 3; }; 4; break; 5; } ",
+		$commands = " while (1) { 1; while(1) { 2; break; 3; }; 4; break; 5;  } ", 
+                " for (;;) { 1; for(;;) { 2; break; 3; }; 4; break; 5; } ", 
                 " foreach(`$a in 1,2,3) { 1; foreach( `$b in 1,2,3 ) { 2; break; 3; }; 4; break; 5; } "
 		$results = "1", "2", "4"
         $i = 0
@@ -342,10 +342,10 @@ Describe "ParserTests (admin\monad\tests\monad\src\engine\core\ParserTests.cs)" 
 			$result | should be $results
 		}
     }
-
+	
 	It "Use break in two loops with same label. (line 967)" {
-		$commands = " :foo while (1) { 1; :foo while(1) { 2; break foo; 3; }; 4; break; 5;  } ",
-                " :foo for (;;) { 1; :foo for(;;) { 2; break foo; 3; }; 4; break; 5; } ",
+		$commands = " :foo while (1) { 1; :foo while(1) { 2; break foo; 3; }; 4; break; 5;  } ", 
+                " :foo for (;;) { 1; :foo for(;;) { 2; break foo; 3; }; 4; break; 5; } ", 
                 " :foo foreach(`$a in 1,2,3) { 1; :foo foreach( `$b in 1,2,3 ) { 2; break foo; 3; }; 4; break; 5; } "
 		$results = "1", "2", "4"
         $i = 0
@@ -355,10 +355,10 @@ Describe "ParserTests (admin\monad\tests\monad\src\engine\core\ParserTests.cs)" 
 			$result | should be $results
 		}
     }
-
+	
 	It "Try continue inside of different loop statements. (line 1039)" {
-		$commands = " `$a = 0; while (`$a -lt 2) { `$a; `$a += 1; continue; 2; } ",
-                " for (`$a = 0;`$a -lt 2; `$a += 1) { 9; continue; 3; } ",
+		$commands = " `$a = 0; while (`$a -lt 2) { `$a; `$a += 1; continue; 2; } ", 
+                " for (`$a = 0;`$a -lt 2; `$a += 1) { 9; continue; 3; } ", 
                 " foreach(`$a in 0,1) { `$a; continue; 2; } "
 		$result = ExecuteCommand $commands[0]
 		$result | should be "0", "1"
@@ -367,10 +367,10 @@ Describe "ParserTests (admin\monad\tests\monad\src\engine\core\ParserTests.cs)" 
 		$result = ExecuteCommand $commands[2]
 		$result | should be "0", "1"
     }
-
+	
 	It "Use a label to continue an inner loop. (line 1059)" {
-		$commands = " `$x = 0; while (`$x -lt 1) { `$x += 1; `$x; `$a = 0; :foo while(`$a -lt 2) { `$a += 1; `$a; continue foo; 3; }; 4; continue; 5;  } ",
-                " for (`$x = 0;`$x -lt 1;`$x += 1) { 1; :foo for(`$a = 0; `$a -lt 2; `$a += 1) { `$a; continue foo; 3; }; 4; continue; 5; } ",
+		$commands = " `$x = 0; while (`$x -lt 1) { `$x += 1; `$x; `$a = 0; :foo while(`$a -lt 2) { `$a += 1; `$a; continue foo; 3; }; 4; continue; 5;  } ", 
+                " for (`$x = 0;`$x -lt 1;`$x += 1) { 1; :foo for(`$a = 0; `$a -lt 2; `$a += 1) { `$a; continue foo; 3; }; 4; continue; 5; } ", 
                 " foreach(`$a in 1) { 1; :foo foreach( `$b in 1,2 ) { `$b; continue foo; 3; }; 4; continue; 5; } "
 		$result = ExecuteCommand $commands[0]
 		$result | should be "1", "1", "2", "4"
@@ -379,10 +379,10 @@ Describe "ParserTests (admin\monad\tests\monad\src\engine\core\ParserTests.cs)" 
 		$result = ExecuteCommand $commands[2]
 		$result | should be "1", "1", "2", "4"
     }
-
+	
 	It "Use continue with a label on a nested loop. (line 1059)" {
-		$commands = " `$x = 0; :foo while (`$x -lt 2) { `$x; `$x += 1; :bar while(1) { 2; continue foo; 3; }; 4; continue; 5;  } ",
-                " :foo for (`$x = 0;`$x -lt 2;`$x += 1) { 1; :bar for(;;) { 2; continue foo; 3; }; 4; continue; 5; } ",
+		$commands = " `$x = 0; :foo while (`$x -lt 2) { `$x; `$x += 1; :bar while(1) { 2; continue foo; 3; }; 4; continue; 5;  } ", 
+                " :foo for (`$x = 0;`$x -lt 2;`$x += 1) { 1; :bar for(;;) { 2; continue foo; 3; }; 4; continue; 5; } ", 
                 " :foo foreach(`$a in 1,2) { 1; :bar foreach( `$b in 1,2,3 ) { 2; continue foo; 3; }; 4; continue; 5; } "
 		$result = ExecuteCommand $commands[0]
 		$result | should be "0", "2", "1", "2"
@@ -391,136 +391,136 @@ Describe "ParserTests (admin\monad\tests\monad\src\engine\core\ParserTests.cs)" 
 		$result = ExecuteCommand $commands[2]
 		$result | should be "1", "2", "1", "2"
     }
-
+	
 	It "This test will check that it is a syntax error to use if without a code block. (line 1141)" {
         try {
-            ExecuteCommand 'if ("true")'
+            ExecuteCommand 'if ("true")' 
             throw "Execution OK"
         }
         catch {
             $_.FullyQualifiedErrorId | Should be "IncompleteParseException"
         }
     }
-
+	
 	It "This test will check that it is a syntax error if the if condition is not complete. (line 1150)" {
         try {
-            ExecuteCommand 'if ('
+            ExecuteCommand 'if (' 
             throw "Execution OK"
         }
         catch {
             $_.FullyQualifiedErrorId | Should be "IncompleteParseException"
         }
     }
-
+	
 	It "This test will check that it is a syntax error to have an if condition without parentheses. (line 1159)" {
         try {
-            ExecuteCommand 'if "true" { 1} else {2}'
+            ExecuteCommand 'if "true" { 1} else {2}' 
             throw "Execution OK"
         }
         catch {
             $_.FullyQualifiedErrorId | Should be "ParseException"
         }
     }
-
+	
 	It "This test will check that the parser throws a syntax error when the if condition is missing the closing parentheses. (line 1168)" {
         try {
-            ExecuteCommand 'if ("true"  { 1};'
+            ExecuteCommand 'if ("true"  { 1};' 
             throw "Execution OK"
         }
         catch {
             $_.FullyQualifiedErrorId | Should be "ParseException"
         }
     }
-
+	
 	It "This test will check that it is a syntax error to have an else keyword without the corresponding code block. (line 1177)" {
         try {
-            ExecuteCommand 'if ("true") {1} else'
+            ExecuteCommand 'if ("true") {1} else' 
             throw "Execution OK"
         }
         catch {
             $_.FullyQualifiedErrorId | Should be "IncompleteParseException"
         }
     }
-
+	
 	It "This test will check that the parser throws a syntax error when a foreach loop is not complete. (line 1238)" {
         try {
-            ExecuteCommand '$count=0;$files = $(get-childitem / -filter *.txt );foreach ($i ;$count'
+            ExecuteCommand '$count=0;$files = $(get-childitem / -filter *.txt );foreach ($i ;$count' 
             throw "Execution OK"
         }
         catch {
             $_.FullyQualifiedErrorId | Should be "ParseException"
         }
     }
-
+	
 	It "This test will check that the parser throws a syntax error if the foreach loop is not complete. (line 1248)" {
         try {
-            ExecuteCommand '$count=0;$files = $(get-childitem / -filter *.txt );foreach ($i in ;$count'
+            ExecuteCommand '$count=0;$files = $(get-childitem / -filter *.txt );foreach ($i in ;$count' 
             throw "Execution OK"
         }
         catch {
             $_.FullyQualifiedErrorId | Should be "ParseException"
         }
     }
-
+	
 	It "This will test that the parser throws a syntax error if the foreach loop is missing a closing parentheses. (line 1258)" {
         try {
-            ExecuteCommand '$count=0;$files = $(get-childitem / -filter *.txt );foreach ($i in $files ;$count'
+            ExecuteCommand '$count=0;$files = $(get-childitem / -filter *.txt );foreach ($i in $files ;$count' 
             throw "Execution OK"
         }
         catch {
             $_.FullyQualifiedErrorId | Should be "ParseException"
         }
     }
-
+	
 	It "Test that if an exception is thrown from the try block it will be caught in the appropropriate catch block and that the finally block will run regardless of whether an exception is thrown. (line 1317)" {
         $result = ExecuteCommand 'try { try { throw (new-object System.ArgumentException) } catch [System.DivideByZeroException] { } finally { "Finally" } } catch { $_.Exception.GetType().FullName }'
 		$result | should be "Finally", "System.ArgumentException"
     }
-
+	
 	It "Test that null can be passed to a method that expects a reference type. (line 1439)" {
         $result = ExecuteCommand '$test = "String";$test.CompareTo($())'
 		$result | should be 1
     }
-
+	
 	It "Tests that command expansion operators can be used as a parameter to an object method. (line 1507)" {
         $result = ExecuteCommand '$test = "String";$test.SubString($("hello" | foreach-object { $_.length - 2 } ))'
 		$result | should be "ing"
     }
-
+	
 	It "Test that & can be used as a parameter as long as it is quoted. (line 1606)" {
         $result = ExecuteCommand 'testcmd-parserbvt `&get-childitem'
 		$result | should be "&get-childitem;unset;unset"
 		$result = ExecuteCommand 'testcmd-parserbvt `&*'
 		$result | should be "&*;unset;unset"
     }
-
+	
 	It "Run a command with parameters. (line 1621)" {
         $result = ExecuteCommand 'testcmd-parserBVT -Property1 set'
 		$result | should be "set;unset;unset"
     }
-
+	
 	It "Test that typing a number at the command line will return that number. (line 1630)" {
         $result = ExecuteCommand '3'
 		$result | should be "3"
-		$result.gettype() |should be ([int])
+		$result.gettype() |should be ([int]) 
     }
-
+	
 	It "This test will check that an msh script can be run without invoking. (line 1641)" {
         "1">$testfile
         $result = ExecuteCommand ". $testfile"
 		$result | should be 1
     }
-
+	
 	It "Test that an alias is resolved before a function. (line 1657)" {
         $result = ExecuteCommand 'set-alias parserInvokeTest testcmd-parserBVT;function parserInvokeTest { 3 };parserInvokeTest'
 		$result | should be "unset;unset;unset"
     }
-
+	
 	It "Test that functions are resolved before cmdlets. (line 1678)"{
         $result = ExecuteCommand 'function testcmd-parserBVT { 3 };testcmd-parserBVT'
 		$result | should be "3"
     }
-
+	
 	It "Check that a command that uses shell execute can be run from the command line and that no exception is thrown. (line 1702)" {
 		if ( $IsLinux -or $IsOSX ) {
             # because we execute on *nix based on executable bit, and the file name doesn't matter
@@ -533,7 +533,7 @@ Describe "ParserTests (admin\monad\tests\monad\src\engine\core\ParserTests.cs)" 
         }
         { ExecuteCommand "$shellfile" } | Should Not Throw
     }
-
+	
 	Context "Boolean Tests (starting at line 1723 to line 1772)" {
         $testData = @(
             @{ Script = '"False"'; Expected = $true }
@@ -551,7 +551,7 @@ Describe "ParserTests (admin\monad\tests\monad\src\engine\core\ParserTests.cs)" 
             ExecuteCommand $Script | Should be $Expected
         }
     }
-
+	
 	Context "Comparison operator Tests (starting at line 1785 to line 1842)" {
         $testData = @(
 			@{ Script = 'if (1 -and 1) { $true } else { $false }'; Expected = $true }
@@ -591,7 +591,7 @@ Describe "ParserTests (admin\monad\tests\monad\src\engine\core\ParserTests.cs)" 
             ExecuteCommand $Script | Should be $Expected
         }
     }
-
+	
     Context "Arithmetic and String Comparison Tests (starting at line 1848 to line 1943)" {
         $testData = @(
             @{ Script = '$a=10; if( !$a -eq 10) { $a=1 } else {$a=2};$a'; Expected = 2 }
@@ -622,7 +622,7 @@ Describe "ParserTests (admin\monad\tests\monad\src\engine\core\ParserTests.cs)" 
             ExecuteCommand $Script | Should be $Expected
         }
     }
-
+	
 	Context "Comparison Operators with Arrays Tests (starting at line 2015 to line 2178)" {
         $testData = @(
             @{ Script = "@(3) -eq 3"; Expected = "3" }
@@ -637,24 +637,24 @@ Describe "ParserTests (admin\monad\tests\monad\src\engine\core\ParserTests.cs)" 
             ExecuteCommand $Script | Should be $Expected
         }
     }
-
+	
 	It "A simple test for trapping a specific exception. Expected Result: The exception is caught and ignored. (line 2265)" {
         { ExecuteCommand "trap [InvalidCastException] { continue;  }; [int] 'abc'" } | Should Not Throw
     }
-
+	
 	It "Test that assign to input var and use then execute a script block with piped input. (line 2297)"{
         $result = ExecuteCommand '$input = 1,2,3;4,-5,6 | & { $input }'
-		 $result -join "" | should be (4,-5,6 -join "")
+		 $result -join "" | should be (4,-5,6 -join "") 
     }
-
+	
 	It "Test that pipe objects into a script and use arguments. (line 2313)"{
 		"`$input; `$args;">$testfile
         $result = ExecuteCommand "1,2,3 | $testfile"
-		$result -join "" | should be (1, 2, 3 -join "")
+		$result -join "" | should be (1, 2, 3 -join "") 
 		$result = ExecuteCommand "$testfile 4 -5 6 -blah -- foo -bar"
 		$result | should be "4", "-5", "6", "-blah", "foo", "-bar"
     }
-
+	
 	Context "Numerical Notations Tests (starting at line 2374 to line 2452)" {
         $testData = @(
 			#Test various numbers using the standard notation.
@@ -696,12 +696,12 @@ Describe "ParserTests (admin\monad\tests\monad\src\engine\core\ParserTests.cs)" 
             ExecuteCommand $Script | Should be $Expected
         }
     }
-
+	
 	It "This is a simple test of the concatenation of two arrays. (line 2460)"{
         $result = ExecuteCommand '1,2,3 + 4,5,6'
-		$result -join "" | should be (1, 2, 3, 4, 5, 6 -join "")
+		$result -join "" | should be (1, 2, 3, 4, 5, 6 -join "") 
     }
-
+	
 	It "Test that an incomplete parse exception is thrown if the array is unfinished. (line 2473)"{
 		try {
             ExecuteCommand '1,2,'
@@ -711,7 +711,7 @@ Describe "ParserTests (admin\monad\tests\monad\src\engine\core\ParserTests.cs)" 
             $_.FullyQualifiedErrorId | Should be "IncompleteParseException"
         }
     }
-
+	
 	It "Test that the unary comma is not valid in cmdlet parameters. (line 2482)"{
 		try {
             ExecuteCommand 'write-output 2,,1'
@@ -721,7 +721,7 @@ Describe "ParserTests (admin\monad\tests\monad\src\engine\core\ParserTests.cs)" 
             $_.FullyQualifiedErrorId | Should be "ParseException"
         }
     }
-
+	
 	It 'Test that "$var:" will expand to nothing inside a string. (line 2551)'{
 		try {
             ExecuteCommand '"$var:"'
@@ -731,18 +731,18 @@ Describe "ParserTests (admin\monad\tests\monad\src\engine\core\ParserTests.cs)" 
             $_.FullyQualifiedErrorId | Should be "ParseException"
         }
     }
-
+	
 	It "Tests the assignment to a read-only property (line 2593)"{
 		$result = ExecuteCommand '$A=$(testcmd-parserBVT -returntype array); $A.rank =5;$A.rank'
         $result | Should be "1"
     }
-
+	
 	It 'Tests accessing using null as index. (line 2648)'{
 		ExecuteCommand '$A=$(testcmd-parserBVT -returntype array); $A[$NONEXISTING_VARIABLE];'
         $PowerShell.HadErrors | should be $true
         $PowerShell.Streams.Error.FullyQualifiedErrorId | should be "NullArrayIndex"
     }
-
+	
 	It 'Tests the parser response to ArrayName[. (line 2678)'{
 		try {
             ExecuteCommand '$A=$(testcmd-parserBVT -returntype array); $A[ ;'
@@ -752,7 +752,7 @@ Describe "ParserTests (admin\monad\tests\monad\src\engine\core\ParserTests.cs)" 
             $_.FullyQualifiedErrorId | Should be "ParseException"
         }
     }
-
+	
 	It 'Tests the parser response to ArrayName[]. (line 2687)'{
 		try {
             ExecuteCommand '$A=$(testcmd-parserBVT -returntype array); $A[] ;'
@@ -762,7 +762,7 @@ Describe "ParserTests (admin\monad\tests\monad\src\engine\core\ParserTests.cs)" 
             $_.FullyQualifiedErrorId | Should be "ParseException"
         }
     }
-
+	
 	#Issue#1430
 	It "Tests function scopes in a script. (line 2800)" -Pending{
 		" function global:func { 'global' }; " +
@@ -771,11 +771,11 @@ Describe "ParserTests (admin\monad\tests\monad\src\engine\core\ParserTests.cs)" 
                 " script:func; " +
                 " global:func; ">$testfile
         $result = ExecuteCommand "function func { 'notcalled' };. $testfile"
-		$result -join "" | should be ("default", "default", "global" -join "")
+		$result -join "" | should be ("default", "default", "global" -join "") 
 		$result = ExecuteCommand "func"
 		$result | should be "global"
     }
-
+	
 	It 'Test piping arguments to a script block. The objects should be accessible from "$input". (line 2870)'{
 		ExecuteCommand '$script = { $input; };$results = @(0,0),-1 | &$script'
 		$result = ExecuteCommand '$results[0][0]'
@@ -785,29 +785,29 @@ Describe "ParserTests (admin\monad\tests\monad\src\engine\core\ParserTests.cs)" 
 		$result = ExecuteCommand '$results[1]'
         $result | Should be "-1"
     }
-
+	
 	It 'Test piping null into a scriptblock. The script block should not be passed anything. (line 2903)'{
 		$result = ExecuteCommand '$() | &{ $count = 0; foreach ($i in $input) { $count++ }; $count }'
         $result | Should be "1"
 		$result = ExecuteCommand '$() | &{ $input }'
         $result | Should BeNullOrEmpty
     }
-
+	
 	It 'Test that types in System.dll are found automatically. (line 2951)'{
 		$result = ExecuteCommand '[   System.IO.FileInfo]'
         $result | Should be "System.IO.FileInfo"
     }
-
+		
 	Context "Mathematical Operations Tests (starting at line 2975 to line 3036)" {
         $testData = @(
             @{ Script = '$a=6; $a -= 2;$a'; Expected = 4 }
 			@{ Script = "20 %
 			6"; Expected = "2" }
-			@{ Script = "(20 %
-			6 *
-			4  +
-			2 ) /
-			2 -
+			@{ Script = "(20 % 
+			6 * 
+			4  + 
+			2 ) / 
+			2 - 
 			3"; Expected = "2" }
         )
         It "<Script> should return <Expected>" -TestCases $testData {
@@ -815,12 +815,12 @@ Describe "ParserTests (admin\monad\tests\monad\src\engine\core\ParserTests.cs)" 
             ExecuteCommand $Script | Should be $Expected
         }
     }
-
+	
 	It 'This test will call a cmdlet that returns an array and assigns it to a variable.  Then it will concatenate this array with itself and check that what results is an array of double the size of the original. (line 3148)'{
 		$result = ExecuteCommand '$list=$(testcmd-parserBVT -ReturnType "array"); $list = $list + $list;$list.length'
         $result | Should be 6
     }
-
+	
     It "A here string must have one line (line 3266)" {
         try {
             ExecuteCommand "@`"`"@"
@@ -830,4 +830,4 @@ Describe "ParserTests (admin\monad\tests\monad\src\engine\core\ParserTests.cs)" 
             $_.FullyQualifiedErrorId | should be "ParseException"
         }
     }
-}
+} 


### PR DESCRIPTION
Partially address issue #2751.  I believe this change falls into compat bucket #3 - unlikely grey area.  This fact has been reviewed and accepted by the PowerShell as indicated in issue #2751.