### PR TITLE
Display PM and WS in MB instead of KB

### DIFF
--- a/src/System.Management.Automation/commands/utility/FormatAndOutput/common/DefaultFormatters/DotNetTypes_format_ps1xml.cs
+++ b/src/System.Management.Automation/commands/utility/FormatAndOutput/common/DefaultFormatters/DotNetTypes_format_ps1xml.cs
@@ -534,17 +534,17 @@ namespace System.Management.Automation.Runspaces
             yield return new FormatViewDefinition("process",
                 TableControl.Create()
                     .AddHeader(Alignment.Right, label: "NPM(K)", width: 7)
-                    .AddHeader(Alignment.Right, label: "PM(K)", width: 8)
-                    .AddHeader(Alignment.Right, label: "WS(K)", width: 10)
+                    .AddHeader(Alignment.Right, label: "PM(M)", width: 8)
+                    .AddHeader(Alignment.Right, label: "WS(M)", width: 10)
                     .AddHeader(Alignment.Right, label: "CPU(s)", width: 10)
                     .AddHeader(Alignment.Right, width: 6)
                     .AddHeader(Alignment.Right, width: 3)
                     .AddHeader()
                     .StartRowDefinition()
                         .AddScriptBlockColumn("[long]($_.NPM / 1024)")
-                        .AddScriptBlockColumn("[long]($_.PM / 1024)")
-                        .AddScriptBlockColumn("[long]($_.WS / 1024)")
-                        .AddScriptBlockColumn(@"if ($_.CPU -ne $()) { $_.CPU.ToString(""N"") }")
+                        .AddScriptBlockColumn("\"{0:N2}\" -f [float]($_.PM / 1MB)")
+                        .AddScriptBlockColumn("\"{0:N2}\" -f [float]($_.WS / 1MB)")
+                        .AddScriptBlockColumn("\"{0:N2}\" -f [float]($_.CPU)")
                         .AddPropertyColumn("Id")
                         .AddPropertyColumn("SI")
                         .AddPropertyColumn("ProcessName")
@@ -585,14 +585,14 @@ namespace System.Management.Automation.Runspaces
         {
             yield return new FormatViewDefinition("ProcessWithUserName",
                 TableControl.Create()
-                    .AddHeader(Alignment.Right, label: "WS(K)", width: 10)
+                    .AddHeader(Alignment.Right, label: "WS(M)", width: 10)
                     .AddHeader(Alignment.Right, label: "CPU(s)", width: 8)
                     .AddHeader(Alignment.Right, width: 6)
                     .AddHeader(width: 22)
                     .AddHeader()
                     .StartRowDefinition()
-                        .AddScriptBlockColumn("[long]($_.WS / 1024)")
-                        .AddScriptBlockColumn(@"if ($_.CPU -ne $()) { $_.CPU.ToString(""N"") }")
+                        .AddScriptBlockColumn("\"{0:N2}\" -f [float]($_.WS / 1MB)")
+                        .AddScriptBlockColumn("\"{0:N2}\" -f [float]($_.CPU)")
                         .AddPropertyColumn("Id")
                         .AddPropertyColumn("UserName")
                         .AddPropertyColumn("ProcessName")
@@ -860,13 +860,13 @@ namespace System.Management.Automation.Runspaces
                         .AddScriptBlockColumn(@"
 					$eventType = $_.EventType;
 					if($_.EventType -eq 100)
-					{$eventType = ""BEGIN_SYSTEM_CHANGE"";}				
+					{$eventType = ""BEGIN_SYSTEM_CHANGE"";}
 					if($_.EventType -eq 101)
-					{$eventType = ""END_SYSTEM_CHANGE"";}				
+					{$eventType = ""END_SYSTEM_CHANGE"";}
 					if($_.EventType -eq 102)
-					{$eventType = ""BEGIN_NESTED_SYSTEM_CHANGE"";}				
+					{$eventType = ""BEGIN_NESTED_SYSTEM_CHANGE"";}
 					if($_.EventType -eq 103)
-					{$eventType = ""END_NESTED_SYSTEM_CHANGE"";}				
+					{$eventType = ""END_NESTED_SYSTEM_CHANGE"";}
 					return $eventType;
 				")
                         .AddScriptBlockColumn(@"


### PR DESCRIPTION
Modify output of Get-Process to display PM and WS in MB instead of KB.
Closes #2910 

This is how it looks after the changes:
(Command run: `Get-Process | Sort-Object -Descending WS`)
![image](https://cloud.githubusercontent.com/assets/11466676/21458576/b1d7e2ac-c95d-11e6-833a-28624ee31d46.png)
