### PR TITLE
Added alias (Path) to the FilePath parameter of the Out-File cmdlet.

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/out-file/Out-File.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/out-file/Out-File.cs
@@ -38,6 +38,7 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// mandatory file name to write to
         /// </summary>
+        [Alias("Path")]
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ByPath")]
         public string FilePath
         {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Out-File.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Out-File.Tests.ps1
@@ -18,10 +18,11 @@ Describe "Out-File DRT Unit Tests" -Tags "CI" {
 }
 
 Describe "Out-File" -Tags "CI" {
-    $expectedContent = "some test text"
-    $inObject = New-Object psobject -Property @{text=$expectedContent}
-    $testfile = Join-Path -Path $TestDrive -ChildPath outfileTest.txt
-
+    BeforeAll {
+	    $expectedContent = "some test text"
+	    $inObject = New-Object psobject -Property @{text=$expectedContent}
+        $testfile = Join-Path -Path $TestDrive -ChildPath outfileTest.txt
+	}
     AfterEach {
 	Remove-Item -Path $testfile -Force
     }
@@ -128,7 +129,7 @@ Describe "Out-File" -Tags "CI" {
 	Set-ItemProperty -Path $testfile -Name IsReadOnly -Value $false
     }
     
-	It "Should be able to use the 'Path' alias for the 'FilePath' parameter" {
+    It "Should be able to use the 'Path' alias for the 'FilePath' parameter" {
     { Out-File -Path $testfile } | Should Not Throw
     }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Out-File.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Out-File.Tests.ps1
@@ -127,4 +127,11 @@ Describe "Out-File" -Tags "CI" {
 	# reset to not read only so it can be deleted
 	Set-ItemProperty -Path $testfile -Name IsReadOnly -Value $false
     }
+    It "Creates a file using Out-File with the alias 'Path' for the -filepath parameter" {
+    {Out-File -path .\test.txt | Should Not Throw}
+    
+    #Remove the test file it created.
+    Remove-Item .\test.txt -ErrorAction SilentlyContinue
+    }
+
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Out-File.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Out-File.Tests.ps1
@@ -127,10 +127,9 @@ Describe "Out-File" -Tags "CI" {
 	# reset to not read only so it can be deleted
 	Set-ItemProperty -Path $testfile -Name IsReadOnly -Value $false
     }
-    It "Should be able to use the 'Path' alias for the 'FilePath' parameter" {
-    {Out-File -Path $testfile -InputObject $expectedContent | Should Not Throw}
     
-
+	It "Should be able to use the 'Path' alias for the 'FilePath' parameter" {
+    { Out-File -Path $testfile } | Should Not Throw
     }
 
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Out-File.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Out-File.Tests.ps1
@@ -19,118 +19,117 @@ Describe "Out-File DRT Unit Tests" -Tags "CI" {
 
 Describe "Out-File" -Tags "CI" {
     BeforeAll {
-	    $expectedContent = "some test text"
-	    $inObject = New-Object psobject -Property @{text=$expectedContent}
+        $expectedContent = "some test text"
+        $inObject = New-Object psobject -Property @{text=$expectedContent}
         $testfile = Join-Path -Path $TestDrive -ChildPath outfileTest.txt
-	}
+    }
+
     AfterEach {
-	Remove-Item -Path $testfile -Force
+        Remove-Item -Path $testfile -Force
     }
 
     It "Should be able to be called without error" {
-	{ Out-File -FilePath $testfile }   | Should Not Throw
+        { Out-File -FilePath $testfile }   | Should Not Throw
     }
 
     It "Should be able to accept string input via piping" {
-	{ $expectedContent | Out-File -FilePath $testfile } | Should Not Throw
+        { $expectedContent | Out-File -FilePath $testfile } | Should Not Throw
 
-	$actual = Get-Content $testfile
+        $actual = Get-Content $testfile
 
-	$actual | Should Be $expectedContent
+        $actual | Should Be $expectedContent
     }
 
     It "Should be able to accept string input via the InputObject switch" {
-	{ Out-File -FilePath $testfile -InputObject $expectedContent } | Should Not Throw
+        { Out-File -FilePath $testfile -InputObject $expectedContent } | Should Not Throw
 
-	$actual = Get-Content $testfile
+        $actual = Get-Content $testfile
 
-	$actual | Should Be $expectedContent
+        $actual | Should Be $expectedContent
     }
 
     It "Should be able to accept object input" {
-	{ $inObject | Out-File -FilePath $testfile } | Should Not Throw
+        { $inObject | Out-File -FilePath $testfile } | Should Not Throw
 
-	{ Out-File -FilePath $testfile -InputObject $inObject } | Should Not Throw
+        { Out-File -FilePath $testfile -InputObject $inObject } | Should Not Throw
     }
 
     It "Should not overwrite when the noclobber switch is used" {
 
-	Out-File -FilePath $testfile -InputObject $inObject
+        Out-File -FilePath $testfile -InputObject $inObject
 
-	{ Out-File -FilePath $testfile -InputObject $inObject -NoClobber -ErrorAction SilentlyContinue }   | Should Throw "already exists."
-	{ Out-File -FilePath $testfile -InputObject $inObject -NoOverWrite -ErrorAction SilentlyContinue } | Should Throw "already exists."
+        { Out-File -FilePath $testfile -InputObject $inObject -NoClobber -ErrorAction SilentlyContinue }   | Should Throw "already exists."
+        { Out-File -FilePath $testfile -InputObject $inObject -NoOverWrite -ErrorAction SilentlyContinue } | Should Throw "already exists."
 
-	$actual = Get-Content $testfile
+        $actual = Get-Content $testfile
 
-	$actual[0] | Should Be ""
-	$actual[1] | Should Match "text"
-	$actual[2] | Should Match "----"
-	$actual[3] | Should Match "some test text"
+        $actual[0] | Should Be ""
+        $actual[1] | Should Match "text"
+        $actual[2] | Should Match "----"
+        $actual[3] | Should Match "some test text"
     }
 
     It "Should Append a new line when the append switch is used" {
-	{ Out-File -FilePath $testfile -InputObject $inObject }         | Should Not Throw
-	{ Out-File -FilePath $testfile -InputObject $inObject -Append } | Should Not Throw
+        { Out-File -FilePath $testfile -InputObject $inObject }         | Should Not Throw
+        { Out-File -FilePath $testfile -InputObject $inObject -Append } | Should Not Throw
 
-	$actual = Get-Content $testfile
+        $actual = Get-Content $testfile
 
-	$actual[0]  | Should Be ""
-	$actual[1]  | Should Match "text"
-	$actual[2]  | Should Match "----"
-	$actual[3]  | Should Match "some test text"
-	$actual[4]  | Should Be ""
-	$actual[5]  | Should Be ""
-	$actual[6]  | Should Be ""
-	$actual[7]  | Should Match "text"
-	$actual[8]  | Should Match "----"
-	$actual[9]  | Should Match "some test text"
-	$actual[10] | Should Be ""
-	$actual[11] | Should Be ""
-
+        $actual[0]  | Should Be ""
+        $actual[1]  | Should Match "text"
+        $actual[2]  | Should Match "----"
+        $actual[3]  | Should Match "some test text"
+        $actual[4]  | Should Be ""
+        $actual[5]  | Should Be ""
+        $actual[6]  | Should Be ""
+        $actual[7]  | Should Match "text"
+        $actual[8]  | Should Match "----"
+        $actual[9]  | Should Match "some test text"
+        $actual[10] | Should Be ""
+        $actual[11] | Should Be ""
     }
 
     It "Should limit each line to the specified number of characters when the width switch is used on objects" {
 
-	Out-File -FilePath $testfile -Width 10 -InputObject $inObject
+        Out-File -FilePath $testfile -Width 10 -InputObject $inObject
 
-	$actual = Get-Content $testfile
+        $actual = Get-Content $testfile
 
-	$actual[0] | Should Be ""
-	$actual[1] | Should Be "text      "
-	$actual[2] | Should Be "----      "
-	$actual[3] | Should Be "some te..."
-
+        $actual[0] | Should Be ""
+        $actual[1] | Should Be "text      "
+        $actual[2] | Should Be "----      "
+        $actual[3] | Should Be "some te..."
     }
 
     It "Should allow the cmdlet to overwrite an existing read-only file" {
-	# create a read-only text file
-	{ Out-File -FilePath $testfile -InputObject $inObject }                | Should Not Throw
-	Set-ItemProperty -Path $testfile -Name IsReadOnly -Value $true
+        # create a read-only text file
+        { Out-File -FilePath $testfile -InputObject $inObject }                | Should Not Throw
+        Set-ItemProperty -Path $testfile -Name IsReadOnly -Value $true
 
-	# write information to the RO file
-	{ Out-File -FilePath $testfile -InputObject $inObject -Append -Force } | Should Not Throw
+        # write information to the RO file
+        { Out-File -FilePath $testfile -InputObject $inObject -Append -Force } | Should Not Throw
 
-	$actual = Get-Content $testfile
+        $actual = Get-Content $testfile
 
-	$actual[0]  | Should Be ""
-	$actual[1]  | Should Match "text"
-	$actual[2]  | Should Match "----"
-	$actual[3]  | Should Match "some test text"
-	$actual[4]  | Should Be ""
-	$actual[5]  | Should Be ""
-	$actual[6]  | Should Be ""
-	$actual[7]  | Should Match "text"
-	$actual[8]  | Should Match "----"
-	$actual[9]  | Should Match "some test text"
-	$actual[10] | Should Be ""
-	$actual[11] | Should Be ""
+        $actual[0]  | Should Be ""
+        $actual[1]  | Should Match "text"
+        $actual[2]  | Should Match "----"
+        $actual[3]  | Should Match "some test text"
+        $actual[4]  | Should Be ""
+        $actual[5]  | Should Be ""
+        $actual[6]  | Should Be ""
+        $actual[7]  | Should Match "text"
+        $actual[8]  | Should Match "----"
+        $actual[9]  | Should Match "some test text"
+        $actual[10] | Should Be ""
+        $actual[11] | Should Be ""
 
-	# reset to not read only so it can be deleted
-	Set-ItemProperty -Path $testfile -Name IsReadOnly -Value $false
+        # reset to not read only so it can be deleted
+        Set-ItemProperty -Path $testfile -Name IsReadOnly -Value $false
     }
     
     It "Should be able to use the 'Path' alias for the 'FilePath' parameter" {
-    { Out-File -Path $testfile } | Should Not Throw
+        { Out-File -Path $testfile } | Should Not Throw
     }
-
 }
+

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Out-File.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Out-File.Tests.ps1
@@ -127,11 +127,10 @@ Describe "Out-File" -Tags "CI" {
 	# reset to not read only so it can be deleted
 	Set-ItemProperty -Path $testfile -Name IsReadOnly -Value $false
     }
-    It "Creates a file using Out-File with the alias 'Path' for the -filepath parameter" {
-    {Out-File -path .\test.txt | Should Not Throw}
+    It "Should be able to use the 'Path' alias for the 'FilePath' parameter" {
+    {Out-File -Path $testfile -InputObject $expectedContent | Should Not Throw}
     
-    #Remove the test file it created.
-    Remove-Item .\test.txt -ErrorAction SilentlyContinue
+
     }
 
 }


### PR DESCRIPTION
Relevant issue: https://github.com/PowerShell/PowerShell/issues/2923

I'm new to Github beyond using it to store some personal projects, so, if I did something wrong, sorry and just let me know! It seemed a pretty easy one for a newbie to change without accidentally breaking anything else.

I made sure to build and test it beforehand:
![out-file](https://cloud.githubusercontent.com/assets/4411919/21590142/f31e1270-d0c6-11e6-903c-22dfdaf04b49.PNG)
