### PR TITLE
Adding PlatformNotSupportedException to Counter cmdlets when running on IoT.

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Diagnostics/ExportCounterCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Diagnostics/ExportCounterCommand.cs
@@ -150,9 +150,14 @@ namespace Microsoft.PowerShell.Commands
         //
         protected override void BeginProcessing()
         {
-            _resourceMgr = Microsoft.PowerShell.Commands.Diagnostics.Common.CommonUtilities.GetResourceManager();
 
 #if CORECLR
+            if (Platform.IsIoT)
+            {
+                // IoT does not have the '$env:windir\System32\pdh.dll' assembly which is required by this cmdlet.
+                throw new PlatformNotSupportedException();
+            }
+
             // PowerShell Core requires at least Windows 7,
             // so no version test is needed
             _pdhHelper = new PdhHelper(false);
@@ -172,6 +177,7 @@ namespace Microsoft.PowerShell.Commands
 
             _pdhHelper = new PdhHelper(osVersion.Major < 6);
 #endif
+            _resourceMgr = Microsoft.PowerShell.Commands.Diagnostics.Common.CommonUtilities.GetResourceManager();
 
             //
             // Validate the Format and CounterSamples arguments

--- a/src/Microsoft.PowerShell.Commands.Diagnostics/GetCounterCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Diagnostics/GetCounterCommand.cs
@@ -205,15 +205,21 @@ namespace Microsoft.PowerShell.Commands
         //
         protected override void BeginProcessing()
         {
-            _resourceMgr = Microsoft.PowerShell.Commands.Diagnostics.Common.CommonUtilities.GetResourceManager();
 
 #if CORECLR
+            if (Platform.IsIoT)
+            {
+                // IoT does not have the '$env:windir\System32\pdh.dll' assembly which is required by this cmdlet.
+                throw new PlatformNotSupportedException();
+            }
+
             // PowerShell Core requires at least Windows 7,
             // so no version test is needed
             _pdhHelper = new PdhHelper(false);
 #else
             _pdhHelper = new PdhHelper(System.Environment.OSVersion.Version.Major < 6);
 #endif
+            _resourceMgr = Microsoft.PowerShell.Commands.Diagnostics.Common.CommonUtilities.GetResourceManager();
 
             uint res = _pdhHelper.ConnectToDataSource();
             if (res != 0)

--- a/src/Microsoft.PowerShell.Commands.Diagnostics/ImportCounterCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Diagnostics/ImportCounterCommand.cs
@@ -188,14 +188,21 @@ namespace Microsoft.PowerShell.Commands
         //
         protected override void BeginProcessing()
         {
-            _resourceMgr = Microsoft.PowerShell.Commands.Diagnostics.Common.CommonUtilities.GetResourceManager();
+
 #if CORECLR
+            if (Platform.IsIoT)
+            {
+                // IoT does not have the '$env:windir\System32\pdh.dll' assembly which is required by this cmdlet.
+                throw new PlatformNotSupportedException();
+            }
+
             // PowerShell Core requires at least Windows 7,
             // so no version test is needed
             _pdhHelper = new PdhHelper(false);
 #else
             _pdhHelper = new PdhHelper(System.Environment.OSVersion.Version.Major < 6);
 #endif
+            _resourceMgr = Microsoft.PowerShell.Commands.Diagnostics.Common.CommonUtilities.GetResourceManager();
         }
 
         //

--- a/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/CounterTestHelperFunctions.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/CounterTestHelperFunctions.ps1
@@ -282,7 +282,8 @@ function CompareCounterSets
 function SkipCounterTests
 {
     if ([System.Management.Automation.Platform]::IsLinux -or
-        [System.Management.Automation.Platform]::IsOSX)
+        [System.Management.Automation.Platform]::IsOSX -or
+        [System.Management.Automation.Platform]::IsIoT)
     {
         return $true
     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/Get-Counter.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/Get-Counter.Tests.ps1
@@ -241,3 +241,19 @@ Describe "Feature tests for Get-Counter cmdlet" -Tags "Feature" {
         }
     }
 }
+
+Describe "Get-Counter cmdlet does not run on IoT" -Tags "CI" {
+
+    It "Get-Counter throws PlatformNotSupportedException" -Skip:$(-not [System.Management.Automation.Platform]::IsIoT)  {
+
+        try
+        {
+            Get-Counter
+            throw "'Get-Counter' on IoT is expected to throw a PlatformNotSupportedException, and it did not."
+        }
+        catch
+        {
+            $_.FullyQualifiedErrorId | should be "System.PlatformNotSupportedException,Microsoft.PowerShell.Commands.GetCounterCommand"
+        }
+    }
+}

--- a/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/Import-Counter.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/Import-Counter.Tests.ps1
@@ -454,3 +454,19 @@ Describe "Feature tests for Import-Counter cmdlet" -Tags "Feature" {
         }
     }
 }
+
+Describe "Import-Counter cmdlet does not run on IoT" -Tags "CI" {
+
+    It "Import-Counter throws PlatformNotSupportedException" -Skip:$(-not [System.Management.Automation.Platform]::IsIoT)  {
+
+        try
+        {
+            Import-Counter -Path "$testDrive\ProcessorData.blg"
+            throw "'Import-Counter -Path $testDrive\ProcessorData.blg' on IoT is expected to throw a PlatformNotSupportedException, and it did not."
+        }
+        catch
+        {
+            $_.FullyQualifiedErrorId | should be "System.PlatformNotSupportedException,Microsoft.PowerShell.Commands.ImportCounterCommand"
+        }
+    }
+}


### PR DESCRIPTION
We have enabled the Counter cmdlets for PowerShell on OneCore for Windows. This means that these cmdlets are available Full Desktop with CoreCLR, Nano Server and IoT. However, one of the dependencies, the '$env:windir\System32\pdh.dll'  assembly, is not available on IoT. Because of this, when the user tries to use the Counter cmdlets on IoT, they will get a  PlatformNotSupportedException.

This PR includes the code change and new test cases to validate that PlatformNotSupportedException is thrown on IoT.