### PR TITLE
Fix test where Export-Alias * fails when only single file exists

### DIFF
--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Export-Alias.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Export-Alias.Tests.ps1
@@ -147,16 +147,20 @@ Describe "Export-Alias" -Tags "CI" {
 		$fulltestpath       = Join-Path -Path $testAliasDirectory -ChildPath $testAliases
 	}
 
-    BeforeEach {
+	BeforeEach {
 		New-Item -Path $testAliasDirectory -ItemType Directory -Force
-    }
+	}
 
-    It "Should be able to create a file in the specified location"{
+	AfterEach {
+		Remove-Item -Path $testAliasDirectory -Recurse -Force
+	}
+
+	It "Should be able to create a file in the specified location"{
 		Export-Alias $fulltestpath
 		Test-Path $fulltestpath | Should be $true
-    }
+  }
 
-    It "Should create a file with the list of aliases that match the expected list" {
+  It "Should create a file with the list of aliases that match the expected list" {
 		Export-Alias $fulltestpath
 		Test-Path $fulltestpath | Should Be $true
 
@@ -168,7 +172,5 @@ Describe "Export-Alias" -Tags "CI" {
 			# We loop through the expected list and not the other because the output writes some comments to the file.
 			$expected[$i] | Should Match $actual[$i].Name
 		}
-    }
-
-    Remove-Item -Path $testAliasDirectory -Recurse -Force
+  }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Export-Alias.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Export-Alias.Tests.ps1
@@ -1,10 +1,10 @@
 Describe "Export-Alias DRT Unit Tests" -Tags "CI" {
-    $testAliasDirectory = Join-Path -Path $TestDrive -ChildPath ExportAliasTestDirectory
-    $testAliases        = "TestAliases"
-    $fulltestpath       = Join-Path -Path $testAliasDirectory -ChildPath $testAliases
 
-    BeforeEach {
-		New-Item -Path $testAliasDirectory -ItemType Directory -Force
+	BeforeAll {
+		$testAliasDirectory = Join-Path -Path $TestDrive -ChildPath ExportAliasTestDirectory
+		$testAliases        = "TestAliases"
+    	$fulltestpath       = Join-Path -Path $testAliasDirectory -ChildPath $testAliases
+
 		remove-item alias:abcd* -force
 		remove-item alias:ijkl* -force
 		set-alias abcd01 efgh01
@@ -15,8 +15,17 @@ Describe "Export-Alias DRT Unit Tests" -Tags "CI" {
 		set-alias ijkl02 mnop02
 		set-alias ijkl03 mnop03
 		set-alias ijkl04 mnop04
+	}
+
+	AfterAll {
+		remove-item alias:abcd* -force
+		remove-item alias:ijkl* -force
+	}
+
+    BeforeEach {
+		New-Item -Path $testAliasDirectory -ItemType Directory -Force
     }
-	
+
 	AfterEach {
 		Remove-Item -Path $testAliasDirectory -Recurse -Force
 	}
@@ -25,22 +34,28 @@ Describe "Export-Alias DRT Unit Tests" -Tags "CI" {
 		New-Item -Path $fulltestpath -ItemType File -Force
 		{Export-Alias $fulltestpath}| Should Not Throw
     }
-	
-	It "Export-Alias Resolve To Multiple will throw PSInvalidOperationException" {	
+
+	It "Export-Alias resolving to multiple files will throw ReadWriteMultipleFilesNotSupported" {
 		try {
-			Export-Alias *
+			$null = New-Item -Path $TestDrive\foo -ItemType File
+			$null = New-Item -Path $TestDrive\bar -ItemType File
+			Export-Alias $TestDrive\*
 			Throw "Execution OK"
-		} 
+		}
 		catch {
 			$_.FullyQualifiedErrorId | Should be "ReadWriteMultipleFilesNotSupported,Microsoft.PowerShell.Commands.ExportAliasCommand"
 		}
+		finally{
+			Remove-Item $TestDrive\foo -Force -ErrorAction SilentlyContinue
+			Remove-Item $TestDrive\bar -Force -ErrorAction SilentlyContinue
+		}
 	}
-	
-	It "Export-Alias with Invalid Scope will throw PSArgumentException" {	
+
+	It "Export-Alias with Invalid Scope will throw PSArgumentException" {
 		try {
 			Export-Alias $fulltestpath -scope foobar
 			Throw "Execution OK"
-		} 
+		}
 		catch {
 			$_.FullyQualifiedErrorId | Should be "Argument,Microsoft.PowerShell.Commands.ExportAliasCommand"
 		}
@@ -50,18 +65,18 @@ Describe "Export-Alias DRT Unit Tests" -Tags "CI" {
 		Export-Alias $fulltestpath abcd01 -passthru
 		$fulltestpath| Should ContainExactly '"abcd01","efgh01","","None"'
     }
-	
+
 	It "Export-Alias As CSV"{
 		Export-Alias $fulltestpath abcd01 -As CSV -passthru
 		$fulltestpath| Should ContainExactly '"abcd01","efgh01","","None"'
     }
-	
+
 	It "Export-Alias As CSV With Description"{
 		Export-Alias $fulltestpath abcd01 -As CSV -description "My Aliases" -passthru
 		$fulltestpath| Should ContainExactly '"abcd01","efgh01","","None"'
 		$fulltestpath| Should ContainExactly "My Aliases"
     }
-	
+
 	It "Export-Alias As CSV With Multiline Description"{
 		Export-Alias $fulltestpath abcd01 -As CSV -description "My Aliases\nYour Aliases\nEveryones Aliases" -passthru
 		$fulltestpath| Should ContainExactly '"abcd01","efgh01","","None"'
@@ -69,12 +84,12 @@ Describe "Export-Alias DRT Unit Tests" -Tags "CI" {
 		$fulltestpath| Should ContainExactly "Your Aliases"
 		$fulltestpath| Should ContainExactly "Everyones Aliases"
     }
-	
+
 	It "Export-Alias As Script"{
 		Export-Alias $fulltestpath abcd01 -As Script -passthru
 		$fulltestpath| Should ContainExactly 'set-alias -Name:"abcd01" -Value:"efgh01" -Description:"" -Option:"None"'
     }
-	
+
 	It "Export-Alias As Script With Multiline Description"{
 		Export-Alias $fulltestpath abcd01 -As Script -description "My Aliases\nYour Aliases\nEveryones Aliases" -passthru
 		$fulltestpath| Should ContainExactly 'set-alias -Name:"abcd01" -Value:"efgh01" -Description:"" -Option:"None"'
@@ -82,14 +97,14 @@ Describe "Export-Alias DRT Unit Tests" -Tags "CI" {
 		$fulltestpath| Should ContainExactly "Your Aliases"
 		$fulltestpath| Should ContainExactly "Everyones Aliases"
     }
-	
+
 	It "Export-Alias for Force Test"{
 		Export-Alias $fulltestpath abcd01
 		Export-Alias $fulltestpath abcd02 -force
 		$fulltestpath| Should Not ContainExactly '"abcd01","efgh01","","None"'
 		$fulltestpath| Should ContainExactly '"abcd02","efgh02","","None"'
     }
-	
+
 	It "Export-Alias for Force ReadOnly Test" {
 		Export-Alias $fulltestpath abcd01
 		if ( $IsWindows )
@@ -100,7 +115,7 @@ Describe "Export-Alias DRT Unit Tests" -Tags "CI" {
 		{
 			chmod 444 $fulltestpath
 		}
-		
+
 		try{
 			Export-Alias $fulltestpath abcd02
 		}
@@ -111,7 +126,7 @@ Describe "Export-Alias DRT Unit Tests" -Tags "CI" {
 		$fulltestpath| Should Not ContainExactly '"abcd01","efgh01","","None"'
 		$fulltestpath| Should Not ContainExactly '"abcd02","efgh02","","None"'
 		$fulltestpath| Should ContainExactly '"abcd03","efgh03","","None"'
-		
+
 		if ( $IsWindows )
 		{
 			attrib -r $fulltestpath
@@ -120,39 +135,39 @@ Describe "Export-Alias DRT Unit Tests" -Tags "CI" {
 		{
 			chmod 777 $fulltestpath
 		}
-		
+
     }
 }
 
 Describe "Export-Alias" -Tags "CI" {
-    $testAliasDirectory = Join-Path -Path $TestDrive -ChildPath ExportAliasTestDirectory
-    $testAliases        = "TestAliases"
-    $fulltestpath       = Join-Path -Path $testAliasDirectory -ChildPath $testAliases
+
+	BeforeAll {
+		$testAliasDirectory = Join-Path -Path $TestDrive -ChildPath ExportAliasTestDirectory
+		$testAliases        = "TestAliases"
+		$fulltestpath       = Join-Path -Path $testAliasDirectory -ChildPath $testAliases
+	}
 
     BeforeEach {
-	New-Item -Path $testAliasDirectory -ItemType Directory -Force
+		New-Item -Path $testAliasDirectory -ItemType Directory -Force
     }
 
     It "Should be able to create a file in the specified location"{
-	Export-Alias $fulltestpath
-
-	Test-Path $fulltestpath | Should be $true
+		Export-Alias $fulltestpath
+		Test-Path $fulltestpath | Should be $true
     }
 
     It "Should create a file with the list of aliases that match the expected list" {
-	Export-Alias $fulltestpath
+		Export-Alias $fulltestpath
+		Test-Path $fulltestpath | Should Be $true
 
-	Test-Path $fulltestpath | Should Be $true
+		$actual   = Get-Content $fulltestpath | Sort-Object
+		$expected = Get-Command -CommandType Alias
 
-	$actual   = Get-Content $fulltestpath | Sort-Object
-	$expected = Get-Command -CommandType Alias
-	
-	for ( $i=0; $i -lt $expected.Length; $i++)
-	{
-	    # We loop through the expected list and not the other because the output writes some comments to the file.
-	    $expected[$i] | Should Match $actual[$i].Name
-	}
-
+		for ( $i=0; $i -lt $expected.Length; $i++)
+		{
+			# We loop through the expected list and not the other because the output writes some comments to the file.
+			$expected[$i] | Should Match $actual[$i].Name
+		}
     }
 
     Remove-Item -Path $testAliasDirectory -Recurse -Force


### PR DESCRIPTION
The test expects multiple files to be present at the location. We
explicitly create multiple files now under $TestDrive and use that the
location for Export-Alias
Also, so test structure changes.