### PR TITLE
Jameswtruher/travisdailybuild

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -400,6 +400,7 @@ cmd.exe /C cd /d "$location" "&" "$($vcVarsPath)\vcvarsall.bat" "$NativeHostArch
 
     if($PSModuleRestore)
     {
+        $ProgressPreference = "SilentlyContinue"
         # Downloading the PowerShellGet and PackageManagement modules.
         # $Options.Output is pointing to something like "...\src\powershell-win-core\bin\Debug\netcoreapp1.1\win10-x64\publish\powershell.exe",
         # so we need to get its parent directory
@@ -835,7 +836,14 @@ function Test-PSPesterResults
     if ([int]$x.'test-results'.failures -gt 0)
     {
         logerror "TEST FAILURES"
-        foreach ( $testfail in $x.SelectNodes('.//test-case[@result = "Failure"]'))
+        # switch between methods, SelectNode is not available on dotnet core
+        if ( "System.Xml.XmlDocumentXPathExtensions" -as "Type" ) {
+            $failures = [System.Xml.XmlDocumentXPathExtensions]::SelectNodes($x."test-results",'.//test-case[@result = "Failure"]')
+        }
+        else {
+            $failures = $x.SelectNodes('.//test-case[@result = "Failure"]')
+        }
+        foreach ( $testfail in $failures )
         {
             Show-PSPesterError $testfail
         }
@@ -2813,6 +2821,8 @@ function Restore-PSModule
 
     log ("Name='{0}', Destination='{1}', Repository='{2}'" -f ($Name -join ','), $Destination, $RepositoryName)
 
+    # do not output progress
+    $ProgressPreference = "SilentlyContinue"
     $Name | ForEach-Object {
 
         $command = @{

--- a/build.psm1
+++ b/build.psm1
@@ -837,7 +837,7 @@ function Test-PSPesterResults
     {
         logerror "TEST FAILURES"
         # switch between methods, SelectNode is not available on dotnet core
-        if ( "System.Xml.XmlDocumentXPathExtensions" -as "Type" ) {
+        if ( "System.Xml.XmlDocumentXPathExtensions" -as [Type] ) {
             $failures = [System.Xml.XmlDocumentXPathExtensions]::SelectNodes($x."test-results",'.//test-case[@result = "Failure"]')
         }
         else {

--- a/test/powershell/Language/LanguageTestSupport.psm1
+++ b/test/powershell/Language/LanguageTestSupport.psm1
@@ -24,17 +24,56 @@ function Get-RuntimeError
     [CmdletBinding()]
     param(
         [Parameter(ValueFromPipeline=$True,Mandatory=$True)]
-        [string]$src
+        [string]$src,
+        [Parameter()]
+        [int]$Timeout = 0
     )
-
+ 
     $errors = $null
     try 
     {
-        [scriptblock]::Create($src).Invoke() > $null
+        # some tests cannot be run in a isolated runspace
+        # easily because they require more than just a single
+        # execution
+        if ( $Timeout -eq 0 )
+        {
+            [scriptblock]::Create($src).Invoke() > $null
+        }
+        else
+        {
+            $ps = [powershell]::Create()
+            $ps.AddScript($src) > $null
+            $ar = $ps.BeginInvoke()
+            # give it 250 milliseconds to complete
+            start-sleep -mill 250
+            if ( $ar.IsCompleted ) {
+                $ps.EndInvoke($ar)
+            }
+            # wait another ${Timeout} seconds, then give up
+            else {
+                Start-Sleep -sec $Timeout
+                if ( $ar.IsCompleted ) {
+                    # this can throw, which will be picked up below
+                    $ps.EndInvoke($ar)
+                }
+                else {
+                    # if it didn't throw, then return a constructed error
+                    $ER = Write-Error "Operation Timed Out ('$src')" 2>&1
+                    return $ER
+                }
+            }
+        }
     }
     catch 
     {
+        write-verbose -verbose "caught"
         return $_.Exception.InnerException.ErrorRecord
+    }
+    finally
+    {
+        if ( $ps -ne $null ) {
+            $ps.dispose()
+        }
     }
 }
 
@@ -76,7 +115,7 @@ function ShouldBeParseError
         if ($SkipAndCheckRuntimeError) 
         {
             It "error should happen at parse time, not at runtime" -Skip {}
-            $errors = Get-RuntimeError -Src $src
+            $errors = Get-RuntimeError -Src $src -Timeout 5
             # for runtime errors we will only get the first one
             $expectedErrors = ,$expectedErrors[0]
             $expectedOffsets = ,$expectedOffsets[0]

--- a/test/powershell/Language/LanguageTestSupport.psm1
+++ b/test/powershell/Language/LanguageTestSupport.psm1
@@ -66,7 +66,6 @@ function Get-RuntimeError
     }
     catch 
     {
-        write-verbose -verbose "caught"
         return $_.Exception.InnerException.ErrorRecord
     }
     finally
@@ -115,7 +114,7 @@ function ShouldBeParseError
         if ($SkipAndCheckRuntimeError) 
         {
             It "error should happen at parse time, not at runtime" -Skip {}
-            $errors = Get-RuntimeError -Src $src -Timeout 5
+            $errors = Get-RuntimeError -Src $src -Timeout 10
             # for runtime errors we will only get the first one
             $expectedErrors = ,$expectedErrors[0]
             $expectedOffsets = ,$expectedOffsets[0]

--- a/test/powershell/Language/Scripting/NativeExecution/NativeLinuxCommands.Tests.ps1
+++ b/test/powershell/Language/Scripting/NativeExecution/NativeLinuxCommands.Tests.ps1
@@ -1,28 +1,37 @@
+if ( $IsWindows ) {
+    $PesterSkipOrPending = @{ Skip = $true }
+}
+elseif ( $IsOSX ) {
+    $PesterSkipOrPending = @{ Pending = $true }
+}
+else {
+    $PesterSkipOrPending = @{}
+}
 Describe "NativeLinuxCommands" -tags "CI" {
     It "Should return a type of System.Object for hostname cmdlet" {
         (hostname).GetType().BaseType | Should Be 'System.Object'
         (hostname).GetType().Name | Should Be String
     }
 
-    It "Should find Application grep" -Skip:$IsWindows {
+    It "Should find Application grep" @PesterSkipOrPending {
         (get-command grep).CommandType | Should Be Application
     }
 
-    It "Should pipe to grep and get result" -Skip:$IsWindows {
+    It "Should pipe to grep and get result" @PesterSkipOrPending {
         "hello world" | grep hello | Should Be "hello world"
     }
 
-    It "Should find Application touch" -Skip:$IsWindows {
+    It "Should find Application touch" @PesterSkipOrPending {
         (get-command touch).CommandType | Should Be Application
     }
 
-    It "Should not redirect standard input if native command is the first command in pipeline (1)" -Skip:$IsWindows {
+    It "Should not redirect standard input if native command is the first command in pipeline (1)" @PesterSkipOrPending {
         stty | ForEach-Object -Begin { $out = @() } -Process { $out += $_ }
         $out.Length -gt 0 | Should Be $true
         $out[0] -like "speed * baud; line =*" | Should Be $true
     }
 
-    It "Should not redirect standard input if native command is the first command in pipeline (2)" -Skip:$IsWindows {
+    It "Should not redirect standard input if native command is the first command in pipeline (2)" @PesterSkipOrPending {
         $out = stty
         $out.Length -gt 0 | Should Be $true
         $out[0] -like "speed * baud; line =*" | Should Be $true

--- a/test/powershell/Language/Scripting/ScriptHelp.Tests.ps1
+++ b/test/powershell/Language/Scripting/ScriptHelp.Tests.ps1
@@ -1,4 +1,6 @@
-﻿ Describe 'get-help HelpFunc1' -Tags "Feature" { 
+$ProgressPreference = "SilentlyContinue"
+
+Describe 'get-help HelpFunc1' -Tags "Feature" { 
     BeforeAll {
     function TestHelpError {
         [CmdletBinding()]
@@ -22,7 +24,7 @@
         It '$x.relatedLinks.navigationLink[0].uri' {  $x.relatedLinks.navigationLink[0].uri | Should Be "http://blogs.msdn.com/powershell" }
         It '$x.relatedLinks.navigationLink[1].linkText' { $x.relatedLinks.navigationLink[1].linkText | Should Be "other commands" }
         It '$x.examples.example.code' { $x.examples.example.code | Should Be "If you need an example, you're hopeless." }
-        It '$x.inputTypes.inputType.type.name‘ { $x.inputTypes.inputType.type.name | Should Be "Anything you like." }
+        It '$x.inputTypes.inputType.type.name' { $x.inputTypes.inputType.type.name | Should Be "Anything you like." }
         It '$x.returnValues.returnValue.type.name' { $x.returnValues.returnValue.type.name | Should Be  "Nothing." }
         It '$x.Component' { $x.Component | Should Be "Something" }
         It '$x.Role' { $x.Role | Should Be "CrazyUser" }

--- a/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/CounterTestHelperFunctions.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/CounterTestHelperFunctions.ps1
@@ -142,7 +142,10 @@ using System.Text;
     }
 "@
 
-Add-Type -TypeDefinition $helperSource
+if ( $IsWindows )
+{
+    Add-Type -TypeDefinition $helperSource
+}
 
 # Strip off machine name, if present, from counter path
 function RemoveMachineName
@@ -167,8 +170,11 @@ function RemoveMachineName
 # Retrieve the counters array from the Registry
 function GetCounters
 {
-    $key = 'Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Perflib\CurrentLanguage'
-    return (Get-ItemProperty -Path $key -Name Counter).Counter
+    if ( $IsWindows )
+    {
+        $key = 'Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Perflib\CurrentLanguage'
+        return (Get-ItemProperty -Path $key -Name Counter).Counter
+    }
 }
 
 # Translate a counter name from English to a localized counter name

--- a/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/CounterTestHelperFunctions.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/CounterTestHelperFunctions.ps1
@@ -288,7 +288,8 @@ function CompareCounterSets
 function SkipCounterTests
 {
     if ([System.Management.Automation.Platform]::IsLinux -or
-        [System.Management.Automation.Platform]::IsOSX)
+        [System.Management.Automation.Platform]::IsOSX -or
+        [System.Management.Automation.Platform]::IsIoT)
     {
         return $true
     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/Import-Counter.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/Import-Counter.Tests.ps1
@@ -7,18 +7,26 @@ $cmdletName = "Import-Counter"
 
 . "$PSScriptRoot/CounterTestHelperFunctions.ps1"
 
-$counterPaths = @(
-    (TranslateCounterPath "\Memory\Available Bytes")
-    (TranslateCounterPath "\processor(*)\% Processor time")
-    (TranslateCounterPath "\Processor(_Total)\% Processor Time")
-    (TranslateCounterPath "\PhysicalDisk(_Total)\Current Disk Queue Length")
-    (TranslateCounterPath "\PhysicalDisk(_Total)\Disk Bytes/sec")
-    (TranslateCounterPath "\PhysicalDisk(_Total)\Disk Read Bytes/sec")
-)
-$setNames = @{
-    Memory = (TranslateCounterName "memory")
-    PhysicalDisk = (TranslateCounterName "physicaldisk")
-    Processor = (TranslateCounterName "processor")
+if ( $IsWindows )
+{
+    $counterPaths = @(
+        (TranslateCounterPath "\Memory\Available Bytes")
+        (TranslateCounterPath "\processor(*)\% Processor time")
+        (TranslateCounterPath "\Processor(_Total)\% Processor Time")
+        (TranslateCounterPath "\PhysicalDisk(_Total)\Current Disk Queue Length")
+        (TranslateCounterPath "\PhysicalDisk(_Total)\Disk Bytes/sec")
+        (TranslateCounterPath "\PhysicalDisk(_Total)\Disk Read Bytes/sec")
+        )
+    $setNames = @{
+        Memory = (TranslateCounterName "memory")
+        PhysicalDisk = (TranslateCounterName "physicaldisk")
+        Processor = (TranslateCounterName "processor")
+        }
+}
+else 
+{
+    $counterPaths = @()
+    $setNames = @{}
 }
 
 $badSamplesBlgPath = Join-Path $PSScriptRoot "assets" "BadCounterSamples.blg"
@@ -35,12 +43,12 @@ function SetScriptVars([string]$rootPath, [int]$maxSamples, [bool]$export)
     $script:tsvPath = Join-Path $rootPath "$rootFilename.tsv"
 
     $script:counterSamples = $null
-    if ($maxSamples)
+    if ($maxSamples -and $IsWindows)
     {
         $script:counterSamples = Get-Counter -Counter $counterPaths -MaxSamples $maxSamples
     }
 
-    if ($export)
+    if ($export -and $IsWindows)
     {
         Export-Counter -Force -FileFormat "blg" -Path $script:blgPath -InputObject $script:counterSamples
         Export-Counter -Force -FileFormat "csv" -Path $script:csvPath -InputObject $script:counterSamples
@@ -110,7 +118,7 @@ function RunTest($testCase)
         }
 
         $cmd = ConstructCommand $testCase
-        Write-Host "Command to run: $cmd"
+        # Write-Host "Command to run: $cmd"
         $cmd = $cmd + " -ErrorAction SilentlyContinue -ErrorVariable errVar"
 
         $errVar = $null

--- a/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/Import-Counter.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/Import-Counter.Tests.ps1
@@ -7,7 +7,17 @@ $cmdletName = "Import-Counter"
 
 . "$PSScriptRoot/CounterTestHelperFunctions.ps1"
 
-if ( $IsWindows )
+if ( $IsWindows -and ! [System.Management.Automation.Platform]::IsIoT )
+{
+    $ShouldRun = $true
+}
+else
+{
+    # don't run on IoT, Linux, or Mac
+    $ShouldRun = $false
+}
+
+if ( $ShouldRun )
 {
     $counterPaths = @(
         (TranslateCounterPath "\Memory\Available Bytes")
@@ -43,12 +53,12 @@ function SetScriptVars([string]$rootPath, [int]$maxSamples, [bool]$export)
     $script:tsvPath = Join-Path $rootPath "$rootFilename.tsv"
 
     $script:counterSamples = $null
-    if ($maxSamples -and $IsWindows)
+    if ($maxSamples -and $ShouldRun)
     {
         $script:counterSamples = Get-Counter -Counter $counterPaths -MaxSamples $maxSamples
     }
 
-    if ($export -and $IsWindows)
+    if ($export -and $ShouldRun)
     {
         Export-Counter -Force -FileFormat "blg" -Path $script:blgPath -InputObject $script:counterSamples
         Export-Counter -Force -FileFormat "csv" -Path $script:csvPath -InputObject $script:counterSamples

--- a/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/Import-Counter.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/Import-Counter.Tests.ps1
@@ -7,17 +7,9 @@ $cmdletName = "Import-Counter"
 
 . "$PSScriptRoot/CounterTestHelperFunctions.ps1"
 
-if ( $IsWindows -and ! [System.Management.Automation.Platform]::IsIoT )
-{
-    $ShouldRun = $true
-}
-else
-{
-    # don't run on IoT, Linux, or Mac
-    $ShouldRun = $false
-}
+$SkipTests = SkipCounterTests
 
-if ( $ShouldRun )
+if ( ! $SkipTests )
 {
     $counterPaths = @(
         (TranslateCounterPath "\Memory\Available Bytes")
@@ -53,12 +45,12 @@ function SetScriptVars([string]$rootPath, [int]$maxSamples, [bool]$export)
     $script:tsvPath = Join-Path $rootPath "$rootFilename.tsv"
 
     $script:counterSamples = $null
-    if ($maxSamples -and $ShouldRun)
+    if ($maxSamples -and ! $SkipTests )
     {
         $script:counterSamples = Get-Counter -Counter $counterPaths -MaxSamples $maxSamples
     }
 
-    if ($export -and $ShouldRun)
+    if ($export -and ! $SkipTests )
     {
         Export-Counter -Force -FileFormat "blg" -Path $script:blgPath -InputObject $script:counterSamples
         Export-Counter -Force -FileFormat "csv" -Path $script:csvPath -InputObject $script:counterSamples

--- a/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/Import-Counter.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/Import-Counter.Tests.ps1
@@ -118,7 +118,6 @@ function RunTest($testCase)
         }
 
         $cmd = ConstructCommand $testCase
-        # Write-Host "Command to run: $cmd"
         $cmd = $cmd + " -ErrorAction SilentlyContinue -ErrorVariable errVar"
 
         $errVar = $null

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ComputerInfo.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ComputerInfo.Tests.ps1
@@ -1318,7 +1318,7 @@ try {
         } 
 
 
-        It "(special case) Test for property = OsFreeSpaceInPagingFiles" -Skip:([System.Management.Automation.Platform]::IsIoT) {
+        It "(special case) Test for property = OsFreeSpaceInPagingFiles" -Skip:([System.Management.Automation.Platform]::IsIoT -or !$IsWindows) {
             ($observed.OsFreeSpaceInPagingFiles -gt 0) | Should Be $true
         } 
 

--- a/test/powershell/Modules/PowerShellGet/PowerShellGet.Tests.ps1
+++ b/test/powershell/Modules/PowerShellGet/PowerShellGet.Tests.ps1
@@ -1,4 +1,7 @@
-﻿$RepositoryName = 'INTGallery'
+﻿# no progress output during these tests
+$ProgressPreference = "SilentlyContinue"
+
+$RepositoryName = 'INTGallery'
 $SourceLocation = 'https://dtlgalleryint.cloudapp.net'
 $RegisteredINTRepo = $false
 $ContosoServer = 'ContosoServer'
@@ -89,6 +92,7 @@ function Remove-InstalledModules
 {
     Get-InstalledModule -Name $ContosoServer -AllVersions -ErrorAction SilentlyContinue | Uninstall-Module -Force
 }
+
 
 Describe "PowerShellGet - Module tests" -tags "Feature" {
 

--- a/test/powershell/Modules/PowerShellGet/PowerShellGet.Tests.ps1
+++ b/test/powershell/Modules/PowerShellGet/PowerShellGet.Tests.ps1
@@ -93,7 +93,6 @@ function Remove-InstalledModules
     Get-InstalledModule -Name $ContosoServer -AllVersions -ErrorAction SilentlyContinue | Uninstall-Module -Force
 }
 
-
 Describe "PowerShellGet - Module tests" -tags "Feature" {
 
     BeforeEach {

--- a/test/powershell/engine/Help/HelpSystem.Tests.ps1
+++ b/test/powershell/engine/Help/HelpSystem.Tests.ps1
@@ -19,7 +19,7 @@ function UpdateHelpFromLocalContentPath
     }
     else
     {
-        Update-Help -Module $ModuleName -Force -Verbose -ErrorAction Stop
+        Update-Help -Module $ModuleName -Force -ErrorAction Stop
     }
 }
 

--- a/tools/travis.ps1
+++ b/tools/travis.ps1
@@ -17,13 +17,6 @@ $pesterParam = @{ 'binDir' = $output }
 if ($isFullBuild) {
     $pesterParam['Tag'] = @('CI','Feature','Scenario')
     $pesterParam['ExcludeTag'] = @()
-    # cron jobs create log files which include the stdout of Pester
-    # which creates too much data for travis to put in the log file
-    # and the job is then cancelled. Add Quiet to reduce the log size
-    # the xunit log created by pester is what is important
-    if ( $env:TRAVIS_EVENT_TYPE -eq 'cron' ) {
-        $pesterParam['Quiet'] = $true
-    }
 } else {
     $pesterParam['Tag'] = @('CI')
     $pesterParam['ThrowOnFailure'] = $true


### PR DESCRIPTION
enable daily test run support in travis

This also includes a number of test changes which need to be reviewed by the test owners
@lzybkr I've made changes in parser tests to support async execution to avoid test run hangs which have sporadically appeared. Now, if one of those tests hang, it (the test) will fail rather than the entire run.
@Francisco-Gamino, I've made changes to the help tests, counter and management tests

once this is merged, I'll have an addition PR to put the test run badge in the ReadMe.md (after I create the cron job to actually run the tests)