### PR TITLE
Fixing NoException! message in tests where an exception was expected,…

### DIFF
--- a/docs/testing-guidelines/WritingPesterTests.md
+++ b/docs/testing-guidelines/WritingPesterTests.md
@@ -59,7 +59,7 @@ it "Get-Item on a nonexisting file should have error PathNotFound" {
     try
     {
         get-item "ThisFileCannotPossiblyExist" -ErrorAction Stop
-        throw "No Exception!"
+        throw "Expected an exception throw, but no Exception was thrown."
     }
     catch
     {

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/TestGetCommand.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/TestGetCommand.Tests.ps1
@@ -244,7 +244,7 @@
         try
         {       
             Get-Command testgetcommand-dynamicparametersdcr -testtorun returnduplicateparameter -ErrorAction Stop
-            throw "No Exception!"
+            throw "Expected an exception throw, but no Exception was thrown."
         }
         catch
         {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Start-Process.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Start-Process.Tests.ps1
@@ -74,7 +74,7 @@ Describe "Start-Process" -Tags @("CI","SLOW") {
         try 
         {
             Start-Process -Verb runas -FilePath $pingCommand -ArgumentList $pingParam
-            throw "No Exception!"
+            throw "Expected an exception throw, but no Exception was thrown."
         }
         catch
         {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/TimeZone.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/TimeZone.Tests.ps1
@@ -167,7 +167,7 @@ Describe "Set-Timezone test cases" -Tags @('Feature', 'RequireAdminOnWindows') {
         try
         {
             Set-TimeZone -Id "zzInvalidID"
-            throw "No Exception!"
+            throw "Expected an exception throw, but no Exception was thrown."
         }
         catch
         {
@@ -196,7 +196,7 @@ Describe "Set-Timezone test cases" -Tags @('Feature', 'RequireAdminOnWindows') {
         try
         {
             Set-TimeZone -Name "zzINVALID_Name"
-            throw "No Exception!"
+            throw "Expected an exception throw, but no Exception was thrown."
         }
         catch
         {

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/ExecutionPolicy.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/ExecutionPolicy.Tests.ps1
@@ -919,7 +919,7 @@ ZoneId=$FileType
         )
         try {
             Set-ExecutionPolicy -Scope $policyScope -ExecutionPolicy Restricted
-            throw "No Exception!"
+            throw "Expected an exception throw, but no Exception was thrown."
         }
         catch {
             $_.FullyQualifiedErrorId | Should Be "CantSetGroupPolicy,Microsoft.PowerShell.Commands.SetExecutionPolicyCommand"

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/SecureString.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/SecureString.Tests.ps1
@@ -14,7 +14,7 @@ Describe "SecureString conversion tests" -Tags "CI" {
     It "using null arguments to ConvertFrom-SecureString produces an exception" {
         try {
             ConvertFrom-SecureString -secureString $null -key $null
-            throw "No Exception!"
+            throw "Expected an exception throw, but no Exception was thrown."
         }
         catch {
             $_.FullyQualifiedErrorId | should be "ParameterArgumentValidationErrorNullNotAllowed,Microsoft.PowerShell.Commands.ConvertFromSecureStringCommand"

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Export-Alias.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Export-Alias.Tests.ps1
@@ -118,7 +118,7 @@ Describe "Export-Alias DRT Unit Tests" -Tags "CI" {
 
 		try{
 			Export-Alias $fulltestpath abcd02
-			throw "No Exception!"
+			throw "Expected an exception throw, but no Exception was thrown."
 		}
 		catch{
 			$_.FullyQualifiedErrorId | Should be "FileOpenFailure,Microsoft.PowerShell.Commands.ExportAliasCommand"

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-Wide.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-Wide.Tests.ps1
@@ -27,7 +27,7 @@ Describe "Format-Wide" -Tags "CI" {
         try
 		{
 			Format-Wide -InputObject $(Get-ChildItem) -Property CreationTime -View aoeu
-			throw "No Exception!"
+			throw "Expected an exception throw, but no Exception was thrown."
 		}
 		catch
 		{

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Alias.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Alias.Tests.ps1
@@ -224,7 +224,7 @@ Describe "Get-Alias null tests" -Tags "CI" {
       try 
       {
           Get-Alias -Name $data
-          throw "No Exception!"
+          throw "Expected an exception throw, but no Exception was thrown."
       }
       catch { $_.FullyQualifiedErrorId | Should Be 'ParameterArgumentValidationError,Microsoft.PowerShell.Commands.GetAliasCommand' }
     }
@@ -235,7 +235,7 @@ Describe "Get-Alias null tests" -Tags "CI" {
       try 
       {
           $data | Get-Alias -ErrorAction Stop
-          throw "No Exception!"
+          throw "Expected an exception throw, but no Exception was thrown."
       }
       catch { $_.FullyQualifiedErrorId | Should Be 'ParameterArgumentValidationError,Microsoft.PowerShell.Commands.GetAliasCommand' }
     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Uptime.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Uptime.Tests.ps1
@@ -32,7 +32,7 @@ Describe "Get-Uptime" -Tags "CI" {
             [system.management.automation.internal.internaltesthooks]::SetTestHook('StopwatchIsNotHighResolution', $true) 
 
             Get-Uptime
-            throw "No Exception!"
+            throw "Expected an exception throw, but no Exception was thrown."
         }
         catch
         {

--- a/test/powershell/engine/ParameterBinding/ParameterBinding.Tests.ps1
+++ b/test/powershell/engine/ParameterBinding/ParameterBinding.Tests.ps1
@@ -15,7 +15,7 @@
         try
         {
             test-PositionalBinding1 1
-            throw "No Exception!"
+            throw "Expected an exception throw, but no Exception was thrown."
         }
         catch
         {
@@ -65,7 +65,7 @@
         try
         {
             test-allownullattributes -Parameter2 1 -Parameter3 $null -ShowMe 1
-            throw "No Exception!"
+            throw "Expected an exception throw, but no Exception was thrown."
         }
         catch
         {
@@ -91,7 +91,7 @@
         try
         {
             test-namedwithboolishargument -Parameter2 -Parameter1
-            throw "No Exception!"
+            throw "Expected an exception throw, but no Exception was thrown."
         }
         catch
         {
@@ -151,7 +151,7 @@
         try
         {
             test-singleintparameter -Parameter1 'dookie'
-            throw "No Exception!"
+            throw "Expected an exception throw, but no Exception was thrown."
         }
         catch
         {
@@ -270,7 +270,7 @@
         try
         {
             test-nameconflicts6 -Parameter2 1
-            throw "No Exception!"
+            throw "Expected an exception throw, but no Exception was thrown."
         }
         catch
         {


### PR DESCRIPTION
… but one was not thrown.

Fixes #2971 