### PR TITLE
New-Item -ItemType SymbolicLink cannot understand directory path ending with slash on Linux

### DIFF
--- a/src/System.Management.Automation/engine/SessionStateContainer.cs
+++ b/src/System.Management.Automation/engine/SessionStateContainer.cs
@@ -9,6 +9,7 @@ using System.Management.Automation.Runspaces;
 using System.Management.Automation.Internal;
 using System.Reflection;
 using Dbg = System.Management.Automation;
+using System.IO;
 
 #pragma warning disable 1634, 1691 // Stops compiler from warning about unknown warnings
 #pragma warning disable 56500
@@ -3689,9 +3690,16 @@ namespace System.Management.Automation
 
             foreach (string path in paths)
             {
+                string resolvePath = null;
                 if (path == null)
                 {
                     PSTraceSource.NewArgumentNullException("paths");
+                }
+                else
+                {
+                    // To be compatible with Linux OS. Which will be either '/' or '\' depends on the OS type.
+                    char[] charsToTrim = {' ', Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar};
+                    resolvePath = path.TrimEnd(charsToTrim);
                 }
 
                 ProviderInfo provider = null;
@@ -3705,7 +3713,7 @@ namespace System.Management.Automation
                 if (String.IsNullOrEmpty(name))
                 {
                     string providerPath =
-                        Globber.GetProviderPath(path, context, out provider, out driveInfo);
+                        Globber.GetProviderPath(resolvePath, context, out provider, out driveInfo);
 
                     providerInstance = GetProviderInstance(provider);
                     providerPaths.Add(providerPath);
@@ -3714,7 +3722,7 @@ namespace System.Management.Automation
                 {
                     providerPaths =
                         Globber.GetGlobbedProviderPathsFromMonadPath(
-                                path,
+                                resolvePath,
                                 true,
                                 context,
                                 out provider,

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/New-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/New-Item.Tests.ps1
@@ -181,4 +181,10 @@ Describe "New-Item with links" -Tags @('CI', 'RequireAdminOnWindows') {
             $_.FullyQualifiedErrorId | Should Be "NewItemSymbolicLinkElevationRequired,Microsoft.PowerShell.Commands.NewItemCommand"
         }
     }
+
+    It "New-Item -ItemType SymbolicLink should understand directory path ending with slash" {
+        $folderName = [System.IO.Path]::GetRandomFileName()            
+        $symbolicLinkPath = New-Item -ItemType SymbolicLink -Path "$tmpDirectory/$folderName/" -Value "/bar/"
+        $symbolicLinkPath | Should Not Be $null
+    }
 }


### PR DESCRIPTION
Relevant issue: #2865

Steps to reproduce
```powershell
New-Item -ItemType SymbolicLink -Path /foo/ -Value /bar/
```
Expected behavior

Symbolic link is created from /foo/ to /bar/.

Actual behavior
```
New-Item : No such file or directory
```
Removing the slash at the end of the Path argument makes the call behave as expected. This is counterintuitive, as a slash at the end of a path generally works fine in PowerShell scripts to designate directories (and directory links).

Environment data

Running PowerShell on Ubuntu 16.04.
```
> $PSVersionTable
Name                           Value
----                           -----
PSVersion                      6.0.0-alpha
PSEdition                      Core
PSCompatibleVersions           {1.0, 2.0, 3.0, 4.0...}
BuildVersion                   3.0.0.0
GitCommitId                    v6.0.0-alpha.12
CLRVersion
WSManStackVersion              3.0
PSRemotingProtocolVersion      2.3
SerializationVersion           1.1.0.1
```