### PR TITLE
Add dependent symlinks in package for libmi.so

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -1423,6 +1423,13 @@ It consists of a cross-platform command-line shell and associated scripting lang
     New-Item -Force -ItemType SymbolicLink -Path "/tmp/$Name" -Target "$Destination/$Name" >$null
 
     if ($IsCentos) {
+        # add two symbolic links to system shared libraries that libmi.so is dependent on to handle
+        # platform specific changes. This is the only set of platforms needed for this currently
+        # as Ubuntu has these specific library files in the platform and OSX builds for itself 
+        # against the correct versions.
+        New-Item -Force -ItemType SymbolicLink -Target "/lib64/libssl.so.10" -Path "$Staging/libssl.so.1.0.0" >$null
+        New-Item -Force -ItemType SymbolicLink -Target "/lib64/libcrypto.so.10" -Path "$Staging/libcrypto.so.1.0.0" >$null
+
         $AfterInstallScript = [io.path]::GetTempFileName()
         $AfterRemoveScript = [io.path]::GetTempFileName()
         @'


### PR DESCRIPTION
When installing PSRP client bits for Centos with powershell we need to also add a couple of symbolic links for both crypto and ssl system libraries. This is because we create libmi.so in a platform independent way and to work around platform differences we use the symbolic links. 
This change adds the necessary changes to the packaging build script before it generates the platform package bundle.
Ubuntu does not need this change as the library names already match on that platform with the names we chose to use.