### PR TITLE
Another attempt to make native timer test less flaky

### DIFF
--- a/test/powershell/Common/Test.Helpers.psm1
+++ b/test/powershell/Common/Test.Helpers.psm1
@@ -1,4 +1,4 @@
-function Wait-CompleteExecution
+function Wait-UntilTrue
 {
     [CmdletBinding()]
     param ( 
@@ -66,5 +66,5 @@ function ShouldBeErrorId
         }
 }
 
-export-modulemember -function Wait-CompleteExecution,Test-IsElevated, ShouldBeErrorId
+export-modulemember -function Wait-UntilTrue,Test-IsElevated, ShouldBeErrorId
 

--- a/test/powershell/Language/Classes/Scripting.Classes.BasicParsing.Tests.ps1
+++ b/test/powershell/Language/Classes/Scripting.Classes.BasicParsing.Tests.ps1
@@ -1,7 +1,7 @@
 #
 # Copyright (c) Microsoft Corporation, 2014
 #
-Import-Module $PSScriptRoot\..\LanguageTestSupport.psm1 -force
+Import-Module $PSScriptRoot\..\LanguageTestSupport.psm1
 
 Describe 'Positive Parse Properties Tests' -Tags "CI" {
     It 'PositiveParsePropertiesTest' {

--- a/test/powershell/Language/Parser/Parsing.Tests.ps1
+++ b/test/powershell/Language/Parser/Parsing.Tests.ps1
@@ -1,4 +1,4 @@
-﻿Import-Module $PSScriptRoot\..\LanguageTestSupport.psm1 -force
+﻿Import-Module $PSScriptRoot\..\LanguageTestSupport.psm1
 set-strictmode -v 2    
 
     

--- a/test/powershell/Language/Scripting/Debugging/Debugging.Tests.ps1
+++ b/test/powershell/Language/Scripting/Debugging/Debugging.Tests.ps1
@@ -34,7 +34,7 @@ Describe "Breakpoints when set should be hit" -tag "CI" {
 
 Describe "It should be possible to reset runspace debugging" -tag "Feature" {
     BeforeAll {
-        import-module $helperModule -force
+        import-module $helperModule
         $path = setup -pass -f TestScript_2.ps1 -content $script2
         $scriptPath = "$testdrive/TestScript_2.ps1"
         $iss = [initialsessionstate]::CreateDefault2();

--- a/test/powershell/Language/Scripting/Debugging/Debugging.Tests.ps1
+++ b/test/powershell/Language/Scripting/Debugging/Debugging.Tests.ps1
@@ -58,7 +58,7 @@ Describe "It should be possible to reset runspace debugging" -tag "Feature" {
 
         # Run script file until breakpoint hit.
         $ar = $ps.AddScript("$scriptPath").BeginInvoke()
-        $completed = Wait-CompleteExecution { $rs.Debugger.InBreakPoint -eq $true } -timeout 10000 -interval 200 
+        $completed = Wait-UntilTrue { $rs.Debugger.InBreakPoint -eq $true } -timeout 10000 -interval 200 
         $ps.Stop()
         $rs.ResetRunspaceState()
     }

--- a/test/powershell/Language/Scripting/NativeExecution/NativeCommandProcessor.Tests.ps1
+++ b/test/powershell/Language/Scripting/NativeExecution/NativeCommandProcessor.Tests.ps1
@@ -23,7 +23,7 @@ Describe 'native commands lifecycle' -tags 'Feature' {
 
         # waiting 30 seconds, because powershell startup time could be long on the slow machines,
         # such as CI
-        Wait-CompleteExecution { $rs.RunspaceAvailability -eq 'Available' } -timeout 30000 -interval 100 | Should Be $true
+        Wait-UntilTrue { $rs.RunspaceAvailability -eq 'Available' } -timeout 30000 -interval 100 | Should Be $true
 
         $ps.Stop()
         $rs.ResetRunspaceState()

--- a/test/powershell/Language/Scripting/NativeExecution/NativeCommandProcessor.Tests.ps1
+++ b/test/powershell/Language/Scripting/NativeExecution/NativeCommandProcessor.Tests.ps1
@@ -5,7 +5,7 @@ $helperModule = join-path $common Test.Helpers.psm1
 Describe 'native commands lifecycle' -tags 'Feature' {
 
     BeforeAll {
-        Import-Module $helperModule -force
+        Import-Module $helperModule
         $powershell = Join-Path -Path $PsHome -ChildPath "powershell"
     }
 

--- a/test/powershell/Modules/PowerShellGet/PowerShellGet.Tests.ps1
+++ b/test/powershell/Modules/PowerShellGet/PowerShellGet.Tests.ps1
@@ -68,7 +68,7 @@ $PSVersionTable
 $env:PSModulePath
 
 Get-Module -ListAvailable -Name PackageManagement, PowerShellGet
-Import-Module PackageManagement -force -verbose
+Import-Module PackageManagement -verbose
 Get-PackageProvider -ListAvailable
 
 $repo = Get-PSRepository -ErrorAction SilentlyContinue | 

--- a/test/tools/CodeCoverageAutomation/Start-CodeCoverageRun.ps1
+++ b/test/tools/CodeCoverageAutomation/Start-CodeCoverageRun.ps1
@@ -59,7 +59,7 @@ try
 
     Write-LogPassThru -Message "Expansion complete."
 
-    Import-Module "$openCoverPath\OpenCover" -force
+    Import-Module "$openCoverPath\OpenCover"
     Install-OpenCover -TargetDirectory $openCoverTargetDirectory -force
     Write-LogPassThru -Message "OpenCover installed."
 


### PR DESCRIPTION
Suppresses #2805 
Fix #2802

Updated per @lzybkr proposal: now `native | ps` runs in the separate runspace.
Opening a new PR, because I accidentally messed up Travis CI in the previos one, when I pushed to the main repo.