### PR TITLE
Use correct win32 console mode w/ external commands

### DIFF
--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleControl.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleControl.cs
@@ -654,6 +654,8 @@ namespace Microsoft.PowerShell
             ProcessedOutput = 0x001,  // yes, I know they are the same values as some flags defined above.
             WrapEndOfLine = 0x002,
             VirtualTerminal = 0x004,
+            // Error getting console mode
+            Unknown = 0xffffffff,
         }
 
         /// <summary>


### PR DESCRIPTION
At startup, we need to save the current console mode before potentially
enabling VT100 support.

Then, when running an external command, we should use that initial
console mode instead of whatever mode we changed it to.

An application can't rely on the shell enabling VT100 because enabling
by default can cause problems for some applications, therefore
Windows applications must enable VT100 themselves.

Fixes #1177