### PR TITLE
Fixed a null dereference in `UsingStatementRule()`

### DIFF
--- a/src/System.Management.Automation/engine/parser/Parser.cs
+++ b/src/System.Management.Automation/engine/parser/Parser.cs
@@ -4426,6 +4426,7 @@ namespace System.Management.Automation.Language
             if (itemAst == null)
             {
                 ReportError(itemToken.Extent, () => ParserStrings.InvalidValueForUsingItemName, itemToken.Text);
+                return new ErrorStatementAst(ExtentOf(usingToken, itemToken));
             }
 
             if (!(itemAst is StringConstantExpressionAst) && (kind != UsingStatementKind.Module || !(itemAst is HashtableAst)))


### PR DESCRIPTION
Fixes [#2992](https://github.com/PowerShell/PowerShell/issues/2992).

Single line fix that returns an `ErrorStatementAst` after a null check, rather than continuing to next check and dereferencing.