### PR TITLE
Adding '$pshome/cultureName/default.help.txt' to PowerShell Windows Core project. 

### DIFF
--- a/src/System.Management.Automation/help/ProviderContext.cs
+++ b/src/System.Management.Automation/help/ProviderContext.cs
@@ -4,6 +4,7 @@ Copyright (c) Microsoft Corporation.  All rights reserved.
 
 using System.Management.Automation.Provider;
 using System.Xml;
+using System.Management.Automation.Internal;
 
 using Dbg = System.Management.Automation.Diagnostics;
 
@@ -51,6 +52,13 @@ namespace System.Management.Automation
         /// </summary>
         internal MamlCommandHelpInfo GetProviderSpecificHelpInfo(string helpItemName)
         {
+            if (InternalTestHooks.BypassOnlineHelpRetrieval)
+            {
+                // By returning null, we force get-help to return generic help
+                // which includes a helpUri that points to the fwlink defined in the cmdlet code.
+                return null;
+            }
+
             // Get the provider.
             ProviderInfo providerInfo = null;
             PSDriveInfo driveInfo = null;

--- a/src/powershell-win-core/project.json
+++ b/src/powershell-win-core/project.json
@@ -85,7 +85,8 @@
         "Microsoft.PowerShell.LocalAccounts": "6.0.0-*",
         "Microsoft.Management.Infrastructure.CimCmdlets": "6.0.0-*",
         "Microsoft.WSMan.Management": "6.0.0-*",
-        "PSDesiredStateConfiguration": "1.0.0-alpha01"
+        "PSDesiredStateConfiguration": "1.0.0-alpha01",
+        "PowerShellHelpFiles": "1.0.0-alpha01"
     },
 
     "frameworks": {

--- a/test/powershell/engine/Help/HelpSystem.OnlineHelp.Tests.ps1
+++ b/test/powershell/engine/Help/HelpSystem.OnlineHelp.Tests.ps1
@@ -3,23 +3,16 @@
     # The csv files (V2Cmdlets.csv and V3Cmdlets.csv) contain a list of cmdlets and expected HelpURIs.
     # The HelpURI is part of the cmdlet metadata, and when the user runs 'get-help <cmdletName> -online'
     # the browser navigates to the address in the HelpURI. However, if a help file is present, the HelpURI
-    # on the file take precedence over the one in the cmdlet metadata. Therefore, the help content
-    # in the box needs to be deleted before running the tests, because otherwise, the HelpURI
-    # (when calling get-help -online) might not matched the one in the csv file.
+    # on the file take precedence over the one in the cmdlet metadata.
 
     BeforeAll {
         $SavedProgressPreference = $ProgressPreference
         $ProgressPreference = "SilentlyContinue"
 
-        # Enable the test hook
+        # Enable the test hook. This does the following:
+        # 1) get-help will not find a help file; instead, it will generate a metadata driven object.
+        # 2) get-help -online <cmdletName>  will return the helpuri instead of opening the default web browser.
         [system.management.automation.internal.internaltesthooks]::SetTestHook('BypassOnlineHelpRetrieval', $true)
-
-        # Remove the help content
-        Write-Verbose "Deleting help content for get-help -online tests" -Verbose
-        foreach ($path in @("$pshome\en-US", "$pshome\Modules"))
-        {
-            Get-ChildItem $path -Include "*help.xml" -Recurse -ea SilentlyContinue | Remove-Item -Force -ErrorAction SilentlyContinue
-        }
     }
 
     AfterAll {

--- a/test/powershell/engine/Help/HelpSystem.Tests.ps1
+++ b/test/powershell/engine/Help/HelpSystem.Tests.ps1
@@ -62,6 +62,17 @@ function RunTestCase
     }
 }
 
+Describe "Validate that <pshome>/<culture>/default.help.txt is present" -Tags @('CI') {
+
+    It "Get-Help returns information about the help system." {
+
+        $help = Get-Help
+        $help.Name | Should Be "default"
+        $help.Category | Should Be "HelpFile"
+        $help.Synopsis | Should Match "SHORT DESCRIPTION"
+    }
+}
+
 Describe "Validate that get-help <cmdletName> works" -Tags @('CI', 'RequireAdminOnWindows') {
     BeforeAll {
         $SavedProgressPreference = $ProgressPreference


### PR DESCRIPTION
Fixing issue '$pshome/cultureName/default.help.txt' is missing #1731

Added package PowerShellHelpFiles to the PowerShell Windows Core project (src/powershell-win-core/project.json) to include the help files when PowerShell is published.

Added a test to validate that '$pshome/cultureName/default.help.txt' is present. This is done by calling 'get-help' which returns information about the help system.

Updated the get-help cmdlet to force return a metadata driven object when the test hook BypassOnlineHelpRetrieval is enable.

Updated get-help -online tests to not delete the help files before running, and updated the comments in the test code.