### PR TITLE
Added functionality to improve failure triaging

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,3 @@
 # name: codecov.yml
 fixes:
-    - "master/PowerShell-master::"
+    - "projects/powershell-*::"

--- a/test/tools/CodeCoverageAutomation/Start-CodeCoverageRun.ps1
+++ b/test/tools/CodeCoverageAutomation/Start-CodeCoverageRun.ps1
@@ -162,7 +162,7 @@ try
     Invoke-RestMethod 'https://codecov.io/bash' -OutFile $bashScript
     Write-BashInvokerScript -path $bashScriptInvoker
 
-    if(Test-Path $bashScriptInvoker -and $bashScript -and $cygwinPath)
+    if(Test-Path $bashScriptInvoker -and $bashScript -and $cygwinLocation)
     {
         Write-LogPassThru -Message "Uploading to CodeCov"
         $cygwinPath = "/cygdrive/" + $outputLog.Replace("\", "/").Replace(":","")

--- a/test/tools/CodeCoverageAutomation/Start-CodeCoverageRun.ps1
+++ b/test/tools/CodeCoverageAutomation/Start-CodeCoverageRun.ps1
@@ -199,9 +199,14 @@ finally
     ## See if Azure log directory is mounted
     if(Test-Path $azureLogDrive)
     {
-        $destinationPath = Join-Path $env:Temp ("CodeCoverageLogs-{0:yyyy/mm/dd}-{0:hh:mm:ss}.zip" -f [datetime]::Now)
+        ##Create yyyy-dd folder
+        $monthFolder = "{0:yyyy-mm}" -f [datetime]::Now
+        $monthFolderFullPath = New-Item -Path (Join-Path $azureLogDrive $monthFolder) -ItemType Directory -Force
+        $windowsFolderPath = New-Item (Join-Path $monthFolderFullPath "Windows") -ItemType Directory -Force
+
+        $destinationPath = Join-Path $env:Temp ("CodeCoverageLogs-{0:yyyy_MM_dd}-{0:hh_mm_ss}.zip" -f [datetime]::Now)
         Compress-Archive -Path $elevatedLogs,$unelevatedLogs,$outputLog -DestinationPath $destinationPath
-        Copy-Item $destinationPath $azureLogDrive -Force -ErrorAction SilentlyContinue
+        Copy-Item $destinationPath $windowsFolderPath -Force -ErrorAction SilentlyContinue
     }
 
     ## Disable the cleanup till we stabilize.

--- a/test/tools/CodeCoverageAutomation/Start-CodeCoverageRun.ps1
+++ b/test/tools/CodeCoverageAutomation/Start-CodeCoverageRun.ps1
@@ -174,7 +174,8 @@ try
             "-f $cygwinPath"
             "-X gcov",
             "-B master",
-            "-C $commitId")
+            "-C $commitId",
+            "-X network")
 
         $codecovParmetersString = $codecovParmeters -join ' '
 


### PR DESCRIPTION
- Nunit logs will be created to tests.
- Logs are copied to the Azure share.
- Pester is run with -Quiet
- Elevated and unelevated runs for tests with appropriate tags