### PR TITLE
Fix get-help online test

### DIFF
--- a/test/powershell/engine/Help/HelpSystem.OnlineHelp.Tests.ps1
+++ b/test/powershell/engine/Help/HelpSystem.OnlineHelp.Tests.ps1
@@ -54,7 +54,7 @@
 Describe 'Get-Help -Online opens the default web browser and navigates to the cmdlet help content' -Tags "Feature" {
 
     $skipTest = [System.Management.Automation.Platform]::IsIoT -or
-    [System.Management.Automation.Platform]::IsNanoServer
+                [System.Management.Automation.Platform]::IsNanoServer
 
     if($IsWindows)
     {

--- a/test/powershell/engine/Help/HelpSystem.OnlineHelp.Tests.ps1
+++ b/test/powershell/engine/Help/HelpSystem.OnlineHelp.Tests.ps1
@@ -62,9 +62,16 @@ Describe 'Get-Help -Online opens the default web browser and navigates to the cm
         $progId = [Microsoft.Win32.Registry]::GetValue($regKey, "ProgId", $null)
         if($progId)
         {
-            $browserKey = [Microsoft.Win32.Registry]::ClassesRoot.OpenSubKey('AppXq0fevzme2pys62n3e0fbqa7peapykr8v\shell\open\command', $false)
-            $browserExe = $browserKey.GetValue($null)
-            if($browserExe -notmatch '.exe')
+            $browserKey = [Microsoft.Win32.Registry]::ClassesRoot.OpenSubKey("$progId\shell\open\command", $false)
+            if($browserKey)
+            {
+                $browserExe = $browserKey.GetValue($null)
+                if($browserExe -notmatch '.exe')
+                {
+                    $skipTest = $true
+                }
+            }
+            else
             {
                 $skipTest = $true
             }

--- a/test/powershell/engine/Help/HelpSystem.OnlineHelp.Tests.ps1
+++ b/test/powershell/engine/Help/HelpSystem.OnlineHelp.Tests.ps1
@@ -54,29 +54,25 @@
 Describe 'Get-Help -Online opens the default web browser and navigates to the cmdlet help content' -Tags "Feature" {
 
     $skipTest = [System.Management.Automation.Platform]::IsIoT -or
-                [System.Management.Automation.Platform]::IsNanoServer
+    [System.Management.Automation.Platform]::IsNanoServer
+
+    if($IsWindows)
+    {
+        $regKey = "HKEY_CURRENT_USER\Software\Microsoft\Windows\Shell\Associations\UrlAssociations\http\UserChoice"
+        $progId = [Microsoft.Win32.Registry]::GetValue($regKey, "ProgId", $null)
+        if($progId)
+        {
+            $browserKey = [Microsoft.Win32.Registry]::ClassesRoot.OpenSubKey('AppXq0fevzme2pys62n3e0fbqa7peapykr8v\shell\open\command', $false)
+            $browserExe = $browserKey.GetValue($null)
+            if($browserExe -notmatch '.exe')
+            {
+                $skipTest = $true
+            }
+        }
+    }
 
     It "Get-Help get-process -online" -skip:$skipTest {
-        try
-        {
-            Get-Help get-process -Online
-            $nothingThrown = $true
-        }
-        catch
-        {
-            if($_.FullyQualifiedErrorId -eq 'InvalidOperation,Microsoft.PowerShell.Commands.GetHelpCommand')
-            {
-                $errorCanBeSkipped = $true
-                $errorThrown = $_
-            }
-        }
-        finally
-        {
-            if((-not $errorCanBeSkipped) -and (-not $nothingThrown))
-            {
-                { throw $errorThrown } | Should Not Throw
-            }
-        }
+        { Get-Help get-process -online } | Should Not Throw
     }
 }
 

--- a/test/powershell/engine/Help/HelpSystem.OnlineHelp.Tests.ps1
+++ b/test/powershell/engine/Help/HelpSystem.OnlineHelp.Tests.ps1
@@ -56,6 +56,7 @@ Describe 'Get-Help -Online opens the default web browser and navigates to the cm
     $skipTest = [System.Management.Automation.Platform]::IsIoT -or
                 [System.Management.Automation.Platform]::IsNanoServer
 
+    # this code is a workaround for issue: https://github.com/PowerShell/PowerShell/issues/3079
     if((-not ($skipTest)) -and $IsWindows)
     {
         $skipTest = $true

--- a/test/powershell/engine/Help/HelpSystem.OnlineHelp.Tests.ps1
+++ b/test/powershell/engine/Help/HelpSystem.OnlineHelp.Tests.ps1
@@ -57,8 +57,26 @@ Describe 'Get-Help -Online opens the default web browser and navigates to the cm
                 [System.Management.Automation.Platform]::IsNanoServer
 
     It "Get-Help get-process -online" -skip:$skipTest {
-
-        { Get-Help get-process -online } | Should Not Throw
+        try
+        {
+            Get-Help get-process -Online
+            $nothingThrown = $true
+        }
+        catch
+        {
+            if($_.FullyQualifiedErrorId -eq 'InvalidOperation,Microsoft.PowerShell.Commands.GetHelpCommand')
+            {
+                $errorCanBeSkipped = $true
+                $errorThrown = $_
+            }
+        }
+        finally
+        {
+            if((-not $errorCanBeSkipped) -and (-not $nothingThrown))
+            {
+                { throw $errorThrown } | Should Not Throw
+            }
+        }
     }
 }
 

--- a/test/powershell/engine/Help/HelpSystem.OnlineHelp.Tests.ps1
+++ b/test/powershell/engine/Help/HelpSystem.OnlineHelp.Tests.ps1
@@ -56,8 +56,9 @@ Describe 'Get-Help -Online opens the default web browser and navigates to the cm
     $skipTest = [System.Management.Automation.Platform]::IsIoT -or
                 [System.Management.Automation.Platform]::IsNanoServer
 
-    if($IsWindows)
+    if((-not ($skipTest)) -and $IsWindows)
     {
+        $skipTest = $true
         $regKey = "HKEY_CURRENT_USER\Software\Microsoft\Windows\Shell\Associations\UrlAssociations\http\UserChoice"
 
         try
@@ -68,22 +69,21 @@ Describe 'Get-Help -Online opens the default web browser and navigates to the cm
                 $browserKey = [Microsoft.Win32.Registry]::ClassesRoot.OpenSubKey("$progId\shell\open\command", $false)
                 if($browserKey)
                 {
-                    $browserExe = $browserKey.GetValue($null)
-                    if($browserExe -notmatch '.exe')
+                    $browserExe = ($browserKey.GetValue($null) -replace '"', '') -split " "
+
+                    if ($browserExe.count -ge 1)
                     {
-                        $skipTest = $true
+                        if($browserExe[0] -match '.exe')
+                        {
+                            $skipTest = $false
+                        }
                     }
-                }
-                else
-                {
-                    $skipTest = $true
                 }
             }
         }
         catch
         {
             # We are not able to access Registry, skipping test.
-            $skipTest = $true
         }
     }
 

--- a/test/powershell/engine/Help/HelpSystem.OnlineHelp.Tests.ps1
+++ b/test/powershell/engine/Help/HelpSystem.OnlineHelp.Tests.ps1
@@ -59,22 +59,31 @@ Describe 'Get-Help -Online opens the default web browser and navigates to the cm
     if($IsWindows)
     {
         $regKey = "HKEY_CURRENT_USER\Software\Microsoft\Windows\Shell\Associations\UrlAssociations\http\UserChoice"
-        $progId = [Microsoft.Win32.Registry]::GetValue($regKey, "ProgId", $null)
-        if($progId)
+
+        try
         {
-            $browserKey = [Microsoft.Win32.Registry]::ClassesRoot.OpenSubKey("$progId\shell\open\command", $false)
-            if($browserKey)
+            $progId = [Microsoft.Win32.Registry]::GetValue($regKey, "ProgId", $null)
+            if($progId)
             {
-                $browserExe = $browserKey.GetValue($null)
-                if($browserExe -notmatch '.exe')
+                $browserKey = [Microsoft.Win32.Registry]::ClassesRoot.OpenSubKey("$progId\shell\open\command", $false)
+                if($browserKey)
+                {
+                    $browserExe = $browserKey.GetValue($null)
+                    if($browserExe -notmatch '.exe')
+                    {
+                        $skipTest = $true
+                    }
+                }
+                else
                 {
                     $skipTest = $true
                 }
             }
-            else
-            {
-                $skipTest = $true
-            }
+        }
+        catch
+        {
+            # We are not able to access Registry, skipping test.
+            $skipTest = $true
         }
     }
 


### PR DESCRIPTION
Fix the get-help -online test so that when a default browser is not set,
the test does not fail.