### PR TITLE
Fix GetComputerInfo test for looking up registry

### DIFF
--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ComputerInfo.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ComputerInfo.Tests.ps1
@@ -750,18 +750,25 @@ public static extern int LCIDToLocaleName(uint localeID, System.Text.StringBuild
         param([string]$propertyName)
 
         $key = 'HKLM:\Software\Microsoft\Windows NT\CurrentVersion\'
-        $regValue = (Get-ItemProperty -Path $key -Name $propertyName).$propertyName
-        if ($propertyName -eq "InstallDate")
+        $regKey = Get-ItemProperty -Path $key -Name $propertyName -ErrorAction SilentlyContinue
+
+        ### Skip if property is not found
+        if($regKey)
         {
-            # more complicated case: InstallDate
-            if ($regValue)
+            $regValue = $regKey.$propertyName
+
+            if ($propertyName -eq "InstallDate")
             {
-                return Get-UnixSecondsToDateTime $regValue
+                # more complicated case: InstallDate
+                if ($regValue)
+                {
+                    return Get-UnixSecondsToDateTime $regValue
+                }
             }
-        }
-        else
-        {
-            return $regValue
+            else
+            {
+                return $regValue
+            }
         }
     }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ComputerInfo.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ComputerInfo.Tests.ps1
@@ -750,26 +750,22 @@ public static extern int LCIDToLocaleName(uint localeID, System.Text.StringBuild
         param([string]$propertyName)
 
         $key = 'HKLM:\Software\Microsoft\Windows NT\CurrentVersion\'
-        $regKey = Get-ItemProperty -Path $key -Name $propertyName -ErrorAction SilentlyContinue
+        $regValue = (Get-ItemProperty -Path $key -Name $propertyName -ErrorAction SilentlyContinue).$propertyName
 
-        ### Skip if property is not found
-        if($regKey)
+        if ($propertyName -eq "InstallDate")
         {
-            $regValue = $regKey.$propertyName
-
-            if ($propertyName -eq "InstallDate")
+            # more complicated case: InstallDate
+            if ($regValue)
             {
-                # more complicated case: InstallDate
-                if ($regValue)
-                {
-                    return Get-UnixSecondsToDateTime $regValue
-                }
-            }
-            else
-            {
-                return $regValue
+                return Get-UnixSecondsToDateTime $regValue
             }
         }
+        else
+        {
+            return $regValue
+        }
+
+        return $null
     }
 
     function Get-ExpectedComputerInfoValue


### PR DESCRIPTION
Error is thrown if property is not found. 