### PR TITLE
Implement RoleDefinitions RoleCapabilityFiles keyword

### DIFF
--- a/src/System.Management.Automation/engine/remoting/commands/NewPSSessionConfigurationFile.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/NewPSSessionConfigurationFile.cs
@@ -735,7 +735,7 @@ namespace Microsoft.PowerShell.Commands
                 if (_roleDefinitions == null)
                 {
                     result.Append(SessionConfigurationUtils.ConfigFragment(ConfigFileConstants.RoleDefinitions, RemotingErrorIdStrings.DISCRoleDefinitionsComment,
-                        "@{ 'CONTOSO\\SqlAdmins' = @{ RoleCapabilities = 'SqlAdministration' }; 'CONTOSO\\ServerMonitors' = @{ VisibleCmdlets = 'Get-Process' } } ", streamWriter, true));
+                        "@{ 'CONTOSO\\SqlAdmins' = @{ RoleCapabilities = 'SqlAdministration' }; 'CONTOSO\\SqlManaged' = @{ RoleCapabilityFiles = 'C:\\RoleCapability\\SqlManaged.psrc' }; 'CONTOSO\\ServerMonitors' = @{ VisibleCmdlets = 'Get-Process' } } ", streamWriter, true));
                 }
                 else
                 {

--- a/src/System.Management.Automation/engine/remoting/fanin/InitialSessionStateProvider.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/InitialSessionStateProvider.cs
@@ -947,6 +947,7 @@ namespace System.Management.Automation.Remoting
         internal static readonly string ScriptsToProcess = "ScriptsToProcess";
         internal static readonly string SessionType = "SessionType";
         internal static readonly string RoleCapabilities = "RoleCapabilities";
+        internal static readonly string RoleCapabilityFiles = "RoleCapabilityFiles";
         internal static readonly string RunAsVirtualAccount = "RunAsVirtualAccount";
         internal static readonly string RunAsVirtualAccountGroups = "RunAsVirtualAccountGroups";
         internal static readonly string TranscriptDirectory = "TranscriptDirectory";
@@ -981,6 +982,7 @@ namespace System.Management.Automation.Remoting
             new ConfigTypeEntry(PowerShellVersion,              new ConfigTypeEntry.TypeValidationCallback(StringTypeValidationCallback)),
             new ConfigTypeEntry(RequiredGroups,                 new ConfigTypeEntry.TypeValidationCallback(HashtableTypeValidationCallback)),
             new ConfigTypeEntry(RoleCapabilities,               new ConfigTypeEntry.TypeValidationCallback(StringArrayTypeValidationCallback)),
+            new ConfigTypeEntry(RoleCapabilityFiles,            new ConfigTypeEntry.TypeValidationCallback(StringArrayTypeValidationCallback)),
             new ConfigTypeEntry(RoleDefinitions,                new ConfigTypeEntry.TypeValidationCallback(HashtableTypeValidationCallback)),
             new ConfigTypeEntry(RunAsVirtualAccount,            new ConfigTypeEntry.TypeValidationCallback(BooleanTypeValidationCallback)),
             new ConfigTypeEntry(RunAsVirtualAccountGroups,      new ConfigTypeEntry.TypeValidationCallback(StringArrayTypeValidationCallback)),
@@ -1391,6 +1393,7 @@ namespace System.Management.Automation.Remoting
         private static readonly HashSet<string> s_allowedRoleCapabilityKeys = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
         {
             "RoleCapabilities",
+            "RoleCapabilityFiles",
             "ModulesToImport",
             "VisibleAliases",
             "VisibleCmdlets",
@@ -1808,8 +1811,11 @@ namespace System.Management.Automation.Remoting
         }
 
         // Takes the "RoleCapabilities" node in the config hash, and merges its values into the base configuration.
+        private const string PSRCExtension = ".psrc";
         private void MergeRoleCapabilitiesIntoConfigHash()
         {
+            List<string> psrcFiles = new List<string>();
+
             if (_configHash.ContainsKey(ConfigFileConstants.RoleCapabilities))
             {
                 string[] roleCapabilities = TryGetStringArray(_configHash[ConfigFileConstants.RoleCapabilities]);
@@ -1821,17 +1827,50 @@ namespace System.Management.Automation.Remoting
                         string roleCapabilityPath = GetRoleCapabilityPath(roleCapability);
                         if (String.IsNullOrEmpty(roleCapabilityPath))
                         {
-                            string message = StringUtil.Format(RemotingErrorIdStrings.CouldNotFindRoleCapability, roleCapability, roleCapability + ".psrc");
+                            string message = StringUtil.Format(RemotingErrorIdStrings.CouldNotFindRoleCapability, roleCapability, roleCapability + PSRCExtension);
                             PSInvalidOperationException ioe = new PSInvalidOperationException(message);
                             ioe.SetErrorId("CouldNotFindRoleCapability");
                             throw ioe;
                         }
 
-                        DISCPowerShellConfiguration roleCapabilityConfiguration = new DISCPowerShellConfiguration(roleCapabilityPath, null);
-                        IDictionary roleCapabilityConfigurationItems = roleCapabilityConfiguration.ConfigHash;
-                        MergeConfigHashIntoConfigHash(roleCapabilityConfigurationItems);
+                        psrcFiles.Add(roleCapabilityPath);
                     }
                 }
+            }
+
+            if (ConfigHash.ContainsKey(ConfigFileConstants.RoleCapabilityFiles))
+            {
+                string[] roleCapabilityFiles = TryGetStringArray(ConfigHash[ConfigFileConstants.RoleCapabilityFiles]);
+                if (roleCapabilityFiles != null)
+                {
+                    foreach (var roleCapabilityFilePath in roleCapabilityFiles)
+                    {
+                        if (!Path.GetExtension(roleCapabilityFilePath).Equals(psrcExtenstion, StringComparison.OrdinalIgnoreCase))
+                        {
+                            string message = StringUtil.Format(RemotingErrorIdStrings.InvalidRoleCapabilityFileExtension, roleCapabilityFilePath);
+                            PSInvalidOperationException ioe = new PSInvalidOperationException(message);
+                            ioe.SetErrorId("InvalidRoleCapabilityFileExtension");
+                            throw ioe;
+                        }
+
+                        if (!File.Exists(roleCapabilityFilePath))
+                        {
+                            string message = StringUtil.Format(RemotingErrorIdStrings.CouldNotFindRoleCapabilityFile, roleCapabilityFilePath);
+                            PSInvalidOperationException ioe = new PSInvalidOperationException(message);
+                            ioe.SetErrorId("CouldNotFindRoleCapabilityFile");
+                            throw ioe;
+                        }
+
+                        psrcFiles.Add(roleCapabilityFilePath);
+                    }
+                }
+            }
+
+            foreach (var roleCapabilityFile in psrcFiles)
+            {
+                DISCPowerShellConfiguration roleCapabilityConfiguration = new DISCPowerShellConfiguration(roleCapabilityFile, null);
+                IDictionary roleCapabilityConfigurationItems = roleCapabilityConfiguration.ConfigHash;
+                MergeConfigHashIntoConfigHash(roleCapabilityConfigurationItems);
             }
         }
 

--- a/src/System.Management.Automation/engine/remoting/fanin/InitialSessionStateProvider.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/InitialSessionStateProvider.cs
@@ -1845,7 +1845,7 @@ namespace System.Management.Automation.Remoting
                 {
                     foreach (var roleCapabilityFilePath in roleCapabilityFiles)
                     {
-                        if (!Path.GetExtension(roleCapabilityFilePath).Equals(psrcExtenstion, StringComparison.OrdinalIgnoreCase))
+                        if (!Path.GetExtension(roleCapabilityFilePath).Equals(PSRCExtension, StringComparison.OrdinalIgnoreCase))
                         {
                             string message = StringUtil.Format(RemotingErrorIdStrings.InvalidRoleCapabilityFileExtension, roleCapabilityFilePath);
                             PSInvalidOperationException ioe = new PSInvalidOperationException(message);

--- a/src/System.Management.Automation/resources/RemotingErrorIdStrings.resx
+++ b/src/System.Management.Automation/resources/RemotingErrorIdStrings.resx
@@ -936,7 +936,7 @@ Do you want to continue?</value>
     <value>{0} may need to restart the WinRM service if a configuration using this name has recently been unregistered, certain system data structures may still be cached. In that case, a restart of WinRM may be required.
 All WinRM sessions connected to Windows PowerShell session configurations, such as Microsoft.PowerShell and session configurations that are created with the Register-PSSessionConfiguration cmdlet, are disconnected.</value>
   </data>
-   <data name="WinRMForceRestartWarning" xml:space="preserve">
+  <data name="WinRMForceRestartWarning" xml:space="preserve">
     <value>You are running in a remote session and have selected the Force option which means the WinRM service may restart.If the WinRM service restarts then this remote session will be terminated and you will need to create a new session to continue</value>
   </data>
   <data name="JobSourceAdapterCannotSaveNullJob" xml:space="preserve">
@@ -1359,9 +1359,6 @@ All WinRM sessions connected to Windows PowerShell session configurations, such 
   <data name="ReceivePSSessionInDebugMode" xml:space="preserve">
     <value>The remote session command is currently stopped in the debugger.  Use the Enter-PSSession cmdlet to connect interactively to the remote session and automatically enter into the console debugger.</value>
   </data>
-  <data name="RCDisconnectDebug" xml:space="preserve">
-    <value>Session {0} with instance ID {1} on computer {2} has been disconnected because the script running on the session has stopped at a breakpoint. Use the Enter-PSSession cmdlet on this session to connect back to the session and begin interactive debugging.</value>
-  </data>
   <data name="RemoteDebuggingEndpointVersionError" xml:space="preserve">
     <value>The remote session to which you are connected does not support remote debugging. You must connect to a remote computer that is running Windows PowerShell {0} or greater.</value>
   </data>
@@ -1635,5 +1632,11 @@ All WinRM sessions connected to Windows PowerShell session configurations, such 
   </data>
   <data name="SSHConnectionDuplicateKeyPath" xml:space="preserve">
     <value>The provided SSHConnection hashtable contains both a KeyFilePath and IdentityFilePath parameter.  Only one can be specified.</value>
+  </data>
+  <data name="CouldNotFindRoleCapabilityFile" xml:space="preserve">
+    <value>Could not find the provided role capability file {0}.</value>
+  </data>
+  <data name="InvalidRoleCapabilityFileExtension" xml:space="preserve">
+    <value>The provided role capability file {0} does not have the required .psrc extension.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/RemotingErrorIdStrings.resx
+++ b/src/System.Management.Automation/resources/RemotingErrorIdStrings.resx
@@ -1359,6 +1359,9 @@ All WinRM sessions connected to Windows PowerShell session configurations, such 
   <data name="ReceivePSSessionInDebugMode" xml:space="preserve">
     <value>The remote session command is currently stopped in the debugger.  Use the Enter-PSSession cmdlet to connect interactively to the remote session and automatically enter into the console debugger.</value>
   </data>
+  <data name="RCDisconnectDebug" xml:space="preserve">
+    <value>Session {0} with instance ID {1} on computer {2} has been disconnected because the script running on the session has stopped at a breakpoint. Use the Enter-PSSession cmdlet on this session to connect back to the session and begin interactive debugging.</value>
+  </data>
   <data name="RemoteDebuggingEndpointVersionError" xml:space="preserve">
     <value>The remote session to which you are connected does not support remote debugging. You must connect to a remote computer that is running Windows PowerShell {0} or greater.</value>
   </data>

--- a/test/powershell/engine/Remoting/RoleCapabilityFiles.Tests.ps1
+++ b/test/powershell/engine/Remoting/RoleCapabilityFiles.Tests.ps1
@@ -1,0 +1,84 @@
+##
+## PowerShell Remoting Endpoint Role Capability Files Tests
+##
+
+Describe "Remote session configuration RoleDefintion RoleCapabilityFiles key tests" -Tags "Feature" {
+
+    BeforeAll {
+
+        if (!$IsWindows)
+        {
+            $originalDefaultParameterValues = $PSDefaultParameterValues.Clone()
+            $PSDefaultParameterValues["it:skip"] = $true
+        }
+        else
+        {
+            [string] $RoleCapDirectory = (New-Item -Path "$TestDrive\RoleCapability" -ItemType Directory -Force).FullName
+
+            [string] $GoodRoleCapFile = "$RoleCapDirectory\TestGoodRoleCap.psrc"
+            New-PSRoleCapabilityFile -Path $GoodRoleCapFile -VisibleCmdlets 'Get-Command','Get-Process','Clear-Host','Out-Default','Select-Object','Get-FormatData','Get-Help'
+
+            [string] $BadRoleCapFile = "$RoleCapDirectory\TestBadRoleCap.psrc"
+            New-PSRoleCapabilityFile -Path $BadRoleCapFile -VisibleCmdlets *
+            [string] $BadRoleCapFile = $BadRoleCapFile.Replace('.psrc', 'psbad')
+
+            [string] $PSSessionConfigFile = "$RoleCapDirectory\TestConfig.pssc"
+        }
+    }
+
+    AfterAll {
+
+        if (!$IsWindows)
+        {
+            $global:PSDefaultParameterValues = $originalDefaultParameterValues
+        }
+    }
+
+    It "Verifies missing role capability file error" {
+
+        New-PSSessionConfigurationFile -Path $PSSessionConfigFile -RoleDefinitions @{
+            Administrators = @{ RoleCapabilityFiles = "$RoleCapDirectory\NoFile.psrc" }
+        }
+
+        try
+        {
+            $iss = [initialsessionstate]::CreateFromSessionConfigurationFile($PSSessionConfigFile, { $true })
+            throw 'Should have thrown CouldNotFindRoleCapabilityFile exception'
+        }
+        catch [System.Management.Automation.MethodInvocationException]
+        {
+            ([System.Management.Automation.PSInvalidOperationException] $_.Exception.InnerException).ErrorRecord.FullyQualifiedErrorId | Should Be 'CouldNotFindRoleCapabilityFile'
+        }
+    }
+
+    It "Verifies incorrect role capability file extenstion error" {
+
+        New-PSSessionConfigurationFile -Path $PSSessionConfigFile -RoleDefinitions @{
+            Administrators = @{ RoleCapabilityFiles = "$BadRoleCapFile" }
+        }
+
+        try
+        {
+            $iss = [initialsessionstate]::CreateFromSessionConfigurationFile($PSSessionConfigFile, { $true })
+            throw 'Should have thrown InvalidRoleCapabilityFileExtension exception'
+        }
+        catch [System.Management.Automation.MethodInvocationException]
+        {
+            ([System.Management.Automation.PSInvalidOperationException] $_.Exception.InnerException).ErrorRecord.FullyQualifiedErrorId | Should Be 'InvalidRoleCapabilityFileExtension'
+        }
+    }
+
+    It "Verifies good role capability file" {
+
+        New-PSSessionConfigurationFile -Path $PSSessionConfigFile -RoleDefinitions @{
+            Administrators = @{ RoleCapabilityFiles = "$GoodRoleCapFile" }
+        }
+
+        $iss = [initialsessionstate]::CreateFromSessionConfigurationFile($PSSessionConfigFile, { $true })
+        [powershell] $ps = [powershell]::Create($iss)
+        $result = $ps.AddCommand('Get-Process').AddParameter('Name', 'PowerShell*').Invoke()
+
+        $result.Count | Should Not Be 0
+        $ps.Dispose()
+    }
+}

--- a/test/powershell/engine/Remoting/RoleCapabilityFiles.Tests.ps1
+++ b/test/powershell/engine/Remoting/RoleCapabilityFiles.Tests.ps1
@@ -47,15 +47,7 @@ Describe "Remote session configuration RoleDefintion RoleCapabilityFiles key tes
         }
         catch
         {
-            [System.Management.Automation.MethodInvocationException] $expectedException = [System.Management.Automation.MethodInvocationException] $_.Exception
-            if ($expectedException -ne $null)
-            {
-                ([System.Management.Automation.PSInvalidOperationException] $expectedException.InnerException).ErrorRecord.FullyQualifiedErrorId | Should Be 'CouldNotFindRoleCapabilityFile'
-            }
-            else
-            {
-                throw 'Unexpected Exception'
-            }
+            ([System.Management.Automation.PSInvalidOperationException] ($_.Exception).InnerException).ErrorRecord.FullyQualifiedErrorId | Should Be 'CouldNotFindRoleCapabilityFile'
         }
     }
 
@@ -72,15 +64,7 @@ Describe "Remote session configuration RoleDefintion RoleCapabilityFiles key tes
         }
         catch
         {
-            [System.Management.Automation.MethodInvocationException] $expectedException = [System.Management.Automation.MethodInvocationException] $_.Exception
-            if ($expectedException -ne $null)
-            {
-                ([System.Management.Automation.PSInvalidOperationException] $expectedException.InnerException).ErrorRecord.FullyQualifiedErrorId | Should Be 'InvalidRoleCapabilityFileExtension'
-            }
-            else
-            {
-                throw 'Unexpected Exception'
-            }
+            ([System.Management.Automation.PSInvalidOperationException] ($_.Exception).InnerException).ErrorRecord.FullyQualifiedErrorId | Should Be 'InvalidRoleCapabilityFileExtension'
         }
     }
 
@@ -102,15 +86,7 @@ Describe "Remote session configuration RoleDefintion RoleCapabilityFiles key tes
         }
         catch
         {
-            [System.Management.Automation.MethodInvocationException] $expectedException = [System.Management.Automation.MethodInvocationException] $_.Exception
-            if ($expectedException -ne $null)
-            {
-                ($expectedException.InnerException.GetType().FullName) | Should Be 'System.Management.Automation.CommandNotFoundException'
-            }
-            else
-            {
-                throw 'Unexpected Exception'
-            }
+            ($_.Exception).InnerException.GetType().FullName | Should Be 'System.Management.Automation.CommandNotFoundException'
         }
 
         $ps.Dispose()

--- a/test/powershell/engine/Remoting/RoleCapabilityFiles.Tests.ps1
+++ b/test/powershell/engine/Remoting/RoleCapabilityFiles.Tests.ps1
@@ -40,6 +40,7 @@ Describe "Remote session configuration RoleDefintion RoleCapabilityFiles key tes
             Administrators = @{ RoleCapabilityFiles = "$RoleCapDirectory\NoFile.psrc" }
         }
 
+        $fullyQualifiedErrorId = ""
         try
         {
             $iss = [initialsessionstate]::CreateFromSessionConfigurationFile($PSSessionConfigFile, { $true })
@@ -47,7 +48,12 @@ Describe "Remote session configuration RoleDefintion RoleCapabilityFiles key tes
         }
         catch
         {
-            ([System.Management.Automation.PSInvalidOperationException] ($_.Exception).InnerException).ErrorRecord.FullyQualifiedErrorId | Should Be 'CouldNotFindRoleCapabilityFile'
+            $psioe = [System.Management.Automation.PSInvalidOperationException] ($_.Exception).InnerException
+            if ($psioe -ne $null)
+            {
+                $fullyQualifiedErrorId = $psioe.ErrorRecord.FullyQualifiedErrorId
+            }
+            $fullyQualifiedErrorId | Should Be 'CouldNotFindRoleCapabilityFile'
         }
     }
 
@@ -57,6 +63,7 @@ Describe "Remote session configuration RoleDefintion RoleCapabilityFiles key tes
             Administrators = @{ RoleCapabilityFiles = "$BadRoleCapFile" }
         }
 
+        $fullyQualifiedErrorId = ""
         try
         {
             $iss = [initialsessionstate]::CreateFromSessionConfigurationFile($PSSessionConfigFile, { $true })
@@ -64,7 +71,12 @@ Describe "Remote session configuration RoleDefintion RoleCapabilityFiles key tes
         }
         catch
         {
-            ([System.Management.Automation.PSInvalidOperationException] ($_.Exception).InnerException).ErrorRecord.FullyQualifiedErrorId | Should Be 'InvalidRoleCapabilityFileExtension'
+            $psioe = [System.Management.Automation.PSInvalidOperationException] ($_.Exception).InnerException
+            if ($psioe -ne $null)
+            {
+                $fullyQualifiedErrorId = $psioe.ErrorRecord.FullyQualifiedErrorId
+            }
+            $fullyQualifiedErrorId | Should Be 'InvalidRoleCapabilityFileExtension'
         }
     }
 
@@ -79,6 +91,7 @@ Describe "Remote session configuration RoleDefintion RoleCapabilityFiles key tes
         [powershell] $ps = [powershell]::Create($iss)
         $null = $ps.AddCommand('Get-Service')
 
+        $exceptionTypeName = ""
         try
         {
             $ps.Invoke()
@@ -86,7 +99,11 @@ Describe "Remote session configuration RoleDefintion RoleCapabilityFiles key tes
         }
         catch
         {
-            ($_.Exception).InnerException.GetType().FullName | Should Be 'System.Management.Automation.CommandNotFoundException'
+            if ($_.Exception.InnerException -ne $null)
+            {
+                $exceptionTypeName = $_.Exception.InnerException.GetType().FullName
+            }
+            $exceptionTypeName | Should Be 'System.Management.Automation.CommandNotFoundException'
         }
 
         $ps.Dispose()


### PR DESCRIPTION
This change adds the ability to specify RoleDefinition RoleCapability with a file path name.  Previously a RoleCapability would be defined by a name and then a RoleCapability file with that name and .psrc extension would have to be placed within a $PSModulePath module under a RoleCapabilities directory. 

Now a role capability can also be specified by providing a single file path name using the new RoleCapabilityFiles keyword in a RoleDefinition. Both the previous RoleCapabilities keyword and the new RoleCapabilityFiles keyword are now supported for specifying role capabilities.

Example
---------
```powershell
New-PSSessionConfigurationFile -Path .\MyConfig.pssc -RoleDefinitions @{
    Administrators = @{ RoleCapabilityFiles = "C:\AdminCaps.psrc" }
}
```