### PR TITLE
Add ShouldProcess to New-FileCatalog and Test-FileCatalog

### DIFF
--- a/src/Microsoft.PowerShell.Security/security/CatalogCommands.cs
+++ b/src/Microsoft.PowerShell.Security/security/CatalogCommands.cs
@@ -89,26 +89,35 @@ namespace Microsoft.PowerShell.Commands
 
             Collection<string> paths = new Collection<string>();
 
+            bool _ShouldProcess = false;
+
             if (Path != null)
             {
                 foreach (string p in Path)
                 {
                     foreach (PathInfo tempPath in SessionState.Path.GetResolvedPSPathFromPSPath(p))
                     {
-                        paths.Add(tempPath.ProviderPath);
+                        if (ShouldProcess(tempPath.ProviderPath))
+                        {
+                            paths.Add(tempPath.ProviderPath);
+                            _ShouldProcess = true;
+                        }
                     }
                 }
             }
 
-            string drive = null;
-
-            // resolve catalog destination Path
-            if (!SessionState.Path.IsPSAbsolute(catalogFilePath, out drive) && !System.IO.Path.IsPathRooted(catalogFilePath))
+            if (_ShouldProcess)
             {
-                catalogFilePath = SessionState.Path.GetUnresolvedProviderPathFromPSPath(catalogFilePath);
-            }
+                string drive = null;
 
-            PerformAction(paths, catalogFilePath);
+                // resolve catalog destination Path
+                if (!SessionState.Path.IsPSAbsolute(catalogFilePath, out drive) && !System.IO.Path.IsPathRooted(catalogFilePath))
+                {
+                    catalogFilePath = SessionState.Path.GetUnresolvedProviderPathFromPSPath(catalogFilePath);
+                }
+
+                PerformAction(paths, catalogFilePath);
+            }
         }
 
         /// <summary>

--- a/src/Microsoft.PowerShell.Security/security/CatalogCommands.cs
+++ b/src/Microsoft.PowerShell.Security/security/CatalogCommands.cs
@@ -89,8 +89,6 @@ namespace Microsoft.PowerShell.Commands
 
             Collection<string> paths = new Collection<string>();
 
-            bool _ShouldProcess = false;
-
             if (Path != null)
             {
                 foreach (string p in Path)
@@ -100,13 +98,13 @@ namespace Microsoft.PowerShell.Commands
                         if (ShouldProcess(tempPath.ProviderPath))
                         {
                             paths.Add(tempPath.ProviderPath);
-                            _ShouldProcess = true;
                         }
                     }
                 }
             }
 
-            if (_ShouldProcess)
+            // We add 'paths.Count > 0' to support 'ShouldProcess()'
+            if (paths.Count > 0 )
             {
                 string drive = null;
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/FileCatalog.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/FileCatalog.Tests.ps1
@@ -42,6 +42,25 @@ Describe "Test suite for NewFileCatalogAndTestFileCatalogCmdlets" -Tags "CI" {
 
     Context "NewAndTestCatalogTests PositiveTestCases when validation Succeeds" {
 
+        It "NewFileCatalogWithSingleFile with WhatIf" {
+
+            $sourcePath = Join-Path $testDataPath '\CatalogTestFile1.mof'
+            # use existant Path for the directory when .cat file name is not specified
+            $catalogPath = $testDataPath
+            try
+            {
+                $null = New-FileCatalog -Path $sourcePath -CatalogFilePath $catalogPath -WhatIf
+                $result = Test-Path -Path ($catalogPath + "\catalog.cat")
+            }
+            finally
+            {
+                Remove-Item "$catalogPath\catalog.cat" -Force -ErrorAction SilentlyContinue
+            }
+
+            # Validate result properties
+            $result | Should Be $false
+        }
+
         It "NewFileCatalogFolder" {
 
             $sourcePath = Join-Path $testDataPath 'UserConfigProv\DSCResources\scriptdsc'

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/FileCatalog.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/FileCatalog.Tests.ps1
@@ -47,14 +47,16 @@ Describe "Test suite for NewFileCatalogAndTestFileCatalogCmdlets" -Tags "CI" {
             $sourcePath = Join-Path $testDataPath '\CatalogTestFile1.mof'
             # use existant Path for the directory when .cat file name is not specified
             $catalogPath = $testDataPath
+            $catalogFile = $catalogPath + "\catalog.cat"
+
             try
             {
                 $null = New-FileCatalog -Path $sourcePath -CatalogFilePath $catalogPath -WhatIf
-                $result = Test-Path -Path ($catalogPath + "\catalog.cat")
+                $result = Test-Path -Path $catalogFile
             }
             finally
             {
-                Remove-Item "$catalogPath\catalog.cat" -Force -ErrorAction SilentlyContinue
+                Remove-Item $catalogFile -Force -ErrorAction SilentlyContinue
             }
 
             # Validate result properties


### PR DESCRIPTION
Close #3068

Add support `-WhatIf` and `-Confirm` to `New-FileCatalog` and add a
test.
`Test-FileCatalog` has a common code base with `New-FileCatalog` so it
automatically get the same. I believe that adding a separate test in
this case doesn't make sense.