### PR TITLE
Create a badge for the daily test runs in travis-ci

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,9 +80,9 @@ If you have any problems building, please consult the developer [FAQ][].
 
 ### Build status of nightly builds
 
-| AppVeyor (Windows)       | Code Coverage Status |
-|--------------------------|----------------------|
-| [![av-nightly-image][]][av-nightly-site] | [![cc-image][]][cc-site] |
+| AppVeyor (Windows)       | Travis CI (Linux / macOS) | Code Coverage Status |
+|--------------------------|---------------------------|----------------------|
+| [![av-nightly-image][]][av-nightly-site] | [![tv-nightly-image][]][tv-site] | [![cc-image][]][cc-site] |
 
 [bd-linux]: docs/building/linux.md
 [bd-windows]: docs/building/windows-core.md
@@ -94,6 +94,7 @@ If you have any problems building, please consult the developer [FAQ][].
 [tv-site]: https://travis-ci.org/PowerShell/PowerShell/branches
 [av-image]: https://ci.appveyor.com/api/projects/status/nsng9iobwa895f98/branch/master?svg=true
 [av-site]: https://ci.appveyor.com/project/PowerShell/powershell
+[tv-nightly-image]: https://jimtru1979.blob.core.windows.net/badges/DailyBuildStatus.svg
 [av-nightly-image]: https://ci.appveyor.com/api/projects/status/46yd4jogtm2jodcq?svg=true
 [av-nightly-site]: https://ci.appveyor.com/project/PowerShell/powershell-f975h
 [cc-site]: https://coveralls.io/github/PowerShell/PowerShell?branch=master

--- a/tools/travis.ps1
+++ b/tools/travis.ps1
@@ -1,5 +1,89 @@
 Import-Module $PSScriptRoot/../build.psm1 -Force
 
+# This function retrieves the appropriate svg to be used when presenting
+# the daily test run badge
+# the location in azure is public readonly
+function Get-DailyBadge
+{
+    param (
+        [Parameter(Mandatory=$true,Position=0)][ValidateSet("Pass","Fail")]$result
+        )
+    $PASS = "https://jimtru1979.blob.core.windows.net/badges/DailyBuild.Pass.svg"
+    $FAIL = "https://jimtru1979.blob.core.windows.net/badges/DailyBuild.Fail.svg"
+
+    if ( $result -eq "Pass" ) { $BadgeUrl = $PASS } else { $BadgeUrl = $FAIL }
+    $response = Invoke-WebRequest -Uri $BadgeUrl
+    if ( $response.StatusCode -ne 200 ) { throw "Could not read badge '$BadgeUrl'" }
+    $response.Content
+}
+
+# This function uses Azure REST api to update the daily test pass results
+# it relies on writing a specific SVG into a constant location so the
+# README.MD can report on the status of the daily test pass
+# it also relies on two environment variables which need to be set in the
+# Travis-CI config which is the account name and key for the azure blob location
+#
+# the best way to do this would be if travis-ci supported a webcall to get
+# the status of cron_job builds, but it doesn't, so we have this
+function Set-DailyBuildBadge
+{
+    param ( [Parameter(Mandatory=$true,Position=0)]$content )
+    $method = "PUT"
+    $headerDate = '2014-02-14'
+    $headerDate = '2015-12-11'
+
+    $storageAccountName = $Env:TestResultAccountName
+    $storageAccountKey = $Env:TestResultAccountKey
+
+    # this is the url referenced in README.MD which displays the badge
+    $Url = "https://jimtru1979.blob.core.windows.net/badges/DailyBuildStatus.svg"
+
+    $body = $content
+    $bytes = ([System.Text.Encoding]::UTF8.GetBytes($body))
+    $contentLength = $bytes.length
+
+    $headers = @{
+        "x-ms-date"      = [datetime]::UtcNow.ToString("R", [System.Globalization.CultureInfo]::InvariantCulture)
+        "Content-Length" = "$contentLength"
+        "x-ms-blob-type" = "BlockBlob"
+        "x-ms-version"   = "$headerDate"
+    }
+
+    $contentType = "image/svg+xml"
+    # more info: https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/put-blob
+    $signatureString = "$method`n" +
+        "`n" +
+        "`n" +
+        "$contentLength`n" +
+        "`n" +
+        "${contentType}`n" +
+        "`n" +
+        "`n" +
+        "`n" +
+        "`n" +
+        "`n" +
+        "`n"
+
+    #Add CanonicalizedHeaders
+    $signatureString += "x-ms-blob-type:" + $headers["x-ms-blob-type"] + "`n"
+    $signatureString += "x-ms-date:" + $headers["x-ms-date"] + "`n"
+    $signatureString += "x-ms-version:" + $headers["x-ms-version"] + "`n"
+    #Add CanonicalizedResource
+    $uri = New-Object System.Uri -ArgumentList $url
+    $signatureString += "/" + $storageAccountName + $uri.AbsolutePath
+
+    $dataToMac = [System.Text.Encoding]::UTF8.GetBytes($signatureString)
+    $accountKeyBytes = [System.Convert]::FromBase64String($storageAccountKey)
+    $hmac = new-object System.Security.Cryptography.HMACSHA256((,$accountKeyBytes))
+    $signature = [System.Convert]::ToBase64String($hmac.ComputeHash($dataToMac))
+
+    $headers["Authorization"]  = "SharedKey " + $storageAccountName + ":" + $signature
+
+    write-verbose $signatureString
+    $response = Invoke-RestMethod -Uri $Url -Method $method -headers $headers -Body $body -ContentType "image/svg+xml"
+}
+
+
 # https://docs.travis-ci.com/user/environment-variables/
 # TRAVIS_EVENT_TYPE: Indicates how the build was triggered.
 # One of push, pull_request, api, cron.
@@ -23,10 +107,39 @@ if ($isFullBuild) {
 }
 
 Start-PSPester @pesterParam
+
 if (-not $isPr) {
     # Only build packages for branches, not pull requests
     Start-PSPackage
-    Test-PSPesterResults
+    try {
+        # this throws if there was an error
+        Test-PSPesterResults
+        $result = "PASS"
+    }
+    catch {
+        $resultError = $_
+        $result = "FAIL"
+    }
+    if ( $isFullBuild ) {
+        # now update the badge if you've done a full build, these are not fatal issues
+        try {
+            $svgData = Get-DailyBadge -result $result
+            if ( ! $svgData ) {
+                write-warning "Could not retrieve $result badge"
+            }
+            else {
+                Write-Verbose -verbose "Setting status badge to '$result'"
+                Set-DailyBuildBadge -content $svgData
+            }
+        }
+        catch {
+            Write-Warning "Could not update status badge: $_"
+        }
+    }
+    # if the tests did not pass, throw the reason why
+    if ( $result -eq "FAIL" ) {
+        Throw $resultError
+    }
 }
 
 Start-PSxUnit


### PR DESCRIPTION
It updates an azure blob with an SVG and that location is referenced by the
README.md file. TravisCI doesn't support this directly so in order to report
on the status of a daily test run there, we need to do this.
Provide error reporting in case the badge can't be set

The location where the badge is stored in azure should be moved eventually to a global resource where we keep other azure blobs. We don't have that yet, but this will do. Also, the location in azure is globally readable, but not globally writable. Travis-CI configuration must be updated to include the two required environment variables.