### PR TITLE
error message and status code in the Invoke-WebRequest cmdlet [Fixes#…

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebRequestPSCmdlet.CoreClr.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebRequestPSCmdlet.CoreClr.cs
@@ -350,17 +350,7 @@ namespace Microsoft.PowerShell.Commands
                         HttpResponseMessage response = GetResponse(client, request);
                         if (!response.IsSuccessStatusCode)
                         {
-                            using(var reader = new StreamReader(StreamHelper.GetResponseStream(response)))
-                            {
-                                var detailMsg = reader.ReadToEnd();
-                                var msg = string.Format(CultureInfo.CurrentCulture, WebCmdletStrings.NotSuccessStatusCode, response.StatusCode, response.ReasonPhrase);
-                                ErrorRecord er = new ErrorRecord(new WebException(msg) { Response = response }, "WebCmdletWebResponseException", ErrorCategory.InvalidOperation, request);
-                                if (!String.IsNullOrEmpty(detailMsg))
-                                {
-                                    er.ErrorDetails = new ErrorDetails(detailMsg);
-                                }
-                                ThrowTerminatingError(er);
-                            }
+                            ThrowNotSuccessStatusCodeError(request, response);
                         }
 
                         string contentType = ContentHelper.GetContentType(response);
@@ -421,6 +411,21 @@ namespace Microsoft.PowerShell.Commands
         #endregion Overrides
 
         #region Helper Methods
+
+        private void ThrowNotSuccessStatusCodeError(HttpRequestMessage request, HttpResponseMessage response)
+        {
+            using(var reader = new StreamReader(StreamHelper.GetResponseStream(response)))
+            {
+                var detailMsg = reader.ReadToEnd();
+                var msg = string.Format(CultureInfo.CurrentCulture, WebCmdletStrings.NotSuccessStatusCode, response.StatusCode, response.ReasonPhrase);
+                ErrorRecord er = new ErrorRecord(new WebException(msg) { Response = response }, "WebCmdletWebResponseException", ErrorCategory.InvalidOperation, request);
+                if (!String.IsNullOrEmpty(detailMsg))
+                {
+                    er.ErrorDetails = new ErrorDetails(detailMsg);
+                }
+                ThrowTerminatingError(er);
+            }
+        }
 
         /// <summary>
         /// Sets the ContentLength property of the request and writes the specified content to the request's RequestStream.

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebRequestPSCmdlet.CoreClr.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebRequestPSCmdlet.CoreClr.cs
@@ -16,6 +16,7 @@ using System.Globalization;
 using System.Security.Cryptography;
 using System.Threading;
 using System.Xml;
+using Microsoft.PowerShell.CoreClr.Stubs;
 
 namespace Microsoft.PowerShell.Commands
 {

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/WebCmdletStrings.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/WebCmdletStrings.resx
@@ -211,6 +211,6 @@
     <value>Conversion from JSON failed with error: {0}</value>
   </data>
   <data name="NotSuccessStatusCode" xml:space="preserve">
-    <value>The remote server returned an error: ({0:d}) {1}.</value>
+    <value>The remote server returned an error: ({0}) {1}.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/WebCmdletStrings.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/WebCmdletStrings.resx
@@ -210,4 +210,7 @@
   <data name="JsonDeserializationFailed" xml:space="preserve">
     <value>Conversion from JSON failed with error: {0}</value>
   </data>
+  <data name="NotSuccessStatusCode" xml:space="preserve">
+    <value>The remote server returned an error: ({0:d}) {1}.</value>
+  </data>
 </root>

--- a/src/System.Management.Automation/CoreCLR/CorePsStub.cs
+++ b/src/System.Management.Automation/CoreCLR/CorePsStub.cs
@@ -11,6 +11,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.Win32;
 using System.Management.Automation.Remoting;
+using System.Net.Http;
 
 #pragma warning disable 1591, 1572, 1571, 1573, 1587, 1570, 0067
 
@@ -471,6 +472,23 @@ namespace Microsoft.PowerShell.CoreClr.Stubs
     /// </summary>
     public sealed class AppDomainUnloadedException : Exception
     {
+    }
+
+    /// <summary>
+    /// Stub for WebException
+    /// </summary>
+    public sealed class WebException : Exception
+    {
+        /// <summary>
+        /// Creates a new instance of the <see cref='System.Net.WebException'/>
+        /// </summary>
+        /// <param name="message"></param>
+        public WebException(string message) : base(message) { }
+
+        /// <summary>
+        /// Gets the error message returned from the remote host.
+        /// </summary>
+        public HttpResponseMessage Response { get; set; }
     }
 
     #endregion Exception_Related

--- a/src/System.Management.Automation/CoreCLR/CorePsStub.cs
+++ b/src/System.Management.Automation/CoreCLR/CorePsStub.cs
@@ -480,7 +480,7 @@ namespace Microsoft.PowerShell.CoreClr.Stubs
     public sealed class WebException : Exception
     {
         /// <summary>
-        /// Creates a new instance of the <see cref='System.Net.WebException'/>
+        /// Creates a new instance of the WebException
         /// </summary>
         /// <param name="message"></param>
         public WebException(string message) : base(message) { }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -399,6 +399,20 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
         $result = ExecuteWebCommand -command $command
         $result.Error | Should BeNullOrEmpty
     }
+
+    It "Invoke-WebRequest should read content if status is unsuccessful" {
+
+        $command = "Invoke-WebRequest http://httpbin.org/status/418"
+        $result = ExecuteWebCommand -command $command
+        $result.Error.ErrorDetails.Message | Should Match "\-=\[ teapot \]"
+    }
+
+    It "Invoke-WebRequest should return status code if status is unsuccessful" {
+
+        $command = "Invoke-WebRequest http://httpbin.org/status/500"
+        $result = ExecuteWebCommand -command $command
+        $result.Error.Exception.Response.StatusCode | Should be 500
+    }
 }
 
 Describe "Invoke-RestMethod tests" -Tags "Feature" {


### PR DESCRIPTION
fixes [#2113](https://github.com/PowerShell/PowerShell/issues/2113)

**before the change (in CoreCLR)**:
```
PS C:\>  Invoke-RestMethod http://httpbin.org/status/418
Invoke-RestMethod : Response status code does not indicate success: 418 (I'M A
TEAPOT).
PS C:\> $error[0].Exception.Response
(nothing)
```
**after the change**
```
PS C:\> Invoke-RestMethod http://httpbin.org/status/418
Invoke-RestMethod :
    -=[ teapot ]=-
       _...._
     .'  _ _ `.
    | ."` ^ `". _,
    \_;`"---"`|//
      |       ;/
      \_     _/
        `"""`
At line:1 char:1...
PS C:\> $error[0].Exception.Response
Version             : 1.1
Content             : System.Net.Http.StreamContent
StatusCode          : 418
ReasonPhrase        : I'M A TEAPOT
Headers             : {[Connection, System.String[]], [Date, System.String[]],
                      [Server, System.String[]], [Access-Control-Allow-Origin,
                      System.String[]]...}
RequestMessage      : Method: GET, RequestUri:
                      'http://httpbin.org/status/418', Version: 1.1, Content:
                      <null>, Headers:
                      {...
PS C:\> Invoke-RestMethod http://httpbin.org/status/500
Invoke-RestMethod : The remote server returned an error: (500) INTERNAL SERVER ERROR.
```
