### PR TITLE
Approve console cmdlets tests

### DIFF
--- a/test/powershell/Common/TestHostCS.psm1
+++ b/test/powershell/Common/TestHostCS.psm1
@@ -304,7 +304,7 @@ function New-TestHost
     }
 
     if ( ! ("TestHost.TestHost" -as "type" )) {
-       $t = add-Type -pass $definition -ref $references -WarningAction SilentlyContinue 
+       $t = add-Type -pass $definition -ref $references
     }
 
     [TestHost.TestHost]::New()

--- a/test/powershell/Common/TestHostCS.psm1
+++ b/test/powershell/Common/TestHostCS.psm1
@@ -171,12 +171,17 @@ namespace TestHost
 
         public override void Write(string value)
         {
-            Streams.ConsoleOutput.Add(value);
+            Streams.ConsoleOutput.Add("::"+value+":NoNewLine");
         }
 
         public override void Write(ConsoleColor foregroundColor, ConsoleColor backgroundColor, string value)
         {
-            Streams.ConsoleOutput.Add(value);
+            Streams.ConsoleOutput.Add(foregroundColor+":"+backgroundColor+":"+value+":NoNewLine");
+        }
+
+        public override void WriteLine(ConsoleColor foregroundColor, ConsoleColor backgroundColor, string value)
+        {
+            Streams.ConsoleOutput.Add(foregroundColor+":"+backgroundColor+":"+value+":NewLine");
         }
 
         public override void WriteDebugLine(string message)
@@ -191,7 +196,7 @@ namespace TestHost
 
         public override void WriteLine(string value)
         {
-            Streams.ConsoleOutput.Add(value);
+            Streams.ConsoleOutput.Add("::"+value+":NewLine");
         }
 
         public override void WriteProgress(long sourceId, ProgressRecord record)
@@ -207,6 +212,15 @@ namespace TestHost
         public override void WriteWarningLine(string message)
         {
             Streams.Warning.Add(message);
+        }
+
+        public override void WriteInformation(InformationRecord record)
+        {
+            HostInformationMessage hostOutput = record.MessageData as HostInformationMessage;
+            if (hostOutput != null) {
+                 string message = hostOutput.Message;
+                 Streams.Information.Add(message);
+            }
         }
     }
 
@@ -290,7 +304,7 @@ function New-TestHost
     }
 
     if ( ! ("TestHost.TestHost" -as "type" )) {
-       $t = add-Type -pass $definition -ref $references
+       $t = add-Type -pass $definition -ref $references -WarningAction SilentlyContinue 
     }
 
     [TestHost.TestHost]::New()

--- a/test/powershell/Common/TestHostCS.psm1
+++ b/test/powershell/Common/TestHostCS.psm1
@@ -169,6 +169,12 @@ namespace TestHost
             return ss;
         }
 
+        // Cmdlets call 'Write' and 'WriteLine' methods implicitly.
+        // To see difference between 'Write' and 'WriteLine' with and w/o colors in the debug output
+        // we need use a meta information.
+        // So we make a output string as:
+        // <Foregraund color name> : <Background color name> : <'user value'> : <'NewLine' or 'NoNewLine'>
+        //
         public override void Write(string value)
         {
             Streams.ConsoleOutput.Add("::"+value+":NoNewLine");

--- a/test/powershell/Host/HostUtilities.Tests.ps1
+++ b/test/powershell/Host/HostUtilities.Tests.ps1
@@ -1,8 +1,5 @@
-﻿if (-not (Get-Module TestRemoting -ErrorAction SilentlyContinue))
-{
-    $remotingModule = Join-Path $PSScriptRoot "../Common/TestRemoting.psm1"
-    Import-Module $remotingModule
-}
+﻿$remotingModule = Join-Path $PSScriptRoot "../Common/TestRemoting.psm1"
+Import-Module $remotingModule
 
 Describe "InvokeOnRunspace method argument error handling" -tags "Feature" {
 

--- a/test/powershell/Language/Scripting/ParameterBinding.Tests.ps1
+++ b/test/powershell/Language/Scripting/ParameterBinding.Tests.ps1
@@ -1,5 +1,5 @@
-﻿Import-Module $PSScriptRoot\..\..\Common\Test.Helpers.psm1
-Import-Module $PSScriptRoot\..\..\Common\TestHostCS.psm1
+﻿Import-Module $PSScriptRoot\..\..\Common\Test.Helpers.psm1 -ErrorAction SilentlyContinue
+Import-Module $PSScriptRoot\..\..\Common\TestHostCS.psm1 -ErrorAction SilentlyContinue
 
 Describe "Tests for parameter binding" -Tags "CI" {
     Context 'Test of Mandatory parameters' {

--- a/test/powershell/Language/Scripting/ParameterBinding.Tests.ps1
+++ b/test/powershell/Language/Scripting/ParameterBinding.Tests.ps1
@@ -1,14 +1,5 @@
-﻿if ( ! (get-module -ea silentlycontinue Test.Helpers ))
-{
-    $hostmodule = Join-Path $PSScriptRoot "../../Common/Test.Helpers.psm1"
-    import-module $hostmodule
-}
-
-if ( ! (get-module -ea silentlycontinue TestHostCS ))
-{
-    $hostmodule = Join-Path $PSScriptRoot "../../Common/TestHostCS.psm1"
-    import-module $hostmodule
-}
+﻿Import-Module $PSScriptRoot\..\..\Common\Test.Helpers.psm1
+Import-Module $PSScriptRoot\..\..\Common\TestHostCS.psm1
 
 Describe "Tests for parameter binding" -Tags "CI" {
     Context 'Test of Mandatory parameters' {

--- a/test/powershell/Language/Scripting/ParameterBinding.Tests.ps1
+++ b/test/powershell/Language/Scripting/ParameterBinding.Tests.ps1
@@ -1,5 +1,14 @@
-﻿Import-Module $PSScriptRoot\..\..\Common\Test.Helpers.psm1
-Import-Module $PSScriptRoot\..\..\Common\TestHostCS.psm1
+﻿if ( ! (get-module -ea silentlycontinue Test.Helpers ))
+{
+    $hostmodule = Join-Path $PSScriptRoot "../../Common/Test.Helpers.psm1"
+    import-module $hostmodule
+}
+
+if ( ! (get-module -ea silentlycontinue TestHostCS ))
+{
+    $hostmodule = Join-Path $PSScriptRoot "../../Common/TestHostCS.psm1"
+    import-module $hostmodule
+}
 
 Describe "Tests for parameter binding" -Tags "CI" {
     Context 'Test of Mandatory parameters' {

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Out-Host.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Out-Host.Tests.ps1
@@ -1,6 +1,6 @@
 # this is sensitive to the location of this test and the common directory"
 $hostmodule = Join-Path $PSScriptRoot "../../Common/TestHostCS.psm1"
-import-module $hostmodule
+import-module $hostmodule -ErrorAction SilentlyContinue
 
 Describe "Out-Host Tests" -tag CI {
     BeforeAll {

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Out-Host.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Out-Host.Tests.ps1
@@ -27,8 +27,9 @@ Describe "Out-Host Tests" -tag CI {
     }
     It "Out-Host writes to host output" {
         $stringToWrite = "thing to write"
+        $stringExpected = "::$($stringToWrite):NewLine"
         $result = $ps.AddScript("Out-Host -inputobject '$stringToWrite'").Invoke()
         $th.UI.Streams.ConsoleOutput.Count | should be 1
-        $th.UI.Streams.ConsoleOutput[0] | should be $stringToWrite
+        $th.UI.Streams.ConsoleOutput[0] | should be $stringExpected
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Out-Host.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Out-Host.Tests.ps1
@@ -1,12 +1,6 @@
-
-if ( ! (get-module -ea silentlycontinue TestHostCS ))
-{
-    # this is sensitive to the location of this test and the common directory"
-    $pestertestroot = resolve-path "$psscriptroot/../.."
-    $common = join-path $pestertestroot Common
-    $hostmodule = join-path $common TestHostCS.psm1
-    import-module $hostmodule
-}
+# this is sensitive to the location of this test and the common directory"
+$hostmodule = Join-Path $PSScriptRoot "../../Common/TestHostCS.psm1"
+import-module $hostmodule
 
 Describe "Out-Host Tests" -tag CI {
     BeforeAll {

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/GetCredential.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/GetCredential.Tests.ps1
@@ -1,8 +1,6 @@
-if ( ! (get-module -ea silentlycontinue TestHostCS ))
-{
-    $hostmodule = Join-Path $PSScriptRoot "../../Common/TestHostCS.psm1"
-    import-module $hostmodule
-}
+$hostmodule = Join-Path $PSScriptRoot "../../Common/TestHostCS.psm1"
+import-module $hostmodule
+
 Describe "Get-Credential Test" -tag "CI" {
     BeforeAll {
         $th = New-TestHost

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/GetCredential.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/GetCredential.Tests.ps1
@@ -1,5 +1,5 @@
 $hostmodule = Join-Path $PSScriptRoot "../../Common/TestHostCS.psm1"
-import-module $hostmodule
+import-module $hostmodule -ErrorAction SilentlyContinue
 
 Describe "Get-Credential Test" -tag "CI" {
     BeforeAll {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Implicit.Remoting.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Implicit.Remoting.Tests.ps1
@@ -1,5 +1,5 @@
 ﻿$remotingModule = Join-Path $PSScriptRoot "../../Common/TestRemoting.psm1"
-Import-Module $remotingModule
+Import-Module $remotingModule -ErrorAction SilentlyContinue
 
 Describe "Implicit remoting and CIM cmdlets with AllSigned and Restricted policy" -tags "Feature" {
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Implicit.Remoting.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Implicit.Remoting.Tests.ps1
@@ -1,9 +1,5 @@
-﻿
-if (-not (Get-Module TestRemoting -ErrorAction SilentlyContinue))
-{
-    $remotingModule = Join-Path $PSScriptRoot "../../Common/TestRemoting.psm1"
-    Import-Module $remotingModule
-}
+﻿$remotingModule = Join-Path $PSScriptRoot "../../Common/TestRemoting.psm1"
+Import-Module $remotingModule
 
 Describe "Implicit remoting and CIM cmdlets with AllSigned and Restricted policy" -tags "Feature" {
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Read-Host.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Read-Host.Tests.ps1
@@ -1,8 +1,6 @@
-if ( ! (get-module -ea silentlycontinue TestHostCS ))
-{
-    $hostmodule = Join-Path $PSScriptRoot "../../Common/TestHostCS.psm1"
-    import-module $hostmodule
-}
+$hostmodule = Join-Path $PSScriptRoot "../../Common/TestHostCS.psm1"
+import-module $hostmodule
+
 Describe "Read-Host Test" -tag "CI" {
     BeforeAll {
         $th = New-TestHost

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Read-Host.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Read-Host.Tests.ps1
@@ -1,5 +1,5 @@
 $hostmodule = Join-Path $PSScriptRoot "../../Common/TestHostCS.psm1"
-import-module $hostmodule
+import-module $hostmodule -ErrorAction SilentlyContinue
 
 Describe "Read-Host Test" -tag "CI" {
     BeforeAll {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Host.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Host.Tests.ps1
@@ -1,18 +1,93 @@
-﻿Describe "Write-Host DRT Unit Tests" -Tags "CI" {
+﻿Describe "Write-Host DRT Unit Tests" -Tags "Slow","Feature" {
 
     BeforeAll {
         $powershell = Join-Path -Path $PsHome -ChildPath "powershell"
+
+        $testData = @(
+            @{ Name = '-Separator';Command = "Write-Host a,b,c -Separator '+'"; returnCount = 1; returnValue = @("a+b+c") }
+            @{ Name = '-NoNewline=true';Command = "Write-Host a,b -NoNewline:`$true;Write-Host a,b"; returnCount = 1; returnValue = @("a ba b") }
+            @{ Name = '-NoNewline=false';Command = "Write-Host a1,b1;Write-Host a2,b2"; returnCount = 2; returnValue = @("a1 b1","a2 b2") }
+        )
     }
 
+    It "write-Host works with '<Name>' switch" -TestCases:$testData -Pending:$IsOSX {
+        param($Command, $returnCount, $returnValue)
 
-    $testData = @(
-        @{ Name = 'NoNewline';Command = "Write-Host a,b -Separator ',' -ForegroundColor Yellow -BackgroundColor DarkBlue -NoNewline"; returnValue = "a,b" }
-        @{ Name = 'Separator';Command = "Write-Host a,b,c -Separator '+'"; returnValue = "a+b+c" }
-    )
+        [array]$result = & $powershell -noprofile $Command
+        $result.Count | Should Be $returnCount
+        $result[0] | Should Be $returnValue[0]
+        $result[1] | Should Be $returnValue[1]
+    }
+}
 
-    It "write-Host works with '<Name>' switch" -TestCases $testData -Pending:$IsOSX {
-        param($Command, $returnValue)
+Describe "Write-Host test wrong colors" -Tags "CI" {
 
-        & $powershell -noprofile $Command | Should Be $returnValue
+    BeforeAll {
+        $testWrongColor = @(
+            @{ ForegroundColor = -1; BackgroundColor = 'Red' }
+            @{ ForegroundColor = 16; BackgroundColor = 'Red' }
+            @{ ForegroundColor = 'Red'; BackgroundColor = -1 }
+            @{ ForegroundColor = 'Red'; BackgroundColor = 16 }
+        )
+    }
+
+    It 'Should throw if color is invalid: ForegroundColor = <ForegroundColor>; BackgroundColor = <BackgroundColor>' -TestCases:$testWrongColor {
+      param($ForegroundColor, $BackgroundColor)
+      try
+      {
+          Write-Host "No output from Write-Host" -ForegroundColor $ForegroundColor -BackgroundColor $BackgroundColor
+          throw "No Exception!"
+      }
+      catch { $_.FullyQualifiedErrorId | Should Be 'CannotConvertArgumentNoMessage,Microsoft.PowerShell.Commands.WriteHostCommand' }
+    }
+}
+
+Describe "Write-Host test with TestHostCS" -Tags "CI" {
+
+    BeforeAll {
+        if ( -not (get-module -ea SilentlyContinue TestHostCS )) {
+            $hostmodule = Join-Path $PSScriptRoot "../../Common/TestHostCS.psm1"
+            import-module $hostmodule
+        }
+        $th = New-TestHost
+        $rs = [runspacefactory]::Createrunspace($th)
+        $rs.open()
+        $ps = [powershell]::Create()
+        $ps.Runspace = $rs
+
+        $testHostCSData = @(
+            @{ Name = 'defaults';Command = "Write-Host a,b,c"; returnCount = 1; returnValue = @("White:Black:a b c:NewLine") }
+            @{ Name = '-Separator';Command = "Write-Host a,b,c -Separator '+'"; returnCount = 1; returnValue = @("White:Black:a+b+c:NewLine") }
+            @{ Name = '-Separator, colors and -NoNewLine';Command = "Write-Host a,b,c -Separator ',' -ForegroundColor Yellow -BackgroundColor DarkBlue -NoNewline"; returnCount = 1; returnValue = @("Yellow:DarkBlue:a,b,c:NoNewLine") }
+            @{ Name = '-NoNewline:$true and colors';Command = "Write-Host a,b -NoNewline:`$true -ForegroundColor Red -BackgroundColor Green;Write-Host a,b"; returnCount = 2; returnValue = @("Red:Green:a b:NoNewLine", "White:Black:a b:NewLine") }
+            @{ Name = '-NoNewline:$false and colors';Command = "Write-Host a,b -NoNewline:`$false -ForegroundColor Red -BackgroundColor Green;Write-Host a,b"; returnCount = 2; returnValue = @("Red:Green:a b:NewLine","White:Black:a b:NewLine") }
+        )
+
+    }
+
+    AfterAll {
+        $rs.Close()
+        $rs.Dispose()
+        $ps.Dispose()
+    }
+
+    AfterEach {
+        $ps.Commands.Clear()
+        $th.ui.Streams.Clear()
+    }
+
+    It "write-Host works with <Name>" -TestCases:$testHostCSData {
+        param($Command, $returnCount, $returnValue)
+        $ps.AddScript($Command).Invoke()
+        $result = $th.ui.Streams.ConsoleOutput
+
+        # I wonder that a console output is duplicated in Information Stream - Is it by design?
+        Write-Host $th.ui.Streams.Information.Count
+        Write-Host $th.ui.Streams.Information[0]
+        Write-Host $th.ui.Streams.Information[1]
+
+        $result.Count | Should Be $returnCount
+        $result[0] | Should Be $returnValue[0]
+        $result[1] | Should Be $returnValue[1]
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Host.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Host.Tests.ps1
@@ -1,4 +1,4 @@
-﻿Describe "Write-Host DRT Unit Tests" -Tags "Slow","Feature" {
+﻿Describe "Write-Host with default Console Host" -Tags "Slow","Feature" {
 
     BeforeAll {
         $powershell = Join-Path -Path $PsHome -ChildPath "powershell"
@@ -14,13 +14,16 @@
         param($Command, $returnCount, $returnValue)
 
         [array]$result = & $powershell -noprofile $Command
+
         $result.Count | Should Be $returnCount
-        $result[0] | Should Be $returnValue[0]
-        $result[1] | Should Be $returnValue[1]
+        foreach ($i in 0..($returnCount - 1))
+        {
+            $result[$i] | Should Be $returnValue[$i]
+        }
     }
 }
 
-Describe "Write-Host test wrong colors" -Tags "CI" {
+Describe "Write-Host with wrong colors" -Tags "CI" {
 
     BeforeAll {
         $testWrongColor = @(
@@ -42,11 +45,11 @@ Describe "Write-Host test wrong colors" -Tags "CI" {
     }
 }
 
-Describe "Write-Host test with TestHostCS" -Tags "CI" {
+Describe "Write-Host with TestHostCS" -Tags "CI" {
 
     BeforeAll {
         $hostmodule = Join-Path $PSScriptRoot "../../Common/TestHostCS.psm1"
-        import-module $hostmodule
+        import-module $hostmodule -ErrorAction SilentlyContinue
         $th = New-TestHost
         $rs = [runspacefactory]::Createrunspace($th)
         $rs.open()
@@ -55,6 +58,7 @@ Describe "Write-Host test with TestHostCS" -Tags "CI" {
 
         $testHostCSData = @(
             @{ Name = 'defaults';                          Command = "Write-Host a,b,c";                                                                             returnCount = 1; returnValue = @("White:Black:a b c:NewLine") }
+            @{ Name = '-Object';                           Command = "Write-Host -Object a,b,c";                                                                     returnCount = 1; returnValue = @("White:Black:a b c:NewLine") }
             @{ Name = '-Separator';                        Command = "Write-Host a,b,c -Separator '+'";                                                              returnCount = 1; returnValue = @("White:Black:a+b+c:NewLine") }
             @{ Name = '-Separator, colors and -NoNewLine'; Command = "Write-Host a,b,c -Separator ',' -ForegroundColor Yellow -BackgroundColor DarkBlue -NoNewline"; returnCount = 1; returnValue = @("Yellow:DarkBlue:a,b,c:NoNewLine") }
             @{ Name = '-NoNewline:$true and colors';       Command = "Write-Host a,b -NoNewline:`$true -ForegroundColor Red -BackgroundColor Green;Write-Host a,b";  returnCount = 2; returnValue = @("Red:Green:a b:NoNewLine", "White:Black:a b:NewLine") }
@@ -74,18 +78,20 @@ Describe "Write-Host test with TestHostCS" -Tags "CI" {
         $th.ui.Streams.Clear()
     }
 
-    It "write-Host works with <Name>" -TestCases:$testHostCSData {
+    It "Write-Host works with <Name>" -TestCases:$testHostCSData {
         param($Command, $returnCount, $returnValue)
         $ps.AddScript($Command).Invoke()
         $result = $th.ui.Streams.ConsoleOutput
 
         # I wonder that a console output is duplicated in Information Stream - Is it by design?
-        Write-Host $th.ui.Streams.Information.Count
-        Write-Host $th.ui.Streams.Information[0]
-        Write-Host $th.ui.Streams.Information[1]
+        $th.ui.Streams.Information.Count | Should Be $returnCount
+        $th.ui.Streams.Information[0] | Should Be $returnValue[0]
+        $th.ui.Streams.Information[1] | Should Be $returnValue[1]
 
         $result.Count | Should Be $returnCount
-        $result[0] | Should Be $returnValue[0]
-        $result[1] | Should Be $returnValue[1]
+        foreach ($i in 0..($returnCount - 1))
+        {
+            $result[$i] | Should Be $returnValue[$i]
+        }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Host.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Host.Tests.ps1
@@ -4,9 +4,9 @@
         $powershell = Join-Path -Path $PsHome -ChildPath "powershell"
 
         $testData = @(
-            @{ Name = '-Separator';Command = "Write-Host a,b,c -Separator '+'"; returnCount = 1; returnValue = @("a+b+c") }
-            @{ Name = '-NoNewline=true';Command = "Write-Host a,b -NoNewline:`$true;Write-Host a,b"; returnCount = 1; returnValue = @("a ba b") }
-            @{ Name = '-NoNewline=false';Command = "Write-Host a1,b1;Write-Host a2,b2"; returnCount = 2; returnValue = @("a1 b1","a2 b2") }
+            @{ Name = '-Separator';       Command = "Write-Host a,b,c -Separator '+'";                 returnCount = 1; returnValue = @("a+b+c") }
+            @{ Name = '-NoNewline=true';  Command = "Write-Host a,b -NoNewline:`$true;Write-Host a,b"; returnCount = 1; returnValue = @("a ba b") }
+            @{ Name = '-NoNewline=false'; Command = "Write-Host a1,b1;Write-Host a2,b2";               returnCount = 2; returnValue = @("a1 b1","a2 b2") }
         )
     }
 
@@ -24,8 +24,8 @@ Describe "Write-Host test wrong colors" -Tags "CI" {
 
     BeforeAll {
         $testWrongColor = @(
-            @{ ForegroundColor = -1; BackgroundColor = 'Red' }
-            @{ ForegroundColor = 16; BackgroundColor = 'Red' }
+            @{ ForegroundColor = -1;    BackgroundColor = 'Red' }
+            @{ ForegroundColor = 16;    BackgroundColor = 'Red' }
             @{ ForegroundColor = 'Red'; BackgroundColor = -1 }
             @{ ForegroundColor = 'Red'; BackgroundColor = 16 }
         )
@@ -45,10 +45,8 @@ Describe "Write-Host test wrong colors" -Tags "CI" {
 Describe "Write-Host test with TestHostCS" -Tags "CI" {
 
     BeforeAll {
-        if ( -not (get-module -ea SilentlyContinue TestHostCS )) {
-            $hostmodule = Join-Path $PSScriptRoot "../../Common/TestHostCS.psm1"
-            import-module $hostmodule
-        }
+        $hostmodule = Join-Path $PSScriptRoot "../../Common/TestHostCS.psm1"
+        import-module $hostmodule
         $th = New-TestHost
         $rs = [runspacefactory]::Createrunspace($th)
         $rs.open()
@@ -56,11 +54,11 @@ Describe "Write-Host test with TestHostCS" -Tags "CI" {
         $ps.Runspace = $rs
 
         $testHostCSData = @(
-            @{ Name = 'defaults';Command = "Write-Host a,b,c"; returnCount = 1; returnValue = @("White:Black:a b c:NewLine") }
-            @{ Name = '-Separator';Command = "Write-Host a,b,c -Separator '+'"; returnCount = 1; returnValue = @("White:Black:a+b+c:NewLine") }
-            @{ Name = '-Separator, colors and -NoNewLine';Command = "Write-Host a,b,c -Separator ',' -ForegroundColor Yellow -BackgroundColor DarkBlue -NoNewline"; returnCount = 1; returnValue = @("Yellow:DarkBlue:a,b,c:NoNewLine") }
-            @{ Name = '-NoNewline:$true and colors';Command = "Write-Host a,b -NoNewline:`$true -ForegroundColor Red -BackgroundColor Green;Write-Host a,b"; returnCount = 2; returnValue = @("Red:Green:a b:NoNewLine", "White:Black:a b:NewLine") }
-            @{ Name = '-NoNewline:$false and colors';Command = "Write-Host a,b -NoNewline:`$false -ForegroundColor Red -BackgroundColor Green;Write-Host a,b"; returnCount = 2; returnValue = @("Red:Green:a b:NewLine","White:Black:a b:NewLine") }
+            @{ Name = 'defaults';                          Command = "Write-Host a,b,c";                                                                             returnCount = 1; returnValue = @("White:Black:a b c:NewLine") }
+            @{ Name = '-Separator';                        Command = "Write-Host a,b,c -Separator '+'";                                                              returnCount = 1; returnValue = @("White:Black:a+b+c:NewLine") }
+            @{ Name = '-Separator, colors and -NoNewLine'; Command = "Write-Host a,b,c -Separator ',' -ForegroundColor Yellow -BackgroundColor DarkBlue -NoNewline"; returnCount = 1; returnValue = @("Yellow:DarkBlue:a,b,c:NoNewLine") }
+            @{ Name = '-NoNewline:$true and colors';       Command = "Write-Host a,b -NoNewline:`$true -ForegroundColor Red -BackgroundColor Green;Write-Host a,b";  returnCount = 2; returnValue = @("Red:Green:a b:NoNewLine", "White:Black:a b:NewLine") }
+            @{ Name = '-NoNewline:$false and colors';      Command = "Write-Host a,b -NoNewline:`$false -ForegroundColor Red -BackgroundColor Green;Write-Host a,b"; returnCount = 2; returnValue = @("Red:Green:a b:NewLine","White:Black:a b:NewLine") }
         )
 
     }


### PR DESCRIPTION
Main improvements refer to tests of the Write-Host cmdlet.
Original tests:
1. Slow because run external processes
2. Don't test colors and -NoNewLine in fact.

Done:
1. The original tests is preserved (deleted one as redundant) but marked
by 'Slow' tag. They is preserved because they actually check the output
on the work, not a test console.
2. Add negative color tests. (Code cover grow!)
3. Add tests based on TestHostCS. This test host has been refined so we
can see colors and a new line in output.
4. Add minor fixes for test modules loads.

Also I add support for Information stream. I originally planned to use
it but not actually used. However, I have left this as a useful addition
for future tests.
I wonder that a Write-Host console output is duplicated in Information
Stream - Is it by design? I left a debug print on this matter in the
test code.