### PR TITLE
Pass null rather than "localhost" to CimSession.Create

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/GetComputerInfoCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/GetComputerInfoCommand.cs
@@ -79,7 +79,7 @@ namespace Microsoft.PowerShell.Commands
 
         #region Static Data and Constants
         private const string activity = "Get-ComputerInfo";
-        private const string localMachineName = "localhost";
+        private const string localMachineName = null;
         #endregion Static Data and Constants
 
         #region Instance Data


### PR DESCRIPTION
Fixes #3080