### PR TITLE
Implement -version parameter in console host (address part of https:/…

### DIFF
--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
@@ -316,6 +316,14 @@ namespace Microsoft.PowerShell
             }
         }
 
+        internal bool ShowVersion
+        {
+            get
+            {
+                return _showVersion;
+            }
+        }
+
         internal Serialization.DataFormat OutputFormat
         {
             get
@@ -500,7 +508,6 @@ namespace Microsoft.PowerShell
 
                 // chop off the first character so that we're agnostic wrt specifying / or -
                 // in front of the switch name.
-
                 switchKey = switchKey.Substring(1);
 
                 // chop off the second dash so we're agnostic wrt specifying - or --
@@ -508,6 +515,19 @@ namespace Microsoft.PowerShell
                 {
                     switchKey = switchKey.Substring(1);
                 }
+
+                // If version is in the commandline, don't continue to look at any other parameters
+                if (MatchSwitch(switchKey, "version", "v"))
+                {
+                    _showVersion = true;
+                    _showBanner = false;
+                    _noInteractive = true;
+                    _skipUserInit = true;
+                    _noExit = false;
+                    _commandLineCommand = "'powershell ' + $psversiontable.gitcommitid";
+                    break;
+                }
+
 
                 if (MatchSwitch(switchKey, "help", "h") || MatchSwitch(switchKey, "?", "?"))
                 {
@@ -551,6 +571,7 @@ namespace Microsoft.PowerShell
                 {
                     _sshServerMode = true;
                 }
+
                 else if (MatchSwitch(switchKey, "configurationname", "config"))
                 {
                     ++i;
@@ -1091,6 +1112,7 @@ namespace Microsoft.PowerShell
         private bool _serverMode;
         private bool _namedPipeServerMode;
         private bool _sshServerMode;
+        private bool _showVersion;
         private string _configurationName;
         private PSHostUserInterface _hostUI;
         private bool _showHelp;

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
@@ -524,7 +524,6 @@ namespace Microsoft.PowerShell
                     _noInteractive = true;
                     _skipUserInit = true;
                     _noExit = false;
-                    _commandLineCommand = "'powershell ' + $psversiontable.gitcommitid";
                     break;
                 }
 
@@ -571,7 +570,6 @@ namespace Microsoft.PowerShell
                 {
                     _sshServerMode = true;
                 }
-
                 else if (MatchSwitch(switchKey, "configurationname", "config"))
                 {
                     ++i;

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
@@ -195,7 +195,7 @@ namespace Microsoft.PowerShell
                     // Alternatively, we could call s_theConsoleHost.UI.WriteLine(s_theConsoleHost.Version.ToString());
                     // or start up the engine and retrieve the information via $psversiontable.GitCommitId
                     // but this returns the semantic version and avoids executing a script
-                    s_theConsoleHost.UI.WriteLine("powershell " + PSVersionInfo.GetCommitInfo());
+                    s_theConsoleHost.UI.WriteLine("powershell " + PSVersionInfo.GitCommitId);
                     return 0;
                 }
 

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
@@ -190,6 +190,15 @@ namespace Microsoft.PowerShell
 
                 s_cpp.Parse(tempArgs);
 
+                if (s_cpp.ShowVersion)
+                {
+                    // Alternatively, we could call s_theConsoleHost.UI.WriteLine(s_theConsoleHost.Version.ToString());
+                    // or start up the engine and retrieve the information via $psversiontable.GitCommitId
+                    // but this returns the semantic version and avoids executing a script
+                    s_theConsoleHost.UI.WriteLine("powershell " + PSVersionInfo.GetCommitInfo());
+                    return 0;
+                }
+
                 // Servermode parameter validation check.
                 if ((s_cpp.ServerMode && s_cpp.NamedPipeServerMode) || (s_cpp.ServerMode && s_cpp.SocketServerMode) || (s_cpp.NamedPipeServerMode && s_cpp.SocketServerMode))
                 {

--- a/src/System.Management.Automation/engine/PSVersionInfo.cs
+++ b/src/System.Management.Automation/engine/PSVersionInfo.cs
@@ -153,6 +153,14 @@ namespace System.Management.Automation
             }
         }
 
+        internal static string GitCommitId
+        {
+            get
+            {
+                return (string)GetPSVersionTable()["GitCommitId"];
+            }
+        }
+
         internal static Version CLRVersion
         {
             get

--- a/test/powershell/Host/ConsoleHost.Tests.ps1
+++ b/test/powershell/Host/ConsoleHost.Tests.ps1
@@ -164,6 +164,20 @@ Describe "ConsoleHost unit tests" -tags "Feature" {
             $actual | Should Be $expected
         }
 
+        It "-Version should return the engine version" {
+            $currentVersion = "powershell " + $PSVersionTable.GitCommitId.ToString()
+            $observed = & $powershell -version
+            $observed | should be $currentVersion
+        }
+
+        It "-Version should ignore other parameters" {
+            $currentVersion = "powershell " + $PSVersionTable.GitCommitId.ToString()
+            $observed = & $powershell -version -command get-date
+            # no extraneous output
+            $observed | should be $currentVersion
+            
+        }
+
     }
 
     Context "Pipe to/from powershell" {

--- a/test/powershell/Host/ConsoleHost.Tests.ps1
+++ b/test/powershell/Host/ConsoleHost.Tests.ps1
@@ -175,9 +175,7 @@ Describe "ConsoleHost unit tests" -tags "Feature" {
             $observed = & $powershell -version -command get-date
             # no extraneous output
             $observed | should be $currentVersion
-            
         }
-
     }
 
     Context "Pipe to/from powershell" {


### PR DESCRIPTION
#1084

This does not support providing a specific version to run, but
like most other *nix commands, -version will now return the version
of the PowerShell Engine. 'powershell' is prepended to the output to
match other *nix commands. We are using gitcommitid which includes more
info about the build.