### PR TITLE
Remove async tests for parser

### DIFF
--- a/test/powershell/Language/LanguageTestSupport.psm1
+++ b/test/powershell/Language/LanguageTestSupport.psm1
@@ -23,46 +23,13 @@ function Get-RuntimeError
 {
     [CmdletBinding()]
     param(
-        [Parameter(ValueFromPipeline=$True,Mandatory=$True)]
-        [string]$src,
-        [Parameter()]
-        [int]$Timeout = 0
+        [Parameter(ValueFromPipeline=$True,Mandatory=$True)][string]$src
     )
  
     $errors = $null
     try
     {
-        # some tests cannot be run in a isolated runspace
-        # easily because they require more than just a single
-        # execution
-        if ( $Timeout -eq 0 )
-        {
-            [scriptblock]::Create($src).Invoke() > $null
-        }
-        else
-        {
-            $ps = [powershell]::Create()
-            $ps.AddScript($src) > $null
-            $ar = $ps.BeginInvoke()
-            # give it 250 milliseconds to complete
-            start-sleep -mill 250
-            if ( $ar.IsCompleted ) {
-                $ps.EndInvoke($ar)
-            }
-            # wait another ${Timeout} seconds, then give up
-            else {
-                Start-Sleep -sec $Timeout
-                if ( $ar.IsCompleted ) {
-                    # this can throw, which will be picked up below
-                    $ps.EndInvoke($ar)
-                }
-                else {
-                    # if it didn't throw, then return a constructed error
-                    $ER = Write-Error "Operation Timed Out ('$src')" 2>&1
-                    return $ER
-                }
-            }
-        }
+        [scriptblock]::Create($src).Invoke() > $null
     }
     catch
     {
@@ -114,7 +81,7 @@ function ShouldBeParseError
         if ($SkipAndCheckRuntimeError)
         {
             It "error should happen at parse time, not at runtime" -Skip {}
-            $errors = Get-RuntimeError -Src $src -Timeout 10
+            $errors = Get-RuntimeError -Src $src
             # for runtime errors we will only get the first one
             $expectedErrors = ,$expectedErrors[0]
             $expectedOffsets = ,$expectedOffsets[0]

--- a/test/powershell/Language/LanguageTestSupport.psm1
+++ b/test/powershell/Language/LanguageTestSupport.psm1
@@ -35,12 +35,6 @@ function Get-RuntimeError
     {
         return $_.Exception.InnerException.ErrorRecord
     }
-    finally
-    {
-        if ( $ps -ne $null ) {
-            $ps.dispose()
-        }
-    }
 }
 
 function position_message


### PR DESCRIPTION
this is a fix for https://github.com/PowerShell/PowerShell/issues/3069
and removes an attempt to work-around the issue of tests hanging on Travis-CI.

The hanging tests in Travis-CI have now been seen in a number of places, getting a dump during this condition has been problematic. 