### PR TITLE
Small typo in archive cmdlets tests

### DIFF
--- a/test/powershell/Modules/Microsoft.PowerShell.Archive/Pester.Commands.Cmdlets.Archive.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Archive/Pester.Commands.Cmdlets.Archive.Tests.ps1
@@ -12,9 +12,8 @@ Describe "Test suite for Microsoft.PowerShell.Archive module" -Tags "CI" {
     }
     BeforeAll {
         # remove the archive module forcefully, to be sure we get the correct version
-        if ( Get-Module Microsoft.PowerShell.Archive. ) {
-            Remove-Module Microsoft.PowerShell.Archive -force
-        }
+        Remove-Module Microsoft.PowerShell.Archive -force
+
         # Version comparisons should use a System.Version rather than SemanticVersion
         $PSVersion = $PSVersionTable.PSVersion -as [Version]
         # Write-Progress not supported yet on Core

--- a/test/powershell/Modules/Microsoft.PowerShell.Archive/Pester.Commands.Cmdlets.Archive.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Archive/Pester.Commands.Cmdlets.Archive.Tests.ps1
@@ -12,7 +12,7 @@ Describe "Test suite for Microsoft.PowerShell.Archive module" -Tags "CI" {
     }
     BeforeAll {
         # remove the archive module forcefully, to be sure we get the correct version
-        Remove-Module Microsoft.PowerShell.Archive -force
+        Remove-Module Microsoft.PowerShell.Archive -Force -ErrorAction SilentlyContinue
 
         # Version comparisons should use a System.Version rather than SemanticVersion
         $PSVersion = $PSVersionTable.PSVersion -as [Version]


### PR DESCRIPTION
Extra point in the module name.
Moreover, there is no need to check that the module is loaded