### PR TITLE
Adding Dockerfile labels from label-schema.org

### DIFF
--- a/docker/nightly/centos7/Dockerfile
+++ b/docker/nightly/centos7/Dockerfile
@@ -1,7 +1,12 @@
 FROM microsoft/powershell:centos7
-MAINTAINER Andrew Schwartzmeyer <andschwa@microsoft.com>
-LABEL Readme.md="https://github.com/PowerShell/PowerShell/blob/master/docker/README.md"
-LABEL Description="This Dockerfile will install and build the latest release of PS."
+
+# Metadata as defined at http://label-schema.org
+# Additional labels are inherited from microsoft/powershell:centos7
+ARG VCS_REF
+ARG BUILD_DATE
+LABEL org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.vcs-ref=$VCS_REF \
+      org.label-schema.docker.cmd="docker run -it microsoft/powershell-nightly:centos7"
 
 ARG fork=PowerShell
 ARG branch=master

--- a/docker/nightly/fedora24/Dockerfile
+++ b/docker/nightly/fedora24/Dockerfile
@@ -1,7 +1,12 @@
 FROM microsoft/powershell:fedora24
-MAINTAINER Andrew Schwartzmeyer <andschwa@microsoft.com>
-LABEL Readme.md="https://github.com/PowerShell/PowerShell/blob/master/docker/README.md"
-LABEL Description="This Dockerfile will install and build the latest release of PS."
+
+# Metadata as defined at http://label-schema.org
+# Additional labels are inherited from microsoft/powershell:fedora24
+ARG VCS_REF
+ARG BUILD_DATE
+LABEL org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.vcs-ref=$VCS_REF \
+      org.label-schema.docker.cmd="docker run -it microsoft/powershell-nightly:fedora24"
 
 ARG fork=PowerShell
 ARG branch=master

--- a/docker/nightly/ubuntu14.04/Dockerfile
+++ b/docker/nightly/ubuntu14.04/Dockerfile
@@ -1,7 +1,12 @@
 FROM microsoft/powershell:ubuntu14.04
-MAINTAINER Andrew Schwartzmeyer <andschwa@microsoft.com>
-LABEL Readme.md="https://github.com/PowerShell/PowerShell/blob/master/docker/README.md"
-LABEL Description="This Dockerfile will install and build the latest release of PS."
+
+# Metadata as defined at http://label-schema.org
+# Additional labels are inherited from microsoft/powershell:ubuntu14.04
+ARG VCS_REF
+ARG BUILD_DATE
+LABEL org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.vcs-ref=$VCS_REF \
+      org.label-schema.docker.cmd="docker run -it microsoft/powershell-nightly:ubuntu14.04"
 
 ARG fork=PowerShell
 ARG branch=master

--- a/docker/nightly/ubuntu16.04/Dockerfile
+++ b/docker/nightly/ubuntu16.04/Dockerfile
@@ -1,7 +1,12 @@
 FROM microsoft/powershell:ubuntu16.04
-MAINTAINER Andrew Schwartzmeyer <andschwa@microsoft.com>
-LABEL Readme.md="https://github.com/PowerShell/PowerShell/blob/master/docker/README.md"
-LABEL Description="This Dockerfile will install and build the latest release of PS."
+
+# Metadata as defined at http://label-schema.org
+# Additional labels are inherited from microsoft/powershell:ubuntu16.04
+ARG VCS_REF
+ARG BUILD_DATE
+LABEL org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.vcs-ref=$VCS_REF \
+      org.label-schema.docker.cmd="docker run -it microsoft/powershell-nightly:ubuntu16.04"
 
 ARG fork=PowerShell
 ARG branch=master

--- a/docker/release/centos7/Dockerfile
+++ b/docker/release/centos7/Dockerfile
@@ -1,8 +1,26 @@
 FROM centos:7
-MAINTAINER Andrew Schwartzmeyer <andschwa@microsoft.com>
 
+ARG POWERSHELL_VERSION=6.0.0-alpha.15
 ARG POWERSHELL_RELEASE=v6.0.0-alpha.15
 ARG POWERSHELL_PACKAGE=powershell-6.0.0_alpha.15-1.el7.centos.x86_64.rpm
+
+# Maintainer label and metadata as defined at http://label-schema.org
+ARG VCS_REF
+ARG BUILD_DATE
+LABEL maintainer="Andrew Schwartzmeyer <andschwa@microsoft.com>" \
+      org.label-schema.schema-version="1.0" \
+      org.label-schema.vendor="Microsoft" \
+      org.label-schema.name="PowerShell" \
+      org.label-schema.version=$POWERSHELL_VERSION \
+      org.label-schema.license="MIT" \
+      org.label-schema.description="PowerShell is a cross-platform (Windows, Linux, and macOS) automation and configuration tool/framework that works well with existing tools and is optimized for dealing with structured data, REST APIs, and object models. It includes a command-line shell, an associated scripting language and a framework for processing cmdlets." \
+      org.label-schema.url="https://microsoft.com/powershell" \
+      org.label-schema.usage="https://github.com/PowerShell/PowerShell/tree/master/docs/learning-powershell" \
+      org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.vcs-url="https://github.com/PowerShell/PowerShell.git" \
+      org.label-schema.vcs-ref=$VCS_REF \
+      org.label-schema.vcs-type="Git" \
+      org.label-schema.docker.cmd="docker run -it microsoft/powershell:centos7"
 
 # Setup the locale
 ENV LANG en_US.UTF-8

--- a/docker/release/fedora24/Dockerfile
+++ b/docker/release/fedora24/Dockerfile
@@ -1,5 +1,4 @@
 FROM fedora:24
-MAINTAINER Andrew Schwartzmeyer <andschwa@microsoft.com>
 
 # TODO: Until a release of PowerShell for Fedora 24 is available,
 # this Dockerfile installs the CentOS 7 version for compatibility.
@@ -14,8 +13,24 @@ ARG LIBICU50_SOURCE=https://www.mirrorservice.org/sites/mirror.centos.org/7.2.15
 ARG LIBICU50_PACKAGE=libicu-50.1.2-15.el7.x86_64.rpm
 ARG LIBICU50_PACKAGE_MD5=c3c1ebaabc8d1619377d535698784953
 
-# Install the English language pack first
+# Maintainer label and metadata as defined at http://label-schema.org
+ARG VCS_REF
+ARG BUILD_DATE
+LABEL maintainer="Andrew Schwartzmeyer <andschwa@microsoft.com>" \
+      org.label-schema.schema-version="1.0" \
+      org.label-schema.vendor="Microsoft" \
+      org.label-schema.name="PowerShell" \
+      org.label-schema.version=$POWERSHELL_VERSION \
+      org.label-schema.license="MIT" \
+      org.label-schema.description="PowerShell is a cross-platform (Windows, Linux, and macOS) automation and configuration tool/framework that works well with existing tools and is optimized for dealing with structured data, REST APIs, and object models. It includes a command-line shell, an associated scripting language and a framework for processing cmdlets." \
+      org.label-schema.url="https://microsoft.com/powershell" \
+      org.label-schema.usage="https://github.com/PowerShell/PowerShell/tree/master/docs/learning-powershell" \
+      org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.vcs-url="https://github.com/PowerShell/PowerShell.git" \
+      org.label-schema.vcs-ref=$VCS_REF \
+      org.label-schema.docker.cmd="docker run -it microsoft/powershell:fedora24"
 
+# Install the English language pack first
 RUN dnf install -y glibc glibc-langpack-en glibc-locale-source
 
 ENV LANG en_US.UTF-8

--- a/docker/release/nanoserver/Dockerfile
+++ b/docker/release/nanoserver/Dockerfile
@@ -1,11 +1,26 @@
 # escape=`
 FROM microsoft/nanoserver
-MAINTAINER brycem@microsoft.com
-LABEL Readme.md="https://github.com/PowerShell/PowerShell/blob/master/docker/README.md"
-LABEL Description="This Dockerfile will install the latest release of PS."
 
+ARG POWERSHELL_VERSION=6.0.0-alpha.14
 ARG POWERSHELL_ZIP=https://github.com/PowerShell/PowerShell/releases/download/v6.0.0-alpha.14/powershell-6.0.0-alpha.14-win10-x64.zip
 ARG POWERSHELL_SHA256=3F5FD873B6E3062D9741B019BC645E6F20999BE66B2FDAA4374495FEBEDD0E03
+
+# Maintainer label and metadata as defined at http://label-schema.org
+ARG VCS_REF
+ARG BUILD_DATE
+LABEL maintainer="brycem@microsoft.com" `
+      org.label-schema.schema-version="1.0" `
+      org.label-schema.vendor="Microsoft" `
+      org.label-schema.name="PowerShell" `
+      org.label-schema.version=$POWERSHELL_VERSION `
+      org.label-schema.license="MIT" `
+      org.label-schema.description="PowerShell is a cross-platform (Windows, Linux, and macOS) automation and configuration tool/framework that works well with existing tools and is optimized for dealing with structured data, REST APIs, and object models. It includes a command-line shell, an associated scripting language and a framework for processing cmdlets." `
+      org.label-schema.url="https://microsoft.com/powershell" `
+      org.label-schema.usage="https://github.com/PowerShell/PowerShell/tree/master/docs/learning-powershell" `
+      org.label-schema.build-date=$BUILD_DATE `
+      org.label-schema.vcs-url="https://github.com/PowerShell/PowerShell.git" `
+      org.label-schema.vcs-ref=$VCS_REF `
+      org.label-schema.docker.cmd="docker run -it microsoft/powershell:nanoserver"
 
 # Setup PowerShell - Log-to > C:\Docker.log
 SHELL ["C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe", "-command"]

--- a/docker/release/ubuntu14.04/Dockerfile
+++ b/docker/release/ubuntu14.04/Dockerfile
@@ -1,8 +1,25 @@
 FROM ubuntu:trusty
-MAINTAINER Andrew Schwartzmeyer <andschwa@microsoft.com>
 
+ARG POWERSHELL_VERSION=6.0.0-alpha.15
 ARG POWERSHELL_RELEASE=v6.0.0-alpha.15
 ARG POWERSHELL_PACKAGE=powershell_6.0.0-alpha.15-1ubuntu1.14.04.1_amd64.deb
+
+# Maintainer label and metadata as defined at http://label-schema.org
+ARG VCS_REF
+ARG BUILD_DATE
+LABEL maintainer="Andrew Schwartzmeyer <andschwa@microsoft.com>" \
+      org.label-schema.schema-version="1.0" \
+      org.label-schema.vendor="Microsoft" \
+      org.label-schema.name="PowerShell" \
+      org.label-schema.version=$POWERSHELL_VERSION \
+      org.label-schema.license="MIT" \
+      org.label-schema.description="PowerShell is a cross-platform (Windows, Linux, and macOS) automation and configuration tool/framework that works well with existing tools and is optimized for dealing with structured data, REST APIs, and object models. It includes a command-line shell, an associated scripting language and a framework for processing cmdlets." \
+      org.label-schema.url="https://microsoft.com/powershell" \
+      org.label-schema.usage="https://github.com/PowerShell/PowerShell/tree/master/docs/learning-powershell" \
+      org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.vcs-url="https://github.com/PowerShell/PowerShell.git" \
+      org.label-schema.vcs-ref=$VCS_REF \
+      org.label-schema.docker.cmd="docker run -it microsoft/powershell:ubuntu14.04"
 
 # Setup the locale
 ENV LANG en_US.UTF-8

--- a/docker/release/ubuntu16.04/Dockerfile
+++ b/docker/release/ubuntu16.04/Dockerfile
@@ -1,8 +1,25 @@
 FROM ubuntu:xenial
-MAINTAINER Andrew Schwartzmeyer <andschwa@microsoft.com>
 
+ARG POWERSHELL_VERSION=6.0.0-alpha.15
 ARG POWERSHELL_RELEASE=v6.0.0-alpha.15
 ARG POWERSHELL_PACKAGE=powershell_6.0.0-alpha.15-1ubuntu1.16.04.1_amd64.deb
+
+# Maintainer label and metadata as defined at http://label-schema.org
+ARG VCS_REF
+ARG BUILD_DATE
+LABEL maintainer="Andrew Schwartzmeyer <andschwa@microsoft.com>" \
+      org.label-schema.schema-version="1.0" \
+      org.label-schema.vendor="Microsoft" \
+      org.label-schema.name="PowerShell" \
+      org.label-schema.version=$POWERSHELL_VERSION \
+      org.label-schema.license="MIT" \
+      org.label-schema.description="PowerShell is a cross-platform (Windows, Linux, and macOS) automation and configuration tool/framework that works well with existing tools and is optimized for dealing with structured data, REST APIs, and object models. It includes a command-line shell, an associated scripting language and a framework for processing cmdlets." \
+      org.label-schema.url="https://microsoft.com/powershell" \
+      org.label-schema.usage="https://github.com/PowerShell/PowerShell/tree/master/docs/learning-powershell" \
+      org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.vcs-url="https://github.com/PowerShell/PowerShell.git" \
+      org.label-schema.vcs-ref=$VCS_REF \
+      org.label-schema.docker.cmd="docker run -it microsoft/powershell:ubuntu16.04"
 
 # Setup the locale
 ENV LANG en_US.UTF-8

--- a/docker/release/windowsservercore/Dockerfile
+++ b/docker/release/windowsservercore/Dockerfile
@@ -1,11 +1,26 @@
 # escape=`
 FROM microsoft/windowsservercore
-MAINTAINER brycem@microsoft.com
-LABEL Readme.md="https://github.com/PowerShell/PowerShell/blob/master/docker/README.md"
-LABEL Description="This Dockerfile will install the latest release of PS."
 
+ARG POWERSHELL_VERSION=6.0.0-alpha.14
 ARG POWERSHELL_MSI=https://github.com/PowerShell/PowerShell/releases/download/v6.0.0-alpha.14/PowerShell_6.0.0.14-alpha.14-win10-x64.msi
 ARG POWERSHELL_SHA256=503F3AD52223699765895D3E9615FBD7988194693BCB725BE90C9EF0CD594447
+
+# Maintainer label and metadata as defined at http://label-schema.org
+ARG VCS_REF
+ARG BUILD_DATE
+LABEL maintainer="brycem@microsoft.com" `
+      org.label-schema.schema-version="1.0" `
+      org.label-schema.vendor="Microsoft" `
+      org.label-schema.name="PowerShell" `
+      org.label-schema.version=$POWERSHELL_VERSION `
+      org.label-schema.license="MIT" `
+      org.label-schema.description="PowerShell is a cross-platform (Windows, Linux, and macOS) automation and configuration tool/framework that works well with existing tools and is optimized for dealing with structured data, REST APIs, and object models. It includes a command-line shell, an associated scripting language and a framework for processing cmdlets." `
+      org.label-schema.url="https://microsoft.com/powershell" `
+      org.label-schema.usage="https://github.com/PowerShell/PowerShell/tree/master/docs/learning-powershell" `
+      org.label-schema.build-date=$BUILD_DATE `
+      org.label-schema.vcs-url="https://github.com/PowerShell/PowerShell.git" `
+      org.label-schema.vcs-ref=$VCS_REF `
+      org.label-schema.docker.cmd="docker run -it microsoft/powershell:windowsservercore"
 
 # Setup PowerShell - Log-to > C:\Docker.log
 SHELL ["C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe", "-command"]


### PR DESCRIPTION
There is a drive from some within the container community towards a standard label schema for container images.

> Label Schema Convention DRAFT (1.0.0-rc.1)
> http://label-schema.org/rc1/
> 
> Docker Inc. express a preference that container labels should be namespaced. Label Schema is a community project to provide a shared namespace for use by multiple tools, specifically org.label-schema.
>
> By providing a shared and community owned namespace we aim to:
> - Avoid duplication in cases where the same information is needed in multiple labels
> - Encourage the use of labels, both by image creators and by tool builders which might consume them
> - Codify good community practice in a way that is easy to consume and keep up-to-date with

There are some blog posts that discuss this:
- [Building agreement around Docker labels](https://puppet.com/blog/building-agreement-around-docker-labels)
- [MicroBadger - helping you manage your containers](http://blog.microscaling.com/2016/06/microbadger-manage-your-containers.html)
- [New for the Image-Conscious Container: Label-Schema.org](https://medium.com/microscaling-systems/new-for-the-image-conscious-container-label-schema-org-78654a270f07#.5nlpzvz0i)

[MicroBadger](http://microbadger.com) provides tooling around these labels to provide badges and docker image details. See the following examples:
- [MicroBadger - Metadata from image puppet/puppetserver](https://microbadger.com/images/puppet/puppetserver)
- [GitHub - puppetlabs/puppet-in-docker](https://github.com/puppetlabs/puppet-in-docker)

In this PR, I've updated all the Dockerfiles to contain the org.label-schema labels. The `docker build` command will now expect two arguments: `BUILD_DATE` and `VCS_REF`.

Running the following command:
```
$ docker build --build-arg BUILD_DATE="`date -u +"%Y-%m-%dT%H:%M:%SZ"`" --build-arg VCS_REF="`git rev-parse HEAD`" -t "microsoft/powershell:centos7" "centos7"
```
Will result in:
```
$ docker inspect d3d8d9675474 -f "{{json .Config.Labels}}" | jq .
{
  "build-date": "20161214",
  "license": "GPLv2",
  "maintainer": "Andrew Schwartzmeyer <andschwa@microsoft.com>",
  "name": "CentOS Base Image",
  "org.label-schema.build-date": "2017-02-11T02:55:17Z",
  "org.label-schema.description": "PowerShell is a cross-platform (Windows, Linux, and macOS) automation and configuration tool/framework that works well with existing tools and is optimized for dealing with structured data, REST APIs, and object models. It includes a command-line shell, an associated scripting language and a framework for processing cmdlets.",
  "org.label-schema.docker.cmd": "docker run -it microsoft/powershell:centos7",
  "org.label-schema.license": "MIT",
  "org.label-schema.name": "PowerShell",
  "org.label-schema.schema-version": "1.0",
  "org.label-schema.url": "https://microsoft.com/powershell",
  "org.label-schema.usage": "https://github.com/PowerShell/PowerShell/tree/master/docs/learning-powershell",
  "org.label-schema.vcs-ref": "39c44b4",
  "org.label-schema.vcs-type": "Git",
  "org.label-schema.vcs-url": "https://github.com/PowerShell/PowerShell.git",
  "org.label-schema.vendor": "Microsoft",
  "org.label-schema.version": "6.0.0-alpha.15",
  "vendor": "CentOS"
}
```
The non "org.label-schema" labels have been pulled through from the base CentOS image. I used this additive label mechanism to only include the labels in the nightly Dockerfiles that may be different from the release container image that they are based on. This should reduce overhead of editing these labels.

All of the containers may be built using the existing `launch.sh` method by including the `BUILDARGS` environment variable as follows:
```
BUILDS=release DISTROS=centos7 BUILDARGS="--build-arg BUILD_DATE=\"`date -u +"%Y-%m-%dT%H:%M:%SZ"`\" --build-arg VCS_REF=\"`git rev-parse HEAD`\"" ./launch.sh
```