### PR TITLE
Fix GetType() bad pattern and related issues in tests

### DIFF
--- a/test/powershell/Host/ConsoleHost.Tests.ps1
+++ b/test/powershell/Host/ConsoleHost.Tests.ps1
@@ -16,21 +16,22 @@ Describe 'minishell for native executables' -Tag 'CI' {
 
         It 'gets a hashtable object from minishell' {
             $output = & $powershell -noprofile { @{'a' = 'b'} }
-            ($output | measure).Count | Should Be 1
-            ($output.GetType().Name) | Should Be 'Hashtable'
+            ($output | Measure-Object).Count | Should Be 1
+            $output | Should BeOfType 'Hashtable'
             $output['a'] | Should Be 'b'
         }
 
         It 'gets the error stream from minishell' {
             $output = & $powershell -noprofile { Write-Error 'foo' } 2>&1
-            ($output | measure).Count | Should Be 1
-            ($output.GetType().Name) | Should Be 'ErrorRecord'
+            ($output | Measure-Object).Count | Should Be 1
+            $output | Should BeOfType 'System.Management.Automation.ErrorRecord'
             $output.FullyQualifiedErrorId | Should Be 'Microsoft.PowerShell.Commands.WriteErrorException'
         }
 
         It 'gets the information stream from minishell' {
             $output = & $powershell -noprofile { Write-Information 'foo' } 6>&1
-            ($output.GetType().Name) | Should Be 'InformationRecord'
+            ($output | Measure-Object).Count | Should Be 1
+            $output | Should BeOfType 'System.Management.Automation.InformationRecord'
             $output | Should Be 'foo'
         }
     }
@@ -150,7 +151,7 @@ Describe "ConsoleHost unit tests" -tags "Feature" {
         }
         foreach ($x in "--help", "-help", "-h", "-?", "--he", "-hel", "--HELP", "-hEl") {
             It "Accepts '$x' as a parameter for help" {
-                & $powershell -noprofile $x | ?{ $_ -match "PowerShell[.exe] -Help | -? | /?" } | Should Not BeNullOrEmpty
+                & $powershell -noprofile $x | Where-Object { $_ -match "PowerShell[.exe] -Help | -? | /?" } | Should Not BeNullOrEmpty
             }
         }
 

--- a/test/powershell/Language/Classes/Scripting.Classes.Exceptions.Tests.ps1
+++ b/test/powershell/Language/Classes/Scripting.Classes.Exceptions.Tests.ps1
@@ -322,11 +322,11 @@ Describe "Exception from initializer" -Tags "CI" {
     It "static member w/ ctor" {
         try {
             $null = [MSFT_6397334c]::a
-            throw "[MSFT_6397334c]::a should have thrown"
+            throw "No Exception!"
         }
         catch
         {
-            $_.Exception.GetType().FullName | Should Be System.TypeInitializationException
+            $_.Exception | Should BeOfType System.TypeInitializationException
             $e  = $_.Exception.InnerException.InnerException.ErrorRecord
             $e.FullyQualifiedErrorId | Should Be InvalidCastFromStringToInteger
             $e.InvocationInfo.Line | Should Match 'a = "zz"'
@@ -336,11 +336,11 @@ Describe "Exception from initializer" -Tags "CI" {
     It "static member w/o ctor" {
         try {
             $null = [MSFT_6397334d]::a
-            throw "[MSFT_6397334d]::a should have thrown"
+            throw "No Exception!"
         }
         catch
         {
-            $_.Exception.GetType().FullName | Should Be System.TypeInitializationException
+            $_.Exception | Should BeOfType System.TypeInitializationException
             $e  = $_.Exception.InnerException.InnerException.ErrorRecord
             $e.FullyQualifiedErrorId | Should Be InvalidCastFromStringToInteger
             $e.InvocationInfo.Line | Should Match 'a = "zz"'

--- a/test/powershell/Language/Classes/scripting.Classes.inheritance.tests.ps1
+++ b/test/powershell/Language/Classes/scripting.Classes.inheritance.tests.ps1
@@ -72,12 +72,10 @@ Describe 'Classes inheritance syntax' -Tags "CI" {
         [A]::b = [B]::new()
         try {
             [A]::b = "bla"
+            throw "No Exception!"
         } catch {
-            $_.Exception.GetType().Name | Should Be SetValueInvocationException
-            return
+            $_.Exception | Should BeOfType SetValueInvocationException
         }
-        # Fail, if come heres
-        '' | Should Be "Exception expected"
     }
 }
 
@@ -419,12 +417,10 @@ Describe 'Classes inheritance ctors' -Tags "CI" {
 
         try {
             [B]::new(101)
+            throw "No Exception!"
         } catch {
-            $_.Exception.GetType().Name | Should Be MethodException
-            return
+            $_.Exception | Should BeOfType MethodException
         }
-        # Fail
-        '' | Should Be "Exception expected"
     }
 
     It 'call default base ctor implicitly' {

--- a/test/powershell/Language/Classes/scripting.Classes.inheritance.tests.ps1
+++ b/test/powershell/Language/Classes/scripting.Classes.inheritance.tests.ps1
@@ -74,7 +74,7 @@ Describe 'Classes inheritance syntax' -Tags "CI" {
             [A]::b = "bla"
             throw "No Exception!"
         } catch {
-            $_.Exception | Should BeOfType SetValueInvocationException
+            $_.Exception | Should BeOfType 'System.Management.Automation.SetValueInvocationException'
         }
     }
 }
@@ -419,7 +419,7 @@ Describe 'Classes inheritance ctors' -Tags "CI" {
             [B]::new(101)
             throw "No Exception!"
         } catch {
-            $_.Exception | Should BeOfType MethodException
+            $_.Exception | Should BeOfType "System.Management.Automation.MethodException"
         }
     }
 

--- a/test/powershell/Language/Interop/DotNet/DotNetAPI.Tests.ps1
+++ b/test/powershell/Language/Interop/DotNet/DotNetAPI.Tests.ps1
@@ -20,6 +20,6 @@ Describe "DotNetAPI" -Tags "CI" {
     It "Should be able to create a new instance of a .Net object" {
 	[System.Guid]$guidVal = [System.Guid]::NewGuid()
 
-	$guidVal.GetType().Name | Should Be "Guid"
+	$guidVal | Should BeOfType Guid
     }
 }

--- a/test/powershell/Language/LanguageTestSupport.psm1
+++ b/test/powershell/Language/LanguageTestSupport.psm1
@@ -165,7 +165,7 @@ function Test-ErrorStmt
         $ast = Get-ParseResults $src -Ast
         $asts = @(Flatten-Ast $ast.EndBlock.Statements[0])
 
-        It 'Type is ErrorStatementAst' { $asts[0].GetType() | Should Be System.Management.Automation.Language.ErrorStatementAst }
+        It 'Type is ErrorStatementAst' { $asts[0] | Should BeOfType System.Management.Automation.Language.ErrorStatementAst }
         It "`$asts.count" { $asts.Count | Should Be ($a.Count + 1) }
         It "`$asts[0].Extent.Text" { $asts[0].Extent.Text | Should Be $errorStmtExtent }
         for ($i = 0; $i -lt $a.Count; ++$i)
@@ -198,7 +198,7 @@ function Test-Ast
         $ast = Get-ParseResults $src -Ast
         $ast = $ast.EndBlock.Statements[0]
         Context "Ast Validation: <<$src>>" {
-            $ast.GetType() | Should Be System.Management.Automation.Language.ErrorStatementAst
+            $ast | Should BeOfType System.Management.Automation.Language.ErrorStatementAst
             $ast.Flags.ContainsKey($flagName) | Should be $true
 
             $asts = @(Flatten-Ast $ast.Flags[$flagName].Item2)

--- a/test/powershell/Language/Parser/Ast.Tests.ps1
+++ b/test/powershell/Language/Parser/Ast.Tests.ps1
@@ -6,7 +6,7 @@ Describe "The SafeGetValue method on AST returns safe values" -Tags "CI" {
             @{ one = 1 }
             }.ast.Find({$args[0] -is $HashtableAstType}, $true)
         $HtAst | Should Not BeNullOrEmpty
-        $HtAst.SafeGetValue().GetType().Name | Should be Hashtable
+        $HtAst.SafeGetValue() | Should BeOfType "Hashtable"
     }
     It "An Array is returned from a LiteralArrayAst" {
         $ArrayAstType = [ArrayLiteralAst]
@@ -14,7 +14,7 @@ Describe "The SafeGetValue method on AST returns safe values" -Tags "CI" {
             @( 1,2,3,4)
             }.ast.Find({$args[0] -is $ArrayAstType}, $true)
         $ArrayAst | Should Not BeNullOrEmpty
-        $ArrayAst.SafeGetValue().GetType().Name | Should be "Object[]"
+        ,$ArrayAst.SafeGetValue() | Should BeOfType "Object[]"
     }
     It "The proper error is returned when a variable is referenced" {
         $ast = { $a }.Ast.Find({$args[0] -is "VariableExpressionAst"},$true)

--- a/test/powershell/Language/Parser/Ast.Tests.ps1
+++ b/test/powershell/Language/Parser/Ast.Tests.ps1
@@ -5,6 +5,7 @@ Describe "The SafeGetValue method on AST returns safe values" -Tags "CI" {
         $HtAst = {
             @{ one = 1 }
             }.ast.Find({$args[0] -is $HashtableAstType}, $true)
+        $HtAst | Should Not BeNullOrEmpty
         $HtAst.SafeGetValue().GetType().Name | Should be Hashtable
     }
     It "An Array is returned from a LiteralArrayAst" {
@@ -12,13 +13,14 @@ Describe "The SafeGetValue method on AST returns safe values" -Tags "CI" {
         $ArrayAst = {
             @( 1,2,3,4)
             }.ast.Find({$args[0] -is $ArrayAstType}, $true)
+        $ArrayAst | Should Not BeNullOrEmpty
         $ArrayAst.SafeGetValue().GetType().Name | Should be "Object[]"
     }
     It "The proper error is returned when a variable is referenced" {
         $ast = { $a }.Ast.Find({$args[0] -is "VariableExpressionAst"},$true)
         try {
             $ast.SafeGetValue() | out-null
-            Throw "Execution Succeeded"
+            throw "No Exception!"
         }
         catch {
             $_.FullyQualifiedErrorId | Should be "InvalidOperationException"
@@ -28,7 +30,7 @@ Describe "The SafeGetValue method on AST returns safe values" -Tags "CI" {
     It "A ScriptBlock AST fails with the proper error" {
         try {
             { 1 }.Ast.SafeGetValue()
-            Throw "Execution Succeeded"
+            throw "No Exception!"
         }
         catch {
             $_.FullyQualifiedErrorId | Should be "InvalidOperationException"

--- a/test/powershell/Language/Parser/BNotOperator.Tests.ps1
+++ b/test/powershell/Language/Parser/BNotOperator.Tests.ps1
@@ -39,25 +39,25 @@ Describe "bnot on enums" -Tags "CI" {
             It "max - 1" {
                 $res = -bnot $enumType::MaxMinus1
                 $res | Should Be $enumType::MinPlus1
-                $res.GetType() | Should Be $enumType
+                $res | Should BeOfType $enumType
             }
 
             It "min + 1" {
                 $res = -bnot $enumType::MinPlus1
                 $res | Should Be $enumType::MaxMinus1
-                $res.GetType() | Should Be $enumType
+                $res | Should BeOfType $enumType
             }
 
             It "Max" {
                 $res = -bnot $enumType::Max
                 $res | Should Be $enumType::Min
-                $res.GetType() | Should Be $enumType
+                $res | Should BeOfType $enumType
             }
 
             It "Min" {
                 $res = -bnot $enumType::Min
                 $res | Should Be $enumType::Max
-                $res.GetType() | Should Be $enumType
+                $res | Should BeOfType $enumType
             }
         }
     }
@@ -90,25 +90,25 @@ Describe "bnot on integral types" -Tags "CI" {
                 It "max - 1" {
                     $res = -bnot $maxMinus1
                     $res | Should Be (-bnot [int]$maxMinus1)
-                    $res.GetType() | Should Be $expectedResultType
+                    $res | Should BeOfType $expectedResultType
                 }
 
                 It "min + 1" {
                     $res = -bnot $minPlus1
                     $res | Should Be (-bnot [int]$minPlus1)
-                    $res.GetType() | Should Be $expectedResultType
+                    $res | Should BeOfType $expectedResultType
                 }
 
                 It "max" {
                     $res = -bnot $max
                     $res | Should Be (-bnot [int]$max)
-                    $res.GetType() | Should Be $expectedResultType
+                    $res | Should BeOfType $expectedResultType
                 }
 
                 It "min" {
                     $res = -bnot $min
                     $res | Should Be (-bnot [int]$min)
-                    $res.GetType() | Should Be $expectedResultType
+                    $res | Should BeOfType $expectedResultType
                 }
                 return
             }
@@ -116,25 +116,25 @@ Describe "bnot on integral types" -Tags "CI" {
             It "max - 1" {
                 $res = -bnot $maxMinus1
                 $res | Should Be $minPlus1
-                $res.GetType() | Should Be $expectedResultType
+                $res | Should BeOfType $expectedResultType
             }
 
             It "min + 1" {
                 $res = -bnot $minPlus1
                 $res | Should Be $maxMinus1
-                $res.GetType() | Should Be $expectedResultType
+                $res | Should BeOfType $expectedResultType
             }
 
             It "max" {
                 $res = -bnot $max
                 $res | Should Be $min
-                $res.GetType() | Should Be $expectedResultType
+                $res | Should BeOfType $expectedResultType
             }
 
             It "min" {
                 $res = -bnot $min
                 $res | Should Be $max
-                $res.GetType() | Should Be $expectedResultType
+                $res | Should BeOfType $expectedResultType
             }
         }
     }

--- a/test/powershell/Language/Parser/LanguageAndParser.TestFollowup.Tests.ps1
+++ b/test/powershell/Language/Parser/LanguageAndParser.TestFollowup.Tests.ps1
@@ -4,7 +4,7 @@ Describe "Clone array" -Tags "CI" {
     It "Cast in target expr" {
         (([int[]](42)).clone()) | Should Be 42
         (([int[]](1..5)).clone()).Length | Should Be 5
-        (([int[]](1..5)).clone()) | Should BeOfType [int[]]
+        (([int[]](1..5)).clone()).GetType() | Should Be ([int[]])
 
     }
     It "Cast not in target expr" {

--- a/test/powershell/Language/Parser/LanguageAndParser.TestFollowup.Tests.ps1
+++ b/test/powershell/Language/Parser/LanguageAndParser.TestFollowup.Tests.ps1
@@ -4,7 +4,7 @@ Describe "Clone array" -Tags "CI" {
     It "Cast in target expr" {
         (([int[]](42)).clone()) | Should Be 42
         (([int[]](1..5)).clone()).Length | Should Be 5
-        (([int[]](1..5)).clone()).GetType() | Should Be ([int[]])
+        (([int[]](1..5)).clone()) | Should BeOfType [int[]]
 
     }
     It "Cast not in target expr" {

--- a/test/powershell/Language/Scripting/ActionPreference.Tests.ps1
+++ b/test/powershell/Language/Scripting/ActionPreference.Tests.ps1
@@ -19,9 +19,9 @@
 
             It '$err.Count' { $err.Count | Should Be 1 }
             It '$err[0] should not be $null' { $err[0] | Should Not Be $null }
-            It '$err[0].GetType().Name' { $err[0].GetType().Name | Should Be ActionPreferenceStopException }
+            It '$err[0].GetType().Name' { $err[0] | Should BeOfType "System.Management.Automation.ActionPreferenceStopException" }
             It '$err[0].ErrorRecord' { $err[0].ErrorRecord | Should not BeNullOrEmpty }
-            It '$err[0].ErrorRecord.Exception.GetType().Name' { $err[0].ErrorRecord.Exception.GetType().Name | Should Be ItemNotFoundException }
+            It '$err[0].ErrorRecord.Exception.GetType().Name' { $err[0].ErrorRecord.Exception | Should BeOfType "System.Management.Automation.ItemNotFoundException" }
         }
 
         It 'ActionPreference Ignore Works' {

--- a/test/powershell/Language/Scripting/Debugging/DebuggerScriptTests.Tests.ps1
+++ b/test/powershell/Language/Scripting/Debugging/DebuggerScriptTests.Tests.ps1
@@ -290,17 +290,13 @@ Describe "Unit tests for various script breakpoints" -Tags "CI" {
         {
             & $command
 
-	        It "Script should fail to verify exception" {
-		        $false | Should Be $true
-	        }
+            throw "No Exception!"
         }
         catch
         {
-            $type = $_.Exception.GetType().Name
-
-	        It "Script failed expected exception" {
-		        $type | Should Be $exception
-	        }
+            It "Script failed expected exception" {
+                $_.Exception.GetType().Name | Should Be $exception
+            }
         }
     }
 

--- a/test/powershell/Language/Scripting/I18n.Tests.ps1
+++ b/test/powershell/Language/Scripting/I18n.Tests.ps1
@@ -52,6 +52,7 @@ Describe 'Testing of script internationalization' -Tags "CI" {
 
         import-localizedData mydata -uiculture nl-NL -ea SilentlyContinue -ev ev
 
+        $ev | Should Not BeNullOrEmpty
         $ev[0].Exception.GetType() | Should Be System.Management.Automation.PSInvalidOperationException
     }
 
@@ -110,6 +111,7 @@ Describe 'Testing of script internationalization' -Tags "CI" {
             import-localizedData mydata -filename bad
           }
 
+        $script:exception.exception | Should Not BeNullOrEmpty
         $script:exception.exception.gettype() | Should Be System.management.automation.psinvalidoperationexception
         }
 

--- a/test/powershell/Language/Scripting/I18n.Tests.ps1
+++ b/test/powershell/Language/Scripting/I18n.Tests.ps1
@@ -53,7 +53,7 @@ Describe 'Testing of script internationalization' -Tags "CI" {
         import-localizedData mydata -uiculture nl-NL -ea SilentlyContinue -ev ev
 
         $ev | Should Not BeNullOrEmpty
-        $ev[0].Exception.GetType() | Should Be System.Management.Automation.PSInvalidOperationException
+        $ev[0].Exception | Should BeOfType "System.Management.Automation.PSInvalidOperationException"
     }
 
     It 'Import different file name is done correctly' {
@@ -112,7 +112,7 @@ Describe 'Testing of script internationalization' -Tags "CI" {
           }
 
         $script:exception.exception | Should Not BeNullOrEmpty
-        $script:exception.exception.gettype() | Should Be System.management.automation.psinvalidoperationexception
+        $script:exception.exception | Should BeOfType System.management.automation.psinvalidoperationexception
         }
 
     It 'Import if psd1 file is done correctly' {

--- a/test/powershell/Language/Scripting/NativeExecution/NativeLinuxCommands.Tests.ps1
+++ b/test/powershell/Language/Scripting/NativeExecution/NativeLinuxCommands.Tests.ps1
@@ -8,11 +8,10 @@ else {
     $PesterSkipOrPending = @{}
 }
 Describe "NativeLinuxCommands" -tags "CI" {
-    It "Should return a type of System.Object for hostname cmdlet" {
+    It "Should return a type of 'string' for hostname cmdlet" {
         $result = hostname
         $result | Should Not BeNullOrEmpty
-        $result.GetType().BaseType | Should Be 'System.Object'
-        $result.GetType().Name | Should Be String
+        $result | Should BeOfType string
     }
 
     It "Should find Application grep" @PesterSkipOrPending {

--- a/test/powershell/Language/Scripting/NativeExecution/NativeLinuxCommands.Tests.ps1
+++ b/test/powershell/Language/Scripting/NativeExecution/NativeLinuxCommands.Tests.ps1
@@ -9,8 +9,10 @@ else {
 }
 Describe "NativeLinuxCommands" -tags "CI" {
     It "Should return a type of System.Object for hostname cmdlet" {
-        (hostname).GetType().BaseType | Should Be 'System.Object'
-        (hostname).GetType().Name | Should Be String
+        $result = hostname
+        $result | Should Not BeNullOrEmpty
+        $result.GetType().BaseType | Should Be 'System.Object'
+        $result.GetType().Name | Should Be String
     }
 
     It "Should find Application grep" @PesterSkipOrPending {

--- a/test/powershell/Language/Scripting/OutErrorVariable.Tests.ps1
+++ b/test/powershell/Language/Scripting/OutErrorVariable.Tests.ps1
@@ -301,7 +301,7 @@ Describe "Update both OutVariable and ErrorVariable" -Tags "CI" {
         It '$get_item_err.count and $get_item_err[0].exception' {
             $get_item_err.count | Should Be 1
             $get_item_err[0].exception | Should Not BeNullOrEmpty
-            $get_item_err[0].exception.GetType() | Should Be 'System.Management.Automation.ItemNotFoundException'
+            $get_item_err[0].exception | Should BeOftype 'System.Management.Automation.ItemNotFoundException'
         }
     }
 

--- a/test/powershell/Language/Scripting/OutErrorVariable.Tests.ps1
+++ b/test/powershell/Language/Scripting/OutErrorVariable.Tests.ps1
@@ -290,12 +290,19 @@ Describe "Update both OutVariable and ErrorVariable" -Tags "CI" {
 
     Context 'Error variable in multi-command pipeline (with native cmdlet)' {
 
-        (get-foo -ev foo_err | get-item -ev get_item_err ) 2>&1 > $null
+        BeforeAll {
+            (get-foo -ev foo_err | get-item -ev get_item_err ) 2>&1 > $null
+        }
 
-        $foo_err | Should Be "foo-error"
+        It '$foo_err should be "foo-error"' {
+            $foo_err | Should Be "foo-error"
+        }
 
-        It '$get_item_err.count' { $get_item_err.count | Should Be 1 }
-        It '$get_item_err[0].exception' { $get_item_err[0].exception.GetType() | Should Be 'System.Management.Automation.ItemNotFoundException' }
+        It '$get_item_err.count and $get_item_err[0].exception' {
+            $get_item_err.count | Should Be 1
+            $get_item_err[0].exception | Should Not BeNullOrEmpty
+            $get_item_err[0].exception.GetType() | Should Be 'System.Management.Automation.ItemNotFoundException'
+        }
     }
 
     It 'Multi-command pipeline with nested commands' {

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Job.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Job.Tests.ps1
@@ -7,10 +7,10 @@ Describe "Job Cmdlet Tests" -Tag "CI" {
             $j = start-job -scriptblock { 1 + 1 }
         }
         It "Start-Job produces a job object" {
-            $j.gettype().fullname | should be "System.Management.Automation.PSRemotingJob"
+            $j | Should BeOfType System.Management.Automation.Job
         }
         It "Get-Job retrieves a job object" {
-            (Get-Job -id $j.id).gettype().fullname | should be "System.Management.Automation.PSRemotingJob"
+            (Get-Job -id $j.id) | Should BeOfType System.Management.Automation.Job
         }
         It "Remove-Job can remove a job" {
             remove-job $j -force

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Alias.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Alias.Tests.ps1
@@ -50,7 +50,7 @@ Describe "Basic Alias Provider Tests" -Tags "CI" {
 
     It "Test executing the new alias" {
         $result = Invoke-Expression $testAliasName
-        $result.GetType().Name | Should Be "DateTime"
+        $result | Should BeOfType DateTime
     }
 }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ComputerInfo.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ComputerInfo.Tests.ps1
@@ -1333,7 +1333,7 @@ try {
 
         It "(special case) Test for property = OsLocalDateTime" -Pending:$true {
             $computerInfo = Get-ComputerInfo
-            $computerInfo.GetType().Name | Should Be "ComputerInfo"
+            $computerInfo | Should BeOfType "ComputerInfo"
         }
 
         It "(special case) Test for property = OsMaxNumberOfProcesses" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ComputerInfo.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ComputerInfo.Tests.ps1
@@ -1194,7 +1194,7 @@ try {
 
         It "Verify type returned by Get-ComputerInfo" {
             $computerInfo = Get-ComputerInfo
-            $computerInfo.GetType().Name | Should Be "ComputerInfo"
+            $computerInfo | Should BeOfType Microsoft.PowerShell.Commands.ComputerInfo
         }
     }
 
@@ -1331,7 +1331,7 @@ try {
             ($observed.OsFreeVirtualMemory -gt 0) | Should Be $true
         }
 
-        It "(special case) Test for property = OsLocalDateTime" {
+        It "(special case) Test for property = OsLocalDateTime" -Pending:$true {
             $computerInfo = Get-ComputerInfo
             $computerInfo.GetType().Name | Should Be "ComputerInfo"
         }
@@ -1356,7 +1356,7 @@ try {
         It "(special case) Test for Filter Property - Property filter with special wild card * and fixed" {
             $propertyFilter = @("BiosC*","*")
             $computerInfo = Get-ComputerInfo -Property $propertyFilter
-            $computerInfo.GetType().Name | Should Be "ComputerInfo"
+            $computerInfo | Should BeOfType Microsoft.PowerShell.Commands.ComputerInfo
         }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Content.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Content.Tests.ps1
@@ -18,30 +18,24 @@ Describe "Get-Content" -Tags "CI" {
     Remove-Item -Path $testPath -Force
     Remove-Item -Path $testPath2 -Force
   }
-  It "Should throw an error on a directory  " {# also tests that -erroraction SilentlyContinue will work.
-    Get-Content . -ErrorAction SilentlyContinue | Should Throw
+  It "Should throw an error on a directory  " {
+        try {
+            Get-Content . -ErrorAction Stop
+            throw "No Exception!"
+        }
+        catch {
+            $_.FullyQualifiedErrorId | should be "GetContentReaderUnauthorizedAccessError,Microsoft.PowerShell.Commands.GetContentCommand"
+        }
   }
-  It "Should return an Object when listing only a single line" {
-	  (Get-Content -Path $testPath).GetType().BaseType.Name | Should Be "Object"
+  It "Should return an Object when listing only a single line and the correct information from a file" {
+        $content = (Get-Content -Path $testPath)
+        $content | Should Be $testString
+        $content.GetType().BaseType.Name | Should Be "Object"
   }
-  It "Should deliver an array object when listing a file with multiple lines" {
-	  (Get-Content -Path $testPath2).GetType().BaseType.Name | Should Be "Array"
-  }
-  It "Should return the correct information from a file" {
-	  (Get-Content -Path $testPath) | Should Be $testString
-  }
-  It "Should be able to call using the gc alias" {
-	  { gc -Path $testPath } | Should Not Throw
-  }
-  It "Should be able to call using the type alias" {
-	  { type -Path $testPath } | Should Not Throw
-  }
-  It "Should return the same values for aliases" {
-	  $getContentAlias = Get-Content -Path $testPath
-	  $gcAlias         = gc -Path $testPath
-	  $typeAlias       = type -Path $testPath
-    $getContentAlias | Should Be $gcAlias
-    $getContentAlias | Should Be $typeAlias
+  It "Should deliver an array object when listing a file with multiple lines and the correct information from a file" {
+        $content = (Get-Content -Path $testPath2)
+        @(Compare-Object $content $testString2.Split($nl) -SyncWindow 0).Length | Should Be 0
+        $content.GetType().BaseType.Name | Should Be "Array"
   }
   It "Should be able to return a specific line from a file" {
 	  (Get-Content -Path $testPath2)[1] | Should be $secondline

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Content.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Content.Tests.ps1
@@ -30,12 +30,13 @@ Describe "Get-Content" -Tags "CI" {
   It "Should return an Object when listing only a single line and the correct information from a file" {
         $content = (Get-Content -Path $testPath)
         $content | Should Be $testString
-        $content.GetType().BaseType.Name | Should Be "Object"
+        $content.Count | Should Be 1
+        $content | Should BeOfType "System.String"
   }
   It "Should deliver an array object when listing a file with multiple lines and the correct information from a file" {
         $content = (Get-Content -Path $testPath2)
         @(Compare-Object $content $testString2.Split($nl) -SyncWindow 0).Length | Should Be 0
-        $content.GetType().BaseType.Name | Should Be "Array"
+        ,$content | Should BeOfType "System.Array"
   }
   It "Should be able to return a specific line from a file" {
 	  (Get-Content -Path $testPath2)[1] | Should be $secondline

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-EventLog.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-EventLog.Tests.ps1
@@ -12,12 +12,14 @@
     #CmdLets are not yet implemented, so these cases are -Pending:($True) for now...
     It "should return an array of eventlogs objects when called with -AsString parameter" -Pending:($True) {
       {$result=Get-EventLog -AsString -ea stop}    | Should Not Throw
+      $result | Should Not BeNullOrEmpty
       $result.GetType().BaseType.Name              | Should Be "Array"
       $result -eq "Application"                    | Should Be "Application"
       $result.Count -ge 3                          | Should Be $true
     }
     It "should return a list of eventlog objects when called with -List parameter" -Pending:($True) {
       {$result=Get-EventLog -List -ea stop}        | Should Not Throw
+      $result | Should Not BeNullOrEmpty
       $result.GetType().BaseType.Name              | Should Be "array"
       {$logs=$result|Select -ExpandProperty Log}  | Should Not Throw
       $logs -eq "System"                           | Should Be "System"

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-EventLog.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-EventLog.Tests.ps1
@@ -13,15 +13,15 @@
     It "should return an array of eventlogs objects when called with -AsString parameter" -Pending:($True) {
       {$result=Get-EventLog -AsString -ea stop}    | Should Not Throw
       $result | Should Not BeNullOrEmpty
-      $result.GetType().BaseType.Name              | Should Be "Array"
+      ,$result                                     | Should BeOfType "System.Array"
       $result -eq "Application"                    | Should Be "Application"
       $result.Count -ge 3                          | Should Be $true
     }
     It "should return a list of eventlog objects when called with -List parameter" -Pending:($True) {
       {$result=Get-EventLog -List -ea stop}        | Should Not Throw
       $result | Should Not BeNullOrEmpty
-      $result.GetType().BaseType.Name              | Should Be "array"
-      {$logs=$result|Select -ExpandProperty Log}  | Should Not Throw
+      ,$result                                     | Should BeOfType "System.Array"
+      {$logs=$result|Select -ExpandProperty Log}   | Should Not Throw
       $logs -eq "System"                           | Should Be "System"
       $logs.Count -ge 3                            | Should Be $true
     }
@@ -29,7 +29,7 @@
       {$result=get-eventlog -LogName Application -Newest 100 -ea stop} | Should Not Throw
       $result                                      | Should Not BeNullOrEmpty
       $result.Length -le 100                       | Should Be $true
-      $result[0].GetType().Name                    | Should Be "EventLogEntry"
+      $result[0]                                   | Should BeOfType "EventLogEntry"
     }
     It "should throw 'AmbiguousParameterSetException' when called with both -LogName and -List parameters" -Pending:($True) {
       try {Get-EventLog -LogName System -List -ea stop; Throw "Previous statement unexpectedly succeeded..."

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Item.Tests.ps1
@@ -1,20 +1,28 @@
 Describe "Get-Item" -Tags "CI" {
     It "Should list all the items in the current working directory when asterisk is used" {
-	(Get-Item (Join-Path -Path $PSScriptRoot -ChildPath "*")).GetType().BaseType | Should Be 'array'
-	(Get-Item (Join-Path -Path $PSScriptRoot -ChildPath "*")).GetType().Name | Should Be 'Object[]'
+        $items = Get-Item (Join-Path -Path $PSScriptRoot -ChildPath "*")
+        $items | Should Not BeNullOrEmpty
+        $items.GetType().BaseType | Should Be 'array'
+        $items.GetType().Name | Should Be 'Object[]'
     }
 
     It "Should return the name of the current working directory when a dot is used" {
-	(Get-Item $PSScriptRoot).GetType().BaseType | Should Be 'System.IO.FileSystemInfo'
-	(Get-Item $PSScriptRoot).Name | Should Be (Split-Path $PSScriptRoot -Leaf)
+        $item = Get-Item $PSScriptRoot
+        $item | Should Not BeNullOrEmpty
+        $item.GetType().BaseType | Should Be 'System.IO.FileSystemInfo'
+        $item.Name | Should Be (Split-Path $PSScriptRoot -Leaf)
     }
 
     It "Should return the proper Name and BaseType for directory objects vs file system objects" {
-	(Get-Item $PSScriptRoot).GetType().Name | Should Be 'DirectoryInfo'
-	(Get-Item (Join-Path -Path $PSScriptRoot -ChildPath Get-Item.Tests.ps1)).GetType().Name | Should Be 'FileInfo'
+        $rootitem = Get-Item $PSScriptRoot
+        $rootitem | Should Not BeNullOrEmpty
+        $rootitem.GetType().Name | Should Be 'DirectoryInfo'
+        $childitem = (Get-Item (Join-Path -Path $PSScriptRoot -ChildPath Get-Item.Tests.ps1))
+        $childitem | Should Not BeNullOrEmpty
+        $childitem.GetType().Name | Should Be 'FileInfo'
     }
 
     It "Should have mode flags set" {
-	Get-ChildItem $PSScriptRoot | foreach-object { $_.Mode | Should Not BeNullOrEmpty }
+        Get-ChildItem $PSScriptRoot | foreach-object { $_.Mode | Should Not BeNullOrEmpty }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Item.Tests.ps1
@@ -1,25 +1,20 @@
 Describe "Get-Item" -Tags "CI" {
     It "Should list all the items in the current working directory when asterisk is used" {
         $items = Get-Item (Join-Path -Path $PSScriptRoot -ChildPath "*")
-        $items | Should Not BeNullOrEmpty
-        $items.GetType().BaseType | Should Be 'array'
-        $items.GetType().Name | Should Be 'Object[]'
+        ,$items | Should BeOfType 'System.Object[]'
     }
 
     It "Should return the name of the current working directory when a dot is used" {
         $item = Get-Item $PSScriptRoot
-        $item | Should Not BeNullOrEmpty
-        $item.GetType().BaseType | Should Be 'System.IO.FileSystemInfo'
+        $item | Should BeOfType 'System.IO.DirectoryInfo'
         $item.Name | Should Be (Split-Path $PSScriptRoot -Leaf)
     }
 
     It "Should return the proper Name and BaseType for directory objects vs file system objects" {
         $rootitem = Get-Item $PSScriptRoot
-        $rootitem | Should Not BeNullOrEmpty
-        $rootitem.GetType().Name | Should Be 'DirectoryInfo'
+        $rootitem | Should BeOfType 'System.IO.DirectoryInfo'
         $childitem = (Get-Item (Join-Path -Path $PSScriptRoot -ChildPath Get-Item.Tests.ps1))
-        $childitem | Should Not BeNullOrEmpty
-        $childitem.GetType().Name | Should Be 'FileInfo'
+        $childitem | Should BeOfType 'System.IO.FileInfo'
     }
 
     It "Should have mode flags set" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Process.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Process.Tests.ps1
@@ -6,13 +6,17 @@ Describe "Get-Process for admin" -Tags @('CI', 'RequireAdminOnWindows') {
 
 Describe "Get-Process" -Tags "CI" {
     # These tests are no good, please replace!
+    BeforeAll {
+        $ps = Get-Process
+    }
     It "Should return a type of Object[] for Get-Process cmdlet" -Pending:$IsOSX {
-        (Get-Process).GetType().BaseType | Should Be 'array'
-        (Get-Process).GetType().Name | Should Be Object[]
+        $ps | Should Not BeNullOrEmpty
+        $ps.GetType().BaseType | Should Be 'array'
+        $ps.GetType().Name | Should Be Object[]
     }
 
     It "Should have not empty Name flags set for Get-Process object" -Pending:$IsOSX {
-        Get-Process | foreach-object { $_.Name | Should Not BeNullOrEmpty }
+        $ps | foreach-object { $_.Name | Should Not BeNullOrEmpty }
     }
 }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Process.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Process.Tests.ps1
@@ -10,9 +10,7 @@ Describe "Get-Process" -Tags "CI" {
         $ps = Get-Process
     }
     It "Should return a type of Object[] for Get-Process cmdlet" -Pending:$IsOSX {
-        $ps | Should Not BeNullOrEmpty
-        $ps.GetType().BaseType | Should Be 'array'
-        $ps.GetType().Name | Should Be Object[]
+        ,$ps | Should BeOfType "System.Object[]"
     }
 
     It "Should have not empty Name flags set for Get-Process object" -Pending:$IsOSX {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Push-Location.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Push-Location.Tests.ps1
@@ -47,7 +47,7 @@ Describe "Test-Push-Location" -Tags "CI" {
     }
 
     It "Should produce a pathinfo object when the passthru parameter is used" {
-	Push-Location .. -PassThru | ForEach-Object { $_.GetType().Name | Should Be PathInfo }
+        Push-Location .. -PassThru | ForEach-Object { $_ | Should BeOfType "System.Management.Automation.PathInfo" }
     }
 
     # final cleanup

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Location.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Location.Tests.ps1
@@ -1,13 +1,20 @@
 Describe "Set-Location" -Tags "CI" {
-    $startDirectory = Get-Location
 
-    if ($IsWindows)
-    {
-        $target = "C:\"
+    BeforeAll {
+        $startDirectory = Get-Location
+
+        if ($IsWindows)
+        {
+            $target = "C:\"
+        }
+        else
+        {
+            $target = "/"
+        }
     }
-    else
-    {
-        $target = "/"
+
+    AfterAll {
+        Set-Location $startDirectory
     }
 
     It "Should be able to be called without error" {
@@ -19,40 +26,10 @@ Describe "Set-Location" -Tags "CI" {
         { Set-Location env: }   | Should Not Throw
     }
 
-    It "Should be able use the cd alias without error" {
-        { cd $target } | Should Not Throw
-    }
-
-    It "Should be able to use the chdir alias without error" {
-        { chdir $target } | Should Not Throw
-    }
-
-    It "Should be able to use the sl alias without error" {
-        { sl $target } | Should Not Throw
-    }
-
     It "Should have the correct current location when using the set-location cmdlet" {
         Set-Location $startDirectory
 
         $(Get-Location).Path | Should Be $startDirectory.Path
-    }
-
-    It "Should have the correct current location when using the cd alias" {
-        cd $target
-
-        $(Get-Location).Path | Should Be $target
-    }
-
-    It "Should have the correct current location when using the chdir alias" {
-        chdir $target
-
-        $(Get-Location).Path | Should Be $target
-    }
-
-    It "Should have the correct current location when using the chdir alias" {
-        sl $target
-
-        $(Get-Location).Path | Should Be $target
     }
 
     It "Should be able to use the Path switch" {
@@ -60,23 +37,22 @@ Describe "Set-Location" -Tags "CI" {
     }
 
     It "Should generate a pathinfo object when using the Passthru switch" {
-        $(Set-Location $target -PassThru).GetType().Name | Should Be PathInfo
+        $result = Set-Location $target -PassThru
+        $result | Should BeOfType System.Management.Automation.PathInfo
     }
 
-    Context 'cd with no arguments' {
+    Context 'Set-Location with no arguments' {
 
-        It 'Should go to $env:HOME when cd run with no arguments from FileSystem provider' {
+        It 'Should go to $env:HOME when Set-Location run with no arguments from FileSystem provider' {
             Set-Location 'TestDrive:\'
-            cd
+            Set-Location
             (Get-Location).Path | Should Be (Get-PSProvider FileSystem).Home
         }
 
-        It 'Should go to $env:HOME when cd run with no arguments from Env: provider' {
+        It 'Should go to $env:HOME when Set-Location run with no arguments from Env: provider' {
             Set-Location 'Env:'
-            cd
+            Set-Location
             (Get-Location).Path | Should Be (Get-PSProvider FileSystem).Home
         }
     }
-
-    Set-Location $startDirectory
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Split-Path.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Split-Path.Tests.ps1
@@ -1,9 +1,14 @@
 Describe "Split-Path" -Tags "CI" {
 
     It "Should return a string object when invoked" {
-	( Split-Path . ).GetType().Name          | Should Be "String"
-	( Split-Path . -Leaf ).GetType().Name    | Should Be "String"
-	( Split-Path . -Resolve ).GetType().Name | Should Be "String"
+        $result = Split-Path .
+        $result | Should BeOfType String
+
+        $result = Split-Path . -Leaf
+        $result | Should BeOfType String
+
+        $result = Split-Path . -Resolve
+        $result | Should BeOfType String
     }
 
     It "Should return the name of the drive when the qualifier switch is used" {
@@ -33,21 +38,22 @@ Describe "Split-Path" -Tags "CI" {
     }
 
     It "Should be able to accept regular expression input and output an array for multiple objects" {
-	$testDir = $TestDrive
-	$testFile1     = "testfile1.ps1"
-	$testFile2     = "testfile2.ps1"
-	$testFilePath1 = Join-Path -Path $testDir -ChildPath $testFile1
-	$testFilePath2 = Join-Path -Path $testDir -ChildPath $testFile2
+        $testDir = $TestDrive
+        $testFile1     = "testfile1.ps1"
+        $testFile2     = "testfile2.ps1"
+        $testFilePath1 = Join-Path -Path $testDir -ChildPath $testFile1
+        $testFilePath2 = Join-Path -Path $testDir -ChildPath $testFile2
 
-	New-Item -ItemType file -Path $testFilePath1, $testFilePath2 -Force
+        New-Item -ItemType file -Path $testFilePath1, $testFilePath2 -Force
 
-	Test-Path $testFilePath1 | Should Be $true
-	Test-Path $testFilePath2 | Should Be $true
+        Test-Path $testFilePath1 | Should Be $true
+        Test-Path $testFilePath2 | Should Be $true
 
-	$actual = ( Split-Path (Join-Path -Path $testDir -ChildPath "*file*.ps1") -Leaf -Resolve ) | Sort-Object
-	$actual.GetType().BaseType.Name | Should Be "Array"
-	$actual[0]                      | Should Be $testFile1
-	$actual[1]                      | Should Be $testFile2
+        $actual = ( Split-Path (Join-Path -Path $testDir -ChildPath "testfile*.ps1") -Leaf -Resolve ) | Sort-Object
+        $actual.Count                   | Should Be 2
+        $actual[0]                      | Should Be $testFile1
+        $actual[1]                      | Should Be $testFile2
+        $actual.GetType().BaseType.Name | Should Be "Array"
     }
 
     It "Should be able to tell if a given path is an absolute path" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Split-Path.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Split-Path.Tests.ps1
@@ -53,7 +53,7 @@ Describe "Split-Path" -Tags "CI" {
         $actual.Count                   | Should Be 2
         $actual[0]                      | Should Be $testFile1
         $actual[1]                      | Should Be $testFile2
-        $actual.GetType().BaseType.Name | Should Be "Array"
+        ,$actual                        | Should BeOfType "System.Array"
     }
 
     It "Should be able to tell if a given path is an absolute path" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/TimeZone.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/TimeZone.Tests.ps1
@@ -42,8 +42,8 @@ Describe "Get-Timezone test case no switches" -Tags "CI" {
 Describe "Get-Timezone test cases" -Tags "CI" {
 
     It "Call without ListAvailable switch returns an object of type TimeZoneInfo" {
-        $result = (Get-TimeZone).GetType().Name
-        $result | Should Be "TimeZoneInfo"
+        $result = Get-TimeZone
+        $result | Should BeOfType TimeZoneInfo
     }
 
     It "Call WITH ListAvailable switch returns ArrayList of TimeZoneInfo objects where the list is greater than 0 item" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/TimeZone.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/TimeZone.Tests.ps1
@@ -50,18 +50,18 @@ Describe "Get-Timezone test cases" -Tags "CI" {
         $list = Get-TimeZone -ListAvailable
         $list.Count -gt 0 | Should Be $true
 
-        $list.GetType().Name | Should Be "Object[]"
-        $list[0].GetType().Name | Should Be "TimeZoneInfo"
+        ,$list | Should BeOfType "Object[]"
+        $list[0] | Should BeOfType "TimeZoneInfo"
     }
 
     It "Call with ListAvailable switch returns a list containing TimeZoneInfo.Local" {
-        $observedIdList = Get-TimeZone -ListAvailable | select -ExpandProperty Id
+        $observedIdList = Get-TimeZone -ListAvailable | Select-Object -ExpandProperty Id
         $oneExpectedId = ([System.TimeZoneInfo]::Local).Id
         $observedIdList -contains $oneExpectedId | Should Be $true
     }
 
     It "Call with ListAvailable switch returns a list containing one returned by Get-TimeZone" {
-        $observedIdList = Get-TimeZone -ListAvailable | select -ExpandProperty Id
+        $observedIdList = Get-TimeZone -ListAvailable | Select-Object -ExpandProperty Id
         $oneExpectedId = (Get-TimeZone).Id
         $observedIdList -contains $oneExpectedId | Should Be $true
     }
@@ -85,7 +85,7 @@ Describe "Get-Timezone test cases" -Tags "CI" {
 
     It "Call Get-TimeZone using ID param and multiple items, one is wild card but error action ignore works as expected" {
         $result = Get-TimeZone -Id @("Cape Verde Standard Time","Morocco Standard Time","*","Azores Standard Time") `
-                               -ErrorAction SilentlyContinue | % Id
+                               -ErrorAction SilentlyContinue | ForEach-Object Id
         $expectedIdList = @("Cape Verde Standard Time","Morocco Standard Time","Azores Standard Time")
         Assert-ListsSame $expectedIdList $result
     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/AclCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/AclCmdlets.Tests.ps1
@@ -1,6 +1,7 @@
 Describe "Acl cmdlets are available and operate properly" -Tag CI {
     It "Get-Acl returns an ACL object" -pending:(!$IsWindows) {
         $ACL = get-acl $TESTDRIVE
+        $ACL | Should Not BeNullOrEmpty
         $ACL.gettype().FullName | Should be "System.Security.AccessControl.DirectorySecurity"
     }
     It "Set-Acl can set the ACL of a directory" -pending {

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/AclCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/AclCmdlets.Tests.ps1
@@ -1,8 +1,7 @@
 Describe "Acl cmdlets are available and operate properly" -Tag CI {
     It "Get-Acl returns an ACL object" -pending:(!$IsWindows) {
         $ACL = get-acl $TESTDRIVE
-        $ACL | Should Not BeNullOrEmpty
-        $ACL.gettype().FullName | Should be "System.Security.AccessControl.DirectorySecurity"
+        $ACL | Should BeOfType "System.Security.AccessControl.DirectorySecurity"
     }
     It "Set-Acl can set the ACL of a directory" -pending {
         Setup -d testdir

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/ExecutionPolicy.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/ExecutionPolicy.Tests.ps1
@@ -9,7 +9,7 @@ Describe "ExecutionPolicy" -Tags "CI" {
         }
 
         It "Should return Microsoft.Powershell.ExecutionPolicy PSObject on Windows" -Skip:($IsLinux -Or $IsOSX) {
-            (Get-ExecutionPolicy).GetType() | Should Be Microsoft.Powershell.ExecutionPolicy
+            Get-ExecutionPolicy | Should BeOfType Microsoft.Powershell.ExecutionPolicy
         }
     }
 
@@ -504,6 +504,8 @@ ZoneId=$FileType
                     {
                         $exception = $_
                     }
+
+                    $exception.Exception | Should Not BeNullOrEmpty
 
                     $exceptionType = $exception.Exception.getType()
                     $result = $exceptionType

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/GetCredential.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/GetCredential.Tests.ps1
@@ -22,7 +22,7 @@ Describe "Get-Credential Test" -tag "CI" {
     }
     It "Get-Credential with message, produces a credential object" {
         $cred = $ps.AddScript("Get-Credential -UserName Joe -Message Foo").Invoke() | Select-Object -First 1
-        $cred.gettype().FullName | Should Be "System.Management.Automation.PSCredential"
+        $cred | Should BeOfType System.Management.Automation.PSCredential
         $netcred = $cred.GetNetworkCredential()
         $netcred.UserName | Should be "Joe"
         $netcred.Password | Should be "this is a test"
@@ -30,7 +30,7 @@ Describe "Get-Credential Test" -tag "CI" {
     }
     It "Get-Credential with title, produces a credential object" {
         $cred = $ps.AddScript("Get-Credential -UserName Joe -Title CustomTitle").Invoke() | Select-Object -First 1
-        $cred.gettype().FullName | Should Be "System.Management.Automation.PSCredential"
+        $cred | Should BeOfType System.Management.Automation.PSCredential
         $netcred = $cred.GetNetworkCredential()
         $netcred.UserName | Should be "Joe"
         $netcred.Password | Should be "this is a test"
@@ -38,7 +38,7 @@ Describe "Get-Credential Test" -tag "CI" {
     }
     It "Get-Credential with only username, produces a credential object" {
         $cred = $ps.AddScript("Get-Credential -UserName Joe").Invoke() | Select-Object -First 1
-        $cred.gettype().FullName | Should Be "System.Management.Automation.PSCredential"
+        $cred | Should BeOfType System.Management.Automation.PSCredential
         $netcred = $cred.GetNetworkCredential()
         $netcred.UserName | Should be "Joe"
         $netcred.Password | Should be "this is a test"
@@ -46,7 +46,7 @@ Describe "Get-Credential Test" -tag "CI" {
     }
     It "Get-Credential with title and message, produces a credential object" {
         $cred = $ps.AddScript("Get-Credential -UserName Joe -Message Foo -Title CustomTitle").Invoke() | Select-Object -First 1
-        $cred.gettype().FullName | Should Be "System.Management.Automation.PSCredential"
+        $cred | Should BeOfType System.Management.Automation.PSCredential
         $netcred = $cred.GetNetworkCredential()
         $netcred.UserName | Should be "Joe"
         $netcred.Password | Should be "this is a test"
@@ -54,7 +54,7 @@ Describe "Get-Credential Test" -tag "CI" {
     }
     It "Get-Credential without parameters" {
         $cred = $ps.AddScript("Get-Credential").Invoke() | Select-Object -First 1
-        $cred.gettype().FullName | Should Be "System.Management.Automation.PSCredential"
+        $cred | Should BeOfType System.Management.Automation.PSCredential
         $netcred = $cred.GetNetworkCredential()
         $netcred.UserName | Should be "John"
         $netcred.Password | Should be "This is a test"
@@ -62,7 +62,7 @@ Describe "Get-Credential Test" -tag "CI" {
     }
     It "Get-Credential `$null" {
         $cred = $ps.AddScript("Get-Credential `$null").Invoke() | Select-Object -First 1
-        $cred.gettype().FullName | Should Be "System.Management.Automation.PSCredential"
+        $cred | Should BeOfType System.Management.Automation.PSCredential
         $netcred = $cred.GetNetworkCredential()
         $netcred.UserName | Should be "John"
         $netcred.Password | Should be "This is a test"
@@ -70,7 +70,7 @@ Describe "Get-Credential Test" -tag "CI" {
     }
     It "Get-Credential -Credential `$null" {
         $cred = $ps.AddScript("Get-Credential -Credential `$null").Invoke() | Select-Object -First 1
-        $cred.gettype().FullName | Should Be "System.Management.Automation.PSCredential"
+        $cred | Should BeOfType System.Management.Automation.PSCredential
         $netcred = $cred.GetNetworkCredential()
         $netcred.UserName | Should be "John"
         $netcred.Password | Should be "This is a test"
@@ -78,7 +78,7 @@ Describe "Get-Credential Test" -tag "CI" {
     }
     it "Get-Credential Joe" {
         $cred = $ps.AddScript("Get-Credential Joe").Invoke() | Select-Object -First 1
-        $cred.gettype().FullName | Should Be "System.Management.Automation.PSCredential"
+        $cred | Should BeOfType System.Management.Automation.PSCredential
         $netcred = $cred.GetNetworkCredential()
         $netcred.UserName | Should be "Joe"
         $netcred.Password | Should be "This is a test"
@@ -86,7 +86,7 @@ Describe "Get-Credential Test" -tag "CI" {
     }
     it "Get-Credential -Credential Joe" {
         $cred = $ps.AddScript("Get-Credential Joe").Invoke() | Select-Object -First 1
-        $cred.gettype().FullName | Should Be "System.Management.Automation.PSCredential"
+        $cred | Should BeOfType System.Management.Automation.PSCredential
         $netcred = $cred.GetNetworkCredential()
         $netcred.UserName | Should be "Joe"
         $netcred.Password | Should be "This is a test"
@@ -97,7 +97,7 @@ Describe "Get-Credential Test" -tag "CI" {
         $credential = [pscredential]::new("John", $password)
 
         $cred = Get-Credential $credential
-        $cred.gettype().FullName | Should Be "System.Management.Automation.PSCredential"
+        $cred | Should BeOfType System.Management.Automation.PSCredential
         $netcred = $cred.GetNetworkCredential()
         $netcred.UserName | Should be "John"
         $netcred.Password | Should be "CredTest"

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/SecureString.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/SecureString.Tests.ps1
@@ -35,7 +35,7 @@ Describe "SecureString conversion tests" -Tags "CI" {
 
     It "Can convert to a secure string" {
         $ss = ConvertTo-SecureString -AsPlainText -Force abcd
-        $ss.GetType().Name | should be "SecureString"
+        $ss | Should BeOfType SecureString
     }
     It "can convert back from a secure string" {
         $secret = "abcd"

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Add-Member.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Add-Member.Tests.ps1
@@ -132,13 +132,13 @@
 
     It "Successful alias, no type" {
         $results = Add-Member -InputObject a -MemberType AliasProperty -Name Cnt -Value Length -passthru
-        $results.Cnt.GetType().Name | Should Be 'Int32'
+        $results.Cnt | Should BeOfType Int32
         $results.Cnt | Should Be 1
     }
 
     It "Successful alias, with type" {
         $results = add-member -InputObject a -MemberType AliasProperty -Name Cnt -Value Length -SecondValue String -passthru
-        $results.Cnt.GetType().Name | Should Be 'String'
+        $results.Cnt | Should BeOfType String
         $results.Cnt | Should Be '1'
     }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertFrom-Csv.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertFrom-Csv.Tests.ps1
@@ -24,9 +24,8 @@ a,b,c
         $csvContent   = Get-Content $testcsv
         $actualresult = $csvContent | ConvertFrom-Csv
 
-        $actualresult | Should Not BeNullOrEmpty
-        $actualresult.GetType().BaseType.Name | Should Be "Array"
-        $actualresult[0].GetType().Name          | Should Be "PSCustomObject"
+        ,$actualresult | Should BeOfType "System.Array"
+        $actualresult[0] | Should BeOfType "PSCustomObject"
 
         #Should have a name property in the result
         $actualresult[0].Name | Should Be $testName
@@ -40,9 +39,8 @@ a,b,c
         $csvContent   = Get-Content $testcsv
         $actualresult = $csvContent | ConvertFrom-Csv -Delimiter ";"
 
-        $actualresult | Should Not BeNullOrEmpty
-        $actualresult.GetType().BaseType.Name    | Should Be "Array"
-        $actualresult[0].GetType().Name          | Should Be "PSCustomObject"
+        ,$actualresult | Should BeOfType "System.Array"
+        $actualresult[0] | Should BeOfType "PSCustomObject"
 
         # ConvertFrom-Csv takes the first line of the input as a header by default
         $actualresult.Length | Should Be $($csvContent.Length - 1)

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertFrom-Csv.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertFrom-Csv.Tests.ps1
@@ -20,7 +20,8 @@ a,b,c
 	$csvContent   = Get-Content $testcsv
 	$actualresult = $csvContent | ConvertFrom-Csv
 
-	$actualresult.GetType().BaseType.Name | Should Be "Array"
+	$actualresult | Should Not BeNullOrEmpty
+    $actualresult.GetType().BaseType.Name | Should Be "Array"
 	$actualresult[0].GetType().Name          | Should Be "PSCustomObject"
 
 	#Should have a name property in the result
@@ -35,7 +36,8 @@ a,b,c
 	$csvContent   = Get-Content $testcsv
 	$actualresult = $csvContent | ConvertFrom-Csv -Delimiter ";"
 
-	$actualresult.GetType().BaseType.Name    | Should Be "Array"
+	$actualresult | Should Not BeNullOrEmpty
+    $actualresult.GetType().BaseType.Name    | Should Be "Array"
 	$actualresult[0].GetType().Name          | Should Be "PSCustomObject"
 
 	# ConvertFrom-Csv takes the first line of the input as a header by default

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertFrom-Csv.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertFrom-Csv.Tests.ps1
@@ -1,55 +1,59 @@
 $here = Split-Path -Parent $MyInvocation.MyCommand.Path
 
 Describe "ConvertFrom-Csv" -Tags "CI" {
-    $testObject = "a", "1"
-    $testcsv = Join-Path -Path (Join-Path -Path $here -ChildPath assets) -ChildPath TestCsv2.csv
-    $testName = "Zaphod BeebleBrox"
-    $testColumns = @"
+
+    BeforeAll {
+        $testObject = "a", "1"
+        $testcsv = Join-Path -Path (Join-Path -Path $here -ChildPath assets) -ChildPath TestCsv2.csv
+        $testName = "Zaphod BeebleBrox"
+        $testColumns = @"
 a,b,c
 1,2,3
 "@
+    }
+
     It "Should be able to be called" {
-	{ ConvertFrom-Csv -InputObject $testObject } | Should Not Throw
+        { ConvertFrom-Csv -InputObject $testObject } | Should Not Throw
     }
 
     It "Should be able to pipe" {
-	{ $testObject | ConvertFrom-Csv } | Should Not Throw
+        { $testObject | ConvertFrom-Csv } | Should Not Throw
     }
 
     It "Should have expected results when using piped inputs" {
-	$csvContent   = Get-Content $testcsv
-	$actualresult = $csvContent | ConvertFrom-Csv
+        $csvContent   = Get-Content $testcsv
+        $actualresult = $csvContent | ConvertFrom-Csv
 
-	$actualresult | Should Not BeNullOrEmpty
-    $actualresult.GetType().BaseType.Name | Should Be "Array"
-	$actualresult[0].GetType().Name          | Should Be "PSCustomObject"
+        $actualresult | Should Not BeNullOrEmpty
+        $actualresult.GetType().BaseType.Name | Should Be "Array"
+        $actualresult[0].GetType().Name          | Should Be "PSCustomObject"
 
-	#Should have a name property in the result
-	$actualresult[0].Name | Should Be $testName
+        #Should have a name property in the result
+        $actualresult[0].Name | Should Be $testName
     }
 
     It "Should be able to set a delimiter" {
-	{ $testcsv | ConvertFrom-Csv -Delimiter ";" } | Should Not Throw
+        { $testcsv | ConvertFrom-Csv -Delimiter ";" } | Should Not Throw
     }
 
     It "Should actually delimit the output" {
-	$csvContent   = Get-Content $testcsv
-	$actualresult = $csvContent | ConvertFrom-Csv -Delimiter ";"
+        $csvContent   = Get-Content $testcsv
+        $actualresult = $csvContent | ConvertFrom-Csv -Delimiter ";"
 
-	$actualresult | Should Not BeNullOrEmpty
-    $actualresult.GetType().BaseType.Name    | Should Be "Array"
-	$actualresult[0].GetType().Name          | Should Be "PSCustomObject"
+        $actualresult | Should Not BeNullOrEmpty
+        $actualresult.GetType().BaseType.Name    | Should Be "Array"
+        $actualresult[0].GetType().Name          | Should Be "PSCustomObject"
 
-	# ConvertFrom-Csv takes the first line of the input as a header by default
-	$actualresult.Length | Should Be $($csvContent.Length - 1)
+        # ConvertFrom-Csv takes the first line of the input as a header by default
+        $actualresult.Length | Should Be $($csvContent.Length - 1)
     }
 
     It "Should be able to have multiple columns" {
-	$actualData   = $testColumns | ConvertFrom-Csv
+        $actualData   = $testColumns | ConvertFrom-Csv
 
-	$actualLength = $($( $actualData | gm) | Where-Object {$_.MemberType -eq "NoteProperty" }).Length
+        $actualLength = $($( $actualData | gm) | Where-Object {$_.MemberType -eq "NoteProperty" }).Length
 
-	$actualLength | Should Be 3
+        $actualLength | Should Be 3
     }
 }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertFrom-StringData.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertFrom-StringData.Tests.ps1
@@ -55,11 +55,11 @@ bazz = 2
     }
 
     It "Should return a keycollection for the keys" {
-	$(ConvertFrom-StringData -StringData 'a=b').Keys.gettype().Name | Should Be "KeyCollection"
+        $(ConvertFrom-StringData -StringData 'a=b').Keys.PSObject.TypeNames[0] | Should Be "System.Collections.Hashtable+KeyCollection"
     }
 
     It "Should return a valuecollection for the values" {
-	$(ConvertFrom-StringData -StringData 'a=b').Values.gettype().Name | Should Be "ValueCollection"
+	$(ConvertFrom-StringData -StringData 'a=b').Values.PSObject.TypeNames[0] | Should Be "System.Collections.Hashtable+ValueCollection"
     }
 
     It "Should work for multiple lines" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertFrom-StringData.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertFrom-StringData.Tests.ps1
@@ -30,7 +30,8 @@ bazz = 2
     }
 
     It "Should return a hashtable" {
-	$(ConvertFrom-StringData -StringData 'a=b').GetType().Name | Should Be "Hashtable"
+	$result = ConvertFrom-StringData -StringData 'a=b'
+    $result | Should BeOfType Hashtable
     }
 
     It "Should throw if not in x=y format" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Csv.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Csv.Tests.ps1
@@ -47,7 +47,8 @@ Describe "ConvertTo-Csv" -Tags "CI" {
     It "Should output an array of objects" {
 	$result = $testObject | ConvertTo-Csv
 
-	$result.GetType().BaseType.Name | Should Be "Array"
+	$result | Should Not BeNullOrEmpty
+    $result.GetType().BaseType.Name | Should Be "Array"
     }
 
     It "Should return the type of data in the first element of the output array" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Csv.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Csv.Tests.ps1
@@ -45,10 +45,8 @@ Describe "ConvertTo-Csv" -Tags "CI" {
     }
 
     It "Should output an array of objects" {
-	$result = $testObject | ConvertTo-Csv
-
-	$result | Should Not BeNullOrEmpty
-    $result.GetType().BaseType.Name | Should Be "Array"
+        $result = $testObject | ConvertTo-Csv
+        ,$result | Should BeOfType "System.Array"
     }
 
     It "Should return the type of data in the first element of the output array" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-SecureString.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-SecureString.Tests.ps1
@@ -4,7 +4,7 @@ Describe "ConvertTo-SecureString" -Tags "CI" {
 
 	It "Should return System.Security.SecureString after converting plaintext variable"{
 	    $PesterTestConvert = (ConvertTo-SecureString "plaintextpester" -AsPlainText -force)
-	    ($PesterTestConvert).GetType() | Should Be securestring
+	    $PesterTestConvert | Should BeOfType securestring
 
 	}
     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/FormatHex.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/FormatHex.Tests.ps1
@@ -30,7 +30,7 @@ Describe "FormatHex" -tags "CI" {
         # the input data should be treated as string.
         $result = $inputText1 | Format-Hex
         $result | Should Not Be $null
-        $result.GetType().Name | Should Be 'ByteCollection'
+        ,$result | Should BeOfType 'Microsoft.PowerShell.Commands.ByteCollection'
         $actualResult = $result.ToString()
         ($actualResult -match $inputText1) | Should Be $true
     }
@@ -44,7 +44,7 @@ Describe "FormatHex" -tags "CI" {
 
         $result =  Format-Hex -InputObject $inputBytes
         $result | Should Not Be $null
-        $result.GetType().Name | Should Be 'ByteCollection'
+        ,$result | Should BeOfType 'Microsoft.PowerShell.Commands.ByteCollection'
         $actualResult = $result.ToString()
         ($actualResult -match $inputText1) | Should Be $true
     }
@@ -54,7 +54,7 @@ Describe "FormatHex" -tags "CI" {
 
         $result =  Format-Hex -Path $inputFile1
         $result | Should Not Be $null
-        $result.GetType().Name | Should Be 'ByteCollection'
+        ,$result | Should BeOfType 'Microsoft.PowerShell.Commands.ByteCollection'
         $actualResult = $result.ToString()
         ($actualResult -match $inputText1) | Should Be $true
     }
@@ -64,7 +64,7 @@ Describe "FormatHex" -tags "CI" {
 
         $result =  Format-Hex $inputFile1
         $result | Should Not BeNullOrEmpty
-        $result.GetType().Name | Should Be 'ByteCollection'
+        ,$result | Should BeOfType 'Microsoft.PowerShell.Commands.ByteCollection'
         $actualResult = $result.ToString()
         ($actualResult -match $inputText1) | Should Be $true
     }
@@ -74,7 +74,7 @@ Describe "FormatHex" -tags "CI" {
 
         $result =  Format-Hex -LiteralPath $inputFile1
         $result | Should Not BeNullOrEmpty
-        $result.GetType().Name | Should Be 'ByteCollection'
+        ,$result | Should BeOfType 'Microsoft.PowerShell.Commands.ByteCollection'
         $actualResult = $result.ToString()
         ($actualResult -match $inputText1) | Should Be $true
     }
@@ -84,7 +84,7 @@ Describe "FormatHex" -tags "CI" {
 
         $result = Get-ChildItem $inputFile1 | Format-Hex
         $result | Should Not BeNullOrEmpty
-        $result.GetType().Name | Should Be 'ByteCollection'
+        ,$result | Should BeOfType 'Microsoft.PowerShell.Commands.ByteCollection'
         $actualResult = $result.ToString()
         ($actualResult -match $inputText1) | Should Be $true
     }
@@ -94,7 +94,7 @@ Describe "FormatHex" -tags "CI" {
 
         $result =  Format-Hex -InputObject $inputText1 -Encoding ASCII
         $result | Should Not BeNullOrEmpty
-        $result.GetType().Name | Should Be 'ByteCollection'
+        ,$result | Should BeOfType 'Microsoft.PowerShell.Commands.ByteCollection'
         $actualResult = $result.ToString()
         ($actualResult -match $inputText1) | Should Be $true
     }
@@ -104,7 +104,7 @@ Describe "FormatHex" -tags "CI" {
 
         $result = 1,2,3,4 | Format-Hex
         $result | Should Not BeNullOrEmpty
-        $result.GetType().Name | Should Be 'ByteCollection'
+        ,$result | Should BeOfType 'Microsoft.PowerShell.Commands.ByteCollection'
         $actualResult = $result.ToString()
         # whitespace sensitive
         $actualResult | should be "00000000   01 02 03 04                                      ....            "
@@ -116,7 +116,7 @@ Describe "FormatHex" -tags "CI" {
 
         $result = 65..68 | Format-Hex
         $result | Should Not BeNullOrEmpty
-        $result.GetType().Name | Should Be 'ByteCollection'
+        ,$result | Should BeOfType 'Microsoft.PowerShell.Commands.ByteCollection'
         $actualResult = $result.ToString()
         # whitespace sensitive
         $actualResult | should be "00000000   41 42 43 44                                      ABCD            "
@@ -127,7 +127,7 @@ Describe "FormatHex" -tags "CI" {
 
         $result = 1,2,3,4 | Format-Hex -Raw
         $result | Should Not BeNullOrEmpty
-        $result.GetType().Name | Should Be 'ByteCollection'
+        ,$result | Should BeOfType 'Microsoft.PowerShell.Commands.ByteCollection'
         $actualResult = $result.ToString()
         # whitespace sensitive
         $actualResult | should be "00000000   01 00 00 00 02 00 00 00 03 00 00 00 04 00 00 00  ................"
@@ -138,7 +138,7 @@ Describe "FormatHex" -tags "CI" {
 
         $result = [int64]::MaxValue | Format-Hex
         $result | Should Not BeNullOrEmpty
-        $result.GetType().Name | Should Be 'ByteCollection'
+        ,$result | Should BeOfType 'Microsoft.PowerShell.Commands.ByteCollection'
         $actualResult = $result.ToString()
         # whitespace sensitive
         $actualResult | Should Match "00000000   FF FF FF FF FF FF FF 7F                          ."
@@ -152,7 +152,7 @@ Describe "FormatHex" -tags "CI" {
         $i64 = 9223372036854775807 # an int64
         $result = $b,$i16,$i32,$i64 | format-Hex
         $result | Should Not BeNullOrEmpty
-        $result.GetType().Name |  should be 'ByteCollection'
+        ,$result | Should BeOfType 'Microsoft.PowerShell.Commands.ByteCollection'
         $actualResult = $result.ToString()
         $actualResult | should Match "00000000   41 FF 7F FF FF FF 7F FF FF FF FF FF FF FF 7F     A"
     }
@@ -166,8 +166,8 @@ Describe "FormatHex" -tags "CI" {
         # this will cause 2 lines to be emitted
         $result = $b,$i16,$i32,$i64 | format-Hex -Raw
         $result | Should Not BeNullOrEmpty
-        $result[0].GetType().Name |  should be 'ByteCollection'
-        $result[1].GetType().Name |  should be 'ByteCollection'
+        $result[0] | Should BeOfType 'Microsoft.PowerShell.Commands.ByteCollection'
+        $result[1] | Should BeOfType 'Microsoft.PowerShell.Commands.ByteCollection'
         $result0 = $result[0].ToString()
         $result0 | should match "00000000   41 00 00 00 FF 7F 00 00 FF FF FF 7F FF FF FF FF  A"
         $result1 = $result[1].ToString()
@@ -178,7 +178,7 @@ Describe "FormatHex" -tags "CI" {
     It "ValidateEachBufferHasCorrectContentForStreamingText" {
         $result = "a" * 30 | Format-Hex
         $result | Should Not BeNullOrEmpty
-        $result.GetType().Name | Should Be 'ByteCollection'
+        ,$result | Should BeOfType 'Microsoft.PowerShell.Commands.ByteCollection'
         $actualResult = $result.ToString() -split "`r`n"
         $actualResult.Count | should be 2
         $actualResult[0].ToString() | Should be "00000000   61 61 61 61 61 61 61 61 61 61 61 61 61 61 61 61  aaaaaaaaaaaaaaaa"
@@ -200,7 +200,7 @@ Describe "FormatHex" -tags "CI" {
     It "ValidateStreamOfBytesFromFileHasProperOutput" {
         $result = Get-Content $InputFile1 -Encoding Byte | Format-Hex
         $result | Should Not BeNullOrEmpty
-        $result.GetType().Name | Should Be "ByteCollection"
+        ,$result | Should BeOfType 'Microsoft.PowerShell.Commands.ByteCollection'
         if ( $IsCoreCLR ) {
             $result.ToString() | Should be    "00000000   48 65 6C 6C 6F 20 57 6F 72 6C 64                 Hello World     "
         }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/FormatHex.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/FormatHex.Tests.ps1
@@ -151,6 +151,7 @@ Describe "FormatHex" -tags "CI" {
         $i32 = 2147483647 # an int32
         $i64 = 9223372036854775807 # an int64
         $result = $b,$i16,$i32,$i64 | format-Hex
+        $result | Should Not BeNullOrEmpty
         $result.GetType().Name |  should be 'ByteCollection'
         $actualResult = $result.ToString()
         $actualResult | should Match "00000000   41 FF 7F FF FF FF 7F FF FF FF FF FF FF FF 7F     A"
@@ -164,6 +165,7 @@ Describe "FormatHex" -tags "CI" {
         $i64 = 9223372036854775807 # an int64
         # this will cause 2 lines to be emitted
         $result = $b,$i16,$i32,$i64 | format-Hex -Raw
+        $result | Should Not BeNullOrEmpty
         $result[0].GetType().Name |  should be 'ByteCollection'
         $result[1].GetType().Name |  should be 'ByteCollection'
         $result0 = $result[0].ToString()

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Alias.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Alias.Tests.ps1
@@ -184,20 +184,20 @@ Describe "Get-Alias" -Tags "CI" {
 
         $val1 | ForEach-Object{ $i++};
         if($i -lt 2) {
-            $val1.GetType().BaseType.FullName | Should Be "System.Management.Automation.CommandInfo"
+            $val1 | Should BeOfType "System.Management.Automation.CommandInfo"
         }
         else
         {
-            $val1.GetType().BaseType.FullName | Should Be "System.Array"
+            ,$val1 | Should BeOfType "System.Array"
         }
 
         $val2 | ForEach-Object{ $i++};
         if($i -lt 2) {
-            $val2.GetType().BaseType.FullName | Should Be "System.Management.Automation.CommandInfo"
+            $val2 | Should BeOfType "System.Management.Automation.CommandInfo"
         }
         else
         {
-            $val2.GetType().BaseType.FullName | Should Be "System.Array"
+            ,$val2 | Should BeOfType "System.Array"
         }
     }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Alias.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Alias.Tests.ps1
@@ -179,6 +179,9 @@ Describe "Get-Alias" -Tags "CI" {
         $val2=(Get-Alias c*)
         $i=0
 
+        $val1 | Should Not BeNullOrEmpty
+        $val2 | Should Not BeNullOrEmpty
+
         $val1 | ForEach-Object{ $i++};
         if($i -lt 2) {
             $val1.GetType().BaseType.FullName | Should Be "System.Management.Automation.CommandInfo"

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Culture.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Culture.Tests.ps1
@@ -10,7 +10,7 @@ Describe "Get-Culture" -Tags "CI" {
 
     It "Should return a type of CultureInfo for Get-Culture cmdlet" {
 
-	(Get-Culture).GetType() | Should Be CultureInfo
+	Get-Culture | Should BeOfType CultureInfo
 
     }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Date.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Date.Tests.ps1
@@ -2,7 +2,7 @@ Describe "Get-Date DRT Unit Tests" -Tags "CI" {
     It "Get-Date with all parameters returns proper results" {
         $date = [datetime]::Now + ([timespan]::new(0,0,30))
         $result = Get-Date -Date $date -Year 1973 -Month 2 -Day 22 -Hour 15 -Minute 40 -Second 10 -Millisecond 200
-        $result.GetType() | Should be ([Datetime])
+        $result | Should BeOfType Datetime
         $result.Year | Should be 1973
         $result.Month| Should be 2
         $result.Day | Should be 22
@@ -81,10 +81,6 @@ Describe "Get-Date DRT Unit Tests" -Tags "CI" {
 
 
 Describe "Get-Date" -Tags "CI" {
-    It "Should return a DateTime object upon being called" {
-	(Get-Date).GetType().Name.Equals('DateTime') | Should Be $true
-    }
-
     It "Should have colons when ToString method is used" {
 	(Get-Date).ToString().Contains(":")                   | Should be $true
 	(Get-Date -DisplayHint Time).ToString().Contains(":") | Should be $true

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Event.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Event.Tests.ps1
@@ -11,7 +11,7 @@ Describe "Get-Event" -Tags "CI" {
     Context "Check return type of Get-Event" {
 
 	It "Should return PSEventArgs as return type of Get-Event" {
-	    { ( Get-Event -SourceIdentifier PesterTestEvent ).GetType() | Should Be System.Management.Automation.PSEventArgs }
+	    Get-Event -SourceIdentifier PesterTestEvent | Should BeOfType System.Management.Automation.PSEventArgs
 	}
     }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-EventSubscriber.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-EventSubscriber.Tests.ps1
@@ -9,7 +9,7 @@ Describe "Get-EventSubscriber" -Tags "CI" {
 	It "Should return System.Management.Automation.PSEventSubscriber as return type of New-Event" {
 	    $pesterobject = (New-Object System.Collections.ObjectModel.ObservableCollection[object])
 	    Register-ObjectEvent -InputObject $pesterobject -EventName CollectionChanged -SourceIdentifier PesterTestRegister
-	    (Get-EventSubscriber).GetType() | Should Be System.Management.Automation.PSEventSubscriber
+	    Get-EventSubscriber | Should BeOfType System.Management.Automation.PSEventSubscriber
 	}
     }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-FormatData.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-FormatData.Tests.ps1
@@ -2,12 +2,10 @@ Describe "Get-FormatData" -Tags "CI" {
 
     Context "Check return type of Get-FormatData" {
 
-	It "Should return an object[] as the return type" {
-	    (Get-FormatData).GetType() | Should be System.Object[]
-	}
-
-	It "Should return a System.Object[] with a count greater than 0" {
-	    (Get-formatData).Count | Should BeGreaterThan 0
-	}
+        It "Should return an object[] as the return type" {
+            $result = Get-FormatData
+            $result.Count  | Should BeGreaterThan 0
+            $result.GetType() | Should be System.Object[]
+        }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-FormatData.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-FormatData.Tests.ps1
@@ -4,8 +4,7 @@ Describe "Get-FormatData" -Tags "CI" {
 
         It "Should return an object[] as the return type" {
             $result = Get-FormatData
-            $result.Count  | Should BeGreaterThan 0
-            $result.GetType() | Should be System.Object[]
+            ,$result | Should BeOfType "System.Object[]"
         }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Host.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Host.Tests.ps1
@@ -5,17 +5,3 @@ Describe "Get-Host DRT Unit Tests" -Tags "CI" {
         $results.GetType().Name | Should Be InternalHost
     }
 }
-
-Describe "Get-Host" -Tags "CI" {
-    It "Should return a type of InternalHost for Get-Host cmdlet" {
-
-	(Get-Host).GetType().Name | Should Be InternalHost
-
-    }
-
-    It "Should have $ host variable be equivalent to Get-Host object" {
-
-	Get-Host | Should Be $host
-
-    }
-}

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Host.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Host.Tests.ps1
@@ -2,6 +2,6 @@ Describe "Get-Host DRT Unit Tests" -Tags "CI" {
     It "Should works proper with get-host" {
         $results = Get-Host
         $results | Should Be $Host
-        $results.GetType().Name | Should Be InternalHost
+        $results.PSObject.TypeNames[0] | Should Be "System.Management.Automation.Internal.Host.InternalHost"
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Member.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Member.Tests.ps1
@@ -23,12 +23,12 @@ Describe "Get-Member" -Tags "CI" {
 	$e = "anoeduntodeu" #test strings
 	$f = 'asntoheusth' #test strings
 
-	$a.GetType().Name | Should Be 'Int32'
-	$b.GetType().Name | Should Be 'Double'
-	$c.GetType().Name | Should Be 'Boolean'
-	$d.GetType().Name | Should Be 'Object[]'
-	$e.GetType().Name | Should Be 'String'
-	$f.GetType().Name | Should Be 'String'
+	$a | Should BeOfType 'Int32'
+	$b | Should BeOfType 'Double'
+	$c | Should BeOfType 'Boolean'
+	,$d | Should BeOfType 'Object[]'
+	$e | Should BeOfType 'String'
+	$f | Should BeOfType 'String'
     }
 
     It "Should be able to be called on a newly created PSObject" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Random.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Random.Tests.ps1
@@ -123,6 +123,7 @@ Describe "Get-Random" -Tags "CI" {
 
     It "Should return an array " {
 	$randomNumber = Get-Random -InputObject 1, 2, 3, 5, 8, 13 -Count 3
+    $randomNumber.Count | Should Be 3
 	$randomNumber.GetType().BaseType | Should Be array
     }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Random.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Random.Tests.ps1
@@ -65,7 +65,7 @@ Describe "Get-Random DRT Unit Tests" -Tags "CI" {
         $result = Get-Random -Maximum $maximum -Minimum $minimum
         $result | Should BeGreaterThan $greaterThan
         $result | Should BeLessThan $lessThan
-        $result.GetType().FullName | Should Be $type
+        $result | Should BeOfType $type
 
     }
 
@@ -124,7 +124,7 @@ Describe "Get-Random" -Tags "CI" {
     It "Should return an array " {
 	$randomNumber = Get-Random -InputObject 1, 2, 3, 5, 8, 13 -Count 3
     $randomNumber.Count | Should Be 3
-	$randomNumber.GetType().BaseType | Should Be array
+	,$randomNumber | Should BeOfType "System.Array"
     }
 
     It "Should return three random numbers for array of 1,2,3,5,8,13 " {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-RunspaceDebug.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-RunspaceDebug.Tests.ps1
@@ -2,9 +2,10 @@ Describe "Get-RunspaceDebug" -Tags "CI" {
 
     Context "Check return types of RunspaceDebug" {
 
-	It "Should return Microsoft.Powershell.Commands.PSRunspaceDebug as the return type" {
-	    $rs = Get-RunspaceDebug
-	    $rs[0].GetType().Name | Should Be PSRunspaceDebug
-	}
+    It "Should return Microsoft.Powershell.Commands.PSRunspaceDebug as the return type" {
+        $rs = Get-RunspaceDebug
+        $rs | Should Not BeNullOrEmpty
+        $rs[0].GetType().Name | Should Be PSRunspaceDebug
+    }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-RunspaceDebug.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-RunspaceDebug.Tests.ps1
@@ -5,7 +5,7 @@ Describe "Get-RunspaceDebug" -Tags "CI" {
     It "Should return Microsoft.Powershell.Commands.PSRunspaceDebug as the return type" {
         $rs = Get-RunspaceDebug
         $rs | Should Not BeNullOrEmpty
-        $rs[0].GetType().Name | Should Be PSRunspaceDebug
+        $rs[0] | Should BeOfType "Microsoft.PowerShell.Commands.PSRunspaceDebug"
     }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-UICulture.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-UICulture.Tests.ps1
@@ -1,9 +1,7 @@
 Describe "Get-UICulture" -Tags "CI" {
-    It "Should return a type of CultureInfo as the name of the type" {
-	(Get-UICulture).GetType().Name | Should Match CultureInfo
-    }
-
     It "Should have $ PsUICulture variable be equivalent to Get-UICulture object" {
-	(Get-UICulture).Name | Should Be $PsUICulture
+        $result = Get-UICulture
+        $result.Name | Should Be $PsUICulture
+        $result | Should BeOfType CultureInfo
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Unique.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Unique.Tests.ps1
@@ -18,72 +18,45 @@ Describe "Get-Unique DRT Unit Tests" -Tags "CI" {
 }
 
 Describe "Get-Unique" -Tags "CI" {
-    $sortedList1 = 1,2,2,3,3,4,5
-    It "Should be able to use the Get-Unique cmdlet without error with inputObject switch" {
-	{ Get-Unique -InputObject $sortedList1 } | Should Not Throw
+
+    BeforeAll {
+        $sortedList1 = 1,2,2,3,3,4,5
+        $expectedOutput1 = 1,2,3,4,5
+        $collection     = "a", "b", "b", "d"
+        $expectedOutput2 = "a", "b", "d"
     }
 
-    It "Should be able to uset the gu alias without error" {
-	{ gu -InputObject $sortedList1 } | Should Not Throw
+    It "Should be able to use the Get-Unique cmdlet without error with inputObject switch" {
+        { Get-Unique -InputObject $sortedList1 } | Should Not Throw
     }
 
     It "Should output an array" {
-	$(Get-Unique -InputObject $sortedList1).GetType().BaseType | Should Be Array
+        $result = Get-Unique -InputObject $sortedList1
+        $result | Should Not BeNullOrEmpty
+        $result.GetType().BaseType | Should Be Array
     }
 
     It "Should output an array of unchanged items when the InputObject switch is used" {
-	$actual   = Get-Unique -InputObject $sortedList1
-
-	$actual[0] | Should Be $sortedList1[0]
-	$actual[1] | Should Be $sortedList1[1]
-	$actual[2] | Should Be $sortedList1[2]
-	$actual[3] | Should Be $sortedList1[3]
-	$actual[4] | Should Be $sortedList1[4]
-	$actual[5] | Should Be $sortedList1[5]
-	$actual[6] | Should Be $sortedList1[6]
-
-	$actual.Length | Should Be 7
+        $actual   = Get-Unique -InputObject $sortedList1
+        $(Compare-Object $actual $sortedList1 -SyncWindow 0).Length | Should Be 0
     }
 
     It "Should accept piped input" {
-	{ $actualOutput = $sortedList1 | Get-Unique } | Should Not Throw
+        { $actualOutput = $sortedList1 | Get-Unique } | Should Not Throw
     }
 
     It "Should have the expected output when piped input is used" {
-	$actualOutput   = $sortedList1 | Get-Unique
-	$expectedOutput = 1,2,3,4,5
-
-	$actualOutput.Length | Should Be $expectedOutput.Length
-
-	$actualOutput[0] | Should Be $expectedOutput[0]
-	$actualOutput[1] | Should Be $expectedOutput[1]
-	$actualOutput[2] | Should Be $expectedOutput[2]
-	$actualOutput[3] | Should Be $expectedOutput[3]
-	$actualOutput[4] | Should Be $expectedOutput[4]
+        $actualOutput   = $sortedList1 | Get-Unique
+        $(Compare-Object $actualOutput $expectedOutput1 -SyncWindow 0).Length | Should Be 0
     }
 
     It "Should be able to input a collection in the inputObject switch" {
-	$collection = "a", "b", "b", "d"
-	$actual     = Get-Unique -InputObject $collection
-
-	$actual.Length | Should Be $collection.Length
-
-	$actual[0] | Should Be $collection[0]
-	$actual[1] | Should Be $collection[1]
-	$actual[2] | Should Be $collection[2]
-	$actual[3] | Should Be $collection[3]
+        $actual = Get-Unique -InputObject $collection
+        $(Compare-Object $actual $collection -SyncWindow 0).Length | Should Be 0
     }
 
     It "Should get the unique items when piped collection input is used" {
-	$collection     = "a", "b", "b", "d"
-	$expectedOutput = "a", "b", "d"
-
-	$actual = $collection | Get-Unique
-
-	$actual.Length | Should Be $expectedOutput.Length
-
-	$actual[0] | Should Be $expectedOutput[0]
-	$actual[1] | Should Be $expectedOutput[1]
-	$actual[2] | Should Be $expectedOutput[2]
+        $actual = $collection | Get-Unique
+        $(Compare-Object $actual $expectedOutput2 -SyncWindow 0).Length | Should Be 0
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Unique.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Unique.Tests.ps1
@@ -10,10 +10,10 @@ Describe "Get-Unique DRT Unit Tests" -Tags "CI" {
         $results[2] | Should Be "ba"
         $results[3] | Should Be "BA"
 
-        $results[0].GetType().FullName | Should be System.String
-        $results[1].GetType().FullName | Should be System.String
-        $results[2].GetType().FullName | Should be System.String
-        $results[3].GetType().FullName | Should be System.String
+        $results[0] | Should BeOfType "System.String"
+        $results[1] | Should BeOfType "System.String"
+        $results[2] | Should BeOfType "System.String"
+        $results[3] | Should BeOfType "System.String"
     }
 }
 
@@ -33,7 +33,7 @@ Describe "Get-Unique" -Tags "CI" {
     It "Should output an array" {
         $result = Get-Unique -InputObject $sortedList1
         $result | Should Not BeNullOrEmpty
-        $result.GetType().BaseType | Should Be Array
+        ,$result | Should BeOfType "System.Array"
     }
 
     It "Should output an array of unchanged items when the InputObject switch is used" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Uptime.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Uptime.Tests.ps1
@@ -17,13 +17,11 @@ Describe "Get-Uptime" -Tags "CI" {
     }
     It "Get-Uptime return timespan (default -Timespan)" {
         $upt = Get-Uptime
-        $upt | Should Not Be $null
-        ($upt).Gettype().Name | Should Be "Timespan"
+        $upt | Should BeOfType "Timespan"
     }
     It "Get-Uptime -Since return DateTime" {
         $upt = Get-Uptime -Since
-        $upt | Should Not Be $null
-        ($upt).Gettype().Name | Should Be "DateTime"
+        $upt | Should BeOfType "DateTime"
     }
     It "Get-Uptime throw if IsHighResolution == false" {
         try

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Group-Object.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Group-Object.Tests.ps1
@@ -7,12 +7,15 @@ Describe "Group-Object DRT Unit Tests" -Tags "CI" {
         $results.Group.Count | Should Be 4
         $results.Name | Should Be aA,AA
         $results.Group | Should Be aA,aA,AA,AA
-        $results.Group.GetType().BaseType | Should Be Array
+        ,$results | Should BeOfType "System.Array"
     }
 }
 
 Describe "Group-Object" -Tags "CI" {
-    $testObject = Get-ChildItem
+
+    BeforeAll {
+        $testObject = Get-ChildItem
+    }
 
     It "Should be called using an object as piped without error with no switches" {
 	{$testObject | Group-Object } | Should Not Throw
@@ -32,30 +35,31 @@ Describe "Group-Object" -Tags "CI" {
     }
 
     It "Should use the group alias" {
-	{ group -InputObject $testObject } | Should Not Throw
+        { Group-Object -InputObject $testObject } | Should Not Throw
     }
 
     It "Should create a collection when the inputObject parameter is used" {
-	$actualParam = Group-Object -InputObject $testObject
+        $actualParam = Group-Object -InputObject $testObject
+        $actualParam.Group.Gettype().Name | Should Be 'Collection`1'
+    }
 
-    $actualParam.Group | Should Not BeNullOrEmpty
-    $actualParam.Group.GetType().Name | Should Be "Collection``1"
+    It "Should return object of 'GroupInfo' type" {
+        $actualParam = Group-Object -InputObject $testObject
+        $actualParam | Should BeOfType "Microsoft.PowerShell.Commands.GroupInfo"
     }
 
     It "Should output an array when piped input is used" {
         $actual = $testObject | Group-Object
 
-        $actual.Group | Should Not BeNullOrEmpty
-        $actual.Group.GetType().BaseType | Should Be Array
+        ,$actual | Should BeOfType "System.Array"
     }
 
     It "Should have the same output between the group alias and the group-object cmdlet" {
-	$actualAlias = group -InputObject $testObject
-	$actualCmdlet = Group-Object -InputObject $testObject
+        $actualAlias = Group-Object -InputObject $testObject
+        $actualCmdlet = Group-Object -InputObject $testObject
 
-	$actualAlias.Name[0] | Should Be $actualCmdlet.Name[0]
-	$actualAlias.Group[0] | Should Be $actualCmdlet.Group[0]
-
+        $actualAlias.Name[0] | Should Be $actualCmdlet.Name[0]
+        $actualAlias.Group[0] | Should Be $actualCmdlet.Group[0]
     }
 
     It "Should be able to use the property switch without error" {
@@ -84,7 +88,7 @@ Describe "Group-Object" -Tags "CI" {
         $actual = $testObject | Group-Object -AsHashTable
 
         $actual | Should Not BeNullOrEmpty
-        $actual.GetType().Name | Should be "Hashtable"
+        $actual | Should BeOfType "System.Collections.Hashtable"
     }
 
     It "Should be able to access when output as hash table" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Group-Object.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Group-Object.Tests.ps1
@@ -38,13 +38,15 @@ Describe "Group-Object" -Tags "CI" {
     It "Should create a collection when the inputObject parameter is used" {
 	$actualParam = Group-Object -InputObject $testObject
 
-	$actualParam.Group.GetType().Name | Should Be "Collection``1"
+    $actualParam.Group | Should Not BeNullOrEmpty
+    $actualParam.Group.GetType().Name | Should Be "Collection``1"
     }
 
     It "Should output an array when piped input is used" {
-	$actual = $testObject | Group-Object
+        $actual = $testObject | Group-Object
 
-	$actual.Group.GetType().BaseType | Should Be Array
+        $actual.Group | Should Not BeNullOrEmpty
+        $actual.Group.GetType().BaseType | Should Be Array
     }
 
     It "Should have the same output between the group alias and the group-object cmdlet" {
@@ -79,9 +81,10 @@ Describe "Group-Object" -Tags "CI" {
     }
 
     It "Should be able to output a hashtable datatype" {
-	$actual = $testObject | Group-Object -AsHashTable
+        $actual = $testObject | Group-Object -AsHashTable
 
-	$actual.GetType().Name | Should be "Hashtable"
+        $actual | Should Not BeNullOrEmpty
+        $actual.GetType().Name | Should be "Hashtable"
     }
 
     It "Should be able to access when output as hash table" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Measure-Command.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Measure-Command.Tests.ps1
@@ -2,25 +2,25 @@ Describe "Measure-Command" -Tags "CI" {
 
     Context "Validate return types for Measure-Command" {
 
-	It "Should return TimeSpan as the return type" {
-	    (Measure-Command { Get-Date }).GetType() | Should Be timespan
-	}
+        It "Should return TimeSpan as the return type" {
+            Measure-Command { Get-Date } | Should BeOfType timespan
+        }
     }
 
     Context "Validate that it is executing commands correctly" {
 
-	It "Should return TimeSpan after executing a script" {
-	    (Measure-Command { echo hi }).GetType() | Should Be timespan
-	}
+        It "Should return TimeSpan after executing a script" {
+            Measure-Command { echo hi } | Should BeOfType timespan
+        }
 
-	It "Should return TimeSpan after executing a cmdlet" {
-	    $pesterscript = Join-Path -Path (Join-Path -Path $PSScriptRoot -ChildPath assets) -ChildPath echoscript.ps1
-	    $testfile = $pesterscript
-	    $testcommand = "echo pestertestscript"
-	    $testcommand | Add-Content -Path $testfile
+        It "Should return TimeSpan after executing a cmdlet" {
+            $pesterscript = Join-Path -Path (Join-Path -Path $PSScriptRoot -ChildPath assets) -ChildPath echoscript.ps1
+            $testfile = $pesterscript
+            $testcommand = "echo pestertestscript"
+            $testcommand | Add-Content -Path $testfile
 
-	    (Measure-Command { $pesterscript }).GetType() | Should Be timespan
-	    Remove-Item $testfile
-	}
+            Measure-Command { $pesterscript } | Should BeOfType timespan
+            Remove-Item $testfile
+        }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/New-Event.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/New-Event.Tests.ps1
@@ -2,9 +2,9 @@ Describe "New-Event" -Tags "CI" {
 
     Context "Check return type of New-Event" {
 
-	It "Should return PSEventArgs as return type of New-Event" {
-	    (New-Event -SourceIdentifier a).GetType() | Should Be System.Management.Automation.PSEventArgs
-	}
+        It "Should return PSEventArgs as return type of New-Event" {
+            New-Event -SourceIdentifier a | Should BeOfType System.Management.Automation.PSEventArgs
+        }
     }
 
     Context "Check New-Event can register an event"{

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/New-TimeSpan.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/New-TimeSpan.Tests.ps1
@@ -1,7 +1,8 @@
 Describe "New-TimeSpan DRT Unit Tests" -Tags "CI" {
+
      It "Should works proper with new-timespan"{
          $results =  New-TimeSpan -Days 10 -Hours 10 -Minutes 10 -Seconds 10
-         $results.GetType() | Should Be timespan
+         $results | Should BeOfType "System.Timespan"
          $results.Days | Should Be 10
          $results.Hours | Should Be 10
          $results.Minutes | Should Be 10
@@ -10,10 +11,10 @@ Describe "New-TimeSpan DRT Unit Tests" -Tags "CI" {
 }
 
 Describe "New-TimeSpan" -Tags "CI" {
-    It "Should be able to create a new timespan object" {
-	New-Variable -Name testObject -Value $(New-TimeSpan)
 
-	$testObject.GetType() | Should Be timespan
+    It "Should be able to create a new timespan object" {
+        New-Variable -Name testObject -Value $(New-TimeSpan)
+        $testObject | Should BeOfType "System.Timespan"
     }
 
     Context "Core Functionality Tests" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/NewGuid.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/NewGuid.Tests.ps1
@@ -2,7 +2,7 @@
 
     It "returns a new guid" {
         $guid = New-Guid
-        $guid.GetType().FullName | Should Be "System.Guid"
+        $guid | Should BeOfType System.Guid
     }
 
     It "should not be all zeros" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/NewTemporaryFile.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/NewTemporaryFile.Tests.ps1
@@ -20,7 +20,7 @@ Describe "NewTemporaryFile" -Tags "CI" {
         $tempFile = New-TemporaryFile
 
         Test-Path $tempFile | Should be $true
-        $tempFile.GetType().Name | Should be "FileInfo"
+        $tempFile | Should BeOfType System.IO.FileInfo
 
         if(Test-Path $tempFile)
         {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Out-String.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Out-String.Tests.ps1
@@ -16,8 +16,6 @@ Describe "Out-String" -Tags "CI" {
     It "Should accumulate the strings and returns them as a single string" {
 	$testArray = "a", " b"
 
-	$testArray.GetType().BaseType | Should Be array
-
 	$testArray | Out-String | Should Be "a$nl b$nl"
 
 	$($testArray | Out-String).GetType() | Should Be string

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Out-String.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Out-String.Tests.ps1
@@ -3,7 +3,7 @@ Describe "Out-String DRT Unit Tests" -Tags "CI" {
     It "check display of properties with names containing wildcard characters" {
         $results = new-object psobject | add-member -passthru noteproperty 'name with square brackets: [0]' 'myvalue' | out-string
         $results.Length | Should BeGreaterThan 1
-        $results.GetType() | Should Be string
+        $results | Should BeOfType "System.String"
         $results.Contains("myvalue") | Should Be $true
         $results.Contains("name with square brackets: [0]") | Should Be $true
     }
@@ -11,22 +11,23 @@ Describe "Out-String DRT Unit Tests" -Tags "CI" {
 }
 
 Describe "Out-String" -Tags "CI" {
-    $nl = [Environment]::NewLine
+
+    BeforeAll {
+        $nl = [Environment]::NewLine
+    }
 
     It "Should accumulate the strings and returns them as a single string" {
-	$testArray = "a", " b"
+        $testArray = "a", " b"
 
-	$testArray | Out-String | Should Be "a$nl b$nl"
-
-	$($testArray | Out-String).GetType() | Should Be string
+        $testArray | Out-String | Should Be "a$nl b$nl"
+        ,$($testArray | Out-String) | Should BeOfType "System.String"
     }
 
     It "Should be able to return an array of strings using the stream switch" {
-	$testInput = "a", "b"
+        $testInput = "a", "b"
 
-	$($testInput | Out-String).GetType() | Should Be string
-
-	$($testInput | Out-String -Stream).GetType().BaseType.Name | Should Be array
+        ,$($testInput | Out-String) | Should BeOfType "System.String"
+        ,$($testInput | Out-String -Stream) | Should BeOfType "System.Array"
     }
 
     It "Should send all objects through a pipeline when not using the stream switch" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Pester.Commands.Cmdlets.Json.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Pester.Commands.Cmdlets.Json.Tests.ps1
@@ -260,7 +260,7 @@ Describe "Json Tests" -Tags "Feature" {
             $json = "[1,2,3,4,5,6]"
             $result = ConvertFrom-Json $json
             $result.Count | Should Be 6
-            $result.GetType().BaseType.fullname | Should Be "System.Array"
+            ,$result | Should BeOfType "System.Array"
         }
 
         It "ConvertFrom-Json with a float value" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Read-Host.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Read-Host.Tests.ps1
@@ -30,7 +30,7 @@ Describe "Read-Host Test" -tag "CI" {
     }
     It "Read-Host returns a secure string when using -AsSecureString parameter" {
         $result = $ps.AddScript("Read-Host -AsSecureString").Invoke() | select-object -first 1
-        $result.GetType().Name | should be "SecureString"
+        $result | Should BeOfType SecureString
         [pscredential]::New("foo",$result).GetNEtworkCredential().Password | should BeExactly TEST
 
     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Register-EngineEvent.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Register-EngineEvent.Tests.ps1
@@ -2,7 +2,7 @@ Describe "Register-EngineEvent" -Tags "CI" {
 
     Context "Check return type of Register-ObjectEvent" {
 	It "Should return System.Management.Automation.PSEventJob as return type of Register-EngineEvent" {
-	    ( Register-EngineEvent -SourceIdentifier PesterTestRegister -Action {echo registerengineevent} ).GetType() | Should Be System.Management.Automation.PSEventJob
+	    Register-EngineEvent -SourceIdentifier PesterTestRegister -Action {echo registerengineevent} | Should BeOfType System.Management.Automation.PSEventJob
 	    Unregister-Event -sourceidentifier PesterTestRegister
 	}
     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Register-ObjectEvent.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Register-ObjectEvent.Tests.ps1
@@ -12,7 +12,7 @@ Describe "Register-ObjectEvent" -Tags "CI" {
 
 	It "Should return System.Management.Automation.PSEventSubscriber as return type of New-Event with the registered sourceidentifier" {
 	    Register-ObjectEvent -InputObject $pesterobject -EventName CollectionChanged -SourceIdentifier PesterTestRegister
-	    (Get-EventSubscriber -SourceIdentifier PesterTestRegister).GetType() | Should Be System.Management.Automation.PSEventSubscriber
+	    Get-EventSubscriber -SourceIdentifier PesterTestRegister | Should BeOfType System.Management.Automation.PSEventSubscriber
 	}
     }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-String.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-String.Tests.ps1
@@ -15,8 +15,7 @@ Describe "Select-String" -Tags "CI" {
 
     it "Should return an array data type when multiple matches are found" {
         $result = $testinputtwo | Select-String -Pattern "hello"
-        $result | Should Not BeNullOrEmpty
-        $result.gettype().basetype | Should Be Array
+        ,$result | Should BeOfType "System.Array"
     }
 
 	it "Should return the same result for the alias sls and Select-String " {
@@ -27,17 +26,15 @@ Describe "Select-String" -Tags "CI" {
 	    $equal | Should Be True
 	}
 
-	it "Should return an object type when one match is found" {
-	    $result = $testinputtwo | Select-String -Pattern "hello" -CaseSensitive
-        $result | Should Not BeNullOrEmpty
-        $result.gettype().basetype | Should Be System.Object
-	}
+    it "Should return an object type when one match is found" {
+        $result = $testinputtwo | Select-String -Pattern "hello" -CaseSensitive
+        ,$result | Should BeOfType "System.Object"
+    }
 
-	it "Should return matchinfo type" {
-	    $result = $testinputtwo | Select-String -Pattern "hello" -CaseSensitive
-        $result | Should Not BeNullOrEmpty
-        $result.gettype().name | Should Be MatchInfo
-	}
+    it "Should return matchinfo type" {
+        $result = $testinputtwo | Select-String -Pattern "hello" -CaseSensitive
+        ,$result | Should BeOfType "Microsoft.PowerShell.Commands.MatchInfo"
+    }
 
 	it "Should be called without an error using ca for casesensitive " {
 	    {$testinputone | Select-String -Pattern "hello" -ca } | Should Not Throw
@@ -59,19 +56,18 @@ Describe "Select-String" -Tags "CI" {
 	    { Select-String -InputObject "some stuff", "other stuff" -Pattern "other" } | Should Not Throw
 	}
 
-	it "Should return system.object when the input object switch is used on a collection" {
-	    $result = Select-String -InputObject "some stuff", "other stuff" -pattern "other"
-        $result | Should Not BeNullOrEmpty
-        $result.gettype().basetype | Should Be System.Object
-	}
+    it "Should return system.object when the input object switch is used on a collection" {
+        $result = Select-String -InputObject "some stuff", "other stuff" -pattern "other"
+        ,$result | Should BeOfType "System.Object"
+    }
 
 	it "Should return null or empty when the input object switch is used on a collection and the pattern does not exist" {
 	    Select-String -InputObject "some stuff", "other stuff" -Pattern "neither" | Should BeNullOrEmpty
 	}
 
-	it "Should return a bool type when the quiet switch is used" {
-	    ($testinputtwo | Select-String -Quiet "hello" -CaseSensitive).gettype() | Should Be Bool
-	}
+    it "Should return a bool type when the quiet switch is used" {
+        ,($testinputtwo | Select-String -Quiet "hello" -CaseSensitive) | Should BeOfType "System.Boolean"
+    }
 
 	it "Should be true when select string returns a positive result when the quiet switch is used" {
 	    ($testinputtwo | Select-String -Quiet "hello" -CaseSensitive) | Should Be $True
@@ -106,18 +102,16 @@ Describe "Select-String" -Tags "CI" {
 	    Remove-Item $testInputFile -Force
 	}
 
-	It "Should return an object when a match is found is the file on only one line" {
-	    $result = Select-String $testInputFile -Pattern "string"
-        $result | Should Not BeNullOrEmpty
-        $result.GetType().BaseType | Should be System.Object
-	}
+    It "Should return an object when a match is found is the file on only one line" {
+        $result = Select-String $testInputFile -Pattern "string"
+        ,$result | Should BeOfType "System.Object"
+    }
 
-	It "Should return an array when a match is found is the file on several lines" {
-	    $result = Select-String $testInputFile -Pattern "in"
-        $result | Should Not BeNullOrEmpty
-        $result.GetType().BaseType | Should be array
-	    $result[0].GetType().Name  | Should Be MatchInfo
-	}
+    It "Should return an array when a match is found is the file on several lines" {
+        $result = Select-String $testInputFile -Pattern "in"
+        ,$result | Should BeOfType "System.Array"
+        $result[0] | Should BeOfType "Microsoft.PowerShell.Commands.MatchInfo"
+    }
 
 	It "Should return the name of the file and the string that 'string' is found if there is only one lines that has a match" {
 	    $expected = $testInputFile + ":1:This is a text string, and another string"

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-String.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-String.Tests.ps1
@@ -13,9 +13,11 @@ Describe "Select-String" -Tags "CI" {
 	    { $testinputone | sls -Pattern "hello" } | Should Not Throw
 	}
 
-	it "Should return an array data type when multiple matches are found" {
-	    ( $testinputtwo | Select-String -Pattern "hello").gettype().basetype | Should Be Array
-	}
+    it "Should return an array data type when multiple matches are found" {
+        $result = $testinputtwo | Select-String -Pattern "hello"
+        $result | Should Not BeNullOrEmpty
+        $result.gettype().basetype | Should Be Array
+    }
 
 	it "Should return the same result for the alias sls and Select-String " {
 	    $firstMatch = $testinputone | Select-String -Pattern "hello"
@@ -26,11 +28,15 @@ Describe "Select-String" -Tags "CI" {
 	}
 
 	it "Should return an object type when one match is found" {
-	    ( $testinputtwo | Select-String -Pattern "hello" -CaseSensitive).gettype().basetype | Should Be System.Object
+	    $result = $testinputtwo | Select-String -Pattern "hello" -CaseSensitive
+        $result | Should Not BeNullOrEmpty
+        $result.gettype().basetype | Should Be System.Object
 	}
 
 	it "Should return matchinfo type" {
-	    ( $testinputtwo | Select-String -Pattern "hello" -CaseSensitive).gettype().name | Should Be MatchInfo
+	    $result = $testinputtwo | Select-String -Pattern "hello" -CaseSensitive
+        $result | Should Not BeNullOrEmpty
+        $result.gettype().name | Should Be MatchInfo
 	}
 
 	it "Should be called without an error using ca for casesensitive " {
@@ -54,7 +60,9 @@ Describe "Select-String" -Tags "CI" {
 	}
 
 	it "Should return system.object when the input object switch is used on a collection" {
-	    ( Select-String -InputObject "some stuff", "other stuff" -pattern "other" ).gettype().basetype | Should Be System.Object
+	    $result = Select-String -InputObject "some stuff", "other stuff" -pattern "other"
+        $result | Should Not BeNullOrEmpty
+        $result.gettype().basetype | Should Be System.Object
 	}
 
 	it "Should return null or empty when the input object switch is used on a collection and the pattern does not exist" {
@@ -99,12 +107,16 @@ Describe "Select-String" -Tags "CI" {
 	}
 
 	It "Should return an object when a match is found is the file on only one line" {
-	    (Select-String $testInputFile -Pattern "string").GetType().BaseType | Should be System.Object
+	    $result = Select-String $testInputFile -Pattern "string"
+        $result | Should Not BeNullOrEmpty
+        $result.GetType().BaseType | Should be System.Object
 	}
 
 	It "Should return an array when a match is found is the file on several lines" {
-	    (Select-String $testInputFile -Pattern "in").GetType().BaseType | Should be array
-	    (Select-String $testInputFile -Pattern "in")[0].GetType().Name  | Should Be MatchInfo
+	    $result = Select-String $testInputFile -Pattern "in"
+        $result | Should Not BeNullOrEmpty
+        $result.GetType().BaseType | Should be array
+	    $result[0].GetType().Name  | Should Be MatchInfo
 	}
 
 	It "Should return the name of the file and the string that 'string' is found if there is only one lines that has a match" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Error.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Error.Tests.ps1
@@ -5,6 +5,7 @@ Describe "Write-Error DRT Unit Tests" -Tags "CI" {
         $e.GetType().Name | Should Be 'ErrorRecord'
 
         #Exception verification
+        $e.Exception | Should Not BeNullOrEmpty
         $e.Exception.GetType().Name | Should Be 'WriteErrorException'
         $e.Exception.Message | Should Be 'myerrortext'
         $e.Exception.Data.Count | Should Be 0

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Error.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Error.Tests.ps1
@@ -1,12 +1,10 @@
 Describe "Write-Error DRT Unit Tests" -Tags "CI" {
     It "Should be works with command: write-error myerrortext" {
         $e = Write-Error myerrortext 2>&1
-        $e | Should Not BeNullOrEmpty
-        $e.GetType().Name | Should Be 'ErrorRecord'
+        $e | Should BeOfType 'System.Management.Automation.ErrorRecord'
 
         #Exception verification
-        $e.Exception | Should Not BeNullOrEmpty
-        $e.Exception.GetType().Name | Should Be 'WriteErrorException'
+        $e.Exception | Should BeOfType 'Microsoft.PowerShell.Commands.WriteErrorException'
         $e.Exception.Message | Should Be 'myerrortext'
         $e.Exception.Data.Count | Should Be 0
         $e.Exception.InnerException | Should BeNullOrEmpty
@@ -35,11 +33,10 @@ Describe "Write-Error DRT Unit Tests" -Tags "CI" {
         $exception = New-Object -TypeName System.ArgumentNullException -ArgumentList paramname
         $e = Write-Error -Message myerrortext -Exception $exception -ErrorId myerrorid -Category syntaxerror -TargetObject TargetObject -CategoryActivity myactivity -CategoryReason myreason -CategoryTargetName mytargetname -CategoryTargetType mytargettype -RecommendedAction myrecommendedaction 2>&1
         $e | Should Not BeNullOrEmpty
-        $e.GetType().Name | Should Be 'ErrorRecord'
+        $e | Should BeOfType 'System.Management.Automation.ErrorRecord'
 
         #Exception verification
-        $e.Exception | Should Not BeNullOrEmpty
-        $e.Exception.GetType().Name | Should Be 'ArgumentNullException'
+        $e.Exception | Should BeOfType 'System.ArgumentNullException'
         $e.Exception.ParamName | Should Be 'paramname'
         $e.Exception.Data.Count | Should Be 0
         $e.Exception.InnerException | Should BeNullOrEmpty

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Stream.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Stream.Tests.ps1
@@ -86,9 +86,9 @@ Describe "Stream writer tests" -Tags "CI" {
        It "Write-Information outputs an information object" -Pending:($IsOSX) {
            # redirect the streams is sufficient
            $result = Write-Information "Test Message" *>&1
-           $result.GetType().Fullname | Should be "System.Management.Automation.InformationRecord"
            $result.NativeThreadId | Should Not Be 0
            $result.ProcessId | Should Be $pid
+           $result | Should BeOfType System.Management.Automation.InformationRecord
            if ($IsWindows)
            {
                # Use Match instead of Be so we can avoid dealing with a potential domain name

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/object.tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/object.tests.ps1
@@ -84,7 +84,7 @@ Describe "Object cmdlets" -Tags "CI" {
 
         It 'returns a GenericMeasureInfoObject' {
             $gmi = 1,2,3 | measure-object -max -min
-            $gmi.GetType().FullName | Should Be 'Microsoft.PowerShell.Commands.GenericMeasureInfo'
+            $gmi | Should BeOfType Microsoft.PowerShell.Commands.GenericMeasureInfo
         }
 
         It 'should return correct error for non-numeric input' {

--- a/test/powershell/engine/Remoting/SSHRemotingAPI.Tests.ps1
+++ b/test/powershell/engine/Remoting/SSHRemotingAPI.Tests.ps1
@@ -2,24 +2,6 @@ Describe "SSH Remoting API Tests" -Tags "Feature" {
 
     Context "SSHConnectionInfo Class Tests" {
 
-        It "SSHConnectionInfo constructor should throw null argument exception for null UserName parameter" -Pending:$true {
-
-            # The test is pending because it is wrong or we have bug in code!
-            try
-            {
-                [System.Management.Automation.Runspaces.SSHConnectionInfo]::new(
-                    [System.Management.Automation.Internal.AutomationNull]::Value,
-                    "localhost",
-                    [System.Management.Automation.Internal.AutomationNull]::Value)
-
-                throw "No Exception!"
-            }
-            catch
-            {
-                $_.FullyQualifiedErrorId | Should Be "PSArgumentNullException"
-            }
-        }
-
         It "SSHConnectionInfo constructor should throw null argument exception for null HostName parameter" {
 
             try

--- a/test/powershell/engine/Remoting/SSHRemotingAPI.Tests.ps1
+++ b/test/powershell/engine/Remoting/SSHRemotingAPI.Tests.ps1
@@ -2,8 +2,9 @@ Describe "SSH Remoting API Tests" -Tags "Feature" {
 
     Context "SSHConnectionInfo Class Tests" {
 
-        It "SSHConnectionInfo constructor should throw null argument exception for null UserName parameter" {
+        It "SSHConnectionInfo constructor should throw null argument exception for null UserName parameter" -Pending:$true {
 
+            # The test is pending because it is wrong or we have bug in code!
             try
             {
                 [System.Management.Automation.Runspaces.SSHConnectionInfo]::new(
@@ -11,11 +12,11 @@ Describe "SSH Remoting API Tests" -Tags "Feature" {
                     "localhost",
                     [System.Management.Automation.Internal.AutomationNull]::Value)
 
-                throw "SSHConnectionInfo constructor did not throw expected PSArgumentNullException exception"
+                throw "No Exception!"
             }
             catch
             {
-                $_.FullyQualifiedErrorId | Should Match "PSArgumentNullException"
+                $_.FullyQualifiedErrorId | Should Be "PSArgumentNullException"
             }
         }
 
@@ -28,11 +29,11 @@ Describe "SSH Remoting API Tests" -Tags "Feature" {
                     [System.Management.Automation.Internal.AutomationNull]::Value,
                     [System.Management.Automation.Internal.AutomationNull]::Value)
 
-                throw "SSHConnectionInfo constructor did not throw expected PSArgumentNullException exception"
+                throw "No Exception!"
             }
             catch
             {
-                $_.FullyQualifiedErrorId | Should Match "PSArgumentNullException"
+                $_.FullyQualifiedErrorId | Should Be "PSArgumentNullException"
             }
         }
 
@@ -48,17 +49,11 @@ Describe "SSH Remoting API Tests" -Tags "Feature" {
                 $rs = [runspacefactory]::CreateRunspace($sshConnectionInfo)
                 $rs.Open()
 
-                throw "SSHConnectionInfo did not throw expected FileNotFoundException exception"
+                throw "No Exception!"
             }
             catch
             {
-                $expectedFileNotFoundExecption = $null
-                if (($_.Exception -ne $null) -and ($_.Exception.InnerException -ne $null))
-                {
-                    $expectedFileNotFoundExecption = $_.Exception.InnerException.InnerException
-                }
-
-                ($expectedFileNotFoundExecption.GetType().FullName) | Should Be "System.IO.FileNotFoundException"
+                $_.Exception.InnerException.InnerException | Should BeOfType System.IO.FileNotFoundException
             }
         }
     }


### PR DESCRIPTION
$var.GetType() can raise an exception in tests so we should check $var
before make the call. A large part of the tests does not make this
check.
I start with searching ".GetType()" but discovered many related issues
in tests (reduntant and unneeded tests, "throw" bad pattens, bugs,
formattings (sorry!) and so on) - I had to fix them too.

According to our test roadmap, we must increase the code coverage from 45 up to 90% i.e. twice. Bad patterns and bad formatting will slow down our movement. I hope the team will support me in this PR.