### PR TITLE
Fix for duplicate types in TypeTable

### DIFF
--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -1309,7 +1309,7 @@ namespace System.Management.Automation.Runspaces
         }
 
         /// <summary>
-        ///
+        /// Add items to this collection.
         /// </summary>
         /// <param name="items"></param>
         public void Add(IEnumerable<T> items)
@@ -1322,6 +1322,27 @@ namespace System.Management.Automation.Runspaces
                 foreach (T element in items)
                 {
                     _internalCollection.Add(element);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Special add for TypeTable type entries that removes redundant file entries.
+        /// </summary>
+        internal void AddTypeTableTypesInfo(IEnumerable<T> items)
+        {
+            if (!(items is IEnumerable<SessionStateTypeEntry>)) { throw new PSInvalidOperationException(); }
+
+            lock (_syncObject)
+            {
+                foreach (var element in items)
+                {
+                    var typeEntry = element as SessionStateTypeEntry;
+                    if (typeEntry.TypeData != null)
+                    {
+                        // Skip type file entries.
+                        _internalCollection.Add(element);
+                    }
                 }
             }
         }
@@ -3851,7 +3872,12 @@ namespace System.Management.Automation.Runspaces
                     context.TypeTable = typeTable;
 
                     Types.Clear();
-                    Types.Add(typeTable.typesInfo);
+
+                    // A TypeTable contains types info along with type file references used to create the types info,
+                    // which is redundant information.  When resused in a runspace the ISS unpacks the file types again
+                    // resulting in duplicate types and duplication errors when processed.
+                    // So use this special Add method to filter all types files found in the TypeTable.
+                    Types.AddTypeTableTypesInfo(typeTable.typesInfo);
 
                     return;
                 }

--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -1331,7 +1331,7 @@ namespace System.Management.Automation.Runspaces
         /// </summary>
         internal void AddTypeTableTypesInfo(IEnumerable<T> items)
         {
-            if (!(items is IEnumerable<SessionStateTypeEntry>)) { throw new PSInvalidOperationException(); }
+            if (typeof(T) != typeof(SessionStateTypeEntry)) { throw new PSInvalidOperationException(); }
 
             lock (_syncObject)
             {

--- a/test/powershell/Common/TestTypeFile.ps1xml
+++ b/test/powershell/Common/TestTypeFile.ps1xml
@@ -1,0 +1,13 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+
+<Types>
+  <Type>
+    <Name>System.Array</Name>
+    <Members>
+      <AliasProperty>
+        <Name>Count</Name>
+        <ReferencedMemberName>Length</ReferencedMemberName>
+      </AliasProperty>
+    </Members>
+  </Type>
+</Types>

--- a/test/powershell/Common/TestTypeFile.ps1xml
+++ b/test/powershell/Common/TestTypeFile.ps1xml
@@ -5,7 +5,7 @@
     <Name>System.Array</Name>
     <Members>
       <AliasProperty>
-        <Name>Count</Name>
+        <Name>Counts</Name>
         <ReferencedMemberName>Length</ReferencedMemberName>
       </AliasProperty>
     </Members>

--- a/test/powershell/engine/InitialSessionState.Tests.ps1
+++ b/test/powershell/engine/InitialSessionState.Tests.ps1
@@ -89,17 +89,7 @@ Describe "TypeTable duplicate types in reused runspace InitialSessionState TypeT
 
         It "Verifies that a reused InitialSessionState object created from a TypeTable object does not have duplicate types" {
 
-            $errs = $null
-            try
-            {
-                $rs2.Open()
-            }
-            catch
-            {
-                $errs = $_
-            }
-
-            $errs | Should Be $null
+            { $rs2.Open() } | Should Not Throw
         }
     }
 

--- a/test/powershell/engine/InitialSessionState.Tests.ps1
+++ b/test/powershell/engine/InitialSessionState.Tests.ps1
@@ -121,13 +121,8 @@ Describe "TypeTable duplicate types in reused runspace InitialSessionState TypeT
             }
             catch
             {
-                if ($_.Exception.InnerException -ne $null)
-                {
-                    $errorId = $_.Exception.InnerException.ErrorRecord.FullyQualifiedErrorId
-                }
+                $_.Exception.InnerException.ErrorRecord.FullyQualifiedErrorId | Should Be "ErrorsUpdatingTypes"
             }
-
-            $errorId | Should Be "ErrorsUpdatingTypes"
         }
     }
 }


### PR DESCRIPTION
When a TypeTable is created it includes the types from type files provided along with references to the type files.  When the InitialSessionState (ISS) object processes these types it reads the type files again and ends up with duplicate type entries.  PowerShell V5.1 ISS type processing was re-written to improve performance and no longer removes duplicate types, so that this scenario (runspace ISS reuse) results in errors causing a regression.

The fix is to copy only type data when a TypeTable is passed to the ISS.