### PR TITLE
Fix PSModuleInfo.CaptureLocals to not do ValidateAttribute check when capturing variables from the caller's scope

### DIFF
--- a/src/System.Management.Automation/engine/Modules/PSModuleInfo.cs
+++ b/src/System.Management.Automation/engine/Modules/PSModuleInfo.cs
@@ -1378,7 +1378,10 @@ namespace System.Management.Automation
                     // Only copy simple mutable variables...
                     if (v.Options == ScopedItemOptions.None && !(v is NullVariable))
                     {
-                        PSVariable newVar = new PSVariable(v.Name, v.Value, v.Options, v.Attributes, v.Description);
+                        PSVariable newVar = new PSVariable(v.Name, v.Value, v.Options, v.Description);
+                        // The variable is already defined/set in the scope, and that means the attributes
+                        // have already been checked if it was needed, so we don't do it again.
+                        newVar.AddParameterAttributesNoChecks(v.Attributes);
                         SessionState.Internal.NewVariable(newVar, false);
                     }
                 }

--- a/test/powershell/engine/Api/GetNewClosure.Tests.ps1
+++ b/test/powershell/engine/Api/GetNewClosure.Tests.ps1
@@ -1,0 +1,39 @@
+Describe "ScriptBlock.GetNewClosure()" -tags "CI" {
+    
+    BeforeAll {
+        function SimpleFunction_GetNewClosure
+        {
+            param([ValidateNotNull()] $Name)
+
+            & { 'OK' }.GetNewClosure()
+        }
+
+        function ScriptCmdlet_GetNewClosure
+        {
+            [CmdletBinding()]
+            param(
+                [Parameter()]
+                [ValidateNotNullOrEmpty()]
+                [string] $Name = "",
+
+                [Parameter()]
+                [ValidateRange(1,3)]
+                [int] $Value = 4
+            )
+
+            & { $Value; $Name }.GetNewClosure()
+        }
+    }
+
+    It "Parameter attributes should not get evaluated again in GetNewClosure - SimpleFunction" {
+        SimpleFunction_GetNewClosure | Should Be "OK"
+    }
+
+    It "Parameter attributes should not get evaluated again in GetNewClosure - ScriptCmdlet" {
+        $result = ScriptCmdlet_GetNewClosure
+        $result.Count | Should Be 2
+        $result[0] | Should Be 4
+        $result[1] | Should Be ""
+    }
+}
+

--- a/test/powershell/engine/Api/GetNewClosure.Tests.ps1
+++ b/test/powershell/engine/Api/GetNewClosure.Tests.ps1
@@ -1,6 +1,10 @@
 Describe "ScriptBlock.GetNewClosure()" -tags "CI" {
     
     BeforeAll {
+
+        ## No error should occur when calling GetNewClosure because:
+        ## 1. ValidateAttributes are not evaluated on parameter default values
+        ## 2. GetNewClosure no longer forces validation on existing variables
         function SimpleFunction_GetNewClosure
         {
             param([ValidateNotNull()] $Name)
@@ -36,4 +40,3 @@ Describe "ScriptBlock.GetNewClosure()" -tags "CI" {
         $result[1] | Should Be ""
     }
 }
-


### PR DESCRIPTION
fix #3144 