### PR TITLE
Define roles and their responsibilities in a PR

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -183,7 +183,7 @@ See [Contributing to documentation related to PowerShell](#contributing-to-docum
     If no Reviewer is chosen, the Assignee shall choose Reviewer(s) as appropriate.
     * If an Author is a [PowerShell Team](https://github.com/orgs/PowerShell/people) member,
       then the Author **is required** to choose Reviewer(s) and an Assignee for the PR.
-  * For a PR to be merged, it must be approved by at least one PowerShell Team member or collaborator,
+  * For a PR to be merged, it must be approved by at least one PowerShell Team member or Collaborator,
     so additional Reviewer(s) may be added by the Assignee as appropriate.
     The Assignee may also be re-assigned by Maintainers.
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -174,7 +174,7 @@ See [Contributing to documentation related to PowerShell](#contributing-to-docum
     * A Reviewer can be anyone from the collaborators.
       A Reviewer reviews the change of a PR,
       leaves comments for the Author to address,
-      and approve the PR when the change looks good.
+      and approves the PR when the change looks good.
     * An Assignee must be a maintainer, who monitors the progress of the PR,
       coordinates the review process, and merges the PR after it's approved.
       The Assignee may or may not be a Reviewer of the PR at the same time.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -169,29 +169,29 @@ See [Contributing to documentation related to PowerShell](#contributing-to-docum
 
 #### Pull Request - Code Review
 
-* Author, Reviewer and Assignee of a PR
+* Author, Reviewer, and Assignee of a PR
   * Reviewer and Assignee are two separate roles of a PR.
     * A Reviewer can be anyone from the collaborators.
-      Reviewer reviews the change of a PR,
-      leaves comments for Author to address,
+      A Reviewer reviews the change of a PR,
+      leaves comments for the Author to address,
       and approve the PR when the change looks good.
-    * An Assignee must be a maintainer, who monitors progress of the PR,
+    * An Assignee must be a maintainer, who monitors the progress of the PR,
       coordinates the review process, and merges the PR after it's approved.
-      Assignee may or may not be a Reviewer of the PR at the same time.
-  * Author is encouraged to choose Reviewer(s) and Assignee for the PR.
-    If no Assignee is chosen, one of maintainers will be assigned to it.
-    If no Reviewer is chosen, Assignee will choose Reviewer(s) as appropriate.
-    * If Author is a [PowerShell Team](https://github.com/orgs/PowerShell/people) member,
-      then Author **is required** to choose Reviewer(s) and Assignee of the PR.
-  * Assignee may be re-assigned by maintainers,
+      The Assignee may or may not be a Reviewer of the PR at the same time.
+  * An Author is encouraged to choose Reviewer(s) and Assignee for the PR.
+    If no Assignee is chosen, one of maintainers shall be assigned to it.
+    If no Reviewer is chosen, Assignee shall choose Reviewer(s) as appropriate.
+    * If an Author is a [PowerShell Team](https://github.com/orgs/PowerShell/people) member,
+      then the Author **is required** to choose Reviewer(s) and Assignee of the PR.
+  * The Assignee may be re-assigned by maintainers,
     and more Reviewer(s) may be added by Assignee as appropriate.
 
-* Author **is responsible** to drive the PR to the Approved state.
+* An Author **is responsible** for driving the PR to the Approved state.
   After a successful test pass, Reviewer(s) can start a code review,
   commenting on any changes that might need to be made.
-  Author addresses the comments, and ping Reviewer(s) to start the nexe iteration.
+  The Author addresses the comments, and pings Reviewer(s) to start the next iteration.
   If the review is making no progress (or very slow),
-  Author can always ask Assignee to help coordinate the process and keep it moving.
+  the Author can always ask the Assignee to help coordinate the process and keep it moving.
 
 * Additional feedback is always welcome!
   Even if you are not designated as a Reviewer,

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -169,12 +169,32 @@ See [Contributing to documentation related to PowerShell](#contributing-to-docum
 
 #### Pull Request - Code Review
 
-* After a successful test pass,
-  the area maintainers will do a code review,
+* Author, Reviewer and Assignee of a PR
+  * Reviewer and Assignee are two separate roles of a PR.
+    * A Reviewer can be anyone from the collaborators.
+      Reviewer reviews the change of a PR,
+      leaves comments for Author to address,
+      and approve the PR when the change looks good.
+    * An Assignee must be a maintainer, who monitors progress of the PR,
+      coordinates the review process, and merges the PR after it's approved.
+      Assignee may or may not be a Reviewer of the PR at the same time.
+  * Author is encouraged to choose Reviewer(s) and Assignee for the PR.
+    If no Assignee is chosen, one of maintainers will be assigned to it.
+    If no Reviewer is chosen, Assignee will choose Reviewer(s) as appropriate.
+    * If Author is a [PowerShell Team](https://github.com/orgs/PowerShell/people) member,
+      then Author **is required** to choose Reviewer(s) and Assignee of the PR.
+  * Assignee may be re-assigned by maintainers,
+    and more Reviewer(s) may be added by Assignee as appropriate.
+
+* Author **is responsible** to drive the PR to the Approved state.
+  After a successful test pass, Reviewer(s) can start a code review,
   commenting on any changes that might need to be made.
+  Author addresses the comments, and ping Reviewer(s) to start the nexe iteration.
+  If the review is making no progress (or very slow),
+  Author can always ask Assignee to help coordinate the process and keep it moving.
 
 * Additional feedback is always welcome!
-  Even if you are not designated as an area's maintainer,
+  Even if you are not designated as a Reviewer,
   feel free to review others' pull requests anyway.
   Leave your comments even if everything looks good;
   a simple "Looks good to me" or "LGTM" will suffice.
@@ -191,7 +211,7 @@ See [Contributing to documentation related to PowerShell](#contributing-to-docum
 * Once the code review is done,
   all merge conflicts are resolved,
   and the CI system build status is passing,
-  a maintainer will merge your changes.
+  the PR Assignee will merge your changes.
 
 * For more information on the the PowerShell maintainers' process,
   see the [documentation](../docs/maintainers).

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -35,7 +35,7 @@ Contributing to Issues
   [open a new issue](https://github.com/PowerShell/PowerShell/issues/new),
   making sure to follow the directions as best you can.
 * If the issue is marked as [`Up-for-Grabs`][up-for-grabs],
-  the PowerShell maintainers are looking for help with the issue.
+  the PowerShell Maintainers are looking for help with the issue.
 
 Contributing to Documentation
 -----------------------------
@@ -127,7 +127,7 @@ See [Contributing to documentation related to PowerShell](#contributing-to-docum
   either update the changelog in your pull request or
   add a comment in the PR description saying that the change may warrant a note in the changelog.
   New changes always go into the **Unreleased** section.
-  Keeping the changelog up-to-date simplifies the release process for maintainers.
+  Keeping the changelog up-to-date simplifies the release process for Maintainers.
   An example:
     ```
     Unreleased
@@ -169,27 +169,29 @@ See [Contributing to documentation related to PowerShell](#contributing-to-docum
 
 #### Pull Request - Code Review
 
-* Roles of a PR: Author, Reviewer, and Assignee
+* Roles and Responsibilities of a PR: Author, Reviewer, and Assignee
   * Reviewer and Assignee are two separate roles of a PR.
-    * A Reviewer can be anyone from the collaborators.
+    * A Reviewer can be anyone who wants to contribute.
       A Reviewer reviews the change of a PR,
       leaves comments for the Author to address,
       and approves the PR when the change looks good.
-    * An Assignee must be a maintainer, who monitors the progress of the PR,
-      coordinates the review process, and merges the PR after it's approved.
+    * An Assignee must be a [Maintainer](../docs/maintainers), who monitors the progress of the PR,
+      coordinates the review process, and merges the PR after it's been approved.
       The Assignee may or may not be a Reviewer of the PR at the same time.
   * An Author is encouraged to choose Reviewer(s) and Assignee for the PR.
-    If no Assignee is chosen, one of maintainers shall be assigned to it.
+    If no Assignee is chosen, one of Maintainers shall be assigned to it.
     If no Reviewer is chosen, Assignee shall choose Reviewer(s) as appropriate.
     * If an Author is a [PowerShell Team](https://github.com/orgs/PowerShell/people) member,
       then the Author **is required** to choose Reviewer(s) and Assignee of the PR.
-  * The Assignee may be re-assigned by maintainers,
-    and more Reviewer(s) may be added by Assignee as appropriate.
+  * For a PR to be merged, it must be approved by at least one PowerShell Team member or Collaborator,
+    so additional Reviewer(s) may be added by Assignee as appropriate.
+    The Assignee may also be re-assigned by Maintainers.
 
-* An Author **is responsible** for driving the PR to the Approved state.
-  After a successful test pass, Reviewer(s) can start a code review,
-  commenting on any changes that might need to be made.
-  The Author addresses the comments, and pings Reviewer(s) to start the next iteration.
+* A Reviewer can postpone the code review if CI builds fail,
+  but also can start the code review early regardless of the CI builds.
+
+* The Author **is responsible** for driving the PR to the Approved state.
+  The Author addresses review comments, and pings Reviewer(s) to start the next iteration.
   If the review is making no progress (or very slow),
   the Author can always ask the Assignee to help coordinate the process and keep it moving.
 
@@ -213,7 +215,7 @@ See [Contributing to documentation related to PowerShell](#contributing-to-docum
   and the CI system build status is passing,
   the PR Assignee will merge your changes.
 
-* For more information on the the PowerShell maintainers' process,
+* For more information on the the PowerShell Maintainers' process,
   see the [documentation](../docs/maintainers).
 
 Making Breaking Changes

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -178,13 +178,13 @@ See [Contributing to documentation related to PowerShell](#contributing-to-docum
     * An Assignee must be a [Maintainer](../docs/maintainers), who monitors the progress of the PR,
       coordinates the review process, and merges the PR after it's been approved.
       The Assignee may or may not be a Reviewer of the PR at the same time.
-  * An Author is encouraged to choose Reviewer(s) and Assignee for the PR.
-    If no Assignee is chosen, one of Maintainers shall be assigned to it.
-    If no Reviewer is chosen, Assignee shall choose Reviewer(s) as appropriate.
+  * An Author is encouraged to choose Reviewer(s) and an Assignee for the PR.
+    If no Assignee is chosen, one of the Maintainers shall be assigned to it.
+    If no Reviewer is chosen, the Assignee shall choose Reviewer(s) as appropriate.
     * If an Author is a [PowerShell Team](https://github.com/orgs/PowerShell/people) member,
-      then the Author **is required** to choose Reviewer(s) and Assignee of the PR.
-  * For a PR to be merged, it must be approved by at least one PowerShell Team member or Collaborator,
-    so additional Reviewer(s) may be added by Assignee as appropriate.
+      then the Author **is required** to choose Reviewer(s) and an Assignee for the PR.
+  * For a PR to be merged, it must be approved by at least one PowerShell Team member or collaborator,
+    so additional Reviewer(s) may be added by the Assignee as appropriate.
     The Assignee may also be re-assigned by Maintainers.
 
 * A Reviewer can postpone the code review if CI builds fail,

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -169,7 +169,7 @@ See [Contributing to documentation related to PowerShell](#contributing-to-docum
 
 #### Pull Request - Code Review
 
-* Author, Reviewer, and Assignee of a PR
+* Roles of a PR: Author, Reviewer, and Assignee
   * Reviewer and Assignee are two separate roles of a PR.
     * A Reviewer can be anyone from the collaborators.
       A Reviewer reviews the change of a PR,

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,7 @@
+<!--
+
+If you are a [PowerShell Team](https://github.com/orgs/PowerShell/people) member, please make sure you choose the Reviewer(s) and Assignee for your PR.
+If you are not, feel free to choose them if you are familiar with the team. Or leave them blank and let maintainers choose them for you.
+For more information about the roles of Reviewer and Assignee, refer to [CONTRIBUTING.md](CONTRIBUTING.md#pull-request---code-review)
+
+-->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,7 @@
 <!--
 
 If you are a [PowerShell Team](https://github.com/orgs/PowerShell/people) member, please make sure you choose the Reviewer(s) and Assignee for your PR.
-If you are not, feel free to choose them if you are familiar with the team. Or leave them blank and let maintainers choose them for you.
+If you are not, feel free to choose them if you are familiar with the team. Alternatively, leave the fields blank and let maintainers choose them for you.
 For more information about the roles of Reviewer and Assignee, refer to [CONTRIBUTING.md](CONTRIBUTING.md#pull-request---code-review)
 
 -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,7 @@
 <!--
 
 If you are a [PowerShell Team](https://github.com/orgs/PowerShell/people) member, please make sure you choose the Reviewer(s) and Assignee for your PR.
-If you are not, feel free to choose them if you are familiar with the team. Alternatively, leave the fields blank and let maintainers choose them for you.
+If you are not part of the PowerShell Team, you can leave the fields blank and the Maintainers will choose them for you. If you are familiar with the team, feel free to add some Reviewers yourself.
 For more information about the roles of Reviewer and Assignee, refer to [CONTRIBUTING.md](CONTRIBUTING.md#pull-request---code-review)
 
 -->


### PR DESCRIPTION
Reviewer and Assignee of a PR should be separate roles.
- Reviewers do code review, and eventually approve the PR
- Assignee is a maintainer, who monitors the progress of the PR, coordinates the review process, and merges PR after it's approved.
When submitting a new PR, the author is encouraged to choose Reviewer(s) and Assignee for the PR. If either Reviewer or Assignee is left blank, maintainers will choose them for the PR.
However, for PowerShell Team members, You are **required** to choose them yourself for the PR.
**Note that**, even if you are not designated as a Reviewer for a PR, you can still feel free to jump in and review the change.

**The PR author is responsible to drive the PR to the Approved state.** The author should ping the reviewer(s) when they don't respond timely enough (or event talk to them if you can). If the review process is making no progress (or too slow), the author can always contact the Assignee to help coordinate the process, for example, if the reviewer(s) don't respond back for too long, the Assignee can review the existing comments and decide if the PR is in good state or a new reviewer should be pulled in.

A template will be added to pull request, to remind the author to choose Reviewer(s) and Assignee for the PR.