### PR TITLE
Fixed broken link in create-powershell-scripts.md

### DIFF
--- a/docs/learning-powershell/create-powershell-scripts.md
+++ b/docs/learning-powershell/create-powershell-scripts.md
@@ -29,7 +29,7 @@ Get-NetIPAddress | Where-Object {$_.AddressFamily -eq 'IPv4'} | ForEach-Object I
 ```
 As before, save the file as .\NetIP.ps1 and execute within a PowerShell environment.
 Note: If you are using Windows, make sure you set the PowerShell's execution policy to "RemoteSigned" in this case.
-See [Running PowerShell Scripts Is as Easy as 1-2-3](run-ps) for more details.
+See [Running PowerShell Scripts Is as Easy as 1-2-3][run-ps] for more details.
 
 ```PowerShell
 PS C:\> NetIP.ps1

--- a/docs/learning-powershell/create-powershell-scripts.md
+++ b/docs/learning-powershell/create-powershell-scripts.md
@@ -58,4 +58,3 @@ else {
 # Remove loopback address from output regardless of platform
 $IP | Where-Object {$_ -ne '127.0.0.1'}
 ```
-[run-ps]:http://windowsitpro.com/powershell/running-powershell-scripts-easy-1-2-3

--- a/docs/learning-powershell/create-powershell-scripts.md
+++ b/docs/learning-powershell/create-powershell-scripts.md
@@ -58,3 +58,4 @@ else {
 # Remove loopback address from output regardless of platform
 $IP | Where-Object {$_ -ne '127.0.0.1'}
 ```
+[run-ps]:http://windowsitpro.com/powershell/running-powershell-scripts-easy-1-2-3

--- a/docs/learning-powershell/create-powershell-scripts.md
+++ b/docs/learning-powershell/create-powershell-scripts.md
@@ -29,7 +29,7 @@ Get-NetIPAddress | Where-Object {$_.AddressFamily -eq 'IPv4'} | ForEach-Object I
 ```
 As before, save the file as .\NetIP.ps1 and execute within a PowerShell environment.
 Note: If you are using Windows, make sure you set the PowerShell's execution policy to "RemoteSigned" in this case.
-See [Running PowerShell Scripts Is as Easy as 1-2-3](http://windowsitpro.com/powershell/running-powershell-scripts-easy-1-2-3) for more details.
+See [Running PowerShell Scripts Is as Easy as 1-2-3](run-ps) for more details.
 
 ```PowerShell
 PS C:\> NetIP.ps1

--- a/docs/learning-powershell/create-powershell-scripts.md
+++ b/docs/learning-powershell/create-powershell-scripts.md
@@ -29,7 +29,7 @@ Get-NetIPAddress | Where-Object {$_.AddressFamily -eq 'IPv4'} | ForEach-Object I
 ```
 As before, save the file as .\NetIP.ps1 and execute within a PowerShell environment.
 Note: If you are using Windows, make sure you set the PowerShell's execution policy to "RemoteSigned" in this case.
-See [Running PowerShell Scripts Is as Easy as 1-2-3](run-ps) for more details.
+See [Running PowerShell Scripts Is as Easy as 1-2-3](http://windowsitpro.com/powershell/running-powershell-scripts-easy-1-2-3) for more details.
 
 ```PowerShell
 PS C:\> NetIP.ps1


### PR DESCRIPTION
The reference-style link `run-ps` wasn't working to redirect to the blog post, so I switched it to an inline-style.