### PR TITLE
return HTTP response for error status as part of exception

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebRequestPSCmdlet.CoreClr.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebRequestPSCmdlet.CoreClr.cs
@@ -396,7 +396,10 @@ namespace Microsoft.PowerShell.Commands
                             }
                             finally
                             {
-                                reader.Dispose();
+                                if (reader != null)
+                                {
+                                    reader.Dispose();
+                                }
                             }
                             if (!String.IsNullOrEmpty(detailMsg))
                             {
@@ -404,6 +407,7 @@ namespace Microsoft.PowerShell.Commands
                             }
                             ThrowTerminatingError(er);
                         }
+
                         ProcessResponse(response);
                         UpdateSession(response);
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebRequestPSCmdlet.CoreClr.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebRequestPSCmdlet.CoreClr.cs
@@ -391,7 +391,6 @@ namespace Microsoft.PowerShell.Commands
                         WriteVerbose(reqVerboseMsg);
 
                         HttpResponseMessage response = GetResponse(client, request);
-                        response.EnsureSuccessStatusCode();
 
                         string contentType = ContentHelper.GetContentType(response);
                         string respVerboseMsg = string.Format(CultureInfo.CurrentCulture,
@@ -399,12 +398,17 @@ namespace Microsoft.PowerShell.Commands
                             response.Content.Headers.ContentLength,
                             contentType);
                         WriteVerbose(respVerboseMsg);
+
+                        if (!response.IsSuccessStatusCode)
+                        {
                             string message = String.Format(CultureInfo.CurrentCulture, WebCmdletStrings.ResponseStatusCodeFailure,
                                 response.StatusCode.ToString(), response.ReasonPhrase);
                             HttpResponseException httpEx = new HttpResponseException(message);
                             httpEx.Response = response;
                             ErrorRecord er = new ErrorRecord(httpEx, "WebCmdletWebResponseException", ErrorCategory.InvalidOperation, request);
                             er.ErrorDetails = new ErrorDetails(message);
+                            ThrowTerminatingError(er);
+                        }
                         ProcessResponse(response);
                         UpdateSession(response);
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebRequestPSCmdlet.CoreClr.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebRequestPSCmdlet.CoreClr.cs
@@ -22,45 +22,23 @@ namespace Microsoft.PowerShell.Commands
     /// <summary>
     /// Exception class for webcmdlets to enable returning HTTP error response
     /// </summary>    
-    public class HttpResponseException : Exception
+    public sealed class HttpResponseException : Exception
     {
-        private HttpResponseMessage _response;
-        private HttpStatusCode _status;
-        private HttpResponseHeaders _headers;
-
         /// <summary>
         /// Constructor for HttpResponseException
         /// </summary>
         /// <param name="message">Message for the exception</param>
-        public HttpResponseException (string message) : base(message)
-        {}
+        /// <param name="response">Response from the HTTP server</param>
+        public HttpResponseException (string message, HttpResponseMessage response) : base(message)
+        {
+            Response = response;
+        }
 
         /// <summary>
         /// HTTP error response
         /// </summary>
-        public HttpResponseMessage Response
-        {
-            get { return _response; }
-            set { _response = value; }
-        }
+        public HttpResponseMessage Response { get; set; }
 
-        /// <summary>
-        /// HTTP error status code
-        /// </summary>
-        public HttpStatusCode Status
-        {
-            get { return _status; }
-            set { _status = value; }
-        }
-
-        /// <summary>
-        /// HTTP error headers
-        /// </summary>
-        public HttpResponseHeaders Headers
-        {
-            get { return _headers; }
-            set { _headers = value; }
-        }
     }
 
     /// <summary>
@@ -403,8 +381,7 @@ namespace Microsoft.PowerShell.Commands
                         {
                             string message = String.Format(CultureInfo.CurrentCulture, WebCmdletStrings.ResponseStatusCodeFailure,
                                 response.StatusCode.ToString(), response.ReasonPhrase);
-                            HttpResponseException httpEx = new HttpResponseException(message);
-                            httpEx.Response = response;
+                            HttpResponseException httpEx = new HttpResponseException(message, response);
                             ErrorRecord er = new ErrorRecord(httpEx, "WebCmdletWebResponseException", ErrorCategory.InvalidOperation, request);
                             er.ErrorDetails = new ErrorDetails(message);
                             ThrowTerminatingError(er);

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebRequestPSCmdlet.CoreClr.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebRequestPSCmdlet.CoreClr.cs
@@ -20,6 +20,50 @@ using System.Xml;
 namespace Microsoft.PowerShell.Commands
 {
     /// <summary>
+    /// Exception class for webcmdlets to enable returning HTTP error response
+    /// </summary>    
+    public class HttpResponseException : Exception
+    {
+        private HttpResponseMessage _response;
+        private HttpStatusCode _status;
+        private HttpResponseHeaders _headers;
+
+        /// <summary>
+        /// Constructor for HttpResponseException
+        /// </summary>
+        /// <param name="message">Message for the exception</param>
+        public HttpResponseException (string message) : base(message)
+        {}
+
+        /// <summary>
+        /// HTTP error response
+        /// </summary>
+        public HttpResponseMessage Response
+        {
+            get { return _response; }
+            set { _response = value; }
+        }
+
+        /// <summary>
+        /// HTTP error status code
+        /// </summary>
+        public HttpStatusCode Status
+        {
+            get { return _status; }
+            set { _status = value; }
+        }
+
+        /// <summary>
+        /// HTTP error headers
+        /// </summary>
+        public HttpResponseHeaders Headers
+        {
+            get { return _headers; }
+            set { _headers = value; }
+        }
+    }
+
+    /// <summary>
     /// Base class for Invoke-RestMethod and Invoke-WebRequest commands.
     /// </summary>
     public abstract partial class WebRequestPSCmdlet : PSCmdlet
@@ -355,6 +399,12 @@ namespace Microsoft.PowerShell.Commands
                             response.Content.Headers.ContentLength,
                             contentType);
                         WriteVerbose(respVerboseMsg);
+                            string message = String.Format(CultureInfo.CurrentCulture, WebCmdletStrings.ResponseStatusCodeFailure,
+                                response.StatusCode.ToString(), response.ReasonPhrase);
+                            HttpResponseException httpEx = new HttpResponseException(message);
+                            httpEx.Response = response;
+                            ErrorRecord er = new ErrorRecord(httpEx, "WebCmdletWebResponseException", ErrorCategory.InvalidOperation, request);
+                            er.ErrorDetails = new ErrorDetails(message);
                         ProcessResponse(response);
                         UpdateSession(response);
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebRequestPSCmdlet.CoreClr.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebRequestPSCmdlet.CoreClr.cs
@@ -379,16 +379,26 @@ namespace Microsoft.PowerShell.Commands
                         if (!response.IsSuccessStatusCode)
                         {
                             string message = String.Format(CultureInfo.CurrentCulture, WebCmdletStrings.ResponseStatusCodeFailure,
-                                Convert.ToInt32(response.StatusCode).ToString(), response.ReasonPhrase);
+                                (int)response.StatusCode, response.ReasonPhrase);
                             HttpResponseException httpEx = new HttpResponseException(message, response);
                             ErrorRecord er = new ErrorRecord(httpEx, "WebCmdletWebResponseException", ErrorCategory.InvalidOperation, request);
                             string detailMsg = "";
-                            using (StreamReader reader = new StreamReader(StreamHelper.GetResponseStream(response)))
+                            try
                             {
-                                // remove HTML tags making it easier to read
-                                detailMsg = System.Text.RegularExpressions.Regex.Replace(reader.ReadToEnd(), "<[^>]*>","");
+                                using (StreamReader reader = new StreamReader(StreamHelper.GetResponseStream(response)))
+                                {
+                                    // remove HTML tags making it easier to read
+                                    detailMsg = System.Text.RegularExpressions.Regex.Replace(reader.ReadToEnd(), "<[^>]*>","");
+                                }
                             }
-                            er.ErrorDetails = new ErrorDetails(detailMsg);
+                            catch (Exception)
+                            {
+                                // catch all
+                            }
+                            if (!String.IsNullOrEmpty(detailMsg))
+                            {
+                                er.ErrorDetails = new ErrorDetails(detailMsg);
+                            }
                             ThrowTerminatingError(er);
                         }
                         ProcessResponse(response);

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/WebCmdletStrings.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/WebCmdletStrings.resx
@@ -210,4 +210,7 @@
   <data name="JsonDeserializationFailed" xml:space="preserve">
     <value>Conversion from JSON failed with error: {0}</value>
   </data>
+  <data name="ResponseStatusCodeFailure" xml:space="preserve">
+    <value>Response status code does not indicate success: {0} ({1}).</value>
+  </data>
 </root>

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -399,6 +399,11 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
         $result = ExecuteWebCommand -command $command
         $result.Error | Should BeNullOrEmpty
     }
+        $result.Error.Exception | Should BeOfType Microsoft.PowerShell.Commands.HttpResponseException
+        $result.Error.Exception.Response.StatusCode | Should Be 418
+        $result.Error.Exception.Response.ReasonPhrase | Should Be "I'm a teapot"
+        $result.Error.Exception.Message | Should Be "Response status code does not indicate success: 418 (I'm a teapot)."
+        $result.Error.FullyQualifiedErrorId | Should Be "WebCmdletWebResponseException,Microsoft.PowerShell.Commands.InvokeWebRequestCommand"
 }
 
 Describe "Invoke-RestMethod tests" -Tags "Feature" {
@@ -642,6 +647,11 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
         $result = ExecuteWebCommand -command $command
         $result.Error | Should BeNullOrEmpty
     }
+        $result.Error.Exception | Should BeOfType Microsoft.PowerShell.Commands.HttpResponseException
+        $result.Error.Exception.Response.StatusCode | Should Be 418
+        $result.Error.Exception.Response.ReasonPhrase | Should Be "I'm a teapot"
+        $result.Error.Exception.Message | Should Be "Response status code does not indicate success: 418 (I'm a teapot)."
+        $result.Error.FullyQualifiedErrorId | Should Be "WebCmdletWebResponseException,Microsoft.PowerShell.Commands.InvokeRestMethodCommand"
 }
 
 Describe "Validate Invoke-WebRequest and Invoke-RestMethod -InFile" -Tags "Feature" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -399,6 +399,18 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
         $result = ExecuteWebCommand -command $command
         $result.Error | Should BeNullOrEmpty
     }
+
+    It "Validate Invoke-WebRequest returns HTTP errors in exception" {
+
+        $command = "Invoke-WebRequest -Uri http://httpstat.us/418"
+        $result = ExecuteWebCommand -command $command
+
+        $result.Error.Exception | Should BeOfType Microsoft.PowerShell.Commands.HttpResponseException
+        $result.Error.Exception.Response.StatusCode | Should Be 418
+        $result.Error.Exception.Response.ReasonPhrase | Should Be "I'm a teapot"
+        $result.Error.Exception.Message | Should Be "Response status code does not indicate success: 418 (I'm a teapot)."
+        $result.Error.FullyQualifiedErrorId | Should Be "WebCmdletWebResponseException,Microsoft.PowerShell.Commands.InvokeWebRequestCommand"
+    }
 }
 
 Describe "Invoke-RestMethod tests" -Tags "Feature" {
@@ -641,6 +653,17 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
         $command = "Invoke-RestMethod -Uri 'http://httpbin.org/encoding/utf8'"
         $result = ExecuteWebCommand -command $command
         $result.Error | Should BeNullOrEmpty
+    }
+
+    It "Validate Invoke-RestMethod returns HTTP errors in exception" {
+
+        $command = "Invoke-RestMethod -Uri http://httpstat.us/418"
+        $result = ExecuteWebCommand -command $command
+        $result.Error.Exception | Should BeOfType Microsoft.PowerShell.Commands.HttpResponseException
+        $result.Error.Exception.Response.StatusCode | Should Be 418
+        $result.Error.Exception.Response.ReasonPhrase | Should Be "I'm a teapot"
+        $result.Error.Exception.Message | Should Be "Response status code does not indicate success: 418 (I'm a teapot)."
+        $result.Error.FullyQualifiedErrorId | Should Be "WebCmdletWebResponseException,Microsoft.PowerShell.Commands.InvokeRestMethodCommand"
     }
 }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -399,11 +399,18 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
         $result = ExecuteWebCommand -command $command
         $result.Error | Should BeNullOrEmpty
     }
+
+    It "Validate Invoke-WebRequest returns HTTP errors in exception" {
+
+        $command = "Invoke-WebRequest -Uri http://httpstat.us/418"
+        $result = ExecuteWebCommand -command $command
+
         $result.Error.Exception | Should BeOfType Microsoft.PowerShell.Commands.HttpResponseException
         $result.Error.Exception.Response.StatusCode | Should Be 418
         $result.Error.Exception.Response.ReasonPhrase | Should Be "I'm a teapot"
         $result.Error.Exception.Message | Should Be "Response status code does not indicate success: 418 (I'm a teapot)."
         $result.Error.FullyQualifiedErrorId | Should Be "WebCmdletWebResponseException,Microsoft.PowerShell.Commands.InvokeWebRequestCommand"
+    }
 }
 
 Describe "Invoke-RestMethod tests" -Tags "Feature" {
@@ -647,11 +654,17 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
         $result = ExecuteWebCommand -command $command
         $result.Error | Should BeNullOrEmpty
     }
+
+    It "Validate Invoke-RestMethod returns HTTP errors in exception" {
+
+        $command = "Invoke-RestMethod -Uri http://httpstat.us/418"
+        $result = ExecuteWebCommand -command $command
         $result.Error.Exception | Should BeOfType Microsoft.PowerShell.Commands.HttpResponseException
         $result.Error.Exception.Response.StatusCode | Should Be 418
         $result.Error.Exception.Response.ReasonPhrase | Should Be "I'm a teapot"
         $result.Error.Exception.Message | Should Be "Response status code does not indicate success: 418 (I'm a teapot)."
         $result.Error.FullyQualifiedErrorId | Should Be "WebCmdletWebResponseException,Microsoft.PowerShell.Commands.InvokeRestMethodCommand"
+    }
 }
 
 Describe "Validate Invoke-WebRequest and Invoke-RestMethod -InFile" -Tags "Feature" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -402,9 +402,10 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
 
     It "Validate Invoke-WebRequest returns HTTP errors in exception" {
 
-        $command = "Invoke-WebRequest -Uri http://httpstat.us/418"
+        $command = "Invoke-WebRequest -Uri http://httpbin.org/status/418"
         $result = ExecuteWebCommand -command $command
 
+        $result.Error.ErrorDetails.Message | Should Match "\-=\[ teapot \]"
         $result.Error.Exception | Should BeOfType Microsoft.PowerShell.Commands.HttpResponseException
         $result.Error.Exception.Response.StatusCode | Should Be 418
         $result.Error.Exception.Response.ReasonPhrase | Should Be "I'm a teapot"
@@ -657,8 +658,10 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
 
     It "Validate Invoke-RestMethod returns HTTP errors in exception" {
 
-        $command = "Invoke-RestMethod -Uri http://httpstat.us/418"
+        $command = "Invoke-RestMethod -Uri http://httpbin.org/status/418"
         $result = ExecuteWebCommand -command $command
+
+        $result.Error.ErrorDetails.Message | Should Match "\-=\[ teapot \]"
         $result.Error.Exception | Should BeOfType Microsoft.PowerShell.Commands.HttpResponseException
         $result.Error.Exception.Response.StatusCode | Should Be 418
         $result.Error.Exception.Response.ReasonPhrase | Should Be "I'm a teapot"

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -409,7 +409,7 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
         $result.Error.Exception | Should BeOfType Microsoft.PowerShell.Commands.HttpResponseException
         $result.Error.Exception.Response.StatusCode | Should Be 418
         $result.Error.Exception.Response.ReasonPhrase | Should Be "I'm a teapot"
-        $result.Error.Exception.Message | Should Be "Response status code does not indicate success: 418 (I'm a teapot)."
+        $result.Error.Exception.Message | Should Match ": 418 \(I'm a teapot\)\."
         $result.Error.FullyQualifiedErrorId | Should Be "WebCmdletWebResponseException,Microsoft.PowerShell.Commands.InvokeWebRequestCommand"
     }
 }
@@ -665,7 +665,7 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
         $result.Error.Exception | Should BeOfType Microsoft.PowerShell.Commands.HttpResponseException
         $result.Error.Exception.Response.StatusCode | Should Be 418
         $result.Error.Exception.Response.ReasonPhrase | Should Be "I'm a teapot"
-        $result.Error.Exception.Message | Should Be "Response status code does not indicate success: 418 (I'm a teapot)."
+        $result.Error.Exception.Message | Should Match ": 418 \(I'm a teapot\)\."
         $result.Error.FullyQualifiedErrorId | Should Be "WebCmdletWebResponseException,Microsoft.PowerShell.Commands.InvokeRestMethodCommand"
     }
 }


### PR DESCRIPTION
Addresses #2193 

When Invoke-WebRequest or Invoke-RestMethod receives a HTTS status error code, an exception is returned and the user can't get the HTTP response without additional work.  This change makes it more consistent with Windows PowerShell in that a Response property which contains the HttpResponse is a member of the resulting Exception.