### PR TITLE
Fix for race bug in WSMan command plugin instance close operation

### DIFF
--- a/src/System.Management.Automation/engine/remoting/fanin/WSManPlugin.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/WSManPlugin.cs
@@ -473,15 +473,13 @@ namespace System.Management.Automation.Remoting
                 return;
             }
 
-            SetThreadProperties(mgdShellSession.creationRequestDetails);
             // update the internal data store only if this is not receive operation.
             if (!context.isReceiveOperation)
             {
                 DeleteFromActiveShellSessions(context.shellContext);
             }
 
-            string errorMsg = StringUtil.Format(RemotingErrorIdStrings.WSManPluginOperationClose);
-            System.Exception reasonForClose = new System.Exception(errorMsg);
+            System.Exception reasonForClose = new System.Exception(RemotingErrorIdStrings.WSManPluginOperationClose);
             mgdShellSession.CloseOperation(context, reasonForClose);
         }
 
@@ -502,7 +500,7 @@ namespace System.Management.Automation.Remoting
                 //Dbg.Assert(false, "context.shellContext not matched");
                 return;
             }
-            SetThreadProperties(mgdShellSession.creationRequestDetails);
+
             mgdShellSession.CloseCommandOperation(context);
         }
 

--- a/src/System.Management.Automation/engine/remoting/fanin/WSManPluginShellSession.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/WSManPluginShellSession.cs
@@ -698,6 +698,8 @@ namespace System.Management.Automation.Remoting
                 }
             }
 
+            WSManPluginInstance.SetThreadProperties(creationRequestDetails);
+
             bool isRcvOpShuttingDown = (context.isShuttingDown) && (context.isReceiveOperation);
             bool isRcvOp = context.isReceiveOperation;
             bool isShuttingDown = context.isShuttingDown;
@@ -796,6 +798,8 @@ namespace System.Management.Automation.Remoting
                     isClosed = true;
                 }
             }
+
+            WSManPluginInstance.SetThreadProperties(creationRequestDetails);
 
             bool isRcvOp = context.isReceiveOperation;
             // only one thread will be here.


### PR DESCRIPTION
This fixes a rare race condition that can crash the WinRM service when remote sessions are closing.
From the crash stack dump it is clear that the exception comes from a SetThreadProperties call that references an invalid unmanaged data handle which was previously released.  The data handle is released when the plugin command instance is closed and the error occurs when two threads contend to close the same object.

The close command and close session operations are designed to be multi-thread safe, but the SetThreadProperties call is done before the atomic check is performed.  The fix is to move the SetThreadProperties call after the atomic check to ensure it is only called when the object is in the opened state.