### PR TITLE
Fix powershell to not crash on converting recursive array to bool

### DIFF
--- a/src/System.Management.Automation/engine/LanguagePrimitives.cs
+++ b/src/System.Management.Automation/engine/LanguagePrimitives.cs
@@ -935,7 +935,7 @@ namespace System.Management.Automation
                     // but since we don't want this to recurse indefinitely
                     // we explicitly check the case where it would recurse
                     // and deal with it.
-                    IList firstElement = objectArray[0] as IList;
+                    IList firstElement = PSObject.Base(objectArray[0]) as IList;
 
                     if (firstElement == null)
                     {

--- a/test/powershell/engine/Api/LanguagePrimitive.Tests.ps1
+++ b/test/powershell/engine/Api/LanguagePrimitive.Tests.ps1
@@ -25,4 +25,9 @@
         $ObjArray = [System.Management.Automation.LanguagePrimitives]::ConvertTo($col, [object[]])
         $ObjArray.Length | Should Be $col.Count
     }
+
+    It "Casting recursive array to bool should not cause crash" {
+        $a[0] = $a = [PSObject](,1)
+        [System.Management.Automation.LanguagePrimitives]::IsTrue($a) | Should Be $true
+    }
 }


### PR DESCRIPTION
Fixing #3207