### PR TITLE
Updated docker release images to pull powershell package from Microsoft Repo

### DIFF
--- a/docker/release/centos7/Dockerfile
+++ b/docker/release/centos7/Dockerfile
@@ -14,11 +14,12 @@ RUN yum install -y \
     && yum clean all
 
 # Download and configure Microsoft Repository config file
-RUN curl https://packages.microsoft.com/config/rhel/7/prod.repo > /etc/yum.repos.d/microsoft.repo
+RUN curl https://packages.microsoft.com/config/rhel/7/prod.repo | tee /etc/yum.repos.d/microsoft.repo
 
 # Install latest powershell from Microsoft YUM Repo
 RUN yum install -y \
         powershell
 
 # Use PowerShell as the default shell
+# Use array to avoid Docker prepending /bin/sh -c
 ENTRYPOINT [ "powershell" ]

--- a/docker/release/centos7/Dockerfile
+++ b/docker/release/centos7/Dockerfile
@@ -1,8 +1,7 @@
-FROM centos:7
-MAINTAINER Andrew Schwartzmeyer <andschwa@microsoft.com>
+# Docker image file that describes an Centos7 image with PowerShell installed from Microsoft YUM Repo
 
-ARG POWERSHELL_RELEASE=v6.0.0-alpha.16
-ARG POWERSHELL_PACKAGE=powershell-6.0.0_alpha.16-1.el7.centos.x86_64.rpm
+FROM centos:7
+MAINTAINER Raghu Shantha <raghus@microsoft.com>
 
 # Setup the locale
 ENV LANG en_US.UTF-8
@@ -10,27 +9,16 @@ ENV LC_ALL $LANG
 RUN localedef --charmap=UTF-8 --inputfile=en_US $LANG
 
 # Install dependencies and clean up
-RUN yum install -y \
-        glibc \
-        libcurl \
-        ca-certificates \
-        libgcc \
-        libicu \
-        openssl \
-        libstdc++ \
-        ncurses-base \
-        libunwind \
-        uuid \
-        zlib \
-        which \
+RUN yum install -y \       
         curl \
-        git \
     && yum clean all
 
-# Install PowerShell package and clean up
-RUN curl -SLO https://github.com/PowerShell/PowerShell/releases/download/$POWERSHELL_RELEASE/$POWERSHELL_PACKAGE \
-    && yum install -y $POWERSHELL_PACKAGE \
-    && rm $POWERSHELL_PACKAGE
+# Download and configure Microsoft Repository config file
+RUN curl https://packages.microsoft.com/config/rhel/7/prod.repo > /etc/yum.repos.d/microsoft.repo
 
-# Use array to avoid Docker prepending /bin/sh -c
+# Install latest powershell from Microsoft YUM Repo
+RUN yum install -y \
+        powershell
+
+# Use PowerShell as the default shell
 ENTRYPOINT [ "powershell" ]

--- a/docker/release/ubuntu14.04/Dockerfile
+++ b/docker/release/ubuntu14.04/Dockerfile
@@ -11,10 +11,10 @@ RUN locale-gen $LANG && update-locale
 # Install dependencies and clean up
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-		apt-utils \
-		ca-certificates \		
-		curl \       
-		apt-transport-https \		
+        apt-utils \
+        ca-certificates \
+        curl \
+        apt-transport-https \	
     && rm -rf /var/lib/apt/lists/*
 
 # Import the public repository GPG keys for Microsoft

--- a/docker/release/ubuntu14.04/Dockerfile
+++ b/docker/release/ubuntu14.04/Dockerfile
@@ -1,8 +1,7 @@
-FROM ubuntu:trusty
-MAINTAINER Andrew Schwartzmeyer <andschwa@microsoft.com>
+# Docker image file that describes an Ubuntu14.04 image with PowerShell installed from Microsoft APT Repo
 
-ARG POWERSHELL_RELEASE=v6.0.0-alpha.16
-ARG POWERSHELL_PACKAGE=powershell_6.0.0-alpha.16-1ubuntu1.14.04.1_amd64.deb
+FROM ubuntu:trusty
+MAINTAINER Raghu Shantha <raghus@microsoft.com>
 
 # Setup the locale
 ENV LANG en_US.UTF-8
@@ -12,25 +11,22 @@ RUN locale-gen $LANG && update-locale
 # Install dependencies and clean up
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-        libc6 \
-        libcurl3 \
-        ca-certificates \
-        libgcc1 \
-        libicu52 \
-        libssl1.0.0 \
-        libstdc++6 \
-        libtinfo5 \
-        libunwind8 \
-        libuuid1 \
-        zlib1g \
-        curl \
-        git \
+		apt-utils \
+		ca-certificates \		
+		curl \       
+		apt-transport-https \		
     && rm -rf /var/lib/apt/lists/*
 
-# Install PowerShell package and clean up
-RUN curl -SLO https://github.com/PowerShell/PowerShell/releases/download/$POWERSHELL_RELEASE/$POWERSHELL_PACKAGE \
-    && dpkg -i $POWERSHELL_PACKAGE \
-    && rm $POWERSHELL_PACKAGE
+# Import the public repository GPG keys for Microsoft
+RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
+	
+# Register the Microsoft Ubuntu 14.04 repository
+RUN curl https://packages.microsoft.com/config/ubuntu/14.04/prod.list | tee /etc/apt/sources.list.d/microsoft.list
 
-# Use array to avoid Docker prepending /bin/sh -c
+# Install powershell from Microsoft Repo
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+	powershell
+
+# Use PowerShell as the default shell
 ENTRYPOINT [ "powershell" ]

--- a/docker/release/ubuntu14.04/Dockerfile
+++ b/docker/release/ubuntu14.04/Dockerfile
@@ -29,4 +29,5 @@ RUN apt-get update \
 	powershell
 
 # Use PowerShell as the default shell
+# Use array to avoid Docker prepending /bin/sh -c
 ENTRYPOINT [ "powershell" ]

--- a/docker/release/ubuntu16.04/Dockerfile
+++ b/docker/release/ubuntu16.04/Dockerfile
@@ -11,16 +11,16 @@ RUN locale-gen $LANG && update-locale
 # Install dependencies and clean up
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-		apt-utils \
-		ca-certificates \
-		curl \
-		apt-transport-https \	
+        apt-utils \
+        ca-certificates \
+        curl \
+        apt-transport-https \	
     && rm -rf /var/lib/apt/lists/*
     
 # Import the public repository GPG keys for Microsoft
 RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
 	
-# Register the Microsoft Ubuntu 14.04 repository
+# Register the Microsoft Ubuntu 16.04 repository
 RUN curl https://packages.microsoft.com/config/ubuntu/16.04/prod.list | tee /etc/apt/sources.list.d/microsoft.list
 
 # Install powershell from Microsoft Repo

--- a/docker/release/ubuntu16.04/Dockerfile
+++ b/docker/release/ubuntu16.04/Dockerfile
@@ -1,8 +1,7 @@
-FROM ubuntu:xenial
-MAINTAINER Andrew Schwartzmeyer <andschwa@microsoft.com>
+# Docker image file that describes an Ubuntu16.04 image with PowerShell installed from Microsoft APT Repo
 
-ARG POWERSHELL_RELEASE=v6.0.0-alpha.16
-ARG POWERSHELL_PACKAGE=powershell_6.0.0-alpha.16-1ubuntu1.16.04.1_amd64.deb
+FROM ubuntu:xenial
+MAINTAINER Raghu Shantha <raghus@microsoft.com>
 
 # Setup the locale
 ENV LANG en_US.UTF-8
@@ -12,25 +11,22 @@ RUN locale-gen $LANG && update-locale
 # Install dependencies and clean up
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-        libc6 \
-        libcurl3 \
-        ca-certificates \
-        libgcc1 \
-        libicu55 \
-        libssl1.0.0 \
-        libstdc++6 \
-        libtinfo5 \
-        libunwind8 \
-        libuuid1 \
-        zlib1g \
-        curl \
-        git \
+		apt-utils \
+		ca-certificates \
+		curl \
+		apt-transport-https \	
     && rm -rf /var/lib/apt/lists/*
+    
+# Import the public repository GPG keys for Microsoft
+RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
+	
+# Register the Microsoft Ubuntu 14.04 repository
+RUN curl https://packages.microsoft.com/config/ubuntu/16.04/prod.list | tee /etc/apt/sources.list.d/microsoft.list
 
-# Install PowerShell package and clean up
-RUN curl -SLO https://github.com/PowerShell/PowerShell/releases/download/$POWERSHELL_RELEASE/$POWERSHELL_PACKAGE \
-    && dpkg -i $POWERSHELL_PACKAGE \
-    && rm $POWERSHELL_PACKAGE
+# Install powershell from Microsoft Repo
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+	powershell
 
-# Use array to avoid Docker prepending /bin/sh -c
+# Use PowerShell as the default shell
 ENTRYPOINT [ "powershell" ]

--- a/docker/release/ubuntu16.04/Dockerfile
+++ b/docker/release/ubuntu16.04/Dockerfile
@@ -29,4 +29,5 @@ RUN apt-get update \
 	powershell
 
 # Use PowerShell as the default shell
+# Use array to avoid Docker prepending /bin/sh -c
 ENTRYPOINT [ "powershell" ]


### PR DESCRIPTION
This change enables docker images to be populated with latest powershell from Microsoft YUM/APT repos,
instead of pulling the release from GitHub.

Now there is no need to update the image for every release. We only need to publish the package to MS Repo.

(Note: This change does not include Fedora. I will update the Fedora dockerfile after https://github.com/PowerShell/PowerShell/issues/1882 is taken care of)