### PR TITLE
Allow PowerShell to start even if Data, Home, and Cache folders cannot be created

### DIFF
--- a/src/System.Management.Automation/CoreCLR/CorePsPlatform.cs
+++ b/src/System.Management.Automation/CoreCLR/CorePsPlatform.cs
@@ -261,7 +261,14 @@ namespace System.Management.Automation
                         // create the xdg folder if needed
                         if (!Directory.Exists(xdgDataHomeDefault))
                         {
-                            Directory.CreateDirectory(xdgDataHomeDefault);
+                            try
+                            {
+                                Directory.CreateDirectory(xdgDataHomeDefault);
+                            }
+                            catch (UnauthorizedAccessException)
+                            {
+                                //service accounts won't have permission to create user folder
+                            }
                         }
                         return xdgDataHomeDefault;
                     }
@@ -277,7 +284,14 @@ namespace System.Management.Automation
                         //xdg values have not been set
                         if (!Directory.Exists(xdgModuleDefault)) //module folder not always guaranteed to exist
                         {
-                            Directory.CreateDirectory(xdgModuleDefault);
+                            try
+                            {
+                                Directory.CreateDirectory(xdgModuleDefault);
+                            }
+                            catch (UnauthorizedAccessException)
+                            {
+                                //service accounts won't have permission to create user folder
+                            }
                         }
                         return xdgModuleDefault;
                     }
@@ -296,7 +310,14 @@ namespace System.Management.Automation
                         //xdg values have not been set
                         if (!Directory.Exists(xdgCacheDefault)) //module folder not always guaranteed to exist
                         {
-                            Directory.CreateDirectory(xdgCacheDefault);
+                            try
+                            {
+                                Directory.CreateDirectory(xdgCacheDefault);
+                            }
+                            catch (UnauthorizedAccessException)
+                            {
+                                //service accounts won't have permission to create user folder
+                            }
                         }
 
                         return xdgCacheDefault;
@@ -306,7 +327,14 @@ namespace System.Management.Automation
                     {
                         if (!Directory.Exists(Path.Combine(xdgcachehome, "powershell")))
                         {
-                            Directory.CreateDirectory(Path.Combine(xdgcachehome, "powershell"));
+                            try
+                            {
+                                Directory.CreateDirectory(Path.Combine(xdgcachehome, "powershell"));
+                            }
+                            catch (UnauthorizedAccessException)
+                            {
+                                //service accounts won't have permission to create user folder
+                            }                                
                         }
 
                         return Path.Combine(xdgcachehome, "powershell");

--- a/test/powershell/Host/ConsoleHost.Tests.ps1
+++ b/test/powershell/Host/ConsoleHost.Tests.ps1
@@ -381,6 +381,28 @@ foo
             }
         }
     }
+
+    Context "Data, Config, and Cache locations" {
+        BeforeEach {
+            $XDG_CACHE_HOME = $env:XDG_CACHE_HOME
+            $XDG_DATA_HOME = $env:XDG_DATA_HOME
+            $XDG_CONFIG_HOME = $env:XDG_CONFIG_HOME
+        }
+
+        AfterEach {
+            $env:XDG_CACHE_HOME = $XDG_CACHE_HOME
+            $env:XDG_DATA_HOME = $XDG_DATA_HOME
+            $env:XDG_CONFIG_HOME = $XDG_CONFIG_HOME            
+        }
+
+        It "Should start if Data, Config, and Cache location is not accessible" -skip:($IsWindows) {
+            $env:XDG_CACHE_HOME = "/dev/cpu"
+            $env:XDG_DATA_HOME = "/dev/cpu"
+            $env:XDG_CONFIG_HOME = "/dev/cpu"
+            $output = & powershell -noprofile -Command { (get-command).count }
+            [int]$output | Should BeGreaterThan 0
+        }
+    }
 }
 
 Describe "Console host api tests" -Tag CI {


### PR DESCRIPTION
Allow Directory Creation failures to continue for Service Account use scenarios that don't have home directories

addresses https://github.com/PowerShell/PowerShell/issues/3011
