### PR TITLE
Fix New-LocalUser cmdlet to roll back user in case of user attributes assignment failure.

### DIFF
--- a/src/Microsoft.PowerShell.LocalAccounts/LocalAccounts/Sam.cs
+++ b/src/Microsoft.PowerShell.LocalAccounts/LocalAccounts/Sam.cs
@@ -1271,6 +1271,14 @@ namespace System.Management.Automation.SecurityAccountsManager
                                             },
                                             userHandle);
             }
+            catch (Exception)
+            {
+                if (IntPtr.Zero != userHandle)
+                {
+                    SamApi.SamDeleteUser(userHandle);
+                }
+                throw;
+            }
             finally
             {
                 if (buffer != IntPtr.Zero)

--- a/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalUser.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalUser.Tests.ps1
@@ -348,6 +348,17 @@ try {
             VerifyFailingTest $sb "InvalidPassword,Microsoft.PowerShell.Commands.NewLocalUserCommand"
         }
 
+        It "User should not be created when invalid password is provided" {
+            $sb = {
+                New-LocalUser TestUserNew1 -Password (ConvertTo-SecureString ("A"*257) -AsPlainText -Force)
+            }
+            VerifyFailingTest $sb "InvalidPassword,Microsoft.PowerShell.Commands.NewLocalUserCommand"
+            $sb1 = {
+                Get-LocalUser TestUserNew1
+            }
+            VerifyFailingTest $sb1 "UserNotFound,Microsoft.PowerShell.Commands.GetLocalUserCommand"
+        }
+
         It "Can set UserMayNotChangePassword" {
             $result = New-LocalUser TestUserNew1 -NoPassword -UserMayNotChangePassword
 


### PR DESCRIPTION
Resolving #3242

At this point, user account is created even if some error happens while
user attributes assignment (like setting password). The cmdlet throws a
non-terminating error but ends up creating the user. This behavior is
confusing. As per the changes, the localuser account will be rolled back
if there is any error in user attributes assignment.

