### PR TITLE
Do not reject Windows' reserved device names on non-Windows platforms.

### DIFF
--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -1110,6 +1110,7 @@ namespace System.Management.Automation
 
         internal static bool IsReservedDeviceName(string destinationPath)
         {
+#if !UNIX
             string[] reservedDeviceNames = { "CON", "PRN", "AUX", "CLOCK$", "NUL",
                                              "COM0", "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9",
                                              "LPT0", "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9" };
@@ -1133,7 +1134,7 @@ namespace System.Management.Automation
                     return true;
                 }
             }
-
+#endif
             return false;
         }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
@@ -1,3 +1,4 @@
+Import-Module $PSScriptRoot\..\..\Common\Test.Helpers.psm1
 Describe "Basic FileSystem Provider Tests" -Tags "CI" {
     BeforeAll {
         $testDir = "TestDir"
@@ -20,6 +21,10 @@ Describe "Basic FileSystem Provider Tests" -Tags "CI" {
             $newTestFile = "NewTestFile.txt"
             $testContent = "Some Content"
             $testContent2 = "More Content"
+            $tempFile = $testFile + ".tmp"
+            $reservedNames = "CON", "PRN", "AUX", "CLOCK$", "NUL",
+                             "COM0", "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9",
+                             "LPT0", "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9"
         }
 
         BeforeEach {
@@ -103,6 +108,55 @@ Describe "Basic FileSystem Provider Tests" -Tags "CI" {
             $contentBefore.Count | Should Be 1
             $contentAfter.Count | Should Be 0
         }
+
+         It "Copy-Item on Windows rejects Windows reserved device names" -Skip:(-not $IsWindows) {
+             foreach ($deviceName in $reservedNames)
+             {
+                { Copy-Item -Path $testFile -Destination $deviceName -ErrorAction Stop } | ShouldBeErrorId "CopyError,Microsoft.PowerShell.Commands.CopyItemCommand"
+             }
+         }
+
+         It "Move-Item on Windows rejects Windows reserved device names" -Skip:(-not $IsWindows) {
+             foreach ($deviceName in $reservedNames)
+             {
+                { Move-Item -Path $testFile -Destination $deviceName -ErrorAction Stop } | ShouldBeErrorId "MoveError,Microsoft.PowerShell.Commands.MoveItemCommand"
+             }
+         }
+
+         It "Rename-Item on Windows rejects Windows reserved device names" -Skip:(-not $IsWindows) {
+             foreach ($deviceName in $reservedNames)
+             {
+                { Rename-Item -Path $testFile -NewName $deviceName -ErrorAction Stop } | ShouldBeErrorId "RenameError,Microsoft.PowerShell.Commands.RenameItemCommand"
+             }
+         }
+
+         It "Copy-Item on Unix succeeds with Windows reserved device names" -Skip:($IsWindows) {
+             foreach ($deviceName in $reservedNames)
+             {
+                Copy-Item -Path $testFile -Destination $deviceName -Force -ErrorAction SilentlyContinue
+                Test-Path $deviceName | Should Be $true
+             }
+         }
+
+         It "Move-Item on Unix succeeds with Windows reserved device names" -Skip:($IsWindows) {
+             foreach ($deviceName in $reservedNames)
+             {
+                Copy-Item -Path $testFile -Destination $tempFile -Force
+                Move-Item -Path $testFile -Destination $deviceName -Force -ErrorAction SilentlyContinue
+                Test-Path $deviceName | Should Be $true
+                Rename-Item -Path $tempFile -NewName $testFile
+             }
+         }
+
+         It "Rename-Item on Unix succeeds with Windows reserved device names" -Skip:($IsWindows) {
+             foreach ($deviceName in $reservedNames)
+             {
+                Copy-Item -Path $testFile -Destination $tempFile -Force
+                Rename-Item -Path $testFile -NewName $deviceName -Force -ErrorAction SilentlyContinue
+                Test-Path $deviceName | Should Be $true
+                Rename-Item -Path $tempFile -NewName $testFile
+             }
+         }
     }
 
     Context "Validate basic host navigation functionality" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
@@ -21,7 +21,6 @@ Describe "Basic FileSystem Provider Tests" -Tags "CI" {
             $newTestFile = "NewTestFile.txt"
             $testContent = "Some Content"
             $testContent2 = "More Content"
-            $tempFile = $testFile + ".tmp"
             $reservedNames = "CON", "PRN", "AUX", "CLOCK$", "NUL",
                              "COM0", "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9",
                              "LPT0", "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9"
@@ -141,20 +140,18 @@ Describe "Basic FileSystem Provider Tests" -Tags "CI" {
          It "Move-Item on Unix succeeds with Windows reserved device names" -Skip:($IsWindows) {
              foreach ($deviceName in $reservedNames)
              {
-                Copy-Item -Path $testFile -Destination $tempFile -Force
                 Move-Item -Path $testFile -Destination $deviceName -Force -ErrorAction SilentlyContinue
                 Test-Path $deviceName | Should Be $true
-                Rename-Item -Path $tempFile -NewName $testFile
+                New-Item -Path $testFile -ItemType File -Force -ErrorAction SilentlyContinue
              }
          }
 
          It "Rename-Item on Unix succeeds with Windows reserved device names" -Skip:($IsWindows) {
              foreach ($deviceName in $reservedNames)
              {
-                Copy-Item -Path $testFile -Destination $tempFile -Force
                 Rename-Item -Path $testFile -NewName $deviceName -Force -ErrorAction SilentlyContinue
                 Test-Path $deviceName | Should Be $true
-                Rename-Item -Path $tempFile -NewName $testFile
+                New-Item -Path $testFile -ItemType File -Force -ErrorAction SilentlyContinue
              }
          }
     }


### PR DESCRIPTION
Fixes #3221
