### PR TITLE
changed default encoding to Windows-1252 

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/ContentHelper.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/ContentHelper.Common.cs
@@ -17,6 +17,8 @@ namespace Microsoft.PowerShell.Commands
         private static readonly char[] s_contentTypeParamSeparator = { ';' };
 
         // default codepage encoding for web content.  See RFC 2616.
+        // since HTML5 which is commonly used now treats ISO-8859-1 the same as Windows-1252,
+        // we should be fine leaving this as ISO-8859-1 for compatibility reasons
         private const string _defaultCodePage = "ISO-8859-1";
 
         #endregion Constants

--- a/src/System.Management.Automation/project.json
+++ b/src/System.Management.Automation/project.json
@@ -189,7 +189,8 @@
                 "System.Threading.Tasks.Parallel": "4.3.0",
                 "System.Xml.XPath.XmlDocument": "4.3.0",
                 "System.Xml.XmlDocument": "4.3.0",
-                "System.Xml.XmlSerializer": "4.3.0"
+                "System.Xml.XmlSerializer": "4.3.0",
+                "System.Text.Encoding.CodePages": "4.3.0"
             }
         },
         "net451": {

--- a/src/System.Management.Automation/utils/ClrFacade.cs
+++ b/src/System.Management.Automation/utils/ClrFacade.cs
@@ -380,9 +380,12 @@ namespace System.Management.Automation
             if (s_defaultEncoding == null)
             {
 #if CORECLR     // Encoding.Default is not in CoreCLR
-                // As suggested by CoreCLR team (tarekms), use latin1 (ISO-8859-1, CodePage 28591) as the default encoding.
-                // We will revisit this if it causes any failures when running tests on Core PS.
-                s_defaultEncoding = Encoding.GetEncoding(28591);
+                // Suggested by CoreCLR team (tarekms), use latin1 (ISO-8859-1, CodePage 28591) as the default encoding.
+                // However, printable characters in the codepoint range 0x80-0x9F are unavailable.  Logical choice is to
+                // use Windows-1252 which is a superset of ISO-8859-1 and adopted by HTML5 which treats ISO-8859-1 as
+                // mismarked Windows-1252 encoding.
+                Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+                s_defaultEncoding = Encoding.GetEncoding(1252);
 #else
                 s_defaultEncoding = Encoding.Default;
 #endif

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Content.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Content.Tests.ps1
@@ -15,7 +15,7 @@ Describe "Set-Content cmdlet tests" -Tags "CI" {
             $result| Should be "$file1"
         }
     }
-    Context "Set-Content/Get-Content should set/get the content of an exisiting file" {
+    Context "Set-Content/Get-Content should set/get the content of an existing file" {
         BeforeAll {
           New-Item -Path $filePath1 -ItemType File -Force
         }
@@ -106,5 +106,15 @@ Describe "Set-Content should work for PSDrive with UNC path as root" -Tags @('CI
             Remove-PSDrive -Name Foo
             net share testshare /delete
         }
+    }
+}
+
+Describe "Set-Content encoding tests" -Tags @('CI') {
+    It "Should correct use Windows-1252 encoding by default" {
+        # this character is not available in ISO-8859-1 which is a subset of Windows-1252
+        [char]$char = [Convert]::ToChar(8364) # '€'
+
+        $char | Set-Content -Path testdrive:/test.txt
+        [int][char](Get-Content -Path testdrive:/test.txt) | Should Be ([int]($char))
     }
 }


### PR DESCRIPTION
which is a superset of ISO-8859-1 the previous default so that extended printable characters commonly used are available

addresses #3258 
<!--

If you are a PowerShell Team member, please make sure you choose the Reviewer(s) and Assignee for your PR.
If you are not from the PowerShell Team, you can leave the fields blank and the Maintainers will choose them for you. If you are familiar with the team, feel free to mention some Reviewers yourself.

For more information about the roles of Reviewer and Assignee, refer to CONTRIBUTING.md.

-->
