### PR TITLE
Fixed typos that caused test to fail.

### DIFF
--- a/test/powershell/engine/Remoting/InvokeCommandRemoteDebug.Tests.ps1
+++ b/test/powershell/engine/Remoting/InvokeCommandRemoteDebug.Tests.ps1
@@ -4,7 +4,7 @@
 
 if ($IsWindows)
 {
-    $remotingModule = Join-Path $PSScriptRoot "../Common/TestRemoting.psm1"
+    $remotingModule = Join-Path $PSScriptRoot "../../Common/TestRemoting.psm1"
     Import-Module $remotingModule -ErrorAction SilentlyContinue
 
     $typeDef = @'
@@ -150,7 +150,7 @@ Describe "Invoke-Command remote debugging tests" -Tags 'Feature' {
             [powershell] $ps2 = [powershell]::Create()
             $ps2.Runspace = $rs2
 
-            $remoteSession = New-RemoteRunspace
+            $remoteSession = New-RemoteSession
         }
     }
 


### PR DESCRIPTION
I checked this in with a couple of typos that caused the test to fail in our system.  The first was a bad path to the TestRemoting.psm1 helper module.  And the other was using New-RemoteRunspace to get a remote session.