### PR TITLE
Corect xUnit heading and linting warnings

### DIFF
--- a/docs/testing-guidelines/testing-guidelines.md
+++ b/docs/testing-guidelines/testing-guidelines.md
@@ -49,7 +49,9 @@ These green check boxes and red crosses are **clickable** as well.
 They will bring you to the corresponding page with details.
 
 ## Test Frameworks
+
 ### Pester
+
 Our script-based test framework is [Pester](https://github.com/Pester/Pester).
 This is the framework which we are using internally at Microsoft for new script-based tests, 
 and a large number of the tests which are part of the PowerShell project have been migrated from that test base.
@@ -59,45 +61,60 @@ Substantial changes were required, to get Pester executing on non-Windows system
 These changes are not yet in the official Pester code base.
 Some features of Pester may not be available or may have incorrect behavior.
 Please make sure to create issues in [PowerShell/PowerShell](https://github.com/PowerShell/PowerShell/issues) (not Pester) for anything that you find.
+
 #### Test Tags
+
 The Pester framework allows `Describe` blocks to be tagged, and our CI system relies on those tags to invoke our tests.
+
 One of the following tags must be used:
+
 * `CI` - this tag indicates that the tests in the `Describe` block will be executed as part of the CI/PR process
-* `Feature` - tests with this tag will not be executed as part of the CI/PR process, but they will be executed on a daily basis as part of a `cron` driven build
-They indicate that the test will be validating more behavior, or will be using remote network resources (ex: package management tests)
+* `Feature` - tests with this tag will not be executed as part of the CI/PR process, but they will be executed on a daily basis as part of a `cron` driven build. They indicate that the test will be validating more behavior, or will be using remote network resources (ex: package management tests)
 * `Scenario` - this tag indicates a larger scale test interacting with multiple areas of functionality and/or remote resources, these tests are also run daily.
 
 Additionally, the tag:
+
 * `SLOW` indicates that the test takes a somewhat longer time to execute (97% of our `CI` tests take 100ms or less), a test which takes longer than 1 second should be considered as a candidate for being tagged `Slow`
+
 ### xUnit
+
 For those tests which are not easily run via Pester, we have decided to use [xUnit](https://xunit.github.io/) as the test framework.
 Currently, we have a minuscule number of tests which are run by using xUnit.
 
 ## Running tests outside of CI
+
 When working on new features or fixes, it is natural to want to run those tests locally before making a PR.
 Two helper functions are part of the build.psm1 module to help with that:
+
 * `Start-PSPester` will execute all Pester tests which are run by the CI system
 * `Start-PSxUnit` will execute the available xUnit tests run by the CI system
+
 Our CI system runs these as well; there should be no difference between running these on your dev system, versus in CI.
 
 When running tests in this way, be sure that you have started PowerShell with `-noprofile` as some tests will fail if the
 environment is not the default or has any customization.
 
 For example, to run all the Pester tests for CI (assuming you are at the root of the PowerShell repo):
+
 ```
 Import-Module ./build.psm1
 Start-PSPester
 ```
+
 If you wish to run specific tests, that is possible as well:
+
 ```
 Start-PSPester -Path test/powershell/engine/Api
 ```
+
 Or a specific Pester test file:
+
 ```
 Start-PSPester -Path test/powershell/engine/Api/XmlAdapter.Tests.ps1
 ```
 
 ### What happens after your PR?
+
 When your PR has successfully passed the CI test gates, your changes will be used to create PowerShell binaries which can be run
 in Microsoft's internal test frameworks.
 The tests that you created for your change and the library of historical tests will be run to determine if any regressions are present.
@@ -106,10 +123,13 @@ If these tests find regressions, you'll be notified that your PR is not ready, a
 
 
 ## Test Layout
+
 We have taken a functional approach to the layout of our Pester tests and you should place new tests in their appropriate location.
 If you are making a fix to a cmdlet in a module, the test belongs in the module directory.
 If you are unsure, you can make it part of your PR, or create an issue.
+
 The current layout of tests is:
+
 * test/powershell/engine
 * test/powershell/engine/Api
 * test/powershell/engine/Basic
@@ -144,4 +164,3 @@ The current layout of tests is:
 * test/powershell/Modules/Microsoft.PowerShell.Security
 * test/powershell/Modules/Microsoft.PowerShell.Utility
 * test/powershell/Modules/PSReadLine
-


### PR DESCRIPTION
I noticed that the xUnit heading as rendered on GitHub was not displaying as a heading. I made some other whitespace adjustments to make my markdown linter happier while I was in there. It was looking for a return line around headings, lists, and code blocks.
