### PR TITLE
test was using system installed powershell rather than the targeted one

### DIFF
--- a/test/powershell/Host/ConsoleHost.Tests.ps1
+++ b/test/powershell/Host/ConsoleHost.Tests.ps1
@@ -399,7 +399,7 @@ foo
             $env:XDG_CACHE_HOME = "/dev/cpu"
             $env:XDG_DATA_HOME = "/dev/cpu"
             $env:XDG_CONFIG_HOME = "/dev/cpu"
-            $output = & powershell -noprofile -Command { (get-command).count }
+            $output = & $powershell -noprofile -Command { (get-command).count }
             [int]$output | Should BeGreaterThan 0
         }
     }


### PR DESCRIPTION
missing character to use targeted powershell that was just built rather than system installed one