### PR TITLE
fixed drifting of progress bar on Unix

### DIFF
--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostRawUserInterface.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostRawUserInterface.cs
@@ -1805,14 +1805,11 @@ namespace Microsoft.PowerShell
                 //if x is exceeding buffer width, reset to the next line
                 if (origin.X >= BufferSize.Width)
                 {
-                    origin.X = 1;
+                    origin.X = 0;
                 }
 
                 //write the character from contents
                 Console.Out.Write(charitem.Character);
-
-                //advance the character one position
-                origin.X++;
             }
 
             //reset the cursor to the original position


### PR DESCRIPTION
progress bar was incorrectly setting the original x position which causes the progress to slowly move to the right in certain cases

addresses #3202 

need some suggestions on how to add a test for this