### PR TITLE
Updated tags of automounted drives tests

### DIFF
--- a/test/powershell/Provider/Pester.AutomountedDrives.Tests.ps1
+++ b/test/powershell/Provider/Pester.AutomountedDrives.Tests.ps1
@@ -4,7 +4,7 @@
  # used for validating automounted PowerShell drives.
  ############################################################################################>
 $script:TestSourceRoot = $PSScriptRoot
-Describe "Test suite for validating automounted PowerShell drives" -Tags "CI","Slow" {
+Describe "Test suite for validating automounted PowerShell drives" -Tags @('Feature', 'Slow', 'RequireAdminOnWindows') {
 
     BeforeAll {
         $powershell = Join-Path -Path $PsHome -ChildPath "powershell"


### PR DESCRIPTION
Two updates with this PR:
1) reclassified automounted drives tests to be 'Feature' instead of 'CI' because this is more accurate;
2) fixed failures in tests setup caused by "subst.exe" native utility having problems running as child process of powershell process tree run under "runas.exe /trustlevel:0x20000" (in Start-UnelevatedProcess in build.psm1).