### PR TITLE
Add dummy GET parameter to nightly Travis CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ If you have any problems building, please consult the developer [FAQ][].
 [tv-site]: https://travis-ci.org/PowerShell/PowerShell/branches
 [av-image]: https://ci.appveyor.com/api/projects/status/nsng9iobwa895f98/branch/master?svg=true
 [av-site]: https://ci.appveyor.com/project/PowerShell/powershell
-[tv-nightly-image]: https://jimtru1979.blob.core.windows.net/badges/DailyBuildStatus.svg
+[tv-nightly-image]: https://jimtru1979.blob.core.windows.net/badges/DailyBuildStatus.svg?dummy=unused
 [av-nightly-image]: https://ci.appveyor.com/api/projects/status/46yd4jogtm2jodcq?svg=true
 [av-nightly-site]: https://ci.appveyor.com/project/PowerShell/powershell-f975h
 [cc-site]: https://coveralls.io/github/PowerShell/PowerShell?branch=master


### PR DESCRIPTION
Trying to fix #3150 

I think that pasing a parameter may fool github into avoiding caching the result.
It obviously works right now, because it hits non-cached version

![image](https://cloud.githubusercontent.com/assets/816680/23780011/e1a8079c-04f8-11e7-92f2-4d916ea2f1f4.png)

I also think it's better to have a false red, then false green badge.