### PR TITLE
Fixing Foreach magic method on List[T]

### DIFF
--- a/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
+++ b/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
@@ -6513,7 +6513,7 @@ namespace System.Management.Automation.Language
             }
 
             var psMethod = methodInfo as PSMethod;
-            if (psMethod != null)
+            if (psMethod != null && !IsListForeachMagicMethod(methodInfo, target, args))
             {
                 var data = (DotNetAdapter.MethodCacheEntry)psMethod.adapterData;
 
@@ -6584,6 +6584,15 @@ namespace System.Management.Automation.Language
                                            Expression.Constant(typeForMessage.FullName), Expression.Constant(Name)),
                 restrictions).WriteToDebugLog(this);
         }
+
+		private bool IsListForeachMagicMethod(PSMethodInfo methodInfo, DynamicMetaObject target, DynamicMetaObject[] args)
+		{
+			return methodInfo.Name == "ForEach" &&
+				target.RuntimeType.Name == "List`1" &&
+				target.RuntimeType.Namespace == "System.Collections.Generic" &&
+				(args.Length != 1 || !args[0].RuntimeType.FullName.StartsWith("System.Action"));
+		}
+
 
         internal static DynamicMetaObject InvokeDotNetMethod(
             CallInfo callInfo,

--- a/test/powershell/Language/Scripting/ListMagicForeach.ps1
+++ b/test/powershell/Language/Scripting/ListMagicForeach.ps1
@@ -1,0 +1,38 @@
+Describe 'Magic Foreach works with List[T]' -Tags "CI" {
+    It 'Calls magic scriptblock for each item' {
+		[int[]] $i = 1..10
+		$list = [System.Collections.Generic.List[int]]::new($i)		
+		$sum = 0
+		$list.Foreach{$sum += $_ }
+		$sum | Should be 55
+	}	
+
+	It 'Calls List[T].Foreach when argument is Action' {
+		[int[]] $i = 1..10
+		$list = [System.Collections.Generic.List[int]]::new($i)		
+		$sum = 0
+		class CountHelper {
+			static [int] $I
+		}
+		[CountHelper]::I = 0
+		[Action[int]] $action = {param($i) [CountHelper]::I += $i }
+		$list.Foreach($action)
+		[CountHelper]::I | Should be 55
+	}
+
+	It 'Calls magic item method when argument is methodName' {
+		[int[]] $i = 1..3
+		$list = [System.Collections.Generic.List[int]]::new($i)		
+		$sum = 0
+
+		$list.Foreach('ToString') -join ',' | Should be "1,2,3"		
+	}
+
+	It 'Calls magic item method when argument is methodName + args ' {
+		[int[]] $i = 9,10,11
+		$list = [System.Collections.Generic.List[int]]::new($i)		
+		$sum = 0
+
+		$list.Foreach('ToString', 'x') -join ',' | Should be "9,a,b"		
+	}
+}


### PR DESCRIPTION
Special casing List[T].Foreach to call List.Foreach when the argument is
System.Action and to invoke MagicForeach otherwise.

Tests added for each case.


