### PR TITLE
Surface inner exception message to ErrorDetails message

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebRequestPSCmdlet.CoreClr.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebRequestPSCmdlet.CoreClr.cs
@@ -445,6 +445,10 @@ namespace Microsoft.PowerShell.Commands
                     catch (HttpRequestException ex)
                     {
                         ErrorRecord er = new ErrorRecord(ex, "WebCmdletWebResponseException", ErrorCategory.InvalidOperation, request);
+                        if (ex.InnerException != null)
+                        {
+                            er.ErrorDetails = new ErrorDetails(ex.InnerException.Message);
+                        }
                         ThrowTerminatingError(er);
                     }
                 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -441,6 +441,16 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
         $result.Error.Exception.Message | Should Match ": 418 \(I'm a teapot\)\."
         $result.Error.FullyQualifiedErrorId | Should Be "WebCmdletWebResponseException,Microsoft.PowerShell.Commands.InvokeWebRequestCommand"
     }
+
+    It "Validate Invoke-WebRequest returns native HTTPS error message in exception" {
+
+        $command = "Invoke-WebRequest -Uri https://incomplete.chain.badssl.com"
+        $result = ExecuteWebCommand -command $command
+
+        # need to check against inner exception since Linux and Windows uses different HTTP client libraries so errors aren't the same
+        $result.Error.ErrorDetails.Message | Should Match $result.Error.Exception.InnerException.Message
+        $result.Error.FullyQualifiedErrorId | Should Be "WebCmdletWebResponseException,Microsoft.PowerShell.Commands.InvokeWebRequestCommand"
+    }
 }
 
 Describe "Invoke-RestMethod tests" -Tags "Feature" {
@@ -725,6 +735,16 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
         $result.Error.Exception.Message | Should Match ": 418 \(I'm a teapot\)\."
         $result.Error.FullyQualifiedErrorId | Should Be "WebCmdletWebResponseException,Microsoft.PowerShell.Commands.InvokeRestMethodCommand"
     }
+
+    It "Validate Invoke-RestMethod returns native HTTPS error message in exception" {
+
+        $command = "Invoke-RestMethod -Uri https://incomplete.chain.badssl.com"
+        $result = ExecuteWebCommand -command $command
+
+        # need to check against inner exception since Linux and Windows uses different HTTP client libraries so errors aren't the same
+        $result.Error.ErrorDetails.Message | Should Match $result.Error.Exception.InnerException.Message
+        $result.Error.FullyQualifiedErrorId | Should Be "WebCmdletWebResponseException,Microsoft.PowerShell.Commands.InvokeRestMethodCommand"
+    }    
 }
 
 Describe "Validate Invoke-WebRequest and Invoke-RestMethod -InFile" -Tags "Feature" {


### PR DESCRIPTION
Currently, if there is an exception, the cmdlet wraps it with a generic exception and the error message the user gets interactively is a generic one that something bad happened.
They then will look at the innerexception message to determine the right course of action.
This change puts the innerexception.Message as the ErrorDetail message

Addresses https://github.com/PowerShell/PowerShell/issues/2942