### PR TITLE
Support backgrounding pipelines with ampersand

### DIFF
--- a/src/System.Management.Automation/engine/parser/Compiler.cs
+++ b/src/System.Management.Automation/engine/parser/Compiler.cs
@@ -1945,7 +1945,7 @@ namespace System.Management.Automation.Language
 
             var pipelineAst = stmt as PipelineAst;
             // If it's a pipeline that isn't being backgrounded, try to optimize expression
-            if (pipelineAst != null && ! pipelineAst.BackgroundProcess)
+            if (pipelineAst != null && ! pipelineAst.Background)
             {
                 var expr = pipelineAst.GetPureExpression();
                 if (expr != null) { return Compile(expr); }
@@ -2986,7 +2986,7 @@ namespace System.Management.Automation.Language
                 exprs.Add(UpdatePosition(pipelineAst));
             }
 
-            if (pipelineAst.BackgroundProcess)
+            if (pipelineAst.Background)
             {
                 Expression invokeBackgroundPipe = Expression.Call(
                     CachedReflectionInfo.PipelineOps_InvokePipelineInBackground,
@@ -2999,7 +2999,7 @@ namespace System.Management.Automation.Language
                 var pipeElements = pipelineAst.PipelineElements;
                 var firstCommandExpr = (pipeElements[0] as CommandExpressionAst);
     
-                if (firstCommandExpr != null && pipeElements.Count == 1 && ! pipelineAst.BackgroundProcess)
+                if (firstCommandExpr != null && pipeElements.Count == 1)
                 {
                     if (firstCommandExpr.Redirections.Count > 0)
                     {
@@ -3015,7 +3015,7 @@ namespace System.Management.Automation.Language
                     Expression input;
                     int i, commandsInPipe;
     
-                    if (firstCommandExpr != null  && !pipelineAst.BackgroundProcess)
+                    if (firstCommandExpr != null)
                     {
                         if (firstCommandExpr.Redirections.Count > 0)
                         {

--- a/src/System.Management.Automation/engine/parser/Parser.cs
+++ b/src/System.Management.Automation/engine/parser/Parser.cs
@@ -2451,7 +2451,7 @@ namespace System.Management.Automation.Language
                     {
                         endErrorStatement = fileNameExpr.Extent;
                         condition = new PipelineAst(fileNameExpr.Extent,
-                                                    new CommandExpressionAst(fileNameExpr.Extent, fileNameExpr, null), false);
+                                                    new CommandExpressionAst(fileNameExpr.Extent, fileNameExpr, null), background: false);
 
                         if (!specifiedFlags.ContainsKey("file"))
                         {
@@ -5182,7 +5182,7 @@ namespace System.Management.Automation.Language
 
             Token pipeToken = null;
             bool scanning = true;
-            bool backgroundProcess = false;
+            bool background = false;
             while (scanning)
             {
                 CommandBaseAst commandAst;
@@ -5297,7 +5297,7 @@ namespace System.Management.Automation.Language
                     case TokenKind.Ampersand:
                         SkipToken();
                         scanning = false;
-                        backgroundProcess = true;
+                        background = true;
                         break;
                     case TokenKind.Pipe:
                         SkipToken();
@@ -5334,7 +5334,7 @@ namespace System.Management.Automation.Language
                 return null;
             }
 
-            return new PipelineAst(ExtentOf(startExtent, pipelineElements[pipelineElements.Count - 1]), pipelineElements, backgroundProcess);
+            return new PipelineAst(ExtentOf(startExtent, pipelineElements[pipelineElements.Count - 1]), pipelineElements, background);
         }
 
         private RedirectionAst RedirectionRule(RedirectionToken redirectionToken, RedirectionAst[] redirections, ref IScriptExtent extent)

--- a/src/System.Management.Automation/engine/parser/ast.cs
+++ b/src/System.Management.Automation/engine/parser/ast.cs
@@ -5472,13 +5472,14 @@ namespace System.Management.Automation.Language
         /// </summary>
         /// <param name="extent">The extent of the pipeline.</param>
         /// <param name="pipelineElements">The collection of commands representing the pipeline.</param>
+        /// <param name="backgroundProcess">Indicates that this pipeline should be run in the background</param>
         /// <exception cref="PSArgumentNullException">
         /// If <paramref name="extent"/> is null.
         /// </exception>
         /// <exception cref="PSArgumentException">
         /// If <paramref name="pipelineElements"/> is null or is an empty collection.
         /// </exception>
-        public PipelineAst(IScriptExtent extent, IEnumerable<CommandBaseAst> pipelineElements)
+        public PipelineAst(IScriptExtent extent, IEnumerable<CommandBaseAst> pipelineElements, bool backgroundProcess)
             : base(extent)
         {
             if (pipelineElements == null || !pipelineElements.Any())
@@ -5486,8 +5487,47 @@ namespace System.Management.Automation.Language
                 throw PSTraceSource.NewArgumentException("pipelineElements");
             }
 
+            this.BackgroundProcess = backgroundProcess;
             this.PipelineElements = new ReadOnlyCollection<CommandBaseAst>(pipelineElements.ToArray());
             SetParents(PipelineElements);
+        }
+
+        /// <summary>
+        /// Construct a pipeline from a collection of commands.
+        /// </summary>
+        /// <param name="extent">The extent of the pipeline.</param>
+        /// <param name="pipelineElements">The collection of commands representing the pipeline.</param>
+        /// <exception cref="PSArgumentNullException">
+        /// If <paramref name="extent"/> is null.
+        /// </exception>
+        /// <exception cref="PSArgumentException">
+        /// If <paramref name="pipelineElements"/> is null or is an empty collection.
+        /// </exception>
+        public PipelineAst(IScriptExtent extent, IEnumerable<CommandBaseAst> pipelineElements) :this (extent, pipelineElements, false)
+        {
+
+        }
+
+        /// <summary>
+        /// Construct a pipeline from a single command.
+        /// </summary>
+        /// <param name="extent">The extent of the pipeline (which should be the extent of the command).</param>
+        /// <param name="commandAst">The command for the pipeline.</param>
+        /// <param name="backgroundProcess">Indicates that this pipeline should be run in the background</param>
+        /// <exception cref="PSArgumentNullException">
+        /// If <paramref name="extent"/> or <paramref name="commandAst"/> is null.
+        /// </exception>
+        public PipelineAst(IScriptExtent extent, CommandBaseAst commandAst, bool backgroundProcess)
+            : base(extent)
+        {
+            if (commandAst == null)
+            {
+                throw PSTraceSource.NewArgumentNullException("commandAst");
+            }
+
+            this.BackgroundProcess = backgroundProcess;
+            this.PipelineElements = new ReadOnlyCollection<CommandBaseAst>(new CommandBaseAst[] { commandAst });
+            SetParent(commandAst);
         }
 
         /// <summary>
@@ -5498,22 +5538,20 @@ namespace System.Management.Automation.Language
         /// <exception cref="PSArgumentNullException">
         /// If <paramref name="extent"/> or <paramref name="commandAst"/> is null.
         /// </exception>
-        public PipelineAst(IScriptExtent extent, CommandBaseAst commandAst)
-            : base(extent)
+        public PipelineAst(IScriptExtent extent, CommandBaseAst commandAst) :this (extent, commandAst, false)
         {
-            if (commandAst == null)
-            {
-                throw PSTraceSource.NewArgumentNullException("commandAst");
-            }
 
-            this.PipelineElements = new ReadOnlyCollection<CommandBaseAst>(new CommandBaseAst[] { commandAst });
-            SetParent(commandAst);
         }
 
         /// <summary>
         /// A non-null, non-empty collection of commands that represent the pipeline.
         /// </summary>
         public ReadOnlyCollection<CommandBaseAst> PipelineElements { get; private set; }
+
+        /// <summary>
+        /// Indicates that this pipeline should be run in the background.
+        /// </summary>
+        public bool BackgroundProcess { get; private set; }
 
         /// <summary>
         /// If the pipeline represents a pure expression, the expression is returned, otherwise null is returned.
@@ -5540,7 +5578,7 @@ namespace System.Management.Automation.Language
         public override Ast Copy()
         {
             var newPipelineElements = CopyElements(this.PipelineElements);
-            return new PipelineAst(this.Extent, newPipelineElements);
+            return new PipelineAst(this.Extent, newPipelineElements, this.BackgroundProcess);
         }
 
         internal override IEnumerable<PSTypeName> GetInferredType(CompletionContext context)
@@ -6314,9 +6352,10 @@ namespace System.Management.Automation.Language
                 throw PSTraceSource.NewArgumentException("operator");
             }
 
-            // If the assignment is just an expression - remove the pipeline wrapping the expression.
+            // If the assignment is just an expression and the expression is not backgrounded then
+            // remove the pipeline wrapping the expression.
             var pipelineAst = right as PipelineAst;
-            if (pipelineAst != null)
+            if (pipelineAst != null && ! pipelineAst.BackgroundProcess)
             {
                 if (pipelineAst.PipelineElements.Count == 1)
                 {
@@ -6662,7 +6701,7 @@ namespace System.Management.Automation.Language
 
             var cmdAst = new CommandAst(this.Extent, cea, TokenKind.Unknown, null);
 
-            var pipeLineAst = new PipelineAst(this.Extent, cmdAst);
+            var pipeLineAst = new PipelineAst(this.Extent, cmdAst, false);
             var funcStatements = ConfigurationExtraParameterStatements.Select(statement => (StatementAst)statement.Copy()).ToList();
             funcStatements.Add(pipeLineAst);
             var statmentBlockAst = new StatementBlockAst(this.Extent, funcStatements, null);
@@ -6702,7 +6741,7 @@ namespace System.Management.Automation.Language
             var setItemCmdlet = new CommandAst(this.Extent, setItemCmdElements, TokenKind.Unknown, null);
             #endregion
 
-            var returnPipelineAst = new PipelineAst(this.Extent, setItemCmdlet);
+            var returnPipelineAst = new PipelineAst(this.Extent, setItemCmdlet, false);
 
             SetParent(returnPipelineAst);
 
@@ -7247,7 +7286,7 @@ namespace System.Management.Automation.Language
             //
             var cmdAst = new CommandAst(FunctionName.Extent, cea, TokenKind.Unknown, null);
             cmdAst.DefiningKeyword = Keyword;
-            _commandCallPipelineAst = new PipelineAst(FunctionName.Extent, cmdAst);
+            _commandCallPipelineAst = new PipelineAst(FunctionName.Extent, cmdAst, false);
             return _commandCallPipelineAst;
         }
 

--- a/src/System.Management.Automation/engine/parser/ast.cs
+++ b/src/System.Management.Automation/engine/parser/ast.cs
@@ -5472,14 +5472,14 @@ namespace System.Management.Automation.Language
         /// </summary>
         /// <param name="extent">The extent of the pipeline.</param>
         /// <param name="pipelineElements">The collection of commands representing the pipeline.</param>
-        /// <param name="backgroundProcess">Indicates that this pipeline should be run in the background</param>
+        /// <param name="background">Indicates that this pipeline should be run in the background</param>
         /// <exception cref="PSArgumentNullException">
         /// If <paramref name="extent"/> is null.
         /// </exception>
         /// <exception cref="PSArgumentException">
         /// If <paramref name="pipelineElements"/> is null or is an empty collection.
         /// </exception>
-        public PipelineAst(IScriptExtent extent, IEnumerable<CommandBaseAst> pipelineElements, bool backgroundProcess)
+        public PipelineAst(IScriptExtent extent, IEnumerable<CommandBaseAst> pipelineElements, bool background)
             : base(extent)
         {
             if (pipelineElements == null || !pipelineElements.Any())
@@ -5487,7 +5487,7 @@ namespace System.Management.Automation.Language
                 throw PSTraceSource.NewArgumentException("pipelineElements");
             }
 
-            this.BackgroundProcess = backgroundProcess;
+            this.Background = background;
             this.PipelineElements = new ReadOnlyCollection<CommandBaseAst>(pipelineElements.ToArray());
             SetParents(PipelineElements);
         }
@@ -5503,7 +5503,7 @@ namespace System.Management.Automation.Language
         /// <exception cref="PSArgumentException">
         /// If <paramref name="pipelineElements"/> is null or is an empty collection.
         /// </exception>
-        public PipelineAst(IScriptExtent extent, IEnumerable<CommandBaseAst> pipelineElements) :this (extent, pipelineElements, backgroundProcess: false)
+        public PipelineAst(IScriptExtent extent, IEnumerable<CommandBaseAst> pipelineElements) :this (extent, pipelineElements, background: false)
         {
 
         }
@@ -5513,11 +5513,11 @@ namespace System.Management.Automation.Language
         /// </summary>
         /// <param name="extent">The extent of the pipeline (which should be the extent of the command).</param>
         /// <param name="commandAst">The command for the pipeline.</param>
-        /// <param name="backgroundProcess">Indicates that this pipeline should be run in the background</param>
+        /// <param name="background">Indicates that this pipeline should be run in the background</param>
         /// <exception cref="PSArgumentNullException">
         /// If <paramref name="extent"/> or <paramref name="commandAst"/> is null.
         /// </exception>
-        public PipelineAst(IScriptExtent extent, CommandBaseAst commandAst, bool backgroundProcess)
+        public PipelineAst(IScriptExtent extent, CommandBaseAst commandAst, bool background)
             : base(extent)
         {
             if (commandAst == null)
@@ -5525,7 +5525,7 @@ namespace System.Management.Automation.Language
                 throw PSTraceSource.NewArgumentNullException("commandAst");
             }
 
-            this.BackgroundProcess = backgroundProcess;
+            this.Background = background;
             this.PipelineElements = new ReadOnlyCollection<CommandBaseAst>(new CommandBaseAst[] { commandAst });
             SetParent(commandAst);
         }
@@ -5538,7 +5538,7 @@ namespace System.Management.Automation.Language
         /// <exception cref="PSArgumentNullException">
         /// If <paramref name="extent"/> or <paramref name="commandAst"/> is null.
         /// </exception>
-        public PipelineAst(IScriptExtent extent, CommandBaseAst commandAst) :this (extent, commandAst, backgroundProcess: false)
+        public PipelineAst(IScriptExtent extent, CommandBaseAst commandAst) :this (extent, commandAst, background: false)
         {
 
         }
@@ -5551,7 +5551,7 @@ namespace System.Management.Automation.Language
         /// <summary>
         /// Indicates that this pipeline should be run in the background.
         /// </summary>
-        public bool BackgroundProcess { get; private set; }
+        public bool Background { get; private set; }
 
         /// <summary>
         /// If the pipeline represents a pure expression, the expression is returned, otherwise null is returned.
@@ -5578,7 +5578,7 @@ namespace System.Management.Automation.Language
         public override Ast Copy()
         {
             var newPipelineElements = CopyElements(this.PipelineElements);
-            return new PipelineAst(this.Extent, newPipelineElements, this.BackgroundProcess);
+            return new PipelineAst(this.Extent, newPipelineElements, this.Background);
         }
 
         internal override IEnumerable<PSTypeName> GetInferredType(CompletionContext context)
@@ -6355,7 +6355,7 @@ namespace System.Management.Automation.Language
             // If the assignment is just an expression and the expression is not backgrounded then
             // remove the pipeline wrapping the expression.
             var pipelineAst = right as PipelineAst;
-            if (pipelineAst != null && ! pipelineAst.BackgroundProcess)
+            if (pipelineAst != null && ! pipelineAst.Background)
             {
                 if (pipelineAst.PipelineElements.Count == 1)
                 {
@@ -6701,7 +6701,7 @@ namespace System.Management.Automation.Language
 
             var cmdAst = new CommandAst(this.Extent, cea, TokenKind.Unknown, null);
 
-            var pipeLineAst = new PipelineAst(this.Extent, cmdAst, backgroundProcess: false);
+            var pipeLineAst = new PipelineAst(this.Extent, cmdAst, background: false);
             var funcStatements = ConfigurationExtraParameterStatements.Select(statement => (StatementAst)statement.Copy()).ToList();
             funcStatements.Add(pipeLineAst);
             var statmentBlockAst = new StatementBlockAst(this.Extent, funcStatements, null);
@@ -6741,7 +6741,7 @@ namespace System.Management.Automation.Language
             var setItemCmdlet = new CommandAst(this.Extent, setItemCmdElements, TokenKind.Unknown, null);
             #endregion
 
-            var returnPipelineAst = new PipelineAst(this.Extent, setItemCmdlet, backgroundProcess: false);
+            var returnPipelineAst = new PipelineAst(this.Extent, setItemCmdlet, background: false);
 
             SetParent(returnPipelineAst);
 
@@ -7286,7 +7286,7 @@ namespace System.Management.Automation.Language
             //
             var cmdAst = new CommandAst(FunctionName.Extent, cea, TokenKind.Unknown, null);
             cmdAst.DefiningKeyword = Keyword;
-            _commandCallPipelineAst = new PipelineAst(FunctionName.Extent, cmdAst, false);
+            _commandCallPipelineAst = new PipelineAst(FunctionName.Extent, cmdAst, background: false);
             return _commandCallPipelineAst;
         }
 

--- a/src/System.Management.Automation/engine/parser/ast.cs
+++ b/src/System.Management.Automation/engine/parser/ast.cs
@@ -5503,7 +5503,7 @@ namespace System.Management.Automation.Language
         /// <exception cref="PSArgumentException">
         /// If <paramref name="pipelineElements"/> is null or is an empty collection.
         /// </exception>
-        public PipelineAst(IScriptExtent extent, IEnumerable<CommandBaseAst> pipelineElements) :this (extent, pipelineElements, false)
+        public PipelineAst(IScriptExtent extent, IEnumerable<CommandBaseAst> pipelineElements) :this (extent, pipelineElements, backgroundProcess: false)
         {
 
         }
@@ -5538,7 +5538,7 @@ namespace System.Management.Automation.Language
         /// <exception cref="PSArgumentNullException">
         /// If <paramref name="extent"/> or <paramref name="commandAst"/> is null.
         /// </exception>
-        public PipelineAst(IScriptExtent extent, CommandBaseAst commandAst) :this (extent, commandAst, false)
+        public PipelineAst(IScriptExtent extent, CommandBaseAst commandAst) :this (extent, commandAst, backgroundProcess: false)
         {
 
         }
@@ -6701,7 +6701,7 @@ namespace System.Management.Automation.Language
 
             var cmdAst = new CommandAst(this.Extent, cea, TokenKind.Unknown, null);
 
-            var pipeLineAst = new PipelineAst(this.Extent, cmdAst, false);
+            var pipeLineAst = new PipelineAst(this.Extent, cmdAst, backgroundProcess: false);
             var funcStatements = ConfigurationExtraParameterStatements.Select(statement => (StatementAst)statement.Copy()).ToList();
             funcStatements.Add(pipeLineAst);
             var statmentBlockAst = new StatementBlockAst(this.Extent, funcStatements, null);
@@ -6741,7 +6741,7 @@ namespace System.Management.Automation.Language
             var setItemCmdlet = new CommandAst(this.Extent, setItemCmdElements, TokenKind.Unknown, null);
             #endregion
 
-            var returnPipelineAst = new PipelineAst(this.Extent, setItemCmdlet, false);
+            var returnPipelineAst = new PipelineAst(this.Extent, setItemCmdlet, backgroundProcess: false);
 
             SetParent(returnPipelineAst);
 

--- a/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
+++ b/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
@@ -467,7 +467,7 @@ namespace System.Management.Automation
         }
 
         internal static void InvokePipelineInBackground(
-                                            CommandBaseAst[] pipeElementAsts,
+                                            PipelineAst pipelineAst,
                                             FunctionContext funcContext)
         {
             PipelineProcessor pipelineProcessor = new PipelineProcessor();
@@ -483,9 +483,8 @@ namespace System.Management.Automation
 
                 CommandProcessorBase commandProcessor = null;
 
-                var pipelineAst = (PipelineAst)pipeElementAsts[0].Parent;
                 // For background jobs rewrite the pipeline as a Start-Job command
-                var scriptblockBodyString = ((PipelineAst)pipeElementAsts[0].Parent).Extent.Text;
+                var scriptblockBodyString = pipelineAst.Extent.Text;
                 var pipelineOffset = pipelineAst.Extent.StartOffset;
                 var variables = pipelineAst.FindAll(x => x is VariableExpressionAst, true);
                 // Used to make sure that the job runs in the current directory

--- a/src/System.Management.Automation/resources/ParserStrings.resx
+++ b/src/System.Management.Automation/resources/ParserStrings.resx
@@ -446,9 +446,6 @@ Possible matches are</value>
   <data name="InvalidEndOfLine" xml:space="preserve">
     <value>The token '{0}' is not a valid statement separator in this version.</value>
   </data>
-  <data name="AmpersandNotAllowed" xml:space="preserve">
-    <value>The ampersand (&amp;) character is not allowed. The &amp; operator is reserved for future use; wrap an ampersand in double quotation marks ("&amp;") to pass it as part of a string.</value>
-  </data>
   <data name="FromKeywordNotAllowed" xml:space="preserve">
     <value>The 'from' keyword is not supported in this version of the language.</value>
   </data>

--- a/test/powershell/Language/Parser/Parsing.Tests.ps1
+++ b/test/powershell/Language/Parser/Parsing.Tests.ps1
@@ -278,7 +278,6 @@ Describe 'Pipes parsing' -Tags "CI" {
     ShouldBeParseError 'gps|' EmptyPipeElement 4
     ShouldBeParseError '1|1' ExpressionsMustBeFirstInPipeline 2
     ShouldBeParseError '$a=' ExpectedValueExpression 3
-    ShouldBeParseError '1 &' UnexpectedToken,MissingExpression 2,2
 }
 
 Describe 'commands parsing' -Tags "CI" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Job.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Job.Tests.ps1
@@ -200,12 +200,22 @@ Describe "Ampersand background test" -tag "CI","Slow" {
         }
         It 'Make sure that $global:PID from the parent process does not overwrite $global:PID in the child process' {
             $j = Write-Output $global:pid &
-            $cpid = Receive-Job $j -Wait
+            $cpid = Receive-Job -Wait $j
             $pid | Should Not BeExactly $cpid
         }
         It "starts in the current directory" {
             $j = Get-Location | Foreach-Object -MemberName Path &
             Receive-Job -Wait $j | Should Be ($pwd.Path)
+        }
+        It "Test that output redirection is done in the background job" {
+            $j = Write-Output hello > $TESTDRIVE/hello.txt &
+            Receive-Job -Wait $j | Should Be $null
+            Get-Content $TESTDRIVE/hello.txt | Should BeExactly "hello"
+        }
+        It "Test that error redirection is done in the background job" {
+            $j = Write-Error MyError 2> $TESTDRIVE/myerror.txt &
+            Receive-Job -Wait $j | Should Be $null
+            Get-Content -Raw $TESTDRIVE/myerror.txt | Should Match "MyError"
         }
     }
     Context "Backgrounding expressions" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Job.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Job.Tests.ps1
@@ -184,14 +184,14 @@ Describe "Ampersand background test" -tag "CI","Slow" {
         It "doesn't cause error when variable is missing" {
             Remove-Item variable:name -ErrorAction Ignore
             $j = write-output "Hi $name" &
-            Receive-Job $j -Wait | Should Match "Hi "
+            Receive-Job $j -Wait | Should BeExactly "Hi "
         }
         It "Copies variables to the child process" {
             $n1 = "Bob"
             $n2 = "Mary"
             ${n 3} = "Bill"
             $j = Write-Output "Hi $n1! Hi ${n2}! Hi ${n 3}!" &
-            Receive-Job $j -Wait | Should Match "Hi Bob! Hi Mary! Hi Bill!"
+            Receive-Job $j -Wait | Should BeExactly "Hi Bob! Hi Mary! Hi Bill!"
         }
         It 'Make sure that $PID from the parent process does not overwrite $PID in the child process' {
             $j = Write-Output $pid &
@@ -218,20 +218,7 @@ Describe "Ampersand background test" -tag "CI","Slow" {
         }
         It "handles backgrounding mixed expressions" {
             $j = 1..10 | ForEach-Object -Begin {$s=0} -Process {$s += $_} -End {$s} &
-            Receive-Job -wait $j | should be 55
-        }
-    }
-    Context "Backgrounding expressions" {
-        AfterEach {
-            Get-Job | Remove-Job -force
-        }
-        It "handles backgrounding expressions" {
-            $j = 2+3 &
-            rcjb $j -wait | Should Be 5
-        }
-        It "handles backgrounding mixed expressions" {
-            $j = 1..10 | foreach { $_ } &
-            rcjb -wait $j | foreach {$s=0} {$s += $_} {$s} | should be 55
+            Receive-Job -Wait $j | Should Be 55
         }
     }
 }


### PR DESCRIPTION
<!--

If you are a PowerShell Team member, please make sure you choose the Reviewer(s) and Assignee for your PR.
If you are not from the PowerShell Team, you can leave the fields blank and the Maintainers will choose them for you. If you are familiar with the team, feel free to mention some Reviewers yourself.

For more information about the roles of Reviewer and Assignee, refer to CONTRIBUTING.md.

-->
This implements support for backgrounding pipelines with &. Putting & at the end of a pipeline will cause the pipeline to be run as a PowerShell job. When a pipeline is backgrounded a job object is returned. Once the pipeline is running as a job, all of the normal job cmdlets can be used to manage the job. Variables (ignoring process-specific variables) used in the pipeline are automatically copied to the job so
```powershell
copy $foo $bar &
```
just works. The job is also run in the current directory instead of the user's home directory as is the case with `Start-Job`. 

Addresses #716
