### PR TITLE
Including Directions for Installing/Upgrading via Linux Package Managers (from packages.microsoft.com)

### DIFF
--- a/docs/installation/linux.md
+++ b/docs/installation/linux.md
@@ -27,6 +27,31 @@ Once the package is installed, run `powershell` from a terminal.
 Ubuntu 14.04
 ============
 
+**Installation via Package Repository**
+
+PowerShell Core, for Linux, is published to package repositories for easy installation (and updates). This is the preferred method. 
+
+```
+# Import the public repository GPG keys
+curl https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
+
+# Register the Microsoft Ubuntu repository
+curl https://packages.microsoft.com/config/ubuntu/14.04/prod.list | sudo tee /etc/apt/sources.list.d/microsoft.list
+
+# Update apt-get
+sudo apt-get update
+
+# Install PowerShell
+sudo apt-get install -y powershell
+
+# Start PowerShell
+powershell
+```
+
+After registering the Microsoft repository once as superuser, from then on, you just need to use ```sudo apt-get upgrade powershell``` to update it.
+
+**Installation via Direct Download**
+
 Using [Ubuntu 14.04][], download the Debian package
 `powershell_6.0.0-alpha.17-1ubuntu1.14.04.1_amd64.deb`
 from the [releases][] page onto the Ubuntu machine.
@@ -53,6 +78,31 @@ sudo apt-get remove powershell
 Ubuntu 16.04
 ============
 
+**Installation via Package Repository**
+
+PowerShell Core, for Linux, is published to package repositories for easy installation (and updates). This is the preferred method.
+
+```
+# Import the public repository GPG keys
+curl https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
+
+# Register the Microsoft Ubuntu repository
+curl https://packages.microsoft.com/config/ubuntu/16.04/prod.list | sudo tee /etc/apt/sources.list.d/microsoft.list
+
+# Update apt-get
+sudo apt update
+
+# Install PowerShell
+sudo apt install -y powershell
+
+# Start PowerShell
+powershell
+```
+
+After registering the Microsoft repository once as superuser, from then on, you just need to use ```sudo apt upgrade powershell``` to update it.
+
+**Installation via Direct Download**
+
 Using [Ubuntu 16.04][], download the Debian package
 `powershell_6.0.0-alpha.17-1ubuntu1.16.04.1_amd64.deb`
 from the [releases][] page onto the Ubuntu machine.
@@ -61,17 +111,17 @@ Then execute the following in the terminal:
 
 ```sh
 sudo dpkg -i powershell_6.0.0-alpha.17-1ubuntu1.16.04.1_amd64.deb
-sudo apt-get install -f
+sudo apt install -f
 ```
 
 > Please note that `dpkg -i` will fail with unmet dependencies;
-> the next command, `apt-get install -f` resolves these
+> the next command, `apt install -f` resolves these
 > and then finishes configuring the PowerShell package.
 
 **Uninstallation**
 
 ```sh
-sudo apt-get remove powershell
+sudo apt remove powershell
 ```
 
 [Ubuntu 16.04]: http://releases.ubuntu.com/16.04/
@@ -80,6 +130,31 @@ This works for Debian Stretch (now testing) as well.
 
 CentOS 7
 ========
+
+**Installation via Package Repository**
+
+PowerShell Core, for Linux, is published to package repositories for easy installation (and updates). This is the preferred method.
+
+```
+# Enter superuser mode
+sudo su 
+
+# Register the Microsoft RedHat repository
+curl https://packages.microsoft.com/config/rhel/7/prod.repo > /etc/yum.repos.d/microsoft.repo
+
+# Exit superuser mode
+exit
+
+# Install PowerShell
+sudo yum install -y powershell
+
+# Start PowerShell
+powershell
+```
+
+After registering the Microsoft repository once as superuser, from then on, you just need to use ```sudo yum update powershell``` to update it.
+
+**Installation via Direct Download**
 
 Using [CentOS 7][], download the RPM package
 `powershell-6.0.0_alpha.17-1.el7.centos.x86_64.rpm`

--- a/docs/installation/linux.md
+++ b/docs/installation/linux.md
@@ -90,16 +90,16 @@ curl https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
 curl https://packages.microsoft.com/config/ubuntu/16.04/prod.list | sudo tee /etc/apt/sources.list.d/microsoft.list
 
 # Update apt-get
-sudo apt update
+sudo apt-get update
 
 # Install PowerShell
-sudo apt install -y powershell
+sudo apt-get install -y powershell
 
 # Start PowerShell
 powershell
 ```
 
-After registering the Microsoft repository once as superuser, from then on, you just need to use ```sudo apt upgrade powershell``` to update it.
+After registering the Microsoft repository once as superuser, from then on, you just need to use ```sudo apt-get upgrade powershell``` to update it.
 
 **Installation via Direct Download**
 
@@ -111,17 +111,17 @@ Then execute the following in the terminal:
 
 ```sh
 sudo dpkg -i powershell_6.0.0-alpha.17-1ubuntu1.16.04.1_amd64.deb
-sudo apt install -f
+sudo apt-get install -f
 ```
 
 > Please note that `dpkg -i` will fail with unmet dependencies;
-> the next command, `apt install -f` resolves these
+> the next command, `apt-get install -f` resolves these
 > and then finishes configuring the PowerShell package.
 
 **Uninstallation**
 
 ```sh
-sudo apt remove powershell
+sudo apt-get remove powershell
 ```
 
 [Ubuntu 16.04]: http://releases.ubuntu.com/16.04/


### PR DESCRIPTION
Linux install documentation doesn't include any information about packages.microsoft.com, which was announced last month as supporting package hosting for PowerShell Core:
https://blogs.msdn.microsoft.com/powershell/2017/02/01/installing-latest-powershell-core-6-0-release-on-linux-just-got-easier/

I am including what is practically a copy-paste, from the blog, for the respective distros.