### PR TITLE
Fixed defaults values for some parameters in OpenCover module

### DIFF
--- a/test/tools/OpenCover/OpenCover.psm1
+++ b/test/tools/OpenCover/OpenCover.psm1
@@ -256,7 +256,7 @@ function Expand-ZipArchive([string] $Path, [string] $DestinationPath)
 #>
 function Get-CodeCoverage
 {
-    param ( [string]$CoverageXmlFile = "$pwd/OpenCover.xml" )
+    param ( [string]$CoverageXmlFile = "$home/Documents/OpenCover.xml" )
     $xmlPath = (get-item $CoverageXmlFile).Fullname
     (Get-CoverageData -xmlPath $xmlPath)
 }
@@ -416,7 +416,7 @@ function Install-OpenCover
 .Description
    Invoke-OpenCover runs tests under OpenCover by executing tests on PowerShell.exe located at $PowerShellExeDirectory.
 .EXAMPLE
-   Invoke-OpenCover -TestDirectory $pwd/test/powershell -PowerShellExeDirectory $pwd/src/powershell-win-core/bin/CodeCoverage/netcoreapp1.0/win10-x64
+   Invoke-OpenCover -TestDirectory $pwd/test/powershell -PowerShellExeDirectory $pwd/src/powershell-win-core/bin/CodeCoverage/netcoreapp1.1/win10-x64
 #>
 function Invoke-OpenCover
 {
@@ -425,9 +425,9 @@ function Invoke-OpenCover
         [parameter()]$OutputLog = "$home/Documents/OpenCover.xml",
         [parameter()]$TestDirectory = "$($script:psRepoPath)/test/powershell",
         [parameter()]$OpenCoverPath = "$home/OpenCover",
-        [parameter()]$PowerShellExeDirectory = "$($script:psRepoPath)/src/powershell-win-core/bin/CodeCoverage/netcoreapp1.0/win10-x64/publish",
-        [parameter()]$PesterLogElevated = "$pwd/TestResultsElevated.xml",
-        [parameter()]$PesterLogUnelevated = "$pwd/TestResultsUnelevated.xml",
+        [parameter()]$PowerShellExeDirectory = "$($script:psRepoPath)/src/powershell-win-core/bin/CodeCoverage/netcoreapp1.1/win10-x64/publish",
+        [parameter()]$PesterLogElevated = "$home/Documents/TestResultsElevated.xml",
+        [parameter()]$PesterLogUnelevated = "$home/Documents/TestResultsUnelevated.xml",
         [parameter()]$PesterLogFormat = "NUnitXml",
         [switch]$CIOnly
         )


### PR DESCRIPTION
some defaults were using $pwd which likely ends up creating xml files in the local git repo which then shows up as untracked files in git

previous default path for powershell.exe expected to be under netcoreapp1.0, but need to update to netcoreapp1.1

