### PR TITLE
Fix use of registry in nightly tests causing failure on Linux

### DIFF
--- a/test/powershell/engine/Help/HelpSystem.OnlineHelp.Tests.ps1
+++ b/test/powershell/engine/Help/HelpSystem.OnlineHelp.Tests.ps1
@@ -52,24 +52,23 @@ Describe 'Get-Help -Online opens the default web browser and navigates to the cm
     if((-not ($skipTest)) -and $IsWindows)
     {
         $skipTest = $true
-        $regKey = "HKEY_CURRENT_USER\Software\Microsoft\Windows\Shell\Associations\UrlAssociations\http\UserChoice"
+        $regKey = "HKCU:\Software\Microsoft\Windows\Shell\Associations\UrlAssociations\http\UserChoice"
 
         try
         {
-            $progId = [Microsoft.Win32.Registry]::GetValue($regKey, "ProgId", $null)
+            $progId = (Get-ItemProperty $regKey).ProgId
             if($progId)
             {
-                $browserKey = [Microsoft.Win32.Registry]::ClassesRoot.OpenSubKey("$progId\shell\open\command", $false)
-                if($browserKey)
+                if ((Get-PSDrive -Name HKCR) -eq $Null)
                 {
-                    $browserExe = ($browserKey.GetValue($null) -replace '"', '') -split " "
-
-                    if ($browserExe.count -ge 1)
+                    New-PSDrive -PSProvider registry -Root HKEY_CLASSES_ROOT -Name HKCR | Should NotBeNullOrEmpty
+                }
+                $browserExe = ((Get-ItemProperty "HKCR:\$progId\shell\open\command")."(default)" -replace '"', '') -split " "
+                if ($browserExe.count -ge 1)
+                {
+                    if($browserExe[0] -match '.exe')
                     {
-                        if($browserExe[0] -match '.exe')
-                        {
-                            $skipTest = $false
-                        }
+                        $skipTest = $false
                     }
                 }
             }


### PR DESCRIPTION
It appears that Pester is causing PowerShell to reflect on the Win32.Registry type which causes a `type initialization` exception even if not being used on Linux.   Changed usage of registry to psdrive to avoid this problem.

Addresses https://github.com/PowerShell/PowerShell/issues/3098

<!--

If you are a PowerShell Team member, please make sure you choose the Reviewer(s) and Assignee for your PR.
If you are not from the PowerShell Team, you can leave the fields blank and the Maintainers will choose them for you. If you are familiar with the team, feel free to mention some Reviewers yourself.

For more information about the roles of Reviewer and Assignee, refer to CONTRIBUTING.md.

-->
