### PR TITLE
Out-Default incorrectly staying in transcript state

### DIFF
--- a/src/System.Management.Automation/commands/utility/FormatAndOutput/out-console/ConsoleLineOutput.cs
+++ b/src/System.Management.Automation/commands/utility/FormatAndOutput/out-console/ConsoleLineOutput.cs
@@ -321,7 +321,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                     // If the host is in "transcribe only"
                     // mode (due to an implicitly added call to Out-Default -Transcribe),
                     // then don't call the actual host API.
-                    if (!_console.TranscribeOnly)
+                    if (_console.TranscribeOnlyCount == 0)
                     {
                         _console.WriteLine(s);
                     }

--- a/src/System.Management.Automation/commands/utility/FormatAndOutput/out-console/OutConsole.cs
+++ b/src/System.Management.Automation/commands/utility/FormatAndOutput/out-console/OutConsole.cs
@@ -160,11 +160,11 @@ namespace Microsoft.PowerShell.Commands
                 return;
             }
 
-            if (Transcript)
+            if (_transcriptStateChanged)
             {
                 Host.UI.TranscribeOnly = _savedTranscribeOnly;
+                _transcriptStateChanged = false;
             }
-
             _disposed = true;
         }
 

--- a/src/System.Management.Automation/commands/utility/FormatAndOutput/out-console/OutConsole.cs
+++ b/src/System.Management.Automation/commands/utility/FormatAndOutput/out-console/OutConsole.cs
@@ -79,7 +79,11 @@ namespace Microsoft.PowerShell.Commands
                 mrt.MergeUnclaimedPreviousErrorResults = true;
             }
 
-            _savedTranscribeOnly = Host.UI.TranscribeOnly;
+            if (Transcript)
+            {
+                _incrementedTranscibeOnlyCount = true;
+                Host.UI.TranscribeOnlyCount++;
+            }
 
             // This needs to be done directly through the command runtime, as Out-Default
             // doesn't actually write pipeline objects.
@@ -98,7 +102,6 @@ namespace Microsoft.PowerShell.Commands
         {
             if (Transcript)
             {
-                Host.UI.TranscribeOnly = true;
                 WriteObject(InputObject);
             }
 
@@ -152,14 +155,23 @@ namespace Microsoft.PowerShell.Commands
                 return;
             }
 
-            base.InternalDispose();
-            Host.UI.TranscribeOnly = _savedTranscribeOnly;
+            try
+            {
+                base.InternalDispose();
+            }
+            finally
+            {
+                if (_incrementedTranscibeOnlyCount && --Host.UI.TranscribeOnlyCount < 0)
+                {
+                    Host.UI.TranscribeOnlyCount = 0;
+                }
+            }
             _disposed = true;
         }
 
         private bool _disposed = false;
+        private bool _incrementedTranscibeOnlyCount = false;
         private ArrayList _outVarResults = null;
-        private bool _savedTranscribeOnly = false;
     }
 
     /// <summary>

--- a/src/System.Management.Automation/commands/utility/FormatAndOutput/out-console/OutConsole.cs
+++ b/src/System.Management.Automation/commands/utility/FormatAndOutput/out-console/OutConsole.cs
@@ -43,7 +43,7 @@ namespace Microsoft.PowerShell.Commands
     /// default sink (display to console screen)
     /// </summary>
     [Cmdlet(VerbsData.Out, "Default", HelpUri = "https://go.microsoft.com/fwlink/?LinkID=113362", RemotingCapability = RemotingCapability.None)]
-    public class OutDefaultCommand : FrontEndCommandBase, IDisposable
+    public class OutDefaultCommand : FrontEndCommandBase
     {
         /// <summary>
         /// Determines whether objects should be sent to API consumers.
@@ -152,6 +152,7 @@ namespace Microsoft.PowerShell.Commands
                 return;
             }
 
+            base.InternalDispose();
             Host.UI.TranscribeOnly = _savedTranscribeOnly;
             _disposed = true;
         }

--- a/src/System.Management.Automation/commands/utility/FormatAndOutput/out-console/OutConsole.cs
+++ b/src/System.Management.Automation/commands/utility/FormatAndOutput/out-console/OutConsole.cs
@@ -79,16 +79,7 @@ namespace Microsoft.PowerShell.Commands
                 mrt.MergeUnclaimedPreviousErrorResults = true;
             }
 
-            if (!_transcriptStateChanged)
-            {
-                _savedTranscribeOnly = Host.UI.TranscribeOnly;
-            }
-
-            if (Transcript)
-            {
-                _transcriptStateChanged = true;
-                Host.UI.TranscribeOnly = true;
-            }
+            _savedTranscribeOnly = Host.UI.TranscribeOnly;
 
             // This needs to be done directly through the command runtime, as Out-Default
             // doesn't actually write pipeline objects.
@@ -107,6 +98,7 @@ namespace Microsoft.PowerShell.Commands
         {
             if (Transcript)
             {
+                Host.UI.TranscribeOnly = true;
                 WriteObject(InputObject);
             }
 
@@ -160,18 +152,13 @@ namespace Microsoft.PowerShell.Commands
                 return;
             }
 
-            if (_transcriptStateChanged)
-            {
-                Host.UI.TranscribeOnly = _savedTranscribeOnly;
-                _transcriptStateChanged = false;
-            }
+            Host.UI.TranscribeOnly = _savedTranscribeOnly;
             _disposed = true;
         }
 
         private bool _disposed = false;
         private ArrayList _outVarResults = null;
         private bool _savedTranscribeOnly = false;
-        private static bool _transcriptStateChanged = false;
     }
 
     /// <summary>

--- a/src/System.Management.Automation/engine/hostifaces/MshHostUserInterface.cs
+++ b/src/System.Management.Automation/engine/hostifaces/MshHostUserInterface.cs
@@ -386,11 +386,11 @@ namespace System.Management.Automation.Host
         }
 
         /// <summary>
-        /// Flag to determine whether the host is in "Transcribe Only" mode,
+        /// Count to determine whether the host is in "Transcribe Only" mode,
         /// so that when content is sent through Out-Default it doesn't
-        /// make it to the actual host.
+        /// make it to the actual host if count == 0
         /// </summary>
-        internal bool TranscribeOnly { get; set; }
+        internal int TranscribeOnlyCount { get; set; }
 
         /// <summary>
         /// Flag to determine whether the host is transcribing.

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Out-Default.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Out-Default.Tests.ps1
@@ -24,5 +24,16 @@ Describe "Out-Default Tests" -tag CI {
 
     It "Out-Default reverts transcription state when exception occurs in pipeline" {
         & $powershell -c "try { & { throw } | Out-Default -Transcript } catch {}; 'Hello'" | Should BeExactly "Hello"
-    }    
+    }
+
+    It "Out-Default reverts transcription state even if Dispose() isn't called" {
+        $script = @"
+            `$sp = {Out-Default -Transcript}.GetSteppablePipeline();
+            `$sp.Begin(`$false);
+            `$sp = `$null;
+            [GC]::Collect();
+            'hello'
+"@
+        & $powershell -c $script | Should BeExactly 'hello'
+    }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Out-Default.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Out-Default.Tests.ps1
@@ -6,7 +6,7 @@ Describe "Out-Default Tests" -tag CI {
         $powershell = "$PSHOME/powershell"
     }
 
-    It "'Out-Default -Transcript' shows up in transcript, but not pipeline" {
+    It "'Out-Default -Transcript' shows up in transcript, but not host" {
         $script = @"
             `$null = Start-Transcript -Path "$testdrive\transcript.txt";
             'hello' | Microsoft.PowerShell.Core\Out-Default -Transcript;

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Out-Default.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Out-Default.Tests.ps1
@@ -1,0 +1,13 @@
+Describe "Out-Default Tests" -tag CI {
+    BeforeAll {
+        $powershell = "$PSHOME/powershell"
+    }
+
+    It "Out-Default reverts transcription state when used more than once in a pipeline" {
+        & $powershell -c "Out-Default -Transcript | Out-Default -Transcript; 'Hello'" | Should BeExactly "Hello"
+    }
+
+    It "Out-Default reverts transcription state when exception occurs in pipeline" {
+        & $powershell -c "try { & { throw } | Out-Default -Transcript } catch {}; 'Hello'" | Should BeExactly "Hello"
+    }    
+}


### PR DESCRIPTION
Out-Default was incorrectly caching transcription state as the subsequent use was caching the already changed state

Out-Default needed to implement IDispose pattern so transcription state reverts back on exception in pipeline

Addresses https://github.com/PowerShell/PowerShell/issues/3390

<!--

If you are a PowerShell Team member, please make sure you choose the Reviewer(s) and Assignee for your PR.
If you are not from the PowerShell Team, you can leave the fields blank and the Maintainers will choose them for you. If you are familiar with the team, feel free to mention some Reviewers yourself.

For more information about the roles of Reviewer and Assignee, refer to CONTRIBUTING.md.

-->
