### PR TITLE
WIP - Implement Get-Hash cmdlet

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetHash.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetHash.cs
@@ -124,18 +124,18 @@ namespace Microsoft.PowerShell.Commands
                 {
                     foreach (string str in InputString)
                     {
-						if (str == null)
-						{
-							WriteStringHashInfo(Algorithm, string.Empty, string.Empty, Encoding);
-							Exception exception = new Exception("Hash for 'null' string is 'null'");
-							WriteError(new ErrorRecord(exception, "GetHashInvalidData", ErrorCategory.InvalidData, null));
-						}
-						else
-						{
-							byte[] bytehash = hasher.ComputeHash(EncodingConversion.Convert(this, Encoding).GetBytes(str));
-							string hash = BitConverter.ToString(bytehash).Replace("-","");
-							WriteStringHashInfo(Algorithm, hash, str, Encoding);
-						}
+                        if (str == null)
+                        {
+                            WriteStringHashInfo(Algorithm, string.Empty, string.Empty, Encoding);
+                            Exception exception = new Exception("Hash for 'null' string is 'null'");
+                            WriteError(new ErrorRecord(exception, "GetHashInvalidData", ErrorCategory.InvalidData, null));
+                        }
+                        else
+                        {
+                            byte[] bytehash = hasher.ComputeHash(EncodingConversion.Convert(this, Encoding).GetBytes(str));
+                            string hash = BitConverter.ToString(bytehash).Replace("-","");
+                            WriteStringHashInfo(Algorithm, hash, str, Encoding);
+                        }
                     }
                 }
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetHash.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetHash.cs
@@ -16,7 +16,7 @@ namespace Microsoft.PowerShell.Commands
                                                                  StreamParameterSet
                                                                  })]
     [OutputType(typeof(StringHashInfo), ParameterSetName = new[] { StringHashParameterSet })]
-    public class GetFileHashCommand : HashCmdletBase
+    public class GetHashCommand : HashCmdletBase
     {
         /// <summary>
         /// Path parameter
@@ -124,27 +124,18 @@ namespace Microsoft.PowerShell.Commands
                 {
                     foreach (string str in InputString)
                     {
-                        try
-                        {
-                            //if (str == null)
-                            //{
-                            //    WriteStringHashInfo(Algorithm, string.Empty, string.Empty, Encoding);
-                            //    Exception exception = new Exception("Hash for 'null' string is 'null'", ex);
-                            //    WriteError(new ErrorRecord(exception, "GetHashInvalidData", ErrorCategory.InvalidData, null));
-                            //}
-                            //else
-                            //{
-                                byte[] bytehash = hasher.ComputeHash(EncodingConversion.Convert(this, Encoding).GetBytes(str));
-                                string hash = BitConverter.ToString(bytehash).Replace("-","");
-                                WriteStringHashInfo(Algorithm, hash, str, Encoding);
-                            //}
-                        }
-                        catch (Exception ex)
-                        {
-                            WriteStringHashInfo(Algorithm, string.Empty, string.Empty, Encoding);
-                            Exception exception = new Exception("Hash for 'null' string is 'null'", ex);
-                            WriteError(new ErrorRecord(exception, "GetHashInvalidData", ErrorCategory.InvalidData, null));
-                        }
+						if (str == null)
+						{
+							WriteStringHashInfo(Algorithm, string.Empty, string.Empty, Encoding);
+							Exception exception = new Exception("Hash for 'null' string is 'null'");
+							WriteError(new ErrorRecord(exception, "GetHashInvalidData", ErrorCategory.InvalidData, null));
+						}
+						else
+						{
+							byte[] bytehash = hasher.ComputeHash(EncodingConversion.Convert(this, Encoding).GetBytes(str));
+							string hash = BitConverter.ToString(bytehash).Replace("-","");
+							WriteStringHashInfo(Algorithm, hash, str, Encoding);
+						}
                     }
                 }
 

--- a/src/Modules/Unix/Microsoft.PowerShell.Utility/Microsoft.PowerShell.Utility.psd1
+++ b/src/Modules/Unix/Microsoft.PowerShell.Utility/Microsoft.PowerShell.Utility.psd1
@@ -20,7 +20,7 @@ CmdletsToExport= "Format-List", "Format-Custom", "Format-Table", "Format-Wide",
     "Clear-Variable", "Export-Clixml", "Import-Clixml", "Import-PowerShellDataFile", "ConvertTo-Xml", "Select-Xml", "Write-Debug",
     "Write-Verbose", "Write-Warning", "Write-Error", "Write-Information", "Write-Output", "Set-PSBreakpoint",
     "Get-PSBreakpoint", "Remove-PSBreakpoint", "Enable-PSBreakpoint", "Disable-PSBreakpoint", "Get-PSCallStack",
-    "Send-MailMessage", "Get-TraceSource", "Set-TraceSource", "Trace-Command", "Get-FileHash",
+    "Send-MailMessage", "Get-TraceSource", "Set-TraceSource", "Trace-Command", "Get-Hash",
     "Get-Runspace", "Debug-Runspace", "Enable-RunspaceDebug", "Disable-RunspaceDebug",
     "Get-RunspaceDebug", "Wait-Debugger" , "Get-Uptime", "New-TemporaryFile", "Get-Verb", "Format-Hex", "Remove-Alias"
 FunctionsToExport= "Import-PowerShellDataFile"

--- a/src/Modules/Windows-Core/Microsoft.PowerShell.Utility/Microsoft.PowerShell.Utility.psd1
+++ b/src/Modules/Windows-Core/Microsoft.PowerShell.Utility/Microsoft.PowerShell.Utility.psd1
@@ -20,7 +20,7 @@ CmdletsToExport= "Format-List", "Format-Custom", "Format-Table", "Format-Wide",
     "Clear-Variable", "Export-Clixml", "Import-Clixml", "Import-PowerShellDataFile","ConvertTo-Xml", "Select-Xml", "Write-Debug",
     "Write-Verbose", "Write-Warning", "Write-Error", "Write-Information", "Write-Output", "Set-PSBreakpoint",
     "Get-PSBreakpoint", "Remove-PSBreakpoint", "New-TemporaryFile", "Enable-PSBreakpoint", "Disable-PSBreakpoint", "Get-PSCallStack",
-    "Send-MailMessage", "Get-TraceSource", "Set-TraceSource", "Trace-Command", "Get-FileHash",
+    "Send-MailMessage", "Get-TraceSource", "Set-TraceSource", "Trace-Command", "Get-Hash",
     "Unblock-File", "Get-Runspace", "Debug-Runspace", "Enable-RunspaceDebug", "Disable-RunspaceDebug",
     "Get-RunspaceDebug", "Wait-Debugger" , "Get-Uptime", "Get-Verb", "Format-Hex", "Remove-Alias"
 FunctionsToExport= "ConvertFrom-SddlString"

--- a/src/Modules/Windows-Full/Microsoft.PowerShell.Utility/Microsoft.PowerShell.Utility.psd1
+++ b/src/Modules/Windows-Full/Microsoft.PowerShell.Utility/Microsoft.PowerShell.Utility.psd1
@@ -22,7 +22,7 @@ CmdletsToExport= "Format-List", "Format-Custom", "Format-Table", "Format-Wide",
     "Clear-Variable", "Export-Clixml", "Import-Clixml", "Import-PowerShellDataFile", "ConvertTo-Xml", "Select-Xml", "Write-Debug",
     "Write-Verbose", "Write-Warning", "Write-Error", "Write-Information", "Write-Output", "Set-PSBreakpoint", "Get-PSBreakpoint",
     "Remove-PSBreakpoint", "Enable-PSBreakpoint", "Disable-PSBreakpoint", "Get-PSCallStack",
-    "Send-MailMessage", "Get-TraceSource", "Set-TraceSource", "Trace-Command", "Show-Command", "Unblock-File", "Get-FileHash",
+    "Send-MailMessage", "Get-TraceSource", "Set-TraceSource", "Trace-Command", "Show-Command", "Unblock-File", "Get-Hash",
     "Get-Runspace", "Debug-Runspace", "Enable-RunspaceDebug", "Disable-RunspaceDebug", "Get-RunspaceDebug", "Wait-Debugger",
     "ConvertFrom-String", "Convert-String" , "Get-Uptime", "New-TemporaryFile", "Get-Verb", "Format-Hex"
 FunctionsToExport= "ConvertFrom-SddlString"

--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -4605,6 +4605,7 @@ end
                     new SessionStateAliasEntry("ghy", "Get-History", "", ReadOnly),
                     new SessionStateAliasEntry("gi", "Get-Item", "", ReadOnly),
                     new SessionStateAliasEntry("gl", "Get-Location", "", ReadOnly),
+                    new SessionStateAliasEntry("Get-FileHash", "Get-Hash", "", ReadOnly),
                     new SessionStateAliasEntry("gm", "Get-Member", "", ReadOnly),
                     new SessionStateAliasEntry("gmo", "Get-Module", "", ReadOnly),
                     new SessionStateAliasEntry("gp", "Get-ItemProperty", "", ReadOnly),

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Hash.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Hash.Tests.ps1
@@ -109,5 +109,14 @@ Describe "Get-Hash tests for files" -Tags "CI" {
             $result.Hash | Should Be "4A6DA9F1C0827143BB19FC4B0F2A8057BC1DF55F6D1F62FA3B917BA458E8F570"
             $result.Path | Should Be $testDocument
         }
+
+        It "With '-Path': using a pipe" {
+            $result = Get-ChildItem $testDocument | Get-Hash
+
+            $result | Should BeOfType 'Microsoft.PowerShell.Commands.FileHashInfo'
+            $result.Algorithm | Should Be "SHA256"
+            $result.Hash | Should Be "4A6DA9F1C0827143BB19FC4B0F2A8057BC1DF55F6D1F62FA3B917BA458E8F570"
+            $result.Path | Should Be $testDocument
+        }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Hash.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Hash.Tests.ps1
@@ -79,17 +79,17 @@ Describe "Get-Hash tests for files" -Tags "CI" {
         }
 
         It "Should be throw for wrong algorithm name" {
-            { Get-Hash $testDocument -Algorithm wrongAlgorithm } | ShouldBeErrorId "ParameterArgumentValidationError,Microsoft.PowerShell.Commands.GetFileHashCommand"
+            { Get-Hash $testDocument -Algorithm wrongAlgorithm } | ShouldBeErrorId "ParameterArgumentValidationError,Microsoft.PowerShell.Commands.GetHashCommand"
         }
     }
 
     Context "Paths tests" {
         It "With '-Path': no file exist" {
-            { Get-Hash -Path nofileexist.ttt -ErrorAction Stop } | ShouldBeErrorId "FileNotFound,Microsoft.PowerShell.Commands.GetFileHashCommand"
+            { Get-Hash -Path nofileexist.ttt -ErrorAction Stop } | ShouldBeErrorId "FileNotFound,Microsoft.PowerShell.Commands.GetHashCommand"
         }
 
         It "With '-LiteralPath': no file exist" {
-            { Get-Hash -LiteralPath nofileexist.ttt -ErrorAction Stop } | ShouldBeErrorId "FileNotFound,Microsoft.PowerShell.Commands.GetFileHashCommand"
+            { Get-Hash -LiteralPath nofileexist.ttt -ErrorAction Stop } | ShouldBeErrorId "FileNotFound,Microsoft.PowerShell.Commands.GetHashCommand"
         }
 
         It "With '-Path': file exist" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Hash.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Hash.Tests.ps1
@@ -1,9 +1,7 @@
-Import-Module $PSScriptRoot\..\..\Common\Test.Helpers.psm1
 Describe "Get-Hash tests for files" -Tags "CI" {
 
     BeforeAll {
         $testDocument = Join-Path -Path $PSScriptRoot -ChildPath assets testablescript.ps1
-        Write-Host $testDocument
     }
 
     Context "Default result tests" {
@@ -55,12 +53,19 @@ Describe "Get-Hash tests for files" -Tags "CI" {
             $testBytes = Get-Content $testDocument -Raw -Encoding Byte
             $testString = [System.Text.Encoding]::UTF8.GetString($testBytes)
             $algorithmResult = Get-Hash -InputString $testString -Algorithm $algorithm -Encoding UTF8
+            $algorithmResultFromPipe = $testString | Get-Hash -Algorithm $algorithm -Encoding UTF8
 
             $algorithmResult | Should BeOfType 'Microsoft.PowerShell.Commands.StringHashInfo'
             $algorithmResult.Algorithm | Should Be $algorithm
             $algorithmResult.Hash | Should Be $hash
             $algorithmResult.Encoding | Should Be 'UTF8'
             $algorithmResult.HashedString | Should Be $testString
+
+            $algorithmResultFromPipe | Should BeOfType 'Microsoft.PowerShell.Commands.StringHashInfo'
+            $algorithmResultFromPipe.Algorithm | Should Be $algorithm
+            $algorithmResultFromPipe.Hash | Should Be $hash
+            $algorithmResultFromPipe.Encoding | Should Be 'UTF8'
+            $algorithmResultFromPipe.HashedString | Should Be $testString
         }
 
         It "Should be able to get the correct hash for 'null' String" {
@@ -74,7 +79,7 @@ Describe "Get-Hash tests for files" -Tags "CI" {
         }
 
         It "Should be throw for wrong algorithm name" {
-            { Get-Hash Get-Hash $testDocument -Algorithm wrongAlgorithm } | ShouldBeErrorId "ParameterArgumentValidationError,Microsoft.PowerShell.Commands.GetFileHashCommand"
+            { Get-Hash $testDocument -Algorithm wrongAlgorithm } | ShouldBeErrorId "ParameterArgumentValidationError,Microsoft.PowerShell.Commands.GetFileHashCommand"
         }
     }
 
@@ -89,11 +94,19 @@ Describe "Get-Hash tests for files" -Tags "CI" {
 
         It "With '-Path': file exist" {
             $result = Get-Hash -Path $testDocument
+
+            $result | Should BeOfType 'Microsoft.PowerShell.Commands.FileHashInfo'
+            $result.Algorithm | Should Be "SHA256"
+            $result.Hash | Should Be "4A6DA9F1C0827143BB19FC4B0F2A8057BC1DF55F6D1F62FA3B917BA458E8F570"
             $result.Path | Should Be $testDocument
         }
 
         It "With '-LiteralPath': file exist" {
             $result = Get-Hash -LiteralPath $testDocument
+
+            $result | Should BeOfType 'Microsoft.PowerShell.Commands.FileHashInfo'
+            $result.Algorithm | Should Be "SHA256"
+            $result.Hash | Should Be "4A6DA9F1C0827143BB19FC4B0F2A8057BC1DF55F6D1F62FA3B917BA458E8F570"
             $result.Path | Should Be $testDocument
         }
     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Hash.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Hash.Tests.ps1
@@ -1,0 +1,100 @@
+Import-Module $PSScriptRoot\..\..\Common\Test.Helpers.psm1
+Describe "Get-Hash tests for files" -Tags "CI" {
+
+    BeforeAll {
+        $testDocument = Join-Path -Path $PSScriptRoot -ChildPath assets testablescript.ps1
+        Write-Host $testDocument
+    }
+
+    Context "Default result tests" {
+        It "Should default to correct algorithm, hash and path" {
+            $result = Get-Hash $testDocument
+
+            $result | Should BeOfType 'Microsoft.PowerShell.Commands.FileHashInfo'
+            $result.Algorithm | Should Be "SHA256"
+            $result.Hash | Should Be "4A6DA9F1C0827143BB19FC4B0F2A8057BC1DF55F6D1F62FA3B917BA458E8F570"
+            $result.Path | Should Be $testDocument
+        }
+    }
+
+    Context "Algorithm tests" {
+        BeforeAll {
+            # Keep "sHA1" below! It is for testing that the cmdlet accept a hash algorithm name in any case!
+            $testcases =
+                @{ algorithm = "sHA1";   hash = "01B865D143E07ECC875AB0EFC0A4429387FD0CF7" },
+                @{ algorithm = "SHA256"; hash = "4A6DA9F1C0827143BB19FC4B0F2A8057BC1DF55F6D1F62FA3B917BA458E8F570" },
+                @{ algorithm = "SHA384"; hash = "656215B6A07011E625206F43E57873F49AD7B36DFCABB70F6CDCE2303D7A603E55D052774D26F339A6D80A264340CB8C" },
+                @{ algorithm = "SHA512"; hash = "C688C33027D89ACAC920545471C8053D8F64A54E21D0415F1E03766DDCDA215420E74FAFD1DC399864C6B6B5723A3358BD337339906797A39090B02229BF31FE" },
+                @{ algorithm = "MD5";    hash = "7B09811D1631C9FD46B39D1D35522F0A" }
+        }
+
+        It "Should be able to get the correct hash by Path from <algorithm> algorithm" -TestCases $testCases {
+            param($algorithm, $hash)
+            $algorithmResult = Get-Hash -Path $testDocument -Algorithm $algorithm
+
+            $algorithmResult | Should BeOfType 'Microsoft.PowerShell.Commands.FileHashInfo'
+            $algorithmResult.Algorithm | Should Be $algorithm
+            $algorithmResult.Hash | Should Be $hash
+            $algorithmResult.Path | Should Be $testDocument
+        }
+
+        It "Should be able to get the correct hash by InputStream from <algorithm> algorithm" -TestCases $testCases {
+            param($algorithm, $hash)
+            $testFileStream = [System.IO.File]::OpenRead($testDocument)
+            $algorithmResult = Get-Hash -InputStream $testFileStream -Algorithm $algorithm
+
+            $algorithmResult | Should BeOfType 'Microsoft.PowerShell.Commands.FileHashInfo'
+            $algorithmResult.Algorithm | Should Be $algorithm
+            $algorithmResult.Hash | Should Be $hash
+        }
+
+        It "Should be able to get the correct hash by String from <algorithm> algorithm" -TestCases $testCases {
+            param($algorithm, $hash)
+            # Simple trick needed to get a test string from byte sequence because the test file contains BOM.
+            # It allows to reuse the file hashes.
+            $testBytes = Get-Content $testDocument -Raw -Encoding Byte
+            $testString = [System.Text.Encoding]::UTF8.GetString($testBytes)
+            $algorithmResult = Get-Hash -InputString $testString -Algorithm $algorithm -Encoding UTF8
+
+            $algorithmResult | Should BeOfType 'Microsoft.PowerShell.Commands.StringHashInfo'
+            $algorithmResult.Algorithm | Should Be $algorithm
+            $algorithmResult.Hash | Should Be $hash
+            $algorithmResult.Encoding | Should Be 'UTF8'
+            $algorithmResult.HashedString | Should Be $testString
+        }
+
+        It "Should be able to get the correct hash for 'null' String" {
+            $result = Get-Hash -InputString $null
+
+            $result | Should BeOfType 'Microsoft.PowerShell.Commands.StringHashInfo'
+            $result.Algorithm | Should Be 'SHA256'
+            $result.Hash | Should Be $null
+            $result.Encoding | Should Be 'Default'
+            $result.HashedString | Should Be $null
+        }
+
+        It "Should be throw for wrong algorithm name" {
+            { Get-Hash Get-Hash $testDocument -Algorithm wrongAlgorithm } | ShouldBeErrorId "ParameterArgumentValidationError,Microsoft.PowerShell.Commands.GetFileHashCommand"
+        }
+    }
+
+    Context "Paths tests" {
+        It "With '-Path': no file exist" {
+            { Get-Hash -Path nofileexist.ttt -ErrorAction Stop } | ShouldBeErrorId "FileNotFound,Microsoft.PowerShell.Commands.GetFileHashCommand"
+        }
+
+        It "With '-LiteralPath': no file exist" {
+            { Get-Hash -LiteralPath nofileexist.ttt -ErrorAction Stop } | ShouldBeErrorId "FileNotFound,Microsoft.PowerShell.Commands.GetFileHashCommand"
+        }
+
+        It "With '-Path': file exist" {
+            $result = Get-Hash -Path $testDocument
+            $result.Path | Should Be $testDocument
+        }
+
+        It "With '-LiteralPath': file exist" {
+            $result = Get-Hash -LiteralPath $testDocument
+            $result.Path | Should Be $testDocument
+        }
+    }
+}

--- a/test/powershell/engine/Basic/DefaultCommands.Tests.ps1
+++ b/test/powershell/engine/Basic/DefaultCommands.Tests.ps1
@@ -60,6 +60,7 @@ Describe "Verify approved aliases list" -Tags "CI" {
 "Alias",  "gcm",                                "Get-Command",                        $($FullCLR -or $CoreWindows -or $CoreUnix),   "ReadOnly",         ""
 "Alias",  "gcs",                                "Get-PSCallStack",                    $($FullCLR -or $CoreWindows -or $CoreUnix),   "ReadOnly",         ""
 "Alias",  "gdr",                                "Get-PSDrive",                        $($FullCLR -or $CoreWindows -or $CoreUnix),   "ReadOnly",         ""
+"Alias",  "Get-FileHash",                       "Get-Hash",                           $(             $CoreWindows -or $CoreUnix),   "ReadOnly",         "AllScope"
 "Alias",  "ghy",                                "Get-History",                        $($FullCLR -or $CoreWindows -or $CoreUnix),   "ReadOnly",         ""
 "Alias",  "gi",                                 "Get-Item",                           $($FullCLR -or $CoreWindows -or $CoreUnix),   "ReadOnly",         ""
 "Alias",  "gin",                                "Get-ComputerInfo",                   $($FullCLR -or $CoreWindows              ),   "",                 ""
@@ -256,7 +257,7 @@ Describe "Verify approved aliases list" -Tags "CI" {
 "Cmdlet", "Get-EventLog",                                       ,                     $($FullCLR                               )
 "Cmdlet", "Get-EventSubscriber",                                ,                     $($FullCLR -or $CoreWindows -or $CoreUnix)
 "Cmdlet", "Get-ExecutionPolicy",                                ,                     $($FullCLR -or $CoreWindows -or $CoreUnix)
-"Cmdlet", "Get-FileHash",                                       ,                     $(             $CoreWindows -or $CoreUnix)
+"Cmdlet", "Get-Hash",                                           ,                     $(             $CoreWindows -or $CoreUnix)
 "Cmdlet", "Get-FormatData",                                     ,                     $($FullCLR -or $CoreWindows -or $CoreUnix)
 "Cmdlet", "Get-Help",                                           ,                     $($FullCLR -or $CoreWindows -or $CoreUnix)
 "Cmdlet", "Get-History",                                        ,                     $($FullCLR -or $CoreWindows -or $CoreUnix)


### PR DESCRIPTION
It is first experimental implementation Get-Hash cmdlet for https://github.com/PowerShell/PowerShell-RFC/blob/master/2-Draft-Accepted/RFC0018-Get-StringHash.md

1. According to the RFC the type of Encoding parameter is `FileSystemCmdletProviderEncoding` but I had to use `EncodingConversion class` because the API contains useful methods and can be easily _enhanced_ in future (to support full set of codepages). Now multiple Utility cmdlets uses it. In contrast, a code using `FileSystemCmdletProviderEncoding` type is distributed in FileProvider and it's hard to reuse it although it is designated as the preferred (?) in https://github.com/PowerShell/PowerShell-RFC/blob/master/1-Draft/RFC0020-DefaultFileEncoding.md We also talked about that we should rationalize the use of encoding so `EncodingConversion class` looks like the best option.
2. Added `ValueFromPipelineByPropertyName` to `Path` parameter that is skipped in the RFC 0018.
3. ~~After the implementation we can really see that `Path` and `InputString` parameters have the same type and cannot be both `ValueFromPipeline`. Perhaps here we understand that it is better for UX to have both options and we should split on `Get-FileHash` and `Get-StringHash` still. Until concluding on this I haven't added pipeline tests.~~ We follow `Select-String` pattern as suggested by @rkeithhill.
4. ~~I wanted to implement `ValidateEncoding` attribute but was blocked so how to implement Tab Completion. I need help.~~ We should follow #4119.