### PR TITLE
Get-help may return multiple instances of the same help file

### DIFF
--- a/src/System.Management.Automation/help/HelpProvider.cs
+++ b/src/System.Management.Automation/help/HelpProvider.cs
@@ -273,7 +273,11 @@ namespace System.Management.Automation
             Diagnostics.Assert(searchPaths != null,
                 "HelpSystem returned an null search path");
 
-            searchPaths.Add(GetDefaultShellSearchPath());
+            string defaultShellSearchPath = GetDefaultShellSearchPath();
+            if (!searchPaths.Contains(defaultShellSearchPath))
+            {
+                searchPaths.Add(defaultShellSearchPath);
+            }
 
             return searchPaths;
         }

--- a/src/System.Management.Automation/help/MUIFileSearcher.cs
+++ b/src/System.Management.Automation/help/MUIFileSearcher.cs
@@ -161,7 +161,7 @@ namespace System.Management.Automation
                             string leafFileName = Path.GetFileName(file);
                             string uniqueToDirectory = Path.Combine(directory, leafFileName);
 
-                            if (!_uniqueMatches.Contains(uniqueToDirectory))
+                            if (!_result.Contains(path) && !_uniqueMatches.Contains(uniqueToDirectory))
                             {
                                 _result.Add(path);
                                 _uniqueMatches[uniqueToDirectory] = true;

--- a/test/powershell/engine/Help/HelpSystem.Tests.ps1
+++ b/test/powershell/engine/Help/HelpSystem.Tests.ps1
@@ -180,3 +180,13 @@ Describe "Validate that Get-Help returns provider-specific help" -Tags @('CI', '
         }
     }
 }
+
+Describe "Validate about_help.txt under culture specific folder works" -Tags @('CI') {
+
+    It "Get-Help about_should should return help text and not multiple HelpInfo objects" {
+
+        $help = Get-Help about_should
+        $help.count | Should Be 1
+        $help | Should BeOfType System.String
+    }
+}

--- a/test/powershell/engine/Help/HelpSystem.Tests.ps1
+++ b/test/powershell/engine/Help/HelpSystem.Tests.ps1
@@ -182,11 +182,25 @@ Describe "Validate that Get-Help returns provider-specific help" -Tags @('CI', '
 }
 
 Describe "Validate about_help.txt under culture specific folder works" -Tags @('CI') {
+    BeforeAll {
+        $savedPSModulePath = $env:PSModulePath
+        $env:PSModulePath += ";TestDrive:\Modules"
+        $modulePath = "TestDrive:\Modules\Test"
+        $null = New-Item -Path $modulePath\en-us -ItemType Directory -Force
+        New-ModuleManifest -Path $modulePath\test.psd1 -RootModule test.psm1
+        Set-Content -Path $modulePath\test.psm1 -Value "function foo{}"
+        Set-Content -Path $modulePath\en-us\about_testhelp.help.txt -Value "Hello" -NoNewline
+        Import-Module test
+    }
 
-    It "Get-Help about_should should return help text and not multiple HelpInfo objects" {
+    AfterAll {
+        $env:PSModulePath = $savedPSModulePath
+    }
 
-        $help = Get-Help about_should
+    It "Get-Help should return help text and not multiple HelpInfo objects" {
+
+        $help = Get-Help about_testhelp
         $help.count | Should Be 1
-        $help | Should BeOfType System.String
+        $help | Should BeExactly "Hello"
     }
 }

--- a/test/powershell/engine/Help/HelpSystem.Tests.ps1
+++ b/test/powershell/engine/Help/HelpSystem.Tests.ps1
@@ -183,21 +183,18 @@ Describe "Validate that Get-Help returns provider-specific help" -Tags @('CI', '
 
 Describe "Validate about_help.txt under culture specific folder works" -Tags @('CI') {
     BeforeAll {
-        $savedPSModulePath = $env:PSModulePath
-        $env:PSModulePath += ";TestDrive:\Modules"
-        $modulePath = "TestDrive:\Modules\Test"
-        $null = New-Item -Path $modulePath\en-us -ItemType Directory -Force
+        $modulePath = "$pshome\Modules\Test"
+        $null = New-Item -Path $modulePath\en-US -ItemType Directory -Force
         New-ModuleManifest -Path $modulePath\test.psd1 -RootModule test.psm1
         Set-Content -Path $modulePath\test.psm1 -Value "function foo{}"
-        Set-Content -Path $modulePath\en-us\about_testhelp.help.txt -Value "Hello" -NoNewline
-        Import-Module test
+        Set-Content -Path $modulePath\en-US\about_testhelp.help.txt -Value "Hello" -NoNewline
     }
 
     AfterAll {
-        $env:PSModulePath = $savedPSModulePath
+        Remove-Item $modulePath -Recurse -Force
     }
 
-    It "Get-Help should return help text and not multiple HelpInfo objects" {
+    It "Get-Help should return help text and not multiple HelpInfo objects when help is under `$pshome path" {
 
         $help = Get-Help about_testhelp
         $help.count | Should Be 1


### PR DESCRIPTION
While building directories to search it may add the default shell directory twice to the list of directories to search (this is more of a perf issue of searching it twice than the root cause of the problem)

When a file is found, it generates a new unique key, however, the unique key is based on the root folder and not the actual one that contains the file, so a duplicate can result.

Addresses #3399 