### PR TITLE
Fix to use alternative API to check for lock down policy when wldp assembly is not loaded

### DIFF
--- a/src/System.Management.Automation/security/nativeMethods.cs
+++ b/src/System.Management.Automation/security/nativeMethods.cs
@@ -1951,6 +1951,240 @@ namespace System.Management.Automation.Security
             }
             return DllExists;
         }
+
+        #region NtQuerySystemInformation
+
+        /// <summary>
+        /// NtQuerySystemInformation
+        /// MSDN Reference: https://msdn.microsoft.com/en-us/library/windows/desktop/ms724509(v=vs.85).aspx
+        /// </summary>
+        internal enum SYSTEM_INFORMATION_CLASS : uint
+        {
+            SystemBasicInformation = 0,
+            SystemProcessorInformation = 1,    // obsolete...delete
+            SystemPerformanceInformation = 2,
+            SystemTimeOfDayInformation = 3,
+            SystemPathInformation = 4,
+            SystemProcessInformation = 5,
+            SystemCallCountInformation = 6,
+            SystemDeviceInformation = 7,
+            SystemProcessorPerformanceInformation = 8,
+            SystemFlagsInformation = 9,
+            SystemCallTimeInformation = 10,
+            SystemModuleInformation = 11,
+            SystemLocksInformation = 12,
+            SystemStackTraceInformation = 13,
+            SystemPagedPoolInformation = 14,
+            SystemNonPagedPoolInformation = 15,
+            SystemHandleInformation = 16,
+            SystemObjectInformation = 17,
+            SystemPageFileInformation = 18,
+            SystemVdmInstemulInformation = 19,
+            SystemVdmBopInformation = 20,
+            SystemFileCacheInformation = 21,
+            SystemPoolTagInformation = 22,
+            SystemInterruptInformation = 23,
+            SystemDpcBehaviorInformation = 24,
+            SystemFullMemoryInformation = 25,
+            SystemLoadGdiDriverInformation = 26,
+            SystemUnloadGdiDriverInformation = 27,
+            SystemTimeAdjustmentInformation = 28,
+            SystemSummaryMemoryInformation = 29,
+            SystemMirrorMemoryInformation = 30,
+            SystemPerformanceTraceInformation = 31,
+            SystemObsolete0 = 32,
+            SystemExceptionInformation = 33,
+            SystemCrashDumpStateInformation = 34,
+            SystemKernelDebuggerInformation = 35,
+            SystemContextSwitchInformation = 36,
+            SystemRegistryQuotaInformation = 37,
+            SystemExtendServiceTableInformation = 38,
+            SystemPrioritySeperation = 39,
+            SystemVerifierAddDriverInformation = 40,
+            SystemVerifierRemoveDriverInformation = 41,
+            SystemProcessorIdleInformation = 42,
+            SystemLegacyDriverInformation = 43,
+            SystemCurrentTimeZoneInformation = 44,
+            SystemLookasideInformation = 45,
+            SystemTimeSlipNotification = 46,
+            SystemSessionCreate = 47,
+            SystemSessionDetach = 48,
+            SystemSessionInformation = 49,
+            SystemRangeStartInformation = 50,
+            SystemVerifierInformation = 51,
+            SystemVerifierThunkExtend = 52,
+            SystemSessionProcessInformation = 53,
+            SystemLoadGdiDriverInSystemSpace = 54,
+            SystemNumaProcessorMap = 55,
+            SystemPrefetcherInformation = 56,
+            SystemExtendedProcessInformation = 57,
+            SystemRecommendedSharedDataAlignment = 58,
+            SystemComPlusPackage = 59,
+            SystemNumaAvailableMemory = 60,
+            SystemProcessorPowerInformation = 61,
+            SystemEmulationBasicInformation = 62,
+            SystemEmulationProcessorInformation = 63,
+            SystemExtendedHandleInformation = 64,
+            SystemLostDelayedWriteInformation = 65,
+            SystemBigPoolInformation = 66,
+            SystemSessionPoolTagInformation = 67,
+            SystemSessionMappedViewInformation = 68,
+            SystemHotpatchInformation = 69,
+            SystemObjectSecurityMode = 70,
+            SystemWatchdogTimerHandler = 71,
+            SystemWatchdogTimerInformation = 72,
+            SystemLogicalProcessorInformation = 73,
+            SystemWow64SharedInformationObsolete = 74,
+            SystemRegisterFirmwareTableInformationHandler = 75,
+            SystemFirmwareTableInformation = 76,
+            SystemModuleInformationEx = 77,
+            SystemVerifierTriageInformation = 78,
+            SystemSuperfetchInformation = 79,
+            SystemMemoryListInformation = 80,
+            SystemFileCacheInformationEx = 81,
+            SystemThreadPriorityClientIdInformation = 82,
+            SystemProcessorIdleCycleTimeInformation = 83,
+            SystemVerifierCancellationInformation = 84,
+            SystemProcessorPowerInformationEx = 85,
+            SystemRefTraceInformation = 86,
+            SystemSpecialPoolInformation = 87,
+            SystemProcessIdInformation = 88,
+            SystemErrorPortInformation = 89,
+            SystemBootEnvironmentInformation = 90,
+            SystemHypervisorInformation = 91,
+            SystemVerifierInformationEx = 92,
+            SystemTimeZoneInformation = 93,
+            SystemImageFileExecutionOptionsInformation = 94,
+            SystemCoverageInformation = 95,
+            SystemPrefetchPatchInformation = 96,
+            SystemVerifierFaultsInformation = 97,
+            SystemSystemPartitionInformation = 98,
+            SystemSystemDiskInformation = 99,
+            SystemProcessorPerformanceDistribution = 100,
+            SystemNumaProximityNodeInformation = 101,
+            SystemDynamicTimeZoneInformation = 102,
+            SystemCodeIntegrityInformation = 103,
+            SystemProcessorMicrocodeUpdateInformation = 104,
+            SystemProcessorBrandString = 105,
+            SystemVirtualAddressInformation = 106,
+            SystemLogicalProcessorAndGroupInformation = 107,
+            SystemProcessorCycleTimeInformation = 108,
+            SystemStoreInformation = 109,
+            SystemRegistryAppendString = 110,
+            SystemAitSamplingValue = 111,
+            SystemVhdBootInformation = 112,
+            SystemCpuQuotaInformation = 113,
+            SystemNativeBasicInformation = 114,
+            SystemErrorPortTimeouts = 115,
+            SystemLowPriorityIoInformation = 116,
+            SystemBootEntropyInformation = 117,
+            SystemVerifierCountersInformation = 118,
+            SystemPagedPoolInformationEx = 119,
+            SystemSystemPtesInformationEx = 120,
+            SystemNodeDistanceInformation = 121,
+            SystemAcpiAuditInformation = 122,
+            SystemBasicPerformanceInformation = 123,
+            SystemQueryPerformanceCounterInformation = 124,
+            SystemSessionBigPoolInformation = 125,
+            SystemBootGraphicsInformation = 126,
+            SystemScrubPhysicalMemoryInformation = 127,
+            SystemBadPageInformation = 128,
+            SystemProcessorProfileControlArea = 129,
+            SystemCombinePhysicalMemoryInformation = 130,
+            SystemEntropyInterruptTimingInformation = 131,
+            SystemConsoleInformation = 132,
+            SystemPlatformBinaryInformation = 133,
+            SystemPolicyInformation = 134,
+            SystemHypervisorProcessorCountInformation = 135,
+            SystemDeviceDataInformation = 136,
+            SystemDeviceDataEnumerationInformation = 137,
+            SystemMemoryTopologyInformation = 138,
+            SystemMemoryChannelInformation = 139,
+            SystemBootLogoInformation = 140,
+            SystemProcessorPerformanceInformationEx = 141,
+            SystemCriticalProcessErrorLogInformation = 142,
+            SystemSecureBootPolicyInformation = 143,
+            SystemPageFileInformationEx = 144,
+            SystemSecureBootInformation = 145,
+            SystemEntropyInterruptTimingRawInformation = 146,
+            SystemPortableWorkspaceEfiLauncherInformation = 147,
+            SystemFullProcessInformation = 148,
+            SystemKernelDebuggerInformationEx = 149,
+            SystemBootMetadataInformation = 150,
+            SystemSoftRebootInformation = 151,
+            SystemElamCertificateInformation = 152,
+            SystemOfflineDumpConfigInformation = 153,
+            SystemProcessorFeaturesInformation = 154,
+            SystemRegistryReconciliationInformation = 155,
+            SystemEdidInformation = 156,
+            SystemManufacturingInformation = 157,
+            SystemEnergyEstimationConfigInformation = 158,
+            SystemHypervisorDetailInformation = 159,
+            SystemProcessorCycleStatsInformation = 160,
+            SystemVmGenerationCountInformation = 161,
+            SystemTrustedPlatformModuleInformation = 162,
+            SystemKernelDebuggerFlags = 163,
+            SystemCodeIntegrityPolicyInformation = 164,
+            SystemIsolatedUserModeInformation = 165,
+            SystemHardwareSecurityTestInterfaceResultsInformation = 166,
+            SystemSingleModuleInformation = 167,
+            SystemAllowedCpuSetsInformation = 168,
+            SystemDmaProtectionInformation = 169,
+            SystemInterruptCpuSetsInformation = 170,
+            SystemSecureBootPolicyFullInformation = 171,
+            SystemCodeIntegrityPolicyFullInformation = 172,
+            SystemAffinitizedInterruptProcessorInformation = 173,
+            SystemRootSiloInformation = 174,
+            SystemCpuSetInformation = 175,
+            SystemCpuSetTagInformation = 176,
+            SystemWin32WerStartCallout = 177,
+            SystemSecureKernelProfileInformation = 178,
+            SystemCodeIntegrityPlatformManifestInformation = 179,
+            SystemInterruptSteeringInformation = 180,
+            SystemSupportedProcessorArchitectures = 181,
+            SystemMemoryUsageInformation = 182
+        }
+
+        internal enum CodeIntegrityPolicyOptions : uint
+        {
+            CODEINTEGRITYPOLICY_OPTION_ENABLED = 0x1,
+            CODEINTEGRITYPOLICY_OPTION_AUDIT_ENABLED = 0x02,
+            CODEINTEGRITYPOLICY_OPTION_WHQL_SIGNED_ENABLED = 0x04,
+            CODEINTEGRITYPOLICY_OPTION_EV_WHQL_SIGNED_ENABLED = 0x08,
+            CODEINTEGRITYPOLICY_OPTION_UMCI_ENABLED = 0x10,
+            CODEINTEGRITYPOLICY_OPTION_SCRIPT_ENFORCEMENT_DISABLED = 0x20,
+            CODEINTEGRITYPOLICY_OPTION_HOST_POLICY_ENFORCEMENT_ENABLED = 0x40,
+            CODEINTEGRITYPOLICY_OPTION_POLICY_ALLOW_UNSIGNED = 0x80
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct SYSTEM_CODEINTEGRITYPOLICY_INFORMATION
+        {
+            internal UInt32 Options;
+            internal UInt32 HVCIOptions;
+            internal UInt64 Version;
+            internal GUID PolicyGuid;
+        }
+
+        /// <summary>
+        /// This is a specific overload of the NtQuerySystemInformation for code integrity policy
+        /// information.  
+        /// </summary>
+        /// <param name="SystemInformationClass">This *must* be a class that returns
+        /// SYSTEM_CODEINTEGRITYPOLICY_INFORMATION information.</param>
+        /// <param name="ciPolicyInfo">SYSTEM_CODEINTEGRITYPOLICY_INFORMATION</param>
+        /// <param name="ciPolicyLength"></param>
+        /// <param name="ReturnLength"></param>
+        /// <returns></returns>
+        [DllImport("ntdll.dll", EntryPoint = "NtQuerySystemInformation")]
+        internal static extern int NtQueryCodeIntegrityPolicyInfo(
+            SYSTEM_INFORMATION_CLASS SystemInformationClass,
+            ref SYSTEM_CODEINTEGRITYPOLICY_INFORMATION ciPolicyInfo,
+            uint ciPolicyLength,
+            ref uint ReturnLength
+        );
+
+        #endregion
     }
 
     // Constants needed for Catalog Error Handling


### PR DESCRIPTION
This change is ported from the Windows code base and addresses issue #1734.  An alternate API is used to determine system wide lockdown policy if the wldp assembly could not load.