### PR TITLE
Use Product Semantic version in the MSI installer where possible

### DIFF
--- a/assets/Product.wxs
+++ b/assets/Product.wxs
@@ -12,7 +12,7 @@
   <?define ProductVersion = "$(env.ProductVersion)" ?>
   <?define ProductSemanticVersion = "$(env.ProductSemanticVersion)" ?>
   <?define ProductVersionWithName = "$(var.ProductName)_$(var.ProductVersion)"?>
-  <?define ProductSemanticVersionWithName = "$(var.ProductName)_$(env.ProductSemanticVersion)"?>
+  <?define ProductSemanticVersionWithName = "$(var.ProductName)-$(env.ProductSemanticVersion)"?>
   <?define ProductTargetArchitecture = "$(env.ProductTargetArchitecture)"?>
   <?define ProductProgFilesDir = "$(env.ProductProgFilesDir)" ?>
 

--- a/assets/Product.wxs
+++ b/assets/Product.wxs
@@ -10,14 +10,16 @@
   <?define ProductName = "$(env.ProductName)" ?>
   <?define ProductGuid = "$(env.ProductGuid)" ?>
   <?define ProductVersion = "$(env.ProductVersion)" ?>
+  <?define ProductSemanticVersion = "$(env.ProductSemanticVersion)" ?>
   <?define ProductVersionWithName = "$(var.ProductName)_$(var.ProductVersion)"?>
+  <?define ProductSemanticVersionWithName = "$(var.ProductName)_$(env.ProductSemanticVersion)"?>
   <?define ProductTargetArchitecture = "$(env.ProductTargetArchitecture)"?>
   <?define ProductProgFilesDir = "$(env.ProductProgFilesDir)" ?>
 
   <!-- Generate Your Own GUID for both ID and UpgradeCode attributes. -->
   <!-- Note:  UpgradeCode GUID MUST REMAIN SAME THROUGHOUT ALL VERSIONS -->
   <!-- Otherwise, updates won't occur -->
-  <Product Id="$(var.ProductGuid)" Name="$(var.ProductVersionWithName)" Language="1033" Version="$(var.ProductVersion)" Manufacturer="Microsoft Corporation" UpgradeCode="{f7ba3e58-0be8-443b-ac91-f99dd1e7bd3b}">
+  <Product Id="$(var.ProductGuid)" Name="$(var.ProductSemanticVersionWithName)" Language="1033" Version="$(var.ProductVersion)" Manufacturer="Microsoft Corporation" UpgradeCode="{f7ba3e58-0be8-443b-ac91-f99dd1e7bd3b}">
     <!-- Properties About The Package -->
     <Package Id="*" Keywords="Installer" Platform="$(var.ProductTargetArchitecture)" InstallerVersion="200" Compressed="yes" InstallScope="perMachine" Description="PowerShell package" Comments="PowerShell for every system" />
 
@@ -55,7 +57,7 @@
     <Directory Id="TARGETDIR" Name="SourceDir">
       <Directory Id="$(var.ProductProgFilesDir)">
         <Directory Id="INSTALLFOLDER" Name="PowerShell">
-          <Directory Id="$(var.ProductVersionWithName)" Name="$(var.ProductVersion)">
+          <Directory Id="$(var.ProductVersionWithName)" Name="$(var.ProductSemanticVersion)">
             <Component Id="ProductVersionFolder" Guid="{e1a7f05e-0cd6-4227-80a8-e4fb311f045c}">
               <CreateFolder/>
             </Component>
@@ -63,11 +65,11 @@
         </Directory>        
       </Directory>
       <Directory Id="ProgramMenuFolder">
-        <Directory Id="ApplicationProgramsFolder" Name="$(var.ProductVersionWithName)">
+        <Directory Id="ApplicationProgramsFolder" Name="$(var.ProductSemanticVersionWithName)">
           <Component Id="ApplicationProgramsMenuShortcut" Guid="{A77507A7-F970-4618-AC30-20AFE36EE2EB}">
             <Shortcut Id="PowerShell_ProgramsMenuShortcut"
-              Name="$(var.ProductVersionWithName)"
-              Description="$(var.ProductVersionWithName)"
+              Name="$(var.ProductSemanticVersionWithName)"
+              Description="$(var.ProductSemanticVersionWithName)"
               Target="[$(var.ProductVersionWithName)]PowerShell.exe"
               WorkingDirectory="$(var.ProductVersionWithName)"
               Icon = "PowerShellExe.ico" />
@@ -75,7 +77,7 @@
             <RemoveFolder Id="ApplicationProgramsFolder" On="uninstall"/>
 
             <RegistryValue Root="HKCU"
-                           Key="Software\Microsoft\$(var.ProductVersionWithName)\ProgramsMenuShortcut"
+                           Key="Software\Microsoft\$(var.ProductSemanticVersionWithName)\ProgramsMenuShortcut"
                            Name="installed"
                            Type="integer"
                            Value="1" KeyPath="yes"/>

--- a/build.psm1
+++ b/build.psm1
@@ -2569,7 +2569,7 @@ function New-MSIPackage
     $msiLocationPath = Join-Path $pwd "$packageName.msi"
     Remove-Item -ErrorAction SilentlyContinue $msiLocationPath -Force
 
-    & $wixHeatExePath dir  $ProductSourcePath -dr  $productVersionWithName -cg $productVersionWithName -gg -sfrag -srd -scom -sreg -out $wixFragmentPath -var env.ProductSourcePath -v | Write-Verbose    
+    & $wixHeatExePath dir  $ProductSourcePath -dr  $productVersionWithName -cg $productVersionWithName -gg -sfrag -srd -scom -sreg -out $wixFragmentPath -var env.ProductSourcePath -v | Write-Verbose
     & $wixCandleExePath  "$ProductWxsPath"  "$wixFragmentPath" -out (Join-Path "$env:Temp" "\\") -arch x64 -v | Write-Verbose
     & $wixLightExePath -out $msiLocationPath $wixObjProductPath $wixObjFragmentPath -ext WixUIExtension -dWixUILicenseRtf="$LicenseFilePath" -v | Write-Verbose
 

--- a/build.psm1
+++ b/build.psm1
@@ -2538,8 +2538,8 @@ function New-MSIPackage
     Write-Verbose "Place dependencies such as icons to $assetsInSourcePath"
     Copy-Item "$AssetsPath\*.ico" $assetsInSourcePath -Force
 
-    $productVersionWithName = $ProductName + "_" + $ProductVersion
-    $productSemanticVersionWithName = $ProductName + "_" + $ProductSemanticVersion
+    $productVersionWithName = $ProductName + '_' + $ProductVersion
+    $productSemanticVersionWithName = $ProductName + '-' + $ProductSemanticVersion
 
     Write-Verbose "Create MSI for Product $productSemanticVersionWithName"
 
@@ -2569,7 +2569,7 @@ function New-MSIPackage
     $msiLocationPath = Join-Path $pwd "$packageName.msi"
     Remove-Item -ErrorAction SilentlyContinue $msiLocationPath -Force
 
-    & $wixHeatExePath dir  $ProductSourcePath -dr  $productVersionWithName -cg $productVersionWithName -gg -sfrag -srd -scom -sreg -out $wixFragmentPath -var env.ProductSourcePath -v | Write-Verbose
+    & $wixHeatExePath dir  $ProductSourcePath -dr  $productVersionWithName -cg $productVersionWithName -gg -sfrag -srd -scom -sreg -out $wixFragmentPath -var env.ProductSourcePath -v | Write-Verbose    
     & $wixCandleExePath  "$ProductWxsPath"  "$wixFragmentPath" -out (Join-Path "$env:Temp" "\\") -arch x64 -v | Write-Verbose
     & $wixLightExePath -out $msiLocationPath $wixObjProductPath $wixObjFragmentPath -ext WixUIExtension -dWixUILicenseRtf="$LicenseFilePath" -v | Write-Verbose
 
@@ -2674,7 +2674,7 @@ function New-AppxPackage
     Write-Verbose "Place AppxManifest dependencies such as images to $assetsInSourcePath"
     Copy-Item "$AssetsPath\*.png" $assetsInSourcePath -Force
 
-    $appxPackageName = $PackageName + "_" + $PackageSemanticVersion
+    $appxPackageName = $PackageName + "-" + $PackageSemanticVersion
     if ($PackageNameSuffix) {
         $appxPackageName = $appxPackageName, $PackageNameSuffix -join "-"
     }
@@ -2716,7 +2716,7 @@ function New-ZipPackage
 
     $ProductSemanticVersion = Get-PackageSemanticVersion -Version $PackageVersion
 
-    $zipPackageName = $PackageName + "_" + $ProductSemanticVersion
+    $zipPackageName = $PackageName + "-" + $ProductSemanticVersion
     if ($PackageNameSuffix) {
         $zipPackageName = $zipPackageName, $PackageNameSuffix -join "-"
     }

--- a/build.psm1
+++ b/build.psm1
@@ -2548,7 +2548,8 @@ function New-MSIPackage
     [Environment]::SetEnvironmentVariable("ProductName", $ProductName, "Process")
     [Environment]::SetEnvironmentVariable("ProductGuid", $ProductGuid, "Process")
     [Environment]::SetEnvironmentVariable("ProductVersion", $ProductVersion, "Process")
-    [Environment]::SetEnvironmentVariable("ProductVersionWithName", $productVersionWithName, "Process")
+    [Environment]::SetEnvironmentVariable("ProductSemanticVersion", $ProductSemanticVersion, "Process")
+    [Environment]::SetEnvironmentVariable("ProductVersionWithName", $productVersionWithName, "Process")    
     [Environment]::SetEnvironmentVariable("ProductTargetArchitecture", $ProductTargetArchitecture, "Process")
     $ProductProgFilesDir = "ProgramFiles64Folder"
     if ($ProductTargetArchitecture -eq "x86")


### PR DESCRIPTION
This PR takes care of  issues  #2660, #2661 

Semantic version will be used where possible. Note that WiX toolset mostly likes to work with sequence based versioning - major.minor[.build[.revision]]

![image](https://cloud.githubusercontent.com/assets/11727200/24378539/26389522-12f8-11e7-891d-56b94213c4b1.png)


![image](https://cloud.githubusercontent.com/assets/11727200/24378563/3ef64762-12f8-11e7-88bf-ece56dc314f5.png)

![image](https://cloud.githubusercontent.com/assets/11727200/24378587/57c7ee4e-12f8-11e7-88bf-a5a620499417.png)


