### PR TITLE
PowerShell doesn't start if env var HOME is not defined

### DIFF
--- a/src/System.Management.Automation/engine/hostifaces/LocalConnection.cs
+++ b/src/System.Management.Automation/engine/hostifaces/LocalConnection.cs
@@ -1267,6 +1267,8 @@ namespace System.Management.Automation.Runspaces
                         RunspaceOpening = null;
                     }
 
+                    Platform.RemoveTemporaryDirectory();
+
                     // Dispose the event manager
                     if (this.ExecutionContext != null && this.ExecutionContext.Events != null)
                     {

--- a/src/System.Management.Automation/utils/PsUtils.cs
+++ b/src/System.Management.Automation/utils/PsUtils.cs
@@ -604,6 +604,30 @@ namespace System.Management.Automation
 #endif
         }
 
+        /// <summary>
+        /// Get a temporary directory to use, needs to be unique to avoid collision
+        /// </summary>
+        internal static string GetTemporaryDirectory()
+        {
+            string tempDir = String.Empty;
+            string tempPath = Path.GetTempPath();
+            do
+            {
+                tempDir = Path.Combine(tempPath,System.Guid.NewGuid().ToString());
+            }
+            while (Directory.Exists(tempDir));
+
+            try
+            {
+                Directory.CreateDirectory(tempDir);
+            }
+            catch (UnauthorizedAccessException)
+            {
+                tempDir = String.Empty; // will become current working directory
+            }
+            return tempDir;
+        }
+
         internal static string GetHostName()
         {
             // Note: non-windows CoreCLR does not support System.Net yet

--- a/test/powershell/Host/ConsoleHost.Tests.ps1
+++ b/test/powershell/Host/ConsoleHost.Tests.ps1
@@ -403,6 +403,12 @@ foo
             [int]$output | Should BeGreaterThan 0
         }
     }
+
+    Context "HOME environment variable" {
+        It "Should start if HOME is not defined" -skip:($IsWindows) {
+            bash -c "unset HOME;$powershell -c '1+1'" | Should BeExactly 2
+        }
+    }
 }
 
 Describe "Console host api tests" -Tag CI {


### PR DESCRIPTION
In some environments (like Puppet), the HOME env var is not defined and this causes PowerShell to fail to start as it assumes HOME is available and tries to end up concatenating $null with a string.  Fix is to return an empty string instead of $null.  Side effect is that some working directories like `.cache` get created in the current working directory instead of HOME (which doesn't exist in this case) which seems acceptable.

Addresses https://github.com/PowerShell/PowerShell/issues/1794