### PR TITLE
Rename OSX package name to include operating system information

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,3 +1,0 @@
-{
-    "projects": ["src"]
-}


### PR DESCRIPTION
Fix #3058

This PR also remove `Start-PSRelease` from `build.psm1`, which is not used in our release-build pipeline.
`global.json` is also removed as it's not necessary now.

After renaming, the OSX package name will be like this: powershell-6.0.0-alpha.17-osx.10.11-x64.pkg
I have verified the renamed OSX package can be installed without a problem.