### PR TITLE
Replace string-compare-based test for copying to same file with more …

### DIFF
--- a/src/System.Management.Automation/CoreCLR/CorePsPlatform.cs
+++ b/src/System.Management.Automation/CoreCLR/CorePsPlatform.cs
@@ -515,6 +515,11 @@ namespace System.Management.Automation
             return Unix.NativeMethods.IsDirectory(path);
         }
 
+        internal static bool NonWindowsIsSameFileSystemItem(string pathOne, string pathTwo)
+        {
+            return Unix.NativeMethods.IsSameFileSystemItem(pathOne, pathTwo);
+        }
+
         internal static bool NonWindowsIsExecutable(string path)
         {
             return Unix.NativeMethods.IsExecutable(path);
@@ -530,7 +535,7 @@ namespace System.Management.Automation
             return IsOSX ? Unix.NativeMethods.GetPPid(pid) : Unix.GetProcFSParentPid(pid);
         }
 
-       
+
 
         // Unix specific implementations of required functionality
         //
@@ -722,6 +727,11 @@ namespace System.Management.Automation
                 [DllImport(psLib, CharSet = CharSet.Ansi, SetLastError = true)]
                 [return: MarshalAs(UnmanagedType.I1)]
                 internal static extern bool IsDirectory([MarshalAs(UnmanagedType.LPStr)]string filePath);
+
+                [DllImport(psLib, CharSet = CharSet.Ansi, SetLastError = true)]
+                [return: MarshalAs(UnmanagedType.I1)]
+                internal static extern bool IsSameFileSystemItem([MarshalAs(UnmanagedType.LPStr)]string filePathOne,
+                                                                 [MarshalAs(UnmanagedType.LPStr)]string filePathTwo);
             }
         }
     }

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -62,6 +62,11 @@ namespace Microsoft.PowerShell.Commands
         // copy script will accomodate the new value.
         private const int FILETRANSFERSIZE = 4 * 1024 * 1024;
 
+        // The name of the key in an exception's Data dictionary when attempting
+        // to copy an item onto itself.
+        private const string SelfCopyDataKey = "SelfCopy";
+
+
         /// <summary>
         /// An instance of the PSTraceSource class used for trace output
         /// using "FileSystemProvider" as the category.
@@ -3460,14 +3465,14 @@ namespace Microsoft.PowerShell.Commands
             _excludeMatcher = SessionStateUtilities.CreateWildcardsFromStrings(Exclude, WildcardOptions.IgnoreCase);
 
             // if the source and destination path are same (for a local copy) then flag it as error.
-            if ((toSession == null) && (fromSession == null) && path.Equals(destinationPath, StringComparison.OrdinalIgnoreCase))
+            if ((toSession == null) && (fromSession == null) && InternalSymbolicLinkLinkCodeMethods.IsSameFileSystemItem(path, destinationPath))
             {
                 String error = StringUtil.Format(FileSystemProviderStrings.CopyError, path);
                 Exception e = new IOException(error);
+                e.Data[SelfCopyDataKey] = destinationPath;
                 WriteError(new ErrorRecord(e, "CopyError", ErrorCategory.WriteError, path));
                 return;
             }
-
             // Copy-Item from session
             if (fromSession != null)
             {
@@ -3777,14 +3782,14 @@ namespace Microsoft.PowerShell.Commands
                 }
 
                 //if the source and destination path are same then flag it as error.
-                if (destinationPath.Equals(file.FullName, StringComparison.OrdinalIgnoreCase))
+                if (InternalSymbolicLinkLinkCodeMethods.IsSameFileSystemItem(destinationPath, file.FullName))
                 {
                     String error = StringUtil.Format(FileSystemProviderStrings.CopyError, destinationPath);
                     Exception e = new IOException(error);
+                    e.Data[SelfCopyDataKey] = file.FullName;
                     WriteError(new ErrorRecord(e, "CopyError", ErrorCategory.WriteError, destinationPath));
                     return;
                 }
-
                 // Verify that the target doesn't represent a device name
                 if (PathIsReservedDeviceName(destinationPath, "CopyError"))
                 {
@@ -8211,6 +8216,42 @@ namespace Microsoft.PowerShell.Commands
             return isHardLink;
         }
 
+        internal static bool IsSameFileSystemItem(string pathOne, string pathTwo)
+        {
+#if UNIX
+            return Platform.NonWindowsIsSameFileSystemItem(pathOne, pathTwo);
+#else
+            return WinIsSameFileSystemItem(pathOne, pathTwo);
+#endif
+        }
+
+        internal static bool WinIsSameFileSystemItem(string pathOne, string pathTwo)
+        {
+            var access = FileAccess.Read;
+            var share = FileShare.Read;
+            var creation = FileMode.Open;
+            var attributes = FileAttributes.BackupSemantics | FileAttributes.PosixSemantics;
+
+            using (var sfOne = AlternateDataStreamUtilities.NativeMethods.CreateFile(pathOne, access, share, IntPtr.Zero, creation, (int)attributes, IntPtr.Zero))
+            using (var sfTwo = AlternateDataStreamUtilities.NativeMethods.CreateFile(pathTwo, access, share, IntPtr.Zero, creation, (int)attributes, IntPtr.Zero))
+            {
+                if (!sfOne.IsInvalid && !sfTwo.IsInvalid)
+                {
+                    BY_HANDLE_FILE_INFORMATION  infoOne;
+                    BY_HANDLE_FILE_INFORMATION  infoTwo;
+                    if (   GetFileInformationByHandle(sfOne.DangerousGetHandle(), out infoOne)
+                        && GetFileInformationByHandle(sfTwo.DangerousGetHandle(), out infoTwo))
+                    {
+                        return    infoOne.VolumeSerialNumber == infoTwo.VolumeSerialNumber
+                               && infoOne.FileIndexHigh == infoTwo.FileIndexHigh
+                               && infoOne.FileIndexLow == infoTwo.FileIndexLow;
+                    }
+                }
+            }
+
+            return false;
+        }
+
         internal static bool IsHardLink(ref IntPtr handle)
         {
 #if UNIX
@@ -8664,7 +8705,7 @@ namespace System.Management.Automation.Internal
             // the code above seems cleaner and more robust than the IAttachmentExecute approach
         }
 
-        private static class NativeMethods
+        internal static class NativeMethods
         {
             internal const int ERROR_HANDLE_EOF = 38;
             internal enum StreamInfoLevels { FindStreamInfoStandard = 0 }

--- a/src/libpsl-native/src/CMakeLists.txt
+++ b/src/libpsl-native/src/CMakeLists.txt
@@ -13,6 +13,7 @@ add_library(psl-native SHARED
   geterrorcategory.cpp
   isfile.cpp
   isdirectory.cpp
+  issamefilesystemitem.cpp
   issymlink.cpp
   isexecutable.cpp
   setdate.cpp

--- a/src/libpsl-native/src/issamefilesystemitem.cpp
+++ b/src/libpsl-native/src/issamefilesystemitem.cpp
@@ -1,0 +1,48 @@
+//! @file issamefilesystemitem.cpp
+//! @author Jeff Bienstadt <v-jebien@microsoft.com>
+//! @brief returns if two paths ultimately point to the same filesystem object
+
+#include "getstat.h"
+#include "issamefilesystemitem.h"
+
+#include <assert.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+//! @brief returns if two paths ultimately refer to the same file or directory.
+//!
+//! IsSameFileSystemItem
+//!
+//! @param[in] path_one
+//! @parblock
+//! A pointer to the buffer that contains the first path.
+//!
+//! char* is marshaled as an LPStr, which on Linux is UTF-8.
+//! @endparblock
+//!
+//! @param[in] path_two
+//! @parblock
+//! A pointer to the buffer that contains the second path.
+//!
+//! char* is marshaled as an LPStr, which on Linux is UTF-8.
+//! @endparblock
+//!
+//! @retval true if both paths point to the same filesystem object,
+//! false otherwise
+//!
+bool IsSameFileSystemItem(const char* path_one, const char* path_two)
+{
+    assert(path_one);
+    assert(path_two);
+
+    struct stat buf_1;
+    struct stat buf_2;
+
+    if (GetStat(path_one, &buf_1) == 0 && GetStat(path_two, &buf_2) == 0)
+    {
+        return buf_1.st_dev == buf_2.st_dev && buf_1.st_ino == buf_2.st_ino;
+    }
+
+    return false;
+}

--- a/src/libpsl-native/src/issamefilesystemitem.cpp
+++ b/src/libpsl-native/src/issamefilesystemitem.cpp
@@ -1,6 +1,6 @@
 //! @file issamefilesystemitem.cpp
 //! @author Jeff Bienstadt <v-jebien@microsoft.com>
-//! @brief returns if two paths ultimately point to the same filesystem object
+//! @brief Determines whether two paths ultimately point to the same filesystem object
 
 #include "getstat.h"
 #include "issamefilesystemitem.h"
@@ -10,7 +10,7 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
-//! @brief returns if two paths ultimately refer to the same file or directory.
+//! @brief Returns a boolean value indicating whether two paths ultimately refer to the same file or directory.
 //!
 //! IsSameFileSystemItem
 //!

--- a/src/libpsl-native/src/issamefilesystemitem.h
+++ b/src/libpsl-native/src/issamefilesystemitem.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "pal.h"
+
+#include <stdbool.h>
+
+PAL_BEGIN_EXTERNC
+
+bool IsSameFileSystemItem(const char* path_one, const char* path_two);
+
+PAL_END_EXTERNC

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
@@ -252,13 +252,12 @@ Describe "Copy-Item can avoid copying an item onto itself" -Tags "CI", "RequireA
         # For now, we'll assume the tests are running the platform's
         # native filesystem, in its default mode
         $isCaseSensitive = $IsLinux
-        $canDirSymLink = $IsWindows
-        $canJunction = $IsWindows
 
         # The name of the key in an exception's Data dictionary when an
         # attempt is made to copy an item onto itself.
         $selfCopyKey = "SelfCopy"
 
+        $TestDrive = "TestDrive:"
         $subDir = "$TestDrive/sub"
         $otherSubDir = "$TestDrive/other-sub"
         $fileName = "file.txt"
@@ -283,12 +282,9 @@ Describe "Copy-Item can avoid copying an item onto itself" -Tags "CI", "RequireA
         New-Item -ItemType SymbolicLink $symToOtherFile -Value $otherFile >$null
         New-Item -ItemType HardLink $hardToOtherFile -Value $otherFile >$null
 
-        if ($canJunction)
+        if ($IsWindows)
         {
             New-Item -ItemType Junction $junctionToOther -Value $otherSubDir >$null
-        }
-        if ($canDirSymLink)
-        {
             New-Item -ItemType SymbolicLink $symdToOther -Value $otherSubDir >$null
         }
     }
@@ -376,14 +372,6 @@ Describe "Copy-Item can avoid copying an item onto itself" -Tags "CI", "RequireA
                 [string]$Source,
                 [string]$Destination
             )
-
-            # The source and destination paths must exist.
-            # If either do not, it's because they could not be created in the BeforeAll block
-            # This is not a test failure, but rather a precondition failure.
-            if ((-Not (Test-Path -Path $Source)) -or (-Not (Test-Path -Path $Destination)))
-            {
-                return
-            }
 
             { Copy-Item -Path $Source -Destination $Destination -ErrorAction Stop } | ShouldBeErrorId "CopyError,Microsoft.PowerShell.Commands.CopyItemCommand"
             $Error[0].Exception | Should BeOfType System.IO.IOException

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
@@ -330,9 +330,9 @@ Describe "Copy-Item can avoid copying an item onto itself" -Tags "CI", "RequireA
             }
             else
             {
-                Copy-Item -Path $sourcePath -Destination $destinationPath -ErrorAction SilentlyContinue | ShouldBeErrorId "CopyError,Microsoft.PowerShell.Commands.CopyItemCommand"
-                $_.Exception | Should BeOfType System.IO.IOException
-                $_.Exception.Data[$selfCopyKey] | Should Not Be $null
+                { Copy-Item -Path $sourcePath -Destination $destinationPath -ErrorAction Stop } | ShouldBeErrorId "CopyError,Microsoft.PowerShell.Commands.CopyItemCommand"
+                $Error[0].Exception | Should BeOfType System.IO.IOException
+                $Error[0].Exception.Data[$selfCopyKey] | Should Not Be $null
             }
         }
     }
@@ -806,7 +806,7 @@ Describe "Extended FileSystem Path/Location Cmdlet Provider Tests" -Tags "Featur
             $result = Split-Path -Path $level1_0Full -Leaf
             $result | Should Be $level1_0
         }
-        
+
         It 'Validate LeafBase' {
             $result = Split-Path -Path "$level2_1Full$fileExt" -LeafBase
             $result | Should Be $level2_1

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
@@ -361,6 +361,18 @@ Describe "Copy-Item can avoid copying an item onto itself" -Tags "CI", "RequireA
                     Destination = $otherSubDir
                 }
             )
+
+            function TestSelfCopy
+            {
+                Param (
+                    [string]$Source,
+                    [string]$Destination
+                )
+
+                { Copy-Item -Path $Source -Destination $Destination -ErrorAction Stop } | ShouldBeErrorId "CopyError,Microsoft.PowerShell.Commands.CopyItemCommand"
+                $Error[0].Exception | Should BeOfType System.IO.IOException
+                $Error[0].Exception.Data[$selfCopyKey] | Should Not Be $null
+            }
         }
 
         It "<Name>" -TestCases $testCases {
@@ -370,9 +382,7 @@ Describe "Copy-Item can avoid copying an item onto itself" -Tags "CI", "RequireA
                 [string]$Destination
             )
 
-            { Copy-Item -Path $Source -Destination $Destination -ErrorAction Stop } | ShouldBeErrorId "CopyError,Microsoft.PowerShell.Commands.CopyItemCommand"
-            $Error[0].Exception | Should BeOfType System.IO.IOException
-            $Error[0].Exception.Data[$selfCopyKey] | Should Not Be $null
+            TestSelfCopy $Source $Destination
         }
 
         It "<Name>" -TestCases $windowsTestCases -Skip:(-not $IsWindows) {
@@ -382,9 +392,7 @@ Describe "Copy-Item can avoid copying an item onto itself" -Tags "CI", "RequireA
                 [string]$Destination
             )
 
-            { Copy-Item -Path $Source -Destination $Destination -ErrorAction Stop } | ShouldBeErrorId "CopyError,Microsoft.PowerShell.Commands.CopyItemCommand"
-            $Error[0].Exception | Should BeOfType System.IO.IOException
-            $Error[0].Exception.Data[$selfCopyKey] | Should Not Be $null
+            TestSelfCopy $Source $Destination
         }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
@@ -349,24 +349,33 @@ Describe "Copy-Item can avoid copying an item onto itself" -Tags "CI", "RequireA
             )
 
             # Junctions and directory symbolic links are Windows and NTFS only
-            if ($IsWindows)
-            {
-                $testCases += @(
-                    @{
-                        Name = "Copy junction to target"
-                        Source = $junctionToOther
-                        Destination = $otherSubDir
-                    }
-                    @{
-                        Name = "Copy directory symbolic link to target"
-                        Source = $symdToOther
-                        Destination = $otherSubDir
-                    }
-                )
-            }
+            $windowsTestCases = @(
+                @{
+                    Name = "Copy junction to target"
+                    Source = $junctionToOther
+                    Destination = $otherSubDir
+                }
+                @{
+                    Name = "Copy directory symbolic link to target"
+                    Source = $symdToOther
+                    Destination = $otherSubDir
+                }
+            )
         }
 
         It "<Name>" -TestCases $testCases {
+            Param (
+                [string]$Name,
+                [string]$Source,
+                [string]$Destination
+            )
+
+            { Copy-Item -Path $Source -Destination $Destination -ErrorAction Stop } | ShouldBeErrorId "CopyError,Microsoft.PowerShell.Commands.CopyItemCommand"
+            $Error[0].Exception | Should BeOfType System.IO.IOException
+            $Error[0].Exception.Data[$selfCopyKey] | Should Not Be $null
+        }
+
+        It "<Name>" -TestCases $windowsTestCases -Skip:(-not $IsWindows) {
             Param (
                 [string]$Name,
                 [string]$Source,


### PR DESCRIPTION
Fix #1930.

Rather than relying on case-insensitive string compares of source and destination paths, use operating system calls to determine whether two paths refer to the same file. This solves not only the case-insensitivity issue but also allows the cmdlet to operate properly if the destination is a hard or symbolic link to the source.

The Windows side is implemented in C#. The Unix side is implemented partially in native code.