### PR TITLE
Fix for job dropping runspace close error

### DIFF
--- a/src/System.Management.Automation/engine/remoting/client/Job.cs
+++ b/src/System.Management.Automation/engine/remoting/client/Job.cs
@@ -3270,7 +3270,8 @@ namespace System.Management.Automation
                             helper);
             }
             // there is a failure reason available in the runspace
-            else if (runspace.RunspaceStateInfo.State == RunspaceState.Broken)
+            else if ((runspace.RunspaceStateInfo.State == RunspaceState.Broken) ||
+                     (runspace.RunspaceStateInfo.Reason != null))
             {
                 failureException = runspace.RunspaceStateInfo.Reason;
                 object targetObject = runspace.ConnectionInfo.ComputerName;


### PR DESCRIPTION
If a job process crashes the client session cannot close cleanly and will error with an operation timeout, but the job class error handling code does not detect this case and the job state becomes "Completed" instead of "Failed".  The fix to detect this error condition is a simple one line addition.

I didn't add a test for this because it is a very specific error condition that involves crashing a process and I am concerned about de-stabilizing running tests by invoking WER or rescue debuggers.