### PR TITLE
Add option -NoProxy to WebCmdlet

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/InvokeRestMethodCommand.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/InvokeRestMethodCommand.Common.cs
@@ -17,6 +17,7 @@ namespace Microsoft.PowerShell.Commands
         /// gets or sets the parameter Method
         /// </summary>
         [Parameter(ParameterSetName = "StandardMethod")]
+        [Parameter(ParameterSetName = "StandardMethodNoProxy")]
         public override WebRequestMethod Method
         {
             get { return base.Method; }
@@ -26,7 +27,8 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// gets or sets the parameter CustomMethod
         /// </summary>
-        [Parameter(ParameterSetName = "CustomMethod")]
+        [Parameter(Mandatory=true,ParameterSetName = "CustomMethod")]
+        [Parameter(Mandatory=true,ParameterSetName = "CustomMethodNoProxy")]
         [Alias("CM")]
         [ValidateNotNullOrEmpty]
         public override string CustomMethod

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -148,6 +148,7 @@ namespace Microsoft.PowerShell.Commands
         /// gets or sets the Method property
         /// </summary>
         [Parameter(ParameterSetName = "StandardMethod")]
+        [Parameter(ParameterSetName = "StandardMethodNoProxy")]
         public virtual WebRequestMethod Method
         {
             get { return _method; }
@@ -158,7 +159,8 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// gets or sets the CustomMethod property
         /// </summary>
-        [Parameter(ParameterSetName = "CustomMethod")]
+        [Parameter(Mandatory=true,ParameterSetName = "CustomMethod")]
+        [Parameter(Mandatory=true,ParameterSetName = "CustomMethodNoProxy")]
         [Alias("CM")]
         [ValidateNotNullOrEmpty]
         public virtual string CustomMethod
@@ -170,25 +172,39 @@ namespace Microsoft.PowerShell.Commands
 
         #endregion
 
+        #region NoProxy
+
+        /// <summary>
+        /// gets or sets the NoProxy property
+        /// </summary>
+        [Parameter(Mandatory=true,ParameterSetName = "CustomMethodNoProxy")]
+        [Parameter(Mandatory=true,ParameterSetName = "StandardMethodNoProxy")]
+        public virtual SwitchParameter NoProxy { get; set; }
+
+        #endregion
+
         #region Proxy
 
         /// <summary>
         /// gets or sets the Proxy property
         /// </summary>
-        [Parameter]
+        [Parameter(ParameterSetName = "StandardMethod")]
+        [Parameter(ParameterSetName = "CustomMethod")]
         public virtual Uri Proxy { get; set; }
 
         /// <summary>
         /// gets or sets the ProxyCredential property
         /// </summary>
-        [Parameter]
+        [Parameter(ParameterSetName = "StandardMethod")]
+        [Parameter(ParameterSetName = "CustomMethod")]
         [Credential]
         public virtual PSCredential ProxyCredential { get; set; }
 
         /// <summary>
         /// gets or sets the ProxyUseDefaultCredentials property
         /// </summary>
-        [Parameter]
+        [Parameter(ParameterSetName = "StandardMethod")]
+        [Parameter(ParameterSetName = "CustomMethod")]
         public virtual SwitchParameter ProxyUseDefaultCredentials { get; set; }
 
         #endregion

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebRequestPSCmdlet.CoreClr.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebRequestPSCmdlet.CoreClr.cs
@@ -105,7 +105,11 @@ namespace Microsoft.PowerShell.Commands
                 handler.Credentials = WebSession.Credentials;
             }
 
-            if (WebSession.Proxy != null)
+            if (NoProxy)
+            {
+                handler.UseProxy = false;
+            }
+            else if (WebSession.Proxy != null)
             {
                 handler.Proxy = WebSession.Proxy;
             }
@@ -155,13 +159,17 @@ namespace Microsoft.PowerShell.Commands
         {
             Uri requestUri = PrepareUri(uri);
             HttpMethod httpMethod = null;
-          
+
             switch (ParameterSetName)
             {
+                case "StandardMethodNoProxy":
+                    goto case "StandardMethod";
                 case "StandardMethod":
                     // set the method if the parameter was provided
                     httpMethod = GetHttpMethod(Method);
                     break;
+                case "CustomMethodNoProxy":
+                    goto case "CustomMethod";
                 case "CustomMethod":
                     if (!string.IsNullOrEmpty(CustomMethod))
                     {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/FullClr/WebRequestPSCmdlet.FullClr.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/FullClr/WebRequestPSCmdlet.FullClr.cs
@@ -79,13 +79,19 @@ namespace Microsoft.PowerShell.Commands
                 request.Credentials = WebSession.Credentials;
             }
 
-            if (null != WebSession.Proxy)
+            if (NoProxy)
+            {
+                handler.UseProxy = false;
+            }
+            else if (WebSession.Proxy != null)
             {
                 request.Proxy = WebSession.Proxy;
             }
 
             switch (ParameterSetName)
             {
+                case "StandardMethodNoProxy":
+                    goto case "StandardMethod";
                 case "StandardMethod":
                     if (WebRequestMethod.Default != Method)
                     {
@@ -93,6 +99,8 @@ namespace Microsoft.PowerShell.Commands
                         request.Method = Method.ToString().ToUpperInvariant();
                     }
                     break;
+                case "CustomMethodNoProxy":
+                    goto case "CustomMethod";
                 case "CustomMethod":
                     // set the method if the parameter was provided
                     request.Method = CustomMethod.ToUpperInvariant();


### PR DESCRIPTION
<!--

If you are a PowerShell Team member, please make sure you choose the Reviewer(s) and Assignee for your PR.
If you are not from the PowerShell Team, you can leave the fields blank and the Maintainers will choose them for you. If you are familiar with the team, feel free to mention some Reviewers yourself.

For more information about the roles of Reviewer and Assignee, refer to CONTRIBUTING.md.

-->
This commit adds a `-NoProxy` parameter to the WebCmdlet, used by both `Invoke-WebRequest` and `Invoke-RestMethod`. The fix is intended to allow for bypassing a DefaultWebProxy, such as a system configured one for direct requests.

References #3418 

I did not figure out where I can update the help files relevant to this, I'd appreciate being pointed in the right direction for this.