### PR TITLE
Incorrect Stringbuilder usage

### DIFF
--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -3937,7 +3937,7 @@ namespace System.Management.Automation.Runspaces
 
             if (errors.Count > 0)
             {
-                var allErrors = new StringBuilder('\n');
+                var allErrors = new StringBuilder("\n");
                 foreach (string error in errors)
                 {
                     if (!string.IsNullOrEmpty(error))


### PR DESCRIPTION
StringBuilder doesn't have a [constructor](https://msdn.microsoft.com/en-us/library/system.text.stringbuilder.stringbuilder(v=vs.110).aspx) that takes a char.  In this case, the char is only used to inadvertently define capacity when the intent is to populate the StringBuilder with a newline.

Addresses https://github.com/PowerShell/PowerShell/issues/3457

Looked through the code for StringBuilder and only found this one occurrence of incorrect usage