### PR TITLE
Fix Default/OEM encoding behavior PowerShell Core

### DIFF
--- a/src/Microsoft.PowerShell.SDK/Microsoft.PowerShell.SDK.csproj
+++ b/src/Microsoft.PowerShell.SDK/Microsoft.PowerShell.SDK.csproj
@@ -85,7 +85,7 @@
     <PackageReference Include="System.ServiceModel.Primitives" Version="4.3.0" />
     <PackageReference Include="System.ServiceModel.Security" Version="4.3.0" />
     <PackageReference Include="System.ServiceProcess.ServiceController" Version="4.3.0" />
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="4.0.11" />
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="4.0.1" />
     <PackageReference Include="System.Text.Encodings.Web" Version="4.3.0" />
     <PackageReference Include="System.Threading.AccessControl" Version="4.3.0" />
     <PackageReference Include="System.Threading.Overlapped" Version="4.3.0" />

--- a/src/Microsoft.PowerShell.SDK/Microsoft.PowerShell.SDK.csproj
+++ b/src/Microsoft.PowerShell.SDK/Microsoft.PowerShell.SDK.csproj
@@ -85,7 +85,7 @@
     <PackageReference Include="System.ServiceModel.Primitives" Version="4.3.0" />
     <PackageReference Include="System.ServiceModel.Security" Version="4.3.0" />
     <PackageReference Include="System.ServiceProcess.ServiceController" Version="4.3.0" />
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="4.3.0" />
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="4.0.11" />
     <PackageReference Include="System.Text.Encodings.Web" Version="4.3.0" />
     <PackageReference Include="System.Threading.AccessControl" Version="4.3.0" />
     <PackageReference Include="System.Threading.Overlapped" Version="4.3.0" />

--- a/src/Microsoft.PowerShell.SDK/Microsoft.PowerShell.SDK.csproj
+++ b/src/Microsoft.PowerShell.SDK/Microsoft.PowerShell.SDK.csproj
@@ -85,7 +85,6 @@
     <PackageReference Include="System.ServiceModel.Primitives" Version="4.3.0" />
     <PackageReference Include="System.ServiceModel.Security" Version="4.3.0" />
     <PackageReference Include="System.ServiceProcess.ServiceController" Version="4.3.0" />
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="4.0.1" />
     <PackageReference Include="System.Text.Encodings.Web" Version="4.3.0" />
     <PackageReference Include="System.Threading.AccessControl" Version="4.3.0" />
     <PackageReference Include="System.Threading.Overlapped" Version="4.3.0" />

--- a/src/System.Management.Automation/System.Management.Automation.csproj
+++ b/src/System.Management.Automation/System.Management.Automation.csproj
@@ -47,6 +47,7 @@
     <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.3.0" />
     <PackageReference Include="System.Security.Cryptography.Pkcs" Version="4.3.0" />
     <PackageReference Include="System.Security.Cryptography.X509Certificates" Version="4.3.0" />
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="4.3.0" />
     <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
     <PackageReference Include="System.Threading.Tasks.Parallel" Version="4.3.0" />
     <PackageReference Include="System.Xml.XPath.XmlDocument" Version="4.3.0" />

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -7569,8 +7569,7 @@ namespace Microsoft.PowerShell.Commands
 
                 case FileSystemCmdletProviderEncoding.Oem:
                     {
-                        uint oemCP = NativeMethods.GetOEMCP();
-                        encoding = System.Text.Encoding.GetEncoding((int)oemCP);
+                        encoding = ClrFacade.GetOEMEncoding();
                     }
                     break;
 

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -7606,11 +7606,6 @@ namespace Microsoft.PowerShell.Commands
             } // get
         } // WasStreamTypeSpecified
 
-        private static class NativeMethods
-        {
-            [DllImport(PinvokeDllNames.GetOEMCPDllName, SetLastError = false, CharSet = CharSet.Unicode)]
-            internal static extern uint GetOEMCP();
-        }
     } // class FileSystemContentDynamicParametersBase
 
     /// <summary>

--- a/src/System.Management.Automation/utils/ClrFacade.cs
+++ b/src/System.Management.Automation/utils/ClrFacade.cs
@@ -539,7 +539,7 @@ namespace System.Management.Automation
 #if UNUX        // PowerShell Core on Unix
                 s_defaultEncoding = Encoding.UTF8;
 #elif CORECLR   // PowerShell Core on Windows
-                EncodingRegisterProvider()
+                EncodingRegisterProvider();
 
                 uint currentAnsiCp = NativeMethods.GetACP();
                 s_defaultEncoding = Encoding.GetEncoding((int)currentAnsiCp);
@@ -562,7 +562,7 @@ namespace System.Management.Automation
 #if UNUX        // PowerShell Core on Unix
                 s_oemEncoding = GetDefaultEncoding();
 #elif CORECLR   // PowerShell Core on Windows
-                EncodingRegisterProvider()
+                EncodingRegisterProvider();
 
                 uint oemCp = NativeMethods.GetOEMCP();
                 s_oemEncoding = Encoding.GetEncoding((int)oemCp);
@@ -577,7 +577,7 @@ namespace System.Management.Automation
 
         private static volatile Encoding s_oemEncoding;
 
-        private static EncodingRegisterProvider()
+        private static void EncodingRegisterProvider()
         {
             if (s_defaultEncoding == null && s_oemEncoding == null)
             {

--- a/src/System.Management.Automation/utils/ClrFacade.cs
+++ b/src/System.Management.Automation/utils/ClrFacade.cs
@@ -585,7 +585,7 @@ namespace System.Management.Automation
                 Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
             }
         }
-#end
+#endif
 
         #endregion Encoding
 

--- a/src/System.Management.Automation/utils/ClrFacade.cs
+++ b/src/System.Management.Automation/utils/ClrFacade.cs
@@ -537,19 +537,19 @@ namespace System.Management.Automation
             if (s_defaultEncoding == null)
             {
 #if UNUX        // PowerShell Core on Unix
-                s_defaultEncoding = Encoding.UTF8;
+                s_defaultEncoding = Encoding.UTF8Encoding(false);
 #elif CORECLR   // PowerShell Core on Windows
                 EncodingRegisterProvider();
 
                 uint currentAnsiCp = NativeMethods.GetACP();
                 s_defaultEncoding = Encoding.GetEncoding((int)currentAnsiCp);
-
 #else           // Windows PowerShell
                 s_defaultEncoding = Encoding.Default;
 #endif
             }
             return s_defaultEncoding;
         }
+
         private static volatile Encoding s_defaultEncoding;
 
         /// <summary>
@@ -577,14 +577,15 @@ namespace System.Management.Automation
 
         private static volatile Encoding s_oemEncoding;
 
+#if CORECLR
         private static void EncodingRegisterProvider()
         {
             if (s_defaultEncoding == null && s_oemEncoding == null)
             {
                 Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
             }
-
         }
+#end
 
         #endregion Encoding
 

--- a/src/System.Management.Automation/utils/ClrFacade.cs
+++ b/src/System.Management.Automation/utils/ClrFacade.cs
@@ -530,7 +530,7 @@ namespace System.Management.Automation
         #region Encoding
 
         /// <summary>
-        /// Facade for getting Encoding.Default
+        /// Facade for getting default encoding
         /// </summary>
         internal static Encoding GetDefaultEncoding()
         {

--- a/src/System.Management.Automation/utils/ClrFacade.cs
+++ b/src/System.Management.Automation/utils/ClrFacade.cs
@@ -536,8 +536,8 @@ namespace System.Management.Automation
         {
             if (s_defaultEncoding == null)
             {
-#if UNUX        // PowerShell Core on Unix
-                s_defaultEncoding = Encoding.UTF8Encoding(false);
+#if UNIX        // PowerShell Core on Unix
+                s_defaultEncoding = new UTF8Encoding(false);
 #elif CORECLR   // PowerShell Core on Windows
                 EncodingRegisterProvider();
 
@@ -559,7 +559,7 @@ namespace System.Management.Automation
         {
             if (s_oemEncoding == null)
             {
-#if UNUX        // PowerShell Core on Unix
+#if UNIX        // PowerShell Core on Unix
                 s_oemEncoding = GetDefaultEncoding();
 #elif CORECLR   // PowerShell Core on Windows
                 EncodingRegisterProvider();

--- a/src/System.Management.Automation/utils/PInvokeDllNames.cs
+++ b/src/System.Management.Automation/utils/PInvokeDllNames.cs
@@ -17,7 +17,6 @@ namespace System.Management.Automation
         internal const string QueryDosDeviceDllName = "api-ms-win-core-file-l1-1-0.dll";                     /*1*/
         internal const string CreateSymbolicLinkDllName = "api-ms-win-core-file-l2-1-0.dll";                 /*2*/
         internal const string GetOEMCPDllName = "api-ms-win-core-localization-l1-2-0.dll";                   /*3*/
-        internal const string GetACPDllName = "api-ms-win-core-localization-l1-2-0.dll";                   /*3*/
         internal const string DeviceIoControlDllName = "api-ms-win-core-io-l1-1-0.dll";                      /*4*/
         internal const string CreateFileDllName = "api-ms-win-core-file-l1-1-0.dll";                         /*5*/
         internal const string DeleteFileDllName = "api-ms-win-core-file-l1-1-0.dll";                         /*6*/
@@ -136,11 +135,11 @@ namespace System.Management.Automation
         internal const string CreateToolhelp32SnapshotDllName = "api-ms-win-core-toolhelp-l1-1-0";           /*120*/
         internal const string Process32FirstDllName = "api-ms-win-core-toolhelp-l1-1-0";                     /*121*/
         internal const string Process32NextDllName = "api-ms-win-core-toolhelp-l1-1-0";                      /*122*/
+        internal const string GetACPDllName = "api-ms-win-core-localization-l1-2-0.dll";                     /*123*/
 #else
         internal const string QueryDosDeviceDllName = "kernel32.dll";                                        /*1*/
         internal const string CreateSymbolicLinkDllName = "kernel32.dll";                                    /*2*/
         internal const string GetOEMCPDllName = "kernel32.dll";                                              /*3*/
-        internal const string GetACPDllName = "kernel32.dll";                                                /*3*/
         internal const string DeviceIoControlDllName = "kernel32.dll";                                       /*4*/
         internal const string CreateFileDllName = "kernel32.dll";                                            /*5*/
         internal const string DeleteFileDllName = "kernel32.dll";                                            /*6*/
@@ -259,6 +258,7 @@ namespace System.Management.Automation
         internal const string CreateToolhelp32SnapshotDllName = "kernel32.dll";                              /*120*/
         internal const string Process32FirstDllName = "kernel32.dll";                                        /*121*/
         internal const string Process32NextDllName = "kernel32.dll";                                         /*122*/
+        internal const string GetACPDllName = "kernel32.dll";                                                /*123*/
 #endif
     }
 }

--- a/src/System.Management.Automation/utils/PInvokeDllNames.cs
+++ b/src/System.Management.Automation/utils/PInvokeDllNames.cs
@@ -17,6 +17,7 @@ namespace System.Management.Automation
         internal const string QueryDosDeviceDllName = "api-ms-win-core-file-l1-1-0.dll";                     /*1*/
         internal const string CreateSymbolicLinkDllName = "api-ms-win-core-file-l2-1-0.dll";                 /*2*/
         internal const string GetOEMCPDllName = "api-ms-win-core-localization-l1-2-0.dll";                   /*3*/
+        internal const string GetACPDllName = "api-ms-win-core-localization-l1-2-0.dll";                   /*3*/
         internal const string DeviceIoControlDllName = "api-ms-win-core-io-l1-1-0.dll";                      /*4*/
         internal const string CreateFileDllName = "api-ms-win-core-file-l1-1-0.dll";                         /*5*/
         internal const string DeleteFileDllName = "api-ms-win-core-file-l1-1-0.dll";                         /*6*/
@@ -139,6 +140,7 @@ namespace System.Management.Automation
         internal const string QueryDosDeviceDllName = "kernel32.dll";                                        /*1*/
         internal const string CreateSymbolicLinkDllName = "kernel32.dll";                                    /*2*/
         internal const string GetOEMCPDllName = "kernel32.dll";                                              /*3*/
+        internal const string GetACPDllName = "kernel32.dll";                                                /*3*/
         internal const string DeviceIoControlDllName = "kernel32.dll";                                       /*4*/
         internal const string CreateFileDllName = "kernel32.dll";                                            /*5*/
         internal const string DeleteFileDllName = "kernel32.dll";                                            /*6*/


### PR DESCRIPTION
Based on conclusion in discussion #3248

- [x] - OEM

We need internal fix because .Net Core haven't "OEM" term.
The fix should provide PowerShell Core behavior:
   - on Windows - as Windows PowerShell based on GetOEMCP() and legacy encodings (System.Text.Encoding.CodePages)
   - on Unix - the same as default encoding in PowerShell Core

- [x] - Default

We need internal fix because [CoreFX default](https://github.com/dotnet/coreclr/blob/ab0fbce6b629d081c1102d353abab0d8febd4487/src/mscorlib/src/System/Text/Encoding.cs#L1244) for [all platforms is UTF8](https://github.com/dotnet/coreclr/blob/ab0fbce6b629d081c1102d353abab0d8febd4487/src/mscorlib/src/System/Text/Encoding.cs#L1235)
Until we have completed Encoding RFC we should restore behaivor as in Windows PowerShell.
The fix should provide PowerShell Core behavior:
   - on Windows - as Windows PowerShell based on GetACP() and legacy encodings (System.Text.Encoding.CodePages)
   - on Unix - UTF-8 without BOM (We are expecting that the same will be [in CoreFX](https://github.com/dotnet/coreclr/issues/10643))

- [ ] - Tests

Now we don't have a full set of encoding tests (only for redirections). I believe we need to create them during future RFC implementation, not now.