### PR TITLE
Fix tests for WebCmdlets after -NoProxy addition

### DIFF
--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -258,8 +258,8 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
     }
 
     $testCase = @(
-        @{ proxy_address = "http://localhost:8080"; name = 'http_proxy'; protocol = 'http' }
-        @{ proxy_address = "http://localhost:8080"; name = 'https_proxy'; protocol = 'https' }
+        @{ proxy_address = "http://localhost:9"; name = 'http_proxy'; protocol = 'http' }
+        @{ proxy_address = "http://localhost:9"; name = 'https_proxy'; protocol = 'https' }
     )
 
     It "Validate Invoke-WebRequest error with -Proxy option set - '<name>'" -TestCases $testCase {
@@ -629,17 +629,17 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
     }
 
     $testCase = @(
-        @{ proxy_address = "http://localhost:8080"; name = 'http_proxy'; protocol = 'http' }
-        @{ proxy_address = "http://localhost:8080"; name = 'https_proxy'; protocol = 'https' }
+        @{ proxy_address = "http://localhost:9"; name = 'http_proxy'; protocol = 'http' }
+        @{ proxy_address = "http://localhost:9"; name = 'https_proxy'; protocol = 'https' }
     )
 
     It "Validate Invoke-RestMethod error with -Proxy option - '<name>'" -TestCases $testCase {
         param($proxy_address, $name, $protocol)
 
-        $command = "Invoke-RestMethod -Uri '${protocol}://httpbin.org/' -Proxy '${proxy_address}' -TimeoutSec 2"
+        $command = "Invoke-RestMethod -Uri '${protocol}://httpbin.org/' -Proxy '${proxy_address}'"
 
         $result = ExecuteWebCommand -command $command
-        $result.Error.FullyQualifiedErrorId | Should Be "System.Threading.Tasks.TaskCanceledException,Microsoft.PowerShell.Commands.InvokeRestMethodCommand"
+        $result.Error.FullyQualifiedErrorId | Should Be "WebCmdletWebResponseException,Microsoft.PowerShell.Commands.InvokeRestMethodCommand"
     }
 
     It "Validate Invoke-RestMethod error with environment proxy set - '<name>'" -TestCases $testCase {


### PR DESCRIPTION
<!--

If you are a PowerShell Team member, please make sure you choose the Reviewer(s) and Assignee for your PR.
If you are not from the PowerShell Team, you can leave the fields blank and the Maintainers will choose them for you. If you are familiar with the team, feel free to mention some Reviewers yourself.

For more information about the roles of Reviewer and Assignee, refer to CONTRIBUTING.md.

-->
First of all, I am sorry that the tests didn't work after the merge to master.

To fix the behavior I propose these changes as attached in this PR.

Two changes:
- Removed the `-TimeoutSec` option and modified the expected Error to be consistent across platforms.
  - On Windows, the error message was as expected (as in the original test), meanwhile Linux gave a response error instead of the thread cancel as Windows had reported. Changed behavior by removing the timeout so it will properly test against the same Error on both Linux and Windows.
- Changed the port of the phony proxy it looks for from port 8080 to 38080.
  - Under Linux, if you run Tomcat or another service on port 8080 on the build machine, the tests will not work if they hit a responding port.
  - In ideal circumstances you have a clean build machine, sadly not always. This change is to accommodate that scenario.