### PR TITLE
Replace 'libpsrpclient' with 'psrp' package

### DIFF
--- a/src/powershell-unix/powershell-unix.csproj
+++ b/src/powershell-unix/powershell-unix.csproj
@@ -32,7 +32,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="libpsrpclient" Version="1.0.0-*" />
+    <PackageReference Include="psrp" Version="1.1.0-*" />
     <PackageReference Include="PSDesiredStateConfiguration" Version="1.0.0-alpha01" />
     <PackageReference Include="PowerShellHelpFiles" Version="1.0.0-alpha01" />
   </ItemGroup>


### PR DESCRIPTION
The package `libpsrpclient` was replaced by `psrp` in #3271. However this was missed when moving from `project.json` to MSBuild. This PR makes this update.