### PR TITLE
Skip the parser tests that are run by 'ShouldBeParseError' in Travis Full Build

### DIFF
--- a/test/powershell/Language/Classes/Scripting.Classes.BasicParsing.Tests.ps1
+++ b/test/powershell/Language/Classes/Scripting.Classes.BasicParsing.Tests.ps1
@@ -11,11 +11,15 @@ try {
 #  2. For nightly build, build with '-CrossGen' but don't run the parsing tests
 # In this way, we will continue to exercise these parsing tests for each CI build, and skip them for nightly
 # build to avoid a hang.
-# Note: this change should be reverted once the 'CrossGen' issue is fixed by CoreCLR.
+# Note: this change should be reverted once the 'CrossGen' issue is fixed by CoreCLR. The issue is tracked by
+#       https://github.com/dotnet/coreclr/issues/9745
 #
 $isFullBuild = $env:TRAVIS_EVENT_TYPE -eq 'cron' -or $env:TRAVIS_EVENT_TYPE -eq 'api'
 $defaultParamValues = $PSdefaultParameterValues.Clone()
-$PSDefaultParameterValues["it:skip"] = (!$IsWindows -and $isFullBuild)
+$IsSkipped = (!$IsWindows -and $isFullBuild)
+$PSDefaultParameterValues["it:skip"] = $IsSkipped
+$PSDefaultParameterValues["ShouldBeParseError:SkipInTravisFullBuild"] = $IsSkipped
+
 
 Describe 'Positive Parse Properties Tests' -Tags "CI" {
     It 'PositiveParsePropertiesTest' {

--- a/test/powershell/Language/LanguageTestSupport.psm1
+++ b/test/powershell/Language/LanguageTestSupport.psm1
@@ -81,6 +81,7 @@ function ShouldBeParseError
     #       https://github.com/dotnet/coreclr/issues/9745
     #
     if ($SkipInTravisFullBuild) {
+        ## Report that we skipped the test and return
         It "Parse error expected: <<$src>>" -Skip {}
         return
     }

--- a/test/powershell/Language/LanguageTestSupport.psm1
+++ b/test/powershell/Language/LanguageTestSupport.psm1
@@ -65,8 +65,25 @@ function ShouldBeParseError
         # This is a temporary solution after moving type creation from parse time to runtime
         [switch]$SkipAndCheckRuntimeError,
         # for test coverarage purpose, tests validate columnNumber or offset
-        [switch]$CheckColumnNumber
+        [switch]$CheckColumnNumber,
+        # Skip this test in Travis CI nightly build
+        [switch]$SkipInTravisFullBuild
     )
+
+    #
+    # CrossGen'ed assemblies cause a hang to happen when running tests with this helper function in Linux and OSX.
+    # The issue has been reported to CoreCLR team. We need to work around it for now with the following approach:
+    #  1. For pull request and push commit, build without '-CrossGen' and run the parsing tests
+    #  2. For nightly build, build with '-CrossGen' but don't run the parsing tests
+    # In this way, we will continue to exercise these parsing tests for each CI build, and skip them for nightly
+    # build to avoid a hang.
+    # Note: this change should be reverted once the 'CrossGen' issue is fixed by CoreCLR. The issue is tracked by
+    #       https://github.com/dotnet/coreclr/issues/9745
+    #
+    if ($SkipInTravisFullBuild) {
+        It "Parse error expected: <<$src>>" -Skip {}
+        return
+    }
 
     Context "Parse error expected: <<$src>>" {
         # Test case error if this fails


### PR DESCRIPTION
The hang issue in parser tests was due to a bug in Unix version `crosgen`, and it was worked around via #3191.

As described in #3191, we want to run parser tests in CI builds without the corssgen'ed powershell assemblies, and skip those tests in night builds with crossgen'ed powershell assemblies. However, #3191 didn't completely disable those parser tests in the nightly builds, because many of them run through the helper function `ShouldBeParseError`. This causes hang to heppn in nightly build, like https://travis-ci.org/PowerShell/PowerShell/jobs/217938705

This PR fix it and skip all those parser tests in nightly builds.

Note that **it's OK** to skip those parser tests in nightly builds because:
- Parser tests are executed in every CI builds without problem because we don't use crossgen'ed assemblies in CI builds.
- We use crossgen'ed powershell assemblies in nightly builds to exercise those crossgen'ed assemblies, and running those parser tests will cause a hang to happen randomly.