### PR TITLE
Fix New-Item to create correct symlink type (#2915)

### DIFF
--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -2138,9 +2138,9 @@ namespace Microsoft.PowerShell.Commands
                     // non-existing targets on either Windows or Linux.
                     try
                     {
-                        exists = (itemType == ItemType.SymbolicLink)
-                            ? true // pretend it exists if we're making a symbolic link
-                            : CheckItemExists(strTargetPath, out isDirectory);
+                        exists = CheckItemExists(strTargetPath, out isDirectory);
+                        if (itemType == ItemType.SymbolicLink)
+                            exists = true; // pretend the target exists if we're making a symbolic link
                     }
                     catch (Exception e)
                     {


### PR DESCRIPTION
Fix #2915
Now creates a file symlink to a file target and to an non-existent target, and a directory symlink to a directory target.


## Creating Links with New-Item

The `New-Item` cmdlet allows for creating file system *links*.
In general, `New-Item` can create four types of links:

- **Hard Link**
  - Created when `-ItemType` is `HardLink`
- **Symbolic Link**
  - Created when `-ItemType` is `SymbolicLink` **and** either the target exists and is a file, or the target does *not* exist
    - In Windows, if the target is a directory then `New-Item -ItemType Symbolic Link` will create a *directory* symbolic link, not a "plain" symbolic link.
    - In Linux and OS X, `New-Item -ItemType Symbolic Link` will *always* create a "plain" symbolic link, regardless of whether the target is a file or directory, or whether the target exists or not.
  - In Windows, elevated privileges are required to create a symbolic link.
- **_Directory_ Symbolic Link**
  - Created when `-ItemType` is `SymbolicLink` **and** the target exists and is a directory
  - Supported only on NTFS file system
  - In Windows, elevated privileges are required to create a *directory* symbolic link.
  - In Linux and OS X, `New-Item` will not create a *directory* symbolic link, even on an NTFS volume.
- **Directory Junction**
  - Supported only on NTFS file system
  - In Linux and OS X, `New-Item` will not create a directory junction, even on an NTFS volume.
    - Currently, `New-Item` will begin to create the junction by creating the link directory. When the attempt to turn the newly-created directory into a junction fails, `New-Item` will delete the new directory and silently fail.

#### The following table shows the types of links and targets the `New-Item` cmdlet can create on **Windows**:
<table>
<th>Link Type / Target</th><th>Existing File</th><th>Existing Directory</th><th>Non-Existent</th><th>"Plain" Symbolic Link</th><th>Directory Symbolic Link</th><th>Directory Junction</th>
<tr align="center">
  <th scope="row">Hard Link</th>
  <td>Yes</td>
  <td>No</td>
  <td>No</td>
  <td>Yes</td>
  <td>No</td>
  <td>No</td>
</tr>
<tr align="center">
  <th scope="row">"Plain" Symbolic Link</th>
  <td>Yes</td>
  <td>No<a href="#footnote_1"><sup>1</sup></a></td>
  <td>Yes</td>
  <td>Yes</td>
  <td>No<a href="#footnote_1"><sup>1</sup></a></td>
  <td>No<a href="#footnote_1"><sup>1</sup></a></td>
</tr>
<tr align="center">
  <th scope="row"><it>Directory</it> Symbolic Link</th>
  <td>No<a href="#footnote_1"><sup>1</sup></a></td>
  <td>Yes</td>
  <td>No<a href="#footnote_1"><sup>1</sup></a></td>
  <td>No<a href="#footnote_1"><sup>1</sup></a></td>
  <td>Yes</td>
  <td>Yes</td>
</tr>
<tr align="center">
  <th scope="row">Directory Junction</th>
  <td>No</td>
  <td>Yes</td>
  <td>No</td>
  <td>No</td>
  <td>Yes</td>
  <td>Yes</td>
</tr>
</table>
<a name="footnote_1">1</a> While the NTFS file system and the Windows operating system support "plain" symbolic links to existing directories and *directory* symbolic links to files and to non-existent items, the `New-Item` cmdlet cannot create them.

#### The following table shows the types of links and targets the `New-Item` cmdlet can create on **Linux** and **OS X**:
<table>
<th>Link Type / Target</th><th>Existing File</th><th>Existing Directory</th><th>Non-Existent</th><th>"Plain" Symbolic Link</th><th>Directory Symbolic Link</th><th>Directory Junction</th>
<tr align="center">
  <th scope="row">Hard Link</th>
  <td>Yes</td>
  <td>No</td>
  <td>No</td>
  <td>Yes</td>
  <td>No</td>
  <td>No</td>
</tr>
<tr align="center">
  <th scope="row">"Plain" Symbolic Link</th>
  <td>Yes</td>
  <td>Yes</td>
  <td>Yes</td>
  <td>Yes</td>
  <td>No</td>
  <td>No</td>
</tr>
<tr align="center">
  <th scope="row"><it>Directory</it> Symbolic Link<a href="#footnote_2"><sup>2</sup></a></th>
  <td>No</td>
  <td>No</td>
  <td>No</td>
  <td>No</td>
  <td>No</td>
  <td>No</td>
</tr>
<tr align="center">
  <th scope="row">Directory Junction<a href="#footnote_2"><sup>2</sup></a></th>
  <td>No</td>
  <td>No</td>
  <td>No</td>
  <td>No</td>
  <td>No</td>
  <td>No</td>
</tr>
</table>
<a name="footnote_2">2</a> The Linux and OS X operating systems do not support *directory* symbolic links or directory junctions.
