### PR TITLE
Equivalent of bash 'set -e' (#3415)

### DIFF
--- a/src/System.Management.Automation/engine/ExecutionContext.cs
+++ b/src/System.Management.Automation/engine/ExecutionContext.cs
@@ -1005,6 +1005,46 @@ namespace System.Management.Automation
             }
         }
 
+        internal ActionPreference NativeCommandExceptionPreferenceVariable
+        {
+            get
+            {
+                bool defaultUsed = false;
+                return this.GetEnumPreference<ActionPreference>(
+                    SpecialVariables.NativeCommandExceptionPreferenceVarPath,
+                    InitialSessionState.defaultNativeCommandExceptionPreference,
+                    out defaultUsed);
+            }
+            set
+            {
+                this.EngineSessionState.SetVariable(
+                    SpecialVariables.NativeCommandExceptionPreferenceVarPath,
+                    LanguagePrimitives.ConvertTo(value, typeof(ActionPreference), CultureInfo.InvariantCulture),
+                    true,
+                    CommandOrigin.Internal);
+            }
+        }
+
+        internal ActionPreference NativeCommandPipeFailPreferenceVariable
+        {
+            get
+            {
+                bool defaultUsed = false;
+                return this.GetEnumPreference<ActionPreference>(
+                    SpecialVariables.NativeCommandPipeFailPreferenceVarPath,
+                    InitialSessionState.defaultNativeCommandPipeFailPreference,
+                    out defaultUsed);
+            }
+            set
+            {
+                this.EngineSessionState.SetVariable(
+                    SpecialVariables.NativeCommandPipeFailPreferenceVarPath,
+                    LanguagePrimitives.ConvertTo(value, typeof(ActionPreference), CultureInfo.InvariantCulture),
+                    true,
+                    CommandOrigin.Internal);
+            }
+        }
+
         internal ActionPreference WarningActionPreferenceVariable
         {
             get

--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -4820,6 +4820,8 @@ end
 
         internal const ActionPreference defaultDebugPreference = ActionPreference.SilentlyContinue;
         internal const ActionPreference defaultErrorActionPreference = ActionPreference.Continue;
+        internal const ActionPreference defaultNativeCommandExceptionPreference = ActionPreference.Continue;
+        internal const ActionPreference defaultNativeCommandPipeFailPreference = ActionPreference.SilentlyContinue;
         internal const ActionPreference defaultProgressPreference = ActionPreference.Continue;
         internal const ActionPreference defaultVerbosePreference = ActionPreference.SilentlyContinue;
         internal const ActionPreference defaultWarningPreference = ActionPreference.Continue;
@@ -4873,6 +4875,20 @@ end
                 SpecialVariables.ErrorActionPreference,
                 defaultErrorActionPreference,
                 RunspaceInit.ErrorActionPreferenceDescription,
+                ScopedItemOptions.None,
+                new ArgumentTypeConverterAttribute(typeof(ActionPreference))
+                ),
+            new SessionStateVariableEntry(
+                SpecialVariables.NativeCommandExceptionPreference,
+                defaultNativeCommandExceptionPreference,
+                RunspaceInit.NativeCommandExceptionPreferenceDescription,
+                ScopedItemOptions.None,
+                new ArgumentTypeConverterAttribute(typeof(ActionPreference))
+                ),
+            new SessionStateVariableEntry(
+                SpecialVariables.NativeCommandPipeFailPreference,
+                defaultNativeCommandPipeFailPreference,
+                RunspaceInit.NativeCommandPipeFailPreferenceDescription,
                 ScopedItemOptions.None,
                 new ArgumentTypeConverterAttribute(typeof(ActionPreference))
                 ),

--- a/src/System.Management.Automation/engine/MshCommandRuntime.cs
+++ b/src/System.Management.Automation/engine/MshCommandRuntime.cs
@@ -3313,6 +3313,79 @@ namespace System.Management.Automation
 
         internal PagingParameters PagingParameters { get; set; }
 
+        private ActionPreference _nativeCommandException = InitialSessionState.defaultNativeCommandExceptionPreference;
+        private bool _isNativeCommandExceptionPreferenceCached = false;
+        /// <summary>
+        /// ErrorActNativeCommandException tells the command what to do when throwing a native command failure exception
+        /// </summary>
+        /// <exception cref="System.Management.Automation.ExtendedTypeSystemException">
+        /// (get-only) An error occurred accessing $NativeCommandException.
+        /// </exception>
+        internal ActionPreference NativeCommandException
+        {
+            get
+            {
+                // Setting CommonParameters.ErrorAction has highest priority
+                if (IsNativeCommandExceptionSet)
+                    return _nativeCommandException;
+
+                // Do not exit if debugging
+                if (Debug)
+                    return ActionPreference.Continue;
+
+                // fall back to $NativeCommandException
+                if (!_isNativeCommandExceptionPreferenceCached)
+                {
+                    bool defaultUsed = false;
+                    _errorAction = Context.GetEnumPreference<ActionPreference>(SpecialVariables.NativeCommandExceptionPreferenceVarPath, _nativeCommandException, out defaultUsed);
+                    _isNativeCommandExceptionPreferenceCached = true;
+                }
+                return _nativeCommandException;
+            }
+            set
+            {
+                _nativeCommandException = value;
+                IsNativeCommandExceptionSet = true;
+            } // set
+        }
+
+        internal bool IsNativeCommandExceptionSet { get; private set; } = false;
+
+        private ActionPreference _nativeCommandPipeFail = InitialSessionState.defaultNativeCommandPipeFailPreference;
+        private bool _isNativeCommandPipeFailPreferenceCached = false;
+        /// <summary>
+        /// ErrorActNativeCommandException tells the command what to do when throwing a native command failure exception
+        /// </summary>
+        /// <exception cref="System.Management.Automation.ExtendedTypeSystemException">
+        /// (get-only) An error occurred accessing $NativeCommandException.
+        /// </exception>
+        internal ActionPreference NativeCommandPipeFail
+        {
+            get
+            {
+                // Setting CommonParameters.ErrorAction has highest priority
+                if (IsNativeCommandPipeFailSet)
+                    return _nativeCommandPipeFail;
+
+                // fall back to $NativeCommandException
+                if (!_isNativeCommandPipeFailPreferenceCached)
+                {
+                    bool defaultUsed = false;
+                    _errorAction = Context.GetEnumPreference<ActionPreference>(SpecialVariables.NativeCommandPipeFailPreferenceVarPath, _nativeCommandException, out defaultUsed);
+                    _isNativeCommandPipeFailPreferenceCached = true;
+                }
+                return _nativeCommandPipeFail;
+            }
+            set
+            {
+                _nativeCommandPipeFail = value;
+                IsNativeCommandPipeFailSet = true;
+            } // set
+        }
+
+        internal bool IsNativeCommandPipeFailSet { get; private set; } = false;
+
+
         #endregion Preference
 
         #region Continue/Confirm

--- a/src/System.Management.Automation/engine/SpecialVariables.cs
+++ b/src/System.Management.Automation/engine/SpecialVariables.cs
@@ -178,6 +178,12 @@ namespace System.Management.Automation
         internal const string ErrorActionPreference = "ErrorActionPreference";
         internal static readonly VariablePath ErrorActionPreferenceVarPath = new VariablePath(ErrorActionPreference);
 
+        internal const string NativeCommandExceptionPreference = "NativeCommandExceptionPreference";
+        internal static readonly VariablePath NativeCommandExceptionPreferenceVarPath = new VariablePath(NativeCommandExceptionPreference);
+
+        internal const string NativeCommandPipeFailPreference = "NativeCommandPipeFailPreference";
+        internal static readonly VariablePath NativeCommandPipeFailPreferenceVarPath = new VariablePath(NativeCommandPipeFailPreference);
+
         internal const string ProgressPreference = "ProgressPreference";
         internal static readonly VariablePath ProgressPreferenceVarPath = new VariablePath(ProgressPreference);
 
@@ -279,6 +285,8 @@ namespace System.Management.Automation
                                                                     SpecialVariables.WarningPreference,
                                                                     SpecialVariables.InformationPreference,
                                                                     SpecialVariables.ConfirmPreference,
+                                                                    SpecialVariables.NativeCommandExceptionPreference,
+                                                                    SpecialVariables.NativeCommandPipeFailPreference,
                                                                 };
 
         internal static readonly Type[] PreferenceVariableTypes = {
@@ -289,6 +297,8 @@ namespace System.Management.Automation
                                                                     /* WarningPreference */     typeof(ActionPreference),
                                                                     /* InformationPreference */ typeof(ActionPreference),
                                                                     /* ConfirmPreference */     typeof(ConfirmImpact),
+                                                                    /* NativePreference */      typeof(ActionPreference),
+                                                                    /* NativePreference */      typeof(ActionPreference),
                                                                   };
 
         // The following variables are created in every session w/ AllScope.  We avoid creating local slots when we
@@ -356,5 +366,7 @@ namespace System.Management.Automation
         Warning = 13,
         Information = 14,
         Confirm = 15,
+        NativeCommandException = 15,
+        NativeCommandPipeFail = 15,
     }
 }

--- a/src/System.Management.Automation/engine/runtime/CompiledScriptBlock.cs
+++ b/src/System.Management.Automation/engine/runtime/CompiledScriptBlock.cs
@@ -2032,6 +2032,16 @@ namespace System.Management.Automation
                 _localsTuple.SetPreferenceVariable(PreferenceVariable.Confirm,
                                                    _commandRuntime.Confirm ? ConfirmImpact.Low : ConfirmImpact.None);
             }
+            if(_commandRuntime.IsNativeCommandExceptionSet)
+            {
+                _localsTuple.SetPreferenceVariable(PreferenceVariable.NativeCommandException,
+                                                   _commandRuntime.NativeCommandException);
+            }
+            if(_commandRuntime.IsNativeCommandPipeFailSet)
+            {
+                _localsTuple.SetPreferenceVariable(PreferenceVariable.NativeCommandPipeFail,
+                                                   _commandRuntime.NativeCommandPipeFail);
+            }
         }
 
         #region StopProcessing functionality for script cmdlets

--- a/src/System.Management.Automation/resources/ParserStrings.resx
+++ b/src/System.Management.Automation/resources/ParserStrings.resx
@@ -575,6 +575,9 @@ Possible matches are</value>
   <data name="ProgramFailedToExecute" xml:space="preserve">
     <value>Program '{0}' failed to run: {1}{2}.</value>
   </data>
+  <data name="ProgramFailedToComplete" xml:space="preserve">
+    <value>Program '{0}' failed: {1}{2}.</value>
+  </data>
   <data name="CantInvokeInBinaryModule" xml:space="preserve">
     <value>Cannot use '&amp;' to invoke in the context of binary module '{0}'. Specify a non-binary module after the '&amp;' and try the operation again.</value>
   </data>

--- a/src/System.Management.Automation/resources/RunspaceInit.resx
+++ b/src/System.Management.Automation/resources/RunspaceInit.resx
@@ -162,6 +162,12 @@
   <data name="ErrorActionPreferenceDescription" xml:space="preserve">
     <value>Dictates the action taken when an error message is delivered</value>
   </data>
+  <data name="NativeCommandExceptionPreferenceDescription" xml:space="preserve">
+    <value>Dictates whether the exception thrown for a native command failure is non-terminating or terminating</value>
+  </data>
+  <data name="NativeCommandPipeFailPreferenceDescription" xml:space="preserve">
+    <value>Dictates if an exception is thrown when an native command returns a non-zero exit code</value>
+  </data>
   <data name="ProgressPreferenceDescription" xml:space="preserve">
     <value>Dictates the action taken when progress records are delivered</value>
   </data>

--- a/src/System.Management.Automation/utils/CommandProcessorExceptions.cs
+++ b/src/System.Management.Automation/utils/CommandProcessorExceptions.cs
@@ -17,10 +17,6 @@ namespace System.Management.Automation
     [Serializable]
     public class ApplicationFailedException : RuntimeException
     {
-        #region private
-        private const string errorIdString = "NativeCommandFailed";
-        #endregion
-
         #region ctor
 
         #region Serialization
@@ -44,9 +40,7 @@ namespace System.Management.Automation
         /// <returns> constructed object </returns>
         public ApplicationFailedException() : base()
         {
-            base.SetErrorId(errorIdString);
-            base.SetErrorCategory(ErrorCategory.ResourceUnavailable);
-        }
+            }
 
         /// <summary>
         /// Initializes a new instance of the ApplicationFailedException class and defines the error message.
@@ -55,8 +49,6 @@ namespace System.Management.Automation
         /// <returns> constructed object </returns>
         public ApplicationFailedException(string message) : base(message)
         {
-            base.SetErrorId(errorIdString);
-            base.SetErrorCategory(ErrorCategory.ResourceUnavailable);
         }
 
         /// <summary>
@@ -68,8 +60,6 @@ namespace System.Management.Automation
         /// <returns> constructed object </returns>
         internal ApplicationFailedException(string message, string errorId) : base(message)
         {
-            base.SetErrorId(errorId);
-            base.SetErrorCategory(ErrorCategory.ResourceUnavailable);
         }
 
         /// <summary>
@@ -83,8 +73,6 @@ namespace System.Management.Automation
         internal ApplicationFailedException(string message, string errorId, Exception innerException)
             : base(message, innerException)
         {
-            base.SetErrorId(errorId);
-            base.SetErrorCategory(ErrorCategory.ResourceUnavailable);
         }
 
         /// <summary>
@@ -98,9 +86,195 @@ namespace System.Management.Automation
                         Exception innerException)
                 : base(message, innerException)
         {
+        }
+        #endregion ctor
+    } // ApplicationFailedException
+
+
+    /// <summary>
+    /// Defines the exception that is thrown if a native command fails to start
+    /// </summary>
+   [Serializable]
+    public class ApplicationFailedToRunException : ApplicationFailedException
+    {
+        #region private
+        private const string errorIdString = "NativeCommandFailed";
+        #endregion
+
+        #region ctor
+
+        #region Serialization
+        /// <summary>
+        /// Initializes a new instance of the ApplicationFailedToRunException class and defines the serialization information,
+        /// and streaming context.
+        /// </summary>
+        /// <param name="info">The serialization information to use when initializing this object</param>
+        /// <param name="context">The streaming context to use when initializing this object</param>
+        /// <returns> constructed object </returns>
+        protected ApplicationFailedToRunException(SerializationInfo info,
+                           StreamingContext context)
+                : base(info, context)
+        {
+        }
+        #endregion Serialization
+
+        /// <summary>
+        /// Initializes a new instance of the class ApplicationFailedToRunException.
+        /// </summary>
+        /// <returns> constructed object </returns>
+        public ApplicationFailedToRunException() : base()
+        {
+            base.SetErrorId(errorIdString);
+            base.SetErrorCategory(ErrorCategory.ResourceUnavailable);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the ApplicationFailedToRunException class and defines the error message.
+        /// </summary>
+        /// <param name="message">The error message to use when initializing this object</param>
+        /// <returns> constructed object </returns>
+        public ApplicationFailedToRunException(string message) : base(message)
+        {
+            base.SetErrorId(errorIdString);
+            base.SetErrorCategory(ErrorCategory.ResourceUnavailable);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the ApplicationFailedToRunException class and defines the error message and
+        /// errorID.
+        /// </summary>
+        /// <param name="message">The error message to use when initializing this object</param>
+        /// <param name="errorId">The errorId to use when initializing this object</param>
+        /// <returns> constructed object </returns>
+        internal ApplicationFailedToRunException(string message, string errorId) : base(message)
+        {
+            base.SetErrorId(errorId);
+            base.SetErrorCategory(ErrorCategory.ResourceUnavailable);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the ApplicationFailedToRunException class and defines the error message,
+        /// error ID and inner exception.
+        /// </summary>
+        /// <param name="message">The error message to use when initializing this object</param>
+        /// <param name="errorId">The errorId to use when initializing this object</param>
+        /// <param name="innerException">The inner exception to use when initializing this object</param>
+        /// <returns> constructed object </returns>
+        internal ApplicationFailedToRunException(string message, string errorId, Exception innerException)
+            : base(message, innerException)
+        {
+            base.SetErrorId(errorId);
+            base.SetErrorCategory(ErrorCategory.ResourceUnavailable);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the ApplicationFailedToRunException class and defines the error message and
+        /// inner exception.
+        /// </summary>
+        /// <param name="message">The error message to use when initializing this object</param>
+        /// <param name="innerException">The inner exception to use when initializing this object</param>
+        /// <returns> constructed object </returns>
+        public ApplicationFailedToRunException(string message,
+                        Exception innerException)
+                : base(message, innerException)
+        {
             base.SetErrorId(errorIdString);
             base.SetErrorCategory(ErrorCategory.ResourceUnavailable);
         }
         #endregion ctor
-    } // ApplicationFailedException
+    } // ApplicationFailedToRunException
+
+
+    /// <summary>
+    /// Defines the exception that is thrown if a native command fails to complete
+    /// </summary>
+    [Serializable]
+    public class ApplicationFailedToCompleteException : ApplicationFailedException
+    {
+        #region private
+        private const string errorIdString = "NativeCommandFailure";
+        #endregion
+
+        #region ctor
+
+        #region Serialization
+        /// <summary>
+        /// Initializes a new instance of the ApplicationFailedToCompleteException class and defines the serialization information,
+        /// and streaming context.
+        /// </summary>
+        /// <param name="info">The serialization information to use when initializing this object</param>
+        /// <param name="context">The streaming context to use when initializing this object</param>
+        /// <returns> constructed object </returns>
+        protected ApplicationFailedToCompleteException(SerializationInfo info,
+                           StreamingContext context)
+                : base(info, context)
+        {
+        }
+        #endregion Serialization
+
+        /// <summary>
+        /// Initializes a new instance of the class ApplicationFailedToCompleteException.
+        /// </summary>
+        /// <returns> constructed object </returns>
+        public ApplicationFailedToCompleteException() : base()
+        {
+            base.SetErrorId(errorIdString);
+            base.SetErrorCategory(ErrorCategory.NotSpecified);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the ApplicationFailedToCompleteException class and defines the error message.
+        /// </summary>
+        /// <param name="message">The error message to use when initializing this object</param>
+        /// <returns> constructed object </returns>
+        public ApplicationFailedToCompleteException(string message) : base(message)
+        {
+            base.SetErrorId(errorIdString);
+            base.SetErrorCategory(ErrorCategory.NotSpecified);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the ApplicationFailedToCompleteException class and defines the error message and
+        /// errorID.
+        /// </summary>
+        /// <param name="message">The error message to use when initializing this object</param>
+        /// <param name="errorId">The errorId to use when initializing this object</param>
+        /// <returns> constructed object </returns>
+        internal ApplicationFailedToCompleteException(string message, string errorId) : base(message)
+        {
+            base.SetErrorId(errorId);
+            base.SetErrorCategory(ErrorCategory.NotSpecified);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the ApplicationFailedToCompleteException class and defines the error message,
+        /// error ID and inner exception.
+        /// </summary>
+        /// <param name="message">The error message to use when initializing this object</param>
+        /// <param name="errorId">The errorId to use when initializing this object</param>
+        /// <param name="innerException">The inner exception to use when initializing this object</param>
+        /// <returns> constructed object </returns>
+        internal ApplicationFailedToCompleteException(string message, string errorId, Exception innerException)
+            : base(message, innerException)
+        {
+            base.SetErrorId(errorId);
+            base.SetErrorCategory(ErrorCategory.NotSpecified);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the ApplicationFailedToCompleteException class and defines the error message and
+        /// inner exception.
+        /// </summary>
+        /// <param name="message">The error message to use when initializing this object</param>
+        /// <param name="innerException">The inner exception to use when initializing this object</param>
+        /// <returns> constructed object </returns>
+        public ApplicationFailedToCompleteException(string message,
+                        Exception innerException)
+                : base(message, innerException)
+        {
+            base.SetErrorId(errorIdString);
+            base.SetErrorCategory(ErrorCategory.NotSpecified);
+        }
+        #endregion ctor
+    } // ApplicationFailedToCompleteException
 } // namespace System.Management.Automation

--- a/src/System.Management.Automation/utils/ExecutionExceptions.cs
+++ b/src/System.Management.Automation/utils/ExecutionExceptions.cs
@@ -1096,6 +1096,7 @@ namespace System.Management.Automation
         #endregion Serialization
     } // HaltCommandException
     #endregion HaltCommandException
+
 } // namespace System.Management.Automation
 
 #pragma warning restore 56506


### PR DESCRIPTION
Add preference to throw exception on $lastexitcode!=0, like bash ’set -e’.
Only throw with commands *not* used in an expression/if/loop value.

$NativeCommandPipeFailPreference=“continue”: like ‘set -e;set +o pipefail’.
An exception is thrown for a native command giving a non-zero exit code,
if it is the the last command in the pipeline.

$NativeCommandPipeFailPreference=“silentlycontinue”: like ‘set +e’.
No exception is thrown on non-zero exit codes. This is the default.

$NativeCommandPipeFailPreference=“stop”: like ‘set -e;set -o pipefail’.
An exception is thrown for a native command giving a non-zero exit code.

With $NativeCommandExceptionPreference "continue" (the default),
a RuntimeException is thrown, handing off to PowerShell error handling.

With $NativeCommandExceptionPreference “stop”, an ExitException is thrown,
terminating the shell regardless of other PowerShell error handling.
Note: If PowerShell exits, the OS is given exit code 1 rather than forwarding the command exit code

to resolve #3415
