### PR TITLE
Invariable order of $PSVersionTable

### DIFF
--- a/src/System.Management.Automation/engine/PSVersionInfo.cs
+++ b/src/System.Management.Automation/engine/PSVersionInfo.cs
@@ -5,6 +5,8 @@ Copyright (c) Microsoft Corporation.  All rights reserved.
 using System.Diagnostics;
 using System.Reflection;
 using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
 using System.Globalization;
 using System.Management.Automation.Internal;
 using Microsoft.Win32;
@@ -21,7 +23,7 @@ namespace System.Management.Automation
         internal const string PSVersionName = "PSVersion";
         internal const string SerializationVersionName = "SerializationVersion";
         internal const string WSManStackVersionName = "WSManStackVersion";
-        private static Hashtable s_psVersionTable = null;
+        private static PSVersionHashTable s_psVersionTable = null;
 
         /// <summary>
         /// A constant to track current PowerShell Version.
@@ -54,7 +56,7 @@ namespace System.Management.Automation
         // Static Constructor.
         static PSVersionInfo()
         {
-            s_psVersionTable = new Hashtable(StringComparer.OrdinalIgnoreCase);
+            s_psVersionTable = new PSVersionHashTable(StringComparer.OrdinalIgnoreCase);
 
             s_psVersionTable[PSVersionInfo.PSVersionName] = s_psV6Version;
             s_psVersionTable["PSEdition"] = PSEditionValue;
@@ -71,7 +73,7 @@ namespace System.Management.Automation
 #endif
         }
 
-        internal static Hashtable GetPSVersionTable()
+        internal static PSVersionHashTable GetPSVersionTable()
         {
             return s_psVersionTable;
         }
@@ -313,6 +315,43 @@ namespace System.Management.Automation
         }
 
         #endregion
+    }
+
+    /// <summary>
+    /// Represents an implementation of '$PSVersionTable' variable.
+    /// The implementation contains ordered 'Keys' and 'GetEnumerator' to get user-friendly output.
+    /// </summary>
+    public sealed class PSVersionHashTable : Hashtable, IEnumerable
+    {
+        internal PSVersionHashTable(IEqualityComparer equalityComparer) : base(equalityComparer)
+        {
+        }
+
+        /// <summary>
+        /// Returns ordered collection with Keys of 'PSVersionHashTable'
+        /// </summary>
+        public override ICollection Keys
+        {
+            get
+            {
+                Array arr = new string[base.Keys.Count];
+                base.Keys.CopyTo(arr, 0);
+                Array.Sort(arr, StringComparer.OrdinalIgnoreCase);
+                return arr;
+            }
+        }
+
+        /// <summary>
+        /// Returns an enumerator for 'PSVersionHashTable'.
+        /// The enumeration is ordered (based on ordered version of 'Keys').
+        /// </summary>
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            foreach (string key in Keys)
+            {
+                yield return new System.Collections.DictionaryEntry(key, this[key]);
+            }
+        }
     }
 
     /// <summary>

--- a/src/System.Management.Automation/engine/PSVersionInfo.cs
+++ b/src/System.Management.Automation/engine/PSVersionInfo.cs
@@ -5,8 +5,6 @@ Copyright (c) Microsoft Corporation.  All rights reserved.
 using System.Diagnostics;
 using System.Reflection;
 using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
 using System.Globalization;
 using System.Management.Automation.Internal;
 using Microsoft.Win32;

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Variable.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Variable.Tests.ps1
@@ -115,4 +115,14 @@ Describe "Validate special variables" -Tags "CI" {
     It "Verify `$PSVersionTable.PSEdition" {
         $PSVersionTable["PSEdition"] | Should Be "Core"
     }
+
+    It "Verify `$PSVersionTable is ordered" {
+        $keys1 = $PSVersionTable.Keys
+        $keys1sorted = $keys1 | Sort-Object
+        $keys2 = ($PSVersionTable | Format-Table -HideTableHeaders -Property Name | Out-String) -split [System.Environment]::NewLine | Where-Object {$_}
+        $keys2sorted = $keys2 | Sort-Object
+
+        Compare-Object -ReferenceObject $keys1 -DifferenceObject $keys1sorted -SyncWindow 0 | Should Be $null
+        Compare-Object -ReferenceObject $keys2 -DifferenceObject $keys2sorted -SyncWindow 0 | Should Be $null
+    }
 }


### PR DESCRIPTION
Fix #3031.
Provides output $PSVersionTable properties in alphabetical order.

