### PR TITLE
Use IntPtr(-1) for INVALID_HANDLE_VALUE instead of IntPtr.Zero

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
@@ -2608,7 +2608,6 @@ namespace Microsoft.PowerShell.Commands
     internal static class ProcessNativeMethods
     {
         // Fields
-        internal static readonly IntPtr INVALID_HANDLE_VALUE = IntPtr.Zero;
         internal static UInt32 GENERIC_READ = 0x80000000;
         internal static UInt32 GENERIC_WRITE = 0x40000000;
         internal static UInt32 FILE_ATTRIBUTE_NORMAL = 0x80000000;

--- a/src/System.Management.Automation/utils/PlatformInvokes.cs
+++ b/src/System.Management.Automation/utils/PlatformInvokes.cs
@@ -558,7 +558,7 @@ namespace System.Management.Automation
 #if !UNIX
 
         // Fields
-        internal static readonly IntPtr INVALID_HANDLE_VALUE = IntPtr.Zero;
+        internal static readonly IntPtr INVALID_HANDLE_VALUE = new IntPtr(-1);
         internal static UInt32 GENERIC_READ = 0x80000000;
         internal static UInt32 GENERIC_WRITE = 0x40000000;
         internal static UInt32 FILE_ATTRIBUTE_NORMAL = 0x80000000;

--- a/src/powershell-native/nativemsh/pwrshexe/MainEntry.cpp
+++ b/src/powershell-native/nativemsh/pwrshexe/MainEntry.cpp
@@ -1139,11 +1139,6 @@ BOOL IsWow64()
 {
     HANDLE hCurrentProc = GetCurrentProcess();
 
-    if (INVALID_HANDLE_VALUE == hCurrentProc)
-    {
-        return false;
-    }
-
     BOOL isWow64Process = FALSE;
     BOOL ret = IsWow64Process(hCurrentProc, &isWow64Process);
 
@@ -1152,7 +1147,7 @@ BOOL IsWow64()
         return isWow64Process;
     }
 
-    return false;
+    return FALSE;
 }
 
 /**********************************************************************


### PR DESCRIPTION
- Fix incorrect handling of GetCurrentProcess() API return value in IsWow64() function (MainEntry.cpp)
- Remove unused INVALID_HANDLE_VALUE field from ProcessNativeMethods class (Process.cs)

Fixes #3540

<!--

If you are a PowerShell Team member, please make sure you choose the Reviewer(s) and Assignee for your PR.
If you are not from the PowerShell Team, you can leave the fields blank and the Maintainers will choose them for you. If you are familiar with the team, feel free to mention some Reviewers yourself.

For more information about the roles of Reviewer and Assignee, refer to CONTRIBUTING.md.

-->
