### PR TITLE
Added -i swtich to powershell for interactive

### DIFF
--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
@@ -570,6 +570,10 @@ namespace Microsoft.PowerShell
                 {
                     _sshServerMode = true;
                 }
+                else if (MatchSwitch(switchKey, "interactive", "i"))
+                {
+                    _noInteractive = false;
+                }
                 else if (MatchSwitch(switchKey, "configurationname", "config"))
                 {
                     ++i;
@@ -801,7 +805,7 @@ namespace Microsoft.PowerShell
                 {
                     ParseFormat(args, ref i, ref _outFormat, CommandLineParameterParserStrings.MissingOutputFormatParameter);
                 }
-                else if (MatchSwitch(switchKey, "inputformat", "i") || MatchSwitch(switchKey, "if", "i"))
+                else if (MatchSwitch(switchKey, "inputformat", "in") || MatchSwitch(switchKey, "if", "if"))
                 {
                     ParseFormat(args, ref i, ref _inFormat, CommandLineParameterParserStrings.MissingInputFormatParameter);
                 }

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/ManagedEntranceStrings.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/ManagedEntranceStrings.resx
@@ -127,7 +127,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.</value>
   </data>
   <data name="ShellHelp" xml:space="preserve">
     <value>PowerShell[.exe] [-PSConsoleFile &lt;file&gt; | -Version &lt;version&gt;]
-    [-NoLogo] [-NoExit] [-Sta] [-Mta] [-NoProfile] [-NonInteractive]
+    [-NoLogo] [-NoExit] [-Sta] [-Mta] [-NoProfile] [-NonInteractive] [-Interactive]
     [-InputFormat {Text | XML}] [-OutputFormat {Text | XML}]
     [-WindowStyle &lt;style&gt;] [-EncodedCommand &lt;Base64EncodedCommand&gt;]
     [-ConfigurationName &lt;string&gt;]
@@ -163,6 +163,9 @@ PowerShell[.exe] -Help | -? | /?
 
 -NonInteractive
     Does not present an interactive prompt to the user.
+
+-Interactive
+    Present an interactive prompt to the user.
 
 -InputFormat
     Describes the format of data sent to Windows PowerShell. Valid values are

--- a/test/powershell/Host/ConsoleHost.Tests.ps1
+++ b/test/powershell/Host/ConsoleHost.Tests.ps1
@@ -267,8 +267,13 @@ Describe "ConsoleHost unit tests" -tags "Feature" {
         # All of the following tests replace the prompt (either via an initial command or interactively)
         # so that we can read StandardOutput and reliably know exactly what the prompt is.
 
-        It "Interactive redirected input" {
-            $si = NewProcessStartInfo "-noprofile -nologo" -RedirectStdIn
+        It "Interactive redirected input" -TestCases @(
+            @{InteractiveSwitch = ""}
+            @{InteractiveSwitch = " -IntERactive"}
+            @{InteractiveSwitch = " -i"}
+        ) {
+            param($interactiveSwitch)
+            $si = NewProcessStartInfo "-noprofile -nologo$interactiveSwitch" -RedirectStdIn
             $process = RunPowerShell $si
             $process.StandardInput.Write("`$function:prompt = { 'PS> ' }`n")
             $null = $process.StandardOutput.ReadLine()


### PR DESCRIPTION
On Unix, it is a convention for shells to accept `-i` for an interactive shell and many
tools expect this behavior (`script` for example, and when setting powershell as the
default shell) and calls the shell with the `-i` switch.  This change is breaking in
that `-i` previously could be used as short hand to match `-inputformat` which now will
need to be `-in`.

Addresses https://github.com/PowerShell/PowerShell/issues/3319
<!--

If you are a PowerShell Team member, please make sure you choose the Reviewer(s) and Assignee for your PR.
If you are not from the PowerShell Team, you can leave the fields blank and the Maintainers will choose them for you. If you are familiar with the team, feel free to mention some Reviewers yourself.

For more information about the roles of Reviewer and Assignee, refer to CONTRIBUTING.md.

-->
