### PR TITLE
Fixed ability to tab-complete on $error[0]

### DIFF
--- a/src/System.Management.Automation/engine/SessionState.cs
+++ b/src/System.Management.Automation/engine/SessionState.cs
@@ -120,7 +120,7 @@ namespace System.Management.Automation
             }
 
             // Set variable $Error
-            PSVariable errorvariable = new PSVariable("Error", new ArrayList(), ScopedItemOptions.Constant);
+            PSVariable errorvariable = new PSVariable(SpecialVariables.Error, new ArrayList(), ScopedItemOptions.Constant);
             GlobalScope.SetVariable(errorvariable.Name, errorvariable, false, false, this, fastPath: true);
 
 

--- a/src/System.Management.Automation/engine/SpecialVariables.cs
+++ b/src/System.Management.Automation/engine/SpecialVariables.cs
@@ -111,10 +111,10 @@ namespace System.Management.Automation
         internal const string PSCmdlet = "PSCmdlet";
         internal static readonly VariablePath PSCmdletVarPath = new VariablePath("PSCmdlet");
 
-        internal const string Error = "error";
+        internal const string Error = "Error";
         internal static readonly VariablePath ErrorVarPath = new VariablePath("global:" + Error);
 
-        internal const string EventError = "error";
+        internal const string EventError = "Error";
         internal static readonly VariablePath EventErrorVarPath = new VariablePath("script:" + EventError);
 
         internal const string PathExt = "env:PATHEXT";

--- a/src/System.Management.Automation/engine/runtime/Operations/VariableOps.cs
+++ b/src/System.Management.Automation/engine/runtime/Operations/VariableOps.cs
@@ -170,6 +170,10 @@ namespace System.Management.Automation
             CommandOrigin origin = sessionState.CurrentScope.ScopeOrigin;
 
             SessionStateScope scope;
+            if (String.Compare(variablePath.QualifiedName, SpecialVariables.Error, StringComparison.OrdinalIgnoreCase) == 0)
+            {
+                variablePath = new VariablePath(SpecialVariables.ErrorVarPath.UserPath);
+            }
             PSVariable var = sessionState.GetVariableItem(variablePath, out scope, origin);
 
             if (var != null)

--- a/test/powershell/Host/TabCompletion/BugFix.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/BugFix.Tests.ps1
@@ -54,4 +54,26 @@ Describe "Tab completion bug fix" -Tags "CI" {
            $result.CompletionMatches[1].CompletionText | Should Be $DatetimeProperties[1].Name # DateTime
        }
     }
+    It "Issue#3373 - '`$error[0].<tab>' should work" {
+        try {
+            5/0
+        }
+        catch {
+            $e = $error[0]
+        }
+        $cmd = "5/0;`$error[0]."
+        $result = TabExpansion2 -inputScript $cmd -cursorColumn $cmd.Length
+        $result.CompletionMatches.Count | Should Be ($e | Get-Member).Count
+    }
+    It "'`$error[0].fullyQ<tab>' should work" {
+        try {
+            5/0
+        }
+        catch {
+            $e = $error[0]
+        }
+        $cmd = "5/0;`$error[0].fullyQ"
+        $result = TabExpansion2 -inputScript $cmd -cursorColumn $cmd.Length
+        $result.CompletionMatches[0].CompletionText | Should BeExactly "FullyQualifiedErrorId"
+    }
 }


### PR DESCRIPTION
$error is actually $global:error, however, internally it's updated as ExecutionContext.DollarErrorVariable even though an `error` variable is in the variable table of the session state (however it's not writable).  During CommandCompletion this `error` variable is found before getting to global scope, but is empty so tab-complete returns no results.  Fix is to transform CommandCompletion calls to $error as $global:error so that it is found in the correct global scope.

Also fixed some hardcoded strings to use already defined consts for variable names related to Error.

Addresses https://github.com/PowerShell/PowerShell/issues/3373
