### PR TITLE
Fix Start-Process with -UseNewEnvironment switch

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
@@ -1843,7 +1843,12 @@ namespace Microsoft.PowerShell.Commands
                 //UseNewEnvironment
                 if (_UseNewEnvironment)
                 {
-                    ClrFacade.GetProcessEnvironment(startInfo).Clear();
+                    var environmentVars = ClrFacade.GetProcessEnvironment(startInfo);
+                    string envProgramFiles = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
+                    string envProgramFilesX86 = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86);
+                    environmentVars.Clear();
+                    environmentVars.Add("ProgramFiles", envProgramFiles);
+                    environmentVars.Add("ProgramFiles(x86)", envProgramFilesX86);
                     LoadEnvironmentVariable(startInfo, Environment.GetEnvironmentVariables(EnvironmentVariableTarget.Machine));
                     LoadEnvironmentVariable(startInfo, Environment.GetEnvironmentVariables(EnvironmentVariableTarget.User));
                 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Start-Process.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Start-Process.Tests.ps1
@@ -19,6 +19,10 @@ Describe "Start-Process" -Tags @("CI","SLOW") {
         }
     }
 
+    AfterEach {
+        Remove-Item -Path $tempFile -Force -ErrorAction SilentlyContinue
+    }
+
     # Note that ProcessName may still be `powershell` due to dotnet/corefx#5378
     # This has been fixed on Linux, but not on OS X
 
@@ -72,6 +76,14 @@ Describe "Start-Process" -Tags @("CI","SLOW") {
 	    $dirEntry.Length | Should BeGreaterThan 0
     }
 
+    # It is not 'Start-Process' test. It tests that PowerShell can start after removing all environment variables.
+    It "Should run PowerShell subprocess with '-UseNewEnvironment' without error" {
+            $powershell = Join-Path -Path $PsHome -ChildPath "powershell"
+            $process = Start-Process $powershell -ArgumentList "-Command Set-Content -Path $tempfile -Value 'testvalue'" -Wait -UseNewEnvironment
+	    $dirEntry = get-childitem $tempFile
+	    $dirEntry.Length | Should BeGreaterThan 0
+    }
+
     # Marking this test 'pending' to unblock daily builds. Filed issue : https://github.com/PowerShell/PowerShell/issues/2396
     It "Should handle stdin redirection without error" -Pending {
 	    $process = Start-Process sort -Wait -RedirectStandardOutput $tempFile -RedirectStandardInput $assetsFile
@@ -115,6 +127,4 @@ Describe "Start-Process" -Tags @("CI","SLOW") {
         $process.Id | Should BeGreaterThan 1
         $process | Stop-Process
     }
-
-    Remove-Item -Path $tempFile -Force
 }


### PR DESCRIPTION
Fixed #3545.

I fixed by restore "ProgramFiles" and "ProgramFiles(X86)"environment variables for subprocess.
I don't understand how PowerShell use it in start time and perhaps my fix is not in right place.
