### PR TITLE
Fix the Read-Host test that fails in OSX

### DIFF
--- a/test/powershell/Host/assets/Read-Host.Output.expect
+++ b/test/powershell/Host/assets/Read-Host.Output.expect
@@ -9,19 +9,13 @@ set timeout 60
 
 spawn $powershell -nologo -noprofile Read-Host prompt
 
-expect "prompt: $" {
-    send "input\r"
+expect  {
+    "prompt: $" { send "input\r" ; exp_continue }
+    "input\r\ninput\r" { exit 2 }
+    "input\r\n" { exit 0 }
 }
 
-# This is the old, incorrect behavior
-expect "input\r\ninput\r" {
-    exit 2
-}
-
-# This is the expected behavior
-expect "input\r\n" {
-    exit 0
-}
-
-# Anything else is wrong
+# ExitCode: 2 -- this is the old, incorrect behavior
+# ExitCode: 0 -- this is the expected behavior
+# ExitCode: 1 -- anything else is wrong
 exit 1


### PR DESCRIPTION
See the failed test in https://travis-ci.org/PowerShell/PowerShell/jobs/223817346
The test `"[Console]::ReadKey() implementation on non-Windows"` uses the `expect` utility to check the prompt, feed the input and check the output.
After moving to `netcoreapp2.0`, the implementation of `PSHost.UI.Prompt` starts to write out some ANSI terminal control codes, which cause the test to fail because the second expect `expect "input\r\ninput\r"` in the tests would test all output until the spawned powershell process exit. This change fixes the test.

Note the `Read-Host prompt` works as expected with `netcoreapp2.0` on Linux/OSX/Windows:
```
## Linux
bash:99> /home/dongbo/PowerShell/src/powershell-unix/bin/Linux/netcoreapp2.0/ubuntu.16.04-x64/publish/powershell -nologo -noprofile Read-Host prompt
prompt: input
input

## OSX
PowerShells-MacBook:assets psbuildacct$ /Users/psbuildacct/PowerShell/src/powershell-unix/bin/Linux/netcoreapp2.0/osx.10.12-x64/publish/powershell -nologo -noprofile Read-Host prompt
prompt: input
input

## Windows
PS:1> D:\PowerShell\src\powershell-win-core\bin\Debug\netcoreapp2.0\win10-x64\publish\powershell.exe -nologo -noprofile
Read-Host prompt
prompt: input
input
```