### PR TITLE
Add telemetry to the console host to report platform and version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,9 @@ dotnet-uninstall-debian-packages.sh
 # ignore the version file as it is generated at build time
 powershell.version
 
+# ignore the telemetry semaphore file
+DELETE_ME_TO_DISABLE_CONSOLEHOST_TELEMETRY
+
 # default location for produced nuget packages
 /nuget-artifacts
 

--- a/build.psm1
+++ b/build.psm1
@@ -160,6 +160,9 @@ function Start-PSBuild {
     # save Git description to file for PowerShell to include in PSVersionTable
     git --git-dir="$PSScriptRoot/.git" describe --dirty --abbrev=60 > "$psscriptroot/powershell.version"
 
+    # create the telemetry flag file
+    $null = new-item -force -type file "$psscriptroot/DELETE_ME_TO_DISABLE_CONSOLEHOST_TELEMETRY"
+
     # simplify ParameterSetNames
     if ($PSCmdlet.ParameterSetName -eq 'FullCLR') {
         $FullCLR = $true

--- a/src/Microsoft.PowerShell.ConsoleHost/Microsoft.PowerShell.ConsoleHost.csproj
+++ b/src/Microsoft.PowerShell.ConsoleHost/Microsoft.PowerShell.ConsoleHost.csproj
@@ -25,6 +25,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\System.Management.Automation\System.Management.Automation.csproj" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.2.0" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
@@ -257,6 +257,9 @@ namespace Microsoft.PowerShell
                         s_theConsoleHost.UI.WriteWarningLine(preStartWarning);
                     }
 
+                    // Send startup telemetry for ConsoleHost startup
+                    ApplicationInsightsTelemetry.SendPSCoreStartupTelemetry();
+
                     ClrFacade.StartProfileOptimization(
                         s_theConsoleHost.LoadPSReadline()
                             ? "StartupProfileData-Interactive"

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/Telemetry.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/Telemetry.cs
@@ -23,9 +23,12 @@ namespace Microsoft.PowerShell
         /// </summary>
         public const string TelemetrySemaphoreFilename = "DELETE_ME_TO_DISABLE_CONSOLEHOST_TELEMETRY";
 
+        /// <summary>
+        /// The path to the semaphore file which enables telemetry
+        /// </summary>
         public static string TelemetrySemaphoreFilePath = Path.Combine(
-            Path.GetDirectoryName(typeof(PSVersionInfo).GetTypeInfo().Assembly.Location),
-            TelemetrySemaphoreFileName);
+            Utils.GetApplicationBase(Utils.DefaultPowerShellShellID),
+            TelemetrySemaphoreFilename);
 
         // Telemetry client to be reused when we start sending more telemetry
         private static TelemetryClient _telemetryClient = null;
@@ -41,10 +44,10 @@ namespace Microsoft.PowerShell
         /// </summary>
         private static void SendTelemetry(string eventName, Dictionary<string,string>payload)
         {
-            // if the semaphore file exists, try to send telemetry
-            if ( File.Exists(TelemetrySemaphoreFilePath ) )
+            try
             {
-                try
+                // if the semaphore file exists, try to send telemetry
+                if (Utils.NativeFileExists(TelemetrySemaphoreFilePath))
                 {
                     TelemetryConfiguration.Active.InstrumentationKey = _psCoreTelemetryKey;
                     TelemetryConfiguration.Active.TelemetryChannel.DeveloperMode = _developerMode;
@@ -54,10 +57,10 @@ namespace Microsoft.PowerShell
                     }
                     _telemetryClient.TrackEvent(eventName, payload, null);
                 }
-                catch (Exception)
-                {
-                    ; // Do nothing, telemetry can't be sent
-                }
+            }
+            catch (Exception)
+            {
+                ; // Do nothing, telemetry can't be sent
             }
         }
 

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/Telemetry.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/Telemetry.cs
@@ -1,0 +1,56 @@
+using System;
+using Microsoft.ApplicationInsights;
+using Microsoft.ApplicationInsights.DataContracts;
+using Microsoft.ApplicationInsights.Extensibility;
+using System.Management.Automation;
+using System.Security.Cryptography;
+using System.Collections.Generic;
+using System.Reflection;
+using System.IO;
+
+namespace Microsoft.PowerShell
+{
+    /// <summary>
+    /// send up telemetry for startup
+    /// </summary>
+    public class ApplicationInsightsTelemetry
+    {
+        // Telemetry client to be reused when we start sending more telemetry
+        private static TelemetryClient telemetryClient = null;
+        // TODO: Set this to false for release
+        private static bool developerMode = true;
+        // PSCoreInsight2 telemetry key
+        private const string psCoreTelemetryKey = "ee4b2115-d347-47b0-adb6-b19c2c763808"; // PSCoreInsight2
+        /// <summary>
+        /// Send the telemetry
+        /// </summary>
+        private static void SendTelemetry(string eventName, Dictionary<string,string>payload) 
+        {
+            TelemetryConfiguration.Active.InstrumentationKey = psCoreTelemetryKey;
+            // This is set to be sure that the telemetry is quickly delivered
+            TelemetryConfiguration.Active.TelemetryChannel.DeveloperMode = developerMode;
+            if ( telemetryClient == null ) 
+            {
+                telemetryClient = new TelemetryClient();
+            }
+            telemetryClient.TrackEvent(eventName, payload, null);
+        }
+        /// <summary>
+        /// Create the startup payload and send it up
+        /// </summary>
+        public static void SendPSCoreStartupTelemetry()
+        {
+            var properties = new Dictionary<string, string>();
+            properties.Add("GitCommitID", PSVersionInfo.GitCommitId);
+            string OSVersion;
+            try {
+                OSVersion = Environment.OSVersion.ToString();
+            }
+            catch {
+                OSVersion = "unknown";
+            }
+            properties.Add("OSVersionInfo", OSVersion);
+            SendTelemetry("PSCoreStartup", properties);
+        }
+    }
+}

--- a/src/powershell-unix/powershell-unix.csproj
+++ b/src/powershell-unix/powershell-unix.csproj
@@ -19,7 +19,7 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
     </Content>
-    <Content Include="*.so;*.dylib;..\..\license_thirdparty_proprietary.txt;..\..\powershell.version">
+    <Content Include="*.so;*.dylib;..\..\license_thirdparty_proprietary.txt;..\..\powershell.version;..\..\DELETE_ME_TO_DISABLE_CONSOLEHOST_TELEMETRY">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
     </Content>

--- a/src/powershell-win-core/powershell-win-core.csproj
+++ b/src/powershell-win-core/powershell-win-core.csproj
@@ -23,7 +23,7 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
     </Content>
-    <Content Include="..\..\license_thirdparty_proprietary.txt;..\..\powershell.version">
+    <Content Include="..\..\license_thirdparty_proprietary.txt;..\..\powershell.version;..\..\DELETE_ME_TO_DISABLE_CONSOLEHOST_TELEMETRY">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
     </Content>


### PR DESCRIPTION
Produce simple telemetry via Application Insights for the PowerShell Core console host.

This is limited to the console host and is not meant as generalized telemetry code for PowerShell Core. It will capture the GitCommitID and Platform Information when the console host starts. It enables opting out of sending telemetry. This does not include the changes required in setup to opt out of telemetry, which will be in a later PR.