### PR TITLE
Adding support for native command globbing on UNIX

### DIFF
--- a/test/powershell/Language/Scripting/NativeExecution/NativeUnixGlobbing.Tests.ps1
+++ b/test/powershell/Language/Scripting/NativeExecution/NativeUnixGlobbing.Tests.ps1
@@ -1,0 +1,53 @@
+$PesterSkip = if ( $IsWindows ) { @{ Skip = $true } } else { @{} }
+
+Describe 'Native UNIX globbing tests' -tags "CI" {
+
+    BeforeAll {
+        if (-not $IsWindows )
+        {
+            "" > "$TESTDRIVE/abc.txt"
+            "" > "$TESTDRIVE/bbb.txt"
+            "" > "$TESTDRIVE/cbb.txt"
+        }
+    }
+
+    # Test * expansion
+    It 'The globbing pattern *.txt should match 3 files' @PesterSkip {
+        (/bin/ls $TESTDRIVE/*.txt).Length | Should Be 3
+    }
+    It 'The globbing pattern *b.txt should match 2 files whose basenames end in "b"' @PesterSkip {
+        (/bin/ls $TESTDRIVE/*b.txt).Length | Should Be 2
+    }
+    # Test character classes
+    It 'The globbing pattern should match 2 files whose names start with either "a" or "b"' @PesterSkip {
+        (/bin/ls $TESTDRIVE/[ab]*.txt).Length | Should Be 2
+    }
+    It 'Globbing abc.* should return one file name "abc.txt"' @PesterSkip {
+        /bin/ls $TESTDRIVE/abc.* | Should Match "abc.txt"
+    }
+    # Test that ? matches any single character
+    It 'Globbing [cde]b?.* should return one file name "cbb.txt"' @PesterSkip {
+        /bin/ls $TESTDRIVE/[cde]b?.* | Should Match "cbb.txt"
+    }
+    It 'Should return the original pattern if there are no matches' @PesterSkip {
+        /bin/echo $TESTDRIVE/*.nosuchfile | Should Match "\*\.nosuchfile$"
+    }
+    # Test the behavior in non-filesystem drives
+    It 'Should not expand patterns on non-filesystem drives' @PesterSkip {
+        /bin/echo env:ps* | Should BeExactly "env:ps*"
+    }
+    # Test the behavior for files with spaces in the names
+    It 'Globbing filenames with spaces should match 2 files' @PesterSkip {
+        "" > "$TESTDRIVE/foo bar.txt"
+        "" > "$TESTDRIVE/foo baz.txt"
+        (/bin/ls $TESTDRIVE/foo*.txt).Length | Should Be 2
+    }
+    # Test ~ expansion
+    It 'Tilde should be replaced by the filesystem provider home directory' @PesterSkip {
+        /bin/echo ~ | Should BeExactly ($executioncontext.SessionState.Provider.Get("FileSystem").Home)
+    }
+    # Test ~ expansion with a path fragment (e.g. ~/foo)
+    It '~/foo should be replaced by the <filesystem provider home directory>/foo' @PesterSkip {
+        /bin/echo ~/foo | Should BeExactly "$($executioncontext.SessionState.Provider.Get("FileSystem").Home)/foo"
+    }
+}

--- a/test/powershell/Language/Scripting/NativeExecution/NativeUnixGlobbing.Tests.ps1
+++ b/test/powershell/Language/Scripting/NativeExecution/NativeUnixGlobbing.Tests.ps1
@@ -1,4 +1,3 @@
-$PesterSkip = if ( $IsWindows ) { @{ Skip = $true } } else { @{} }
 
 Describe 'Native UNIX globbing tests' -tags "CI" {
 
@@ -9,45 +8,52 @@ Describe 'Native UNIX globbing tests' -tags "CI" {
             "" > "$TESTDRIVE/bbb.txt"
             "" > "$TESTDRIVE/cbb.txt"
         }
+
+        $defaultParamValues = $PSDefaultParameterValues.Clone()
+        $PSDefaultParameterValues["it:skip"] = $IsWindows
+    }
+
+    AfterAll {
+        $global:PSDefaultParameterValues = $defaultParamValues
     }
 
     # Test * expansion
-    It 'The globbing pattern *.txt should match 3 files' @PesterSkip {
+    It 'The globbing pattern *.txt should match 3 files' {
         (/bin/ls $TESTDRIVE/*.txt).Length | Should Be 3
     }
-    It 'The globbing pattern *b.txt should match 2 files whose basenames end in "b"' @PesterSkip {
+    It 'The globbing pattern *b.txt should match 2 files whose basenames end in "b"' {
         (/bin/ls $TESTDRIVE/*b.txt).Length | Should Be 2
     }
     # Test character classes
-    It 'The globbing pattern should match 2 files whose names start with either "a" or "b"' @PesterSkip {
+    It 'The globbing pattern should match 2 files whose names start with either "a" or "b"' {
         (/bin/ls $TESTDRIVE/[ab]*.txt).Length | Should Be 2
     }
-    It 'Globbing abc.* should return one file name "abc.txt"' @PesterSkip {
+    It 'Globbing abc.* should return one file name "abc.txt"' {
         /bin/ls $TESTDRIVE/abc.* | Should Match "abc.txt"
     }
     # Test that ? matches any single character
-    It 'Globbing [cde]b?.* should return one file name "cbb.txt"' @PesterSkip {
+    It 'Globbing [cde]b?.* should return one file name "cbb.txt"' {
         /bin/ls $TESTDRIVE/[cde]b?.* | Should Match "cbb.txt"
     }
-    It 'Should return the original pattern if there are no matches' @PesterSkip {
+    It 'Should return the original pattern if there are no matches' {
         /bin/echo $TESTDRIVE/*.nosuchfile | Should Match "\*\.nosuchfile$"
     }
     # Test the behavior in non-filesystem drives
-    It 'Should not expand patterns on non-filesystem drives' @PesterSkip {
+    It 'Should not expand patterns on non-filesystem drives' {
         /bin/echo env:ps* | Should BeExactly "env:ps*"
     }
     # Test the behavior for files with spaces in the names
-    It 'Globbing filenames with spaces should match 2 files' @PesterSkip {
+    It 'Globbing filenames with spaces should match 2 files' {
         "" > "$TESTDRIVE/foo bar.txt"
         "" > "$TESTDRIVE/foo baz.txt"
         (/bin/ls $TESTDRIVE/foo*.txt).Length | Should Be 2
     }
     # Test ~ expansion
-    It 'Tilde should be replaced by the filesystem provider home directory' @PesterSkip {
+    It 'Tilde should be replaced by the filesystem provider home directory' {
         /bin/echo ~ | Should BeExactly ($executioncontext.SessionState.Provider.Get("FileSystem").Home)
     }
     # Test ~ expansion with a path fragment (e.g. ~/foo)
-    It '~/foo should be replaced by the <filesystem provider home directory>/foo' @PesterSkip {
+    It '~/foo should be replaced by the <filesystem provider home directory>/foo' {
         /bin/echo ~/foo | Should BeExactly "$($executioncontext.SessionState.Provider.Get("FileSystem").Home)/foo"
     }
 }


### PR DESCRIPTION
This change enables globbing (wildcard expansion) against the file system for native commands like /bin/ls. Expansion is only done in the file system. In non-filesystem drives expansion is not done and the pattern is returned unchanged. 

Limitations:

Currently quoting is not honored so for a command like `/bin/ls "*.txt"`, wildcard expansion will still be done. Adding support for bare word detection will come in a future PR.  Use --% to suppress wildcard expansion e.g. git add --% * 

This (partially) fixes #954  

<!--

If you are a PowerShell Team member, please make sure you choose the Reviewer(s) and Assignee for your PR.
If you are not from the PowerShell Team, you can leave the fields blank and the Maintainers will choose them for you. If you are familiar with the team, feel free to mention some Reviewers yourself.

For more information about the roles of Reviewer and Assignee, refer to CONTRIBUTING.md.

-->
