### PR TITLE
PSVersionTable should have entry for OS and Platform

### DIFF
--- a/src/System.Management.Automation/engine/PSVersionInfo.cs
+++ b/src/System.Management.Automation/engine/PSVersionInfo.cs
@@ -64,10 +64,13 @@ namespace System.Management.Automation
             s_psVersionTable[PSVersionInfo.SerializationVersionName] = new Version(InternalSerializer.DefaultVersion);
             s_psVersionTable[PSVersionInfo.PSRemotingProtocolVersionName] = RemotingConstants.ProtocolVersion;
             s_psVersionTable[PSVersionInfo.WSManStackVersionName] = GetWSManStackVersion();
+            s_psVersionTable["Platform"] = Environment.OSVersion.Platform.ToString();
 #if CORECLR
+            s_psVersionTable["OS"] = Runtime.InteropServices.RuntimeInformation.OSDescription.ToString();
             s_psVersionTable["CLRVersion"] = null;
 #else
             s_psVersionTable["CLRVersion"] = Environment.Version;
+            s_psVersionTable["OS"] = Environment.OSVersion.ToString();
 #endif
         }
 

--- a/test/powershell/Host/PSVersionTable.Tests.ps1
+++ b/test/powershell/Host/PSVersionTable.Tests.ps1
@@ -1,25 +1,45 @@
 Describe "PSVersionTable" -Tags "CI" {
     It "Should have version table entries" {
-	$PSVersionTable.Count | Should Be 9
+       $PSVersionTable.Count | Should Be 11
     }
 
     It "Should have the right version table entries" {
-	$PSVersionTable.ContainsKey("PSVersion")                 | Should Be True
-	$PSVersionTable.ContainsKey("PSEdition")                 | Should Be True
-	$PSVersionTable.ContainsKey("WSManStackVersion")         | Should Be True
-	$PSVersionTable.ContainsKey("SerializationVersion")      | Should Be True
-	$PSVersionTable.ContainsKey("CLRVersion")                | Should Be True
-	$PSVersionTable.ContainsKey("BuildVersion")              | Should Be True
-	$PSVersionTable.ContainsKey("PSCompatibleVersions")      | Should Be True
-	$PSVersionTable.ContainsKey("PSRemotingProtocolVersion") | Should Be True
-	$PSVersionTable.ContainsKey("GitCommitId")               | Should Be True
+       $PSVersionTable.ContainsKey("PSVersion")                 | Should Be True
+       $PSVersionTable.ContainsKey("PSEdition")                 | Should Be True
+       $PSVersionTable.ContainsKey("WSManStackVersion")         | Should Be True
+       $PSVersionTable.ContainsKey("SerializationVersion")      | Should Be True
+       $PSVersionTable.ContainsKey("CLRVersion")                | Should Be True
+       $PSVersionTable.ContainsKey("BuildVersion")              | Should Be True
+       $PSVersionTable.ContainsKey("PSCompatibleVersions")      | Should Be True
+       $PSVersionTable.ContainsKey("PSRemotingProtocolVersion") | Should Be True
+       $PSVersionTable.ContainsKey("GitCommitId")               | Should Be True
+       $PSVersionTable.ContainsKey("Platform")                  | Should Be True
+       $PSVersionTable.ContainsKey("OS")                        | Should Be True
 
     }
     It "GitCommitId property should not contain an error" {
-        $PSVersionTable.GitCommitId | Should not match "powershell.version"
+       $PSVersionTable.GitCommitId | Should not match "powershell.version"
     }
 
     It "Should have the correct edition" -Skip:(!$IsCoreCLR) {
-	$PSVersionTable["PSEdition"] | Should Be "Core"
+	   $PSVersionTable["PSEdition"] | Should Be "Core"
+    }
+
+    It "Should have the correct platform info" {
+       $platform = [String][System.Environment]::OSVersion.Platform
+	   [String]$PSVersionTable["Platform"] | Should Be $platform
+    }
+
+    It "Should have the correct OS info" {
+       if ($IsCoreCLR)
+       {
+           $OSDescription = [String][System.Runtime.InteropServices.RuntimeInformation]::OSDescription
+	       [String]$PSVersionTable["OS"] | Should Be $OSDescription
+       }
+       else
+       {
+           $OSDescription = [String][System.Environment]::OSVersion
+           [String]$PSVersionTable["OS"] | Should Be $OSDescription
+       }
     }
 }


### PR DESCRIPTION
This is to resolve #1635

$PSVersionTable.OS now outputs [Runtime.InteropServices.RuntimeInformation]::OSDescription ([System.Environment]::OSVersion if not under coreclr)
$PSVersionTable.Platform outputs [System.Environment]::OSVersion.Platform
