### PR TITLE
Part 2 - Improve ValidateCount attribute error message

### DIFF
--- a/src/System.Management.Automation/engine/Attributes.cs
+++ b/src/System.Management.Automation/engine/Attributes.cs
@@ -1311,8 +1311,8 @@ namespace System.Management.Automation
 
             if (MinLength == MaxLength && len != MaxLength)
             {
-                throw new ValidationMetadataException("ValidateCountExactlyFailure",
-                    null, Metadata.ValidateCountExactlyFailure,
+                throw new ValidationMetadataException("ValidateCountExactFailure",
+                    null, Metadata.ValidateCountExactFailure,
                     MaxLength, len);
             }
 

--- a/src/System.Management.Automation/engine/Attributes.cs
+++ b/src/System.Management.Automation/engine/Attributes.cs
@@ -1311,22 +1311,15 @@ namespace System.Management.Automation
 
             if (MinLength == MaxLength && len != MaxLength)
             {
-                throw new ValidationMetadataException("ValidateCountNotExactlyEqual",
-                    null, Metadata.ValidateCountFailure,
-                    MinLength, MaxLength, len);
+                throw new ValidationMetadataException("ValidateCountExactlyFailure",
+                    null, Metadata.ValidateCountExactlyFailure,
+                    MaxLength, len);
             }
 
-            if (len < MinLength)
+            if (len < MinLength || len > MaxLength)
             {
-                throw new ValidationMetadataException("ValidateCountSmallerThanMin",
-                    null, Metadata.ValidateCountFailure,
-                    MinLength, MaxLength, len);
-            }
-
-            if (len > MaxLength)
-            {
-                throw new ValidationMetadataException("ValidateCountGreaterThanMax",
-                    null, Metadata.ValidateCountFailure,
+                throw new ValidationMetadataException("ValidateCountMinMaxFailure",
+                    null, Metadata.ValidateCountMinMaxFailure,
                     MinLength, MaxLength, len);
             }
         }

--- a/src/System.Management.Automation/resources/Metadata.resx
+++ b/src/System.Management.Automation/resources/Metadata.resx
@@ -144,7 +144,10 @@
   <data name="ValidateCountNotInArray" xml:space="preserve">
     <value>The ValidateCount attribute cannot be applied to a non-array parameter. Either remove the attribute from the parameter or make the parameter an array parameter.</value>
   </data>
-  <data name="ValidateCountFailure" xml:space="preserve">
+  <data name="ValidateCountExactlyFailure" xml:space="preserve">
+    <value>The parameter requires exactly {0} value(s) - {1} value(s) were provided.</value>
+  </data>
+  <data name="ValidateCountMinMaxFailure" xml:space="preserve">
     <value>The parameter requires at least {0} value(s) and no more than {1} value(s) - {2} value(s) were provided.</value>
   </data>
   <data name="ValidateCountMaxLengthSmallerThanMinLength" xml:space="preserve">

--- a/src/System.Management.Automation/resources/Metadata.resx
+++ b/src/System.Management.Automation/resources/Metadata.resx
@@ -144,7 +144,7 @@
   <data name="ValidateCountNotInArray" xml:space="preserve">
     <value>The ValidateCount attribute cannot be applied to a non-array parameter. Either remove the attribute from the parameter or make the parameter an array parameter.</value>
   </data>
-  <data name="ValidateCountExactlyFailure" xml:space="preserve">
+  <data name="ValidateCountExactFailure" xml:space="preserve">
     <value>The parameter requires exactly {0} value(s) - {1} value(s) were provided.</value>
   </data>
   <data name="ValidateCountMinMaxFailure" xml:space="preserve">

--- a/test/powershell/engine/ValidateAttributes.Tests.ps1
+++ b/test/powershell/engine/ValidateAttributes.Tests.ps1
@@ -8,9 +8,9 @@ Describe 'Validate Attributes Tests' -Tags 'CI' {
                @{ sb = { function Local:foo { param([ValidateCount(-1,2)] [string[]] $bar) }; foo         }; FullyQualifiedErrorId = "ExceptionConstructingAttribute";             InnerErrorId = "" }
                @{ sb = { function Local:foo { param([ValidateCount(1,-1)] [string[]] $bar) }; foo         }; FullyQualifiedErrorId = "ExceptionConstructingAttribute";             InnerErrorId = "" }
                @{ sb = { function Local:foo { param([ValidateCount(2, 1)] [string[]] $bar) }; foo         }; FullyQualifiedErrorId = "ValidateRangeMaxLengthSmallerThanMinLength"; InnerErrorId = "" }
-               @{ sb = { function Local:foo { param([ValidateCount(2, 2)] [string[]] $bar) }; foo 1       }; FullyQualifiedErrorId = "ParameterArgumentValidationError,foo";       InnerErrorId = "ValidateCountNotExactlyEqual" }
-               @{ sb = { function Local:foo { param([ValidateCount(2, 3)] [string[]] $bar) }; foo 1       }; FullyQualifiedErrorId = "ParameterArgumentValidationError,foo";       InnerErrorId = "ValidateCountSmallerThanMin" }
-               @{ sb = { function Local:foo { param([ValidateCount(2, 3)] [string[]] $bar) }; foo 1,2,3,4 }; FullyQualifiedErrorId = "ParameterArgumentValidationError,foo";       InnerErrorId = "ValidateCountGreaterThanMax" }
+               @{ sb = { function Local:foo { param([ValidateCount(2, 2)] [string[]] $bar) }; foo 1       }; FullyQualifiedErrorId = "ParameterArgumentValidationError,foo";       InnerErrorId = "ValidateCountExactlyFailure" }
+               @{ sb = { function Local:foo { param([ValidateCount(2, 3)] [string[]] $bar) }; foo 1       }; FullyQualifiedErrorId = "ParameterArgumentValidationError,foo";       InnerErrorId = "ValidateCountMinMaxFailure" }
+               @{ sb = { function Local:foo { param([ValidateCount(2, 3)] [string[]] $bar) }; foo 1,2,3,4 }; FullyQualifiedErrorId = "ParameterArgumentValidationError,foo";       InnerErrorId = "ValidateCountMinMaxFailure" }
            )
         }
 

--- a/test/powershell/engine/ValidateAttributes.Tests.ps1
+++ b/test/powershell/engine/ValidateAttributes.Tests.ps1
@@ -8,7 +8,7 @@ Describe 'Validate Attributes Tests' -Tags 'CI' {
                @{ sb = { function Local:foo { param([ValidateCount(-1,2)] [string[]] $bar) }; foo         }; FullyQualifiedErrorId = "ExceptionConstructingAttribute";             InnerErrorId = "" }
                @{ sb = { function Local:foo { param([ValidateCount(1,-1)] [string[]] $bar) }; foo         }; FullyQualifiedErrorId = "ExceptionConstructingAttribute";             InnerErrorId = "" }
                @{ sb = { function Local:foo { param([ValidateCount(2, 1)] [string[]] $bar) }; foo         }; FullyQualifiedErrorId = "ValidateRangeMaxLengthSmallerThanMinLength"; InnerErrorId = "" }
-               @{ sb = { function Local:foo { param([ValidateCount(2, 2)] [string[]] $bar) }; foo 1       }; FullyQualifiedErrorId = "ParameterArgumentValidationError,foo";       InnerErrorId = "ValidateCountExactlyFailure" }
+               @{ sb = { function Local:foo { param([ValidateCount(2, 2)] [string[]] $bar) }; foo 1       }; FullyQualifiedErrorId = "ParameterArgumentValidationError,foo";       InnerErrorId = "ValidateCountExactFailure" }
                @{ sb = { function Local:foo { param([ValidateCount(2, 3)] [string[]] $bar) }; foo 1       }; FullyQualifiedErrorId = "ParameterArgumentValidationError,foo";       InnerErrorId = "ValidateCountMinMaxFailure" }
                @{ sb = { function Local:foo { param([ValidateCount(2, 3)] [string[]] $bar) }; foo 1,2,3,4 }; FullyQualifiedErrorId = "ParameterArgumentValidationError,foo";       InnerErrorId = "ValidateCountMinMaxFailure" }
            )


### PR DESCRIPTION
Based on discussion https://github.com/PowerShell/PowerShell/pull/3596#discussion_r113464969

Leave only two message for:
1. Count is not in allowed range.
2. Count is not exactly equal allowed value.

/cc @lzybkr @mklement0