### PR TITLE
Make sure nuget package version suffix applies to all ProjectReference

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -1723,6 +1723,15 @@ function Publish-NuGetFeed
     # Add .NET CLI tools to PATH
     Find-Dotnet
 
+    if ($VersionSuffix) {
+        ## NuGet/Home #3953, #4337 -- dotnet pack - version suffix missing from ProjectReference
+        ## Workaround:
+        ##   dotnet restore /p:VersionSuffix=<suffix> # Bake the suffix into project.assets.json
+        ##   dotnet pack --version-suffix <suffix>
+        $TopProject = (New-PSOptions).Top
+        dotnet restore $TopProject "/p:VersionSuffix=$VersionSuffix"
+    }
+
     try {
         Push-Location $PSScriptRoot
         @(


### PR DESCRIPTION
Due to a breaking change (likely by design) in dotnet-cli, `dotnet pack --version-suffix` doesn't apply the same suffix to all its referenced project anymore. A workaround is used.
See https://github.com/NuGet/Home/issues/4337 and https://github.com/NuGet/Home/issues/3953 for more information.