### PR TITLE
Disable schema validation in ScriptWriter.cs

### DIFF
--- a/src/System.Management.Automation/cimSupport/cmdletization/ScriptWriter.cs
+++ b/src/System.Management.Automation/cimSupport/cmdletization/ScriptWriter.cs
@@ -47,6 +47,10 @@ namespace Microsoft.PowerShell.Cmdletization
             ScriptWriter.s_xmlReaderSettings.MaxCharactersFromEntities = 16384; // generous guess for the upper bound
             ScriptWriter.s_xmlReaderSettings.MaxCharactersInDocument = 128 * 1024 * 1024; // generous guess for the upper bound
 
+#if CORECLR // The XML Schema file 'cmdlets-over-objects.xsd' is missing in Github, and it's likely the resource string
+            //'CmdletizationCoreResources.Xml_cmdletsOverObjectsXsd' needs to be reworked to work in .NET Core.
+            ScriptWriter.s_xmlReaderSettings.DtdProcessing = DtdProcessing.Ignore;
+#else
             ScriptWriter.s_xmlReaderSettings.DtdProcessing = DtdProcessing.Parse; // Allowing DTD parsing with limits of MaxCharactersFromEntities/MaxCharactersInDocument
             ScriptWriter.s_xmlReaderSettings.XmlResolver = null; // do not fetch external documents
             // xsd schema related settings
@@ -58,6 +62,7 @@ namespace Microsoft.PowerShell.Cmdletization
             ScriptWriter.s_xmlReaderSettings.Schemas = new XmlSchemaSet();
             ScriptWriter.s_xmlReaderSettings.Schemas.Add(null, cmdletizationSchemaReader);
             ScriptWriter.s_xmlReaderSettings.Schemas.XmlResolver = null; // do not fetch external documents
+#endif
         }
 
         #endregion Static code reused for reading cmdletization xml


### PR DESCRIPTION
Add back the `#if CORECLR` that was removed when moving powershell to `netcoreapp2.0`.
The schema validation fails in powershell core because:
1. The XML Schema file `cmdlets-over-objects.xsd` is missing in Github
2. The resource string `CmdletizationCoreResources.Xml_cmdletsOverObjectsXsd` likely needs to be reworked to make the schema validation work.

The failure causes powershell core to fail to load CDXML modules that worked before moving to `netcoreapp2.0`.

Note that powershell core doesn't validate XML schemas due to the missing of related APIs in .NET Core 1.1 and prior versions. The `#if CORECLR` here was removed when moving to `netcore2.0` without verifying if the schema validation functionality actually works, so it should be reverted.