### PR TITLE
Rename Ubuntu14 package to include Debian8

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -1623,7 +1623,7 @@ esac
     # iteration is "debian_revision"
     # usage of this to differentiate distributions is allowed by non-standard
     if ($IsUbuntu14) {
-        $Iteration += "ubuntu1.14.04.1"
+        $Iteration += "ubuntu1.14.04.1-debian8"
     } elseif ($IsUbuntu16) {
         $Iteration += "ubuntu1.16.04.1"
     }


### PR DESCRIPTION
This is related to #1903 (Release .deb packages for Debian 8 "jessie").

With this change, package name for Ubuntu14 package will be changed:
from:
powershell_6.0.0-alpha.18-1ubuntu1.14.04.1_amd64.deb
to:
powershell_6.0.0-alpha.18-1ubuntu1.14.04.1-debian8_amd64.deb