### PR TITLE
Change Get-ChildItem to list the content of a link to a directory on Unix. (#1958)

### DIFF
--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -1521,14 +1521,6 @@ namespace Microsoft.PowerShell.Commands
                 if (isDirectory)
                 {
                     DirectoryInfo directory = new DirectoryInfo(path);
-
-                    if (!Platform.IsWindows && Platform.NonWindowsIsSymLink(directory))
-                    {
-                        // For Linux, treat symlink to directories like a file
-                        WriteItemObject(directory, path, false);
-                        return;
-                    }
-
                     // Enumerate the directory
                     Dir(directory, recurse, depth, nameOnly, returnContainers);
                 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
@@ -367,6 +367,32 @@ Describe "Hard link and symbolic link tests" -Tags "CI", "RequireAdminOnWindows"
         }
     }
 
+    Context "Get-ChildItem and symbolic links" {
+        BeforeAll {
+            $subDir = Join-Path $TestDrive "bar"
+            $subLink = Join-Path $TestDrive "foo"
+            $subFile1 = Join-Path $subDir "File1.txt"
+            $subFile2 = Join-Path $subDir "File2.txt"
+
+            New-Item -ItemType Directory -Path $subDir
+            New-Item -ItemType File -Path $subFile1
+            New-Item -ItemType File -Path $subFile2
+
+            $filenamePattern = "File[12]\.txt"
+        }
+        AfterAll {
+            Remove-Item -Path $subLink -Force
+        }
+
+        It "Get-ChildItem gets content of linked-to directory" {
+            New-Item -ItemType SymbolicLink -Path $subLink -Value $subDir
+            $ci = Get-ChildItem $subLink
+            $ci.Count | Should BeExactly 2
+            $ci[0].Name | Should MatchExactly $filenamePattern
+            $ci[1].Name | Should MatchExactly $filenamePattern
+        }
+    }
+
     Context "Remove-Item and hard/symbolic links" {
         BeforeAll {
             $testCases = @(


### PR DESCRIPTION
Fix #1958
Brings Get-ChildItem in line with ls command on Unix and with the PowerShell behavior on Windows when the link is a directory symbolic link.