### PR TITLE
Update powershell to use .NET Core 2.0.0-preview1-002106-00

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ version: 6.0.0-alpha.18-{build}
 
 image: Visual Studio 2015
 
-# cache version - netcoreapp.2.0.0-preview1-001913-00
+# cache version - netcoreapp.2.0.0-preview1-002106-00
 cache:
   - '%LocalAppData%\Microsoft\dotnet -> appveyor.yml'
   - '%HOMEDRIVE%%HOMEPATH%\.nuget\packages -> appveyor.yml'

--- a/build.psm1
+++ b/build.psm1
@@ -967,7 +967,7 @@ function Install-Dotnet {
     [CmdletBinding()]
     param(
         [string]$Channel = "preview",
-        [string]$Version = "2.0.0-preview1-005724",
+        [string]$Version = "2.0.0-preview1-005952",
         [switch]$NoSudo
     )
 
@@ -1029,7 +1029,7 @@ function Start-PSBootstrap {
         [string]$Channel = "preview",
         # we currently pin dotnet-cli version, and will
         # update it when more stable version comes out.
-        [string]$Version = "2.0.0-preview1-005724",
+        [string]$Version = "2.0.0-preview1-005952",
         [switch]$Package,
         [switch]$NoSudo,
         [switch]$Force
@@ -2760,14 +2760,14 @@ function Start-CrossGen {
     # The crossgen tool is only published for these particular runtimes
     $crossGenRuntime = if ($IsWindows) {
         if ($Runtime -match "-x86") {
-            "win7-x86"
+            "win-x86"
         } else {
-            "win7-x64"
+            "win-x64"
         }
     } elseif ($IsLinux) {
         "linux-x64"
     } elseif ($IsOSX) {
-        "osx.10.12-x64"
+        "osx-x64"
     }
 
     if (-not $crossGenRuntime) {

--- a/src/Microsoft.PowerShell.Commands.Management/Microsoft.PowerShell.Commands.Management.csproj
+++ b/src/Microsoft.PowerShell.Commands.Management/Microsoft.PowerShell.Commands.Management.csproj
@@ -78,7 +78,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.ServiceProcess.ServiceController" Version="4.4.0-preview1-25204-02" />
+    <PackageReference Include="System.ServiceProcess.ServiceController" Version="4.4.0-preview1-25302-01" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.PowerShell.Commands.Utility/Microsoft.PowerShell.Commands.Utility.csproj
+++ b/src/Microsoft.PowerShell.Commands.Utility/Microsoft.PowerShell.Commands.Utility.csproj
@@ -91,7 +91,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.0.0" />
-    <PackageReference Include="System.ValueTuple" Version="4.4.0-preview1-25204-02" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.PowerShell.CoreCLR.Eventing/Microsoft.PowerShell.CoreCLR.Eventing.csproj
+++ b/src/Microsoft.PowerShell.CoreCLR.Eventing/Microsoft.PowerShell.CoreCLR.Eventing.csproj
@@ -32,7 +32,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Security.Principal.Windows" Version="4.4.0-preview1-25204-02" />
+    <PackageReference Include="System.Security.Principal.Windows" Version="4.4.0-preview1-25302-01" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.PowerShell.SDK/Microsoft.PowerShell.SDK.csproj
+++ b/src/Microsoft.PowerShell.SDK/Microsoft.PowerShell.SDK.csproj
@@ -17,17 +17,17 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Data.SqlClient" Version="4.4.0-preview1-25204-02" />
-    <PackageReference Include="System.IO.Packaging" Version="4.4.0-preview1-25204-02" />
-    <PackageReference Include="System.Net.Http.WinHttpHandler" Version="4.4.0-preview1-25204-02" />
-    <PackageReference Include="System.ServiceModel.Duplex" Version="4.4.0-beta-25205-01" />
-    <PackageReference Include="System.ServiceModel.Http" Version="4.4.0-beta-25205-01" />
-    <PackageReference Include="System.ServiceModel.NetTcp" Version="4.4.0-beta-25205-01" />
-    <PackageReference Include="System.ServiceModel.Primitives" Version="4.4.0-beta-25205-01" />
-    <PackageReference Include="System.ServiceModel.Security" Version="4.4.0-beta-25205-01" />
-    <PackageReference Include="System.Text.Encodings.Web" Version="4.4.0-preview1-25204-02" />
-    <PackageReference Include="System.Threading.AccessControl" Version="4.4.0-preview1-25204-02" />
-    <PackageReference Include="System.Private.ServiceModel" Version="4.4.0-beta-25205-01" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.4.0-preview1-25302-01" />
+    <PackageReference Include="System.IO.Packaging" Version="4.4.0-preview1-25302-01" />
+    <PackageReference Include="System.Net.Http.WinHttpHandler" Version="4.4.0-preview1-25302-01" />
+    <PackageReference Include="System.ServiceModel.Duplex" Version="4.4.0-preview1-25302-01" />
+    <PackageReference Include="System.ServiceModel.Http" Version="4.4.0-preview1-25302-01" />
+    <PackageReference Include="System.ServiceModel.NetTcp" Version="4.4.0-preview1-25302-01" />
+    <PackageReference Include="System.ServiceModel.Primitives" Version="4.4.0-preview1-25302-01" />
+    <PackageReference Include="System.ServiceModel.Security" Version="4.4.0-preview1-25302-01" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="4.4.0-preview1-25302-01" />
+    <PackageReference Include="System.Threading.AccessControl" Version="4.4.0-preview1-25302-01" />
+    <PackageReference Include="System.Private.ServiceModel" Version="4.4.0-preview1-25302-01" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.WSMan.Management/Interop.cs
+++ b/src/Microsoft.WSMan.Management/Interop.cs
@@ -14,10 +14,6 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Text;
-#if CORECLR
-// Use stub for TypeLibTypeAttribute
-using Microsoft.PowerShell.CoreClr.Stubs;
-#endif
 
 #pragma warning disable 1591
 

--- a/src/System.Management.Automation/CoreCLR/CorePsStub.cs
+++ b/src/System.Management.Automation/CoreCLR/CorePsStub.cs
@@ -32,18 +32,6 @@ namespace Microsoft.PowerShell.CoreClr.Stubs
         NoZone = -1,
     }
 
-    /// <summary>
-    /// Stub for TypeLibTypeAttribute
-    /// </summary>
-    public sealed class TypeLibTypeAttribute : Attribute
-    {
-        /// <summary>
-        ///
-        /// </summary>
-        /// <param name="flags"></param>
-        public TypeLibTypeAttribute(short flags) { }
-    }
-
     #endregion Misc_Types
 
     #region SystemManagementStubs

--- a/src/System.Management.Automation/System.Management.Automation.csproj
+++ b/src/System.Management.Automation/System.Management.Automation.csproj
@@ -19,12 +19,13 @@
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.PowerShell.CoreCLR.AssemblyLoadContext\Microsoft.PowerShell.CoreCLR.AssemblyLoadContext.csproj" />
     <ProjectReference Include="..\Microsoft.PowerShell.CoreCLR.Eventing\Microsoft.PowerShell.CoreCLR.Eventing.csproj" />
-    <PackageReference Include="Microsoft.Win32.Registry.AccessControl" Version="4.4.0-preview1-25204-02" />
+    <PackageReference Include="Microsoft.Win32.Registry.AccessControl" Version="4.4.0-preview1-25302-01" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.1" />
-    <PackageReference Include="System.IO.FileSystem.AccessControl" Version="4.4.0-preview1-25204-02" />
-    <PackageReference Include="System.Security.AccessControl" Version="4.4.0-preview1-25204-02" />
-    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="4.4.0-preview1-25204-02" />
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="4.4.0-preview1-25204-02" />
+    <PackageReference Include="System.IO.FileSystem.AccessControl" Version="4.4.0-preview1-25302-01" />
+    <PackageReference Include="System.Security.AccessControl" Version="4.4.0-preview1-25302-01" />
+    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="4.4.0-preview1-25302-01" />
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="4.4.0-preview1-25302-01" />
+    <PackageReference Include="Microsoft.Management.Infrastructure" Version="1.0.0-alpha*" />
   </ItemGroup>
 
   <PropertyGroup>
@@ -144,9 +145,5 @@
   <PropertyGroup Condition=" '$(Configuration)' == 'CodeCoverage' ">
     <DebugType>full</DebugType>
   </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Management.Infrastructure" Version="1.0.0-alpha*" />
-  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Use 2.0 CLI/SDK of version `2.0.0-preview1-005952` to keep in sync with the .NET Core 2.0 //Build dogfood instructions. The version of `Microsoft.NetCore.App` in use is `2.0.0-preview1-002106-00`.

The following two dotnet issues are addressed in `2.0.0-preview1-005952` CLI/SDK:
https://github.com/dotnet/corefx/issues/17797
https://github.com/dotnet/cli/issues/6352
