### PR TITLE
Enable Get-TimeZone for *nix and Mac OS.

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/TimeZoneCommands.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/TimeZoneCommands.cs
@@ -1,5 +1,3 @@
-#if !UNIX
-
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -66,15 +64,7 @@ namespace Microsoft.PowerShell.Commands
                     {
                         WriteObject(TimeZoneInfo.FindSystemTimeZoneById(tzid));
                     }
-#if CORECLR
-                    // TimeZoneNotFoundException is thrown by TimeZoneInfo, but not
-                    // publicly visible (so can't be caught), so for now we're catching
-                    // the parent exception time. This should be removed once the more
-                    // specific exception is available.
-                    catch (Exception e)
-#else
                     catch (TimeZoneNotFoundException e)
-#endif
                     {
                         WriteError(new ErrorRecord(e, TimeZoneHelper.TimeZoneNotFoundError,
                             ErrorCategory.InvalidArgument, "Id"));
@@ -103,14 +93,8 @@ namespace Microsoft.PowerShell.Commands
                         {
                             string message = string.Format(CultureInfo.InvariantCulture,
                                 TimeZoneResources.TimeZoneNameNotFound, tzname);
-#if CORECLR
-                        // Because .NET Core does not currently expose the TimeZoneNotFoundException
-                        // we need to throw the more generic parent exception class for the time being.
-                        // This should be removed once the correct exception class is available.
-                        Exception e = new Exception(message);
-#else
+
                             Exception e = new TimeZoneNotFoundException(message);
-#endif
                             WriteError(new ErrorRecord(e, TimeZoneHelper.TimeZoneNotFoundError,
                                 ErrorCategory.InvalidArgument, "Name"));
                         }
@@ -125,6 +109,7 @@ namespace Microsoft.PowerShell.Commands
         }
     }
 
+#if !UNIX
 
     /// <summary>
     /// A cmdlet to set the system's local time zone.
@@ -804,7 +789,7 @@ namespace Microsoft.PowerShell.Commands
 #endregion Win32 interop helper
     }
 
-
+#endif
     /// <summary>
     /// static Helper class for working with system time zones.
     /// </summary>
@@ -862,5 +847,3 @@ namespace Microsoft.PowerShell.Commands
         }
     }
 }
-
-#endif

--- a/src/Modules/Unix/Microsoft.PowerShell.Management/Microsoft.PowerShell.Management.psd1
+++ b/src/Modules/Unix/Microsoft.PowerShell.Management/Microsoft.PowerShell.Management.psd1
@@ -48,5 +48,6 @@ CmdletsToExport=@("Add-Content",
     "Rename-ItemProperty",
     "Resolve-Path",
     "Set-Content",
-    "Set-ItemProperty")
+    "Set-ItemProperty",
+    "Get-TimeZone")
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Unimplemented-Cmdlet.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Unimplemented-Cmdlet.Tests.ps1
@@ -18,7 +18,6 @@ Describe "Unimplemented Management Cmdlet Tests" -Tags "CI" {
 
         "Test-Connection",
 
-        "Get-TimeZone",
         "Set-TimeZone"
     )
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Default-Aliases.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Default-Aliases.Tests.ps1
@@ -93,7 +93,7 @@ Describe "Verify approved aliases list" -Tags "CI" {
             "gsn -> Get-PSSession"                    =             $FullCLR -or $CoreWindows -or $CoreUnix
             "gsnp -> Get-PSSnapin"                    =             $FullCLR
             "gsv -> Get-Service"                      =             $FullCLR -or $CoreWindows -or $CoreUnix
-            "gtz -> Get-TimeZone"                     =                          $CoreWindows
+            "gtz -> Get-TimeZone"                     =             $FullCLR -or $CoreWindows -or $CoreUnix
             "gu -> Get-Unique"                        =             $FullCLR -or $CoreWindows -or $CoreUnix
             "gv -> Get-Variable"                      =             $FullCLR -or $CoreWindows -or $CoreUnix
             "gwmi -> Get-WmiObject"                   =             $FullCLR


### PR DESCRIPTION
- Get-TimeZone can be enabled now as the required classes are available in .Net Standard 2.0.
- Removed workaround for TimeZoneNotFoundException
- Test fixes
- Fixes #3605 


<!--

If you are a PowerShell Team member, please make sure you choose the Reviewer(s) and Assignee for your PR.
If you are not from the PowerShell Team, you can leave the fields blank and the Maintainers will choose them for you. If you are familiar with the team, feel free to mention some Reviewers yourself.

For more information about the roles of Reviewer and Assignee, refer to CONTRIBUTING.md.

-->
