### PR TITLE
Temporary workaround to fix the PSVersion issue in beta.1 release

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -158,7 +158,10 @@ function Start-PSBuild {
     }
 
     # save Git description to file for PowerShell to include in PSVersionTable
-    git --git-dir="$PSScriptRoot/.git" describe --dirty --abbrev=60 > "$psscriptroot/powershell.version"
+    #git --git-dir="$PSScriptRoot/.git" describe --dirty --abbrev=60 > "$psscriptroot/powershell.version"
+
+    # temporary hack to resolve the version issue
+    "v6.0.0-beta.1" > "$psscriptroot/powershell.version"
 
     # create the telemetry flag file
     $null = new-item -force -type file "$psscriptroot/DELETE_ME_TO_DISABLE_CONSOLEHOST_TELEMETRY"

--- a/src/System.Management.Automation/engine/PSVersionInfo.cs
+++ b/src/System.Management.Automation/engine/PSVersionInfo.cs
@@ -47,7 +47,7 @@ namespace System.Management.Automation
         private static Version s_psV4Version = new Version(4, 0);
         private static Version s_psV5Version = new Version(5, 0);
         private static Version s_psV51Version = new Version(5, 1, NTVerpVars.PRODUCTBUILD, NTVerpVars.PRODUCTBUILD_QFE);
-        private static SemanticVersion s_psV6Version = new SemanticVersion(6, 0, 0, "alpha");
+        private static SemanticVersion s_psV6Version = new SemanticVersion(6, 0, 0, "beta");
 
         /// <summary>
         /// A constant to track current PowerShell Edition


### PR DESCRIPTION
> private static SemanticVersion s_psV6Version = new SemanticVersion(6, 0, 0, "alpha");

Background: PSVersion is hard-coded in `PSVersionInfo.cs`, and this wasn't aware of until we pushed the release tag and built packages. This PR is a temporary workaround to unblock the release.

It includes 2 changes:
1. Change s_psV6Version to `new SemanticVersion(6, 0, 0, "beta");`
    This version shouldn't be hard-coded, #3739 shall be fixed.
2. Change `Start-PSBuild` to always write `"v6.0.0-beta.1"` to powershell.version.
    This hack shall be reverted after the release. Tracking by #3741