### PR TITLE
Temporary workaround #2 to fix the PSVersion issue in beta.1 release

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -1258,7 +1258,8 @@ function Start-PSPackage {
 
     # Use Git tag if not given a version
     if (-not $Version) {
-        $Version = (git --git-dir="$PSScriptRoot/.git" describe) -Replace '^v'
+        #$Version = (git --git-dir="$PSScriptRoot/.git" describe) -Replace '^v'
+        $Version = "6.0.0-beta.1"
     }
 
     $Source = Split-Path -Path $Script:Options.Output -Parent


### PR DESCRIPTION
Another `git --git-dir="$PSScriptRoot/.git" describe` in build script needs to be replaced with `6.0.0-beta.1`. 
The change needs to be reverted after the release. Tracked by #3741
