### PR TITLE
Update releasing.md about NuGet package suffix

### DIFF
--- a/docs/maintainers/releasing.md
+++ b/docs/maintainers/releasing.md
@@ -246,7 +246,7 @@ Run `Publish-NuGetFeed` to generate PowerShell NuGet packages:
 Import-Module .\build.psm1
 Start-PSBootstrap -Package
 Start-PSBuild -Clean -Publish
-$VersionSuffix = ((git describe) -split '-')[-1] -replace "\."
+$VersionSuffix = ((git describe) -split '-')[-1]
 Publish-NuGetFeed -VersionSuffix $VersionSuffix
 ```
 


### PR DESCRIPTION
Per the discussion in #2354, we now use a version like `6.0.0-beta.1` for our NuGet packages. This PR updates `releasing.md` to keep in sync.