### PR TITLE
Do not send telemetry in CI

### DIFF
--- a/tools/appveyor.psm1
+++ b/tools/appveyor.psm1
@@ -311,6 +311,12 @@ function Invoke-AppVeyorTest
         Write-Host -Foreground Green 'Running all CoreCLR tests..'
     }
 
+    # Remove telemetry semaphore file in CI
+    $telemetrySemaphoreFilepath = Join-Path $env:CoreOutput DELETE_ME_TO_DISABLE_CONSOLEHOST_TELEMETRY
+    if ( Test-Path "${telemetrySemaphoreFilepath}" ) {
+        Remove-Item -Force ${telemetrySemaphoreFilepath}
+    }
+
     Start-PSPester -bindir $env:CoreOutput -outputFile $testResultsNonAdminFile -Unelevate -Tag @() -ExcludeTag ($ExcludeTag + @('RequireAdminOnWindows'))
     Write-Host -Foreground Green 'Upload CoreCLR Non-Admin test results'
     Update-AppVeyorTestResults -resultsFile $testResultsNonAdminFile

--- a/tools/travis.ps1
+++ b/tools/travis.ps1
@@ -123,6 +123,12 @@ if ($isFullBuild) {
     $pesterParam['ThrowOnFailure'] = $true
 }
 
+# Remove telemetry semaphore file in CI
+$telemetrySemaphoreFilepath = Join-Path $output DELETE_ME_TO_DISABLE_CONSOLEHOST_TELEMETRY
+if ( Test-Path "${telemetrySemaphoreFilepath}" ) {
+    Remove-Item -force ${telemetrySemaphoreFilepath}
+}
+
 Start-PSPester @pesterParam
 
 if (-not $isPr) {


### PR DESCRIPTION
This removes the telemetry semaphore file in CI for both Travis-CI and AppVeyor

These are done in the travis-cs and appveyor scripts because I only want to remove the telemetry from our CI systems. I want to continue to gather telemetry from local builds which tells us how many are using custom vs release builds.