### PR TITLE
Fix build version handling when creating SemanticVersion objects

### DIFF
--- a/src/System.Management.Automation/engine/PSVersionInfo.cs
+++ b/src/System.Management.Automation/engine/PSVersionInfo.cs
@@ -493,11 +493,11 @@ namespace System.Management.Automation
         /// <param name="version">The version.</param>
         public SemanticVersion(Version version)
         {
-            if (version.Revision > 0 || version.Build < 0) throw PSTraceSource.NewArgumentException(nameof(version));
+            if (version.Revision > 0) throw PSTraceSource.NewArgumentException(nameof(version));
 
             Major = version.Major;
             Minor = version.Minor;
-            Patch = version.Build;
+            Patch = version.Build == -1 ? 0 : version.Build;
             var psobj = new PSObject(version);
             var labelNote = psobj.Properties[LabelPropertyName];
             if (labelNote != null)

--- a/test/powershell/engine/SemanticVersion.Tests.ps1
+++ b/test/powershell/engine/SemanticVersion.Tests.ps1
@@ -50,6 +50,9 @@ Describe "SemanticVersion api tests" -Tags 'CI' {
         }
 
         It "version arg constructor" {
+            $v = [SemanticVersion]::new([Version]::new(1, 2))
+            $v.ToString() | Should Be '1.2.0'
+
             $v = [SemanticVersion]::new([Version]::new(1, 2, 3))
             $v.ToString() | Should Be '1.2.3'
         }


### PR DESCRIPTION
Fix #3786

The appropriate [SemanticVersion] constructor now accepts a [version] instance that has only major and minor components specified, in which case the patch component now defaults to 0.

<!--

If you are a PowerShell Team member, please make sure you choose the Reviewer(s) and Assignee for your PR.
If you are not from the PowerShell Team, you can leave the fields blank and the Maintainers will choose them for you. If you are familiar with the team, feel free to mention some Reviewers yourself.

For more information about the roles of Reviewer and Assignee, refer to CONTRIBUTING.md.

-->
