### PR TITLE
Update format-hex tests to include -TestCase parameter

### DIFF
--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/FormatHex.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/FormatHex.Tests.ps1
@@ -353,7 +353,7 @@ Describe "FormatHex" -tags "CI" {
 
     Context "Continues to Process Valid Paths" {
 
-        $skipTest = ([System.Management.Automation.Platform]::IsLinux -or [System.Management.Automation.Platform]::IsOSX)
+        $skipTest = ([System.Management.Automation.Platform]::IsLinux -or [System.Management.Automation.Platform]::IsOSX -or (-not $certProviderAvailable))
 
         $testCases = @(
             @{
@@ -375,7 +375,7 @@ Describe "FormatHex" -tags "CI" {
             }
         )
 
-        It "<Name>" -Skip:$($skipTest -or (-not $certProviderAvailable)) -TestCase $testCases {
+        It "<Name>" -Skip:$skipTest -TestCase $testCases {
 
             param ($Name, $PathCase, $InvalidPath, $ExpectedFullyQualifiedErrorId)
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/FormatHex.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/FormatHex.Tests.ps1
@@ -37,6 +37,8 @@ Describe "FormatHex" -tags "CI" {
             $thumbprint = $certificateProvider[0].Thumbprint
             $certProviderAvailable = $true
         }
+
+        $skipTest = ([System.Management.Automation.Platform]::IsLinux -or [System.Management.Automation.Platform]::IsOSX -or (-not $certProviderAvailable))
     }
 
     Context "InputObject Paramater" {
@@ -309,7 +311,6 @@ Describe "FormatHex" -tags "CI" {
     Context "Validate Error Scenarios" {
 
         $testDirectory = $inputFile1.DirectoryName
-        $skipTest = ([System.Management.Automation.Platform]::IsLinux -or [System.Management.Automation.Platform]::IsOSX)
 
         $testCases = @(
             @{
@@ -327,7 +328,7 @@ Describe "FormatHex" -tags "CI" {
             }
         )
 
-        It "<Name>" -Skip:$($skipTest -or (-not $certProviderAvailable)) -TestCase $testCases {
+        It "<Name>" -Skip:$skipTest -TestCase $testCases {
 
             param ($Name, $PathParameterErrorCase, $Path, $InputObject, $InputObjectErrorCase, $ExpectedFullyQualifiedErrorId)
 
@@ -352,8 +353,6 @@ Describe "FormatHex" -tags "CI" {
     }
 
     Context "Continues to Process Valid Paths" {
-
-        $skipTest = ([System.Management.Automation.Platform]::IsLinux -or [System.Management.Automation.Platform]::IsOSX -or (-not $certProviderAvailable))
 
         $testCases = @(
             @{

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/FormatHex.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/FormatHex.Tests.ps1
@@ -14,115 +14,127 @@
         Hexadecimal equivalent of the input data is displayed.
 #>
 
-function RunInputObjectTestCase($testCase)
+function RunInputObjectTestCase($testCases)
 {
-    It "$($testCase.Name)" {
+    It "<Name>" -TestCase $testCases{
 
-        $result = Format-Hex -InputObject $testCase.InputObject
+        param ($Name, $InputObject, $Count, $ExpectedResult)
+
+        $result = Format-Hex -InputObject $InputObject
 
         $result | Should Not Be $null
-        $result.count | Should Be $testCase.Count
+        $result.count | Should Be $Count
         $result | Should BeOfType 'Microsoft.PowerShell.Commands.ByteCollection'
-        $result.ToString() | Should Match $testCase.ExpectedResult
+        $result.ToString() | Should Match $ExpectedResult
     }
 }
 
-function RunObjectFromPipelineTestCase($testCase)
+function RunObjectFromPipelineTestCase($testCases)
 {
-    It "$($testCase.Name)" {
+    It "<Name>" -Testcase $testCases {
 
-        $result = $testCase.InputObject | Format-Hex
+        param ($Name, $InputObject, $Count, $ExpectedResult, $ExpectedSecondResult)
+
+        $result = $InputObject | Format-Hex
 
         $result | Should Not Be $null
-        $result.count | Should Be $testCase.Count
+        $result.count | Should Be $Count
         $result | Should BeOfType 'Microsoft.PowerShell.Commands.ByteCollection'
-        $result[0].ToString() | Should Match $testCase.ExpectedResult
+        $result[0].ToString() | Should Match $ExpectedResult
 
         if ($result.count > 1)
         {
-            $result[1].ToString() | Should Match $testCase.ExpectedSecondResult
+            $result[1].ToString() | Should Match $ExpectedSecondResult
         }
     }
 }
 
-function RunPathAndLiteralPathParameterTestCase($testCase)
+function RunPathAndLiteralPathParameterTestCase($testCases)
 {
-    It "$($testCase.Name)" {
+    It "<Name>" -TestCase $testCases {
 
-        if ($testCase.PathCase)
+        param ($Name, $PathCase, $Path, $ExpectedResult, $ExpectedSecondResult)
+
+        if ($PathCase)
         {
-            $result =  Format-Hex -Path $testCase.Path
+            $result =  Format-Hex -Path $Path
         }
         else # LiteralPath
         {
-            $result = Format-Hex -LiteralPath $testCase.Path
+            $result = Format-Hex -LiteralPath $Path
         }
 
         $result | Should Not Be $null
         $result | Should BeOfType 'Microsoft.PowerShell.Commands.ByteCollection'
-        $result[0].ToString() | Should Match $testCase.ExpectedResult
+        $result[0].ToString() | Should Match $ExpectedResult
 
         if ($result.count > 1)
         {
-            $result[1].ToString() | Should Match $testCase.ExpectedSecondResult
+            $result[1].ToString() | Should Match $ExpectedSecondResult
         }
     }
 }
 
-function RunEncodingTestCase($testCase)
+function RunEncodingTestCase($testCases)
 {
-    It "$($testCase.Name)" {
+    It "<Name>" -TestCase $testCases {
 
-        $result = Format-Hex -InputObject 'hello' -Encoding $testCase.Encoding
+        param ($Name, $Encoding, $Count, $ExpectedResult)
+
+        $result = Format-Hex -InputObject 'hello' -Encoding $Encoding
 
         $result | Should Not Be $null
-        $result.count | Should Be $testCase.Count
+        $result.count | Should Be $Count
         $result | Should BeOfType 'Microsoft.PowerShell.Commands.ByteCollection'
-        $result[0].ToString() | Should Match $testCase.ExpectedResult
+        $result[0].ToString() | Should Match $ExpectedResult
     }
 }
 
-function RunContinuesToProcessCase($testCase)
+function RunContinuesToProcessCase($testCases)
 {
     $skipTest = ([System.Management.Automation.Platform]::IsLinux -or [System.Management.Automation.Platform]::IsOSX)
 
-    It "$($testCase.Name)" -Skip:$($skipTest -or (-not $certProviderAvailable)) {
+    It "<Name>" -Skip:$($skipTest -or (-not $certProviderAvailable)) -TestCase $testCases {
+
+        param ($Name, $PathCase, $InvalidPath, $ExpectedFullyQualifiedErrorId)
 
         $output = $null
         $errorThrown = $null
 
-        if ($testCase.PathCase)
+        if ($PathCase)
         {
-            $output = Format-Hex -Path $testCase.InvalidPath, $inputFile1 -ErrorVariable errorThrown -ErrorAction SilentlyContinue
+            $output = Format-Hex -Path $InvalidPath, $inputFile1 -ErrorVariable errorThrown -ErrorAction SilentlyContinue
         }
         else # LiteralPath
         {
-            $output = Format-Hex -LiteralPath $testCase.InvalidPath, $inputFile1 -ErrorVariable errorThrown -ErrorAction SilentlyContinue
+            $output = Format-Hex -LiteralPath $InvalidPath, $inputFile1 -ErrorVariable errorThrown -ErrorAction SilentlyContinue
         }
 
         $errorThrown | Should Not Be $null
-        $errorThrown.FullyQualifiedErrorId | Should Match $testCase.ExpectedFullyQualifiedErrorId
+        $errorThrown.FullyQualifiedErrorId | Should Match $ExpectedFullyQualifiedErrorId
 
         $output | Should Not Be $null
         $output[0].ToString() | Should Match $inputText1
     }
 }
 
-function RunExpectedErrorTestCase($testCase)
+function RunExpectedErrorTestCase($testCases)
 {
     $skipTest = ([System.Management.Automation.Platform]::IsLinux -or [System.Management.Automation.Platform]::IsOSX)
 
-    It "$($testCase.Name)" -Skip:$($skipTest -or (-not $certProviderAvailable)) {
+    It "<Name>" -Skip:$($skipTest -or (-not $certProviderAvailable)) -TestCase $testCases {
+
+        param ($Name, $PathParameterErrorCase, $Path, $InputObject, $InputObjectErrorCase, $ExpectedFullyQualifiedErrorId)
 
         try
         {
-            if ($testCase.PathParameterErrorCase)
+            if ($PathParameterErrorCase)
             {
-                $result = Format-Hex -Path $testCase.Path -ErrorAction Stop
+                $result = Format-Hex -Path $Path -ErrorAction Stop
             }
-            if ($testCase.InputObjectErrorCase)
+            if ($InputObjectErrorCase)
             {
-                $result = Format-Hex -InputObject $testCase.InputObject -ErrorAction Stop
+                $result = Format-Hex -InputObject $InputObject -ErrorAction Stop
             }
         }
         catch
@@ -131,7 +143,7 @@ function RunExpectedErrorTestCase($testCase)
         }
 
         $thrownError | Should Not Be $null
-        $thrownError.FullyQualifiedErrorId | Should Match $testCase.ExpectedFullyQualifiedErrorId
+        $thrownError.FullyQualifiedErrorId | Should Match $ExpectedFullyQualifiedErrorId
     }
 }
 
@@ -216,10 +228,7 @@ Describe "FormatHex" -tags "CI" {
             }
         )
 
-        foreach ($testCase in $testCases)
-        {
-            RunInputObjectTestCase $testCase
-        }
+        RunInputObjectTestCase $testCases
     }
 
     Context "InputObject From Pipeline" {
@@ -284,10 +293,7 @@ Describe "FormatHex" -tags "CI" {
             }
         )
 
-        foreach ($testCase in $testCases)
-        {
-            RunObjectFromPipelineTestCase $testCase
-        }
+        RunObjectFromPipelineTestCase $testCases
     }
 
     Context "Path Paramater" {
@@ -320,10 +326,7 @@ Describe "FormatHex" -tags "CI" {
             }
         )
 
-        foreach ($testCase in $testCases)
-        {
-            RunPathAndLiteralPathParameterTestCase $testCase
-        }
+        RunPathAndLiteralPathParameterTestCase $testCases
     }
 
     Context "LiteralPath Paramater" {
@@ -343,10 +346,7 @@ Describe "FormatHex" -tags "CI" {
             }
         )
 
-        foreach ($testCase in $testCases)
-        {
-            RunPathAndLiteralPathParameterTestCase $testCase
-        }
+        RunPathAndLiteralPathParameterTestCase $testCases
     }
 
     Context "Encoding Parameter" {
@@ -389,10 +389,7 @@ Describe "FormatHex" -tags "CI" {
             }
         )
 
-    foreach ($testCase in $testCases)
-    {
-        RunEncodingTestCase $testCase
-    }
+    RunEncodingTestCase $testCases
 }
 
     Context "Validate Error Scenarios" {
@@ -415,10 +412,7 @@ Describe "FormatHex" -tags "CI" {
             }
         )
 
-        foreach ($testCase in $testCases)
-        {
-            RunExpectedErrorTestCase $testCase
-        }
+        RunExpectedErrorTestCase $testCases
     }
 
     Context "Continues to Process Valid Paths" {
@@ -443,10 +437,7 @@ Describe "FormatHex" -tags "CI" {
             }
         )
 
-        foreach ($testCase in $testCases)
-        {
-            RunContinuesToProcessCase $testCase
-        }
+        RunContinuesToProcessCase $testCases
     }
 
     Context "Cmdlet Functionality" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/FormatHex.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/FormatHex.Tests.ps1
@@ -107,7 +107,7 @@ Describe "FormatHex" -tags "CI" {
 
             $result.count | Should Be $Count
             $result | Should BeOfType 'Microsoft.PowerShell.Commands.ByteCollection'
-            $result.ToString() | Should Match $ExpectedResult
+            $result.ToString() | Should MatchExactly $ExpectedResult
         }
     }
 
@@ -181,16 +181,16 @@ Describe "FormatHex" -tags "CI" {
 
             $result.count | Should Be $Count
             $result | Should BeOfType 'Microsoft.PowerShell.Commands.ByteCollection'
-            $result[0].ToString() | Should Match $ExpectedResult
+            $result[0].ToString() | Should MatchExactly $ExpectedResult
 
             if ($result.count -gt 1)
             {
-                $result[1].ToString() | Should Match $ExpectedSecondResult
+                $result[1].ToString() | Should MatchExactly $ExpectedSecondResult
             }
         }
     }
 
-    Context "Path and LiteralPath Paramaters" {
+    Context "Path and LiteralPath Parameters" {
 
         $testDirectory = $inputFile1.DirectoryName
 
@@ -247,11 +247,11 @@ Describe "FormatHex" -tags "CI" {
             }
 
             $result | Should BeOfType 'Microsoft.PowerShell.Commands.ByteCollection'
-            $result[0].ToString() | Should Match $ExpectedResult
+            $result[0].ToString() | Should MatchExactly $ExpectedResult
 
             if ($result.count -gt 1)
             {
-                $result[1].ToString() | Should Match $ExpectedSecondResult
+                $result[1].ToString() | Should MatchExactly $ExpectedSecondResult
             }
         }
     }
@@ -304,7 +304,7 @@ Describe "FormatHex" -tags "CI" {
 
             $result.count | Should Be $Count
             $result | Should BeOfType 'Microsoft.PowerShell.Commands.ByteCollection'
-            $result[0].ToString() | Should Match $ExpectedResult
+            $result[0].ToString() | Should MatchExactly $ExpectedResult
         }
     }
 
@@ -348,7 +348,7 @@ Describe "FormatHex" -tags "CI" {
                 $thrownError = $_
             }
 
-            $thrownError.FullyQualifiedErrorId | Should Match $ExpectedFullyQualifiedErrorId
+            $thrownError.FullyQualifiedErrorId | Should MatchExactly $ExpectedFullyQualifiedErrorId
         }
     }
 
@@ -390,10 +390,10 @@ Describe "FormatHex" -tags "CI" {
                 $output = Format-Hex -LiteralPath $InvalidPath, $inputFile1 -ErrorVariable errorThrown -ErrorAction SilentlyContinue
             }
 
-            $errorThrown.FullyQualifiedErrorId | Should Match $ExpectedFullyQualifiedErrorId
+            $errorThrown.FullyQualifiedErrorId | Should MatchExactly $ExpectedFullyQualifiedErrorId
 
             $output.Length | Should Be 1
-            $output[0].ToString() | Should Match $inputText1
+            $output[0].ToString() | Should MatchExactly $inputText1
         }
     }
 
@@ -406,7 +406,7 @@ Describe "FormatHex" -tags "CI" {
             $result | Should Not BeNullOrEmpty
             ,$result | Should BeOfType 'Microsoft.PowerShell.Commands.ByteCollection'
             $actualResult = $result.ToString()
-            $actualResult | Should Match $inputText1
+            $actualResult | Should MatchExactly $inputText1
         }
 
         It "Validate file input from Pipeline 'Get-ChildItem `$inputFile1 | Format-Hex'" {
@@ -416,7 +416,7 @@ Describe "FormatHex" -tags "CI" {
             $result | Should Not BeNullOrEmpty
             ,$result | Should BeOfType 'Microsoft.PowerShell.Commands.ByteCollection'
             $actualResult = $result.ToString()
-            $actualResult | Should Match $inputText1
+            $actualResult | Should MatchExactly $inputText1
         }
 
         It "Validate that streamed text does not have buffer underrun problems ''a' * 30 | Format-Hex'" {
@@ -425,7 +425,7 @@ Describe "FormatHex" -tags "CI" {
 
             $result | Should Not BeNullOrEmpty
             ,$result | Should BeOfType 'Microsoft.PowerShell.Commands.ByteCollection'
-            $result.ToString() | Should be "00000000   61 61 61 61 61 61 61 61 61 61 61 61 61 61 61 61  aaaaaaaaaaaaaaaa`r`n00000010   61 61 61 61 61 61 61 61 61 61 61 61 61 61        aaaaaaaaaaaaaa  "
+            $result.ToString() | Should MatchExactly "00000000   61 61 61 61 61 61 61 61 61 61 61 61 61 61 61 61  aaaaaaaaaaaaaaaa`r`n00000010   61 61 61 61 61 61 61 61 61 61 61 61 61 61        aaaaaaaaaaaaaa  "
         }
 
         It "Validate that files do not have buffer underrun problems 'Format-Hex -path `$InputFile4'" {
@@ -434,9 +434,9 @@ Describe "FormatHex" -tags "CI" {
 
             $result | Should Not BeNullOrEmpty
             $result.Count | Should Be 3
-            $result[0].ToString() | Should be "00000000   4E 6F 77 20 69 73 20 74 68 65 20 77 69 6E 74 65  Now is the winte"
-            $result[1].ToString() | Should be "00000010   72 20 6F 66 20 6F 75 72 20 64 69 73 63 6F 6E 74  r of our discont"
-            $result[2].ToString() | Should be "00000020   65 6E 74                                         ent             "
+            $result[0].ToString() | Should MatchExactly "00000000   4E 6F 77 20 69 73 20 74 68 65 20 77 69 6E 74 65  Now is the winte"
+            $result[1].ToString() | Should MatchExactly "00000010   72 20 6F 66 20 6F 75 72 20 64 69 73 63 6F 6E 74  r of our discont"
+            $result[2].ToString() | Should MatchExactly "00000020   65 6E 74                                         ent             "
         }
     }
 }


### PR DESCRIPTION
Addressing issue #3382 'Use -TestCases parameter in FormatHex.Tests.ps1'.

* Replaced the 'foreach' with the -TestCases parameter in the test helper functions.

