### PR TITLE
Make ConsoleHost honor NoEcho on Unix platforms

### DIFF
--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostRawUserInterface.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostRawUserInterface.cs
@@ -1745,10 +1745,10 @@ namespace Microsoft.PowerShell
         /// from the keyboard device, blocking processing until a keystroke is
         /// typed that matches the specified keystroke options.
         /// </summary>
-        /// <param name="options">Unused</param>
+        /// <param name="options">Only NoEcho is supported.</param>
         public override KeyInfo ReadKey(ReadKeyOptions options)
         {
-            ConsoleKeyInfo key = Console.ReadKey();
+            ConsoleKeyInfo key = Console.ReadKey((options & ReadKeyOptions.NoEcho) != 0);
             return new KeyInfo((int)key.Key, key.KeyChar, new ControlKeyStates(), true);
         }
 


### PR DESCRIPTION
Fix #3183
this also affects Linux as well.

This does not provide support for IncludeKeyDown or IncludeKeyUp, but does not
echo the character when provided. In order to support IncludeKeyDown and IncludeKeyUp a
more substantial rewrite will be needed as Console.ReadKey doesn't support this behavior.

