### PR TITLE
Removed automatically adding year to copyright message

### DIFF
--- a/src/System.Management.Automation/engine/Modules/NewModuleManifestCommand.cs
+++ b/src/System.Management.Automation/engine/Modules/NewModuleManifestCommand.cs
@@ -930,7 +930,7 @@ namespace Microsoft.PowerShell.Commands
 
                 if (string.IsNullOrEmpty(_copyright))
                 {
-                    _copyright = StringUtil.Format(Modules.DefaultCopyrightMessage, DateTime.Now.Year, _author);
+                    _copyright = StringUtil.Format(Modules.DefaultCopyrightMessage, _author);
                 }
 
                 FileStream fileStream;

--- a/src/System.Management.Automation/engine/remoting/commands/NewPSSessionConfigurationFile.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/NewPSSessionConfigurationFile.cs
@@ -658,7 +658,7 @@ namespace Microsoft.PowerShell.Commands
                 {
                     if (String.IsNullOrEmpty(_copyright))
                     {
-                        _copyright = StringUtil.Format(Modules.DefaultCopyrightMessage, DateTime.Now.Year, _author);
+                        _copyright = StringUtil.Format(Modules.DefaultCopyrightMessage, _author);
                     }
                     result.Append(SessionConfigurationUtils.ConfigFragment(ConfigFileConstants.Copyright, RemotingErrorIdStrings.DISCCopyrightComment,
                         SessionConfigurationUtils.QuoteName(_copyright), streamWriter, false));
@@ -1505,7 +1505,7 @@ namespace Microsoft.PowerShell.Commands
                 // Copyright
                 if (String.IsNullOrEmpty(_copyright))
                 {
-                    _copyright = StringUtil.Format(Modules.DefaultCopyrightMessage, DateTime.Now.Year, _author);
+                    _copyright = StringUtil.Format(Modules.DefaultCopyrightMessage, _author);
                 }
                 result.Append(SessionConfigurationUtils.ConfigFragment(ConfigFileConstants.Copyright, RemotingErrorIdStrings.DISCCopyrightComment,
                     SessionConfigurationUtils.QuoteName(_copyright), streamWriter, false));

--- a/src/System.Management.Automation/resources/Modules.resx
+++ b/src/System.Management.Automation/resources/Modules.resx
@@ -274,7 +274,7 @@
     <value>Unknown</value>
   </data>
   <data name="DefaultCopyrightMessage" xml:space="preserve">
-    <value>(c) {0} {1}. All rights reserved.</value>
+    <value>(c) {0}. All rights reserved.</value>
   </data>
   <data name="RemovingImportedFunction" xml:space="preserve">
     <value>Removing the imported "{0}" function.</value>


### PR DESCRIPTION
Removed automatically adding year to copyright message for file generated by New-ModuleManifest and New-PSRoleCapabilityFile.

<!--

If you are a PowerShell Team member, please make sure you choose the Reviewer(s) and Assignee for your PR.
If you are not from the PowerShell Team, you can leave the fields blank and the Maintainers will choose them for you. If you are familiar with the team, feel free to mention some Reviewers yourself.

For more information about the roles of Reviewer and Assignee, refer to CONTRIBUTING.md.

-->
