### PR TITLE
Make Get-ChildItem continue enumeration when encountering error on contained item (#2856)

### DIFF
--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -1581,10 +1581,11 @@ namespace System.Management.Automation.Internal
         internal static bool StopwatchIsNotHighResolution;
 
         // Will be either "delete" or "rename" during tests.
-        internal static string GciEnumerationAction = null;
+        internal static bool GciEnumerationActionDelete = false;
+        internal static bool GciEnumerationActionRename = false;
 
         /// <summary>This member is used for internal test purposes.</summary>
-        public static void SetTestHook(string property, object value)
+        public static void SetTestHook(string property, bool value)
         {
             var fieldInfo = typeof(InternalTestHooks).GetField(property, BindingFlags.Static | BindingFlags.NonPublic);
             if (fieldInfo != null)

--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -1580,8 +1580,9 @@ namespace System.Management.Automation.Internal
         // Simulate 'System.Diagnostics.Stopwatch.IsHighResolution is false' to test Get-Uptime throw
         internal static bool StopwatchIsNotHighResolution;
 
-        // Will be either "delete" or "rename" during tests.
+        // Used in the FileSystemProvider to simulate deleting a file during enumeration in Get-ChildItem
         internal static bool GciEnumerationActionDelete = false;
+        // Used in the FileSystemProvider to simulate renaming a file during enumeration in Get-ChildItem
         internal static bool GciEnumerationActionRename = false;
 
         /// <summary>This member is used for internal test purposes.</summary>

--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -13,6 +13,7 @@ using Microsoft.Win32;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Collections;
 using System.Collections.ObjectModel;
 using System.Collections.Generic;
 using System.Collections.Concurrent;
@@ -1580,8 +1581,13 @@ namespace System.Management.Automation.Internal
         // Simulate 'System.Diagnostics.Stopwatch.IsHighResolution is false' to test Get-Uptime throw
         internal static bool StopwatchIsNotHighResolution;
 
+        // Name of a file to either delete or rename during directory enumeration.
+        internal static string GciEnumerationActionFilename = null;
+        // New name of the above file when renaming. Used only when GciEnumerationActionFilename is set.
+        internal static string GciEnumerationActionRename = null;
+
         /// <summary>This member is used for internal test purposes.</summary>
-        public static void SetTestHook(string property, bool value)
+        public static void SetTestHook(string property, object value)
         {
             var fieldInfo = typeof(InternalTestHooks).GetField(property, BindingFlags.Static | BindingFlags.NonPublic);
             if (fieldInfo != null)

--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -1580,10 +1580,8 @@ namespace System.Management.Automation.Internal
         // Simulate 'System.Diagnostics.Stopwatch.IsHighResolution is false' to test Get-Uptime throw
         internal static bool StopwatchIsNotHighResolution;
 
-        // Name of a file to either delete or rename during directory enumeration.
-        internal static string GciEnumerationActionFilename = null;
-        // New name of the above file when renaming. Used only when GciEnumerationActionFilename is set.
-        internal static string GciEnumerationActionRename = null;
+        // Will be either "delete" or "rename" during tests.
+        internal static string GciEnumerationAction = null;
 
         /// <summary>This member is used for internal test purposes.</summary>
         public static void SetTestHook(string property, object value)

--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -13,7 +13,6 @@ using Microsoft.Win32;
 using System.Globalization;
 using System.IO;
 using System.Linq;
-using System.Collections;
 using System.Collections.ObjectModel;
 using System.Collections.Generic;
 using System.Collections.Concurrent;

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -1659,7 +1659,6 @@ namespace Microsoft.PowerShell.Commands
                             return;
                         }
 
-#if DEBUG
                         // Internal test code, run only if the
                         // 'GciEnumerationActionFilename' test hook is set
                         var testActionFilename = InternalTestHooks.GciEnumerationActionFilename;
@@ -1677,7 +1676,6 @@ namespace Microsoft.PowerShell.Commands
                                 File.Move(fullName, newFullName);
                             }
                         }
-#endif
 
                         try
                         {

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -1659,22 +1659,22 @@ namespace Microsoft.PowerShell.Commands
                             return;
                         }
 
-                        // Internal test code, run only if the
-                        // 'GciEnumerationAction' test hook is set
-                        if (InternalTestHooks.GciEnumerationAction == "delete")
+                        // Internal test code, run only if one of the
+                        // 'GciEnumerationAction' test hooks are set.
+                        if (InternalTestHooks.GciEnumerationActionDelete)
                         {
-                            if (filesystemInfo.Name == "c")
+                            if (filesystemInfo.Name == "c283d143-2116-4809-bf11-4f7d61613f92")
                             {
                                 var fullName = Path.Combine(directory.FullName, filesystemInfo.Name);
                                 File.Delete(fullName);
                             }
                         }
-                        else if (InternalTestHooks.GciEnumerationAction == "rename")
+                        else if (InternalTestHooks.GciEnumerationActionRename)
                         {
-                            if (filesystemInfo.Name == "B")
+                            if (filesystemInfo.Name == "B1B691A9-B7B1-4584-AED7-5259511BEEC4")
                             {
                                 var fullName = Path.Combine(directory.FullName, filesystemInfo.Name);
-                                var newFullName = Path.Combine(directory.FullName, "Z");
+                                var newFullName = Path.Combine(directory.FullName, "77efd2bb-92aa-4ad3-979a-18936a4bd565");
                                 File.Move(fullName, newFullName);
                             }
                         }

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -1659,8 +1659,9 @@ namespace Microsoft.PowerShell.Commands
                             return;
                         }
 
+#if DEBUG
                         // Internal test code, run only if the
-                        // "GciEnumerationActionFilename" test hook is set
+                        // 'GciEnumerationActionFilename' test hook is set
                         var testActionFilename = InternalTestHooks.GciEnumerationActionFilename;
                         if (filesystemInfo.Name == testActionFilename)
                         {
@@ -1676,31 +1677,37 @@ namespace Microsoft.PowerShell.Commands
                                 File.Move(fullName, newFullName);
                             }
                         }
+#endif
 
                         try
                         {
                             bool attributeFilter = true;
                             bool switchAttributeFilter = true;
-                            bool filterHidden = false;           // "Hidden" is specified somewhere in the expression
-                            bool switchFilterHidden = false;     // "Hidden" is specified somewhere in the parameters
+                            // 'Hidden' is specified somewhere in the expression
+                            bool filterHidden = false;
+                            // 'Hidden' is specified somewhere in the parameters
+                            bool switchFilterHidden = false;
 
                             if (null != evaluator)
                             {
-                                attributeFilter = evaluator.Evaluate(filesystemInfo.Attributes);  // expressions
+                                attributeFilter = evaluator.Evaluate(filesystemInfo.Attributes);
                                 filterHidden = evaluator.ExistsInExpression(FileAttributes.Hidden);
                             }
                             if (null != switchEvaluator)
                             {
-                                switchAttributeFilter = switchEvaluator.Evaluate(filesystemInfo.Attributes);  // switch parameters
+                                switchAttributeFilter = switchEvaluator.Evaluate(filesystemInfo.Attributes);
                                 switchFilterHidden = switchEvaluator.ExistsInExpression(FileAttributes.Hidden);
                             }
 
                             bool hidden = false;
-                            if (!Force) hidden = (filesystemInfo.Attributes & FileAttributes.Hidden) != 0;
+                            if (!Force)
+                            {
+                                hidden = (filesystemInfo.Attributes & FileAttributes.Hidden) != 0;
+                            }
 
-                            // if "Hidden" is explicitly specified anywhere in the attribute filter, then override
+                            // If 'Hidden' is explicitly specified anywhere in the attribute filter, then override
                             // default hidden attribute filter.
-                            // if specification is to return all containers, then do not do attribute filter on
+                            // If specification is to return all containers, then do not do attribute filter on
                             // the containers.
                             bool attributeSatisfy =
                                 ((attributeFilter && switchAttributeFilter) ||

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -1663,7 +1663,7 @@ namespace Microsoft.PowerShell.Commands
                         // 'GciEnumerationAction' test hooks are set.
                         if (InternalTestHooks.GciEnumerationActionDelete)
                         {
-                            if (string.Equals(filesystemInfo.Name, "c283d143-2116-4809-bf11-4f7d61613f92", StringComparison.Ordinal))
+                            if (string.Equals(filesystemInfo.Name, "c283d143-2116-4809-bf11-4f7d61613f92", StringComparison.InvariantCulture))
                             {
                                 File.Delete(filesystemInfo.FullName);
                             }

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -1663,19 +1663,17 @@ namespace Microsoft.PowerShell.Commands
                         // 'GciEnumerationAction' test hooks are set.
                         if (InternalTestHooks.GciEnumerationActionDelete)
                         {
-                            if (filesystemInfo.Name == "c283d143-2116-4809-bf11-4f7d61613f92")
+                            if (string.Equals(filesystemInfo.Name, "c283d143-2116-4809-bf11-4f7d61613f92", StringComparison.Ordinal))
                             {
-                                var fullName = Path.Combine(directory.FullName, filesystemInfo.Name);
-                                File.Delete(fullName);
+                                File.Delete(filesystemInfo.FullName);
                             }
                         }
                         else if (InternalTestHooks.GciEnumerationActionRename)
                         {
-                            if (filesystemInfo.Name == "B1B691A9-B7B1-4584-AED7-5259511BEEC4")
+                            if (string.Equals(filesystemInfo.Name, "B1B691A9-B7B1-4584-AED7-5259511BEEC4", StringComparison.InvariantCulture))
                             {
-                                var fullName = Path.Combine(directory.FullName, filesystemInfo.Name);
                                 var newFullName = Path.Combine(directory.FullName, "77efd2bb-92aa-4ad3-979a-18936a4bd565");
-                                File.Move(fullName, newFullName);
+                                File.Move(filesystemInfo.FullName, newFullName);
                             }
                         }
 

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -1660,19 +1660,21 @@ namespace Microsoft.PowerShell.Commands
                         }
 
                         // Internal test code, run only if the
-                        // 'GciEnumerationActionFilename' test hook is set
-                        var testActionFilename = InternalTestHooks.GciEnumerationActionFilename;
-                        if (filesystemInfo.Name == testActionFilename)
+                        // 'GciEnumerationAction' test hook is set
+                        if (InternalTestHooks.GciEnumerationAction == "delete")
                         {
-                            var fullName = Path.Combine(directory.FullName, filesystemInfo.Name);
-                            var newFilename = InternalTestHooks.GciEnumerationActionRename;
-                            if (String.IsNullOrEmpty(newFilename))
+                            if (filesystemInfo.Name == "c")
                             {
+                                var fullName = Path.Combine(directory.FullName, filesystemInfo.Name);
                                 File.Delete(fullName);
                             }
-                            else
+                        }
+                        else if (InternalTestHooks.GciEnumerationAction == "rename")
+                        {
+                            if (filesystemInfo.Name == "B")
                             {
-                                var newFullName = Path.Combine(directory.FullName, newFilename);
+                                var fullName = Path.Combine(directory.FullName, filesystemInfo.Name);
+                                var newFullName = Path.Combine(directory.FullName, "Z");
                                 File.Move(fullName, newFullName);
                             }
                         }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ChildItem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ChildItem.Tests.ps1
@@ -4,12 +4,18 @@ Describe "Get-ChildItem" -Tags "CI" {
 
         BeforeAll {
             # Create Test data
-            $null = New-Item -Path $TestDrive -Name "a" -ItemType "File" -Force
-            $null = New-Item -Path $TestDrive -Name "B" -ItemType "File" -Force
-            $null = New-Item -Path $TestDrive -Name "c" -ItemType "File" -Force
-            $null = New-Item -Path $TestDrive -Name "D" -ItemType "File" -Force
-            $null = New-Item -Path $TestDrive -Name "E" -ItemType "Directory" -Force
-            $null = New-Item -Path $TestDrive -Name ".F" -ItemType "File" -Force | %{$_.Attributes = "hidden"}
+            $item_a = "a3fe710a-31af-4834-bc29-d0b584589838"
+            $item_B = "B1B691A9-B7B1-4584-AED7-5259511BEEC4"
+            $item_c = "c283d143-2116-4809-bf11-4f7d61613f92"
+            $item_D = "D39B4FD9-3E1D-4DD5-8718-22FE2C934CE3"
+            $item_E = "D1AB99AD-4A24-49CE-AECF-E2A77376ACC0"
+            $item_F = ".F81D8514-8862-4227-B041-0529B1656A43" 
+            $null = New-Item -Path $TestDrive -Name $item_a -ItemType "File" -Force
+            $null = New-Item -Path $TestDrive -Name $item_B -ItemType "File" -Force
+            $null = New-Item -Path $TestDrive -Name $item_c -ItemType "File" -Force
+            $null = New-Item -Path $TestDrive -Name $item_D -ItemType "File" -Force
+            $null = New-Item -Path $TestDrive -Name $item_E -ItemType "Directory" -Force
+            $null = New-Item -Path $TestDrive -Name $item_F -ItemType "File" -Force | %{$_.Attributes = "hidden"}
         }
 
         It "Should list the contents of the current folder" {
@@ -34,25 +40,25 @@ Describe "Get-ChildItem" -Tags "CI" {
 
         It "Should list files in sorted order" {
             $files = Get-ChildItem -Path $TestDrive
-            $files[0].Name     | Should Be "E"
-            $files[1].Name     | Should Be "a"
-            $files[2].Name     | Should Be "B"
-            $files[3].Name     | Should Be "c"
-            $files[4].Name     | Should Be "D"
+            $files[0].Name     | Should Be $item_E
+            $files[1].Name     | Should Be $item_a
+            $files[2].Name     | Should Be $item_B
+            $files[3].Name     | Should Be $item_c
+            $files[4].Name     | Should Be $item_D
         }
 
         It "Should list hidden files as well when 'Force' parameter is used" {
             $files = Get-ChildItem -path $TestDrive -Force
             $files | Should not be $null
             $files.Count | Should be 6
-            $files.Name.Contains(".F")
+            $files.Name.Contains($item_F)
         }
 
         It "Should list only hidden files when 'Hidden' parameter is used" {
             $files = Get-ChildItem -path $TestDrive -Hidden
             $files | Should not be $null
             $files.Count | Should be 1
-            $files[0].Name | Should Be ".F"
+            $files[0].Name | Should Be $item_F
         }
         It "Should give .sys file if the fullpath is specified with hidden and force parameter" -Skip:(!$IsWindows){
             $file = Get-ChildItem -path "$env:SystemDrive\\pagefile.sys" -Hidden
@@ -62,9 +68,9 @@ Describe "Get-ChildItem" -Tags "CI" {
         }
         It "Should continue enumerating a directory when a contained item is deleted" {
             $Error.Clear()
-            [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook("GciEnumerationAction", "delete")
+            [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook("GciEnumerationActionDelete", $true)
             $result = Get-ChildItem -Path $TestDrive -ErrorAction SilentlyContinue
-            [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook("GciEnumerationAction", $null)
+            [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook("GciEnumerationActionDelete", $false)
             if ($IsWindows)
             {
                 $Error.Count | Should BeExactly 0
@@ -80,9 +86,9 @@ Describe "Get-ChildItem" -Tags "CI" {
         }
         It "Should continue enumerating a directory when a contained item is renamed" {
             $Error.Clear()
-            [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook("GciEnumerationAction", "rename")
+            [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook("GciEnumerationActionRename", $true)
             $result = Get-ChildItem -Path $TestDrive -ErrorAction SilentlyContinue
-            [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook("GciEnumerationAction", $null)
+            [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook("GciEnumerationActionRename", $false)
             if ($IsWindows)
             {
                 $Error.Count | Should BeExactly 0

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ChildItem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ChildItem.Tests.ps1
@@ -60,27 +60,43 @@ Describe "Get-ChildItem" -Tags "CI" {
             $file.Count | Should be 1
             $file.Name | Should be "pagefile.sys"
         }
-        It "Should continue enumerating a directory when a contained item is deleted" -Skip:($IsWindows) {
+        It "Should continue enumerating a directory when a contained item is deleted" {
             $Error.Clear()
             [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook("GciEnumerationActionFilename", "c")
             $result = Get-ChildItem -Path $TestDrive -ErrorAction SilentlyContinue
             [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook("GciEnumerationActionFilename", $null)
-            $Error.Count | Should BeExactly 1
-            $Error[0].FullyQualifiedErrorId | Should BeExactly "DirIOError,Microsoft.PowerShell.Commands.GetChildItemCommand"
-            $Error[0].Exception | Should BeOfType System.Io.FileNotFoundException
-            $result.Count | Should BeExactly 4
+            if ($IsWindows)
+            {
+                $Error.Count | Should BeExactly 0
+                $result.Count | Should BeExactly 5
+            }
+            else
+            {
+                $Error.Count | Should BeExactly 1
+                $Error[0].FullyQualifiedErrorId | Should BeExactly "DirIOError,Microsoft.PowerShell.Commands.GetChildItemCommand"
+                $Error[0].Exception | Should BeOfType System.Io.FileNotFoundException
+                $result.Count | Should BeExactly 4
+            }
         }
-        It "Should continue enumerating a directory when a contained item is renamed" -Skip:($IsWindows) {
+        It "Should continue enumerating a directory when a contained item is renamed" {
             $Error.Clear()
             [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook("GciEnumerationActionFilename", "B")
             [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook("GciEnumerationActionRename", "Z")
             $result = Get-ChildItem -Path $TestDrive -ErrorAction SilentlyContinue
             [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook("GciEnumerationActionRename", $null)
             [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook("GciEnumerationActionFilename", $null)
-            $Error.Count | Should BeExactly 1
-            $Error[0].FullyQualifiedErrorId | Should BeExactly "DirIOError,Microsoft.PowerShell.Commands.GetChildItemCommand"
-            $Error[0].Exception | Should BeOfType System.Io.FileNotFoundException
-            $result.Count | Should BeExactly 3
+            if ($IsWindows)
+            {
+                $Error.Count | Should BeExactly 0
+                $result.Count | Should BeExactly 4
+            }
+            else
+            {
+                $Error.Count | Should BeExactly 1
+                $Error[0].FullyQualifiedErrorId | Should BeExactly "DirIOError,Microsoft.PowerShell.Commands.GetChildItemCommand"
+                $Error[0].Exception | Should BeOfType System.Io.FileNotFoundException
+                $result.Count | Should BeExactly 3
+            }
         }
     }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ChildItem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ChildItem.Tests.ps1
@@ -60,6 +60,28 @@ Describe "Get-ChildItem" -Tags "CI" {
             $file.Count | Should be 1
             $file.Name | Should be "pagefile.sys"
         }
+        It "Should continue enumerating a directory when a contained item is deleted" -Skip:($IsWindows) {
+            $Error.Clear()
+            [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook("GciEnumerationActionFilename", "c")
+            $result = Get-ChildItem -Path $TestDrive -ErrorAction SilentlyContinue
+            [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook("GciEnumerationActionFilename", $null)
+            $Error.Count | Should BeExactly 1
+            $Error[0].FullyQualifiedErrorId | Should BeExactly "DirIOError,Microsoft.PowerShell.Commands.GetChildItemCommand"
+            $Error[0].Exception | Should BeOfType System.Io.FileNotFoundException
+            $result.Count | Should BeExactly 4
+        }
+        It "Should continue enumerating a directory when a contained item is renamed" -Skip:($IsWindows) {
+            $Error.Clear()
+            [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook("GciEnumerationActionFilename", "B")
+            [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook("GciEnumerationActionRename", "Z")
+            $result = Get-ChildItem -Path $TestDrive -ErrorAction SilentlyContinue
+            [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook("GciEnumerationActionRename", $null)
+            [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook("GciEnumerationActionFilename", $null)
+            $Error.Count | Should BeExactly 1
+            $Error[0].FullyQualifiedErrorId | Should BeExactly "DirIOError,Microsoft.PowerShell.Commands.GetChildItemCommand"
+            $Error[0].Exception | Should BeOfType System.Io.FileNotFoundException
+            $result.Count | Should BeExactly 3
+        }
     }
 
     Context 'Env: Provider' {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ChildItem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ChildItem.Tests.ps1
@@ -8,7 +8,7 @@ Describe "Get-ChildItem" -Tags "CI" {
             $item_B = "B1B691A9-B7B1-4584-AED7-5259511BEEC4"
             $item_c = "c283d143-2116-4809-bf11-4f7d61613f92"
             $item_D = "D39B4FD9-3E1D-4DD5-8718-22FE2C934CE3"
-            $item_E = "D1AB99AD-4A24-49CE-AECF-E2A77376ACC0"
+            $item_E = "EE150FEB-0F21-4AFF-8066-AF59E925810C"
             $item_F = ".F81D8514-8862-4227-B041-0529B1656A43" 
             $null = New-Item -Path $TestDrive -Name $item_a -ItemType "File" -Force
             $null = New-Item -Path $TestDrive -Name $item_B -ItemType "File" -Force
@@ -51,7 +51,7 @@ Describe "Get-ChildItem" -Tags "CI" {
             $files = Get-ChildItem -path $TestDrive -Force
             $files | Should not be $null
             $files.Count | Should be 6
-            $files.Name.Contains($item_F)
+            $files.Name.Contains($item_F) | Should Be $true
         }
 
         It "Should list only hidden files when 'Hidden' parameter is used" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ChildItem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ChildItem.Tests.ps1
@@ -62,9 +62,9 @@ Describe "Get-ChildItem" -Tags "CI" {
         }
         It "Should continue enumerating a directory when a contained item is deleted" {
             $Error.Clear()
-            [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook("GciEnumerationActionFilename", "c")
+            [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook("GciEnumerationAction", "delete")
             $result = Get-ChildItem -Path $TestDrive -ErrorAction SilentlyContinue
-            [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook("GciEnumerationActionFilename", $null)
+            [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook("GciEnumerationAction", $null)
             if ($IsWindows)
             {
                 $Error.Count | Should BeExactly 0
@@ -80,11 +80,9 @@ Describe "Get-ChildItem" -Tags "CI" {
         }
         It "Should continue enumerating a directory when a contained item is renamed" {
             $Error.Clear()
-            [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook("GciEnumerationActionFilename", "B")
-            [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook("GciEnumerationActionRename", "Z")
+            [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook("GciEnumerationAction", "rename")
             $result = Get-ChildItem -Path $TestDrive -ErrorAction SilentlyContinue
-            [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook("GciEnumerationActionRename", $null)
-            [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook("GciEnumerationActionFilename", $null)
+            [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook("GciEnumerationAction", $null)
             if ($IsWindows)
             {
                 $Error.Count | Should BeExactly 0


### PR DESCRIPTION
Fix #2856 

Added try/catch within the enumeration loop to allow the enumeration to continue after encountering an error such as an item within the directory being deleted or renamed.

To assist in testing, two new internal test hooks have been added which cause Get-ChildItem to either delete or rename a specific file (file name hard-coded) when encountered during enumeration.