### PR TITLE
Removed import-module $helperModule as it is not needed.

### DIFF
--- a/test/powershell/Language/Scripting/Debugging/Debugging.Tests.ps1
+++ b/test/powershell/Language/Scripting/Debugging/Debugging.Tests.ps1
@@ -30,7 +30,6 @@ Describe "Breakpoints when set should be hit" -tag "CI" {
 
 Describe "It should be possible to reset runspace debugging" -tag "Feature" {
     BeforeAll {
-        import-module $helperModule
         $path = setup -pass -f TestScript_2.ps1 -content $script2
         $scriptPath = "$testdrive/TestScript_2.ps1"
         $iss = [initialsessionstate]::CreateDefault2();

--- a/test/powershell/Language/Scripting/NativeExecution/NativeCommandProcessor.Tests.ps1
+++ b/test/powershell/Language/Scripting/NativeExecution/NativeCommandProcessor.Tests.ps1
@@ -1,7 +1,6 @@
 Describe 'native commands lifecycle' -tags 'Feature' {
 
     BeforeAll {
-        Import-Module $helperModule
         $powershell = Join-Path -Path $PsHome -ChildPath "powershell"
     }
 


### PR DESCRIPTION
$helperModule is not defined anymore after refactoring changes. Import-Module is not necessary, hence removed.
This is was not caught by CI as these are Feature tests.
This caused the daily build to be broken.

Related to changes done in: https://github.com/PowerShell/PowerShell/pull/3456 

<!--

If you are a PowerShell Team member, please make sure you choose the Reviewer(s) and Assignee for your PR.
If you are not from the PowerShell Team, you can leave the fields blank and the Maintainers will choose them for you. If you are familiar with the team, feel free to mention some Reviewers yourself.

For more information about the roles of Reviewer and Assignee, refer to CONTRIBUTING.md.

-->
