### PR TITLE
Enable PSReadline to work on NanoServer

### DIFF
--- a/src/Microsoft.PowerShell.PSReadLine/ConsoleKeyChordConverter.cs
+++ b/src/Microsoft.PowerShell.PSReadLine/ConsoleKeyChordConverter.cs
@@ -324,7 +324,7 @@ namespace Microsoft.PowerShell
             // get corresponding character  - may be 0, 1 or 2 in length (diacritics)
             var chars = new char[2];
             int charCount = NativeMethods.ToUnicode(
-                        virtualKey, scanCode, state, chars, chars.Length, NativeMethods.MENU_IS_INACTIVE);
+                virtualKey, scanCode, state, chars, chars.Length, NativeMethods.MENU_IS_INACTIVE);
 
             // TODO: support diacritics (charCount == 2)
             if (charCount == 1)

--- a/src/Microsoft.PowerShell.PSReadLine/ConsoleKeyChordConverter.cs
+++ b/src/Microsoft.PowerShell.PSReadLine/ConsoleKeyChordConverter.cs
@@ -1,4 +1,4 @@
-﻿/********************************************************************++
+/********************************************************************++
 Copyright (c) Microsoft Corporation.  All rights reserved.
 --********************************************************************/
 
@@ -323,8 +323,16 @@ namespace Microsoft.PowerShell
 
             // get corresponding character  - may be 0, 1 or 2 in length (diacritics)
             var chars = new char[2];
-            int charCount = NativeMethods.ToUnicode(
-                virtualKey, scanCode, state, chars, chars.Length, NativeMethods.MENU_IS_INACTIVE);
+            int charCount = 1;
+            try
+            {
+                charCount = NativeMethods.ToUnicode(
+                    virtualKey, scanCode, state, chars, chars.Length, NativeMethods.MENU_IS_INACTIVE);
+            }
+            catch (System.EntryPointNotFoundException)
+            {
+                // assume not unicode
+            }
 
             // TODO: support diacritics (charCount == 2)
             if (charCount == 1)

--- a/src/Microsoft.PowerShell.PSReadLine/ConsoleKeyChordConverter.cs
+++ b/src/Microsoft.PowerShell.PSReadLine/ConsoleKeyChordConverter.cs
@@ -231,7 +231,6 @@ namespace Microsoft.PowerShell
             return valid;
         }
 
-#if UNIX
         // this is borrowed from the CoreFX internal System.IO.StdInReader class
         // https://github.com/dotnet/corefx/blob/5b2ae6aa485773cd5569f56f446698633c9ad945/src/System.Console/src/System/IO/StdInReader.cs#L222
         private static ConsoleKey GetKeyFromCharValue(char x, out bool isShift, out bool isCtrl)
@@ -303,9 +302,8 @@ namespace Microsoft.PowerShell
 
             return default(ConsoleKey);
         }
-#else
-        private static bool _toUnicodeApiAvailable = true;
 
+#if !UNIX
         internal static char GetCharFromConsoleKey(ConsoleKey key, ConsoleModifiers modifiers)
         {
             // default for unprintables and unhandled
@@ -325,19 +323,8 @@ namespace Microsoft.PowerShell
 
             // get corresponding character  - may be 0, 1 or 2 in length (diacritics)
             var chars = new char[2];
-            int charCount = 1;
-            if (_toUnicodeApiAvailable)
-            {
-                try
-                {
-                    charCount = NativeMethods.ToUnicode(
+            int charCount = NativeMethods.ToUnicode(
                         virtualKey, scanCode, state, chars, chars.Length, NativeMethods.MENU_IS_INACTIVE);
-                }
-                catch (System.EntryPointNotFoundException)
-                {
-                    _toUnicodeApiAvailable = false;  // api not available on NanoServer
-                }
-            }
 
             // TODO: support diacritics (charCount == 2)
             if (charCount == 1)

--- a/src/Microsoft.PowerShell.PSReadLine/ConsoleKeyChordConverter.cs
+++ b/src/Microsoft.PowerShell.PSReadLine/ConsoleKeyChordConverter.cs
@@ -304,6 +304,8 @@ namespace Microsoft.PowerShell
             return default(ConsoleKey);
         }
 #else
+        private static bool _toUnicodeApiAvailable = true;
+
         internal static char GetCharFromConsoleKey(ConsoleKey key, ConsoleModifiers modifiers)
         {
             // default for unprintables and unhandled
@@ -324,14 +326,17 @@ namespace Microsoft.PowerShell
             // get corresponding character  - may be 0, 1 or 2 in length (diacritics)
             var chars = new char[2];
             int charCount = 1;
-            try
+            if (_toUnicodeApiAvailable)
             {
-                charCount = NativeMethods.ToUnicode(
-                    virtualKey, scanCode, state, chars, chars.Length, NativeMethods.MENU_IS_INACTIVE);
-            }
-            catch (System.EntryPointNotFoundException)
-            {
-                // assume not unicode
+                try
+                {
+                    charCount = NativeMethods.ToUnicode(
+                        virtualKey, scanCode, state, chars, chars.Length, NativeMethods.MENU_IS_INACTIVE);
+                }
+                catch (System.EntryPointNotFoundException)
+                {
+                    _toUnicodeApiAvailable = false;  // api not available on NanoServer
+                }
             }
 
             // TODO: support diacritics (charCount == 2)

--- a/src/Microsoft.PowerShell.PSReadLine/ConsoleLib.cs
+++ b/src/Microsoft.PowerShell.PSReadLine/ConsoleLib.cs
@@ -1,4 +1,4 @@
-﻿/********************************************************************++
+/********************************************************************++
 Copyright (c) Microsoft Corporation.  All rights reserved.
 --********************************************************************/
 
@@ -691,7 +691,15 @@ namespace Microsoft.PowerShell.Internal
 
             CONSOLE_FONT_INFO_EX fontInfo = new CONSOLE_FONT_INFO_EX();
             fontInfo.cbSize = Marshal.SizeOf(fontInfo);
-            bool result = NativeMethods.GetCurrentConsoleFontEx(consoleHandle.DangerousGetHandle(), false, ref fontInfo);
+            bool result = true;
+            try
+            {
+                result = NativeMethods.GetCurrentConsoleFontEx(consoleHandle.DangerousGetHandle(), false, ref fontInfo);
+            }
+            catch (System.EntryPointNotFoundException)
+            {
+                // ignore for Nanoserver
+            }
 
             if (result == false)
             {
@@ -865,7 +873,6 @@ namespace Microsoft.PowerShell.Internal
             CONSOLE_FONT_INFO_EX fontInfo = ConhostConsole.GetConsoleFontInfo(consoleHandle);
             int fontType = fontInfo.FontFamily & NativeMethods.FontTypeMask;
             _trueTypeInUse = (fontType & NativeMethods.TrueTypeFont) == NativeMethods.TrueTypeFont;
-
         }
 
         public void EndRender()

--- a/src/Microsoft.PowerShell.PSReadLine/ConsoleLib.cs
+++ b/src/Microsoft.PowerShell.PSReadLine/ConsoleLib.cs
@@ -426,6 +426,7 @@ namespace Microsoft.PowerShell.Internal
         private bool _istmInitialized = false;
         private TEXTMETRIC _tm = new TEXTMETRIC();
         private bool _trueTypeInUse = false;
+        private static bool _getCurrentConsoleFontExApiAvailable = true;
 
         private readonly Lazy<SafeFileHandle> _outputHandle = new Lazy<SafeFileHandle>(() =>
         {
@@ -692,13 +693,16 @@ namespace Microsoft.PowerShell.Internal
             CONSOLE_FONT_INFO_EX fontInfo = new CONSOLE_FONT_INFO_EX();
             fontInfo.cbSize = Marshal.SizeOf(fontInfo);
             bool result = true;
-            try
+            if (_getCurrentConsoleFontExApiAvailable)
             {
-                result = NativeMethods.GetCurrentConsoleFontEx(consoleHandle.DangerousGetHandle(), false, ref fontInfo);
-            }
-            catch (System.EntryPointNotFoundException)
-            {
-                // ignore for Nanoserver
+                try
+                {
+                    result = NativeMethods.GetCurrentConsoleFontEx(consoleHandle.DangerousGetHandle(), false, ref fontInfo);
+                }
+                catch (System.EntryPointNotFoundException)
+                {
+                    _getCurrentConsoleFontExApiAvailable = false;  // api not available on NanoServer
+                }
             }
 
             if (result == false)


### PR DESCRIPTION
PSReadline uses two native Win32 apis to determine font and unicode information which is not available on NanoServer.  Fix is to assume the input is one byte in character in size and not using a truetype font.  This should work for most use cases.

Manually tested this change with our published dockerfile for NanoServer.

Fix https://github.com/PowerShell/PowerShell/issues/3463