### PR TITLE
Adding Server 2008 R2 to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ You can download and install a PowerShell package for any of the following platf
 | ---------------------------------- | ---------------------- | ----------------------------- |
 | Windows 10 / Server 2016 (x64)     | [.msi][rl-windows10]   | [Instructions][in-windows]    |
 | Windows 8.1 / Server 2012 R2 (x64) | [.msi][rl-windows81]   | [Instructions][in-windows]    |
-| Windows 7 (x64)                    | [.msi][rl-windows7-64] | [Instructions][in-windows]    |
+| Windows 7 / Server 2008 R2 (x64)   | [.msi][rl-windows7-64] | [Instructions][in-windows]    |
 | Windows 7 (x86)                    | [.msi][rl-windows7-86] | [Instructions][in-windows]    |
 | Ubuntu 16.04                       | [.deb][rl-ubuntu16]    | [Instructions][in-ubuntu16]   |
 | Ubuntu 14.04                       | [.deb][rl-ubuntu14]    | [Instructions][in-ubuntu14]   |


### PR DESCRIPTION
Server 2008 R2 was missing from the README. It's a supported platform (on x64), so I added it. 😄 