### PR TITLE
Support Link Header pagination in WebCmdlets

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/InvokeRestMethodCommand.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/InvokeRestMethodCommand.Common.cs
@@ -37,6 +37,29 @@ namespace Microsoft.PowerShell.Commands
             set { base.CustomMethod = value; }
         }
 
+        /// <summary>
+        /// enable automatic following of rel links
+        /// </summary>
+        [Parameter]
+        [Alias("FL")]
+        public SwitchParameter FollowRelLink
+        {
+            get { return base._followRelLink; }
+            set { base._followRelLink = value; }
+        }
+
+        /// <summary>
+        /// gets or sets the maximum number of rel links to follow
+        /// </summary>
+        [Parameter]
+        [Alias("ML")]
+        [ValidateRange(0, Int32.MaxValue)]
+        public int MaximumFollowRelLink
+        {
+            get { return base._maximumFollowRelLink; }
+            set { base._maximumFollowRelLink = value; }
+        }
+
         #endregion Parameters
 
         #region Helper Methods

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/InvokeRestMethodCommand.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/InvokeRestMethodCommand.Common.cs
@@ -53,7 +53,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         [Parameter]
         [Alias("ML")]
-        [ValidateRange(0, Int32.MaxValue)]
+        [ValidateRange(1, Int32.MaxValue)]
         public int MaximumFollowRelLink
         {
             get { return base._maximumFollowRelLink; }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/InvokeWebRequestCommand.CoreClr.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/InvokeWebRequestCommand.CoreClr.cs
@@ -46,6 +46,7 @@ namespace Microsoft.PowerShell.Commands
                 // creating a MemoryStream wrapper to response stream here to support IsStopping.
                 responseStream = new WebResponseContentMemoryStream(responseStream, StreamHelper.ChunkSize, this);
                 WebResponseObject ro = WebResponseObjectFactory.GetResponseObject(response, responseStream, this.Context, UseBasicParsing);
+                ro.RelationLink = _relationLink;
                 WriteObject(ro);
 
                 // use the rawcontent stream from WebResponseObject for further

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/InvokeWebRequestCommand.CoreClr.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/InvokeWebRequestCommand.CoreClr.cs
@@ -21,6 +21,14 @@ namespace Microsoft.PowerShell.Commands
         #region Virtual Method Overrides
 
         /// <summary>
+        /// Default constructor for InvokeWebRequestCommand
+        /// </summary>
+        public InvokeWebRequestCommand() : base()
+        {
+            this._parseRelLink = true;
+        }
+
+        /// <summary>
         /// Process the web response and output corresponding objects.
         /// </summary>
         /// <param name="response"></param>

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebRequestPSCmdlet.CoreClr.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebRequestPSCmdlet.CoreClr.cs
@@ -16,6 +16,9 @@ using System.Globalization;
 using System.Security.Cryptography;
 using System.Threading;
 using System.Xml;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+using System.Linq;
 
 namespace Microsoft.PowerShell.Commands
 {
@@ -60,6 +63,21 @@ namespace Microsoft.PowerShell.Commands
         /// Cancellation token source
         /// </summary>
         private CancellationTokenSource _cancelToken = null;
+
+        /// <summary>
+        /// Automatically follow Rel Links
+        /// </summary>
+        internal bool _followRelLink = false;
+
+        /// <summary>
+        /// Automatically follow Rel Links
+        /// </summary>
+        internal Dictionary<string, string> _relationLink = null;
+
+        /// <summary>
+        /// Maximum number of Rel Links to follow
+        /// </summary>
+        internal int _maximumFollowRelLink = -1;
 
         private HttpMethod GetHttpMethod(WebRequestMethod method)
         {
@@ -374,91 +392,117 @@ namespace Microsoft.PowerShell.Commands
                 PrepareSession();
 
                 using (HttpClient client = GetHttpClient())
-                using (HttpRequestMessage request = GetRequest(Uri))
                 {
-                    FillRequestStream(request);
-                    try
+                    int followedRelLink = 0;
+                    do
                     {
-                        long requestContentLength = 0;
-                        if (request.Content != null)
-                            requestContentLength = request.Content.Headers.ContentLength.Value;
-
-                        string reqVerboseMsg = String.Format(CultureInfo.CurrentCulture,
-                            "{0} {1} with {2}-byte payload",
-                            request.Method,
-                            request.RequestUri,
-                            requestContentLength);
-                        WriteVerbose(reqVerboseMsg);
-
-                        HttpResponseMessage response = GetResponse(client, request);
-
-                        string contentType = ContentHelper.GetContentType(response);
-                        string respVerboseMsg = string.Format(CultureInfo.CurrentCulture,
-                            "received {0}-byte response of content type {1}",
-                            response.Content.Headers.ContentLength,
-                            contentType);
-                        WriteVerbose(respVerboseMsg);
-
-                        if (!response.IsSuccessStatusCode)
+                        if (followedRelLink > 0)
                         {
-                            string message = String.Format(CultureInfo.CurrentCulture, WebCmdletStrings.ResponseStatusCodeFailure,
-                                (int)response.StatusCode, response.ReasonPhrase);
-                            HttpResponseException httpEx = new HttpResponseException(message, response);
-                            ErrorRecord er = new ErrorRecord(httpEx, "WebCmdletWebResponseException", ErrorCategory.InvalidOperation, request);
-                            string detailMsg = "";
-                            StreamReader reader = null;
+                            string linkVerboseMsg = string.Format(CultureInfo.CurrentCulture,
+                                "Following rel link {0}",
+                                Uri.AbsoluteUri);
+                            WriteVerbose(linkVerboseMsg);
+                        }
+
+                        using (HttpRequestMessage request = GetRequest(Uri))
+                        {
+                            FillRequestStream(request);
                             try
                             {
-                                reader = new StreamReader(StreamHelper.GetResponseStream(response));
-                                // remove HTML tags making it easier to read
-                                detailMsg = System.Text.RegularExpressions.Regex.Replace(reader.ReadToEnd(), "<[^>]*>","");
-                            }
-                            catch (Exception)
-                            {
-                                // catch all
-                            }
-                            finally
-                            {
-                                if (reader != null)
+                                long requestContentLength = 0;
+                                if (request.Content != null)
+                                    requestContentLength = request.Content.Headers.ContentLength.Value;
+
+                                string reqVerboseMsg = String.Format(CultureInfo.CurrentCulture,
+                                    "{0} {1} with {2}-byte payload",
+                                    request.Method,
+                                    request.RequestUri,
+                                    requestContentLength);
+                                WriteVerbose(reqVerboseMsg);
+
+                                HttpResponseMessage response = GetResponse(client, request);
+
+                                string contentType = ContentHelper.GetContentType(response);
+                                string respVerboseMsg = string.Format(CultureInfo.CurrentCulture,
+                                    "received {0}-byte response of content type {1}",
+                                    response.Content.Headers.ContentLength,
+                                    contentType);
+                                WriteVerbose(respVerboseMsg);
+
+                                if (!response.IsSuccessStatusCode)
                                 {
-                                    reader.Dispose();
+                                    string message = String.Format(CultureInfo.CurrentCulture, WebCmdletStrings.ResponseStatusCodeFailure,
+                                        (int)response.StatusCode, response.ReasonPhrase);
+                                    HttpResponseException httpEx = new HttpResponseException(message, response);
+                                    ErrorRecord er = new ErrorRecord(httpEx, "WebCmdletWebResponseException", ErrorCategory.InvalidOperation, request);
+                                    string detailMsg = "";
+                                    StreamReader reader = null;
+                                    try
+                                    {
+                                        reader = new StreamReader(StreamHelper.GetResponseStream(response));
+                                        // remove HTML tags making it easier to read
+                                        detailMsg = System.Text.RegularExpressions.Regex.Replace(reader.ReadToEnd(), "<[^>]*>","");
+                                    }
+                                    catch (Exception)
+                                    {
+                                        // catch all
+                                    }
+                                    finally
+                                    {
+                                        if (reader != null)
+                                        {
+                                            reader.Dispose();
+                                        }
+                                    }
+                                    if (!String.IsNullOrEmpty(detailMsg))
+                                    {
+                                        er.ErrorDetails = new ErrorDetails(detailMsg);
+                                    }
+                                    ThrowTerminatingError(er);
+                                }
+
+                                ParseLinkHeader(response, Uri);
+                                ProcessResponse(response);
+                                UpdateSession(response);
+
+                                // If we hit our maximum redirection count, generate an error.
+                                // Errors with redirection counts of greater than 0 are handled automatically by .NET, but are
+                                // impossible to detect programmatically when we hit this limit. By handling this ourselves
+                                // (and still writing out the result), users can debug actual HTTP redirect problems.
+                                if (WebSession.MaximumRedirection == 0) // Indicate "HttpClientHandler.AllowAutoRedirect == false"
+                                {
+                                    if (response.StatusCode == HttpStatusCode.Found ||
+                                        response.StatusCode == HttpStatusCode.Moved ||
+                                        response.StatusCode == HttpStatusCode.MovedPermanently)
+                                    {
+                                        ErrorRecord er = new ErrorRecord(new InvalidOperationException(), "MaximumRedirectExceeded", ErrorCategory.InvalidOperation, request);
+                                        er.ErrorDetails = new ErrorDetails(WebCmdletStrings.MaximumRedirectionCountExceeded);
+                                        WriteError(er);
+                                    }
                                 }
                             }
-                            if (!String.IsNullOrEmpty(detailMsg))
+                            catch (HttpRequestException ex)
                             {
-                                er.ErrorDetails = new ErrorDetails(detailMsg);
+                                ErrorRecord er = new ErrorRecord(ex, "WebCmdletWebResponseException", ErrorCategory.InvalidOperation, request);
+                                if (ex.InnerException != null)
+                                {
+                                    er.ErrorDetails = new ErrorDetails(ex.InnerException.Message);
+                                }
+                                ThrowTerminatingError(er);
                             }
-                            ThrowTerminatingError(er);
-                        }
 
-                        ProcessResponse(response);
-                        UpdateSession(response);
-
-                        // If we hit our maximum redirection count, generate an error.
-                        // Errors with redirection counts of greater than 0 are handled automatically by .NET, but are
-                        // impossible to detect programmatically when we hit this limit. By handling this ourselves
-                        // (and still writing out the result), users can debug actual HTTP redirect problems.
-                        if (WebSession.MaximumRedirection == 0) // Indicate "HttpClientHandler.AllowAutoRedirect == false"
-                        {
-                            if (response.StatusCode == HttpStatusCode.Found ||
-                                response.StatusCode == HttpStatusCode.Moved ||
-                                response.StatusCode == HttpStatusCode.MovedPermanently)
+                            if (_followRelLink)
                             {
-                                ErrorRecord er = new ErrorRecord(new InvalidOperationException(), "MaximumRedirectExceeded", ErrorCategory.InvalidOperation, request);
-                                er.ErrorDetails = new ErrorDetails(WebCmdletStrings.MaximumRedirectionCountExceeded);
-                                WriteError(er);
+                                if (!_relationLink.ContainsKey("next"))
+                                {
+                                    return;
+                                }
+                                Uri = new Uri(_relationLink["next"]);
+                                followedRelLink++;
                             }
                         }
                     }
-                    catch (HttpRequestException ex)
-                    {
-                        ErrorRecord er = new ErrorRecord(ex, "WebCmdletWebResponseException", ErrorCategory.InvalidOperation, request);
-                        if (ex.InnerException != null)
-                        {
-                            er.ErrorDetails = new ErrorDetails(ex.InnerException.Message);
-                        }
-                        ThrowTerminatingError(er);
-                    }
+                    while (_followRelLink && (followedRelLink < _maximumFollowRelLink));
                 }
             }
             catch (CryptographicException ex)
@@ -617,6 +661,40 @@ namespace Microsoft.PowerShell.Commands
             string body = FormatDictionary(content);
             return (SetRequestContent(request, body));
 
+        }
+
+        internal void ParseLinkHeader(HttpResponseMessage response, System.Uri requestUri)
+        {
+            if (_relationLink == null)
+            {
+                _relationLink = new Dictionary<string, string>();
+            }
+            else
+            {
+                _relationLink.Clear();
+            }
+
+            // we only support the URL in angle brackets and `rel`, other attributes are ignored
+            // user can still parse it themselves via the Headers property
+            Regex regex = new Regex("<(?<url>.*?)>;\\srel=\"(?<rel>.*?)\"");
+            IEnumerable<string> links;
+            if (response.Headers.TryGetValues("Link", out links))
+            {
+                foreach(string link in links.FirstOrDefault().Split(","))
+                {
+                    Match match = regex.Match(link);
+                    if (match.Success)
+                    {
+                        string url = match.Groups["url"].Value;
+                        string rel = match.Groups["rel"].Value;
+                        if (!_relationLink.ContainsKey(rel))
+                        {
+                            Uri absoluteUri = new Uri(requestUri, url);
+                            _relationLink.Add(rel, absoluteUri.AbsoluteUri.ToString());
+                        }
+                    }
+                }
+            }
         }
 
         #endregion Helper Methods

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebResponseObject.CoreClr.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebResponseObject.CoreClr.cs
@@ -9,8 +9,6 @@ using System.Text;
 using System.Net.Http;
 using System.Collections.Generic;
 using System.IO;
-using System.Text.RegularExpressions;
-using System.Linq;
 
 namespace Microsoft.PowerShell.Commands
 {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebResponseObject.CoreClr.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebResponseObject.CoreClr.cs
@@ -44,7 +44,7 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// gets the RelationLink property
         /// </summary>
-        public Dictionary<string, string> RelationLink { get; set; }
+        public Dictionary<string, string> RelationLink { get; internal set; }
 
         #endregion
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebResponseObject.CoreClr.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebResponseObject.CoreClr.cs
@@ -9,6 +9,8 @@ using System.Text;
 using System.Net.Http;
 using System.Collections.Generic;
 using System.IO;
+using System.Text.RegularExpressions;
+using System.Linq;
 
 namespace Microsoft.PowerShell.Commands
 {
@@ -40,6 +42,11 @@ namespace Microsoft.PowerShell.Commands
                 return headers;
             }
         }
+
+        /// <summary>
+        /// gets the RelationLink property
+        /// </summary>
+        public Dictionary<string, string> RelationLink { get; set; }
 
         #endregion
 

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/WebCmdletStrings.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/WebCmdletStrings.resx
@@ -213,4 +213,13 @@
   <data name="ResponseStatusCodeFailure" xml:space="preserve">
     <value>Response status code does not indicate success: {0} ({1}).</value>
   </data>
+  <data name="FollowingRelLinkVerboseMsg" xml:space="preserve">
+    <value>Following rel link {0}</value>
+  </data>
+  <data name="WebMethodInvocationVerboseMsg" xml:space="preserve">
+    <value>{0} {1} with {2}-byte payload</value>
+  </data>
+  <data name="WebResponseVerboseMsg" xml:space="preserve">
+    <value>received {0}-byte response of content type {1}</value>
+  </data>
 </root>

--- a/src/System.Management.Automation/commands/utility/FormatAndOutput/common/DefaultFormatters/PowerShellCore_format_ps1xml.cs
+++ b/src/System.Management.Automation/commands/utility/FormatAndOutput/common/DefaultFormatters/PowerShellCore_format_ps1xml.cs
@@ -1271,6 +1271,7 @@ namespace System.Management.Automation.Runspaces
                         .AddItemProperty(@"Links")
                         .AddItemProperty(@"ParsedHtml")
                         .AddItemProperty(@"RawContentLength")
+                        .AddItemProperty(@"RelationLink")
                     .EndEntry()
                 .EndList());
         }
@@ -1291,6 +1292,7 @@ namespace System.Management.Automation.Runspaces
                                 ", label: "RawContent")
                         .AddItemProperty(@"Headers")
                         .AddItemProperty(@"RawContentLength")
+                        .AddItemProperty(@"RelationLink")
                     .EndEntry()
                 .EndList());
         }

--- a/test/tools/Modules/HttpListener/HttpListener.psm1
+++ b/test/tools/Modules/HttpListener/HttpListener.psm1
@@ -136,6 +136,51 @@ Function Start-HTTPListener {
                                 $output = $request | ConvertTo-Json
                             }
                         }
+                        "linkheader"
+                        {
+                            $maxLinks = $queryItems["maxlinks"]
+                            if ($maxlinks -eq $null)
+                            {
+                                $maxLinks = 3
+                            }
+                            $linkNumber = [int]$queryItems["linknumber"]
+                            $prev = ""
+                            if ($linkNumber -eq 0)
+                            {
+                                $linkNumber = 1
+                            }
+                            else
+                            {
+                                # use $urlPrefix to ensure output is resolved to absolute uri
+                                $prev = ", <$($urlPrefix)?test=linkheader&maxlinks=$maxlinks&linknumber=$($linkNumber-1); rel=`"prev`""
+                            }
+                            $links = ""
+                            if ($linkNumber -lt $maxLinks)
+                            {
+                                switch ($queryItems["type"])
+                                {
+                                    "noUrl"
+                                    {
+                                        $links = "<>; rel=`"next`","
+                                    }
+                                    "malformed"
+                                    {
+                                        $links = "{url}; foo,"
+                                    }
+                                    "noRel"
+                                    {
+                                        $links = "<url>; foo=`"bar`","
+                                    }
+                                    default
+                                    {
+                                        $links = "<$($urlPrefix)?test=linkheader&maxlinks=$maxlinks&linknumber=$($linkNumber+1)>; rel=`"next`", "
+                                    }
+                                }
+                            }
+                            $links = "$links<$($urlPrefix)?test=linkheader&maxlinks=$maxlinks&linknumber=$maxlinks>; rel=`"last`"$prev"
+                            $outputHeader.Add("Link", $links)
+                            $output = "{ `"output`": `"$linkNumber`"}"
+                        }                        
                         default
                         {
                             $statusCode = [System.Net.HttpStatusCode]::NotFound


### PR DESCRIPTION
Implements https://github.com/PowerShell/PowerShell-RFC/blob/master/2-Draft-Accepted/RFC0021-Link-header-based-pagination-for-WebCmdlets.md

When the response includes a Link Header (https://tools.ietf.org/html/rfc5988#page-6), for Invoke-WebRequest we create a RelationLink property that is a Dictionary representing the URLs and rel attributes and ensure the URLs are absolute to make it easier for the developer to use.  For Invoke-RestMethod, we expose a -FollowRelLink switch to automatically follow 'next' rel links to the end until we hit the optional -MaximumFollowRelLink parameter value.

Since we will eventually remove the FullClr code, I didn't make the effort to add the same changes to the CoreClr sources to the FullClr sources.

Fix https://github.com/PowerShell/PowerShell/issues/3041

Doc update https://github.com/PowerShell/PowerShell-Docs/pull/1232