### PR TITLE
Fix check for Wix toolset

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -2462,13 +2462,18 @@ function New-MSIPackage
 
     )
 
-    $wixToolsetBinPath = "${env:ProgramFiles(x86)}\WiX Toolset v3.10\bin"
+    ## AppVeyor base image might update the version for Wix. Hence, we should
+    ## not hard code version numbers.
+    $wixToolsetBinPath = "${env:ProgramFiles(x86)}\WiX Toolset *\bin"
 
     Write-Verbose "Ensure Wix Toolset is present on the machine @ $wixToolsetBinPath"
     if (-not (Test-Path $wixToolsetBinPath))
     {
         throw "Wix Toolset is required to create MSI package. Please install Wix from https://wix.codeplex.com/downloads/get/1540240"
     }
+
+    ## Get the latest if multiple versions exist.
+    $wixToolsetBinPath = (Get-ChildItem $wixToolsetBinPath).FullName | Sort-Object -Descending | Select-Object -First 1
 
     Write-Verbose "Initialize Wix executables - Heat.exe, Candle.exe, Light.exe"
     $wixHeatExePath = Join-Path $wixToolsetBinPath "Heat.exe"


### PR DESCRIPTION
Wix toolset is part of the AppVeyor base image. The daily build did not generate a MSI since Wix toolset was not found.
AppVeyor updated the Wix version in the base image and our checks failed.
The fix removes the hardcoded version from path. It also guards against multiple side-by-side versions.

<!--

If you are a PowerShell Team member, please make sure you choose the Reviewer(s) and Assignee for your PR.
If you are not from the PowerShell Team, you can leave the fields blank and the Maintainers will choose them for you. If you are familiar with the team, feel free to mention some Reviewers yourself.

For more information about the roles of Reviewer and Assignee, refer to CONTRIBUTING.md.

-->
