### PR TITLE
Fix Invoke-Item to accept a file path with spaces on Unix platforms

### DIFF
--- a/src/System.Management.Automation/engine/NativeCommandParameterBinder.cs
+++ b/src/System.Management.Automation/engine/NativeCommandParameterBinder.cs
@@ -306,7 +306,7 @@ namespace System.Management.Automation
         /// Check to see if the string contains spaces and therefore must be quoted.
         /// </summary>
         /// <param name="stringToCheck">The string to check for spaces</param>
-        private bool NeedQuotes(string stringToCheck)
+        internal static bool NeedQuotes(string stringToCheck)
         {
             bool needQuotes = false, followingBackslash = false;
             int quoteCount = 0;

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -1327,27 +1327,39 @@ namespace Microsoft.PowerShell.Commands
             {
                 System.Diagnostics.Process invokeProcess = new System.Diagnostics.Process();
 
-#if UNIX
-                invokeProcess.StartInfo.FileName = Platform.IsLinux ? "xdg-open" : /* OS X */ "open";
-                invokeProcess.StartInfo.Arguments = path;
-                invokeProcess.Start();
-#elif CORECLR
                 try
                 {
-                    // Try Process.Start first. This works for executables even on headless SKUs.
+                    // Try Process.Start first.
+                    //  - In FullCLR, this is all we need to do.
+                    //  - In CoreCLR, this works for executables on Win/Unix platforms
                     invokeProcess.StartInfo.FileName = path;
                     invokeProcess.Start();
                 }
-                catch (Win32Exception)
+#if UNIX
+                catch (Win32Exception ex) when (ex.NativeErrorCode == 13)
                 {
+                    // Error code 13 -- Permission denied.
+                    // The file is possibly not an executable, so we try invoking the default program that handles this file.
+                    const string quoteFormat = "\"{0}\"";
+                    invokeProcess.StartInfo.FileName = Platform.IsLinux ? "xdg-open" : /* OS X */ "open";
+                    if (NativeCommandParameterBinder.NeedQuotes(path))
+                    {
+                        path = string.Format(CultureInfo.InvariantCulture, quoteFormat, path);
+                    }
+                    invokeProcess.StartInfo.Arguments = path;
+                    invokeProcess.Start();
+                }
+#elif CORECLR
+                catch (Win32Exception ex) when (ex.NativeErrorCode == 193)
+                {
+                    // Error code 193 -- BAD_EXE_FORMAT (not a valid Win32 application).
                     // If it's headless SKUs, rethrow.
                     if (Platform.IsNanoServer || Platform.IsIoT) { throw; }
                     // If it's full Windows, then try ShellExecute.
                     ShellExecuteHelper.Start(invokeProcess.StartInfo);
                 }
 #else
-                invokeProcess.StartInfo.FileName = path;
-                invokeProcess.Start();
+                finally { /* Nothing to do in FullCLR */ }
 #endif
             }
         } // InvokeDefaultAction

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Invoke-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Invoke-Item.Tests.ps1
@@ -44,7 +44,7 @@ Describe "Invoke-Item basic tests" -Tags "CI" {
         ## This is needed because 'ping' on Unix write out usage to stderr,
         ## while 'ping.exe' on Windows writes out usage to stdout.
         & $powershell -noprofile "Invoke-Item $executable" 2>&1 > $redirectFile
-        Select-String -Path $redirectFile -Pattern "ping" -SimpleMatch | Should Not BeNullOrEmpty
+        Select-String -Path $redirectFile -Pattern "usage: ping" -SimpleMatch | Should Not BeNullOrEmpty
     }
 }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Invoke-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Invoke-Item.Tests.ps1
@@ -23,14 +23,15 @@ Describe "Invoke-Item basic tests" -Tags "CI" {
         $redirectFile = Join-Path -Path $TestDrive -ChildPath "redirect1.txt"
         ## Redirect stderr to a file. So if 'xdg-open' or 'open' failed to open the text file, an error
         ## message from 'xdg-open' or 'open' would be written to the redirection file.
-        Start-Process -FilePath $powershell -ArgumentList "-noprofile Invoke-Item '$TestFile'" -RedirectStandardError $redirectFile
-
-        ## If the text file was successfully opened, the length of redirection file should be 0 as no
+        $proc = Start-Process -FilePath $powershell -ArgumentList "-noprofile Invoke-Item '$TestFile'" -RedirectStandardError $redirectFile -PassThru
+        $proc.WaitForExit(3000) > $null
+        ## If the text file was successfully opened, the length of redirection file should be 0 since no
         ## error message was written to it.
         $item = Get-Item -Path $redirectFile
-        if ($item.Length > 0) {
+        if ($item.Length -gt 0) {
             ## Write the error message out in case the test fails
-            Get-Content $redirectFile -Raw | Write-Host
+            Write-Host "Error Message Detected:" -ForegroundColor DarkYellow
+            Get-Content $redirectFile | Write-Host -ForegroundColor Yellow
         }
         $item.Length | Should Be 0
     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Invoke-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Invoke-Item.Tests.ps1
@@ -21,14 +21,16 @@ Describe "Invoke-Item basic tests" -Tags "CI" {
         param($TestFile)
 
         $redirectFile = Join-Path -Path $TestDrive -ChildPath "redirect1.txt"
-        ## Redirect stderr to a file. So if 'xdg-open' or 'open' fail to open the text file, an error
-        ## message from 'xdg-open' or 'open' will be written to the file.
-        & $powershell -noprofile "Invoke-Item '$TestFile'" 2> $redirectFile
+        ## Redirect stderr to a file. So if 'xdg-open' or 'open' failed to open the text file, an error
+        ## message from 'xdg-open' or 'open' would be written to the redirection file.
+        Start-Process -FilePath $powershell -ArgumentList "-noprofile Invoke-Item '$TestFile'" -RedirectStandardError $redirectFile
+
         ## If the text file was successfully opened, the length of redirection file should be 0 as no
         ## error message was written to it.
         $item = Get-Item -Path $redirectFile
         if ($item.Length > 0) {
-            Get-Content $redirectFile -Raw
+            ## Write the error message out in case the test fails
+            Get-Content $redirectFile -Raw | Write-Host
         }
         $item.Length | Should Be 0
     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Invoke-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Invoke-Item.Tests.ps1
@@ -22,11 +22,15 @@ Describe "Invoke-Item basic tests" -Tags "CI" {
 
         $redirectFile = Join-Path -Path $TestDrive -ChildPath "redirect1.txt"
         ## Redirect stderr to a file. So if 'xdg-open' or 'open' fail to open the text file, an error
-        ## message from 'xdg-open' or 'open' will be written to the file. 
+        ## message from 'xdg-open' or 'open' will be written to the file.
         & $powershell -noprofile "Invoke-Item '$TestFile'" 2> $redirectFile
         ## If the text file was successfully opened, the length of redirection file should be 0 as no
         ## error message was written to it.
-        Get-Item -Path $redirectFile | ForEach-Object Length | Should Be 0
+        $item = Get-Item -Path $redirectFile
+        if ($item.Length > 0) {
+            Get-Content $redirectFile -Raw
+        }
+        $item.Length | Should Be 0
     }
 
     It "Should invoke an executable file without error" {


### PR DESCRIPTION
Address #2900

Root Cause
------------
On Unix platforms, we are currently depending on `xdg-open` on Linux and `open` on OSX to open the default program for a registered file type, so the file path is served as an argument to `xdg-open` and `open`. However, we didn't handle the case when path contains spaces.

Fix
---
Use the method `NativeCommandParameterBinder.NeedQuotes`, which is used by powershell native command processor, to check if quote is needed. If yes, add quotes in the same way as our native command processor (see the code [here](https://github.com/PowerShell/PowerShell/blob/master/src/System.Management.Automation/engine/NativeCommandParameterBinder.cs#L198)).
There is another problem with the current `Invoke-Item` on Linux and OSX -- it cannot invoke an executable properly. The fix is to first run `Process.Start` directly with the file path, and if it fails, then try `xdg-open` or `open`.