### PR TITLE
Add tab completion for Export-Counter -FileFormat parameter

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Diagnostics/ExportCounterCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Diagnostics/ExportCounterCommand.cs
@@ -65,12 +65,13 @@ namespace Microsoft.PowerShell.Commands
                 ValueFromPipelineByPropertyName = false,
                 HelpMessageBaseName = "GetEventResources")]
         [ValidateNotNull]
+        [ValidateSet("blg", "csv", "tsv")]
         public string FileFormat
         {
             get { return _format; }
             set { _format = value; }
         }
-        private string _format = "BLG";
+        private string _format = "blg";
 
 
 
@@ -180,9 +181,9 @@ namespace Microsoft.PowerShell.Commands
             _resourceMgr = Microsoft.PowerShell.Commands.Diagnostics.Common.CommonUtilities.GetResourceManager();
 
             //
-            // Validate the Format and CounterSamples arguments
+            // Set output format (log file type)
             //
-            ValidateFormat();
+            SetOutputFormat();
 
             if (Circular.IsPresent && _maxSize == 0)
             {
@@ -311,26 +312,20 @@ namespace Microsoft.PowerShell.Commands
             }
         }
 
-        // ValidateFormat() helper.
-        // Validates Format argument: only "BLG", "TSV" and "CSV" are valid strings (case-insensitive)
+        // Determines Log File Type based on FileFormat parameter
         //
-        private void ValidateFormat()
+        private void SetOutputFormat()
         {
             switch (_format.ToLowerInvariant())
             {
-                case "blg":
-                    _outputFormat = PdhLogFileType.PDH_LOG_TYPE_BINARY;
-                    break;
                 case "csv":
                     _outputFormat = PdhLogFileType.PDH_LOG_TYPE_CSV;
                     break;
                 case "tsv":
                     _outputFormat = PdhLogFileType.PDH_LOG_TYPE_TSV;
                     break;
-                default:
-                    string msg = string.Format(CultureInfo.InvariantCulture, _resourceMgr.GetString("CounterInvalidFormat"), _format);
-                    Exception exc = new Exception(msg);
-                    ThrowTerminatingError(new ErrorRecord(exc, "CounterInvalidFormat", ErrorCategory.InvalidArgument, null));
+                default:  // By default file format is blg
+                    _outputFormat = PdhLogFileType.PDH_LOG_TYPE_BINARY;
                     break;
             }
         }

--- a/src/Microsoft.PowerShell.Commands.Diagnostics/resources/GetEventResources.resx
+++ b/src/Microsoft.PowerShell.Commands.Diagnostics/resources/GetEventResources.resx
@@ -216,9 +216,6 @@ The defined template is following:
   <data name="IncorrectEventVersion" xml:space="preserve">
     <value>Event cannot be written because the specified version {0} for event {1} is not defined for the provider {2}.  Please correct the version and try again.</value>
   </data>
-  <data name="CounterInvalidFormat" xml:space="preserve">
-    <value>The {0} format type is not a valid format for a counter file. Possible values for the Format parameter are .blg, .csv, or .tsv.</value>
-  </data>
   <data name="Counter32FileLimit" xml:space="preserve">
     <value>You cannot import more than 32 .blg counter log files in each command.</value>
   </data>

--- a/src/Microsoft.PowerShell.Commands.Diagnostics/resources/GetEventResources.txt
+++ b/src/Microsoft.PowerShell.Commands.Diagnostics/resources/GetEventResources.txt
@@ -52,7 +52,6 @@ CounterExportSampleNotInInitialSet=The {0} performance counter cannot be exporte
 CounterPathTranslationFailed=The default values for this command failed. Error: {0:x8}.
 CounterContinuousOrMaxSamples=The Continuous parameter and the MaxSamples parameter cannot be used in the same command.
 CounterSampleDataInvalid=The data in one of the performance counter samples is not valid. View the Status property for each PerformanceCounterSample object to make sure it contains valid data.
-CounterInvalidFormat=The {0} format type is not a valid format for a counter file. Possible values for the Format parameter are .blg, .csv, or .tsv.
 CounterCircularNoMaxSize=The Circular parameter will be ignored unless the MaxSize parameter is also specified.
 ExportCtrWin7Required=This cmdlet can be run only on Microsoft Windows 7 and above.
 FileOpenFailed=Unable to open the {0} file for writing.

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -33,7 +33,8 @@ Describe "TabCompletion" -Tags CI {
     It 'Should complete format-table hashtable' {
         $res = TabExpansion2 -inputScript 'Get-ChildItem | Format-Table @{ ' -cursorColumn 'Get-ChildItem | Format-Table @{ '.Length
         $res.CompletionMatches.Count | Should Be 5
-        $res.CompletionMatches.Foreach{$_.CompletionText -in 'Label', 'Width', 'Alignment', 'Expression', 'FormatString' | Should Be $true}
+        $completionText = $res.CompletionMatches.CompletionText | Sort-Object
+        $completionText -join ' ' | Should Be 'Alignment Expression FormatString Label Width'
     }
 
 
@@ -46,37 +47,43 @@ Describe "TabCompletion" -Tags CI {
         param($cmd)
         $res = TabExpansion2 -inputScript "Get-ChildItem | $cmd -GroupBy @{ " -cursorColumn "Get-ChildItem | $cmd -GroupBy @{ ".Length
         $res.CompletionMatches.Count | Should Be 3
-        $res.CompletionMatches.Foreach{$_.CompletionText -in 'Label', 'Expression', 'FormatString' | Should Be $true}
+        $completionText = $res.CompletionMatches.CompletionText | Sort-Object
+        $completionText -join ' ' | Should Be 'Expression FormatString Label'
     }
 
     It 'Should complete format-list hashtable' {
         $res = TabExpansion2 -inputScript 'Get-ChildItem | Format-List @{ ' -cursorColumn 'Get-ChildItem | Format-List @{ '.Length
         $res.CompletionMatches.Count | Should Be 3
-        $res.CompletionMatches.Foreach{$_.CompletionText -in 'Label', 'Expression', 'FormatString' | Should Be $true}
+        $completionText = $res.CompletionMatches.CompletionText | Sort-Object
+        $completionText -join ' ' | Should Be 'Expression FormatString Label'
     }
 
     It 'Should complete format-wide hashtable' {
         $res = TabExpansion2 -inputScript 'Get-ChildItem | Format-Wide @{ ' -cursorColumn 'Get-ChildItem | Format-Wide @{ '.Length
         $res.CompletionMatches.Count | Should Be 2
-        $res.CompletionMatches.Foreach{$_.CompletionText -in 'Expression', 'FormatString' | Should Be $true}
+        $completionText = $res.CompletionMatches.CompletionText | Sort-Object
+        $completionText -join ' ' | Should Be 'Expression FormatString'
     }
 
     It 'Should complete format-custom  hashtable' {
         $res = TabExpansion2 -inputScript 'Get-ChildItem | Format-Custom @{ ' -cursorColumn 'Get-ChildItem | Format-Custom @{ '.Length
         $res.CompletionMatches.Count | Should Be 2
-        $res.CompletionMatches.Foreach{$_.CompletionText -in 'Expression', 'Depth' | Should Be $true}
+        $completionText = $res.CompletionMatches.CompletionText | Sort-Object
+        $completionText -join ' ' | Should Be 'Depth Expression'
     }
 
     It 'Should complete Select-Object  hashtable' {
         $res = TabExpansion2 -inputScript 'Get-ChildItem | Select-Object @{ ' -cursorColumn 'Get-ChildItem | Select-Object @{ '.Length
         $res.CompletionMatches.Count | Should Be 2
-        $res.CompletionMatches.Foreach{$_.CompletionText -in 'Name', 'Expression' | Should Be $true}
+        $completionText = $res.CompletionMatches.CompletionText | Sort-Object
+        $completionText -join ' '| Should Be 'Expression Name'
     }
 
     It 'Should complete Sort-Object  hashtable' {
         $res = TabExpansion2 -inputScript 'Get-ChildItem | Sort-Object @{ ' -cursorColumn 'Get-ChildItem | Sort-Object @{ '.Length
         $res.CompletionMatches.Count | Should Be 3
-        $res.CompletionMatches.Foreach{$_.CompletionText -in 'Expression', 'Ascending', 'Descending' | Should Be $true}
+        $completionText = $res.CompletionMatches.CompletionText | Sort-Object
+        $completionText -join ' '| Should Be 'Ascending Descending Expression'
     }
 
     It 'Should complete New-Object  hashtable' {
@@ -87,7 +94,7 @@ Describe "TabCompletion" -Tags CI {
         }
         $res = TabExpansion2 -inputScript 'New-Object -TypeName X -Property @{ ' -cursorColumn 'New-Object -TypeName X -Property @{ '.Length
         $res.CompletionMatches.Count | Should Be 3
-        $res.CompletionMatches.Foreach{$_.CompletionText -in 'A', 'B', 'C' | Should Be $true}
+        $res.CompletionMatches.CompletionText -join ' ' | Should Be 'A B C'
     }
 
     It 'Should complete "Get-Process -Id " with Id and name in tooltip' {
@@ -102,5 +109,12 @@ Describe "TabCompletion" -Tags CI {
     It 'Should complete keyword' -skip {
         $res = TabExpansion2 -inputScript 'using nam' -cursorColumn 'using nam'.Length
         $res.CompletionMatches[0].CompletionText | Should be 'namespace'
+    }
+
+    It 'Should complete "Export-Counter -FileFormat" with available output formats'-Skip:(!$IsWindows) {
+        $res = TabExpansion2 -inputScript 'Export-Counter -FileFormat ' -cursorColumn 'Export-Counter -FileFormat '.Length
+        $res.CompletionMatches.Count | Should Be 3
+        $completionText = $res.CompletionMatches.CompletionText | Sort-Object
+        $completionText -join ' '| Should Be 'blg csv tsv'
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/Export-Counter.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/Export-Counter.Tests.ps1
@@ -177,11 +177,6 @@ Describe "Feature tests for Export-Counter cmdlet" -Tags "Feature" {
                 Parameters = "-MaxSize -2"
                 ExpectedErrorId = "CannotConvertArgumentNoMessage,Microsoft.PowerShell.Commands.ExportCounterCommand"
             }
-            @{
-                Name = "Fails when given invalid file format"
-                FileFormat = "dat"
-                ExpectedErrorId = "CounterInvalidFormat,Microsoft.PowerShell.Commands.ExportCounterCommand"
-            }
         )
 
         foreach ($testCase in $testCases)


### PR DESCRIPTION
* Fixing #3180 
* Added ValidateSet to the -FileFormat parameter for possible log file types and updated the function that was previously validating the file formats.
* Removed the invalid format error message from resources files.
* Updated tests to reflect new FullyQualifiedErrorId. 