### PR TITLE
Make PSReadline render correct portion of prompt on Unix when it's a multi-line string

### DIFF
--- a/src/Microsoft.PowerShell.PSReadLine/ReadLine.cs
+++ b/src/Microsoft.PowerShell.PSReadLine/ReadLine.cs
@@ -560,6 +560,13 @@ namespace Microsoft.PowerShell
 
 #if UNIX // TODO: not necessary if ReadBufferLines worked, or if rendering worked on spans instead of complete lines
             string newPrompt = GetPrompt();
+            int index = newPrompt.LastIndexOf('\n');
+            if (index != -1)
+            {
+                // The prompt text could be a multi-line string, and in such case
+                // we only want the part of it shown on the current line.
+                newPrompt = newPrompt.Substring(index + 1);
+            }
             var bufferLineCount = (newPrompt.Length) / (_console.BufferWidth) + 1;
             _consoleBuffer = ReadBufferLines(_initialY, bufferLineCount);
 

--- a/src/Microsoft.PowerShell.PSReadLine/ReadLine.cs
+++ b/src/Microsoft.PowerShell.PSReadLine/ReadLine.cs
@@ -564,7 +564,7 @@ namespace Microsoft.PowerShell
             if (index != -1)
             {
                 // The prompt text could be a multi-line string, and in such case
-                // we only want the part of it shown on the current line.
+                // we only want the part of it that is shown on the input line.
                 newPrompt = newPrompt.Substring(index + 1);
             }
             var bufferLineCount = (newPrompt.Length) / (_console.BufferWidth) + 1;


### PR DESCRIPTION
Issue Summary
----------------
My `prompt` function returns a multi-line string. On Linux, when typing any input, `PSReadline` tries to render the whole prompt string again, instead of just the portion that is shown on the current line, which results in a bad prompt:
![image](https://cloud.githubusercontent.com/assets/127450/26474399/c046913c-4165-11e7-9eac-c340db738efb.png)

Fix
---
Check whether the prompt is multi-line or not. If it is, then only use the part that is shown in the input line.

Additional Info
----------------
I am using VT100 escape sequences to colorize my prompt string, and I found that PSReadline doesn't work with VT100 on Unix, because it's calling `Console.Write(Char)` instead of `Console.Write(String)` (see code [here](https://github.com/PowerShell/PowerShell/blob/master/src/Microsoft.PowerShell.PSReadLine/ConsoleLib.cs#L1048)). I tried to fix that along with this PR, but it turns out to be not trivial, so I will postpone that fix to another PR.
Since PSReadline doesn't work with VT100 on Unix yet, you need to make sure that the part of the prompt string shown on the input line does not contain any escape sequences. Otherwise, you will see random characters like in the above screenshot.

Prompt function I use on Unix
---------------------------------
I think it would be useful to share the prompt function I'm using on Unix. It works fine with this fix.
```
function Prompt
{
    $id = 1
    $historyItem = Get-History -Count 1
    if ($historyItem)
    {
        $id = $historyItem.Id + 1
    }

    if ($host.UI.SupportsVirtualTerminal)
    {
        $CSI = [char]0x1b + '['
        "${CSI}00m${CSI}01;30m[$($executionContext.SessionState.Path.CurrentLocation)]${CSI}00m`nPS:${id}$('>' * ($nestedPromptLevel + 1)) "
    }
    else
    {
        
        Write-Host -ForegroundColor DarkGray "[$($executionContext.SessionState.Path.CurrentLocation)]"
        "PS:$id$('>' * ($nestedPromptLevel + 1)) "
    }
}
```