### PR TITLE
Enable Send-MailMessage on CoreCLR

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/Microsoft.PowerShell.Commands.Utility.csproj
+++ b/src/Microsoft.PowerShell.Commands.Utility/Microsoft.PowerShell.Commands.Utility.csproj
@@ -35,7 +35,6 @@
     <Compile Remove="commands\utility\FormatAndOutput\OutGridView\TableView.cs" />
     <Compile Remove="commands\utility\FormatAndOutput\out-printer\PrinterLineOutput.cs" />
     <Compile Remove="commands\utility\FormatAndOutput\out-printer\out-printer.cs" />
-    <Compile Remove="commands\utility\Send-MailMessage.cs" />
     <Compile Remove="commands\utility\ShowCommand\ShowCommand.cs" />
     <Compile Remove="commands\utility\ShowCommand\ShowCommandCommandInfo.cs" />
     <Compile Remove="commands\utility\ShowCommand\ShowCommandModuleInfo.cs" />
@@ -60,17 +59,15 @@
     <Compile Remove="gen\UtilityMshSnapinResources.cs" />
     <Compile Remove="gen\OutPrinterDisplayStrings.cs" />
     <Compile Remove="gen\UpdateListStrings.cs" />
-    <Compile Remove="gen\SendMailMessageStrings.cs" />
     <Compile Remove="gen\ConvertFromStringResources.cs" />
     <Compile Remove="gen\ConvertStringResources.cs" />
     <Compile Remove="gen\FlashExtractStrings.cs" />
     <Compile Remove="gen\ImmutableStrings.cs" />
-    
+
     <EmbeddedResource Remove="resources\FormatAndOut_out_gridview.resx" />
     <EmbeddedResource Remove="resources\UtilityMshSnapinResources.resx" />
     <EmbeddedResource Remove="resources\OutPrinterDisplayStrings.resx" />
     <EmbeddedResource Remove="resources\UpdateListStrings.resx" />
-    <EmbeddedResource Remove="resources\SendMailMessageStrings.resx" />
     <EmbeddedResource Remove="resources\ConvertFromStringResources.resx" />
     <EmbeddedResource Remove="resources\ConvertStringResources.resx" />
     <EmbeddedResource Remove="resources\FlashExtractStrings.resx" />

--- a/src/Modules/Unix/Microsoft.PowerShell.Utility/Microsoft.PowerShell.Utility.psd1
+++ b/src/Modules/Unix/Microsoft.PowerShell.Utility/Microsoft.PowerShell.Utility.psd1
@@ -20,7 +20,7 @@ CmdletsToExport= "Format-List", "Format-Custom", "Format-Table", "Format-Wide",
     "Clear-Variable", "Export-Clixml", "Import-Clixml", "Import-PowerShellDataFile", "ConvertTo-Xml", "Select-Xml", "Write-Debug",
     "Write-Verbose", "Write-Warning", "Write-Error", "Write-Information", "Write-Output", "Set-PSBreakpoint",
     "Get-PSBreakpoint", "Remove-PSBreakpoint", "Enable-PSBreakpoint", "Disable-PSBreakpoint", "Get-PSCallStack",
-    "Get-TraceSource", "Set-TraceSource", "Trace-Command", "Get-FileHash",
+    "Send-MailMessage", "Get-TraceSource", "Set-TraceSource", "Trace-Command", "Get-FileHash",
     "Get-Runspace", "Debug-Runspace", "Enable-RunspaceDebug", "Disable-RunspaceDebug",
     "Get-RunspaceDebug", "Wait-Debugger" , "Get-Uptime", "New-TemporaryFile", "Get-Verb", "Format-Hex"
 FunctionsToExport= "Import-PowerShellDataFile"

--- a/src/Modules/Windows-Core/Microsoft.PowerShell.Utility/Microsoft.PowerShell.Utility.psd1
+++ b/src/Modules/Windows-Core/Microsoft.PowerShell.Utility/Microsoft.PowerShell.Utility.psd1
@@ -20,7 +20,7 @@ CmdletsToExport= "Format-List", "Format-Custom", "Format-Table", "Format-Wide",
     "Clear-Variable", "Export-Clixml", "Import-Clixml", "Import-PowerShellDataFile","ConvertTo-Xml", "Select-Xml", "Write-Debug",
     "Write-Verbose", "Write-Warning", "Write-Error", "Write-Information", "Write-Output", "Set-PSBreakpoint",
     "Get-PSBreakpoint", "Remove-PSBreakpoint", "New-TemporaryFile", "Enable-PSBreakpoint", "Disable-PSBreakpoint", "Get-PSCallStack",
-    "Get-TraceSource", "Set-TraceSource", "Trace-Command", "Get-FileHash",
+    "Send-MailMessage", "Get-TraceSource", "Set-TraceSource", "Trace-Command", "Get-FileHash",
     "Unblock-File", "Get-Runspace", "Debug-Runspace", "Enable-RunspaceDebug", "Disable-RunspaceDebug",
     "Get-RunspaceDebug", "Wait-Debugger" , "Get-Uptime", "Get-Verb", "Format-Hex"
 FunctionsToExport= "ConvertFrom-SddlString"

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Send-MailMessage.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Send-MailMessage.Tests.ps1
@@ -1,0 +1,135 @@
+Describe "Basic Send-MailMessage tests" -Tags CI {
+    function read-mail
+    {
+        Param(
+            [parameter(Mandatory=$true)]
+            [String]
+            $mailBox
+        )
+
+        $state = "init"
+        $mail = Get-Content $mailBox
+        $rv = @{}
+        foreach ($line in $mail)
+        {
+            switch ($state)
+            {
+                "init"
+                {
+                    if ($line.Length -gt 0)
+                    {
+                        $state = "headers"
+                    }
+                }
+                "headers"
+                {
+                    if ($line.StartsWith("From: "))
+                    {
+                        $rv.From = $line.Substring(6)
+                    }
+                    elseif ($line.StartsWith("To: "))
+                    {
+                        if ($rv.To -eq $null)
+                        {
+                            $rv.To = @()
+                        }
+
+                        $rv.To += $line.Substring(4)
+                    }
+                    elseif ($line.StartsWith("Subject: "))
+                    {
+                        $rv.Subject = $line.Substring(9);
+                    }
+                    elseif ($line.Length -eq 0)
+                    {
+                        $state = "body"
+                    }
+                }
+                "body"
+                {
+                    if ($line.Length -eq 0)
+                    {
+                        $state = "done"
+                        continue
+                    }
+
+                    if ($rv.Body -eq $null)
+                    {
+                        $rv.Body = @()
+                    }
+
+                    $rv.Body += $line
+                }
+            }
+        }
+
+        return $rv
+    }
+
+    BeforeAll {
+        $PesterArgs = @{ Name = "Can send mail message from user to self"}
+        $alreadyHasMail = $true
+
+        if (-not $IsLinux)
+        {
+            $PesterArgs["Skip"] = $true
+            $PesterArgs["Name"] += " (skipped: not Linux)"
+            return
+        }
+
+        $user = "jeff"
+        $inPassword = Select-String "^${user}:" /etc/passwd -ErrorAction SilentlyContinue
+        if (-not $inPassword)
+        {
+            $PesterArgs["Pending"] = $true
+            $PesterArgs["Name"] += " (pending: user not in /etc/passwd)"
+            return
+        }
+
+        $domain = "Chinstrap"
+        if ($domain -ne [System.Environment]::MachineName)
+        {
+            $PesterArgs["Pending"] = $true
+            $PesterArgs["Name"] += " (pending: machine name not '$domain')"
+            return
+        }
+        $address = "$user@$domain"
+        $mailStore = "/var/mail"
+        $mailBox = Join-Path $mailStore $user
+        $mailBoxFile = Get-Item $mailBox -ErrorAction SilentlyContinue
+        if ($mailBoxFile -ne $null -and $mailBoxFile.Length -gt 2)
+        {
+            $PesterArgs["Pending"] = $true
+            $PesterArgs["Name"] += " (pending: mailbox not empty)"
+            return
+        }
+        $alreadyHasMail = $false
+        Set-Content -Value "" -Path $mailBox -Force -ErrorAction SilentlyContinue
+        $mailBoxFile = Get-Item $mailBox -ErrorAction SilentlyContinue
+        if ($mailBoxFile -eq $null -or $mailBoxFile.Length -gt 2)
+        {
+            $PesterArgs["Pending"] = $true
+            $PesterArgs["Name"] += " (pending: did not clear or create mailbox)"
+            return
+        }
+    }
+    AfterAll {
+       if (-not $alreadyHasMail)
+       {
+           Set-Content -Value "" -Path $mailBox -Force -ErrorAction SilentlyContinue
+       }
+    }
+
+    It @PesterArgs {
+        $body = "Greetings from me."
+        $subject = "Test message"
+        Send-MailMessage -To $address -From $address -Subject $subject -Body $body -SmtpServer 127.0.0.1
+        Test-Path -Path $mailBox | Should Be $true
+        $mail = read-mail $mailBox
+        $mail.From | Should BeExactly $address
+        $mail.To.Count | Should BeExactly 1
+        $mail.To[0] | Should BeExactly $address
+        $mail.Body.Count | Should BeExactly 1
+        $mail.Body[0] | Should BeExactly $body
+    }
+}

--- a/test/powershell/engine/DefaultCommands.Tests.ps1
+++ b/test/powershell/engine/DefaultCommands.Tests.ps1
@@ -392,7 +392,7 @@ Describe "Verify approved aliases list" -Tags "CI" {
 "Cmdlet", "Select-Object",                                      ,                     $($FullCLR -or $CoreWindows -or $CoreUnix)
 "Cmdlet", "Select-String",                                      ,                     $($FullCLR -or $CoreWindows -or $CoreUnix)
 "Cmdlet", "Select-Xml",                                         ,                     $($FullCLR -or $CoreWindows -or $CoreUnix)
-"Cmdlet", "Send-MailMessage",                                   ,                     $($FullCLR                               )
+"Cmdlet", "Send-MailMessage",                                   ,                     $($FullCLR -or $CoreWindows -or $CoreUnix)
 "Cmdlet", "Set-Acl",                                            ,                     $($FullCLR -or $CoreWindows              )
 "Cmdlet", "Set-Alias",                                          ,                     $($FullCLR -or $CoreWindows -or $CoreUnix)
 "Cmdlet", "Set-AuthenticodeSignature",                          ,                     $($FullCLR -or $CoreWindows              )


### PR DESCRIPTION
Contributes to the completion of #2123 and #2240.

Now that the requisite components are implemented in corefx, compilation of the Send-MailMessage cmdlet has been enabled.

This PR includes a test script that allows the cmdlet to be tested against a working local SMTP server, but only on Linux and under specific conditions. A separate issue will be opened for improving test coverage and including additional platforms.