### PR TITLE
Move Start-TypeGen logic from Build.psm1 to SDK csproj file

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -535,8 +535,8 @@ Fix steps:
 
     # publish netcoreapp2.0 reference assemblies
     try {
-        Push-Location "$PSScriptRoot/src/TypeCatalogGen"
-        $refAssemblies = Get-Content -Path $incFileName | Where-Object { $_ -like "*microsoft.netcore.app*" } | ForEach-Object { $_.TrimEnd(';') }
+        Push-Location "$PSScriptRoot/src/Microsoft.PowerShell.SDK/gen"
+        $refAssemblies = Get-Content -Path "RefAssemblyList.inc" | Where-Object { $_ -like "*microsoft.netcore.app*" } | ForEach-Object { $_.TrimEnd(';') }
         $refDestFolder = Join-Path -Path $publishPath -ChildPath "ref"
 
         if (Test-Path $refDestFolder -PathType Container) {
@@ -1715,33 +1715,12 @@ function Start-TypeGen
     # Add .NET CLI tools to PATH
     Find-Dotnet
 
-    $GetDependenciesTargetPath = "$PSScriptRoot/src/Microsoft.PowerShell.SDK/obj/Microsoft.PowerShell.SDK.csproj.TypeCatalog.targets"
-    $GetDependenciesTargetValue = @'
-<Project>
-    <Target Name="_GetDependencies"
-            DependsOnTargets="ResolveAssemblyReferencesDesignTime">
-        <ItemGroup>
-            <_RefAssemblyPath Include="%(_ReferencesFromRAR.ResolvedPath)%3B" Condition=" '%(_ReferencesFromRAR.Type)' == 'assembly' And '%(_ReferencesFromRAR.PackageName)' != 'Microsoft.Management.Infrastructure' " />
-        </ItemGroup>
-        <WriteLinesToFile File="$(_DependencyFile)" Lines="@(_RefAssemblyPath)" Overwrite="true" />
-    </Target>
-</Project>
-'@
-    Set-Content -Path $GetDependenciesTargetPath -Value $GetDependenciesTargetValue -Force -Encoding Ascii
-
     Push-Location "$PSScriptRoot/src/Microsoft.PowerShell.SDK"
     try {
-        $ps_inc_file = "$PSScriptRoot/src/TypeCatalogGen/$IncFileName"
-        dotnet msbuild .\Microsoft.PowerShell.SDK.csproj /t:_GetDependencies "/property:DesignTimeBuild=true;_DependencyFile=$ps_inc_file" /nologo
+        dotnet msbuild .\Microsoft.PowerShell.SDK.csproj /t:"Clean;TypeCatalogGen" "/property:DesignTimeBuild=true"
     } finally {
         Pop-Location
-    }
-
-    Push-Location "$PSScriptRoot/src/TypeCatalogGen"
-    try {
-        dotnet run ../System.Management.Automation/CoreCLR/CorePsTypeCatalog.cs $IncFileName
-    } finally {
-        Pop-Location
+        log "Finish Start-TypeGen"
     }
 }
 

--- a/src/Microsoft.PowerShell.SDK/Microsoft.PowerShell.SDK.csproj
+++ b/src/Microsoft.PowerShell.SDK/Microsoft.PowerShell.SDK.csproj
@@ -29,4 +29,54 @@
     <PackageReference Include="Microsoft.NETCore.Windows.ApiSets" Version="1.0.1" />
   </ItemGroup>
 
+  <!-- TypeCatalogGen properties -->
+  <PropertyGroup>
+    <RefAssemblyRelPath>gen</RefAssemblyRelPath>
+    <RefAssemblyFileName>RefAssemblyList.inc</RefAssemblyFileName>
+    <RefAssemblyDirPath>$(MSBuildProjectDirectory)\$(RefAssemblyRelPath)</RefAssemblyDirPath>
+    <RefAssemblyFilePath>$(RefAssemblyDirPath)\$(RefAssemblyFileName)</RefAssemblyFilePath>
+
+    <CorePsTypeCatalogFilePath>$(MSBuildProjectDirectory)\..\Microsoft.PowerShell.CoreCLR.AssemblyLoadContext/CorePsTypeCatalog.cs</CorePsTypeCatalogFilePath>
+    <TypeCatalogProjectFilePath>$(MSBuildProjectDirectory)\..\TypeCatalogGen\TypeCatalogGen.csproj</TypeCatalogProjectFilePath>
+  </PropertyGroup>
+
+  <!-- Create file with Assembly Reference list -->
+  <Target Name="ResolveAssemblyReferencesDesignTimeSDK"
+               DependsOnTargets="ResolveAssemblyReferencesDesignTime"
+               Condition=" '$(DesignTimeBuild)' == 'true' ">
+
+    <MakeDir Directories="$(RefAssemblyRelPath)" Condition=" !Exists('$(RefAssemblyRelPath)') "/>
+
+    <ItemGroup>
+        <_RefAssemblyPath Include="%(_ReferencesFromRAR.ResolvedPath)%3B" Condition=" '%(_ReferencesFromRAR.Type)' == 'assembly' And '%(_ReferencesFromRAR.PackageName)' != 'Microsoft.Management.Infrastructure' " />
+    </ItemGroup>
+
+    <ReadLinesFromFile
+       File="$(RefAssemblyFilePath)" >
+       <Output
+          TaskParameter="Lines"
+          ItemName="ItemsFromFile"/>
+    </ReadLinesFromFile>
+
+    <WriteLinesToFile
+       Condition=" @(ItemsFromFile) != @(_RefAssemblyPath) "
+       File="$(RefAssemblyFilePath)"
+       Lines="@(_RefAssemblyPath)" Overwrite="true" />
+  </Target>
+
+  <!-- Used in standard Clean target -->
+  <ItemGroup>
+    <Clean Include="$(RefAssemblyDirPath)\**"/>
+  </ItemGroup>
+
+  <Target Name="TypeCatalogGen"
+               DependsOnTargets="ResolveAssemblyReferencesDesignTimeSDK"
+               Condition=" '$(DesignTimeBuild)' == 'true' "
+               Inputs="$(RefAssemblyFilePath)"
+               Outputs="$(CorePsTypeCatalogFilePath)">
+
+    <Message Text="Project File Name" />
+    <Exec Command="dotnet run --project $(TypeCatalogProjectFilePath) $(CorePsTypeCatalogFilePath) $(RefAssemblyFilePath) "/>
+  </Target>
+
 </Project>


### PR DESCRIPTION
Related #3400
(Also it is one step to unblock #3690)

Now Microsoft.PowerShell.SDK.csproj:
1. Generate Reference Assembly List ("RefAssemblyList.inc" file) in project local sub directory "gen" (Target Name="TypeCatalogGen"):
 - Check if Reference Assembly List is updated and only then overwrite RefAssemblyList.inc
 - If RefAssemblyList.inc is updated then generate new CorePsTypeCatalog.cs 
2. Support Clean target to remove RefAssemblyList.inc (for rebuild)



<!--

If you are a PowerShell Team member, please make sure you choose the Reviewer(s) and Assignee for your PR.
If you are not from the PowerShell Team, you can leave the fields blank and the Maintainers will choose them for you. If you are familiar with the team, feel free to mention some Reviewers yourself.

For more information about the roles of Reviewer and Assignee, refer to CONTRIBUTING.md.

-->
