### PR TITLE
Remove BuildVersion from  $PSVersionTable

### DIFF
--- a/src/System.Management.Automation/engine/PSVersionInfo.cs
+++ b/src/System.Management.Automation/engine/PSVersionInfo.cs
@@ -20,7 +20,6 @@ namespace System.Management.Automation
         internal const string PSRemotingProtocolVersionName = "PSRemotingProtocolVersion";
         internal const string PSVersionName = "PSVersion";
         internal const string PSEditionName = "PSEdition";
-        internal const string PSBuildVersionName = "BuildVersion";
         internal const string PSGitCommitIdName = "GitCommitId";
         internal const string PSCompatibleVersionsName = "PSCompatibleVersions";
         internal const string PSCLRVersionName = "CLRVersion";
@@ -65,7 +64,6 @@ namespace System.Management.Automation
 
             s_psVersionTable[PSVersionInfo.PSVersionName] = s_psV6Version;
             s_psVersionTable[PSVersionInfo.PSEditionName] = PSEditionValue;
-            s_psVersionTable[PSBuildVersionName] = GetBuildVersion();
             s_psVersionTable[PSGitCommitIdName] = GetCommitInfo();
             s_psVersionTable[PSCompatibleVersionsName] = new Version[] { s_psV1Version, s_psV2Version, s_psV3Version, s_psV4Version, s_psV5Version, s_psV51Version, s_psV6Version };
             s_psVersionTable[PSVersionInfo.SerializationVersionName] = new Version(InternalSerializer.DefaultVersion);
@@ -92,13 +90,6 @@ namespace System.Management.Automation
             // Downlevel systems don't support SemanticVersion, but Version is most likely good enough anyway.
             result[PSVersionInfo.PSVersionName] = (Version)(SemanticVersion)s_psVersionTable[PSVersionInfo.PSVersionName];
             return result;
-        }
-
-        internal static Version GetBuildVersion()
-        {
-            string assemblyPath = typeof(PSVersionInfo).GetTypeInfo().Assembly.Location;
-            string buildVersion = FileVersionInfo.GetVersionInfo(assemblyPath).FileVersion;
-            return new Version(buildVersion);
         }
 
         // Get the commit id from the powershell.version file. If the powershell.version file doesn't exist, use the string "N/A"
@@ -176,14 +167,6 @@ namespace System.Management.Automation
             get
             {
                 return (Version)GetPSVersionTable()[PSCLRVersionName];
-            }
-        }
-
-        internal static Version BuildVersion
-        {
-            get
-            {
-                return (Version)GetPSVersionTable()[PSBuildVersionName];
             }
         }
 

--- a/src/System.Management.Automation/engine/remoting/client/clientremotesession.cs
+++ b/src/System.Management.Automation/engine/remoting/client/clientremotesession.cs
@@ -531,7 +531,7 @@ namespace System.Management.Automation.Remoting
                     new PSRemotingDataStructureException(RemotingErrorIdStrings.ClientNegotiationFailed,
                         RemoteDataNameStrings.PS_STARTUP_PROTOCOL_VERSION_NAME,
                         serverProtocolVersion,
-                        PSVersionInfo.BuildVersion,
+                        PSVersionInfo.GitCommitId,
                         RemotingConstants.ProtocolVersion);
                 throw reasonOfFailure;
             }
@@ -545,7 +545,7 @@ namespace System.Management.Automation.Remoting
                     new PSRemotingDataStructureException(RemotingErrorIdStrings.ClientNegotiationFailed,
                         RemoteDataNameStrings.PSVersion,
                         serverPSVersion.ToString(),
-                        PSVersionInfo.BuildVersion,
+                        PSVersionInfo.GitCommitId,
                         RemotingConstants.ProtocolVersion);
                 throw reasonOfFailure;
             }
@@ -559,7 +559,7 @@ namespace System.Management.Automation.Remoting
                     new PSRemotingDataStructureException(RemotingErrorIdStrings.ClientNegotiationFailed,
                         RemoteDataNameStrings.SerializationVersion,
                         serverSerVersion.ToString(),
-                        PSVersionInfo.BuildVersion,
+                        PSVersionInfo.GitCommitId,
                         RemotingConstants.ProtocolVersion);
                 throw reasonOfFailure;
             }

--- a/src/System.Management.Automation/engine/remoting/client/remotingprotocolimplementation.cs
+++ b/src/System.Management.Automation/engine/remoting/client/remotingprotocolimplementation.cs
@@ -638,7 +638,7 @@ namespace System.Management.Automation.Remoting
                         // this will happen if expected properties are not
                         // received for session capability
                         throw new PSRemotingDataStructureException(RemotingErrorIdStrings.ClientNotFoundCapabilityProperties,
-                            dse.Message, PSVersionInfo.BuildVersion, RemotingConstants.ProtocolVersion);
+                            dse.Message, PSVersionInfo.GitCommitId, RemotingConstants.ProtocolVersion);
                     }
 
                     RemoteSessionStateMachineEventArgs capabilityArg = new RemoteSessionStateMachineEventArgs(RemoteSessionEvent.NegotiationReceived);

--- a/src/System.Management.Automation/engine/remoting/fanin/WSManPlugin.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/WSManPlugin.cs
@@ -1056,7 +1056,7 @@ namespace System.Management.Automation.Remoting
                             StringUtil.Format(
                                 RemotingErrorIdStrings.WSManPluginOptionNotUnderstood,
                                 option.name,
-                                System.Management.Automation.PSVersionInfo.BuildVersion,
+                                System.Management.Automation.PSVersionInfo.GitCommitId,
                                 WSManPluginConstants.PowerShellStartupProtocolVersionValue));
                         return false;
                     }
@@ -1071,7 +1071,7 @@ namespace System.Management.Automation.Remoting
                     StringUtil.Format(
                         RemotingErrorIdStrings.WSManPluginProtocolVersionNotFound,
                         WSManPluginConstants.PowerShellStartupProtocolVersionName,
-                        System.Management.Automation.PSVersionInfo.BuildVersion,
+                        System.Management.Automation.PSVersionInfo.GitCommitId,
                         WSManPluginConstants.PowerShellStartupProtocolVersionValue));
                 return false;
             }
@@ -1113,7 +1113,7 @@ namespace System.Management.Automation.Remoting
                 StringUtil.Format(
                     RemotingErrorIdStrings.WSManPluginProtocolVersionNotMatch,
                     WSManPluginConstants.PowerShellStartupProtocolVersionValue,
-                    System.Management.Automation.PSVersionInfo.BuildVersion,
+                    System.Management.Automation.PSVersionInfo.GitCommitId,
                     clientVersionString));
             return false;
         }

--- a/src/System.Management.Automation/engine/remoting/server/serverremotesession.cs
+++ b/src/System.Management.Automation/engine/remoting/server/serverremotesession.cs
@@ -1042,7 +1042,7 @@ namespace System.Management.Automation.Remoting
                         new PSRemotingDataStructureException(RemotingErrorIdStrings.ServerConnectFailedOnNegotiation,
                             RemoteDataNameStrings.PS_STARTUP_PROTOCOL_VERSION_NAME,
                             clientProtocolVersion,
-                            PSVersionInfo.BuildVersion,
+                            PSVersionInfo.GitCommitId,
                             RemotingConstants.ProtocolVersion);
                     throw reasonOfFailure;
                 }
@@ -1092,7 +1092,7 @@ namespace System.Management.Automation.Remoting
                         new PSRemotingDataStructureException(RemotingErrorIdStrings.ServerNegotiationFailed,
                             RemoteDataNameStrings.PS_STARTUP_PROTOCOL_VERSION_NAME,
                             clientProtocolVersion,
-                            PSVersionInfo.BuildVersion,
+                            PSVersionInfo.GitCommitId,
                             RemotingConstants.ProtocolVersion);
                     throw reasonOfFailure;
                 }
@@ -1108,7 +1108,7 @@ namespace System.Management.Automation.Remoting
                     new PSRemotingDataStructureException(RemotingErrorIdStrings.ServerNegotiationFailed,
                         RemoteDataNameStrings.PSVersion,
                         clientPSVersion,
-                        PSVersionInfo.BuildVersion,
+                        PSVersionInfo.GitCommitId,
                         RemotingConstants.ProtocolVersion);
                 throw reasonOfFailure;
             }
@@ -1123,7 +1123,7 @@ namespace System.Management.Automation.Remoting
                     new PSRemotingDataStructureException(RemotingErrorIdStrings.ServerNegotiationFailed,
                         RemoteDataNameStrings.SerializationVersion,
                         clientSerVersion,
-                        PSVersionInfo.BuildVersion,
+                        PSVersionInfo.GitCommitId,
                         RemotingConstants.ProtocolVersion);
                 throw reasonOfFailure;
             }

--- a/src/System.Management.Automation/engine/remoting/server/serverremotingprotocolimplementation.cs
+++ b/src/System.Management.Automation/engine/remoting/server/serverremotingprotocolimplementation.cs
@@ -211,7 +211,7 @@ namespace System.Management.Automation.Remoting
                         // this will happen if expected properties are not
                         // received for session capability
                         throw new PSRemotingDataStructureException(RemotingErrorIdStrings.ServerNotFoundCapabilityProperties,
-                            dse.Message, PSVersionInfo.BuildVersion, RemotingConstants.ProtocolVersion);
+                            dse.Message, PSVersionInfo.GitCommitId, RemotingConstants.ProtocolVersion);
                     }
 
                     RemoteSessionStateMachineEventArgs capabilityArg = new RemoteSessionStateMachineEventArgs(RemoteSessionEvent.NegotiationReceived);

--- a/test/powershell/Host/PSVersionTable.Tests.ps1
+++ b/test/powershell/Host/PSVersionTable.Tests.ps1
@@ -1,6 +1,6 @@
 Describe "PSVersionTable" -Tags "CI" {
     It "Should have version table entries" {
-       $PSVersionTable.Count | Should Be 11
+       $PSVersionTable.Count | Should Be 10
     }
 
     It "Should have the right version table entries" {
@@ -9,7 +9,6 @@ Describe "PSVersionTable" -Tags "CI" {
        $PSVersionTable.ContainsKey("WSManStackVersion")         | Should Be True
        $PSVersionTable.ContainsKey("SerializationVersion")      | Should Be True
        $PSVersionTable.ContainsKey("CLRVersion")                | Should Be True
-       $PSVersionTable.ContainsKey("BuildVersion")              | Should Be True
        $PSVersionTable.ContainsKey("PSCompatibleVersions")      | Should Be True
        $PSVersionTable.ContainsKey("PSRemotingProtocolVersion") | Should Be True
        $PSVersionTable.ContainsKey("GitCommitId")               | Should Be True


### PR DESCRIPTION
Close #1415

Motivation
------
PowerShell Committee concluded to remove BuildVersion property from `$PSVersionTable` as unneeded - now we use new `GitCommitId` property.

Fix
---
Remove BuildVersion from PSVersionHashTable and PSVersionInfo types and replace `BuildVersion` with `GitCommitId` in codes.
