### PR TITLE
Make Move-Item work with its -Include, -Exclude, and -Filter parameters

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Navigation.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Navigation.cs
@@ -3510,7 +3510,7 @@ namespace Microsoft.PowerShell.Commands
             Collection<PathInfo> results = new Collection<PathInfo>();
             try
             {
-                results = SessionState.Path.GetResolvedPSPathFromPSPath(path);
+                results = SessionState.Path.GetResolvedPSPathFromPSPath(path, CmdletProviderContext);
             }
             catch (PSNotSupportedException notSupported)
             {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Move-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Move-Item.Tests.ps1
@@ -11,4 +11,73 @@ Describe "Move-Item tests" -Tag "CI" {
         test-path $target | Should be $true
         "$target" | Should ContainExactly "This is content"
     }
+
+    Context "Move-Item with filters" {
+        BeforeAll {
+            $filterPath = "$TESTDRIVE/filterTests"
+            $moveToPath = "$TESTDRIVE/dest-dir"
+            $renameToPath = Join-Path $filterPath "move.txt"
+            $filePath = Join-Path $filterPath "*"
+            $fooFile = "foo.txt"
+            $barFile = "bar.txt"
+            $booFile = "boo.txt"
+            $fooPath = Join-Path $filterPath $fooFile
+            $barPath = Join-Path $filterPath $barFile
+            $booPath = Join-Path $filterPath $booFile
+            $newFooPath = Join-Path $moveToPath $fooFile
+            $newBarPath = Join-Path $moveToPath $barFile
+            $newBooPath = Join-Path $moveToPath $booFile
+            $fooContent = "foo content"
+            $barContent = "bar content"
+            $booContent = "boo content"
+        }
+        BeforeEach {
+            New-Item -ItemType Directory -Path $filterPath
+            New-Item -ItemType Directory -Path $moveToPath
+            New-Item -ItemType File -Path $fooPath -Value $fooContent
+            New-Item -ItemType File -Path $barPath -Value $barContent
+            New-Item -ItemType File -Path $booPath -Value $booContent
+        }
+        AfterEach {
+            Remove-Item $filterPath -Recurse -Force -ErrorAction SilentlyContinue
+            Remove-Item $moveToPath -Recurse -Force -ErrorAction SilentlyContinue
+        }
+        It "Can move to different directory, filtered with -Include" {
+            Move-Item -Path $filePath -Destination $moveToPath -Include "bar*"
+            Test-Path -Path $barPath | Should Be $false
+            Test-Path -Path $newBarPath | Should Be $true
+            $newBarPath | Should ContainExactly $barContent
+        }
+        It "Can move to different directory, filtered with -Exclude" {
+            Move-Item -Path $filePath -Destination $moveToPath -Exclude "b*"
+            Test-Path -Path $fooPath | Should Be $false
+            Test-Path -Path $newFooPath | Should Be $true
+            $newFooPath | Should ContainExactly $fooContent
+        }
+        It "Can move to different directory, filtered with -Filter" {
+            Move-Item -Path $filePath -Destination $moveToPath -Filter "bo*"
+            Test-Path -Path $booPath | Should Be $false
+            Test-Path -Path $newBooPath | Should Be $true
+            $newBooPath | Should ContainExactly $booContent
+        }
+
+        It "Can rename via move, filtered with -Include" {
+            Move-Item -Path $filePath -Destination $renameToPath -Include "bar*"
+            Test-Path -Path $renameToPath | Should Be $true
+            Test-Path -Path $barPath | Should Be $false
+            $renameToPath | Should ContainExactly $barContent
+        }
+        It "Can rename via move, filtered with -Exclude" {
+            Move-Item -Path $filePath -Destination $renameToPath -Exclude "b*"
+            Test-Path -Path $renameToPath | Should Be $true
+            Test-Path -Path $fooPath | Should Be $false
+            $renameToPath | Should ContainExactly $fooContent
+        }
+        It "Can rename via move, filtered with -Filter" {
+            Move-Item -Path $filePath -Destination $renameToPath -Filter "bo*"
+            Test-Path -Path $renameToPath | Should Be $true
+            Test-Path -Path $booPath | Should Be $false
+            $renameToPath | Should ContainExactly $booContent
+        }
+    }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Move-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Move-Item.Tests.ps1
@@ -44,39 +44,57 @@ Describe "Move-Item tests" -Tag "CI" {
         }
         It "Can move to different directory, filtered with -Include" {
             Move-Item -Path $filePath -Destination $moveToPath -Include "bar*"
+            $? | Should Be $true
             Test-Path -Path $barPath | Should Be $false
             Test-Path -Path $newBarPath | Should Be $true
+            Test-Path -Path $booPath | Should Be $true
+            Test-Path -Path $fooPath | Should Be $true
             $newBarPath | Should ContainExactly $barContent
         }
         It "Can move to different directory, filtered with -Exclude" {
             Move-Item -Path $filePath -Destination $moveToPath -Exclude "b*"
+            $? | Should Be $true
             Test-Path -Path $fooPath | Should Be $false
             Test-Path -Path $newFooPath | Should Be $true
+            Test-Path -Path $booPath | Should Be $true
+            Test-Path -Path $barPath | Should Be $true
             $newFooPath | Should ContainExactly $fooContent
         }
         It "Can move to different directory, filtered with -Filter" {
             Move-Item -Path $filePath -Destination $moveToPath -Filter "bo*"
+            $? | Should Be $true
             Test-Path -Path $booPath | Should Be $false
             Test-Path -Path $newBooPath | Should Be $true
+            Test-Path -Path $barPath | Should Be $true
+            Test-Path -Path $fooPath | Should Be $true
             $newBooPath | Should ContainExactly $booContent
         }
 
         It "Can rename via move, filtered with -Include" {
             Move-Item -Path $filePath -Destination $renameToPath -Include "bar*"
+            $? | Should Be $true
             Test-Path -Path $renameToPath | Should Be $true
             Test-Path -Path $barPath | Should Be $false
+            Test-Path -Path $booPath | Should Be $true
+            Test-Path -Path $fooPath | Should Be $true
             $renameToPath | Should ContainExactly $barContent
         }
         It "Can rename via move, filtered with -Exclude" {
             Move-Item -Path $filePath -Destination $renameToPath -Exclude "b*"
+            $? | Should Be $true
             Test-Path -Path $renameToPath | Should Be $true
             Test-Path -Path $fooPath | Should Be $false
+            Test-Path -Path $booPath | Should Be $true
+            Test-Path -Path $barPath | Should Be $true
             $renameToPath | Should ContainExactly $fooContent
         }
         It "Can rename via move, filtered with -Filter" {
             Move-Item -Path $filePath -Destination $renameToPath -Filter "bo*"
+            $? | Should Be $true
             Test-Path -Path $renameToPath | Should Be $true
             Test-Path -Path $booPath | Should Be $false
+            Test-Path -Path $fooPath | Should Be $true
+            Test-Path -Path $barPath | Should Be $true
             $renameToPath | Should ContainExactly $booContent
         }
     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Move-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Move-Item.Tests.ps1
@@ -45,7 +45,6 @@ Describe "Move-Item tests" -Tag "CI" {
         It "Can move to different directory, filtered with -Include" {
             Move-Item -Path $filePath -Destination $moveToPath -Include "bar*" -ErrorVariable e -ErrorAction SilentlyContinue
             $e | Should BeNullOrEmpty
-            #Test-Path -Path $barPath | Should Be $false
             $barPath | Should Not Exist
             $newBarPath | Should Exist
             $booPath | Should Exist

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Move-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Move-Item.Tests.ps1
@@ -32,69 +32,70 @@ Describe "Move-Item tests" -Tag "CI" {
             $booContent = "boo content"
         }
         BeforeEach {
-            New-Item -ItemType Directory -Path $filterPath
-            New-Item -ItemType Directory -Path $moveToPath
-            New-Item -ItemType File -Path $fooPath -Value $fooContent
-            New-Item -ItemType File -Path $barPath -Value $barContent
-            New-Item -ItemType File -Path $booPath -Value $booContent
+            New-Item -ItemType Directory -Path $filterPath | Out-Null
+            New-Item -ItemType Directory -Path $moveToPath | Out-Null
+            New-Item -ItemType File -Path $fooPath -Value $fooContent | Out-Null
+            New-Item -ItemType File -Path $barPath -Value $barContent | Out-Null
+            New-Item -ItemType File -Path $booPath -Value $booContent | Out-Null
         }
         AfterEach {
             Remove-Item $filterPath -Recurse -Force -ErrorAction SilentlyContinue
             Remove-Item $moveToPath -Recurse -Force -ErrorAction SilentlyContinue
         }
         It "Can move to different directory, filtered with -Include" {
-            Move-Item -Path $filePath -Destination $moveToPath -Include "bar*"
-            $? | Should Be $true
-            Test-Path -Path $barPath | Should Be $false
-            Test-Path -Path $newBarPath | Should Be $true
-            Test-Path -Path $booPath | Should Be $true
-            Test-Path -Path $fooPath | Should Be $true
+            Move-Item -Path $filePath -Destination $moveToPath -Include "bar*" -ErrorVariable e -ErrorAction SilentlyContinue
+            $e | Should BeNullOrEmpty
+            #Test-Path -Path $barPath | Should Be $false
+            $barPath | Should Not Exist
+            $newBarPath | Should Exist
+            $booPath | Should Exist
+            $fooPath | Should Exist
             $newBarPath | Should ContainExactly $barContent
         }
         It "Can move to different directory, filtered with -Exclude" {
-            Move-Item -Path $filePath -Destination $moveToPath -Exclude "b*"
-            $? | Should Be $true
-            Test-Path -Path $fooPath | Should Be $false
-            Test-Path -Path $newFooPath | Should Be $true
-            Test-Path -Path $booPath | Should Be $true
-            Test-Path -Path $barPath | Should Be $true
+            Move-Item -Path $filePath -Destination $moveToPath -Exclude "b*" -ErrorVariable e -ErrorAction SilentlyContinue
+            $e | Should BeNullOrEmpty
+            $fooPath | Should Not Exist
+            $newFooPath | Should Exist
+            $booPath | Should Exist
+            $barPath | Should Exist
             $newFooPath | Should ContainExactly $fooContent
         }
         It "Can move to different directory, filtered with -Filter" {
-            Move-Item -Path $filePath -Destination $moveToPath -Filter "bo*"
-            $? | Should Be $true
-            Test-Path -Path $booPath | Should Be $false
-            Test-Path -Path $newBooPath | Should Be $true
-            Test-Path -Path $barPath | Should Be $true
-            Test-Path -Path $fooPath | Should Be $true
+            Move-Item -Path $filePath -Destination $moveToPath -Filter "bo*" -ErrorVariable e -ErrorAction SilentlyContinue
+            $e | Should BeNullOrEmpty
+            $booPath | Should Not Exist
+            $newBooPath | Should Exist
+            $barPath | Should Exist
+            $fooPath | Should Exist
             $newBooPath | Should ContainExactly $booContent
         }
 
         It "Can rename via move, filtered with -Include" {
-            Move-Item -Path $filePath -Destination $renameToPath -Include "bar*"
-            $? | Should Be $true
-            Test-Path -Path $renameToPath | Should Be $true
-            Test-Path -Path $barPath | Should Be $false
-            Test-Path -Path $booPath | Should Be $true
-            Test-Path -Path $fooPath | Should Be $true
+            Move-Item -Path $filePath -Destination $renameToPath -Include "bar*" -ErrorVariable e -ErrorAction SilentlyContinue
+            $e | Should BeNullOrEmpty
+            $renameToPath | Should Exist
+            $barPath | Should Not Exist
+            $booPath | Should Exist
+            $fooPath | Should Exist
             $renameToPath | Should ContainExactly $barContent
         }
         It "Can rename via move, filtered with -Exclude" {
-            Move-Item -Path $filePath -Destination $renameToPath -Exclude "b*"
-            $? | Should Be $true
-            Test-Path -Path $renameToPath | Should Be $true
-            Test-Path -Path $fooPath | Should Be $false
-            Test-Path -Path $booPath | Should Be $true
-            Test-Path -Path $barPath | Should Be $true
+            Move-Item -Path $filePath -Destination $renameToPath -Exclude "b*" -ErrorVariable e -ErrorAction SilentlyContinue
+            $e | Should BeNullOrEmpty
+            $renameToPath | Should Exist
+            $fooPath | Should Not Exist
+            $booPath | Should Exist
+            $barPath | Should Exist
             $renameToPath | Should ContainExactly $fooContent
         }
         It "Can rename via move, filtered with -Filter" {
-            Move-Item -Path $filePath -Destination $renameToPath -Filter "bo*"
-            $? | Should Be $true
-            Test-Path -Path $renameToPath | Should Be $true
-            Test-Path -Path $booPath | Should Be $false
-            Test-Path -Path $fooPath | Should Be $true
-            Test-Path -Path $barPath | Should Be $true
+            Move-Item -Path $filePath -Destination $renameToPath -Filter "bo*" -ErrorVariable e -ErrorAction SilentlyContinue
+            $e | Should BeNullOrEmpty
+            $renameToPath | Should Exist
+            $booPath | Should Not Exist
+            $fooPath | Should Exist
+            $barPath | Should Exist
             $renameToPath | Should ContainExactly $booContent
         }
     }


### PR DESCRIPTION
Fixed #2385 

Invoke the correct overload of SessionState.Path.GetResolvedPSPathFromPSPath, passing the cmdlet context object.