### PR TITLE
Update regular expression to filter out Json contents that do not start with an array for ConvertFrom-Json.

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/JsonObject.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/JsonObject.cs
@@ -53,8 +53,8 @@ namespace Microsoft.PowerShell.Commands
                 // This issue is being tracked by https://github.com/JamesNK/Newtonsoft.Json/issues/1321.
                 // To work around this, we need to identify when input is a Json array, and then try to parse it via JArray.Parse().
 
-                // If input starts with '[' or ends with ']' (ignoring white spaces).
-                if ((Regex.Match(input, @"(^\s*\[)|(\s*\]$)")).Success)
+                // If input starts with '[' (ignoring white spaces).
+                if ((Regex.Match(input, @"^\s*\[")).Success)
                 {
                     // JArray.Parse() will throw a JsonException if the array is invalid.
                     // This will be caught by the catch block below, and then throw an


### PR DESCRIPTION
<!--

If you are a PowerShell Team member, please make sure you choose the Reviewer(s) and Assignee for your PR.
If you are not from the PowerShell Team, you can leave the fields blank and the Maintainers will choose them for you. If you are familiar with the team, feel free to mention some Reviewers yourself.

For more information about the roles of Reviewer and Assignee, refer to CONTRIBUTING.md.

-->

Updated regular expression to filter out Json contents which do not start with an array. Originally, we were looking at Json contents which started and ended with the array markers (‘[‘ and ‘]’); however, there is no need to have an end marker check. The reason for this is that we are only trying to detect an invalid array when multiple lines are piped to ConvertFrom-Json, and these will always start with ‘[‘. If an array is detected (starts with ‘[‘), then it will be validated by JArray.Parse(input).
