### PR TITLE
Move to latest .NET Core and enable `-SkipCertificateCheck` on OSX

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ version: 6.0.0-beta.2-{build}
 
 image: Visual Studio 2015
 
-# cache version - netcoreapp.2.0.0-preview2-25324-03
+# cache version - netcoreapp.2.0.0-preview2-25407-01
 cache:
   - '%LocalAppData%\Microsoft\dotnet -> appveyor.yml'
   - '%HOMEDRIVE%%HOMEPATH%\.nuget\packages -> appveyor.yml'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ version: 6.0.0-beta.2-{build}
 
 image: Visual Studio 2015
 
-# cache version - netcoreapp.2.0.0-preview1-002106-00
+# cache version - netcoreapp.2.0.0-preview2-25324-03
 cache:
   - '%LocalAppData%\Microsoft\dotnet -> appveyor.yml'
   - '%HOMEDRIVE%%HOMEPATH%\.nuget\packages -> appveyor.yml'

--- a/build.psm1
+++ b/build.psm1
@@ -982,7 +982,7 @@ function Install-Dotnet {
     [CmdletBinding()]
     param(
         [string]$Channel = "preview",
-        [string]$Version = "2.0.0-preview1-005952",
+        [string]$Version = "2.0.0-preview2-006195",
         [switch]$NoSudo
     )
 
@@ -1044,7 +1044,7 @@ function Start-PSBootstrap {
         [string]$Channel = "preview",
         # we currently pin dotnet-cli version, and will
         # update it when more stable version comes out.
-        [string]$Version = "2.0.0-preview1-005952",
+        [string]$Version = "2.0.0-preview2-006195",
         [switch]$Package,
         [switch]$NoSudo,
         [switch]$Force

--- a/build.psm1
+++ b/build.psm1
@@ -982,7 +982,7 @@ function Install-Dotnet {
     [CmdletBinding()]
     param(
         [string]$Channel = "preview",
-        [string]$Version = "2.0.0-preview2-006195",
+        [string]$Version = "2.0.0-preview2-006388",
         [switch]$NoSudo
     )
 
@@ -1044,7 +1044,7 @@ function Start-PSBootstrap {
         [string]$Channel = "preview",
         # we currently pin dotnet-cli version, and will
         # update it when more stable version comes out.
-        [string]$Version = "2.0.0-preview2-006195",
+        [string]$Version = "2.0.0-preview2-006388",
         [switch]$Package,
         [switch]$NoSudo,
         [switch]$Force

--- a/src/Microsoft.PowerShell.Commands.Management/Microsoft.PowerShell.Commands.Management.csproj
+++ b/src/Microsoft.PowerShell.Commands.Management/Microsoft.PowerShell.Commands.Management.csproj
@@ -78,7 +78,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.ServiceProcess.ServiceController" Version="4.4.0-preview1-25302-01" />
+    <PackageReference Include="System.ServiceProcess.ServiceController" Version="4.4.0-preview2-25324-02" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.PowerShell.Commands.Management/Microsoft.PowerShell.Commands.Management.csproj
+++ b/src/Microsoft.PowerShell.Commands.Management/Microsoft.PowerShell.Commands.Management.csproj
@@ -78,7 +78,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.ServiceProcess.ServiceController" Version="4.4.0-preview2-25324-02" />
+    <PackageReference Include="System.ServiceProcess.ServiceController" Version="4.4.0-preview2-25405-01" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.PowerShell.Commands.Utility/Microsoft.PowerShell.Commands.Utility.csproj
+++ b/src/Microsoft.PowerShell.Commands.Utility/Microsoft.PowerShell.Commands.Utility.csproj
@@ -90,7 +90,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.0.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.1.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.PowerShell.Commands.Utility/Microsoft.PowerShell.Commands.Utility.csproj
+++ b/src/Microsoft.PowerShell.Commands.Utility/Microsoft.PowerShell.Commands.Utility.csproj
@@ -90,7 +90,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.1.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.2.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebRequestPSCmdlet.CoreClr.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebRequestPSCmdlet.CoreClr.cs
@@ -147,7 +147,7 @@ namespace Microsoft.PowerShell.Commands
 
             if (SkipCertificateCheck)
             {
-                handler.ServerCertificateCustomValidationCallback = delegate { return true; };
+                handler.ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator;
             }
 
             if (WebSession.MaximumRedirection > -1)

--- a/src/Microsoft.PowerShell.ConsoleHost/Microsoft.PowerShell.ConsoleHost.csproj
+++ b/src/Microsoft.PowerShell.ConsoleHost/Microsoft.PowerShell.ConsoleHost.csproj
@@ -25,7 +25,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\System.Management.Automation\System.Management.Automation.csproj" />
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.2.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.3.0" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/Microsoft.PowerShell.CoreCLR.Eventing/Microsoft.PowerShell.CoreCLR.Eventing.csproj
+++ b/src/Microsoft.PowerShell.CoreCLR.Eventing/Microsoft.PowerShell.CoreCLR.Eventing.csproj
@@ -32,7 +32,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Security.Principal.Windows" Version="4.4.0-preview2-25324-02" />
+    <PackageReference Include="System.Security.Principal.Windows" Version="4.4.0-preview2-25405-01" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.PowerShell.CoreCLR.Eventing/Microsoft.PowerShell.CoreCLR.Eventing.csproj
+++ b/src/Microsoft.PowerShell.CoreCLR.Eventing/Microsoft.PowerShell.CoreCLR.Eventing.csproj
@@ -32,7 +32,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Security.Principal.Windows" Version="4.4.0-preview1-25302-01" />
+    <PackageReference Include="System.Security.Principal.Windows" Version="4.4.0-preview2-25324-02" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.PowerShell.SDK/Microsoft.PowerShell.SDK.csproj
+++ b/src/Microsoft.PowerShell.SDK/Microsoft.PowerShell.SDK.csproj
@@ -17,17 +17,17 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Data.SqlClient" Version="4.4.0-preview1-25302-01" />
-    <PackageReference Include="System.IO.Packaging" Version="4.4.0-preview1-25302-01" />
-    <PackageReference Include="System.Net.Http.WinHttpHandler" Version="4.4.0-preview1-25302-01" />
-    <PackageReference Include="System.ServiceModel.Duplex" Version="4.4.0-preview1-25302-01" />
-    <PackageReference Include="System.ServiceModel.Http" Version="4.4.0-preview1-25302-01" />
-    <PackageReference Include="System.ServiceModel.NetTcp" Version="4.4.0-preview1-25302-01" />
-    <PackageReference Include="System.ServiceModel.Primitives" Version="4.4.0-preview1-25302-01" />
-    <PackageReference Include="System.ServiceModel.Security" Version="4.4.0-preview1-25302-01" />
-    <PackageReference Include="System.Text.Encodings.Web" Version="4.4.0-preview1-25302-01" />
-    <PackageReference Include="System.Threading.AccessControl" Version="4.4.0-preview1-25302-01" />
-    <PackageReference Include="System.Private.ServiceModel" Version="4.4.0-preview1-25302-01" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.4.0-preview2-25324-02" />
+    <PackageReference Include="System.IO.Packaging" Version="4.4.0-preview2-25324-02" />
+    <PackageReference Include="System.Net.Http.WinHttpHandler" Version="4.4.0-preview2-25324-02" />
+    <PackageReference Include="System.ServiceModel.Duplex" Version="4.4.0-preview2-25324-01" />
+    <PackageReference Include="System.ServiceModel.Http" Version="4.4.0-preview2-25324-01" />
+    <PackageReference Include="System.ServiceModel.NetTcp" Version="4.4.0-preview2-25324-01" />
+    <PackageReference Include="System.ServiceModel.Primitives" Version="4.4.0-preview2-25324-01" />
+    <PackageReference Include="System.ServiceModel.Security" Version="4.4.0-preview2-25324-01" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="4.4.0-preview2-25324-02" />
+    <PackageReference Include="System.Threading.AccessControl" Version="4.4.0-preview2-25324-02" />
+    <PackageReference Include="System.Private.ServiceModel" Version="4.4.0-preview2-25324-01" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.PowerShell.SDK/Microsoft.PowerShell.SDK.csproj
+++ b/src/Microsoft.PowerShell.SDK/Microsoft.PowerShell.SDK.csproj
@@ -17,17 +17,17 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Data.SqlClient" Version="4.4.0-preview2-25324-02" />
-    <PackageReference Include="System.IO.Packaging" Version="4.4.0-preview2-25324-02" />
-    <PackageReference Include="System.Net.Http.WinHttpHandler" Version="4.4.0-preview2-25324-02" />
-    <PackageReference Include="System.ServiceModel.Duplex" Version="4.4.0-preview2-25324-01" />
-    <PackageReference Include="System.ServiceModel.Http" Version="4.4.0-preview2-25324-01" />
-    <PackageReference Include="System.ServiceModel.NetTcp" Version="4.4.0-preview2-25324-01" />
-    <PackageReference Include="System.ServiceModel.Primitives" Version="4.4.0-preview2-25324-01" />
-    <PackageReference Include="System.ServiceModel.Security" Version="4.4.0-preview2-25324-01" />
-    <PackageReference Include="System.Text.Encodings.Web" Version="4.4.0-preview2-25324-02" />
-    <PackageReference Include="System.Threading.AccessControl" Version="4.4.0-preview2-25324-02" />
-    <PackageReference Include="System.Private.ServiceModel" Version="4.4.0-preview2-25324-01" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.4.0-preview2-25405-01" />
+    <PackageReference Include="System.IO.Packaging" Version="4.4.0-preview2-25405-01" />
+    <PackageReference Include="System.Net.Http.WinHttpHandler" Version="4.4.0-preview2-25405-01" />
+    <PackageReference Include="System.ServiceModel.Duplex" Version="4.4.0-preview2-25405-01" />
+    <PackageReference Include="System.ServiceModel.Http" Version="4.4.0-preview2-25405-01" />
+    <PackageReference Include="System.ServiceModel.NetTcp" Version="4.4.0-preview2-25405-01" />
+    <PackageReference Include="System.ServiceModel.Primitives" Version="4.4.0-preview2-25405-01" />
+    <PackageReference Include="System.ServiceModel.Security" Version="4.4.0-preview2-25405-01" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="4.4.0-preview2-25405-01" />
+    <PackageReference Include="System.Threading.AccessControl" Version="4.4.0-preview2-25405-01" />
+    <PackageReference Include="System.Private.ServiceModel" Version="4.4.0-preview2-25405-01" />
   </ItemGroup>
 
 </Project>

--- a/src/System.Management.Automation/System.Management.Automation.csproj
+++ b/src/System.Management.Automation/System.Management.Automation.csproj
@@ -19,12 +19,12 @@
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.PowerShell.CoreCLR.AssemblyLoadContext\Microsoft.PowerShell.CoreCLR.AssemblyLoadContext.csproj" />
     <ProjectReference Include="..\Microsoft.PowerShell.CoreCLR.Eventing\Microsoft.PowerShell.CoreCLR.Eventing.csproj" />
-    <PackageReference Include="Microsoft.Win32.Registry.AccessControl" Version="4.4.0-preview2-25324-02" />
+    <PackageReference Include="Microsoft.Win32.Registry.AccessControl" Version="4.4.0-preview2-25405-01" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.1" />
-    <PackageReference Include="System.IO.FileSystem.AccessControl" Version="4.4.0-preview2-25324-02" />
-    <PackageReference Include="System.Security.AccessControl" Version="4.4.0-preview2-25324-02" />
-    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="4.4.0-preview2-25324-02" />
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="4.4.0-preview2-25324-02" />
+    <PackageReference Include="System.IO.FileSystem.AccessControl" Version="4.4.0-preview2-25405-01" />
+    <PackageReference Include="System.Security.AccessControl" Version="4.4.0-preview2-25405-01" />
+    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="4.4.0-preview2-25405-01" />
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="4.4.0-preview2-25405-01" />
     <PackageReference Include="Microsoft.Management.Infrastructure" Version="1.0.0-alpha*" />
   </ItemGroup>
 

--- a/src/System.Management.Automation/System.Management.Automation.csproj
+++ b/src/System.Management.Automation/System.Management.Automation.csproj
@@ -19,12 +19,12 @@
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.PowerShell.CoreCLR.AssemblyLoadContext\Microsoft.PowerShell.CoreCLR.AssemblyLoadContext.csproj" />
     <ProjectReference Include="..\Microsoft.PowerShell.CoreCLR.Eventing\Microsoft.PowerShell.CoreCLR.Eventing.csproj" />
-    <PackageReference Include="Microsoft.Win32.Registry.AccessControl" Version="4.4.0-preview1-25302-01" />
+    <PackageReference Include="Microsoft.Win32.Registry.AccessControl" Version="4.4.0-preview2-25324-02" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.1" />
-    <PackageReference Include="System.IO.FileSystem.AccessControl" Version="4.4.0-preview1-25302-01" />
-    <PackageReference Include="System.Security.AccessControl" Version="4.4.0-preview1-25302-01" />
-    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="4.4.0-preview1-25302-01" />
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="4.4.0-preview1-25302-01" />
+    <PackageReference Include="System.IO.FileSystem.AccessControl" Version="4.4.0-preview2-25324-02" />
+    <PackageReference Include="System.Security.AccessControl" Version="4.4.0-preview2-25324-02" />
+    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="4.4.0-preview2-25324-02" />
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="4.4.0-preview2-25324-02" />
     <PackageReference Include="Microsoft.Management.Infrastructure" Version="1.0.0-alpha*" />
   </ItemGroup>
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ChildItem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ChildItem.Tests.ps1
@@ -66,7 +66,9 @@ Describe "Get-ChildItem" -Tags "CI" {
             $file.Count | Should be 1
             $file.Name | Should be "pagefile.sys"
         }
-        It "Should continue enumerating a directory when a contained item is deleted" {
+        # Test is pending on Unix platforms because of a behavior change in the latest .NET Core.
+        # Tracked by https://github.com/dotnet/corefx/issues/20456
+        It "Should continue enumerating a directory when a contained item is deleted" -Pending:(!$IsWindows) {
             $Error.Clear()
             [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook("GciEnumerationActionDelete", $true)
             $result = Get-ChildItem -Path $TestDrive -ErrorAction SilentlyContinue
@@ -84,7 +86,9 @@ Describe "Get-ChildItem" -Tags "CI" {
                 $result.Count | Should BeExactly 4
             }
         }
-        It "Should continue enumerating a directory when a contained item is renamed" {
+        # Test is pending on Unix platforms because of a behavior change in the latest .NET Core.
+        # Tracked by https://github.com/dotnet/corefx/issues/20456
+        It "Should continue enumerating a directory when a contained item is renamed" -Pending:(!$IsWindows) {
             $Error.Clear()
             [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook("GciEnumerationActionRename", $true)
             $result = Get-ChildItem -Path $TestDrive -ErrorAction SilentlyContinue

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -443,9 +443,7 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
         $jsonContent.headers.'User-Agent' | Should Match "WindowsPowerShell"
     }
 
-    ## 'HttpClientHandler.ServerCertificateCustomValidationCallback' currently doesn't work in netcoreapp2.0 on Mac at all.
-    ## This is tracked by powershell issue #3648.
-    It "Validate Invoke-WebRequest -SkipCertificateCheck" -Pending:$IsOSX {
+    It "Validate Invoke-WebRequest -SkipCertificateCheck" {
 
         # validate that exception is thrown for URI with expired certificate
         $command = "Invoke-WebRequest -Uri 'https://expired.badssl.com'"
@@ -837,9 +835,7 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
         $jsonContent.headers.'User-Agent' | Should Match "WindowsPowerShell"
     }
 
-    ## 'HttpClientHandler.ServerCertificateCustomValidationCallback' currently doesn't work in netcoreapp2.0 on Mac at all.
-    ## This is tracked by powershell issue #3648.
-    It "Validate Invoke-RestMethod -SkipCertificateCheck" -Pending:$IsOSX {
+    It "Validate Invoke-RestMethod -SkipCertificateCheck" {
 
         # HTTP method HEAD must be used to not retrieve an unparsable HTTP body
         # validate that exception is thrown for URI with expired certificate


### PR DESCRIPTION
Fix #3648

Summary
----------
A workaround has been made in .NET Core to allow accept any certificate: https://github.com/dotnet/corefx/issues/19709
To enable `-SkipCertificateCheck` in web cmdlets, we need to move to the latest .NET Core, and also use `HttpClientHandler.DangerousAcceptAnyServerCertificateValidator` as the callback delegate.

New Issues
------------
There are 2 problems with the latest .NET Core:
1. Behavior change in `FileSystemInfo.Attribute` causes 2 tests to fail on Unix platforms. https://github.com/dotnet/corefx/issues/20456 was filed to track the behavior change. These 2 tests are currently marked as `-Pending` for now.
2. VSCode C# extension doesn't support .NET Core `2.0.0-preview2-*` SDK. When using `2.0.0-preview2` packages and dotnet-cli, you will get a `MissingMethodException` opening the project in VSCode (see below). This is tracked by https://github.com/OmniSharp/omnisharp-vscode/issues/1495, and hopefully will be addressed this week according to this comment: https://github.com/OmniSharp/omnisharp-vscode/issues/1495#issuecomment-304547648
```
[fail]: OmniSharp.MSBuild.ProjectFile.ProjectFileInfo
        The "ResolvePackageDependencies" task failed unexpectedly.
System.MissingMethodException: Method not found: 'System.Collections.Generic.IList`1<NuGet.Packaging.Core.PackageDependency> NuGet.ProjectModel.LockFileTargetLibrary.get_Dependencies()'.
   at Microsoft.NET.Build.Tasks.ResolvePackageDependencies.GetPackageDependencies(LockFileTargetLibrary package, String targetName, Dictionary`2 resolvedPackageVersions, HashSet`1 transitiveProjectRefs)
   at Microsoft.NET.Build.Tasks.ResolvePackageDependencies.GetPackageAndFileDependencies(LockFileTarget target)
   at Microsoft.NET.Build.Tasks.ResolvePackageDependencies.RaiseLockFileTargets()
   at Microsoft.NET.Build.Tasks.ResolvePackageDependencies.ExecuteCore()
   at Microsoft.NET.Build.Tasks.TaskBase.Execute()
   at Microsoft.Build.BackEnd.TaskExecutionHost.Microsoft.Build.BackEnd.ITaskExecutionHost.Execute()
   at Microsoft.Build.BackEnd.TaskBuilder.<ExecuteInstantiatedTask>d__26.MoveNext()
```