### PR TITLE
Fixed ScriptsToProcess when -Version param is used in Import-Module

### DIFF
--- a/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
@@ -2769,37 +2769,57 @@ namespace Microsoft.PowerShell.Commands
 
             if (scriptsToProcess != null)
             {
-                foreach (string scriptFile in scriptsToProcess)
+                Version savedBaseMinimumVersion = BaseMinimumVersion;
+                Version savedBaseMaximumVersion = BaseMaximumVersion;
+                Version savedBaseRequiredVersion = BaseRequiredVersion;
+                Guid? savedBaseGuid = BaseGuid;
+
+                try
                 {
-                    bool found = false;
-                    PSModuleInfo module = LoadModule(scriptFile,
-                        moduleBase,
-                        string.Empty, // prefix (-Prefix shouldn't be applied to dot sourced scripts)
-                        null,
-                        ref options,
-                        manifestProcessingFlags,
-                        out found);
+                    BaseMinimumVersion = null;
+                    BaseMaximumVersion = null;
+                    BaseRequiredVersion = null;
+                    BaseGuid = null;
 
-                    // If we're in analysis, add the detected exports to this module's
-                    // exports
-                    if (found && (ss == null))
+                    foreach (string scriptFile in scriptsToProcess)
                     {
-                        foreach (string detectedCmdlet in module.ExportedCmdlets.Keys)
-                        {
-                            manifestInfo.AddDetectedCmdletExport(detectedCmdlet);
-                        }
+                        bool found = false;
+                        PSModuleInfo module = LoadModule(scriptFile,
+                            moduleBase,
+                            string.Empty, // prefix (-Prefix shouldn't be applied to dot sourced scripts)
+                            null,
+                            ref options,
+                            manifestProcessingFlags,
+                            out found);
 
-                        foreach (string detectedFunction in module.ExportedFunctions.Keys)
+                        // If we're in analysis, add the detected exports to this module's
+                        // exports
+                        if (found && (ss == null))
                         {
-                            manifestInfo.AddDetectedFunctionExport(detectedFunction);
-                        }
+                            foreach (string detectedCmdlet in module.ExportedCmdlets.Keys)
+                            {
+                                manifestInfo.AddDetectedCmdletExport(detectedCmdlet);
+                            }
 
-                        foreach (string detectedAlias in module.ExportedAliases.Keys)
-                        {
-                            manifestInfo.AddDetectedAliasExport(detectedAlias,
-                                module.ExportedAliases[detectedAlias].Definition);
+                            foreach (string detectedFunction in module.ExportedFunctions.Keys)
+                            {
+                                manifestInfo.AddDetectedFunctionExport(detectedFunction);
+                            }
+
+                            foreach (string detectedAlias in module.ExportedAliases.Keys)
+                            {
+                                manifestInfo.AddDetectedAliasExport(detectedAlias,
+                                    module.ExportedAliases[detectedAlias].Definition);
+                            }
                         }
                     }
+                }
+                finally
+                {
+                    BaseMinimumVersion = savedBaseMinimumVersion;
+                    BaseMaximumVersion = savedBaseMaximumVersion;
+                    BaseRequiredVersion = savedBaseRequiredVersion;
+                    BaseGuid = savedBaseGuid;
                 }
             }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Import-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Import-Module.Tests.ps1
@@ -38,7 +38,6 @@ Describe "Import-Module with ScriptsToProcess" -Tags "CI" {
 
     AfterAll {
         Pop-Location
-        #Remove-Item $moduleRootPath -Recurse -Force -ErrorAction SilentlyContinue
     }
 
     BeforeEach {

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Import-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Import-Module.Tests.ps1
@@ -49,24 +49,17 @@ Describe "Import-Module with ScriptsToProcess" -Tags "CI" {
         remove-module $m -Force -ErrorAction SilentlyContinue
         Remove-Item out.txt -Force -ErrorAction SilentlyContinue
     }
-    
-    It "Verify ScriptsToProcess are executed for top-level module" {
-        Import-Module .\module1.psd1
-        Get-Content out.txt | Should Be '1'
-    }
 
-    It "Verify ScriptsToProcess are executed for top-level and nested module" {
-        Import-Module .\module2.psd1
-        Get-Content out.txt | Should Be '21'
-    }
-    
-    It "Verify ScriptsToProcess are executed for top-level module when -Version is specified" {
-        Import-Module .\module1.psd1 -Version 1.0
-        Get-Content out.txt | Should Be '1'
-    }
+    $testCases = @(
+            @{ TestNameSuffix = 'for top-level module'; ipmoParms =  @{'Name'='.\module1.psd1'}; Expected = '1' }
+            @{ TestNameSuffix = 'for top-level and nested module'; ipmoParms =  @{'Name'='.\module2.psd1'}; Expected = '21' }
+            @{ TestNameSuffix = 'for top-level module when -Version is specified'; ipmoParms =  @{'Name'='.\module1.psd1'; 'Version'='1.0'}; Expected = '1' }
+            @{ TestNameSuffix = 'for top-level and nested module when -Version is specified'; ipmoParms =  @{'Name'='.\module2.psd1'; 'Version'='1.0'}; Expected = '21' }
+        )
 
-    It "Verify ScriptsToProcess are executed for top-level and nested module when -Version is specified" {
-        Import-Module .\module2.psd1 -Version 1.0
-        Get-Content out.txt | Should Be '21'
+    It "Verify ScriptsToProcess are executed <TestNameSuffix>" -TestCases $testCases {
+        param($TestNameSuffix,$ipmoParms,$Expected)
+        Import-Module @ipmoParms
+        Get-Content out.txt | Should Be $Expected
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Import-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Import-Module.Tests.ps1
@@ -22,3 +22,52 @@
         (Get-Module -Name $moduleName).Name | Should Be $moduleName
     }
 }
+
+Describe "Import-Module with ScriptsToProcess" -Tags "CI" {
+    
+    BeforeAll {
+        $moduleRootPath = Join-Path $TestDrive 'TestModules'
+        New-Item $moduleRootPath -ItemType Directory -Force | Out-Null
+        Push-Location $moduleRootPath
+
+        "1 | Out-File out.txt -Append -NoNewline" | Out-File script1.ps1
+        "2 | Out-File out.txt -Append -NoNewline" | Out-File script2.ps1
+        New-ModuleManifest module1.psd1 -ScriptsToProcess script1.ps1
+        New-ModuleManifest module2.psd1 -ScriptsToProcess script2.ps1 -NestedModules module1.psd1
+    }
+
+    AfterAll {
+        Pop-Location
+        #Remove-Item $moduleRootPath -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
+    BeforeEach {
+        New-Item out.txt -ItemType File -Force | Out-Null
+    }
+
+    AfterEach {
+        $m = @('module1','module2','script1','script2')
+        remove-module $m -Force -ErrorAction SilentlyContinue
+        Remove-Item out.txt -Force -ErrorAction SilentlyContinue
+    }
+    
+    It "Verify ScriptsToProcess are executed for top-level module" {
+        Import-Module .\module1.psd1
+        Get-Content out.txt | Should Be '1'
+    }
+
+    It "Verify ScriptsToProcess are executed for top-level and nested module" {
+        Import-Module .\module2.psd1
+        Get-Content out.txt | Should Be '21'
+    }
+    
+    It "Verify ScriptsToProcess are executed for top-level module when -Version is specified" {
+        Import-Module .\module1.psd1 -Version 1.0
+        Get-Content out.txt | Should Be '1'
+    }
+
+    It "Verify ScriptsToProcess are executed for top-level and nested module when -Version is specified" {
+        Import-Module .\module2.psd1 -Version 1.0
+        Get-Content out.txt | Should Be '21'
+    }
+}


### PR DESCRIPTION
This is fix for #3738 "ScriptsToProcess not honored when Import-Module is passed -Version param".

The bug was cased by existing check in LoadModule functions:

> If  MinimumVersion/RequiredVersion/MaximumVersion has been specified, then only try to process manifest modules...
> If the -Version flag was specified, don't look for non-manifest modules.

When loading usual module files, this check is valid;
However, same LoadModule function is used to load ScriptsToProcess - and this when this check was 
triggered and ScriptsToProcess were not executed.

The fix is to work around that condition for ScriptsToProcess in the same way it is currently done for NestedModules - temporary reset the version info for the duration of processing ScriptsToProcess / NestedModules.

Test results before the fix:
![befoerfix](https://cloud.githubusercontent.com/assets/11860095/26646461/92a7ddf0-45f0-11e7-9327-c8d08b3c7612.png)

Test results after the fix:
![afterfix](https://cloud.githubusercontent.com/assets/11860095/26646462/92a9f7c0-45f0-11e7-8848-54cd63e8741b.png)