### PR TITLE
Added functionality to load Windows Powershell Modules

### DIFF
--- a/src/System.Management.Automation/engine/PropertyAccessor.cs
+++ b/src/System.Management.Automation/engine/PropertyAccessor.cs
@@ -108,6 +108,12 @@ namespace System.Management.Automation
         internal abstract string GetDefaultSourcePath();
         internal abstract void SetDefaultSourcePath(string defaultPath);
 
+        /// <summary>
+        /// Allow loading assemblies by searching in GAC.
+        /// </summary>
+        /// <returns>Boolean indicating whether assemblies should be loaded from the GAC</returns>
+        internal abstract bool GetAllowGacLoading();
+
         #endregion // Interface Methods
     }
 
@@ -316,6 +322,16 @@ namespace System.Management.Automation
             string fileName = Path.Combine(psHomeConfigDirectory, configFileName);
 
             WriteValueToFile<string>(fileName, "DefaultSourcePath", defaultPath);
+        }
+
+        /// <summary>
+        /// Allow loading assemblies by searching in GAC.
+        /// </summary>
+        /// <returns>Boolean indicating whether assemblies should be loaded from the GAC</returns>
+        internal override bool GetAllowGacLoading()
+        {
+            string fileName = Path.Combine(psHomeConfigDirectory, configFileName);
+            return ReadValueFromFile<bool>(fileName, "AllowGacLoading");
         }
 
         private T ReadValueFromFile<T>(string fileName, string key)
@@ -678,6 +694,15 @@ namespace System.Management.Automation
         internal override void SetDefaultSourcePath(string defaultPath)
         {
             SetRegistryString(Registry.LocalMachine, DefaultSourcePathRegPath, DefaultSourcePathRegKey, defaultPath);
+        }
+
+        /// <summary>
+        /// Allow loading assemblies by searching in GAC.
+        /// </summary>
+        /// <returns>Always true, as this is for Full CLR.</returns>
+        internal override bool GetAllowGacLoading()
+        {
+            return true;
         }
 
         /// <summary>

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Import-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Import-Module.Tests.ps1
@@ -22,3 +22,27 @@
         (Get-Module -Name $moduleName).Name | Should Be $moduleName
     }
 }
+
+Describe "Import-Module for Binary Modules in GAC" -Tags 'CI' {
+
+    BeforeAll {
+        ##To enable loading assemblies from GAC, we need to add an entry to PowershellProperties.json
+        $PropertiesFilePath = Join-Path $pshome 'PowershellProperties.json'
+        $savePSProperties = Get-Content $PropertiesFilePath -Raw
+        $PSProperties = ConvertFrom-Json $savePSProperties
+        $PSProperties | Add-Member -MemberType NoteProperty -Name 'AllowGacLoading' -Value 'true'
+        $PSProperties | ConvertTo-Json | Out-File $PropertiesFilePath -Force
+    }
+
+    AfterAll {
+        #Reset the PowershellProperties.json file.
+        $savePSProperties | Out-File $PropertiesFilePath -Force -ErrorAction SilentlyContinue
+        Remove-Module PSScheduledJob -Force -ErrorAction SilentlyContinue
+    }
+
+    It "Load PSScheduledJob from Windows Powershell Modules folder" -Skip:(-not $IsWindows) {
+        $modulePath = Join-Path $env:windir "System32/WindowsPowershell/v1.0/Modules/PSScheduledJob"
+        Import-Module $modulePath
+        (Get-Command New-JobTrigger).Name | Should Be 'New-JobTrigger'
+    }
+}


### PR DESCRIPTION
A lot of binary modules written for Windows Powershell (Full cLR) use GAC for their assemblies.
CoreCLR does not have a GAC and hence fails to locate the assemblies.

Added functionality to search the well known location of GAC on Windows to load the assemblies.
This functionality can be opted-in by adding a key-value to PowershellProperties.json file at $PSHOME.
The key-value pair for enabling GAC loading is: "AllowGacLoading" : "true"

<!--

If you are a PowerShell Team member, please make sure you choose the Reviewer(s) and Assignee for your PR.
If you are not from the PowerShell Team, you can leave the fields blank and the Maintainers will choose them for you. If you are familiar with the team, feel free to mention some Reviewers yourself.

For more information about the roles of Reviewer and Assignee, refer to CONTRIBUTING.md.

-->
