### PR TITLE
Refactor PowerShell Core to use the default CoreCLR loader instead

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/cimSupport/cmdletization/cim/cimConverter.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/cimSupport/cmdletization/cim/cimConverter.cs
@@ -80,7 +80,7 @@ namespace Microsoft.PowerShell.Cim
 
             internal void Copy(SecureString source, int offset)
             {
-                IntPtr plainTextString = ClrFacade.SecureStringToCoTaskMemUnicode(source);
+                IntPtr plainTextString = Marshal.SecureStringToCoTaskMemUnicode(source);
                 try
                 {
                     unsafe

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Process.cs
@@ -641,7 +641,7 @@ namespace Microsoft.PowerShell.Commands
                         {
                             //assigning to tempmodule to rethrow for exceptions on 64 bit machines
                             tempmodule = pmodule;
-                            WriteObject(ClrFacade.GetProcessModuleFileVersionInfo(pmodule), true);
+                            WriteObject(pmodule.FileVersionInfo, true);
                         }
                     }
                     catch (InvalidOperationException exception)
@@ -658,7 +658,7 @@ namespace Microsoft.PowerShell.Commands
                         {
                             if (exception.HResult == 299)
                             {
-                                WriteObject(ClrFacade.GetProcessModuleFileVersionInfo(tempmodule), true);
+                                WriteObject(tempmodule.FileVersionInfo, true);
                             }
                             else
                             {
@@ -710,7 +710,7 @@ namespace Microsoft.PowerShell.Commands
                     //if fileversion of each process is to be displayed
                     try
                     {
-                        WriteObject(ClrFacade.GetProcessModuleFileVersionInfo(PsUtils.GetMainModule(process)), true);
+                        WriteObject(PsUtils.GetMainModule(process).FileVersionInfo, true);
                     }
                     catch (InvalidOperationException exception)
                     {
@@ -726,7 +726,7 @@ namespace Microsoft.PowerShell.Commands
                         {
                             if (exception.HResult == 299)
                             {
-                                WriteObject(ClrFacade.GetProcessModuleFileVersionInfo(PsUtils.GetMainModule(process)), true);
+                                WriteObject(PsUtils.GetMainModule(process).FileVersionInfo, true);
                             }
                             else
                             {
@@ -1966,7 +1966,7 @@ namespace Microsoft.PowerShell.Commands
                 //UseNewEnvironment
                 if (_UseNewEnvironment)
                 {
-                    ClrFacade.GetProcessEnvironment(startInfo).Clear();
+                    startInfo.EnvironmentVariables.Clear();
                     LoadEnvironmentVariable(startInfo, Environment.GetEnvironmentVariables(EnvironmentVariableTarget.Machine));
                     LoadEnvironmentVariable(startInfo, Environment.GetEnvironmentVariables(EnvironmentVariableTarget.User));
                 }
@@ -2173,7 +2173,7 @@ namespace Microsoft.PowerShell.Commands
 
         private void LoadEnvironmentVariable(ProcessStartInfo startinfo, IDictionary EnvironmentVariables)
         {
-            var processEnvironment = ClrFacade.GetProcessEnvironment(startinfo);
+            var processEnvironment = startinfo.EnvironmentVariables;
             foreach (DictionaryEntry entry in EnvironmentVariables)
             {
                 if (processEnvironment.ContainsKey(entry.Key.ToString()))
@@ -2373,12 +2373,7 @@ namespace Microsoft.PowerShell.Commands
             return builder;
         }
 
-        private static byte[] ConvertEnvVarsToByteArray(
-#if CORECLR
-            IDictionary<string, string> sd)
-#else
-            StringDictionary sd)
-#endif
+        private static byte[] ConvertEnvVarsToByteArray(StringDictionary sd)
         {
             string[] array = new string[sd.Count];
             byte[] bytes = null;
@@ -2497,7 +2492,7 @@ namespace Microsoft.PowerShell.Commands
                 creationFlags |= 0x00000004;
 
                 IntPtr AddressOfEnvironmentBlock = IntPtr.Zero;
-                var environmentVars = ClrFacade.GetProcessEnvironment(startinfo);
+                var environmentVars = startinfo.EnvironmentVariables;
                 if (environmentVars != null)
                 {
                     if (this.UseNewEnvironment)
@@ -2647,7 +2642,7 @@ namespace Microsoft.PowerShell.Commands
         internal bool AssignProcessToJobObject(Process process)
         {
             // Add the process to the job object
-            bool result = NativeMethods.AssignProcessToJobObject(_jobObjectHandle, ClrFacade.GetRawProcessHandle(process));
+            bool result = NativeMethods.AssignProcessToJobObject(_jobObjectHandle, process.Handle);
             return result;
         }
 

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Service.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Service.cs
@@ -2054,7 +2054,7 @@ namespace Microsoft.PowerShell.Commands
                 if (null != Credential)
                 {
                     username = Credential.UserName;
-                    password = ClrFacade.SecureStringToCoTaskMemUnicode(Credential.Password);
+                    password = Marshal.SecureStringToCoTaskMemUnicode(Credential.Password);
                 }
 
                 // Create the service

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/AddType.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/AddType.cs
@@ -964,7 +964,7 @@ namespace Microsoft.PowerShell.Commands
                 Assembly assembly = LoadAssemblyHelper(assemblyName);
                 if (assembly == null)
                 {
-                    assembly = LoadFrom(ResolveAssemblyName(assemblyName, false));
+                    assembly = Assembly.LoadFrom(ResolveAssemblyName(assemblyName, false));
                 }
 
                 if (passThru)
@@ -1276,7 +1276,7 @@ namespace Microsoft.PowerShell.Commands
                     {
                         ms.Flush();
                         ms.Seek(0, SeekOrigin.Begin);
-                        Assembly assembly = LoadFrom(ms);
+                        Assembly assembly = Assembly.Load(ms.ToArray());
                         CheckTypesForDuplicates(assembly);
                         if (passThru)
                         {
@@ -1292,7 +1292,7 @@ namespace Microsoft.PowerShell.Commands
                 {
                     if (passThru)
                     {
-                        Assembly assembly = LoadFrom(outputAssembly);
+                        Assembly assembly = Assembly.LoadFrom(outputAssembly);
                         CheckTypesForDuplicates(assembly);
                         WriteTypes(assembly);
                     }
@@ -1317,16 +1317,6 @@ namespace Microsoft.PowerShell.Commands
                     Column = d.Location.GetMappedLineSpan().StartLinePosition.Character + 1, // Convert 0-based to 1-based
                     ErrorNumber = d.Id
                 }).ToArray();
-        }
-
-        private Assembly LoadFrom(Stream assembly)
-        {
-            return ClrFacade.LoadFrom(assembly);
-        }
-
-        private Assembly LoadFrom(string path)
-        {
-            return ClrFacade.LoadFrom(path);
         }
     }
 
@@ -1955,7 +1945,7 @@ namespace Microsoft.PowerShell.Commands
             {
                 foreach (string path in paths)
                 {
-                    generatedTypes.AddRange(ClrFacade.LoadFrom(path).GetTypes());
+                    generatedTypes.AddRange(Assembly.LoadFrom(path).GetTypes());
                 }
             }
             // Load the assembly by name

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Import-LocalizedData.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Import-LocalizedData.cs
@@ -285,7 +285,7 @@ namespace Microsoft.PowerShell.Commands
             {
                 try
                 {
-                    culture = ClrFacade.GetCultureInfo(_uiculture);
+                    culture = CultureInfo.GetCultureInfo(_uiculture);
                 }
                 catch (ArgumentException)
                 {

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
@@ -1079,8 +1079,8 @@ namespace Microsoft.PowerShell
             }
 #endif
 
-            ClrFacade.SetCurrentThreadUiCulture(this.CurrentUICulture);
-            ClrFacade.SetCurrentThreadCulture(this.CurrentCulture);
+            Thread.CurrentThread.CurrentUICulture = this.CurrentUICulture;
+            Thread.CurrentThread.CurrentCulture = this.CurrentCulture;
             // BUG: 610329. Tell PowerShell engine to apply console
             // related properties while launching Pipeline Execution
             // Thread.

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ManagedEntrance.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ManagedEntrance.cs
@@ -9,6 +9,7 @@ using System.Management.Automation.Internal;
 using System.Management.Automation.Runspaces;
 using System.Management.Automation.Tracing;
 using System.Globalization;
+using System.Threading;
 
 #if CORECLR
 using System.Runtime.InteropServices;
@@ -65,8 +66,8 @@ namespace Microsoft.PowerShell
             // The currentUICulture returned NativeCultureResolver supports this non
             // traditional fallback on Vista. So it is important to set currentUICulture
             // in the beginning before we do anything.
-            ClrFacade.SetCurrentThreadUiCulture(NativeCultureResolver.UICulture);
-            ClrFacade.SetCurrentThreadCulture(NativeCultureResolver.Culture);
+            Thread.CurrentThread.CurrentUICulture = NativeCultureResolver.UICulture;
+            Thread.CurrentThread.CurrentCulture = NativeCultureResolver.Culture;
 
             RunspaceConfigForSingleShell configuration = null;
             PSConsoleLoadException warning = null;

--- a/src/Microsoft.PowerShell.CoreCLR.AssemblyLoadContext/CoreCLR/CorePsAssemblyLoadContext.cs
+++ b/src/Microsoft.PowerShell.CoreCLR.AssemblyLoadContext/CoreCLR/CorePsAssemblyLoadContext.cs
@@ -19,7 +19,7 @@ namespace System.Management.Automation
     /// <summary>
     /// The powershell custom AssemblyLoadContext implementation
     /// </summary>
-    internal partial class PowerShellAssemblyLoadContext : AssemblyLoadContext
+    internal partial class PowerShellAssemblyLoadContext
     {
         #region Resource_Strings
 
@@ -44,14 +44,14 @@ namespace System.Management.Automation
         /// <summary>
         /// Initialize a singleton of PowerShellAssemblyLoadContext
         /// </summary>
-        internal static PowerShellAssemblyLoadContext InitializeSingleton(string basePaths, bool useResolvingHandlerOnly)
+        internal static PowerShellAssemblyLoadContext InitializeSingleton(string basePaths)
         {
             lock (s_syncObj)
             {
                 if (Instance != null)
                     throw new InvalidOperationException(SingletonAlreadyInitialized);
 
-                Instance = new PowerShellAssemblyLoadContext(basePaths, useResolvingHandlerOnly);
+                Instance = new PowerShellAssemblyLoadContext(basePaths);
                 return Instance;
             }
         }
@@ -60,48 +60,32 @@ namespace System.Management.Automation
         /// Constructor
         /// </summary>
         /// <param name="basePaths">
-        /// Base directory paths that are separated by semicolon ';'.
-        /// They will be the default paths to probe assemblies.
+        /// Base directory paths that are separated by semicolon ';'. They will be the default paths to probe assemblies.
+        /// The passed-in argument could be null or an empty string, in which case there is no default paths to probe assemblies.
         /// </param>
-        /// <param name="useResolvingHandlerOnly">
-        /// Indicate whether this instance is going to be used as a
-        /// full fledged ALC, or only its 'Resolve' handler is going
-        /// to be used.
-        /// </param>
-        /// <remarks>
-        /// When <paramref name="useResolvingHandlerOnly"/> is true, we will register to the 'Resolving' event of the default
-        /// load context with our 'Resolve' method, and depend on the default load context to resolve/load assemblies for PS.
-        /// This mode is used when TPA list of the native host only contains .NET Core libraries.
-        /// In this case, TPA binder will be consulted before hitting our resolving logic. The binding order of Assembly.Load is:
-        ///     TPA binder --> Resolving event
-        ///
-        /// When <paramref name="useResolvingHandlerOnly"/> is false, we will use this instance as a full fledged load context
-        /// to resolve/load assemblies for PS. This mode is used when TPA list of the native host contains both .NET Core libraries
-        /// and PS assemblies.
-        /// In this case, our Load override will kick in before consulting the TPA binder. The binding order of Assembly.Load is:
-        ///     Load override --> TPA binder --> Resolving event
-        /// </remarks>
-        private PowerShellAssemblyLoadContext(string basePaths, bool useResolvingHandlerOnly)
+        private PowerShellAssemblyLoadContext(string basePaths)
         {
             #region Validation
             if (string.IsNullOrEmpty(basePaths))
             {
-                throw new ArgumentNullException("basePaths");
+                _basePaths = Array.Empty<string>();
             }
-
-            _basePaths = basePaths.Split(new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
-            for (int i = 0; i < _basePaths.Length; i++)
+            else
             {
-                string basePath = _basePaths[i];
-                if (!Directory.Exists(basePath))
+                _basePaths = basePaths.Split(new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+                for (int i = 0; i < _basePaths.Length; i++)
                 {
-                    string message = string.Format(
-                        CultureInfo.CurrentCulture,
-                        BaseFolderDoesNotExist,
-                        basePath);
-                    throw new ArgumentException(message, "basePaths");
+                    string basePath = _basePaths[i];
+                    if (!Directory.Exists(basePath))
+                    {
+                        string message = string.Format(
+                            CultureInfo.CurrentCulture,
+                            BaseFolderDoesNotExist,
+                            basePath);
+                        throw new ArgumentException(message, "basePaths");
+                    }
+                    _basePaths[i] = basePath.Trim();
                 }
-                _basePaths[i] = basePath.Trim();
             }
             #endregion Validation
 
@@ -111,31 +95,14 @@ namespace System.Management.Automation
             // NEXT: Initialize the CoreCLR type catalog dictionary [OrdinalIgnoreCase]
             _coreClrTypeCatalog = InitializeTypeCatalog();
 
-            // LAST: Handle useResolvingHandlerOnly flag
-            _useResolvingHandlerOnly = useResolvingHandlerOnly;
-            _activeLoadContext = useResolvingHandlerOnly ? Default : this;
-            if (useResolvingHandlerOnly)
-            {
-                Default.Resolving += Resolve;
-            }
-            else
-            {
-                var tempSet = new HashSet<string>(_coreClrTypeCatalog.Values, StringComparer.OrdinalIgnoreCase);
-                _tpaSet = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "Microsoft.PowerShell.CoreCLR.AssemblyLoadContext" };
-                foreach (string tpa in tempSet)
-                {
-                    string shortName = tpa.Substring(0, tpa.IndexOf(','));
-                    _tpaSet.Add(shortName);
-                }
-            }
+            // LAST: Register 'Resolving' handler on the default load context.
+            AssemblyLoadContext.Default.Resolving += Resolve;
         }
 
         #endregion Constructor
 
         #region Fields
 
-        private readonly bool _useResolvingHandlerOnly;
-        private readonly AssemblyLoadContext _activeLoadContext;
         private readonly static object s_syncObj = new object();
         private readonly string[] _basePaths;
         // Initially, 'probingPaths' only contains psbase path. But every time we load an assembly through 'LoadFrom(string AssemblyPath)', we
@@ -148,7 +115,6 @@ namespace System.Management.Automation
         //  - Key: namespace qualified type name (FullName)
         //  - Value: strong name of the TPA that contains the type represented by Key.
         private readonly Dictionary<string, string> _coreClrTypeCatalog;
-        private readonly HashSet<string> _tpaSet;
         private readonly string[] _extensions = new string[] { ".ni.dll", ".dll" };
 
         /// <summary>
@@ -191,98 +157,7 @@ namespace System.Management.Automation
 
         #endregion Events
 
-        #region Protected_Internal_Methods
-
-        /// <summary>
-        /// Implement the AssemblyLoadContext.Load(AssemblyName). Search the requested assembly in probing paths.
-        /// Search the file "[assemblyName.Name][.ni].dll" in probing paths. If the file is found and it matches the requested AssemblyName, load it with LoadFromAssemblyPath.
-        /// </summary>
-        protected override Assembly Load(AssemblyName assemblyName)
-        {
-            if (_useResolvingHandlerOnly)
-                throw new NotSupportedException(UseResolvingEventHandlerOnly);
-
-            // We let the default context load the assemblies included in the type catalog as there
-            // appears to be a bug in .NET with method resolution with system libraries loaded by our
-            // context and not the default. We use the short name because some packages have inconsistent
-            // versions between reference and runtime assemblies.
-            if (_tpaSet.Contains(assemblyName.Name))
-                return null;
-
-            return Resolve(this, assemblyName);
-        }
-
-        /// <summary>
-        /// The handler for the Resolving event
-        /// </summary>
-        private Assembly Resolve(AssemblyLoadContext loadContext, AssemblyName assemblyName)
-        {
-            // Probe the assembly cache
-            Assembly asmLoaded;
-            if (TryGetAssemblyFromCache(assemblyName, out asmLoaded))
-                return asmLoaded;
-
-            // Prepare to load the assembly
-            lock (s_syncObj)
-            {
-                // Probe the cache again in case it's already loaded
-                if (TryGetAssemblyFromCache(assemblyName, out asmLoaded))
-                    return asmLoaded;
-
-                // Search the specified assembly in probing paths, and load it through 'LoadFromAssemblyPath' if the file exists and matches the requested AssemblyName.
-                // If the CultureName of the requested assembly is not NullOrEmpty, then it's a resources.dll and we need to search corresponding culture sub-folder.
-                bool isAssemblyFileFound = false, isAssemblyFileMatching = false;
-                string asmCultureName = assemblyName.CultureName ?? string.Empty;
-                string asmFilePath = null;
-
-                for (int i = 0; i < _probingPaths.Count; i++)
-                {
-                    string probingPath = _probingPaths[i];
-                    string asmCulturePath = Path.Combine(probingPath, asmCultureName);
-                    for (int k = 0; k < _extensions.Length; k++)
-                    {
-                        string asmFileName = assemblyName.Name + _extensions[k];
-                        asmFilePath = Path.Combine(asmCulturePath, asmFileName);
-
-                        if (File.Exists(asmFilePath))
-                        {
-                            isAssemblyFileFound = true;
-                            AssemblyName asmNameFound = GetAssemblyName(asmFilePath);
-                            if (IsAssemblyMatching(assemblyName, asmNameFound))
-                            {
-                                isAssemblyFileMatching = true;
-                                break;
-                            }
-                        }
-                    }
-
-                    if (isAssemblyFileFound && isAssemblyFileMatching)
-                    {
-                        break;
-                    }
-                }
-
-                // We failed to find the assembly file; or we found the file, but the assembly file doesn't match the request.
-                // In this case, return null so that other Resolving event handlers can kick in to resolve the request.
-                if (!isAssemblyFileFound || !isAssemblyFileMatching)
-                {
-                    return null;
-                }
-
-                asmLoaded = asmFilePath.EndsWith(".ni.dll", StringComparison.OrdinalIgnoreCase)
-                                ? loadContext.LoadFromNativeImagePath(asmFilePath, null)
-                                : loadContext.LoadFromAssemblyPath(asmFilePath);
-                if (asmLoaded != null)
-                {
-                    // Add the loaded assembly to the cache
-                    s_assemblyCache.TryAdd(assemblyName.Name, asmLoaded);
-                }
-            }
-
-            // Raise AssemblyLoad event
-            OnAssemblyLoaded(asmLoaded);
-            return asmLoaded;
-        }
+        #region Internal_Methods
 
         /// <summary>
         /// Load an IL or NI assembly from its file path.
@@ -292,7 +167,7 @@ namespace System.Management.Automation
             ValidateAssemblyPath(assemblyPath, "assemblyPath");
 
             Assembly asmLoaded;
-            AssemblyName assemblyName = GetAssemblyName(assemblyPath);
+            AssemblyName assemblyName = AssemblyLoadContext.GetAssemblyName(assemblyPath);
 
             // Probe the assembly cache
             if (TryGetAssemblyFromCache(assemblyName, out asmLoaded))
@@ -307,8 +182,8 @@ namespace System.Management.Automation
 
                 // Load the assembly through 'LoadFromNativeImagePath' or 'LoadFromAssemblyPath'
                 asmLoaded = assemblyPath.EndsWith(".ni.dll", StringComparison.OrdinalIgnoreCase)
-                    ? _activeLoadContext.LoadFromNativeImagePath(assemblyPath, null)
-                    : _activeLoadContext.LoadFromAssemblyPath(assemblyPath);
+                    ? AssemblyLoadContext.Default.LoadFromNativeImagePath(assemblyPath, null)
+                    : AssemblyLoadContext.Default.LoadFromAssemblyPath(assemblyPath);
 
                 if (asmLoaded != null)
                 {
@@ -351,7 +226,7 @@ namespace System.Management.Automation
                     return asmLoaded;
 
                 // Load the assembly through 'LoadFromStream'
-                asmLoaded = _activeLoadContext.LoadFromStream(assembly);
+                asmLoaded = AssemblyLoadContext.Default.LoadFromStream(assembly);
                 if (asmLoaded != null)
                 {
                     // Add the loaded assembly to the cache
@@ -367,7 +242,7 @@ namespace System.Management.Automation
         /// <summary>
         /// Get the current loaded assemblies
         /// </summary>
-        internal IEnumerable<Assembly> GetAssemblies(string namespaceQualifiedTypeName)
+        internal IEnumerable<Assembly> GetAssembly(string namespaceQualifiedTypeName)
         {
             // If 'namespaceQualifiedTypeName' is specified and it's a CoreCLR framework type,
             // then we only return that specific TPA assembly.
@@ -392,70 +267,7 @@ namespace System.Management.Automation
                 }
             }
 
-            // Otherwise, we return all assemblies from the AssemblyCache
-            return s_assemblyCache.Values;
-        }
-
-        /// <summary>
-        /// Try adding a new assembly to the cache
-        /// </summary>
-        /// <remarks>
-        /// This is for adding a dynamic assembly to the cache.
-        /// PowerShell generates dynamic assemblies by directly emitting IL, and this API
-        /// is to add such assemblies to the cache so that types in them are discoverable.
-        /// </remarks>
-        internal bool TryAddAssemblyToCache(Assembly assembly)
-        {
-            AssemblyName asmName = assembly.GetName();
-            bool success = s_assemblyCache.TryAdd(asmName.Name, assembly);
-            // Raise AssemblyLoad event
-            if (success) { OnAssemblyLoaded(assembly); }
-            return success;
-        }
-
-        /// <summary>
-        /// Probe for the assembly file with the specified short name for metadata analysis purpose
-        /// </summary>
-        internal string ProbeAssemblyFileForMetadataAnalysis(string assemblyShortName, string additionalSearchPath)
-        {
-            if (string.IsNullOrEmpty(assemblyShortName))
-            {
-                throw new ArgumentNullException("assemblyShortName");
-            }
-
-            bool useAdditionalSearchPath = false;
-            if (!string.IsNullOrEmpty(additionalSearchPath))
-            {
-                if (!Path.IsPathRooted(additionalSearchPath))
-                {
-                    throw new ArgumentException(AbsolutePathRequired, "additionalSearchPath");
-                }
-                useAdditionalSearchPath = Directory.Exists(additionalSearchPath);
-            }
-
-            // Construct the probing paths for searching the specified assembly file
-            string[] metadataProbingPaths = _basePaths;
-            if (useAdditionalSearchPath)
-            {
-                var searchPaths = new List<string>() { additionalSearchPath };
-                searchPaths.AddRange(_basePaths);
-                metadataProbingPaths = searchPaths.ToArray();
-            }
-
-            for (int i = 0; i < metadataProbingPaths.Length; i++)
-            {
-                string metadataProbingPath = metadataProbingPaths[i];
-                for (int k = 0; k < _extensions.Length; k++)
-                {
-                    string asmFileName = assemblyShortName + _extensions[k];
-                    string asmFilePath = Path.Combine(metadataProbingPath, asmFileName);
-                    if (File.Exists(asmFilePath))
-                    {
-                        return asmFilePath;
-                    }
-                }
-            }
-
+            // Otherwise, we return null
             return null;
         }
 
@@ -482,8 +294,7 @@ namespace System.Management.Automation
         /// </remarks>
         internal void SetProfileOptimizationRootImpl(string directoryPath)
         {
-            if (_useResolvingHandlerOnly)
-                _activeLoadContext.SetProfileOptimizationRoot(directoryPath);
+            AssemblyLoadContext.Default.SetProfileOptimizationRoot(directoryPath);
         }
 
         /// <summary>
@@ -500,13 +311,84 @@ namespace System.Management.Automation
         /// </remarks>
         internal void StartProfileOptimizationImpl(string profile)
         {
-            if (_useResolvingHandlerOnly)
-                _activeLoadContext.StartProfileOptimization(profile);
+            AssemblyLoadContext.Default.StartProfileOptimization(profile);
         }
 
-        #endregion Protected_Internal_Methods
+        #endregion Internal_Methods
 
         #region Private_Methods
+
+        /// <summary>
+        /// The handler for the Resolving event
+        /// </summary>
+        private Assembly Resolve(AssemblyLoadContext loadContext, AssemblyName assemblyName)
+        {
+            // Probe the assembly cache
+            Assembly asmLoaded;
+            if (TryGetAssemblyFromCache(assemblyName, out asmLoaded))
+                return asmLoaded;
+
+            // Prepare to load the assembly
+            lock (s_syncObj)
+            {
+                // Probe the cache again in case it's already loaded
+                if (TryGetAssemblyFromCache(assemblyName, out asmLoaded))
+                    return asmLoaded;
+
+                // Search the specified assembly in probing paths, and load it through 'LoadFromAssemblyPath' if the file exists and matches the requested AssemblyName.
+                // If the CultureName of the requested assembly is not NullOrEmpty, then it's a resources.dll and we need to search corresponding culture sub-folder.
+                bool isAssemblyFileFound = false, isAssemblyFileMatching = false;
+                string asmCultureName = assemblyName.CultureName ?? string.Empty;
+                string asmFilePath = null;
+
+                for (int i = 0; i < _probingPaths.Count; i++)
+                {
+                    string probingPath = _probingPaths[i];
+                    string asmCulturePath = Path.Combine(probingPath, asmCultureName);
+                    for (int k = 0; k < _extensions.Length; k++)
+                    {
+                        string asmFileName = assemblyName.Name + _extensions[k];
+                        asmFilePath = Path.Combine(asmCulturePath, asmFileName);
+
+                        if (File.Exists(asmFilePath))
+                        {
+                            isAssemblyFileFound = true;
+                            AssemblyName asmNameFound = AssemblyLoadContext.GetAssemblyName(asmFilePath);
+                            if (IsAssemblyMatching(assemblyName, asmNameFound))
+                            {
+                                isAssemblyFileMatching = true;
+                                break;
+                            }
+                        }
+                    }
+
+                    if (isAssemblyFileFound && isAssemblyFileMatching)
+                    {
+                        break;
+                    }
+                }
+
+                // We failed to find the assembly file; or we found the file, but the assembly file doesn't match the request.
+                // In this case, return null so that other Resolving event handlers can kick in to resolve the request.
+                if (!isAssemblyFileFound || !isAssemblyFileMatching)
+                {
+                    return null;
+                }
+
+                asmLoaded = asmFilePath.EndsWith(".ni.dll", StringComparison.OrdinalIgnoreCase)
+                                ? loadContext.LoadFromNativeImagePath(asmFilePath, null)
+                                : loadContext.LoadFromAssemblyPath(asmFilePath);
+                if (asmLoaded != null)
+                {
+                    // Add the loaded assembly to the cache
+                    s_assemblyCache.TryAdd(assemblyName.Name, asmLoaded);
+                }
+            }
+
+            // Raise AssemblyLoad event
+            OnAssemblyLoaded(asmLoaded);
+            return asmLoaded;
+        }
 
         /// <summary>
         /// Handle the AssemblyLoad event
@@ -689,8 +571,6 @@ namespace System.Management.Automation
     /// </summary>
     public class PowerShellAssemblyLoadContextInitializer
     {
-        private static object[] s_emptyArray = new object[0];
-
         /// <summary>
         /// Create a singleton of PowerShellAssemblyLoadContext.
         /// Then register to the Resolving event of the load context that loads this assembly.
@@ -708,106 +588,7 @@ namespace System.Management.Automation
             if (string.IsNullOrEmpty(basePaths))
                 throw new ArgumentNullException("basePaths");
 
-            PowerShellAssemblyLoadContext.InitializeSingleton(basePaths, useResolvingHandlerOnly: true);
-        }
-
-        /// <summary>
-        /// Create a singleton of PowerShellAssemblyLoadContext.
-        /// Then load System.Management.Automation and call the WSManPluginManagedEntryWrapper delegate.
-        /// </summary>
-        /// <remarks>
-        /// This method is used by the native host of the PSRP plugin.
-        /// </remarks>
-        /// <param name="wkrPtrs">
-        /// Passed to delegate.
-        /// </param>
-        public static int WSManPluginWrapper(IntPtr wkrPtrs)
-        {
-            string basePaths = System.IO.Path.GetDirectoryName(typeof(PowerShellAssemblyLoadContextInitializer).GetTypeInfo().Assembly.Location);
-            string entryAssemblyName = "System.Management.Automation, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35";
-            string entryTypeName = "System.Management.Automation.Remoting.WSManPluginManagedEntryWrapper";
-            string entryMethodName = "InitPlugin";
-            object[] args = { wkrPtrs };
-
-            var psLoadContext = PowerShellAssemblyLoadContext.InitializeSingleton(basePaths, useResolvingHandlerOnly: false);
-            var entryAssembly = psLoadContext.LoadFromAssemblyName(new AssemblyName(entryAssemblyName));
-            var entryType = entryAssembly.GetType(entryTypeName, throwOnError: true, ignoreCase: true);
-            var methodInfo = entryType.GetMethod(entryMethodName, BindingFlags.Static | BindingFlags.Public | BindingFlags.IgnoreCase);
-
-            return (int)methodInfo.Invoke(null, args);
-        }
-
-        /// <summary>
-        /// Create a singleton of PowerShellAssemblyLoadContext.
-        /// Then load the assembly containing the actual entry point using it.
-        /// </summary>
-        /// <param name="basePaths">
-        /// Base directory paths that are separated by semicolon ';'.
-        /// They will be the default paths to probe assemblies.
-        /// </param>
-        /// <param name="entryAssemblyName">
-        /// Name of the assembly that contains the actual entry point.
-        /// </param>
-        /// <returns>
-        /// The assembly that contains the actual entry point.
-        /// </returns>
-        public static Assembly InitializeAndLoadEntryAssembly(string basePaths, AssemblyName entryAssemblyName)
-        {
-            if (string.IsNullOrEmpty(basePaths))
-                throw new ArgumentNullException("basePaths");
-
-            if (entryAssemblyName == null)
-                throw new ArgumentNullException("entryAssemblyName");
-
-            var psLoadContext = PowerShellAssemblyLoadContext.InitializeSingleton(basePaths, useResolvingHandlerOnly: false);
-            return psLoadContext.LoadFromAssemblyName(entryAssemblyName);
-        }
-
-        /// <summary>
-        /// Create a singleton of PowerShellAssemblyLoadContext.
-        /// Then call into the actual entry point based on the given assembly name, type name, method name and arguments.
-        /// </summary>
-        /// <param name="basePaths">
-        /// Base directory paths that are separated by semicolon ';'.
-        /// They will be the default paths to probe assemblies.
-        /// </param>
-        /// <param name="entryAssemblyName">
-        /// Name of the assembly that contains the actual entry point.
-        /// </param>
-        /// <param name="entryTypeName">
-        /// Name of the type that contains the actual entry point.
-        /// </param>
-        /// <param name="entryMethodName">
-        /// Name of the actual entry point method.
-        /// </param>
-        /// <param name="args">
-        /// An array of arguments passed to the entry point method.
-        /// </param>
-        /// <returns>
-        /// The return value of running the entry point method.
-        /// </returns>
-        public static object InitializeAndCallEntryMethod(string basePaths, AssemblyName entryAssemblyName, string entryTypeName, string entryMethodName, object[] args)
-        {
-            if (string.IsNullOrEmpty(basePaths))
-                throw new ArgumentNullException("basePaths");
-
-            if (entryAssemblyName == null)
-                throw new ArgumentNullException("entryAssemblyName");
-
-            if (string.IsNullOrEmpty(entryTypeName))
-                throw new ArgumentNullException("entryTypeName");
-
-            if (string.IsNullOrEmpty(entryMethodName))
-                throw new ArgumentNullException("entryMethodName");
-
-            args = args ?? s_emptyArray;
-
-            var psLoadContext = PowerShellAssemblyLoadContext.InitializeSingleton(basePaths, useResolvingHandlerOnly: false);
-            var entryAssembly = psLoadContext.LoadFromAssemblyName(entryAssemblyName);
-            var entryType = entryAssembly.GetType(entryTypeName, throwOnError: true, ignoreCase: true);
-            var methodInfo = entryType.GetMethod(entryMethodName, BindingFlags.Static | BindingFlags.Public | BindingFlags.IgnoreCase);
-
-            return methodInfo.Invoke(null, args);
+            PowerShellAssemblyLoadContext.InitializeSingleton(basePaths);
         }
     }
 }

--- a/src/System.Management.Automation/CoreCLR/CorePsExtensions.cs
+++ b/src/System.Management.Automation/CoreCLR/CorePsExtensions.cs
@@ -5,9 +5,8 @@ Copyright (c) Microsoft Corporation.  All rights reserved.
 
 namespace Microsoft.PowerShell.CoreCLR
 {
-    using System.IO;
+    using System;
     using System.Reflection;
-    using System.Management.Automation;
 
     /// <summary>
     /// AssemblyExtensions
@@ -19,19 +18,10 @@ namespace Microsoft.PowerShell.CoreCLR
         /// </summary>
         /// <param name="assemblyPath">The path of the file that contains the manifest of the assembly.</param>
         /// <returns>The loaded assembly.</returns>
+        [ObsoleteAttribute("This method is obsolete. Call Assembly.LoadFrom instead", false)]
         public static Assembly LoadFrom(string assemblyPath)
         {
-            return ClrFacade.LoadFrom(assemblyPath);
-        }
-
-        /// <summary>
-        /// Load an assembly given its byte stream
-        /// </summary>
-        /// <param name="assembly">The byte stream of assembly</param>
-        /// <returns>The loaded assembly</returns>
-        public static Assembly LoadFrom(Stream assembly)
-        {
-            return ClrFacade.LoadFrom(assembly);
+            return Assembly.LoadFrom(assemblyPath);
         }
     }
 }

--- a/src/System.Management.Automation/cimSupport/cmdletization/EnumWriter.cs
+++ b/src/System.Management.Automation/cimSupport/cmdletization/EnumWriter.cs
@@ -64,8 +64,8 @@ namespace Microsoft.PowerShell.Cmdletization
                 object integerValue = LanguagePrimitives.ConvertTo(value.Value, underlyingType, CultureInfo.InvariantCulture);
                 eb.DefineLiteral(name, integerValue);
             }
-
-            ClrFacade.CreateEnumType(eb);
+            
+            eb.CreateTypeInfo();
         }
     }
 }

--- a/src/System.Management.Automation/cimSupport/cmdletization/EnumWriter.cs
+++ b/src/System.Management.Automation/cimSupport/cmdletization/EnumWriter.cs
@@ -64,7 +64,7 @@ namespace Microsoft.PowerShell.Cmdletization
                 object integerValue = LanguagePrimitives.ConvertTo(value.Value, underlyingType, CultureInfo.InvariantCulture);
                 eb.DefineLiteral(name, integerValue);
             }
-            
+
             eb.CreateTypeInfo();
         }
     }

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -35,18 +35,10 @@ namespace System.Management.Automation
     {
         static CompletionCompleters()
         {
-#if CORECLR
-            ClrFacade.AddAssemblyLoadHandler(UpdateTypeCacheOnAssemblyLoad);
-#else
             AppDomain.CurrentDomain.AssemblyLoad += UpdateTypeCacheOnAssemblyLoad;
-#endif
         }
 
-#if CORECLR
-        static void UpdateTypeCacheOnAssemblyLoad(Assembly loadedAssembly)
-#else
         private static void UpdateTypeCacheOnAssemblyLoad(object sender, AssemblyLoadEventArgs args)
-#endif
         {
             // Just null out the cache - we'll rebuild it the next time someone tries to complete a type.
             // We could rebuild it now, but we could be loading multiple assemblies (e.g. dependent assemblies)

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -5854,34 +5854,11 @@ namespace System.Management.Automation
 
             #endregion Process_TypeAccelerators
 
-            #region Process_LoadedAssemblies
-
-            var assembliesExcludingPSGenerated = ClrFacade.GetAssemblies();
-            var allPublicTypes = assembliesExcludingPSGenerated.SelectMany(assembly =>
-            {
-                try
-                {
-                    return assembly.GetTypes().Where(TypeResolver.IsPublic);
-                }
-                catch (ReflectionTypeLoadException)
-                {
-                }
-                return Type.EmptyTypes;
-            });
-
-            foreach (var type in allPublicTypes)
-            {
-                HandleNamespace(entries, type.Namespace);
-                HandleType(entries, type.FullName, type.Name, type);
-            }
-
-            #endregion Process_LoadedAssemblies
-
             #region Process_CoreCLR_TypeCatalog
 #if CORECLR
-            // In CoreCLR, we have namespace-qualified type names of all available .NET types stored in TypeCatalog of the AssemblyLoadContext.
+            // In CoreCLR, we have namespace-qualified type names of all available .NET Core types stored in TypeCatalog.
             // Populate the type completion cache using the namespace-qualified type names.
-            foreach (string fullTypeName in ClrFacade.GetAvailableCoreClrDotNetTypes())
+            foreach (string fullTypeName in ClrFacade.AvailableDotNetTypeNames)
             {
                 var typeCompInString = new TypeCompletionInStringFormat { FullTypeName = fullTypeName };
                 HandleNamespace(entries, typeCompInString.Namespace);
@@ -5889,6 +5866,32 @@ namespace System.Management.Automation
             }
 #endif
             #endregion Process_CoreCLR_TypeCatalog
+
+            #region Process_LoadedAssemblies
+
+            foreach (Assembly assembly in ClrFacade.GetAssemblies())
+            {
+#if CORECLR
+                // Ignore the assemblies that are already covered by the type catalog
+                if (ClrFacade.AvailableDotNetAssemblyNames.Contains(assembly.FullName)) { continue; }
+#endif
+                try
+                {
+                    foreach (Type type in assembly.GetTypes())
+                    {
+                        // Ignore non-public types
+                        if (!TypeResolver.IsPublic(type)) { continue; }
+
+                        HandleNamespace(entries, type.Namespace);
+                        HandleType(entries, type.FullName, type.Name, type);
+                    }
+                }
+                catch (ReflectionTypeLoadException)
+                {
+                }
+            }
+
+            #endregion Process_LoadedAssemblies
 
             var grouping = entries.Values.GroupBy(t => t.Key.Count(c => c == '.')).OrderBy(g => g.Key).ToArray();
             var localTypeCache = new TypeCompletionMapping[grouping.Last().Key + 1][];

--- a/src/System.Management.Automation/engine/CommandInfo.cs
+++ b/src/System.Management.Automation/engine/CommandInfo.cs
@@ -7,6 +7,7 @@ using System.Collections.ObjectModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Management.Automation.Language;
 using System.Management.Automation.Runspaces;
+using System.Reflection;
 using System.Runtime.ExceptionServices;
 using Microsoft.PowerShell.Commands;
 
@@ -227,7 +228,7 @@ namespace System.Management.Automation
                             else if (Module.Path.EndsWith(StringLiterals.DependentWorkflowAssemblyExtension, StringComparison.OrdinalIgnoreCase))
                             {
                                 // Binary module (.dll)
-                                Module.SetVersion(ClrFacade.GetAssemblyName(Module.Path).Version);
+                                Module.SetVersion(AssemblyName.GetAssemblyName(Module.Path).Version);
                             }
                         }
 

--- a/src/System.Management.Automation/engine/ExecutionContext.cs
+++ b/src/System.Management.Automation/engine/ExecutionContext.cs
@@ -1375,7 +1375,7 @@ namespace System.Management.Automation
 
                 try
                 {
-                    loadedAssembly = ClrFacade.LoadFrom(filename);
+                    loadedAssembly = Assembly.LoadFrom(filename);
                     return loadedAssembly;
                 }
                 catch (FileNotFoundException fileNotFound)

--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -4467,7 +4467,7 @@ namespace System.Management.Automation.Runspaces
         {
             s_PSSnapInTracer.WriteLine("Loading assembly for psSnapIn {0}", fileName);
 
-            Assembly assembly = ClrFacade.LoadFrom(fileName);
+            Assembly assembly = Assembly.LoadFrom(fileName);
             if (assembly == null)
             {
                 s_PSSnapInTracer.TraceError("Loading assembly for psSnapIn {0} failed", fileName);
@@ -5543,7 +5543,7 @@ if($paths) {
 
             try
             {
-                AssemblyName assemblyName = ClrFacade.GetAssemblyName(psSnapInInfo.AbsoluteModulePath);
+                AssemblyName assemblyName = AssemblyName.GetAssemblyName(psSnapInInfo.AbsoluteModulePath);
 
                 if (!string.Equals(assemblyName.FullName, psSnapInInfo.AssemblyName, StringComparison.OrdinalIgnoreCase))
                 {
@@ -5552,7 +5552,7 @@ if($paths) {
                     throw new PSSnapInException(psSnapInInfo.Name, message);
                 }
 
-                assembly = ClrFacade.LoadFrom(psSnapInInfo.AbsoluteModulePath);
+                assembly = Assembly.LoadFrom(psSnapInInfo.AbsoluteModulePath);
             }
             catch (FileLoadException e)
             {

--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -175,7 +175,7 @@ namespace System.Management.Automation
 
             try
             {
-                p = ClrFacade.SecureStringToCoTaskMemUnicode(ss);
+                p = Marshal.SecureStringToCoTaskMemUnicode(ss);
                 s = Marshal.PtrToStringUni(p);
             }
             finally

--- a/src/System.Management.Automation/engine/hostifaces/LocalPipeline.cs
+++ b/src/System.Management.Automation/engine/hostifaces/LocalPipeline.cs
@@ -217,8 +217,8 @@ namespace System.Management.Automation.Runspaces
                         finally
                         {
                             NestedPipelineExecutionThread = oldNestedPipelineThread;
-                            ClrFacade.SetCurrentThreadCulture(oldCurrentCulture);
-                            ClrFacade.SetCurrentThreadUiCulture(oldCurrentUICulture);
+                            Thread.CurrentThread.CurrentCulture = oldCurrentCulture;
+                            Thread.CurrentThread.CurrentUICulture = oldCurrentUICulture;
                         }
                         break;
                     }

--- a/src/System.Management.Automation/engine/parser/Compiler.cs
+++ b/src/System.Management.Automation/engine/parser/Compiler.cs
@@ -2370,7 +2370,7 @@ namespace System.Management.Automation.Language
 #endif
                 if (File.Exists(assemblyFileName))
                 {
-                    assembly = ClrFacade.LoadFrom(assemblyFileName);
+                    assembly = Assembly.LoadFrom(assemblyFileName);
                 }
             }
             catch

--- a/src/System.Management.Automation/engine/remoting/fanin/InitialSessionStateProvider.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/InitialSessionStateProvider.cs
@@ -700,7 +700,7 @@ namespace System.Management.Automation.Remoting
                         //Rooted path of dll is provided.
                         assemblyPath = assemblyName;
                     }
-                    result = ClrFacade.LoadFrom(assemblyPath);
+                    result = Assembly.LoadFrom(assemblyPath);
                 }
                 catch (FileLoadException e)
                 {

--- a/src/System.Management.Automation/engine/remoting/fanin/WSManNativeAPI.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/WSManNativeAPI.cs
@@ -348,7 +348,7 @@ namespace System.Management.Automation.Remoting.Client
                 _cred.userName = name;
                 if (null != pwd)
                 {
-                    _cred.password = ClrFacade.SecureStringToCoTaskMemUnicode(pwd);
+                    _cred.password = Marshal.SecureStringToCoTaskMemUnicode(pwd);
                 }
 
                 _data = MarshalledObject.Create<WSManUserNameCredentialStruct>(_cred);

--- a/src/System.Management.Automation/engine/remoting/fanin/WSManPlugin.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/WSManPlugin.cs
@@ -383,7 +383,7 @@ namespace System.Management.Automation.Remoting
                 if (Platform.IsWindows)
                 {
                     SafeWaitHandle safeWaitHandle = new SafeWaitHandle(requestDetails.shutdownNotificationHandle, false); // Owned by WinRM
-                    ClrFacade.SetSafeWaitHandle(eventWaitHandle, safeWaitHandle);
+                    eventWaitHandle.SafeWaitHandle = safeWaitHandle;
                 }
                 else
                 {
@@ -1496,7 +1496,7 @@ namespace System.Management.Automation.Remoting
                 if (retrievingLocaleSucceeded && ((uint)WSManNativeApi.WSManDataType.WSMAN_DATA_TYPE_TEXT == localeData.Type))
                 {
                     CultureInfo uiCultureToUse = new CultureInfo(localeData.Text);
-                    ClrFacade.SetCurrentThreadUiCulture(uiCultureToUse);
+                    Thread.CurrentThread.CurrentUICulture = uiCultureToUse;
                 }
             }
             // ignore if there is any exception constructing the culture..
@@ -1510,7 +1510,7 @@ namespace System.Management.Automation.Remoting
                 if (retrievingDataLocaleSucceeded && ((uint)WSManNativeApi.WSManDataType.WSMAN_DATA_TYPE_TEXT == dataLocaleData.Type))
                 {
                     CultureInfo cultureToUse = new CultureInfo(dataLocaleData.Text);
-                    ClrFacade.SetCurrentThreadCulture(cultureToUse);
+                    Thread.CurrentThread.CurrentCulture = cultureToUse;
                 }
             }
             // ignore if there is any exception constructing the culture..

--- a/src/System.Management.Automation/engine/remoting/fanin/WSManPluginShellSession.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/WSManPluginShellSession.cs
@@ -266,7 +266,7 @@ namespace System.Management.Automation.Remoting
                         // Wrap the provided handle so it can be passed to the registration function
                         SafeWaitHandle safeWaitHandle = new SafeWaitHandle(creationRequestDetails.shutdownNotificationHandle, false); // Owned by WinRM
                         EventWaitHandle eventWaitHandle = new EventWaitHandle(false, EventResetMode.AutoReset);
-                        ClrFacade.SetSafeWaitHandle(eventWaitHandle, safeWaitHandle);
+                        eventWaitHandle.SafeWaitHandle = safeWaitHandle;
 
                         // Register shutdown notification handle
                         this.registeredShutDownWaitHandle = ThreadPool.RegisterWaitForSingleObject(

--- a/src/System.Management.Automation/engine/remoting/fanin/WSManPluginTransportManager.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/WSManPluginTransportManager.cs
@@ -337,7 +337,7 @@ namespace System.Management.Automation.Remoting
                     // Wrap the provided handle so it can be passed to the registration function
                     SafeWaitHandle safeWaitHandle = new SafeWaitHandle(requestDetails.shutdownNotificationHandle, false); // Owned by WinRM
                     EventWaitHandle eventWaitHandle = new EventWaitHandle(false, EventResetMode.AutoReset);
-                    ClrFacade.SetSafeWaitHandle(eventWaitHandle, safeWaitHandle);
+                    eventWaitHandle.SafeWaitHandle = safeWaitHandle;
 
                     _registeredShutDownWaitHandle = ThreadPool.RegisterWaitForSingleObject(
                             eventWaitHandle,

--- a/src/System.Management.Automation/help/UpdateHelpCommand.cs
+++ b/src/System.Management.Automation/help/UpdateHelpCommand.cs
@@ -379,7 +379,7 @@ namespace Microsoft.PowerShell.Commands
                         destPaths.Add(module.ModuleBase);
 
 #if !CORECLR // Side-By-Side directories are not present in OneCore environments.
-                        if (IsSystemModule(module.ModuleName) && ClrFacade.Is64BitOperatingSystem())
+                        if (IsSystemModule(module.ModuleName) && Environment.Is64BitOperatingSystem)
                         {
                             string path = Utils.GetApplicationBase(Utils.DefaultPowerShellShellID).Replace("System32", "SysWOW64");
 

--- a/src/System.Management.Automation/minishell/api/RunspaceConfiguration.cs
+++ b/src/System.Management.Automation/minishell/api/RunspaceConfiguration.cs
@@ -246,7 +246,7 @@ namespace System.Management.Automation.Runspaces
             if (assembly == null)
                 throw PSTraceSource.NewArgumentNullException("assembly");
 
-            object[] attributes = ClrFacade.GetCustomAttributes<RunspaceConfigurationTypeAttribute>(assembly);
+            object[] attributes = assembly.GetCustomAttributes(typeof(RunspaceConfigurationTypeAttribute), false);
 
             if (attributes == null || attributes.Length == 0)
             {

--- a/src/System.Management.Automation/resources/ParserStrings.resx
+++ b/src/System.Management.Automation/resources/ParserStrings.resx
@@ -1345,9 +1345,6 @@ ModuleVersion : Version of module to import. If used, ModuleName must represent 
   <data name="CantActivateDocumentInPowerShellCore" xml:space="preserve">
     <value>Cannot run a document in PowerShell Core: {0}.</value>
   </data>
-  <data name="LoadContextNotInitialized" xml:space="preserve">
-    <value>'PowerShellAssemblyLoadContext' is not initialized.</value>
-  </data>
   <data name="MultipleTypeConstraintsOnMethodParam" xml:space="preserve">
     <value>Multiple type constraints are not allowed on a method parameter.</value>
   </data>

--- a/src/System.Management.Automation/security/SecureStringHelper.cs
+++ b/src/System.Management.Automation/security/SecureStringHelper.cs
@@ -85,7 +85,7 @@ namespace Microsoft.PowerShell
 
             if (s.Length > 0)
             {
-                IntPtr ptr = ClrFacade.SecureStringToCoTaskMemUnicode(s);
+                IntPtr ptr = Marshal.SecureStringToCoTaskMemUnicode(s);
 
                 try
                 {

--- a/src/System.Management.Automation/security/SecuritySupport.cs
+++ b/src/System.Management.Automation/security/SecuritySupport.cs
@@ -1565,7 +1565,7 @@ namespace System.Management.Automation
                 {
                     var processModule = PsUtils.GetMainModule(currentProcess);
                     hostname = string.Concat("PowerShell_", processModule.FileName, "_",
-                        ClrFacade.GetProcessModuleFileVersionInfo(processModule).ProductVersion);
+                        processModule.FileVersionInfo.ProductVersion);
                 }
                 catch (ComponentModel.Win32Exception)
                 {

--- a/src/System.Management.Automation/singleshell/config/RunspaceConfigForSingleShell.cs
+++ b/src/System.Management.Automation/singleshell/config/RunspaceConfigForSingleShell.cs
@@ -640,7 +640,7 @@ namespace System.Management.Automation.Runspaces
 
             try
             {
-                AssemblyName assemblyName = ClrFacade.GetAssemblyName(mshsnapinInfo.AbsoluteModulePath);
+                AssemblyName assemblyName = AssemblyName.GetAssemblyName(mshsnapinInfo.AbsoluteModulePath);
                 if (string.Compare(assemblyName.FullName, mshsnapinInfo.AssemblyName, StringComparison.OrdinalIgnoreCase) != 0)
                 {
                     string message = StringUtil.Format(ConsoleInfoErrorStrings.PSSnapInAssemblyNameMismatch, mshsnapinInfo.AbsoluteModulePath, mshsnapinInfo.AssemblyName);
@@ -648,7 +648,7 @@ namespace System.Management.Automation.Runspaces
                     throw new PSSnapInException(mshsnapinInfo.Name, message);
                 }
 
-                assembly = ClrFacade.LoadFrom(mshsnapinInfo.AbsoluteModulePath);
+                assembly = Assembly.LoadFrom(mshsnapinInfo.AbsoluteModulePath);
             }
             catch (FileLoadException e)
             {

--- a/src/System.Management.Automation/utils/ClrFacade.cs
+++ b/src/System.Management.Automation/utils/ClrFacade.cs
@@ -46,7 +46,7 @@ namespace System.Management.Automation
             {
                 PowerShellAssemblyLoadContext.InitializeSingleton(string.Empty);
             }
-        }     
+        }
 
         /// <summary>
         /// We need it to avoid calling lookups inside dynamic assemblies with PS Types, so we exclude it from GetAssemblies().
@@ -160,13 +160,16 @@ namespace System.Management.Automation
 
 #if CORECLR
         /// <summary>
-        /// Get the namespace-qualified type names of all available CoreCLR .NET types.
+        /// Get the namespace-qualified type names of all available .NET Core types shipped with PowerShell Core.
         /// This is used for type name auto-completion in PS engine.
         /// </summary>
-        internal static IEnumerable<string> GetAvailableCoreClrDotNetTypes()
-        {
-            return PSAssemblyLoadContext.GetAvailableDotNetTypes();
-        }
+        internal static IEnumerable<string> AvailableDotNetTypeNames => PSAssemblyLoadContext.AvailableDotNetTypeNames;
+
+        /// <summary>
+        /// Get the assembly names of all available .NET Core assemblies shipped with PowerShell Core.
+        /// This is used for type name auto-completion in PS engine.
+        /// </summary>
+        internal static HashSet<string> AvailableDotNetAssemblyNames => PSAssemblyLoadContext.AvailableDotNetAssemblyNames;
 
         private static PowerShellAssemblyLoadContext PSAssemblyLoadContext => PowerShellAssemblyLoadContext.Instance;
 #endif

--- a/src/System.Management.Automation/utils/CryptoUtils.cs
+++ b/src/System.Management.Automation/utils/CryptoUtils.cs
@@ -995,7 +995,7 @@ namespace System.Management.Automation.Internal
 
             if (_rsaCryptoProvider.CanEncrypt)
             {
-                IntPtr ptr = ClrFacade.SecureStringToCoTaskMemUnicode(secureString);
+                IntPtr ptr = Marshal.SecureStringToCoTaskMemUnicode(secureString);
 
                 if (ptr != IntPtr.Zero)
                 {

--- a/src/TypeCatalogGen/TypeCatalogGen.cs
+++ b/src/TypeCatalogGen/TypeCatalogGen.cs
@@ -424,7 +424,7 @@ using System.Runtime.Loader;
 
 namespace System.Management.Automation
 {{
-    internal partial class PowerShellAssemblyLoadContext : AssemblyLoadContext
+    internal partial class PowerShellAssemblyLoadContext
     {{
         private Dictionary<string, string> InitializeTypeCatalog()
         {{

--- a/src/powershell/Program.cs
+++ b/src/powershell/Program.cs
@@ -3,7 +3,6 @@ Copyright (c) Microsoft Corporation.  All rights reserved.
 --********************************************************************/
 
 using System;
-using System.Management.Automation;
 using System.Reflection;
 
 namespace Microsoft.PowerShell
@@ -21,19 +20,7 @@ namespace Microsoft.PowerShell
         /// </param>
         public static int Main(string[] args)
         {
-#if CORECLR
-            // PowerShell has to set the ALC here, since we don't own the native host
-            string appBase = System.IO.Path.GetDirectoryName(typeof(ManagedPSEntry).GetTypeInfo().Assembly.Location);
-            return (int)PowerShellAssemblyLoadContextInitializer.
-                           InitializeAndCallEntryMethod(
-                               appBase,
-                               new AssemblyName("Microsoft.PowerShell.ConsoleHost, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35"),
-                               "Microsoft.PowerShell.UnmanagedPSEntry",
-                               "Start",
-                               new object[] { string.Empty, args, args.Length });
-#else
             return UnmanagedPSEntry.Start(string.Empty, args, args.Length);
-#endif
         }
     }
 }


### PR DESCRIPTION
Partially fix #3649

Issue Summary
----------------
The API `AppDomain.GetAssemblies` is brought back in .NET Core 2.0 which returns the loaded assemblies from the default loader. Therefore it's possible now for powershell to just depend on the default CoreCLR loader without having our own assembly load context getting in the picture. This would greatly simplify the scenario of hosting powershell in applications.

Fix
---
Remove the code that spins up our own assembly load context. Keep the code that registers our `Resolve` method to the default loader's `Resolving` event, so that we can continue to do special assembly resolution as needed (such as the GAC probing logic needed for consuming FullCLR PS modules).

Essentially, the assembly `Microsoft.PowerShell.CoreCLR.AssemblyLoadContext.dll` is not needed anymore, the remaining code should be moved to S.M.A.dll. However, that will break DSC and other native hosts that are hosting powershell. So this assembly is kept for now.

CoreFX Fixes needed
-----------------------
https://github.com/dotnet/corefx/issues/18989
https://github.com/dotnet/corefx/issues/18877
https://github.com/dotnet/corefx/issues/18791

This PR is not blocked by those CoreFX issues, but it's incomplete until we have the fixes. Those issues have already been addressed, and #3887 will get those fixes for us.
Note that this PR is NOT blocked by #3887.

Follow-up work
-----------------
This PR addresses the first task listed in #3649. Three tasks are remaining.