### PR TITLE
Fix code coverage infrastructure and some failing tests

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -463,7 +463,8 @@ function Compress-TestContent {
         $Destination
     )
 
-    $powerShellTestRoot =  Join-Path $PSScriptRoot 'test\powershell'
+    Publish-PSTestTools
+    $powerShellTestRoot =  Join-Path $PSScriptRoot 'test'
     Add-Type -AssemblyName System.IO.Compression.FileSystem
 
     $resolvedPath = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($Destination)

--- a/test/powershell/Modules/PowerShellGet/PowerShellGet.Tests.ps1
+++ b/test/powershell/Modules/PowerShellGet/PowerShellGet.Tests.ps1
@@ -69,14 +69,8 @@ $script:MyDocumentsScriptsPath = Microsoft.PowerShell.Management\Join-Path -Path
 
 function Initialize
 {
-    # Check if the PackageManagement works in the base-oS or PowerShellCore
-    $PSHome
-    $PSVersionTable
-    $env:PSModulePath
-
-    Get-Module -ListAvailable -Name PackageManagement, PowerShellGet
-    Import-Module PackageManagement -verbose
-    Get-PackageProvider -ListAvailable
+    Import-Module PackageManagement
+    Get-PackageProvider -ListAvailable | Out-Null
 
     $repo = Get-PSRepository -ErrorAction SilentlyContinue |
                 Where-Object {$_.SourceLocation.StartsWith($SourceLocation, [System.StringComparison]::OrdinalIgnoreCase)}

--- a/test/powershell/Modules/PowerShellGet/PowerShellGet.Tests.ps1
+++ b/test/powershell/Modules/PowerShellGet/PowerShellGet.Tests.ps1
@@ -69,6 +69,7 @@ $script:MyDocumentsScriptsPath = Microsoft.PowerShell.Management\Join-Path -Path
 
 function Initialize
 {
+    # Cleaned up commands whose output to console by deleting or piping to Out-Null
     Import-Module PackageManagement
     Get-PackageProvider -ListAvailable | Out-Null
 

--- a/test/powershell/engine/Help/HelpSystem.OnlineHelp.Tests.ps1
+++ b/test/powershell/engine/Help/HelpSystem.OnlineHelp.Tests.ps1
@@ -59,7 +59,7 @@ Describe 'Get-Help -Online opens the default web browser and navigates to the cm
             $progId = (Get-ItemProperty $regKey).ProgId
             if($progId)
             {
-                if ((Get-PSDrive -Name HKCR) -eq $Null)
+                if (-not (Test-Path 'HKCR:\'))
                 {
                     New-PSDrive -PSProvider registry -Root HKEY_CLASSES_ROOT -Name HKCR | Should NotBeNullOrEmpty
                 }

--- a/test/tools/CodeCoverageAutomation/Start-CodeCoverageRun.ps1
+++ b/test/tools/CodeCoverageAutomation/Start-CodeCoverageRun.ps1
@@ -73,6 +73,7 @@ $psCodeZip = "$outputBaseFolder\PSCode.zip"
 $psCodePath = "$outputBaseFolder\PSCode"
 $elevatedLogs = "$outputBaseFolder\TestResults_Elevated.xml"
 $unelevatedLogs = "$outputBaseFolder\TestResults_Unelevated.xml"
+$testToolsPath = "$testPath\tools"
 
 try
 {
@@ -107,13 +108,15 @@ try
     Write-LogPassThru -Message "psbinpath : $psBinPath"
     Write-LogPassThru -Message "elevatedLog : $elevatedLogs"
     Write-LogPassThru -Message "unelevatedLog : $unelevatedLogs"
+    Write-LogPassThru -Message "TestToolsPath : $testToolsPath"
 
     $openCoverParams = @{outputlog = $outputLog;
         TestDirectory = $testPath;
         OpenCoverPath = "$openCoverTargetDirectory\OpenCover";
-        PowerShellExeDirectory = "$psBinPath\publish";
+        PowerShellExeDirectory = "$psBinPath";
         PesterLogElevated = $elevatedLogs;
         PesterLogUnelevated = $unelevatedLogs;
+        TestToolsModulesPath = "$testToolsPath\Modules";
     }
 
     $openCoverParams | Out-String | Write-LogPassThru
@@ -133,7 +136,7 @@ try
 
     Write-LogPassThru -Message "Test run done."
 
-    $gitCommitId = & "$psBinPath\publish\powershell.exe" -noprofile -command { $PSVersiontable.GitCommitId }
+    $gitCommitId = & "$psBinPath\powershell.exe" -noprofile -command { $PSVersiontable.GitCommitId }
     $commitId = $gitCommitId.substring($gitCommitId.LastIndexOf('-g') + 2)
 
     Write-LogPassThru -Message $commitId

--- a/test/tools/OpenCover/OpenCover.psm1
+++ b/test/tools/OpenCover/OpenCover.psm1
@@ -429,6 +429,7 @@ function Invoke-OpenCover
         [parameter()]$PesterLogElevated = "$pwd/TestResultsElevated.xml",
         [parameter()]$PesterLogUnelevated = "$pwd/TestResultsUnelevated.xml",
         [parameter()]$PesterLogFormat = "NUnitXml",
+        [parameter()]$TestToolsModulesPath = "$($script:psRepoPath)/test/tools/Modules",
         [switch]$CIOnly
         )
 
@@ -453,7 +454,9 @@ function Invoke-OpenCover
     }
 
     # create the arguments for OpenCover
-    $targetArgs = "-c", "Set-ExecutionPolicy Bypass -Force -Scope Process;", "Invoke-Pester","${TestDirectory}"
+
+    $startupArgs =  '$env:PSModulePath = "$($env:PSModulePath);$TestToolsPath";Set-ExecutionPolicy Bypass -Force -Scope Process;'
+    $targetArgs = "-c","${startupArgs}", "Invoke-Pester","${TestDirectory}"
 
     if ( $CIOnly )
     {

--- a/test/tools/OpenCover/OpenCover.psm1
+++ b/test/tools/OpenCover/OpenCover.psm1
@@ -423,13 +423,13 @@ function Invoke-OpenCover
     [CmdletBinding(SupportsShouldProcess=$true)]
     param (
         [parameter()]$OutputLog = "$home/Documents/OpenCover.xml",
-        [parameter()]$TestDirectory = "$($script:psRepoPath)/test/powershell",
+        [parameter()]$TestDirectory = "${script:psRepoPath}/test/powershell",
         [parameter()]$OpenCoverPath = "$home/OpenCover",
-        [parameter()]$PowerShellExeDirectory = "$($script:psRepoPath)/src/powershell-win-core/bin/CodeCoverage/netcoreapp1.0/win10-x64/publish",
+        [parameter()]$PowerShellExeDirectory = "${script:psRepoPath}/src/powershell-win-core/bin/CodeCoverage/netcoreapp2.0/win10-x64/publish",
         [parameter()]$PesterLogElevated = "$pwd/TestResultsElevated.xml",
         [parameter()]$PesterLogUnelevated = "$pwd/TestResultsUnelevated.xml",
         [parameter()]$PesterLogFormat = "NUnitXml",
-        [parameter()]$TestToolsModulesPath = "$($script:psRepoPath)/test/tools/Modules",
+        [parameter()]$TestToolsModulesPath = "${script:psRepoPath}/test/tools/Modules",
         [switch]$CIOnly
         )
 
@@ -455,7 +455,7 @@ function Invoke-OpenCover
 
     # create the arguments for OpenCover
 
-    $startupArgs =  '$env:PSModulePath = "$($env:PSModulePath);$TestToolsPath";Set-ExecutionPolicy Bypass -Force -Scope Process;'
+    $startupArgs =  '$env:PSModulePath = "${env:PSModulePath};$TestToolsPath";Set-ExecutionPolicy Bypass -Force -Scope Process;'
     $targetArgs = "-c","${startupArgs}", "Invoke-Pester","${TestDirectory}"
 
     if ( $CIOnly )


### PR DESCRIPTION
* Fixed tests that were failing or throwing unnecessary information on screen.
* Updated the paths to powershell.exe as per the new artifact layout.
* Added Publish-PSTestTools to Compress-TestContent
* Added PS Test tools to PSModulePath before starting tests.

<!--

If you are a PowerShell Team member, please make sure you choose the Reviewer(s) and Assignee for your PR.
If you are not from the PowerShell Team, you can leave the fields blank and the Maintainers will choose them for you. If you are familiar with the team, feel free to mention some Reviewers yourself.

For more information about the roles of Reviewer and Assignee, refer to CONTRIBUTING.md.

-->
