### PR TITLE
Add version to PowerShell banner

### DIFF
--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ManagedEntrance.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ManagedEntrance.cs
@@ -114,9 +114,10 @@ namespace Microsoft.PowerShell
 #else
                 var banner = ManagedEntranceStrings.ShellBanner;
 #endif
+                var formattedBanner = string.Format(CultureInfo.InvariantCulture, banner, PSVersionInfo.GitCommitId);
                 exitCode = Microsoft.PowerShell.ConsoleShell.Start(
                     configuration,
-                    banner,
+                    formattedBanner,
                     ManagedEntranceStrings.ShellHelp,
                     warning == null ? null : warning.Message,
                     args);

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/ManagedEntranceStrings.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/ManagedEntranceStrings.resx
@@ -119,11 +119,13 @@
   </resheader>
   <data name="ShellBanner" xml:space="preserve">
     <value>Windows PowerShell 
-Copyright (C) Microsoft Corporation. All rights reserved.</value>
+Copyright (C) Microsoft Corporation. All rights reserved.
+Version: {0}</value>
   </data>
   <data name="ShellBannerNonWindowsPowerShell" xml:space="preserve">
     <value>PowerShell 
-Copyright (C) Microsoft Corporation. All rights reserved.</value>
+Copyright (C) Microsoft Corporation. All rights reserved.
+Version: {0}</value>
   </data>
   <data name="ShellHelp" xml:space="preserve">
     <value>PowerShell[.exe] [-PSConsoleFile &lt;file&gt; | -Version &lt;version&gt;]

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/ManagedEntranceStrings.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/ManagedEntranceStrings.resx
@@ -118,14 +118,12 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ShellBanner" xml:space="preserve">
-    <value>Windows PowerShell 
-Copyright (C) Microsoft Corporation. All rights reserved.
-Version: {0}</value>
+    <value>Windows PowerShell {0}
+Copyright (C) Microsoft Corporation. All rights reserved.</value>
   </data>
   <data name="ShellBannerNonWindowsPowerShell" xml:space="preserve">
-    <value>PowerShell 
-Copyright (C) Microsoft Corporation. All rights reserved.
-Version: {0}</value>
+    <value>PowerShell {0}
+Copyright (C) Microsoft Corporation. All rights reserved.</value>
   </data>
   <data name="ShellHelp" xml:space="preserve">
     <value>PowerShell[.exe] [-PSConsoleFile &lt;file&gt; | -Version &lt;version&gt;]


### PR DESCRIPTION
Close #3895 

Motivation
---
Since we support side-by-side, it makes it easier to see which PowerShell version you started rather than checking $psversiontable or $pshome.

Fix
---

Add "GitCommitId" to PowerShell banner.

Follow-up work
---
Based on #3690 later we will change a GitCommitId format.