### PR TITLE
Enhance ResGen tool to support a command line argument

### DIFF
--- a/src/ResGen/Program.cs
+++ b/src/ResGen/Program.cs
@@ -10,12 +10,30 @@ namespace ConsoleApplication
     {
         public static void Main(string[] args)
         {
-            // we are assuming resgen is run with 'dotnet run'
-            // so we can use relative paths
-            foreach (string folder in Directory.EnumerateDirectories(".."))
+            IEnumerable<string> dirs;
+            string fileFilter;
+
+            if (args.Length == 1)
+            {
+                // We are assuming resgen is run with 'dotnet run pathToResxFile.resx'.
+                fileFilter = Path.GetFileName(args[0]);
+                string moduleDirectory = Directory.GetParent(Path.GetDirectoryName(args[0])).FullName;
+                dirs = new List<string>() { moduleDirectory };
+            }
+            else
+            {
+                // We are assuming resgen is run with 'dotnet run'
+                // so we can use relative path to get a parent directory
+                // to process all *.resx files in all project subdirectories.
+                fileFilter = "*.resx";
+                dirs = Directory.EnumerateDirectories("..");
+            }
+
+            foreach (string folder in dirs)
             {
                 string moduleName = Path.GetFileName(folder);
                 string resourcePath = Path.Combine(folder, "resources");
+
                 if (Directory.Exists(resourcePath))
                 {
                     string genFolder = Path.Combine(folder, "gen");
@@ -24,7 +42,7 @@ namespace ConsoleApplication
                         Directory.CreateDirectory(genFolder);
                     }
 
-                    foreach (string resxPath in Directory.EnumerateFiles(resourcePath, "*.resx"))
+                    foreach (string resxPath in Directory.EnumerateFiles(resourcePath, fileFilter))
                     {
                         string className = Path.GetFileNameWithoutExtension(resxPath);
                         string sourceCode = GetStronglyTypeCsFileForResx(resxPath, moduleName, className);

--- a/src/ResGen/Program.cs
+++ b/src/ResGen/Program.cs
@@ -17,7 +17,7 @@ namespace ConsoleApplication
             {
                 // We are assuming resgen is run with 'dotnet run pathToResxFile.resx'.
                 fileFilter = Path.GetFileName(args[0]);
-                string moduleDirectory = Directory.GetParent(Path.GetDirectoryName(args[0])).FullName;
+                string moduleDirectory = Path.GetDirectoryName(Path.GetDirectoryName(args[0]));
                 dirs = new List<string>() { moduleDirectory };
             }
             else


### PR DESCRIPTION
Related #3400

Motivation
---
ResGen tool process all resx files in PowerShell Repo at a time. It is not problem because it works very fast. But updating multiple cs files causes all Repo projects to be recompiled. It really slows down.

We still can not use native resgen from dotnet-cli. See https://github.com/PowerShell/PowerShell/issues/2882#issuecomment-304300044
So we should enhance our ResGen tool, use MSBuild capabilities and process resx files one at a time to avoid unnecessary rebuilds.

Fix
---
We can specify a resx file path parameter on the command line and process resx files one at a time.

Follow-Up work
---
We will clean up Build.psm1 and modify csproj files to use the new feature of ResGen tool with MSBuild for faster project build.
