### PR TITLE
Make 'Start-PSBuild' and 'Start-PSPackage' accept a release tag argument

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -1863,6 +1863,7 @@ function Start-DevPowerShell {
 <#
 .EXAMPLE
 PS C:> Copy-MappedFiles -PslMonadRoot .\src\monad
+
 copy files FROM .\src\monad (old location of submodule) TO src/<project> folders
 #>
 function Copy-MappedFiles {

--- a/build.psm1
+++ b/build.psm1
@@ -131,7 +131,7 @@ function Start-PSBuild {
         [switch]$CrossGen,
 
         [Parameter(ParameterSetName='CoreCLR')]
-        [ValidatePattern("^v\d+\.\d+\.\d+-\w+\.\d+$")]
+        [ValidatePattern("^v\d+\.\d+\.\d+(-\w+\.\d+)?$")]
         [ValidateNotNullOrEmpty()]
         [string]$ReleaseTag
     )
@@ -1220,7 +1220,7 @@ function Start-PSPackage {
         [string]$Version,
 
         [Parameter(ParameterSetName = "ReleaseTag")]
-        [ValidatePattern("^v\d+\.\d+\.\d+-\w+\.\d+$")]
+        [ValidatePattern("^v\d+\.\d+\.\d+(-\w+\.\d+)?$")]
         [ValidateNotNullOrEmpty()]
         [string]$ReleaseTag,
 


### PR DESCRIPTION
Partially fix #3909

Issue Summary
---------------
Currently a release build depends on the release tag to be pushed. We need to break this dependency, so that creating the release tag can be made the last step of a release -- do it only if all preparation of the release is done.

Fix
---
Add a new parameter `-ReleaseTag` to `Start-PSBuild` and `Start-PSPackage` to allow a release tag to be passed in. When the release tag is specified at the command line, it will override the git commit id retrieved from `git describe`.

Example
--------
```
# Build for v6.0.0-beta.3 release
Start-PSBuild -Clean -CrossGen -PSModuleRestore -ReleaseTag v6.0.0-beta.3

# Create package for v6.0.0-beta.3 release
Start-PSPackage -ReleaseTag v6.0.0-beta.3 
```

Follow-up work
---------------
Our VSO build script need to update to somehow accept a release tag value and pass it along when it's specified.