### PR TITLE
Fix Start-PSBuild -SMAOnly with the latest dotnet cli

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -239,7 +239,11 @@ function Start-PSBuild {
 
     $Arguments += "--configuration", $Options.Configuration
     $Arguments += "--framework", $Options.Framework
-    $Arguments += "--runtime", $Options.Runtime
+
+    if (-not $SMAOnly) {
+        # libraries should not have runtime
+        $Arguments += "--runtime", $Options.Runtime
+    }
 
     # handle Restore
     if ($Restore -or -not (Test-Path "$($Options.Top)/obj/project.assets.json")) {


### PR DESCRIPTION
dotnet starts to error out because runtime is passed

I was trying to find a good place in the docs to document `Start-PSBuild -SMAOnly`, but cannot find it. @SteveL-MSFT do you have suggestions?