### PR TITLE
Add 'CSharpVersion7' member into public 'Language' enum

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/AddType.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/AddType.cs
@@ -49,6 +49,11 @@ namespace Microsoft.PowerShell.Commands
 
 #if CORECLR
         /// <summary>
+        /// The C# programming language v7
+        /// </summary>
+        CSharpVersion7,
+
+        /// <summary>
         /// The C# programming language v6
         /// </summary>
         CSharpVersion6,
@@ -633,6 +638,7 @@ namespace Microsoft.PowerShell.Commands
                 case Language.CSharpVersion4:
                 case Language.CSharpVersion5:
                 case Language.CSharpVersion6:
+                case Language.CSharpVersion7:
 #endif
                     return true;
                 default:
@@ -1216,6 +1222,9 @@ namespace Microsoft.PowerShell.Commands
                         break;
                     case Language.CSharpVersion6:
                         parseOptions = new CSharpParseOptions(LanguageVersion.CSharp6);
+                        break;
+                    case Language.CSharpVersion7:
+                        parseOptions = new CSharpParseOptions(LanguageVersion.CSharp7);
                         break;
                     case Language.CSharp:
                         parseOptions = new CSharpParseOptions();

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Add-Type.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Add-Type.Tests.ps1
@@ -1,6 +1,10 @@
 $guid = [Guid]::NewGuid().ToString().Replace("-","")
 
 Describe "Add-Type" -Tags "CI" {
+    It "Public 'Language' enumeration contains all members" {
+        [Enum]::GetNames("Microsoft.PowerShell.Commands.Language") -join "," | Should Be "CSharp,CSharpVersion7,CSharpVersion6,CSharpVersion5,CSharpVersion4,CSharpVersion3,CSharpVersion2,CSharpVersion1,VisualBasic,JScript"
+    }
+
     It "Should not throw given a simple class definition" {
         { Add-Type -TypeDefinition "public static class foo { }" } | Should Not Throw
     }


### PR DESCRIPTION
Close #3853 

Public enum 'LanguageVersion' from 'Microsoft.CodeAnalysis.CSharp'
already contains 'CSharp7' member.
After moving PowerShell to .Net Core 2.0 we should add 'CSharpVersion7'
member into public 'Microsoft.PowerShell.Commands.Language' enum too.

This will allow 'Add-Type -Language CSharpVersion7'

