### PR TITLE
Enhance '#requires' directive to check OS

### DIFF
--- a/src/System.Management.Automation/engine/CommandDiscovery.cs
+++ b/src/System.Management.Automation/engine/CommandDiscovery.cs
@@ -558,11 +558,55 @@ namespace System.Management.Automation
         // #Requires -Module
         internal static void VerifyScriptRequirements(ExternalScriptInfo scriptInfo, ExecutionContext context)
         {
+            VerifyOS(scriptInfo);
             VerifyElevatedPrivileges(scriptInfo);
             VerifyPSVersion(scriptInfo);
             VerifyPSEdition(scriptInfo);
             VerifyRequiredModules(scriptInfo, context);
         }
+
+        internal static void VerifyOS(ExternalScriptInfo scriptInfo)
+        {
+            string requiredOS = scriptInfo.RequiredOS;
+            bool trueOS = false;
+
+            if (string.Equals(requiredOS, "Windows", StringComparison.OrdinalIgnoreCase) && Platform.IsWindows)
+            {
+                trueOS = true;
+            } else if (string.Equals(requiredOS, "Linux", StringComparison.OrdinalIgnoreCase) && Platform.IsLinux)
+            {
+                trueOS = true;
+            } else if (string.Equals(requiredOS, "OSX", StringComparison.OrdinalIgnoreCase) && Platform.IsOSX)
+            {
+                trueOS = true;
+            } else if (string.Equals(requiredOS, "Unix", StringComparison.OrdinalIgnoreCase) && !Platform.IsWindows)
+            {
+                trueOS = true;
+            } else if (string.Equals(requiredOS, "Inbox", StringComparison.OrdinalIgnoreCase) && Platform.IsInbox)
+            {
+                trueOS = true;
+            } else if (string.Equals(requiredOS, "IoT", StringComparison.OrdinalIgnoreCase) && Platform.IsIoT)
+            {
+                trueOS = true;
+            } else if (string.Equals(requiredOS, "Nano", StringComparison.OrdinalIgnoreCase) && Platform.IsNanoServer)
+            {
+                trueOS = true;
+            }
+
+            if (requiredOS != null)
+            {
+                if (!trueOS)
+                {
+                    ScriptRequiresException scriptRequiresException =
+                        new ScriptRequiresException(
+                            scriptInfo.Name,
+                            requiredOS,
+                            approvedOSList);
+                    throw scriptRequiresException;
+                }
+            }
+        }
+        internal static string[] approvedOSList = new string[] {"Windows", "Linux", "OSX", "Unix", "Inbox", "IoT", "Nano"};
 
         internal static void VerifyPSVersion(ExternalScriptInfo scriptInfo)
         {

--- a/src/System.Management.Automation/engine/ExternalScriptInfo.cs
+++ b/src/System.Management.Automation/engine/ExternalScriptInfo.cs
@@ -368,6 +368,15 @@ namespace System.Management.Automation
             get { return 0; }
         }
 
+        internal string RequiredOS
+        {
+            get
+            {
+                var data = GetRequiresData();
+                return data == null ? null : data.RequiredOS;
+            }
+        }
+
         internal Version RequiresPSVersion
         {
             get

--- a/src/System.Management.Automation/engine/parser/ast.cs
+++ b/src/System.Management.Automation/engine/parser/ast.cs
@@ -762,6 +762,13 @@ namespace System.Management.Automation.Language
         /// If nothing is specified, this property is false.
         /// </summary>
         public bool IsElevationRequired { get; internal set; }
+
+        /// <summary>
+        /// Specifies if this script requires OS type, specified like:
+        ///     <code>#requires -OS OSX</code>
+        /// If nothing is specified, this property is empty.
+        /// </summary>
+        public string RequiredOS { get; internal set; }
     }
 
     /// <summary>

--- a/src/System.Management.Automation/resources/DiscoveryExceptions.resx
+++ b/src/System.Management.Automation/resources/DiscoveryExceptions.resx
@@ -175,6 +175,9 @@ The #requires statement must be in one of the following formats:
  "#requires -modules &lt;ModuleSpecification&gt;"
  "#requires -runasadministrator"</value>
   </data>
+  <data name="RequiresOSNotCompatible" xml:space="preserve">
+    <value>The script '{0}' cannot be run because it contained a "#requires" statement with an OS of '{1}' that doesn't match the current OS. Approved OS argument values is {2}.</value>
+  </data>
   <data name="RequiresInterpreterNotCompatible" xml:space="preserve">
     <value>The script '{0}' cannot be run because it contained a "#requires" statement with a shell ID of {1} that is incompatible with the current shell. To run this script you must use the shell located at '{2}'.</value>
   </data>

--- a/src/System.Management.Automation/utils/CommandDiscoveryExceptions.cs
+++ b/src/System.Management.Automation/utils/CommandDiscoveryExceptions.cs
@@ -347,6 +347,36 @@ namespace System.Management.Automation
         /// The name of the script containing the #requires statement.
         /// </param>
         ///
+        /// <param name="requiredOS">
+        /// OS name for this exception.
+        /// </param>
+        ///
+        /// <param name="approvedOSList">
+        /// Approved OS names for this exception.
+        /// </param>
+        internal ScriptRequiresException(
+            string commandName,
+            string requiredOS,
+            string[] approvedOSList)
+            : base(BuildMessage(commandName, requiredOS, approvedOSList))
+        {
+            Diagnostics.Assert(!string.IsNullOrEmpty(commandName), "commandName is null or empty when constructing ScriptRequiresException");
+            Diagnostics.Assert(!string.IsNullOrEmpty(requiredOS), "requiredOS is null or empty when constructing ScriptRequiresException");
+            _commandName = commandName;
+            this.SetErrorId("ScriptRequiresUnmatchedOS");
+            this.SetTargetObject(commandName);
+            this.SetErrorCategory(ErrorCategory.InvalidArgument);
+        }
+
+        /// <summary>
+        /// Constructs an ScriptRequiresException. Recommended constructor for the class for
+        /// #requires -RunAsAdministrator statement.
+        /// </summary>
+        ///
+        /// <param name="commandName">
+        /// The name of the script containing the #requires statement.
+        /// </param>
+        ///
         /// <param name="errorId">
         /// The error id for this exception.
         /// </param>
@@ -492,6 +522,17 @@ namespace System.Management.Automation
         #region Private
 
 
+        private static string BuildMessage(
+            string commandName,
+            string requiredOS,
+            string[] approvedOSList)
+        {
+            return StringUtil.Format(
+                    DiscoveryExceptions.RequiresOSNotCompatible,
+                    commandName,
+                    requiredOS,
+                    approvedOSList);
+        }
 
         private static string BuildMessage(
             string commandName,

--- a/test/powershell/engine/Module/ModuleRequires.Tests.ps1
+++ b/test/powershell/engine/Module/ModuleRequires.Tests.ps1
@@ -1,0 +1,41 @@
+Describe "Test '#requires' module directive" -tags "CI" {
+
+    Context "'#requires -OS'" {
+        BeforeAll {
+            function shouldLoad ($OS) {
+                switch ($OS)
+                {
+                    "Windows"   { return [System.Management.Automation.Platform]::isWindows }
+                    "Linux"     { return [System.Management.Automation.Platform]::isLinux }
+                    "OSX"       { return [System.Management.Automation.Platform]::isOSX }
+                    "Unix"      { return [System.Management.Automation.Platform]::isLinux -or [System.Management.Automation.Platform]::isOSX }
+                    "Inbox"     { return [System.Management.Automation.Platform]::IsIoT   -or [System.Management.Automation.Platform]::IsNanoServer }
+                    "IoT"       { return [System.Management.Automation.Platform]::IsIoT }
+                    "Nano"      { return [System.Management.Automation.Platform]::IsNanoServer }
+                    default     { throw "Wrong OS argument value." }
+                }
+            }
+        }
+
+        It "Directive '<moduleCode>' works well" -TestCases (
+            @{ moduleCode = "#requires -OS Windows"; shouldModuleLoad = shouldLoad("Windows")   },
+            @{ moduleCode = "#requires -OS Linux";   shouldModuleLoad = shouldLoad("Linux")     },
+            @{ moduleCode = "#requires -OS OSX";     shouldModuleLoad = shouldLoad("OSX")       },
+            @{ moduleCode = "#requires -OS Unix";    shouldModuleLoad = shouldLoad("Unix")      },
+            @{ moduleCode = "#requires -OS Inbox";   shouldModuleLoad = shouldLoad("Inbox")     },
+            @{ moduleCode = "#requires -OS IoT";     shouldModuleLoad = shouldLoad("IoT")       },
+            @{ moduleCode = "#requires -OS Nano";    shouldModuleLoad = shouldLoad("Nano")      }
+        ) {
+            param ($moduleCode, $shouldModuleLoad)
+
+            $testModulePath = Join-Path $TestDrive "moduleTest-$(New-GUID).psm1"
+            Set-Content -Path $testModulePath -Value $moduleCode -Force
+
+            if ($shouldModuleLoad) {
+                { Import-Module $testModulePath -ErrorAction Stop -Force} | Should Not Throw
+            } else {
+                { Import-Module $testModulePath -ErrorAction Stop } | ShouldBeErrorId "ScriptRequiresUnmatchedOS,Microsoft.PowerShell.Commands.ImportModuleCommand"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Close #3751

Motivation
---
PowerShell Core is a cross-platform, so a module author can write a module for only specific platform.

Enhancement
---
Now in a module import time '#requires' support:

#requires -OS Windows
#requires -OS Linux
#requires -OS OSX
#requires -OS Unix
#requires -OS Inbox
#requires -OS IoT
#requires -OS Nano

Here:
 - Unix is Linux or OSX
 - InBox is IoT or Nano
 - Nano is Nano Server

Additional considerations
---
Our CI systems don't run tests for IoT and Nano so we have to run it in a special way.
