### PR TITLE
PSReadline unusable on ServerCore container

### DIFF
--- a/src/Microsoft.PowerShell.PSReadLine/ConsoleLib.cs
+++ b/src/Microsoft.PowerShell.PSReadLine/ConsoleLib.cs
@@ -727,9 +727,7 @@ namespace Microsoft.PowerShell.Internal
 
             if (result == false)
             {
-                int err = Marshal.GetLastWin32Error();
-                Win32Exception innerException = new Win32Exception(err);
-                throw new Exception("Failed to get console font information.", innerException);
+                _getCurrentConsoleFontExApiAvailable = false; // api not supported on ServerCore
             }
             return fontInfo;
         }


### PR DESCRIPTION
The GetCurrentConsoleFontEx() api is available, but fails with unspecified error code on ServerCore running in container.  Using similar logic to NanoServer where the api is not available, don't make the error fatal.  Ignore the error so PSReadline continues to work.  Impact is if using ServerCore on non-English (double char wide) characters.

Fix #3927 