### PR TITLE
Change New-ModuleManifest encoding to UTF8NoBOM on non-Windows platforms

### DIFF
--- a/src/System.Management.Automation/engine/Modules/NewModuleManifestCommand.cs
+++ b/src/System.Management.Automation/engine/Modules/NewModuleManifestCommand.cs
@@ -941,7 +941,7 @@ namespace Microsoft.PowerShell.Commands
                 PathUtils.MasterStreamOpen(
                     this,
                     filePath,
-                    EncodingConversion.Unicode,
+                    new UTF8Encoding(false), // UTF-8, no BOM
                     /* defaultEncoding */ false,
                     /* Append */ false,
                     /* Force */ false,

--- a/src/System.Management.Automation/engine/Modules/NewModuleManifestCommand.cs
+++ b/src/System.Management.Automation/engine/Modules/NewModuleManifestCommand.cs
@@ -941,7 +941,11 @@ namespace Microsoft.PowerShell.Commands
                 PathUtils.MasterStreamOpen(
                     this,
                     filePath,
+#if UNIX
                     new UTF8Encoding(false), // UTF-8, no BOM
+#else
+                    EncodingConversion.Unicode, // UTF-16 with BOM
+#endif
                     /* defaultEncoding */ false,
                     /* Append */ false,
                     /* Force */ false,
@@ -1167,5 +1171,5 @@ namespace Microsoft.PowerShell.Commands
         }
     }
 
-    #endregion
+#endregion
 } // Microsoft.PowerShell.Commands

--- a/test/powershell/engine/Module/NewModuleManifest.Tests.ps1
+++ b/test/powershell/engine/Module/NewModuleManifest.Tests.ps1
@@ -20,6 +20,12 @@ Describe "New-ModuleManifest tests" -tags "CI" {
         $module.PrivateData.PSData.ProjectUri | Should BeExactly $absoluteUri
     }
 
+    It "Verify module manifest encoding" {
+        New-ModuleManifest -Path $testModulePath
+        # verify first line of the manifest - 3 bytes - '#' '\r' '\n' - in UTF-8 no BOM this should be @(35,13,10)
+        Get-Content -Encoding Byte -Path $testModulePath -TotalCount 3 | Should Be @(35,13,10)
+    }
+
     It "Relative URIs are not allowed" {
         $testUri = [Uri]"../foo"
 

--- a/test/powershell/engine/Module/NewModuleManifest.Tests.ps1
+++ b/test/powershell/engine/Module/NewModuleManifest.Tests.ps1
@@ -35,9 +35,9 @@ Describe "New-ModuleManifest tests" -tags "CI" {
 
     It "Verify module manifest encoding on non-Windows " -Skip:($IsWindows) {
         
-        # verify first line of the manifest - 3 characters - '#' '\r' '\n'
-        # On non-Windows platforms - in UTF-8 no BOM - this should be @(35,13,10)
-        TestNewModuleManifestEncoding -expected @(35,13,10)
+        # verify first line of the manifest - 2 characters - '#' '\n'
+        # On non-Windows platforms - in UTF-8 no BOM - this should be @(35,10)
+        TestNewModuleManifestEncoding -expected @(35,10)
     }
 
     It "Relative URIs are not allowed" {

--- a/test/powershell/engine/Module/NewModuleManifest.Tests.ps1
+++ b/test/powershell/engine/Module/NewModuleManifest.Tests.ps1
@@ -20,10 +20,24 @@ Describe "New-ModuleManifest tests" -tags "CI" {
         $module.PrivateData.PSData.ProjectUri | Should BeExactly $absoluteUri
     }
 
-    It "Verify module manifest encoding" {
+    function TestNewModuleManifestEncoding {
+        param ([byte[]]$expected)
         New-ModuleManifest -Path $testModulePath
-        # verify first line of the manifest - 3 bytes - '#' '\r' '\n' - in UTF-8 no BOM this should be @(35,13,10)
-        Get-Content -Encoding Byte -Path $testModulePath -TotalCount 3 | Should Be @(35,13,10)
+        (Get-Content -Encoding Byte -Path $testModulePath -TotalCount $expected.Length) -join ',' | Should Be ($expected -join ',')
+    }
+
+    It "Verify module manifest encoding on Windows " -Skip:(-not $IsWindows) {
+        
+        # verify first line of the manifest - 3 characters - '#' '\r' '\n'
+        # On Windows platforms - in UTF-16 with BOM - this should be @(255,254,35,0,13,0,10,0)
+        TestNewModuleManifestEncoding -expected @(255,254,35,0,13,0,10,0)
+    }
+
+    It "Verify module manifest encoding on non-Windows " -Skip:($IsWindows) {
+        
+        # verify first line of the manifest - 3 characters - '#' '\r' '\n'
+        # On non-Windows platforms - in UTF-8 no BOM - this should be @(35,13,10)
+        TestNewModuleManifestEncoding -expected @(35,13,10)
     }
 
     It "Relative URIs are not allowed" {


### PR DESCRIPTION
This addresses #3789 
Currently New-ModuleManifest creates psd1 manifests in UTF-16 with BOM; this creates problems for Linux tools and Git diff'er.
This fix changes encoding of New-ModuleManifest to be UTF8 (no BOM).
Also mentioned New-ModuleManifest in "[RFC 0020 DefaultFileEncoding](https://github.com/PowerShell/PowerShell-RFC/blob/master/1-Draft/RFC0020-DefaultFileEncoding.md)".
