### PR TITLE
Implement Unicode escape parsing

### DIFF
--- a/src/System.Management.Automation/engine/parser/tokenizer.cs
+++ b/src/System.Management.Automation/engine/parser/tokenizer.cs
@@ -1280,6 +1280,7 @@ namespace System.Management.Automation.Language
                     if (i == 0)
                     {
                         // Sequence must have at least one hex char.
+                        Release(sb);
                         IScriptExtent errorExtent = NewScriptExtent(escSeqStartIndex, _currentIndex);
                         ReportError(errorExtent, () => ParserStrings.InvalidUnicodeEscapeSequence);
                         return s_invalidChar;
@@ -1291,6 +1292,7 @@ namespace System.Management.Automation.Language
                 {
                     UngetChar();
 
+                    Release(sb);
                     ReportError(_currentIndex,
                         i < s_maxNumberOfUnicodeHexDigits
                             ? (Expression<Func<string>>)(() => ParserStrings.InvalidUnicodeEscapeSequence)
@@ -1300,6 +1302,7 @@ namespace System.Management.Automation.Language
                 else if (i == s_maxNumberOfUnicodeHexDigits) {
                     UngetChar();
 
+                    Release(sb);
                     ReportError(_currentIndex, () => ParserStrings.TooManyDigitsInUnicodeEscapeSequence);
                     return s_invalidChar;
                 }

--- a/src/System.Management.Automation/engine/parser/tokenizer.cs
+++ b/src/System.Management.Automation/engine/parser/tokenizer.cs
@@ -509,7 +509,7 @@ namespace System.Management.Automation.Language
 
         // Unicode replacement char used to represent an unknown, unrecognized or unrepresentable character in a
         // Unicode escape sequence.
-        private static readonly string s_unknownUnicodeChar = ((char)0xffdd).ToString();
+        private static readonly string s_unknownUnicodeChar = ((char)0xfffd).ToString();
         private static readonly int s_maxNumberOfUnicodeHexDigits = 6;
 
         private readonly Parser _parser;

--- a/src/System.Management.Automation/engine/parser/tokenizer.cs
+++ b/src/System.Management.Automation/engine/parser/tokenizer.cs
@@ -510,6 +510,7 @@ namespace System.Management.Automation.Language
         // Unicode replacement char used to represent an unknown, unrecognized or unrepresentable character in a
         // Unicode escape sequence.
         private static readonly string s_unknownUnicodeChar = ((char)0xffdd).ToString();
+        private static readonly int s_maxNumberOfUnicodeHexDigits = 6;
 
         private readonly Parser _parser;
         private PositionHelper _positionHelper;
@@ -1254,7 +1255,6 @@ namespace System.Management.Automation.Language
         private string ScanUnicodeEscapeSequence()
         {
             int escSeqStartIndex = _currentIndex - 2;
-            const int maxNumberOfHexDigits = 6;
 
             char c = GetChar();
             if (c != '{')
@@ -1269,7 +1269,7 @@ namespace System.Management.Automation.Language
             // Scan the rest of the Unicode escape sequence - one to six hex digits terminated plus the closing '}'.
             var sb = GetStringBuilder();
             int i;
-            for (i = 0; i < maxNumberOfHexDigits + 1; i++)
+            for (i = 0; i < s_maxNumberOfUnicodeHexDigits + 1; i++)
             {
                 c = GetChar();
 
@@ -1291,12 +1291,12 @@ namespace System.Management.Automation.Language
                     UngetChar();
 
                     ReportError(_currentIndex,
-                        i < maxNumberOfHexDigits
+                        i < s_maxNumberOfUnicodeHexDigits
                             ? (Expression<Func<string>>)(() => ParserStrings.InvalidUnicodeEscapeSequence)
                             : () => ParserStrings.MissingUnicodeEscapeSequenceTerminator);
                     return s_unknownUnicodeChar;
                 }
-                else if (i == maxNumberOfHexDigits) {
+                else if (i == s_maxNumberOfUnicodeHexDigits) {
                     UngetChar();
 
                     ReportError(_currentIndex, () => ParserStrings.TooManyDigitsInUnicodeEscapeSequence);

--- a/src/System.Management.Automation/resources/ParserStrings.resx
+++ b/src/System.Management.Automation/resources/ParserStrings.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -129,11 +129,8 @@
   <data name="IncompleteString" xml:space="preserve">
     <value>Incomplete string token.</value>
   </data>
-  <data name="EmptyUnicodeEscapeSequence" xml:space="preserve">
-    <value>An empty `u${} Unicode escape sequence was found. At least one hex digit is required inside the braces.</value>
-  </data>
   <data name="InvalidUnicodeEscapeSequence" xml:space="preserve">
-    <value>The Unicode escape sequence is not valid. A valid sequence is `u followed by four hex digits.</value>
+    <value>The Unicode escape sequence is not valid. A valid sequence is `u{ followed by one to six hex digits and a closing '}'.</value>
   </data>
   <data name="InvalidUnicodeEscapeSequenceValue" xml:space="preserve">
     <value>The Unicode escape sequence value is out of range. The maximum value is 0x10FFFF.</value>
@@ -1054,10 +1051,10 @@ Possible matches are</value>
     <value>The script block that defines function '{0}' cannot be null or empty. Provide a non-empty script block in the function definition dictionary, and then try the operation again.</value>
   </data>
   <data name="ImportDscResourceNeedParams" xml:space="preserve">
-    <value>The syntax of the Import-DscResource dynamic keyword is: 
-   
+    <value>The syntax of the Import-DscResource dynamic keyword is:
+
 Import-DscResource  [-Name &lt;ResourceName(s)&gt;]  [-ModuleName  &lt;ModuleName(s)&gt;] [-ModuleVersion &lt;ModuleVersion&gt;].
-  
+
 Name          : Names of one or more resources to import.
 ModuleName    : Module names or ModuleSpecification objects of one or more modules to import.
 ModuleVersion : Version of module to import. If used, ModuleName must represent only one module by name.</value>
@@ -1087,7 +1084,7 @@ ModuleVersion : Version of module to import. If used, ModuleName must represent 
     <value>'{0}' is not a valid value for property '{1}' on class '{2}'. Please change the value to one of the following strings: {3}.</value>
   </data>
   <data name="UnsupportedValueForProperty" xml:space="preserve">
-    <value>At least one of the values '{0}' is not supported or valid for property '{1}' on class '{2}'. Please specify only supported values: 
+    <value>At least one of the values '{0}' is not supported or valid for property '{1}' on class '{2}'. Please specify only supported values:
 {3}.</value>
   </data>
   <data name="MissingValueForMandatoryProperty" xml:space="preserve">
@@ -1170,7 +1167,7 @@ ModuleVersion : Version of module to import. If used, ModuleName must represent 
     <value>Only one type may be specified on class members.</value>
   </data>
   <data name="TypeCreationError" xml:space="preserve">
-    <value>Error during creation of type "{0}". Error message: 
+    <value>Error during creation of type "{0}". Error message:
 {1}</value>
   </data>
   <data name="CannotConvertValue" xml:space="preserve">

--- a/src/System.Management.Automation/resources/ParserStrings.resx
+++ b/src/System.Management.Automation/resources/ParserStrings.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!--
-    Microsoft ResX Schema
-
+  <!-- 
+    Microsoft ResX Schema 
+    
     Version 2.0
-
-    The primary goals of this format is to allow a simple XML format
-    that is mostly human readable. The generation and parsing of the
-    various data types are done through the TypeConverter classes
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
     associated with the data types.
-
+    
     Example:
-
+    
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-
-    There are any number of "resheader" rows that contain simple
+                
+    There are any number of "resheader" rows that contain simple 
     name/value pairs.
-
-    Each data row contains a name, and value. The row also contains a
-    type or mimetype. Type corresponds to a .NET class that support
-    text/value conversion through the TypeConverter architecture.
-    Classes that don't support this are serialized and stored with the
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
     mimetype set.
-
-    The mimetype is used for serialized objects, and tells the
-    ResXResourceReader how to depersist the object. This is currently not
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
     extensible. For a given mimetype the value must be set accordingly:
-
-    Note - application/x-microsoft.net.object.binary.base64 is the format
-    that the ResXResourceWriter will generate, however the reader can
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
     read any of the formats listed below.
-
+    
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-
+    
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array
+    value   : The object must be serialized into a byte array 
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -128,6 +128,21 @@
   </data>
   <data name="IncompleteString" xml:space="preserve">
     <value>Incomplete string token.</value>
+  </data>
+  <data name="EmptyUnicodeEscapeSequence" xml:space="preserve">
+    <value>An empty `u${} Unicode escape sequence was found. At least one hex digit is required inside the braces.</value>
+  </data>
+  <data name="InvalidUnicodeEscapeSequence" xml:space="preserve">
+    <value>The Unicode escape sequence is not valid. A valid sequence is `u followed by four hex digits.</value>
+  </data>
+  <data name="InvalidUnicodeEscapeSequenceValue" xml:space="preserve">
+    <value>The Unicode escape sequence value is out of range. The maximum value is 0x10FFFF.</value>
+  </data>
+  <data name="MissingUnicodeEscapeSequenceTerminator" xml:space="preserve">
+    <value>The Unicode escape sequence is missing the closing '}'.</value>
+  </data>
+  <data name="TooManyDigitsInUnicodeEscapeSequence" xml:space="preserve">
+    <value>The Unicode escape sequence contains more than the maximum of six hex digits between braces.</value>
   </data>
   <data name="NumberBothLongAndFloatingPoint" xml:space="preserve">
     <value>A number cannot be both a long and floating point.</value>
@@ -1039,10 +1054,10 @@ Possible matches are</value>
     <value>The script block that defines function '{0}' cannot be null or empty. Provide a non-empty script block in the function definition dictionary, and then try the operation again.</value>
   </data>
   <data name="ImportDscResourceNeedParams" xml:space="preserve">
-    <value>The syntax of the Import-DscResource dynamic keyword is:
-
+    <value>The syntax of the Import-DscResource dynamic keyword is: 
+   
 Import-DscResource  [-Name &lt;ResourceName(s)&gt;]  [-ModuleName  &lt;ModuleName(s)&gt;] [-ModuleVersion &lt;ModuleVersion&gt;].
-
+  
 Name          : Names of one or more resources to import.
 ModuleName    : Module names or ModuleSpecification objects of one or more modules to import.
 ModuleVersion : Version of module to import. If used, ModuleName must represent only one module by name.</value>
@@ -1072,7 +1087,7 @@ ModuleVersion : Version of module to import. If used, ModuleName must represent 
     <value>'{0}' is not a valid value for property '{1}' on class '{2}'. Please change the value to one of the following strings: {3}.</value>
   </data>
   <data name="UnsupportedValueForProperty" xml:space="preserve">
-    <value>At least one of the values '{0}' is not supported or valid for property '{1}' on class '{2}'. Please specify only supported values:
+    <value>At least one of the values '{0}' is not supported or valid for property '{1}' on class '{2}'. Please specify only supported values: 
 {3}.</value>
   </data>
   <data name="MissingValueForMandatoryProperty" xml:space="preserve">
@@ -1155,7 +1170,7 @@ ModuleVersion : Version of module to import. If used, ModuleName must represent 
     <value>Only one type may be specified on class members.</value>
   </data>
   <data name="TypeCreationError" xml:space="preserve">
-    <value>Error during creation of type "{0}". Error message:
+    <value>Error during creation of type "{0}". Error message: 
 {1}</value>
   </data>
   <data name="CannotConvertValue" xml:space="preserve">

--- a/test/powershell/Language/Parser/Parser.Tests.ps1
+++ b/test/powershell/Language/Parser/Parser.Tests.ps1
@@ -273,16 +273,6 @@
     Context "Test Unicode escape sequences." {
         # These tests require the file to be saved with a BOM.  Unfortunately when this UTF8 file is read by
         # PowerShell without a BOM, the file is incorrectly interpreted as ASCII.
-        It 'Test that Unicode escape sequence `u2195 in string returns the ↕ character.' {
-            $result = ExecuteCommand '"foo`u2195abc"'
-            $result | should be "foo↕abc"
-        }
-
-        It 'Test that Unicode escape sequence `u2195 in here string returns the ↕ character.' {
-            $result = ExecuteCommand ("@`"`n`n" + 'foo`u2195abc' + "`n`n`"@")
-            $result | should be "`nfoo↕abc`n"
-        }
-
         It 'Test that the bracketed Unicode escape sequence `u{0} returns minimum char.' {
             $result = ExecuteCommand '"`u{0}"'
             [int]$result[0] | should be 0
@@ -299,38 +289,48 @@
             $result | should be '©'
         }
 
+        It 'Test that Unicode escape sequence `u{2195} in string returns the ↕ character.' {
+            $result = ExecuteCommand '"foo`u{2195}abc"'
+            $result | should be "foo↕abc"
+        }
+
         It 'Test that the bracketed Unicode escape sequence `u{1f44d} returns surrogate pair for emoji 👍 character.' {
             $result = ExecuteCommand '"`u{1f44d}"'
             $result | should be "👍"
         }
 
+        It 'Test that Unicode escape sequence `u{2195} in here string returns the ↕ character.' {
+            $result = ExecuteCommand ("@`"`n`n" + 'foo`u{2195}abc' + "`n`n`"@")
+            $result | should be "`nfoo↕abc`n"
+        }
+
         It 'Test that Unicode escape sequence in single quoted is not processed.' {
-            $result = ExecuteCommand '''foo`u2195abc'''
-            $result | should be 'foo`u2195abc'
+            $result = ExecuteCommand '''foo`u{2195}abc'''
+            $result | should be 'foo`u{2195}abc'
         }
 
         It 'Test that Unicode escape sequence in single quoted here string is not processed.' {
             $result = ExecuteCommand @"
 @'
 
-foo``u2195abc
+foo``u{2195}abc
 
 '@
 "@
-            $result | should be "`r`nfoo``u2195abc`r`n"
+            $result | should be "`r`nfoo``u{2195}abc`r`n"
         }
 
         It "Test that two consecutive Unicode escape sequences are tokenized correctly." {
-            $result = ExecuteCommand '"`u007b`u007d"'
+            $result = ExecuteCommand '"`u{007b}`u{007d}"'
             $result | should be '{}'
         }
 
         It "Test that a Unicode escape sequence can be used in a command name." {
-            function xyzzy`u2195($p) {$p}
-            $cmd = Get-Command xyzzy`u2195 -ErrorAction SilentlyContinue
+            function xyzzy`u{2195}($p) {$p}
+            $cmd = Get-Command xyzzy`u{2195} -ErrorAction SilentlyContinue
             $cmd | should not BeNullOrEmpty
             $cmd.Name | should be 'xyzzy↕'
-            xyzzy`u2195 42 | should be 42
+            xyzzy`u{2195} 42 | should be 42
         }
 
         It "Test that a Unicode escape sequence can be used in a variable name." {

--- a/test/powershell/Language/Parser/Parser.Tests.ps1
+++ b/test/powershell/Language/Parser/Parser.Tests.ps1
@@ -1,4 +1,4 @@
-Describe "ParserTests (admin\monad\tests\monad\src\engine\core\ParserTests.cs)" -Tags "CI" {
+﻿Describe "ParserTests (admin\monad\tests\monad\src\engine\core\ParserTests.cs)" -Tags "CI" {
     BeforeAll {
 		$functionDefinitionFile = Join-Path -Path $TestDrive -ChildPath "functionDefinition.ps1"
 		$functionDefinition = @'
@@ -268,6 +268,82 @@ Describe "ParserTests (admin\monad\tests\monad\src\engine\core\ParserTests.cs)" 
     It "Test that escaping the character 'e' returns the ESC character (0x1b)." {
         $result = ExecuteCommand '"`e"'
         $result | should be ([char]0x1b)
+    }
+
+    Context "Test Unicode escape sequences." {
+        # These tests require the file to be saved with a BOM.  Unfortunately when this UTF8 file is read by
+        # PowerShell without a BOM, the file is incorrectly interpreted as ASCII.
+        It 'Test that Unicode escape sequence `u2195 in string returns the ↕ character.' {
+            $result = ExecuteCommand '"foo`u2195abc"'
+            $result | should be "foo↕abc"
+        }
+
+        It 'Test that Unicode escape sequence `u2195 in here string returns the ↕ character.' {
+            $result = ExecuteCommand ("@`"`n`n" + 'foo`u2195abc' + "`n`n`"@")
+            $result | should be "`nfoo↕abc`n"
+        }
+
+        It 'Test that the bracketed Unicode escape sequence `u{0} returns minimum char.' {
+            $result = ExecuteCommand '"`u{0}"'
+            [int]$result[0] | should be 0
+        }
+
+        It 'Test that the bracketed Unicode escape sequence `u{10FFFF} returns maximum surrogate char pair.' {
+            $result = ExecuteCommand '"`u{10FFFF}"'
+            [int]$result[0] | should be 0xDBFF # max value for high surrogate of surrogate pair
+            [int]$result[1] | should be 0xDFFF # max value for low surrogate of surrogate pair
+        }
+
+        It 'Test that the bracketed Unicode escape sequence `u{a9} returns the © character.' {
+            $result = ExecuteCommand '"`u{a9}"'
+            $result | should be '©'
+        }
+
+        It 'Test that the bracketed Unicode escape sequence `u{1f44d} returns surrogate pair for emoji 👍 character.' {
+            $result = ExecuteCommand '"`u{1f44d}"'
+            $result | should be "👍"
+        }
+
+        It 'Test that Unicode escape sequence in single quoted is not processed.' {
+            $result = ExecuteCommand '''foo`u2195abc'''
+            $result | should be 'foo`u2195abc'
+        }
+
+        It 'Test that Unicode escape sequence in single quoted here string is not processed.' {
+            $result = ExecuteCommand @"
+@'
+
+foo``u2195abc
+
+'@
+"@
+            $result | should be "`r`nfoo``u2195abc`r`n"
+        }
+
+        It "Test that two consecutive Unicode escape sequences are tokenized correctly." {
+            $result = ExecuteCommand '"`u007b`u007d"'
+            $result | should be '{}'
+        }
+
+        It "Test that a Unicode escape sequence can be used in a command name." {
+            function xyzzy`u2195($p) {$p}
+            $cmd = Get-Command xyzzy`u2195 -ErrorAction SilentlyContinue
+            $cmd | should not BeNullOrEmpty
+            $cmd.Name | should be 'xyzzy↕'
+            xyzzy`u2195 42 | should be 42
+        }
+
+        It "Test that a Unicode escape sequence can be used in a variable name." {
+            ${fooxyzzy`u{2195}} = 42
+            $var = Get-Variable -Name fooxyzzy* -ErrorAction SilentlyContinue
+            $var | should not BeNullOrEmpty
+            $var.Name | should be "fooxyzzy↕"
+            $var.Value | should be 42
+        }
+
+        It "Test that a Unicode escape sequence can be used in an argument." {
+            Write-Output `u{a9}` Acme` Inc | should be "© Acme Inc"
+        }
     }
 
 	It "Test that escaping any character with no special meaning just returns that char. (line 602)" {

--- a/test/powershell/Language/Parser/Parsing.Tests.ps1
+++ b/test/powershell/Language/Parser/Parsing.Tests.ps1
@@ -304,13 +304,14 @@ Describe 'Hash Expression parsing' -Tags "CI" {
 }
 
 Describe 'Unicode escape sequence parsing' -Tag "CI" {
-    ShouldBeParseError '"`u{}"' InvalidUnicodeEscapeSequence 1
-    ShouldBeParseError '"`u{110000}"' InvalidUnicodeEscapeSequenceValue 4 # error offset is "`u{>>1<<10000}"
+    ShouldBeParseError '"`u{}"' InvalidUnicodeEscapeSequence 1                 # error span is >>`u{}<<
+    ShouldBeParseError '"`u{219z}"' InvalidUnicodeEscapeSequence 7             # error offset is "`u{219>>z<<}"
+    ShouldBeParseError '"`u{12345z}"' InvalidUnicodeEscapeSequence 9           # error offset is "`u{12345>>z<<}"
     ShouldBeParseError '"`u{1234567}"' TooManyDigitsInUnicodeEscapeSequence 10 # error offset is "`u{123456>>7<<}"
-    ShouldBeParseError '"`u{219z}"' MissingUnicodeEscapeSequenceTerminator 7 # error offset "`u{219>>z<<}"
+    ShouldBeParseError '"`u{110000}"' InvalidUnicodeEscapeSequenceValue 4      # error offset is "`u{>>1<<10000}"
     ShouldBeParseError '"`u2195}"' InvalidUnicodeEscapeSequence 1
-    ShouldBeParseError '"`u{' MissingUnicodeEscapeSequenceTerminator,TerminatorExpectedAtEndOfString 4,0
-    ShouldBeParseError '"`u{1' MissingUnicodeEscapeSequenceTerminator,TerminatorExpectedAtEndOfString 5,0
+    ShouldBeParseError '"`u{' InvalidUnicodeEscapeSequence,TerminatorExpectedAtEndOfString 4,0
+    ShouldBeParseError '"`u{1' InvalidUnicodeEscapeSequence,TerminatorExpectedAtEndOfString 5,0
     ShouldBeParseError '"`u{123456' MissingUnicodeEscapeSequenceTerminator,TerminatorExpectedAtEndOfString 10,0
     ShouldBeParseError '"`u{1234567' TooManyDigitsInUnicodeEscapeSequence,TerminatorExpectedAtEndOfString 10,0
 }

--- a/test/powershell/Language/Parser/Parsing.Tests.ps1
+++ b/test/powershell/Language/Parser/Parsing.Tests.ps1
@@ -304,14 +304,11 @@ Describe 'Hash Expression parsing' -Tags "CI" {
 }
 
 Describe 'Unicode escape sequence parsing' -Tag "CI" {
+    ShouldBeParseError '"`u{}"' InvalidUnicodeEscapeSequence 1
     ShouldBeParseError '"`u{110000}"' InvalidUnicodeEscapeSequenceValue 4 # error offset is "`u{>>1<<10000}"
     ShouldBeParseError '"`u{1234567}"' TooManyDigitsInUnicodeEscapeSequence 10 # error offset is "`u{123456>>7<<}"
-    ShouldBeParseError '"`u219z"' InvalidUnicodeEscapeSequence 1
-    ShouldBeParseError '"`u{219z"' MissingUnicodeEscapeSequenceTerminator 7 # error offset "`u{219>>z<<"
-    ShouldBeParseError '"`u{}"' EmptyUnicodeEscapeSequence 1
-    ShouldBeParseError '"`u' InvalidUnicodeEscapeSequence,TerminatorExpectedAtEndOfString 1,0
-    ShouldBeParseError '"`u123' InvalidUnicodeEscapeSequence,TerminatorExpectedAtEndOfString 1,0
-    ShouldBeParseError '"`u219z' InvalidUnicodeEscapeSequence,TerminatorExpectedAtEndOfString 1,0
+    ShouldBeParseError '"`u{219z}"' MissingUnicodeEscapeSequenceTerminator 7 # error offset "`u{219>>z<<}"
+    ShouldBeParseError '"`u2195}"' InvalidUnicodeEscapeSequence 1
     ShouldBeParseError '"`u{' MissingUnicodeEscapeSequenceTerminator,TerminatorExpectedAtEndOfString 4,0
     ShouldBeParseError '"`u{1' MissingUnicodeEscapeSequenceTerminator,TerminatorExpectedAtEndOfString 5,0
     ShouldBeParseError '"`u{123456' MissingUnicodeEscapeSequenceTerminator,TerminatorExpectedAtEndOfString 10,0

--- a/test/powershell/Language/Parser/Parsing.Tests.ps1
+++ b/test/powershell/Language/Parser/Parsing.Tests.ps1
@@ -302,3 +302,18 @@ Describe 'expressions parsing' -Tags "CI" {
 Describe 'Hash Expression parsing' -Tags "CI" {
     ShouldBeParseError '@{ a=1;b=2;c=3;' MissingEndCurlyBrace 2
 }
+
+Describe 'Unicode escape sequence parsing' -Tag "CI" {
+    ShouldBeParseError '"`u{110000}"' InvalidUnicodeEscapeSequenceValue 4 # error offset is "`u{>>1<<10000}"
+    ShouldBeParseError '"`u{1234567}"' TooManyDigitsInUnicodeEscapeSequence 10 # error offset is "`u{123456>>7<<}"
+    ShouldBeParseError '"`u219z"' InvalidUnicodeEscapeSequence 1
+    ShouldBeParseError '"`u{219z"' MissingUnicodeEscapeSequenceTerminator 7 # error offset "`u{219>>z<<"
+    ShouldBeParseError '"`u{}"' EmptyUnicodeEscapeSequence 1
+    ShouldBeParseError '"`u' InvalidUnicodeEscapeSequence,TerminatorExpectedAtEndOfString 1,0
+    ShouldBeParseError '"`u123' InvalidUnicodeEscapeSequence,TerminatorExpectedAtEndOfString 1,0
+    ShouldBeParseError '"`u219z' InvalidUnicodeEscapeSequence,TerminatorExpectedAtEndOfString 1,0
+    ShouldBeParseError '"`u{' MissingUnicodeEscapeSequenceTerminator,TerminatorExpectedAtEndOfString 4,0
+    ShouldBeParseError '"`u{1' MissingUnicodeEscapeSequenceTerminator,TerminatorExpectedAtEndOfString 5,0
+    ShouldBeParseError '"`u{123456' MissingUnicodeEscapeSequenceTerminator,TerminatorExpectedAtEndOfString 10,0
+    ShouldBeParseError '"`u{1234567' TooManyDigitsInUnicodeEscapeSequence,TerminatorExpectedAtEndOfString 10,0
+}


### PR DESCRIPTION
This addresses the last item in issue #2751.  The implementation supports the following forms of Unicode escape sequences:

`` "`u2195"`` evals to `↕`
`` "`u{4}"`` evals to control char 0x4 (EOT)
`` "`u{a9}"`` evals to `©`
`` "`u{2195}"`` evals to `↕`
`` "`u{1f44d}"`` evals to `👍`

In addition, you can use Unicode escape sequences when naming a variable:
```posh
${foo`u{2195}} = 42 # creates variable named: foo↕
```
And you can specify a Unicode sequence as an argument:
```posh
Write-Host `u{a9}` Acme` Inc # outputs: © Acme Inc
```
**Concerns**
* For the implementation I had to change the signature of `Backtick()` to return a `string` instead of `char`.  This was necessary to support Unicode surrogate pairs like `` "`u{1f44d}"`` which consists of two Unicode characters. This required updating six call sites of `Backtick()`.  The primary approach I took was that if the string length was greater than 1, then we have a character from the Unicode astral plane and is not of further interest to the parser. So I put the string in the sb/formatSb StringBuilder and `continue` the scanning loop.  Otherwise, we have a single character, which I assign to the local `c` (char) variable and allow processing in that loop iteration to continue.

* I had to change the encoding of the `Parser.Tests.ps1` file to UTF8 w/BOM.  That's because Pester apparently reads the file with the default encoding and the Unicode characters I have in the file do not get recognized correctly.  BTW I've noticed this before where `Get-Content` (without specify -Encoding UTF8) on a UTF8 file w/no BOM and with Unicode characters seems to use ASCII encoding and that is no bueno.  

* For the bracket syntax, I'm only supporting up to 6 hex digits.  The underlying API we use is `Char.ConvertFromUtf32()` and that supports values up to `0x10FFFF`, which 6 hex digits is sufficient to specify.  In fact with 6 digits you can specify invalid values (over 0x10FFFF) - the parser errors appropriately on those.

* I could use some help with wording on the ParserStrings error messages I added.  Or at the very least, these should be reviewed.  Sorry about the trailing whitespace removal (isn't everybody using VSCode with editor.trimTrailingWhitespace set to true by now?)

* This will require a change to the EditorSyntax project to get it to properly recognize the bracketed form in a variable declaration.