### PR TITLE
Allow use of long paths

### DIFF
--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -1153,8 +1153,22 @@ namespace System.Management.Automation
 
         internal class NativeMethods
         {
-            [DllImport(PinvokeDllNames.GetFileAttributesDllName, CharSet = CharSet.Unicode, SetLastError = true)]
-            internal static extern int GetFileAttributes(string lpFileName);
+            private static string EnsureLongPathPrefix(string path)
+            {
+                if (!path.StartsWith(@"\\?\", StringComparison.Ordinal))
+                    return @"\\?\" + path;
+
+                return path;
+            }
+
+            [DllImport(PinvokeDllNames.GetFileAttributesDllName, EntryPoint = "GetFileAttributesW", CharSet = CharSet.Unicode, SetLastError = true)]
+            private static extern int GetFileAttributesPrivate(string lpFileName);
+
+            internal static int GetFileAttributes(string fileName)
+            {
+                fileName = EnsureLongPathPrefix(fileName);
+                return GetFileAttributesPrivate(fileName);
+            }
 
             [Flags]
             internal enum FileAttributes

--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -1153,9 +1153,9 @@ namespace System.Management.Automation
 
         internal class NativeMethods
         {
-            private static string EnsureLongPathPrefix(string path)
+            private static string EnsureLongPathPrefixIfNeeded(string path)
             {
-                if (!path.StartsWith(@"\\?\", StringComparison.Ordinal))
+                if (path.Length >= MAX_PATH && !path.StartsWith(@"\\?\", StringComparison.Ordinal))
                     return @"\\?\" + path;
 
                 return path;
@@ -1166,7 +1166,7 @@ namespace System.Management.Automation
 
             internal static int GetFileAttributes(string fileName)
             {
-                fileName = EnsureLongPathPrefix(fileName);
+                fileName = EnsureLongPathPrefixIfNeeded(fileName);
                 return GetFileAttributesPrivate(fileName);
             }
 


### PR DESCRIPTION
Fixes  #3891

When calling Windows native API to determine if an item exists, ensure the path is prepended with `\\?\` to allow for paths > 260 characters.
