### PR TITLE
shebang without .ps1 extension ends up in recursive loop calling powershell

### DIFF
--- a/test/powershell/Host/ConsoleHost.Tests.ps1
+++ b/test/powershell/Host/ConsoleHost.Tests.ps1
@@ -176,6 +176,18 @@ Describe "ConsoleHost unit tests" -tags "Feature" {
             # no extraneous output
             $observed | should be $currentVersion
         }
+
+        $testCases =
+            @{interpreter = "#!${pshome}/powershell"},
+            @{interpreter = "#!${pshome}/powershell.exe"}
+
+        It "Should properly execute shebang script that doesn't have .ps1 extension" -TestCases $testCases {
+            param($Interpreter)
+            $scriptPath = "~/shebangtest"
+            Set-Content -Path $scriptPath -Value $Interpreter
+            Add-Content -Path $scriptPath -Value "'hello'"
+            & $powershell $scriptPath | Should BeExactly 'hello'
+        }
     }
 
     Context "Pipe to/from powershell" {


### PR DESCRIPTION
Fix https://github.com/PowerShell/PowerShell/issues/1103

On Linux, when a shebang is encountered (first two bytes are #!), it looks for the interpreter to pass the pass to.  In this case, if it is powershell it calls powershell with a path to the script.  If the script doesn't
have a .ps1 extension, powershell treats it like a native command and executes it as such.  The OS
sees the shebang and again calls powershell with the script.  This causes a hang (and will eventually consume all the OS resources as it keeps spawning new powershells).

Fix is to inspect the file to see if it contains the shebang magic number.  If so, we check if the running
powershell is the interpreter.  If so, we treat it the same as a .ps1 script.  Otherwise, we execute it as
a native command and expect the OS to find the correct interpreter (could be different version of powershell, for example).