### PR TITLE
Alter test httplistener to use a new runspace rather than a job

### DIFF
--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -146,11 +146,12 @@ function GetTestData
 Describe "Invoke-WebRequest tests" -Tags "Feature" {
 
     BeforeAll {
-        $null = Start-HttpListener -AsJob -Port 8080
+        $response = Start-HttpListener -Port 8080
     }
 
     AfterAll {
         $null = Stop-HttpListener -Port 8080
+        $response.PowerShell.Dispose()
     }
 
     # Validate the output of Invoke-WebRequest
@@ -576,11 +577,12 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
 Describe "Invoke-RestMethod tests" -Tags "Feature" {
 
     BeforeAll {
-        $null = Start-HttpListener -AsJob -Port 8081
+        $response = Start-HttpListener -Port 8081
     }
 
     AfterAll {
         $null = Stop-HttpListener -Port 8081
+        $response.PowerShell.Dispose()
     }
 
     It "Invoke-RestMethod returns User-Agent" {


### PR DESCRIPTION
fix for #3912 

This improves the performance of the listener by not relying on a new
process starting up to run the listener. It improves the debugability
of tests by providing more direct access to the session executing
the listener. It also reverses the blocking nature of starting the
listener. By default, Start-HttpListener will no longer block, you need
to use -Foreground to have Start-HttpListener block. Lastly, create
a way to catch errors if the listener has a problem. If code in the
listener throws, it emits an error record.

fix the tests which use the listener
