### PR TITLE
Fix non-fatal pester test failures

### DIFF
--- a/test/powershell/Language/Classes/scripting.enums.tests.ps1
+++ b/test/powershell/Language/Classes/scripting.enums.tests.ps1
@@ -74,11 +74,6 @@ Describe 'enums' -Tags "CI" {
 }
 
 Describe 'Basic enum errors' -Tags "CI" {
-
-    AfterAll {
-        Remove-Module LanguageTestSupport
-    }
-
     ShouldBeParseError 'enum' MissingNameAfterKeyword 4
     ShouldBeParseError 'enum foo' MissingTypeBody 8
     ShouldBeParseError 'enum foo {' MissingEndCurlyBrace 10

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Debug-Runspace.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Debug-Runspace.Tests.ps1
@@ -9,7 +9,7 @@ Describe "Debug-Runspace" -tag "CI" {
     }
     AfterAll {
         if ( $rs1 ) { $rs1.Dispose() }
-        if ( $rs2 ) { $rs1.Dispose() }
+        if ( $rs2 ) { $rs2.Dispose() }
     }
 
     It "Debugging a runspace should fail if the name is ambiguous" {

--- a/test/powershell/engine/Remoting/SSHRemotingAPI.Tests.ps1
+++ b/test/powershell/engine/Remoting/SSHRemotingAPI.Tests.ps1
@@ -1,5 +1,3 @@
-Import-Module $PSScriptRoot\..\..\Common\Test.Helpers.psm1
-
 Describe "SSH Remoting API Tests" -Tags "Feature" {
 
     Context "SSHConnectionInfo Class Tests" {

--- a/test/powershell/engine/ValidateAttributes.Tests.ps1
+++ b/test/powershell/engine/ValidateAttributes.Tests.ps1
@@ -1,5 +1,3 @@
-Import-Module $PSScriptRoot\..\Common\Test.Helpers.psm1
-
 Describe 'Validate Attributes Tests' -Tags 'CI' {
 
     Context "ValidateCount" {


### PR DESCRIPTION
On another PR, I see a bunch of red error messages, but they appear to not actually fail the tests, but makes it hard to determine what actually failed.  Cleaned up the tests.  It appears that with the refactoring of the test modules, some lines of code were missed.  There were also cut and paste issues in the test code so cleanup doesn't happen correctly.