### PR TITLE
Add cache for GetApplicationBase

### DIFF
--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/Telemetry.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/Telemetry.cs
@@ -24,7 +24,7 @@ namespace Microsoft.PowerShell
 
         // The path to the semaphore file which enables telemetry
         private static string TelemetrySemaphoreFilePath = Path.Combine(
-            Utils.GetApplicationBase(Utils.DefaultPowerShellShellID),
+            Utils.GetApplicationBaseDefaultPowerShell(),
             TelemetrySemaphoreFilename);
 
         // Telemetry client to be reused when we start sending more telemetry

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/Telemetry.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/Telemetry.cs
@@ -24,7 +24,7 @@ namespace Microsoft.PowerShell
 
         // The path to the semaphore file which enables telemetry
         private static string TelemetrySemaphoreFilePath = Path.Combine(
-            Utils.GetApplicationBaseDefaultPowerShell(),
+            Utils.DefaultPowerShellAppBase,
             TelemetrySemaphoreFilename);
 
         // Telemetry client to be reused when we start sending more telemetry

--- a/src/System.Management.Automation/CoreCLR/CorePsPlatform.cs
+++ b/src/System.Management.Automation/CoreCLR/CorePsPlatform.cs
@@ -159,7 +159,7 @@ namespace System.Management.Automation
                 if (IsNanoServer || IsIoT)
                 {
                     _isInbox = string.Equals(
-                        Utils.GetApplicationBase(Utils.DefaultPowerShellShellID),
+                        Utils.GetApplicationBaseDefaultPowerShell(),
                         Utils.GetApplicationBaseFromRegistry(Utils.DefaultPowerShellShellID),
                         StringComparison.OrdinalIgnoreCase);
                 }

--- a/src/System.Management.Automation/CoreCLR/CorePsPlatform.cs
+++ b/src/System.Management.Automation/CoreCLR/CorePsPlatform.cs
@@ -159,7 +159,7 @@ namespace System.Management.Automation
                 if (IsNanoServer || IsIoT)
                 {
                     _isInbox = string.Equals(
-                        Utils.GetApplicationBaseDefaultPowerShell(),
+                        Utils.DefaultPowerShellAppBase,
                         Utils.GetApplicationBaseFromRegistry(Utils.DefaultPowerShellShellID),
                         StringComparison.OrdinalIgnoreCase);
                 }

--- a/src/System.Management.Automation/commands/utility/FormatAndOutput/common/DisplayDatabase/FormatTable.cs
+++ b/src/System.Management.Automation/commands/utility/FormatAndOutput/common/DisplayDatabase/FormatTable.cs
@@ -306,7 +306,7 @@ namespace System.Management.Automation.Runspaces
         /// <returns></returns>
         public static FormatTable LoadDefaultFormatFiles()
         {
-            string psHome = Utils.GetApplicationBaseDefaultPowerShell();
+            string psHome = Utils.DefaultPowerShellAppBase;
             List<string> defaultFormatFiles = new List<string>();
             if (!string.IsNullOrEmpty(psHome))
             {

--- a/src/System.Management.Automation/commands/utility/FormatAndOutput/common/DisplayDatabase/FormatTable.cs
+++ b/src/System.Management.Automation/commands/utility/FormatAndOutput/common/DisplayDatabase/FormatTable.cs
@@ -306,8 +306,7 @@ namespace System.Management.Automation.Runspaces
         /// <returns></returns>
         public static FormatTable LoadDefaultFormatFiles()
         {
-            string shellId = Utils.DefaultPowerShellShellID;
-            string psHome = Utils.GetApplicationBase(shellId);
+            string psHome = Utils.GetApplicationBaseDefaultPowerShell();
             List<string> defaultFormatFiles = new List<string>();
             if (!string.IsNullOrEmpty(psHome))
             {

--- a/src/System.Management.Automation/commands/utility/FormatAndOutput/common/DisplayDatabase/typeDataManager.cs
+++ b/src/System.Management.Automation/commands/utility/FormatAndOutput/common/DisplayDatabase/typeDataManager.cs
@@ -490,7 +490,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             {
                 var builtInGenerators = new Dictionary<string, Tuple<bool, TypeGenerator>>(StringComparer.OrdinalIgnoreCase);
 
-                var psHome = Utils.GetApplicationBaseDefaultPowerShell();
+                var psHome = Utils.DefaultPowerShellAppBase;
 
                 builtInGenerators.Add(Path.Combine(psHome, "Certificate.format.ps1xml"), GetBuiltin(false, Certificate_Format_Ps1Xml.GetFormatData));
                 builtInGenerators.Add(Path.Combine(psHome, "Diagnostics.Format.ps1xml"), GetBuiltin(false, Diagnostics_Format_Ps1Xml.GetFormatData));

--- a/src/System.Management.Automation/commands/utility/FormatAndOutput/common/DisplayDatabase/typeDataManager.cs
+++ b/src/System.Management.Automation/commands/utility/FormatAndOutput/common/DisplayDatabase/typeDataManager.cs
@@ -490,7 +490,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             {
                 var builtInGenerators = new Dictionary<string, Tuple<bool, TypeGenerator>>(StringComparer.OrdinalIgnoreCase);
 
-                var psHome = Utils.GetApplicationBase(Utils.DefaultPowerShellShellID);
+                var psHome = Utils.GetApplicationBaseDefaultPowerShell();
 
                 builtInGenerators.Add(Path.Combine(psHome, "Certificate.format.ps1xml"), GetBuiltin(false, Certificate_Format_Ps1Xml.GetFormatData));
                 builtInGenerators.Add(Path.Combine(psHome, "Diagnostics.Format.ps1xml"), GetBuiltin(false, Diagnostics_Format_Ps1Xml.GetFormatData));

--- a/src/System.Management.Automation/engine/DataStoreAdapterProvider.cs
+++ b/src/System.Management.Automation/engine/DataStoreAdapterProvider.cs
@@ -105,7 +105,7 @@ namespace System.Management.Automation
                 string psHome = null;
                 try
                 {
-                    psHome = Utils.GetApplicationBase(Utils.DefaultPowerShellShellID);
+                    psHome = Utils.GetApplicationBaseDefaultPowerShell();
                 }
                 catch (System.Security.SecurityException)
                 {

--- a/src/System.Management.Automation/engine/DataStoreAdapterProvider.cs
+++ b/src/System.Management.Automation/engine/DataStoreAdapterProvider.cs
@@ -105,7 +105,7 @@ namespace System.Management.Automation
                 string psHome = null;
                 try
                 {
-                    psHome = Utils.GetApplicationBaseDefaultPowerShell();
+                    psHome = Utils.DefaultPowerShellAppBase;
                 }
                 catch (System.Security.SecurityException)
                 {

--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -46,7 +46,7 @@ namespace System.Management.Automation.Runspaces
             {
                 // Building the catalog is expensive, so force that to happen early on a background thread, and do so
                 // on a file we are very likely to read anyway.
-                var pshome = Utils.GetApplicationBaseDefaultPowerShell();
+                var pshome = Utils.DefaultPowerShellAppBase;
                 var unused = SecuritySupport.IsProductBinary(Path.Combine(pshome, "Modules", "Microsoft.PowerShell.Utility", "Microsoft.PowerShell.Utility.psm1"));
             });
 
@@ -1597,7 +1597,7 @@ namespace System.Management.Automation.Runspaces
 
         private static void IncludePowerShellCoreFormats(InitialSessionState iss)
         {
-            string psHome = Utils.GetApplicationBaseDefaultPowerShell();
+            string psHome = Utils.DefaultPowerShellAppBase;
             if (string.IsNullOrEmpty(psHome))
             {
                 return;
@@ -4207,7 +4207,7 @@ namespace System.Management.Automation.Runspaces
 
             // We skip checking if the file exists when it's in $PSHOME because of magic
             // where we have the former contents of those files built into the engine directly.
-            var psHome = Utils.GetApplicationBaseDefaultPowerShell();
+            var psHome = Utils.DefaultPowerShellAppBase;
 
             foreach (string file in psSnapInInfo.Types)
             {

--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -46,7 +46,7 @@ namespace System.Management.Automation.Runspaces
             {
                 // Building the catalog is expensive, so force that to happen early on a background thread, and do so
                 // on a file we are very likely to read anyway.
-                var pshome = Utils.GetApplicationBase(Utils.DefaultPowerShellShellID);
+                var pshome = Utils.GetApplicationBaseDefaultPowerShell();
                 var unused = SecuritySupport.IsProductBinary(Path.Combine(pshome, "Modules", "Microsoft.PowerShell.Utility", "Microsoft.PowerShell.Utility.psm1"));
             });
 
@@ -1597,7 +1597,7 @@ namespace System.Management.Automation.Runspaces
 
         private static void IncludePowerShellCoreFormats(InitialSessionState iss)
         {
-            string psHome = Utils.GetApplicationBase(Utils.DefaultPowerShellShellID);
+            string psHome = Utils.GetApplicationBaseDefaultPowerShell();
             if (string.IsNullOrEmpty(psHome))
             {
                 return;
@@ -4207,7 +4207,7 @@ namespace System.Management.Automation.Runspaces
 
             // We skip checking if the file exists when it's in $PSHOME because of magic
             // where we have the former contents of those files built into the engine directly.
-            var psHome = Utils.GetApplicationBase(Utils.DefaultPowerShellShellID);
+            var psHome = Utils.GetApplicationBaseDefaultPowerShell();
 
             foreach (string file in psSnapInInfo.Types)
             {

--- a/src/System.Management.Automation/engine/Modules/ImportModuleCommand.cs
+++ b/src/System.Management.Automation/engine/Modules/ImportModuleCommand.cs
@@ -1768,11 +1768,11 @@ namespace Microsoft.PowerShell.Commands
                 {
                     if (m.Name.Equals(moduleName, StringComparison.OrdinalIgnoreCase))
                     {
-                        m.SetModuleBase(Utils.GetApplicationBaseDefaultPowerShell());
+                        m.SetModuleBase(Utils.DefaultPowerShellAppBase);
                         // Also set  ModuleBase for nested modules of Engine modules
                         foreach (var nestedModule in m.NestedModules)
                         {
-                            nestedModule.SetModuleBase(Utils.GetApplicationBaseDefaultPowerShell());
+                            nestedModule.SetModuleBase(Utils.DefaultPowerShellAppBase);
                         }
                     }
                 }
@@ -1781,11 +1781,11 @@ namespace Microsoft.PowerShell.Commands
                 {
                     if (m.Name.Equals(moduleName, StringComparison.OrdinalIgnoreCase))
                     {
-                        m.SetModuleBase(Utils.GetApplicationBaseDefaultPowerShell());
+                        m.SetModuleBase(Utils.DefaultPowerShellAppBase);
                         // Also set  ModuleBase for nested modules of Engine modules
                         foreach (var nestedModule in m.NestedModules)
                         {
-                            nestedModule.SetModuleBase(Utils.GetApplicationBaseDefaultPowerShell());
+                            nestedModule.SetModuleBase(Utils.DefaultPowerShellAppBase);
                         }
                     }
                 }

--- a/src/System.Management.Automation/engine/Modules/ImportModuleCommand.cs
+++ b/src/System.Management.Automation/engine/Modules/ImportModuleCommand.cs
@@ -1768,11 +1768,11 @@ namespace Microsoft.PowerShell.Commands
                 {
                     if (m.Name.Equals(moduleName, StringComparison.OrdinalIgnoreCase))
                     {
-                        m.SetModuleBase(Utils.GetApplicationBase(Utils.DefaultPowerShellShellID));
+                        m.SetModuleBase(Utils.GetApplicationBaseDefaultPowerShell());
                         // Also set  ModuleBase for nested modules of Engine modules
                         foreach (var nestedModule in m.NestedModules)
                         {
-                            nestedModule.SetModuleBase(Utils.GetApplicationBase(Utils.DefaultPowerShellShellID));
+                            nestedModule.SetModuleBase(Utils.GetApplicationBaseDefaultPowerShell());
                         }
                     }
                 }
@@ -1781,11 +1781,11 @@ namespace Microsoft.PowerShell.Commands
                 {
                     if (m.Name.Equals(moduleName, StringComparison.OrdinalIgnoreCase))
                     {
-                        m.SetModuleBase(Utils.GetApplicationBase(Utils.DefaultPowerShellShellID));
+                        m.SetModuleBase(Utils.GetApplicationBaseDefaultPowerShell());
                         // Also set  ModuleBase for nested modules of Engine modules
                         foreach (var nestedModule in m.NestedModules)
                         {
-                            nestedModule.SetModuleBase(Utils.GetApplicationBase(Utils.DefaultPowerShellShellID));
+                            nestedModule.SetModuleBase(Utils.GetApplicationBaseDefaultPowerShell());
                         }
                     }
                 }

--- a/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
@@ -4680,7 +4680,7 @@ namespace Microsoft.PowerShell.Commands
 
             if (listOfStrings != null)
             {
-                var psHome = Utils.GetApplicationBase(Utils.DefaultPowerShellShellID);
+                var psHome = Utils.GetApplicationBaseDefaultPowerShell();
                 string alternateDirToCheck = null;
                 if (moduleBase.StartsWith(psHome, StringComparison.OrdinalIgnoreCase))
                 {

--- a/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
@@ -4680,7 +4680,7 @@ namespace Microsoft.PowerShell.Commands
 
             if (listOfStrings != null)
             {
-                var psHome = Utils.GetApplicationBaseDefaultPowerShell();
+                var psHome = Utils.DefaultPowerShellAppBase;
                 string alternateDirToCheck = null;
                 if (moduleBase.StartsWith(psHome, StringComparison.OrdinalIgnoreCase))
                 {

--- a/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
@@ -557,7 +557,7 @@ namespace System.Management.Automation
 
             try
             {
-                string psHome = Utils.GetApplicationBase(Utils.DefaultPowerShellShellID);
+                string psHome = Utils.GetApplicationBaseDefaultPowerShell();
                 if (!string.IsNullOrEmpty(psHome))
                 {
                     // Win8: 584267 Powershell Modules are listed twice in x86, and cannot be removed

--- a/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
@@ -557,7 +557,7 @@ namespace System.Management.Automation
 
             try
             {
-                string psHome = Utils.GetApplicationBaseDefaultPowerShell();
+                string psHome = Utils.DefaultPowerShellAppBase;
                 if (!string.IsNullOrEmpty(psHome))
                 {
                     // Win8: 584267 Powershell Modules are listed twice in x86, and cannot be removed

--- a/src/System.Management.Automation/engine/Modules/ModuleUtils.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleUtils.cs
@@ -410,7 +410,7 @@ namespace System.Management.Automation.Internal
                     tempModuleInfo = new PSModuleInfo(moduleShortName, modulePath, null, null);
                     if (InitialSessionState.IsEngineModule(moduleShortName))
                     {
-                        tempModuleInfo.SetModuleBase(Utils.GetApplicationBaseDefaultPowerShell());
+                        tempModuleInfo.SetModuleBase(Utils.DefaultPowerShellAppBase);
                     }
 
                     //moduleVersionRequired is bypassed by FullyQualifiedModule from calling method. This is the only place where guid will be involved.

--- a/src/System.Management.Automation/engine/Modules/ModuleUtils.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleUtils.cs
@@ -410,7 +410,7 @@ namespace System.Management.Automation.Internal
                     tempModuleInfo = new PSModuleInfo(moduleShortName, modulePath, null, null);
                     if (InitialSessionState.IsEngineModule(moduleShortName))
                     {
-                        tempModuleInfo.SetModuleBase(Utils.GetApplicationBase(Utils.DefaultPowerShellShellID));
+                        tempModuleInfo.SetModuleBase(Utils.GetApplicationBaseDefaultPowerShell());
                     }
 
                     //moduleVersionRequired is bypassed by FullyQualifiedModule from calling method. This is the only place where guid will be involved.

--- a/src/System.Management.Automation/engine/TypeTable.cs
+++ b/src/System.Management.Automation/engine/TypeTable.cs
@@ -3440,8 +3440,7 @@ namespace System.Management.Automation.Runspaces
             string typesFilePath = string.Empty;
             string typesV3FilePath = string.Empty;
 
-            string shellId = Utils.DefaultPowerShellShellID;
-            var psHome = Utils.GetApplicationBase(shellId);
+            var psHome = Utils.GetApplicationBaseDefaultPowerShell();
             if (!string.IsNullOrEmpty(psHome))
             {
                 typesFilePath = Path.Combine(psHome, "types.ps1xml");
@@ -4404,7 +4403,7 @@ namespace System.Management.Automation.Runspaces
             var result = false;
             var errorCount = errors.Count;
 
-            var psHome = Utils.GetApplicationBase(Utils.DefaultPowerShellShellID);
+            var psHome = Utils.GetApplicationBaseDefaultPowerShell();
             if (string.Equals(Path.Combine(psHome, "types.ps1xml"), filePath, StringComparison.OrdinalIgnoreCase))
             {
                 ProcessTypeData(filePath, errors, Types_Ps1Xml.Get());

--- a/src/System.Management.Automation/engine/TypeTable.cs
+++ b/src/System.Management.Automation/engine/TypeTable.cs
@@ -3440,7 +3440,7 @@ namespace System.Management.Automation.Runspaces
             string typesFilePath = string.Empty;
             string typesV3FilePath = string.Empty;
 
-            var psHome = Utils.GetApplicationBaseDefaultPowerShell();
+            var psHome = Utils.DefaultPowerShellAppBase;
             if (!string.IsNullOrEmpty(psHome))
             {
                 typesFilePath = Path.Combine(psHome, "types.ps1xml");
@@ -4403,7 +4403,7 @@ namespace System.Management.Automation.Runspaces
             var result = false;
             var errorCount = errors.Count;
 
-            var psHome = Utils.GetApplicationBaseDefaultPowerShell();
+            var psHome = Utils.DefaultPowerShellAppBase;
             if (string.Equals(Path.Combine(psHome, "types.ps1xml"), filePath, StringComparison.OrdinalIgnoreCase))
             {
                 ProcessTypeData(filePath, errors, Types_Ps1Xml.Get());

--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -238,20 +238,35 @@ namespace System.Management.Automation
         }
 #endif
 
+        private static string s_GetApplicationBaseDefaultPowerShell = InitGetApplicationBaseDefaultPowerShell();
+
+        private static string InitGetApplicationBaseDefaultPowerShell()
+        {
+            return GetApplicationBase(Utils.DefaultPowerShellShellID);
+        }
+
         /// <summary>
-        /// Gets the application base for current monad version
+        /// Gets the application base for current PowerShell version.
         /// </summary>
         /// <returns>
-        /// applicationbase path for current monad version installation
+        /// Applicationbase path for current PowerShell version installation.
         /// </returns>
         /// <exception cref="SecurityException">
-        /// if caller doesn't have permission to read the key
+        /// if caller doesn't have permission to read the key.
         /// </exception>
+        internal static string GetApplicationBaseDefaultPowerShell()
+        {
+            return s_GetApplicationBaseDefaultPowerShell;
+        }
+
         internal static string GetApplicationBase(string shellId)
         {
 #if CORECLR
-            // Use the location of SMA.dll as the application base
-            // Assembly.GetEntryAssembly and GAC are not in CoreCLR.
+            if (s_GetApplicationBaseDefaultPowerShell != null)
+            {
+                return s_GetApplicationBaseDefaultPowerShell;
+            }
+            // Use the location of SMA.dll as the application base.
             Assembly assembly = typeof(PSObject).GetTypeInfo().Assembly;
             return Path.GetDirectoryName(assembly.Location);
 #else
@@ -312,7 +327,7 @@ namespace System.Management.Automation
                 List<string> baseDirectories = new List<string>();
 
                 // Retrieve the application base from the registry
-                string appBase = GetApplicationBase(DefaultPowerShellShellID);
+                string appBase = Utils.GetApplicationBaseDefaultPowerShell();
                 if (!string.IsNullOrEmpty(appBase))
                 {
                     baseDirectories.Add(appBase);
@@ -381,7 +396,7 @@ namespace System.Management.Automation
         /// </summary>
         internal static bool IsRunningFromSysWOW64()
         {
-            return Utils.GetApplicationBase(Utils.DefaultPowerShellShellID).Contains("SysWOW64");
+            return GetApplicationBaseDefaultPowerShell().Contains("SysWOW64");
         }
 
         /// <summary>

--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -238,33 +238,14 @@ namespace System.Management.Automation
         }
 #endif
 
-        private static string s_GetApplicationBaseDefaultPowerShell = InitGetApplicationBaseDefaultPowerShell();
-
-        private static string InitGetApplicationBaseDefaultPowerShell()
-        {
-            return GetApplicationBase(Utils.DefaultPowerShellShellID);
-        }
-
-        /// <summary>
-        /// Gets the application base for current PowerShell version.
-        /// </summary>
-        /// <returns>
-        /// Applicationbase path for current PowerShell version installation.
-        /// </returns>
-        /// <exception cref="SecurityException">
-        /// if caller doesn't have permission to read the key.
-        /// </exception>
-        internal static string GetApplicationBaseDefaultPowerShell()
-        {
-            return s_GetApplicationBaseDefaultPowerShell;
-        }
+        internal static string DefaultPowerShellAppBase { get; } = GetApplicationBase(DefaultPowerShellShellID);
 
         internal static string GetApplicationBase(string shellId)
         {
 #if CORECLR
-            if (s_GetApplicationBaseDefaultPowerShell != null)
+            if (DefaultPowerShellAppBase != null)
             {
-                return s_GetApplicationBaseDefaultPowerShell;
+                return DefaultPowerShellAppBase;
             }
             // Use the location of SMA.dll as the application base.
             Assembly assembly = typeof(PSObject).GetTypeInfo().Assembly;
@@ -327,7 +308,7 @@ namespace System.Management.Automation
                 List<string> baseDirectories = new List<string>();
 
                 // Retrieve the application base from the registry
-                string appBase = Utils.GetApplicationBaseDefaultPowerShell();
+                string appBase = Utils.DefaultPowerShellAppBase;
                 if (!string.IsNullOrEmpty(appBase))
                 {
                     baseDirectories.Add(appBase);
@@ -396,7 +377,7 @@ namespace System.Management.Automation
         /// </summary>
         internal static bool IsRunningFromSysWOW64()
         {
-            return GetApplicationBaseDefaultPowerShell().Contains("SysWOW64");
+            return DefaultPowerShellAppBase.Contains("SysWOW64");
         }
 
         /// <summary>

--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -243,10 +243,6 @@ namespace System.Management.Automation
         internal static string GetApplicationBase(string shellId)
         {
 #if CORECLR
-            if (DefaultPowerShellAppBase != null)
-            {
-                return DefaultPowerShellAppBase;
-            }
             // Use the location of SMA.dll as the application base.
             Assembly assembly = typeof(PSObject).GetTypeInfo().Assembly;
             return Path.GetDirectoryName(assembly.Location);

--- a/src/System.Management.Automation/engine/hostifaces/PowerShellProcessInstance.cs
+++ b/src/System.Management.Automation/engine/hostifaces/PowerShellProcessInstance.cs
@@ -37,10 +37,10 @@ namespace System.Management.Automation.Runspaces
         static PowerShellProcessInstance()
         {
 #if UNIX
-            s_PSExePath = Path.Combine(Utils.GetApplicationBaseDefaultPowerShell(),
+            s_PSExePath = Path.Combine(Utils.DefaultPowerShellAppBase,
                             "powershell");
 #else
-            s_PSExePath = Path.Combine(Utils.GetApplicationBaseDefaultPowerShell(),
+            s_PSExePath = Path.Combine(Utils.DefaultPowerShellAppBase,
                             "powershell.exe");
 #endif
         }

--- a/src/System.Management.Automation/engine/hostifaces/PowerShellProcessInstance.cs
+++ b/src/System.Management.Automation/engine/hostifaces/PowerShellProcessInstance.cs
@@ -37,10 +37,10 @@ namespace System.Management.Automation.Runspaces
         static PowerShellProcessInstance()
         {
 #if UNIX
-            s_PSExePath = Path.Combine(Utils.GetApplicationBase(Utils.DefaultPowerShellShellID),
+            s_PSExePath = Path.Combine(Utils.GetApplicationBaseDefaultPowerShell(),
                             "powershell");
 #else
-            s_PSExePath = Path.Combine(Utils.GetApplicationBase(Utils.DefaultPowerShellShellID),
+            s_PSExePath = Path.Combine(Utils.GetApplicationBaseDefaultPowerShell(),
                             "powershell.exe");
 #endif
         }

--- a/src/System.Management.Automation/engine/remoting/commands/CustomShellCommands.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/CustomShellCommands.cs
@@ -964,7 +964,7 @@ else
                     }
                 }
 
-                string destPath = System.IO.Path.Combine(Utils.GetApplicationBase(Utils.DefaultPowerShellShellID), "SessionConfig",
+                string destPath = System.IO.Path.Combine(Utils.GetApplicationBaseDefaultPowerShell(), "SessionConfig",
                     shellName + "_" + sessionGuid.ToString() + StringLiterals.PowerShellDISCFileExtension);
                 if (string.Equals(ProcessorArchitecture, "x86", StringComparison.OrdinalIgnoreCase))
                 {
@@ -3414,7 +3414,7 @@ Set-PSSessionConfiguration $args[0] $args[1] $args[2] $args[3] $args[4] $args[5]
                     _gmsaAccount = _configTable[ConfigFileConstants.GMSAAccount] as string;
                 }
 
-                string destPath = System.IO.Path.Combine(Utils.GetApplicationBase(Utils.DefaultPowerShellShellID), "SessionConfig",
+                string destPath = System.IO.Path.Combine(Utils.GetApplicationBaseDefaultPowerShell(), "SessionConfig",
                     shellName + "_" + sessionGuid.ToString() + StringLiterals.PowerShellDISCFileExtension);
 
                 // If the config file with the same guid name already exists then it would be overwritten.

--- a/src/System.Management.Automation/engine/remoting/commands/CustomShellCommands.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/CustomShellCommands.cs
@@ -964,7 +964,7 @@ else
                     }
                 }
 
-                string destPath = System.IO.Path.Combine(Utils.GetApplicationBaseDefaultPowerShell(), "SessionConfig",
+                string destPath = System.IO.Path.Combine(Utils.DefaultPowerShellAppBase, "SessionConfig",
                     shellName + "_" + sessionGuid.ToString() + StringLiterals.PowerShellDISCFileExtension);
                 if (string.Equals(ProcessorArchitecture, "x86", StringComparison.OrdinalIgnoreCase))
                 {
@@ -3414,7 +3414,7 @@ Set-PSSessionConfiguration $args[0] $args[1] $args[2] $args[3] $args[4] $args[5]
                     _gmsaAccount = _configTable[ConfigFileConstants.GMSAAccount] as string;
                 }
 
-                string destPath = System.IO.Path.Combine(Utils.GetApplicationBaseDefaultPowerShell(), "SessionConfig",
+                string destPath = System.IO.Path.Combine(Utils.DefaultPowerShellAppBase, "SessionConfig",
                     shellName + "_" + sessionGuid.ToString() + StringLiterals.PowerShellDISCFileExtension);
 
                 // If the config file with the same guid name already exists then it would be overwritten.

--- a/src/System.Management.Automation/help/UpdateHelpCommand.cs
+++ b/src/System.Management.Automation/help/UpdateHelpCommand.cs
@@ -381,7 +381,7 @@ namespace Microsoft.PowerShell.Commands
 #if !CORECLR // Side-By-Side directories are not present in OneCore environments.
                         if (IsSystemModule(module.ModuleName) && Environment.Is64BitOperatingSystem)
                         {
-                            string path = Utils.GetApplicationBase(Utils.DefaultPowerShellShellID).Replace("System32", "SysWOW64");
+                            string path = Utils.GetApplicationBaseDefaultPowerShell().Replace("System32", "SysWOW64");
 
                             destPaths.Add(path);
                         }

--- a/src/System.Management.Automation/help/UpdateHelpCommand.cs
+++ b/src/System.Management.Automation/help/UpdateHelpCommand.cs
@@ -381,7 +381,7 @@ namespace Microsoft.PowerShell.Commands
 #if !CORECLR // Side-By-Side directories are not present in OneCore environments.
                         if (IsSystemModule(module.ModuleName) && Environment.Is64BitOperatingSystem)
                         {
-                            string path = Utils.GetApplicationBaseDefaultPowerShell().Replace("System32", "SysWOW64");
+                            string path = Utils.DefaultPowerShellAppBase.Replace("System32", "SysWOW64");
 
                             destPaths.Add(path);
                         }

--- a/src/System.Management.Automation/minishell/api/FormatAndTypeDataHelper.cs
+++ b/src/System.Management.Automation/minishell/api/FormatAndTypeDataHelper.cs
@@ -103,7 +103,7 @@ namespace System.Management.Automation.Runspaces
             Collection<PSSnapInTypeAndFormatErrors> returnValue = new Collection<PSSnapInTypeAndFormatErrors>();
 
             string baseFolder = GetBaseFolder(runspaceConfiguration, independentErrors);
-            var psHome = Utils.GetApplicationBase(Utils.DefaultPowerShellShellID);
+            var psHome = Utils.GetApplicationBaseDefaultPowerShell();
 
             // this hashtable will be used to check whether this is duplicated file for types or formats.
             HashSet<string> fullFileNameSet = new HashSet<string>(StringComparer.OrdinalIgnoreCase);

--- a/src/System.Management.Automation/minishell/api/FormatAndTypeDataHelper.cs
+++ b/src/System.Management.Automation/minishell/api/FormatAndTypeDataHelper.cs
@@ -103,7 +103,7 @@ namespace System.Management.Automation.Runspaces
             Collection<PSSnapInTypeAndFormatErrors> returnValue = new Collection<PSSnapInTypeAndFormatErrors>();
 
             string baseFolder = GetBaseFolder(runspaceConfiguration, independentErrors);
-            var psHome = Utils.GetApplicationBaseDefaultPowerShell();
+            var psHome = Utils.DefaultPowerShellAppBase;
 
             // this hashtable will be used to check whether this is duplicated file for types or formats.
             HashSet<string> fullFileNameSet = new HashSet<string>(StringComparer.OrdinalIgnoreCase);

--- a/src/System.Management.Automation/security/Authenticode.cs
+++ b/src/System.Management.Automation/security/Authenticode.cs
@@ -386,7 +386,7 @@ namespace System.Management.Automation
 
                             if (!Signature.CatalogApiAvailable.HasValue)
                             {
-                                string productFile = Path.Combine(Utils.GetApplicationBase(Utils.DefaultPowerShellShellID), "Modules\\Microsoft.PowerShell.Utility\\Microsoft.PowerShell.Utility.psm1");
+                                string productFile = Path.Combine(Utils.GetApplicationBaseDefaultPowerShell(), "Modules\\Microsoft.PowerShell.Utility\\Microsoft.PowerShell.Utility.psm1");
                                 if (signature.Status != SignatureStatus.Valid)
                                 {
                                     if (string.Equals(filename, productFile, StringComparison.OrdinalIgnoreCase))

--- a/src/System.Management.Automation/security/Authenticode.cs
+++ b/src/System.Management.Automation/security/Authenticode.cs
@@ -386,7 +386,7 @@ namespace System.Management.Automation
 
                             if (!Signature.CatalogApiAvailable.HasValue)
                             {
-                                string productFile = Path.Combine(Utils.GetApplicationBaseDefaultPowerShell(), "Modules\\Microsoft.PowerShell.Utility\\Microsoft.PowerShell.Utility.psm1");
+                                string productFile = Path.Combine(Utils.DefaultPowerShellAppBase, "Modules\\Microsoft.PowerShell.Utility\\Microsoft.PowerShell.Utility.psm1");
                                 if (signature.Status != SignatureStatus.Valid)
                                 {
                                     if (string.Equals(filename, productFile, StringComparison.OrdinalIgnoreCase))

--- a/src/System.Management.Automation/singleshell/config/MshSnapinInfo.cs
+++ b/src/System.Management.Automation/singleshell/config/MshSnapinInfo.cs
@@ -896,7 +896,7 @@ namespace System.Management.Automation
 
         internal static void ReadRegistryInfo(out Version assemblyVersion, out string publicKeyToken, out string culture, out string architecture, out string applicationBase, out Version psVersion)
         {
-            applicationBase = Utils.GetApplicationBaseDefaultPowerShell();
+            applicationBase = Utils.DefaultPowerShellAppBase;
             Dbg.Assert(!string.IsNullOrEmpty(applicationBase),
                 string.Format(CultureInfo.CurrentCulture, "{0} is empty or null", RegistryStrings.MonadEngine_ApplicationBase));
 

--- a/src/System.Management.Automation/singleshell/config/MshSnapinInfo.cs
+++ b/src/System.Management.Automation/singleshell/config/MshSnapinInfo.cs
@@ -896,7 +896,7 @@ namespace System.Management.Automation
 
         internal static void ReadRegistryInfo(out Version assemblyVersion, out string publicKeyToken, out string culture, out string architecture, out string applicationBase, out Version psVersion)
         {
-            applicationBase = Utils.GetApplicationBase(Utils.DefaultPowerShellShellID);
+            applicationBase = Utils.GetApplicationBaseDefaultPowerShell();
             Dbg.Assert(!string.IsNullOrEmpty(applicationBase),
                 string.Format(CultureInfo.CurrentCulture, "{0} is empty or null", RegistryStrings.MonadEngine_ApplicationBase));
 

--- a/src/System.Management.Automation/utils/PSTelemetryMethods.cs
+++ b/src/System.Management.Automation/utils/PSTelemetryMethods.cs
@@ -168,7 +168,7 @@ namespace Microsoft.PowerShell.Telemetry.Internal
             var companyName = foundModule.CompanyName;
             bool couldBeMicrosoftModule =
                 (modulePath != null &&
-                 (modulePath.StartsWith(Utils.GetApplicationBaseDefaultPowerShell(), StringComparison.OrdinalIgnoreCase) ||
+                 (modulePath.StartsWith(Utils.DefaultPowerShellAppBase, StringComparison.OrdinalIgnoreCase) ||
                   // The following covers both 64 and 32 bit Program Files by assuming 32bit is just ...\Program Files + " (x86)"
                   modulePath.StartsWith(Platform.GetFolderPath(Environment.SpecialFolder.ProgramFiles), StringComparison.OrdinalIgnoreCase))) ||
                 (companyName != null &&

--- a/src/System.Management.Automation/utils/PSTelemetryMethods.cs
+++ b/src/System.Management.Automation/utils/PSTelemetryMethods.cs
@@ -168,7 +168,7 @@ namespace Microsoft.PowerShell.Telemetry.Internal
             var companyName = foundModule.CompanyName;
             bool couldBeMicrosoftModule =
                 (modulePath != null &&
-                 (modulePath.StartsWith(Utils.GetApplicationBase(Utils.DefaultPowerShellShellID), StringComparison.OrdinalIgnoreCase) ||
+                 (modulePath.StartsWith(Utils.GetApplicationBaseDefaultPowerShell(), StringComparison.OrdinalIgnoreCase) ||
                   // The following covers both 64 and 32 bit Program Files by assuming 32bit is just ...\Program Files + " (x86)"
                   modulePath.StartsWith(Platform.GetFolderPath(Environment.SpecialFolder.ProgramFiles), StringComparison.OrdinalIgnoreCase))) ||
                 (companyName != null &&


### PR DESCRIPTION
Motivation
---
We call Utils.GetApplicationBase() multiple times at startup and later so we need cache the one to exclude a reflection.

Fix
---
1. Add a static getter-only property named `DefaultPowerShellAppBase` in `Utils.cs`.
2. Refactor code to directly use cached value.

Additional considerations
---
Code that uses a ShellId from Context has not been changed, although it is only associated with the Windows PowerShell (FullCLR).
