### PR TITLE
Fix the issue Wildcard matching should be used in help file search

### DIFF
--- a/src/System.Management.Automation/help/MUIFileSearcher.cs
+++ b/src/System.Management.Automation/help/MUIFileSearcher.cs
@@ -122,9 +122,9 @@ namespace System.Management.Automation
             ArrayList result = new ArrayList();
             string[] files = Directory.GetFiles(path);
 
-            string regexPattern = pattern.Replace(".", @"\.");
-            regexPattern = regexPattern.Replace("*", ".*");
-            regexPattern = regexPattern.Replace("?", ".?");
+            var wildcardPattern = WildcardPattern.ContainsWildcardCharacters(pattern)
+                ? WildcardPattern.Get(pattern, WildcardOptions.IgnoreCase)
+                : null;
 
             foreach (string filePath in files)
             {
@@ -133,11 +133,12 @@ namespace System.Management.Automation
                     result.Add(filePath);
                     break;
                 }
-                // If the input is pattern instead of string, we need to use Regex expression.
-                if (pattern.Contains("*") || pattern.Contains("?"))
-                {             
-                    if (Regex.IsMatch(filePath, regexPattern))
-                    {
+
+                if (wildcardPattern != null)
+                {
+                    string fileName = Path.GetFileName(filePath);
+                    if (wildcardPattern.IsMatch(fileName))
+                    {             
                         result.Add(filePath);
                     }
                 }


### PR DESCRIPTION
Fix issue #3967

Summary of the issue:

According to Jason's suggestion, replace the regex expression with wildcard.

Root cause of the issue:

This is an code improvement. The existed test cases are covering the scenario