### PR TITLE
adding type inference for Foreach-Object -MemberName  

### DIFF
--- a/src/System.Management.Automation/engine/parser/TypeInferenceVisitor.cs
+++ b/src/System.Management.Automation/engine/parser/TypeInferenceVisitor.cs
@@ -1028,7 +1028,6 @@ namespace System.Management.Automation
             {
                 if (type.Type == typeof(PSObject))
                 {
-                    
                     continue;
                 }
                 var members = _context.GetMembersByInferredType(type, isStatic, filter: null);

--- a/test/powershell/engine/Api/TypeInference.Tests.ps1
+++ b/test/powershell/engine/Api/TypeInference.Tests.ps1
@@ -302,6 +302,12 @@ Describe "Type inference Tests" -tags "CI" {
         }
     }
 
+    It "Infers type from foreach-object with membername" {
+        $res = [AstTypeInference]::InferTypeOf( { Get-ChildItem | ForEach-Object -MemberName Directory }.Ast)
+        $res.Count | Should Be 1
+        $res.Name | Should Be "System.IO.DirectoryInfo"
+    }
+
     It "Infers type from OutputTypeAttribute" {
         $res = [AstTypeInference]::InferTypeOf( { Get-Process -Id 2345 }.Ast)
         $gpsOutput = [Microsoft.PowerShell.Commands.GetProcessCommand].GetCustomAttributes([System.Management.Automation.OutputTypeAttribute], $false).Type
@@ -565,7 +571,8 @@ Describe "Type inference Tests" -tags "CI" {
                 [Y]::new().ScriptProp
             }.Ast)
 
-        $res.Count | Should be 0
+        $res.Count | Should be 1
+        $res.Name | Should be System.Int32
     }
 
     It 'Infers type of script property with outputtype' {


### PR DESCRIPTION
Fixes #2596

This PR adds type inference support for the 'MemberName' parameterset for Foreach-Object.

Before this PR:
```
#this works
Get-Process | % {$_.MainModule} | % Com<Tab>
#this doesn't
Get-Process | % MainModule | % Com<Tab>
```
After this PR:
```
#this works (completes Company)
Get-Process | % {$_.MainModule} | % Com<Tab>
Get-Process | % MainModule | % Com<Tab> 
```