### PR TITLE
Added logic in AssemblyLoadContext to load assembly from GAC.

### DIFF
--- a/src/Microsoft.PowerShell.CoreCLR.AssemblyLoadContext/CoreCLR/CorePsAssemblyLoadContext.cs
+++ b/src/Microsoft.PowerShell.CoreCLR.AssemblyLoadContext/CoreCLR/CorePsAssemblyLoadContext.cs
@@ -300,7 +300,7 @@ namespace System.Management.Automation
                 if(String.IsNullOrEmpty(_winDir))
                 {
                     //cache value of '_winDir' folder in member variable.
-                    _winDir = Environment.GetEnvironmentVariable("_winDir");
+                    _winDir = Environment.GetEnvironmentVariable("winDir");
                 }
 
                 if (String.IsNullOrEmpty(_gacPathMSIL))

--- a/src/Microsoft.PowerShell.CoreCLR.AssemblyLoadContext/CoreCLR/CorePsAssemblyLoadContext.cs
+++ b/src/Microsoft.PowerShell.CoreCLR.AssemblyLoadContext/CoreCLR/CorePsAssemblyLoadContext.cs
@@ -63,8 +63,10 @@ namespace System.Management.Automation
         /// </param>
         private PowerShellAssemblyLoadContext(string basePaths)
         {
+#if !UNIX
             // Set GAC related member variables to null
             _winDir = _gacPath32 = _gacPath64 = _gacPathMSIL = null;
+#endif
 
             // FIRST: Validate and populate probing paths
             if (string.IsNullOrEmpty(basePaths))
@@ -108,10 +110,12 @@ namespace System.Management.Automation
         private readonly Dictionary<string, string> _coreClrTypeCatalog;
         private readonly Lazy<HashSet<string>> _availableDotNetAssemblyNames;
 
+#if !UNIX
         private string _winDir;
         private string _gacPathMSIL;
         private string _gacPath32;
         private string _gacPath64;
+#endif
 
         /// <summary>
         /// Assembly cache across the AppDomain

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Import-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Import-Module.Tests.ps1
@@ -76,8 +76,7 @@ Describe "Import-Module for Binary Modules in GAC" -Tags 'CI' {
 
         It "Load PSScheduledJob from Windows Powershell Modules folder should fail" -Skip:(-not $IsWindows) {
             $modulePath = Join-Path $env:windir "System32/WindowsPowershell/v1.0/Modules/PSScheduledJob"
-            Import-Module $modulePath -ErrorAction SilentlyContinue -ErrorVariable err
-            $err.FullyQualifiedErrorId | Should Be "Modules_ModuleFileNotFound,Microsoft.PowerShell.Commands.ImportModuleCommand"
+            { Import-Module $modulePath -ErrorAction SilentlyContinue } | ShouldBeErrorId 'FormatXmlUpdateException,Microsoft.PowerShell.Commands.ImportModuleCommand'
         }
     }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Import-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Import-Module.Tests.ps1
@@ -63,3 +63,29 @@ Describe "Import-Module with ScriptsToProcess" -Tags "CI" {
         Get-Content out.txt | Should Be $Expected
     }
 }
+
+Describe "Import-Module for Binary Modules in GAC" -Tags 'CI' {
+    Context "Modules are not loaded from GAC" {
+        BeforeAll {
+            [System.Management.Automation.PowerShellAssemblyLoadContextTestHooks]::SetTestHook('AllowGACLoading', $false)
+        }
+
+        AfterAll {
+            [System.Management.Automation.PowerShellAssemblyLoadContextTestHooks]::SetTestHook('AllowGACLoading', $true)
+        }
+
+        It "Load PSScheduledJob from Windows Powershell Modules folder should fail" -Skip:(-not $IsWindows) {
+            $modulePath = Join-Path $env:windir "System32/WindowsPowershell/v1.0/Modules/PSScheduledJob"
+            Import-Module $modulePath -ErrorAction SilentlyContinue -ErrorVariable err
+            $err.FullyQualifiedErrorId | Should Be "Modules_ModuleFileNotFound,Microsoft.PowerShell.Commands.ImportModuleCommand"
+        }
+    }
+
+    Context "Modules are loaded from GAC" {
+        It "Load PSScheduledJob from Windows Powershell Modules folder" -Skip:(-not $IsWindows) {
+            $modulePath = Join-Path $env:windir "System32/WindowsPowershell/v1.0/Modules/PSScheduledJob"
+            Import-Module $modulePath
+            (Get-Command New-JobTrigger).Name | Should Be 'New-JobTrigger'
+        }
+    }
+}


### PR DESCRIPTION
Fixes #2592 

When Resolve method is not able to find the assembly, we try to look it up from GAC.
If found, the assembly is loaded and cached.
There is a TestHook to disable GAC loading, but it is enabled by default.

<!--

If you are a PowerShell Team member, please make sure you choose the Reviewer(s) and Assignee for your PR.
If you are not from the PowerShell Team, you can leave the fields blank and the Maintainers will choose them for you. If you are familiar with the team, feel free to mention some Reviewers yourself.

For more information about the roles of Reviewer and Assignee, refer to CONTRIBUTING.md.

-->
