### PR TITLE
Enhance formatting to exclude explicit newlines when writing errors

### DIFF
--- a/src/System.Management.Automation/commands/utility/FormatAndOutput/common/BaseOutputtingCommand.cs
+++ b/src/System.Management.Automation/commands/utility/FormatAndOutput/common/BaseOutputtingCommand.cs
@@ -540,6 +540,8 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
 
         private void ProcessOutOfBandPayload(FormatEntryData fed)
         {
+            var screenColumnWidth = fed.width ?? _lo.ColumnNumber;
+
             // try if it is raw text
             RawTextFormatEntry rte = fed.formatEntryInfo as RawTextFormatEntry;
             if (rte != null)
@@ -548,7 +550,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 {
                     ComplexWriter complexWriter = new ComplexWriter();
 
-                    complexWriter.Initialize(_lo, _lo.ColumnNumber);
+                    complexWriter.Initialize(_lo, screenColumnWidth);
                     complexWriter.WriteString(rte.text);
                 }
                 else
@@ -565,7 +567,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             {
                 ComplexWriter complexWriter = new ComplexWriter();
 
-                complexWriter.Initialize(_lo, _lo.ColumnNumber);
+                complexWriter.Initialize(_lo, screenColumnWidth);
                 complexWriter.WriteObject(cve.formatValueList);
 
                 return;
@@ -579,7 +581,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 _lo.WriteLine("");
 
                 string[] properties = ListOutputContext.GetProperties(lve);
-                listWriter.Initialize(properties, _lo.ColumnNumber, _lo.DisplayCells);
+                listWriter.Initialize(properties, screenColumnWidth, _lo.DisplayCells);
                 string[] values = ListOutputContext.GetValues(lve);
                 listWriter.WriteProperties(values, _lo);
 

--- a/src/System.Management.Automation/commands/utility/FormatAndOutput/common/DefaultFormatters/PowerShellCore_format_ps1xml.cs
+++ b/src/System.Management.Automation/commands/utility/FormatAndOutput/common/DefaultFormatters/PowerShellCore_format_ps1xml.cs
@@ -717,7 +717,7 @@ namespace System.Management.Automation.Runspaces
         private static IEnumerable<FormatViewDefinition> ViewsOf_System_Management_Automation_ErrorRecord()
         {
             yield return new FormatViewDefinition("ErrorInstance",
-                CustomControl.Create(outOfBand: true)
+                CustomControl.Create(outOfBand: true, width: Int32.MaxValue)
                     .StartEntry()
                         .AddScriptBlockExpressionBinding(@"
                                     if (($_.FullyQualifiedErrorId -ne ""NativeCommandErrorMessage"" -and $_.FullyQualifiedErrorId -ne ""NativeCommandError"") -and $ErrorView -ne ""CategoryView"")

--- a/src/System.Management.Automation/commands/utility/FormatAndOutput/common/DisplayDatabase/displayDescriptionData.cs
+++ b/src/System.Management.Automation/commands/utility/FormatAndOutput/common/DisplayDatabase/displayDescriptionData.cs
@@ -546,6 +546,11 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         internal bool outOfBand;
 
         /// <summary>
+        /// Override default console host width.
+        /// </summary>
+        internal int? width;
+
+        /// <summary>
         /// Set if the view is for help output, used so we can prune the view from Get-FormatData
         /// because those views are too complicated and big for remoting.
         /// </summary>
@@ -712,6 +717,11 @@ namespace System.Management.Automation
         /// regardless of previous objects that may have selected the shape.
         /// </summary>
         public bool OutOfBand { get; set; }
+
+        /// <summary>
+        /// Set explicit limit for Width. Default width is a console host width.
+        /// </summary>
+        public int? Width { get; set; }
 
         internal abstract void WriteToXml(FormatXmlWriter writer);
 

--- a/src/System.Management.Automation/commands/utility/FormatAndOutput/common/DisplayDatabase/displayDescriptionData_Complex.cs
+++ b/src/System.Management.Automation/commands/utility/FormatAndOutput/common/DisplayDatabase/displayDescriptionData_Complex.cs
@@ -93,9 +93,9 @@ namespace System.Management.Automation
         }
 
         /// <summary/>
-        public static CustomControlBuilder Create(bool outOfBand = false)
+        public static CustomControlBuilder Create(bool outOfBand = false, int? width = null)
         {
-            var customControl = new CustomControl { OutOfBand = outOfBand };
+            var customControl = new CustomControl { OutOfBand = outOfBand, Width = width };
             return new CustomControlBuilder(customControl);
         }
 

--- a/src/System.Management.Automation/commands/utility/FormatAndOutput/common/DisplayDatabase/typeDataXmlLoader.cs
+++ b/src/System.Management.Automation/commands/utility/FormatAndOutput/common/DisplayDatabase/typeDataXmlLoader.cs
@@ -465,6 +465,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             ViewDefinition view = new ViewDefinition();
             view.appliesTo = appliesTo;
             view.name = formatView.Name;
+            view.width = formatView.Control.Width;
 
             var firstTypeName = typeNames[0];
             PSControl control = formatView.Control;

--- a/src/System.Management.Automation/commands/utility/FormatAndOutput/common/FormatViewManager.cs
+++ b/src/System.Management.Automation/commands/utility/FormatAndOutput/common/FormatViewManager.cs
@@ -568,6 +568,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
 
             FormatEntryData fed = outOfBandViewGenerator.GeneratePayload(so, enumerationLimit);
             fed.outOfBand = true;
+            fed.width = view?.width;
             fed.SetStreamTypeFromPSObject(so);
 
             errors = outOfBandViewGenerator.ErrorManager.DrainFailedResultList();

--- a/src/System.Management.Automation/commands/utility/FormatAndOutput/common/FormattingObjects.cs
+++ b/src/System.Management.Automation/commands/utility/FormatAndOutput/common/FormattingObjects.cs
@@ -149,6 +149,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         public FormatEntryInfo formatEntryInfo = null;
 
         public bool outOfBand = false;
+        public int? width = null;
         public WriteStreamType writeStream = WriteStreamType.None;
         internal bool isHelpObject = false;
 

--- a/src/System.Management.Automation/commands/utility/FormatAndOutput/common/FormattingObjectsDeserializer.cs
+++ b/src/System.Management.Automation/commands/utility/FormatAndOutput/common/FormattingObjectsDeserializer.cs
@@ -561,6 +561,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             base.Deserialize(so, deserializer);
             this.formatEntryInfo = (FormatEntryInfo)deserializer.DeserializeMandatoryMemberObject(so, "formatEntryInfo");
             this.outOfBand = deserializer.DeserializeBoolMemberVariable(so, "outOfBand");
+            this.width = deserializer.DeserializeIntMemberVariable(so, "width");
             this.writeStream = deserializer.DeserializeWriteStreamTypeMemberVariable(so);
             this.isHelpObject = so.IsHelpObject;
         }

--- a/src/System.Management.Automation/engine/serialization.cs
+++ b/src/System.Management.Automation/engine/serialization.cs
@@ -7428,6 +7428,7 @@ namespace Microsoft.PowerShell
 
             result.GroupBy = GetPropertyValue<PSControlGroupBy>(deserializedControl, "GroupBy", RehydrationFlags.MissingPropertyOk);
             result.OutOfBand = GetPropertyValue<bool>(deserializedControl, "OutOfBand", RehydrationFlags.MissingPropertyOk);
+            result.Width = GetPropertyValue<int?>(deserializedControl, "Width", RehydrationFlags.MissingPropertyOk);
             return result;
         }
 


### PR DESCRIPTION
Fix #3813 
Fix #1491

Problem
---
Newlines are added by console width when ErrorRecord formatted.

Solution
---
Override the format width with Int32.MaxValue for ErrorRecord type.


