### PR TITLE
Update README.md about the '1.11.0-beta4' VSCode C# extension

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -503,6 +503,7 @@ throw-testcasesItMockDescribe
 Gitter
 microsoft.com
 msi
+omnisharp-vscode
 opencode
 pkg
  - src/libpsl-native/README.md

--- a/README.md
+++ b/README.md
@@ -144,7 +144,8 @@ See [working with the PowerShell repository](docs/git) for more information.
 > Note: To develop with VSCode on OSX and Linux, you need to install the [`v1.11.0-beta4`][beta-csharp] C# extension by following these [instructions][install-beta-csharp].
 >
 > PowerShell is building against the .NET Core `2.0.0-preview2` packages using the .NET Core `2.0.0-preview2` SDK.
-`v1.13.0` VSCode + `v1.10.0` C# extension works fine with the .NET Core `2.0.0-preview2` SDK on Windows. However, on OSX and Linux you need to use the `v1.11.0-beta4` C# extension due to [OmniSharp/omnisharp-vscode#1495][omnisharp-1495].
+`v1.13.0` VSCode + `v1.10.0` C# extension works fine with the .NET Core `2.0.0-preview2` SDK on Windows.
+However, on OSX and Linux you need to use the `v1.11.0-beta4` C# extension due to [omnisharp-vscode issue #1495][omnisharp-1495].
 
 [beta-csharp]: https://github.com/OmniSharp/omnisharp-vscode/releases/tag/v1.11.0-beta4
 [install-beta-csharp]: https://github.com/OmniSharp/omnisharp-vscode/wiki/Installing-Beta-Releases

--- a/README.md
+++ b/README.md
@@ -141,6 +141,15 @@ See [working with the PowerShell repository](docs/git) for more information.
 
 ## Developing and Contributing
 
+> Note: To develop with VSCode on OSX and Linux, you need to install the [`v1.11.0-beta4`][beta-csharp] C# extension by following these [instructions][install-beta-csharp].
+>
+> PowerShell is building against the .NET Core `2.0.0-preview2` packages using the .NET Core `2.0.0-preview2` SDK.
+`v1.13.0` VSCode + `v1.10.0` C# extension works fine with the .NET Core `2.0.0-preview2` SDK on Windows. However, on OSX and Linux you need to use the `v1.11.0-beta4` C# extension due to [OmniSharp/omnisharp-vscode#1495][omnisharp-1495].
+
+[beta-csharp]: https://github.com/OmniSharp/omnisharp-vscode/releases/tag/v1.11.0-beta4
+[install-beta-csharp]: https://github.com/OmniSharp/omnisharp-vscode/wiki/Installing-Beta-Releases
+[omnisharp-1495]: https://github.com/OmniSharp/omnisharp-vscode/issues/1495
+
 Please see the [Contribution Guide][] for how to develop and contribute.
 
 If you have any problems, please consult the [known issues][], developer [FAQ][], and [GitHub issues][].


### PR DESCRIPTION
Fix #4004

.NET Core `2.0.0-preview2` SDK is not supported by the latest v1.10.0 VSCode C# extension on OSX and Linux. People need to install `v1.11.0-beta4` C# extension to make it work. Update the README.md to let people know this more easily.
