### PR TITLE
Change positional parameter for powershell.exe from -Command to -File

### DIFF
--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
@@ -1820,7 +1820,17 @@ namespace Microsoft.PowerShell
                 s_tracer.WriteLine("running -file '{0}'", filePath);
 
                 Pipeline tempPipeline = exec.CreatePipeline();
-                Command c = new Command(filePath, false, false);
+                Command c;
+                // if file doesn't have .ps1 extension, we read the contents and treat it as a script to support shebang with no .ps1 extension usage
+                if (!Path.GetExtension(filePath).Equals(".ps1", StringComparison.OrdinalIgnoreCase))
+                {
+                    string script = File.ReadAllText(filePath);
+                    c = new Command(script, isScript: true, useLocalScope: false);
+                }
+                else
+                {
+                    c = new Command(filePath, false, false);
+                }
                 tempPipeline.Commands.Add(c);
 
                 if (initialCommandArgs != null)

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/ManagedEntranceStrings.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/ManagedEntranceStrings.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!--
-    Microsoft ResX Schema
-
+  <!-- 
+    Microsoft ResX Schema 
+    
     Version 2.0
-
-    The primary goals of this format is to allow a simple XML format
-    that is mostly human readable. The generation and parsing of the
-    various data types are done through the TypeConverter classes
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
     associated with the data types.
-
+    
     Example:
-
+    
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-
-    There are any number of "resheader" rows that contain simple
+                
+    There are any number of "resheader" rows that contain simple 
     name/value pairs.
-
-    Each data row contains a name, and value. The row also contains a
-    type or mimetype. Type corresponds to a .NET class that support
-    text/value conversion through the TypeConverter architecture.
-    Classes that don't support this are serialized and stored with the
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
     mimetype set.
-
-    The mimetype is used for serialized objects, and tells the
-    ResXResourceReader how to depersist the object. This is currently not
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
     extensible. For a given mimetype the value must be set accordingly:
-
-    Note - application/x-microsoft.net.object.binary.base64 is the format
-    that the ResXResourceWriter will generate, however the reader can
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
     read any of the formats listed below.
-
+    
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-
+    
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array
+    value   : The object must be serialized into a byte array 
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -142,7 +142,7 @@ PowerShell[.exe] -Help | -? | /?
     file, use Export-Console in Windows PowerShell.
 
 -Version
-    Starts the specified version of Windows PowerShell.
+    Starts the specified version of Windows PowerShell. 
     Enter a version number with the parameter, such as "-version 2.0".
 
 -NoLogo
@@ -179,8 +179,8 @@ PowerShell[.exe] -Help | -? | /?
     Sets the window style to Normal, Minimized, Maximized or Hidden.
 
 -EncodedCommand
-    Accepts a base-64-encoded string version of a command. Use this parameter
-    to submit commands to Windows PowerShell that require complex quotation
+    Accepts a base-64-encoded string version of a command. Use this parameter 
+    to submit commands to Windows PowerShell that require complex quotation 
     marks or curly braces.
 
 -ConfigurationName
@@ -188,24 +188,24 @@ PowerShell[.exe] -Help | -? | /?
     This can be any endpoint registered on the local machine including the
     default Windows PowerShell remoting endpoints or a custom endpoint having
     specific user role capabilities.
-
+    
 -File
-    Runs the specified script in the local scope ("dot-sourced"), so that the
-    functions and variables that the script creates are available in the
-    current session. Enter the script file path and any parameters.
-    File must be the last parameter in the command, because all characters
-    typed after the File parameter name are interpreted
+    Runs the specified script in the local scope ("dot-sourced"), so that the 
+    functions and variables that the script creates are available in the 
+    current session. Enter the script file path and any parameters. 
+    File must be the last parameter in the command, because all characters 
+    typed after the File parameter name are interpreted 
     as the script file path followed by the script parameters.
 
 -ExecutionPolicy
-    Sets the default execution policy for the current session and saves it
-    in the $env:PSExecutionPolicyPreference environment variable.
-    This parameter does not change the Windows PowerShell execution policy
+    Sets the default execution policy for the current session and saves it 
+    in the $env:PSExecutionPolicyPreference environment variable. 
+    This parameter does not change the Windows PowerShell execution policy 
     that is set in the registry.
 
 -Command
     Executes the specified commands (and any parameters) as though they were
-    typed at the Windows PowerShell command prompt, and then exits, unless
+    typed at the Windows PowerShell command prompt, and then exits, unless 
     NoExit is specified. The value of Command can be "-", a string. or a
     script block.
 
@@ -218,7 +218,7 @@ PowerShell[.exe] -Help | -? | /?
     parent shell as deserialized XML objects, not live objects.
 
     If the value of Command is a string, Command must be the last parameter
-    in the command , because any characters typed after the command are
+    in the command , because any characters typed after the command are 
     interpreted as the command arguments.
 
     To write a string that runs a Windows PowerShell command, use the format:

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/ManagedEntranceStrings.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/ManagedEntranceStrings.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -131,9 +131,9 @@ Copyright (C) Microsoft Corporation. All rights reserved.</value>
     [-InputFormat {Text | XML}] [-OutputFormat {Text | XML}]
     [-WindowStyle &lt;style&gt;] [-EncodedCommand &lt;Base64EncodedCommand&gt;]
     [-ConfigurationName &lt;string&gt;]
-    [-File &lt;filePath&gt; &lt;args&gt;] [-ExecutionPolicy &lt;ExecutionPolicy&gt;]
     [-Command { - | &lt;script-block&gt; [-args &lt;arg-array&gt;]
                   | &lt;string&gt; [&lt;CommandParameters&gt;] } ]
+    [-File &lt;filePath&gt; &lt;args&gt;] [-ExecutionPolicy &lt;ExecutionPolicy&gt;]
 
 PowerShell[.exe] -Help | -? | /?
 
@@ -142,7 +142,7 @@ PowerShell[.exe] -Help | -? | /?
     file, use Export-Console in Windows PowerShell.
 
 -Version
-    Starts the specified version of Windows PowerShell. 
+    Starts the specified version of Windows PowerShell.
     Enter a version number with the parameter, such as "-version 2.0".
 
 -NoLogo
@@ -179,8 +179,8 @@ PowerShell[.exe] -Help | -? | /?
     Sets the window style to Normal, Minimized, Maximized or Hidden.
 
 -EncodedCommand
-    Accepts a base-64-encoded string version of a command. Use this parameter 
-    to submit commands to Windows PowerShell that require complex quotation 
+    Accepts a base-64-encoded string version of a command. Use this parameter
+    to submit commands to Windows PowerShell that require complex quotation
     marks or curly braces.
 
 -ConfigurationName
@@ -188,24 +188,24 @@ PowerShell[.exe] -Help | -? | /?
     This can be any endpoint registered on the local machine including the
     default Windows PowerShell remoting endpoints or a custom endpoint having
     specific user role capabilities.
-    
+
 -File
-    Runs the specified script in the local scope ("dot-sourced"), so that the 
-    functions and variables that the script creates are available in the 
-    current session. Enter the script file path and any parameters. 
-    File must be the last parameter in the command, because all characters 
-    typed after the File parameter name are interpreted 
+    Runs the specified script in the local scope ("dot-sourced"), so that the
+    functions and variables that the script creates are available in the
+    current session. Enter the script file path and any parameters.
+    File must be the last parameter in the command, because all characters
+    typed after the File parameter name are interpreted
     as the script file path followed by the script parameters.
 
 -ExecutionPolicy
-    Sets the default execution policy for the current session and saves it 
-    in the $env:PSExecutionPolicyPreference environment variable. 
-    This parameter does not change the Windows PowerShell execution policy 
+    Sets the default execution policy for the current session and saves it
+    in the $env:PSExecutionPolicyPreference environment variable.
+    This parameter does not change the Windows PowerShell execution policy
     that is set in the registry.
 
 -Command
     Executes the specified commands (and any parameters) as though they were
-    typed at the Windows PowerShell command prompt, and then exits, unless 
+    typed at the Windows PowerShell command prompt, and then exits, unless
     NoExit is specified. The value of Command can be "-", a string. or a
     script block.
 
@@ -218,7 +218,7 @@ PowerShell[.exe] -Help | -? | /?
     parent shell as deserialized XML objects, not live objects.
 
     If the value of Command is a string, Command must be the last parameter
-    in the command , because any characters typed after the command are 
+    in the command , because any characters typed after the command are
     interpreted as the command arguments.
 
     To write a string that runs a Windows PowerShell command, use the format:
@@ -237,6 +237,7 @@ EXAMPLES
     PowerShell -ConfigurationName AdminRoles
     PowerShell -Command {Get-EventLog -LogName security}
     PowerShell -Command "&amp; {Get-EventLog -LogName security}"
+    PowerShell HelloWorld.ps1
 
     # To use the -EncodedCommand parameter:
     $command = 'dir "c:\program files" '

--- a/test/powershell/Host/ConsoleHost.Tests.ps1
+++ b/test/powershell/Host/ConsoleHost.Tests.ps1
@@ -200,6 +200,16 @@ Describe "ConsoleHost unit tests" -tags "Feature" {
             $observed[0] | Should Be "foo"
             $observed[1] | Should Be "bar"
         }
+
+        It "-File should return exit code from script"  -TestCases @(
+            @{Filename = "test.ps1"},
+            @{Filename = "test"}
+        ) {
+            param($Filename)
+            Set-Content -Path $testdrive/$Filename -Value 'exit 123'
+            & $powershell $testdrive/$Filename
+            $LASTEXITCODE | Should Be 123
+        }        
     }
 
     Context "Pipe to/from powershell" {

--- a/test/powershell/Host/ConsoleHost.Tests.ps1
+++ b/test/powershell/Host/ConsoleHost.Tests.ps1
@@ -176,6 +176,30 @@ Describe "ConsoleHost unit tests" -tags "Feature" {
             # no extraneous output
             $observed | should be $currentVersion
         }
+
+        It "-File should be default parameter" {
+            Set-Content -Path $testdrive/test -Value "'hello'"
+            $observed = & $powershell $testdrive/test
+            $observed | Should Be "hello"
+        }
+
+        It "-File accepts scripts with and without .ps1 extension" -TestCases @(
+            @{Filename="test.ps1"},
+            @{Filename="test"}
+        ) {
+            param($Filename)
+            Set-Content -Path $testdrive/$Filename -Value "'hello'"
+            $observed = & $powershell -File $testdrive/$Filename
+            $observed | Should Be "hello"
+        }
+
+        It "-File should pass additional arguments to script" {
+            Set-Content -Path $testdrive/script.ps1 -Value 'foreach($arg in $args){$arg}'
+            $observed = & $powershell $testdrive/script.ps1 foo bar
+            $observed.Count | Should Be 2
+            $observed[0] | Should Be "foo"
+            $observed[1] | Should Be "bar"
+        }
     }
 
     Context "Pipe to/from powershell" {
@@ -204,7 +228,7 @@ Describe "ConsoleHost unit tests" -tags "Feature" {
 
     Context "Redirected standard output" {
         It "Simple redirected output" {
-            $si = NewProcessStartInfo "-noprofile 1+1"
+            $si = NewProcessStartInfo "-noprofile -c 1+1"
             $process = RunPowerShell $si
             $process.StandardOutput.ReadToEnd() | Should Be 2
             EnsureChildHasExited $process
@@ -217,14 +241,14 @@ Describe "ConsoleHost unit tests" -tags "Feature" {
         # So none of these tests should close StandardInput
 
         It "Redirected input w/ implicit -Command w/ -NonInteractive" {
-            $si = NewProcessStartInfo "-NonInteractive -noprofile 1+1" -RedirectStdIn
+            $si = NewProcessStartInfo "-NonInteractive -noprofile -c 1+1" -RedirectStdIn
             $process = RunPowerShell $si
             $process.StandardOutput.ReadToEnd() | Should Be 2
             EnsureChildHasExited $process
         }
 
         It "Redirected input w/ implicit -Command w/o -NonInteractive" {
-            $si = NewProcessStartInfo "-noprofile 1+1" -RedirectStdIn
+            $si = NewProcessStartInfo "-noprofile -c 1+1" -RedirectStdIn
             $process = RunPowerShell $si
             $process.StandardOutput.ReadToEnd() | Should Be 2
             EnsureChildHasExited $process
@@ -295,7 +319,7 @@ Describe "ConsoleHost unit tests" -tags "Feature" {
         }
 
         It "Interactive redirected input w/ initial command" {
-            $si = NewProcessStartInfo "-noprofile -noexit ""`$function:prompt = { 'PS> ' }""" -RedirectStdIn
+            $si = NewProcessStartInfo "-noprofile -noexit -c ""`$function:prompt = { 'PS> ' }""" -RedirectStdIn
             $process = RunPowerShell $si
             $process.StandardInput.Write("1+1`n")
             $process.StandardOutput.ReadLine() | Should Be "PS> 1+1"
@@ -309,7 +333,7 @@ Describe "ConsoleHost unit tests" -tags "Feature" {
         }
 
         It "Redirected input explicit prompting (-File -)" {
-            $si = NewProcessStartInfo "-noprofile -File -" -RedirectStdIn
+            $si = NewProcessStartInfo "-noprofile -" -RedirectStdIn
             $process = RunPowerShell $si
             $process.StandardInput.Write("`$function:prompt = { 'PS> ' }`n")
             $null = $process.StandardOutput.ReadLine()
@@ -322,7 +346,7 @@ Describe "ConsoleHost unit tests" -tags "Feature" {
         }
 
         It "Redirected input no prompting (-Command -)" {
-            $si = NewProcessStartInfo "-noprofile -" -RedirectStdIn
+            $si = NewProcessStartInfo "-noprofile -Command -" -RedirectStdIn
             $process = RunPowerShell $si
             $process.StandardInput.Write("1+1`n")
             $process.StandardOutput.ReadLine() | Should Be "2"
@@ -355,7 +379,7 @@ foo
         }
 
         It "Redirected input w/ nested prompt" {
-            $si = NewProcessStartInfo "-noprofile -noexit ""`$function:prompt = { 'PS' + ('>'*(`$nestedPromptLevel+1)) + ' ' }""" -RedirectStdIn
+            $si = NewProcessStartInfo "-noprofile -noexit -c ""`$function:prompt = { 'PS' + ('>'*(`$nestedPromptLevel+1)) + ' ' }""" -RedirectStdIn
             $process = RunPowerShell $si
             $process.StandardInput.Write("`$host.EnterNestedPrompt()`n")
             $process.StandardOutput.ReadLine() | Should Be "PS> `$host.EnterNestedPrompt()"
@@ -397,7 +421,7 @@ foo
         AfterEach {
             $env:XDG_CACHE_HOME = $XDG_CACHE_HOME
             $env:XDG_DATA_HOME = $XDG_DATA_HOME
-            $env:XDG_CONFIG_HOME = $XDG_CONFIG_HOME            
+            $env:XDG_CONFIG_HOME = $XDG_CONFIG_HOME
         }
 
         It "Should start if Data, Config, and Cache location is not accessible" -skip:($IsWindows) {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Invoke-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Invoke-Item.Tests.ps1
@@ -33,7 +33,7 @@ Describe "Invoke-Item basic tests" -Tags "CI" {
 
             ## Redirect stderr to a file. So if 'open' failed to open the text file, an error
             ## message from 'open' would be written to the redirection file.
-            $proc = Start-Process -FilePath $powershell -ArgumentList "-noprofile Invoke-Item '$TestFile'" `
+            $proc = Start-Process -FilePath $powershell -ArgumentList "-noprofile -c Invoke-Item '$TestFile'" `
                                   -RedirectStandardError $redirectErr `
                                   -PassThru
             $proc.WaitForExit(3000) > $null

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Invoke-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Invoke-Item.Tests.ps1
@@ -52,10 +52,10 @@ Describe "Invoke-Item basic tests" -Tags "CI" {
 
         if ($IsWindows) {
             ## 'ping.exe' on Windows writes out usage to stdout.
-            & $powershell "-noprofile" "Invoke-Item '$executable'" > $redirectFile
+            & $powershell -noprofile -c "Invoke-Item '$executable'" > $redirectFile
         } else {
             ## 'ping' on Unix write out usage to stderr
-            & $powershell "-noprofile" "Invoke-Item '$executable'" 2> $redirectFile
+            & $powershell -noprofile -c "Invoke-Item '$executable'" 2> $redirectFile
         }
         Get-Content $redirectFile -Raw | Should Match "usage: ping"
     }

--- a/test/powershell/Modules/Microsoft.Powershell.Host/Start-Transcript.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.Powershell.Host/Start-Transcript.Tests.ps1
@@ -110,7 +110,7 @@ Describe "Start-Transcript, Stop-Transcript tests" -tags "CI" {
         try{
             $ps = [powershell]::Create()
             $ps.addscript("Start-Transcript -path $transcriptFilePath").Invoke()
-            $ps.addscript('$rs = [system.management.automation.runspaces.runspacefactory]::CreateRunspace()').Invoke()      
+            $ps.addscript('$rs = [system.management.automation.runspaces.runspacefactory]::CreateRunspace()').Invoke()
             $ps.addscript('$rs.open()').Invoke()
             $ps.addscript('$rs.Dispose()').Invoke()
             $ps.addscript('Write-Host "After Dispose"').Invoke()
@@ -121,16 +121,16 @@ Describe "Start-Transcript, Stop-Transcript tests" -tags "CI" {
                 }
             }
 
-        
+
         Test-Path $transcriptFilePath | Should be $true
         $transcriptFilePath | Should contain "After Dispose"
     }
 
     It "Transcription should be closed if the only runspace gets closed" {
         $powerShellPath = [System.Diagnostics.Process]::GetCurrentProcess().Path
-        $powerShellCommand = $powerShellPath + ' "start-transcript $transcriptFilePath; Write-Host ''Before Dispose'';"'
+        $powerShellCommand = $powerShellPath + ' -c "start-transcript $transcriptFilePath; Write-Host ''Before Dispose'';"'
         Invoke-Expression $powerShellCommand
-        
+
         Test-Path $transcriptFilePath | Should be $true
         $transcriptFilePath | Should contain "Before Dispose"
         $transcriptFilePath | Should contain "Windows PowerShell transcript end"

--- a/test/powershell/SDK/PSDebugging.Tests.ps1
+++ b/test/powershell/SDK/PSDebugging.Tests.ps1
@@ -38,7 +38,7 @@ Describe "PowerShell Command Debugging" -tags "CI" {
     }
 
     It "Should be able to step into debugging" {
-        $debugfn = NewProcessStartInfo "-noprofile ""`$function:foo = { 'bar' }""" -RedirectStdIn
+        $debugfn = NewProcessStartInfo "-noprofile -c ""`$function:foo = { 'bar' }""" -RedirectStdIn
         $process = RunPowerShell $debugfn
         $process.StandardInput.Write("Set-PsBreakpoint -command foo`n")
 
@@ -57,7 +57,7 @@ Describe "PowerShell Command Debugging" -tags "CI" {
     }
 
     It "Should be able to continue into debugging" {
-        $debugfn = NewProcessStartInfo "-noprofile ""`$function:foo = { 'bar' }""" -RedirectStdIn
+        $debugfn = NewProcessStartInfo "-noprofile -c ""`$function:foo = { 'bar' }""" -RedirectStdIn
         $process = RunPowerShell $debugfn
         $process.StandardInput.Write("Set-PsBreakpoint -command foo`n")
 
@@ -74,7 +74,7 @@ Describe "PowerShell Command Debugging" -tags "CI" {
     }
 
     It -Pending "Should be able to list help for debugging" {
-        $debugfn = NewProcessStartInfo "-noprofile ""`$function:foo = { 'bar' }""" -RedirectStdIn
+        $debugfn = NewProcessStartInfo "-noprofile -c ""`$function:foo = { 'bar' }""" -RedirectStdIn
         $process = RunPowerShell $debugfn
         $process.StandardInput.Write("Set-PsBreakpoint -command foo`n")
 
@@ -97,7 +97,7 @@ Describe "PowerShell Command Debugging" -tags "CI" {
 
 
     It "Should be able to step over debugging" {
-        $debugfn = NewProcessStartInfo "-noprofile ""`$function:foo = { 'bar' }""" -RedirectStdIn
+        $debugfn = NewProcessStartInfo "-noprofile -c ""`$function:foo = { 'bar' }""" -RedirectStdIn
         $process = RunPowerShell $debugfn
         $process.StandardInput.Write("Set-PsBreakpoint -command foo`n")
 
@@ -114,7 +114,7 @@ Describe "PowerShell Command Debugging" -tags "CI" {
 
 
     It "Should be able to step out of debugging" {
-        $debugfn = NewProcessStartInfo "-noprofile ""`$function:foo = { 'bar' }""" -RedirectStdIn
+        $debugfn = NewProcessStartInfo "-noprofile -c ""`$function:foo = { 'bar' }""" -RedirectStdIn
         $process = RunPowerShell $debugfn
         $process.StandardInput.Write("Set-PsBreakpoint -command foo`n")
 
@@ -128,7 +128,7 @@ Describe "PowerShell Command Debugging" -tags "CI" {
     }
 
     It "Should be able to quit debugging" {
-        $debugfn = NewProcessStartInfo "-noprofile ""`$function:foo = { 'bar' }""" -RedirectStdIn
+        $debugfn = NewProcessStartInfo "-noprofile -c ""`$function:foo = { 'bar' }""" -RedirectStdIn
         $process = RunPowerShell $debugfn
         $process.StandardInput.Write("Set-PsBreakpoint -command foo`n")
 
@@ -142,7 +142,7 @@ Describe "PowerShell Command Debugging" -tags "CI" {
     }
 
     It -Pending "Should be able to list source code in debugging" {
-        $debugfn = NewProcessStartInfo "-noprofile ""`$function:foo = { 'bar' }""" -RedirectStdIn
+        $debugfn = NewProcessStartInfo "-noprofile -c ""`$function:foo = { 'bar' }""" -RedirectStdIn
         $process = RunPowerShell $debugfn
         $process.StandardInput.Write("Set-PsBreakpoint -command foo`n") | Write-Host
 
@@ -165,7 +165,7 @@ Describe "PowerShell Command Debugging" -tags "CI" {
 
 
     It -Pending "Should be able to get the call stack in debugging" {
-        $debugfn = NewProcessStartInfo "-noprofile ""`$function:foo = { 'bar' }""" -RedirectStdIn
+        $debugfn = NewProcessStartInfo "-noprofile -c ""`$function:foo = { 'bar' }""" -RedirectStdIn
         $process = RunPowerShell $debugfn
         $process.StandardInput.Write("Set-PsBreakpoint -command foo`n") | Write-Host
 


### PR DESCRIPTION
Previously powershell.exe treated unknown arguments as a command line to execute.  To align with POSIX so that things like shebang scripts work correctly, we are changing powershell.exe so that it treats unknown arguments (aka positional argument) as a file.  This means that `powershell foo` will now attempt to use `foo` as a PowerShell script whereas previously `foo` would be treated as a command to execute.  This doesn't affect existing usage of either `-File` nor `-Command`.  Fixed tests that didn't explicitly use `-Command` parameter.

Note that some of the changes below for trailing whitespace was due to VSCode setting.

Fix https://github.com/PowerShell/PowerShell/issues/1103
Fix https://github.com/PowerShell/PowerShell/issues/3959