### PR TITLE
Make Get-ChildItem follow symlinks on demand, with checks for link loops

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/GetChildrenCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/GetChildrenCommand.cs
@@ -172,25 +172,6 @@ namespace Microsoft.PowerShell.Commands
         }
 
         /// <summary>
-        /// Gets or sets whether symbolic links are to be followed when recursing.
-        /// </summary>
-        [Parameter]
-        public SwitchParameter FollowSymlink
-        {
-            get
-            {
-                return _followSymlink;
-            }
-            set
-            {
-                _followSymlink = value;
-                if (value == true)
-                    Recurse = true;
-            }
-        }
-        private bool _followSymlink = false;
-
-        /// <summary>
         /// Gets or sets the force property
         /// </summary>
         ///

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/GetChildrenCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/GetChildrenCommand.cs
@@ -184,6 +184,8 @@ namespace Microsoft.PowerShell.Commands
             set
             {
                 _followSymlink = value;
+                if (value == true)
+                    Recurse = true;
             }
         }
         private bool _followSymlink = false;

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/GetChildrenCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/GetChildrenCommand.cs
@@ -172,6 +172,23 @@ namespace Microsoft.PowerShell.Commands
         }
 
         /// <summary>
+        /// Gets or sets whether symbolic links are to be followed when recursing.
+        /// </summary>
+        [Parameter]
+        public SwitchParameter FollowSymlink
+        {
+            get
+            {
+                return _followSymlink;
+            }
+            set
+            {
+                _followSymlink = value;
+            }
+        }
+        private bool _followSymlink = false;
+
+        /// <summary>
         /// Gets or sets the force property
         /// </summary>
         ///

--- a/src/System.Management.Automation/CoreCLR/CorePsPlatform.cs
+++ b/src/System.Management.Automation/CoreCLR/CorePsPlatform.cs
@@ -587,6 +587,11 @@ namespace System.Management.Automation
             return Unix.NativeMethods.IsSameFileSystemItem(pathOne, pathTwo);
         }
 
+        internal static bool NonWindowsGetInodeData(string path, out UInt64 device, out UInt64 inode)
+        {
+            return Unix.NativeMethods.GetInodeData(path, out device, out inode) == 0;
+        }
+
         internal static bool NonWindowsIsExecutable(string path)
         {
             return Unix.NativeMethods.IsExecutable(path);
@@ -797,6 +802,10 @@ namespace System.Management.Automation
                 [return: MarshalAs(UnmanagedType.I1)]
                 internal static extern bool IsSameFileSystemItem([MarshalAs(UnmanagedType.LPStr)]string filePathOne,
                                                                  [MarshalAs(UnmanagedType.LPStr)]string filePathTwo);
+
+                [DllImport(psLib, CharSet = CharSet.Ansi, SetLastError = true)]
+                internal static extern int GetInodeData([MarshalAs(UnmanagedType.LPStr)]string path,
+                                                        out UInt64 device, out UInt64 inode);
             }
         }
     }

--- a/src/System.Management.Automation/CoreCLR/CorePsPlatform.cs
+++ b/src/System.Management.Automation/CoreCLR/CorePsPlatform.cs
@@ -587,9 +587,14 @@ namespace System.Management.Automation
             return Unix.NativeMethods.IsSameFileSystemItem(pathOne, pathTwo);
         }
 
-        internal static bool NonWindowsGetInodeData(string path, out UInt64 device, out UInt64 inode)
+        internal static bool NonWindowsGetInodeData(string path, out System.ValueTuple<UInt64, UInt64> inodeData)
         {
-            return Unix.NativeMethods.GetInodeData(path, out device, out inode) == 0;
+            UInt64 device = 0UL;
+            UInt64 inode = 0UL;
+            var result = Unix.NativeMethods.GetInodeData(path, out device, out inode);
+
+            inodeData = (device, inode);
+            return result == 0;
         }
 
         internal static bool NonWindowsIsExecutable(string path)

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -1821,7 +1821,7 @@ namespace Microsoft.PowerShell.Commands
                                         continue;
                                     }
                                 }
-                                else if (tracker.IsPathVisited(recursiveDirectory.FullName, true))
+                                else if (!tracker.TryVisitPath(recursiveDirectory.FullName))
                                 {
                                     WriteWarning(StringUtil.Format(FileSystemProviderStrings.AlreadyListedDirectory,
                                                                    recursiveDirectory.FullName));
@@ -7365,42 +7365,25 @@ namespace Microsoft.PowerShell.Commands
             }
 
             /// <summary>
-            /// Determine if a path has been visited. Optionally mark the path as
-            /// having been visited if it has not already
+            /// Attempt to mark a path as having been visited.
             /// </summary>
             /// <param name="path">
-            /// Path to the file system item to be checked.
-            /// </param>
-            /// <param name="visitIfNotAlready">
-            /// Flag to indicate whether the path should be marked as visited if
-            /// it has not already been visited.
+            /// Path to the file system item to be visited.
             /// </param>
             /// <returns>
-            /// True if the path had already been visited, false otherwise.
+            /// True if the path had not been previously visited and was
+            /// successfully marked as visited, false otherwise.
             /// </returns>
-            /// <remarks>
-            /// If the visitIfNotAlready parameter is true and the path had not
-            /// already been visited, this method returns false but marks the
-            /// path as visited so that subsequent calls with a path to the same
-            /// file system item will return true.
-            /// </remarks>
-            internal bool IsPathVisited(string path, bool visitIfNotAlready)
+            internal bool TryVisitPath(string path)
             {
-                bool isPathVisited = false;
+                bool returnValue = false;
 
                 if (InternalSymbolicLinkLinkCodeMethods.GetInodeData(path, out (UInt64, UInt64) inodeData))
                 {
-                    if (visitIfNotAlready)
-                    {
-                        isPathVisited = !_visitations.Add(inodeData);
-                    }
-                    else
-                    {
-                        isPathVisited = _visitations.Contains(inodeData);
-                    }
+                    returnValue = _visitations.Add(inodeData);
                 }
 
-                return isPathVisited;
+                return returnValue;
             }
         }
 

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -67,7 +67,6 @@ namespace Microsoft.PowerShell.Commands
         /// Mark a path as visited.
         /// </summary>
         /// <param name="path">Path to the file or directory to be marked as visited.</param>
-        /// <returns>True if the path was successfully added to the visited list, false otherwise</returns>
         internal void VisitPath(string path)
         {
             var inodeData = (0UL, 0UL);
@@ -1674,7 +1673,9 @@ namespace Microsoft.PowerShell.Commands
             ReturnContainers returnContainers)
         {
             if (tracker != null)
+            {
                 tracker.VisitPath(directory.FullName);
+            }
 
             List<IEnumerable<FileSystemInfo>> target = new List<IEnumerable<FileSystemInfo>>();
 

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -1621,7 +1621,7 @@ namespace Microsoft.PowerShell.Commands
             uint depth,
             bool nameOnly,
             ReturnContainers returnContainers,
-            InodeTracker tracker)   // tracker will be non-null only if the user invoked the -FollowSymLinks switch parameter.
+            InodeTracker tracker)   // tracker will be non-null only if the user invoked the -FollowSymLinks and -Recurse switch parameters.
         {
             List<IEnumerable<FileSystemInfo>> target = new List<IEnumerable<FileSystemInfo>>();
 

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -71,6 +71,7 @@ namespace Microsoft.PowerShell.Commands
         public bool Visit(string path)
         {
             var inodeData = (0UL, 0UL);
+
             if (InternalSymbolicLinkLinkCodeMethods.GetInodeData(path, out inodeData))
             {
                 _visitations[inodeData] = true;
@@ -8343,8 +8344,7 @@ namespace Microsoft.PowerShell.Commands
                     if (GetFileInformationByHandle(sf.DangerousGetHandle(), out info))
                     {
                         UInt64 tmp = info.FileIndexHigh;
-                        tmp <<= 32;
-                        tmp |= info.FileIndexLow;
+                        tmp = (tmp << 32) | info.FileIndexLow;
 
                         inodeData = (info.VolumeSerialNumber, tmp);
 

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -72,14 +72,7 @@ namespace Microsoft.PowerShell.Commands
 
             if (InternalSymbolicLinkLinkCodeMethods.GetInodeData(path, out inodeData))
             {
-                if (_visitations.ContainsKey(inodeData))
-                {
-                    rv = false;
-                }
-                else
-                {
-                    _visitations[inodeData] = true;
-                }
+                rv = _visitations.TryAdd(inodeData, true);
             }
 
             return rv;

--- a/src/System.Management.Automation/resources/FileSystemProviderStrings.resx
+++ b/src/System.Management.Automation/resources/FileSystemProviderStrings.resx
@@ -340,6 +340,6 @@
     <value>Cannot create symbolic link because the path {0} already exists.</value>
   </data>
   <data name="AlreadyListedDirectory" xml:space="preserve">
-    <value>Not listing already-visited directory {0}.</value>
+    <value>Skip already-visited directory {0}.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/FileSystemProviderStrings.resx
+++ b/src/System.Management.Automation/resources/FileSystemProviderStrings.resx
@@ -340,6 +340,6 @@
     <value>Cannot create symbolic link because the path {0} already exists.</value>
   </data>
   <data name="AlreadyListedDirectory" xml:space="preserve">
-    <value>Directory {0} has already been listed.</value>
+    <value>Not listing already-listed directory {0}.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/FileSystemProviderStrings.resx
+++ b/src/System.Management.Automation/resources/FileSystemProviderStrings.resx
@@ -339,4 +339,7 @@
   <data name="SymlinkItemExists" xml:space="preserve">
     <value>Cannot create symbolic link because the path {0} already exists.</value>
   </data>
+  <data name="AlreadyListedDirectory" xml:space="preserve">
+    <value>Directory {0} has already been listed.</value>
+  </data>
 </root>

--- a/src/System.Management.Automation/resources/FileSystemProviderStrings.resx
+++ b/src/System.Management.Automation/resources/FileSystemProviderStrings.resx
@@ -340,6 +340,6 @@
     <value>Cannot create symbolic link because the path {0} already exists.</value>
   </data>
   <data name="AlreadyListedDirectory" xml:space="preserve">
-    <value>Not listing already-listed directory {0}.</value>
+    <value>Not listing already-visited directory {0}.</value>
   </data>
 </root>

--- a/src/libpsl-native/src/CMakeLists.txt
+++ b/src/libpsl-native/src/CMakeLists.txt
@@ -11,6 +11,7 @@ add_library(psl-native SHARED
   getlinkcount.cpp
   getfullyqualifiedname.cpp
   geterrorcategory.cpp
+  getinodedata.cpp
   isfile.cpp
   isdirectory.cpp
   issamefilesystemitem.cpp

--- a/src/libpsl-native/src/getinodedata.cpp
+++ b/src/libpsl-native/src/getinodedata.cpp
@@ -1,0 +1,56 @@
+//! @file getinodedata.cpp
+//! @author Jeff Bienstadt <v-jebien@microsoft.com>
+//! @brief Retrieve the device ID and inode number of a file
+
+#include "getinodedata.h"
+
+#include <assert.h>
+#include <errno.h>
+#include <locale.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <string>
+
+//! @brief GetInodeData retrieves a file's device and inode information.
+//!
+//! GetInodeData
+//!
+//! @param[in] fileName
+//! @parblock
+//! A pointer to the buffer that contains the file path
+//!
+//! char* is marshaled as an LPStr, which on Linux is UTF-8.
+//! @endparblock
+//!
+//! @param[out] device
+//! @parblock
+//! Points to a uint64_t value that will contain the file's device ID.
+//! @endparblock
+//!
+//! @param[out] inode
+//! @parblock
+//! Points to a uint64_t value that will contain the file's inode number.
+//! @endparblock
+//!
+//! @retval 0 If the function succeeds, -1 otherwise.
+//!
+
+int32_t GetInodeData(const char* fileName, uint64_t* device, uint64_t* inode)
+{
+    assert(fileName);
+    assert(device);
+    assert(inode);
+    errno = 0;
+
+    struct stat statBuf;
+    int ret = stat(fileName, &statBuf);
+
+    if (ret == 0)
+    {
+        *device = statBuf.st_dev;
+        *inode = statBuf.st_ino;
+    }
+
+    return ret;
+}

--- a/src/libpsl-native/src/getinodedata.h
+++ b/src/libpsl-native/src/getinodedata.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "pal.h"
+
+PAL_BEGIN_EXTERNC
+
+int32_t GetInodeData(const char* fileName, uint64_t* device, uint64_t* inode);
+
+PAL_END_EXTERNC


### PR DESCRIPTION
Fixes #3951

    Add the dynamic parameter -FollowSymlink to Get-ChildItem.
    Add a mechanism for tracking visited directories.
    Add native code to get device/inode information on Unix/Windows.
    Add warning when refusing to enter an already-visited directory.
