### PR TITLE
Fixed test to not create a file called `1` when run

### DIFF
--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/FormatHex.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/FormatHex.Tests.ps1
@@ -1,4 +1,4 @@
-﻿# This is a Pester test suite to validate the Format-Hex cmdlet in the Microsoft.PowerShell.Utility module.
+# This is a Pester test suite to validate the Format-Hex cmdlet in the Microsoft.PowerShell.Utility module.
 #
 # Copyright (c) Microsoft Corporation, 2015
 #
@@ -38,7 +38,7 @@ function RunObjectFromPipelineTestCase($testCase)
         $result | Should BeOfType 'Microsoft.PowerShell.Commands.ByteCollection'
         $result[0].ToString() | Should Match $testCase.ExpectedResult
 
-        if ($result.count > 1)
+        if ($result.count -gt 1)
         {
             $result[1].ToString() | Should Match $testCase.ExpectedSecondResult
         }
@@ -51,7 +51,7 @@ function RunPathAndLiteralPathParameterTestCase($testCase)
 
         if ($testCase.PathCase)
         {
-            $result =  Format-Hex -Path $testCase.Path
+            $result = Format-Hex -Path $testCase.Path
         }
         else # LiteralPath
         {
@@ -62,9 +62,14 @@ function RunPathAndLiteralPathParameterTestCase($testCase)
         $result | Should BeOfType 'Microsoft.PowerShell.Commands.ByteCollection'
         $result[0].ToString() | Should Match $testCase.ExpectedResult
 
-        if ($result.count > 1)
+        if ($result.count -gt 1)
         {
-            $result[1].ToString() | Should Match $testCase.ExpectedSecondResult
+            $expectedResult = $testCase.ExpectedSecondResult
+            if ($expectedResult.Length -gt 16)  # content larger than 16 bytes show up in next row
+            {
+                $expectedResult = $expectedResult.SubString(0, 16)
+            }
+            $result[1].ToString() | Should Match $expectedResult
         }
     }
 }


### PR DESCRIPTION
When using `Start-PSPester` a file called `1` was being created.  This is due to incorrect usage of a redirection operator `>` when it should have been the comparison operator `-gt`.  After fixing this, a new
code path started executing which had incorrect assumption as the Format-Hex cmdlet works with
16-bytes at a time, so fixed that logic.
