### PR TITLE
Move PowerShell back to .NET Core 2.0.0-preview1-002106-00

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,16 +141,6 @@ See [working with the PowerShell repository](docs/git) for more information.
 
 ## Developing and Contributing
 
-> Note: To develop with VSCode on OSX and Linux, you need to install the [`v1.11.0-beta4`][beta-csharp] C# extension by following these [instructions][install-beta-csharp].
->
-> PowerShell is building against the .NET Core `2.0.0-preview2` packages using the .NET Core `2.0.0-preview2` SDK.
-`v1.13.0` VSCode + `v1.10.0` C# extension works fine with the .NET Core `2.0.0-preview2` SDK on Windows.
-However, on OSX and Linux you need to use the `v1.11.0-beta4` C# extension due to [omnisharp-vscode issue #1495][omnisharp-1495].
-
-[beta-csharp]: https://github.com/OmniSharp/omnisharp-vscode/releases/tag/v1.11.0-beta4
-[install-beta-csharp]: https://github.com/OmniSharp/omnisharp-vscode/wiki/Installing-Beta-Releases
-[omnisharp-1495]: https://github.com/OmniSharp/omnisharp-vscode/issues/1495
-
 Please see the [Contribution Guide][] for how to develop and contribute.
 
 If you have any problems, please consult the [known issues][], developer [FAQ][], and [GitHub issues][].

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ version: 6.0.0-beta.2-{build}
 
 image: Visual Studio 2015
 
-# cache version - netcoreapp.2.0.0-preview1-002106-00 
+# cache version - netcoreapp.2.0.0-preview1-002106-00
 cache:
   - '%LocalAppData%\Microsoft\dotnet -> appveyor.yml'
   - '%HOMEDRIVE%%HOMEPATH%\.nuget\packages -> appveyor.yml'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ version: 6.0.0-beta.2-{build}
 
 image: Visual Studio 2015
 
-# cache version - netcoreapp.2.0.0-preview2-25407-01
+# cache version - netcoreapp.2.0.0-preview1-002106-00 
 cache:
   - '%LocalAppData%\Microsoft\dotnet -> appveyor.yml'
   - '%HOMEDRIVE%%HOMEPATH%\.nuget\packages -> appveyor.yml'

--- a/build.psm1
+++ b/build.psm1
@@ -988,7 +988,7 @@ function Install-Dotnet {
     [CmdletBinding()]
     param(
         [string]$Channel = "preview",
-        [string]$Version = "2.0.0-preview2-006388",
+        [string]$Version = "2.0.0-preview1-005952",
         [switch]$NoSudo
     )
 
@@ -1050,7 +1050,7 @@ function Start-PSBootstrap {
         [string]$Channel = "preview",
         # we currently pin dotnet-cli version, and will
         # update it when more stable version comes out.
-        [string]$Version = "2.0.0-preview2-006388",
+        [string]$Version = "2.0.0-preview1-005952",
         [switch]$Package,
         [switch]$NoSudo,
         [switch]$Force

--- a/src/Microsoft.PowerShell.Commands.Management/Microsoft.PowerShell.Commands.Management.csproj
+++ b/src/Microsoft.PowerShell.Commands.Management/Microsoft.PowerShell.Commands.Management.csproj
@@ -78,7 +78,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.ServiceProcess.ServiceController" Version="4.4.0-preview2-25405-01" />
+    <PackageReference Include="System.ServiceProcess.ServiceController" Version="4.4.0-preview1-25302-01" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebRequestPSCmdlet.CoreClr.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebRequestPSCmdlet.CoreClr.cs
@@ -147,7 +147,7 @@ namespace Microsoft.PowerShell.Commands
 
             if (SkipCertificateCheck)
             {
-                handler.ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator;
+                handler.ServerCertificateCustomValidationCallback = delegate { return true; };
             }
 
             if (WebSession.MaximumRedirection > -1)

--- a/src/Microsoft.PowerShell.CoreCLR.Eventing/Microsoft.PowerShell.CoreCLR.Eventing.csproj
+++ b/src/Microsoft.PowerShell.CoreCLR.Eventing/Microsoft.PowerShell.CoreCLR.Eventing.csproj
@@ -32,7 +32,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Security.Principal.Windows" Version="4.4.0-preview2-25405-01" />
+    <PackageReference Include="System.Security.Principal.Windows" Version="4.4.0-preview1-25302-01" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.PowerShell.SDK/Microsoft.PowerShell.SDK.csproj
+++ b/src/Microsoft.PowerShell.SDK/Microsoft.PowerShell.SDK.csproj
@@ -17,17 +17,17 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Data.SqlClient" Version="4.4.0-preview2-25405-01" />
-    <PackageReference Include="System.IO.Packaging" Version="4.4.0-preview2-25405-01" />
-    <PackageReference Include="System.Net.Http.WinHttpHandler" Version="4.4.0-preview2-25405-01" />
-    <PackageReference Include="System.ServiceModel.Duplex" Version="4.4.0-preview2-25405-01" />
-    <PackageReference Include="System.ServiceModel.Http" Version="4.4.0-preview2-25405-01" />
-    <PackageReference Include="System.ServiceModel.NetTcp" Version="4.4.0-preview2-25405-01" />
-    <PackageReference Include="System.ServiceModel.Primitives" Version="4.4.0-preview2-25405-01" />
-    <PackageReference Include="System.ServiceModel.Security" Version="4.4.0-preview2-25405-01" />
-    <PackageReference Include="System.Text.Encodings.Web" Version="4.4.0-preview2-25405-01" />
-    <PackageReference Include="System.Threading.AccessControl" Version="4.4.0-preview2-25405-01" />
-    <PackageReference Include="System.Private.ServiceModel" Version="4.4.0-preview2-25405-01" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.4.0-preview1-25302-01" />
+    <PackageReference Include="System.IO.Packaging" Version="4.4.0-preview1-25302-01" />
+    <PackageReference Include="System.Net.Http.WinHttpHandler" Version="4.4.0-preview1-25302-01" />
+    <PackageReference Include="System.ServiceModel.Duplex" Version="4.4.0-preview1-25302-01" />
+    <PackageReference Include="System.ServiceModel.Http" Version="4.4.0-preview1-25302-01" />
+    <PackageReference Include="System.ServiceModel.NetTcp" Version="4.4.0-preview1-25302-01" />
+    <PackageReference Include="System.ServiceModel.Primitives" Version="4.4.0-preview1-25302-01" />
+    <PackageReference Include="System.ServiceModel.Security" Version="4.4.0-preview1-25302-01" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="4.4.0-preview1-25302-01" />
+    <PackageReference Include="System.Threading.AccessControl" Version="4.4.0-preview1-25302-01" />
+    <PackageReference Include="System.Private.ServiceModel" Version="4.4.0-preview1-25302-01" />
   </ItemGroup>
 
 </Project>

--- a/src/System.Management.Automation/System.Management.Automation.csproj
+++ b/src/System.Management.Automation/System.Management.Automation.csproj
@@ -19,12 +19,12 @@
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.PowerShell.CoreCLR.AssemblyLoadContext\Microsoft.PowerShell.CoreCLR.AssemblyLoadContext.csproj" />
     <ProjectReference Include="..\Microsoft.PowerShell.CoreCLR.Eventing\Microsoft.PowerShell.CoreCLR.Eventing.csproj" />
-    <PackageReference Include="Microsoft.Win32.Registry.AccessControl" Version="4.4.0-preview2-25405-01" />
+    <PackageReference Include="Microsoft.Win32.Registry.AccessControl" Version="4.4.0-preview1-25302-01" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.1" />
-    <PackageReference Include="System.IO.FileSystem.AccessControl" Version="4.4.0-preview2-25405-01" />
-    <PackageReference Include="System.Security.AccessControl" Version="4.4.0-preview2-25405-01" />
-    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="4.4.0-preview2-25405-01" />
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="4.4.0-preview2-25405-01" />
+    <PackageReference Include="System.IO.FileSystem.AccessControl" Version="4.4.0-preview1-25302-01" />
+    <PackageReference Include="System.Security.AccessControl" Version="4.4.0-preview1-25302-01" />
+    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="4.4.0-preview1-25302-01" />
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="4.4.0-preview1-25302-01" />
     <PackageReference Include="Microsoft.Management.Infrastructure" Version="1.0.0-alpha*" />
   </ItemGroup>
 

--- a/test/powershell/Language/Scripting/NativeExecution/NativeCommandProcessor.Tests.ps1
+++ b/test/powershell/Language/Scripting/NativeExecution/NativeCommandProcessor.Tests.ps1
@@ -24,7 +24,9 @@ Describe 'native commands with pipeline' -tags 'Feature' {
         $rs.ResetRunspaceState()
     }
 
-    It "native | native | native should work fine" {
+    # Make this test pending because of too many regressions in the latest .NET Core
+    # and thus we have to get back to an older .NET Core.
+    It "native | native | native should work fine" -Pending {
 
         if ($IsWindows) {
             $result = @(ping.exe | findstr.exe count | findstr.exe ping)

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ChildItem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ChildItem.Tests.ps1
@@ -66,9 +66,7 @@ Describe "Get-ChildItem" -Tags "CI" {
             $file.Count | Should be 1
             $file.Name | Should be "pagefile.sys"
         }
-        # Test is pending on Unix platforms because of a behavior change in the latest .NET Core.
-        # Tracked by https://github.com/dotnet/corefx/issues/20456
-        It "Should continue enumerating a directory when a contained item is deleted" -Pending:(!$IsWindows) {
+        It "Should continue enumerating a directory when a contained item is deleted" {
             $Error.Clear()
             [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook("GciEnumerationActionDelete", $true)
             $result = Get-ChildItem -Path $TestDrive -ErrorAction SilentlyContinue
@@ -86,9 +84,7 @@ Describe "Get-ChildItem" -Tags "CI" {
                 $result.Count | Should BeExactly 4
             }
         }
-        # Test is pending on Unix platforms because of a behavior change in the latest .NET Core.
-        # Tracked by https://github.com/dotnet/corefx/issues/20456
-        It "Should continue enumerating a directory when a contained item is renamed" -Pending:(!$IsWindows) {
+        It "Should continue enumerating a directory when a contained item is renamed" {
             $Error.Clear()
             [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook("GciEnumerationActionRename", $true)
             $result = Get-ChildItem -Path $TestDrive -ErrorAction SilentlyContinue

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -443,7 +443,9 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
         $jsonContent.headers.'User-Agent' | Should Match "WindowsPowerShell"
     }
 
-    It "Validate Invoke-WebRequest -SkipCertificateCheck" {
+    ## 'HttpClientHandler.ServerCertificateCustomValidationCallback' currently doesn't work in netcoreapp2.0 on Mac at all.
+    ## This is tracked by powershell issue #3648.
+    It "Validate Invoke-WebRequest -SkipCertificateCheck" -Pending:$IsOSX {
 
         # validate that exception is thrown for URI with expired certificate
         $command = "Invoke-WebRequest -Uri 'https://expired.badssl.com'"
@@ -835,7 +837,9 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
         $jsonContent.headers.'User-Agent' | Should Match "WindowsPowerShell"
     }
 
-    It "Validate Invoke-RestMethod -SkipCertificateCheck" {
+    ## 'HttpClientHandler.ServerCertificateCustomValidationCallback' currently doesn't work in netcoreapp2.0 on Mac at all.
+    ## This is tracked by powershell issue #3648.
+    It "Validate Invoke-RestMethod -SkipCertificateCheck" -Pending:$IsOSX {
 
         # HTTP method HEAD must be used to not retrieve an unparsable HTTP body
         # validate that exception is thrown for URI with expired certificate


### PR DESCRIPTION
Move back to .NET Core 2.0.0-preview1-002106-00 (.NET Core SDK 2.0.0-preview1-005952) due to the regression we get in the latest .NET Core: https://github.com/dotnet/corefx/issues/21095

Along with this change, we back out the `-SkipCertificateCheck` fix and some test changes.