### PR TITLE
Remove ClrVersion property from $PSVersionTable

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -190,7 +190,7 @@ function Start-PSBuild {
 
     if ($IsWindows) {
         # cmake is needed to build powershell.exe
-        $precheck = $precheck -and (precheck 'cmake' 'cmake not found. Run Start-PSBootstrap. You can also install it from https://chocolatey.org/packages/cmake')
+        $precheck = $precheck -and (precheck 'cmake' 'cmake not found. Run "Start-PSBootstrap -BuildNative". You can also install it from https://chocolatey.org/packages/cmake')
 
         Use-MSBuild
 
@@ -213,7 +213,7 @@ function Start-PSBuild {
 
     } elseif ($IsLinux -or $IsOSX) {
         foreach ($Dependency in 'cmake', 'make', 'g++') {
-            $precheck = $precheck -and (precheck $Dependency "Build dependency '$Dependency' not found. Run Start-PSBootstrap.")
+            $precheck = $precheck -and (precheck $Dependency "Build dependency '$Dependency' not found. Run 'Start-PSBootstrap -BuildNative'.")
         }
     }
 

--- a/src/System.Management.Automation/engine/PSVersionInfo.cs
+++ b/src/System.Management.Automation/engine/PSVersionInfo.cs
@@ -72,7 +72,6 @@ namespace System.Management.Automation
 #if CORECLR
             s_psVersionTable[PSOSName] = Runtime.InteropServices.RuntimeInformation.OSDescription.ToString();
 #else
-            s_psVersionTable[PSCLRVersionName] = Environment.Version;
             s_psVersionTable[PSOSName] = Environment.OSVersion.ToString();
 #endif
         }

--- a/src/System.Management.Automation/engine/PSVersionInfo.cs
+++ b/src/System.Management.Automation/engine/PSVersionInfo.cs
@@ -71,7 +71,6 @@ namespace System.Management.Automation
             s_psVersionTable[PSVersionInfo.WSManStackVersionName] = GetWSManStackVersion();
             s_psVersionTable[PSPlatformName] = Environment.OSVersion.Platform.ToString();
 #if CORECLR
-            s_psVersionTable[PSCLRVersionName] = null;
             s_psVersionTable[PSOSName] = Runtime.InteropServices.RuntimeInformation.OSDescription.ToString();
 #else
             s_psVersionTable[PSCLRVersionName] = Environment.Version;

--- a/src/System.Management.Automation/engine/PSVersionInfo.cs
+++ b/src/System.Management.Automation/engine/PSVersionInfo.cs
@@ -22,7 +22,6 @@ namespace System.Management.Automation
         internal const string PSEditionName = "PSEdition";
         internal const string PSGitCommitIdName = "GitCommitId";
         internal const string PSCompatibleVersionsName = "PSCompatibleVersions";
-        internal const string PSCLRVersionName = "CLRVersion";
         internal const string PSPlatformName = "Platform";
         internal const string PSOSName = "OS";
         internal const string SerializationVersionName = "SerializationVersion";
@@ -158,14 +157,6 @@ namespace System.Management.Automation
             get
             {
                 return (string)GetPSVersionTable()[PSGitCommitIdName];
-            }
-        }
-
-        internal static Version CLRVersion
-        {
-            get
-            {
-                return (Version)GetPSVersionTable()[PSCLRVersionName];
             }
         }
 

--- a/test/powershell/Host/PSVersionTable.Tests.ps1
+++ b/test/powershell/Host/PSVersionTable.Tests.ps1
@@ -1,6 +1,6 @@
 Describe "PSVersionTable" -Tags "CI" {
     It "Should have version table entries" {
-       $PSVersionTable.Count | Should Be 10
+       $PSVersionTable.Count | Should Be 9
     }
 
     It "Should have the right version table entries" {
@@ -8,7 +8,6 @@ Describe "PSVersionTable" -Tags "CI" {
        $PSVersionTable.ContainsKey("PSEdition")                 | Should Be True
        $PSVersionTable.ContainsKey("WSManStackVersion")         | Should Be True
        $PSVersionTable.ContainsKey("SerializationVersion")      | Should Be True
-       $PSVersionTable.ContainsKey("CLRVersion")                | Should Be True
        $PSVersionTable.ContainsKey("PSCompatibleVersions")      | Should Be True
        $PSVersionTable.ContainsKey("PSRemotingProtocolVersion") | Should Be True
        $PSVersionTable.ContainsKey("GitCommitId")               | Should Be True


### PR DESCRIPTION
The ClrVersion property of $PSVersionTable is not useful with CoreCLR and end users should not be using
that value to determine compatibility.  Recommendation from dotnet team is to remove that property.

Fix https://github.com/PowerShell/PowerShell/issues/1395