### PR TITLE
Cmdlets: Set -Subject parameter to non-mandatory on Send-MailMessage command

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Send-MailMessage.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Send-MailMessage.cs
@@ -191,7 +191,7 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Specifies the  subject of the email message.
         /// </summary>
-        [Parameter(Mandatory = true, Position = 1)]
+        [Parameter(Mandatory = false, Position = 1)]
         [Alias("sub")]
         [ValidateNotNullOrEmpty]
         public String Subject


### PR DESCRIPTION
Fixes #4043 

Cheers,
Trevor Sullivan