### PR TITLE
Refactor CompletionCompleters.cs to avoid constructing unnecessary CompletionContext instances

### DIFF
--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
@@ -35,6 +35,23 @@ namespace System.Management.Automation
         internal PseudoBindingInfo PseudoBindingInfo { get; set; }
         internal TypeInferenceContext TypeInferenceContext { get; set; }
 
+        /// <summary>
+        /// Default constructor.
+        /// </summary>
+        internal CompletionContext() { }
+
+        /// <summary>
+        /// In 'CompletionCompleters.cs', we sometimes need to create a new 'CompletionContext' for a new 'wordToCompletion',
+        /// but we want to reuse the 'PowerShellExecutionHelper' and 'ExecutionContext' from the existing 'CompletionContext'.
+        /// This constructor is for this purpose.
+        /// </summary>
+        internal CompletionContext(string wordToComplete, CompletionContext context)
+        {
+            this.WordToComplete = wordToComplete;
+            this.Helper = context.Helper;
+            this.ExecutionContext = context.ExecutionContext;
+        }
+
         internal bool GetOption(string option, bool @default)
         {
             if (Options == null || !Options.ContainsKey(option))

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
@@ -35,23 +35,6 @@ namespace System.Management.Automation
         internal PseudoBindingInfo PseudoBindingInfo { get; set; }
         internal TypeInferenceContext TypeInferenceContext { get; set; }
 
-        /// <summary>
-        /// Default constructor.
-        /// </summary>
-        internal CompletionContext() { }
-
-        /// <summary>
-        /// In 'CompletionCompleters.cs', we sometimes need to create a new 'CompletionContext' for a new 'wordToCompletion',
-        /// but we want to reuse the 'PowerShellExecutionHelper' and 'ExecutionContext' from the existing 'CompletionContext'.
-        /// This constructor is for this purpose.
-        /// </summary>
-        internal CompletionContext(string wordToComplete, CompletionContext context)
-        {
-            this.WordToComplete = wordToComplete;
-            this.Helper = context.Helper;
-            this.ExecutionContext = context.ExecutionContext;
-        }
-
         internal bool GetOption(string option, bool @default)
         {
             if (Options == null || !Options.ContainsKey(option))

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -119,7 +119,7 @@ namespace System.Management.Automation
                 var commandInfos = context.Helper.ExecuteCurrentPowerShell(out exceptionThrown);
 
                 // Complete against pseudo commands that work only in the script workflow.
-                // It's for argument completion when RelatedAst is null, don't complete pseudo commands for arguments
+                // If RelatedAst is null then it's for argument completion, because we don't complete pseudo commands for arguments
                 if (lastAst != null)
                 {
                     commandInfos = CompleteWorkflowCommand(commandName, lastAst, commandInfos);
@@ -129,11 +129,11 @@ namespace System.Management.Automation
                 {
                     // OrderBy is using stable sorting
                     var sortedCommandInfos = commandInfos.OrderBy(a => a, new CommandNameComparer());
-                    commandResults = MakeCommandsUnique(sortedCommandInfos, false, addAmpersandIfNecessary, quote, context);
+                    commandResults = MakeCommandsUnique(sortedCommandInfos, false, addAmpersandIfNecessary, quote);
                 }
                 else
                 {
-                    commandResults = MakeCommandsUnique(commandInfos, false, addAmpersandIfNecessary, quote, context);
+                    commandResults = MakeCommandsUnique(commandInfos, false, addAmpersandIfNecessary, quote);
                 }
 
                 if (lastAst != null)
@@ -185,16 +185,31 @@ namespace System.Management.Automation
                     if (commandInfos != null && commandInfos.Count > 1)
                     {
                         var sortedCommandInfos = commandInfos.OrderBy(a => a, new CommandNameComparer());
-                        commandResults = MakeCommandsUnique(sortedCommandInfos, true, addAmpersandIfNecessary, quote, context);
+                        commandResults = MakeCommandsUnique(sortedCommandInfos, true, addAmpersandIfNecessary, quote);
                     }
                     else
                     {
-                        commandResults = MakeCommandsUnique(commandInfos, true, addAmpersandIfNecessary, quote, context);
+                        commandResults = MakeCommandsUnique(commandInfos, true, addAmpersandIfNecessary, quote);
                     }
                 }
             }
 
             return commandResults;
+        }
+
+        /// <summary>
+        /// Construct a new instance of CompletionContext with RelatedAst = null.
+        /// For argument completion, we don't want to complete against pseudo commands that only work in the script workflow.
+        /// The way to avoid that is to pass in a CompletionContext with RelatedAst = null.
+        /// </summary>
+        private static CompletionContext NewContextToCompleteCommandAsArgument(CompletionContext context)
+        {
+            return new CompletionContext {
+                WordToComplete = context.WordToComplete,
+                Helper = context.Helper,
+                ExecutionContext = context.ExecutionContext,
+                Options = context.Options
+            };
         }
 
         private static readonly HashSet<string> s_keywordsToExcludeFromAddingAmpersand
@@ -253,7 +268,7 @@ namespace System.Management.Automation
             return new CompletionResult(name, listItem, CompletionResultType.Command, syntax);
         }
 
-        internal static List<CompletionResult> MakeCommandsUnique(IEnumerable<PSObject> commandInfoPsObjs, bool includeModulePrefix, bool addAmpersandIfNecessary, string quote, CompletionContext context)
+        internal static List<CompletionResult> MakeCommandsUnique(IEnumerable<PSObject> commandInfoPsObjs, bool includeModulePrefix, bool addAmpersandIfNecessary, string quote)
         {
             List<CompletionResult> results = new List<CompletionResult>();
             if (commandInfoPsObjs == null || !commandInfoPsObjs.Any())
@@ -1326,7 +1341,8 @@ namespace System.Management.Automation
                 {
                     // For argument completion, we don't want to complete against pseudo commands that only work in the script workflow.
                     // The way to avoid that is to pass in a CompletionContext with RelatedAst = null
-                    var commandResults = CompleteCommand(new CompletionContext(context.WordToComplete, context));
+                    var newContext = NewContextToCompleteCommandAsArgument(context);
+                    var commandResults = CompleteCommand(newContext);
                     if (commandResults != null)
                         result.AddRange(commandResults);
                 }
@@ -2043,7 +2059,7 @@ namespace System.Management.Automation
                     {
                         if (parameterName.Equals("Module", StringComparison.OrdinalIgnoreCase))
                         {
-                            NativeCompletionGetCommand(context.WordToComplete, null, parameterName, result, context);
+                            NativeCompletionGetCommand(context, null, parameterName, result);
                             break;
                         }
                         if (parameterName.Equals("Name", StringComparison.OrdinalIgnoreCase))
@@ -2054,12 +2070,12 @@ namespace System.Management.Automation
                             {
                                 foreach (string module in moduleNames)
                                 {
-                                    NativeCompletionGetCommand(context.WordToComplete, module, parameterName, result, context);
+                                    NativeCompletionGetCommand(context, module, parameterName, result);
                                 }
                             }
                             else
                             {
-                                NativeCompletionGetCommand(context.WordToComplete, null, parameterName, result, context);
+                                NativeCompletionGetCommand(context, null, parameterName, result);
                             }
                             break;
                         }
@@ -2074,13 +2090,13 @@ namespace System.Management.Automation
                     }
                 case "Show-Command":
                     {
-                        NativeCompletionGetHelpCommand(context.WordToComplete, parameterName, false, result, context);
+                        NativeCompletionGetHelpCommand(context, parameterName, false, result);
                         break;
                     }
                 case "help":
                 case "Get-Help":
                     {
-                        NativeCompletionGetHelpCommand(context.WordToComplete, parameterName, true, result, context);
+                        NativeCompletionGetHelpCommand(context, parameterName, true, result);
                         break;
                     }
                 case "Invoke-Expression":
@@ -2089,7 +2105,8 @@ namespace System.Management.Automation
                         {
                             // For argument completion, we don't want to complete against pseudo commands that only work in the script workflow.
                             // The way to avoid that is to pass in a CompletionContext with RelatedAst = null
-                            var commandResults = CompleteCommand(new CompletionContext(context.WordToComplete, context));
+                            var newContext = NewContextToCompleteCommandAsArgument(context);
+                            var commandResults = CompleteCommand(newContext);
                             if (commandResults != null)
                                 result.AddRange(commandResults);
                         }
@@ -2101,7 +2118,7 @@ namespace System.Management.Automation
                 case "Remove-EventLog":
                 case "Write-EventLog":
                     {
-                        NativeCompletionEventLogCommands(context.WordToComplete, parameterName, result, context);
+                        NativeCompletionEventLogCommands(context, parameterName, result);
                         break;
                     }
                 case "Get-Job":
@@ -2112,7 +2129,7 @@ namespace System.Management.Automation
                 case "Suspend-Job":
                 case "Resume-Job":
                     {
-                        NativeCompletionJobCommands(context.WordToComplete, parameterName, result, context);
+                        NativeCompletionJobCommands(context, parameterName, result);
                         break;
                     }
                 case "Disable-ScheduledJob":
@@ -2120,23 +2137,23 @@ namespace System.Management.Automation
                 case "Get-ScheduledJob":
                 case "Unregister-ScheduledJob":
                     {
-                        NativeCompletionScheduledJobCommands(context.WordToComplete, parameterName, result, context);
+                        NativeCompletionScheduledJobCommands(context, parameterName, result);
                         break;
                     }
                 case "Get-Module":
                     {
                         bool loadedModulesOnly = boundArguments == null || !boundArguments.ContainsKey("ListAvailable");
-                        NativeCompletionModuleCommands(context.WordToComplete, parameterName, loadedModulesOnly, false, result, context);
+                        NativeCompletionModuleCommands(context, parameterName, loadedModulesOnly, false, result);
                         break;
                     }
                 case "Remove-Module":
                     {
-                        NativeCompletionModuleCommands(context.WordToComplete, parameterName, true, false, result, context);
+                        NativeCompletionModuleCommands(context, parameterName, true, false, result);
                         break;
                     }
                 case "Import-Module":
                     {
-                        NativeCompletionModuleCommands(context.WordToComplete, parameterName, false, true, result, context);
+                        NativeCompletionModuleCommands(context, parameterName, false, true, result);
                         break;
                     }
                 case "Debug-Process":
@@ -2145,7 +2162,7 @@ namespace System.Management.Automation
                 case "Wait-Process":
                 case "Enter-PSHostProcess":
                     {
-                        NativeCompletionProcessCommands(context.WordToComplete, parameterName, result, context);
+                        NativeCompletionProcessCommands(context, parameterName, result);
                         break;
                     }
                 case "Get-PSDrive":
@@ -2153,7 +2170,7 @@ namespace System.Management.Automation
                     {
                         if (parameterName.Equals("PSProvider", StringComparison.OrdinalIgnoreCase))
                         {
-                            NativeCompletionProviderCommands(context.WordToComplete, parameterName, result, context);
+                            NativeCompletionProviderCommands(context, parameterName, result);
                         }
                         else if (parameterName.Equals("Name", StringComparison.OrdinalIgnoreCase))
                         {
@@ -2162,12 +2179,12 @@ namespace System.Management.Automation
                             {
                                 foreach (string psProvider in psProviders)
                                 {
-                                    NativeCompletionDriveCommands(context.WordToComplete, psProvider, parameterName, result, context);
+                                    NativeCompletionDriveCommands(context, psProvider, parameterName, result);
                                 }
                             }
                             else
                             {
-                                NativeCompletionDriveCommands(context.WordToComplete, null, parameterName, result, context);
+                                NativeCompletionDriveCommands(context, null, parameterName, result);
                             }
                         }
 
@@ -2175,12 +2192,12 @@ namespace System.Management.Automation
                     }
                 case "New-PSDrive":
                     {
-                        NativeCompletionProviderCommands(context.WordToComplete, parameterName, result, context);
+                        NativeCompletionProviderCommands(context, parameterName, result);
                         break;
                     }
                 case "Get-PSProvider":
                     {
-                        NativeCompletionProviderCommands(context.WordToComplete, parameterName, result, context);
+                        NativeCompletionProviderCommands(context, parameterName, result);
                         break;
                     }
                 case "Get-Service":
@@ -2191,7 +2208,7 @@ namespace System.Management.Automation
                 case "Stop-Service":
                 case "Suspend-Service":
                     {
-                        NativeCompletionServiceCommands(context.WordToComplete, parameterName, result, context);
+                        NativeCompletionServiceCommands(context, parameterName, result);
                         break;
                     }
                 case "Clear-Variable":
@@ -2199,43 +2216,43 @@ namespace System.Management.Automation
                 case "Remove-Variable":
                 case "Set-Variable":
                     {
-                        NativeCompletionVariableCommands(context.WordToComplete, parameterName, result, context);
+                        NativeCompletionVariableCommands(context, parameterName, result);
                         break;
                     }
                 case "Get-Alias":
                     {
-                        NativeCompletionAliasCommands(context.WordToComplete, parameterName, result, context);
+                        NativeCompletionAliasCommands(context, parameterName, result);
                         break;
                     }
                 case "Get-TraceSource":
                 case "Set-TraceSource":
                 case "Trace-Command":
                     {
-                        NativeCompletionTraceSourceCommands(context.WordToComplete, parameterName, result, context);
+                        NativeCompletionTraceSourceCommands(context, parameterName, result);
                         break;
                     }
                 case "Push-Location":
                 case "Set-Location":
                     {
-                        NativeCompletionSetLocationCommand(context.WordToComplete, parameterName, result, context);
+                        NativeCompletionSetLocationCommand(context, parameterName, result);
                         break;
                     }
                 case "Move-Item":
                 case "Copy-Item":
                     {
-                        NativeCompletionCopyMoveItemCommand(context.WordToComplete, parameterName, result, context);
+                        NativeCompletionCopyMoveItemCommand(context, parameterName, result);
                         break;
                     }
                 case "New-Item":
                     {
-                        NativeCompletionNewItemCommand(context.WordToComplete, parameterName, result, context);
+                        NativeCompletionNewItemCommand(context, parameterName, result);
                         break;
                     }
                 case "ForEach-Object":
                     {
                         if (parameterName.Equals("MemberName", StringComparison.OrdinalIgnoreCase))
                         {
-                            NativeCompletionMemberName(context.WordToComplete, result, commandAst, context);
+                            NativeCompletionMemberName(context, result, commandAst);
                         }
                         break;
                     }
@@ -2250,7 +2267,7 @@ namespace System.Management.Automation
                     {
                         if (parameterName.Equals("Property", StringComparison.OrdinalIgnoreCase))
                         {
-                            NativeCompletionMemberName(context.WordToComplete, result, commandAst, context);
+                            NativeCompletionMemberName(context, result, commandAst);
                         }
                         break;
                     }
@@ -2260,7 +2277,7 @@ namespace System.Management.Automation
                          || parameterName.Equals("ExcludeProperty", StringComparison.OrdinalIgnoreCase)
                          || parameterName.Equals("ExpandProperty", StringComparison.OrdinalIgnoreCase))
                         {
-                            NativeCompletionMemberName(context.WordToComplete, result, commandAst, context);
+                            NativeCompletionMemberName(context, result, commandAst);
                         }
                         break;
                     }
@@ -2287,7 +2304,7 @@ namespace System.Management.Automation
 
                 default:
                     {
-                        NativeCompletionPathArgument(context.WordToComplete, parameterName, result, context);
+                        NativeCompletionPathArgument(context, parameterName, result);
                         break;
                     }
             }
@@ -2772,14 +2789,17 @@ namespace System.Management.Automation
             result.AddRange(namespaceResults.OrderBy(x => x.ListItemText, StringComparer.OrdinalIgnoreCase));
         }
 
-        private static void NativeCompletionGetCommand(string commandName, string moduleName, string paramName, List<CompletionResult> result, CompletionContext context)
+        private static void NativeCompletionGetCommand(CompletionContext context, string moduleName, string paramName, List<CompletionResult> result)
         {
             if (!string.IsNullOrEmpty(paramName) && paramName.Equals("Name", StringComparison.OrdinalIgnoreCase))
             {
                 RemoveLastNullCompletionResult(result);
 
                 // Available commands
-                var commandResults = CompleteCommand(new CompletionContext(commandName, context), moduleName);
+                // For argument completion, we don't want to complete against pseudo commands that only work in the script workflow.
+                // The way to avoid that is to pass in a CompletionContext with RelatedAst = null
+                var newContext = NewContextToCompleteCommandAsArgument(context);
+                var commandResults = CompleteCommand(newContext, moduleName);
                 if (commandResults != null)
                     result.AddRange(commandResults);
 
@@ -2789,7 +2809,7 @@ namespace System.Management.Automation
                     // ps1 files and directories. We only complete the files with .ps1 extension for Get-Command, because the -Syntax
                     // may only works on files with .ps1 extension
                     var ps1Extension = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { StringLiterals.PowerShellScriptFileExtension };
-                    var moduleFilesResults = new List<CompletionResult>(CompleteFilename(new CompletionContext(commandName, context), false, ps1Extension));
+                    var moduleFilesResults = new List<CompletionResult>(CompleteFilename(context, false, ps1Extension));
                     if (moduleFilesResults.Count > 0)
                         result.AddRange(moduleFilesResults);
                 }
@@ -2801,7 +2821,7 @@ namespace System.Management.Automation
                 RemoveLastNullCompletionResult(result);
 
                 var modules = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-                var moduleResults = CompleteModuleName(new CompletionContext(commandName, context), true);
+                var moduleResults = CompleteModuleName(context, true);
                 if (moduleResults != null)
                 {
                     foreach (CompletionResult moduleResult in moduleResults)
@@ -2814,7 +2834,7 @@ namespace System.Management.Automation
                     }
                 }
 
-                moduleResults = CompleteModuleName(new CompletionContext(commandName, context), false);
+                moduleResults = CompleteModuleName(context, false);
                 if (moduleResults != null)
                 {
                     foreach (CompletionResult moduleResult in moduleResults)
@@ -2831,28 +2851,31 @@ namespace System.Management.Automation
             }
         }
 
-        private static void NativeCompletionGetHelpCommand(string commandName, string paramName, bool isHelpRelated, List<CompletionResult> result, CompletionContext context)
+        private static void NativeCompletionGetHelpCommand(CompletionContext context, string paramName, bool isHelpRelated, List<CompletionResult> result)
         {
             if (!string.IsNullOrEmpty(paramName) && paramName.Equals("Name", StringComparison.OrdinalIgnoreCase))
             {
                 RemoveLastNullCompletionResult(result);
 
                 // Available commands
+                // For argument completion, we don't want to complete against pseudo commands that only work in the script workflow.
+                // The way to avoid that is to pass in a CompletionContext with RelatedAst = null
                 const CommandTypes commandTypes = CommandTypes.Cmdlet | CommandTypes.Function | CommandTypes.Alias | CommandTypes.ExternalScript | CommandTypes.Workflow | CommandTypes.Configuration;
-                var commandResults = CompleteCommand(new CompletionContext(commandName, context), null, commandTypes);
+                var newContext = NewContextToCompleteCommandAsArgument(context);
+                var commandResults = CompleteCommand(newContext, null, commandTypes);
                 if (commandResults != null)
                     result.AddRange(commandResults);
 
                 // ps1 files and directories
                 var ps1Extension = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { StringLiterals.PowerShellScriptFileExtension };
-                var fileResults = new List<CompletionResult>(CompleteFilename(new CompletionContext(commandName, context), false, ps1Extension));
+                var fileResults = new List<CompletionResult>(CompleteFilename(context, false, ps1Extension));
                 if (fileResults.Count > 0)
                     result.AddRange(fileResults);
 
                 if (isHelpRelated)
                 {
                     // Available topics
-                    var helpTopicResults = CompleteHelpTopics(new CompletionContext(commandName, context));
+                    var helpTopicResults = CompleteHelpTopics(context);
                     if (helpTopicResults != null)
                         result.AddRange(helpTopicResults);
                 }
@@ -2861,13 +2884,13 @@ namespace System.Management.Automation
             }
         }
 
-        private static void NativeCompletionEventLogCommands(string logName, string paramName, List<CompletionResult> result, CompletionContext context)
+        private static void NativeCompletionEventLogCommands(CompletionContext context, string paramName, List<CompletionResult> result)
         {
             if (!string.IsNullOrEmpty(paramName) && paramName.Equals("LogName", StringComparison.OrdinalIgnoreCase))
             {
                 RemoveLastNullCompletionResult(result);
 
-                logName = logName ?? string.Empty;
+                var logName = context.WordToComplete ?? string.Empty;
                 var quote = HandleDoubleAndSingleQuote(ref logName);
 
                 if (!logName.EndsWith("*", StringComparison.Ordinal))
@@ -2912,12 +2935,12 @@ namespace System.Management.Automation
             }
         }
 
-        private static void NativeCompletionJobCommands(string wordToComplete, string paramName, List<CompletionResult> result, CompletionContext context)
+        private static void NativeCompletionJobCommands(CompletionContext context, string paramName, List<CompletionResult> result)
         {
             if (string.IsNullOrEmpty(paramName))
                 return;
 
-            wordToComplete = wordToComplete ?? string.Empty;
+            var wordToComplete = context.WordToComplete ?? string.Empty;
             var quote = HandleDoubleAndSingleQuote(ref wordToComplete);
 
             if (!wordToComplete.EndsWith("*", StringComparison.Ordinal))
@@ -2998,12 +3021,12 @@ namespace System.Management.Automation
             }
         }
 
-        private static void NativeCompletionScheduledJobCommands(string wordToComplete, string paramName, List<CompletionResult> result, CompletionContext context)
+        private static void NativeCompletionScheduledJobCommands(CompletionContext context, string paramName, List<CompletionResult> result)
         {
             if (string.IsNullOrEmpty(paramName))
                 return;
 
-            wordToComplete = wordToComplete ?? string.Empty;
+            var wordToComplete = context.WordToComplete ?? string.Empty;
             var quote = HandleDoubleAndSingleQuote(ref wordToComplete);
 
             if (!wordToComplete.EndsWith("*", StringComparison.Ordinal))
@@ -3072,7 +3095,7 @@ namespace System.Management.Automation
             }
         }
 
-        private static void NativeCompletionModuleCommands(string assemblyOrModuleName, string paramName, bool loadedModulesOnly, bool isImportModule, List<CompletionResult> result, CompletionContext context)
+        private static void NativeCompletionModuleCommands(CompletionContext context, string paramName, bool loadedModulesOnly, bool isImportModule, List<CompletionResult> result)
         {
             if (string.IsNullOrEmpty(paramName))
             {
@@ -3094,10 +3117,11 @@ namespace System.Management.Automation
                                 StringLiterals.PowerShellCmdletizationFileExtension,
                                 StringLiterals.WorkflowFileExtension
                             };
-                    var moduleFilesResults = new List<CompletionResult>(CompleteFilename(new CompletionContext(assemblyOrModuleName, context), false, moduleExtensions));
+                    var moduleFilesResults = new List<CompletionResult>(CompleteFilename(context, false, moduleExtensions));
                     if (moduleFilesResults.Count > 0)
                         result.AddRange(moduleFilesResults);
 
+                    var assemblyOrModuleName = context.WordToComplete;
                     if (assemblyOrModuleName.IndexOfAny(Utils.Separators.DirectoryOrDrive) != -1)
                     {
                         // The partial input is a path, then we don't iterate modules under $ENV:PSModulePath
@@ -3105,7 +3129,7 @@ namespace System.Management.Automation
                     }
                 }
 
-                var moduleResults = CompleteModuleName(new CompletionContext(assemblyOrModuleName, context), loadedModulesOnly);
+                var moduleResults = CompleteModuleName(context, loadedModulesOnly);
                 if (moduleResults != null && moduleResults.Count > 0)
                     result.AddRange(moduleResults);
 
@@ -3116,7 +3140,7 @@ namespace System.Management.Automation
                 RemoveLastNullCompletionResult(result);
 
                 var moduleExtensions = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { ".dll" };
-                var moduleFilesResults = new List<CompletionResult>(CompleteFilename(new CompletionContext(assemblyOrModuleName, context), false, moduleExtensions));
+                var moduleFilesResults = new List<CompletionResult>(CompleteFilename(context, false, moduleExtensions));
                 if (moduleFilesResults.Count > 0)
                     result.AddRange(moduleFilesResults);
 
@@ -3124,12 +3148,12 @@ namespace System.Management.Automation
             }
         }
 
-        private static void NativeCompletionProcessCommands(string wordToComplete, string paramName, List<CompletionResult> result, CompletionContext context)
+        private static void NativeCompletionProcessCommands(CompletionContext context, string paramName, List<CompletionResult> result)
         {
             if (string.IsNullOrEmpty(paramName))
                 return;
 
-            wordToComplete = wordToComplete ?? string.Empty;
+            var wordToComplete = context.WordToComplete ?? string.Empty;
             var quote = HandleDoubleAndSingleQuote(ref wordToComplete);
 
             if (!wordToComplete.EndsWith("*", StringComparison.Ordinal))
@@ -3205,7 +3229,7 @@ namespace System.Management.Automation
             }
         }
 
-        private static void NativeCompletionProviderCommands(string providerName, string paramName, List<CompletionResult> result, CompletionContext context)
+        private static void NativeCompletionProviderCommands(CompletionContext context, string paramName, List<CompletionResult> result)
         {
             if (string.IsNullOrEmpty(paramName) || !paramName.Equals("PSProvider", StringComparison.OrdinalIgnoreCase))
             {
@@ -3214,7 +3238,7 @@ namespace System.Management.Automation
 
             RemoveLastNullCompletionResult(result);
 
-            providerName = providerName ?? string.Empty;
+            var providerName = context.WordToComplete ?? string.Empty;
             var quote = HandleDoubleAndSingleQuote(ref providerName);
 
 
@@ -3252,14 +3276,14 @@ namespace System.Management.Automation
             result.Add(CompletionResult.Null);
         }
 
-        private static void NativeCompletionDriveCommands(string wordToComplete, string psProvider, string paramName, List<CompletionResult> result, CompletionContext context)
+        private static void NativeCompletionDriveCommands(CompletionContext context, string psProvider, string paramName, List<CompletionResult> result)
         {
             if (string.IsNullOrEmpty(paramName) || !paramName.Equals("Name", StringComparison.OrdinalIgnoreCase))
                 return;
 
             RemoveLastNullCompletionResult(result);
 
-            wordToComplete = wordToComplete ?? string.Empty;
+            var wordToComplete = context.WordToComplete ?? string.Empty;
             var quote = HandleDoubleAndSingleQuote(ref wordToComplete);
 
             if (!wordToComplete.EndsWith("*", StringComparison.Ordinal))
@@ -3301,12 +3325,12 @@ namespace System.Management.Automation
             result.Add(CompletionResult.Null);
         }
 
-        private static void NativeCompletionServiceCommands(string wordToComplete, string paramName, List<CompletionResult> result, CompletionContext context)
+        private static void NativeCompletionServiceCommands(CompletionContext context, string paramName, List<CompletionResult> result)
         {
             if (string.IsNullOrEmpty(paramName))
                 return;
 
-            wordToComplete = wordToComplete ?? string.Empty;
+            var wordToComplete = context.WordToComplete ?? string.Empty;
             var quote = HandleDoubleAndSingleQuote(ref wordToComplete);
 
             if (!wordToComplete.EndsWith("*", StringComparison.Ordinal))
@@ -3384,7 +3408,7 @@ namespace System.Management.Automation
             }
         }
 
-        private static void NativeCompletionVariableCommands(string variableName, string paramName, List<CompletionResult> result, CompletionContext context)
+        private static void NativeCompletionVariableCommands(CompletionContext context, string paramName, List<CompletionResult> result)
         {
             if (string.IsNullOrEmpty(paramName) || !paramName.Equals("Name", StringComparison.OrdinalIgnoreCase))
             {
@@ -3393,7 +3417,7 @@ namespace System.Management.Automation
 
             RemoveLastNullCompletionResult(result);
 
-            variableName = variableName ?? string.Empty;
+            var variableName = context.WordToComplete ?? string.Empty;
             var quote = HandleDoubleAndSingleQuote(ref variableName);
             if (!variableName.EndsWith("*", StringComparison.Ordinal))
             {
@@ -3438,7 +3462,7 @@ namespace System.Management.Automation
             result.Add(CompletionResult.Null);
         }
 
-        private static void NativeCompletionAliasCommands(string commandName, string paramName, List<CompletionResult> result, CompletionContext context)
+        private static void NativeCompletionAliasCommands(CompletionContext context, string paramName, List<CompletionResult> result)
         {
             if (string.IsNullOrEmpty(paramName) ||
                 (!paramName.Equals("Definition", StringComparison.OrdinalIgnoreCase) &&
@@ -3452,7 +3476,7 @@ namespace System.Management.Automation
             var powerShellExecutionHelper = context.Helper;
             if (paramName.Equals("Name", StringComparison.OrdinalIgnoreCase))
             {
-                commandName = commandName ?? string.Empty;
+                var commandName = context.WordToComplete ?? string.Empty;
                 var quote = HandleDoubleAndSingleQuote(ref commandName);
 
                 if (!commandName.EndsWith("*", StringComparison.Ordinal))
@@ -3490,13 +3514,16 @@ namespace System.Management.Automation
             {
                 // Complete for the parameter Definition
                 // Available commands
+                // For argument completion, we don't want to complete against pseudo commands that only work in the script workflow.
+                // The way to avoid that is to pass in a CompletionContext with RelatedAst = null
                 const CommandTypes commandTypes = CommandTypes.Cmdlet | CommandTypes.Function | CommandTypes.ExternalScript | CommandTypes.Workflow | CommandTypes.Configuration;
-                var commandResults = CompleteCommand(new CompletionContext(commandName, context), null, commandTypes);
+                var newContext = NewContextToCompleteCommandAsArgument(context);
+                var commandResults = CompleteCommand(newContext, null, commandTypes);
                 if (commandResults != null && commandResults.Count > 0)
                     result.AddRange(commandResults);
 
                 // The parameter Definition takes a file
-                var fileResults = new List<CompletionResult>(CompleteFilename(new CompletionContext(commandName, context)));
+                var fileResults = new List<CompletionResult>(CompleteFilename(context));
                 if (fileResults.Count > 0)
                     result.AddRange(fileResults);
             }
@@ -3504,7 +3531,7 @@ namespace System.Management.Automation
             result.Add(CompletionResult.Null);
         }
 
-        private static void NativeCompletionTraceSourceCommands(string traceSourceName, string paramName, List<CompletionResult> result, CompletionContext context)
+        private static void NativeCompletionTraceSourceCommands(CompletionContext context, string paramName, List<CompletionResult> result)
         {
             if (string.IsNullOrEmpty(paramName) || !paramName.Equals("Name", StringComparison.OrdinalIgnoreCase))
             {
@@ -3513,7 +3540,7 @@ namespace System.Management.Automation
 
             RemoveLastNullCompletionResult(result);
 
-            traceSourceName = traceSourceName ?? string.Empty;
+            var traceSourceName = context.WordToComplete ?? string.Empty;
             var quote = HandleDoubleAndSingleQuote(ref traceSourceName);
 
             if (!traceSourceName.EndsWith("*", StringComparison.Ordinal))
@@ -3551,7 +3578,7 @@ namespace System.Management.Automation
             result.Add(CompletionResult.Null);
         }
 
-        private static void NativeCompletionSetLocationCommand(string dirName, string paramName, List<CompletionResult> result, CompletionContext context)
+        private static void NativeCompletionSetLocationCommand(CompletionContext context, string paramName, List<CompletionResult> result)
         {
             if (string.IsNullOrEmpty(paramName) ||
                 (!paramName.Equals("Path", StringComparison.OrdinalIgnoreCase) &&
@@ -3562,7 +3589,7 @@ namespace System.Management.Automation
 
             RemoveLastNullCompletionResult(result);
 
-            context.WordToComplete = dirName ?? string.Empty;
+            context.WordToComplete = context.WordToComplete ?? string.Empty;
             var clearLiteralPath = false;
             if (paramName.Equals("LiteralPath", StringComparison.OrdinalIgnoreCase))
             {
@@ -3587,11 +3614,10 @@ namespace System.Management.Automation
         /// <summary>
         /// Provides completion results for NewItemCommand
         /// </summary>
-        /// <param name="itemTypeToComplete">The item provided by user for completion.</param>
+        /// <param name="context">Completion context.</param>
         /// <param name="paramName">Name of the parameter whose value needs completion.</param>
         /// <param name="result">List of completion suggestions.</param>
-        /// <param name="context">Completion context.</param>
-        private static void NativeCompletionNewItemCommand(string itemTypeToComplete, string paramName, List<CompletionResult> result, CompletionContext context)
+        private static void NativeCompletionNewItemCommand(CompletionContext context, string paramName, List<CompletionResult> result)
         {
             if (string.IsNullOrEmpty(paramName))
             {
@@ -3614,9 +3640,9 @@ namespace System.Management.Automation
             {
                 if (paramName.Equals("ItemType", StringComparison.OrdinalIgnoreCase))
                 {
-                    if (!String.IsNullOrEmpty(itemTypeToComplete))
+                    if (!String.IsNullOrEmpty(context.WordToComplete))
                     {
-                        WildcardPattern patternEvaluator = WildcardPattern.Get(itemTypeToComplete + "*", WildcardOptions.IgnoreCase);
+                        WildcardPattern patternEvaluator = WildcardPattern.Get(context.WordToComplete + "*", WildcardOptions.IgnoreCase);
 
                         if (patternEvaluator.IsMatch("file"))
                         {
@@ -3653,7 +3679,7 @@ namespace System.Management.Automation
             }
         }
 
-        private static void NativeCompletionCopyMoveItemCommand(string pathName, string paramName, List<CompletionResult> result, CompletionContext context)
+        private static void NativeCompletionCopyMoveItemCommand(CompletionContext context, string paramName, List<CompletionResult> result)
         {
             if (string.IsNullOrEmpty(paramName))
             {
@@ -3662,14 +3688,14 @@ namespace System.Management.Automation
 
             if (paramName.Equals("LiteralPath", StringComparison.OrdinalIgnoreCase) || paramName.Equals("Path", StringComparison.OrdinalIgnoreCase))
             {
-                NativeCompletionPathArgument(pathName, paramName, result, context);
+                NativeCompletionPathArgument(context, paramName, result);
             }
             else if (paramName.Equals("Destination", StringComparison.OrdinalIgnoreCase))
             {
                 // The parameter Destination for Move-Item and Copy-Item takes literal path
                 RemoveLastNullCompletionResult(result);
 
-                context.WordToComplete = pathName ?? string.Empty;
+                context.WordToComplete = context.WordToComplete ?? string.Empty;
                 var clearLiteralPath = TurnOnLiteralPathOption(context);
 
                 try
@@ -3688,7 +3714,7 @@ namespace System.Management.Automation
             }
         }
 
-        private static void NativeCompletionPathArgument(string pathName, string paramName, List<CompletionResult> result, CompletionContext context)
+        private static void NativeCompletionPathArgument(CompletionContext context, string paramName, List<CompletionResult> result)
         {
             if (string.IsNullOrEmpty(paramName) ||
                 (!paramName.Equals("LiteralPath", StringComparison.OrdinalIgnoreCase) &&
@@ -3700,7 +3726,7 @@ namespace System.Management.Automation
 
             RemoveLastNullCompletionResult(result);
 
-            context.WordToComplete = pathName ?? string.Empty;
+            context.WordToComplete = context.WordToComplete ?? string.Empty;
             var clearLiteralPath = false;
             if (paramName.Equals("LiteralPath", StringComparison.OrdinalIgnoreCase))
             {
@@ -3722,7 +3748,7 @@ namespace System.Management.Automation
             result.Add(CompletionResult.Null);
         }
 
-        private static void NativeCompletionMemberName(string wordToComplete, List<CompletionResult> result, CommandAst commandAst, CompletionContext context)
+        private static void NativeCompletionMemberName(CompletionContext context, List<CompletionResult> result, CommandAst commandAst)
         {
             // Command is something like where-object/foreach-object/format-list/etc. where there is a parameter that is a property name
             // and we want member names based on the input object, which is either the parameter InputObject, or comes from the pipeline.
@@ -3758,7 +3784,7 @@ namespace System.Management.Automation
                 prevType = AstTypeInference.InferTypeOf(pipelineAst.PipelineElements[i - 1], context.TypeInferenceContext, TypeInferenceRuntimePermissions.AllowSafeEval);
             }
 
-            CompleteMemberByInferredType(context, prevType, result, wordToComplete + "*", filter: IsPropertyMember, isStatic: false);
+            CompleteMemberByInferredType(context, prevType, result, context.WordToComplete + "*", filter: IsPropertyMember, isStatic: false);
             result.Add(CompletionResult.Null);
         }
 

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -2059,7 +2059,7 @@ namespace System.Management.Automation
                     {
                         if (parameterName.Equals("Module", StringComparison.OrdinalIgnoreCase))
                         {
-                            NativeCompletionGetCommand(context, null, parameterName, result);
+                            NativeCompletionGetCommand(context, /* moduleName: */ null, parameterName, result);
                             break;
                         }
                         if (parameterName.Equals("Name", StringComparison.OrdinalIgnoreCase))
@@ -2075,7 +2075,7 @@ namespace System.Management.Automation
                             }
                             else
                             {
-                                NativeCompletionGetCommand(context, null, parameterName, result);
+                                NativeCompletionGetCommand(context, /* moduleName: */ null, parameterName, result);
                             }
                             break;
                         }
@@ -2090,13 +2090,13 @@ namespace System.Management.Automation
                     }
                 case "Show-Command":
                     {
-                        NativeCompletionGetHelpCommand(context, parameterName, false, result);
+                        NativeCompletionGetHelpCommand(context, parameterName, /* isHelpRelated: */ false, result);
                         break;
                     }
                 case "help":
                 case "Get-Help":
                     {
-                        NativeCompletionGetHelpCommand(context, parameterName, true, result);
+                        NativeCompletionGetHelpCommand(context, parameterName, /* isHelpRelated: */ true, result);
                         break;
                     }
                 case "Invoke-Expression":
@@ -2143,17 +2143,17 @@ namespace System.Management.Automation
                 case "Get-Module":
                     {
                         bool loadedModulesOnly = boundArguments == null || !boundArguments.ContainsKey("ListAvailable");
-                        NativeCompletionModuleCommands(context, parameterName, loadedModulesOnly, false, result);
+                        NativeCompletionModuleCommands(context, parameterName, loadedModulesOnly, /* isImportModule: */ false, result);
                         break;
                     }
                 case "Remove-Module":
                     {
-                        NativeCompletionModuleCommands(context, parameterName, true, false, result);
+                        NativeCompletionModuleCommands(context, parameterName, /* loadedModulesOnly: */ true, /* isImportModule: */ false, result);
                         break;
                     }
                 case "Import-Module":
                     {
-                        NativeCompletionModuleCommands(context, parameterName, false, true, result);
+                        NativeCompletionModuleCommands(context, parameterName, /* loadedModulesOnly: */ false, /* isImportModule: */ true, result);
                         break;
                     }
                 case "Debug-Process":
@@ -2184,7 +2184,7 @@ namespace System.Management.Automation
                             }
                             else
                             {
-                                NativeCompletionDriveCommands(context, null, parameterName, result);
+                                NativeCompletionDriveCommands(context, /* psProvider: */ null, parameterName, result);
                             }
                         }
 


### PR DESCRIPTION
Fix #4037

These are purely refactoring changes and should not alter any behaviors or functionalities.

We actually only need to create a new CompletionContext instance sometimes to complete a command as an argument, because for argument completion, we don't want to complete against pseudo commands that only work in the workflow script, and the way to avoid that is to pass in a CompletionContext with `RelatedAst = null`.
However, it seems this pattern is copied for file completion and module name completion at some places. This PR refactored the corresponding code to avoid unnecessary construction of CompletionContext instances.

This PR also changes the `NativeCompletion*Commands` methods to extract the `wordToComplete` from the `CompletionContext` that is passed in. This makes it easier to reason from the code.