### PR TITLE
Travis-CI nightly build failing due to start-sleep tests

### DIFF
--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Start-Sleep.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Start-Sleep.Tests.ps1
@@ -9,7 +9,7 @@ Describe "Start-Sleep DRT Unit Tests" -Tags "CI" {
         Start-Sleep -Seconds 1
         $watch.Stop()
         $watch.ElapsedMilliseconds | Should BeGreaterThan 950
-        $watch.ElapsedMilliseconds | Should BeLessThan 1050
+        $watch.ElapsedMilliseconds | Should BeLessThan 1100
     }
 
     It "Should work properly when sleeping with Milliseconds" {
@@ -17,7 +17,7 @@ Describe "Start-Sleep DRT Unit Tests" -Tags "CI" {
         Start-Sleep -Milliseconds 1000
         $watch.Stop()
         $watch.ElapsedMilliseconds | Should BeGreaterThan 950
-        $watch.ElapsedMilliseconds | Should BeLessThan 1050
+        $watch.ElapsedMilliseconds | Should BeLessThan 1100
     }
 
     It "Should work properly when sleeping with ms alias" {
@@ -25,7 +25,7 @@ Describe "Start-Sleep DRT Unit Tests" -Tags "CI" {
         Start-Sleep -ms 1000
         $watch.Stop()
         $watch.ElapsedMilliseconds | Should BeGreaterThan 950
-        $watch.ElapsedMilliseconds | Should BeLessThan 1050
+        $watch.ElapsedMilliseconds | Should BeLessThan 1100
     }
 }
 


### PR DESCRIPTION
Tests were failing in CI nightly build as the timing was off past 1050ms (was actually 1053ms).  Adding a slightly bigger window.

<!--

If you are a PowerShell Team member, please make sure you choose the Reviewer(s) and Assignee for your PR.
If you are not from the PowerShell Team, you can leave the fields blank and the Maintainers will choose them for you. If you are familiar with the team, feel free to mention some Reviewers yourself.

For more information about the roles of Reviewer and Assignee, refer to CONTRIBUTING.md.

-->
