### PR TITLE
Use -c when calling powershell.exe in tests to avoid issues when argument positions change

### DIFF
--- a/test/powershell/Host/Base-Directory.Tests.ps1
+++ b/test/powershell/Host/Base-Directory.Tests.ps1
@@ -38,12 +38,12 @@ Describe "Configuration file locations" -tags "CI","Slow" {
         }
 
         It @ItArgs "Profile location should be correct" {
-            & $powershell -noprofile `$PROFILE | Should Be $expectedProfile
+            & $powershell -noprofile -c `$PROFILE | Should Be $expectedProfile
         }
 
         It @ItArgs "PSModulePath should contain the correct path" {
             $env:PSModulePath = ""
-            $actual = & $powershell -noprofile `$env:PSModulePath
+            $actual = & $powershell -noprofile -c `$env:PSModulePath
             $actual | Should Match ([regex]::Escape($expectedModule))
         }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Host.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Host.Tests.ps1
@@ -13,7 +13,7 @@
     It "write-Host works with '<Name>' switch" -TestCases:$testData -Pending:$IsOSX {
         param($Command, $returnCount, $returnValue)
 
-        [array]$result = & $powershell -noprofile $Command
+        [array]$result = & $powershell -noprofile -c $Command
 
         $result.Count | Should Be $returnCount
         foreach ($i in 0..($returnCount - 1))


### PR DESCRIPTION
Updated tests to explicitly use `-c` to indicate a command