### PR TITLE
Add missing timestamper cert to the newer catalog signing APIs

### DIFF
--- a/src/System.Management.Automation/security/Authenticode.cs
+++ b/src/System.Management.Automation/security/Authenticode.cs
@@ -363,10 +363,23 @@ namespace System.Management.Automation
                             DWORD error = GetErrorFromSignatureState(sigInfo.nSignatureState);
 
                             X509Certificate2 cert = null;
+
                             if (ppCertContext != IntPtr.Zero)
                             {
                                 cert = new X509Certificate2(ppCertContext);
-                                signature = new Signature(filename, error, cert);
+
+                                // Get the time stamper certificate if available
+                                IntPtr pProvSigner = IntPtr.Zero;
+                                X509Certificate2 timestamperCert = null;
+                                TryGetProviderSigner(phStateData, ref pProvSigner, ref timestamperCert);
+                                if (timestamperCert != null)
+                                {
+                                    signature = new Signature(filename, error, cert, timestamperCert);
+                                }
+                                else
+                                {
+                                    signature = new Signature(filename, error, cert);
+                                }
 
                                 switch (sigInfo.nSignatureType)
                                 {
@@ -578,59 +591,35 @@ namespace System.Management.Automation
             DWORD error,
             NativeMethods.WINTRUST_DATA wtd)
         {
-            Signature signature = null;
-            X509Certificate2 signerCert = null;
-            X509Certificate2 timestamperCert = null;
-
             s_tracer.WriteLine("GetSignatureFromWintrustData: error: {0}", error);
 
-            // The GetLastWin32Error of this is checked, but PreSharp doesn't seem to be
-            // able to see that.
-#pragma warning disable 56523
-            IntPtr pProvData =
-                NativeMethods.WTHelperProvDataFromStateData(wtd.hWVTStateData);
-#pragma warning enable 56523
-
-            if (pProvData != IntPtr.Zero)
+            Signature signature = null;
+            IntPtr pProvSigner = IntPtr.Zero;
+            X509Certificate2 timestamperCert = null;
+            if (TryGetProviderSigner(wtd.hWVTStateData, ref pProvSigner, ref timestamperCert))
             {
-                IntPtr pProvSigner =
-                    NativeMethods.WTHelperGetProvSignerFromChain(pProvData, 0, 0, 0);
-                if (pProvSigner != IntPtr.Zero)
+                //
+                // get cert of the signer
+                //
+                X509Certificate2 signerCert = GetCertFromChain(pProvSigner);
+
+                if (signerCert != null)
                 {
-                    //
-                    // get cert of the signer
-                    //
-                    signerCert = GetCertFromChain(pProvSigner);
-
-                    if (signerCert != null)
+                    if (timestamperCert != null)
                     {
-                        NativeMethods.CRYPT_PROVIDER_SGNR provSigner =
-                            (NativeMethods.CRYPT_PROVIDER_SGNR)
-                            ClrFacade.PtrToStructure<NativeMethods.CRYPT_PROVIDER_SGNR>(pProvSigner);
-                        if (provSigner.csCounterSigners == 1)
-                        {
-                            //
-                            // time stamper cert available
-                            //
-                            timestamperCert = GetCertFromChain(provSigner.pasCounterSigners);
-                        }
-
-                        if (timestamperCert != null)
-                        {
-                            signature = new Signature(filePath,
-                                                      error,
-                                                      signerCert,
-                                                      timestamperCert);
-                        }
-                        else
-                        {
-                            signature = new Signature(filePath,
-                                                        error,
-                                                        signerCert);
-                        }
-
-                        signature.SignatureType = SignatureType.Authenticode;
+                        signature = new Signature(filePath,
+                                                  error,
+                                                  signerCert,
+                                                  timestamperCert);
                     }
+                    else
+                    {
+                        signature = new Signature(filePath,
+                                                  error,
+                                                  signerCert);
+                    }
+
+                    signature.SignatureType = SignatureType.Authenticode;
                 }
             }
 
@@ -642,6 +631,41 @@ namespace System.Management.Automation
             }
 
             return signature;
+        }
+
+        [ArchitectureSensitive]
+        private static bool TryGetProviderSigner(IntPtr wvtStateData, ref IntPtr pProvSigner, ref X509Certificate2 timestamperCert)
+        {
+            // The GetLastWin32Error of this is checked, but PreSharp doesn't seem to be
+            // able to see that.
+#pragma warning disable 56523
+            IntPtr pProvData =
+                NativeMethods.WTHelperProvDataFromStateData(wvtStateData);
+#pragma warning enable 56523
+
+            if (pProvData != IntPtr.Zero)
+            {
+                pProvSigner =
+                    NativeMethods.WTHelperGetProvSignerFromChain(pProvData, 0, 0, 0);
+
+                if (pProvSigner != IntPtr.Zero)
+                {
+                    NativeMethods.CRYPT_PROVIDER_SGNR provSigner =
+                        (NativeMethods.CRYPT_PROVIDER_SGNR)
+                        ClrFacade.PtrToStructure<NativeMethods.CRYPT_PROVIDER_SGNR>(pProvSigner);
+                    if (provSigner.csCounterSigners == 1)
+                    {
+                        //
+                        // time stamper cert available
+                        //
+                        timestamperCert = GetCertFromChain(provSigner.pasCounterSigners);
+                    }
+
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         [ArchitectureSensitive]

--- a/src/System.Management.Automation/security/Authenticode.cs
+++ b/src/System.Management.Automation/security/Authenticode.cs
@@ -369,9 +369,7 @@ namespace System.Management.Automation
                                 cert = new X509Certificate2(ppCertContext);
 
                                 // Get the time stamper certificate if available
-                                IntPtr pProvSigner = IntPtr.Zero;
-                                X509Certificate2 timestamperCert = null;
-                                TryGetProviderSigner(phStateData, ref pProvSigner, ref timestamperCert);
+                                TryGetProviderSigner(phStateData, out IntPtr pProvSigner, out X509Certificate2 timestamperCert);
                                 if (timestamperCert != null)
                                 {
                                     signature = new Signature(filename, error, cert, timestamperCert);
@@ -594,9 +592,7 @@ namespace System.Management.Automation
             s_tracer.WriteLine("GetSignatureFromWintrustData: error: {0}", error);
 
             Signature signature = null;
-            IntPtr pProvSigner = IntPtr.Zero;
-            X509Certificate2 timestamperCert = null;
-            if (TryGetProviderSigner(wtd.hWVTStateData, ref pProvSigner, ref timestamperCert))
+            if (TryGetProviderSigner(wtd.hWVTStateData, out IntPtr pProvSigner, out X509Certificate2 timestamperCert))
             {
                 //
                 // get cert of the signer
@@ -634,8 +630,11 @@ namespace System.Management.Automation
         }
 
         [ArchitectureSensitive]
-        private static bool TryGetProviderSigner(IntPtr wvtStateData, ref IntPtr pProvSigner, ref X509Certificate2 timestamperCert)
+        private static bool TryGetProviderSigner(IntPtr wvtStateData, out IntPtr pProvSigner, out X509Certificate2 timestamperCert)
         {
+            pProvSigner = IntPtr.Zero;
+            timestamperCert = null;
+
             // The GetLastWin32Error of this is checked, but PreSharp doesn't seem to be
             // able to see that.
 #pragma warning disable 56523


### PR DESCRIPTION
This fixes Issue #4060

Code to obtain the file signature time stamp cert was missing from the newer catalog signing APIs, with the result that Get-AuthenticodeSignature would not include the time stamp cert in the Signature object.

Fix is to refactor and use the older API code for obtaining this.

I didn't add a test for this because no catalog signing tests are in GitHub yet and porting them will be a separate work item.