### PR TITLE
Redefine the unicode output condition for nanoserver for "more" function

### DIFF
--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -5329,7 +5329,7 @@ end
         internal const string DefaultMoreFunctionText = @"
 param([string[]]$paths)
 # Nano needs to use Unicode, but Windows and Linux need the default
-$OutputEncoding = if ($IsWindows -and $IsCoreCLR) {
+$OutputEncoding = if ([System.Management.Automation.Platform]::IsNanoServer -or [System.Management.Automation.Platform]::IsIoT) {
     [System.Text.Encoding]::Unicode
 } else {
     [System.Console]::OutputEncoding


### PR DESCRIPTION
Fix issue #2909 

I haven't included a test case with this fix because 
1. unicode issue is better to be judged by eye.
2. this issue only repros in a non-english windows system with ps running under cmd window. Our current test environment won't touch this scenario.

Thus, one time manual verification might be enough.

Summary of the issue:

Under non-english OS, if user start ps core under comandline and type "help <cmdletName>", the  output will be one character per line

Root cause of the issue:
Only Nano needs to use Unicode, but Windows and Linux need the default encoding. The way we judge if the current os is Nano server has been outdated.
Fix:
Update the condition we use to judge nano server.