### PR TITLE
Fixed BaseDirectory tests by adding -c instead of positional argument

### DIFF
--- a/test/powershell/Host/Base-Directory.Tests.ps1
+++ b/test/powershell/Host/Base-Directory.Tests.ps1
@@ -88,14 +88,14 @@ Describe "Configuration file locations" -tags "CI","Slow" {
         It @ItArgs "Profile should respect XDG_CONFIG_HOME" {
             $env:XDG_CONFIG_HOME = $TestDrive
             $expected = [IO.Path]::Combine($TestDrive, "powershell", $profileName)
-            & $powershell -noprofile `$PROFILE | Should Be $expected
+            & $powershell -noprofile -c `$PROFILE | Should Be $expected
         }
 
         It @ItArgs "PSModulePath should respect XDG_DATA_HOME" {
             $env:PSModulePath = ""
             $env:XDG_DATA_HOME = $TestDrive
             $expected = [IO.Path]::Combine($TestDrive, "powershell", "Modules")
-            $actual = & $powershell -noprofile `$env:PSModulePath
+            $actual = & $powershell -noprofile -c `$env:PSModulePath
             $actual | Should Match $expected
         }
 


### PR DESCRIPTION
Fix the test failing on Travis CI, due to change 41f65de57c540a9b6e058c67baabbe5b10ce18e8
PowerShell now expects the positional parameter as a file for POSIX compliance. The test needed to be updated accordingly.
