### PR TITLE
MacOS test failing for read-host

### DIFF
--- a/test/powershell/Host/assets/Read-Host.Output.expect
+++ b/test/powershell/Host/assets/Read-Host.Output.expect
@@ -7,7 +7,7 @@ set powershell [lindex $argv 0]
 
 set timeout 60
 
-spawn $powershell -nologo -noprofile Read-Host prompt
+spawn $powershell -nologo -noprofile -command Read-Host prompt
 
 expect  {
     "prompt: $" { send "input\r" ; exp_continue }


### PR DESCRIPTION
We changed powershell.exe to require -c to execute command