### PR TITLE
Static analysis: Fix usage of XmlReader to ensure XmlResolver is null

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/InvokeRestMethodCommand.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/InvokeRestMethodCommand.Common.cs
@@ -133,6 +133,7 @@ namespace Microsoft.PowerShell.Commands
             xrs.IgnoreProcessingInstructions = true;
             xrs.MaxCharactersFromEntities = 1024;
             xrs.DtdProcessing = DtdProcessing.Ignore;
+            xrs.XmlResolver = null;
 
             return xrs;
         }

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/Serialization.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/Serialization.cs
@@ -197,7 +197,7 @@ namespace Microsoft.PowerShell
             switch (format)
             {
                 case DataFormat.XML:
-                    _xmlReader = XmlReader.Create(textReader);
+                    _xmlReader = XmlReader.Create(textReader,  new XmlReaderSettings { XmlResolver = null });
                     _xmlDeserializer = new Deserializer(_xmlReader);
                     break;
                 case DataFormat.Text:

--- a/src/Microsoft.PowerShell.Security/security/CertificateProvider.cs
+++ b/src/Microsoft.PowerShell.Security/security/CertificateProvider.cs
@@ -2876,9 +2876,7 @@ namespace Microsoft.PowerShell.Commands
                     currentUICulture.ToString(),
                     this.ProviderInfo.HelpFile);
                 XmlReaderSettings settings = new XmlReaderSettings();
-#if !CORECLR
                 settings.XmlResolver = null;
-#endif
                 using (XmlReader reader = XmlReader.Create(fullHelpPath, settings))
                 {
                     document.Load(reader);

--- a/src/Microsoft.PowerShell.Workflow.ServiceCore/ServiceCore/WorkflowCore/WorkflowRuntimeCompilation.cs
+++ b/src/Microsoft.PowerShell.Workflow.ServiceCore/ServiceCore/WorkflowCore/WorkflowRuntimeCompilation.cs
@@ -135,7 +135,7 @@ namespace Microsoft.PowerShell.Workflow
                 {
                     project.AddItem("XamlAppDef", file);
 
-                    XamlXmlReader reader = new XamlXmlReader(XmlReader.Create(file), new XamlSchemaContext());
+                    XamlXmlReader reader = new XamlXmlReader(XmlReader.Create(file, new XmlReaderSettings { XmlResolver = null }), new XamlSchemaContext());
                     using (reader)
                     {
                         while (reader.Read())

--- a/src/System.Management.Automation/engine/TypeTable.cs
+++ b/src/System.Management.Automation/engine/TypeTable.cs
@@ -4178,7 +4178,7 @@ namespace System.Management.Automation.Runspaces
             {
 #if CORECLR
                 // In OneCore powershell, XmlTextReader is not in CoreCLR, so we have to use XmlReader.Create method
-                XmlReader reader = XmlReader.Create(xmlStream, new XmlReaderSettings { IgnoreWhitespace = true });
+                XmlReader reader = XmlReader.Create(xmlStream, new XmlReaderSettings { IgnoreWhitespace = true, XmlResolver = null });
 #else
                 // In Full powershell, we create a XmlTextReader, so loadContext.reader is guaranteed to implement IXmlLineInfo
                 XmlReader reader = new XmlTextReader(xmlStream) { WhitespaceHandling = WhitespaceHandling.Significant };

--- a/src/System.Management.Automation/engine/remoting/fanin/OutOfProcTransportManager.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/OutOfProcTransportManager.cs
@@ -65,9 +65,7 @@ namespace System.Management.Automation.Remoting
             XmlReaderSettings.CheckCharacters = false;
             XmlReaderSettings.IgnoreComments = true;
             XmlReaderSettings.IgnoreProcessingInstructions = true;
-#if !CORECLR  // No XmlReaderSettings.XmlResolver in CoreCLR
             XmlReaderSettings.XmlResolver = null;
-#endif
             XmlReaderSettings.ConformanceLevel = ConformanceLevel.Fragment;
         }
 

--- a/src/System.Management.Automation/engine/remoting/fanin/PSSessionConfigurationData.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/PSSessionConfigurationData.cs
@@ -89,9 +89,7 @@ namespace System.Management.Automation.Remoting
                 IgnoreComments = true,
                 IgnoreProcessingInstructions = true,
                 MaxCharactersInDocument = 10000,
-#if !CORECLR // No XmlReaderSettings.XmlResolver in CoreCLR
                 XmlResolver = null,
-#endif
                 ConformanceLevel = ConformanceLevel.Fragment
             };
 

--- a/src/System.Management.Automation/engine/serialization.cs
+++ b/src/System.Management.Automation/engine/serialization.cs
@@ -4027,14 +4027,10 @@ namespace System.Management.Automation
             xrs.IgnoreWhitespace = false;
             xrs.MaxCharactersFromEntities = 1024;
             xrs.XmlResolver = null;
-            //xrs.DtdProcessing = DtdProcessing.Prohibit; //because system.management.automation needs to build as 2.0
-            //xrs.ProhibitDtd = true;
-#if !CORECLR
-            // XmlReaderSettings.Schemas/ValidationFlags/ValidationType/XmlResolver Not In CoreCLR
+            xrs.DtdProcessing = DtdProcessing.Prohibit;
             xrs.Schemas = null;
             xrs.ValidationFlags = System.Xml.Schema.XmlSchemaValidationFlags.None;
             xrs.ValidationType = ValidationType.None;
-#endif
             return xrs;
         }
 
@@ -4052,14 +4048,9 @@ namespace System.Management.Automation
             settings.MaxCharactersFromEntities = 1024;
             settings.MaxCharactersInDocument = 512 * 1024 * 1024; // 512M characters = 1GB
             settings.XmlResolver = null;
-
-#if CORECLR // DtdProcessing.Parse Not In CoreCLR
-            settings.DtdProcessing = DtdProcessing.Ignore;
-#else       // XmlReaderSettings.ValidationFlags/ValidationType/XmlResolver Not In CoreCLR
             settings.DtdProcessing = DtdProcessing.Parse;   // Allowing DTD parsing with limits of MaxCharactersFromEntities/MaxCharactersInDocument
             settings.ValidationFlags = System.Xml.Schema.XmlSchemaValidationFlags.None;
             settings.ValidationType = ValidationType.None;
-#endif
             return settings;
         }
 

--- a/src/System.Management.Automation/engine/serialization.cs
+++ b/src/System.Management.Automation/engine/serialization.cs
@@ -4026,6 +4026,7 @@ namespace System.Management.Automation
             xrs.IgnoreProcessingInstructions = true;
             xrs.IgnoreWhitespace = false;
             xrs.MaxCharactersFromEntities = 1024;
+            xrs.XmlResolver = null;
             //xrs.DtdProcessing = DtdProcessing.Prohibit; //because system.management.automation needs to build as 2.0
             //xrs.ProhibitDtd = true;
 #if !CORECLR
@@ -4033,7 +4034,6 @@ namespace System.Management.Automation
             xrs.Schemas = null;
             xrs.ValidationFlags = System.Xml.Schema.XmlSchemaValidationFlags.None;
             xrs.ValidationType = ValidationType.None;
-            xrs.XmlResolver = null;
 #endif
             return xrs;
         }
@@ -4051,6 +4051,7 @@ namespace System.Management.Automation
             settings.IgnoreWhitespace = true;
             settings.MaxCharactersFromEntities = 1024;
             settings.MaxCharactersInDocument = 512 * 1024 * 1024; // 512M characters = 1GB
+            settings.XmlResolver = null;
 
 #if CORECLR // DtdProcessing.Parse Not In CoreCLR
             settings.DtdProcessing = DtdProcessing.Ignore;
@@ -4058,7 +4059,6 @@ namespace System.Management.Automation
             settings.DtdProcessing = DtdProcessing.Parse;   // Allowing DTD parsing with limits of MaxCharactersFromEntities/MaxCharactersInDocument
             settings.ValidationFlags = System.Xml.Schema.XmlSchemaValidationFlags.None;
             settings.ValidationType = ValidationType.None;
-            settings.XmlResolver = null;
 #endif
             return settings;
         }


### PR DESCRIPTION
The default XmlResolver will attempt to resolve external resources, recommendation is to explicitly set to null which will raise exception if malicious xml attempts to cause xmlreader to access external resources.  Dotnet Core 2.0 now has XmlResolver.

Static analysis bugs:

TFS:12477148, 12477346, 12477347, 12477929, 12477938, 12477942, 12478520, 12478531, 12478540, 12478800, 12478801, 12478803, 12478810, 12478811, 12479280, 12479288, 12479295, 12479302, 12479304