### PR TITLE
Minimize writing ANSI escape sequences in PSReadline

### DIFF
--- a/src/Microsoft.PowerShell.PSReadLine/ConsoleLib.cs
+++ b/src/Microsoft.PowerShell.PSReadLine/ConsoleLib.cs
@@ -1075,11 +1075,11 @@ namespace Microsoft.PowerShell.Internal
                 // TODO: use escape sequences for better perf
                 var nextForegroundColor = buffer[i].ForegroundColor;
                 var nextBackgroundColor = buffer[i].BackgroundColor;
-                if (lastForegroundColor != nextForegroundColor)
+                if (nextForegroundColor != lastForegroundColor)
                 {
                     Console.ForegroundColor = lastForegroundColor = nextForegroundColor;
                 }
-                if (lastBackgroundColor != nextBackgroundColor)
+                if (nextBackgroundColor != lastBackgroundColor)
                 {
                     Console.BackgroundColor = lastBackgroundColor = nextBackgroundColor;
                 }
@@ -1087,13 +1087,13 @@ namespace Microsoft.PowerShell.Internal
                 Console.Write(buffer[i].UnicodeChar);
             }
 
-            if (backgroundColor != lastBackgroundColor)
-            {
-                Console.BackgroundColor = backgroundColor;
-            }
             if (foregroundColor != lastForegroundColor)
             {
                 Console.ForegroundColor = foregroundColor;
+            }
+            if (backgroundColor != lastBackgroundColor)
+            {
+                Console.BackgroundColor = backgroundColor;
             }
         }
 

--- a/src/Microsoft.PowerShell.PSReadLine/ConsoleLib.cs
+++ b/src/Microsoft.PowerShell.PSReadLine/ConsoleLib.cs
@@ -1068,17 +1068,33 @@ namespace Microsoft.PowerShell.Internal
 
             Console.SetCursorPosition(0, (top>=0) ? top : 0);
 
+            var lastForegroundColor = (ConsoleColor)(-1);
+            var lastBackgroundColor = (ConsoleColor)(-1);
             for (int i = 0; i < buffer.Length; ++i)
             {
                 // TODO: use escape sequences for better perf
-                Console.ForegroundColor =  buffer[i].ForegroundColor;
-                Console.BackgroundColor =  buffer[i].BackgroundColor;
+                var nextForegroundColor = buffer[i].ForegroundColor;
+                var nextBackgroundColor = buffer[i].BackgroundColor;
+                if (lastForegroundColor != nextForegroundColor)
+                {
+                    Console.ForegroundColor = lastForegroundColor = nextForegroundColor;
+                }
+                if (lastBackgroundColor != nextBackgroundColor)
+                {
+                    Console.BackgroundColor = lastBackgroundColor = nextBackgroundColor;
+                }
 
                 Console.Write(buffer[i].UnicodeChar);
             }
 
-            Console.BackgroundColor = backgroundColor;
-            Console.ForegroundColor = foregroundColor;
+            if (backgroundColor != lastBackgroundColor)
+            {
+                Console.BackgroundColor = backgroundColor;
+            }
+            if (foregroundColor != lastForegroundColor)
+            {
+                Console.ForegroundColor = foregroundColor;
+            }
         }
 
         public void ScrollBuffer(int lines)


### PR DESCRIPTION
Instead of changing Console.*groundColor on every character, only set
the color when the color changes - this avoids writing out ANSI escape
sequences after every character.

Fixes #4075