### PR TITLE
Fix spurious error generated when importing cmdlets from an in-memory assembly

### DIFF
--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -4494,10 +4494,15 @@ namespace System.Management.Automation.Runspaces
             string throwAwayHelpFile = null;
             PSSnapInHelpers.AnalyzePSSnapInAssembly(assembly, assemblyPath, null, module, true, out cmdlets, out aliases, out providers, out throwAwayHelpFile);
 
-            SessionStateAssemblyEntry assemblyEntry =
-                new SessionStateAssemblyEntry(assembly.FullName, assemblyPath);
+            // If this is an in-memory assembly, don't added it to the list of AssemblyEntries
+            // since it can't be loaded by path or name
+            if (! string.IsNullOrEmpty(assembly.Location))
+            {
+                SessionStateAssemblyEntry assemblyEntry =
+                    new SessionStateAssemblyEntry(assembly.FullName, assemblyPath);
+                this.Assemblies.Add(assemblyEntry);
+            }
 
-            this.Assemblies.Add(assemblyEntry);
 
             if (cmdlets != null)
             {

--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -4503,7 +4503,6 @@ namespace System.Management.Automation.Runspaces
                 this.Assemblies.Add(assemblyEntry);
             }
 
-
             if (cmdlets != null)
             {
                 foreach (SessionStateCmdletEntry cmdlet in cmdlets.Values)

--- a/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
@@ -6844,6 +6844,15 @@ namespace Microsoft.PowerShell.Commands
 
                 assemblyVersion = GetAssemblyVersionNumber(assemblyToLoad);
                 assembly = assemblyToLoad;
+                // If this is an in-memory only assembly, add it directly to the assembly cache if
+                // it isn't already there.
+                if (string.IsNullOrEmpty(assembly.Location))
+                {
+                    if (! Context.AssemblyCache.ContainsKey(assembly.FullName))
+                    {
+                        Context.AssemblyCache.Add(assembly.FullName, assembly);
+                    }
+                }
             }
             else
             {
@@ -7197,7 +7206,6 @@ namespace Microsoft.PowerShell.Commands
             {
                 AddModuleToModuleTables(this.Context, this.TargetSessionState.Internal, module);
             }
-
             return module;
         }
 

--- a/test/powershell/Language/Parser/ParameterBinding.Tests.ps1
+++ b/test/powershell/Language/Parser/ParameterBinding.Tests.ps1
@@ -47,7 +47,7 @@ Describe 'Argument transformation attribute on optional argument with explicit $
 '@
     $mod = Add-Type -PassThru -TypeDefinition $tdefinition
 
-    Import-Module $mod[0].Assembly
+    Import-Module $mod[0].Assembly -ErrorVariable ErrorImportingModule
 
     function Invoke-ScriptFunctionTakesObject
     {
@@ -67,6 +67,10 @@ Describe 'Argument transformation attribute on optional argument with explicit $
         return $Address
     }
 
+
+    It "There was no error importing the in-memory module" {
+        $ErrorImportingModule | Should Be $null
+    }
 
     It "Script function takes object" {
         Invoke-ScriptFunctionTakesObject | Should Be 42


### PR DESCRIPTION
Fixes #4025 where a test importing cmdlets from an in-memory assembly produced an spurious error.

<!--

If you are a PowerShell Team member, please make sure you choose the Reviewer(s) and Assignee for your PR.
If you are not from the PowerShell Team, you can leave the fields blank and the Maintainers will choose them for you. If you are familiar with the team, feel free to mention some Reviewers yourself.

For more information about the roles of Reviewer and Assignee, refer to CONTRIBUTING.md.

-->
