### PR TITLE
Fix for SSH remoting when SSH client abruptly terminates

### DIFF
--- a/src/System.Management.Automation/engine/remoting/fanin/OutOfProcTransportManager.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/OutOfProcTransportManager.cs
@@ -1514,7 +1514,7 @@ namespace System.Management.Automation.Remoting.Client
                     if (error == null)
                     {
                         // Stream is closed unexpectedly.
-                        throw new PSInvalidOperationException(RemotingErrorIdStrings.SSHTerminated);
+                        throw new PSInvalidOperationException(RemotingErrorIdStrings.SSHAbruptlyTerminated);
                     }
 
                     if (error.Length == 0)

--- a/src/System.Management.Automation/engine/remoting/fanin/OutOfProcTransportManager.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/OutOfProcTransportManager.cs
@@ -1514,7 +1514,7 @@ namespace System.Management.Automation.Remoting.Client
                     if (error == null)
                     {
                         // Stream is closed unexpectedly.
-                        throw new PSInvalidOperationException("SSH abruptly terminated.");
+                        throw new PSInvalidOperationException(RemotingErrorIdStrings.SSHTerminated);
                     }
 
                     if (error.Length == 0)

--- a/src/System.Management.Automation/engine/remoting/fanin/OutOfProcTransportManager.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/OutOfProcTransportManager.cs
@@ -1511,11 +1511,6 @@ namespace System.Management.Automation.Remoting.Client
                 while (true)
                 {
                     string error = ReadError(reader);
-                    if (error == null)
-                    {
-                        // Stream is closed unexpectedly.
-                        throw new PSInvalidOperationException(RemotingErrorIdStrings.SSHAbruptlyTerminated);
-                    }
 
                     if (error.Length == 0)
                     {
@@ -1561,7 +1556,8 @@ namespace System.Management.Automation.Remoting.Client
 
             if (error == null)
             {
-                return error;
+                // Stream is closed unexpectedly.
+                throw new PSInvalidOperationException(RemotingErrorIdStrings.SSHAbruptlyTerminated);
             }
 
             if ((error.Length == 0) ||

--- a/src/System.Management.Automation/engine/remoting/fanin/OutOfProcTransportManager.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/OutOfProcTransportManager.cs
@@ -1511,8 +1511,15 @@ namespace System.Management.Automation.Remoting.Client
                 while (true)
                 {
                     string error = ReadError(reader);
-                    if (string.IsNullOrEmpty(error))
+                    if (error == null)
                     {
+                        // Stream is closed unexpectedly.
+                        throw new PSInvalidOperationException("SSH abruptly terminated.");
+                    }
+
+                    if (error.Length == 0)
+                    {
+                        // Ignore
                         continue;
                     }
 
@@ -1523,6 +1530,10 @@ namespace System.Management.Automation.Remoting.Client
                         StringUtil.Format(RemotingErrorIdStrings.SSHClientEndWithErrorMessage, error));
                     HandleSSHError(psrte);
                 }
+            }
+            catch (ObjectDisposedException)
+            {
+                // Normal reader thread end.
             }
             catch (Exception e)
             {
@@ -1548,7 +1559,12 @@ namespace System.Management.Automation.Remoting.Client
             // Blocking read from StdError stream
             string error = reader.ReadLine();
 
-            if (string.IsNullOrEmpty(error) ||
+            if (error == null)
+            {
+                return error;
+            }
+
+            if ((error.Length == 0) ||
                 error.IndexOf("WARNING:", StringComparison.OrdinalIgnoreCase) > -1)
             {
                 // Handle as interactive warning message

--- a/src/System.Management.Automation/resources/RemotingErrorIdStrings.resx
+++ b/src/System.Management.Automation/resources/RemotingErrorIdStrings.resx
@@ -1636,4 +1636,7 @@ All WinRM sessions connected to Windows PowerShell session configurations, such 
   <data name="InvalidRoleCapabilityFileExtension" xml:space="preserve">
     <value>The provided role capability file {0} does not have the required .psrc extension.</value>
   </data>
+  <data name="SSHTerminated" >
+    <value>The SSH transport process has abruptly terminated causing this remote session to break.</value>
+  </data>
 </root>

--- a/src/System.Management.Automation/resources/RemotingErrorIdStrings.resx
+++ b/src/System.Management.Automation/resources/RemotingErrorIdStrings.resx
@@ -1636,7 +1636,7 @@ All WinRM sessions connected to Windows PowerShell session configurations, such 
   <data name="InvalidRoleCapabilityFileExtension" xml:space="preserve">
     <value>The provided role capability file {0} does not have the required .psrc extension.</value>
   </data>
-  <data name="SSHTerminated" >
+  <data name="SSHAbruptlyTerminated" >
     <value>The SSH transport process has abruptly terminated causing this remote session to break.</value>
   </data>
 </root>


### PR DESCRIPTION
This PR is for Issue #4122

If the SSH client process that PowerShell is using for the SSH transport terminates abruptly the StreamReader will return null instead of closing the pipe for a normal process exit.

The current error stream reading code ignores null StreamReader values resulting in a hang where the remote session never ends.

Fix is to throw an error when this occurs.
