### PR TITLE
Added comma to replaced characters in assemblyname

### DIFF
--- a/src/System.Management.Automation/engine/parser/PSType.cs
+++ b/src/System.Management.Automation/engine/parser/PSType.cs
@@ -1113,12 +1113,13 @@ namespace System.Management.Automation.Language
             var definedTypes = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
             // First character is a special mark that allows us to cheaply ignore dynamic generated assemblies in ClrFacede.GetAssemblies()
-            // Two replaces at the end are for not-allowed characters. They are replaced by similar-looking chars.
+            // The replaces at the end are for not-allowed characters. They are replaced by similar-looking chars.
             string assemblyName = ClrFacade.FIRST_CHAR_PSASSEMBLY_MARK + (string.IsNullOrWhiteSpace(rootAst.Extent.File)
                                       ? "powershell"
                                       : rootAst.Extent.File
                                       .Replace('\\', (char)0x29f9)
                                       .Replace('/', (char)0x29f9)
+                                      .Replace(',', (char)0x201a)
                                       .Replace(':', (char)0x0589));
 
             var assembly = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName(assemblyName),

--- a/src/System.Management.Automation/engine/parser/PSType.cs
+++ b/src/System.Management.Automation/engine/parser/PSType.cs
@@ -1112,7 +1112,7 @@ namespace System.Management.Automation.Language
 
             var definedTypes = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-            // First character is a special mark that allows us to cheaply ignore dynamic generated assemblies in ClrFacede.GetAssemblies()
+            // First character is a special mark that allows us to cheaply ignore dynamic generated assemblies in ClrFacade.GetAssemblies()
             // The replaces at the end are for not-allowed characters. They are replaced by similar-looking chars.
             string assemblyName = ClrFacade.FIRST_CHAR_PSASSEMBLY_MARK + (string.IsNullOrWhiteSpace(rootAst.Extent.File)
                                       ? "powershell"

--- a/test/powershell/Language/Classes/Scripting.Classes.RunPath.Tests.ps1
+++ b/test/powershell/Language/Classes/Scripting.Classes.RunPath.Tests.ps1
@@ -15,7 +15,6 @@ class MyClass { static [string]$MyProperty = 'Some value' }
 [MyClass]::MyProperty
 '@ | Out-File -FilePath $FilePath
 
-        { . $FilePath } | Should Not Throw
         ( . $FilePath ) | Should Match 'Some value'
     }
 }

--- a/test/powershell/Language/Classes/Scripting.Classes.RunPath.Tests.ps1
+++ b/test/powershell/Language/Classes/Scripting.Classes.RunPath.Tests.ps1
@@ -1,6 +1,6 @@
 Describe "Script with a class definition run path" {
 
-    It "Script with a class definition can run from a path without a comma" {
+    It "Script with a class definition can run from a path without a comma" -Tags "CI" {
 
         $FilePath = '.\MyTest.ps1'
 
@@ -20,7 +20,7 @@ Describe "Script with a class definition run path" {
         $Success | Should Be $True
     }
 
-    It "Script with a class definition can run from a path with a comma" {
+    It "Script with a class definition can run from a path with a comma" -Tags "CI" {
 
         $FilePath = '.\My,Test.ps1'
 

--- a/test/powershell/Language/Classes/Scripting.Classes.RunPath.Tests.ps1
+++ b/test/powershell/Language/Classes/Scripting.Classes.RunPath.Tests.ps1
@@ -1,6 +1,6 @@
-Describe "Script with a class definition run path" {
+Describe "Script with a class definition run path" -Tags "CI" {
 
-    It "Script with a class definition can run from a path without a comma" -Tags "CI" {
+    It "Script with a class definition can run from a path without a comma" {
 
         $FilePath = '.\MyTest.ps1'
 
@@ -20,7 +20,7 @@ Describe "Script with a class definition run path" {
         $Success | Should Be $True
     }
 
-    It "Script with a class definition can run from a path with a comma" -Tags "CI" {
+    It "Script with a class definition can run from a path with a comma" {
 
         $FilePath = '.\My,Test.ps1'
 

--- a/test/powershell/Language/Classes/Scripting.Classes.RunPath.Tests.ps1
+++ b/test/powershell/Language/Classes/Scripting.Classes.RunPath.Tests.ps1
@@ -1,0 +1,42 @@
+Describe "Script with a class definition run path" {
+
+    It "Script with a class definition can run from a path without a comma" {
+
+        $FilePath = '.\MyTest.ps1'
+
+        try {
+            'class MyClass { [string]$MyProperty }; $True' | Out-File -FilePath $FilePath
+            $Success = . $FilePath
+        }
+
+        catch {
+            $Success = $False
+        }
+
+        finally {
+            Remove-Item -Path $FilePath
+        }
+
+        $Success | Should Be $True
+    }
+
+    It "Script with a class definition can run from a path with a comma" {
+
+        $FilePath = '.\My,Test.ps1'
+
+        try {
+            'class MyClass { [string]$MyProperty }; $True' | Out-File -FilePath $FilePath
+            $Success = . $FilePath
+        }
+
+        catch {
+            $Success = $False
+        }
+
+        finally {
+            Remove-Item -Path $FilePath
+        }
+
+        $Success | Should Be $True
+    }
+}

--- a/test/powershell/Language/Classes/Scripting.Classes.RunPath.Tests.ps1
+++ b/test/powershell/Language/Classes/Scripting.Classes.RunPath.Tests.ps1
@@ -1,4 +1,4 @@
-Describe "Script with a class definition run path" {
+Describe "Script with a class definition run path" -Tags "CI" {
 
     $TestCases = @(
         @{ FileName =  'MyTest.ps1'; Name = 'path without a comma' }

--- a/test/powershell/Language/Classes/Scripting.Classes.RunPath.Tests.ps1
+++ b/test/powershell/Language/Classes/Scripting.Classes.RunPath.Tests.ps1
@@ -1,42 +1,21 @@
-Describe "Script with a class definition run path" -Tags "CI" {
+Describe "Script with a class definition run path" {
 
-    It "Script with a class definition can run from a path without a comma" {
+    $TestCases = @(
+        @{ FileName =  'MyTest.ps1'; Name = 'path without a comma' }
+        @{ FileName = 'My,Test.ps1'; Name = 'path with a comma'    }
+    )
 
-        $FilePath = '.\MyTest.ps1'
+    It "Script with a class definition can run from a <Name>" -TestCases $TestCases {
+        param( $FileName )
 
-        try {
-            'class MyClass { [string]$MyProperty }; $True' | Out-File -FilePath $FilePath
-            $Success = . $FilePath
-        }
+        $FilePath = Join-Path -Path $TestDrive -ChildPath $FileName
 
-        catch {
-            $Success = $False
-        }
+@'
+class MyClass { static [string]$MyProperty = 'Some value' }
+[MyClass]::MyProperty
+'@ | Out-File -FilePath $FilePath
 
-        finally {
-            Remove-Item -Path $FilePath
-        }
-
-        $Success | Should Be $True
-    }
-
-    It "Script with a class definition can run from a path with a comma" {
-
-        $FilePath = '.\My,Test.ps1'
-
-        try {
-            'class MyClass { [string]$MyProperty }; $True' | Out-File -FilePath $FilePath
-            $Success = . $FilePath
-        }
-
-        catch {
-            $Success = $False
-        }
-
-        finally {
-            Remove-Item -Path $FilePath
-        }
-
-        $Success | Should Be $True
+        { . $FilePath } | Should Not Throw
+        ( . $FilePath ) | Should Match 'Some value'
     }
 }


### PR DESCRIPTION
A script with a native class will not run if it is saved with a name or full path with a comma.

I added the comma to the list of characters that are replaced with a similar character when creating an assemblyName based on a file path. Added pester test to test.

Discussed with Jason Shirk.
