### PR TITLE
added 'semver' as core type accelerator for S.M.A.SemanticVersion

### DIFF
--- a/src/System.Management.Automation/engine/parser/TypeResolver.cs
+++ b/src/System.Management.Automation/engine/parser/TypeResolver.cs
@@ -804,6 +804,7 @@ namespace System.Management.Automation
                     { typeof(XmlDocument),                                 new[] { "xml" } },
                     { typeof(CimSession),                                  new[] { "CimSession" } },
                     { typeof(MailAddress),                                 new[] { "mailaddress" } },
+                    { typeof(SemanticVersion),                             new[] { "semver" } },
 #if !CORECLR
                     // Following types not in CoreCLR
                     { typeof(DirectoryEntry),                              new[] { "adsi" } },


### PR DESCRIPTION

As per https://github.com/PowerShell/PowerShell/issues/3460

Added `[semver]` as a core (safe to use in constrained language mode) type accelerator for `System.Management.Automation.SemanticVersion`. 

Individual accelerators are not currently being tested, so no unit tests were added or updated. 
 
<!--

If you are a PowerShell Team member, please make sure you choose the Reviewer(s) and Assignee for your PR.
If you are not from the PowerShell Team, you can leave the fields blank and the Maintainers will choose them for you. If you are familiar with the team, feel free to mention some Reviewers yourself.

For more information about the roles of Reviewer and Assignee, refer to CONTRIBUTING.md.

-->
