### PR TITLE
Move powershell to `2.0.0-preview3-25426-01` using the .NET CLI `2.0.0-preview2-006502`

### DIFF
--- a/PowerShell.Common.props
+++ b/PowerShell.Common.props
@@ -5,13 +5,13 @@
     <Copyright>(c) Microsoft Corporation. All rights reserved.</Copyright>
 
     <VersionPrefix>6.0.0</VersionPrefix>
-
-    <NeutralLanguage>en-US</NeutralLanguage>
-
     <TargetFramework>netcoreapp2.0</TargetFramework>
+    <RuntimeFrameworkVersion>2.0.0-preview3-25426-01</RuntimeFrameworkVersion>
+
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NeutralLanguage>en-US</NeutralLanguage>
 
     <DelaySign>true</DelaySign>
     <AssemblyOriginatorKeyFile>../signing/visualstudiopublic.snk</AssemblyOriginatorKeyFile>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ version: 6.0.0-beta.3-{build}
 
 image: Visual Studio 2015
 
-# cache version - netcoreapp.2.0.0-preview1-002106-00
+# cache version - netcoreapp.2.0.0-preview3-25426-01
 cache:
   - '%LocalAppData%\Microsoft\dotnet -> appveyor.yml'
   - '%HOMEDRIVE%%HOMEPATH%\.nuget\packages -> appveyor.yml'

--- a/src/Microsoft.PowerShell.Commands.Management/Microsoft.PowerShell.Commands.Management.csproj
+++ b/src/Microsoft.PowerShell.Commands.Management/Microsoft.PowerShell.Commands.Management.csproj
@@ -70,7 +70,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.ServiceProcess.ServiceController" Version="4.4.0-preview1-25302-01" />
+    <PackageReference Include="System.ServiceProcess.ServiceController" Version="4.4.0-preview3-25423-02" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebRequestPSCmdlet.CoreClr.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebRequestPSCmdlet.CoreClr.cs
@@ -165,7 +165,7 @@ namespace Microsoft.PowerShell.Commands
 
             if (SkipCertificateCheck)
             {
-                handler.ServerCertificateCustomValidationCallback = delegate { return true; };
+                handler.ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator; 
             }
 
             // This indicates GetResponse will handle redirects.

--- a/src/Microsoft.PowerShell.CoreCLR.Eventing/Microsoft.PowerShell.CoreCLR.Eventing.csproj
+++ b/src/Microsoft.PowerShell.CoreCLR.Eventing/Microsoft.PowerShell.CoreCLR.Eventing.csproj
@@ -25,7 +25,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Security.Principal.Windows" Version="4.4.0-preview1-25302-01" />
+    <PackageReference Include="System.Security.Principal.Windows" Version="4.4.0-preview3-25423-02" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.PowerShell.PSReadLine/AssemblyInfo.cs
+++ b/src/Microsoft.PowerShell.PSReadLine/AssemblyInfo.cs
@@ -8,14 +8,7 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("PSReadLine")]
-[assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("PSReadLine")]
-[assembly: AssemblyCopyright("Copyright ©  2013")]
 [assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from
@@ -24,16 +17,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("36053fb0-0bd0-4a1c-951c-b2ec109deca3")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.2")]

--- a/src/Microsoft.PowerShell.PSReadLine/Microsoft.PowerShell.PSReadLine.csproj
+++ b/src/Microsoft.PowerShell.PSReadLine/Microsoft.PowerShell.PSReadLine.csproj
@@ -1,22 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <Import Project="..\..\PowerShell.Common.props"/>
+
   <PropertyGroup>
-    <VersionPrefix>6.0.0</VersionPrefix>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <DelaySign>true</DelaySign>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <Description>PowerShell Core's Microsoft.PowerShell.PSReadLine project</Description>
     <AssemblyName>Microsoft.PowerShell.PSReadLine</AssemblyName>
-    <AssemblyOriginatorKeyFile>../signing/visualstudiopublic.snk</AssemblyOriginatorKeyFile>
-    <SignAssembly>true</SignAssembly>
-    <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
-    <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
-    <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
-    <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
-    <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
-    <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
-    <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.PowerShell.SDK/Microsoft.PowerShell.SDK.csproj
+++ b/src/Microsoft.PowerShell.SDK/Microsoft.PowerShell.SDK.csproj
@@ -17,17 +17,17 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Data.SqlClient" Version="4.4.0-preview1-25302-01" />
-    <PackageReference Include="System.IO.Packaging" Version="4.4.0-preview1-25302-01" />
-    <PackageReference Include="System.Net.Http.WinHttpHandler" Version="4.4.0-preview1-25302-01" />
-    <PackageReference Include="System.ServiceModel.Duplex" Version="4.4.0-preview1-25302-01" />
-    <PackageReference Include="System.ServiceModel.Http" Version="4.4.0-preview1-25302-01" />
-    <PackageReference Include="System.ServiceModel.NetTcp" Version="4.4.0-preview1-25302-01" />
-    <PackageReference Include="System.ServiceModel.Primitives" Version="4.4.0-preview1-25302-01" />
-    <PackageReference Include="System.ServiceModel.Security" Version="4.4.0-preview1-25302-01" />
-    <PackageReference Include="System.Text.Encodings.Web" Version="4.4.0-preview1-25302-01" />
-    <PackageReference Include="System.Threading.AccessControl" Version="4.4.0-preview1-25302-01" />
-    <PackageReference Include="System.Private.ServiceModel" Version="4.4.0-preview1-25302-01" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.4.0-preview3-25423-02" />
+    <PackageReference Include="System.IO.Packaging" Version="4.4.0-preview3-25423-02" />
+    <PackageReference Include="System.Net.Http.WinHttpHandler" Version="4.4.0-preview3-25423-02" />
+    <PackageReference Include="System.ServiceModel.Duplex" Version="4.4.0-preview3-25423-01" />
+    <PackageReference Include="System.ServiceModel.Http" Version="4.4.0-preview3-25423-01" />
+    <PackageReference Include="System.ServiceModel.NetTcp" Version="4.4.0-preview3-25423-01" />
+    <PackageReference Include="System.ServiceModel.Primitives" Version="4.4.0-preview3-25423-01" />
+    <PackageReference Include="System.ServiceModel.Security" Version="4.4.0-preview3-25423-01" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="4.4.0-preview3-25423-02" />
+    <PackageReference Include="System.Threading.AccessControl" Version="4.4.0-preview3-25423-02" />
+    <PackageReference Include="System.Private.ServiceModel" Version="4.4.0-preview3-25423-01" />
   </ItemGroup>
 
 </Project>

--- a/src/ResGen/ResGen.csproj
+++ b/src/ResGen/ResGen.csproj
@@ -1,11 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <Import Project="..\..\PowerShell.Common.props"/>
+
   <PropertyGroup>
     <Description>Generates C# typed bindings for .resx files</Description>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <AssemblyName>resgen</AssemblyName>
     <OutputType>Exe</OutputType>
-    <RuntimeIdentifiers>ubuntu.16.10-x64;ubuntu.16.04-x64;ubuntu.14.04-x64;debian.8-x64;centos.7-x64;fedora.24-x64;win7-x86;win7-x64;win81-x64;win10-x64;osx.10.11-x64;osx.10.12-x64;opensuse.13.2-x64;opensuse.42.1-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>ubuntu.16.10-x64;ubuntu.16.04-x64;ubuntu.14.04-x64;debian.8-x64;centos.7-x64;fedora.24-x64;win7-x86;win7-x64;win81-x64;win10-x64;osx.10.12-x64;opensuse.13.2-x64;opensuse.42.1-x64</RuntimeIdentifiers>
   </PropertyGroup>
 
 </Project>

--- a/src/ResGen/ResGen.csproj
+++ b/src/ResGen/ResGen.csproj
@@ -1,10 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <Import Project="..\..\PowerShell.Common.props"/>
-
   <PropertyGroup>
     <Description>Generates C# typed bindings for .resx files</Description>
-    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <AssemblyName>resgen</AssemblyName>
     <OutputType>Exe</OutputType>
     <RuntimeIdentifiers>ubuntu.16.10-x64;ubuntu.16.04-x64;ubuntu.14.04-x64;debian.8-x64;centos.7-x64;fedora.24-x64;win7-x86;win7-x64;win81-x64;win10-x64;osx.10.12-x64;opensuse.13.2-x64;opensuse.42.1-x64</RuntimeIdentifiers>

--- a/src/System.Management.Automation/System.Management.Automation.csproj
+++ b/src/System.Management.Automation/System.Management.Automation.csproj
@@ -11,12 +11,12 @@
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.PowerShell.CoreCLR.AssemblyLoadContext\Microsoft.PowerShell.CoreCLR.AssemblyLoadContext.csproj" />
     <ProjectReference Include="..\Microsoft.PowerShell.CoreCLR.Eventing\Microsoft.PowerShell.CoreCLR.Eventing.csproj" />
-    <PackageReference Include="Microsoft.Win32.Registry.AccessControl" Version="4.4.0-preview1-25302-01" />
+    <PackageReference Include="Microsoft.Win32.Registry.AccessControl" Version="4.4.0-preview3-25423-02" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.1" />
-    <PackageReference Include="System.IO.FileSystem.AccessControl" Version="4.4.0-preview1-25302-01" />
-    <PackageReference Include="System.Security.AccessControl" Version="4.4.0-preview1-25302-01" />
-    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="4.4.0-preview1-25302-01" />
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="4.4.0-preview1-25302-01" />
+    <PackageReference Include="System.IO.FileSystem.AccessControl" Version="4.4.0-preview3-25423-02" />
+    <PackageReference Include="System.Security.AccessControl" Version="4.4.0-preview3-25423-02" />
+    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="4.4.0-preview3-25423-02" />
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="4.4.0-preview3-25423-02" />
     <PackageReference Include="Microsoft.Management.Infrastructure" Version="1.0.0-alpha*" />
   </ItemGroup>
 

--- a/src/TypeCatalogGen/TypeCatalogGen.csproj
+++ b/src/TypeCatalogGen/TypeCatalogGen.csproj
@@ -1,10 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <Import Project="..\..\PowerShell.Common.props"/>
-
   <PropertyGroup>
     <Description>Generates CorePsTypeCatalog.cs given powershell.inc</Description>
-    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <AssemblyName>TypeCatalogGen</AssemblyName>
     <OutputType>Exe</OutputType>
     <RuntimeIdentifiers>ubuntu.14.04-x64;ubuntu.16.04-x64;ubuntu.16.10-x64;debian.8-x64;centos.7-x64;fedora.24-x64;win7-x86;win7-x64;win81-x64;win10-x64;osx.10.12-x64;opensuse.13.2-x64;opensuse.42.1-x64</RuntimeIdentifiers>

--- a/src/TypeCatalogGen/TypeCatalogGen.csproj
+++ b/src/TypeCatalogGen/TypeCatalogGen.csproj
@@ -1,11 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <Import Project="..\..\PowerShell.Common.props"/>
+
   <PropertyGroup>
     <Description>Generates CorePsTypeCatalog.cs given powershell.inc</Description>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <AssemblyName>TypeCatalogGen</AssemblyName>
     <OutputType>Exe</OutputType>
-    <RuntimeIdentifiers>ubuntu.14.04-x64;ubuntu.16.04-x64;ubuntu.16.10-x64;debian.8-x64;centos.7-x64;fedora.24-x64;win7-x86;win7-x64;win81-x64;win10-x64;osx.10.11-x64;osx.10.12-x64;opensuse.13.2-x64;opensuse.42.1-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>ubuntu.14.04-x64;ubuntu.16.04-x64;ubuntu.16.10-x64;debian.8-x64;centos.7-x64;fedora.24-x64;win7-x86;win7-x64;win81-x64;win10-x64;osx.10.12-x64;opensuse.13.2-x64;opensuse.42.1-x64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/src/powershell-unix/powershell-unix.csproj
+++ b/src/powershell-unix/powershell-unix.csproj
@@ -6,7 +6,7 @@
     <Description>PowerShell top-level project with .NET CLI host</Description>
     <AssemblyName>powershell</AssemblyName>
     <OutputType>Exe</OutputType>
-    <RuntimeIdentifiers>ubuntu.14.04-x64;ubuntu.16.04-x64;ubuntu.16.10-x64;debian.8-x64;centos.7-x64;fedora.24-x64;osx.10.11-x64;osx.10.12-x64;opensuse.13.2-x64;opensuse.42.1-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>ubuntu.14.04-x64;ubuntu.16.04-x64;ubuntu.16.10-x64;debian.8-x64;centos.7-x64;fedora.24-x64;osx.10.12-x64;opensuse.13.2-x64;opensuse.42.1-x64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/PSReadLine/PSReadLine.tests.csproj
+++ b/test/PSReadLine/PSReadLine.tests.csproj
@@ -1,20 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <Import Project="..\Test.Common.props"/>
+
   <PropertyGroup>
     <Description>PSReadLine basic tests</Description>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>TestPSReadLine</AssemblyName>
     <OutputType>Exe</OutputType>
-    <RuntimeIdentifiers>ubuntu.14.04-x64;ubuntu.16.04-x64;centos.7-x64;fedora.24-x64;win7-x86;win7-x64;win10-x64;osx.10.11-x64;osx.10.12-x64;opensuse.13.2-x64;opensuse.42.1-x64</RuntimeIdentifiers>
-    <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
-    <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
-    <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
-    <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
-    <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
-    <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
-    <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
+    <RuntimeIdentifiers>ubuntu.14.04-x64;ubuntu.16.04-x64;centos.7-x64;fedora.24-x64;win7-x86;win7-x64;win10-x64;osx.10.12-x64;opensuse.13.2-x64;opensuse.42.1-x64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Test.Common.props
+++ b/test/Test.Common.props
@@ -5,6 +5,8 @@
     <Copyright>(c) Microsoft Corporation. All rights reserved.</Copyright>
 
     <TargetFramework>netcoreapp2.0</TargetFramework>
+    <RuntimeFrameworkVersion>2.0.0-preview3-25426-01</RuntimeFrameworkVersion>
+
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/test/Test.Common.props
+++ b/test/Test.Common.props
@@ -1,0 +1,11 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Product>PowerShell Core Test</Product>
+    <Company>Microsoft Corporation</Company>
+    <Copyright>(c) Microsoft Corporation. All rights reserved.</Copyright>
+
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+</Project>

--- a/test/csharp/csharp.tests.csproj
+++ b/test/csharp/csharp.tests.csproj
@@ -1,13 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <Import Project="..\Test.Common.props"/>
+
   <PropertyGroup>
     <Description>PowerShell On Linux xUnit Tests</Description>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
-    <DelaySign>true</DelaySign>
     <AssemblyName>powershell-tests</AssemblyName>
-    <AssemblyOriginatorKeyFile>../../src/signing/visualstudiopublic.snk</AssemblyOriginatorKeyFile>
-    <SignAssembly>true</SignAssembly>
-    <RuntimeIdentifiers>ubuntu.14.04-x64;ubuntu.16.04-x64;debian.8-x64;centos.7-x64;fedora.24-x64;win7-x86;win7-x64;win81-x64;win10-x64;osx.10.11-x64;osx.10.12-x64;opensuse.13.2-x64;opensuse.42.1-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>ubuntu.14.04-x64;ubuntu.16.04-x64;debian.8-x64;centos.7-x64;fedora.24-x64;win7-x86;win7-x64;win81-x64;win10-x64;osx.10.12-x64;opensuse.13.2-x64;opensuse.42.1-x64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/powershell/Language/Scripting/NativeExecution/NativeCommandProcessor.Tests.ps1
+++ b/test/powershell/Language/Scripting/NativeExecution/NativeCommandProcessor.Tests.ps1
@@ -24,9 +24,7 @@ Describe 'native commands with pipeline' -tags 'Feature' {
         $rs.ResetRunspaceState()
     }
 
-    # Make this test pending because of too many regressions in the latest .NET Core
-    # and thus we have to get back to an older .NET Core.
-    It "native | native | native should work fine" -Pending {
+    It "native | native | native should work fine" {
 
         if ($IsWindows) {
             $result = @(ping.exe | findstr.exe count | findstr.exe ping)

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ChildItem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ChildItem.Tests.ps1
@@ -66,7 +66,9 @@ Describe "Get-ChildItem" -Tags "CI" {
             $file.Count | Should be 1
             $file.Name | Should be $item_F
         }
-        It "Should continue enumerating a directory when a contained item is deleted" {
+        # Test is pending on Unix platforms because of a behavior change in the latest .NET Core.
+        # See https://github.com/dotnet/corefx/issues/20456 for more information.
+        It "Should continue enumerating a directory when a contained item is deleted" -Pending:(!$IsWindows) {
             $Error.Clear()
             [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook("GciEnumerationActionDelete", $true)
             $result = Get-ChildItem -Path $TestDrive -ErrorAction SilentlyContinue
@@ -84,7 +86,9 @@ Describe "Get-ChildItem" -Tags "CI" {
                 $result.Count | Should BeExactly 4
             }
         }
-        It "Should continue enumerating a directory when a contained item is renamed" {
+        # Test is pending on Unix platforms because of a behavior change in the latest .NET Core.
+        # See https://github.com/dotnet/corefx/issues/20456 for more information.
+        It "Should continue enumerating a directory when a contained item is renamed" -Pending:(!$IsWindows) {
             $Error.Clear()
             [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook("GciEnumerationActionRename", $true)
             $result = Get-ChildItem -Path $TestDrive -ErrorAction SilentlyContinue

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -507,9 +507,7 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
         $jsonContent.headers.'User-Agent' | Should Match "WindowsPowerShell"
     }
 
-    ## 'HttpClientHandler.ServerCertificateCustomValidationCallback' currently doesn't work in netcoreapp2.0 on Mac at all.
-    ## This is tracked by powershell issue #3648.
-    It "Validate Invoke-WebRequest -SkipCertificateCheck" -Pending:$IsOSX {
+    It "Validate Invoke-WebRequest -SkipCertificateCheck" {
 
         # validate that exception is thrown for URI with expired certificate
         $command = "Invoke-WebRequest -Uri 'https://expired.badssl.com'"
@@ -954,9 +952,7 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
         $jsonContent.headers.'User-Agent' | Should Match "WindowsPowerShell"
     }
 
-    ## 'HttpClientHandler.ServerCertificateCustomValidationCallback' currently doesn't work in netcoreapp2.0 on Mac at all.
-    ## This is tracked by powershell issue #3648.
-    It "Validate Invoke-RestMethod -SkipCertificateCheck" -Pending:$IsOSX {
+    It "Validate Invoke-RestMethod -SkipCertificateCheck" {
 
         # HTTP method HEAD must be used to not retrieve an unparsable HTTP body
         # validate that exception is thrown for URI with expired certificate

--- a/test/tools/TestExe/TestExe.csproj
+++ b/test/tools/TestExe/TestExe.csproj
@@ -1,9 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <Import Project="..\..\Test.Common.props"/>
-
   <PropertyGroup>
     <Description>Very simple little console class that you can use to for testing PowerShell interaction with native commands</Description>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <AssemblyName>testexe</AssemblyName>
     <OutputType>Exe</OutputType>
     <RuntimeIdentifiers>ubuntu.16.04-x64;ubuntu.14.04-x64;debian.8-x64;centos.7-x64;fedora.24-x64;win7-x86;win7-x64;win81-x64;win10-x64;osx.10.12-x64;opensuse.13.2-x64;opensuse.42.1-x64</RuntimeIdentifiers>

--- a/test/tools/TestExe/TestExe.csproj
+++ b/test/tools/TestExe/TestExe.csproj
@@ -1,11 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <Import Project="..\..\Test.Common.props"/>
+
   <PropertyGroup>
     <Description>Very simple little console class that you can use to for testing PowerShell interaction with native commands</Description>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
     <AssemblyName>testexe</AssemblyName>
     <OutputType>Exe</OutputType>
-    <RuntimeIdentifiers>ubuntu.16.04-x64;ubuntu.14.04-x64;debian.8-x64;centos.7-x64;fedora.24-x64;win7-x86;win7-x64;win81-x64;win10-x64;osx.10.11-x64;osx.10.12-x64;opensuse.13.2-x64;opensuse.42.1-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>ubuntu.16.04-x64;ubuntu.14.04-x64;debian.8-x64;centos.7-x64;fedora.24-x64;win7-x86;win7-x64;win81-x64;win10-x64;osx.10.12-x64;opensuse.13.2-x64;opensuse.42.1-x64</RuntimeIdentifiers>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Fix #3649

Summary
----------
Move PowerShell to .NET Core `2.0.0-preview3-25426-01` by explicitly specify the `RuntimeFrameworkVersion` in .csproj files. `2.0.0-preview3` CLI doesn't work (see https://github.com/dotnet/cli/issues/7013, it's closed but I don't think it should be), so we use .NET CLI `2.0.0-preview2-006502` for now.

Also add `test/Test.Common.props` to hold common properties for test projects.

Note
-----
I have verified the CoreFx issues listed in #3649 are fixed in this .NET Core version.
I have verified that `PackageManagement` and `PowerShellGet` tests are all passed.
I have verified that `Login-AzureRmAccount` from `AzureRM.Netcore` works in powershell with this .NET Core version. 