### PR TITLE
Allow passing $true/$false as parameter to script using -File

### DIFF
--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
@@ -858,6 +858,19 @@ namespace Microsoft.PowerShell
             // of the script to evaluate. If -file comes before -command, it will
             // treat -command as an argument to the script...
 
+            bool? GetBoolValue(string arg)
+            {
+                if (arg.Equals("$true", StringComparison.OrdinalIgnoreCase) || arg.Equals("true", StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+                else if (arg.Equals("$false", StringComparison.OrdinalIgnoreCase) || arg.Equals("false", StringComparison.OrdinalIgnoreCase))
+                {
+                    return false;
+                }
+                return null;
+            }
+
             ++i;
             if (i >= args.Length)
             {
@@ -922,7 +935,6 @@ namespace Microsoft.PowerShell
 
                 i++;
 
-                Regex argPattern = new Regex(@"^.\w+\:", RegexOptions.CultureInvariant);
                 string pendingParameter = null;
 
                 // Accumulate the arguments to this script...
@@ -939,17 +951,25 @@ namespace Microsoft.PowerShell
                     }
                     else if (!string.IsNullOrEmpty(arg) && SpecialCharacters.IsDash(arg[0]))
                     {
-                        Match m = argPattern.Match(arg);
-                        if (m.Success)
+                        int offset = arg.IndexOf(':');
+                        if (offset >= 0)
                         {
-                            int offset = arg.IndexOf(':');
                             if (offset == arg.Length - 1)
                             {
                                 pendingParameter = arg.TrimEnd(':');
                             }
                             else
                             {
-                                _collectedArgs.Add(new CommandParameter(arg.Substring(0, offset), arg.Substring(offset + 1)));
+                                string argValue = arg.Substring(offset + 1);
+                                bool? boolValue = GetBoolValue(argValue);
+                                if (boolValue != null)
+                                {
+                                        _collectedArgs.Add(new CommandParameter(arg.Substring(0, offset), boolValue));
+                                }
+                                else
+                                {
+                                        _collectedArgs.Add(new CommandParameter(arg.Substring(0, offset), argValue));
+                                }
                             }
                         }
                         else
@@ -959,7 +979,15 @@ namespace Microsoft.PowerShell
                     }
                     else
                     {
-                        _collectedArgs.Add(new CommandParameter(null, arg));
+                        bool? boolValue = GetBoolValue(arg);
+                        if (boolValue != null)
+                        {
+                            _collectedArgs.Add(new CommandParameter(null, boolValue));
+                        }
+                        else
+                        {
+                            _collectedArgs.Add(new CommandParameter(null, arg));
+                        }
                     }
                     ++i;
                 }

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
@@ -858,17 +858,20 @@ namespace Microsoft.PowerShell
             // of the script to evaluate. If -file comes before -command, it will
             // treat -command as an argument to the script...
 
-            bool? GetBoolValue(string arg)
+            bool TryGetBoolValue(string arg, out bool boolValue)
             {
                 if (arg.Equals("$true", StringComparison.OrdinalIgnoreCase) || arg.Equals("true", StringComparison.OrdinalIgnoreCase))
                 {
+                    boolValue = true;
                     return true;
                 }
                 else if (arg.Equals("$false", StringComparison.OrdinalIgnoreCase) || arg.Equals("false", StringComparison.OrdinalIgnoreCase))
                 {
-                    return false;
+                    boolValue = false;
+                    return true;
                 }
-                return null;
+                boolValue = false;
+                return false;
             }
 
             ++i;
@@ -961,14 +964,14 @@ namespace Microsoft.PowerShell
                             else
                             {
                                 string argValue = arg.Substring(offset + 1);
-                                bool? boolValue = GetBoolValue(argValue);
-                                if (boolValue != null)
+                                string argName = arg.Substring(0, offset);
+                                if (TryGetBoolValue(argValue, out bool boolValue))
                                 {
-                                        _collectedArgs.Add(new CommandParameter(arg.Substring(0, offset), boolValue));
+                                        _collectedArgs.Add(new CommandParameter(argName, boolValue));
                                 }
                                 else
                                 {
-                                        _collectedArgs.Add(new CommandParameter(arg.Substring(0, offset), argValue));
+                                        _collectedArgs.Add(new CommandParameter(argName, argValue));
                                 }
                             }
                         }
@@ -979,15 +982,7 @@ namespace Microsoft.PowerShell
                     }
                     else
                     {
-                        bool? boolValue = GetBoolValue(arg);
-                        if (boolValue != null)
-                        {
-                            _collectedArgs.Add(new CommandParameter(null, boolValue));
-                        }
-                        else
-                        {
-                            _collectedArgs.Add(new CommandParameter(null, arg));
-                        }
+                        _collectedArgs.Add(new CommandParameter(null, arg));
                     }
                     ++i;
                 }

--- a/test/powershell/Host/ConsoleHost.Tests.ps1
+++ b/test/powershell/Host/ConsoleHost.Tests.ps1
@@ -201,7 +201,39 @@ Describe "ConsoleHost unit tests" -tags "Feature" {
             $observed[1] | Should Be "bar"
         }
 
-        It "-File should return exit code from script: <Filename>" -TestCases @(
+        It "-File should be able to pass bool values as strings to parameters: <BoolString>" -TestCases @(
+            @{BoolString = '$truE';BoolValue = 'True'},
+            @{BoolString = '$falsE';BoolValue = 'False'},
+            @{BoolString = 'truE';BoolValue = 'True'},
+            @{BoolString = 'falsE';BoolValue = 'False'}
+         ) {
+            param([string]$BoolString, [string]$BoolValue)
+            Set-Content -Path $testdrive/test.ps1 -Value 'param([bool]$bool) $bool'
+            $observed = & $powershell -NoProfile -Nologo -File $testdrive/test.ps1 -Bool $BoolString
+            $observed | Should Be $BoolValue
+        }
+
+        It "-File should be able to pass bool values as strings to positional parameters: <BoolString>" -TestCases @(
+            @{BoolString = '$true'; BoolValue = 'True'},
+            @{BoolString = '$false'; BoolValue = 'False'}
+        ) {
+            param([string]$BoolString, [string]$BoolValue)
+            Set-Content -Path $testdrive/test.ps1 -Value 'param([bool]$bool) $bool'
+            $observed = & $powershell -NoProfile -Nologo -File $testdrive/test.ps1 $BoolString
+            $observed | Should Be $BoolValue
+        }
+
+        It "-File should be able to pass bool values as strings to switches: <BoolString>" -TestCases @(
+            @{BoolString = '$true'; BoolValue = 'True'},
+            @{BoolString = '$false'; BoolValue = 'False'}
+        ) {
+            param([string]$BoolString, [string]$BoolValue)
+            Set-Content -Path $testdrive/test.ps1 -Value 'param([switch]$switch) $switch.IsPresent'
+            $observed = & $powershell -NoProfile -Nologo -File $testdrive/test.ps1 -switch:$BoolString
+            $observed | Should Be $BoolValue
+        }
+
+        It "-File should return exit code from script"  -TestCases @(
             @{Filename = "test.ps1"},
             @{Filename = "test"}
         ) {

--- a/test/powershell/Host/ConsoleHost.Tests.ps1
+++ b/test/powershell/Host/ConsoleHost.Tests.ps1
@@ -201,31 +201,37 @@ Describe "ConsoleHost unit tests" -tags "Feature" {
             $observed[1] | Should Be "bar"
         }
 
-        It "-File should be able to pass bool values as strings to parameters: <BoolString>" -TestCases @(
-            @{BoolString = '$truE';BoolValue = 'True'},
-            @{BoolString = '$falsE';BoolValue = 'False'},
-            @{BoolString = 'truE';BoolValue = 'True'},
-            @{BoolString = 'falsE';BoolValue = 'False'}
-         ) {
-            param([string]$BoolString, [string]$BoolValue)
-            Set-Content -Path $testdrive/test.ps1 -Value 'param([bool]$bool) $bool'
-            $observed = & $powershell -NoProfile -Nologo -File $testdrive/test.ps1 -Bool $BoolString
-            $observed | Should Be $BoolValue
-        }
-
-        It "-File should be able to pass bool values as strings to positional parameters: <BoolString>" -TestCases @(
-            @{BoolString = '$true'; BoolValue = 'True'},
-            @{BoolString = '$false'; BoolValue = 'False'}
+        It "-File should be able to pass bool string values as string to parameters: <BoolString>" -TestCases @(
+            # validates case is preserved
+            @{BoolString = '$truE'},
+            @{BoolString = '$falSe'},
+            @{BoolString = 'trUe'},
+            @{BoolString = 'faLse'}
         ) {
-            param([string]$BoolString, [string]$BoolValue)
-            Set-Content -Path $testdrive/test.ps1 -Value 'param([bool]$bool) $bool'
-            $observed = & $powershell -NoProfile -Nologo -File $testdrive/test.ps1 $BoolString
-            $observed | Should Be $BoolValue
+            param([string]$BoolString)
+            Set-Content -Path $testdrive/test.ps1 -Value 'param([string]$bool) $bool'
+            $observed = & $powershell -NoProfile -Nologo -File $testdrive/test.ps1 -Bool $BoolString
+            $observed | Should Be $BoolString
         }
 
-        It "-File should be able to pass bool values as strings to switches: <BoolString>" -TestCases @(
-            @{BoolString = '$true'; BoolValue = 'True'},
-            @{BoolString = '$false'; BoolValue = 'False'}
+        It "-File should be able to pass bool string values as string to positional parameters: <BoolString>" -TestCases @(
+            # validates case is preserved
+            @{BoolString = '$tRue'},
+            @{BoolString = '$falSe'},
+            @{BoolString = 'tRUe'},
+            @{BoolString = 'fALse'}
+        ) {
+            param([string]$BoolString)
+            Set-Content -Path $testdrive/test.ps1 -Value 'param([string]$bool) $bool'
+            $observed = & $powershell -NoProfile -Nologo -File $testdrive/test.ps1 $BoolString
+            $observed | Should BeExactly $BoolString
+        }
+
+        It "-File should be able to pass bool string values as bool to switches: <BoolString>" -TestCases @(
+            @{BoolString = '$tRue'; BoolValue = 'True'},
+            @{BoolString = '$faLse'; BoolValue = 'False'},
+            @{BoolString = 'tRue'; BoolValue = 'True'},
+            @{BoolString = 'fAlse'; BoolValue = 'False'}
         ) {
             param([string]$BoolString, [string]$BoolValue)
             Set-Content -Path $testdrive/test.ps1 -Value 'param([switch]$switch) $switch.IsPresent'


### PR DESCRIPTION
Using powershell.exe to execute a PowerShell script using `-File` currently provides no way to pass $true/$false as parameter values.  Current behavior is that `-File` accumulates passed parameters as strings only.

Fix is to special case this based on discussion with PS-Committee to support $true/$false as parsed values to parameters.  Switch values is also supported as currently documented syntax doesn't work.

Fix https://github.com/PowerShell/PowerShell/issues/4036

Doc change is https://github.com/PowerShell/PowerShell-Docs/pull/1430

<!--

If you are a PowerShell Team member, please make sure you choose the Reviewer(s) and Assignee for your PR.
If you are not from the PowerShell Team, you can leave the fields blank and the Maintainers will choose them for you. If you are familiar with the team, feel free to mention some Reviewers yourself.

For more information about the roles of Reviewer and Assignee, refer to CONTRIBUTING.md.

-->
