### PR TITLE
Refactor MSBuild project files to get PowerShell version from git tag

### DIFF
--- a/PowerShell.Common.props
+++ b/PowerShell.Common.props
@@ -43,18 +43,19 @@
       <PSCoreFormattedVersion Condition = "'$(ReleaseTag)' != '' or '$(PSCoreAdditionalCommits)' == '0'">$(PSCoreBuildVersion) SHA: $(PSCoreCommitSHA)</PSCoreFormattedVersion>
       <PSCoreFormattedVersion Condition = "'$(PSCoreFormattedVersion)' == ''">$(PSCoreBuildVersion) Commits: $(PSCoreAdditionalCommits) SHA: $(PSCoreCommitSHA)</PSCoreFormattedVersion>
 
-      <ProductVersion>$(PSCoreFormattedVersion)</ProductVersion>
       <!--
-            Here we define explicitly 'Version' to set 'FileVersion' by 'GetAssemblyVersion' target in 'Microsoft.NET.GenerateAssemblyInfo.targets'.
+            Here we define explicitly 'Version' to set 'FileVersion' and 'AssemblyVersion' by 'GetAssemblyVersion' target in 'Microsoft.NET.GenerateAssemblyInfo.targets'.
             Here we define explicitly 'InformationalVersion' because by default it is defined as 'Version' by 'GetAssemblyVersion' target in 'Microsoft.NET.GenerateAssemblyInfo.targets'.
       -->
       <Version>$(PSCoreBuildVersion)</Version>
       <InformationalVersion>$(PSCoreFormattedVersion)</InformationalVersion>
+      <ProductVersion>$(PSCoreFormattedVersion)</ProductVersion>
 
       <!--
             We have explicitly assign 'PackageVersion'
             because there is a bug: 'PackageVersion' is correctly assigned as 'Version' in 'NuGet.targets'
             but then immediately redefined as '1.0.0'.
+            Tracking Issue https://github.com/dotnet/sdk/issues/1557
       -->
       <PackageVersion>$(PSCoreBuildVersion)</PackageVersion>
 
@@ -71,7 +72,6 @@
                PSCoreMinorVersion = $(PSCoreMinorVersion);
                PSCorePatchVersion = $(PSCorePatchVersion);
                PSCoreLabelVersion = $(PSCoreLabelVersion);
-               GitCDUP = $(GitCDUP);
                RegexGitVersion = $(RegexGitVersion);
                PSCoreFormattedVersion = $(PSCoreFormattedVersion);
                ProductVersion = $(ProductVersion);

--- a/PowerShell.Common.props
+++ b/PowerShell.Common.props
@@ -1,16 +1,16 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <!--
-        We should ~explicitly~ assign versions properties in the target
+        We should *explicitly* assign version properties in this target
         because:
-          1. By default the version properties defined in global PropertyGroup (not target!) in 'Microsoft.NET.DefaultAssemblyInfo.targets'
-          2. Properties in global 'PropertyGroups' is assigned before any targets
+          1. By default the version properties are defined in global 'PropertyGroup' (not target!) in 'Microsoft.NET.DefaultAssemblyInfo.targets'
+          2. Properties in global 'PropertyGroups' are assigned before any targets
           3. and cannot be conditionally excecuted as targets (after this target).
 
-        To assign versions properties we should excecute the target:
-          '_GenerateRestoreProjectSpec' - before 'Restore' target
-          'GenerateNuspec'              - before 'Pack' target
-          'BeforeBuild'                 - before 'Build' target
+        To assign version properties we should excecute this target:
+          before 'Restore' target - '_GenerateRestoreProjectSpec'
+          before 'Pack' target    - 'GenerateNuspec'
+          before 'Build' target   - 'BeforeBuild'
   -->
   <Target Name="GetPSCoreVersionFromGit"
     BeforeTargets="_GenerateRestoreProjectSpec;GenerateNuspec;BeforeBuild"
@@ -33,15 +33,18 @@
       <PSCoreAdditionalCommits>$([System.Text.RegularExpressions.Regex]::Match($(PowerShellVersion), $(RegexGitVersion)).Groups[2].Value)</PSCoreAdditionalCommits>
       <PSCoreCommitSHA>$([System.Text.RegularExpressions.Regex]::Match($(PowerShellVersion), $(RegexGitVersion)).Groups[3].Value)</PSCoreCommitSHA>
 
-      <RegexSymVer>^((\d+).(\d+).(\d+))(?:-(.+))?</RegexSymVer>
-      <PSCorePrefixVersion>$([System.Text.RegularExpressions.Regex]::Match($(PSCoreBuildVersion), $(RegexSymVer)).Groups[1].Value)</PSCorePrefixVersion>
-      <PSCoreMajorVersion>$([System.Text.RegularExpressions.Regex]::Match($(PSCoreBuildVersion), $(RegexSymVer)).Groups[2].Value)</PSCoreMajorVersion>
-      <PSCoreMinorVersion>$([System.Text.RegularExpressions.Regex]::Match($(PSCoreBuildVersion), $(RegexSymVer)).Groups[3].Value)</PSCoreMinorVersion>
-      <PSCorePatchVersion>$([System.Text.RegularExpressions.Regex]::Match($(PSCoreBuildVersion), $(RegexSymVer)).Groups[4].Value)</PSCorePatchVersion>
-      <PSCoreLabelVersion>$([System.Text.RegularExpressions.Regex]::Match($(PSCoreBuildVersion), $(RegexSymVer)).Groups[5].Value)</PSCoreLabelVersion>
-
       <PSCoreFormattedVersion Condition = "'$(ReleaseTag)' != '' or '$(PSCoreAdditionalCommits)' == '0'">$(PSCoreBuildVersion) SHA: $(PSCoreCommitSHA)</PSCoreFormattedVersion>
       <PSCoreFormattedVersion Condition = "'$(PSCoreFormattedVersion)' == ''">$(PSCoreBuildVersion) Commits: $(PSCoreAdditionalCommits) SHA: $(PSCoreCommitSHA)</PSCoreFormattedVersion>
+
+      <!-- Extract the major, minor and patch version numbers, as well as the preview label.
+           They are currently not used anywhere, so we comment them out for now.
+        <RegexSymVer>^((\d+).(\d+).(\d+))(?:-(.+))?</RegexSymVer>
+        <PSCorePrefixVersion>$([System.Text.RegularExpressions.Regex]::Match($(PSCoreBuildVersion), $(RegexSymVer)).Groups[1].Value)</PSCorePrefixVersion>
+        <PSCoreMajorVersion>$([System.Text.RegularExpressions.Regex]::Match($(PSCoreBuildVersion), $(RegexSymVer)).Groups[2].Value)</PSCoreMajorVersion>
+        <PSCoreMinorVersion>$([System.Text.RegularExpressions.Regex]::Match($(PSCoreBuildVersion), $(RegexSymVer)).Groups[3].Value)</PSCoreMinorVersion>
+        <PSCorePatchVersion>$([System.Text.RegularExpressions.Regex]::Match($(PSCoreBuildVersion), $(RegexSymVer)).Groups[4].Value)</PSCorePatchVersion>
+        <PSCoreLabelVersion>$([System.Text.RegularExpressions.Regex]::Match($(PSCoreBuildVersion), $(RegexSymVer)).Groups[5].Value)</PSCoreLabelVersion>
+      -->
 
       <!--
             Here we define explicitly 'Version' to set 'FileVersion' and 'AssemblyVersion' by 'GetAssemblyVersion' target in 'Microsoft.NET.GenerateAssemblyInfo.targets'.
@@ -61,7 +64,7 @@
 
     </PropertyGroup>
 
-   <!-- for debug output
+    <!-- Output For Debugging
       <WriteLinesToFile File="targetfile1.txt"
         Lines="ReleaseTag=$(ReleaseTag);
                PowerShellVersion=$(PowerShellVersion);
@@ -79,7 +82,8 @@
                ProjectVersion = '!$(ProjectVersion)!'
                InformationalVersion = $(InformationalVersion);
               "
-        Overwrite="true"/-->
+        Overwrite="true" />
+    -->
 
   </Target>
 
@@ -99,7 +103,6 @@
     <DelaySign>true</DelaySign>
     <AssemblyOriginatorKeyFile>../signing/visualstudiopublic.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
-
   </PropertyGroup>
 
 </Project>

--- a/PowerShell.Common.props
+++ b/PowerShell.Common.props
@@ -7,7 +7,7 @@
           2. Properties in global 'PropertyGroups' is assigned before any targets
           3. and cannot be conditionally excecuted as targets (after this target).
 
-        To assign vertions properties we should excecute the target:
+        To assign versions properties we should excecute the target:
           '_GenerateRestoreProjectSpec' - before 'Restore' target
           'GenerateNuspec'              - before 'Pack' target
           'BeforeBuild'                 - before 'Build' target
@@ -28,14 +28,23 @@
       <GitInfoBaseDir Condition="'$(GitInfoBaseDir)' == ''">$(MSBuildProjectDirectory)/$(GitCDUP)/.git</GitInfoBaseDir>
     </PropertyGroup>
 
-    <Exec Command='$(GitExe) --git-dir="$(GitInfoBaseDir)" describe --abbrev=60 --long' ConsoleToMSBuild="true" EchoOff="true">
+    <Exec Command='$(GitExe) --git-dir="$(GitInfoBaseDir)" describe --abbrev=60 --long'
+          ConsoleToMSBuild="true"
+          EchoOff="true">
       <Output TaskParameter="ConsoleOutput" PropertyName="PowerShellVersion" />
     </Exec>
 
     <PropertyGroup>
       <RegexGitVersion>^v(.+)-(\d+)-g(.+)</RegexGitVersion>
-      <PSCoreBuildVersion>$([System.Text.RegularExpressions.Regex]::Match($(PowerShellVersion), $(RegexGitVersion)).Groups[1].Value)</PSCoreBuildVersion>
+    </PropertyGroup>
+
+    <PropertyGroup Condition = "'$(ReleaseTag)' != ''">
+      <PSCoreBuildVersion>$(ReleaseTag)</PSCoreBuildVersion>
       <PSCoreAdditionalCommits>$([System.Text.RegularExpressions.Regex]::Match($(PowerShellVersion), $(RegexGitVersion)).Groups[2].Value)</PSCoreAdditionalCommits>
+    </PropertyGroup>
+
+    <PropertyGroup>
+      <PSCoreBuildVersion Condition = "'$(PSCoreBuildVersion)' == ''">$([System.Text.RegularExpressions.Regex]::Match($(PowerShellVersion), $(RegexGitVersion)).Groups[1].Value)</PSCoreBuildVersion>
       <PSCoreCommitSHA>$([System.Text.RegularExpressions.Regex]::Match($(PowerShellVersion), $(RegexGitVersion)).Groups[3].Value)</PSCoreCommitSHA>
 
       <RegexSymVer>^((\d+).(\d+).(\d+))(?:-(.+))?</RegexSymVer>
@@ -45,7 +54,7 @@
       <PSCorePatchVersion>$([System.Text.RegularExpressions.Regex]::Match($(PSCoreBuildVersion), $(RegexSymVer)).Groups[4].Value)</PSCorePatchVersion>
       <PSCoreLabelVersion>$([System.Text.RegularExpressions.Regex]::Match($(PSCoreBuildVersion), $(RegexSymVer)).Groups[5].Value)</PSCoreLabelVersion>
 
-      <PSCoreFormattedVersion Condition = "'$(PSCoreAdditionalCommits)' == '0'">$(PSCoreBuildVersion) SHA: $(PSCoreCommitSHA)</PSCoreFormattedVersion>
+      <PSCoreFormattedVersion Condition = "'$(ReleaseTag)' != '' or '$(PSCoreAdditionalCommits)' == '0'">$(PSCoreBuildVersion) SHA: $(PSCoreCommitSHA)</PSCoreFormattedVersion>
       <PSCoreFormattedVersion Condition = "'$(PSCoreFormattedVersion)' == ''">$(PSCoreBuildVersion) Commits: $(PSCoreAdditionalCommits) SHA: $(PSCoreCommitSHA)</PSCoreFormattedVersion>
 
       <ProductVersion>$(PSCoreFormattedVersion)</ProductVersion>
@@ -69,8 +78,9 @@
     </PropertyGroup>
 
    <!-- for debug output
-        WriteLinesToFile File="targetfile1.txt"
-        Lines="PowerShellVersion=$(PowerShellVersion);
+      <WriteLinesToFile File="targetfile1.txt"
+        Lines="ReleaseTag=$(ReleaseTag);
+               PowerShellVersion=$(PowerShellVersion);
                PSCoreBuildVersion = $(PSCoreBuildVersion);
                PSCoreAdditionalCommits = $(PSCoreAdditionalCommits);
                PSCoreCommitSHA = $(PSCoreCommitSHA);

--- a/PowerShell.Common.props
+++ b/PowerShell.Common.props
@@ -16,35 +16,21 @@
     BeforeTargets="_GenerateRestoreProjectSpec;GenerateNuspec;BeforeBuild"
   >
 
-    <PropertyGroup>
-      <GitExe>git</GitExe>
-    </PropertyGroup>
-
-    <Exec Command='$(GitExe) rev-parse --show-cdup' ConsoleToMSBuild="true">
-      <Output TaskParameter="ConsoleOutput" PropertyName="GitCDUP" />
-    </Exec>
-
-    <PropertyGroup>
-      <GitInfoBaseDir Condition="'$(GitInfoBaseDir)' == ''">$(MSBuildProjectDirectory)/$(GitCDUP)/.git</GitInfoBaseDir>
-    </PropertyGroup>
-
-    <Exec Command='$(GitExe) --git-dir="$(GitInfoBaseDir)" describe --abbrev=60 --long'
+    <Exec Command='git describe --abbrev=60 --long'
+          WorkingDirectory=$(MSBuildProjectDirectory)
           ConsoleToMSBuild="true"
-          EchoOff="true">
+          StandardOutputImportance="Low">
       <Output TaskParameter="ConsoleOutput" PropertyName="PowerShellVersion" />
     </Exec>
 
-    <PropertyGroup>
-      <RegexGitVersion>^v(.+)-(\d+)-g(.+)</RegexGitVersion>
-    </PropertyGroup>
-
     <PropertyGroup Condition = "'$(ReleaseTag)' != ''">
       <PSCoreBuildVersion>$(ReleaseTag)</PSCoreBuildVersion>
-      <PSCoreAdditionalCommits>$([System.Text.RegularExpressions.Regex]::Match($(PowerShellVersion), $(RegexGitVersion)).Groups[2].Value)</PSCoreAdditionalCommits>
     </PropertyGroup>
 
     <PropertyGroup>
+      <RegexGitVersion>^v(.+)-(\d+)-g(.+)</RegexGitVersion>
       <PSCoreBuildVersion Condition = "'$(PSCoreBuildVersion)' == ''">$([System.Text.RegularExpressions.Regex]::Match($(PowerShellVersion), $(RegexGitVersion)).Groups[1].Value)</PSCoreBuildVersion>
+      <PSCoreAdditionalCommits>$([System.Text.RegularExpressions.Regex]::Match($(PowerShellVersion), $(RegexGitVersion)).Groups[2].Value)</PSCoreAdditionalCommits>
       <PSCoreCommitSHA>$([System.Text.RegularExpressions.Regex]::Match($(PowerShellVersion), $(RegexGitVersion)).Groups[3].Value)</PSCoreCommitSHA>
 
       <RegexSymVer>^((\d+).(\d+).(\d+))(?:-(.+))?</RegexSymVer>

--- a/PowerShell.Common.props
+++ b/PowerShell.Common.props
@@ -1,13 +1,13 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <!--
-        We should *explicitly* assign version properties in this target
-        because:
-          1. By default the version properties are defined in global 'PropertyGroup' (not target!) in 'Microsoft.NET.DefaultAssemblyInfo.targets'
-          2. Properties in global 'PropertyGroups' are assigned before any targets
-          3. and cannot be conditionally excecuted as targets (after this target).
+        We should *explicitly* re-assign version properties in this target
+        because by default the version properties are defined in 'PropertyGroup' (not target!)
+        in 'Microsoft.NET.DefaultAssemblyInfo.targets' *before* any targets.
+        (the 'PropertyGroup' in 'Microsoft.NET.DefaultAssemblyInfo.targets' cannot be conditionally
+        executed after this target.)
 
-        To assign version properties we should excecute this target:
+        To re-assign version properties we should excecute this target:
           before 'Restore' target - '_GenerateRestoreProjectSpec'
           before 'Pack' target    - 'GenerateNuspec'
           before 'Build' target   - 'BeforeBuild'

--- a/PowerShell.Common.props
+++ b/PowerShell.Common.props
@@ -17,7 +17,7 @@
   >
 
     <Exec Command='git describe --abbrev=60 --long'
-          WorkingDirectory=$(MSBuildProjectDirectory)
+          WorkingDirectory="$(MSBuildProjectDirectory)"
           ConsoleToMSBuild="true"
           StandardOutputImportance="Low">
       <Output TaskParameter="ConsoleOutput" PropertyName="PowerShellVersion" />
@@ -50,9 +50,6 @@
       -->
       <Version>$(PSCoreBuildVersion)</Version>
       <InformationalVersion>$(PSCoreFormattedVersion)</InformationalVersion>
-
-      <!--VersionPrefix>$(PSCorePrefixVersion)</VersionPrefix-->
-      <!--VersionSuffix>$(PSCoreLabelVersion)</VersionSuffix-->
 
       <!--
             We have explicitly assign 'PackageVersion'

--- a/PowerShell.Common.props
+++ b/PowerShell.Common.props
@@ -1,16 +1,14 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <!--
-        We should *explicitly* re-assign version properties in this target
-        because by default the version properties are defined in 'PropertyGroup' (not target!)
-        in 'Microsoft.NET.DefaultAssemblyInfo.targets' *before* any targets.
-        (the 'PropertyGroup' in 'Microsoft.NET.DefaultAssemblyInfo.targets' cannot be conditionally
-        executed after this target.)
+      The 'version' property is populated with the default value in 'Microsoft.NET.DefaultAssemblyInfo.targets'
+      *before* any targets get a chance to execute.
+      We need to *explicitly* re-assign the 'version' property and other version tags in this target.
 
-        To re-assign version properties we should excecute this target:
-          before 'Restore' target - '_GenerateRestoreProjectSpec'
-          before 'Pack' target    - 'GenerateNuspec'
-          before 'Build' target   - 'BeforeBuild'
+      In order for the versions assigned here to take effect, we need to execute this target at an early stage:
+        before 'Restore' target - '_GenerateRestoreProjectSpec'
+        before 'Pack' target    - 'GenerateNuspec'
+        before 'Build' target   - 'BeforeBuild'
   -->
   <Target Name="GetPSCoreVersionFromGit"
     BeforeTargets="_GenerateRestoreProjectSpec;GenerateNuspec;BeforeBuild"

--- a/PowerShell.Common.props
+++ b/PowerShell.Common.props
@@ -1,10 +1,100 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <!--
+        We should ~explicitly~ assign versions properties in the target
+        because:
+          1. By default the version properties defined in global PropertyGroup (not target!) in 'Microsoft.NET.DefaultAssemblyInfo.targets'
+          2. Properties in global 'PropertyGroups' is assigned before any targets
+          3. and cannot be conditionally excecuted as targets (after this target).
+
+        To assign vertions properties we should excecute the target:
+          '_GenerateRestoreProjectSpec' - before 'Restore' target
+          'GenerateNuspec'              - before 'Pack' target
+          'BeforeBuild'                 - before 'Build' target
+  -->
+  <Target Name="GetPSCoreVersionFromGit"
+    BeforeTargets="_GenerateRestoreProjectSpec;GenerateNuspec;BeforeBuild"
+  >
+
+    <PropertyGroup>
+      <GitExe>git</GitExe>
+    </PropertyGroup>
+
+    <Exec Command='$(GitExe) rev-parse --show-cdup' ConsoleToMSBuild="true">
+      <Output TaskParameter="ConsoleOutput" PropertyName="GitCDUP" />
+    </Exec>
+
+    <PropertyGroup>
+      <GitInfoBaseDir Condition="'$(GitInfoBaseDir)' == ''">$(MSBuildProjectDirectory)/$(GitCDUP)/.git</GitInfoBaseDir>
+    </PropertyGroup>
+
+    <Exec Command='$(GitExe) --git-dir="$(GitInfoBaseDir)" describe --abbrev=60 --long' ConsoleToMSBuild="true" EchoOff="true">
+      <Output TaskParameter="ConsoleOutput" PropertyName="PowerShellVersion" />
+    </Exec>
+
+    <PropertyGroup>
+      <RegexGitVersion>^v(.+)-(\d+)-g(.+)</RegexGitVersion>
+      <PSCoreBuildVersion>$([System.Text.RegularExpressions.Regex]::Match($(PowerShellVersion), $(RegexGitVersion)).Groups[1].Value)</PSCoreBuildVersion>
+      <PSCoreAdditionalCommits>$([System.Text.RegularExpressions.Regex]::Match($(PowerShellVersion), $(RegexGitVersion)).Groups[2].Value)</PSCoreAdditionalCommits>
+      <PSCoreCommitSHA>$([System.Text.RegularExpressions.Regex]::Match($(PowerShellVersion), $(RegexGitVersion)).Groups[3].Value)</PSCoreCommitSHA>
+
+      <RegexSymVer>^((\d+).(\d+).(\d+))(?:-(.+))?</RegexSymVer>
+      <PSCorePrefixVersion>$([System.Text.RegularExpressions.Regex]::Match($(PSCoreBuildVersion), $(RegexSymVer)).Groups[1].Value)</PSCorePrefixVersion>
+      <PSCoreMajorVersion>$([System.Text.RegularExpressions.Regex]::Match($(PSCoreBuildVersion), $(RegexSymVer)).Groups[2].Value)</PSCoreMajorVersion>
+      <PSCoreMinorVersion>$([System.Text.RegularExpressions.Regex]::Match($(PSCoreBuildVersion), $(RegexSymVer)).Groups[3].Value)</PSCoreMinorVersion>
+      <PSCorePatchVersion>$([System.Text.RegularExpressions.Regex]::Match($(PSCoreBuildVersion), $(RegexSymVer)).Groups[4].Value)</PSCorePatchVersion>
+      <PSCoreLabelVersion>$([System.Text.RegularExpressions.Regex]::Match($(PSCoreBuildVersion), $(RegexSymVer)).Groups[5].Value)</PSCoreLabelVersion>
+
+      <PSCoreFormattedVersion Condition = "'$(PSCoreAdditionalCommits)' == '0'">$(PSCoreBuildVersion) SHA: $(PSCoreCommitSHA)</PSCoreFormattedVersion>
+      <PSCoreFormattedVersion Condition = "'$(PSCoreFormattedVersion)' == ''">$(PSCoreBuildVersion) Commits: $(PSCoreAdditionalCommits) SHA: $(PSCoreCommitSHA)</PSCoreFormattedVersion>
+
+      <ProductVersion>$(PSCoreFormattedVersion)</ProductVersion>
+      <!--
+            Here we define explicitly 'Version' to set 'FileVersion' by 'GetAssemblyVersion' target in 'Microsoft.NET.GenerateAssemblyInfo.targets'.
+            Here we define explicitly 'InformationalVersion' because by default it is defined as 'Version' by 'GetAssemblyVersion' target in 'Microsoft.NET.GenerateAssemblyInfo.targets'.
+      -->
+      <Version>$(PSCoreBuildVersion)</Version>
+      <InformationalVersion>$(PSCoreFormattedVersion)</InformationalVersion>
+
+      <!--VersionPrefix>$(PSCorePrefixVersion)</VersionPrefix-->
+      <!--VersionSuffix>$(PSCoreLabelVersion)</VersionSuffix-->
+
+      <!--
+            We have explicitly assign 'PackageVersion'
+            because there is a bug: 'PackageVersion' is correctly assigned as 'Version' in 'NuGet.targets'
+            but then immediately redefined as '1.0.0'.
+      -->
+      <PackageVersion>$(PSCoreBuildVersion)</PackageVersion>
+
+    </PropertyGroup>
+
+   <!-- for debug output
+        WriteLinesToFile File="targetfile1.txt"
+        Lines="PowerShellVersion=$(PowerShellVersion);
+               PSCoreBuildVersion = $(PSCoreBuildVersion);
+               PSCoreAdditionalCommits = $(PSCoreAdditionalCommits);
+               PSCoreCommitSHA = $(PSCoreCommitSHA);
+               PSCoreMajorVersion = $(PSCoreMajorVersion);
+               PSCoreMinorVersion = $(PSCoreMinorVersion);
+               PSCorePatchVersion = $(PSCorePatchVersion);
+               PSCoreLabelVersion = $(PSCoreLabelVersion);
+               GitCDUP = $(GitCDUP);
+               RegexGitVersion = $(RegexGitVersion);
+               PSCoreFormattedVersion = $(PSCoreFormattedVersion);
+               ProductVersion = $(ProductVersion);
+               Version = $(Version);
+               ProjectVersion = '!$(ProjectVersion)!'
+               InformationalVersion = $(InformationalVersion);
+              "
+        Overwrite="true"/-->
+
+  </Target>
+
   <PropertyGroup>
     <Product>PowerShell Core</Product>
     <Company>Microsoft Corporation</Company>
     <Copyright>(c) Microsoft Corporation. All rights reserved.</Copyright>
 
-    <VersionPrefix>6.0.0</VersionPrefix>
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <RuntimeFrameworkVersion>2.0.0</RuntimeFrameworkVersion>
 
@@ -16,5 +106,7 @@
     <DelaySign>true</DelaySign>
     <AssemblyOriginatorKeyFile>../signing/visualstudiopublic.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
+
   </PropertyGroup>
+
 </Project>

--- a/build.psm1
+++ b/build.psm1
@@ -51,6 +51,8 @@ function Sync-PSTags
 # Gets the latest tag for the current branch
 function Get-PSLatestTag
 {
+    [CmdletBinding()]
+    param()
     # This function won't always return the correct value unless tags have been sync'ed
     # So, Write a warning to run Sync-PSTags
     if(!$tagsUpToDate)
@@ -63,6 +65,7 @@ function Get-PSLatestTag
 
 function Get-PSVersion
 {
+    [CmdletBinding()]
     param(
         [switch]
         $OmitCommitId
@@ -79,6 +82,8 @@ function Get-PSVersion
 
 function Get-PSCommitId
 {
+    [CmdletBinding()]
+    param()
     # This function won't always return the correct value unless tags have been sync'ed
     # So, Write a warning to run Sync-PSTags
     if(!$tagsUpToDate)
@@ -339,7 +344,7 @@ function Start-PSBuild {
     $gitCommitId = $ReleaseTag
     if (-not $gitCommitId) {
         # if ReleaseTag is not specified, use 'git describe' to get the commit id
-        $gitCommitId = Get-PSCommitId
+        $gitCommitId = Get-PSCommitId -WarningAction SilentlyContinue
     }
     $gitCommitId > "$psscriptroot/powershell.version"
 
@@ -417,8 +422,8 @@ Fix steps:
     }
 
     if ($ReleaseTag) {
-        $ReleaseTag1 = $ReleaseTag -Replace '^v'
-        $Arguments += "/property:ReleaseTag=$ReleaseTag1"
+        $ReleaseTagToUse = $ReleaseTag -Replace '^v'
+        $Arguments += "/property:ReleaseTag=$ReleaseTagToUse"
     }
 
     # handle Restore
@@ -1336,8 +1341,8 @@ function Publish-NuGetFeed
     ## We update 'project.assets.json' files with new version tag value by 'GetPSCoreVersionFromGit' target.
     $TopProject = (New-PSOptions).Top
     if ($ReleaseTag) {
-        $ReleaseTag1 = $ReleaseTag -Replace '^v'
-        dotnet restore $TopProject "/property:ReleaseTag=$ReleaseTag1"
+        $ReleaseTagToUse = $ReleaseTag -Replace '^v'
+        dotnet restore $TopProject "/property:ReleaseTag=$ReleaseTagToUse"
     } else {
         dotnet restore $TopProject
     }
@@ -1358,7 +1363,7 @@ function Publish-NuGetFeed
 'Microsoft.PowerShell.SDK'
         ) | ForEach-Object {
             if ($ReleaseTag) {
-                dotnet pack "src/$_" --output $OutputPath "/property:IncludeSymbols=true;ReleaseTag=$ReleaseTag1"
+                dotnet pack "src/$_" --output $OutputPath "/property:IncludeSymbols=true;ReleaseTag=$ReleaseTagToUse"
             } else {
                 dotnet pack "src/$_" --output $OutputPath
             }

--- a/build.psm1
+++ b/build.psm1
@@ -1325,7 +1325,6 @@ function Publish-NuGetFeed
 {
     param(
         [string]$OutputPath = "$PSScriptRoot/nuget-artifacts",
-        [Parameter(ParameterSetName = "ReleaseTag")]
         [ValidatePattern("^v\d+\.\d+\.\d+(-\w+\.\d+)?$")]
         [ValidateNotNullOrEmpty()]
         [string]$ReleaseTag
@@ -1334,10 +1333,6 @@ function Publish-NuGetFeed
     # Add .NET CLI tools to PATH
     Find-Dotnet
 
-    ## NuGet/Home #3953, #4337 -- dotnet pack - version suffix missing from ProjectReference
-    ## Workaround:
-    ##   dotnet restore /p:VersionSuffix=<suffix> # Bake the suffix into project.assets.json
-    ##   dotnet pack --version-suffix <suffix>
     ## We update 'project.assets.json' files with new version tag value by 'GetPSCoreVersionFromGit' target.
     $TopProject = (New-PSOptions).Top
     if ($ReleaseTag) {

--- a/build.psm1
+++ b/build.psm1
@@ -1319,22 +1319,14 @@ function Start-PSBootstrap {
 function Publish-NuGetFeed
 {
     param(
-        [string]$OutputPath = "$PSScriptRoot/nuget-artifacts",
-        [Parameter(Mandatory=$true)]
-        [string]$VersionSuffix
+        [string]$OutputPath = "$PSScriptRoot/nuget-artifacts"
     )
 
     # Add .NET CLI tools to PATH
     Find-Dotnet
 
-    if ($VersionSuffix) {
-        ## NuGet/Home #3953, #4337 -- dotnet pack - version suffix missing from ProjectReference
-        ## Workaround:
-        ##   dotnet restore /p:VersionSuffix=<suffix> # Bake the suffix into project.assets.json
-        ##   dotnet pack --version-suffix <suffix>
-        $TopProject = (New-PSOptions).Top
-        dotnet restore $TopProject "/p:VersionSuffix=$VersionSuffix"
-    }
+    # Update 'project.assets.json' files with new version tag value.
+    dotnet restore $TopProject
 
     try {
         Push-Location $PSScriptRoot

--- a/build.psm1
+++ b/build.psm1
@@ -1358,7 +1358,7 @@ function Publish-NuGetFeed
 'Microsoft.PowerShell.SDK'
         ) | ForEach-Object {
             if ($ReleaseTag) {
-                dotnet pack "src/$_" --output $OutputPath "/property:ReleaseTag=$ReleaseTag1" /p:IncludeSymbols=true
+                dotnet pack "src/$_" --output $OutputPath "/property:IncludeSymbols=true;ReleaseTag=$ReleaseTag1"
             } else {
                 dotnet pack "src/$_" --output $OutputPath
             }

--- a/tools/appveyor.psm1
+++ b/tools/appveyor.psm1
@@ -94,7 +94,7 @@ Function Test-DailyBuild
     {
         return $true
     }
-    
+
     # if [Feature] is in the commit message,
     # Run Daily tests
     if($env:APPVEYOR_REPO_COMMIT_MESSAGE -match '\[feature\]')
@@ -208,7 +208,7 @@ function Invoke-AppVeyorInstall
         }
         elseif($env:APPVEYOR_REPO_COMMIT_MESSAGE -notmatch '^\[Daily\].*$')
         {
-            
+
             $buildName += $env:APPVEYOR_REPO_COMMIT_MESSAGE
         }
         else
@@ -451,24 +451,26 @@ function Invoke-AppveyorFinish
 
         if ($env:APPVEYOR_REPO_TAG_NAME)
         {
-            # ignore the first part of semver, use the preview part
-            $preReleaseVersion = ($env:APPVEYOR_REPO_TAG_NAME).Split('-')[1]
+            $preReleaseVersion = "v$($env:APPVEYOR_REPO_TAG_NAME)"
         }
         else
         {
-            $previewLabel = (git describe --abbrev=0).Split('-')[1].replace('.','')
+            $previewVersion = (git describe --abbrev=0).Split('-')
+            $previewPrefix = $previewVersion[0]
+            $previewLabel = $previewVersion[1].Replace('.','')
+
             if(Test-DailyBuild)
             {
                 $previewLabel= "daily-{0}" -f $previewLabel
             }
 
-            $preReleaseVersion = "$previewLabel-$($env:APPVEYOR_BUILD_NUMBER.replace('.','-'))"
+            $preReleaseVersion = "$previewPrefix-$previewLabel-$($env:APPVEYOR_BUILD_NUMBER.Replace('.','-'))"
         }
 
         # only publish to nuget feed if it is a daily build and tests passed
         if((Test-DailyBuild) -and $env:TestPassed -eq 'True')
         {
-            Publish-NuGetFeed -OutputPath .\nuget-artifacts -VersionSuffix $preReleaseVersion
+            Publish-NuGetFeed -OutputPath .\nuget-artifacts -ReleaseTag "/property:ReleaseTag=$preReleaseVersion"
         }
 
         $nugetArtifacts = Get-ChildItem .\nuget-artifacts -ErrorAction SilentlyContinue | ForEach-Object { $_.FullName }
@@ -498,7 +500,7 @@ function Invoke-AppveyorFinish
             {
                 log "pushing $_ to $env:NUGET_URL"
                 Start-NativeExecution -sb {dotnet nuget push $_ --api-key $env:NUGET_KEY --source "$env:NUGET_URL/api/v2/package"} -IgnoreExitcode
-            }            
+            }
         }
         if(!$pushedAllArtifacts)
         {

--- a/tools/appveyor.psm1
+++ b/tools/appveyor.psm1
@@ -208,7 +208,6 @@ function Invoke-AppVeyorInstall
         }
         elseif($env:APPVEYOR_REPO_COMMIT_MESSAGE -notmatch '^\[Daily\].*$')
         {
-
             $buildName += $env:APPVEYOR_REPO_COMMIT_MESSAGE
         }
         else

--- a/tools/appveyor.psm1
+++ b/tools/appveyor.psm1
@@ -457,7 +457,7 @@ function Invoke-AppveyorFinish
         {
             $previewVersion = (git describe --abbrev=0).Split('-')
             $previewPrefix = $previewVersion[0]
-            $previewLabel = $previewVersion[1].Replace('.','')
+            $previewLabel = $previewVersion[1]
 
             if(Test-DailyBuild)
             {

--- a/tools/appveyor.psm1
+++ b/tools/appveyor.psm1
@@ -451,20 +451,20 @@ function Invoke-AppveyorFinish
 
         if ($env:APPVEYOR_REPO_TAG_NAME)
         {
-            $preReleaseVersion = "v$($env:APPVEYOR_REPO_TAG_NAME)"
+            $preReleaseVersion = $env:APPVEYOR_REPO_TAG_NAME
         }
         else
         {
             $previewVersion = (git describe --abbrev=0).Split('-')
             $previewPrefix = $previewVersion[0]
-            $previewLabel = $previewVersion[1]
+            $previewLabel = $previewVersion[1].replace('.','')
 
             if(Test-DailyBuild)
             {
-                $previewLabel= "daily-{0}" -f $previewLabel
+                $previewLabel= "daily{0}" -f $previewLabel
             }
 
-            $preReleaseVersion = "$previewPrefix-$previewLabel-$($env:APPVEYOR_BUILD_NUMBER.Replace('.','-'))"
+            $preReleaseVersion = "$previewPrefix-$previewLabel.$env:APPVEYOR_BUILD_NUMBER"
         }
 
         # only publish to nuget feed if it is a daily build and tests passed

--- a/tools/appveyor.psm1
+++ b/tools/appveyor.psm1
@@ -470,7 +470,7 @@ function Invoke-AppveyorFinish
         # only publish to nuget feed if it is a daily build and tests passed
         if((Test-DailyBuild) -and $env:TestPassed -eq 'True')
         {
-            Publish-NuGetFeed -OutputPath .\nuget-artifacts -ReleaseTag "/property:ReleaseTag=$preReleaseVersion"
+            Publish-NuGetFeed -OutputPath .\nuget-artifacts -ReleaseTag $preReleaseVersion
         }
 
         $nugetArtifacts = Get-ChildItem .\nuget-artifacts -ErrorAction SilentlyContinue | ForEach-Object { $_.FullName }


### PR DESCRIPTION
Related #3400
Continue #3690 and #4106.

Extract information about the release tag, number of commits since the tag and the hash of the latest commit within a MSBuild target, and bake that information into version properties of the assemblies appropriately.

- New target `GetPSCoreVersionFromGit` depends on (BeforeTargets) Restore and Nuget steps so now we get packages with the right version.
- Added generating a version without suffix (for release tag).
- Now ProductVersion is the same as  AssemblyInformationalVersion