### PR TITLE
Include test case parameter in test description

### DIFF
--- a/test/powershell/Host/ConsoleHost.Tests.ps1
+++ b/test/powershell/Host/ConsoleHost.Tests.ps1
@@ -183,7 +183,7 @@ Describe "ConsoleHost unit tests" -tags "Feature" {
             $observed | Should Be "hello"
         }
 
-        It "-File accepts scripts with and without .ps1 extension" -TestCases @(
+        It "-File accepts scripts with and without .ps1 extension: <Filename>" -TestCases @(
             @{Filename="test.ps1"},
             @{Filename="test"}
         ) {
@@ -201,7 +201,7 @@ Describe "ConsoleHost unit tests" -tags "Feature" {
             $observed[1] | Should Be "bar"
         }
 
-        It "-File should return exit code from script"  -TestCases @(
+        It "-File should return exit code from script: <Filename>" -TestCases @(
             @{Filename = "test.ps1"},
             @{Filename = "test"}
         ) {
@@ -209,7 +209,7 @@ Describe "ConsoleHost unit tests" -tags "Feature" {
             Set-Content -Path $testdrive/$Filename -Value 'exit 123'
             & $powershell $testdrive/$Filename
             $LASTEXITCODE | Should Be 123
-        }        
+        }
     }
 
     Context "Pipe to/from powershell" {
@@ -301,7 +301,7 @@ Describe "ConsoleHost unit tests" -tags "Feature" {
         # All of the following tests replace the prompt (either via an initial command or interactively)
         # so that we can read StandardOutput and reliably know exactly what the prompt is.
 
-        It "Interactive redirected input" -TestCases @(
+        It "Interactive redirected input: <InteractiveSwitch>" -TestCases @(
             @{InteractiveSwitch = ""}
             @{InteractiveSwitch = " -IntERactive"}
             @{InteractiveSwitch = " -i"}

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -37,7 +37,7 @@ Describe "TabCompletion" -Tags CI {
     }
 
 
-    It 'Should complete format-* hashtable on GroupBy' -TestCases (
+    It 'Should complete format-* hashtable on GroupBy: <cmd>' -TestCases (
         @{cmd = 'Format-Table'},
         @{cmd = 'Format-List'},
         @{cmd = 'Format-Wide'},

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -168,13 +168,13 @@ function ExecuteRedirectRequest
             $result.Output = Invoke-WebRequest -Uri $uri -TimeoutSec 5 -Headers $headers -PreserveAuthorizationOnRedirect:$PreserveAuthorizationOnRedirect.IsPresent -Method $Method
             $result.Content = $result.Output.Content | ConvertFrom-Json
         }
-        else 
-        {            
+        else
+        {
             $result.Output = Invoke-RestMethod -Uri $uri -TimeoutSec 5 -Headers $headers -PreserveAuthorizationOnRedirect:$PreserveAuthorizationOnRedirect.IsPresent -Method $Method
             # NOTE: $result.Output should already be a PSObject (Invoke-RestMethod converts the returned json automatically)
             # so simply reference $result.Output
             $result.Content = $result.Output
-        }       
+        }
     }
     catch
     {
@@ -187,7 +187,7 @@ function ExecuteRedirectRequest
 <#
     Defines the list of redirect codes to test as well as the
     expected Method when the redirection is handled.
-    See https://msdn.microsoft.com/en-us/library/windows/apps/system.net.httpstatuscode(v=vs.105).aspx 
+    See https://msdn.microsoft.com/en-us/library/windows/apps/system.net.httpstatuscode(v=vs.105).aspx
     for additonal details.
 #>
 $redirectTests = @(
@@ -287,7 +287,7 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
         $jsonContent.headers.Host | Should Match "httpbin.org"
         $jsonContent.headers.'User-Agent' | Should Match "WindowsPowerShell"
     }
-    
+
     It "Validate Invoke-WebRequest error for -MaximumRedirection" {
 
         $command = "Invoke-WebRequest -Uri 'http://httpbin.org/redirect/3' -MaximumRedirection 2 -TimeoutSec 5"
@@ -295,7 +295,7 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
         $result = ExecuteWebCommand -command $command
         $result.Error.FullyQualifiedErrorId | Should Be "WebCmdletWebResponseException,Microsoft.PowerShell.Commands.InvokeWebRequestCommand"
     }
-    
+
     It "Invoke-WebRequest supports request that returns page containing UTF-8 data." {
 
         $command = "Invoke-WebRequest -Uri http://httpbin.org/encoding/utf8 -TimeoutSec 5"
@@ -529,14 +529,14 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
     }
 
     It "Validate Invoke-WebRequest StandardMethod and CustomMethod parameter sets" {
-        
+
         #Validate that parameter sets are functioning correctly
         $errorId = "AmbiguousParameterSet,Microsoft.PowerShell.Commands.InvokeWebRequestCommand"
         { Invoke-WebRequest -Uri 'http://http.lee.io/method' -Method GET -CustomMethod TEST } | ShouldBeErrorId $errorId
     }
 
     It "Validate Invoke-WebRequest CustomMethod method is used" {
-        
+
         $command = "Invoke-WebRequest -Uri 'http://http.lee.io/method' -CustomMethod TEST"
         $result = ExecuteWebCommand -command $command
         $result.Error | Should BeNullOrEmpty
@@ -544,19 +544,19 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
     }
 
     It "Validate Invoke-WebRequest default ContentType for CustomMethod POST" {
-        
+
         $command = "Invoke-WebRequest -Uri 'http://httpbin.org/post' -CustomMethod POST -Body 'testparam=testvalue'"
         $result = ExecuteWebCommand -command $command
         ($result.Output.Content | ConvertFrom-Json).form.testparam | Should Be "testvalue"
     }
 
     It "Validate Invoke-WebRequest body is converted to query params for CustomMethod GET" {
-        
+
         $command = "Invoke-WebRequest -Uri 'http://httpbin.org/get' -CustomMethod GET -Body @{'testparam'='testvalue'}"
         $result = ExecuteWebCommand -command $command
         ($result.Output.Content | ConvertFrom-Json).args.testparam | Should Be "testvalue"
     }
-    
+
     It "Validate Invoke-WebRequest returns HTTP errors in exception" {
 
         $command = "Invoke-WebRequest -Uri http://httpbin.org/status/418"
@@ -597,10 +597,10 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
         $result.Output.RelationLink["last"] | Should BeExactly "http://localhost:8080/PowerShell?test=linkheader&maxlinks=5&linknumber=5"
     }
 
-    It "Validate Invoke-WebRequest quietly ignores invalid Link Headers in RelationLink property" -TestCases @(
+    It "Validate Invoke-WebRequest quietly ignores invalid Link Headers in RelationLink property: <type>" -TestCases @(
         @{ type = "noUrl" }
         @{ type = "malformed" }
-        @{ type = "noRel" } 
+        @{ type = "noRel" }
     ) {
         param($type)
         $command = "Invoke-WebRequest -Uri 'http://localhost:8080/PowerShell?test=linkheader&type=$type'"
@@ -611,18 +611,18 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
 
     #region Redirect tests
 
-    It "Validates Invoke-WebRequest with -PreserveAuthorizationOnRedirect preserves the authorization header on redirect" -TestCases $redirectTests {
+    It "Validates Invoke-WebRequest with -PreserveAuthorizationOnRedirect preserves the authorization header on redirect: <redirectType> <redirectedMethod>" -TestCases $redirectTests {
         param($redirectType, $redirectedMethod)
 
         $response = ExecuteRedirectRequest -Uri "http://localhost:8080/PowerShell?test=redirect&type=$redirectType" -PreserveAuthorizationOnRedirect
-        
+
         $response.Error | Should BeNullOrEmpty
         # ensure Authorization header has been preserved.
         $response.Content.Headers -contains "Authorization" | Should Be $true
     }
 
 
-    It "Validates Invoke-WebRequest preserves the authorization header on multiple redirects." -TestCases $redirectTests {
+    It "Validates Invoke-WebRequest preserves the authorization header on multiple redirects: <redirectType>" -TestCases $redirectTests {
         param($redirectType)
 
         $response = ExecuteRedirectRequest -Uri "http://localhost:8080/PowerShell?test=redirect&type=$redirectType&multiredirect=true" -PreserveAuthorizationOnRedirect
@@ -632,7 +632,7 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
         $response.Content.Headers -contains "Authorization" | Should Be $true
     }
 
-    It "Validates Invoke-WebRequest strips the authorization header on various redirects" -TestCases $redirectTests {
+    It "Validates Invoke-WebRequest strips the authorization header on various redirects: <redirectType>" -TestCases $redirectTests {
         param($redirectType)
 
         $response = ExecuteRedirectRequest -Uri "http://localhost:8080/PowerShell?test=redirect&type=$redirectType"
@@ -646,11 +646,11 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
 
     # NOTE: Only testing redirection of POST -> GET for unique underlying values of HttpStatusCode.
     # Some names overlap in underlying value.
-    It "Validates Invoke-WebRequest strips the authorization header redirects and switches from POST to GET when it handles the redirect" -TestCases $redirectTests {
+    It "Validates Invoke-WebRequest strips the authorization header redirects and switches from POST to GET when it handles the redirect: <redirectType> <redirectedMethod>" -TestCases $redirectTests {
         param($redirectType, $redirectedMethod)
 
         $response = ExecuteRedirectRequest -Uri "http://localhost:8080/PowerShell?test=redirect&type=$redirectType" -Method 'POST'
-        
+
         $response.Error | Should BeNullOrEmpty
         # ensure user-agent is present (i.e., no false positives )
         $response.Content.Headers -contains "User-Agent" | Should Be $true
@@ -658,9 +658,9 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
         $response.Content.Headers -contains "Authorization" | Should Be $false
         # ensure POST was changed to GET for selected redirections and remains as POST for others.
         $response.Content.HttpMethod | Should Be $redirectedMethod
-    } 
+    }
 
-    #endregion Redirect tests       
+    #endregion Redirect tests
 
     BeforeEach {
         if ($env:http_proxy) {
@@ -981,7 +981,7 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
     }
 
     It "Validate CustomMethod method is used" {
-        
+
         $command = "Invoke-RestMethod -Uri 'http://http.lee.io/method' -CustomMethod TEST"
         $result = ExecuteWebCommand -command $command
         $result.Error | Should BeNullOrEmpty
@@ -989,14 +989,14 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
     }
 
     It "Validate Invoke-RestMethod default ContentType for CustomMethod POST" {
-        
+
         $command = "Invoke-RestMethod -Uri 'http://httpbin.org/post' -CustomMethod POST -Body 'testparam=testvalue'"
         $result = ExecuteWebCommand -command $command
         $result.Output.form.testparam | Should Be "testvalue"
     }
 
     It "Validate Invoke-RestMethod body is converted to query params for CustomMethod GET" {
-        
+
         $command = "Invoke-RestMethod -Uri 'http://httpbin.org/get' -CustomMethod GET -Body @{'testparam'='testvalue'}"
         $result = ExecuteWebCommand -command $command
         $result.Output.args.testparam | Should Be "testvalue"
@@ -1061,10 +1061,10 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
         1..$maxLinksToFollow | ForEach-Object { $result.Output.output[$_ - 1] | Should BeExactly $_ }
     }
 
-    It "Validate Invoke-RestMethod quietly ignores invalid Link Headers if -FollowRelLink is specified" -TestCases @(
+    It "Validate Invoke-RestMethod quietly ignores invalid Link Headers if -FollowRelLink is specified: <type>" -TestCases @(
         @{ type = "noUrl" }
         @{ type = "malformed" }
-        @{ type = "noRel" } 
+        @{ type = "noRel" }
     ) {
         param($type)
         $command = "Invoke-RestMethod -Uri 'http://localhost:8081/PowerShell?test=linkheader&type=$type' -FollowRelLink"
@@ -1074,17 +1074,17 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
 
     #region Redirect tests
 
-    It "Validates Invoke-RestMethod with -PreserveAuthorizationOnRedirect preserves the authorization header on redirect" -TestCases $redirectTests {
+    It "Validates Invoke-RestMethod with -PreserveAuthorizationOnRedirect preserves the authorization header on redirect: <redirectType> <redirectedMethod>" -TestCases $redirectTests {
         param($redirectType, $redirectedMethod)
 
         $response = ExecuteRedirectRequest  -Cmdlet 'Invoke-RestMethod' -Uri "http://localhost:8081/PowerShell?test=redirect&type=$redirectType" -PreserveAuthorizationOnRedirect
-        
+
         $response.Error | Should BeNullOrEmpty
         # ensure Authorization header has been preserved.
         $response.Content.Headers -contains "Authorization" | Should Be $true
     }
 
-    It "Validates Invoke-RestMethod preserves the authorization header on multiple redirects." -TestCases $redirectTests {
+    It "Validates Invoke-RestMethod preserves the authorization header on multiple redirects: <redirectType>" -TestCases $redirectTests {
         param($redirectType)
 
         $response = ExecuteRedirectRequest  -Cmdlet 'Invoke-RestMethod' -Uri "http://localhost:8081/PowerShell?test=redirect&type=$redirectType&multiredirect=true" -PreserveAuthorizationOnRedirect
@@ -1094,7 +1094,7 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
         $response.Content.Headers -contains "Authorization" | Should Be $true
     }
 
-    It "Validates Invoke-RestMethod strips the authorization header on various redirects" -TestCases $redirectTests {
+    It "Validates Invoke-RestMethod strips the authorization header on various redirects: <redirectType>" -TestCases $redirectTests {
         param($redirectType)
 
         $response = ExecuteRedirectRequest  -Cmdlet 'Invoke-RestMethod' -Uri "http://localhost:8081/PowerShell?test=redirect&type=$redirectType"
@@ -1108,11 +1108,11 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
 
     # NOTE: Only testing redirection of POST -> GET for unique underlying values of HttpStatusCode.
     # Some names overlap in underlying value.
-    It "Validates Invoke-RestMethod strips the authorization header redirects and switches from POST to GET when it handles the redirect" -TestCases $redirectTests {
+    It "Validates Invoke-RestMethod strips the authorization header redirects and switches from POST to GET when it handles the redirect: <redirectType> <redirectedMethod>" -TestCases $redirectTests {
         param($redirectType, $redirectedMethod)
 
         $response = ExecuteRedirectRequest  -Cmdlet 'Invoke-RestMethod' -Uri "http://localhost:8081/PowerShell?test=redirect&type=$redirectType" -Method 'POST'
-        
+
         $response.Error | Should BeNullOrEmpty
         # ensure user-agent is present (i.e., no false positives )
         $response.Content.Headers -contains "User-Agent" | Should Be $true
@@ -1120,9 +1120,9 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
         $response.Content.Headers -contains "Authorization" | Should Be $false
         # ensure POST was changed to GET for selected redirections and remains as POST for others.
         $response.Content.HttpMethod | Should Be $redirectedMethod
-    } 
+    }
 
-    #endregion Redirect tests       
+    #endregion Redirect tests
 
     BeforeEach {
         if ($env:http_proxy) {

--- a/test/powershell/engine/Module/TestModuleManifest.Tests.ps1
+++ b/test/powershell/engine/Module/TestModuleManifest.Tests.ps1
@@ -22,7 +22,7 @@ Describe "Test-ModuleManifest tests" -tags "CI" {
         Test-ModuleManifest -Path $testModulePath -ErrorAction Stop | Should BeOfType System.Management.Automation.PSModuleInfo
     }
 
-    It "module manifest containing missing files returns error" -TestCases (
+    It "module manifest containing missing files returns error: <parameter>" -TestCases (
         @{parameter = "RequiredAssemblies"; error = "Modules_InvalidRequiredAssembliesInModuleManifest"},
         @{parameter = "NestedModules"; error = "Modules_InvalidNestedModuleinModuleManifest"},
         @{parameter = "RequiredModules"; error = "Modules_InvalidRequiredModulesinModuleManifest"},
@@ -48,7 +48,7 @@ Describe "Test-ModuleManifest tests" -tags "CI" {
         { Test-ModuleManifest -Path $testModulePath -ErrorAction Stop } | ShouldBeErrorId $errorId
     }
 
-    It "module manifest containing valid unprocessed rootmodule file type succeeds" -TestCases (
+    It "module manifest containing valid unprocessed rootmodule file type succeeds: <rootModuleValue>" -TestCases (
         @{rootModuleValue = "foo.psm1"},
         @{rootModuleValue = "foo.dll"}
     ) {
@@ -65,7 +65,7 @@ Describe "Test-ModuleManifest tests" -tags "CI" {
         $moduleManifest.RootModule | Should Be $rootModuleValue
     }
 
-    It "module manifest containing valid processed empty rootmodule file type fails" -TestCases (
+    It "module manifest containing valid processed empty rootmodule file type fails: <rootModuleValue>" -TestCases (
         @{rootModuleValue = "foo.cdxml"; error = "System.Xml.XmlException"},  # fails when cmdlet tries to read it as XML
         @{rootModuleValue = "foo.xaml"; error = "NotSupported"}   # not supported on PowerShell Core
     ) {
@@ -80,7 +80,7 @@ Describe "Test-ModuleManifest tests" -tags "CI" {
         { Test-ModuleManifest -Path $testModulePath -ErrorAction Stop } | ShouldBeErrorId "$error,Microsoft.PowerShell.Commands.TestModuleManifestCommand"
     }
 
-    It "module manifest containing empty rootmodule succeeds" -TestCases (
+    It "module manifest containing empty rootmodule succeeds: <rootModuleValue>" -TestCases (
         @{rootModuleValue = $null},
         @{rootModuleValue = ""}
     ) {
@@ -96,7 +96,7 @@ Describe "Test-ModuleManifest tests" -tags "CI" {
         $moduleManifest.RootModule | Should BeNullOrEmpty
     }
 
-    It "module manifest containing invalid rootmodule returns error" -TestCases (
+    It "module manifest containing invalid rootmodule returns error: <rootModuleValue>" -TestCases (
         @{rootModuleValue = "foo.psd1"; error = "Modules_InvalidManifest"}
     ) {
 
@@ -110,7 +110,7 @@ Describe "Test-ModuleManifest tests" -tags "CI" {
         { Test-ModuleManifest -Path $testModulePath -ErrorAction Stop } | ShouldBeErrorId "$error,Microsoft.PowerShell.Commands.TestModuleManifestCommand"
     }
 
-    It "module manifest containing non-existing rootmodule returns error" -TestCases (
+    It "module manifest containing non-existing rootmodule returns error: <rootModuleValue>" -TestCases (
         @{rootModuleValue = "doesnotexist.psm1"; error = "Modules_InvalidRootModuleInModuleManifest"}
     ) {
 
@@ -180,7 +180,7 @@ Describe "Tests for circular references in required modules" -tags "CI" {
         $ModuleNames = 1..$moduleCount|%{"TestModule$_"}
 
         CreateTestModules $moduleRootPath $ModuleNames $AddVersion $AddGuid $AddCircularReference
-        
+
         $newpath = [system.io.path]::PathSeparator + "$moduleRootPath"
         $OriginalPSModulePathLength = $env:PSModulePath.Length
         $env:PSModulePath += $newpath

--- a/test/powershell/engine/SemanticVersion.Tests.ps1
+++ b/test/powershell/engine/SemanticVersion.Tests.ps1
@@ -83,24 +83,24 @@ Describe "SemanticVersion api tests" -Tags 'CI' {
             @{ lhs = $v2_1_0; rhs = "3.0"}
             @{ lhs = "1.5"; rhs = $v2_1_0}
         )
-        It "less than" -TestCases $testCases {
+        It "<lhs> less than <rhs>" -TestCases $testCases {
             param($lhs, $rhs)
             $lhs -lt $rhs | Should Be $true
             $rhs -lt $lhs | Should Be $false
         }
-        It "less than or equal" -TestCases $testCases {
+        It "<lhs> less than or equal <rhs>" -TestCases $testCases {
             param($lhs, $rhs)
             $lhs -le $rhs | Should Be $true
             $rhs -le $lhs | Should Be $false
             $lhs -le $lhs | Should Be $true
             $rhs -le $rhs | Should Be $true
         }
-        It "greater than" -TestCases $testCases {
+        It "<lhs> greater than <rhs>" -TestCases $testCases {
             param($lhs, $rhs)
             $lhs -gt $rhs | Should Be $false
             $rhs -gt $lhs | Should Be $true
         }
-        It "greater than or equal" -TestCases $testCases {
+        It "<lhs> greater than or equal <rhs>" -TestCases $testCases {
             param($lhs, $rhs)
             $lhs -ge $rhs | Should Be $false
             $rhs -ge $lhs | Should Be $true
@@ -112,7 +112,7 @@ Describe "SemanticVersion api tests" -Tags 'CI' {
             @{ operand = $v1_0_0 }
             @{ operand = $v1_0_0_alpha }
         )
-        It "Equality" -TestCases $testCases {
+        It "Equality <operand>" -TestCases $testCases {
             param($operand)
             $operand -eq $operand | Should Be $true
             $operand -ne $operand | Should Be $false
@@ -169,7 +169,7 @@ Describe "SemanticVersion api tests" -Tags 'CI' {
             @{ expectedResult = $false; version = "1.0.-1"  }
         )
 
-        It "range check of versions" -TestCases $testCases {
+        It "range check of versions: <version>" -TestCases $testCases {
             param($version, $expectedResult)
             { [SemanticVersion]::new($version) } | Should Throw # PSArgumentException
             { [SemanticVersion]::Parse($version) } | Should Throw # PSArgumentException
@@ -184,7 +184,7 @@ Describe "SemanticVersion api tests" -Tags 'CI' {
             @{ expectedResult = $false; version = "1.0.cc"  }
         )
 
-        It "format errors" -TestCases $testCases {
+        It "format errors: <version>" -TestCases $testCases {
             param($version, $expectedResult)
             { [SemanticVersion]::new($version) } | Should Throw # PSArgumentException
             { [SemanticVersion]::Parse($version) } | Should Throw # PSArgumentException
@@ -213,7 +213,7 @@ Describe "SemanticVersion api tests" -Tags 'CI' {
             @{ expectedResult = "1.0.0-alpha"; semver = [SemanticVersion]::new(1, 0, 0, "alpha") }
             @{ expectedResult = "1.0.0-beta"; semver = [SemanticVersion]::new(1, 0, 0, "beta") }
         )
-        It "Can round trip" -TestCases $testCases {
+        It "Can round trip: <semver>" -TestCases $testCases {
             param($semver, $expectedResult)
 
             $ser = [PSSerializer]::Serialize($semver)


### PR DESCRIPTION
Fix usage of -TestCases so that the parameters show up in the test case description making it easier to see which test case failed

VSCode cleaned up trailing whitespace

<!--

If you are a PowerShell Team member, please make sure you choose the Reviewer(s) and Assignee for your PR.
If you are not from the PowerShell Team, you can leave the fields blank and the Maintainers will choose them for you. If you are familiar with the team, feel free to mention some Reviewers yourself.

For more information about the roles of Reviewer and Assignee, refer to CONTRIBUTING.md.

-->
