### PR TITLE
added markdown lint errors as test failure message

### DIFF
--- a/test/common/markdown/markdown.tests.ps1
+++ b/test/common/markdown/markdown.tests.ps1
@@ -102,24 +102,14 @@ Describe 'Common Tests - Validate Markdown Files' -Tag 'CI' {
 
         $mdIssuesPath | should exist
 
-        [string] $markdownErrors = ""
-        Get-Content -Path $mdIssuesPath | ForEach-Object -Process {
-            if ([string]::IsNullOrEmpty($_) -eq $false -and $_ -ne '--EMPTY--')
-            {
-                Write-Warning -Message $_
-                $markdownErrors += $_ + ", "
-                $mdErrors ++
-            }
-        }
-
+        [string] $markdownErrors = Get-Content -Path $mdIssuesPath
         Remove-Item -Path $mdIssuesPath -Force -ErrorAction SilentlyContinue
-        $markdownErrors | Should BeExactly ""
 
-        if($mdErrors -gt 0)
+        if ($markdownErrors -ne "--EMPTY--")
         {
-            Write-Warning 'See https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md for an explination of the error codes.'
+            $markdownErrors += ' (See https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md for an explanation of the error codes)'
         }
 
-        $mdErrors | Should Be 0
+        $markdownErrors | Should BeExactly "--EMPTY--"
     }
 }

--- a/test/common/markdown/markdown.tests.ps1
+++ b/test/common/markdown/markdown.tests.ps1
@@ -102,15 +102,18 @@ Describe 'Common Tests - Validate Markdown Files' -Tag 'CI' {
 
         $mdIssuesPath | should exist
 
+        [string] $markdownErrors = ""
         Get-Content -Path $mdIssuesPath | ForEach-Object -Process {
             if ([string]::IsNullOrEmpty($_) -eq $false -and $_ -ne '--EMPTY--')
             {
                 Write-Warning -Message $_
+                $markdownErrors += $_ + ", "
                 $mdErrors ++
             }
         }
 
         Remove-Item -Path $mdIssuesPath -Force -ErrorAction SilentlyContinue
+        $markdownErrors | Should BeExactly ""
 
         if($mdErrors -gt 0)
         {


### PR DESCRIPTION
Currently, when the markdown lint tests run in CI, you can't easily see the exact failures by looking at the test results, just that it failed.  With this change, I put the actual lint errors into a test result.

```powershell
WARNING: C:\users\slee\repos\PowerShell\test.md: 1: MD002 First header should be a top level header
WARNING: C:\users\slee\repos\PowerShell\test.md: 5: MD012 Multiple consecutive blank lines
WARNING: C:\users\slee\repos\PowerShell\test.md: 1: MD041 First line in file should be a top level header--EMPTY--
 [-] Should not have errors in any markdown files 34.78s
   Expected string length 0 but was 282. Strings differ at index 0.
   Expected: {}
   But was:  {C:\users\slee\repos\PowerShell\test.md: 1: MD002 First header should be a top level header, C:\users\slee\repos\PowerShell\test.md: 5: MD012 Multiple consecutive blank lines, C:\users\slee\repos\PowerShell\test.md: 1: MD041 First line in file should be a top level header--EMPTY--, }
   -----------^
   at line: 115 in C:\users\slee\repos\PowerShell\test\common\markdown\markdown.tests.ps1
   115:         $markdownErrors | Should BeExactly ""
```

<!--

If you are a PowerShell Team member, please make sure you choose the Reviewer(s) and Assignee for your PR.
If you are not from the PowerShell Team, you can leave the fields blank and the Maintainers will choose them for you. If you are familiar with the team, feel free to mention some Reviewers yourself.

For more information about the roles of Reviewer and Assignee, refer to CONTRIBUTING.md.

-->
