### PR TITLE
Remove UTC and SQM telemetry code

### DIFF
--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
@@ -46,11 +46,11 @@ namespace Microsoft.PowerShell
         :
         PSHost,
         IDisposable,
+        IHostSupportsInteractiveSession
 #if LEGACYTELEMETRY
+        ,
         IHostSupportsInteractiveSession,
         IHostProvidesTelemetryData
-#else
-        IHostSupportsInteractiveSession
 #endif
     {
         #region static methods

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
@@ -46,12 +46,10 @@ namespace Microsoft.PowerShell
         :
         PSHost,
         IDisposable,
-        IHostSupportsInteractiveSession
 #if LEGACYTELEMETRY
-        ,
-        IHostSupportsInteractiveSession,
-        IHostProvidesTelemetryData
+        IHostProvidesTelemetryData,
 #endif
+        IHostSupportsInteractiveSession
     {
         #region static methods
 

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
@@ -28,7 +28,9 @@ using Dbg = System.Management.Automation.Diagnostics;
 using ConsoleHandle = Microsoft.Win32.SafeHandles.SafeFileHandle;
 using NakedWin32Handle = System.IntPtr;
 using System.Management.Automation.Tracing;
+#if LEGACYTELEMETRY
 using Microsoft.PowerShell.Telemetry.Internal;
+#endif
 using Debugger = System.Management.Automation.Debugger;
 
 namespace Microsoft.PowerShell
@@ -44,8 +46,12 @@ namespace Microsoft.PowerShell
         :
         PSHost,
         IDisposable,
+#if LEGACYTELEMETRY
         IHostSupportsInteractiveSession,
         IHostProvidesTelemetryData
+#else
+        IHostSupportsInteractiveSession
+#endif
     {
         #region static methods
 
@@ -271,7 +277,9 @@ namespace Microsoft.PowerShell
             {
                 if (s_theConsoleHost != null)
                 {
+#if LEGACYTELEMETRY
                     TelemetryAPI.ReportExitTelemetry(s_theConsoleHost);
+#endif
                     s_theConsoleHost.Dispose();
                 }
             }
@@ -1038,6 +1046,7 @@ namespace Microsoft.PowerShell
             }
         }
 
+#if LEGACYTELEMETRY
         bool IHostProvidesTelemetryData.HostIsInteractive
         {
             get
@@ -1049,6 +1058,7 @@ namespace Microsoft.PowerShell
         double IHostProvidesTelemetryData.ProfileLoadTimeInMS { get { return _profileLoadTimeInMS; } }
         double IHostProvidesTelemetryData.ReadyForInputTimeInMS { get { return _readyForInputTimeInMS; } }
         int IHostProvidesTelemetryData.InteractiveCommandCount { get { return _interactiveCommandCount; } }
+#endif
 
         private double _profileLoadTimeInMS;
         private double _readyForInputTimeInMS;
@@ -1807,10 +1817,11 @@ namespace Microsoft.PowerShell
                     s_tracer.WriteLine("-noprofile option specified: skipping profiles");
                 }
             }
-
+#if LEGACYTELEMETRY
             // Startup is reported after possibly running the profile, but before running the initial command (or file)
             // if one is specified.
             TelemetryAPI.ReportStartupTelemetry(this);
+#endif
 
             // If a file was specified as the argument to run, then run it...
             if (s_cpp != null && s_cpp.File != null)

--- a/src/System.Management.Automation/engine/CommandCompletion/CommandCompletion.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CommandCompletion.cs
@@ -12,7 +12,9 @@ using System.Globalization;
 using System.Management.Automation.Language;
 using System.Management.Automation.Runspaces;
 using System.Text.RegularExpressions;
+#if LEGACYTELEMETRY
 using Microsoft.PowerShell.Telemetry.Internal;
+#endif
 
 namespace System.Management.Automation
 {
@@ -591,8 +593,10 @@ namespace System.Management.Automation
 
                     var completionResults = results ?? EmptyCompletionResult;
                     sw.Stop();
+#if LEGACYTELEMETRY
                     TelemetryAPI.ReportTabCompletionTelemetry(sw.ElapsedMilliseconds, completionResults.Count,
                         completionResults.Count > 0 ? completionResults[0].ResultType : CompletionResultType.Text);
+#endif
                     return new CommandCompletion(
                         new Collection<CompletionResult>(completionResults),
                         -1,

--- a/src/System.Management.Automation/engine/GetCommandCommand.cs
+++ b/src/System.Management.Automation/engine/GetCommandCommand.cs
@@ -531,6 +531,7 @@ namespace Microsoft.PowerShell.Commands
 
             _timer.Stop();
 
+#if LEGACYTELEMETRY
             // We want telementry on commands people look for but don't exist - this should give us an idea
             // what sort of commands people expect but either don't exist, or maybe should be installed by default.
             // The StartsWith is to avoid logging telemetry when suggestion mode checks the
@@ -539,6 +540,8 @@ namespace Microsoft.PowerShell.Commands
             {
                 Telemetry.Internal.TelemetryAPI.ReportGetCommandFailed(Name, _timer.ElapsedMilliseconds);
             }
+#endif
+
         }
 
         /// <summary>

--- a/src/System.Management.Automation/engine/Modules/ImportModuleCommand.cs
+++ b/src/System.Management.Automation/engine/Modules/ImportModuleCommand.cs
@@ -23,7 +23,9 @@ using System.Management.Automation.Language;
 using Parser = System.Management.Automation.Language.Parser;
 using ScriptBlock = System.Management.Automation.ScriptBlock;
 using Token = System.Management.Automation.Language.Token;
+#if LEGACYTELEMETRY
 using Microsoft.PowerShell.Telemetry.Internal;
+#endif
 
 #if CORECLR
 // Use stub for SecurityZone.
@@ -1720,7 +1722,9 @@ namespace Microsoft.PowerShell.Commands
                     {
                         SetModuleBaseForEngineModules(foundModule.Name, this.Context);
 
+#if LEGACYTELEMETRY
                         TelemetryAPI.ReportModuleLoad(foundModule);
+#endif
                     }
                 }
             }

--- a/src/System.Management.Automation/engine/hostifaces/ConnectionBase.cs
+++ b/src/System.Management.Automation/engine/hostifaces/ConnectionBase.cs
@@ -7,7 +7,9 @@ using System.Linq;
 using System.Threading;
 using System.Management.Automation.Host;
 using System.Management.Automation.Internal;
+#if LEGACYTELEMETRY
 using Microsoft.PowerShell.Telemetry.Internal;
+#endif
 using Dbg = System.Management.Automation.Diagnostics;
 
 #pragma warning disable 1634, 1691 // Stops compiler from warning about unknown warnings
@@ -279,6 +281,7 @@ namespace System.Management.Automation.Runspaces
             OpenHelper(syncCall);
             if (etwEnabled) RunspaceEventSource.Log.OpenRunspaceStop();
 
+#if LEGACYTELEMETRY
             // We report startup telementry when opening the runspace - because this is the first time
             // we are really using PowerShell. This isn't the cleanest place though, because
             // sometimes there are many runspaces created - the callee ensures telemetry is only
@@ -288,6 +291,7 @@ namespace System.Management.Automation.Runspaces
             {
                 TelemetryAPI.ReportStartupTelemetry(null);
             }
+#endif
         }
 
 

--- a/src/System.Management.Automation/engine/hostifaces/LocalConnection.cs
+++ b/src/System.Management.Automation/engine/hostifaces/LocalConnection.cs
@@ -16,7 +16,9 @@ using System.Diagnostics.CodeAnalysis; // for fxcop
 using Dbg = System.Management.Automation.Diagnostics;
 using System.Diagnostics;
 using System.Linq;
+#if LEGACYTELEMETRY
 using Microsoft.PowerShell.Telemetry.Internal;
+#endif
 
 #pragma warning disable 1634, 1691 // Stops compiler from warning about unknown warnings
 
@@ -737,7 +739,9 @@ namespace System.Management.Automation.Runspaces
                 }
             }
 
+#if LEGACYTELEMETRY
             TelemetryAPI.ReportLocalSessionCreated(InitialSessionState, TranscriptionData);
+#endif
         }
 
         /// <summary>
@@ -936,6 +940,8 @@ namespace System.Management.Automation.Runspaces
             RaiseRunspaceStateEvents();
 
             // Report telemetry if we have no more open runspaces.
+
+#if LEGACYTELEMETRY
             bool allRunspacesClosed = true;
             bool hostProvidesExitTelemetry = false;
             foreach (var r in Runspace.RunspaceList)
@@ -956,6 +962,7 @@ namespace System.Management.Automation.Runspaces
             {
                 TelemetryAPI.ReportExitTelemetry(null);
             }
+#endif
         }
 
         /// <summary>

--- a/src/System.Management.Automation/engine/pipeline.cs
+++ b/src/System.Management.Automation/engine/pipeline.cs
@@ -1010,7 +1010,9 @@ namespace System.Management.Automation.Internal
                     CommandState.Started,
                     commandProcessor.Command.MyInvocation);
 
-                //Microsoft.PowerShell.Telemetry.Internal.TelemetryAPI.TraceExecutedCommand(commandProcessor.Command.CommandInfo, commandProcessor.Command.CommandOrigin);
+#if LEGACYTELEMETRY
+                Microsoft.PowerShell.Telemetry.Internal.TelemetryAPI.TraceExecutedCommand(commandProcessor.Command.CommandInfo, commandProcessor.Command.CommandOrigin);
+#endif
 
                 // Log the execution of a command (not script chunks, as they
                 // are not commands in and of themselves)

--- a/src/System.Management.Automation/engine/remoting/client/RemoteRunspacePoolInternal.cs
+++ b/src/System.Management.Automation/engine/remoting/client/RemoteRunspacePoolInternal.cs
@@ -12,7 +12,9 @@ using System.Management.Automation.Internal;
 using System.Management.Automation.Host;
 using System.Collections.ObjectModel;
 using System.Management.Automation.Remoting.Client;
+#if LEGACYTELEMETRY
 using Microsoft.PowerShell.Telemetry.Internal;
+#endif
 
 namespace System.Management.Automation.Runspaces.Internal
 {
@@ -850,7 +852,9 @@ namespace System.Management.Automation.Runspaces.Internal
             PSEtwLog.LogOperationalVerbose(PSEventId.RunspacePoolOpen, PSOpcode.Open,
                             PSTask.CreateRunspace, PSKeyword.UseAlwaysOperational);
 
+#if LEGACYTELEMETRY
             TelemetryAPI.ReportRemoteSessionCreated(_connectionInfo);
+#endif
 
             lock (syncObject)
             {

--- a/src/System.Management.Automation/engine/runtime/CompiledScriptBlock.cs
+++ b/src/System.Management.Automation/engine/runtime/CompiledScriptBlock.cs
@@ -16,7 +16,9 @@ using System.Reflection;
 using System.Runtime.Serialization;
 using System.Text;
 using System.Threading.Tasks;
+#if LEGACYTELEMETRY
 using Microsoft.PowerShell.Telemetry.Internal;
+#endif
 
 namespace System.Management.Automation
 {
@@ -178,11 +180,12 @@ namespace System.Management.Automation
             Compiler compiler = new Compiler();
             compiler.Compile(this, optimize);
 
+#if LEGACYTELEMETRY
             if (!IsProductCode)
             {
                 TelemetryAPI.ReportScriptTelemetry((Ast)_ast, !optimize, sw.ElapsedMilliseconds);
             }
-
+#endif
             if (etwEnabled) ParserEventSource.Log.CompileStop();
         }
 

--- a/src/System.Management.Automation/help/HelpCommands.cs
+++ b/src/System.Management.Automation/help/HelpCommands.cs
@@ -234,7 +234,9 @@ namespace Microsoft.PowerShell.Commands
 #endif
 
         private readonly Stopwatch _timer = new Stopwatch();
+#if LEGACYTELEMETRY
         private bool _updatedHelp;
+#endif
 
         #endregion
 
@@ -252,7 +254,9 @@ namespace Microsoft.PowerShell.Commands
                 if (ShouldContinue(HelpDisplayStrings.UpdateHelpPromptBody, HelpDisplayStrings.UpdateHelpPromptTitle))
                 {
                     System.Management.Automation.PowerShell.Create(RunspaceMode.CurrentRunspace).AddCommand("Update-Help").Invoke();
+#if LEGACYTELEMETRY
                     _updatedHelp = true;
+#endif
                 }
 
                 UpdatableHelpSystem.SetDisablePromptToUpdateHelp();
@@ -332,9 +336,10 @@ namespace Microsoft.PowerShell.Commands
 
                 _timer.Stop();
 
+#if LEGACYTELEMETRY
                 if (!string.IsNullOrEmpty(Name))
                     Microsoft.PowerShell.Telemetry.Internal.TelemetryAPI.ReportGetHelpTelemetry(Name, countOfHelpInfos, _timer.ElapsedMilliseconds, _updatedHelp);
-
+#endif
                 // Write full help as there is only one help info object
                 if (1 == countOfHelpInfos)
                 {

--- a/src/System.Management.Automation/utils/PSTelemetryMethods.cs
+++ b/src/System.Management.Automation/utils/PSTelemetryMethods.cs
@@ -1,3 +1,4 @@
+#if LEGACYTELEMETRY
 /********************************************************************++
 Copyright (c) Microsoft Corporation.  All rights reserved.
 --********************************************************************/
@@ -519,3 +520,4 @@ namespace Microsoft.PowerShell.Telemetry.Internal
         int InteractiveCommandCount { get; }
     }
 }
+#endif

--- a/src/System.Management.Automation/utils/PSTelemetryWrapper.cs
+++ b/src/System.Management.Automation/utils/PSTelemetryWrapper.cs
@@ -1,3 +1,4 @@
+#if LEGACYTELEMETRY
 /********************************************************************++
 Copyright (c) Microsoft Corporation.  All rights reserved.
 --********************************************************************/
@@ -146,3 +147,4 @@ namespace System.Management.Automation.Internal
         }
     }
 }
+#endif


### PR DESCRIPTION
Implementation of #3807 

The historical telemetry code uses WindowsUTC which is not applicable to non-Windows platforms and is superseded by our ApplicationInsight telemetry. `#if LEGACYTELEMETRY` was used to make it easier to track when we add our next round of telemetry.

Change should not be visible to the user, unless they were inspecting the eventlog looking for it. Any SQM telemetry appears to have been disabled in June 2016.