### PR TITLE
PS should try to load the assembly from file path first before loading from assemblyName

### DIFF
--- a/src/System.Management.Automation/engine/ExecutionContext.cs
+++ b/src/System.Management.Automation/engine/ExecutionContext.cs
@@ -1323,14 +1323,37 @@ namespace System.Management.Automation
         [SuppressMessage("Microsoft.Reliability", "CA2001:AvoidCallingProblematicMethods", MessageId = "System.Reflection.Assembly.LoadFrom")]
         internal static Assembly LoadAssembly(string name, string filename, out Exception error)
         {
-            // First we try to load the assembly based on the given name
+            // First we try to load the assembly based on the filename
 
             Assembly loadedAssembly = null;
             error = null;
 
-            string fixedName = null;
-            if (!String.IsNullOrEmpty(name))
+            if (!String.IsNullOrEmpty(filename))
             {
+                try
+                {
+                    loadedAssembly = Assembly.LoadFrom(filename);
+                }
+                catch (FileNotFoundException fileNotFound)
+                {
+                    error = fileNotFound;
+                }
+                catch (FileLoadException fileLoadException)
+                {
+                    error = fileLoadException;
+                }
+                catch (BadImageFormatException badImage)
+                {
+                    error = badImage;
+                }
+                catch (SecurityException securityException)
+                {
+                    error = securityException;
+                }
+            }
+            else if (!String.IsNullOrEmpty(name))
+            {
+                string fixedName = null;
                 // Remove the '.dll' if it's there...
                 fixedName = name.EndsWith(".dll", StringComparison.OrdinalIgnoreCase)
                                 ? Path.GetFileNameWithoutExtension(name)
@@ -1357,76 +1380,15 @@ namespace System.Management.Automation
                 catch (BadImageFormatException badImage)
                 {
                     error = badImage;
-                    return null;
                 }
                 catch (SecurityException securityException)
                 {
                     error = securityException;
-                    return null;
                 }
             }
 
-            if (loadedAssembly != null)
-                return loadedAssembly;
-
-            if (!String.IsNullOrEmpty(filename))
-            {
-                error = null;
-
-                try
-                {
-                    loadedAssembly = Assembly.LoadFrom(filename);
-                    return loadedAssembly;
-                }
-                catch (FileNotFoundException fileNotFound)
-                {
-                    error = fileNotFound;
-                }
-                catch (FileLoadException fileLoadException)
-                {
-                    error = fileLoadException;
-                    return null;
-                }
-                catch (BadImageFormatException badImage)
-                {
-                    error = badImage;
-                    return null;
-                }
-                catch (SecurityException securityException)
-                {
-                    error = securityException;
-                    return null;
-                }
-            }
-
-#if !CORECLR// Assembly.LoadWithPartialName is not in CoreCLR. In CoreCLR, 'LoadWithPartialName' can be replaced by Assembly.Load with the help of AssemblyLoadContext.
-            // Finally try with partial name...
-            if (!String.IsNullOrEmpty(fixedName))
-            {
-                try
-                {
-                    // This is a deprecated API, use of this API needs to be
-                    // reviewed periodically.
-#pragma warning disable 0618
-                    loadedAssembly = Assembly.LoadWithPartialName(fixedName);
-
-                    if (loadedAssembly != null)
-                    {
-                        // In the past, LoadWithPartialName would just return null in most cases when the assembly could not be found or loaded.
-                        // In addition to this, the error was always cleared. So now, clear the error variable only if the assembly was loaded.
-                        error = null;
-                    }
-                    return loadedAssembly;
-                }
-
-                // Expected exceptions are ArgumentNullException and BadImageFormatException. See https://msdn.microsoft.com/en-us/library/12xc5368(v=vs.110).aspx
-                catch (BadImageFormatException badImage)
-                {
-                    error = badImage;
-                }
-            }
-#endif
-            return null;
+            // We either return the loaded Assembly, or return null.
+            return loadedAssembly;
         }
 
         /// <summary>

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Import-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Import-Module.Tests.ps1
@@ -88,3 +88,31 @@ Describe "Import-Module for Binary Modules in GAC" -Tags 'CI' {
         }
     }
 }
+
+Describe "Import-Module for Binary Modules" -Tags 'CI' {
+
+    It "PS should try to load the assembly from file path first" {
+ $src = @"
+using System.Management.Automation;           // Windows PowerShell namespace.
+
+namespace ModuleCmdlets
+{
+  [Cmdlet(VerbsDiagnostic.Test,"BinaryModuleCmdlet1")]   
+  public class TestBinaryModuleCmdlet1Command : Cmdlet
+  {
+    protected override void BeginProcessing()
+    {
+      WriteObject("BinaryModuleCmdlet1 exported by the ModuleCmdlets module.");
+    }
+  }
+}
+"@
+
+    Add-Type -TypeDefinition $src -OutputAssembly $TESTDRIVE\System.dll
+    $assembly = Import-Module $TESTDRIVE\System.dll -Force -PassThru
+
+    #Ignore slash format difference under windows/Unix
+    $path = (Get-ChildItem $TESTDRIVE\System.dll).FullName
+    $assembly.Path | Should be $path
+    }
+ }

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Import-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Import-Module.Tests.ps1
@@ -109,12 +109,12 @@ namespace ModuleCmdlets
 "@
 
     Add-Type -TypeDefinition $src -OutputAssembly $TESTDRIVE\System.dll
-    $assembly = Import-Module $TESTDRIVE\System.dll -Force -PassThru
+    $results = powershell -noprofile -c "`$module = Import-Module $TESTDRIVE\System.dll -Passthru; `$module.ImplementingAssembly.Location; Test-BinaryModuleCmdlet1"
 
     #Ignore slash format difference under windows/Unix
     $path = (Get-ChildItem $TESTDRIVE\System.dll).FullName
-    $assembly.Path | Should be $path
-    Test-BinaryModuleCmdlet1 | Should Be "BinaryModuleCmdlet1 exported by the ModuleCmdlets module."
+    $results[0] | Should Be $path
+    $results[1] | Should BeExactly "BinaryModuleCmdlet1 exported by the ModuleCmdlets module."
     }
  }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Import-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Import-Module.Tests.ps1
@@ -114,5 +114,7 @@ namespace ModuleCmdlets
     #Ignore slash format difference under windows/Unix
     $path = (Get-ChildItem $TESTDRIVE\System.dll).FullName
     $assembly.Path | Should be $path
+    Test-BinaryModuleCmdlet1 | Should Be "BinaryModuleCmdlet1 exported by the ModuleCmdlets module."
     }
  }
+


### PR DESCRIPTION
Fix issue #3325 

Summary of the issue:

visual studio cannot import the right assembly contains in their test vsix package through package manage console. It will always load the assembly contains in the vs location

Root cause of the issue:
loadassembly funtion will always try to load the assembly based on the assembly name first, then try the filename. In this case, no matter what assembly path psd1 file gives, ps will ignore and load the assembly in the vs cache.

Fix:
Since the filename is given, we should try it first before going to the assembly name.

The test scenario of this issue is very specific and does not contains in our ps enviroment. Attached the screen shot before/after the fix.

Before the fix:
![image](https://user-images.githubusercontent.com/16246343/27954472-007e0c64-62c5-11e7-9777-8e3eab72a75c.png)

After the fix:
![image](https://user-images.githubusercontent.com/16246343/27954510-2a9de87a-62c5-11e7-970b-b0bdfcbe50c9.png)
