### PR TITLE
Remove test hooks and tests for files being deleted or renamed during enumeration

### DIFF
--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -1589,11 +1589,6 @@ namespace System.Management.Automation.Internal
         // Simulate 'System.Diagnostics.Stopwatch.IsHighResolution is false' to test Get-Uptime throw
         internal static bool StopwatchIsNotHighResolution;
 
-        // Used in the FileSystemProvider to simulate deleting a file during enumeration in Get-ChildItem
-        internal static bool GciEnumerationActionDelete = false;
-        // Used in the FileSystemProvider to simulate renaming a file during enumeration in Get-ChildItem
-        internal static bool GciEnumerationActionRename = false;
-
         /// <summary>This member is used for internal test purposes.</summary>
         public static void SetTestHook(string property, bool value)
         {

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -1689,24 +1689,6 @@ namespace Microsoft.PowerShell.Commands
                             return;
                         }
 
-                        // Internal test code, run only if one of the
-                        // 'GciEnumerationAction' test hooks are set.
-                        if (InternalTestHooks.GciEnumerationActionDelete)
-                        {
-                            if (string.Equals(filesystemInfo.Name, "c283d143-2116-4809-bf11-4f7d61613f92", StringComparison.InvariantCulture))
-                            {
-                                File.Delete(filesystemInfo.FullName);
-                            }
-                        }
-                        else if (InternalTestHooks.GciEnumerationActionRename)
-                        {
-                            if (string.Equals(filesystemInfo.Name, "B1B691A9-B7B1-4584-AED7-5259511BEEC4", StringComparison.InvariantCulture))
-                            {
-                                var newFullName = Path.Combine(directory.FullName, "77efd2bb-92aa-4ad3-979a-18936a4bd565");
-                                File.Move(filesystemInfo.FullName, newFullName);
-                            }
-                        }
-
                         try
                         {
                             bool attributeFilter = true;

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ChildItem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ChildItem.Tests.ps1
@@ -66,46 +66,6 @@ Describe "Get-ChildItem" -Tags "CI" {
             $file.Count | Should be 1
             $file.Name | Should be $item_F
         }
-        # Test is pending on Unix platforms because of a behavior change in the latest .NET Core.
-        # See https://github.com/dotnet/corefx/issues/20456 for more information.
-        It "Should continue enumerating a directory when a contained item is deleted" -Pending:(!$IsWindows) {
-            $Error.Clear()
-            [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook("GciEnumerationActionDelete", $true)
-            $result = Get-ChildItem -Path $TestDrive -ErrorAction SilentlyContinue
-            [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook("GciEnumerationActionDelete", $false)
-            if ($IsWindows)
-            {
-                $Error.Count | Should BeExactly 0
-                $result.Count | Should BeExactly 5
-            }
-            else
-            {
-                $Error.Count | Should BeExactly 1
-                $Error[0].FullyQualifiedErrorId | Should BeExactly "DirIOError,Microsoft.PowerShell.Commands.GetChildItemCommand"
-                $Error[0].Exception | Should BeOfType System.Io.FileNotFoundException
-                $result.Count | Should BeExactly 4
-            }
-        }
-        # Test is pending on Unix platforms because of a behavior change in the latest .NET Core.
-        # See https://github.com/dotnet/corefx/issues/20456 for more information.
-        It "Should continue enumerating a directory when a contained item is renamed" -Pending:(!$IsWindows) {
-            $Error.Clear()
-            [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook("GciEnumerationActionRename", $true)
-            $result = Get-ChildItem -Path $TestDrive -ErrorAction SilentlyContinue
-            [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook("GciEnumerationActionRename", $false)
-            if ($IsWindows)
-            {
-                $Error.Count | Should BeExactly 0
-                $result.Count | Should BeExactly 4
-            }
-            else
-            {
-                $Error.Count | Should BeExactly 1
-                $Error[0].FullyQualifiedErrorId | Should BeExactly "DirIOError,Microsoft.PowerShell.Commands.GetChildItemCommand"
-                $Error[0].Exception | Should BeOfType System.Io.FileNotFoundException
-                $result.Count | Should BeExactly 3
-            }
-        }
     }
 
     Context 'Env: Provider' {


### PR DESCRIPTION
Addresses issue #4145

Previously with .NET Core, `FileNotFoundException` would be thrown if a file was deleted during an enumeration, and that issue was fixed by #3806. That behavior is changed in newer .NET Core to align with full .NET. So the tests hooks and tests added in #3806 is unneeded now and thus removed.