### PR TITLE
Add Test coverage for XmlCommand.cs

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/XmlCommands.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/XmlCommands.cs
@@ -566,11 +566,11 @@ namespace Microsoft.PowerShell.Commands
 
             if (Depth == 0)
             {
-                _serializer = new CustomSerialization(_xw, _notypeinformation);
+                _serializer = new CustomSerialization(_xw, NoTypeInformation);
             }
             else
             {
-                _serializer = new CustomSerialization(_xw, _notypeinformation, Depth);
+                _serializer = new CustomSerialization(_xw, NoTypeInformation, Depth);
             }
         }
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/XmlCommands.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/XmlCommands.cs
@@ -753,13 +753,6 @@ namespace Microsoft.PowerShell.Commands
                     object result = _deserializer.Deserialize();
                     PSObject psObject = result as PSObject;
 
-                    if (psObject == null && skipped++ >= skip)
-                    {
-                        count++;
-                        _cmdlet.WriteObject(result);
-                        continue;
-                    }
-
                     if (psObject != null)
                     {
                         ICollection c = psObject.BaseObject as ICollection;
@@ -785,6 +778,12 @@ namespace Microsoft.PowerShell.Commands
                                 _cmdlet.WriteObject(result);
                             }
                         }
+                    }
+                    else if (skipped++ >= skip)
+                    {
+                        count++;
+                        _cmdlet.WriteObject(result);
+                        continue;
                     }
                 }
             }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Xml.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Xml.Tests.ps1
@@ -1,4 +1,4 @@
-﻿Describe "ConvertTo-Xml DRT Unit Tests" -Tags "CI" {
+Describe "ConvertTo-Xml DRT Unit Tests" -Tags "CI" {
     $customPSObject = [pscustomobject]@{ "prop1" = "val1"; "prop2" = "val2" }
     $newLine = [System.Environment]::NewLine
     It "Test convertto-xml with a depth parameter" {
@@ -49,5 +49,24 @@
         $expectedValue = '<?xml version="1.0" encoding="utf-8"?><Objects><Object><Property Name="prop1">val1</Property><Property Name="prop2">val2</Property></Object></Objects>'
         $returnObject.OuterXml | Should Be $expectedValue
     }
+
+    It "StopProcessing should work" {
+		$ps = [PowerShell]::Create()
+		$ps.AddCommand("Get-Process")
+		$ps.AddCommand("ConvertTo-Xml")
+		$ps.AddParameter("Depth", 2)
+		$ps.BeginInvoke()
+		$ps.Stop()
+		$ps.InvocationStateInfo.State | Should Be "Stopped"
+    }
+
+    # these tests just cover aspects that aren't normally exercised being used as a cmdlet
+	It "Can read back switch and parameter values using api" {
+        Add-Type -AssemblyName "${pshome}/Microsoft.PowerShell.Commands.Utility.dll"
+
+		$cmd = [Microsoft.PowerShell.Commands.ConvertToXmlCommand]::new()
+		$cmd.NoTypeInformation = $true
+		$cmd.NoTypeInformation | Should Be $true
+	}
 }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Xml.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Xml.Tests.ps1
@@ -1,4 +1,4 @@
-Describe "ConvertTo-Xml DRT Unit Tests" -Tags "CI" {
+﻿Describe "ConvertTo-Xml DRT Unit Tests" -Tags "CI" {
     $customPSObject = [pscustomobject]@{ "prop1" = "val1"; "prop2" = "val2" }
     $newLine = [System.Environment]::NewLine
     It "Test convertto-xml with a depth parameter" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/XMLCommand.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/XMLCommand.Tests.ps1
@@ -30,17 +30,17 @@ Describe "XmlCommand DRT basic functionality Tests" -Tags "CI" {
 	}
 
     AfterEach {
-		remove-item $testfile
+		remove-item $testfile -Force -ErrorAction SilentlyContinue
     }
 
-    It "Import with CliXml directive should work" -Skip:$IsOSX{
-		Get-Process | Export-Clixml $testfile
+ 	It "Import with CliXml directive should work" {
+		Get-Process | Select-Object -First 5 | Export-Clixml $testfile
 		$results = Import-Clixml $testfile
-		$results.Count | Should BeGreaterThan 0
+		$results.Count | Should BeExactly 5
 		$results[0].ToString() | Should Match "System.Diagnostics.Process"
     }
 
-	It "Import with Rehydration should work" -Skip:$IsOSX{
+	It "Import with Rehydration should work" {
 		$property1 = 256
 		$property2 = "abcdef"
 		$isHiddenTestType = [IsHiddenTestType]::New($property1,$property2)
@@ -49,4 +49,111 @@ Describe "XmlCommand DRT basic functionality Tests" -Tags "CI" {
 		$results.Property1 | Should Be $property1
 		$results.Property2 | Should Be $property2
     }
+
+	It "Export-Clixml StopProcessing should succeed" {
+		$ps = [PowerShell]::Create()
+		$ps.AddCommand("Get-Process")
+		$ps.AddCommand("Export-CliXml")
+		$ps.AddParameter("Path", $testfile)
+		$ps.BeginInvoke()
+		$ps.Stop()
+		$ps.InvocationStateInfo.State | Should Be "Stopped"
+	}
+
+	It "Import-Clixml StopProcessing should succeed" {
+		1,2,3 | Export-Clixml -Path $testfile
+		$ps = [PowerShell]::Create()
+		$ps.AddCommand("Get-Process")
+		$ps.AddCommand("Import-CliXml")
+		$ps.AddParameter("Path", $testfile)
+		$ps.BeginInvoke()
+		$ps.Stop()
+		$ps.InvocationStateInfo.State | Should Be "Stopped"
+	}
+
+	It "Export-Clixml using -Depth should work" {
+		class Three
+		{
+			[int] $num = 3;
+		}
+
+		class Two
+		{
+			[Three] $three = [Three]::New();
+		}
+
+		class One
+		{
+			[Two] $two = [Two]::New();
+		}
+
+		$one = [One]::New()
+		$one | Export-Clixml -Depth 2 -Path $testfile
+		$deserialized_one = Import-Clixml -Path $testfile
+		$deserialized_one.two.three.num | Should BeNullOrEmpty
+	}
+
+	It "Import-Clixml should work with XML serialization from powershell.exe" {
+		# need to create separate process so that current powershell doesn't interpret clixml output
+		Start-Process -FilePath $pshome\powershell -RedirectStandardOutput $testfile -Args "-noprofile -nologo -outputformat xml -command get-command import-clixml" -Wait
+		$out = Import-Clixml -Path $testfile
+		$out.Name | Should Be "Import-CliXml"
+		$out.CommandType.ToString() | Should Be "Cmdlet"
+		$out.Source | Should Be "Microsoft.PowerShell.Utility"
+	}
+
+	It "Import-Clixml -IncludeTotalCount always returns unknown total count" {
+		# this cmdlets supports paging, but not this switch
+		[PSCustomObject]@{foo=1;bar=@{hello="world"}} | Export-Clixml -Path $testfile
+		$out = Import-Clixml -Path $testfile -IncludeTotalCount
+		$out[0].ToString() | Should BeExactly "Unknown total count"
+	}
+
+	It "Import-Clixml -First and -Skip work together for simple types" {
+		"one","two","three","four" | Export-Clixml -Path $testfile
+		$out = Import-Clixml -Path $testfile -First 2 -Skip 1
+		$out.Count | Should Be 2
+		$out[0] | Should BeExactly "two"
+		$out[1] | Should BeExactly "three"
+	}
+
+	It "Import-Clixml -First and -Skip work together for collections" {
+		@{a=1;b=2;c=3;d=4} | Export-Clixml -Path $testfile
+		# order not guaranteed, even with [ordered] so we have to be smart here and compare against the full result
+		$out1 = Import-Clixml -Path $testfile	# this results in a hashtable
+		$out2 = Import-Clixml -Path $testfile -First 2 -Skip 1	# this results in a dictionary entry
+		$out2.Count | Should Be 2
+		$array = @()
+		foreach ($obj in $out1.GetEnumerator())
+		{
+			$array += $obj
+		}
+		for($i = 0; $i -lt 2; $i++)
+		{
+			$out2.Item($i).Name | Should Be $array[$i+1].Name
+			$out2.Item($i).Value | Should Be $array[$i+1].Value
+		}
+	}
+
+	# these tests just cover aspects that aren't normally exercised being used as a cmdlet
+	It "Can read back switch and parameter values using api" {
+		Add-Type -AssemblyName "${pshome}/Microsoft.PowerShell.Commands.Utility.dll"
+
+		$cmd = [Microsoft.PowerShell.Commands.ExportClixmlCommand]::new()
+		$cmd.LiteralPath = "foo"
+		$cmd.LiteralPath | Should BeExactly "foo"
+		$cmd.NoClobber = $true
+		$cmd.NoClobber | Should Be $true
+
+		$cmd = [Microsoft.PowerShell.Commands.ImportClixmlCommand]::new()
+		$cmd.LiteralPath = "bar"
+		$cmd.LiteralPath | Should BeExactly "bar"
+
+		$cmd = [Microsoft.PowerShell.Commands.SelectXmlCommand]::new()
+		$cmd.LiteralPath = "foo"
+		$cmd.LiteralPath | Should BeExactly "foo"
+		$xml = [xml]"<a/>"
+		$cmd.Xml = $xml
+		$cmd.Xml | Should Be $xml
+	}
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/xml.tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/xml.tests.ps1
@@ -50,7 +50,7 @@
 
             It $_.testName {
                 @(Select-XML @params).Count | Should Be 1
-                (Select-XML @params).Path | Should Be $fileName
+                (Select-XML @params).Path | Should Be $fileName.FullName
             }
         }
 
@@ -58,6 +58,7 @@
             @{parameter="literalPath"},
             @{parameter="path"}
         ) {
+            param($parameter)
             $__data = "abcdefg"
             $params = @{$parameter="variable:__data"}
             { Select-XML @params "Root" | Should BeErrorId 'ProcessingFile,Microsoft.PowerShell.Commands.SelectXmlCommand' }
@@ -71,10 +72,10 @@
 
         It "-xml works with inputstream" {
             [xml]$xml = "<a xmlns='bar'><b xmlns:b='foo'>hello</b><c>world</c></a>"
-            $node = Select-Xml -Xml $xml -XPath "//b" -Namespace @{b='foo'}
+            $node = Select-Xml -Xml $xml -XPath "//c:b" -Namespace @{c='bar'}
             $node.Path | Should BeExactly "InputStream"
-            $node.Pattern = "//b:b"
-            $node.ToString() | Should Be Exactly "hello"
+            $node.Pattern = "//c:b"
+            $node.ToString() | Should BeExactly "hello"
         }
 
         It "Returns error for invalid xmlnamespace" {
@@ -92,7 +93,7 @@
         }
 
         It "ToString() works correctly with file" {
-            $testfile = "$testdrive/test.xml"
+            $testfile = Join-Path "$testdrive" "test.xml"
             Set-Content -Path $testfile -Value "<a><b>hello</b></a>"
             $node = Select-Xml -Path $testfile -XPath "//b"
             $node.ToString() | Should BeExactly "hello:$testfile"

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/xml.tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/xml.tests.ps1
@@ -49,20 +49,55 @@
             $params = $_.parameters
 
             It $_.testName {
-                @(Select-XML @params).Count | Should Be 1
+                $result = Select-XML @params
+                $result.Count | Should Be 1
+                $result.Path | Should BeExactly $fileName.FullName
             }
         }
 
-        It "literalpath with non filesystem path" {
+        It "non filesystem path using <parameter>" -TestCases @(
+            @{parameter="literalPath"},
+            @{parameter="path"}
+        ) {
+            param($parameter)
             $__data = "abcdefg"
-            Select-XML -literalPath variable:__data "Root" -ErrorVariable selectXmlError -ErrorAction SilentlyContinue
-            $selectXmlError.FullyQualifiedErrorId | Should Be 'ProcessingFile,Microsoft.PowerShell.Commands.SelectXmlCommand'
+            $params = @{$parameter="variable:__data"}
+            { Select-XML @params "Root" | ShouldBeErrorId 'ProcessingFile,Microsoft.PowerShell.Commands.SelectXmlCommand' }
         }
 
-        It "path with non filesystem path" {
-            $__data = "abcdefg"
-            Select-XML -Path variable:\__data "Root" -ErrorVariable selectXmlError -ErrorAction SilentlyContinue
-            $selectXmlError.FullyQualifiedErrorId | Should Be 'ProcessingFile,Microsoft.PowerShell.Commands.SelectXmlCommand'
+        It "Invalid xml file" {
+            $testfile = "$testdrive/test.xml"
+            Set-Content -Path $testfile -Value "<a><b>"
+            { Select-Xml -Path $testfile -XPath foo | ShouldBeErrorId 'ProcessingFile,Microsoft.PowerShell.Commands.SelectXmlCommand' }
+        }
+
+        It "-xml works with inputstream" {
+            [xml]$xml = "<a xmlns='bar'><b xmlns:b='foo'>hello</b><c>world</c></a>"
+            $node = Select-Xml -Xml $xml -XPath "//c:b" -Namespace @{c='bar'}
+            $node.Path | Should BeExactly "InputStream"
+            $node.Pattern = "//c:b"
+            $node.ToString() | Should BeExactly "hello"
+        }
+
+        It "Returns error for invalid xmlnamespace" {
+            [xml]$xml = "<a xmlns='bar'><b xmlns:b='foo'>hello</b><c>world</c></a>"
+            { Select-Xml -Xml $xml -XPath foo -Namespace @{c=$null} | ShouldBeErrorId "PrefixError,Microsoft.PowerShell.Commands.SelectXmlCommand" }
+        }
+
+        It "Returns error for invalid content" {
+            { Select-Xml -Content "hello" -XPath foo | ShouldBeErrorId "InvalidCastToXmlDocument,Microsoft.PowerShell.Commands.SelectXmlCommand" }
+        }
+
+        It "ToString() works correctly on nested node" {
+            $node = Select-Xml -Content "<a><b>one<c>hello</c></b></a>" -XPath "//b"
+            $node.ToString() | Should BeExactly "one<c>hello</c>"
+        }
+
+        It "ToString() works correctly with file" {
+            $testfile = "$testdrive" + [System.IO.Path]::DirectorySeparatorChar + "test.xml"
+            Set-Content -Path $testfile -Value "<a><b>hello</b></a>"
+            $node = Select-Xml -Path $testfile -XPath "//b"
+            $node.ToString() | Should BeExactly "hello:$testfile"
         }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/xml.tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/xml.tests.ps1
@@ -49,9 +49,8 @@
             $params = $_.parameters
 
             It $_.testName {
-                $result = Select-XML @params
-                $result.Count | Should Be 1
-                $result.Path | Should BeExactly $fileName.FullName
+                @(Select-XML @params).Count | Should Be 1
+                (Select-XML @params).Path | Should Be $fileName
             }
         }
 
@@ -59,10 +58,9 @@
             @{parameter="literalPath"},
             @{parameter="path"}
         ) {
-            param($parameter)
             $__data = "abcdefg"
             $params = @{$parameter="variable:__data"}
-            { Select-XML @params "Root" | ShouldBeErrorId 'ProcessingFile,Microsoft.PowerShell.Commands.SelectXmlCommand' }
+            { Select-XML @params "Root" | Should BeErrorId 'ProcessingFile,Microsoft.PowerShell.Commands.SelectXmlCommand' }
         }
 
         It "Invalid xml file" {
@@ -73,10 +71,10 @@
 
         It "-xml works with inputstream" {
             [xml]$xml = "<a xmlns='bar'><b xmlns:b='foo'>hello</b><c>world</c></a>"
-            $node = Select-Xml -Xml $xml -XPath "//c:b" -Namespace @{c='bar'}
+            $node = Select-Xml -Xml $xml -XPath "//b" -Namespace @{b='foo'}
             $node.Path | Should BeExactly "InputStream"
-            $node.Pattern = "//c:b"
-            $node.ToString() | Should BeExactly "hello"
+            $node.Pattern = "//b:b"
+            $node.ToString() | Should Be Exactly "hello"
         }
 
         It "Returns error for invalid xmlnamespace" {
@@ -94,7 +92,7 @@
         }
 
         It "ToString() works correctly with file" {
-            $testfile = "$testdrive" + [System.IO.Path]::DirectorySeparatorChar + "test.xml"
+            $testfile = "$testdrive/test.xml"
             Set-Content -Path $testfile -Value "<a><b>hello</b></a>"
             $node = Select-Xml -Path $testfile -XPath "//b"
             $node.ToString() | Should BeExactly "hello:$testfile"


### PR DESCRIPTION
fixed issues in XmlCommand not working correctly for -First and -Skip
removed dead code form XmlCommand
added tests

I'll see if I can get some code coverage data

Fix https://github.com/PowerShell/PowerShell/issues/4152
<!--

If you are a PowerShell Team member, please make sure you choose the Reviewer(s) and Assignee for your PR.
If you are not from the PowerShell Team, you can leave the fields blank and the Maintainers will choose them for you. If you are familiar with the team, feel free to mention some Reviewers yourself.

For more information about the roles of Reviewer and Assignee, refer to CONTRIBUTING.md.

-->
