### PR TITLE
Checkbox to open PowerShell after the (Windows) installer has finished

### DIFF
--- a/assets/Product.wxs
+++ b/assets/Product.wxs
@@ -33,7 +33,7 @@
     <Property Id="ARPHELPLINK" Value="$(var.InfoURL)" />
 
 	<!-- Checkbox to allow starting PowerShell after the installation (in UI mode only) -->
-	<Property Id="WIXUI_EXITDIALOGOPTIONALCHECKBOXTEXT" Value="Open PowerShell" />
+	<Property Id="WIXUI_EXITDIALOGOPTIONALCHECKBOXTEXT" Value="Open $(env.ProductName)" />
 	<!-- Default value of Checkbox of starting PowerShell after installation -->  
 	<Property Id="WixShellExecTarget" Value="[$(var.ProductVersionWithName)]PowerShell.exe"/>
 	<CustomAction Id="LaunchApplication" BinaryKey="WixCA" DllEntry="WixShellExec" Impersonate="yes" />

--- a/assets/Product.wxs
+++ b/assets/Product.wxs
@@ -31,6 +31,13 @@
 
     <!-- Set properties for add/remove programs -->
     <Property Id="ARPHELPLINK" Value="$(var.InfoURL)" />
+
+	<!-- Checkbox to allow starting PowerShell after the installation (in UI mode only) -->
+	<Property Id="WIXUI_EXITDIALOGOPTIONALCHECKBOXTEXT" Value="Open PowerShell" />
+	<!-- Default value of Checkbox of starting PowerShell after installation -->  
+	<Property Id="WixShellExecTarget" Value="[$(var.ProductVersionWithName)]PowerShell.exe"/>
+	<CustomAction Id="LaunchApplication" BinaryKey="WixCA" DllEntry="WixShellExec" Impersonate="yes" />
+	<UI><Publish Dialog="ExitDialog" Control="Finish" Event="DoAction" Value="LaunchApplication">WIXUI_EXITDIALOGOPTIONALCHECKBOX = 1 and NOT Installed</Publish></UI>
     
     <!-- Prerequisites -->
     <Condition Message="Supported only on Win8 and above"><![CDATA[ Installed OR $(var.MinOSVersionSupported) ]]></Condition>

--- a/build.psm1
+++ b/build.psm1
@@ -2591,8 +2591,8 @@ function New-MSIPackage
     Remove-Item -ErrorAction SilentlyContinue $msiLocationPath -Force
 
     & $wixHeatExePath dir  $ProductSourcePath -dr  $productVersionWithName -cg $productVersionWithName -gg -sfrag -srd -scom -sreg -out $wixFragmentPath -var env.ProductSourcePath -v | Write-Verbose
-    & $wixCandleExePath  "$ProductWxsPath"  "$wixFragmentPath" -out (Join-Path "$env:Temp" "\\") -arch x64 -v | Write-Verbose
-    & $wixLightExePath -out $msiLocationPath $wixObjProductPath $wixObjFragmentPath -ext WixUIExtension -dWixUILicenseRtf="$LicenseFilePath" -v | Write-Verbose
+    & $wixCandleExePath  "$ProductWxsPath"  "$wixFragmentPath" -out (Join-Path "$env:Temp" "\\") -ext WixUIExtension -ext WixUtilExtension -arch x64 -v | Write-Verbose
+    & $wixLightExePath -out $msiLocationPath $wixObjProductPath $wixObjFragmentPath -ext WixUIExtension -ext WixUtilExtension -dWixUILicenseRtf="$LicenseFilePath" -v | Write-Verbose
 
     Remove-Item -ErrorAction SilentlyContinue *.wixpdb -Force
 


### PR DESCRIPTION
Added a checkbox (unchecked by default) to the last dialogue of the Windows installer to provide the option of opening PowerShell because that's what most people want to do if they installed PowerShell.