### PR TITLE
Add sudo built-in function to UNIX builds.

### DIFF
--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -4881,8 +4881,7 @@ function Get-ScriptBlock
     [string] $sudoArgs = Get-SudoArgs -AllArgs $AllArgs
 
     <# tokenize the remaining arguments to identify the type of expression; native or powershell
-       if errors are encountered; assuming a native command and pass the expression through to sudo
-    #>
+       if errors are encountered; assuming a native command and pass the expression through to sudo #>
     $tokens = [System.Management.Automation.PSParser]::Tokenize($AllArgs.ToArray(), [ref] $null)
     foreach ($token in $Tokens)
     {

--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -4880,7 +4880,9 @@ function Get-ScriptBlock
 
     [string] $sudoArgs = Get-SudoArgs -AllArgs $AllArgs
 
-    <# tokenize the remaining arguments to identify the type of expression; native or powershell #>
+    <# tokenize the remaining arguments to identify the type of expression; native or powershell
+       if errors are encountered; assuming a native command and pass the expression through to sudo
+    #>
     $tokens = [System.Management.Automation.PSParser]::Tokenize($AllArgs.ToArray(), [ref] $null)
     foreach ($token in $Tokens)
     {

--- a/test/powershell/engine/DefaultCommands.Tests.ps1
+++ b/test/powershell/engine/DefaultCommands.Tests.ps1
@@ -534,14 +534,17 @@ Describe "Verify approved aliases list" -Tags "CI" {
     }
 }
 
-[string] $userBinPath = Get-Item -Path '~/bin'
-[string] $sudoMockPath = Join-Path (Get-Item -Path '~/bin').FullName -ChildPath 'sudo'
-[string] $sudoText = 'mocksudo.txt'
-[string] $sudoOutputPath = Join-Path (Get-Item -Path '~/bin').FullName -ChildPath $sudotext
-[string] $sudoMock = @"
+if ($CoreUnix)
+{
+[string] $script:userBinPath = Get-Item -Path '~/bin'
+[string] $script:sudoMockPath = Join-Path (Get-Item -Path '~/bin').FullName -ChildPath 'sudo'
+[string] $script:sudoText = 'mocksudo.txt'
+[string] $script:sudoOutputPath = Join-Path (Get-Item -Path '~/bin').FullName -ChildPath $sudotext
+[string] $script:sudoMock = @"
 #!/bin/sh
 echo `$@
 "@
+}
 
 Describe "Verify sudo function on CoreUNIX" -Tags "CI"{
 
@@ -550,10 +553,10 @@ Describe "Verify sudo function on CoreUNIX" -Tags "CI"{
         BeforeAll {
             $skipTest = !$CoreUnix
             if ($skipTest) {return}
-            $sudoscript = $sudoMock.Replace("`r`n", "`n")
+            $sudoscript = $script:sudoMock.Replace("`r`n", "`n")
             # place a mock sudo command in the user's bin folder
-            Set-Content -Path $sudoMockPath -Value $sudoscript
-            chmod 777 $sudoMockPath
+            Set-Content -Path $script:sudoMockPath -Value $sudoscript
+            chmod 777 $script:sudoMockPath
             $items = Get-Command -Name 'sudo' -CommandType Application
             # Verify sudo resolves to the mock
             if ($items -eq $null)
@@ -579,9 +582,9 @@ Describe "Verify sudo function on CoreUNIX" -Tags "CI"{
             if ($skipTest) {return}
 
             # clean up the mock files
-            if (Test-Path -Path $sudoMockPath)
+            if (Test-Path -Path $script:sudoMockPath)
             {
-                Remove-Item -Path $sudoMockPath -ErrorAction Ignore
+                Remove-Item -Path $script:sudoMockPath -ErrorAction Ignore
             }
         }
 

--- a/test/powershell/engine/DefaultCommands.Tests.ps1
+++ b/test/powershell/engine/DefaultCommands.Tests.ps1
@@ -534,7 +534,7 @@ Describe "Verify approved aliases list" -Tags "CI" {
     }
 }
 
-if ($CoreUnix)
+if ($isCoreCLR -and !$IsWindows)
 {
 [string] $script:userBinPath = Get-Item -Path '~/bin'
 [string] $script:sudoMockPath = Join-Path (Get-Item -Path '~/bin').FullName -ChildPath 'sudo'
@@ -551,7 +551,7 @@ Describe "Verify sudo function on CoreUNIX" -Tags "CI"{
     Context "Verify using MOCK sudo" {
 
         BeforeAll {
-            $skipTest = !$CoreUnix
+            $skipTest = ((-not $isCoreCLR) -or $IsWindows)
             if ($skipTest) {return}
             $sudoscript = $script:sudoMock.Replace("`r`n", "`n")
             # place a mock sudo command in the user's bin folder


### PR DESCRIPTION
Fixes https://github.com/PowerShell/PowerShell/issues/3232

Associated function help: https://github.com/PowerShell/PowerShell-Docs/pull/1437

This function wraps calls to the native sudo command to detect commands/expressions requiring PowerShell. In those cases, powershell is invoked with the expression.

