### PR TITLE
make sure we don't return null for share module path

### DIFF
--- a/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
@@ -585,24 +585,16 @@ namespace System.Management.Automation
         /// It's known as "Program Files" module path in windows powershell.
         /// </summary>
         /// <returns></returns>
-        internal static string GetSharedModulePath()
+        private static string GetSharedModulePath()
         {
 #if UNIX
             return Platform.SelectProductNameForDirectory(Platform.XDG_Type.SHARED_MODULES);
 #else
-            string sharedModulePath = string.Empty;
-            string programFilesPath = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
-
-            // If we could not get a path from the special folder call,
-            // fall back to the environment.
-            if(string.IsNullOrEmpty(programFilesPath))
+            string sharedModulePath = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
+           
+            if (!string.IsNullOrEmpty(sharedModulePath))
             {
-                programFilesPath = System.Environment.GetEnvironmentVariable("ProgramFiles");
-            }
-            
-            if (!string.IsNullOrEmpty(programFilesPath))
-            {
-                sharedModulePath = Path.Combine(programFilesPath, Utils.ModuleDirectory);
+                sharedModulePath = Path.Combine(sharedModulePath, Utils.ModuleDirectory);
             }
             return sharedModulePath;
 #endif
@@ -735,8 +727,8 @@ namespace System.Management.Automation
 #if UNIX
             return false;
 #else
-            Dbg.Assert(!string.IsNullOrEmpty(personalModulePath), "caller makes sure it's not null or empty");
-            Dbg.Assert(!string.IsNullOrEmpty(sharedModulePath), "caller makes sure it's not null or empty");
+            Dbg.Assert(!string.IsNullOrEmpty(personalModulePath), "caller makes sure personalModulePath not null or empty");
+            Dbg.Assert(sharedModulePath != null, "caller makes sure sharedModulePath is not null");
 
             const string winSxSModuleDirectory = @"PowerShell\Modules";
             const string winLegacyModuleDirectory = @"WindowsPowerShell\Modules";

--- a/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
@@ -590,8 +590,16 @@ namespace System.Management.Automation
 #if UNIX
             return Platform.SelectProductNameForDirectory(Platform.XDG_Type.SHARED_MODULES);
 #else
-            string sharedModulePath = null;
+            string sharedModulePath = string.Empty;
             string programFilesPath = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
+
+            // If we could not get a path from the special folder call,
+            // fall back to the environment.
+            if(string.IsNullOrEmpty(programFilesPath))
+            {
+                programFilesPath = System.Environment.GetEnvironmentVariable("ProgramFiles");
+            }
+            
             if (!string.IsNullOrEmpty(programFilesPath))
             {
                 sharedModulePath = Path.Combine(programFilesPath, Utils.ModuleDirectory);


### PR DESCRIPTION
fall back to environment if call to get special path doesn't work

<!--

If you are a PowerShell Team member, please make sure you choose the Reviewer(s) and Assignee for your PR.
If you are not from the PowerShell Team, you can leave the fields blank and the Maintainers will choose them for you. If you are familiar with the team, feel free to mention some Reviewers yourself.

For more information about the roles of Reviewer and Assignee, refer to CONTRIBUTING.md.

-->
