### PR TITLE
Fix for implicit remote regression in restricted session

### DIFF
--- a/src/System.Management.Automation/engine/CommandMetadata.cs
+++ b/src/System.Management.Automation/engine/CommandMetadata.cs
@@ -1220,7 +1220,10 @@ end
             typeNameParameter.Attributes.Add(new ValidateLengthAttribute(0, 1000));
             typeNameParameter.Attributes.Add(new ValidateCountAttribute(0, 1000));
 
-            return GetRestrictedCmdlet("Get-FormatData", null, "https://go.microsoft.com/fwlink/?LinkID=144303", typeNameParameter);
+            // This parameter is required for implicit remoting in PS V5.1.
+            ParameterMetadata powershellVersionParameter = new ParameterMetadata("PowerShellVersion", typeof(Version));
+
+            return GetRestrictedCmdlet("Get-FormatData", null, "https://go.microsoft.com/fwlink/?LinkID=144303", typeNameParameter, powershellVersionParameter);
         }
 
         private static CommandMetadata GetRestrictedGetHelp()

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Implicit.Remoting.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Implicit.Remoting.Tests.ps1
@@ -2076,3 +2076,42 @@ Describe "GetCommand locally and remotely" -tags "Feature" {
         $localCommandCount | Should Be $remoteCommandCount
     }
 }
+
+Describe "Import-PSSession on Restricted Session" -tags "Feature","RequireAdminOnWindows","Slow" {
+
+    BeforeAll {
+
+        # Skip tests for non Windows
+        if (! $IsWindows)
+        {
+            $originalDefaultParameters = $PSDefaultParameterValues.Clone()
+            $PSDefaultParameterValues["it:skip"] = $true
+        }
+        else
+        {
+            New-PSSessionConfigurationFile -Path $TestDrive\restricted.pssc -SessionType RestrictedRemoteServer
+            Register-PSSessionConfiguration -Path $TestDrive\restricted.pssc -Name restricted -Force
+            $session = New-PSSession -ComputerName localhost -ConfigurationName restricted
+        }
+    }
+
+    AfterAll {
+
+        if ($originalDefaultParameters -ne $null)
+        {
+            $PSDefaultParameterValues = $originalDefaultParameters
+        }
+        else
+        {
+            if ($session -ne $null) { Remove-PSSession -Session $session -ErrorAction SilentlyContinue }
+            Unregister-PSSessionConfiguration -Name restricted -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    It "Verifies that Import-PSSession works on a restricted session" {
+
+        $errorVariable = $null
+        Import-PSSession -Session $session -AllowClobber -ErrorVariable $errorVariable
+        $errorVariable | Should BeNullOrEmpty
+    }
+}

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Implicit.Remoting.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Implicit.Remoting.Tests.ps1
@@ -2085,7 +2085,7 @@ Describe "Import-PSSession on Restricted Session" -tags "Feature","RequireAdminO
         if (! $IsWindows)
         {
             $originalDefaultParameters = $PSDefaultParameterValues.Clone()
-            $PSDefaultParameterValues["it:skip"] = $true
+            $global:PSDefaultParameterValues["it:skip"] = $true
         }
         else
         {
@@ -2099,7 +2099,7 @@ Describe "Import-PSSession on Restricted Session" -tags "Feature","RequireAdminO
 
         if ($originalDefaultParameters -ne $null)
         {
-            $PSDefaultParameterValues = $originalDefaultParameters
+            $global:PSDefaultParameterValues = $originalDefaultParameters
         }
         else
         {


### PR DESCRIPTION
Issue #4195 

PowerShell 5.1 Get-FormatData has a new required parameter (PowerShellVersion) which was not included in restricted sessions.  So Import-PSSession fails when trying to use the parameter.

Fix is to add this parameter to the restricted session Get-FormatData proxy function.

Repro:
------
```powershell
# Create and register a restricted session endpoint on local machine with PS 5.1
New-PSSessionConfigurationFile -Path c:\restricted.pssc -SessionType RestrictedRemoteServer
Register-PSSessionConfiguration -Path C:\restricted.pssc -Name restricted -Force
 
# Create and import a session instance
$s = New-PSSession -config restricted 
Import-PSSession -Session $s -AllowClobber
 
Result:
Import-PSSession : Running the Get-Command command in a remote session reported the following error: A parameter
cannot be found that matches parameter name 'PowerShellVersion'..
At line:1 char:1
+ Import-PSSession -Session $s -AllowClobber
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidResult: (:) [Import-PSSession], RuntimeException
    + FullyQualifiedErrorId : ErrorFromRemoteCommand,Microsoft.PowerShell.Commands.ImportPSSessionCommand
```