### PR TITLE
Make travis ci quieter

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -1108,7 +1108,7 @@ function Start-PSBootstrap {
                 Push-Location $PSScriptRoot
                 $Submodule = "$PSScriptRoot/src/libpsl-native/test/googletest"
                 Remove-Item -Path $Submodule -Recurse -Force -ErrorAction SilentlyContinue
-                git submodule update --init -- $submodule
+                git submodule --quiet update --init -- $submodule
             } finally {
                 Pop-Location
             }
@@ -1130,7 +1130,7 @@ function Start-PSBootstrap {
 
             # Install dependencies
             Start-NativeExecution {
-                Invoke-Expression "$sudo apt-get update"
+                Invoke-Expression "$sudo apt-get update -qq"
                 Invoke-Expression "$sudo apt-get install -y -qq $Deps"
             }
         } elseif ($IsRedHatFamily) {

--- a/tools/travis.ps1
+++ b/tools/travis.ps1
@@ -111,7 +111,14 @@ $output = Split-Path -Parent (Get-PSOutput -Options (New-PSOptions))
 # without running those class parsing tests so as to avoid the hang.
 # NOTE: this change should be reverted once the 'CrossGen' issue is fixed by CoreCLR. The issue
 #       is tracked by https://github.com/dotnet/coreclr/issues/9745
-Start-PSBuild -CrossGen:$isFullBuild -PSModuleRestore
+$originalProgressPreference = $ProgressPreference
+$ProgressPreference = 'SilentlyContinue' 
+try {
+    Start-PSBuild -CrossGen:$isFullBuild -PSModuleRestore
+}
+finally{
+    $ProgressPreference = $originalProgressPreference    
+}
 
 $pesterParam = @{ 'binDir' = $output }
 


### PR DESCRIPTION
make submodule init and apt-get update in order to make Travis-ci build quieter.
Suppress progress during build in order to make Travis-ci build quieter
