### PR TITLE
Move Bootstrap to install for Travis-CI in order to make the logs quieter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,9 +31,10 @@ install:
       nvm install 6.4.0 &&
       npm install -g markdown-spellcheck@0.11.0;
     fi
+  - ulimit -n 4096
+  - powershell -File tools/travis.ps1 -Bootstrap
 
 script:
-  - ulimit -n 4096
   - powershell -File tools/travis.ps1
   # spellcheck
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then


### PR DESCRIPTION
Moving bootstrap to install causes it to "fold" or hide, unless it fails.  
This makes the logs appear quieter.
move ulimit after verifying it is sticky
https://travis-ci.org/TravisEz13/PowerShell/jobs/253434166

<!--

If you are a PowerShell Team member, please make sure you choose the Reviewer(s) and Assignee for your PR.
If you are not from the PowerShell Team, you can leave the fields blank and the Maintainers will choose them for you. If you are familiar with the team, feel free to mention some Reviewers yourself.

For more information about the roles of Reviewer and Assignee, refer to CONTRIBUTING.md.

-->
