### PR TITLE
Fix C# tests for ValidateSetValuesGenerator

### DIFF
--- a/test/powershell/Language/Classes/Scripting.Classes.Attributes.Tests.ps1
+++ b/test/powershell/Language/Classes/Scripting.Classes.Attributes.Tests.ps1
@@ -294,6 +294,10 @@ Describe 'ValidateSet support a dynamically generated set' -Tag "CI" {
             $testModule = Import-Module $cls.Assembly -PassThru
         }
 
+        AfterAll {
+            Remove-Module -ModuleInfo $testModule
+        }
+
         It 'Throw if IValidateSetValuesGenerator is not implemented' {
             { Get-TestValidateSet0 -Param1 "TestString" -ErrorAction Stop } | ShouldBeErrorId "Argument"
         }

--- a/test/powershell/Language/Classes/Scripting.Classes.Attributes.Tests.ps1
+++ b/test/powershell/Language/Classes/Scripting.Classes.Attributes.Tests.ps1
@@ -297,7 +297,6 @@ Describe 'ValidateSet support a dynamically generated set' -Tag "CI" {
 
         AfterAll {
             Remove-Module -ModuleInfo $testModule
-            Remove-Item $testAssemply -Force -ErrorAction SilentlyContinue
         }
 
         It 'Throw if IValidateSetValuesGenerator is not implemented' {

--- a/test/powershell/Language/Classes/Scripting.Classes.Attributes.Tests.ps1
+++ b/test/powershell/Language/Classes/Scripting.Classes.Attributes.Tests.ps1
@@ -290,8 +290,8 @@ Describe 'ValidateSet support a dynamically generated set' -Tag "CI" {
         }
 '@
 
-            $cls = Add-Type -TypeDefinition $a -PassThru | select -first 1
-			$testModule = Import-Module $cls.Assembly -PassThru
+            $cls = Add-Type -TypeDefinition $a -PassThru | select -First 1
+            $testModule = Import-Module $cls.Assembly -PassThru
         }
 
         It 'Throw if IValidateSetValuesGenerator is not implemented' {

--- a/test/powershell/Language/Classes/Scripting.Classes.Attributes.Tests.ps1
+++ b/test/powershell/Language/Classes/Scripting.Classes.Attributes.Tests.ps1
@@ -292,7 +292,12 @@ Describe 'ValidateSet support a dynamically generated set' -Tag "CI" {
 
             $testAssemply = "$TestDrive\tst-$(New-Guid).dll"
             Add-Type -TypeDefinition $a -OutputAssembly $testAssemply
-            Import-Module $testAssemply
+            $testModule = Import-Module $testAssemply -PassThru
+        }
+
+        AfterAll {
+            Remove-Module -ModuleInfo $testModule
+            Remove-Item $testAssemply -Force -ErrorAction SilentlyContinue
         }
 
         It 'Throw if IValidateSetValuesGenerator is not implemented' {
@@ -433,7 +438,7 @@ Describe 'ValidateSet support a dynamically generated set' -Tag "CI" {
                         [GenValuesWithExpiration]::temp = $true
                         return [string[]]("Test1","TestString2","Test2")
                     }
-                    
+
                 }
             }
 

--- a/test/powershell/Language/Classes/Scripting.Classes.Attributes.Tests.ps1
+++ b/test/powershell/Language/Classes/Scripting.Classes.Attributes.Tests.ps1
@@ -293,10 +293,6 @@ Describe 'ValidateSet support a dynamically generated set' -Tag "CI" {
             $cls = Add-Type -TypeDefinition $a -PassThru | select -First 1
             $testModule = Import-Module $cls.Assembly -PassThru
         }
-		
-		AfterAll {
-			Remove-Module -ModuleInfo $testModule
-		}
 
         AfterAll {
             Remove-Module -ModuleInfo $testModule

--- a/test/powershell/Language/Classes/Scripting.Classes.Attributes.Tests.ps1
+++ b/test/powershell/Language/Classes/Scripting.Classes.Attributes.Tests.ps1
@@ -290,13 +290,8 @@ Describe 'ValidateSet support a dynamically generated set' -Tag "CI" {
         }
 '@
 
-            $testAssemply = "$TestDrive\tst-$(New-Guid).dll"
-            Add-Type -TypeDefinition $a -OutputAssembly $testAssemply
-            $testModule = Import-Module $testAssemply -PassThru
-        }
-
-        AfterAll {
-            Remove-Module -ModuleInfo $testModule
+            $cls = Add-Type -TypeDefinition $a -PassThru | select -first 1
+			$testModule = Import-Module $cls.Assembly -PassThru
         }
 
         It 'Throw if IValidateSetValuesGenerator is not implemented' {

--- a/test/powershell/Language/Classes/Scripting.Classes.Attributes.Tests.ps1
+++ b/test/powershell/Language/Classes/Scripting.Classes.Attributes.Tests.ps1
@@ -293,6 +293,10 @@ Describe 'ValidateSet support a dynamically generated set' -Tag "CI" {
             $cls = Add-Type -TypeDefinition $a -PassThru | select -First 1
             $testModule = Import-Module $cls.Assembly -PassThru
         }
+		
+		AfterAll {
+			Remove-Module -ModuleInfo $testModule
+		}
 
         AfterAll {
             Remove-Module -ModuleInfo $testModule


### PR DESCRIPTION
Daily build failed: https://ci.appveyor.com/project/PowerShell/powershell-f975h

Issue description
---
We dynamically build and load a module with test 'wrong' cmdlets to test C# implementation of a valid values generator.
Later Get-Help tests catches the test 'wrong' cmdlets and throws.

Fix
---
Unload the test module.

/cc @daxian-dbw  
