### PR TITLE
Enable MSI upgrades rather than side-by-side install

### DIFF
--- a/assets/Product.wxs
+++ b/assets/Product.wxs
@@ -36,7 +36,7 @@
     <Condition Message="Supported only on Win8 and above"><![CDATA[ Installed OR $(var.MinOSVersionSupported) ]]></Condition>
 
     <!-- Information About When Older Versions Are Trying To Be Installed-->
-    <MajorUpgrade DowngradeErrorMessage="A newer version of PowerShell is already installed." />
+    <MajorUpgrade AllowSameVersionUpgrades="yes" DowngradeErrorMessage="A newer version of $(env.ProductName) is already installed." />
     
     <!-- Embed Cabinet Files in Product-->
     <MediaTemplate EmbedCab="yes" />


### PR DESCRIPTION
MSI only works against A.B.C type version strings.  So to enable beta.X to beta.X+1 upgrades, we have to use the `AllowSameVersionUpgrades` as they are all effectively 6.0.0 from MSI point of view.

Note that to get Wix toolset working on Win10, you may have to pass `-sval` to light.exe.

Fix https://github.com/PowerShell/PowerShell/issues/3946