### PR TITLE
Support Invoke-Item -Path <folder>

### DIFF
--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -1350,9 +1350,10 @@ namespace Microsoft.PowerShell.Commands
                     invokeProcess.Start();
                 }
 #elif CORECLR
-                catch (Win32Exception ex) when (ex.NativeErrorCode == 193)
+                catch (Win32Exception ex) when (ex.NativeErrorCode == 193 || ex.NativeErrorCode == 5)
                 {
                     // Error code 193 -- BAD_EXE_FORMAT (not a valid Win32 application).
+                    // Error code 5 -- ACCESS_DENIED (a folder is not an app)
                     // If it's headless SKUs, rethrow.
                     if (Platform.IsNanoServer || Platform.IsIoT) { throw; }
                     // If it's full Windows, then try ShellExecute.

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Invoke-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Invoke-Item.Tests.ps1
@@ -61,8 +61,28 @@ Describe "Invoke-Item basic tests" -Tags "CI" {
     }
 
     It "Should invoke a folder without error" {
-        # can't validate that it actually opened, but no error should be returned
-        Invoke-Item -Path $PSHOME
+        if ($IsWindows)
+        {
+            $shell = New-Object -ComObject "Shell.Application"
+            $windows = $shell.Windows()
+
+            $before = $windows.Count
+            Invoke-Item -Path $PSHOME
+            # give it time to open
+            Start-Sleep -Milliseconds 500
+            $after = $windows.Count
+
+            $before + 1 | Should Be $after
+            $item = $windows.Item($after - 1)
+            $item.LocationURL | Should Match ($PSHOME -replace '\\', '/')
+            ## close the windows explorer
+            $item.Quit()
+        }
+        else
+        {
+            # can't validate that it actually opened, but no error should be returned
+            Invoke-Item -Path $PSHOME
+        }
     }
 }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Invoke-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Invoke-Item.Tests.ps1
@@ -28,21 +28,23 @@ Describe "Invoke-Item basic tests" -Tags "CI" {
 
         ## Run this test only on OSX because redirecting stderr of 'xdg-open' results in weird behavior in our Linux CI,
         ## causing this test to fail or the build to hang.
-        It "Should invoke text file '<TestFile>' without error" -Skip:(!$IsOSX) -TestCases $textFileTestCases {
+        It "Should invoke text file '<TestFile>' without error on Mac" -Skip:(!$IsOSX) -TestCases $textFileTestCases {
             param($TestFile)
 
-            ## Redirect stderr to a file. So if 'open' failed to open the text file, an error
-            ## message from 'open' would be written to the redirection file.
-            $proc = Start-Process -FilePath $powershell -ArgumentList "-noprofile -c Invoke-Item '$TestFile'" `
-                                  -RedirectStandardError $redirectErr `
-                                  -PassThru
-            $proc.WaitForExit(3000) > $null
-            if (!$proc.HasExited) {
-                try { $proc.Kill() } catch { }
+            $expectedTitle = Split-Path $TestFile -Leaf
+            $beforeCount = [int]('tell application "TextEdit" to count of windows' | osascript)
+            Invoke-Item -Path $TestFile
+            $startTime = Get-Date
+            $title = [String]::Empty
+            while (((Get-Date) - $startTime).TotalSeconds -lt 5 -and ($title -ne $expectedTitle))
+            {
+                Start-Sleep -Milliseconds 100
+                $title = 'tell application "TextEdit" to get name of front window' | osascript
             }
-            ## If the text file was successfully opened, the redirection file should be empty since no error
-            ## message was written to it.
-            Get-Content $redirectErr -Raw | Should BeNullOrEmpty
+            $afterCount = [int]('tell application "TextEdit" to count of windows' | osascript)
+            $afterCount | Should Be ($beforeCount + 1)
+            $title | Should Be $expectedTitle
+            "tell application ""TextEdit"" to close window ""$expectedTitle""" | osascript
         }
     }
 
@@ -62,19 +64,15 @@ Describe "Invoke-Item basic tests" -Tags "CI" {
 
     Context "Invoke a folder" {
         BeforeAll {
+            $supportedEnvironment = $true
             if ($IsLinux)
             {
                 $appFolder = "$HOME/.local/share/applications"
-                $NoDesktop = $false
-                if ($null -ne (gcm xdg-mime -ErrorAction SilentlyContinue))
+                if (Test-Path $appFolder)
                 {
                     $mimeDefault = xdg-mime query default inode/directory
                     Remove-Item $HOME/InvokeItemTest.Success -Force -ErrorAction SilentlyContinue
-                    if (!(Test-Path $appFolder))
-                    {
-                        New-Item -Path $appFolder -Force
-                    }
-                    Set-Content -Path "$appFolder/InvokeItemTest.desktop" -Verbose -Force -Value @"
+                    Set-Content -Path "$appFolder/InvokeItemTest.desktop" -Force -Value @"
 [Desktop Entry]
 Version=1.0
 Name=InvokeItemTest
@@ -89,13 +87,13 @@ Categories=Application;
                 }
                 else
                 {
-                    $NoDesktop = $true
+                    $supportedEnvironment = $false
                 }
             }
         }
 
         AfterAll {
-            if ($IsLinux -and !$NoDesktop)
+            if ($IsLinux -and $supportedEnvironment)
             {
                 xdg-mime default $mimeDefault inode/directory
                 Remove-Item $appFolder/InvokeItemTest.desktop -Force -ErrorAction SilentlyContinue
@@ -103,7 +101,7 @@ Categories=Application;
             }
         }
 
-        It "Should invoke a folder without error" -Skip:($NoDesktop) {
+        It "Should invoke a folder without error" -Skip:(!$supportedEnvironment) {
             if ($IsWindows)
             {
                 $shell = New-Object -ComObject "Shell.Application"
@@ -135,13 +133,25 @@ Categories=Application;
                 {
                     Start-Sleep -Milliseconds 100
                 }
-
                 Get-Content $HOME/InvokeItemTest.Success | Should Be $PSHOME
             }
             else
             {
-                # can't validate on MacOS, so just make sure no error
+                # validate on MacOS by using AppleScript
+                $beforeCount = [int]('tell application "Finder" to count of windows' | osascript)
                 Invoke-Item -Path $PSHOME
+                $startTime = Get-Date
+                $expectedTitle = Split-Path $PSHOME -Leaf
+                $title = [String]::Empty
+                while (((Get-Date) - $startTime).TotalSeconds -lt 5 -and ($title -ne $expectedTitle))
+                {
+                    Start-Sleep -Milliseconds 100
+                    $title = 'tell application "Finder" to get name of front window' | osascript
+                }
+                $afterCount = [int]('tell application "Finder" to count of windows' | osascript)
+                $afterCount | Should Be ($beforeCount + 1)
+                $title | Should Be $expectedTitle
+                'tell application "Finder" to close front window' | osascript
             }
         }
     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Invoke-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Invoke-Item.Tests.ps1
@@ -68,8 +68,11 @@ Describe "Invoke-Item basic tests" -Tags "CI" {
 
             $before = $windows.Count
             Invoke-Item -Path $PSHOME
-            # give it time to open
-            Start-Sleep -Milliseconds 500
+            $startTime = Get-Date
+            while (((Get-Date) - $startTime).TotalSeconds -lt 5 -and ($windows.Count -eq $before))
+            {
+                Start-Sleep -Milliseconds 100
+            }
             $after = $windows.Count
 
             $before + 1 | Should Be $after

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Invoke-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Invoke-Item.Tests.ps1
@@ -36,7 +36,7 @@ Describe "Invoke-Item basic tests" -Tags "CI" {
             Invoke-Item -Path $TestFile
             $startTime = Get-Date
             $title = [String]::Empty
-            while (((Get-Date) - $startTime).TotalSeconds -lt 5 -and ($title -ne $expectedTitle))
+            while (((Get-Date) - $startTime).TotalSeconds -lt 10 -and ($title -ne $expectedTitle))
             {
                 Start-Sleep -Milliseconds 100
                 $title = 'tell application "TextEdit" to get name of front window' | osascript
@@ -111,7 +111,7 @@ Categories=Application;
                 Invoke-Item -Path $PSHOME
                 $startTime = Get-Date
                 # may take time for explorer to open window
-                while (((Get-Date) - $startTime).TotalSeconds -lt 5 -and ($windows.Count -eq $before))
+                while (((Get-Date) - $startTime).TotalSeconds -lt 10 -and ($windows.Count -eq $before))
                 {
                     Start-Sleep -Milliseconds 100
                 }
@@ -129,7 +129,7 @@ Categories=Application;
                 Invoke-Item -Path $PSHOME
                 $startTime = Get-Date
                 # may take time for handler to start
-                while (((Get-Date) - $startTime).TotalSeconds -lt 5 -and (-not (Test-Path "$HOME/InvokeItemTest.Success")))
+                while (((Get-Date) - $startTime).TotalSeconds -lt 10 -and (-not (Test-Path "$HOME/InvokeItemTest.Success")))
                 {
                     Start-Sleep -Milliseconds 100
                 }
@@ -143,7 +143,7 @@ Categories=Application;
                 $startTime = Get-Date
                 $expectedTitle = Split-Path $PSHOME -Leaf
                 $title = [String]::Empty
-                while (((Get-Date) - $startTime).TotalSeconds -lt 5 -and ($title -ne $expectedTitle))
+                while (((Get-Date) - $startTime).TotalSeconds -lt 10 -and ($title -ne $expectedTitle))
                 {
                     Start-Sleep -Milliseconds 100
                     $title = 'tell application "Finder" to get name of front window' | osascript

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Invoke-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Invoke-Item.Tests.ps1
@@ -59,6 +59,11 @@ Describe "Invoke-Item basic tests" -Tags "CI" {
         }
         Get-Content $redirectFile -Raw | Should Match "usage: ping"
     }
+
+    It "Should invoke a folder without error" {
+        # can't validate that it actually opened, but no error should be returned
+        Invoke-Item -Path $PSHOME
+    }
 }
 
 Describe "Invoke-Item tests on Windows" -Tags "CI","RequireAdminOnWindows" {


### PR DESCRIPTION
On CoreFx, UseShellExecute for Process start is false by default to be cross platform compatible.
In the case of a folder, Process.Start() returns Access Denied as it's not an executable.
On Windows we can use the ShellExecute path to have explorer open the folder.

Fix https://github.com/PowerShell/PowerShell/issues/4252
Fix https://github.com/PowerShell/PowerShell/issues/4282

<!--

If you are a PowerShell Team member, please make sure you choose the Reviewer(s) and Assignee for your PR.
If you are not from the PowerShell Team, you can leave the fields blank and the Maintainers will choose them for you. If you are familiar with the team, feel free to mention some Reviewers yourself.

For more information about the roles of Reviewer and Assignee, refer to CONTRIBUTING.md.

-->
