### PR TITLE
Add unhandled assemblyname characters

### DIFF
--- a/src/System.Management.Automation/engine/parser/PSType.cs
+++ b/src/System.Management.Automation/engine/parser/PSType.cs
@@ -1119,6 +1119,9 @@ namespace System.Management.Automation.Language
                                       .Replace('\\', (char)0x29f9)
                                       .Replace('/', (char)0x29f9)
                                       .Replace(',', (char)0x201a)
+                                      .Replace('\'', (char)0x2019)
+                                      .Replace('=', (char)0xff1d)
+                                      .Replace('~', (char)0x223c)
                                       .Replace(':', (char)0x0589));
 
             var assembly = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName(assemblyName),

--- a/src/System.Management.Automation/engine/parser/PSType.cs
+++ b/src/System.Management.Automation/engine/parser/PSType.cs
@@ -1120,6 +1120,7 @@ namespace System.Management.Automation.Language
                                       .Replace('/', (char)0x29f9)
                                       .Replace(',', (char)0x201a)
                                       .Replace('\'', (char)0x2019)
+                                      .Replace('"', (char)0x201d)
                                       .Replace('=', (char)0xff1d)
                                       .Replace('~', (char)0x223c)
                                       .Replace(':', (char)0x0589));

--- a/test/powershell/Language/Classes/Scripting.Classes.RunPath.Tests.ps1
+++ b/test/powershell/Language/Classes/Scripting.Classes.RunPath.Tests.ps1
@@ -1,8 +1,17 @@
 Describe "Script with a class definition run path" -Tags "CI" {
 
+    if ( $IsLinux -or $IsOSX )
+    {
+        $UnhandledName = "My,'`"=~Test.ps1"
+    }
+    else
+    {
+        $UnhandledName = "My,'=~Test.ps1"
+    }
+
     $TestCases = @(
-        @{ FileName =     'MyTest.ps1'; Name = 'typical path' }
-        @{ FileName = "My,'=~Test.ps1"; Name = 'path with unhandled assemblyname characters' }
+        @{ FileName = 'MyTest.ps1'  ; Name = 'typical path' }
+        @{ FileName = $UnhandledName; Name = 'path with unhandled assemblyname characters' }
     )
 
     It "Script with a class definition can run from a <Name>" -TestCases $TestCases {

--- a/test/powershell/Language/Classes/Scripting.Classes.RunPath.Tests.ps1
+++ b/test/powershell/Language/Classes/Scripting.Classes.RunPath.Tests.ps1
@@ -1,8 +1,8 @@
 Describe "Script with a class definition run path" -Tags "CI" {
 
     $TestCases = @(
-        @{ FileName =  'MyTest.ps1'; Name = 'path without a comma' }
-        @{ FileName = 'My,Test.ps1'; Name = 'path with a comma'    }
+        @{ FileName =     'MyTest.ps1'; Name = 'typical path' }
+        @{ FileName = "My,'=~Test.ps1"; Name = 'path with unhandled assemblyname characters' }
     )
 
     It "Script with a class definition can run from a <Name>" -TestCases $TestCases {


### PR DESCRIPTION
Fixes issue 4193, wherein it was discussed that the apostrophe, equals sign, and tilde are the last three visible en-us characters that are valid Windows file path characters but cause the assemblyname constructor to throw an error, thereby preventing scripts with class definitions from running when used in the script path. This effectively extends PR 4136 which did this for the comma.