### PR TITLE
Register-PSSessionConfiguration fails if SesionConfig folder doesn't exist

### DIFF
--- a/src/System.Management.Automation/engine/remoting/commands/CustomShellCommands.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/CustomShellCommands.cs
@@ -964,7 +964,13 @@ else
                     }
                 }
 
-                string destPath = System.IO.Path.Combine(Utils.DefaultPowerShellAppBase, "SessionConfig",
+                string destFolder = System.IO.Path.Combine(Utils.DefaultPowerShellAppBase, "SessionConfig");
+                if (!Directory.Exists(destFolder))
+                {
+                    Directory.CreateDirectory(destFolder);
+                }
+
+                string destPath = System.IO.Path.Combine(destFolder,
                     shellName + "_" + sessionGuid.ToString() + StringLiterals.PowerShellDISCFileExtension);
                 if (string.Equals(ProcessorArchitecture, "x86", StringComparison.OrdinalIgnoreCase))
                 {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Implicit.Remoting.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Implicit.Remoting.Tests.ps1
@@ -2108,7 +2108,10 @@ Describe "Import-PSSession on Restricted Session" -tags "Feature","RequireAdminO
         }
     }
 
-    It "Verifies that Import-PSSession works on a restricted session" {
+    # Blocked by https://github.com/PowerShell/PowerShell/issues/4275
+    # Need a way to created restricted endpoint based on a different endpoint other than microsoft.powershell which points
+    # to Windows PowerShell 5.1
+    It "Verifies that Import-PSSession works on a restricted session" -Pending {
 
         $errorVariable = $null
         Import-PSSession -Session $session -AllowClobber -ErrorVariable $errorVariable


### PR DESCRIPTION
Create SessionConfig folder if it doesn't exist for Register-PSSessionConfiguration

<!--

If you are a PowerShell Team member, please make sure you choose the Reviewer(s) and Assignee for your PR.
If you are not from the PowerShell Team, you can leave the fields blank and the Maintainers will choose them for you. If you are familiar with the team, feel free to mention some Reviewers yourself.

For more information about the roles of Reviewer and Assignee, refer to CONTRIBUTING.md.

-->
