### PR TITLE
Run CI and Feature tests by default with Start-PSPester

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -762,7 +762,7 @@ function Start-PSPester {
         [string]$OutputFormat = "NUnitXml",
         [string]$OutputFile = "pester-tests.xml",
         [string[]]$ExcludeTag = 'Slow',
-        [string[]]$Tag = "CI",
+        [string[]]$Tag = @("CI","Feature"),
         [string[]]$Path = @("$PSScriptRoot/test/common","$PSScriptRoot/test/powershell"),
         [switch]$ThrowOnFailure,
         [switch]$FullCLR,


### PR DESCRIPTION
Nightly keeps breaking because people forget to run Feature tests (I've done this myself).  Make CI, Feature default for local runs.

Reviewed the AppVeyor and Travis ps1 file and they explicitly include CI or exclude Feature so we should be good
<!--

If you are a PowerShell Team member, please make sure you choose the Reviewer(s) and Assignee for your PR.
If you are not from the PowerShell Team, you can leave the fields blank and the Maintainers will choose them for you. If you are familiar with the team, feel free to mention some Reviewers yourself.

For more information about the roles of Reviewer and Assignee, refer to CONTRIBUTING.md.

-->
