### PR TITLE
Fix ConvertTo-Html single matched column header bug

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/convert-HTML.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/convert-HTML.cs
@@ -283,23 +283,11 @@ namespace Microsoft.PowerShell.Commands
                 string width = p.GetEntry(ConvertHTMLParameterDefinitionKeys.WidthEntryKey) as string;
                 MshExpression ex = p.GetEntry(FormatParameterDefinitionKeys.ExpressionEntryKey) as MshExpression;
                 List<MshExpression> resolvedNames = ex.ResolveNames(_inputObject);
-                if (resolvedNames.Count == 1)
+                foreach (MshExpression resolvedName in resolvedNames)
                 {
                     Hashtable ht = CreateAuxPropertyHT(label, alignment, width);
-                    if (ex.Script != null)
-                        ht.Add(FormatParameterDefinitionKeys.ExpressionEntryKey, ex.Script);
-                    else
-                        ht.Add(FormatParameterDefinitionKeys.ExpressionEntryKey, ex.ToString());
+                    ht.Add(FormatParameterDefinitionKeys.ExpressionEntryKey, resolvedName.ToString());
                     resolvedNameProperty.Add(ht);
-                }
-                else
-                {
-                    foreach (MshExpression resolvedName in resolvedNames)
-                    {
-                        Hashtable ht = CreateAuxPropertyHT(label, alignment, width);
-                        ht.Add(FormatParameterDefinitionKeys.ExpressionEntryKey, resolvedName.ToString());
-                        resolvedNameProperty.Add(ht);
-                    }
                 }
             }
             _resolvedNameMshParameters = ProcessParameter(resolvedNameProperty.ToArray());

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Html.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Html.Tests.ps1
@@ -12,7 +12,7 @@
 
     It "Test ConvertTo-Html with no parameters" {
         $returnObject = $customObject | ConvertTo-Html
-        $returnObject -is [System.Array] | Should Be $true
+        ,$returnObject | Should BeOfType System.Object[]
         $returnString = $returnObject -join $newLine
         $expectedValue = normalizeLineEnds @"
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"  "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">


### PR DESCRIPTION
This replaces abandoned PR #2184 since the fix looks like it might be worthwhile to include. This PR adds the changes requested in the original PR that held it up from being merged.

PR #2241 included the original tests.

FYI: @TimCurwick 