### PR TITLE
updated webcmdlets CI tests to not depend on external website

### DIFF
--- a/test/tools/Modules/HttpListener/HttpListener.psm1
+++ b/test/tools/Modules/HttpListener/HttpListener.psm1
@@ -320,6 +320,21 @@ Function Start-HTTPListener {
             $null = $ps.AddScript($script)
             $null = $ps.AddParameter("port",$port)
             $AsyncResponse = $ps.BeginInvoke()
+            # check that it's up and running
+            $out = $null
+            while ($out.StatusCode -ne 200)
+            {
+                try
+                {
+                    $out = Invoke-WebRequest "http://localhost:${Port}/PowerShell?test=response"
+                }
+                catch 
+                { 
+                    # ignore if listener is not ready 
+                }
+                Start-Sleep -milliseconds 100
+            }
+
             # include the AsyncResponse in the return object
             # it can be used to determine whether execution
             # is still underway, and may be useful in debugging

--- a/test/tools/Modules/HttpListener/HttpListener.psm1
+++ b/test/tools/Modules/HttpListener/HttpListener.psm1
@@ -85,7 +85,7 @@ Function Start-HTTPListener {
             $urlPrefix = "/PowerShell"
             $url = "http://localhost:$Port$urlPrefix"
             $listener.Prefixes.Add($url + "/")  # trailing slash required for registration
-            $listener.AuthenticationSchemes = [System.Net.AuthenticationSchemes]::Anonymous 
+            $listener.AuthenticationSchemes = [System.Net.AuthenticationSchemes]::Anonymous
             try {
                 Write-Warning "Note that thread is blocked waiting for a request.  After using Ctrl-C to stop listening, you need to send a valid HTTP request to stop the listener cleanly."
                 Write-Warning "Use Stop-HttpListener or Invoke-WebRequest -Uri '${Url}?test=exit' to stop the listener."
@@ -95,7 +95,7 @@ Function Start-HTTPListener {
                 while ($exit -eq $false) {
                     $context = $listener.GetContext()
                     $request = $context.Request
-                    
+
                     $queryItems = ParseQueryString($request.Url)
 
                     $test = $queryItems["test"]
@@ -105,7 +105,7 @@ Function Start-HTTPListener {
                     {
                         Write-Verbose -Message "Found Header: $key, $($request.Headers[$key])"
                     }
-                    
+
                     # the status code to return for the response
                     $statusCode = [System.Net.HttpStatusCode]::OK
                     # this is the body of the response, return json/xml as appropriate
@@ -141,8 +141,8 @@ Function Start-HTTPListener {
                             Write-Verbose -Message "Echo request"
                             $output = $request | ConvertTo-Json -Depth 6
                         }
-                        
-                        <# 
+
+                        <#
                             This test provides support for multiple redirection types as well as a custom
                             multi-hop redirection to handle Authorization stripping logic.
                             The following  redirection types are supported:
@@ -153,7 +153,7 @@ Function Start-HTTPListener {
                              ?test=redirectex&type=Found
 
                             WebRequest cmdlet tests also use a special option called multiredirect. This produces two redirects
-                            where the second 
+                            where the second
 
                             Example: test=redirectex&type=Moved&multiredirect=true
 
@@ -196,7 +196,7 @@ Function Start-HTTPListener {
                                $redirectedUrl = "${Url}?test=redirect&type=$type&multiredirect=false"
                             }
                             elseif ($multiredirect -eq $false)
-                            {                      
+                            {
                                 Write-Verbose -Message "Redirect 2 of 2"
                                 $redirectedUrl = "${Url}?test=redirect&type=$type"
                             }
@@ -207,9 +207,9 @@ Function Start-HTTPListener {
                                 if (-not [string]::IsNullOrEmpty($redirectedUrl))
                                 {
                                     $outputHeader.Add("Location",$redirectedUrl)
-                                    Write-Verbose -Message "Redirecting to $($outputHeader.Location)" 
+                                    Write-Verbose -Message "Redirecting to $($outputHeader.Location)"
                                 }
-                            }                               
+                            }
                         }
                         "linkheader"
                         {
@@ -255,7 +255,7 @@ Function Start-HTTPListener {
                             $links = "$links<$($urlPrefix)?test=linkheader&maxlinks=$maxlinks&linknumber=$maxlinks>; rel=`"last`"$prev"
                             $outputHeader.Add("Link", $links)
                             $output = "{ `"output`": `"$linkNumber`"}"
-                        }                        
+                        }
                         default
                         {
                             $statusCode = [System.Net.HttpStatusCode]::NotFound
@@ -271,7 +271,7 @@ Function Start-HTTPListener {
                         {
                             $contentType = 'application/json'
                         }
-                        
+
                         $outputHeader.Add('Content-Type', $contentType)
                         $response.ContentType = $contentType
                         Write-Verbose -Message "Setting ContentType to $contentType"
@@ -286,7 +286,7 @@ Function Start-HTTPListener {
                     {
                         $response.Headers.Add($header, $outputHeader[$header])
                     }
-                    
+
                     if ($output -ne $null)
                     {
                         $buffer = [System.Text.Encoding]::UTF8.GetBytes($output)
@@ -322,17 +322,27 @@ Function Start-HTTPListener {
             $AsyncResponse = $ps.BeginInvoke()
             # check that it's up and running
             $out = $null
-            while ($out.StatusCode -ne 200)
+            $startTime = Get-Date
+            $succeeded = $false
+            while (!$succeeded -and (((Get-Date) - $startTime)).Seconds -lt 10)
             {
                 try
                 {
                     $out = Invoke-WebRequest "http://localhost:${Port}/PowerShell?test=response"
+                    if ($out.StatusCode -eq 200)
+                    {
+                        $succeeded = $true
+                    }
                 }
-                catch 
-                { 
-                    # ignore if listener is not ready 
+                catch
+                {
+                    # ignore if listener is not ready
                 }
                 Start-Sleep -milliseconds 100
+            }
+            if (!$succeeded)
+            {
+                throw "HttpListener failed to respond"
             }
 
             # include the AsyncResponse in the return object


### PR DESCRIPTION
On one of my PRs, the webcmdlets CI tests seems to hang trying to determine if Bing/Google is available.   We shouldn't depend on external website for CI tests.

<!--

If you are a PowerShell Team member, please make sure you choose the Reviewer(s) and Assignee for your PR.
If you are not from the PowerShell Team, you can leave the fields blank and the Maintainers will choose them for you. If you are familiar with the team, feel free to mention some Reviewers yourself.

For more information about the roles of Reviewer and Assignee, refer to CONTRIBUTING.md.

-->
