### PR TITLE
Fix array expression to not return null or throw error

### DIFF
--- a/test/powershell/Language/Scripting/Array.Tests.ps1
+++ b/test/powershell/Language/Scripting/Array.Tests.ps1
@@ -1,4 +1,4 @@
-Describe "ArrayExpression Tests" {
+Describe "ArrayExpression Tests" -Tags "CI" {
     It "@([object[]](1,2,3)) should return an array of object[]" {
         $result = @([object[]](1,2,3))
         $result.GetType().FullName | Should Be "System.Object[]"

--- a/test/powershell/Language/Scripting/Array.Tests.ps1
+++ b/test/powershell/Language/Scripting/Array.Tests.ps1
@@ -1,41 +1,54 @@
 Describe "ArrayExpression Tests" -Tags "CI" {
-    It "@([object[]](1,2,3)) should return an array of object[]" {
+    It "@([object[]](1,2,3)) should return a 3-element array of object[]" {
         $result = @([object[]](1,2,3))
         $result.GetType().FullName | Should Be "System.Object[]"
-        $result.Count | Should Be 3
+        $result.Length | Should Be 3
     }
 
-    It "@([int[]](1,2,3)) should return an array of object[]" {
+    It "@([int[]](1,2,3)) should return a 3-element array of object[]" {
         $result = @([int[]](1,2,3))
         $result.GetType().FullName | Should Be "System.Object[]"
-        $result.Count | Should Be 3
+        $result.Length | Should Be 3
     }
 
-    It "@([object[]]`$null) should return an array of object[]" {
+    It "@([object[]]`$null) should return a 1-element(`$null) array of object[]" {
         $result = @([object[]]$null)
         $result.GetType().FullName | Should Be "System.Object[]"
-        $result.Count | Should Be 1
+        $result.Length | Should Be 1
         $result[0] | Should Be $null
     }
 
-    It "@([int[]]`$null) should return an array of object[]" {
+    It "@([int[]]`$null) should return a 1-element(`$null) array of object[]" {
         $result = @([int[]]$null)
         $result.GetType().FullName | Should Be "System.Object[]"
-        $result.Count | Should Be 1
+        $result.Length | Should Be 1
         $result[0] | Should Be $null
     }
 
-    It "@([object[]][System.Management.Automation.Internal.AutomationNull]::Value) should return an array of object[]" {
+    It "@([object[]][System.Management.Automation.Internal.AutomationNull]::Value) should return a 1-element(`$null) array of object[]" {
         $result = @([object[]][System.Management.Automation.Internal.AutomationNull]::Value)
         $result.GetType().FullName | Should Be "System.Object[]"
-        $result.Count | Should Be 1
+        $result.Length | Should Be 1
         $result[0] | Should Be $null
     }
 
-    It "@([int[]][System.Management.Automation.Internal.AutomationNull]::Value) should return an array of object[]" {
+    It "@([int[]][System.Management.Automation.Internal.AutomationNull]::Value) should return a 1-element(`$null) array of object[]" {
         $result = @([int[]][System.Management.Automation.Internal.AutomationNull]::Value)
         $result.GetType().FullName | Should Be "System.Object[]"
-        $result.Count | Should Be 1
+        $result.Length | Should Be 1
         $result[0] | Should Be $null
+    }
+
+    It "@(`$null) should return a 1-element(`$null) array of object[]" {
+        $result = @($null)
+        $result.GetType().FullName | Should Be "System.Object[]"
+        $result.Length | Should Be 1
+        $result[0] | Should Be $null
+    }
+
+    It "@([System.Management.Automation.Internal.AutomationNull]::Value) should return an empty array of object[]" {
+        $result = @([System.Management.Automation.Internal.AutomationNull]::Value)
+        $result.GetType().FullName | Should Be "System.Object[]"
+        $result.Length | Should Be 0
     }
 }

--- a/test/powershell/Language/Scripting/Array.Tests.ps1
+++ b/test/powershell/Language/Scripting/Array.Tests.ps1
@@ -1,4 +1,10 @@
 Describe "ArrayExpression Tests" {
+    It "@([object[]](1,2,3)) should return an array of object[]" {
+        $result = @([object[]](1,2,3))
+        $result.GetType().FullName | Should Be "System.Object[]"
+        $result.Count | Should Be 3
+    }
+
     It "@([int[]](1,2,3)) should return an array of object[]" {
         $result = @([int[]](1,2,3))
         $result.GetType().FullName | Should Be "System.Object[]"

--- a/test/powershell/Language/Scripting/Array.Tests.ps1
+++ b/test/powershell/Language/Scripting/Array.Tests.ps1
@@ -65,4 +65,11 @@ Describe "ArrayExpression Tests" -Tags "CI" {
         $result.GetType().FullName | Should Be "System.Object[]"
         $result.Length | Should Be 3
     }
+
+    It "@([System.Collections.Generic.List[object]]`$null) should return a 1-element(`$null) array of object[]" {
+        $result = @([System.Collections.Generic.List[object]]$null)
+        $result.GetType().FullName | Should Be "System.Object[]"
+        $result.Length | Should Be 1
+        $result[0] | Should Be $null
+    }
 }

--- a/test/powershell/Language/Scripting/Array.Tests.ps1
+++ b/test/powershell/Language/Scripting/Array.Tests.ps1
@@ -1,0 +1,35 @@
+Describe "ArrayExpression Tests" {
+    It "@([int[]](1,2,3)) should return an array of object[]" {
+        $result = @([int[]](1,2,3))
+        $result.GetType().FullName | Should Be "System.Object[]"
+        $result.Count | Should Be 3
+    }
+
+    It "@([object[]]`$null) should return an array of object[]" {
+        $result = @([object[]]$null)
+        $result.GetType().FullName | Should Be "System.Object[]"
+        $result.Count | Should Be 1
+        $result[0] | Should Be $null
+    }
+
+    It "@([int[]]`$null) should return an array of object[]" {
+        $result = @([int[]]$null)
+        $result.GetType().FullName | Should Be "System.Object[]"
+        $result.Count | Should Be 1
+        $result[0] | Should Be $null
+    }
+
+    It "@([object[]][System.Management.Automation.Internal.AutomationNull]::Value) should return an array of object[]" {
+        $result = @([object[]][System.Management.Automation.Internal.AutomationNull]::Value)
+        $result.GetType().FullName | Should Be "System.Object[]"
+        $result.Count | Should Be 1
+        $result[0] | Should Be $null
+    }
+
+    It "@([int[]][System.Management.Automation.Internal.AutomationNull]::Value) should return an array of object[]" {
+        $result = @([int[]][System.Management.Automation.Internal.AutomationNull]::Value)
+        $result.GetType().FullName | Should Be "System.Object[]"
+        $result.Count | Should Be 1
+        $result[0] | Should Be $null
+    }
+}

--- a/test/powershell/Language/Scripting/Array.Tests.ps1
+++ b/test/powershell/Language/Scripting/Array.Tests.ps1
@@ -57,7 +57,6 @@ Describe "ArrayExpression Tests" -Tags "CI" {
         $result = @([object[]]$a)
         $result.GetType().FullName | Should Be "System.Object[]"
         $result.Length | Should Be 3
-        [object]::ReferenceEquals($a, $result) | Should Be $false
     }
 
     It "@([int[]]`$a) should return a new array" {
@@ -65,6 +64,5 @@ Describe "ArrayExpression Tests" -Tags "CI" {
         $result = @([int[]]$a)
         $result.GetType().FullName | Should Be "System.Object[]"
         $result.Length | Should Be 3
-        [object]::ReferenceEquals($a, $result) | Should Be $false
     }
 }

--- a/test/powershell/Language/Scripting/Array.Tests.ps1
+++ b/test/powershell/Language/Scripting/Array.Tests.ps1
@@ -51,4 +51,20 @@ Describe "ArrayExpression Tests" -Tags "CI" {
         $result.GetType().FullName | Should Be "System.Object[]"
         $result.Length | Should Be 0
     }
+
+    It "@([object[]]`$a) should return a new array" {
+        $a = 1,2,3
+        $result = @([object[]]$a)
+        $result.GetType().FullName | Should Be "System.Object[]"
+        $result.Length | Should Be 3
+        [object]::ReferenceEquals($a, $result) | Should Be $false
+    }
+
+    It "@([int[]]`$a) should return a new array" {
+        $a = 1,2,3
+        $result = @([int[]]$a)
+        $result.GetType().FullName | Should Be "System.Object[]"
+        $result.Length | Should Be 3
+        [object]::ReferenceEquals($a, $result) | Should Be $false
+    }
 }


### PR DESCRIPTION
Fix #4280

Summary
----------
This PR focuses on 3 issues:
1. According to [PowerShell Language Specification Version 3.0](https://www.microsoft.com/en-us/download/details.aspx?id=36389), as quoted: "_The result is the (possibly empty) unconstrained 1-dimensional array_", `@(...)` should only return `object[]` array.
1. `@([object[]]$null).GetType()` fails with error `"You cannot call a method on a null-valued expression."`
1. `@([System.Collections.Generic.List[object]]$null)` fails with error `"Object reference not set to an instance of an object."`

Marked with label `Review-Committee` to review the first issue.