### PR TITLE
Fixed passing common test modules path to unelevated Powershell

### DIFF
--- a/test/tools/CodeCoverageAutomation/Start-CodeCoverageRun.ps1
+++ b/test/tools/CodeCoverageAutomation/Start-CodeCoverageRun.ps1
@@ -187,7 +187,7 @@ try
 
     if($SuppressQuiet)
     {
-        $openCoverParams.Add('$SuppressQuiet', $true)
+        $openCoverParams.Add('SuppressQuiet', $true)
     }
 
     $openCoverParams | Out-String | Write-LogPassThru

--- a/test/tools/CodeCoverageAutomation/Start-CodeCoverageRun.ps1
+++ b/test/tools/CodeCoverageAutomation/Start-CodeCoverageRun.ps1
@@ -2,7 +2,7 @@
     [Parameter(Mandatory = $true, Position = 0)] $coverallsToken,
     [Parameter(Mandatory = $true, Position = 1)] $codecovToken,
     [Parameter(Position = 2)] $azureLogDrive = "L:\",
-    [Parameter] [switch] $SuppressQuiet
+    [switch] $SuppressQuiet
 )
 
 # Read the XML and create a dictionary for FileUID -> file full path.

--- a/test/tools/CodeCoverageAutomation/Start-CodeCoverageRun.ps1
+++ b/test/tools/CodeCoverageAutomation/Start-CodeCoverageRun.ps1
@@ -169,7 +169,7 @@ try
     Install-OpenCover -TargetDirectory $openCoverTargetDirectory -force
     Write-LogPassThru -Message "OpenCover installed."
 
-    Write-LogPassThru -Message "TestDirectory : $testPath"
+    Write-LogPassThru -Message "TestPath : $testPath"
     Write-LogPassThru -Message "openCoverPath : $openCoverTargetDirectory\OpenCover"
     Write-LogPassThru -Message "psbinpath : $psBinPath"
     Write-LogPassThru -Message "elevatedLog : $elevatedLogs"
@@ -177,7 +177,7 @@ try
     Write-LogPassThru -Message "TestToolsPath : $testToolsPath"
 
     $openCoverParams = @{outputlog = $outputLog;
-        TestDirectory = $testPath;
+        TestPath = $testPath;
         OpenCoverPath = "$openCoverTargetDirectory\OpenCover";
         PowerShellExeDirectory = "$psBinPath";
         PesterLogElevated = $elevatedLogs;

--- a/test/tools/CodeCoverageAutomation/Start-CodeCoverageRun.ps1
+++ b/test/tools/CodeCoverageAutomation/Start-CodeCoverageRun.ps1
@@ -1,7 +1,8 @@
 ﻿param(
     [Parameter(Mandatory = $true, Position = 0)] $coverallsToken,
     [Parameter(Mandatory = $true, Position = 1)] $codecovToken,
-    [Parameter(Position = 2)] $azureLogDrive = "L:\"
+    [Parameter(Position = 2)] $azureLogDrive = "L:\",
+    [Parameter] [switch] $Quiet = $true
 )
 
 # Read the XML and create a dictionary for FileUID -> file full path.
@@ -182,6 +183,11 @@ try
         PesterLogElevated = $elevatedLogs;
         PesterLogUnelevated = $unelevatedLogs;
         TestToolsModulesPath = "$testToolsPath\Modules";
+    }
+
+    if($Quiet)
+    {
+        $openCoverParams.Add('Quiet', $true)
     }
 
     $openCoverParams | Out-String | Write-LogPassThru

--- a/test/tools/CodeCoverageAutomation/Start-CodeCoverageRun.ps1
+++ b/test/tools/CodeCoverageAutomation/Start-CodeCoverageRun.ps1
@@ -2,7 +2,7 @@
     [Parameter(Mandatory = $true, Position = 0)] $coverallsToken,
     [Parameter(Mandatory = $true, Position = 1)] $codecovToken,
     [Parameter(Position = 2)] $azureLogDrive = "L:\",
-    [Parameter] [switch] $Quiet = $true
+    [Parameter] [switch] $SuppressQuiet
 )
 
 # Read the XML and create a dictionary for FileUID -> file full path.
@@ -185,9 +185,9 @@ try
         TestToolsModulesPath = "$testToolsPath\Modules";
     }
 
-    if($Quiet)
+    if($SuppressQuiet)
     {
-        $openCoverParams.Add('Quiet', $true)
+        $openCoverParams.Add('$SuppressQuiet', $true)
     }
 
     $openCoverParams | Out-String | Write-LogPassThru

--- a/test/tools/OpenCover/OpenCover.psm1
+++ b/test/tools/OpenCover/OpenCover.psm1
@@ -501,8 +501,6 @@ function Invoke-OpenCover
             # invoke OpenCover unelevated and poll for completion
             "$openCoverBin $cmdlineUnelevated" | Out-File -FilePath "$env:temp\unelevated.ps1" -Force
             runas.exe /trustlevel:0x20000 "powershell.exe -file $env:temp\unelevated.ps1"
-            # wait for process to start
-            Start-Sleep -Seconds 5
             # poll for process exit every 60 seconds
             # timeout of 6 hours
             # Runs currently take about 2.5 - 3 hours, we picked 6 hours to be substantially larger.
@@ -543,7 +541,18 @@ function CreateOpenCoverCmdline($target, $outputLog, $targetArgs)
     $base64targetArgs = [convert]::ToBase64String($bytes)
 
     # the order seems to be important. Always keep -targetargs as the last parameter.
-    $cmdline = "-target:$target","-register:user","-output:${outputLog}","-nodefaultfilters","-oldstyle","-hideskipped:all","-mergeoutput", "-filter:`"+[*]* -[Microsoft.PowerShell.PSReadLine]*`"", "-targetargs:`"-EncodedCommand $base64targetArgs`""
-    return $cmdline
+    $cmdline = "-target:$target",
+        "-register:user",
+        "-output:${outputLog}",
+        "-nodefaultfilters",
+        "-oldstyle",
+        "-hideskipped:all",
+        "-mergeoutput",
+        "-filter:`"+[*]* -[Microsoft.PowerShell.PSReadLine]*`"",
+        "-targetargs:`"-EncodedCommand $base64targetArgs`""
+
+    $cmdlineAsString = $cmdline -join " "
+
+    return $cmdlineAsString
 
 }

--- a/test/tools/OpenCover/OpenCover.psm1
+++ b/test/tools/OpenCover/OpenCover.psm1
@@ -428,7 +428,7 @@ function Invoke-OpenCover
         [parameter()]$PesterLogFormat = "NUnitXml",
         [parameter()]$TestToolsModulesPath = "${script:psRepoPath}/test/tools/Modules",
         [switch]$CIOnly,
-        [switch]$Quiet = $true
+        [switch]$SuppressQuiet
         )
 
     # check for elevation
@@ -482,7 +482,7 @@ function Invoke-OpenCover
     $targetArgsElevated += @("-OutputFile $PesterLogElevated")
     $targetArgsUnelevated += @("-OutputFile $PesterLogUnelevated")
 
-    if($Quiet)
+    if(-not $SuppressQuiet)
     {
         $targetArgsElevated += @("-Quiet")
         $targetArgsUnelevated += @("-Quiet")

--- a/test/tools/OpenCover/OpenCover.psm1
+++ b/test/tools/OpenCover/OpenCover.psm1
@@ -427,7 +427,8 @@ function Invoke-OpenCover
         [parameter()]$PesterLogUnelevated = "$pwd/TestResultsUnelevated.xml",
         [parameter()]$PesterLogFormat = "NUnitXml",
         [parameter()]$TestToolsModulesPath = "${script:psRepoPath}/test/tools/Modules",
-        [switch]$CIOnly
+        [switch]$CIOnly,
+        [switch]$Quiet = $true
         )
 
     # check for elevation
@@ -478,8 +479,14 @@ function Invoke-OpenCover
         $targetArgsUnelevated = $targetArgs + @("-excludeTag @('RequireAdminOnWindows')")
     }
 
-    $targetArgsElevated += @("-OutputFile $PesterLogElevated", "-OutputFormat $PesterLogFormat", "-Quiet")
-    $targetArgsUnelevated += @("-OutputFile $PesterLogUnelevated", "-OutputFormat $PesterLogFormat", "-Quiet")
+    $targetArgsElevated += @("-OutputFile $PesterLogElevated", "-OutputFormat $PesterLogFormat")
+    $targetArgsUnelevated += @("-OutputFile $PesterLogUnelevated", "-OutputFormat $PesterLogFormat")
+
+    if($Quiet)
+    {
+        $targetArgsElevated += @("-Quiet")
+        $targetArgsUnelevated += @("-Quiet")
+    }
 
     $targetArgStringElevated = $targetArgsElevated -join " "
     $targetArgStringUnelevated  = $targetArgsUnelevated -join " "


### PR DESCRIPTION
- Fixed the way common test modules are passed to elevated and unelevated powershell. Earlier, only elevated powershell got those through inheritance as a child process. Now we add them to the startup of the process.

- Fixed error reported by PSScriptAnalyzer about ? / Where-Object

- Converted all the parameters passed to powershell.exe to be a base64 encoded string to avoid complications with quotes.

- Removed code which was updated $env:PSModulePath as we do it in startup args for powershell process instead. 

- Added a way to disable -Quiet for Pester.