### PR TITLE
Added support for converting enums as strings in JSON

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/ConvertToJsonCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/ConvertToJsonCommand.cs
@@ -478,12 +478,6 @@ namespace Microsoft.PowerShell.Commands
                     {
                         rv = obj.ToString();
                     }
-#if !CORECLR
-                    else if (EnumsAsStrings)
-                    {
-                        rv = obj.ToString();
-                    }
-#endif
                     else
                     {
                         rv = obj;

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/ConvertToJsonCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/ConvertToJsonCommand.cs
@@ -14,6 +14,7 @@ using Dbg = System.Management.Automation;
 using System.Management.Automation.Internal;
 #if CORECLR
 using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 #else
 using System.Collections.Specialized;
 using System.Web.Script.Serialization;
@@ -59,6 +60,15 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         [Parameter]
         public SwitchParameter Compress { get; set; }
+
+        /// <summary>
+        /// gets or sets the EnumsAsStrings property.
+        /// If the EnumsAsStrings property is set to true, enum values will
+        /// be converted to their string equivalent. Otherwise, enum values
+        /// will be converted to their numeric equivalent.
+        /// </summary>
+        [Parameter()]
+        public SwitchParameter EnumsAsStrings { get; set; }
 
         #endregion parameters
 
@@ -122,6 +132,10 @@ namespace Microsoft.PowerShell.Commands
                 object preprocessedObject = ProcessValue(objectToProcess, 0);
 #if CORECLR
                 JsonSerializerSettings jsonSettings = new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.None, MaxDepth = 1024 };
+                if (EnumsAsStrings)
+                {
+                    jsonSettings.Converters.Add(new StringEnumConverter());
+                }
                 if (!Compress)
                 {
                     jsonSettings.Formatting = Formatting.Indented;
@@ -464,6 +478,12 @@ namespace Microsoft.PowerShell.Commands
                     {
                         rv = obj.ToString();
                     }
+#if !CORECLR
+                    else if (EnumsAsStrings)
+                    {
+                        rv = obj.ToString();
+                    }
+#endif
                     else
                     {
                         rv = obj;

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Pester.Commands.Cmdlets.Json.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Pester.Commands.Cmdlets.Json.Tests.ps1
@@ -211,6 +211,23 @@ Describe "Json Tests" -Tags "Feature" {
             $emptyStringResult = ConvertFrom-Json ""
             $emptyStringResult | Should Be $null
         }
+
+        It "Convert enumerated values to Json" {
+
+            $sampleObject = [pscustomobject]@{
+                PSTypeName = 'Test.EnumSample'
+                SampleSimpleEnum = [System.Management.Automation.ActionPreference]::Ignore
+                SampleBitwiseEnum = [System.Management.Automation.CommandTypes]'Alias,Function,Cmdlet'
+            }
+
+            $response4 = ConvertTo-Json -InputObject $sampleObject -Compress
+            $response4 | Should Be '{"SampleSimpleEnum":4,"SampleBitwiseEnum":11}'
+
+            $response4 = ConvertTo-Json -InputObject $sampleObject -Compress -EnumsAsStrings
+            $response4 | Should Be '{"SampleSimpleEnum":"Ignore","SampleBitwiseEnum":"Alias, Function, Cmdlet"}'
+
+        }
+
     }
 
     Context "JsonObject Tests" {


### PR DESCRIPTION
There are many scenarios where the default serialization behaviour of ```ConvertTo-Json``` for enumerated types is undesirable. JSON does not contain type information for the properties contained within it, and as a result deserialization of JSON enumerations into a meaningful representation (such as their string representation) is impossible.

This PR adds a new ```-EnumsAsStrings``` parameter to the ```ConvertTo-Json``` cmdlet to provide an alternative serialization option that converts all enumerations to their string representation as part of the serialization process, so that the data remains meaningful when the JSON string is deserialized later.