### PR TITLE
Useful error message when HelpMessage attributes are empty string

### DIFF
--- a/src/System.Management.Automation/engine/Attributes.cs
+++ b/src/System.Management.Automation/engine/Attributes.cs
@@ -686,7 +686,7 @@ namespace System.Management.Automation
             {
                 if (string.IsNullOrEmpty(value))
                 {
-                    throw PSTraceSource.NewArgumentException("value");
+                    throw PSTraceSource.NewArgumentException("HelpMessage");
                 }
                 _helpMessage = value;
             }
@@ -707,7 +707,7 @@ namespace System.Management.Automation
             {
                 if (string.IsNullOrEmpty(value))
                 {
-                    throw PSTraceSource.NewArgumentException("value");
+                    throw PSTraceSource.NewArgumentException("HelpMessageBaseName");
                 }
                 _helpMessageBaseName = value;
             }
@@ -728,7 +728,7 @@ namespace System.Management.Automation
             {
                 if (string.IsNullOrEmpty(value))
                 {
-                    throw PSTraceSource.NewArgumentException("value");
+                    throw PSTraceSource.NewArgumentException("HelpMessageResourceId");
                 }
                 _helpMessageResourceId = value;
             }

--- a/src/System.Management.Automation/engine/CommandDiscovery.cs
+++ b/src/System.Management.Automation/engine/CommandDiscovery.cs
@@ -775,16 +775,6 @@ namespace System.Management.Automation
                             new CommandNotFoundException(reqSyntaxException.Message, reqSyntaxException);
                         throw e;
                     }
-                    catch (PSArgumentException argException)
-                    {
-                        CommandNotFoundException e =
-                            new CommandNotFoundException(
-                                commandInfo.Name,
-                                argException,
-                                "ScriptRequiresInvalidFormat",
-                                DiscoveryExceptions.ScriptRequiresInvalidFormat);
-                        throw e;
-                    }
                     break;
                 case CommandTypes.Filter:
                 case CommandTypes.Function:

--- a/test/powershell/engine/Attributes.Tests.ps1
+++ b/test/powershell/engine/Attributes.Tests.ps1
@@ -1,0 +1,24 @@
+Describe "Attribute tests" -Tags "CI" {
+    BeforeEach {
+        Remove-Item $testdrive/test.ps1 -Force -ErrorAction SilentlyContinue
+    }
+
+    It "<attribute> attribute returns argument error if empty" -TestCases @(
+        @{Attribute="HelpMessage"},
+        @{Attribute="HelpMessageBaseName"},
+        @{Attribute="HelpMessageResourceId"}
+    ) {
+        param($attribute)
+
+        $script = @"
+[CmdletBinding()]
+Param (
+[Parameter($attribute="")]
+[String]`$Parameter1
+)
+Write-Output "Hello"
+"@
+        New-Item -Path $testdrive/test.ps1 -Value $script -ItemType File
+        { & $testdrive/test.ps1 } | ShouldBeErrorId "Argument"
+    }
+}


### PR DESCRIPTION
Fix invalid value error message on some cmdlet attributes to point to the specific attribute.

Removed wrapping of argument exception into not useful requires exception

Before:
```
.\helpmessage.ps1 : Cannot process the #requires statement because it is not in the correct format.
The #requires statement must be in one of the following formats:
 "#requires -shellid <shellID>"
 "#requires -version <major.minor>"
 "#requires -psedition <edition>"
 "#requires -pssnapin <psSnapInName> [-version <major.minor>]"
 "#requires -modules <ModuleSpecification>"
 "#requires -runasadministrator"
At line:1 char:1
+ .\helpmessage.ps1
+ ~~~~~~~~~~~~~~~~~
    + CategoryInfo          : ObjectNotFound: (helpmessage.ps1:String) [], CommandNotFoundException
    + FullyQualifiedErrorId : ScriptRequiresInvalidFormat
```

After:
```
Cannot process argument because the value of argument "HelpMessage" is not valid. Change the value of the
"HelpMessage" argument and run the operation again.
At line:1 char:1
+ .\helpmessage.ps1
+ ~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidArgument: (:) [], RuntimeException
    + FullyQualifiedErrorId : Argument
```

Fix https://github.com/PowerShell/PowerShell/issues/4331

<!--

If you are a PowerShell Team member, please make sure you choose the Reviewer(s) and Assignee for your PR.
If you are not from the PowerShell Team, you can leave the fields blank and the Maintainers will choose them for you. If you are familiar with the team, feel free to mention some Reviewers yourself.

For more information about the roles of Reviewer and Assignee, refer to CONTRIBUTING.md.

-->
