### PR TITLE
Use HTML meta charset attribute value, if present, when the Context-Type header does not specify it.

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/BasicHtmlWebResponseObject.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/BasicHtmlWebResponseObject.Common.cs
@@ -25,6 +25,14 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         public new string Content { get; private set; }
 
+        /// <summary>
+        /// Gets the Encoding that was used to decode the Content
+        /// </summary>
+        /// <value>
+        /// The Encoding used to decode the Content; otherwise, a null reference if the content is not text.
+        /// </value>
+        public Encoding Encoding { get; private set; }
+
         private WebCmdletElementCollection _inputFields;
 
         /// <summary>
@@ -217,14 +225,16 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Reads the response content from the web response.
         /// </summary>
-        private void InitializeContent()
+        protected void InitializeContent()
         {
             string contentType = ContentHelper.GetContentType(BaseResponse);
             if (ContentHelper.IsText(contentType))
             {
+                Encoding encoding = null;
                 // fill the Content buffer
                 string characterSet = WebResponseHelper.GetCharacterSet(BaseResponse);
-                this.Content = StreamHelper.DecodeStream(RawContentStream, characterSet);
+                this.Content = StreamHelper.DecodeStream(RawContentStream, characterSet, out encoding);
+                this.Encoding = encoding;
             }
             else
             {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/HtmlWebResponseObject.CoreClr.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/HtmlWebResponseObject.CoreClr.cs
@@ -49,7 +49,40 @@ namespace Microsoft.PowerShell.Commands
 
         #endregion Constructors
 
+       #region Properties
+
+        /// <summary>
+        /// Gets the Encoding that was used to decode the Content
+        /// </summary>
+        /// <value>
+        /// The Encoding used to decode the Content; otherwise, a null reference if the content is not text.
+        /// </value>
+        public Encoding Encoding { get; private set; }
+
+        #endregion Properties
+
         #region Methods
+
+        // NOTE: Currently this code path is not enabled.
+        // See FillRequestStream in WebRequestPSCmdlet.CoreClr.cs and
+        // GetResponseObject in WebResponseObjectFactory.CoreClr.cs for details.
+        private void InitializeContent()
+        {
+            string contentType = ContentHelper.GetContentType(BaseResponse);
+            string content = null;
+            if (ContentHelper.IsText(contentType))
+            {
+                Encoding encoding = null;
+                // fill the Content buffer
+                string characterSet = WebResponseHelper.GetCharacterSet(BaseResponse);
+                this.Content = StreamHelper.DecodeStream(RawContentStream, characterSet, out encoding);
+                this.Encoding = encoding;
+            }
+            else
+            {
+                this.Content = string.Empty;
+            }
+        }
 
         private void InitializeRawContent(HttpResponseMessage baseResponse)
         {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/InvokeRestMethodCommand.CoreClr.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/InvokeRestMethodCommand.CoreClr.cs
@@ -51,7 +51,7 @@ namespace Microsoft.PowerShell.Commands
                         object obj = null;
                         Exception ex = null;
 
-                        string str = StreamHelper.DecodeStream(responseStream, encoding);
+                        string str = StreamHelper.DecodeStream(responseStream, ref encoding);
                         bool convertSuccess = false;
 
                         // On CoreCLR, we need to explicitly load Json.NET

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/StreamHelper.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/StreamHelper.cs
@@ -465,7 +465,7 @@ namespace Microsoft.PowerShell.Commands
             return result;
         }
 
-        static readonly Regex s_metaexp = new Regex(@"<meta\s*charset\s*=\s*[""']([a-zA-Z0-9]*)[""']");
+        static readonly Regex s_metaexp = new Regex(@"<meta\s+charset\s*=\s*[""'](?<charset>.[^""']+)");
 
         internal static string DecodeStream(Stream stream, ref Encoding encoding)
         {
@@ -482,10 +482,10 @@ namespace Microsoft.PowerShell.Commands
             {
                 // check for a charset attribute on the meta element to override the default.
                 Match match = s_metaexp.Match(content);
-                if (match.Success && match.Groups.Count > 1)
+                if (match.Success)
                 {
                     Encoding localEncoding = null;
-                    string characterSet = match.Groups[1].Value;
+                    string characterSet = match.Groups["charset"].Value;
 
                     if (TryGetEncoding(characterSet, out localEncoding))
                     {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/StreamHelper.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/StreamHelper.cs
@@ -465,7 +465,7 @@ namespace Microsoft.PowerShell.Commands
             return result;
         }
 
-        static readonly Regex s_metaexp = new Regex(@"<meta\s+charset\s*=\s*[""'](?<charset>.[^""']+)");
+        static readonly Regex s_metaexp = new Regex(@"<meta\s[.\n]*[^><]*charset\s*=\s*[""'\n]?(?<charset>[A-Za-z].[^\s""'\n<>]*)[\s""'\n>]");
 
         internal static string DecodeStream(Stream stream, ref Encoding encoding)
         {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -271,6 +271,32 @@ function ExecuteRequestWithCustomUserAgent {
     return $result
 }
 
+# This function calls Invoke-WebRequest with the given uri
+function ExecuteWebRequest
+{
+    param (
+        [Parameter(Mandatory)]
+        [string]
+        $Uri,
+
+        [switch] $UseBasicParsing
+    )
+   $result = [PSObject]@{Output = $null; Error = $null; Content = $null}
+
+    try
+    {
+        $result.Output = Invoke-WebRequest -Uri $Uri -TimeoutSec 5 -UseBasicParsing:$UseBasicParsing.IsPresent
+        $result.Content = $result.Output.Content
+    }
+    catch
+    {
+        $result.Error = $_
+    }
+
+    return $result
+}
+
+
 <#
     Defines the list of redirect codes to test as well as the
     expected Method when the redirection is handled.
@@ -804,6 +830,84 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
     }
 
     #endregion SkipHeaderVerification Tests
+
+    #region charset encoding tests
+
+    Context  "BasicHtmlWebResponseObject Encoding tests" {
+        It "Verifies Invoke-WebRequest detects charset meta value when the ContentType header does not define it." {
+            $output = '<html><head><meta charset="gb2312"></head></html>'
+            $expectedEncoding = [System.Text.Encoding]::GetEncoding('gb2312')
+            $response = ExecuteWebRequest -Uri "http://localhost:8080/PowerShell?test=response&output=$output" -UseBasicParsing
+
+            $response.Error | Should BeNullOrEmpty
+            $response.Output.Encoding.EncodingName | Should Be $expectedEncoding.EncodingName
+            $response.Output | Should BeOfType 'Microsoft.PowerShell.Commands.BasicHtmlWebResponseObject'
+        }
+
+        It "Verifies Invoke-WebRequest ignores meta charset value when Content-Type header defines it." {
+            $output = '<html><head><meta charset="gb2312"></head></html>'
+            # NOTE: meta charset should be ignored
+            $expectedEncoding = [System.Text.Encoding]::UTF8
+            $response = ExecuteWebRequest -Uri "http://localhost:8080/PowerShell?test=response&contenttype=text/html; charset=utf-8&output=$output" -UseBasicParsing
+
+            $response.Error | Should BeNullOrEmpty
+            $response.Output.Encoding.EncodingName | Should Be $expectedEncoding.EncodingName
+            $response.Output | Should BeOfType 'Microsoft.PowerShell.Commands.BasicHtmlWebResponseObject'
+        }
+
+        It "Verifies Invoke-WebRequest honors non-utf8 charsets in the Content-Type header" {
+            $output = '<html><head><meta charset="gb2312"></head></html>'
+            # NOTE: meta charset should be ignored
+            $expectedEncoding = [System.Text.Encoding]::GetEncoding('iso-2022-jp')
+            $response = ExecuteWebRequest -Uri "http://localhost:8080/PowerShell?test=response&contenttype=text/html; charset=iso-2022-jp&output=$output" -UseBasicParsing
+
+            $response.Error | Should BeNullOrEmpty
+            $response.Output.Encoding.EncodingName | Should Be $expectedEncoding.EncodingName
+            $response.Output | Should BeOfType 'Microsoft.PowerShell.Commands.BasicHtmlWebResponseObject'
+        }
+    }
+
+    Context  "HtmlWebResponseObject Encoding" {
+        # these tests are dependent on https://github.com/PowerShell/PowerShell/issues/2867
+        # Currently, all paths return BasicHtmlWebResponseObject
+        It "Verifies Invoke-WebRequest detects charset meta value when the ContentType header does not define it." -Pending {
+            $output = '<html><head><meta charset="gb2312"></head></html>'
+            $expectedEncoding = [System.Text.Encoding]::GetEncoding('gb2312')
+            $response = ExecuteWebRequest -Uri "http://localhost:8080/PowerShell?test=response&output=$output"
+
+            $response.Error | Should BeNullOrEmpty
+            $response.Output.Encoding.EncodingName | Should Be $expectedEncoding.EncodingName
+            # Update to test for HtmlWebResponseObject when mshtl dependency has been resolved.
+            $response.Output | Should BeOfType 'Microsoft.PowerShell.Commands.HtmlWebResponseObject'
+        }
+
+        It "Verifies Invoke-WebRequest ignores meta charset value when Content-Type header defines it." -Pending {
+            $output = '<html><head><meta charset="gb2312"></head></html>'
+            # NOTE: meta charset should be ignored
+            $expectedEncoding = [System.Text.Encoding]::UTF8
+            # Update to test for HtmlWebResponseObject when mshtl dependency has been resolved.
+            $response = ExecuteWebRequest -Uri "http://localhost:8080/PowerShell?test=response&contenttype=text/html; charset=utf-8&output=$output"
+
+            $response.Error | Should BeNullOrEmpty
+            $response.Output.Encoding.EncodingName | Should Be $expectedEncoding.EncodingName
+            # Update to test for HtmlWebResponseObject when mshtl dependency has been resolved.
+            $response.Output | Should BeOfType 'Microsoft.PowerShell.Commands.HtmlWebResponseObject'
+        }
+
+        It "Verifies Invoke-WebRequest honors non-utf8 charsets in the Content-Type header" -Pending {
+            $output = '<html><head><meta charset="gb2312"></head></html>'
+            # NOTE: meta charset should be ignored
+            $expectedEncoding = [System.Text.Encoding]::GetEncoding('iso-2022-jp')
+            $response = ExecuteWebRequest -Uri "http://localhost:8080/PowerShell?test=response&contenttype=text/html; charset=iso-2022-jp&output=$output"
+
+            $response.Error | Should BeNullOrEmpty
+            $response.Output.Encoding.EncodingName | Should Be $expectedEncoding.EncodingName
+            # Update to test for HtmlWebResponseObject when mshtl dependency has been resolved.
+            $response.Output | Should BeOfType 'Microsoft.PowerShell.Commands.HtmlWebResponseObject'
+        }
+    }
+
+    #endregion charset encoding tests
 
     BeforeEach {
         if ($env:http_proxy) {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -865,6 +865,16 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
             $response.Output.Encoding.EncodingName | Should Be $expectedEncoding.EncodingName
             $response.Output | Should BeOfType 'Microsoft.PowerShell.Commands.BasicHtmlWebResponseObject'
         }
+
+        It "Verifies Invoke-WebRequest defaults to iso-8859-1 when an unsupported/invalid charset is declared" {
+            $output = '<html><head><meta charset="invalid"></head></html>'
+            $expectedEncoding = [System.Text.Encoding]::GetEncoding('iso-8859-1')
+            $response = ExecuteWebRequest -Uri "http://localhost:8080/PowerShell?test=response&contenttype=text/html&output=$output" -UseBasicParsing
+
+            $response.Error | Should BeNullOrEmpty
+            $response.Output.Encoding.EncodingName | Should Be $expectedEncoding.EncodingName
+            $response.Output | Should BeOfType 'Microsoft.PowerShell.Commands.BasicHtmlWebResponseObject'
+        }
     }
 
     Context  "HtmlWebResponseObject Encoding" {
@@ -899,6 +909,17 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
             # NOTE: meta charset should be ignored
             $expectedEncoding = [System.Text.Encoding]::GetEncoding('iso-2022-jp')
             $response = ExecuteWebRequest -Uri "http://localhost:8080/PowerShell?test=response&contenttype=text/html; charset=iso-2022-jp&output=$output"
+
+            $response.Error | Should BeNullOrEmpty
+            $response.Output.Encoding.EncodingName | Should Be $expectedEncoding.EncodingName
+            # Update to test for HtmlWebResponseObject when mshtl dependency has been resolved.
+            $response.Output | Should BeOfType 'Microsoft.PowerShell.Commands.HtmlWebResponseObject'
+        }
+
+        It "Verifies Invoke-WebRequest defaults to iso-8859-1 when an unsupported/invalid charset is declared" -Pending {
+            $output = '<html><head><meta charset="invalid"></head></html>'
+            $expectedEncoding = [System.Text.Encoding]::GetEncoding('iso-8859-1')
+            $response = ExecuteWebRequest -Uri "http://localhost:8080/PowerShell?test=response&contenttype=text/html&output=$output"
 
             $response.Error | Should BeNullOrEmpty
             $response.Output.Encoding.EncodingName | Should Be $expectedEncoding.EncodingName

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -835,8 +835,8 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
 
     Context  "BasicHtmlWebResponseObject Encoding tests" {
         It "Verifies Invoke-WebRequest detects charset meta value when the ContentType header does not define it." {
-            $output = '<html><head><meta charset="gb2312"></head></html>'
-            $expectedEncoding = [System.Text.Encoding]::GetEncoding('gb2312')
+            $output = '<html><head><meta charset="Unicode"></head></html>'
+            $expectedEncoding = [System.Text.Encoding]::GetEncoding('Unicode')
             $response = ExecuteWebRequest -Uri "http://localhost:8080/PowerShell?test=response&output=$output" -UseBasicParsing
 
             $response.Error | Should BeNullOrEmpty
@@ -845,7 +845,7 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
         }
 
         It "Verifies Invoke-WebRequest ignores meta charset value when Content-Type header defines it." {
-            $output = '<html><head><meta charset="gb2312"></head></html>'
+            $output = '<html><head><meta charset="utf-32"></head></html>'
             # NOTE: meta charset should be ignored
             $expectedEncoding = [System.Text.Encoding]::UTF8
             $response = ExecuteWebRequest -Uri "http://localhost:8080/PowerShell?test=response&contenttype=text/html; charset=utf-8&output=$output" -UseBasicParsing
@@ -856,10 +856,10 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
         }
 
         It "Verifies Invoke-WebRequest honors non-utf8 charsets in the Content-Type header" {
-            $output = '<html><head><meta charset="gb2312"></head></html>'
+            $output = '<html><head><meta charset="utf-32"></head></html>'
             # NOTE: meta charset should be ignored
-            $expectedEncoding = [System.Text.Encoding]::GetEncoding('iso-2022-jp')
-            $response = ExecuteWebRequest -Uri "http://localhost:8080/PowerShell?test=response&contenttype=text/html; charset=iso-2022-jp&output=$output" -UseBasicParsing
+            $expectedEncoding = [System.Text.Encoding]::GetEncoding('utf-16')
+            $response = ExecuteWebRequest -Uri "http://localhost:8080/PowerShell?test=response&contenttype=text/html; charset=utf-16&output=$output" -UseBasicParsing
 
             $response.Error | Should BeNullOrEmpty
             $response.Output.Encoding.EncodingName | Should Be $expectedEncoding.EncodingName
@@ -881,8 +881,8 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
         # these tests are dependent on https://github.com/PowerShell/PowerShell/issues/2867
         # Currently, all paths return BasicHtmlWebResponseObject
         It "Verifies Invoke-WebRequest detects charset meta value when the ContentType header does not define it." -Pending {
-            $output = '<html><head><meta charset="gb2312"></head></html>'
-            $expectedEncoding = [System.Text.Encoding]::GetEncoding('gb2312')
+            $output = '<html><head><meta charset="Unicode"></head></html>'
+            $expectedEncoding = [System.Text.Encoding]::GetEncoding('Unicode')
             $response = ExecuteWebRequest -Uri "http://localhost:8080/PowerShell?test=response&output=$output"
 
             $response.Error | Should BeNullOrEmpty
@@ -892,7 +892,7 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
         }
 
         It "Verifies Invoke-WebRequest ignores meta charset value when Content-Type header defines it." -Pending {
-            $output = '<html><head><meta charset="gb2312"></head></html>'
+            $output = '<html><head><meta charset="utf-16"></head></html>'
             # NOTE: meta charset should be ignored
             $expectedEncoding = [System.Text.Encoding]::UTF8
             # Update to test for HtmlWebResponseObject when mshtl dependency has been resolved.
@@ -905,10 +905,10 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
         }
 
         It "Verifies Invoke-WebRequest honors non-utf8 charsets in the Content-Type header" -Pending {
-            $output = '<html><head><meta charset="gb2312"></head></html>'
+            $output = '<html><head><meta charset="utf-32"></head></html>'
             # NOTE: meta charset should be ignored
-            $expectedEncoding = [System.Text.Encoding]::GetEncoding('iso-2022-jp')
-            $response = ExecuteWebRequest -Uri "http://localhost:8080/PowerShell?test=response&contenttype=text/html; charset=iso-2022-jp&output=$output"
+            $expectedEncoding = [System.Text.Encoding]::GetEncoding('utf-16')
+            $response = ExecuteWebRequest -Uri "http://localhost:8080/PowerShell?test=response&contenttype=text/html; charset=utf-16&output=$output"
 
             $response.Error | Should BeNullOrEmpty
             $response.Output.Encoding.EncodingName | Should Be $expectedEncoding.EncodingName

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -248,9 +248,9 @@ function ExecuteRequestWithCustomUserAgent {
 
     try {
         $Params = @{
-            Uri                  = $Uri 
-            TimeoutSec           = 5 
-            UserAgent            = $UserAgent 
+            Uri                  = $Uri
+            TimeoutSec           = 5
+            UserAgent            = $UserAgent
             SkipHeaderValidation = $SkipHeaderValidation.IsPresent
         }
         if ($Cmdlet -eq 'Invoke-WebRequest') {
@@ -848,7 +848,7 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
             $output = @'
 <html>
     <head>
-        <meta 
+        <meta
             charset="Unicode"
             >
     </head>
@@ -877,7 +877,7 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
 <html><head>
 <meta http-equiv="content-type" content="text/html; charset=Unicode">
 </head>
-</html>   
+</html>
 '@
             $expectedEncoding = [System.Text.Encoding]::GetEncoding('Unicode')
             $response = ExecuteWebRequest -Uri "http://localhost:8080/PowerShell?test=response&output=$output" -UseBasicParsing
@@ -890,11 +890,11 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
         It "Verifies Invoke-WebRequest detects http-equiv charset meta value newlines are encountered in the element." {
             $output = @'
 <html><head>
-<meta 
-    http-equiv="content-type" 
+<meta
+    http-equiv="content-type"
     content="text/html; charset=Unicode">
 </head>
-</html>   
+</html>
 '@
             $expectedEncoding = [System.Text.Encoding]::GetEncoding('Unicode')
             $response = ExecuteWebRequest -Uri "http://localhost:8080/PowerShell?test=response&output=$output" -UseBasicParsing
@@ -941,7 +941,7 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
 <html><head>
 <meta http-equiv="content-type" content="text/html; charset=Invalid">
 </head>
-</html>   
+</html>
 '@
             $expectedEncoding = [System.Text.Encoding]::GetEncoding('iso-8859-1')
             $response = ExecuteWebRequest -Uri "http://localhost:8080/PowerShell?test=response&contenttype=text/html&output=$output" -UseBasicParsing
@@ -970,7 +970,7 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
             $output = @'
 <html>
     <head>
-        <meta 
+        <meta
             charset="Unicode"
             >
     </head>
@@ -1002,7 +1002,7 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
 <html><head>
 <meta http-equiv="content-type" content="text/html; charset=Unicode">
 </head>
-</html>   
+</html>
 '@
             $expectedEncoding = [System.Text.Encoding]::GetEncoding('Unicode')
             $response = ExecuteWebRequest -Uri "http://localhost:8080/PowerShell?test=response&output=$output"
@@ -1015,11 +1015,11 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
         It "Verifies Invoke-WebRequest detects http-equiv charset meta value newlines are encountered in the element." -Pending {
             $output = @'
 <html><head>
-<meta 
-    http-equiv="content-type" 
+<meta
+    http-equiv="content-type"
     content="text/html; charset=Unicode">
 </head>
-</html>   
+</html>
 '@
             $expectedEncoding = [System.Text.Encoding]::GetEncoding('Unicode')
             $response = ExecuteWebRequest -Uri "http://localhost:8080/PowerShell?test=response&output=$output"
@@ -1028,7 +1028,7 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
             $response.Output.Encoding.EncodingName | Should Be $expectedEncoding.EncodingName
             $response.Output | Should BeOfType 'Microsoft.PowerShell.Commands.HtmlWebResponseObject'
         }
-        
+
         It "Verifies Invoke-WebRequest honors non-utf8 charsets in the Content-Type header" -Pending {
             $output = '<html><head><meta charset="utf-32"></head></html>'
             # NOTE: meta charset should be ignored
@@ -1051,12 +1051,13 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
             # Update to test for HtmlWebResponseObject when mshtl dependency has been resolved.
             $response.Output | Should BeOfType 'Microsoft.PowerShell.Commands.HtmlWebResponseObject'
         }
+
         It "Verifies Invoke-WebRequest defaults to iso-8859-1 when an unsupported/invalid charset is declared using http-equiv" -Pending {
             $output = @'
 <html><head>
 <meta http-equiv="content-type" content="text/html; charset=Invalid">
 </head>
-</html>   
+</html>
 '@
             $expectedEncoding = [System.Text.Encoding]::GetEncoding('iso-8859-1')
             $response = ExecuteWebRequest -Uri "http://localhost:8080/PowerShell?test=response&contenttype=text/html&output=$output"

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -844,6 +844,66 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
             $response.Output | Should BeOfType 'Microsoft.PowerShell.Commands.BasicHtmlWebResponseObject'
         }
 
+        It "Verifies Invoke-WebRequest detects charset meta value when newlines are encountered in the element." {
+            $output = @'
+<html>
+    <head>
+        <meta 
+            charset="Unicode"
+            >
+    </head>
+</html>
+'@
+            $expectedEncoding = [System.Text.Encoding]::GetEncoding('Unicode')
+            $response = ExecuteWebRequest -Uri "http://localhost:8080/PowerShell?test=response&output=$output" -UseBasicParsing
+
+            $response.Error | Should BeNullOrEmpty
+            $response.Output.Encoding.EncodingName | Should Be $expectedEncoding.EncodingName
+            $response.Output | Should BeOfType 'Microsoft.PowerShell.Commands.BasicHtmlWebResponseObject'
+        }
+
+        It "Verifies Invoke-WebRequest detects charset meta value when the attribute value is unquoted." {
+            $output = '<html><head><meta charset = Unicode></head></html>'
+            $expectedEncoding = [System.Text.Encoding]::GetEncoding('Unicode')
+            $response = ExecuteWebRequest -Uri "http://localhost:8080/PowerShell?test=response&output=$output" -UseBasicParsing
+
+            $response.Error | Should BeNullOrEmpty
+            $response.Output.Encoding.EncodingName | Should Be $expectedEncoding.EncodingName
+            $response.Output | Should BeOfType 'Microsoft.PowerShell.Commands.BasicHtmlWebResponseObject'
+        }
+
+        It "Verifies Invoke-WebRequest detects http-equiv charset meta value when the ContentType header does not define it." {
+            $output = @'
+<html><head>
+<meta http-equiv="content-type" content="text/html; charset=Unicode">
+</head>
+</html>   
+'@
+            $expectedEncoding = [System.Text.Encoding]::GetEncoding('Unicode')
+            $response = ExecuteWebRequest -Uri "http://localhost:8080/PowerShell?test=response&output=$output" -UseBasicParsing
+
+            $response.Error | Should BeNullOrEmpty
+            $response.Output.Encoding.EncodingName | Should Be $expectedEncoding.EncodingName
+            $response.Output | Should BeOfType 'Microsoft.PowerShell.Commands.BasicHtmlWebResponseObject'
+        }
+
+        It "Verifies Invoke-WebRequest detects http-equiv charset meta value newlines are encountered in the element." {
+            $output = @'
+<html><head>
+<meta 
+    http-equiv="content-type" 
+    content="text/html; charset=Unicode">
+</head>
+</html>   
+'@
+            $expectedEncoding = [System.Text.Encoding]::GetEncoding('Unicode')
+            $response = ExecuteWebRequest -Uri "http://localhost:8080/PowerShell?test=response&output=$output" -UseBasicParsing
+
+            $response.Error | Should BeNullOrEmpty
+            $response.Output.Encoding.EncodingName | Should Be $expectedEncoding.EncodingName
+            $response.Output | Should BeOfType 'Microsoft.PowerShell.Commands.BasicHtmlWebResponseObject'
+        }
+
         It "Verifies Invoke-WebRequest ignores meta charset value when Content-Type header defines it." {
             $output = '<html><head><meta charset="utf-32"></head></html>'
             # NOTE: meta charset should be ignored
@@ -875,6 +935,21 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
             $response.Output.Encoding.EncodingName | Should Be $expectedEncoding.EncodingName
             $response.Output | Should BeOfType 'Microsoft.PowerShell.Commands.BasicHtmlWebResponseObject'
         }
+
+        It "Verifies Invoke-WebRequest defaults to iso-8859-1 when an unsupported/invalid charset is declared using http-equiv" {
+            $output = @'
+<html><head>
+<meta http-equiv="content-type" content="text/html; charset=Invalid">
+</head>
+</html>   
+'@
+            $expectedEncoding = [System.Text.Encoding]::GetEncoding('iso-8859-1')
+            $response = ExecuteWebRequest -Uri "http://localhost:8080/PowerShell?test=response&contenttype=text/html&output=$output" -UseBasicParsing
+
+            $response.Error | Should BeNullOrEmpty
+            $response.Output.Encoding.EncodingName | Should Be $expectedEncoding.EncodingName
+            $response.Output | Should BeOfType 'Microsoft.PowerShell.Commands.BasicHtmlWebResponseObject'
+        }
     }
 
     Context  "HtmlWebResponseObject Encoding" {
@@ -891,6 +966,24 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
             $response.Output | Should BeOfType 'Microsoft.PowerShell.Commands.HtmlWebResponseObject'
         }
 
+        It "Verifies Invoke-WebRequest detects charset meta value when newlines are encountered in the element." -Pending {
+            $output = @'
+<html>
+    <head>
+        <meta 
+            charset="Unicode"
+            >
+    </head>
+</html>
+'@
+            $expectedEncoding = [System.Text.Encoding]::GetEncoding('Unicode')
+            $response = ExecuteWebRequest -Uri "http://localhost:8080/PowerShell?test=response&output=$output"
+
+            $response.Error | Should BeNullOrEmpty
+            $response.Output.Encoding.EncodingName | Should Be $expectedEncoding.EncodingName
+            $response.Output | Should BeOfType 'Microsoft.PowerShell.Commands.HtmlWebResponseObject'
+        }
+
         It "Verifies Invoke-WebRequest ignores meta charset value when Content-Type header defines it." -Pending {
             $output = '<html><head><meta charset="utf-16"></head></html>'
             # NOTE: meta charset should be ignored
@@ -904,6 +997,38 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
             $response.Output | Should BeOfType 'Microsoft.PowerShell.Commands.HtmlWebResponseObject'
         }
 
+        It "Verifies Invoke-WebRequest detects http-equiv charset meta value when the ContentType header does not define it." -Pending {
+            $output = @'
+<html><head>
+<meta http-equiv="content-type" content="text/html; charset=Unicode">
+</head>
+</html>   
+'@
+            $expectedEncoding = [System.Text.Encoding]::GetEncoding('Unicode')
+            $response = ExecuteWebRequest -Uri "http://localhost:8080/PowerShell?test=response&output=$output"
+
+            $response.Error | Should BeNullOrEmpty
+            $response.Output.Encoding.EncodingName | Should Be $expectedEncoding.EncodingName
+            $response.Output | Should BeOfType 'Microsoft.PowerShell.Commands.HtmlWebResponseObject'
+        }
+
+        It "Verifies Invoke-WebRequest detects http-equiv charset meta value newlines are encountered in the element." -Pending {
+            $output = @'
+<html><head>
+<meta 
+    http-equiv="content-type" 
+    content="text/html; charset=Unicode">
+</head>
+</html>   
+'@
+            $expectedEncoding = [System.Text.Encoding]::GetEncoding('Unicode')
+            $response = ExecuteWebRequest -Uri "http://localhost:8080/PowerShell?test=response&output=$output"
+
+            $response.Error | Should BeNullOrEmpty
+            $response.Output.Encoding.EncodingName | Should Be $expectedEncoding.EncodingName
+            $response.Output | Should BeOfType 'Microsoft.PowerShell.Commands.HtmlWebResponseObject'
+        }
+        
         It "Verifies Invoke-WebRequest honors non-utf8 charsets in the Content-Type header" -Pending {
             $output = '<html><head><meta charset="utf-32"></head></html>'
             # NOTE: meta charset should be ignored
@@ -924,6 +1049,20 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
             $response.Error | Should BeNullOrEmpty
             $response.Output.Encoding.EncodingName | Should Be $expectedEncoding.EncodingName
             # Update to test for HtmlWebResponseObject when mshtl dependency has been resolved.
+            $response.Output | Should BeOfType 'Microsoft.PowerShell.Commands.HtmlWebResponseObject'
+        }
+        It "Verifies Invoke-WebRequest defaults to iso-8859-1 when an unsupported/invalid charset is declared using http-equiv" -Pending {
+            $output = @'
+<html><head>
+<meta http-equiv="content-type" content="text/html; charset=Invalid">
+</head>
+</html>   
+'@
+            $expectedEncoding = [System.Text.Encoding]::GetEncoding('iso-8859-1')
+            $response = ExecuteWebRequest -Uri "http://localhost:8080/PowerShell?test=response&contenttype=text/html&output=$output"
+
+            $response.Error | Should BeNullOrEmpty
+            $response.Output.Encoding.EncodingName | Should Be $expectedEncoding.EncodingName
             $response.Output | Should BeOfType 'Microsoft.PowerShell.Commands.HtmlWebResponseObject'
         }
     }


### PR DESCRIPTION
Fix https://github.com/PowerShell/PowerShell/issues/3267

The change enables checking for the charset meta attribute when the Content-Type header does not define the charset. When found, the text content is re-encoded to the target charset.

A new property has been added to BasicHtmlWebResponseObject and HtmlWebResponseObject to support verifying the encoding. Attempting to do so from the returned content is non-deterministic.
See https://github.com/PowerShell/PowerShell-Docs/pull/1543 for example usage.

NOTE: Three tests are pending the resolution for issue https://github.com/PowerShell/PowerShell/issues/2867