### PR TITLE
Increase code coverage of Get-ChildItem on file system.

### DIFF
--- a/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
@@ -84,6 +84,11 @@ Describe "Basic FileSystem Provider Tests" -Tags "CI" {
             $dirContents.Count | Should Be 2
         }
 
+        It "Verity Get-ChildItem can get the name of a specified item." {
+            $fileName = Get-ChildItem $testFile -Name
+            $fileName | Should BeExactly $fileName
+        }
+
         It "Set-Content to a file" {
             $content =  Set-Content -Value $testContent -Path $testFile -PassThru
             $content | Should BeExactly $testContent

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
@@ -86,7 +86,8 @@ Describe "Basic FileSystem Provider Tests" -Tags "CI" {
 
         It "Verity Get-ChildItem can get the name of a specified item." {
             $fileName = Get-ChildItem $testFile -Name
-            $fileName | Should BeExactly $fileName
+            $fileInfo = Get-ChildItem $testFile
+            $fileName | Should BeExactly $fileInfo.Name
         }
 
         It "Set-Content to a file" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
@@ -84,7 +84,7 @@ Describe "Basic FileSystem Provider Tests" -Tags "CI" {
             $dirContents.Count | Should Be 2
         }
 
-        It "Verity Get-ChildItem can get the name of a specified item." {
+        It "Verify Get-ChildItem can get the name of a specified item." {
             $fileName = Get-ChildItem $testFile -Name
             $fileInfo = Get-ChildItem $testFile
             $fileName | Should BeExactly $fileInfo.Name


### PR DESCRIPTION
Addresses part of #4148.

Using the `-Name` parameter on `Get-ChildItem` exercises a part of the file system provider code not previously covered by tests.
