### PR TITLE
Add test coverage for Registry

### DIFF
--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Registry.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Registry.Tests.ps1
@@ -47,7 +47,7 @@ Describe "Basic Registry Provider Tests" -Tags @("CI", "RequireAdminOnWindows") 
     }
 
     Context "Validate basic registry provider Cmdlets" {
-        It "Verity Test-Path" {
+        It "Verify Test-Path" {
             Test-Path -IsValid Registry::HKCU/Software | Should Be $true
             Test-Path -IsValid Registry::foo/Softare | Should Be $false
         }
@@ -169,7 +169,7 @@ Describe "Basic Registry Provider Tests" -Tags @("CI", "RequireAdminOnWindows") 
             $property."$testPropertyName" | Should Be 0
         }
 
-        It "Verity Clear-Item" {
+        It "Verify Clear-Item" {
             Set-ItemProperty -Path $testKey -Name $testPropertyName -Value $testPropertyValue
             Set-Item -Path $testKey -Value $defaultPropertyValue
             Clear-Item -Path $testKey
@@ -177,7 +177,7 @@ Describe "Basic Registry Provider Tests" -Tags @("CI", "RequireAdminOnWindows") 
             $key.Property.Length | Should BeExactly 0
         }
 
-        It "Verity Clear-Item with -WhatIf" {
+        It "Verify Clear-Item with -WhatIf" {
             Set-ItemProperty -Path $testKey -Name $testPropertyName -Value $testPropertyValue
             Set-Item -Path $testKey -Value $defaultPropertyValue
             Clear-Item -Path $testKey -WhatIf

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Registry.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Registry.Tests.ps1
@@ -57,6 +57,10 @@ Describe "Basic Registry Provider Tests" -Tags @("CI", "RequireAdminOnWindows") 
             $item.PSChildName | Should BeExactly $testKey
         }
 
+        It "Verify Get-Item on inaccessible path" {
+            { Get-Item HKLM:\SAM\SAM -ErrorAction Stop } | ShouldBeErrorId "System.Security.SecurityException,Microsoft.PowerShell.Commands.GetItemCommand"
+        }
+
         It "Verify Get-ChildItem" {
             $items = Get-ChildItem
             $items.Count | Should BeExactly 2


### PR DESCRIPTION
Addresses parts of #4148 

Add coverage for `Get-Item`, `Get-ChildItem`, `Set-Item`, and `Clear-Item`

<!--

If you are a PowerShell Team member, please make sure you choose the Reviewer(s) and Assignee for your PR.
If you are not from the PowerShell Team, you can leave the fields blank and the Maintainers will choose them for you. If you are familiar with the team, feel free to mention some Reviewers yourself.

For more information about the roles of Reviewer and Assignee, refer to CONTRIBUTING.md.

-->
