### PR TITLE
add amazonlinux compatibility in install-powershell.sh

### DIFF
--- a/tools/install-powershell.sh
+++ b/tools/install-powershell.sh
@@ -74,6 +74,11 @@ else
             DIST=`cat /etc/redhat-release |sed s/\ release.*//`
             PSUEDONAME=`cat /etc/redhat-release | sed s/.*\(// | sed s/\)//`
             REV=`cat /etc/redhat-release | sed s/.*release\ // | sed s/\ .*//`
+        elif [ -f /etc/system-release ] ; then
+            DistroBasedOn='redhat'
+            DIST=`cat /etc/system-release |sed s/\ release.*//`
+            PSUEDONAME=`cat /etc/system-release | sed s/.*\(// | sed s/\)//`
+            REV=`cat /etc/system-release | sed s/.*release\ // | sed s/\ .*//`
         elif [ -f /etc/SuSE-release ] ; then
             DistroBasedOn='suse'
             PSUEDONAME=`cat /etc/SuSE-release | tr "\n" ' '| sed s/VERSION.*//`

--- a/tools/installpsh-redhat.sh
+++ b/tools/installpsh-redhat.sh
@@ -64,6 +64,8 @@ else
     elif [ "${OS}" == "Linux" ] ; then
         if [ -f /etc/redhat-release ] ; then
             DistroBasedOn='redhat'
+        if [ -f /etc/system-release ] ; then
+            DistroBasedOn='redhat'
         elif [ -f /etc/SuSE-release ] ; then
             DistroBasedOn='suse'
         elif [ -f /etc/mandrake-release ] ; then
@@ -94,7 +96,7 @@ if (( $EUID != 0 )); then
 fi
 
 #Check that sudo is available
-if [[ "$SUDO" -eq "sudo" ]]; then
+if [[ "$SUDO" -ne "" ]]; then
 
     $SUDO -v
     if [ $? -ne 0 ]; then

--- a/tools/installpsh-redhat.sh
+++ b/tools/installpsh-redhat.sh
@@ -64,7 +64,6 @@ else
     elif [ "${OS}" == "Linux" ] ; then
         if [ -f /etc/redhat-release ] ; then
             DistroBasedOn='redhat'
-        if [ -f /etc/system-release ] ; then
             DistroBasedOn='redhat'
         elif [ -f /etc/SuSE-release ] ; then
             DistroBasedOn='suse'

--- a/tools/installpsh-redhat.sh
+++ b/tools/installpsh-redhat.sh
@@ -64,6 +64,7 @@ else
     elif [ "${OS}" == "Linux" ] ; then
         if [ -f /etc/redhat-release ] ; then
             DistroBasedOn='redhat'
+        elif [ -f /etc/system-release ] ; then
             DistroBasedOn='redhat'
         elif [ -f /etc/SuSE-release ] ; then
             DistroBasedOn='suse'


### PR DESCRIPTION
Amazon linux is a fine mix of CentOS versions ;)  Needed to make a few adaptations to get the installer working for it.  It might also pickup older versions of CentOS that use /etc/system-release instead of /etc/redhat-release