### PR TITLE
Clean up '#if CORE' - use SecurityZone from CoreFX

### DIFF
--- a/src/System.Management.Automation/CoreCLR/CorePsStub.cs
+++ b/src/System.Management.Automation/CoreCLR/CorePsStub.cs
@@ -16,24 +16,6 @@ using Microsoft.Win32;
 // We use the stubs in this namespace to reduce #if/def in the code as much as possible.
 namespace Microsoft.PowerShell.CoreClr.Stubs
 {
-    #region Misc_Types
-
-    /// <summary>
-    /// Stub for SecurityZone
-    /// </summary>
-    public enum SecurityZone
-    {
-        MyComputer = 0,
-        Intranet = 1,
-        Trusted = 2,
-        Internet = 3,
-        Untrusted = 4,
-
-        NoZone = -1,
-    }
-
-    #endregion Misc_Types
-
     #region SystemManagementStubs
 
     // Summary:

--- a/src/System.Management.Automation/System.Management.Automation.csproj
+++ b/src/System.Management.Automation/System.Management.Automation.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="System.IO.FileSystem.AccessControl" Version="4.4.0-preview3-25423-02" />
     <PackageReference Include="System.Security.AccessControl" Version="4.4.0-preview3-25423-02" />
     <PackageReference Include="System.Security.Cryptography.Pkcs" Version="4.4.0-preview3-25423-02" />
+    <PackageReference Include="System.Security.Permissions" Version="4.4.0-preview3-25423-02" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="4.4.0-preview3-25423-02" />
     <PackageReference Include="Microsoft.Management.Infrastructure" Version="1.0.0-alpha*" />
   </ItemGroup>

--- a/src/System.Management.Automation/engine/Modules/ImportModuleCommand.cs
+++ b/src/System.Management.Automation/engine/Modules/ImportModuleCommand.cs
@@ -14,6 +14,7 @@ using System.Management.Automation;
 using System.Management.Automation.Internal;
 using System.Diagnostics.CodeAnalysis;
 using System.Security;
+using System.Security.Permissions;
 using System.Threading;
 using Microsoft.Management.Infrastructure;
 using Microsoft.PowerShell.Cmdletization;
@@ -25,11 +26,6 @@ using ScriptBlock = System.Management.Automation.ScriptBlock;
 using Token = System.Management.Automation.Language.Token;
 #if LEGACYTELEMETRY
 using Microsoft.PowerShell.Telemetry.Internal;
-#endif
-
-#if CORECLR
-// Use stub for SecurityZone.
-using Microsoft.PowerShell.CoreClr.Stubs;
 #endif
 
 //

--- a/src/System.Management.Automation/engine/Modules/ImportModuleCommand.cs
+++ b/src/System.Management.Automation/engine/Modules/ImportModuleCommand.cs
@@ -14,7 +14,6 @@ using System.Management.Automation;
 using System.Management.Automation.Internal;
 using System.Diagnostics.CodeAnalysis;
 using System.Security;
-using System.Security.Permissions;
 using System.Threading;
 using Microsoft.Management.Infrastructure;
 using Microsoft.PowerShell.Cmdletization;

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -16,7 +16,6 @@ using System.Management.Automation.Internal;
 using System.Management.Automation.Provider;
 using System.Security;
 using System.Security.AccessControl;
-using System.Security.Permissions;
 using System.Text;
 using System.Xml;
 using System.Xml.XPath;

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -16,6 +16,7 @@ using System.Management.Automation.Internal;
 using System.Management.Automation.Provider;
 using System.Security;
 using System.Security.AccessControl;
+using System.Security.Permissions;
 using System.Text;
 using System.Xml;
 using System.Xml.XPath;
@@ -23,11 +24,6 @@ using Microsoft.Win32.SafeHandles;
 using Dbg = System.Management.Automation;
 using System.Runtime.InteropServices;
 using System.Management.Automation.Runspaces;
-
-#if CORECLR
-// Use stubs for SecurityZone
-using Microsoft.PowerShell.CoreClr.Stubs;
-#endif
 
 namespace Microsoft.PowerShell.Commands
 {

--- a/src/System.Management.Automation/security/SecurityManager.cs
+++ b/src/System.Management.Automation/security/SecurityManager.cs
@@ -12,12 +12,8 @@ using System.Collections.ObjectModel;
 using System.Management.Automation.Host;
 using System.Management.Automation.Language;
 using System.Security;
+using System.Security.Permissions;
 using System.Security.Cryptography.X509Certificates;
-
-#if CORECLR
-// Use stub for SecurityZone
-using Microsoft.PowerShell.CoreClr.Stubs;
-#endif
 
 namespace Microsoft.PowerShell
 {

--- a/src/System.Management.Automation/security/SecurityManager.cs
+++ b/src/System.Management.Automation/security/SecurityManager.cs
@@ -12,7 +12,6 @@ using System.Collections.ObjectModel;
 using System.Management.Automation.Host;
 using System.Management.Automation.Language;
 using System.Security;
-using System.Security.Permissions;
 using System.Security.Cryptography.X509Certificates;
 
 namespace Microsoft.PowerShell

--- a/src/System.Management.Automation/utils/ClrFacade.cs
+++ b/src/System.Management.Automation/utils/ClrFacade.cs
@@ -15,7 +15,6 @@ using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
 using System.Security;
-using System.Security.Permissions;
 using Microsoft.Win32.SafeHandles;
 using System.Runtime.InteropServices.ComTypes;
 

--- a/src/System.Management.Automation/utils/ClrFacade.cs
+++ b/src/System.Management.Automation/utils/ClrFacade.cs
@@ -15,13 +15,13 @@ using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
 using System.Security;
+using System.Security.Permissions;
 using Microsoft.Win32.SafeHandles;
 using System.Runtime.InteropServices.ComTypes;
 
 #if CORECLR
 using System.Runtime.Loader; /* used in facade APIs related to assembly operations */
 using System.Management.Automation.Host;          /* used in facade API 'GetUninitializedObject' */
-using Microsoft.PowerShell.CoreClr.Stubs;         /* used in facade API 'GetFileSecurityZone' */
 using System.Management.Automation.Internal;
 using System.Text.RegularExpressions;
 #else


### PR DESCRIPTION
Related #4357 and #3565.

Remove the our stub for SecurityZone and use CoreFX implementation.
