### PR TITLE
Clean up '#if CORE' - use TimeZoneInfo and TimeZoneNotFoundException from CoreFX

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/TimeZoneCommands.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/TimeZoneCommands.cs
@@ -276,13 +276,11 @@ namespace Microsoft.PowerShell.Commands
                         ThrowWin32Error();
                     }
 
-#if !CORECLR
                     // broadcast a WM_SETTINGCHANGE notification message to all top-level windows so that they
                     // know to update their notion of the current system time (and time zone) if applicable
                     int result = 0;
                     NativeMethods.SendMessageTimeout((IntPtr)NativeMethods.HWND_BROADCAST, NativeMethods.WM_SETTINGCHANGE,
                         (IntPtr)0, "intl", NativeMethods.SMTO_ABORTIFHUNG, 5000, ref result);
-#endif
 
                     // clear the time zone data or this PowerShell session
                     // will not recognize the new time zone settings
@@ -438,7 +436,6 @@ namespace Microsoft.PowerShell.Commands
 
 #region Native DLL locations
 
-#if CORECLR
             private const string SetDynamicTimeZoneApiDllName = "api-ms-win-core-timezone-l1-1-0.dll";
             private const string GetTimeZoneInformationForYearApiDllName = "api-ms-win-core-timezone-l1-1-0.dll";
             private const string GetCurrentProcessApiDllName = "api-ms-win-downlevel-kernel32-l1-1-0.dll";
@@ -448,9 +445,6 @@ namespace Microsoft.PowerShell.Commands
             private const string AdjustTokenPrivilegesApiDllName = "api-ms-win-downlevel-advapi32-l1-1-1.dll";
             private const string CloseHandleApiDllName = "api-ms-win-downlevel-kernel32-l1-1-0.dll";
             private const string SendMessageTimeoutApiDllName = "ext-ms-win-rtcore-ntuser-window-ext-l1-1-0.dll";
-#else
-            private const string SendMessageTimeoutApiDllName = "user32.dll";
-#endif
 
 #endregion Native DLL locations
 

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/TimeZoneCommands.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/TimeZoneCommands.cs
@@ -48,7 +48,7 @@ namespace Microsoft.PowerShell.Commands
         protected override void ProcessRecord()
         {
             // make sure we've got the latest time zone settings
-            TimeZoneHelper.ClearCachedData();
+            TimeZoneInfo.ClearCachedData();
 
             if (this.ParameterSetName.Equals("ListAvailable", StringComparison.OrdinalIgnoreCase))
             {
@@ -163,7 +163,7 @@ namespace Microsoft.PowerShell.Commands
         {
             // make sure we've got fresh data, in case the requested time zone was added
             // to the system (registry) after our process was started
-            TimeZoneHelper.ClearCachedData();
+            TimeZoneInfo.ClearCachedData();
 
             // acquire a TimeZoneInfo if one wasn't supplied.
             if (this.ParameterSetName.Equals("Id", StringComparison.OrdinalIgnoreCase))
@@ -172,15 +172,7 @@ namespace Microsoft.PowerShell.Commands
                 {
                     InputObject = TimeZoneInfo.FindSystemTimeZoneById(Id);
                 }
-#if CORECLR
-                // TimeZoneNotFoundException is thrown by TimeZoneInfo, but not
-                // publicly visible (so can't be caught), so for now we're catching
-                // the parent exception time. This should be removed once the more
-                // specific exception is available.
-                catch (Exception e)
-#else
                 catch (TimeZoneNotFoundException e)
-#endif
                 {
                     ThrowTerminatingError(new ErrorRecord(
                         e,
@@ -197,14 +189,7 @@ namespace Microsoft.PowerShell.Commands
                 {
                     string message = string.Format(CultureInfo.InvariantCulture,
                         TimeZoneResources.TimeZoneNameNotFound, Name);
-#if CORECLR
-                    // Because .NET Core does not currently expose the TimeZoneNotFoundException
-                    // we need to throw the more generic parent exception class for the time being.
-                    // This should be removed once the correct exception class is available.
-                    Exception e = new Exception(message);
-#else
                     Exception e = new TimeZoneNotFoundException(message);
-#endif
                     ThrowTerminatingError(new ErrorRecord(e,
                         TimeZoneHelper.TimeZoneNotFoundError,
                         ErrorCategory.InvalidArgument,
@@ -233,15 +218,7 @@ namespace Microsoft.PowerShell.Commands
                     // a backing system time zone, otherwise it's an error condition
                     InputObject = TimeZoneInfo.FindSystemTimeZoneById(InputObject.Id);
                 }
-#if CORECLR
-                // TimeZoneNotFoundException is thrown by TimeZoneInfo, but not
-                // publicly visible (so can't be caught), so for now we're catching
-                // the parent exception time. This should be removed once the more
-                // specific exception is available.
-                catch (Exception e)
-#else
                 catch (TimeZoneNotFoundException e)
-#endif
                 {
                     ThrowTerminatingError(new ErrorRecord(
                         e,
@@ -309,7 +286,7 @@ namespace Microsoft.PowerShell.Commands
 
                     // clear the time zone data or this PowerShell session
                     // will not recognize the new time zone settings
-                    TimeZoneHelper.ClearCachedData();
+                    TimeZoneInfo.ClearCachedData();
 
                     if (PassThru.IsPresent)
                     {
@@ -472,14 +449,6 @@ namespace Microsoft.PowerShell.Commands
             private const string CloseHandleApiDllName = "api-ms-win-downlevel-kernel32-l1-1-0.dll";
             private const string SendMessageTimeoutApiDllName = "ext-ms-win-rtcore-ntuser-window-ext-l1-1-0.dll";
 #else
-            private const string SetDynamicTimeZoneApiDllName = "kernel32.dll";
-            private const string GetTimeZoneInformationForYearApiDllName = "kernel32.dll";
-            private const string GetCurrentProcessApiDllName = "kernel32.dll";
-            private const string OpenProcessTokenApiDllName = "advapi32.dll";
-            private const string LookupPrivilegeTokenApiDllName = "advapi32.dll";
-            private const string PrivilegeCheckApiDllName = "advapi32.dll";
-            private const string AdjustTokenPrivilegesApiDllName = "advapi32.dll";
-            private const string CloseHandleApiDllName = "kernel32.dll";
             private const string SendMessageTimeoutApiDllName = "user32.dll";
 #endif
 
@@ -803,22 +772,6 @@ namespace Microsoft.PowerShell.Commands
         internal const string SetTimeZoneFailedError = "SetTimeZoneFailed";
 
 #endregion Error Ids
-
-        /// <summary>
-        /// Clear the cached TimeZoneInfo data.  Note that since TimeZoneInfo.ClearCachedData
-        /// does not exist in .NET Core there is an alternative mechanism (which doesn't seem
-        /// to affect clearing out the cache under the full desktop version of .NET)
-        /// </summary>
-        internal static void ClearCachedData()
-        {
-#if CORECLR
-            // NOTE: .NET Core does not expose the ClearCachedData method, but executing
-            // the specific ConvertTime request below should have the same effect.
-            TimeZoneInfo.ConvertTime(new DateTime(0), TimeZoneInfo.Local);
-#else
-            TimeZoneInfo.ClearCachedData();
-#endif
-        }
 
         /// <summary>
         /// Find the system time zone by checking first against StandardName and then,


### PR DESCRIPTION
Related #3565 and #4357.

In second commit I turn on 'NativeMethods.SendMessageTimeout()'.  it should seems work on Windows. Set-TimeZone` isn't still ported on Unix.