### PR TITLE
Remove ClrFacade.GetUninitializedObject and 'if CORECLR' cleanup

### DIFF
--- a/src/System.Management.Automation/engine/InformationRecord.cs
+++ b/src/System.Management.Automation/engine/InformationRecord.cs
@@ -40,10 +40,7 @@ namespace System.Management.Automation
             this.ManagedThreadId = (uint)System.Threading.Thread.CurrentThread.ManagedThreadId;
         }
 
-        /// <summary>
-        /// Added to enable ClrFacade.GetUninitializedObject to instantiate an uninitialized version of this class.
-        /// </summary>
-        internal InformationRecord() { }
+        private InformationRecord() { }
 
         /// <summary>
         /// Copy constructor

--- a/src/System.Management.Automation/engine/ProgressRecord.cs
+++ b/src/System.Management.Automation/engine/ProgressRecord.cs
@@ -88,12 +88,6 @@ namespace System.Management.Automation
         }
 
         /// <summary>
-        /// Added to enable ClrFacade.GetUninitializedObject to instantiate an uninitialized version of this class.
-        /// </summary>
-        internal ProgressRecord()
-        { }
-
-        /// <summary>
         ///
         /// Gets the Id of the activity to which this record corresponds.  Used as a 'key' for the
         /// linking of subordinate activities.

--- a/src/System.Management.Automation/engine/hostifaces/ChoiceDescription.cs
+++ b/src/System.Management.Automation/engine/hostifaces/ChoiceDescription.cs
@@ -97,13 +97,6 @@ namespace System.Management.Automation.Host
         }
 
         /// <summary>
-        /// Added to enable ClrFacade.GetUninitializedObject to instantiate an uninitialized version of this class.
-        /// </summary>
-        internal
-        ChoiceDescription()
-        { }
-
-        /// <summary>
         ///
         /// Gets a short, human-presentable message to describe and identify the choice.  Think Button label.
         ///

--- a/src/System.Management.Automation/engine/hostifaces/FieldDescription.cs
+++ b/src/System.Management.Automation/engine/hostifaces/FieldDescription.cs
@@ -61,13 +61,6 @@ namespace System.Management.Automation.Host
         }
 
         /// <summary>
-        /// Added to enable ClrFacade.GetUninitializedObject to instantiate an uninitialized version of this class.
-        /// </summary>
-        internal
-        FieldDescription()
-        { }
-
-        /// <summary>
         /// Gets the name of the field.
         /// </summary>
         public string Name { get; } = null;

--- a/src/System.Management.Automation/engine/remoting/common/WireDataFormat/RemoteHostEncoder.cs
+++ b/src/System.Management.Automation/engine/remoting/common/WireDataFormat/RemoteHostEncoder.cs
@@ -9,6 +9,7 @@ using System.Reflection;
 using System.Management.Automation.Host;
 using System.Globalization;
 using System.Security;
+using System.Runtime.Serialization;
 using Dbg = System.Management.Automation.Diagnostics;
 
 namespace System.Management.Automation.Remoting
@@ -86,7 +87,7 @@ namespace System.Management.Automation.Remoting
         /// </summary>
         private static object DecodeClassOrStruct(PSObject psObject, Type type)
         {
-            object obj = ClrFacade.GetUninitializedObject(type);
+            object obj = FormatterServices.GetUninitializedObject(type);
 
             // Field values cannot be null - because for null fields we simply don't transport them.
             foreach (PSPropertyInfo propertyInfo in psObject.Properties)

--- a/src/System.Management.Automation/engine/remoting/common/WireDataFormat/RemoteSessionCapability.cs
+++ b/src/System.Management.Automation/engine/remoting/common/WireDataFormat/RemoteSessionCapability.cs
@@ -62,12 +62,6 @@ namespace System.Management.Automation.Remoting
         }
 
         /// <summary>
-        /// Added to enable ClrFacade.GetUninitializedObject to instantiate an uninitialized version of this class.
-        /// </summary>
-        internal RemoteSessionCapability()
-        { }
-
-        /// <summary>
         /// Create client capability.
         /// </summary>
         internal static RemoteSessionCapability CreateClientCapability()
@@ -405,12 +399,6 @@ namespace System.Management.Automation.Remoting
                 _hostDefaultData = HostDefaultData.Create(host.UI.RawUI);
             }
         }
-
-        /// <summary>
-        /// Added to enable ClrFacade.GetUninitializedObject to instantiate an uninitialized version of this class.
-        /// </summary>
-        internal HostInfo()
-        { }
 
         /// <summary>
         /// Check host chain.

--- a/src/System.Management.Automation/utils/ClrFacade.cs
+++ b/src/System.Management.Automation/utils/ClrFacade.cs
@@ -8,24 +8,18 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Management.Automation.Internal;
 using System.Management.Automation.Language;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Runtime.Loader;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Security;
 using Microsoft.Win32.SafeHandles;
 using System.Runtime.InteropServices.ComTypes;
-
-#if CORECLR
-using System.Runtime.Loader; /* used in facade APIs related to assembly operations */
-using System.Management.Automation.Host;          /* used in facade API 'GetUninitializedObject' */
-using System.Management.Automation.Internal;
-using System.Text.RegularExpressions;
-#else
-using System.Runtime.Serialization;           /* used in facade API 'GetUninitializedObject' */
-#endif
 
 namespace System.Management.Automation
 {
@@ -113,12 +107,8 @@ namespace System.Management.Automation
 
         internal static IEnumerable<Assembly> GetAssemblies(TypeResolutionState typeResolutionState, TypeName typeName)
         {
-#if CORECLR
             string typeNameToSearch = typeResolutionState.GetAlternateTypeName(typeName.Name) ?? typeName.Name;
             return GetAssemblies(typeNameToSearch);
-#else
-            return GetAssemblies();
-#endif
         }
 
         /// <summary>
@@ -130,14 +120,10 @@ namespace System.Management.Automation
         /// </param>
         internal static IEnumerable<Assembly> GetAssemblies(string namespaceQualifiedTypeName = null)
         {
-            return
-#if CORECLR
-            PSAssemblyLoadContext.GetAssembly(namespaceQualifiedTypeName) ??
-#endif
+            return PSAssemblyLoadContext.GetAssembly(namespaceQualifiedTypeName) ??
             AppDomain.CurrentDomain.GetAssemblies().Where(a => !(a.FullName.Length > 0 && a.FullName[0] == FIRST_CHAR_PSASSEMBLY_MARK));
         }
 
-#if CORECLR
         /// <summary>
         /// Get the namespace-qualified type names of all available .NET Core types shipped with PowerShell Core.
         /// This is used for type name auto-completion in PS engine.
@@ -151,7 +137,6 @@ namespace System.Management.Automation
         internal static HashSet<string> AvailableDotNetAssemblyNames => PSAssemblyLoadContext.AvailableDotNetAssemblyNames;
 
         private static PowerShellAssemblyLoadContext PSAssemblyLoadContext => PowerShellAssemblyLoadContext.Instance;
-#endif
 
         #endregion Assembly
 
@@ -497,55 +482,12 @@ namespace System.Management.Automation
         }
 
         /// <summary>
-        /// Facade for FormatterServices.GetUninitializedObject.
-        ///
-        /// In CORECLR, there are two peculiarities with its implementation that affect our own:
-        /// 1. Structures cannot be instantiated using GetConstructor, so they must be filtered out.
-        /// 2. Classes must have a default constructor implemented for GetConstructor to work.
-        ///
-        /// See RemoteHostEncoder.IsEncodingAllowedForClassOrStruct for a list of the required types.
-        /// </summary>
-        /// <param name="type"></param>
-        /// <returns></returns>
-        internal static object GetUninitializedObject(Type type)
-        {
-#if CORECLR
-            switch (type.Name)
-            {
-                case "KeyInfo"://typeof(KeyInfo).Name:
-                    return new KeyInfo(0, ' ', ControlKeyStates.RightAltPressed, false);
-                case "Coordinates"://typeof(Coordinates).Name:
-                    return new Coordinates(0, 0);
-                case "Size"://typeof(Size).Name:
-                    return new Size(0, 0);
-                case "BufferCell"://typeof(BufferCell).Name:
-                    return new BufferCell(' ', ConsoleColor.Black, ConsoleColor.Black, BufferCellType.Complete);
-                case "Rectangle"://typeof(Rectangle).Name:
-                    return new Rectangle(0, 0, 0, 0);
-                default:
-                    ConstructorInfo constructorInfoObj = type.GetConstructor(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic, null, new Type[] { }, null);
-                    if (constructorInfoObj != null)
-                    {
-                        return constructorInfoObj.Invoke(new object[] { });
-                    }
-                    return new object();
-            }
-#else
-            return FormatterServices.GetUninitializedObject(type);
-#endif
-        }
-
-        /// <summary>
         /// Facade for ProfileOptimization.SetProfileRoot
         /// </summary>
         /// <param name="directoryPath">The full path to the folder where profile files are stored for the current application domain.</param>
         internal static void SetProfileOptimizationRoot(string directoryPath)
         {
-#if CORECLR
             PSAssemblyLoadContext.SetProfileOptimizationRootImpl(directoryPath);
-#else
-            System.Runtime.ProfileOptimization.SetProfileRoot(directoryPath);
-#endif
         }
 
         /// <summary>
@@ -554,11 +496,7 @@ namespace System.Management.Automation
         /// <param name="profile">The file name of the profile to use.</param>
         internal static void StartProfileOptimization(string profile)
         {
-#if CORECLR
             PSAssemblyLoadContext.StartProfileOptimizationImpl(profile);
-#else
-            System.Runtime.ProfileOptimization.StartProfile(profile);
-#endif
         }
 
         #endregion Misc


### PR DESCRIPTION
Related #3565 and #4357.
Break up the cleanup work for ClrFacade.cs into multiple PRs.
In this PR, `[System.Runtime.Serialization.FormatterServices]::GetUninitializedObject` is back in .NET Core, so we replace ` ClrFacade.GetUninitializedObject` with it.
