### PR TITLE
Give error instead of crashing if WSMan client lib not available

### DIFF
--- a/src/System.Management.Automation/engine/remoting/fanin/WSManTransportManager.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/WSManTransportManager.cs
@@ -2597,7 +2597,16 @@ namespace System.Management.Automation.Remoting.Client
 #endif
 
                 _handle = IntPtr.Zero;
-                ErrorCode = WSManNativeApi.WSManInitialize(WSManNativeApi.WSMAN_FLAG_REQUESTED_API_VERSION_1_1, ref _handle);
+
+                try
+                {
+                    ErrorCode = WSManNativeApi.WSManInitialize(WSManNativeApi.WSMAN_FLAG_REQUESTED_API_VERSION_1_1, ref _handle);
+                }
+                catch (DllNotFoundException)
+                {
+                    throw new PSRemotingTransportException(
+                        StringUtil.Format(RemotingErrorIdStrings.WSManClientDllNotAvailable));
+                }
 
                 // input / output streams common to all connections
                 _inputStreamSet = new WSManNativeApi.WSManStreamIDSet_ManToUn(

--- a/src/System.Management.Automation/engine/remoting/fanin/WSManTransportManager.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/WSManTransportManager.cs
@@ -2604,8 +2604,7 @@ namespace System.Management.Automation.Remoting.Client
                 }
                 catch (DllNotFoundException)
                 {
-                    throw new PSRemotingTransportException(
-                        StringUtil.Format(RemotingErrorIdStrings.WSManClientDllNotAvailable));
+                    throw new PSRemotingTransportException(RemotingErrorIdStrings.WSManClientDllNotAvailable);
                 }
 
                 // input / output streams common to all connections

--- a/src/System.Management.Automation/resources/RemotingErrorIdStrings.resx
+++ b/src/System.Management.Automation/resources/RemotingErrorIdStrings.resx
@@ -1640,6 +1640,6 @@ All WinRM sessions connected to Windows PowerShell session configurations, such 
     <value>The SSH transport process has abruptly terminated causing this remote session to break.</value>
   </data>
   <data name="WSManClientDllNotAvailable" xml:space="preserve">
-    <value>WSMan client library is not installed</value>
+    <value>This parameter set requires WSMan, and no supported WSMan client library was found. WSMan is either not installed or unavailable for this system.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/RemotingErrorIdStrings.resx
+++ b/src/System.Management.Automation/resources/RemotingErrorIdStrings.resx
@@ -1636,7 +1636,10 @@ All WinRM sessions connected to Windows PowerShell session configurations, such 
   <data name="InvalidRoleCapabilityFileExtension" xml:space="preserve">
     <value>The provided role capability file {0} does not have the required .psrc extension.</value>
   </data>
-  <data name="SSHAbruptlyTerminated" >
+  <data name="SSHAbruptlyTerminated" xml:space="preserve">
     <value>The SSH transport process has abruptly terminated causing this remote session to break.</value>
+  </data>
+  <data name="WSManClientDllNotAvailable" xml:space="preserve">
+    <value>WSMan client library is not installed</value>
   </data>
 </root>


### PR DESCRIPTION
Affects NanoServer Insider build where WinRM is not available.  Currently if user tries `invoke-command`, powershell crashes.

Validated using:
```powershell
PS> docker run -it -v C:\users\slee\repos\PowerShell\src\powershell-wincore\bin\Debug\netcoreapp2.0\win10-x64\publish:c:\powershell microsoft/nanoserver-insider-powershell
PS> c:\powershell\powershell
PS> invoke-command -computer . -command { "hello" }

invoke-command : WSMan client library is not installed
At line:1 char:1
+ invoke-command -ComputerName . -Command { "hello" }
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : ResourceUnavailable: (:) [Invoke-Command], PSRemotingTransportException
    + FullyQualifiedErrorId : System.Management.Automation.Remoting.PSRemotingDataStructureException,Microsoft.PowerSh
   ell.Commands.InvokeCommandCommand
```

Fix https://github.com/PowerShell/PowerShell/issues/4383