### PR TITLE
Fix unblock read only file

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/UnblockFile.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/UnblockFile.cs
@@ -7,6 +7,7 @@ Copyright (c) Microsoft Corporation.  All rights reserved.
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Management.Automation;
 using System.Management.Automation.Internal;
@@ -113,7 +114,15 @@ namespace Microsoft.PowerShell.Commands
             {
                 if (ShouldProcess(path))
                 {
-                    AlternateDataStreamUtilities.DeleteFileStream(path, "Zone.Identifier");
+                    try
+                    {
+                        AlternateDataStreamUtilities.DeleteFileStream(path, "Zone.Identifier");
+                    }
+                    catch (Win32Exception accessException)
+                    {
+                        WriteError(new ErrorRecord(accessException, "RemoveItemUnauthorizedAccessError", ErrorCategory.PermissionDenied, path));
+                    }
+
                 }
             }
         }

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -8770,7 +8770,11 @@ namespace System.Management.Automation.Internal
             }
             string resultPath = path + adjustedStreamName;
 
-            NativeMethods.DeleteFile(resultPath);
+            if (!NativeMethods.DeleteFile(resultPath))
+            {
+                int error = Marshal.GetLastWin32Error();
+                throw new Win32Exception(error);
+            }
         }
 
         internal static void SetZoneOfOrigin(string path, SecurityZone securityZone)

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Unblock-File.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Unblock-File.Tests.ps1
@@ -53,4 +53,19 @@ Describe "Unblock-File" -Tags "CI" {
         Unblock-File -LiteralPath $testfilepath
         Test-UnblockFile | Should Be $true
     }
+
+    It "Throw if a file is read only" {
+        $TestFile = Join-Path $TestDrive "testfileunlock.ps1"
+        Set-Content -Path $TestFile -value 'test'
+        $ZoneIdentifier = {
+            [ZoneTransfer]
+            ZoneId=3
+        }
+        Set-Content -Path $TestFile -Value $ZoneIdentifier -Stream 'Zone.Identifier'
+        Set-ItemProperty -Path $TestFile -Name IsReadOnly -Value $True
+
+        $TestFileCreated = Get-ChildItem $TestFile
+        $TestFileCreated.IsReadOnly | Should Be $true
+        { Unblock-File -LiteralPath $TestFile -ErrorAction Stop } | ShouldBeErrorId "System.ComponentModel.Win32Exception,Microsoft.PowerShell.Commands.UnblockFileCommand"
+    }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Unblock-File.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Unblock-File.Tests.ps1
@@ -7,7 +7,7 @@ function Test-UnblockFile {
             return $true
         }
     }
-    
+
     return $false
 }
 
@@ -37,23 +37,11 @@ Describe "Unblock-File" -Tags "CI" {
     }
 
     It "With '-Path': no file exist" {
-        try {
-            Unblock-File -Path nofileexist.ttt -ErrorAction Stop
-            throw "No Exception!"
-        } 
-        catch {
-            $_.FullyQualifiedErrorId | Should Be "FileNotFound,Microsoft.PowerShell.Commands.UnblockFileCommand"
-        }
+        { Unblock-File -Path nofileexist.ttt -ErrorAction Stop } | ShouldBeErrorId "FileNotFound,Microsoft.PowerShell.Commands.UnblockFileCommand"
     }
 
     It "With '-LiteralPath': no file exist" {
-        try {
-            Unblock-File -LiteralPath nofileexist.ttt -ErrorAction Stop
-            throw "No Exception!"
-        } 
-        catch {
-            $_.FullyQualifiedErrorId | Should Be "FileNotFound,Microsoft.PowerShell.Commands.UnblockFileCommand"
-        }
+        { Unblock-File -LiteralPath nofileexist.ttt -ErrorAction Stop } | ShouldBeErrorId "FileNotFound,Microsoft.PowerShell.Commands.UnblockFileCommand"
     }
 
     It "With '-Path': file exist" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Unblock-File.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Unblock-File.Tests.ps1
@@ -54,7 +54,7 @@ Describe "Unblock-File" -Tags "CI" {
         Test-UnblockFile | Should Be $true
     }
 
-    It "Throw if a file is read only" {
+    It "Write an error if a file is read only" {
         $TestFile = Join-Path $TestDrive "testfileunlock.ps1"
         Set-Content -Path $TestFile -value 'test'
         $ZoneIdentifier = {
@@ -66,6 +66,8 @@ Describe "Unblock-File" -Tags "CI" {
 
         $TestFileCreated = Get-ChildItem $TestFile
         $TestFileCreated.IsReadOnly | Should Be $true
-        { Unblock-File -LiteralPath $TestFile -ErrorAction Stop } | ShouldBeErrorId "System.ComponentModel.Win32Exception,Microsoft.PowerShell.Commands.UnblockFileCommand"
+
+        { Unblock-File -LiteralPath $TestFile -ErrorAction SilentlyContinue } | Should Not Throw
+        $error[0].FullyQualifiedErrorId | Should Be "RemoveItemUnauthorizedAccessError,Microsoft.PowerShell.Commands.UnblockFileCommand"
     }
 }


### PR DESCRIPTION
Adds a new non-terminating error 

Fix #4390.

### Problem ###
If a file is read only it is skipping silently.

### Fix ###
Analize GetLastError() and throw if a file stream hasn't been removed.

First commit only refactor tests to use `ShouldBeErrorId`.