### PR TITLE
Clean up '#if CORE' in Attributes.cs

### DIFF
--- a/src/System.Management.Automation/engine/Attributes.cs
+++ b/src/System.Management.Automation/engine/Attributes.cs
@@ -370,13 +370,7 @@ namespace System.Management.Automation
             get { return _supportsTransactions; }
             set
             {
-#if !CORECLR
                 _supportsTransactions = value;
-#else
-                // Disable 'SupportsTransactions' in CoreCLR
-                // No transaction supported on CSS due to the lack of System.Transactions namespace
-                _supportsTransactions = false;
-#endif
             }
         }
         private bool _supportsTransactions = false;


### PR DESCRIPTION
Related #3565 and #4357.

Now `System.Transactions` is in CoreFX 2.0 but all transaction cmdlets is only in FullCLR and we haven't tests at all.