### PR TITLE
Clean up '#if CORE' in PSPrincipal.cs

### DIFF
--- a/src/System.Management.Automation/engine/remoting/common/WireDataFormat/RemoteSessionCapability.cs
+++ b/src/System.Management.Automation/engine/remoting/common/WireDataFormat/RemoteSessionCapability.cs
@@ -6,11 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Management.Automation.Host;
 using System.Management.Automation.Internal.Host;
-
-#if !CORECLR
-using BinaryFormatter = System.Runtime.Serialization.Formatters.Binary.BinaryFormatter;
-#endif
-
+using System.Runtime.Serialization.Formatters.Binary;
 using Dbg = System.Management.Automation.Diagnostics;
 
 namespace System.Management.Automation.Remoting
@@ -28,10 +24,6 @@ namespace System.Management.Automation.Remoting
         internal Version PSVersion { get; }
         internal Version SerializationVersion { get; }
         internal RemotingDestination RemotingDestination { get; }
-
-#if !CORECLR // TimeZone Not In CoreCLR
-#endif
-
         private static byte[] s_timeZoneInByteFormat;
 
         /// <summary>
@@ -86,16 +78,13 @@ namespace System.Management.Automation.Remoting
         {
             if (null == s_timeZoneInByteFormat)
             {
-#if CORECLR //TODO:CORECLR 'BinaryFormatter' is not in CORE CLR. Since this is TimeZone related and TimeZone is not available on CORE CLR so wait until we solve TimeZone issue.
-                s_timeZoneInByteFormat = Utils.EmptyArray<byte>();
-#else
                 Exception e = null;
                 try
                 {
                     BinaryFormatter formatter = new BinaryFormatter();
                     using (MemoryStream stream = new MemoryStream())
                     {
-                        formatter.Serialize(stream, TimeZone.CurrentTimeZone);
+                        formatter.Serialize(stream, TimeZoneInfo.Local);
                         stream.Seek(0, SeekOrigin.Begin);
                         byte[] result = new byte[stream.Length];
                         stream.Read(result, 0, (int)stream.Length);
@@ -121,19 +110,15 @@ namespace System.Management.Automation.Remoting
                 {
                     s_timeZoneInByteFormat = Utils.EmptyArray<byte>();
                 }
-#endif
             }
 
             return s_timeZoneInByteFormat;
         }
 
-#if !CORECLR // TimeZone Not In CoreCLR
         /// <summary>
         /// Gets the TimeZone of the destination machine. This may be null
         /// </summary>
-        internal TimeZone TimeZone { get; set; }
-#endif
-
+        internal TimeZoneInfo TimeZone { get; set; }
     }
 
     /// <summary>

--- a/src/System.Management.Automation/engine/remoting/fanin/PSPrincipal.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/PSPrincipal.cs
@@ -83,7 +83,7 @@ namespace System.Management.Automation.Remoting
                 ConnectionString = senderInfo.ConnectionString;
                 _applicationArguments = senderInfo._applicationArguments;
 
-                this.clientTimeZone = senderInfo.ClientTimeZone;
+                ClientTimeZone = senderInfo.ClientTimeZone;
             }
             catch (Exception)
             {
@@ -130,10 +130,9 @@ namespace System.Management.Automation.Remoting
         /// </summary>
         public TimeZoneInfo ClientTimeZone
         {
-            get { return clientTimeZone; }
-            internal set { clientTimeZone = value; }
+            get;
+            internal set;
         }
-        private TimeZoneInfo clientTimeZone;
 
         /// <summary>
         /// Connection string used by the client to connect to the server. This is

--- a/src/System.Management.Automation/engine/remoting/fanin/PSPrincipal.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/PSPrincipal.cs
@@ -8,6 +8,7 @@
  * like Exchange.
  */
 
+using System;
 using System.Security.Principal;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.Serialization;
@@ -82,9 +83,7 @@ namespace System.Management.Automation.Remoting
                 ConnectionString = senderInfo.ConnectionString;
                 _applicationArguments = senderInfo._applicationArguments;
 
-#if !CORECLR // TimeZone Not In CoreCLR
                 this.clientTimeZone = senderInfo.ClientTimeZone;
-#endif
             }
             catch (Exception)
             {
@@ -126,17 +125,15 @@ namespace System.Management.Automation.Remoting
             // cmdlets/scripts a chance to modify these.
         }
 
-#if !CORECLR // TimeZone Not In CoreCLR
         /// <summary>
         /// Contains the TimeZone information from the client machine.
         /// </summary>
-        public TimeZone ClientTimeZone
+        public TimeZoneInfo ClientTimeZone
         {
             get { return clientTimeZone; }
             internal set { clientTimeZone = value; }
         }
-        private TimeZone clientTimeZone;
-#endif
+        private TimeZoneInfo clientTimeZone;
 
         /// <summary>
         /// Connection string used by the client to connect to the server. This is

--- a/src/System.Management.Automation/engine/remoting/server/serverremotesession.cs
+++ b/src/System.Management.Automation/engine/remoting/server/serverremotesession.cs
@@ -743,9 +743,8 @@ namespace System.Management.Automation.Remoting
             // This is used by the initial session state configuration providers like Exchange.
             if (Context != null)
             {
-#if !CORECLR // TimeZone Not In CoreCLR
+
                 _senderInfo.ClientTimeZone = Context.ClientCapability.TimeZone;
-#endif
             }
 
             _senderInfo.ApplicationArguments = RemotingDecoder.GetApplicationArguments(rcvdData.Data);

--- a/src/System.Management.Automation/engine/remoting/server/serverremotesession.cs
+++ b/src/System.Management.Automation/engine/remoting/server/serverremotesession.cs
@@ -743,7 +743,6 @@ namespace System.Management.Automation.Remoting
             // This is used by the initial session state configuration providers like Exchange.
             if (Context != null)
             {
-
                 _senderInfo.ClientTimeZone = Context.ClientCapability.TimeZone;
             }
 

--- a/src/System.Management.Automation/engine/serialization.cs
+++ b/src/System.Management.Automation/engine/serialization.cs
@@ -7135,9 +7135,7 @@ namespace Microsoft.PowerShell
 
             PSSenderInfo senderInfo = new PSSenderInfo(psPrincipal, GetPropertyValue<string>(pso, "ConnectionString"));
 
-#if !CORECLR // TimeZone Not In CoreCLR
-            senderInfo.ClientTimeZone = TimeZone.CurrentTimeZone;
-#endif
+            senderInfo.ClientTimeZone = TimeZoneInfo.Local;
             senderInfo.ApplicationArguments = GetPropertyValue<PSPrimitiveDictionary>(pso, "ApplicationArguments");
 
             return senderInfo;


### PR DESCRIPTION
Related #3565 and #4357.

~~The build is failed with "'TimeZone' is obsolete: 'System.TimeZone has been deprecated."~~

~~It seems 'TimeZone' is necessary for backward compatibility with Windows PowerShell. How can we resolve this? Remove?~~

Some files depends on depredicated TimeZone type - migrate them to use TimeZoneInfo.
