### PR TITLE
add defensive measures to Mac invoke-item tests

### DIFF
--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Invoke-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Invoke-Item.Tests.ps1
@@ -32,6 +32,7 @@ Describe "Invoke-Item basic tests" -Tags "Feature" {
             param($TestFile)
 
             $expectedTitle = Split-Path $TestFile -Leaf
+            open -F -a TextEdit
             $beforeCount = [int]('tell application "TextEdit" to count of windows' | osascript)
             Invoke-Item -Path $TestFile
             $startTime = Get-Date
@@ -45,6 +46,7 @@ Describe "Invoke-Item basic tests" -Tags "Feature" {
             $afterCount | Should Be ($beforeCount + 1)
             $title | Should Be $expectedTitle
             "tell application ""TextEdit"" to close window ""$expectedTitle""" | osascript
+            'tell application "TextEdit" to quit' | osascript
         }
     }
 


### PR DESCRIPTION
Implement defensive measures suggested by @mklement0 from https://github.com/PowerShell/PowerShell/pull/4262

add defensive measures to have TextEdit start explicitly bypassing restoring previously open docs and to explicitly close TextEdit after test

<!--

If you are a PowerShell Team member, please make sure you choose the Reviewer(s) and Assignee for your PR.
If you are not from the PowerShell Team, you can leave the fields blank and the Maintainers will choose them for you. If you are familiar with the team, feel free to mention some Reviewers yourself.

For more information about the roles of Reviewer and Assignee, refer to CONTRIBUTING.md.

-->
