### PR TITLE
FileInfo using Format-List is unreadable

### DIFF
--- a/src/System.Management.Automation/commands/utility/FormatAndOutput/common/DefaultFormatters/FileSystem_format_ps1xml.cs
+++ b/src/System.Management.Automation/commands/utility/FormatAndOutput/common/DefaultFormatters/FileSystem_format_ps1xml.cs
@@ -74,7 +74,7 @@ return $_.Length";
                     .GroupByProperty("PSParentPath", customControl: sharedControls[0])
                     .StartEntry(entrySelectedByType: new[] { "System.IO.FileInfo" })
                         .AddItemProperty(@"Name")
-                        .AddItemScriptBlock(LengthScriptBlock)
+                        .AddItemScriptBlock(LengthScriptBlock, label: "Length")
                         .AddItemProperty(@"CreationTime")
                         .AddItemProperty(@"LastWriteTime")
                         .AddItemProperty(@"LastAccessTime")

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-List.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-List.Tests.ps1
@@ -149,5 +149,12 @@ Describe "Format-List DRT basic functionality" -Tags "CI" {
 		$result | Should Match "Length : 2"
 		$result | Should Match "Name   : name3"
 		$result | Should Match "Length : 3"
-	}
+    }
+
+    It "Format-List with FileInfo should work" {
+        $null = New-Item $testdrive\test.txt -ItemType File -Value "hello" -Force
+        $result = Get-ChildItem -File $testdrive\test.txt | Format-List | Out-String
+        $result | Should Match "Name\s*:\s*test.txt"
+        $result | Should Match "Length\s*:\s*5"
+    }
 }


### PR DESCRIPTION
Length script property for List View didn't include a name for the property so it defaulted to using the script as the property name

A search of the code shows this was the only instance that didn't add a property name for a scriptblock for List views

Fix https://github.com/PowerShell/PowerShell/issues/4396

<!--

If you are a PowerShell Team member, please make sure you choose the Reviewer(s) and Assignee for your PR.
If you are not from the PowerShell Team, you can leave the fields blank and the Maintainers will choose them for you. If you are familiar with the team, feel free to mention some Reviewers yourself.

For more information about the roles of Reviewer and Assignee, refer to CONTRIBUTING.md.

-->
