### PR TITLE
Clean up '#if CORE' in RunspaceConfiguration*.cs files

### DIFF
--- a/src/System.Management.Automation/minishell/api/RunspaceConfiguration.cs
+++ b/src/System.Management.Automation/minishell/api/RunspaceConfiguration.cs
@@ -104,43 +104,9 @@ namespace System.Management.Automation.Runspaces
     ///     6. ETS will use type information.
     ///     7. Format and output will use format information.
     /// -->
-#if CORECLR
-    internal
-#else
-    public
-#endif
-    abstract class RunspaceConfiguration
+    internal abstract class RunspaceConfiguration
     {
         #region RunspaceConfiguration Factory
-
-#if V2
-
-        /// <summary>
-        /// Create an instance of default RunspaceConfiguration implementation.
-        /// </summary>
-        /// <return>RunspaceConfiguration instance created</return>
-        /// <exception cref="System.Management.Automation.PSInvalidOperationException">
-        /// Exception thrown when implementation class for RunspaceConfiguration is not found.
-        /// </exception>
-        /// <!--
-        /// This is a RunspaceConfiguration factory function which will create an instance
-        /// of default RunspaceConfiguration-derived type, whose name is decided by an
-        /// assembly attribute in mini-shell.
-        /// -->
-        internal static RunspaceConfiguration Create()
-        {
-            Assembly assembly = Assembly.GetEntryAssembly();
-
-            // If monad engine is hosted by an native application, Assembly.GetEntryAssembly()
-            // will actually return null. In this case, we should throw an exception back.
-            if (assembly == null)
-            {
-                throw tracer.NewInvalidOperationException("MiniShellErrors", "InvalidEntryAssembly");
-            }
-
-            return Create(assembly);
-        }
-#endif
 
         /// <summary>
         /// Create an instance of RunspaceConfiguration type implemented from an assembly.

--- a/src/System.Management.Automation/minishell/api/RunspaceConfigurationEntry.cs
+++ b/src/System.Management.Automation/minishell/api/RunspaceConfigurationEntry.cs
@@ -15,12 +15,7 @@ namespace System.Management.Automation.Runspaces
     /// runspace configuration entries only. Developers should not derive from
     /// this class.
     /// </remarks>
-#if CORECLR
-    internal
-#else
-    public
-#endif
-    abstract class RunspaceConfigurationEntry
+    internal abstract class RunspaceConfigurationEntry
     {
         /// <summary>
         /// Initiate an instance of runspace configuration entry.
@@ -102,12 +97,7 @@ namespace System.Management.Automation.Runspaces
     /// <summary>
     /// Defines class for type configuration entry.
     /// </summary>
-#if CORECLR
-    internal
-#else
-    public
-#endif
-    sealed class TypeConfigurationEntry : RunspaceConfigurationEntry
+    internal sealed class TypeConfigurationEntry : RunspaceConfigurationEntry
     {
         /// <summary>
         /// Initiate an instance for type configuration entry.
@@ -197,12 +187,7 @@ namespace System.Management.Automation.Runspaces
     /// <summary>
     /// Defines class for type configuration entry.
     /// </summary>
-#if CORECLR
-    internal
-#else
-    public
-#endif
-    sealed class FormatConfigurationEntry : RunspaceConfigurationEntry
+    internal sealed class FormatConfigurationEntry : RunspaceConfigurationEntry
     {
         /// <summary>
         /// Initiate an instance for type configuration entry.
@@ -284,12 +269,7 @@ namespace System.Management.Automation.Runspaces
     /// <summary>
     /// Class to define configuration data for cmdlets
     /// </summary>
-#if CORECLR
-    internal
-#else
-    public
-#endif
-    sealed class CmdletConfigurationEntry : RunspaceConfigurationEntry
+    internal sealed class CmdletConfigurationEntry : RunspaceConfigurationEntry
     {
         /// <summary>
         /// Initiate an instance for cmdlet configuration entry.
@@ -359,12 +339,7 @@ namespace System.Management.Automation.Runspaces
     /// <summary>
     /// Define class for provider configuration entry
     /// </summary>
-#if CORECLR
-    internal
-#else
-    public
-#endif
-    sealed class ProviderConfigurationEntry : RunspaceConfigurationEntry
+    internal sealed class ProviderConfigurationEntry : RunspaceConfigurationEntry
     {
         /// <summary>
         /// Initiate an instance for provider configuration entry.
@@ -434,12 +409,7 @@ namespace System.Management.Automation.Runspaces
     /// <summary>
     /// Define class for script configuration entry
     /// </summary>
-#if CORECLR
-    internal
-#else
-    public
-#endif
-    sealed class ScriptConfigurationEntry : RunspaceConfigurationEntry
+    internal sealed class ScriptConfigurationEntry : RunspaceConfigurationEntry
     {
         /// <summary>
         /// Initiate an instance for script configuration entry.
@@ -466,12 +436,7 @@ namespace System.Management.Automation.Runspaces
     /// <summary>
     /// Configuration data for assemblies.
     /// </summary>
-#if CORECLR
-    internal
-#else
-    public
-#endif
-    sealed class AssemblyConfigurationEntry : RunspaceConfigurationEntry
+    internal sealed class AssemblyConfigurationEntry : RunspaceConfigurationEntry
     {
         /// <summary>
         /// Initiate an instance for assembly configuration entry.

--- a/src/System.Management.Automation/minishell/api/RunspaceConfigurationTypeAttribute.cs
+++ b/src/System.Management.Automation/minishell/api/RunspaceConfigurationTypeAttribute.cs
@@ -12,12 +12,7 @@ namespace System.Management.Automation.Runspaces
     /// the type name for MiniShellConfiguration derived class.
     /// -->
     [AttributeUsage(AttributeTargets.Assembly)]
-#if CORECLR
-    internal
-#else
-    public
-#endif
-    sealed class RunspaceConfigurationTypeAttribute : Attribute
+    internal sealed class RunspaceConfigurationTypeAttribute : Attribute
     {
         /// <summary>
         /// Initiate an instance of RunspaceConfigurationTypeAttribute.

--- a/src/System.Management.Automation/minishell/api/RunspaceConfigurationTypeException.cs
+++ b/src/System.Management.Automation/minishell/api/RunspaceConfigurationTypeException.cs
@@ -20,12 +20,7 @@ namespace System.Management.Automation.Runspaces
     ///     2. ISerializable
     /// -->
     [Serializable]
-#if CORECLR
-    internal
-#else
-    public
-#endif
-    class RunspaceConfigurationTypeException : SystemException, IContainsErrorRecord
+    internal class RunspaceConfigurationTypeException : SystemException, IContainsErrorRecord
     {
         /// <summary>
         /// Initiate an instance for RunspaceConfigurationTypeException


### PR DESCRIPTION
Related #3565 and #4357.

Clean up files:
RunspaceConfigurationTypeException.cs
RunspaceConfigurationTypeAttribute.cs
RunspaceConfigurationEntry.cs 
RunspaceConfiguration.cs