### PR TITLE
Win7 loading issue

### DIFF
--- a/src/Microsoft.PowerShell.SDK/Microsoft.PowerShell.SDK.csproj
+++ b/src/Microsoft.PowerShell.SDK/Microsoft.PowerShell.SDK.csproj
@@ -28,6 +28,7 @@
     <PackageReference Include="System.Text.Encodings.Web" Version="4.4.0-preview3-25423-02" />
     <PackageReference Include="System.Threading.AccessControl" Version="4.4.0-preview3-25423-02" />
     <PackageReference Include="System.Private.ServiceModel" Version="4.4.0-preview3-25423-01" />
+    <PackageReference Include="Microsoft.NETCore.Windows.ApiSets" Version="1.0.1" />
   </ItemGroup>
 
 </Project>

--- a/src/System.Management.Automation/System.Management.Automation.csproj
+++ b/src/System.Management.Automation/System.Management.Automation.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="System.Security.Permissions" Version="4.4.0-preview3-25423-02" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="4.4.0-preview3-25423-02" />
     <PackageReference Include="Microsoft.Management.Infrastructure" Version="1.0.0-alpha*" />
+    <PackageReference Include="Microsoft.NETCore.Windows.ApiSets" Version="1.0.1" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/System.Management.Automation/System.Management.Automation.csproj
+++ b/src/System.Management.Automation/System.Management.Automation.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="System.Security.Permissions" Version="4.4.0-preview3-25423-02" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="4.4.0-preview3-25423-02" />
     <PackageReference Include="Microsoft.Management.Infrastructure" Version="1.0.0-alpha*" />
-    <PackageReference Include="Microsoft.NETCore.Windows.ApiSets" Version="1.0.1" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Since .Net Core 2.0, the api sets were moved to a nuget package. Adding a package reference for "Microsoft.NETCore.Windows.ApiSets" gets the required binaries for the Win7 package.

Opening this PR for release branch. Original PR #4438 

Updated by iSazonov:
Fix #3747.