### PR TITLE
Extend -SkipHeaderValidation to include -UserAgent to support non-standard User-Agent headers

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebRequestPSCmdlet.CoreClr.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebRequestPSCmdlet.CoreClr.cs
@@ -283,7 +283,15 @@ namespace Microsoft.PowerShell.Commands
             }
             else
             {
-                request.Headers.Add(HttpKnownHeaderNames.UserAgent, WebSession.UserAgent);
+                if (SkipHeaderValidation)
+                {
+                    request.Headers.TryAddWithoutValidation(HttpKnownHeaderNames.UserAgent, WebSession.UserAgent);
+                }
+                else
+                {
+                    request.Headers.Add(HttpKnownHeaderNames.UserAgent, WebSession.UserAgent);    
+                }
+                
             }
 
             // Set 'Keep-Alive' to false. This means set the Connection to 'Close'.

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -247,12 +247,18 @@ function ExecuteRequestWithCustomUserAgent {
     $result = [PSObject]@{Output = $null; Error = $null; Content = $null}
 
     try {
+        $Params = @{
+            Uri                  = $Uri 
+            TimeoutSec           = 5 
+            UserAgent            = $UserAgent 
+            SkipHeaderValidation = $SkipHeaderValidation.IsPresent
+        }
         if ($Cmdlet -eq 'Invoke-WebRequest') {
-            $result.Output = Invoke-WebRequest -Uri $Uri -TimeoutSec 5 -UserAgent $UserAgent -SkipHeaderValidation:$SkipHeaderValidation.IsPresent
+            $result.Output = Invoke-WebRequest @Params
             $result.Content = $result.Output.Content | ConvertFrom-Json
         }
         else {
-            $result.Output = Invoke-RestMethod -Uri $Uri -TimeoutSec 5 -UserAgent $UserAgent -SkipHeaderValidation:$SkipHeaderValidation.IsPresent
+            $result.Output = Invoke-RestMethod @Params
             # NOTE: $result.Output should already be a PSObject (Invoke-RestMethod converts the returned json automatically)
             # so simply reference $result.Output
             $result.Content = $result.Output

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -227,6 +227,44 @@ function ExecuteRequestWithCustomHeaders
     return $result
 }
 
+# This function calls either Invoke-WebRequest or Invoke-RestMethod with the given uri
+# using the custom UserAgent and the  optional SkipHeaderValidation switch.
+function ExecuteRequestWithCustomUserAgent {
+    param (
+        [Parameter(Mandatory)]
+        [string]
+        $Uri,
+
+        [ValidateSet('Invoke-WebRequest', 'Invoke-RestMethod')]
+        [string] $Cmdlet = 'Invoke-WebRequest',
+
+        [Parameter(Mandatory)]
+        [ValidateNotNull()]
+        [string] $UserAgent,
+
+        [switch] $SkipHeaderValidation
+    )
+    $result = [PSObject]@{Output = $null; Error = $null; Content = $null}
+
+    try {
+        if ($Cmdlet -eq 'Invoke-WebRequest') {
+            $result.Output = Invoke-WebRequest -Uri $Uri -TimeoutSec 5 -UserAgent $UserAgent -SkipHeaderValidation:$SkipHeaderValidation.IsPresent
+            $result.Content = $result.Output.Content | ConvertFrom-Json
+        }
+        else {
+            $result.Output = Invoke-RestMethod -Uri $Uri -TimeoutSec 5 -UserAgent $UserAgent -SkipHeaderValidation:$SkipHeaderValidation.IsPresent
+            # NOTE: $result.Output should already be a PSObject (Invoke-RestMethod converts the returned json automatically)
+            # so simply reference $result.Output
+            $result.Content = $result.Output
+        }
+    }
+    catch {
+        $result.Error = $_
+    }
+
+    return $result
+}
+
 <#
     Defines the list of redirect codes to test as well as the
     expected Method when the redirection is handled.
@@ -732,6 +770,31 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
         $response.Content.Headers -contains "If-Match" | Should Be $true
     }
 
+    It "Verifies Invoke-WebRequest default UserAgent handling with no errors" {
+        $UserAgent = [Microsoft.PowerShell.Commands.PSUserAgent]::InternetExplorer
+        $response = ExecuteRequestWithCustomUserAgent -Uri "http://localhost:8081/PowerShell?test=echo" -UserAgent $UserAgent -Cmdlet "Invoke-WebRequest"
+
+        $response.Error | Should BeNullOrEmpty
+        $response.Content.Headers.'User-Agent' | Should Match $UserAgent
+    }
+
+    It "Verifies Invoke-WebRequest default UserAgent handling reports an error is returned for an invalid UserAgent value" {
+        $UserAgent = 'Invalid:Agent'
+        $response = ExecuteRequestWithCustomUserAgent -Uri "http://localhost:8081/PowerShell?test=echo" -UserAgent $UserAgent  -Cmdlet "Invoke-WebRequest"
+
+        $response.Error | Should Not BeNullOrEmpty
+        $response.Error.FullyQualifiedErrorId | Should Be "System.FormatException,Microsoft.PowerShell.Commands.InvokeRestMethodCommand"
+        $response.Error.Exception.Message | Should Be "The format of value 'Invalid:Agent' is invalid."
+    }
+
+    It "Verifies Invoke-WebRequest UserAgent handling does not report an error when using -SkipHeaderValidation" {
+        $UserAgent = 'Invalid:Agent'
+        $response = ExecuteRequestWithCustomUserAgent -Uri "http://localhost:8081/PowerShell?test=echo" -UserAgent $UserAgent  -SkipHeaderValidation -Cmdlet "Invoke-WebRequest"
+
+        $response.Error | Should BeNullOrEmpty
+        $response.Content.Headers.'User-Agent' | Should Match $UserAgent
+    }
+
     #endregion SkipHeaderVerification Tests
 
     BeforeEach {
@@ -1221,6 +1284,31 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
 
         $response.Error | Should BeNullOrEmpty
         $response.Content.Headers -contains "If-Match" | Should Be $true
+    }
+
+    It "Verifies Invoke-RestMethod default UserAgent handling with no errors" {
+        $UserAgent = [Microsoft.PowerShell.Commands.PSUserAgent]::InternetExplorer
+        $response = ExecuteRequestWithCustomUserAgent -Uri "http://localhost:8081/PowerShell?test=echo" -UserAgent $UserAgent -Cmdlet "Invoke-RestMethod"
+
+        $response.Error | Should BeNullOrEmpty
+        $response.Content.Headers.'User-Agent' | Should Match $UserAgent
+    }
+
+    It "Verifies Invoke-RestMethod default UserAgent handling reports an error is returned for an invalid UserAgent value" {
+        $UserAgent = 'Invalid:Agent'
+        $response = ExecuteRequestWithCustomUserAgent -Uri "http://localhost:8081/PowerShell?test=echo" -UserAgent $UserAgent  -Cmdlet "Invoke-RestMethod"
+
+        $response.Error | Should Not BeNullOrEmpty
+        $response.Error.FullyQualifiedErrorId | Should Be "System.FormatException,Microsoft.PowerShell.Commands.InvokeRestMethodCommand"
+        $response.Error.Exception.Message | Should Be "The format of value 'Invalid:Agent' is invalid."
+    }
+
+    It "Verifies Invoke-RestMethod UserAgent handling does not report an error when using -SkipHeaderValidation" {
+        $UserAgent = 'Invalid:Agent'
+        $response = ExecuteRequestWithCustomUserAgent -Uri "http://localhost:8081/PowerShell?test=echo" -UserAgent $UserAgent  -SkipHeaderValidation -Cmdlet "Invoke-RestMethod"
+
+        $response.Error | Should BeNullOrEmpty
+        $response.Content.Headers.'User-Agent' | Should Match $UserAgent
     }
 
     #endregion SkipHeaderVerification tests


### PR DESCRIPTION
# Synopsis
Extends #4085 to include the `-UserAgent` parameter supplied `User-Agent` header. 

# Description
Some API's, such as [Reddit](https://github.com/reddit/reddit/wiki/API#rules) require special `User-Agent` headers to identify application consumers of the API. Currently, `Invoke-WebRequest`  and `Invoke-RestMethod` are unable to properly use non-compliant `User-Agent` headers. This extends the behavior of the `-SkipHeaderValidation` switch parameter to include the `User-Agent` header supplied by the `-UserAgent` parameter.

## Test Code

```powershell
$Uri = 'http://httpbin.org/headers'
Invoke-WebRequest -Uri $Uri -UserAgent 'Invalid:Agent' -SkipHeaderValidation
Invoke-RestMethod -Uri $Uri -UserAgent 'Invalid:Agent' -SkipHeaderValidation
```

## Current Behavior:

```none
Invoke-WebRequest : The format of value 'Invalid:Agent' is invalid.
At line:2 char:1
+ Invoke-WebRequest -Uri $Uri -UserAgent 'Invalid:Agent'
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [Invoke-WebRequest], FormatException
    + FullyQualifiedErrorId : System.FormatException,Microsoft.PowerShell.Commands.InvokeWebRequestCommand

Invoke-RestMethod : The format of value 'Invalid:Agent' is invalid.
At line:3 char:1
+ Invoke-RestMethod -Uri $Uri -UserAgent 'Invalid:Agent'
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [Invoke-RestMethod], FormatException
    + FullyQualifiedErrorId : System.FormatException,Microsoft.PowerShell.Commands.InvokeRestMethodCommand
```


## New Behavior

```none

StatusCode        : 200
StatusDescription : OK
Content           : {
                      "headers": {
                        "Connection": "close",
                        "Host": "httpbin.org",
                        "User-Agent": "Invalid:Agent"
                      }
                    }

RawContent        : HTTP/1.1 200 OK
                    Connection: keep-alive
                    Date: Thu, 03 Aug 2017 10:25:25 GMT
                    Via: 1.1 vegur
                    Server: meinheld/0.6.1
                    Access-Control-Allow-Origin: *
                    Access-Control-Allow-Credentials: true
                    X-Powered-...
Forms             :
Headers           : {[Connection, System.String[]], [Date, System.String[]], [Via, System.String[]], [Server,
                    System.String[]]...}
Images            : {}
InputFields       : {}
Links             : {}
ParsedHtml        :
RawContentLength  : 113
RelationLink      : {}


headers : @{Connection=close; Host=httpbin.org; User-Agent=Invalid:Agent}
```