### PR TITLE
ensure running `powershell` within PowerShell starts instance of currently running PowerShell

### DIFF
--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
@@ -135,16 +135,12 @@ namespace Microsoft.PowerShell
 #endif
 
             // put PSHOME in front of PATH so that calling `powershell` within `powershell` always starts the same running version
-            StringBuilder path = new StringBuilder(Environment.GetEnvironmentVariable("PATH"));
-            string pathSeparator = ";";
-            if (!Platform.IsWindows)
-            {
-                pathSeparator = ":";
-            }
+            string path = Environment.GetEnvironmentVariable("PATH");
             string pshome = Utils.DefaultPowerShellAppBase;
-            path.Replace(pathSeparator + pshome, "");
-            path.Insert(0, pshome + pathSeparator);
-            Environment.SetEnvironmentVariable("PATH", path.ToString());
+            if (!path.Contains(pshome))
+            {
+                Environment.SetEnvironmentVariable("PATH", pshome + Path.PathSeparator + path);
+            }
 
             try
             {

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
@@ -134,6 +134,18 @@ namespace Microsoft.PowerShell
             }
 #endif
 
+            // put PSHOME in front of PATH so that calling `powershell` within `powershell` always starts the same running version
+            StringBuilder path = new StringBuilder(Environment.GetEnvironmentVariable("PATH"));
+            string pathSeparator = ";";
+            if (!Platform.IsWindows)
+            {
+                pathSeparator = ":";
+            }
+            string pshome = Utils.DefaultPowerShellAppBase;
+            path.Replace(pathSeparator + pshome, "");
+            path.Insert(0, pshome + pathSeparator);
+            Environment.SetEnvironmentVariable("PATH", path.ToString());
+
             try
             {
                 string profileDir;

--- a/test/powershell/Host/ConsoleHost.Tests.ps1
+++ b/test/powershell/Host/ConsoleHost.Tests.ps1
@@ -486,6 +486,12 @@ foo
             bash -c "unset HOME;$powershell -c '1+1'" | Should BeExactly 2
         }
     }
+
+    Context "PATH environment variable" {
+        It "`$PSHOME should be in front so that powershell.exe starts current running PowerShell" {
+            powershell -v | Should Match $psversiontable.GitCommitId
+        }
+    }
 }
 
 Describe "Console host api tests" -Tag CI {


### PR DESCRIPTION
modify PATH env var at startup so that $PSHOME is in front

Fix https://github.com/PowerShell/PowerShell/issues/4194

<!--

If you are a PowerShell Team member, please make sure you choose the Reviewer(s) and Assignee for your PR.
If you are not from the PowerShell Team, you can leave the fields blank and the Maintainers will choose them for you. If you are familiar with the team, feel free to mention some Reviewers yourself.

For more information about the roles of Reviewer and Assignee, refer to CONTRIBUTING.md.

-->
