### PR TITLE
Fix globbing for native commands

### DIFF
--- a/src/System.Management.Automation/engine/NativeCommandParameterBinder.cs
+++ b/src/System.Management.Automation/engine/NativeCommandParameterBinder.cs
@@ -105,9 +105,23 @@ namespace System.Management.Automation
                         //    windbg  -k com:port=\\devbox\pipe\debug,pipe,resets=0,reconnect
                         // The parser produced an array of strings but marked the parameter so we
                         // can properly reconstruct the correct command line.
+                        bool bareWord = false;
+                        var pAst = parameter.ArgumentAst;
+                        if (pAst != null)
+                        {
+                            if (pAst is System.Management.Automation.Language.StringConstantExpressionAst sce)
+                            {
+                                bareWord = sce.StringConstantType == System.Management.Automation.Language.StringConstantType.BareWord;
+                            }
+                            else if (pAst is System.Management.Automation.Language.ExpandableStringExpressionAst ese)
+                            {
+                                bareWord = ese.StringConstantType == System.Management.Automation.Language.StringConstantType.BareWord;
+                            }
+                        }
                         appendOneNativeArgument(Context, argValue,
                             parameter.ArrayIsSingleArgumentForNativeCommand ? ',' : ' ',
-                            sawVerbatimArgumentMarker);
+                            sawVerbatimArgumentMarker,
+                            bareWord);
                     }
                 }
             }
@@ -141,7 +155,8 @@ namespace System.Management.Automation
         /// <param name="obj">The object to append</param>
         /// <param name="separator">A space or comma used when obj is enumerable</param>
         /// <param name="sawVerbatimArgumentMarker">true if the argument occurs after --%</param>
-        private void appendOneNativeArgument(ExecutionContext context, object obj, char separator, bool sawVerbatimArgumentMarker)
+        /// <param name="bareWord">True if the argument was a bare (unquoted) string</param>
+        private void appendOneNativeArgument(ExecutionContext context, object obj, char separator, bool sawVerbatimArgumentMarker, bool bareWord)
         {
             IEnumerator list = LanguagePrimitives.GetEnumerator(obj);
             bool needSeparator = false;
@@ -204,7 +219,7 @@ namespace System.Management.Automation
 #if UNIX
                             // On UNIX systems, we expand arguments containing wildcard expressions against
                             // the file system just like bash, etc.
-                            if (System.Management.Automation.WildcardPattern.ContainsWildcardCharacters(arg))
+                            if (System.Management.Automation.WildcardPattern.ContainsWildcardCharacters(arg) && bareWord)
                             {
                                 // See if the current working directory is a filesystem provider location
                                 // We won't do the expansion if it isn't since native commands can only access the file system.

--- a/src/System.Management.Automation/engine/parser/Compiler.cs
+++ b/src/System.Management.Automation/engine/parser/Compiler.cs
@@ -66,12 +66,12 @@ namespace System.Management.Automation.Language
         internal static readonly MethodInfo CharOps_CompareStringIne =
             typeof(CharOps).GetMethod(nameof(CharOps.CompareStringIne), staticFlags);
 
-        internal static readonly MethodInfo CommandParameterInternal_CreateArgument =
-            typeof(CommandParameterInternal).GetMethod(nameof(CommandParameterInternal.CreateArgument), staticFlags);
-        internal static readonly MethodInfo CommandParameterInternal_CreateParameter =
-            typeof(CommandParameterInternal).GetMethod(nameof(CommandParameterInternal.CreateParameter), staticFlags);
-        internal static readonly MethodInfo CommandParameterInternal_CreateParameterWithArgument =
-            typeof(CommandParameterInternal).GetMethod(nameof(CommandParameterInternal.CreateParameterWithArgument), staticFlags);
+        internal static readonly MethodInfo CommandParameterInternal_CreateArgumentAstOnly =
+            typeof(CommandParameterInternal).GetMethod(nameof(CommandParameterInternal.CreateArgumentAstOnly), staticFlags);
+        internal static readonly MethodInfo CommandParameterInternal_CreateParameterAstOnly =
+            typeof(CommandParameterInternal).GetMethod(nameof(CommandParameterInternal.CreateParameterAstOnly), staticFlags);
+        internal static readonly MethodInfo CommandParameterInternal_CreateParameterWithArgumentAstOnly =
+            typeof(CommandParameterInternal).GetMethod(nameof(CommandParameterInternal.CreateParameterWithArgumentAstOnly), staticFlags);
 
         internal static readonly MethodInfo CommandRedirection_UnbindForExpression =
             typeof(CommandRedirection).GetMethod(nameof(CommandRedirection.UnbindForExpression), instanceFlags);
@@ -3401,8 +3401,8 @@ namespace System.Management.Automation.Language
 
                     bool arrayIsSingleArgumentForNativeCommand = ArgumentIsNotReallyArrayIfCommandIsNative(element);
                     elementExprs[i] =
-                        Expression.Call(CachedReflectionInfo.CommandParameterInternal_CreateArgument,
-                                        Expression.Constant(element.Extent),
+                        Expression.Call(CachedReflectionInfo.CommandParameterInternal_CreateArgumentAstOnly,
+                                        Expression.Constant(element),
                                         Expression.Convert(GetCommandArgumentExpression(element), typeof(object)),
                                         ExpressionCache.Constant(splatted),
                                         ExpressionCache.Constant(arrayIsSingleArgumentForNativeCommand));
@@ -3509,18 +3509,17 @@ namespace System.Management.Automation.Language
                 bool spaceAfterParameter = (errorPos.EndLineNumber != arg.Extent.StartLineNumber ||
                                             errorPos.EndColumnNumber != arg.Extent.StartColumnNumber);
                 bool arrayIsSingleArgumentForNativeCommand = ArgumentIsNotReallyArrayIfCommandIsNative(arg);
-                return Expression.Call(CachedReflectionInfo.CommandParameterInternal_CreateParameterWithArgument,
-                                       Expression.Constant(errorPos),
+                return Expression.Call(CachedReflectionInfo.CommandParameterInternal_CreateParameterWithArgumentAstOnly,
+                                       Expression.Constant(commandParameterAst),
                                        Expression.Constant(commandParameterAst.ParameterName),
                                        Expression.Constant(errorPos.Text),
-                                       Expression.Constant(arg.Extent),
                                        Expression.Convert(GetCommandArgumentExpression(arg), typeof(object)),
                                        ExpressionCache.Constant(spaceAfterParameter),
                                        ExpressionCache.Constant(arrayIsSingleArgumentForNativeCommand));
             }
 
-            return Expression.Call(CachedReflectionInfo.CommandParameterInternal_CreateParameter,
-                                   Expression.Constant(errorPos),
+            return Expression.Call(CachedReflectionInfo.CommandParameterInternal_CreateParameterAstOnly,
+                                   Expression.Constant(commandParameterAst),
                                    Expression.Constant(commandParameterAst.ParameterName),
                                    Expression.Constant(errorPos.Text));
         }

--- a/test/powershell/Language/Scripting/NativeExecution/NativeUnixGlobbing.Tests.ps1
+++ b/test/powershell/Language/Scripting/NativeExecution/NativeUnixGlobbing.Tests.ps1
@@ -38,6 +38,12 @@ Describe 'Native UNIX globbing tests' -tags "CI" {
     It 'Should return the original pattern if there are no matches' {
         /bin/echo $TESTDRIVE/*.nosuchfile | Should Match "\*\.nosuchfile$"
     }
+    It 'Should not expand double-quoted strings' {
+        /bin/echo "*" | Should BeExactly "*"
+    }
+    It 'Should not expand single-quoted strings' {
+        /bin/echo '*' | Should BeExactly "*"
+    }
     # Test the behavior in non-filesystem drives
     It 'Should not expand patterns on non-filesystem drives' {
         /bin/echo env:ps* | Should BeExactly "env:ps*"


### PR DESCRIPTION
<!--

If you are a PowerShell Team member, please make sure you choose the Reviewer(s) and Assignee for your PR.
If you are not from the PowerShell Team, you can leave the fields blank and the Maintainers will choose them for you. If you are familiar with the team, feel free to mention some Reviewers yourself.

For more information about the roles of Reviewer and Assignee, refer to CONTRIBUTING.md.

-->

Fix for #3931. With this change, globbing for native commands will not longer be done if the argument string is quoted (single or double quotes).