### PR TITLE
Add support for Content Headers to BasicHtmlWebResponseObject and HtmlWebResponseObject

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/ContentHelper.CoreClr.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/ContentHelper.CoreClr.cs
@@ -7,6 +7,7 @@ Copyright (c) Microsoft Corporation.  All rights reserved.
 using System.Text;
 using System.Linq;
 using System.Net.Http;
+using System.Net.Http.Headers;
 
 namespace Microsoft.PowerShell.Commands
 {
@@ -37,11 +38,30 @@ namespace Microsoft.PowerShell.Commands
                 raw.AppendFormat("{0} {1} {2}", protocol, statusCode, statusDescription);
                 raw.AppendLine();
             }
-
-            foreach (var entry in response.Headers)
+            
+            HttpHeaders[] headerCollections = 
             {
-                raw.AppendFormat("{0}: {1}", entry.Key, entry.Value.FirstOrDefault());
-                raw.AppendLine();
+                response.Headers, 
+                response.Content == null ? null : response.Content.Headers
+            };
+
+            foreach(var headerCollection in headerCollections)
+            {
+                if(headerCollection == null)
+                {
+                    continue;
+                }
+                foreach (var header in headerCollection)
+                {
+                    // Headers may have multiple entries with different values
+                    foreach (var headerValue in header.Value)
+                    {
+                        raw.Append(header.Key);
+                        raw.Append(": ");
+                        raw.Append(headerValue);
+                        raw.AppendLine();
+                    }
+                }
             }
 
             raw.AppendLine();

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/ContentHelper.CoreClr.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/ContentHelper.CoreClr.cs
@@ -45,9 +45,9 @@ namespace Microsoft.PowerShell.Commands
                 response.Content == null ? null : response.Content.Headers
             };
 
-            foreach(var headerCollection in headerCollections)
+            foreach (var headerCollection in headerCollections)
             {
-                if(headerCollection == null)
+                if (headerCollection == null)
                 {
                     continue;
                 }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebResponseObject.CoreClr.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebResponseObject.CoreClr.cs
@@ -36,7 +36,8 @@ namespace Microsoft.PowerShell.Commands
                 {
                     headers[entry.Key] = entry.Value;
                 }
-                if(BaseResponse.Content != null){
+                if (BaseResponse.Content != null)
+                {
                     foreach (var entry in BaseResponse.Content.Headers)
                     {
                         headers[entry.Key] = entry.Value;

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebResponseObject.CoreClr.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebResponseObject.CoreClr.cs
@@ -36,6 +36,12 @@ namespace Microsoft.PowerShell.Commands
                 {
                     headers[entry.Key] = entry.Value;
                 }
+                if(BaseResponse.Content != null){
+                    foreach (var entry in BaseResponse.Content.Headers)
+                    {
+                        headers[entry.Key] = entry.Value;
+                    }
+                }
 
                 return headers;
             }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -1070,6 +1070,24 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
 
     #endregion charset encoding tests
 
+    It "Verifies Invoke-WebRequest includes Content headers in Headers property" {
+        $command = "Invoke-WebRequest -Uri 'http://httpbin.org/get'"
+        $result = ExecuteWebCommand -command $command
+        ValidateResponse $result
+
+        $result.Output.Headers.'Content-Type' | Should Not BeNullOrEmpty
+        $result.Output.Headers.'Content-Length' | Should Not BeNullOrEmpty
+    }
+
+    It "Verifies Invoke-WebRequest includes Content headers in RawContent property" {
+        $command = "Invoke-WebRequest -Uri 'http://httpbin.org/get'"
+        $result = ExecuteWebCommand -command $command
+        ValidateResponse $result
+
+        $result.Output.RawContent | Should Match 'Content-Type:'
+        $result.Output.RawContent | Should Match 'Content-Length:'
+    }
+
     BeforeEach {
         if ($env:http_proxy) {
             $savedHttpProxy = $env:http_proxy

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -1070,23 +1070,44 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
 
     #endregion charset encoding tests
 
+    #region Content Header Inclusion
     It "Verifies Invoke-WebRequest includes Content headers in Headers property" {
-        $command = "Invoke-WebRequest -Uri 'http://httpbin.org/get'"
+        $uri = "http://localhost:8080/PowerShell?test=response&contenttype=text/plain&output=OK"
+        $command = "Invoke-WebRequest -Uri '$uri'"
         $result = ExecuteWebCommand -command $command
         ValidateResponse $result
 
-        $result.Output.Headers.'Content-Type' | Should Not BeNullOrEmpty
-        $result.Output.Headers.'Content-Length' | Should Not BeNullOrEmpty
+        $result.Output.Headers.'Content-Type' | Should Be 'text/plain'
+        $result.Output.Headers.'Content-Length' | Should Be 2
     }
 
     It "Verifies Invoke-WebRequest includes Content headers in RawContent property" {
-        $command = "Invoke-WebRequest -Uri 'http://httpbin.org/get'"
+        $uri = "http://localhost:8080/PowerShell?test=response&contenttype=text/plain&output=OK"
+        $command = "Invoke-WebRequest -Uri '$uri'"
         $result = ExecuteWebCommand -command $command
         ValidateResponse $result
 
-        $result.Output.RawContent | Should Match 'Content-Type:'
-        $result.Output.RawContent | Should Match 'Content-Length:'
+        $result.Output.RawContent | Should Match ([regex]::Escape('Content-Type: text/plain'))
+        $result.Output.RawContent | Should Match ([regex]::Escape('Content-Length: 2'))
     }
+
+    It "Verifies Invoke-WebRequest Supports Multiple response headers with same name" {
+        $headers = @{
+            'X-Fake-Header' = 'testvalue01','testvalue02'
+        } | ConvertTo-Json -Compress
+        $uri = "http://localhost:8080/PowerShell?test=response&contenttype=text/plain&output=OK&headers=$headers"
+        $command = "Invoke-WebRequest -Uri '$uri'"
+        $result = ExecuteWebCommand -command $command
+        ValidateResponse $result
+
+        $result.Output.Headers.'X-Fake-Header'.Count | Should Be 2
+        $result.Output.Headers.'X-Fake-Header'.Contains('testvalue01') | Should Be $True
+        $result.Output.Headers.'X-Fake-Header'.Contains('testvalue02') | Should Be $True
+        $result.Output.RawContent | Should Match ([regex]::Escape('X-Fake-Header: testvalue01'))
+        $result.Output.RawContent | Should Match ([regex]::Escape('X-Fake-Header: testvalue02'))
+    }
+
+    #endregion Content Header Inclusion
 
     BeforeEach {
         if ($env:http_proxy) {

--- a/test/tools/Modules/HttpListener/HttpListener.psm1
+++ b/test/tools/Modules/HttpListener/HttpListener.psm1
@@ -133,6 +133,14 @@ Function Start-HTTPListener {
                             $statusCode = $queryItems["statuscode"]
                             $contentType = $queryItems["contenttype"]
                             $output = $queryItems["output"]
+                            if ($queryItems['headers'])
+                            {
+                                $headerCollection = $queryItems['headers'] | ConvertFrom-Json
+                                foreach ($header in $headerCollection.psobject.Properties.name)
+                                {
+                                    $outputHeader.add($header,$headerCollection.$header)
+                                }
+                            }
                         }
 
                         # Echo the request as the output.
@@ -284,7 +292,10 @@ Function Start-HTTPListener {
                     $response.Headers.Clear()
                     foreach ($header in $outputHeader.Keys)
                     {
-                        $response.Headers.Add($header, $outputHeader[$header])
+                        foreach ($headerValue in $outputHeader.$header)
+                        {
+                            $response.Headers.Add($header, $headerValue)
+                        }
                     }
 
                     if ($null -ne $output)

--- a/test/tools/Modules/HttpListener/HttpListener.psm1
+++ b/test/tools/Modules/HttpListener/HttpListener.psm1
@@ -133,6 +133,12 @@ Function Start-HTTPListener {
                             $statusCode = $queryItems["statuscode"]
                             $contentType = $queryItems["contenttype"]
                             $output = $queryItems["output"]
+                            
+                            # Pass a JSON collection to the 'headers' field
+                            # /PowerShell?test=response&headers={"Pragma":"no-cache","X-Fake-Header":["testvalue01","testvalue02"]}
+                            # In PowerShell:
+                            # $headers = @{Pragma='no-cache';'X-Fake-Header'='testvalue01','testvalue02'} | ConvertTo-Json -Compress
+                            # $uri = "http://localhost:8080/PowerShell?test=response&headers=$headers"
                             if ($queryItems['headers'])
                             {
                                 $headerCollection = $queryItems['headers'] | ConvertFrom-Json


### PR DESCRIPTION
Fixes #4467

`System.Net.Http.HttpResponseMessage` has split the Content headers from the Response headers. This split appears to be intentional and permanent. This split results in the `Content-Type` and `Content-Length` headers to be missing from the `WebResponseObject.Headers` dictionary and from the `RawContent` property of `BasicHtmlWebResponseObject` and `HtmlWebResponseObject`.

This adds the Content headers back to those locations to make it similar to 5.1.

This also adds support to `RawContent` for multiple response headers with the same field name. `System.Net.Http.Headers.HttpContentHeaders` and `System.Net.Http.Headers.HttpResponseHeaders` implement values as arrays.