### PR TITLE
remove hash validation from nanoserver-insider.

### DIFF
--- a/docker/release/nanoserver-insider/Dockerfile
+++ b/docker/release/nanoserver-insider/Dockerfile
@@ -11,16 +11,11 @@ FROM ${WindowsServerCoreRepo}:$WindowsServerCoreVersion  AS installer-env
 
 # Arguments for installing powershell, must be defined in the container they are used
 ARG PS_VERSION=6.0.0-beta.5
-ARG PS_DOWNLOAD_SHA=DAB8CC377D1BADD91688AEC9277D7696CC8DB2C25CECBCC934BD91AA7C724901
 
 ENV PS_DOWNLOAD_URL https://github.com/PowerShell/PowerShell/releases/download/v$PS_VERSION/PowerShell-$PS_VERSION-win10-win2016-x64.zip
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 RUN Invoke-WebRequest $Env:PS_DOWNLOAD_URL -OutFile powershell.zip
-RUN if ((Get-FileHash powershell.zip -Algorithm sha256).Hash -ne $Env:PS_DOWNLOAD_SHA) { `
-        Write-Host 'CHECKSUM VERIFICATION FAILED!'; `
-        exit 1; `
-    }
 
 RUN Expand-Archive powershell.zip -DestinationPath \PowerShell
 


### PR DESCRIPTION
We are using HTTPS from the same location we are getting the dockerfile from, it should be enough

<!--

If you are a PowerShell Team member, please make sure you choose the Reviewer(s) and Assignee for your PR.
If you are not from the PowerShell Team, you can leave the fields blank and the Maintainers will choose them for you. If you are familiar with the team, feel free to mention some Reviewers yourself.

For more information about the roles of Reviewer and Assignee, refer to CONTRIBUTING.md.

-->
