### PR TITLE
fix shortcut to start in %userprofile% instead of the install folder

### DIFF
--- a/assets/Product.wxs
+++ b/assets/Product.wxs
@@ -32,6 +32,8 @@
     <!-- Set properties for add/remove programs -->
     <Property Id="ARPHELPLINK" Value="$(var.InfoURL)" />
 
+  <!-- Allow using %USERPROFILE% -->
+  <SetProperty Id="UserFolder" Value="[%USERPROFILE]" Before="AppSearch"/>
 	<!-- Checkbox to allow starting PowerShell after the installation (in UI mode only) -->
 	<Property Id="WIXUI_EXITDIALOGOPTIONALCHECKBOXTEXT" Value="Open $(env.ProductName)" />
 	<!-- Default value of Checkbox of starting PowerShell after installation -->  
@@ -78,7 +80,7 @@
               Name="$(var.ProductSemanticVersionWithName)"
               Description="$(var.ProductSemanticVersionWithName)"
               Target="[$(var.ProductVersionWithName)]PowerShell.exe"
-              WorkingDirectory="$(var.ProductVersionWithName)"
+              WorkingDirectory="UserFolder"
               Icon = "PowerShellExe.ico" />
 
             <RemoveFolder Id="ApplicationProgramsFolder" On="uninstall"/>


### PR DESCRIPTION
<!--

If you are a PowerShell Team member, please make sure you choose the Reviewer(s) and Assignee for your PR.
If you are not from the PowerShell Team, you can leave the fields blank and the Maintainers will choose them for you. If you are familiar with the team, feel free to mention some Reviewers yourself.

For more information about the roles of Reviewer and Assignee, refer to CONTRIBUTING.md.

-->
