### PR TITLE
Remove last-modified from headers from travis CI script

### DIFF
--- a/tools/travis.ps1
+++ b/tools/travis.ps1
@@ -50,7 +50,6 @@ function Set-DailyBuildBadge
     $headers = @{
         "x-ms-date"      = $now
         "cache-control"  = "no-cache"
-        "last-modified"  = $now
         "x-ms-blob-type" = "BlockBlob"
         "x-ms-version"   = "$headerDate"
     }


### PR DESCRIPTION
It causes a no such resource error when used

When invoke-webrequest is invoked, the call fails with a resource not found error and the badge is not updated. The documentation is pretty spotty with regard to what that resource (last-modified) could have done. It should be enough to set the cache-control header value to let browsers know to refresh the badge value rather than pulling it from cache.

this change should enable the PowerShell main page to report the proper state of the daily build on travis.

