### PR TITLE
Add an additional acceptance test for the PowerShellGet module

### DIFF
--- a/test/powershell/Modules/PowerShellGet/PowerShellGet.Tests.ps1
+++ b/test/powershell/Modules/PowerShellGet/PowerShellGet.Tests.ps1
@@ -90,7 +90,7 @@ function Initialize
 
 function Remove-InstalledModules
 {
-    Get-InstalledModule -Name $ContosoServer -AllVersions -ErrorAction SilentlyContinue | Uninstall-Module -Force
+    Get-InstalledModule -Name $ContosoServer -AllVersions -ErrorAction SilentlyContinue | PowerShellGet\Uninstall-Module -Force
 }
 
 Describe "PowerShellGet - Module tests" -tags "Feature" {
@@ -223,6 +223,38 @@ Describe "PowerShellGet - Script tests (Admin)" -tags @('Feature', 'RequireAdmin
 
     AfterAll {
         Remove-InstalledScripts
+    }
+}
+
+Describe 'PowerShellGet Type tests' -tags @('BVT','CI') {
+    BeforeAll {
+        Import-Module PowerShellGet -Force
+    }
+
+    It 'Ensure PowerShellGet Types are available' {
+        $PowerShellGetNamespace = 'Microsoft.PowerShell.Commands.PowerShellGet'
+        $PowerShellGetTypeDetails = @{
+            InternalWebProxy = @('GetProxy', 'IsBypassed')
+        }
+
+        if((IsWindows)) {
+            $PowerShellGetTypeDetails['CERT_CHAIN_POLICY_PARA'] = @('cbSize','dwFlags','pvExtraPolicyPara')
+            $PowerShellGetTypeDetails['CERT_CHAIN_POLICY_STATUS'] = @('cbSize','dwError','lChainIndex','lElementIndex','pvExtraPolicyStatus')
+            $PowerShellGetTypeDetails['InternalSafeHandleZeroOrMinusOneIsInvalid'] = @('IsInvalid')
+            $PowerShellGetTypeDetails['InternalSafeX509ChainHandle'] = @('CertFreeCertificateChain','ReleaseHandle','InvalidHandle')
+            $PowerShellGetTypeDetails['Win32Helpers'] = @('CertVerifyCertificateChainPolicy', 'CertDuplicateCertificateChain', 'IsMicrosoftCertificate')
+        }
+
+        if('Microsoft.PowerShell.Telemetry.Internal.TelemetryAPI' -as [Type]) {
+            $PowerShellGetTypeDetails['Telemetry'] = @('TraceMessageArtifactsNotFound', 'TraceMessageNonPSGalleryRegistration')
+        }
+
+        $PowerShellGetTypeDetails.GetEnumerator() | ForEach-Object {
+            $ClassName = $_.Name
+            $Type = "$PowerShellGetNamespace.$ClassName" -as [Type]
+            $Type | Select-Object -ExpandProperty Name | Should Be $ClassName
+            $_.Value | ForEach-Object { $Type.DeclaredMembers.Name -contains $_ | Should Be $true }
+        }
     }
 }
 

--- a/test/powershell/Modules/PowerShellGet/PowerShellGet.Tests.ps1
+++ b/test/powershell/Modules/PowerShellGet/PowerShellGet.Tests.ps1
@@ -226,7 +226,7 @@ Describe "PowerShellGet - Script tests (Admin)" -tags @('Feature', 'RequireAdmin
     }
 }
 
-Describe 'PowerShellGet Type tests' -tags @('BVT','CI') {
+Describe 'PowerShellGet Type tests' -tags @('CI') {
     BeforeAll {
         Import-Module PowerShellGet -Force
     }


### PR DESCRIPTION
- This acceptance test will ensure that there are no regressions in PowerShell build w.r.t. to adding a .NET type in PowerShellGet module.
