### PR TITLE
Fix the hang issue in Travis CI build triggered by the [Feature] tag

### DIFF
--- a/test/powershell/Language/Classes/Scripting.Classes.BasicParsing.Tests.ps1
+++ b/test/powershell/Language/Classes/Scripting.Classes.BasicParsing.Tests.ps1
@@ -7,15 +7,15 @@ try {
 # CrossGen'ed assemblies cause a hang to happen intermittently when running this test suite in Linux and OSX.
 # The issue has been reported to CoreCLR team. We need to work around it for now with the following approach:
 #  1. For pull request and push commit, build without '-CrossGen' and run the parsing tests
-#  2. For nightly build, build with '-CrossGen' but don't run the parsing tests
-# In this way, we will continue to exercise these parsing tests for each CI build, and skip them for nightly
+#  2. For daily build, build with '-CrossGen' but don't run the parsing tests
+# In this way, we will continue to exercise these parsing tests for each CI build, and skip them for daily
 # build to avoid a hang.
 # Note: this change should be reverted once the 'CrossGen' issue is fixed by CoreCLR. The issue is tracked by
 #       https://github.com/dotnet/coreclr/issues/9745
 #
-$isFullBuild = $env:TRAVIS_EVENT_TYPE -eq 'cron' -or $env:TRAVIS_EVENT_TYPE -eq 'api'
+$isDailyBuild = $env:TRAVIS_EVENT_TYPE -eq 'cron' -or $env:TRAVIS_EVENT_TYPE -eq 'api'
 $defaultParamValues = $PSdefaultParameterValues.Clone()
-$IsSkipped = (!$IsWindows -and $isFullBuild)
+$IsSkipped = (!$IsWindows -and $isDailyBuild)
 $PSDefaultParameterValues["it:skip"] = $IsSkipped
 $PSDefaultParameterValues["ShouldBeParseError:SkipInTravisFullBuild"] = $IsSkipped
 

--- a/test/powershell/Language/Classes/scripting.Classes.inheritance.tests.ps1
+++ b/test/powershell/Language/Classes/scripting.Classes.inheritance.tests.ps1
@@ -7,15 +7,15 @@ try {
 # CrossGen'ed assemblies cause a hang to happen intermittently when running this test suite in Linux and OSX.
 # The issue has been reported to CoreCLR team. We need to work around it for now with the following approach:
 #  1. For pull request and push commit, build without '-CrossGen' and run the parsing tests
-#  2. For nightly build, build with '-CrossGen' but don't run the parsing tests
-# In this way, we will continue to exercise these parsing tests for each CI build, and skip them for nightly
+#  2. For daily build, build with '-CrossGen' but don't run the parsing tests
+# In this way, we will continue to exercise these parsing tests for each CI build, and skip them for daily
 # build to avoid a hang.
 # Note: this change should be reverted once the 'CrossGen' issue is fixed by CoreCLR. The issue is tracked by
 #       https://github.com/dotnet/coreclr/issues/9745
 #
-$isFullBuild = $env:TRAVIS_EVENT_TYPE -eq 'cron' -or $env:TRAVIS_EVENT_TYPE -eq 'api'
+$isDailyBuild = $env:TRAVIS_EVENT_TYPE -eq 'cron' -or $env:TRAVIS_EVENT_TYPE -eq 'api'
 $defaultParamValues = $PSdefaultParameterValues.Clone()
-$IsSkipped = (!$IsWindows -and $isFullBuild)
+$IsSkipped = (!$IsWindows -and $isDailyBuild)
 $PSDefaultParameterValues["it:skip"] = $IsSkipped
 $PSDefaultParameterValues["ShouldBeParseError:SkipInTravisFullBuild"] = $IsSkipped
 

--- a/test/powershell/Language/Classes/scripting.Classes.inheritance.tests.ps1
+++ b/test/powershell/Language/Classes/scripting.Classes.inheritance.tests.ps1
@@ -2,6 +2,24 @@
 # Copyright (c) Microsoft Corporation, 2015
 #
 
+try {
+#
+# CrossGen'ed assemblies cause a hang to happen intermittently when running this test suite in Linux and OSX.
+# The issue has been reported to CoreCLR team. We need to work around it for now with the following approach:
+#  1. For pull request and push commit, build without '-CrossGen' and run the parsing tests
+#  2. For nightly build, build with '-CrossGen' but don't run the parsing tests
+# In this way, we will continue to exercise these parsing tests for each CI build, and skip them for nightly
+# build to avoid a hang.
+# Note: this change should be reverted once the 'CrossGen' issue is fixed by CoreCLR. The issue is tracked by
+#       https://github.com/dotnet/coreclr/issues/9745
+#
+$isFullBuild = $env:TRAVIS_EVENT_TYPE -eq 'cron' -or $env:TRAVIS_EVENT_TYPE -eq 'api'
+$defaultParamValues = $PSdefaultParameterValues.Clone()
+$IsSkipped = (!$IsWindows -and $isFullBuild)
+$PSDefaultParameterValues["it:skip"] = $IsSkipped
+$PSDefaultParameterValues["ShouldBeParseError:SkipInTravisFullBuild"] = $IsSkipped
+
+
 Describe 'Classes inheritance syntax' -Tags "CI" {
 
     It 'Base types' {
@@ -520,4 +538,8 @@ class Derived : Base
         $sb.Invoke() | Should Be 200
         $sb.Invoke() | Should Be 200
     }
+}
+
+} finally {
+    $global:PSdefaultParameterValues = $defaultParamValues
 }

--- a/tools/travis.ps1
+++ b/tools/travis.ps1
@@ -110,7 +110,9 @@ else
 
 
 # Run a full build if the build was trigger via cron, api or the commit message contains `[Feature]`
-$isFullBuild = $env:TRAVIS_EVENT_TYPE -eq 'cron' -or $env:TRAVIS_EVENT_TYPE -eq 'api' -or $commitMessage -match '\[feature\]'
+$hasFeatureTag = $commitMessage -match '\[feature\]'
+$isDailyBuild = $env:TRAVIS_EVENT_TYPE -eq 'cron' -or $env:TRAVIS_EVENT_TYPE -eq 'api'
+$isFullBuild = $isDailyBuild -or $hasFeatureTag
 
 if($Bootstrap.IsPresent)
 {
@@ -140,7 +142,8 @@ else
     $originalProgressPreference = $ProgressPreference
     $ProgressPreference = 'SilentlyContinue' 
     try {
-        Start-PSBuild -CrossGen:$isFullBuild -PSModuleRestore
+        ## We use CrossGen build to run tests only if it's the daily build.
+        Start-PSBuild -CrossGen:$isDailyBuild -PSModuleRestore
     }
     finally{
         $ProgressPreference = $originalProgressPreference    
@@ -167,7 +170,7 @@ else
     if (-not $isPr) {
         # Run 'CrossGen' for push commit, so that we can generate package.
         # It won't rebuild powershell, but only CrossGen the already built assemblies.
-        if (-not $isFullBuild) { Start-PSBuild -CrossGen }
+        if (-not $isDailyBuild) { Start-PSBuild -CrossGen }
         
         $packageParams = @{}
         if($env:TRAVIS_BUILD_NUMBER)

--- a/tools/travis.ps1
+++ b/tools/travis.ps1
@@ -199,7 +199,7 @@ else
             $resultError = $_
             $result = "FAIL"
         }
-        if ( $isFullBuild ) {
+        if ( $isDailyBuild ) {
             # now update the badge if you've done a full build, these are not fatal issues
             try {
                 $svgData = Get-DailyBadge -result $result


### PR DESCRIPTION
Some class related parser tests may cause Travis build to hang if they are running with CrossGen'ed assemblies. This is an issue to the CrossGen utility, and it's tracked by https://github.com/dotnet/coreclr/issues/9745.

To work around the issue, we made the following changes to our build:
1. For pull request and push commit, build without '-CrossGen' and run the parsing tests
2. For daily build, build with '-CrossGen' but don't run the parsing tests

The recent `[Feature]` tag support allows us to run the full build in PR or Commit-Push CI builds. The parser tests should run in those `[Feature]` tag builds, so we need to make sure the `[Feature]` tag builds don't use `-CrossGen` before running the tests.

Two other changes:
1. Skip inheritance tests during daily build.
2. Update badge only in daily build.