### PR TITLE
Reactivate pssessionconfiguration tests

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,5 +25,5 @@ after_test:
   - ps: Invoke-AppVeyorAfterTest
 
 on_finish: 
-  - ps: $blockRdp = $true; iex ((new-objectnet.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
   - ps: Invoke-AppveyorFinish

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,4 +25,5 @@ after_test:
   - ps: Invoke-AppVeyorAfterTest
 
 on_finish: 
+  - ps: $blockRdp = $true; iex ((new-objectnet.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
   - ps: Invoke-AppveyorFinish

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/PSSessionConfiguration.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/PSSessionConfiguration.Tests.ps1
@@ -495,7 +495,7 @@ namespace PowershellTestConfigNamespace
                     $Result.Session.UseSharedProcess | Should be $UseSharedProcess
                 }
                 
-                It "Validate Register-PSSessionConfiguration -startupscript parameter" -Pending {
+                It "Validate Register-PSSessionConfiguration -startupscript parameter" {
 
                     $null = Register-PSSessionConfiguration -Name $TestSessionConfigName -path $LocalConfigFilePath -StartupScript $LocalStartupScriptPath -Force
 
@@ -511,14 +511,14 @@ namespace PowershellTestConfigNamespace
                 }
                 
                 
-                It "Validate Register-PSSessionConfiguration -ModulesToImport parameter" -Pending {
+                It "Validate Register-PSSessionConfiguration -ModulesToImport parameter" {
 
                     $null = Register-PSSessionConfiguration -Name $TestSessionConfigName -ModulesToImport $LocalTestModulePath -Force
                     
                     ValidateRemoteEndpoint -TestSessionConfigName $TestSessionConfigName -ScriptToExecute "return IsTestModuleImported" -ExpectedOutput $true -ExpectedError $null
                 }
 
-                It "Validate Register-PSSessionConfiguration with ApplicationBase, AssemblyName and ConfigurationTypeName parameter" -Pending {
+                It "Validate Register-PSSessionConfiguration with ApplicationBase, AssemblyName and ConfigurationTypeName parameter" {
 
                     $null = Register-PSSessionConfiguration -Name $TestSessionConfigName -ApplicationBase $script:TestAssemblyDir -AssemblyName $LocalTestAssemblyName -ConfigurationTypeName "PowershellTestConfigNamespace.PowershellTestConfig" -force
                     
@@ -564,7 +564,7 @@ namespace PowershellTestConfigNamespace
                     $Result.Session.UseSharedProcess | Should be $UseSharedProcess
                 }
                 
-                It "Validate Set-PSSessionConfiguration -startupscript parameter" -Pending {
+                It "Validate Set-PSSessionConfiguration -startupscript parameter" {
 
                     $null = Set-PSSessionConfiguration -Name $TestSessionConfigName -StartupScript $LocalStartupScriptPath
 
@@ -578,14 +578,14 @@ namespace PowershellTestConfigNamespace
                     ValidateRemoteEndpoint -TestSessionConfigName $TestSessionConfigName -ScriptToExecute $null -ExpectedOutput $null -ExpectedError "RemoteConnectionDisallowed,PSSessionOpenFailed"
                 }
                 
-                It "Validate Set-PSSessionConfiguration -ModulesToImport parameter" -Pending {
+                It "Validate Set-PSSessionConfiguration -ModulesToImport parameter" {
 
                     $null = Set-PSSessionConfiguration -Name $TestSessionConfigName -ModulesToImport $LocalTestModulePath -Force
                     
                     ValidateRemoteEndpoint -TestSessionConfigName $TestSessionConfigName -ScriptToExecute "return IsTestModuleImported" -ExpectedOutput $true -ExpectedError $null
                 }
 
-                It "Validate Set-PSSessionConfiguration with ApplicationBase, AssemblyName and ConfigurationTypeName parameter" -Pending {
+                It "Validate Set-PSSessionConfiguration with ApplicationBase, AssemblyName and ConfigurationTypeName parameter" {
 
                     $null = Set-PSSessionConfiguration -Name $TestSessionConfigName -ApplicationBase $script:TestAssemblyDir -AssemblyName $LocalTestAssemblyName -ConfigurationTypeName "PowershellTestConfigNamespace.PowershellTestConfig" -force
                     


### PR DESCRIPTION
This is for debugging the tests in AppVeyor.

It is not yet ready for review or merge.