### PR TITLE
Creates a single package for Windows 

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -353,7 +353,6 @@ Ronn
 Toolset
 v6
 WiX
-Runtimewin7-x64
  - docs/testing-guidelines/PowerShellCoreTestStatus.md
 Add-LocalGroupMember
 add-on

--- a/.spelling
+++ b/.spelling
@@ -353,6 +353,7 @@ Ronn
 Toolset
 v6
 WiX
+Runtimewin7-x64
  - docs/testing-guidelines/PowerShellCoreTestStatus.md
 Add-LocalGroupMember
 add-on

--- a/docs/maintainers/releasing.md
+++ b/docs/maintainers/releasing.md
@@ -165,10 +165,10 @@ Start-PSBuild -Clean -CrossGen -PSModuleRestore -Runtime win7-x64 -Configuration
 ```
 
 ```powershell
-# Create packages for v6.0.0-beta.1 release targeting Windows universal package. 
-# 'win7-x64' / 'win7-x86' will be used as the runtime.
-Start-PSPackage -Type msi -ReleaseTag v6.0.0-beta.1
-Start-PSPackage -Type zip -ReleaseTag v6.0.0-beta.1
+# Create packages for v6.0.0-beta.1 release targeting Windows universal package.
+# 'win7-x64' / 'win7-x86' should be used for -WindowsRuntime.
+Start-PSPackage -Type msi -ReleaseTag v6.0.0-beta.1 -WindowsRuntime 'win7-x64'
+Start-PSPackage -Type zip -ReleaseTag v6.0.0-beta.1 -WindowsRuntime 'win7-x64'
 ```
 
 ## NuGet Packages

--- a/docs/maintainers/releasing.md
+++ b/docs/maintainers/releasing.md
@@ -160,20 +160,15 @@ On Windows, the `-Runtime` parameter should be specified for `Start-PSBuild` to 
 # Install dependencies
 Start-PSBootstrap -Package
 
-# Build for v6.0.0-beta.1 release targeting Windows 10 and Server 2016
-Start-PSBuild -Clean -CrossGen -PSModuleRestore -Runtime win10-x64 -Configuration Release -ReleaseTag v6.0.0-beta.1
+# Build for v6.0.0-beta.1 release targeting Windows universal package, set ```-Runtime``` to ```win7-x64```
+Start-PSBuild -Clean -CrossGen -PSModuleRestore -Runtime win7-x64 -Configuration Release -ReleaseTag v6.0.0-beta.1
 ```
 
-If the package is targeting a downlevel Windows (not Windows 10 or Server 2016),
-the `-WindowsDownLevel` parameter should be specified for `Start-PSPackage`.
-Otherwise, the `-WindowsDownLevel` parameter should be left out.
-
 ```powershell
-# Create packages for v6.0.0-beta.1 release targeting Windows 10 and Server 2016.
-# When creating packages for downlevel Windows, such as Windows 8.1 or Server 2012R2,
-# the parameter '-WindowsDownLevel' must be specified.
-Start-PSPackage -Type msi -ReleaseTag v6.0.0-beta.1 <# -WindowsDownLevel win81-x64 #>
-Start-PSPackage -Type zip -ReleaseTag v6.0.0-beta.1 <# -WindowsDownLevel win81-x64 #>
+# Create packages for v6.0.0-beta.1 release targeting Windows universal package. 
+# 'win7-x64' / 'win7-x86' will be used as the runtime.
+Start-PSPackage -Type msi -ReleaseTag v6.0.0-beta.1
+Start-PSPackage -Type zip -ReleaseTag v6.0.0-beta.1
 ```
 
 ## NuGet Packages

--- a/docs/maintainers/releasing.md
+++ b/docs/maintainers/releasing.md
@@ -160,7 +160,7 @@ On Windows, the `-Runtime` parameter should be specified for `Start-PSBuild` to 
 # Install dependencies
 Start-PSBootstrap -Package
 
-# Build for v6.0.0-beta.1 release targeting Windows universal package, set ```-Runtime``` to ```win7-x64```
+# Build for v6.0.0-beta.1 release targeting Windows universal package, set -Runtime to win7-x64
 Start-PSBuild -Clean -CrossGen -PSModuleRestore -Runtime win7-x64 -Configuration Release -ReleaseTag v6.0.0-beta.1
 ```
 

--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -22,6 +22,11 @@ function Start-PSPackage {
         [ValidateSet("deb", "osxpkg", "rpm", "msi", "zip", "AppImage", "nupkg")]
         [string[]]$Type,
 
+        # Generate windows downlevel package
+        [ValidateSet("win7-x86", "win7-x64")]
+        [ValidateScript({$Environment.IsWindows})]
+        [string]$WindowsRuntime,
+
         [Switch] $Force,
 
         [Switch] $IncludeSymbols,
@@ -30,7 +35,11 @@ function Start-PSPackage {
     )
 
     # Runtime and Configuration settings required by the package
-    ($Runtime, $Configuration) = New-PSOptions -Configuration "Release" -WarningAction SilentlyContinue | ForEach-Object { $_.Runtime, $_.Configuration }
+    ($Runtime, $Configuration) = if ($WindowsRuntime) {
+        $WindowsRuntime, "Release"
+    } else {
+        New-PSOptions -Configuration "Release" -WarningAction SilentlyContinue | ForEach-Object { $_.Runtime, $_.Configuration }
+    }
 
     # We convert the runtime to win7-x64 or win7-x86 to build the universal windows package.
     if($Environment.IsWindows) {

--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -35,6 +35,9 @@ function Start-PSPackage {
     # We convert the runtime to win7-x64 or win7-x86 to build the universal windows package.
     if($Environment.IsWindows) {
         $Runtime = $Runtime -replace "win\d+", "win7"
+
+        # Build the name suffix for win-plat packages
+        $NameSuffix = $Runtime -replace 'win\d+', 'win'
     }
 
     log "Packaging RID: '$Runtime'; Packaging Configuration: '$Configuration'"
@@ -115,11 +118,6 @@ function Start-PSPackage {
         Write-Warning "-Type was not specified, continuing with $Type!"
     }
     log "Packaging Type: $Type"
-
-    # Build the name suffix for win-plat packages
-    if ($Environment.IsWindows) {
-        $NameSuffix = $Runtime -replace 'win\d+', 'win'
-    }
 
     # Add the symbols to the suffix 
     # if symbols are specified to be included


### PR DESCRIPTION
The updates to build.psm1 and packaging.psm1 create a single package (per bitness), which works on all the Windows OS versions, namely Windows 7 / Windows Server 2008 R2, Windows 8.1 / Windows Server 2012 R2, Windows 10 / Windows Server 2016. 

> I am in process of testing the packages on the various OS versions, hence please **DO NOT MERGE**. I will update this PR when testing is complete.

[daxian edited] This PR has been approved by @TravisEz13 and @iSazonov, so I merged it.

Fixes #4315 and #2608 