### PR TITLE
OpenCover and Code coverage improvements

### DIFF
--- a/test/tools/CodeCoverageAutomation/Start-CodeCoverageRun.ps1
+++ b/test/tools/CodeCoverageAutomation/Start-CodeCoverageRun.ps1
@@ -143,6 +143,12 @@ $jsonFile = "$outputBaseFolder\CC.json"
 
 try
 {
+    ## This is required so we do not keep on merging coverage reports.
+    if(Test-Path $outputLog)
+    {
+        Remove-Item $outputLog -Force -ErrorAction SilentlyContinue
+    }
+
     $oldErrorActionPreference = $ErrorActionPreference
     $ErrorActionPreference = 'Stop'
     Write-LogPassThru -Message "Starting downloads."
@@ -264,9 +270,5 @@ finally
 
     ## Disable the cleanup till we stabilize.
     #Remove-Item -recurse -force -path $outputBaseFolder
-
-    ## This is required so we do not keep on merging coverage reports.
-    Remove-Item $outputLog -Force -ErrorAction SilentlyContinue
-
     $ErrorActionPreference = $oldErrorActionPreference
 }

--- a/test/tools/OpenCover/OpenCover.psm1
+++ b/test/tools/OpenCover/OpenCover.psm1
@@ -555,7 +555,7 @@ function CreateOpenCoverCmdline($target, $outputLog, $targetArgs)
         "-hideskipped:all",
         "-mergeoutput",
         "-filter:`"+[*]* -[Microsoft.PowerShell.PSReadLine]*`"",
-        "-targetargs:`"-EncodedCommand $base64targetArgs`""
+        "-targetargs:`"-NoProfile -EncodedCommand $base64targetArgs`""
 
     $cmdlineAsString = $cmdline -join " "
 


### PR DESCRIPTION
- Delete the code coverage output file before the run instead of after the run. So we can remote desktop and see the last runs results,
- Use -noprofile for powershell.exe so that we restrict the testing the PSv6.