### PR TITLE
filesystem tests intermittently fail

### DIFF
--- a/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
@@ -203,17 +203,16 @@ Describe "Basic FileSystem Provider Tests" -Tags "CI" {
 
     Context "Validate behavior when access is denied" {
         BeforeAll {
+            $powershell = Join-Path $PSHOME "powershell"
             if ($IsWindows)
             {
-                $powershell = "powershell.exe"
                 $protectedPath = Join-Path ([environment]::GetFolderPath("windows")) "appcompat" "Programs"
                 $protectedPath2 = Join-Path $protectedPath "Install"
                 $newItemPath = Join-Path $protectedPath "foo"
             }
-            $errFile = "error.txt"
-            $doneFile = "done.txt"
+            $errFile = "$testdrive\error.txt"
+            $doneFile = "$testdrive\done.txt"
         }
-
         AfterEach {
             Remove-Item -Force $errFile -ErrorAction SilentlyContinue
             Remove-Item -Force $doneFile -ErrorAction SilentlyContinue
@@ -231,7 +230,7 @@ Describe "Basic FileSystem Provider Tests" -Tags "CI" {
 
             runas.exe /trustlevel:0x20000 "$powershell -nop -c try { $cmdline -ErrorAction Stop } catch { `$_.FullyQualifiedErrorId | Out-File $errFile }; New-Item -Type File -Path $doneFile"
             $startTime = Get-Date
-            while (((Get-Date) - $startTime).TotalSeconds -lt 5 -and -not (Test-Path $doneFile))
+            while (((Get-Date) - $startTime).TotalSeconds -lt 10 -and -not (Test-Path $doneFile))
             {
                 Start-Sleep -Milliseconds 100
             }


### PR DESCRIPTION
Based on the test output, it looks like two possible problems occurring:

1. test is timing out so it may be taking longer than 5 seconds to run, so increase timeout
2. the errfile from the previous run wasn't removed, not sure where test is writing that file, so moved it to the testdrive

Fix https://github.com/PowerShell/PowerShell/issues/4561
<!--

If you are a PowerShell Team member, please make sure you choose the Reviewer(s) and Assignee for your PR.
If you are not from the PowerShell Team, you can leave the fields blank and the Maintainers will choose them for you. If you are familiar with the team, feel free to mention some Reviewers yourself.

For more information about the roles of Reviewer and Assignee, refer to CONTRIBUTING.md.

-->
