### PR TITLE
Remove alternate file stream code from non-Windows

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/UnblockFile.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/UnblockFile.cs
@@ -14,6 +14,7 @@ using System.Management.Automation.Internal;
 
 #endregion
 
+#if !UNIX
 namespace Microsoft.PowerShell.Commands
 {
     /// <summary>Removes the Zone.Identifier stream from a file.</summary>
@@ -162,3 +163,4 @@ namespace Microsoft.PowerShell.Commands
         }
     }
 }
+#endif

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/UnblockFile.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/UnblockFile.cs
@@ -1,3 +1,4 @@
+#if !UNIX
 /********************************************************************++
 Copyright (c) Microsoft Corporation.  All rights reserved.
 --********************************************************************/
@@ -14,7 +15,6 @@ using System.Management.Automation.Internal;
 
 #endregion
 
-#if !UNIX
 namespace Microsoft.PowerShell.Commands
 {
     /// <summary>Removes the Zone.Identifier stream from a file.</summary>

--- a/src/System.Management.Automation/engine/Modules/ImportModuleCommand.cs
+++ b/src/System.Management.Automation/engine/Modules/ImportModuleCommand.cs
@@ -1304,7 +1304,9 @@ namespace Microsoft.PowerShell.Commands
                     fullPath,
                     file.RawFileData);
 
+#if !UNIX
                 AlternateDataStreamUtilities.SetZoneOfOrigin(fullPath, SecurityZone.Intranet);
+#endif
             }
 
             return relativePathsToCreatedFiles;

--- a/src/System.Management.Automation/namespaces/FileSystemContentStream.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemContentStream.cs
@@ -843,7 +843,9 @@ namespace Microsoft.PowerShell.Commands
             {
                 if (!String.IsNullOrEmpty(streamName))
                 {
+#if !UNIX
                     _stream = AlternateDataStreamUtilities.CreateFileStream(filePath, streamName, fileMode, fileAccess, fileShare);
+#endif
                 }
                 else
                 {
@@ -854,7 +856,9 @@ namespace Microsoft.PowerShell.Commands
             {
                 if (!String.IsNullOrEmpty(streamName))
                 {
+#if !UNIX
                     _stream = AlternateDataStreamUtilities.CreateFileStream(filePath, streamName, fileMode, requestedAccess, fileShare);
+#endif
                 }
                 else
                 {

--- a/src/System.Management.Automation/namespaces/FileSystemContentStream.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemContentStream.cs
@@ -845,6 +845,8 @@ namespace Microsoft.PowerShell.Commands
                 {
 #if !UNIX
                     _stream = AlternateDataStreamUtilities.CreateFileStream(filePath, streamName, fileMode, fileAccess, fileShare);
+#else
+                    throw new PlatformNotSupportedException();
 #endif
                 }
                 else
@@ -858,6 +860,8 @@ namespace Microsoft.PowerShell.Commands
                 {
 #if !UNIX
                     _stream = AlternateDataStreamUtilities.CreateFileStream(filePath, streamName, fileMode, requestedAccess, fileShare);
+#else
+                    throw new PlatformNotSupportedException();
 #endif
                 }
                 else

--- a/src/System.Management.Automation/namespaces/FileSystemContentStream.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemContentStream.cs
@@ -841,30 +841,26 @@ namespace Microsoft.PowerShell.Commands
 
             try
             {
+#if !UNIX
                 if (!String.IsNullOrEmpty(streamName))
                 {
-#if !UNIX
                     _stream = AlternateDataStreamUtilities.CreateFileStream(filePath, streamName, fileMode, fileAccess, fileShare);
-#else
-                    throw new PlatformNotSupportedException();
-#endif
                 }
                 else
+#endif
                 {
                     _stream = new FileStream(filePath, fileMode, fileAccess, fileShare);
                 }
             }
             catch (IOException)
             {
+#if !UNIX
                 if (!String.IsNullOrEmpty(streamName))
                 {
-#if !UNIX
                     _stream = AlternateDataStreamUtilities.CreateFileStream(filePath, streamName, fileMode, requestedAccess, fileShare);
-#else
-                    throw new PlatformNotSupportedException();
-#endif
                 }
                 else
+#endif
                 {
                     _stream = new FileStream(filePath, fileMode, requestedAccess, fileShare);
                 }

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -1046,6 +1046,7 @@ namespace Microsoft.PowerShell.Commands
             path = NormalizePath(path);
             path = EnsureDriveIsRooted(path);
 
+#if !UNIX
             // Remove alternate data stream references
             // See if they've used the inline stream syntax. They have more than one colon.
             int firstColon = path.IndexOf(':');
@@ -1054,6 +1055,7 @@ namespace Microsoft.PowerShell.Commands
             {
                 path = path.Substring(0, secondColon);
             }
+#endif
 
             //Make sure the path is either drive rooted or UNC Path
             if (!IsAbsolutePath(path) && !IsUNCPath(path))
@@ -4686,9 +4688,9 @@ namespace Microsoft.PowerShell.Commands
 
             bool result = CopyFileStreamToRemoteSession(file, remoteFilePath, ps, false, null);
 
+#if !UNIX
             bool targetSupportsAlternateStreams = RemoteTargetSupportsAlternateStreams(ps, remoteFilePath);
 
-#if !UNIX
             // Once the file is copied successfully, check if the file has any alternate data streams
             if (result && targetSupportsAlternateStreams)
             {
@@ -5165,6 +5167,7 @@ namespace Microsoft.PowerShell.Commands
 
             s_tracer.WriteLine("basePath = {0}", basePath);
 
+#if !UNIX
             // Remove alternate data stream references
             // See if they've used the inline stream syntax. They have more than one colon.
             string alternateDataStream = String.Empty;
@@ -5176,6 +5179,7 @@ namespace Microsoft.PowerShell.Commands
                 alternateDataStream = path.Replace(newPath, "");
                 path = newPath;
             }
+#endif
 
             string result = path;
 
@@ -5299,10 +5303,12 @@ namespace Microsoft.PowerShell.Commands
                 }
             } while (false);
 
+#if !UNIX
             if (!String.IsNullOrEmpty(alternateDataStream))
             {
                 result = result + alternateDataStream;
             }
+#endif
 
             return result;
         } // NormalizeRelativePathHelper
@@ -6619,6 +6625,7 @@ namespace Microsoft.PowerShell.Commands
                 } // dynParams != null
             } // DynamicParameters != null
 
+#if !UNIX
             // See if they've used the inline stream syntax. They have more than one colon.
             int firstColon = path.IndexOf(':');
             int secondColon = path.IndexOf(':', firstColon + 1);
@@ -6627,6 +6634,7 @@ namespace Microsoft.PowerShell.Commands
                 streamName = path.Substring(secondColon + 1);
                 path = path.Remove(secondColon);
             }
+#endif
 
             FileSystemContentReaderWriter stream = null;
 
@@ -6765,6 +6773,7 @@ namespace Microsoft.PowerShell.Commands
                 } // dynParams != null
             }
 
+#if !UNIX
             // See if they've used the inline stream syntax. They have more than one colon.
             int firstColon = path.IndexOf(':');
             int secondColon = path.IndexOf(':', firstColon + 1);
@@ -6773,6 +6782,7 @@ namespace Microsoft.PowerShell.Commands
                 streamName = path.Substring(secondColon + 1);
                 path = path.Remove(secondColon);
             }
+#endif
 
             FileSystemContentReaderWriter stream = null;
 

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -2804,17 +2804,22 @@ namespace Microsoft.PowerShell.Commands
                     return;
                 }
 
-#if !UNIX
-                if ((!removeStreams) && iscontainer)
-#else
+#if UNIX
                 if (iscontainer)
-#endif
                 {
                     RemoveDirectoryInfoItem((DirectoryInfo)fsinfo, recurse, Force, true);
                 }
                 else
                 {
-#if !UNIX
+                    RemoveFileInfoItem((FileInfo)fsinfo, Force);
+                }
+#else
+                if ((!removeStreams) && iscontainer)
+                {
+                    RemoveDirectoryInfoItem((DirectoryInfo)fsinfo, recurse, Force, true);
+                }
+                else
+                {
                     // If we want to remove the file streams, retrieve them and remove them.
                     if (removeStreams)
                     {
@@ -2854,11 +2859,11 @@ namespace Microsoft.PowerShell.Commands
                         }
                     }
                     else
-#endif
                     {
                         RemoveFileInfoItem((FileInfo)fsinfo, Force);
                     }
                 }
+#endif
             }
             catch (IOException exception)
             {
@@ -4267,11 +4272,13 @@ namespace Microsoft.PowerShell.Commands
                         ps.AddParameter("force", true);
                     }
 
+#if !UNIX
                     if (isAlternateDataStream)
                     {
                         ps.AddParameter("isAlternateStream", true);
                         ps.AddParameter("streamName", streamName);
                     }
+#endif
 
                     Hashtable op = SafeInvokeCommand.Invoke(ps, this, null);
 

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -6612,8 +6612,10 @@ namespace Microsoft.PowerShell.Commands
                     // Get the wait value
                     waitForChanges = dynParams.Wait;
 
+#if !UNIX
                     // Get the stream name
                     streamName = dynParams.Stream;
+#endif
                 } // dynParams != null
             } // DynamicParameters != null
 
@@ -6756,7 +6758,9 @@ namespace Microsoft.PowerShell.Commands
                         encoding = dynParams.EncodingType;
                     }
 
+#if !UNIX
                     streamName = dynParams.Stream;
+#endif
                     suppressNewline = dynParams.NoNewline.IsPresent;
                 } // dynParams != null
             }
@@ -7628,12 +7632,13 @@ namespace Microsoft.PowerShell.Commands
         [Parameter]
         public FileSystemCmdletProviderEncoding Encoding { get; set; } = FileSystemCmdletProviderEncoding.String;
 
+#if !UNIX
         /// <summary>
         /// A parameter to return a stream of an item.
         /// </summary>
         [Parameter]
         public String Stream { get; set; }
-
+#endif
 
         /// <summary>
         /// Gets the encoding from the specified StreamType parameter.
@@ -7677,11 +7682,13 @@ namespace Microsoft.PowerShell.Commands
     /// </summary>
     public class FileSystemClearContentDynamicParameters
     {
+#if !UNIX
         /// <summary>
         /// A parameter to return a stream of an item.
         /// </summary>
         [Parameter]
         public String Stream { get; set; }
+#endif
     } //FileSystemContentWriterDynamicParameters
 
     /// <summary>
@@ -7805,6 +7812,7 @@ namespace Microsoft.PowerShell.Commands
     /// </summary>
     public class FileSystemProviderGetItemDynamicParameters
     {
+#if !UNIX
         /// <summary>
         /// A parameter to return the streams of an item.
         /// </summary>
@@ -7812,6 +7820,7 @@ namespace Microsoft.PowerShell.Commands
         [ValidateNotNullOrEmpty()]
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays")]
         public string[] Stream { get; set; }
+#endif
     } // class FileSystemItemProviderDynamicParameters
 
     /// <summary>
@@ -7819,6 +7828,7 @@ namespace Microsoft.PowerShell.Commands
     /// </summary>
     public class FileSystemProviderRemoveItemDynamicParameters
     {
+#if !UNIX
         /// <summary>
         /// A parameter to return the streams of an item.
         /// </summary>
@@ -7826,6 +7836,7 @@ namespace Microsoft.PowerShell.Commands
         [ValidateNotNullOrEmpty()]
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays")]
         public string[] Stream { get; set; }
+#endif
     } // class FileSystemItemProviderDynamicParameters
 
     #endregion
@@ -8285,7 +8296,7 @@ namespace Microsoft.PowerShell.Commands
         }
 
 #if !UNIX
-        internal static bool WinIsSameFileSystemItem(string pathOne, string pathTwo)
+        private static bool WinIsSameFileSystemItem(string pathOne, string pathTwo)
         {
             var access = FileAccess.Read;
             var share = FileShare.Read;
@@ -8324,7 +8335,7 @@ namespace Microsoft.PowerShell.Commands
         }
 
 #if !UNIX
-        internal static bool WinGetInodeData(string path, out System.ValueTuple<UInt64, UInt64> inodeData)
+        private static bool WinGetInodeData(string path, out System.ValueTuple<UInt64, UInt64> inodeData)
         {
             var access = FileAccess.Read;
             var share = FileShare.Read;

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -1117,6 +1117,7 @@ namespace Microsoft.PowerShell.Commands
 
             try
             {
+#if !UNIX
                 bool retrieveStreams = false;
                 FileSystemProviderGetItemDynamicParameters dynamicParameters = null;
 
@@ -1146,10 +1147,12 @@ namespace Microsoft.PowerShell.Commands
                         }
                     }
                 }
+#endif
 
                 FileSystemInfo result = GetFileSystemItem(path, ref isContainer, false);
                 if (result != null)
                 {
+#if !UNIX
                     // If we want to retrieve the file streams, retrieve them.
                     if (retrieveStreams)
                     {
@@ -1186,6 +1189,7 @@ namespace Microsoft.PowerShell.Commands
                         }
                     }
                     else
+#endif
                     {
                         // Otherwise, return the item itself.
                         WriteItemObject(result, result.FullName, isContainer);
@@ -2758,6 +2762,7 @@ namespace Microsoft.PowerShell.Commands
             {
                 path = NormalizePath(path);
 
+#if !UNIX
                 bool removeStreams = false;
                 FileSystemProviderRemoveItemDynamicParameters dynamicParameters = null;
 
@@ -2787,6 +2792,7 @@ namespace Microsoft.PowerShell.Commands
                         }
                     }
                 }
+#endif
 
                 bool iscontainer = false;
                 FileSystemInfo fsinfo = GetFileSystemInfo(path, ref iscontainer);
@@ -2798,12 +2804,17 @@ namespace Microsoft.PowerShell.Commands
                     return;
                 }
 
+#if !UNIX
                 if ((!removeStreams) && iscontainer)
+#else
+                if (iscontainer)
+#endif
                 {
                     RemoveDirectoryInfoItem((DirectoryInfo)fsinfo, recurse, Force, true);
                 }
                 else
                 {
+#if !UNIX
                     // If we want to remove the file streams, retrieve them and remove them.
                     if (removeStreams)
                     {
@@ -2843,6 +2854,7 @@ namespace Microsoft.PowerShell.Commands
                         }
                     }
                     else
+#endif
                     {
                         RemoveFileInfoItem((FileInfo)fsinfo, Force);
                     }
@@ -4233,12 +4245,13 @@ namespace Microsoft.PowerShell.Commands
                     wStream = new FileStream(destinationFile.FullName, FileMode.Create);
                 }
 
+#if !UNIX
                 // an alternate stream
                 else
                 {
                     wStream = AlternateDataStreamUtilities.CreateFileStream(destinationFile.FullName, streamName, FileMode.Append, FileAccess.Write, FileShare.ReadWrite);
                 }
-
+#endif
                 long fragmentSize = FILETRANSFERSIZE;
                 long copiedSoFar = 0;
                 long currentIndex = 0;
@@ -4498,11 +4511,12 @@ namespace Microsoft.PowerShell.Commands
                 {
                     fStream = File.OpenRead(file.FullName);
                 }
+#if !UNIX
                 else
                 {
                     fStream = AlternateDataStreamUtilities.CreateFileStream(file.FullName, streamName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
                 }
-
+#endif
                 long remainingFileSize = fStream.Length;
                 do
                 {
@@ -4667,6 +4681,7 @@ namespace Microsoft.PowerShell.Commands
 
             bool targetSupportsAlternateStreams = RemoteTargetSupportsAlternateStreams(ps, remoteFilePath);
 
+#if !UNIX
             // Once the file is copied successfully, check if the file has any alternate data streams
             if (result && targetSupportsAlternateStreams)
             {
@@ -4682,7 +4697,7 @@ namespace Microsoft.PowerShell.Commands
                     }
                 }
             }
-
+#endif
             if (result)
             {
                 SetRemoteFileMetadata(file, Path.Combine(destinationPath, file.Name), ps);
@@ -6828,10 +6843,11 @@ namespace Microsoft.PowerShell.Commands
 
             try
             {
+#if !UNIX
                 bool clearStream = false;
+                string streamName = null;
                 FileSystemClearContentDynamicParameters dynamicParameters = null;
                 FileSystemContentWriterDynamicParameters writerDynamicParameters = null;
-                string streamName = null;
 
                 // We get called during:
                 //     - Clear-Content
@@ -6900,6 +6916,7 @@ namespace Microsoft.PowerShell.Commands
                     }
                 }
                 else
+#endif
                 {
                     string action = FileSystemProviderStrings.ClearContentActionFile;
                     string resource = StringUtil.Format(FileSystemProviderStrings.ClearContentesourceTemplate, path);
@@ -8260,6 +8277,7 @@ namespace Microsoft.PowerShell.Commands
 #endif
         }
 
+#if !UNIX
         internal static bool WinIsSameFileSystemItem(string pathOne, string pathTwo)
         {
             var access = FileAccess.Read;
@@ -8286,6 +8304,7 @@ namespace Microsoft.PowerShell.Commands
 
             return false;
         }
+#endif
 
         internal static bool GetInodeData(string path, out System.ValueTuple<UInt64, UInt64> inodeData)
         {
@@ -8297,6 +8316,7 @@ namespace Microsoft.PowerShell.Commands
             return rv;
         }
 
+#if !UNIX
         internal static bool WinGetInodeData(string path, out System.ValueTuple<UInt64, UInt64> inodeData)
         {
             var access = FileAccess.Read;
@@ -8325,7 +8345,7 @@ namespace Microsoft.PowerShell.Commands
             inodeData = (0, 0);
             return false;
         }
-
+#endif
         internal static bool IsHardLink(ref IntPtr handle)
         {
 #if UNIX
@@ -8632,6 +8652,7 @@ namespace Microsoft.PowerShell.Commands
 
 namespace System.Management.Automation.Internal
 {
+#if !UNIX
     #region AlternateDataStreamUtilities
 
     /// <summary>
@@ -8847,6 +8868,7 @@ namespace System.Management.Automation.Internal
     }
 
     #endregion
+#endif
 
     #region CopyFileFromRemoteUtils
 

--- a/src/System.Management.Automation/security/SecurityManager.cs
+++ b/src/System.Management.Automation/security/SecurityManager.cs
@@ -402,6 +402,9 @@ namespace Microsoft.PowerShell
 
         private bool IsLocalFile(string filename)
         {
+#if UNIX
+            return true;
+#else
             SecurityZone zone = ClrFacade.GetFileSecurityZone(filename);
 
             if (zone == SecurityZone.MyComputer ||
@@ -412,6 +415,7 @@ namespace Microsoft.PowerShell
             }
 
             return false;
+#endif
         }
 
         // Checks that a publisher is trusted by the system or is one of

--- a/src/System.Management.Automation/utils/ClrFacade.cs
+++ b/src/System.Management.Automation/utils/ClrFacade.cs
@@ -147,12 +147,14 @@ namespace System.Management.Automation
         {
             Diagnostics.Assert(Path.IsPathRooted(filePath), "Caller makes sure the path is rooted.");
             Diagnostics.Assert(Utils.NativeFileExists(filePath), "Caller makes sure the file exists.");
+#if !UNIX
             string sysRoot = System.Environment.GetEnvironmentVariable("SystemRoot");
             string urlmonPath = Path.Combine(sysRoot, @"System32\urlmon.dll");
             if (Utils.NativeFileExists(urlmonPath))
             {
                 return MapSecurityZoneWithUrlmon(filePath);
             }
+#endif
             return MapSecurityZoneWithoutUrlmon(filePath);
         }
 

--- a/src/System.Management.Automation/utils/ClrFacade.cs
+++ b/src/System.Management.Automation/utils/ClrFacade.cs
@@ -138,6 +138,7 @@ namespace System.Management.Automation
 
         #endregion Encoding
 
+#if !UNIX
         #region Security
 
         /// <summary>
@@ -147,14 +148,12 @@ namespace System.Management.Automation
         {
             Diagnostics.Assert(Path.IsPathRooted(filePath), "Caller makes sure the path is rooted.");
             Diagnostics.Assert(Utils.NativeFileExists(filePath), "Caller makes sure the file exists.");
-#if !UNIX
             string sysRoot = System.Environment.GetEnvironmentVariable("SystemRoot");
             string urlmonPath = Path.Combine(sysRoot, @"System32\urlmon.dll");
             if (Utils.NativeFileExists(urlmonPath))
             {
                 return MapSecurityZoneWithUrlmon(filePath);
             }
-#endif
             return MapSecurityZoneWithoutUrlmon(filePath);
         }
 
@@ -199,10 +198,8 @@ namespace System.Management.Automation
         /// </remarks>
         private static SecurityZone MapSecurityZoneWithoutUrlmon(string filePath)
         {
-#if !UNIX
             SecurityZone reval = ReadFromZoneIdentifierDataStream(filePath);
             if (reval != SecurityZone.NoZone) { return reval; }
-#endif
             // If it reaches here, then we either couldn't get the ZoneId information, or the ZoneId is invalid.
             // In this case, we try to determine the SecurityZone by analyzing the file path.
             Uri uri = new Uri(filePath);
@@ -241,7 +238,6 @@ namespace System.Management.Automation
             }
         }
 
-#if !UNIX
         /// <summary>
         /// Read the 'Zone.Identifier' alternate data stream to determin SecurityZone of the file.
         /// </summary>
@@ -301,7 +297,6 @@ namespace System.Management.Automation
 
             return SecurityZone.NoZone;
         }
-#endif
         #endregion WithoutUrlmon
 
         /// <summary>
@@ -341,6 +336,7 @@ namespace System.Management.Automation
         }
 
         #endregion Security
+#endif
 
         #region Misc
 

--- a/src/System.Management.Automation/utils/ClrFacade.cs
+++ b/src/System.Management.Automation/utils/ClrFacade.cs
@@ -147,7 +147,6 @@ namespace System.Management.Automation
         {
             Diagnostics.Assert(Path.IsPathRooted(filePath), "Caller makes sure the path is rooted.");
             Diagnostics.Assert(Utils.NativeFileExists(filePath), "Caller makes sure the file exists.");
-#if CORECLR
             string sysRoot = System.Environment.GetEnvironmentVariable("SystemRoot");
             string urlmonPath = Path.Combine(sysRoot, @"System32\urlmon.dll");
             if (Utils.NativeFileExists(urlmonPath))
@@ -155,12 +154,8 @@ namespace System.Management.Automation
                 return MapSecurityZoneWithUrlmon(filePath);
             }
             return MapSecurityZoneWithoutUrlmon(filePath);
-#else
-            return MapSecurityZoneWithUrlmon(filePath);
-#endif
         }
 
-#if CORECLR
         #region WithoutUrlmon
 
         /// <summary>
@@ -202,9 +197,10 @@ namespace System.Management.Automation
         /// </remarks>
         private static SecurityZone MapSecurityZoneWithoutUrlmon(string filePath)
         {
+#if !UNIX
             SecurityZone reval = ReadFromZoneIdentifierDataStream(filePath);
             if (reval != SecurityZone.NoZone) { return reval; }
-
+#endif
             // If it reaches here, then we either couldn't get the ZoneId information, or the ZoneId is invalid.
             // In this case, we try to determine the SecurityZone by analyzing the file path.
             Uri uri = new Uri(filePath);
@@ -243,6 +239,7 @@ namespace System.Management.Automation
             }
         }
 
+#if !UNIX
         /// <summary>
         /// Read the 'Zone.Identifier' alternate data stream to determin SecurityZone of the file.
         /// </summary>
@@ -302,8 +299,8 @@ namespace System.Management.Automation
 
             return SecurityZone.NoZone;
         }
-        #endregion WithoutUrlmon
 #endif
+        #endregion WithoutUrlmon
 
         /// <summary>
         /// Map the file to SecurityZone using urlmon.dll, depending on 'IInternetSecurityManager::MapUrlToZone'.

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Clear-Content.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Clear-Content.Tests.ps1
@@ -83,7 +83,7 @@ Describe "Clear-Content cmdlet tests" -Tags "CI" {
       get-content -Path "TESTDRIVE:/$file3" -stream $streamName | should BeNullOrEmpty
     }
 
-    It "the '-Stream' dynamic parameter is visible to get-command in the filesystem" {
+    It "the '-Stream' dynamic parameter is visible to get-command in the filesystem" -Skip:(!$IsWindows) {
       try {
         push-location TESTDRIVE:
         (get-command clear-content -stream foo).parameters.keys -eq "stream" | should be "stream"

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Content.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Content.Tests.ps1
@@ -134,10 +134,34 @@ Describe "Get-Content" -Tags "CI" {
     Get-Content $testPath | Should BeExactly $testString
   }
 
+  It "Should support NTFS streams using -stream" -Skip:(!$IsWindows) {
+    Set-Content -Path $testPath -Stream hello -Value World
+    Get-Content -Path $testPath | Should Be $testString
+    Get-Content -Path $testPath -Stream hello | Should Be "World"
+    $item = Get-Item -Path $testPath -Stream hello
+    $item | Should BeOfType System.Management.Automation.Internal.AlternateStreamData
+    $item.Stream | Should Be "hello"
+    Clear-Content -Path $testPath -Stream hello
+    Get-Content -Path $testPath -Stream hello | Should BeNullOrEmpty
+    Remove-Item -Path $testPath -Stream hello
+    { Get-Content -Path $testPath -Stream hello | ShouldBeErrorId "GetContentReaderFileNotFoundError,Microsoft.PowerShell.Commands.GetContentCommand" }
+  }
+
   It "Should support colons in filename on Linux/Mac" -Skip:($IsWindows) {
     Set-Content "${testPath}:Stream" -Value "Hello"
     "${testPath}:Stream" | Should Exist
     Get-Content "${testPath}:Stream" | Should BeExactly "Hello"
   }
 
+  It "-Stream is not a valid parameter for <cmdlet> on Linux/Mac" -Skip:($IsWindows) -TestCases @(
+    @{cmdlet="get-content"},
+    @{cmdlet="set-content"},
+    @{cmdlet="clear-content"},
+    @{cmdlet="add-content"},
+    @{cmdlet="get-item"},
+    @{cmdlet="remove-item"}
+  ) {
+    param($cmdlet)
+    (Get-Command $cmdlet).Parameters["stream"] | Should BeNullOrEmpty
+  }  
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Content.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Content.Tests.ps1
@@ -129,13 +129,14 @@ Describe "Get-Content" -Tags "CI" {
 
   It "Should support NTFS streams using colon syntax" -Skip:(!$IsWindows) {
     Set-Content "${testPath}:Stream" -Value "Foo"
-    { Test_path "${testPath}:Stream" | ShouldBeErrorId "ItemExistsNotSupportedError,Microsoft.PowerShell.Commands,TestPathCommand" }
+    { Test-Path "${testPath}:Stream" | ShouldBeErrorId "ItemExistsNotSupportedError,Microsoft.PowerShell.Commands,TestPathCommand" }
     Get-Content "${testPath}:Stream" | Should BeExactly "Foo"
     Get-Content $testPath | Should BeExactly $testString
   }
 
   It "Should support colons in filename on Linux/Mac" -Skip:($IsWindows) {
     Set-Content "${testPath}:Stream" -Value "Hello"
+    "${testPath}:Stream" | Should Exist
     Get-Content "${testPath}:Stream" | Should BeExactly "Hello"
   }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Content.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Content.Tests.ps1
@@ -126,4 +126,17 @@ Describe "Get-Content" -Tags "CI" {
     } else {$expected = "Hell","o,ll","ll","Worll","d`nHell","o2,ll","ll","Worll","d2`n"}
     for ($i = 0; $i -lt $result.Length ; $i++) { $result[$i]  | Should BeExactly $expected[$i]}
   }
+
+  It "Should support NTFS streams using colon syntax" -Skip:(!$IsWindows) {
+    Set-Content "${testPath}:Stream" -Value "Foo"
+    { Test_path "${testPath}:Stream" | ShouldBeErrorId "ItemExistsNotSupportedError,Microsoft.PowerShell.Commands,TestPathCommand" }
+    Get-Content "${testPath}:Stream" | Should BeExactly "Foo"
+    Get-Content $testPath | Should BeExactly $testString
+  }
+
+  It "Should support colons in filename on Linux/Mac" -Skip:($IsWindows) {
+    Set-Content "${testPath}:Stream" -Value "Hello"
+    Get-Content "${testPath}:Stream" | Should BeExactly "Hello"
+  }
+
 }


### PR DESCRIPTION
AlternateStreams support relies on pinvoke to win32 apis which don't work

on non-Windows and produces errors about not loading a dll in the case of copy-item

Fix https://github.com/PowerShell/PowerShell/issues/4542

<!--

If you are a PowerShell Team member, please make sure you choose the Reviewer(s) and Assignee for your PR.
If you are not from the PowerShell Team, you can leave the fields blank and the Maintainers will choose them for you. If you are familiar with the team, feel free to mention some Reviewers yourself.

For more information about the roles of Reviewer and Assignee, refer to CONTRIBUTING.md.

-->
