### PR TITLE
Move to the official .NET Core 2.0

### DIFF
--- a/PowerShell.Common.props
+++ b/PowerShell.Common.props
@@ -6,7 +6,7 @@
 
     <VersionPrefix>6.0.0</VersionPrefix>
     <TargetFramework>netcoreapp2.0</TargetFramework>
-    <RuntimeFrameworkVersion>2.0.0-preview3-25426-01</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>2.0.0</RuntimeFrameworkVersion>
 
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@
 
 image: Visual Studio 2017
 
-# cache version - netcoreapp.2.0.0-preview3-25426-01
+# cache version - netcoreapp.2.0.0
 cache:
   - '%LocalAppData%\Microsoft\dotnet -> appveyor.yml'
   - '%HOMEDRIVE%%HOMEPATH%\.nuget\packages -> appveyor.yml'

--- a/build.psm1
+++ b/build.psm1
@@ -2,8 +2,8 @@
 # On Windows paths is separated by semicolon
 $script:TestModulePathSeparator = [System.IO.Path]::PathSeparator
 
-$dotnetCLIChannel = "preview"
-$dotnetCLIRequiredVersion = "2.0.0-preview2-006502"
+$dotnetCLIChannel = "release"
+$dotnetCLIRequiredVersion = "2.0.0"
 
 # Track if tags have been sync'ed
 $tagsUpToDate = $false

--- a/build.psm1
+++ b/build.psm1
@@ -490,12 +490,6 @@ Fix steps:
         Pop-Location
     }
 
-    # add 'x' permission when building the standalone application
-    # this is temporary workaround to a bug in dotnet.exe, tracking by dotnet/cli issue #6286
-    if ($Options.Configuration -eq "Linux") {
-        chmod u+x $Options.Output
-    }
-
     # publish netcoreapp2.0 reference assemblies
     try {
         Push-Location "$PSScriptRoot/src/TypeCatalogGen"
@@ -798,12 +792,6 @@ function Publish-PSTestTools {
             dotnet publish --output bin --configuration $Options.Configuration --framework $Options.Framework --runtime $Options.Runtime
             $toolPath = Join-Path -Path $tool.Path -ChildPath "bin"
 
-            # add 'x' permission when building the standalone application
-            # this is temporary workaround to a bug in dotnet.exe, tracking by dotnet/cli issue #6286
-            if ($Options.Configuration -eq "Linux") {
-                $executable = Join-Path -Path $toolPath -ChildPath "$($tool.Output)"
-                chmod u+x $executable
-            }
             if ( $env:PATH -notcontains $toolPath ) {
                 $env:PATH = $toolPath+$TestModulePathSeparator+$($env:PATH)
             }
@@ -1843,12 +1831,6 @@ function Start-CrossGen {
         throw "Unable to find latest version of crossgen.exe. 'Please run Start-PSBuild -Clean' first, and then try again."
     }
     Write-Verbose "Matched CrossGen.exe: $crossGenPath" -Verbose
-
-    # 'x' permission is not set for packages restored on Linux/OSX.
-    # this is temporary workaround to a bug in dotnet.exe, tracking by dotnet/cli issue #6286
-    if ($Environment.IsLinux -or $Environment.IsOSX) {
-        chmod u+x $crossGenPath
-    }
 
     # Crossgen.exe requires the following assemblies:
     # mscorlib.dll

--- a/src/Microsoft.PowerShell.Commands.Management/Microsoft.PowerShell.Commands.Management.csproj
+++ b/src/Microsoft.PowerShell.Commands.Management/Microsoft.PowerShell.Commands.Management.csproj
@@ -70,7 +70,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.ServiceProcess.ServiceController" Version="4.4.0-preview3-25423-02" />
+    <PackageReference Include="System.ServiceProcess.ServiceController" Version="4.4.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.PowerShell.Commands.Utility/Microsoft.PowerShell.Commands.Utility.csproj
+++ b/src/Microsoft.PowerShell.Commands.Utility/Microsoft.PowerShell.Commands.Utility.csproj
@@ -79,7 +79,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.2.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.3.1" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.PowerShell.ConsoleHost/Microsoft.PowerShell.ConsoleHost.csproj
+++ b/src/Microsoft.PowerShell.ConsoleHost/Microsoft.PowerShell.ConsoleHost.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\System.Management.Automation\System.Management.Automation.csproj" />
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.3.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.4.0" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/Microsoft.PowerShell.CoreCLR.Eventing/Microsoft.PowerShell.CoreCLR.Eventing.csproj
+++ b/src/Microsoft.PowerShell.CoreCLR.Eventing/Microsoft.PowerShell.CoreCLR.Eventing.csproj
@@ -25,7 +25,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Security.Principal.Windows" Version="4.4.0-preview3-25423-02" />
+    <PackageReference Include="System.Security.Principal.Windows" Version="4.4.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.PowerShell.SDK/Microsoft.PowerShell.SDK.csproj
+++ b/src/Microsoft.PowerShell.SDK/Microsoft.PowerShell.SDK.csproj
@@ -17,17 +17,17 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Data.SqlClient" Version="4.4.0-preview3-25423-02" />
-    <PackageReference Include="System.IO.Packaging" Version="4.4.0-preview3-25423-02" />
-    <PackageReference Include="System.Net.Http.WinHttpHandler" Version="4.4.0-preview3-25423-02" />
-    <PackageReference Include="System.ServiceModel.Duplex" Version="4.4.0-preview3-25423-01" />
-    <PackageReference Include="System.ServiceModel.Http" Version="4.4.0-preview3-25423-01" />
-    <PackageReference Include="System.ServiceModel.NetTcp" Version="4.4.0-preview3-25423-01" />
-    <PackageReference Include="System.ServiceModel.Primitives" Version="4.4.0-preview3-25423-01" />
-    <PackageReference Include="System.ServiceModel.Security" Version="4.4.0-preview3-25423-01" />
-    <PackageReference Include="System.Text.Encodings.Web" Version="4.4.0-preview3-25423-02" />
-    <PackageReference Include="System.Threading.AccessControl" Version="4.4.0-preview3-25423-02" />
-    <PackageReference Include="System.Private.ServiceModel" Version="4.4.0-preview3-25423-01" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.4.0" />
+    <PackageReference Include="System.IO.Packaging" Version="4.4.0" />
+    <PackageReference Include="System.Net.Http.WinHttpHandler" Version="4.4.0" />
+    <PackageReference Include="System.ServiceModel.Duplex" Version="4.4.0" />
+    <PackageReference Include="System.ServiceModel.Http" Version="4.4.0" />
+    <PackageReference Include="System.ServiceModel.NetTcp" Version="4.4.0" />
+    <PackageReference Include="System.ServiceModel.Primitives" Version="4.4.0" />
+    <PackageReference Include="System.ServiceModel.Security" Version="4.4.0" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="4.4.0" />
+    <PackageReference Include="System.Threading.AccessControl" Version="4.4.0" />
+    <PackageReference Include="System.Private.ServiceModel" Version="4.4.0" />
     <PackageReference Include="Microsoft.NETCore.Windows.ApiSets" Version="1.0.1" />
   </ItemGroup>
 

--- a/src/System.Management.Automation/System.Management.Automation.csproj
+++ b/src/System.Management.Automation/System.Management.Automation.csproj
@@ -11,13 +11,13 @@
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.PowerShell.CoreCLR.AssemblyLoadContext\Microsoft.PowerShell.CoreCLR.AssemblyLoadContext.csproj" />
     <ProjectReference Include="..\Microsoft.PowerShell.CoreCLR.Eventing\Microsoft.PowerShell.CoreCLR.Eventing.csproj" />
-    <PackageReference Include="Microsoft.Win32.Registry.AccessControl" Version="4.4.0-preview3-25423-02" />
+    <PackageReference Include="Microsoft.Win32.Registry.AccessControl" Version="4.4.0" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.1" />
-    <PackageReference Include="System.IO.FileSystem.AccessControl" Version="4.4.0-preview3-25423-02" />
-    <PackageReference Include="System.Security.AccessControl" Version="4.4.0-preview3-25423-02" />
-    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="4.4.0-preview3-25423-02" />
-    <PackageReference Include="System.Security.Permissions" Version="4.4.0-preview3-25423-02" />
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="4.4.0-preview3-25423-02" />
+    <PackageReference Include="System.IO.FileSystem.AccessControl" Version="4.4.0" />
+    <PackageReference Include="System.Security.AccessControl" Version="4.4.0" />
+    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="4.4.0" />
+    <PackageReference Include="System.Security.Permissions" Version="4.4.0" />
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="4.4.0" />
     <PackageReference Include="Microsoft.Management.Infrastructure" Version="1.0.0-alpha*" />
   </ItemGroup>
 

--- a/test/Test.Common.props
+++ b/test/Test.Common.props
@@ -5,7 +5,7 @@
     <Copyright>(c) Microsoft Corporation. All rights reserved.</Copyright>
 
     <TargetFramework>netcoreapp2.0</TargetFramework>
-    <RuntimeFrameworkVersion>2.0.0-preview3-25426-01</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>2.0.0</RuntimeFrameworkVersion>
 
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>


### PR DESCRIPTION
.NET Core 2.0 was [officially released](https://blogs.msdn.microsoft.com/dotnet/2017/08/14/announcing-net-core-2-0/) on 8/14/2017.
This PR is to migrate our tooling and build to the official .NET Core 2.0 bits.