### PR TITLE
Use stricter rule to avoid unnecessary unwrapping of PSObject when operating on a COM object

### DIFF
--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -1471,6 +1471,18 @@ namespace System.Management.Automation
         private static readonly Type ComObjectType = typeof(object).Assembly.GetType("System.__ComObject");
 #endif
 
+        internal static bool IsComObject(PSObject psObject)
+        {
+#if UNIX
+            return false;
+#else
+            if (psObject == null) { return false; }
+
+            object obj = PSObject.Base(psObject);
+            return IsComObject(obj);
+#endif
+        }
+
         internal static bool IsComObject(object obj)
         {
 #if UNIX
@@ -1490,7 +1502,6 @@ namespace System.Management.Automation
             // and the results are:
             //    excelApp type: Microsoft.Office.Interop.Excel.ApplicationClass
             //    Is __ComObject assignable from? True
-            obj = PSObject.Base(obj);
             return obj != null && ComObjectType.IsAssignableFrom(obj.GetType());
 #endif
         }

--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -1465,6 +1465,35 @@ namespace System.Management.Automation
             // String.WhitespaceChars will trim aggressively than what the underlying FS does (for ex, NTFS, FAT).
             internal static readonly char[] PathSearchTrimEnd = { (char)0x9, (char)0xA, (char)0xB, (char)0xC, (char)0xD, (char)0x20, (char)0x85, (char)0xA0 };
         }
+
+#if !UNIX
+        // This is to reduce the runtime overhead of the feature query
+        private static readonly Type ComObjectType = typeof(object).Assembly.GetType("System.__ComObject");
+#endif
+
+        internal static bool IsComObject(object obj)
+        {
+#if UNIX
+            return false;
+#else
+            // We can't use System.Runtime.InteropServices.Marshal.IsComObject(obj) since it doesn't work in partial trust.
+            //
+            // There could be strongly typed RWCs whose type is not 'System.__ComObject', but the more specific type should
+            // derive from 'System.__ComObject'. The strongly typed RWCs can be created with 'new' operation via the Primay
+            // Interop Assembly (PIA).
+            // For example, with the PIA 'Microsoft.Office.Interop.Excel', you can write the following code:
+            //    var excelApp = new Microsoft.Office.Interop.Excel.Application();
+            //    Type type = excelApp.GetType();
+            //    Type comObjectType = typeof(object).Assembly.GetType("System.__ComObject");
+            //    Console.WriteLine("excelApp type: {0}", type.FullName);
+            //    Console.WriteLine("Is __ComObject assignable from? {0}", comObjectType.IsAssignableFrom(type));
+            // and the results are:
+            //    excelApp type: Microsoft.Office.Interop.Excel.ApplicationClass
+            //    Is __ComObject assignable from? True
+            obj = PSObject.Base(obj);
+            return obj != null && ComObjectType.IsAssignableFrom(obj.GetType());
+#endif
+        }
     }
 }
 

--- a/src/System.Management.Automation/engine/parser/Compiler.cs
+++ b/src/System.Management.Automation/engine/parser/Compiler.cs
@@ -504,6 +504,9 @@ namespace System.Management.Automation.Language
         internal static readonly MethodInfo VariableOps_SetVariableValue =
             typeof(VariableOps).GetMethod(nameof(VariableOps.SetVariableValue), staticFlags);
 
+        internal static readonly MethodInfo Utils_IsComObject =
+            typeof(Utils).GetMethod(nameof(Utils.IsComObject), staticFlags);
+
         internal static readonly MethodInfo ClassOps_ValidateSetProperty =
             typeof(ClassOps).GetMethod(nameof(ClassOps.ValidateSetProperty), staticPublicFlags);
         internal static readonly MethodInfo ClassOps_CallBaseCtor =

--- a/src/System.Management.Automation/engine/parser/Compiler.cs
+++ b/src/System.Management.Automation/engine/parser/Compiler.cs
@@ -505,7 +505,7 @@ namespace System.Management.Automation.Language
             typeof(VariableOps).GetMethod(nameof(VariableOps.SetVariableValue), staticFlags);
 
         internal static readonly MethodInfo Utils_IsComObject =
-            typeof(Utils).GetMethod(nameof(Utils.IsComObject), staticFlags);
+            typeof(Utils).GetMethod(nameof(Utils.IsComObject), staticFlags, binder: null, types: new Type[] {typeof(object)}, modifiers: null);
 
         internal static readonly MethodInfo ClassOps_ValidateSetProperty =
             typeof(ClassOps).GetMethod(nameof(ClassOps.ValidateSetProperty), staticPublicFlags);

--- a/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
+++ b/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
@@ -352,9 +352,21 @@ namespace System.Management.Automation.Language
                 {
                     exprs[i] = Expression.Call(CachedReflectionInfo.PSObject_Base,
                                                args[i].Expression.Cast(typeof(object)));
-                    restrictions = restrictions
-                        .Merge(args[i].GetSimpleTypeRestriction())
-                        .Merge(BindingRestrictions.GetExpressionRestriction(Expression.NotEqual(exprs[i], args[i].Expression)));
+
+                    if (baseValue == null)
+                    {
+                        // When 'baseValue' is null and 'args[i].Value' is not, 'args[i].Value' must be 'AutomationNull.Value'.
+                        Diagnostics.Assert(args[i].Value == AutomationNull.Value, "PSObject.Base should only return null for AutomationNull.Value");
+                        restrictions = restrictions
+                            .Merge(BindingRestrictions.GetExpressionRestriction(Expression.Equal(args[i].Expression, ExpressionCache.AutomationNullConstant)));
+                    }
+                    else
+                    {
+                        restrictions = restrictions
+                            .Merge(args[i].GetSimpleTypeRestriction())
+                            .Merge(BindingRestrictions.GetTypeRestriction(exprs[i], baseValue.GetType()))
+                            .Merge(BindingRestrictions.GetExpressionRestriction(Expression.NotEqual(exprs[i], args[i].Expression)));
+                    }
                 }
                 else
                 {

--- a/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
+++ b/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
@@ -5862,7 +5862,7 @@ namespace System.Management.Automation.Language
                 (value.Value is PSObject && (PSObject.Base(value.Value) != value.Value)))
             {
                 Object baseObject = PSObject.Base(target.Value);
-                if ((baseObject != null) && Utils.IsComObject(baseObject))
+                if (baseObject != null && Utils.IsComObject(baseObject))
                 {
                     // We unwrap only if the 'base' of 'target' is a COM object. It's unnecessary to unwrap in other cases,
                     // especially in the case that 'target' is a string, we would lose instance members on the PSObject.
@@ -6383,7 +6383,7 @@ namespace System.Management.Automation.Language
                 args.Any(mo => mo.Value is PSObject && (PSObject.Base(mo.Value) != mo.Value)))
             {
                 Object baseObject = PSObject.Base(target.Value);
-                if ((baseObject != null) && Utils.IsComObject(baseObject))
+                if (baseObject != null && Utils.IsComObject(baseObject))
                 {
                     // We unwrap only if the 'base' of 'target' is a COM object. It's unnecessary to unwrap in other cases,
                     // especially in the case that 'target' is a string, we would lose instance members on the PSObject.

--- a/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
+++ b/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
@@ -634,7 +634,8 @@ namespace System.Management.Automation.Language
                 // EnumerableOps.NonEnumerableObjectEnumerator for more comments on how this works.
 
                 var bindingRestrictions = BindingRestrictions.GetExpressionRestriction(
-                    Expression.Call(CachedReflectionInfo.Utils_IsComObject, target.Expression));
+                    Expression.Call(CachedReflectionInfo.Utils_IsComObject,
+                                    Expression.Call(CachedReflectionInfo.PSObject_Base, target.Expression)));
                 return new DynamicMetaObject(
                     Expression.Call(CachedReflectionInfo.EnumerableOps_GetCOMEnumerator, target.Expression), bindingRestrictions).WriteToDebugLog(this);
             }

--- a/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
+++ b/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
@@ -359,15 +359,17 @@ namespace System.Management.Automation.Language
 
         internal static DynamicMetaObject DeferForPSObject(this DynamicMetaObjectBinder binder, DynamicMetaObject[] args, bool targetIsComObject = false)
         {
+            Diagnostics.Assert(args != null && args.Length > 0, "args should not be null or empty");
             Diagnostics.Assert(args.Any(mo => mo.Value is PSObject), "At least one arg must be a psobject");
 
             Expression[] exprs = new Expression[args.Length];
             BindingRestrictions restrictions = BindingRestrictions.Empty;
-            for (int i = 0; i < args.Length; i++)
+
+            // Target maps to arg[0] of the binder.
+            exprs[0] = ProcessOnePSObject(args[0], ref restrictions, targetIsComObject);
+            for (int i = 1; i < args.Length; i++)
             {
-                // Target maps to arg[0] of the binder.
-                bool argIsComObject = (i == 0) && targetIsComObject;
-                exprs[i] = ProcessOnePSObject(args[i], ref restrictions, argIsComObject);
+                exprs[i] = ProcessOnePSObject(args[i], ref restrictions, argIsComObject: false);
             }
 
             return new DynamicMetaObject(DynamicExpression.Dynamic(binder, binder.ReturnType, exprs), restrictions);

--- a/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
+++ b/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
@@ -340,7 +340,7 @@ namespace System.Management.Automation.Language
     {
         internal static DynamicMetaObject DeferForPSObject(this DynamicMetaObjectBinder binder, DynamicMetaObject target, bool targetIsComObject = false)
         {
-            Diagnostics.Assert(target.Value is PSObject, "arg1 must be a psobject");
+            Diagnostics.Assert(target.Value is PSObject, "target must be a psobject");
 
             BindingRestrictions restrictions = BindingRestrictions.Empty;
             Expression expr = ProcessOnePSObject(target, ref restrictions, argIsComObject: targetIsComObject);
@@ -365,7 +365,7 @@ namespace System.Management.Automation.Language
             BindingRestrictions restrictions = BindingRestrictions.Empty;
             for (int i = 0; i < args.Length; i++)
             {
-                // Target maps to arg0 of the binder.
+                // Target maps to arg[0] of the binder.
                 bool argIsComObject = (i == 0) && targetIsComObject;
                 exprs[i] = ProcessOnePSObject(args[i], ref restrictions, argIsComObject);
             }

--- a/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
+++ b/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
@@ -5027,9 +5027,10 @@ namespace System.Management.Automation.Language
                 Object baseObject = PSObject.Base(target.Value);
                 if ((baseObject != null) && (baseObject.GetType().FullName.Equals("System.__ComObject")))
                 {
-                    // We want to defer only if the 'base' is a COM object, so we need to use a more strict
-                    // restriction to make sure other type of PSObject 'target' doesn't fall in the same rule
-                    // and get unwrapped. Otherwise, we will lose instance members on the PSObject.
+                    // We unwrap only if the 'base' is a COM object. It's unnecessary to unwrap in other cases,
+                    // especially in the case of strings, we would lose instance members on the PSObject.
+                    // Therefore, we need to use a stricter restriction to make sure PSObject 'target' with other
+                    // base types doesn't get unwrapped.
                     return this.DeferForPSObject(target, moreRestrictionForArg0: true).WriteToDebugLog(this);
                 }
             }
@@ -5892,9 +5893,10 @@ namespace System.Management.Automation.Language
                 Object baseObject = PSObject.Base(target.Value);
                 if ((baseObject != null) && (baseObject.GetType().FullName.Equals("System.__ComObject")))
                 {
-                    // We want to defer only if the 'base' of 'target' is a COM object, so we need to use a stricter
-                    // restriction to make sure other type of PSObject 'target' doesn't fall in the same rule and get
-                    // unwrapped. Otherwise, we will lose instance members on the PSObject.
+                    // We unwrap only if the 'base' of 'target' is a COM object. It's unnecessary to unwrap in other cases,
+                    // especially in the case that 'target' is a string, we would lose instance members on the PSObject.
+                    // Therefore, we need to use a stricter restriction to make sure PSObject 'target' with other base types
+                    // doesn't get unwrapped.
                     return this.DeferForPSObject(target, value, moreRestrictionForArg0: true).WriteToDebugLog(this);
                 }
             }
@@ -6412,9 +6414,10 @@ namespace System.Management.Automation.Language
                 Object baseObject = PSObject.Base(target.Value);
                 if ((baseObject != null) && (baseObject.GetType().FullName.Equals("System.__ComObject")))
                 {
-                    // We want to defer only if the 'base' of 'target' is a COM object, so we need to use a stricter
-                    // restriction to make sure other type of PSObject 'target' doesn't fall in the same rule and get
-                    // unwrapped. Otherwise, we will lose instance members on the PSObject.
+                    // We unwrap only if the 'base' of 'target' is a COM object. It's unnecessary to unwrap in other cases,
+                    // especially in the case that 'target' is a string, we would lose instance members on the PSObject.
+                    // Therefore, we need to use a stricter restriction to make sure other type of PSObject 'target'
+                    // doesn't get unwrapped.
                     return this.DeferForPSObject(args.Prepend(target).ToArray(), moreRestrictionForArg0: true).WriteToDebugLog(this);
                 }
             }

--- a/test/powershell/engine/COM/COM.Basic.Tests.ps1
+++ b/test/powershell/engine/COM/COM.Basic.Tests.ps1
@@ -55,6 +55,7 @@ try {
             $shell = New-Object -ComObject "Shell.Application"
             $folder = $shell.Namespace("$TESTDRIVE")
             $item = $folder.Items().Item(0)
+            $item = [psobject]::AsPSObject($item)
 
             ## Create a PSObject that has an instance member 'Name' and a script method 'Windows'
             $str = Add-Member -InputObject "abc" -MemberType NoteProperty -Name Name -Value "Hello" -PassThru
@@ -63,21 +64,23 @@ try {
 
         It "GetMember binder should differentiate PSObject that wraps COM object from other PSObjects" {
             ## GetMember on the member name 'Name'.
-            ## '$_' here is a PSObject that wraps a COM object
-            $item | ForEach-Object { $_.Name } > $null
+            $entry1 = ($item, "bar")
+            $entry2 = ($str, "Hello")
 
-            ## '$str' is a PSObject that wraps a string, but with NoteProperty 'Name'
-            $str.Name | Should Be "Hello"
+            foreach ($pair in ($entry1, $entry2, $entry2, $entry1, $entry1, $entry2)) {
+                $pair[0].Name | Should Be $pair[1]
+            }
         }
 
         It "SetMember binder should differentiate PSObject that wraps COM object from other PSObjects" {
             ## SetMember on the member name 'Name'
-            ## '$_' here is a PSObject that wraps a COM object
-            $item | ForEach-Object { $_.Name = "foo" } > $null
+            $entry1 = ($item, "foo")
+            $entry2 = ($str, "World")
 
-            ## '$str' is a PSObject that wraps a string, but with NoteProperty 'Name'
-            $str.Name = "World"
-            $str.Name | Should Be "World"
+            foreach ($pair in ($entry1, $entry2)) {
+                $pair[0].Name = $pair[1]
+                $pair[0].Name | Should Be $pair[1]
+            }
         }
 
         It "InvokeMember binder should differentiate PSObject that wraps COM object from other PSObjects" {

--- a/test/powershell/engine/COM/COM.Basic.Tests.ps1
+++ b/test/powershell/engine/COM/COM.Basic.Tests.ps1
@@ -50,16 +50,18 @@ try {
 
     Describe 'GetMember/SetMember/InvokeMember binders should have more restricted rule for COM object' -Tags "CI" {
         BeforeAll {
-            $null = New-Item -Path $TESTDRIVE/bar -ItemType Directory -Force
+            if ([System.Management.Automation.Platform]::IsWindowsDesktop) {
+                $null = New-Item -Path $TESTDRIVE/bar -ItemType Directory -Force
 
-            $shell = New-Object -ComObject "Shell.Application"
-            $folder = $shell.Namespace("$TESTDRIVE")
-            $item = $folder.Items().Item(0)
-            $item = [psobject]::AsPSObject($item)
+                $shell = New-Object -ComObject "Shell.Application"
+                $folder = $shell.Namespace("$TESTDRIVE")
+                $item = $folder.Items().Item(0)
+                $item = [psobject]::AsPSObject($item)
 
-            ## Create a PSObject that has an instance member 'Name' and a script method 'Windows'
-            $str = Add-Member -InputObject "abc" -MemberType NoteProperty -Name Name -Value "Hello" -PassThru
-            $str = Add-Member -InputObject $str -MemberType ScriptMethod -Name Windows -Value { "Windows" } -PassThru
+                ## Create a PSObject that has an instance member 'Name' and a script method 'Windows'
+                $str = Add-Member -InputObject "abc" -MemberType NoteProperty -Name Name -Value "Hello" -PassThru
+                $str = Add-Member -InputObject $str -MemberType ScriptMethod -Name Windows -Value { "Windows" } -PassThru
+            }
         }
 
         It "GetMember binder should differentiate PSObject that wraps COM object from other PSObjects" {

--- a/test/powershell/engine/COM/COM.Basic.Tests.ps1
+++ b/test/powershell/engine/COM/COM.Basic.Tests.ps1
@@ -16,7 +16,11 @@ try {
             $items = $folder.Items()
 
             ## $items is a collection of all items belong to the folder, and it should be enumerated.
+            $items.Count | Should Be 3
             $items | Measure-Object | ForEach-Object Count | Should Be $items.Count
+
+            $names = $items | ForEach-Object { $_.Name }
+            $names -join "," | Should Be "file1,file2,file3"
         }
 
         It "Should enumerate IEnumVariant interface object without exception" {
@@ -26,6 +30,7 @@ try {
 
             ## $enumVariant is an IEnumVariant interface of all items belong to the folder, and it should be enumerated.
             $enumVariant = $items._NewEnum()
+            $items.Count | Should Be 3
             $enumVariant | Measure-Object | ForEach-Object Count | Should Be $items.Count
         }
 
@@ -40,6 +45,47 @@ try {
             $element = $drives | Select-Object -First 1
             [System.Object]::ReferenceEquals($element, $drives) | Should Be $false
             $element | Should Be $drives.Item($element.DriveLetter)
+        }
+    }
+
+    Describe 'GetMember/SetMember/InvokeMember binders should have more restricted rule for COM object' -Tags "CI" {
+        BeforeAll {
+            $null = New-Item -Path $TESTDRIVE/bar -ItemType Directory -Force
+
+            $shell = New-Object -ComObject "Shell.Application"
+            $folder = $shell.Namespace("$TESTDRIVE")
+            $item = $folder.Items().Item(0)
+
+            ## Create a PSObject that has an instance member 'Name' and a script method 'Windows'
+            $str = Add-Member -InputObject "abc" -MemberType NoteProperty -Name Name -Value "Hello" -PassThru
+            $str = Add-Member -InputObject $str -MemberType ScriptMethod -Name Windows -Value { "Windows" } -PassThru
+        }
+
+        It "GetMember binder should differentiate PSObject that wraps COM object from other PSObjects" {
+            ## GetMember on the member name 'Name'.
+            ## '$_' here is a PSObject that wraps a COM object
+            $item | ForEach-Object { $_.Name } > $null
+
+            ## '$str' is a PSObject that wraps a string, but with NoteProperty 'Name'
+            $str.Name | Should Be "Hello"
+        }
+
+        It "SetMember binder should differentiate PSObject that wraps COM object from other PSObjects" {
+            ## SetMember on the member name 'Name'
+            ## '$_' here is a PSObject that wraps a COM object
+            $item | ForEach-Object { $_.Name = "foo" } > $null
+
+            ## '$str' is a PSObject that wraps a string, but with NoteProperty 'Name'
+            $str.Name = "World"
+            $str.Name | Should Be "World"
+        }
+
+        It "InvokeMember binder should differentiate PSObject that wraps COM object from other PSObjects" {
+            ## InvokeMember on the member name 'Windows'
+            $shell | % { $_.Windows() } > $null
+
+            ## '$str' is a PSObject that wraps a string, but with ScriptMethod 'Windows'
+            $str.Windows() | Should Be "Windows"
         }
     }
 

--- a/test/powershell/engine/COM/COM.Basic.Tests.ps1
+++ b/test/powershell/engine/COM/COM.Basic.Tests.ps1
@@ -82,7 +82,7 @@ try {
 
         It "InvokeMember binder should differentiate PSObject that wraps COM object from other PSObjects" {
             ## InvokeMember on the member name 'Windows'
-            $shell | % { $_.Windows() } > $null
+            $shell | ForEach-Object { $_.Windows() } > $null
 
             ## '$str' is a PSObject that wraps a string, but with ScriptMethod 'Windows'
             $str.Windows() | Should Be "Windows"


### PR DESCRIPTION
Fix #4607

Summary
----------
GetMember/SetMember/InvokeMember operations on a COM object will generate code to unwrap the COM object if it's wrapped in PSObject. Due to a loose restriction, if you have a string wrapped to a PSObject with a ETS member of the the same name, then accessing that member will fail.

Fix
---
Use a more restricted rule by checking the base object type when it's necessary.