### PR TITLE
Replace Pester submodule by download from the gallery

### DIFF
--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Out-Default.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Out-Default.Tests.ps1
@@ -15,7 +15,7 @@ Describe "Out-Default Tests" -tag CI {
 "@
 
         & $powershell -noprofile -command $script | Should BeExactly 'bye'
-        "TestDrive:\transcript.txt" | Should Contain 'hello'
+        "TestDrive:\transcript.txt" | Should -FileContentMatch 'hello'
     }
 
     It "Out-Default reverts transcription state when used more than once in a pipeline" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Clear-Content.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Clear-Content.Tests.ps1
@@ -64,7 +64,7 @@ Describe "Clear-Content cmdlet tests" -Tags "CI" {
     # we could suppress the WhatIf output here if we use the testhost, but it's not necessary
     It "The filesystem provider supports should process" -skip:(!$IsWindows) {
       clear-content TESTDRIVE:\$file2 -WhatIf
-      "TESTDRIVE:\$file2" | should contain "This is content"
+      "TESTDRIVE:\$file2" | Should -FileContentMatch "This is content"
     }
 
     It "The filesystem provider should support ShouldProcess (reference ProviderSupportsShouldProcess member)" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Move-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Move-Item.Tests.ps1
@@ -9,7 +9,7 @@ Describe "Move-Item tests" -Tag "CI" {
         Move-Item $source $target
         test-path $source | Should be $false
         test-path $target | Should be $true
-        "$target" | Should ContainExactly "This is content"
+        "$target" | Should -FileContentMatchExactly "This is content"
     }
 
     Context "Move-Item with filters" {
@@ -49,7 +49,7 @@ Describe "Move-Item tests" -Tag "CI" {
             $newBarPath | Should Exist
             $booPath | Should Exist
             $fooPath | Should Exist
-            $newBarPath | Should ContainExactly $barContent
+            $newBarPath | Should -FileContentMatchExactly $barContent
         }
         It "Can move to different directory, filtered with -Exclude" {
             Move-Item -Path $filePath -Destination $moveToPath -Exclude "b*" -ErrorVariable e -ErrorAction SilentlyContinue
@@ -58,7 +58,7 @@ Describe "Move-Item tests" -Tag "CI" {
             $newFooPath | Should Exist
             $booPath | Should Exist
             $barPath | Should Exist
-            $newFooPath | Should ContainExactly $fooContent
+            $newFooPath | Should -FileContentMatchExactly $fooContent
         }
         It "Can move to different directory, filtered with -Filter" {
             Move-Item -Path $filePath -Destination $moveToPath -Filter "bo*" -ErrorVariable e -ErrorAction SilentlyContinue
@@ -67,7 +67,7 @@ Describe "Move-Item tests" -Tag "CI" {
             $newBooPath | Should Exist
             $barPath | Should Exist
             $fooPath | Should Exist
-            $newBooPath | Should ContainExactly $booContent
+            $newBooPath | Should -FileContentMatchExactly $booContent
         }
 
         It "Can rename via move, filtered with -Include" {
@@ -77,7 +77,7 @@ Describe "Move-Item tests" -Tag "CI" {
             $barPath | Should Not Exist
             $booPath | Should Exist
             $fooPath | Should Exist
-            $renameToPath | Should ContainExactly $barContent
+            $renameToPath | Should -FileContentMatchExactly $barContent
         }
         It "Can rename via move, filtered with -Exclude" {
             Move-Item -Path $filePath -Destination $renameToPath -Exclude "b*" -ErrorVariable e -ErrorAction SilentlyContinue
@@ -86,7 +86,7 @@ Describe "Move-Item tests" -Tag "CI" {
             $fooPath | Should Not Exist
             $booPath | Should Exist
             $barPath | Should Exist
-            $renameToPath | Should ContainExactly $fooContent
+            $renameToPath | Should -FileContentMatchExactly $fooContent
         }
         It "Can rename via move, filtered with -Filter" {
             Move-Item -Path $filePath -Destination $renameToPath -Filter "bo*" -ErrorVariable e -ErrorAction SilentlyContinue
@@ -95,7 +95,7 @@ Describe "Move-Item tests" -Tag "CI" {
             $booPath | Should Not Exist
             $fooPath | Should Exist
             $barPath | Should Exist
-            $renameToPath | Should ContainExactly $booContent
+            $renameToPath | Should -FileContentMatchExactly $booContent
         }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Rename-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Rename-Item.Tests.ps1
@@ -9,6 +9,6 @@ Describe "Rename-Item tests" -Tag "CI" {
         Rename-Item $source $target
         test-path $source | Should be $false
         test-path $target | Should be $true
-        "$target" | Should ContainExactly "This is content"
+        "$target" | Should -FileContentMatchExactly "This is content"
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Export-Alias.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Export-Alias.Tests.ps1
@@ -63,46 +63,46 @@ Describe "Export-Alias DRT Unit Tests" -Tags "CI" {
 
 	It "Export-Alias for Default"{
 		Export-Alias $fulltestpath abcd01 -passthru
-		$fulltestpath| Should ContainExactly '"abcd01","efgh01","","None"'
+		$fulltestpath| Should -FileContentMatchExactly '"abcd01","efgh01","","None"'
     }
 
 	It "Export-Alias As CSV"{
 		Export-Alias $fulltestpath abcd01 -As CSV -passthru
-		$fulltestpath| Should ContainExactly '"abcd01","efgh01","","None"'
+		$fulltestpath| Should -FileContentMatchExactly '"abcd01","efgh01","","None"'
     }
 
 	It "Export-Alias As CSV With Description"{
 		Export-Alias $fulltestpath abcd01 -As CSV -description "My Aliases" -passthru
-		$fulltestpath| Should ContainExactly '"abcd01","efgh01","","None"'
-		$fulltestpath| Should ContainExactly "My Aliases"
+		$fulltestpath| Should -FileContentMatchExactly '"abcd01","efgh01","","None"'
+		$fulltestpath| Should -FileContentMatchExactly "My Aliases"
     }
 
 	It "Export-Alias As CSV With Multiline Description"{
 		Export-Alias $fulltestpath abcd01 -As CSV -description "My Aliases\nYour Aliases\nEveryones Aliases" -passthru
-		$fulltestpath| Should ContainExactly '"abcd01","efgh01","","None"'
-		$fulltestpath| Should ContainExactly "My Aliases"
-		$fulltestpath| Should ContainExactly "Your Aliases"
-		$fulltestpath| Should ContainExactly "Everyones Aliases"
+		$fulltestpath| Should -FileContentMatchExactly '"abcd01","efgh01","","None"'
+		$fulltestpath| Should -FileContentMatchExactly "My Aliases"
+		$fulltestpath| Should -FileContentMatchExactly "Your Aliases"
+		$fulltestpath| Should -FileContentMatchExactly "Everyones Aliases"
     }
 
 	It "Export-Alias As Script"{
 		Export-Alias $fulltestpath abcd01 -As Script -passthru
-		$fulltestpath| Should ContainExactly 'set-alias -Name:"abcd01" -Value:"efgh01" -Description:"" -Option:"None"'
+		$fulltestpath| Should -FileContentMatchExactly 'set-alias -Name:"abcd01" -Value:"efgh01" -Description:"" -Option:"None"'
     }
 
 	It "Export-Alias As Script With Multiline Description"{
 		Export-Alias $fulltestpath abcd01 -As Script -description "My Aliases\nYour Aliases\nEveryones Aliases" -passthru
-		$fulltestpath| Should ContainExactly 'set-alias -Name:"abcd01" -Value:"efgh01" -Description:"" -Option:"None"'
-		$fulltestpath| Should ContainExactly "My Aliases"
-		$fulltestpath| Should ContainExactly "Your Aliases"
-		$fulltestpath| Should ContainExactly "Everyones Aliases"
+		$fulltestpath| Should -FileContentMatchExactly 'set-alias -Name:"abcd01" -Value:"efgh01" -Description:"" -Option:"None"'
+		$fulltestpath| Should -FileContentMatchExactly "My Aliases"
+		$fulltestpath| Should -FileContentMatchExactly "Your Aliases"
+		$fulltestpath| Should -FileContentMatchExactly "Everyones Aliases"
     }
 
 	It "Export-Alias for Force Test"{
 		Export-Alias $fulltestpath abcd01
 		Export-Alias $fulltestpath abcd02 -force
-		$fulltestpath| Should Not ContainExactly '"abcd01","efgh01","","None"'
-		$fulltestpath| Should ContainExactly '"abcd02","efgh02","","None"'
+		$fulltestpath| Should -Not -FileContentMatchExactly '"abcd01","efgh01","","None"'
+		$fulltestpath| Should -FileContentMatchExactly '"abcd02","efgh02","","None"'
     }
 
 	It "Export-Alias for Force ReadOnly Test" {
@@ -124,9 +124,9 @@ Describe "Export-Alias DRT Unit Tests" -Tags "CI" {
 			$_.FullyQualifiedErrorId | Should be "FileOpenFailure,Microsoft.PowerShell.Commands.ExportAliasCommand"
 		}
 		Export-Alias $fulltestpath abcd03 -force
-		$fulltestpath| Should Not ContainExactly '"abcd01","efgh01","","None"'
-		$fulltestpath| Should Not ContainExactly '"abcd02","efgh02","","None"'
-		$fulltestpath| Should ContainExactly '"abcd03","efgh03","","None"'
+		$fulltestpath| Should -Not -FileContentMatchExactly '"abcd01","efgh01","","None"'
+		$fulltestpath| Should -Not -FileContentMatchExactly '"abcd02","efgh02","","None"'
+		$fulltestpath| Should -FileContentMatchExactly '"abcd03","efgh03","","None"'
 
 		if ( $IsWindows )
 		{

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Out-File.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Out-File.Tests.ps1
@@ -11,8 +11,8 @@ Describe "Out-File DRT Unit Tests" -Tags "CI" {
         $tempFile = Join-Path -Path $TestDrive -ChildPath "outfileAppendTest.txt"
         { 'This is first line.' | out-file $tempFile } | Should Not Throw
         { 'This is second line.' | out-file -append $tempFile } | Should Not Throw
-        $tempFile |Should Contain "first"
-        $tempFile |Should Contain "second"
+        $tempFile |Should -FileContentMatch "first"
+        $tempFile |Should -FileContentMatch "second"
         Remove-Item $tempFile -Force
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Remove-Event.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Remove-Event.Tests.ps1
@@ -12,7 +12,7 @@ Describe "Remove-Event" -Tags "CI" {
 
 	It "Should remove an event given a sourceidentifier" {
 	    { Remove-Event -sourceidentifier PesterTimer }
-	    { Get-Event -ErrorAction SilentlyContinue | Should Not Contain PesterTimer }
+	    { Get-Event -ErrorAction SilentlyContinue | Should -Not -FileContentMatch PesterTimer }
 	}
 
 	It "Should remove an event given an event identifier" {
@@ -20,19 +20,19 @@ Describe "Remove-Event" -Tags "CI" {
 	    { $events = $events.EventIdentifier }
 	    { Remove-Event -EventIdentifier $events }
 	    { $events = Get-Event -ErrorAction SilentlyContinue}
-	    { $events.SourceIdentifier | Should Not Contain "PesterTimer" }
+	    { $events.SourceIdentifier | Should -Not -FileContentMatch "PesterTimer" }
 	}
 
 	It "Should be able to remove an event given a pipe from Get-Event" {
 	    { Get-Event -sourceidentifier PesterTimer | Remove-Event }
-	    { Get-Event -ErrorAction SilentlyContinue | Should Not Contain "PesterTimer" }
+	    { Get-Event -ErrorAction SilentlyContinue | Should -Not -FileContentMatch "PesterTimer" }
 
 	}
 
 	It "Should NOT remove an event given the whatif flag" {
 	    { Remove-Event -sourceidentifier PesterTimer -whatif }
 	    { $events = Get-Event }
-	    { $events.SourceIdentifier  | Should Contain "PesterTimer" }
+	    { $events.SourceIdentifier  | Should -FileContentMatch "PesterTimer" }
 	}
     }
 }

--- a/test/powershell/Modules/Microsoft.Powershell.Host/Start-Transcript.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.Powershell.Host/Start-Transcript.Tests.ps1
@@ -32,9 +32,9 @@ Describe "Start-Transcript, Stop-Transcript tests" -tags "CI" {
                     $ps.addscript("Stop-Transcript").Invoke()
 
                     Test-Path $outputFilePath | Should be $true
-                    $outputFilePath | should contain "Get-Date"
+                    $outputFilePath | Should -FileContentMatch "Get-Date"
                     if($append) {
-                        $outputFilePath | Should contain $content
+                        $outputFilePath | Should -FileContentMatch $content
                     }
                 }
             } finally {
@@ -122,7 +122,7 @@ Describe "Start-Transcript, Stop-Transcript tests" -tags "CI" {
         }
 
         Test-Path $transcriptFilePath | Should be $true
-        $transcriptFilePath | Should contain "After Dispose"
+        $transcriptFilePath | Should -FileContentMatch "After Dispose"
     }
 
     It "Transcription should be closed if the only runspace gets closed" {
@@ -131,8 +131,8 @@ Describe "Start-Transcript, Stop-Transcript tests" -tags "CI" {
         Invoke-Expression $powerShellCommand
 
         Test-Path $transcriptFilePath | Should be $true
-        $transcriptFilePath | Should contain "Before Dispose"
-        $transcriptFilePath | Should contain "PowerShell transcript end"
+        $transcriptFilePath | Should -FileContentMatch "Before Dispose"
+        $transcriptFilePath | Should -FileContentMatch "PowerShell transcript end"
     }
 
     It "Transcription should record native command output" {
@@ -144,6 +144,6 @@ Describe "Start-Transcript, Stop-Transcript tests" -tags "CI" {
         Test-Path $transcriptFilePath | Should be $true
 
         $machineName = [System.Environment]::MachineName
-        $transcriptFilePath | Should contain $machineName
+        $transcriptFilePath | Should -FileContentMatch $machineName
     }
 }

--- a/test/powershell/engine/Basic/CommandDiscovery.Tests.ps1
+++ b/test/powershell/engine/Basic/CommandDiscovery.Tests.ps1
@@ -90,7 +90,7 @@
 
         foreach($command in $commands)
         {
-            $command.GetType().Name | should be @("AliasInfo","FunctionInfo","CmdletInfo","FilterInfo")
+            $command.GetType().Name | Should BeIn @("AliasInfo","FunctionInfo","CmdletInfo","FilterInfo")
         }
     }
 


### PR DESCRIPTION
Trying to see can we fix #1371 earlier
According to https://github.com/pester/Pester/issues/639#issuecomment-323405001 pester 4.0.6 has some limitations on linux and mac, but so does the https://github.com/PowerShell/psl-pester

I did few local tests on mac and didn't encounter any problems so far, let see how CI will like this.