### PR TITLE
Correct linux.md macOS brew reinstall command

### DIFF
--- a/docs/installation/linux.md
+++ b/docs/installation/linux.md
@@ -363,7 +363,7 @@ simply update Homebrew's formulae and upgrade PowerShell:
 
 ```sh
 brew update
-brew reinstall powershell
+brew cask reinstall powershell
 ```
 
 > Note: because of [this issue in Cask](https://github.com/caskroom/homebrew-cask/issues/29301), you currently have to do a reinstall to upgrade.


### PR DESCRIPTION
Updated macOS reinstall command. Using the originally written "brew reinstall powershell" fails, as the reinstall needs to be done using "brew cask reinstall powershell".

<!--

If you are a PowerShell Team member, please make sure you choose the Reviewer(s) and Assignee for your PR.
If you are not from the PowerShell Team, you can leave the fields blank and the Maintainers will choose them for you. If you are familiar with the team, feel free to mention some Reviewers yourself.

For more information about the roles of Reviewer and Assignee, refer to CONTRIBUTING.md.

-->
