### PR TITLE
Update install scripts with minor fixes targeting macOS

### DIFF
--- a/tools/install-powershell.sh
+++ b/tools/install-powershell.sh
@@ -21,7 +21,7 @@
 
 #gitrepo paths are overrideable to run from your own fork or branch for testing or private distribution
 
-VERSION="1.1.0"
+VERSION="1.1.1"
 gitreposubpath="PowerShell/PowerShell/master"
 gitreposcriptroot="https://raw.githubusercontent.com/$gitreposubpath/tools"
 gitscriptname="install-powershell.psh"
@@ -139,7 +139,11 @@ elif [ "$DistroBasedOn" == "redhat" ] || [ "$DistroBasedOn" == "debian" ] || [ "
       #Script files are not local - pull from remote
       echo "Could not find \"installpsh-$DistroBasedOn.sh\" next to this script..."
       echo "Pulling it from \"$gitreposcriptroot/installpsh-$DistroBasedOn.sh\""
-      bash <(wget -qO- $gitreposcriptroot/installpsh-$DistroBasedOn.sh) $@
+      if [ "$OS" == "osx" ]; then
+        bash <(curl -s $gitreposcriptroot/installpsh-$DistroBasedOn.sh) $@
+      else
+        bash <(wget -qO- $gitreposcriptroot/installpsh-$DistroBasedOn.sh) $@
+      fi
    fi
 else
     echo "Sorry, your operating system is based on $DistroBasedOn and is not supported by PowerShell Core or this installer at this time."

--- a/tools/installpsh-osx.sh
+++ b/tools/installpsh-osx.sh
@@ -154,7 +154,7 @@ fi
 if [[ "'$*'" =~ includeide ]] ; then
     echo "\n*** Installing VS Code PowerShell IDE..."
     if [[ ! -d $(brew --prefix visual-studio-code) ]]; then
-        if ! brew install visual-studio-code; then
+        if ! brew cask install visual-studio-code; then
             echo "ERROR: Visual Studio Code failed to install..." >&2
             exit 1
         fi


### PR DESCRIPTION
Fixes #4617 
Fixes #4511
Change VS code install to use cask
Change OSX to use curl
Update version number by point release.