### PR TITLE
[feature] Mark Multiple Response Header Test Pending

### DIFF
--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -1204,7 +1204,9 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
         $result.Output.RawContent | Should Match ([regex]::Escape('Content-Length: 2'))
     }
 
-    It "Verifies Invoke-WebRequest Supports Multiple response headers with same name" {
+    # Test pending due to HttpListener limitation on Linux/macOS
+    # https://github.com/PowerShell/PowerShell/pull/4640
+    It "Verifies Invoke-WebRequest Supports Multiple response headers with same name" -Pending {
         $headers = @{
             'X-Fake-Header' = 'testvalue01','testvalue02'
         } | ConvertTo-Json -Compress


### PR DESCRIPTION
The `Verifies Invoke-WebRequest Supports Multiple response headers with same name` test from #4494 is failing on Linux and macOS due to an implementation difference of `HttpListener` on Linux and macOS where multiple response headers are concatenated instead of sent as separate headers.

In Windows:
```
HTTP/1.1 200 OK
Content-Length: 2
Content-Type: text/plain
Server: Microsoft-HTTPAPI/2.0
X-Fake-Header: testvalue01
X-Fake-Header: testvalue02
Date: Tue, 22 Aug 2017 09:49:37 GMT
```

In Linux/macOS:
```
HTTP/1.1 200 OK
X-Fake-Header: testvalue01, testvalue02
Server: Microsoft-NetCore/2.0
Date: Tue, 22 Aug 2017 09:18:18 GMT
Content-Type: text/plain
Content-Length: 2
```

This is not a failure of the test but an issue with the current method used for serving test content with `HttpListener`.

Issue  #4639 has been created to track creating a cross-platform multiple header response solution for this test. In the mean time, mark this test as pending to prevent nightly failures.