### PR TITLE
Replace extension method 'IsComObject(this Type)' with Type.IsCOMObject

### DIFF
--- a/src/System.Management.Automation/engine/CoreAdapter.cs
+++ b/src/System.Management.Automation/engine/CoreAdapter.cs
@@ -2472,8 +2472,8 @@ namespace System.Management.Automation
                 if (declaringTypeInfo.IsValueType ||
                     propertyTypeInfo.IsGenericType ||
                     declaringTypeInfo.IsGenericType ||
-                    property.DeclaringType.IsComObject() ||
-                    property.PropertyType.IsComObject())
+                    property.DeclaringType.IsCOMObject ||
+                    property.PropertyType.IsCOMObject)
                 {
                     this.readOnly = property.GetSetMethod() == null;
                     this.writeOnly = property.GetGetMethod() == null;

--- a/src/System.Management.Automation/engine/MshObject.cs
+++ b/src/System.Management.Automation/engine/MshObject.cs
@@ -463,7 +463,7 @@ namespace System.Management.Automation
 
             if (result == null)
             {
-                if (objectType.IsComObject())
+                if (objectType.IsCOMObject)
                 {
                     // All WinRT types are COM types.
                     // All WinRT types would contain the TypeAttributes flag being set to WindowsRunTime.

--- a/src/System.Management.Automation/utils/ExtensionMethods.cs
+++ b/src/System.Management.Automation/utils/ExtensionMethods.cs
@@ -119,16 +119,6 @@ namespace System.Management.Automation
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static bool IsComObject(this Type type)
-        {
-#if UNIX
-            return false;
-#else
-            return type.IsCOMObject;
-#endif
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static TypeCode GetTypeCode(this Type type)
         {
             return Type.GetTypeCode(type);


### PR DESCRIPTION
Type.IsCOMObject is available on all platforms, so use it directly.