### PR TITLE
Remove parsing script file names as assembly names

### DIFF
--- a/test/powershell/Language/Classes/Scripting.Classes.RunPath.Tests.ps1
+++ b/test/powershell/Language/Classes/Scripting.Classes.RunPath.Tests.ps1
@@ -1,8 +1,18 @@
 Describe "Script with a class definition run path" -Tags "CI" {
 
+    BeforeAll {
+        if ( $IsWindows ) {
+            $TestFileName = "My,'=~Test.ps1"
+        } else {
+            $TestFileName = "My,'`"=~Test.ps1"
+        }
+    }
+
     $TestCases = @(
-        @{ FileName =  'MyTest.ps1'; Name = 'path without a comma' }
-        @{ FileName = 'My,Test.ps1'; Name = 'path with a comma'    }
+        @{ FileName = 'MyTest.ps1'  ; Name = 'typical path' }
+        # We had a bug with some symbols in script file names.
+        # We fixed the bug but leave the test to exclude regression.
+        @{ FileName = $TestFileName; Name = 'path with unhandled assemblyname characters' }
     )
 
     It "Script with a class definition can run from a <Name>" -TestCases $TestCases {


### PR DESCRIPTION
Fix #4193.

### Problem

Before the fix we pass a script file name into 'AssemblyName(assemblyName)' constructor. The constructor is trying to parse the name as an assembly name:
```
'Name <,Culture = CultureInfo> <,Version = Major.Minor.Build.Revision> <, StrongName> <,PublicKeyToken> '\0''
```
See notes in https://msdn.microsoft.com/en-us/library/system.reflection.assemblyname(v=vs.110).aspx

### Fix
Replace 'new AssemblyName(assemblyName)' constructor with 'new
AssemblyName()' to exclude parsing the script file name.

### Additional cosiderations
The PR replaces the frozen PR #4270.