### PR TITLE
clean up coreclr/fullclr statements in tracesource

### DIFF
--- a/src/System.Management.Automation/utils/MshTraceSource.cs
+++ b/src/System.Management.Automation/utils/MshTraceSource.cs
@@ -178,11 +178,6 @@ namespace System.Management.Automation
                     PSTraceSource.TraceCatalog[result.FullName] = result;
                 }
 
-#if !CORECLR    // System.AppDomain is not in ProjectK
-                // Trace the global header if this is the first
-                // trace object for the AppDomain and tracing flags
-                // are enabled.
-
                 if (result.Options != PSTraceSourceOptions.None &&
                     traceHeaders)
                 {
@@ -191,7 +186,6 @@ namespace System.Management.Automation
                     // Trace the object specific tracer information
                     result.TracerObjectHeader(Assembly.GetCallingAssembly());
                 }
-#endif
                 return result;
             }
         }
@@ -359,12 +353,8 @@ namespace System.Management.Automation
         /// <returns>Exception instance ready to throw</returns>
         internal static PSInvalidOperationException NewInvalidOperationException()
         {
-#if CORECLR //TODO:CORECLR StackTrace is not in CoreCLR
-            string message = string.Empty;
-#else
             string message = StringUtil.Format(AutomationExceptions.InvalidOperation,
                     new System.Diagnostics.StackTrace().GetFrame(1).GetMethod().Name);
-#endif
             var e = new PSInvalidOperationException(message);
 
             return e;
@@ -434,12 +424,8 @@ namespace System.Management.Automation
         /// <returns>Exception instance ready to throw</returns>
         internal static PSNotSupportedException NewNotSupportedException()
         {
-#if CORECLR //TODO:CORECLR StackTrace is not in CoreCLR
-            string message = string.Empty;
-#else
             string message = StringUtil.Format(AutomationExceptions.NotSupported,
                 new System.Diagnostics.StackTrace().GetFrame(0).ToString());
-#endif
             var e = new PSNotSupportedException(message);
 
             return e;
@@ -483,12 +469,8 @@ namespace System.Management.Automation
         /// <returns>Exception instance ready to throw</returns>
         internal static PSNotImplementedException NewNotImplementedException()
         {
-#if CORECLR //TODO:CORECLR StackTrace is not in CoreCLR
-            string message = string.Empty;
-#else
             string message = StringUtil.Format(AutomationExceptions.NotImplemented,
                 new System.Diagnostics.StackTrace().GetFrame(0).ToString());
-#endif
             var e = new PSNotImplementedException(message);
 
             return e;

--- a/src/System.Management.Automation/utils/StructuredTraceSource.cs
+++ b/src/System.Management.Automation/utils/StructuredTraceSource.cs
@@ -290,6 +290,7 @@ namespace System.Management.Automation
                 FullName = fullName;
                 _name = name;
 
+                // TODO: move this to startup json file instead of using env var
                 string tracingEnvVar = Environment.GetEnvironmentVariable("MshEnableTrace");
 
                 if (String.Equals(

--- a/src/System.Management.Automation/utils/StructuredTraceSource.cs
+++ b/src/System.Management.Automation/utils/StructuredTraceSource.cs
@@ -290,7 +290,6 @@ namespace System.Management.Automation
                 FullName = fullName;
                 _name = name;
 
-#if !CORECLR // TraceSource.Attributes is not in CoreCLR
                 string tracingEnvVar = Environment.GetEnvironmentVariable("MshEnableTrace");
 
                 if (String.Equals(
@@ -304,7 +303,6 @@ namespace System.Management.Automation
                         _flags = (PSTraceSourceOptions)Enum.Parse(typeof(PSTraceSourceOptions), options, true);
                     }
                 }
-#endif
                 ShowHeaders = traceHeaders;
                 Description = description;
             }
@@ -326,7 +324,6 @@ namespace System.Management.Automation
 #endif
         }
 
-#if !CORECLR // System.AppDomain is not in ProjectK.
         private static bool globalTraceInitialized;
 
         /// <summary>
@@ -375,7 +372,6 @@ namespace System.Management.Automation
 
             globalTraceInitialized = true;
         }
-#endif
 
         /// <summary>
         /// Outputs a header when a new StructuredTraceSource object is created
@@ -1149,9 +1145,6 @@ namespace System.Management.Automation
         /// </returns>
         private static string GetCallingMethodNameAndParameters(int skipFrames)
         {
-#if CORECLR //TODO:CORECLR StackFrame is not in CoreCLR
-            return string.Empty;
-#else
             StringBuilder methodAndParameters = null;
 
             try
@@ -1189,7 +1182,6 @@ namespace System.Management.Automation
                 // normal operation.
             }
             return methodAndParameters.ToString();
-#endif
         }
 
         // The default formatter for TraceError
@@ -1482,7 +1474,6 @@ namespace System.Management.Automation
             get { return _flags != PSTraceSourceOptions.None; }
         }
 
-#if !CORECLR // TraceSource.Attributes is not in CoreCLR
         /// <summary>
         /// Gets the attributes of the TraceSource
         /// </summary>
@@ -1493,7 +1484,6 @@ namespace System.Management.Automation
                 return TraceSource.Attributes;
             }
         }
-#endif
 
         /// <summary>
         /// Gets the listeners for the TraceSource
@@ -1891,7 +1881,6 @@ namespace System.Management.Automation
         {
         }
 
-#if !CORECLR // TraceSource.GetSupportedAttributes is not in CoreCLR
         /// <summary>
         /// Tells the config infrastructure which attributes are supported
         /// for our TraceSource
@@ -1905,7 +1894,6 @@ namespace System.Management.Automation
         {
             return new string[] { "Options" };
         }
-#endif
     }
     #endregion MonadTraceSource
 }


### PR DESCRIPTION
removed `#if` statements for CORECLR/!CORECLR where it no longer applies

there is one remaining as System.Configuration.ConfigurationException doesn't exist in corefx

<!--

If you are a PowerShell Team member, please make sure you choose the Reviewer(s) and Assignee for your PR.
If you are not from the PowerShell Team, you can leave the fields blank and the Maintainers will choose them for you. If you are familiar with the team, feel free to mention some Reviewers yourself.

For more information about the roles of Reviewer and Assignee, refer to CONTRIBUTING.md.

-->
