### PR TITLE
[Regression] Fix for error on Enter-PSSession exit

### DIFF
--- a/src/System.Management.Automation/engine/remoting/commands/PushRunspaceCommand.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/PushRunspaceCommand.cs
@@ -1284,6 +1284,10 @@ namespace Microsoft.PowerShell.Commands
         {
             var sshConnectionInfo = new SSHConnectionInfo(this.UserName, ResolveComputerName(HostName), this.KeyFilePath, this.Port);
             var typeTable = TypeTable.LoadDefaultTypeFiles();
+
+            // Use the class _tempRunspace field while the runspace is being opened so that StopProcessing can be handled at that time.
+            // This is only needed for SSH sessions where a Ctrl+C during an SSH password prompt can abort the session before a connection
+            // is established.
             _tempRunspace = RunspaceFactory.CreateRunspace(sshConnectionInfo, this.Host, typeTable) as RemoteRunspace;
             _tempRunspace.Open();
             _tempRunspace.ShouldCloseOnPop = true;

--- a/src/System.Management.Automation/engine/remoting/commands/PushRunspaceCommand.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/PushRunspaceCommand.cs
@@ -39,6 +39,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         public new Int32 ThrottleLimit { set { } get { return 0; } }
         private ObjectStream _stream;
+        private RemoteRunspace _tempRunspace;
 
         #endregion
 
@@ -534,6 +535,17 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         protected override void StopProcessing()
         {
+            var remoteRunspace = _tempRunspace;
+            if (remoteRunspace != null)
+            {
+                try
+                {
+                    remoteRunspace.CloseAsync();
+                }
+                catch (InvalidRunspaceStateException) { }
+                return;
+            }
+
             IHostSupportsInteractiveSession host = this.Host as IHostSupportsInteractiveSession;
             if (host == null)
             {
@@ -1272,10 +1284,12 @@ namespace Microsoft.PowerShell.Commands
         {
             var sshConnectionInfo = new SSHConnectionInfo(this.UserName, ResolveComputerName(HostName), this.KeyFilePath, this.Port);
             var typeTable = TypeTable.LoadDefaultTypeFiles();
-            var remoteRunspace = RunspaceFactory.CreateRunspace(sshConnectionInfo, this.Host, typeTable) as RemoteRunspace;
-            remoteRunspace.Open();
-            remoteRunspace.ShouldCloseOnPop = true;
-
+            _tempRunspace = RunspaceFactory.CreateRunspace(sshConnectionInfo, this.Host, typeTable) as RemoteRunspace;
+            _tempRunspace.Open();
+            _tempRunspace.ShouldCloseOnPop = true;
+            var remoteRunspace = _tempRunspace;
+            _tempRunspace = null;
+            
             return remoteRunspace;
         }
 

--- a/src/System.Management.Automation/engine/remoting/fanin/OutOfProcTransportManager.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/OutOfProcTransportManager.cs
@@ -1403,6 +1403,7 @@ namespace System.Management.Automation.Remoting.Client
         private StreamWriter _stdInWriter;
         private StreamReader _stdOutReader;
         private StreamReader _stdErrReader;
+        private bool _connectionEstablished;
         private const string _threadName = "SSHTransport Reader Thread";
 
         #endregion
@@ -1464,7 +1465,12 @@ namespace System.Management.Automation.Remoting.Client
         internal override void CloseAsync()
         {
             base.CloseAsync();
-            CloseConnection();
+
+            if (!_connectionEstablished)
+            {
+                // If the connection is not yet estalished then clean up any existing connection state.
+                CloseConnection();
+            }
         }
 
         #endregion
@@ -1642,6 +1648,7 @@ namespace System.Management.Automation.Remoting.Client
                     else
                     {
                         // Normal output data.
+                        if (!_connectionEstablished) { _connectionEstablished = true; }
                         HandleOutputDataReceived(data);
                     }
                 }

--- a/src/System.Management.Automation/engine/remoting/fanin/OutOfProcTransportManager.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/OutOfProcTransportManager.cs
@@ -1647,7 +1647,7 @@ namespace System.Management.Automation.Remoting.Client
                     }
                     else
                     {
-                        // The first PSRP message from the server indicates that the connection is established and that PSRP is running.
+                        // The first received PSRP message from the server indicates that the connection is established and that PSRP is running.
                         if (!_connectionEstablished) { _connectionEstablished = true; }
 
                         // Normal output data.
@@ -2419,3 +2419,4 @@ namespace System.Management.Automation.Remoting.Server
         #endregion
     }
 }
+

--- a/src/System.Management.Automation/engine/remoting/fanin/OutOfProcTransportManager.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/OutOfProcTransportManager.cs
@@ -1647,8 +1647,10 @@ namespace System.Management.Automation.Remoting.Client
                     }
                     else
                     {
-                        // Normal output data.
+                        // The first PSRP message from the server indicates that the connection is established and that PSRP is running.
                         if (!_connectionEstablished) { _connectionEstablished = true; }
+
+                        // Normal output data.
                         HandleOutputDataReceived(data);
                     }
                 }


### PR DESCRIPTION
This is a fix for issue #4686.

I inadvertently created this regression with PR #4475.  The problem is that connection state is terminated before the session close sequence completes.  The fix is to only clean up connection state on session close if the session was never established.

I also added code to Enter-PSSession to handle a similar case where the Cmdlet operation is stopped before the connection or session is created.  This is important for SSH remoting because PowerShell interacts with SSH and it is possible to cancel before a connection is even started.

```powershell
PS > Enter-PSSession -hostname <hostname> -User <username>
<username>@<hostname>'s password:
Ctrl+C
PS >
```
