### PR TITLE
GetNetworkCredential() returns null if PSCredential has null or empty user name

### DIFF
--- a/src/System.Management.Automation/engine/Credential.cs
+++ b/src/System.Management.Automation/engine/Credential.cs
@@ -330,6 +330,12 @@ namespace System.Management.Automation
                                             out string user,
                                             out string domain)
         {
+            if (String.IsNullOrEmpty(input))
+            {
+                user = domain = null;
+                return false;
+            }
+
             SplitUserDomain(input, out user, out domain);
 
             if ((user == null) ||

--- a/test/powershell/engine/Basic/Credential.Tests.ps1
+++ b/test/powershell/engine/Basic/Credential.Tests.ps1
@@ -1,6 +1,6 @@
 Describe "Credential tests" -Tags "CI" {
     It "Explicit cast for an empty credential returns null" {
          # We should explicitly check that the expression returns $null
-         [PSCredential]::Empty.GetNetworkCredential() -eq $null | Should Be $true
+         [PSCredential]::Empty.GetNetworkCredential() | Should Be $null
     }
 }

--- a/test/powershell/engine/Basic/Credential.Tests.ps1
+++ b/test/powershell/engine/Basic/Credential.Tests.ps1
@@ -1,0 +1,6 @@
+Describe "Credential tests" -Tags "CI" {
+    It "Explicit cast for an empty credential returns null" {
+         # We should explicitly check that the expression returns $null
+         [PSCredential]::Empty.GetNetworkCredential() -eq $null | Should Be $true
+    }
+}


### PR DESCRIPTION
Fix #4696

### Problem descriptions

[System.Management.Automation.PSCredential](https://msdn.microsoft.com/en-us/library/system.management.automation.pscredential.empty) allow user name being empty but explicit cast [pscredential]::Empty.GetNetworkCredential() throws.

### Fix

GetNetworkCredential() returns null if PSCredential has null or empty user name
