### PR TITLE
Make TabCompletion case-insensitive for file names on Unix

### DIFF
--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -4061,10 +4061,8 @@ namespace System.Management.Automation
                 var relativePaths = context.GetOption("RelativePaths", @default: defaultRelative);
                 var useLiteralPath = context.GetOption("LiteralPaths", @default: false);
 
-                if (useLiteralPath && LocationGlobber.StringContainsGlobCharacters(wordToComplete))
-                {
-                    wordToComplete = WildcardPattern.Escape(wordToComplete, Utils.Separators.StarOrQuestion);
-                }
+                // We should always escape '[' and ']' if present.
+                wordToComplete = WildcardPattern.Escape(wordToComplete, Utils.Separators.StarOrQuestion);
 
                 if (!defaultRelative && wordToComplete.Length >= 2 && wordToComplete[1] == ':' && char.IsLetter(wordToComplete[0]) && executionContext != null)
                 {
@@ -4072,6 +4070,7 @@ namespace System.Management.Automation
                     // can succeed.  This call will mount the drive if it wasn't already.
                     executionContext.SessionState.Drive.GetAtScope(wordToComplete.Substring(0, 1), "global");
                 }
+
 #if UNIX
                 // We use globbing to get completions.
                 // Globbing is based on system functions which is case-sensitive on Unix.

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -4072,7 +4072,23 @@ namespace System.Management.Automation
                     // can succeed.  This call will mount the drive if it wasn't already.
                     executionContext.SessionState.Drive.GetAtScope(wordToComplete.Substring(0, 1), "global");
                 }
+#if UNIX
+                StringBuilder sb = new StringBuilder();
 
+                foreach (var ch in wordToComplete.ToCharArray())
+                {
+                    if (Char.IsLetter(ch))
+                    {
+                        sb.Append('[').Append(Char.ToLower(ch)).Append(Char.ToUpper(ch)).Append(']');
+                    }
+                    else
+                    {
+                        sb.Append(ch);
+                    }
+                }
+
+                wordToComplete = sb.ToString();
+#endif
                 var powerShellExecutionHelper = context.Helper;
                 powerShellExecutionHelper
                     .AddCommandWithPreferenceSetting("Microsoft.PowerShell.Management\\Resolve-Path")

--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -1356,6 +1356,7 @@ namespace System.Management.Automation
             internal static readonly char[] SpaceOrTab = new char[] { ' ', '\t' };
             internal static readonly char[] Newline = new char[] { '\n' };
             internal static readonly char[] CrLf = new char[] { '\r', '\n' };
+            internal static readonly char[] Brackets = new char[] { '[', ']' };
 
             // (Copied from System.IO.Path so we can call TrimEnd in the same way that Directory.EnumerateFiles would on the search patterns).
             // Trim trailing white spaces, tabs etc but don't be aggressive in removing everything that has UnicodeCategory of trailing space.

--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -1356,7 +1356,6 @@ namespace System.Management.Automation
             internal static readonly char[] SpaceOrTab = new char[] { ' ', '\t' };
             internal static readonly char[] Newline = new char[] { '\n' };
             internal static readonly char[] CrLf = new char[] { '\r', '\n' };
-            internal static readonly char[] Brackets = new char[] { '[', ']' };
 
             // (Copied from System.IO.Path so we can call TrimEnd in the same way that Directory.EnumerateFiles would on the search patterns).
             // Trim trailing white spaces, tabs etc but don't be aggressive in removing everything that has UnicodeCategory of trailing space.

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -493,8 +493,8 @@ Describe "TabCompletion" -Tags CI {
                 $beforeTab = 'filesystem::{0}\Wind' -f $env:SystemDrive
                 $afterTab = 'filesystem::{0}\Windows' -f $env:SystemDrive
             } else {
-                $beforeTab = 'filesystem::/us' -f $env:SystemDrive
-                $afterTab = 'filesystem::/usr' -f $env:SystemDrive
+                $beforeTab = 'filesystem::/sbi' -f $env:SystemDrive
+                $afterTab = 'filesystem::/sbin' -f $env:SystemDrive
             }
             $res = TabExpansion2 -inputScript $beforeTab -cursorColumn $beforeTab.Length
             $res.CompletionMatches.Count | Should BeGreaterThan 0

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -198,8 +198,8 @@ Describe "TabCompletion" -Tags CI {
     Context "File name completion" {
         BeforeAll {
             $oneSubDirLowerTest = "onesubd"
-            $oneSubDirUpperTest = "oNeSubD"
-            $oneSubDirTest = "oneSubDir"
+            $oneSubDirUpperTest = "oneSubD"
+            $oneSubDirTest = "onesubdir"
 
             $tempDir = Join-Path -Path $TestDrive -ChildPath "baseDir"
             $oneSubDir = Join-Path -Path $tempDir -ChildPath $oneSubDirTest
@@ -210,6 +210,13 @@ Describe "TabCompletion" -Tags CI {
             New-Item -Path $oneSubDir -ItemType Directory -Force > $null
             New-Item -Path $oneSubDirPrime -ItemType Directory -Force > $null
             New-Item -Path $twoSubDir -ItemType Directory -Force > $null
+
+            if (!$IsWindows) {
+                $oneSubDirTest2 = "oneSubDir"
+                $oneSubDir2 = Join-Path -Path $tempDir -ChildPath $oneSubDirTest2
+                New-Item -Path $oneSubDir2 -ItemType Directory -Force > $null
+            }
+
 
             $testCases = @(
                 @{ inputStr = "ab"; name = "abc"; localExpected = ".${separator}abc"; oneSubExpected = "..${separator}abc"; twoSubExpected = "..${separator}..${separator}abc" }
@@ -245,7 +252,7 @@ Describe "TabCompletion" -Tags CI {
             Pop-Location
         }
 
-        It "TabCompletion should be case-insensitive for file names" {
+        It "TabCompletion should be case-insensitive for file names on Windows" -Skip:(!$IsWindows) {
             Push-Location -Path $tempDir
             $res = TabExpansion2 -inputScript $oneSubDirLowerTest -cursorColumn $oneSubDirLowerTest.Length
             $res.CompletionMatches.Count | Should BeGreaterThan 0
@@ -254,6 +261,17 @@ Describe "TabCompletion" -Tags CI {
             $res = TabExpansion2 -inputScript $oneSubDirUpperTest -cursorColumn $oneSubDirUpperTest.Length
             $res.CompletionMatches.Count | Should BeGreaterThan 0
             $res.CompletionMatches[0].CompletionText | Should Be ".${separator}$oneSubDirTest"
+        }
+
+        It "TabCompletion should be case-sensitive for file names on Unix" -Skip:($IsWindows) {
+            Push-Location -Path $tempDir
+            $res = TabExpansion2 -inputScript $oneSubDirLowerTest -cursorColumn $oneSubDirLowerTest.Length
+            $res.CompletionMatches.Count | Should BeGreaterThan 0
+            $res.CompletionMatches[0].CompletionText | Should BeExactly ".${separator}$oneSubDirTest"
+
+            $res = TabExpansion2 -inputScript $oneSubDirUpperTest -cursorColumn $oneSubDirUpperTest.Length
+            $res.CompletionMatches.Count | Should BeGreaterThan 0
+            $res.CompletionMatches[0].CompletionText | Should BeExactly ".${separator}$oneSubDirTest2"
         }
 
         It "Input '<inputStr>' should successfully complete" -TestCases $testCases {

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -197,8 +197,12 @@ Describe "TabCompletion" -Tags CI {
 
     Context "File name completion" {
         BeforeAll {
+            $oneSubDirLowerTest = "onesubd"
+            $oneSubDirUpperTest = "oNeSubD"
+            $oneSubDirTest = "oneSubDir"
+
             $tempDir = Join-Path -Path $TestDrive -ChildPath "baseDir"
-            $oneSubDir = Join-Path -Path $tempDir -ChildPath "oneSubDir"
+            $oneSubDir = Join-Path -Path $tempDir -ChildPath $oneSubDirTest
             $oneSubDirPrime = Join-Path -Path $tempDir -ChildPath "prime"
             $twoSubDir = Join-Path -Path $oneSubDir -ChildPath "twoSubDir"
 
@@ -239,6 +243,17 @@ Describe "TabCompletion" -Tags CI {
 
         AfterEach {
             Pop-Location
+        }
+
+        It "TabCompletion should be case-insensitive for file names" {
+            Push-Location -Path $tempDir
+            $res = TabExpansion2 -inputScript $oneSubDirLowerTest -cursorColumn $oneSubDirLowerTest.Length
+            $res.CompletionMatches.Count | Should BeGreaterThan 0
+            $res.CompletionMatches[0].CompletionText | Should Be ".${separator}$oneSubDirTest"
+
+            $res = TabExpansion2 -inputScript $oneSubDirUpperTest -cursorColumn $oneSubDirUpperTest.Length
+            $res.CompletionMatches.Count | Should BeGreaterThan 0
+            $res.CompletionMatches[0].CompletionText | Should Be ".${separator}$oneSubDirTest"
         }
 
         It "Input '<inputStr>' should successfully complete" -TestCases $testCases {


### PR DESCRIPTION
## PR Summary

Attempt to fix #1273 

## PR Checklist

- [ ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
