### PR TITLE
change the default windows RID to win7-<arch>

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -641,6 +641,13 @@ function New-PSOptions {
             }
         }
 
+        # We plan to release packages targetting win7-x64 and win7-x86 RIDs, 
+        # which supports all supported windows platforms.
+        # So we, will change the RID to win7-<arch>
+        if ($Environment.IsWindows) {
+            $Runtime = $Runtime -replace "win\d+", "win7"
+        }
+
         if (-not $Runtime) {
             Throw "Could not determine Runtime Identifier, please update dotnet"
         } else {

--- a/tools/appveyor.psm1
+++ b/tools/appveyor.psm1
@@ -320,7 +320,7 @@ function Invoke-AppVeyorTest
     #
     # CoreCLR
 
-    $env:CoreOutput = Split-Path -Parent (Get-PSOutput -Options (New-PSOptions -Configuration 'Release'))
+    $env:CoreOutput = Split-Path -Parent (Get-PSOutput -Options (Get-PSOptions))
     Write-Host -Foreground Green 'Run CoreCLR tests'
     $testResultsNonAdminFile = "$pwd\TestsResultsNonAdmin.xml"
     $testResultsAdminFile = "$pwd\TestsResultsAdmin.xml"


### PR DESCRIPTION
Addresses an issue where build artifacts are not being produced in daily builds.
