### PR TITLE
Push locals of automatic variables to 'DottedScopes' when dotting script cmdlets

### DIFF
--- a/src/System.Management.Automation/engine/CmdletParameterBinderController.cs
+++ b/src/System.Management.Automation/engine/CmdletParameterBinderController.cs
@@ -215,9 +215,7 @@ namespace System.Management.Automation
             var psCompiledScriptCmdlet = this.Command as PSScriptCmdlet;
             if (psCompiledScriptCmdlet != null)
             {
-                psCompiledScriptCmdlet.PrepareForBinding(
-                    ((ScriptParameterBinder)this.DefaultParameterBinder).LocalScope,
-                    this.CommandLineParameters);
+                psCompiledScriptCmdlet.PrepareForBinding(this.CommandLineParameters);
             }
 
             // Add the passed in arguments to the unboundArguments collection
@@ -1758,14 +1756,6 @@ namespace System.Management.Automation
                         if (_dynamicParameterBinder == null)
                         {
                             s_tracer.WriteLine("Getting the bindable object from the Cmdlet");
-
-                            var psCompiledScriptCmdlet = this.Command as PSScriptCmdlet;
-                            if (psCompiledScriptCmdlet != null)
-                            {
-                                psCompiledScriptCmdlet.PrepareForBinding(
-                                    ((ScriptParameterBinder)this.DefaultParameterBinder).LocalScope,
-                                    this.CommandLineParameters);
-                            }
 
                             // Now get the dynamic parameter bindable object.
                             object dynamicParamBindableObject;

--- a/src/System.Management.Automation/engine/ScriptCommandProcessor.cs
+++ b/src/System.Management.Automation/engine/ScriptCommandProcessor.cs
@@ -269,6 +269,12 @@ namespace System.Management.Automation
             _obsoleteAttribute = _scriptBlock.ObsoleteAttribute;
             _runOptimizedCode = _scriptBlock.Compile(optimized: _context._debuggingMode > 0 ? false : UseLocalScope);
             _localsTuple = _scriptBlock.MakeLocalsTuple(_runOptimizedCode);
+
+            if (UseLocalScope)
+            {
+                Diagnostics.Assert(CommandScope.LocalsTuple == null, "a newly created scope shouldn't have it's tuple set.");
+                CommandScope.LocalsTuple = _localsTuple;
+            }
         }
 
         /// <summary>
@@ -282,12 +288,6 @@ namespace System.Management.Automation
 
         internal override void Prepare(IDictionary psDefaultParameterValues)
         {
-            if (UseLocalScope)
-            {
-                Diagnostics.Assert(CommandScope.LocalsTuple == null, "a newly created scope shouldn't have it's tuple set.");
-                CommandScope.LocalsTuple = _localsTuple;
-            }
-
             _localsTuple.SetAutomaticVariable(AutomaticVariable.MyInvocation, this.Command.MyInvocation, _context);
             _scriptBlock.SetPSScriptRootAndPSCommandPath(_localsTuple, _context);
             _functionContext = new FunctionContext
@@ -585,6 +585,8 @@ namespace System.Management.Automation
 
         protected override void OnSetCurrentScope()
         {
+            // When dotting a script, push the locals of automatic variables to
+            // the 'DottedScopes' of the current scope.
             if (!UseLocalScope)
             {
                 CommandSessionState.CurrentScope.DottedScopes.Push(_localsTuple);
@@ -593,6 +595,8 @@ namespace System.Management.Automation
 
         protected override void OnRestorePreviousScope()
         {
+            // When dotting a script, pop the locals of automatic variables from
+            // the 'DottedScopes' of the current scope.
             if (!UseLocalScope)
             {
                 CommandSessionState.CurrentScope.DottedScopes.Pop();

--- a/src/System.Management.Automation/engine/runtime/CompiledScriptBlock.cs
+++ b/src/System.Management.Automation/engine/runtime/CompiledScriptBlock.cs
@@ -1864,21 +1864,11 @@ namespace System.Management.Automation
         private void EnterScope()
         {
             _commandRuntime.SetVariableListsInPipe();
-
-            if (!_useLocalScope)
-            {
-                this.Context.SessionState.Internal.CurrentScope.DottedScopes.Push(_localsTuple);
-            }
         }
 
         private void ExitScope()
         {
             _commandRuntime.RemoveVariableListsInPipe();
-
-            if (!_useLocalScope)
-            {
-                this.Context.SessionState.Internal.CurrentScope.DottedScopes.Pop();
-            }
         }
 
         private void RunClause(Action<FunctionContext> clause, object dollarUnderbar, object inputToProcess)
@@ -1986,12 +1976,33 @@ namespace System.Management.Automation
             return null;
         }
 
-        public void PrepareForBinding(SessionStateScope scope, CommandLineParameters commandLineParameters)
+        /// <summary>
+        /// If the script cmdlet will run in a new local scope, this method is used to set the locals to the newly created scope.
+        /// </summary>
+        internal void SetLocalsTupleForNewScope(SessionStateScope scope)
         {
-            if (_useLocalScope && scope.LocalsTuple == null)
-            {
-                scope.LocalsTuple = _localsTuple;
-            }
+            Diagnostics.Assert(scope.LocalsTuple == null, "a newly created scope shouldn't have it's tuple set.");
+            scope.LocalsTuple = _localsTuple;
+        }
+
+        /// <summary>
+        /// If the script cmdlet is dotted, this method is used to push the locals to the 'DottedScopes' of the current scope.
+        /// </summary>
+        internal void PushDottedScope(SessionStateScope scope)
+        {
+            scope.DottedScopes.Push(_localsTuple);
+        }
+
+        /// <summary>
+        /// If the script cmdlet is dotted, this method is used to pop the locals from the 'DottedScopes' of the current scope.
+        /// </summary>
+        internal void PopDottedScope(SessionStateScope scope)
+        {
+            scope.DottedScopes.Pop();
+        }
+
+        internal void PrepareForBinding(CommandLineParameters commandLineParameters)
+        {
             _localsTuple.SetAutomaticVariable(AutomaticVariable.PSBoundParameters,
                                               commandLineParameters.GetValueToBindToPSBoundParameters(), this.Context);
             _localsTuple.SetAutomaticVariable(AutomaticVariable.MyInvocation, MyInvocation, this.Context);


### PR DESCRIPTION
Fix #4688

When dotting a script cmdlet, the locals of automatic variables from the `PSScriptCmdlet` is not set up in the current scope before parameter binding. The fix is to push the locals in `CommandProcessor.OnSetCurrentScope` and pop them in `CommandProcessor.OnRestorePreviousScope`, which will be called from `SetCurrentScopeToExecutionScope` and `RestorePreviousScope` respectively.

Summary of changes:
1. When a new local scope is used, currently we set the locals for `CommandProcessor` right before parameter binding (in `BindCommandLineParametersNoValidation`); we set the locals for `ScriptCommandProcessor` in `Prepare`. I moved both to the constructor, right after the new scope is created so that the code is more consistent.

2. In `CmdletParameterBinderController.cs`, we set up the `PSBoundParameters` and `MyInvocation` variables in `HandleCommandLineDynamicParameters` again, which I think is unnecessary because this method is only called from `BindCommandLineParametersNoValidation`, where the setup is done for the first time.

3. Currently, the locals will be set for dotted script cmdlet in `EnterScope()` and `ExitScope()`. Now, that logic is moved to `OnSetCurrentScope` and `OnRestorePreviousScope` of `CommandProcessor`. This not only makes sure that locals are set before parameter binding, but also is consistent with the `ScriptCommandProcessor`.