### PR TITLE
Fix 'using module' when module has non-terminating errors handled with 'SilentlyContinue'

### DIFF
--- a/test/powershell/Language/Classes/scripting.Classes.using.tests.ps1
+++ b/test/powershell/Language/Classes/scripting.Classes.using.tests.ps1
@@ -523,5 +523,27 @@ using module FooForPaths
             }
         }
     }
+
+    Context "module has non-terminating error handled with 'SilentlyContinue'" {
+        BeforeAll {
+            $testFile = Join-Path -Path $TestDrive -ChildPath "testmodule.psm1"
+            $content = @'
+Get-Command -CommandType Application -Name NonExisting -ErrorAction SilentlyContinue
+class TestClass { [string] GetName() { return "TestClass" } }
+'@
+            Set-Content -Path $testFile -Value $content -Force
+        }
+        AfterAll {
+            Remove-Module -Name testmodule -Force -ErrorAction SilentlyContinue
+        }
+
+        It "'using module' should succeed" {
+            $result = [scriptblock]::Create(@"
+using module $testFile
+[TestClass]::new()
+"@).Invoke()
+            $result.GetName() | Should Be "TestClass"
+        }
+    }
 }
 


### PR DESCRIPTION
Attempt to fix #4695

`Compiler.LoadModule` assumes that when `ps.HadErrors == true` the error stream is not empty. However, when `SilentlyContinue` is specified as the error action, the non-terminating error is not kept in `ErrorOutputPipe` of the cmdlet and thus does not appear in `ps.Streams.Error`. So when `ps.HadErrors == true` while `ps.Streams.Error` is empty, it suggests it's OK to ignore the errors because they are explicitly suppressed with `SilentlyContinue` error action.

So in my opinion, the expected behavior of `"using module .\mod.psm1"` in this case should be successful, as if `ps.HaddErrors` is false.