### PR TITLE
Report the same number of basic parsing tests when run in Travis via cron

### DIFF
--- a/test/tools/Modules/HelpersLanguage/HelpersLanguage.psm1
+++ b/test/tools/Modules/HelpersLanguage/HelpersLanguage.psm1
@@ -81,8 +81,21 @@ function ShouldBeParseError
     #       https://github.com/dotnet/coreclr/issues/9745
     #
     if ($SkipInTravisFullBuild) {
-        ## Report that we skipped the test and return
-        It "Parse error expected: <<$src>>" -Skip {}
+        ## Report that we skipped the tests and return
+        ## be sure to report the same number of tests
+        ## it should have the same appearance as if the tests were run
+        Context "Parse error expected: <<$src>>" {
+            if ($SkipAndCheckRuntimeError)
+            {
+                It "error should happen at parse time, not at runtime" -Skip {}
+            }
+            It "Error count" -Skip { }
+            foreach($expectedError in $expectedErrors)
+            {
+                It "Error Id" -Skip { }
+                It "Error position" -Skip { }
+            }
+        }
         return
     }
 


### PR DESCRIPTION

update the logic when tests are skipped on travis for our daily build so it better mirrors what we report when we actually run the tests. This means that when we compare runs across platforms we report on the same tests (even though they're skipped)
