### PR TITLE
Move WebCmdlets HTTPS tests to WebListener

### DIFF
--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -1187,7 +1187,7 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
         
         # Test skipped on macOS pending support for Client Certificate Authentication
         # https://github.com/PowerShell/PowerShell/issues/4650
-        It "Verifies Invoke-WebRequest Certificate Authentication Successful with -Certificate" -skip:$IsOSX {
+        It "Verifies Invoke-WebRequest Certificate Authentication Successful with -Certificate" -Pending:$IsOSX {
             $uri = Get-WebListenerUrl -Https -Test 'Cert'
             $certificate = Get-WebListenerClientCertificate
             $result = Invoke-WebRequest -Uri $uri -Certificate $certificate -SkipCertificateCheck | 
@@ -1728,7 +1728,7 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
         
         # Test skipped on macOS pending support for Client Certificate Authentication
         # https://github.com/PowerShell/PowerShell/issues/4650
-        It "Verifies Invoke-RestMethod Certificate Authentication Successful with -Certificate" -skip:$IsOSX {
+        It "Verifies Invoke-RestMethod Certificate Authentication Successful with -Certificate" -Pending:$IsOSX {
             $uri = Get-WebListenerUrl -Https -Test 'Cert'
             $certificate = Get-WebListenerClientCertificate
             $result = Invoke-RestMethod -uri $uri -Certificate $certificate -SkipCertificateCheck

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -1182,7 +1182,7 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
                 Select-Object -ExpandProperty Content |
                 ConvertFrom-Json
             
-            $result.Status  | Should Be 'FAILED'
+            $result.Status | Should Be 'FAILED'
         }
         
         # Test skipped on macOS pending support for Client Certificate Authentication
@@ -1194,7 +1194,7 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
                 Select-Object -ExpandProperty Content |
                 ConvertFrom-Json
             
-            $result.Status  | Should Be 'OK'
+            $result.Status | Should Be 'OK'
             $result.Thumbprint | Should Be $certificate.Thumbprint
         }
     }
@@ -1723,7 +1723,7 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
             $uri = Get-WebListenerUrl -Https -Test 'Cert'
             $result = Invoke-RestMethod -Uri $uri -SkipCertificateCheck
             
-            $result.Status  | Should Be 'FAILED'
+            $result.Status | Should Be 'FAILED'
         }
         
         # Test skipped on macOS pending support for Client Certificate Authentication
@@ -1733,7 +1733,7 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
             $certificate = Get-WebListenerClientCertificate
             $result = Invoke-RestMethod -uri $uri -Certificate $certificate -SkipCertificateCheck
             
-            $result.Status  | Should Be 'OK'
+            $result.Status | Should Be 'OK'
             $result.Thumbprint | Should Be $certificate.Thumbprint
         }
     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -686,12 +686,14 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
     It "Validate Invoke-WebRequest -SkipCertificateCheck" {
 
         # validate that exception is thrown for URI with expired certificate
-        $command = "Invoke-WebRequest -Uri 'https://expired.badssl.com'"
+        $Uri = Get-WebListenerUrl -Https
+        $command = "Invoke-WebRequest -Uri '$Uri'"
         $result = ExecuteWebCommand -command $command
         $result.Error.FullyQualifiedErrorId | Should Be "WebCmdletWebResponseException,Microsoft.PowerShell.Commands.InvokeWebRequestCommand"
 
         # validate that no exception is thrown for URI with expired certificate when using -SkipCertificateCheck option
-        $command = "Invoke-WebRequest -Uri 'https://expired.badssl.com' -SkipCertificateCheck"
+        $Uri = Get-WebListenerUrl -Https
+        $command = "Invoke-WebRequest -Uri '$Uri' -SkipCertificateCheck"
         $result = ExecuteWebCommand -command $command
         $result.Error | Should BeNullOrEmpty
     }
@@ -747,8 +749,8 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
     }
 
     It "Validate Invoke-WebRequest returns native HTTPS error message in exception" {
-
-        $command = "Invoke-WebRequest -Uri https://incomplete.chain.badssl.com"
+        $uri = Get-WebListenerUrl -Https
+        $command = "Invoke-WebRequest -Uri '$uri'"
         $result = ExecuteWebCommand -command $command
 
         # need to check against inner exception since Linux and Windows uses different HTTP client libraries so errors aren't the same
@@ -1495,12 +1497,13 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
 
         # HTTP method HEAD must be used to not retrieve an unparsable HTTP body
         # validate that exception is thrown for URI with expired certificate
-        $command = "Invoke-RestMethod -Uri 'https://expired.badssl.com' -Method HEAD"
+        $uri= Get-WebListenerUrl -Https
+        $command = "Invoke-RestMethod -Uri '$uri' -Method HEAD"
         $result = ExecuteWebCommand -command $command
         $result.Error.FullyQualifiedErrorId | Should Be "WebCmdletWebResponseException,Microsoft.PowerShell.Commands.InvokeRestMethodCommand"
 
         # validate that no exception is thrown for URI with expired certificate when using -SkipCertificateCheck option
-        $command = "Invoke-RestMethod -Uri 'https://expired.badssl.com' -SkipCertificateCheck -Method HEAD"
+        $command = "Invoke-RestMethod -Uri '$uri' -SkipCertificateCheck -Method HEAD"
         $result = ExecuteWebCommand -command $command
         $result.Error | Should BeNullOrEmpty
     }
@@ -1563,7 +1566,8 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
 
     It "Validate Invoke-RestMethod returns native HTTPS error message in exception" {
 
-        $command = "Invoke-RestMethod -Uri https://incomplete.chain.badssl.com"
+        $uri = Get-WebListenerUrl -Https
+        $command = "Invoke-RestMethod -Uri '$uri'"
         $result = ExecuteWebCommand -command $command
 
         # need to check against inner exception since Linux and Windows uses different HTTP client libraries so errors aren't the same


### PR DESCRIPTION
Resolves #4719

* Move badssl.com tests to local WebListener to remove reliance on external site for test. 
* Move HTTPS tests to their own context

Made separate commits to make it a bit easier to see the changes.