### PR TITLE
Minor update to using-vscode.md

### DIFF
--- a/docs/learning-powershell/using-vscode.md
+++ b/docs/learning-powershell/using-vscode.md
@@ -59,13 +59,13 @@ If you wish to use a specific installation of PowerShell with Visual Studio Code
 
   ```json
     // On Windows:
-    "powershell.developer.powerShellExePath": "c:/Program Files/PowerShell/<version>/powershell.exe"
+    "powershell.powerShellExePath": "c:/Program Files/PowerShell/<version>/powershell.exe"
 
     // On Linux:
-    "powershell.developer.powerShellExePath": "/opt/microsoft/powershell/<version>/powershell"
+    "powershell.powerShellExePath": "/opt/microsoft/powershell/<version>/powershell"
 
     // On macOS:
-    "powershell.developer.powerShellExePath": "/usr/local/microsoft/powershell/<version>/powershell"
+    "powershell.powerShellExePath": "/usr/local/microsoft/powershell/<version>/powershell"
   ```
 
 3. Replace the setting with the path to the desired PowerShell executable


### PR DESCRIPTION
Setting 'powershell.developer.powerShellExePath' is deprecated and should be changed to 'powershell.powerShellExePath'