### PR TITLE
Fix of #4665 to have a simple file based check for the VC++ 2015 redistributables

### DIFF
--- a/assets/Product.wxs
+++ b/assets/Product.wxs
@@ -61,7 +61,7 @@
     <!--We need to show EULA, and provide option to customize download location-->        
     <Property Id="WIXUI_INSTALLDIR" Value="INSTALLFOLDER" />
 
-    <!-- Prerequisite check for Windows Universal C time -->
+    <!-- Prerequisite check for Windows Universal C runtime -->
     <Property Id="UCRTINSTALLED" Secure="yes">
       <DirectorySearch Id="Windows_System32_search1" Path="[WindowsFolder]System32" Depth="0">
         <FileSearch Name="ucrtbase.dll"/>

--- a/assets/Product.wxs
+++ b/assets/Product.wxs
@@ -62,7 +62,7 @@
     <Property Id="WIXUI_INSTALLDIR" Value="INSTALLFOLDER" />
 
     <!-- Prerequisite check for Windows Universal C runtime -->
-    <Property Id="Universal_CRuntime_Installed" Secure="yes">
+    <Property Id="UNIVERSAL_C_RUNTIME_INSTALLED" Secure="yes">
       <DirectorySearch Id="WindowsDirectory" Path="[WindowsFolder]">
         <DirectorySearch Id="System32" Path="System32">
           <FileSearch Id="ucrtbase" Name="ucrtbase.dll"/>
@@ -70,17 +70,17 @@
       </DirectorySearch>
     </Property>	
     <Condition Message="$(env.ProductName) requires the Universal C Runtime to be installed. You can find a download link to it here: https://github.com/PowerShell/PowerShell/blob/master/docs/installation/windows.md#prerequisites">
-      <![CDATA[Installed OR Universal_CRuntime_Installed]]>
+      <![CDATA[Installed OR UNIVERSAL_C_RUNTIME_INSTALLED]]>
     </Condition>
 
      <!-- Prerequisite check for Visual Studio 2015 C++ redistributables -->
-     <Property Id="Visual_CPP_Runtime_Installed" Secure="yes">
+     <Property Id="VISUAL_CPP_RUNTIME_INSTALLED" Secure="yes">
       <DirectorySearchRef Id="System32" Parent="WindowsDirectory" Path="System32">
         <FileSearch Id="vcruntime140" Name="vcruntime140.dll"/>
       </DirectorySearchRef>
     </Property>	
     <Condition Message="$(env.ProductName) requires the Visual Studio 2015 C++ redistributables to be installed. You can find a download link to it here: https://github.com/PowerShell/PowerShell/blob/master/docs/installation/windows.md#prerequisites">
-      <![CDATA[Installed OR Visual_CPP_Runtime_Installed]]>
+      <![CDATA[Installed OR VISUAL_CPP_RUNTIME_INSTALLED]]>
     </Condition>
 
     <Directory Id="TARGETDIR" Name="SourceDir">

--- a/assets/Product.wxs
+++ b/assets/Product.wxs
@@ -60,15 +60,25 @@
 
     <!--We need to show EULA, and provide option to customize download location-->        
     <Property Id="WIXUI_INSTALLDIR" Value="INSTALLFOLDER" />
-	
-    <!-- Prerequisites check for Windows Universal C time and Visual Studio 2015 C++ redistributables -->
+
+    <!-- Prerequisite check for Windows Universal C time -->
     <Property Id="UCRTINSTALLED" Secure="yes">
-      <DirectorySearch Id="Windows_System32" Path="[WindowsFolder]System32" Depth="0">
+      <DirectorySearch Id="Windows_System32_search1" Path="[WindowsFolder]System32" Depth="0">
         <FileSearch Name="ucrtbase.dll"/>
       </DirectorySearch>
     </Property>	
     <Condition Message="$(env.ProductName) requires the Universal C Runtime to be installed. You can download it here: https://www.microsoft.com/download/details.aspx?id=50410">
       <![CDATA[Installed OR UCRTINSTALLED]]>
+    </Condition>
+
+     <!-- Prerequisite check for Visual Studio 2015 C++ redistributables -->
+     <Property Id="VCRUNTIMEINSTALLED" Secure="yes">
+      <DirectorySearch Id="Windows_System32_search2" Path="[WindowsFolder]System32" Depth="0">
+        <FileSearch Name="vcruntime140.dll"/>
+      </DirectorySearch>
+    </Property>	
+    <Condition Message="$(env.ProductName) requires the Visual Studio 2015 C++ redistributables to be installed. You can download it here: https://www.microsoft.com/download/details.aspx?id=48145">
+      <![CDATA[Installed OR VCRUNTIMEINSTALLED]]>
     </Condition>
 
     <Directory Id="TARGETDIR" Name="SourceDir">

--- a/assets/Product.wxs
+++ b/assets/Product.wxs
@@ -69,7 +69,7 @@
         </DirectorySearch>
       </DirectorySearch>
     </Property>	
-    <Condition Message="$(env.ProductName) requires the Universal C Runtime to be installed. You can download it here: https://www.microsoft.com/download/details.aspx?id=50410">
+    <Condition Message="$(env.ProductName) requires the Universal C Runtime to be installed. You can find a download link to it here: https://github.com/PowerShell/PowerShell/blob/master/docs/installation/windows.md#prerequisites">
       <![CDATA[Installed OR Universal_CRuntime_Installed]]>
     </Condition>
 
@@ -79,7 +79,7 @@
         <FileSearch Id="vcruntime140" Name="vcruntime140.dll"/>
       </DirectorySearchRef>
     </Property>	
-    <Condition Message="$(env.ProductName) requires the Visual Studio 2015 C++ redistributables to be installed. You can download it here: https://www.microsoft.com/download/details.aspx?id=48145">
+    <Condition Message="$(env.ProductName) requires the Visual Studio 2015 C++ redistributables to be installed. You can find a download link to it here: https://github.com/PowerShell/PowerShell/blob/master/docs/installation/windows.md#prerequisites">
       <![CDATA[Installed OR Visual_CPP_Runtime_Installed]]>
     </Condition>
 

--- a/assets/Product.wxs
+++ b/assets/Product.wxs
@@ -62,23 +62,25 @@
     <Property Id="WIXUI_INSTALLDIR" Value="INSTALLFOLDER" />
 
     <!-- Prerequisite check for Windows Universal C runtime -->
-    <Property Id="UCRTINSTALLED" Secure="yes">
-      <DirectorySearch Id="Windows_System32_search1" Path="[WindowsFolder]System32" Depth="0">
-        <FileSearch Name="ucrtbase.dll"/>
+    <Property Id="Universal_CRuntime_Installed" Secure="yes">
+      <DirectorySearch Id="WindowsDirectory" Path="[WindowsFolder]">
+        <DirectorySearch Id="System32" Path="System32">
+          <FileSearch Id="ucrtbase" Name="ucrtbase.dll"/>
+        </DirectorySearch>
       </DirectorySearch>
     </Property>	
     <Condition Message="$(env.ProductName) requires the Universal C Runtime to be installed. You can download it here: https://www.microsoft.com/download/details.aspx?id=50410">
-      <![CDATA[Installed OR UCRTINSTALLED]]>
+      <![CDATA[Installed OR Universal_CRuntime_Installed]]>
     </Condition>
 
      <!-- Prerequisite check for Visual Studio 2015 C++ redistributables -->
-     <Property Id="VCRUNTIMEINSTALLED" Secure="yes">
-      <DirectorySearch Id="Windows_System32_search2" Path="[WindowsFolder]System32" Depth="0">
-        <FileSearch Name="vcruntime140.dll"/>
-      </DirectorySearch>
+     <Property Id="Visual_CPP_Runtime_Installed" Secure="yes">
+      <DirectorySearchRef Id="System32" Parent="WindowsDirectory" Path="System32">
+        <FileSearch Id="vcruntime140" Name="vcruntime140.dll"/>
+      </DirectorySearchRef>
     </Property>	
     <Condition Message="$(env.ProductName) requires the Visual Studio 2015 C++ redistributables to be installed. You can download it here: https://www.microsoft.com/download/details.aspx?id=48145">
-      <![CDATA[Installed OR VCRUNTIMEINSTALLED]]>
+      <![CDATA[Installed OR Visual_CPP_Runtime_Installed]]>
     </Condition>
 
     <Directory Id="TARGETDIR" Name="SourceDir">

--- a/test/powershell/Installer/WindowsInstaller.Tests.ps1
+++ b/test/powershell/Installer/WindowsInstaller.Tests.ps1
@@ -14,24 +14,22 @@ Describe "Windows Installer" -Tags "Scenario" {
         $global:PSDefaultParameterValues = $originalDefaultParameterValues
     }
 
-    Context "Universal C Runtime Download Link" {
-        $universalCRuntimeDownloadLink = 'https://www.microsoft.com/download/details.aspx?id=50410'
-        It "Wix file should have download link about Universal C runtime" -Pending {
-           (Get-Content $wixProductFile -Raw).Contains($universalCRuntimeDownloadLink) | Should Be $true
-        }
-        It "Should have download link about Universal C runtime that is reachable" {
-           (Invoke-WebRequest $universalCRuntimeDownloadLink.Replace("https://",'http://')) | Should Not Be $null
-        }
+    $universalCRuntimeDownloadLink = 'https://www.microsoft.com/download/details.aspx?id=50410'
+    $visualStudioCPlusPlusRedistributablesDownloadLink = 'https://www.microsoft.com/download/details.aspx?id=48145'
+
+    $downloadLinks = @(
+        @{ downloadLink = $universalCRuntimeDownloadLink; Name = 'Universal C Runtime' }
+        @{ downloadLink = $visualStudioCPlusPlusRedistributablesDownloadLink; Name = 'Visual Studio C++ 2015 Redistributables' }
+    )
+        
+    It "WiX (Windows Installer XML) file contains download link '<downloadLink>' for '<Name>'" -TestCases $downloadLinks -Test {
+        Param ([string]$downloadLink)
+        (Get-Content $wixProductFile -Raw).Contains($downloadLink) | Should Be $true
     }
 
-    Context "Visual Studio C++ Redistributables Link" {
-        $visualStudioCPlusPlusRedistributablesDownloadLink = 'https://www.microsoft.com/download/details.aspx?id=48145'
-        It "WiX file should have documentation about Visual Studio C++ redistributables" -Pending {
-           (Get-Content $wixProductFile -Raw).Contains($visualStudioCPlusPlusRedistributablesDownloadLink) | Should Be $true
-        }
-        It "Should have download link about Universal C runtime that is reachable" {
-           (Invoke-WebRequest $visualStudioCPlusPlusRedistributablesDownloadLink.Replace("https://",'http://')) | Should Not Be $null
-        }
+    It "Download link '<downloadLink>' for '<Name>' is reachable" -TestCases $downloadLinks -Test {
+        Param ([string]$downloadLink)
+        (Invoke-WebRequest $universalCRuntimeDownloadLink.Replace("https://", 'http://')) | Should Not Be $null
     }
-
+	
 }

--- a/test/powershell/Installer/WindowsInstaller.Tests.ps1
+++ b/test/powershell/Installer/WindowsInstaller.Tests.ps1
@@ -14,23 +14,15 @@ Describe "Windows Installer" -Tags "Scenario" {
         $global:PSDefaultParameterValues = $originalDefaultParameterValues
     }
 
-    $universalCRuntimeDownloadLink = 'https://www.microsoft.com/download/details.aspx?id=50410'
-    $visualStudioCPlusPlusRedistributablesDownloadLink = 'https://www.microsoft.com/download/details.aspx?id=48145'
-
-    $downloadLinks = @(
-        @{ downloadLink = $universalCRuntimeDownloadLink; Name = 'Universal C Runtime' }
-        @{ downloadLink = $visualStudioCPlusPlusRedistributablesDownloadLink; Name = 'Visual Studio C++ 2015 Redistributables' }
-    )
+    $preRequisitesLink =  'https://github.com/PowerShell/PowerShell/blob/master/docs/installation/windows.md#prerequisites'
         
-    It "WiX (Windows Installer XML) file contains download link '<downloadLink>' for '<Name>'" -TestCases $downloadLinks -Test {
-        Param ([string]$downloadLink)
-        (Get-Content $wixProductFile -Raw).Contains($downloadLink) | Should Be $true
+    It "WiX (Windows Installer XML) file contains pre-requisites link $preRequisitesLink" {
+        (Get-Content $wixProductFile -Raw).Contains($preRequisitesLink) | Should Be $true
     }
 
-    It "Download link '<downloadLink>' for '<Name>' is reachable" -TestCases $downloadLinks -Test {
-        Param ([string]$downloadLink)
+    It "Pre-Requisistes link $preRequisitesLink is reachable" -TestCases $downloadLinks -Test {
         # Because an outdated link 'https://www.microsoft.com/download/details.aspx?id=504100000' would still return a 200 reponse (due to a redirection to an error page), it only checks that it returns something
-        (Invoke-WebRequest $universalCRuntimeDownloadLink -UseBasicParsing) | Should Not Be $null
+        (Invoke-WebRequest $preRequisitesLink -UseBasicParsing) | Should Not Be $null
     }
 	
 }

--- a/test/powershell/Installer/WindowsInstaller.Tests.ps1
+++ b/test/powershell/Installer/WindowsInstaller.Tests.ps1
@@ -29,7 +29,8 @@ Describe "Windows Installer" -Tags "Scenario" {
 
     It "Download link '<downloadLink>' for '<Name>' is reachable" -TestCases $downloadLinks -Test {
         Param ([string]$downloadLink)
-        (Invoke-WebRequest $universalCRuntimeDownloadLink.Replace("https://", 'http://')) | Should Not Be $null
+        # Because an outdated link 'https://www.microsoft.com/download/details.aspx?id=504100000' would still return a 200 reponse (due to a redirection to an error page), it only checks that it returns something
+        (Invoke-WebRequest $universalCRuntimeDownloadLink -UseBasicParsing) | Should Not Be $null
     }
 	
 }


### PR DESCRIPTION
To fix #4665 
The previous check registry check of `SOFTWARE\Microsoft\DevDiv\VC\Servicing\14.0\RuntimeMinimum` turned out to not work in the scenario whereby the redistributables were installed via Windows update (which does not use MSI) because the registry entry did not get populated in this case.
In the issue discussion @SteveL-MSFT suggested to have only a simple file based check, therefore this PR simply checks for the existence of `vcruntime140.dll` in the `Windows/System32` folder

The 'Pending' attribute was removed from existing tests since the download links are now present again and the tests were improved using Pester TestCases.