### PR TITLE
Added WSMan Config provider tests

### DIFF
--- a/src/Microsoft.WSMan.Management/ConfigProvider.cs
+++ b/src/Microsoft.WSMan.Management/ConfigProvider.cs
@@ -16,9 +16,7 @@ using System.Runtime.InteropServices;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Security;
-#if !CORECLR
 using System.ServiceProcess;
-#endif
 
 namespace Microsoft.WSMan.Management
 {
@@ -113,11 +111,8 @@ namespace Microsoft.WSMan.Management
 
             try
             {
-                //XmlDocument in CoreCLR does not have file path parameter, use XmlReader
                 XmlReaderSettings readerSettings = new XmlReaderSettings();
-#if !CORECLR
                 readerSettings.XmlResolver = null;
-#endif
                 using (XmlReader reader = XmlReader.Create(helpFile, readerSettings))
                 {
                     document.Load(reader);
@@ -4463,10 +4458,6 @@ namespace Microsoft.WSMan.Management
         /// <returns></returns>
         private bool IsWSManServiceRunning()
         {
-#if CORECLR
-            // TODO once s78 comes in undo this
-            return true;
-#else
             ServiceController svc = new ServiceController("WinRM");
             if (svc != null)
             {
@@ -4476,7 +4467,6 @@ namespace Microsoft.WSMan.Management
                 }
             }
             return false;
-#endif
         }
 
         /// <summary>
@@ -4515,8 +4505,6 @@ namespace Microsoft.WSMan.Management
                 hostfound = true;
             }
 
-            // Domain look up not available on CoreCLR?
-#if !CORECLR
             //Check is TestMac
             if (!hostfound)
             {
@@ -4559,7 +4547,6 @@ namespace Microsoft.WSMan.Management
                     }
                 }
             }
-#endif
             return hostfound;
         }
 
@@ -4857,14 +4844,7 @@ namespace Microsoft.WSMan.Management
                             if (attributecol[i].LocalName.Equals("Value", StringComparison.OrdinalIgnoreCase))
                             {
                                 String ValueAsXML = attributecol[i].Value;
-#if CORECLR
-                                //SecurityElement.Escape() not supported on .NET Core, use WebUtility.HtmlEncode() to replace.
-                                //During the encoding, single quote "\'" convert to "&#39;", then manually convert "&#39;" to "&apos;" since we are encode xml not html;
-                                Value = System.Net.WebUtility.HtmlEncode(ValueAsXML);
-                                Value = Value.Replace("&#39;", "&apos;");
-#else
                                 Value = SecurityElement.Escape(ValueAsXML);
-#endif
                             }
                         }
                         objInitParam.Properties.Add(new PSNoteProperty(Name, Value));
@@ -5007,6 +4987,11 @@ namespace Microsoft.WSMan.Management
         private object ValidateAndGetUserObject(string configurationName, object value)
         {
             PSObject basePsObject = value as PSObject;
+            PSCredential psCredential = null;
+            if (basePsObject == null)
+            {
+                psCredential = value as PSCredential;
+            }
 
             if (configurationName.Equals(WSManStringLiterals.ConfigRunAsPasswordName, StringComparison.OrdinalIgnoreCase))
             {
@@ -5030,6 +5015,10 @@ namespace Microsoft.WSMan.Management
                 if (basePsObject != null && basePsObject.BaseObject is PSCredential)
                 {
                     return basePsObject.BaseObject as PSCredential;
+                }
+                else if (psCredential != null)
+                {
+                    return psCredential;
                 }
                 else
                 {
@@ -5058,18 +5047,9 @@ namespace Microsoft.WSMan.Management
 
             if (value != null)
             {
-#if !CORECLR
-                //coreCLR only supports marshal for unicode
                 IntPtr ptr = Marshal.SecureStringToBSTR(value);
                 passwordValueToAdd = Marshal.PtrToStringAuto(ptr);
                 Marshal.ZeroFreeBSTR(ptr);
-#else
-                IntPtr ptr = SecureStringMarshal.SecureStringToCoTaskMemUnicode(value);
-                passwordValueToAdd = Marshal.PtrToStringUni(ptr);
-                Marshal.ZeroFreeCoTaskMemAnsi(ptr);
-#endif
-
-
             }
 
             return passwordValueToAdd;
@@ -6256,7 +6236,7 @@ param(
     {{
         if ($force -or $pscmdlet.ShouldContinue($queryForStart, $captionForStart))
         {{
-            Restart WinRM -Force -Confirm:$false
+            Restart-Service  WinRM -Force -Confirm:$false
             return $true
         }}
         return $false

--- a/src/Microsoft.WSMan.Management/Microsoft.WSMan.Management.csproj
+++ b/src/Microsoft.WSMan.Management/Microsoft.WSMan.Management.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <ProjectReference Include="..\System.Management.Automation\System.Management.Automation.csproj" />
     <ProjectReference Include="..\Microsoft.WSMan.Runtime\Microsoft.WSMan.Runtime.csproj" />
+    <PackageReference Include="System.ServiceProcess.ServiceController" Version="4.4.0" />    
   </ItemGroup>
 
   <PropertyGroup>

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -1006,3 +1006,65 @@ Describe "Tab completion tests with remote Runspace" -Tags Feature {
         $res.CompletionMatches[0].CompletionText | Should Be $expected
     }
 }
+
+Describe "WSMan Config Provider tab complete tests" -Tags Feature,RequireAdminOnWindows {
+
+    BeforeAll {
+        $originalDefaultParameterValues = $PSDefaultParameterValues.Clone()
+        $PSDefaultParameterValues["it:skip"] = !$IsWindows
+    }
+
+    AfterAll {
+        $PSDefaultParameterValues = $originalDefaultParameterValues
+    }
+
+    It "Tab completion works correctly for Listeners" {
+        $path = "wsman:\localhost\listener\listener"
+        $res = TabExpansion2 -inputScript $path -cursorColumn $path.Length
+        $l = Get-ChildItem WSMan:\localhost\Listener
+        $res.CompletionMatches.Count | Should Be $l.Count
+        for ($i = 0; $i -lt $res.CompletionMatches.Count; $i++) {
+            $res.CompletionMatches[$i].ListItemText | Should Be $l[$i].Name
+        }
+    }
+
+    It "Tab completion gets dynamic parameters for '<path>' using '<parameter>'" -TestCases @(
+        @{path = ""; parameter = "-co"; expected = "ConnectionURI"},
+        @{path = ""; parameter = "-op"; expected = "OptionSet"},
+        @{path = ""; parameter = "-au"; expected = "Authentication"},
+        @{path = ""; parameter = "-ce"; expected = "CertificateThumbprint"},
+        @{path = ""; parameter = "-se"; expected = "SessionOption"},
+        @{path = ""; parameter = "-ap"; expected = "ApplicationName"},
+        @{path = ""; parameter = "-po"; expected = "Port"},
+        @{path = ""; parameter = "-u"; expected = "UseSSL"},
+        @{path = "localhost\plugin"; parameter = "-pl"; expected = "Plugin"},
+        @{path = "localhost\plugin"; parameter = "-sd"; expected = "SDKVersion"},
+        @{path = "localhost\plugin"; parameter = "-re"; expected = "Resource"},
+        @{path = "localhost\plugin"; parameter = "-ca"; expected = "Capability"},
+        @{path = "localhost\plugin"; parameter = "-xm"; expected = "XMLRenderingType"},
+        @{path = "localhost\plugin"; parameter = "-fi"; expected = @("FileName", "File")},
+        @{path = "localhost\plugin"; parameter = "-ru"; expected = "RunAsCredential"},
+        @{path = "localhost\plugin"; parameter = "-us"; expected = "UseSharedProcess"},
+        @{path = "localhost\plugin"; parameter = "-au"; expected = "AutoRestart"},
+        @{path = "localhost\plugin"; parameter = "-pr"; expected = "ProcessIdleTimeoutSec"},
+        @{path = "localhost\Plugin\microsoft.powershell\Resources\"; parameter = "-re"; expected = "ResourceUri"},
+        @{path = "localhost\Plugin\microsoft.powershell\Resources\"; parameter = "-ca"; expected = "Capability"}
+    ) {
+        param($path, $parameter, $expected)
+        $script = "new-item wsman:\$path $parameter"
+        $res = TabExpansion2 -inputScript $script -cursorColumn $script.Length
+        $res.CompletionMatches.Count | Should Be $expected.Count
+        $completionOptions = ""
+        foreach ($completion in $res.CompletionMatches) {
+            $completionOptions += $completion.ListItemText
+        }
+        $completionOptions | Should Be ([string]::Join("", $expected))
+    }
+
+    It "Tab completion get dynamic parameters for initialization parameters" -Pending -TestCases @(
+        @{path = "localhost\Plugin\microsoft.powershell\InitializationParameters\"; parameter = "-pa"; expected = @("ParamName", "ParamValue")}
+    ) {
+        # https://github.com/PowerShell/PowerShell/issues/4744
+        # TODO: move to test cases above once working
+    }
+}

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -1015,16 +1015,16 @@ Describe "WSMan Config Provider tab complete tests" -Tags Feature,RequireAdminOn
     }
 
     AfterAll {
-        $PSDefaultParameterValues = $originalDefaultParameterValues
+        $Global:PSDefaultParameterValues = $originalDefaultParameterValues
     }
 
     It "Tab completion works correctly for Listeners" {
         $path = "wsman:\localhost\listener\listener"
         $res = TabExpansion2 -inputScript $path -cursorColumn $path.Length
-        $l = Get-ChildItem WSMan:\localhost\Listener
-        $res.CompletionMatches.Count | Should Be $l.Count
+        $listener = Get-ChildItem WSMan:\localhost\Listener
+        $res.CompletionMatches.Count | Should Be $listener.Count
         for ($i = 0; $i -lt $res.CompletionMatches.Count; $i++) {
-            $res.CompletionMatches[$i].ListItemText | Should Be $l[$i].Name
+            $res.CompletionMatches[$i].ListItemText | Should Be $listener[$i].Name
         }
     }
 

--- a/test/powershell/Modules/Microsoft.WSMan.Management/ConfigProvider.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.WSMan.Management/ConfigProvider.Tests.ps1
@@ -47,7 +47,7 @@ Describe "WSMan Config Provider" -Tag Feature,RequireAdminOnWindows {
     AfterEach {
         if (-not (Test-Path wsman:))
         {
-            New-PSDrive -Name WSMan -PSProvider WSMan -Root "" -Scope Global > $null
+            $null = New-PSDrive -Name WSMan -PSProvider WSMan -Root "" -Scope Global
         }
     }
 
@@ -113,6 +113,7 @@ Describe "WSMan Config Provider" -Tag Feature,RequireAdminOnWindows {
             $securityContainer = Get-ChildItem "$pluginPath\Resources\$($resource.Name)\Security" | Select-Object -First 1
             $securityProperties = Get-ChildItem $securityContainer.PSPath
             $skippedAttributes = @("ParentResourceUri","xmlns") # these are added by the WSMan Config Provider but not in the original xml
+
             # ParentResourceUri is added by the Config Provider, xmlns existing seems to be dependent on WinRM which is inconsistent
             $securityProperties.Count | Should BeGreaterThan (($pluginXml.PluginConfiguration.Resources.Resource.Security | Get-Member -Type Properties).Count)
             foreach ($securityProperty in $securityProperties) {
@@ -160,7 +161,6 @@ Describe "WSMan Config Provider" -Tag Feature,RequireAdminOnWindows {
             $password = ConvertTo-SecureString "My voice is my passport, verify me" -AsPlainText -Force
             $creds = [pscredential]::new((Get-Random),$password)
             $exception = { Set-Item $testPluginPath\RunAsUser $creds } | ShouldBeErrorId "System.InvalidOperationException,Microsoft.PowerShell.Commands.SetItemCommand"
-            # make sure it's the error we expect
             $exception.Exception.Message | Should Match ".*$badCredentialError.*"
         }
 
@@ -179,7 +179,6 @@ Describe "WSMan Config Provider" -Tag Feature,RequireAdminOnWindows {
             $password = ConvertTo-SecureString "My voice is my passport, verify me" -AsPlainText -Force
             $creds = [pscredential]::new($testUser,$password)
             $exception = { Set-Item $testPluginPath\RunAsUser $creds } | ShouldBeErrorId "System.InvalidOperationException,Microsoft.PowerShell.Commands.SetItemCommand"
-            # make sure it's the error we expect
             $exception.Exception.Message | Should Match ".*$badCredentialError.*"
         }
 

--- a/test/powershell/Modules/Microsoft.WSMan.Management/ConfigProvider.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.WSMan.Management/ConfigProvider.Tests.ps1
@@ -1,0 +1,478 @@
+Describe "WSMan Config Provider" -Tag Feature,RequireAdminOnWindows {
+    BeforeAll {
+        #skip all tests on non-windows platform
+        $originalDefaultParameterValues = $PSDefaultParameterValues.Clone()
+        $PSDefaultParameterValues["it:skip"] = !$IsWindows
+
+        if ($IsWindows) {
+            $badCredentialError = 1326
+            $pluginXml = [xml](winrm g winrm/config/plugin?name=microsoft.powershell -format:xml)
+            $pluginPath = "WSMan:\localhost\Plugin\microsoft.powershell"
+            $testPluginXml = [xml]($pluginXml.OuterXml)
+            $testPluginXml.PlugInConfiguration.Name = "TestPlugin"
+            $testPluginXml.PlugInConfiguration.RemoveAttribute("xml:lang")
+            $testPluginXml.PlugInConfiguration.Resources.Resource.ResourceUri = "http://schemas.microsoft.com/powershell/TestPlugin"
+            $testPluginXml.PlugInConfiguration.Resources.Resource.Security.Uri = "http://schemas.microsoft.com/powershell/TestPlugin"
+            Set-Content $TestDrive\plugin.xml -Value $testPluginXml.OuterXml
+            $null = winrm c winrm/config/plugin?Name=TestPlugin -file:$TestDrive\plugin.xml
+            $testPluginPath = "WSMan:\localhost\Plugin\TestPlugin"
+            $testUser = (Get-Random)
+            $testPass = "Secret123!"
+            $null = net user $testUser $testPass /add
+        }
+    }
+
+    AfterAll {
+        $PSDefaultParameterValues = $originalDefaultParameterValues
+        if ($IsWindows) {
+            $null = winrm d winrm/config/plugin?Name=TestPlugin
+            $null = net user $testUser /DELETE
+        }
+    }
+
+    Function Test-Plugin($plugin, $expectedMissingProperties, $expectedMissingAttributes) {
+        $plugin.PSPath | Should Exist
+        $plugin | Should Not BeNullOrEmpty
+        $testPluginXml = [xml](winrm g winrm/config/plugin?name=$($plugin.Name) -format:xml)
+        $pluginProperties = Get-ChildItem $plugin.PSPath
+        $pluginProperties.Count | Should Be (($testPluginXml.PluginConfiguration | Get-Member -Type Properties).Count + $expectedMissingProperties.Count - $expectedMissingAttributes.Count)
+        foreach ($pluginProperty in $pluginProperties) {
+            if ($pluginProperty.Type -eq "System.String") {
+                $pluginProperty.Value | Should Be $testPluginXml.PluginConfiguration.$($pluginProperty.Name)
+                (Get-Item "$($plugin.PSPath)\$($pluginProperty.Name)").Value | Should Be $testPluginXml.PluginConfiguration.$($pluginProperty.Name)
+            }
+        }
+    }
+
+    AfterEach {
+        if (-not (Test-Path wsman:))
+        {
+            New-PSDrive -Name WSMan -PSProvider WSMan -Root "" -Scope Global > $null
+        }
+    }
+
+    Context "Misc tests" {
+        It "Can remove and add wsman drive" {
+            $w = Get-PSDrive -Name WSMan
+            Remove-PSDrive -Name wsman
+            { Get-PSDrive -Name wsman -ErrorAction Stop } | ShouldBeErrorId "GetLocationNoMatchingDrive,Microsoft.PowerShell.Commands.GetPSDriveCommand"
+            $w2 = $w | New-PSDrive -PSProvider WSMan
+            $w2 | Should BeOfType System.Management.Automation.PSDriveInfo
+            $w2.Name | Should Be "WSMan"
+            $w2.Provider.Name | Should Be "WSMan"
+        }
+
+        It "WSMan Config Provider starts WinRM if it is stopped" {
+            try {
+                Stop-Service WinRM
+                Get-ChildItem wsman:\localhost -Force | Should Not BeNullOrEmpty
+                (Get-Service WinRM).Status | Should Be 'Running'
+            }
+            finally {
+                if ((Get-Service WinRM).Status -eq 'stopped') {
+                    Start-Service WinRM
+                }
+            }
+        }
+    }
+
+    Context "Tab complete tests" {
+
+        It "Tab completion works correctly for Listeners" {
+            $path = "wsman:\localhost\listener\listener"
+            $res = TabExpansion2 -inputScript $path -cursorColumn $path.Length
+            $l = Get-ChildItem WSMan:\localhost\Listener
+            $res.CompletionMatches.Count | Should Be $l.Count
+            for ($i = 0; $i -lt $res.CompletionMatches.Count; $i++)
+            {
+                $res.CompletionMatches[$i].ListItemText | Should Be $l[$i].Name
+            }
+        }
+
+        It "Tab completion gets dynamic parameters for '<path>' using '<parameter>'" -TestCases @(
+            @{path = ""; parameter = "-co"; expected = "ConnectionURI"},
+            @{path = ""; parameter = "-op"; expected = "OptionSet"},
+            @{path = ""; parameter = "-au"; expected = "Authentication"},
+            @{path = ""; parameter = "-ce"; expected = "CertificateThumbprint"},
+            @{path = ""; parameter = "-se"; expected = "SessionOption"},
+            @{path = ""; parameter = "-ap"; expected = "ApplicationName"},
+            @{path = ""; parameter = "-po"; expected = "Port"},
+            @{path = ""; parameter = "-u"; expected = "UseSSL"},
+            @{path = "localhost\plugin"; parameter = "-pl"; expected = "Plugin"},
+            @{path = "localhost\plugin"; parameter = "-sd"; expected = "SDKVersion"},
+            @{path = "localhost\plugin"; parameter = "-re"; expected = "Resource"},
+            @{path = "localhost\plugin"; parameter = "-ca"; expected = "Capability"},
+            @{path = "localhost\plugin"; parameter = "-xm"; expected = "XMLRenderingType"},
+            @{path = "localhost\plugin"; parameter = "-fi"; expected = @("FileName", "File")},
+            @{path = "localhost\plugin"; parameter = "-ru"; expected = "RunAsCredential"},
+            @{path = "localhost\plugin"; parameter = "-us"; expected = "UseSharedProcess"},
+            @{path = "localhost\plugin"; parameter = "-au"; expected = "AutoRestart"},
+            @{path = "localhost\plugin"; parameter = "-pr"; expected = "ProcessIdleTimeoutSec"},
+            @{path = "localhost\Plugin\microsoft.powershell\Resources\"; parameter = "-re"; expected = "ResourceUri"},
+            @{path = "localhost\Plugin\microsoft.powershell\Resources\"; parameter = "-ca"; expected = "Capability"}
+        ) {
+            param($path, $parameter, $expected)
+            $script = "new-item wsman:\$path $parameter"
+            $res = TabExpansion2 -inputScript $script -cursorColumn $script.Length
+            $res.CompletionMatches.Count | Should Be $expected.Count
+            $completionOptions = ""
+            foreach ($completion in $res.CompletionMatches) {
+                $completionOptions += $completion.ListItemText
+            }
+            $completionOptions | Should Be ([string]::Join("", $expected))
+        }
+
+        It "Tab completion get dynamic parameters for initialization parameters" -Pending -TestCases @(
+            @{path = "localhost\Plugin\microsoft.powershell\InitializationParameters\"; parameter = "-pa"; expected = @("ParamName", "ParamValue")}
+        ) {
+            # https://github.com/PowerShell/PowerShell/issues/4744
+            # TODO: move to test cases above once working
+        }
+
+    }
+
+    Context "Get-Item tests" {
+
+        It "Plugin has correct properties" {
+            $plugin = Get-Item $pluginPath
+            Test-Plugin -Plugin $plugin
+        }
+
+        It "Plugin InitializationParameters are correct" {
+            $initializationParameters = Get-ChildItem $pluginPath\InitializationParameters
+            $initializationParameters.Count | Should Be (,$pluginXml.PluginConfiguration.InitializationParameters.Param).Count
+            foreach ($initializationParameter in $initializationParameters) {
+                $initializationParameter.Value | Should Be ($pluginXml.PluginConfiguration.InitializationParameters | Where-Object { $_.Param.Name -eq $initializationParameter.Name }).Param.Value
+                (Get-Item $pluginPath\InitializationParameters\$($initializationParameter.Name)).Value | Should Be ($pluginXml.PluginConfiguration.InitializationParameters | Where-Object { $_.Param.Name -eq $initializationParameter.Name }).Param.Value
+            }
+        }
+
+        It "Plugin Quotas are correct" {
+            $quotas = Get-ChildItem $pluginPath\Quotas
+            $quotas.Count | Should Be ($pluginXml.PluginConfiguration.Quotas | Get-Member -Type Properties).Count
+            foreach ($quota in $quotas) {
+                $quota.Value | Should Be $pluginXml.PluginConfiguration.Quotas.$($quota.Name)
+            }
+        }
+
+        It "Plugin Resources are correct" {
+            $resources = Get-ChildItem $pluginPath\Resources
+            $resources.Count | Should Be (,$pluginXml.PluginConfiguration.Resources.Resource).Count
+        }
+
+        It "Plugin Security Resource is correct" {
+            (,$pluginXml.PluginConfiguration.Resources.Resource).Count | Should Be 1 # by default only Security resource should be there
+            $resource = Get-ChildItem "$pluginPath\Resources" | Select-Object -First 1
+            $resourceUri = Get-Item "$($resource.PSPath)\ResourceUri"
+            $resourceUri.Value | Should Be "http://schemas.microsoft.com/powershell/microsoft.powershell"
+            $securityContainer = Get-ChildItem "$pluginPath\Resources\$($resource.Name)\Security" | Select-Object -First 1
+            $securityProperties = Get-ChildItem $securityContainer.PSPath
+            $skippedAttributes = @("ParentResourceUri","xmlns") # these are added by the WSMan Config Provider but not in the original xml
+            # ParentResourceUri is added by the Config Provider, xmlns existing seems to be dependent on WinRM which is inconsistent
+            $securityProperties.Count | Should BeGreaterThan (($pluginXml.PluginConfiguration.Resources.Resource.Security | Get-Member -Type Properties).Count)
+            foreach ($securityProperty in $securityProperties) {
+                if ($skippedAttributes -notcontains $securityProperty.Name) {
+                    $securityProperty.Value | Should Be ($pluginXml.PluginConfiguration.Resources.Resource.Security.$($securityProperty.Name))
+                    (Get-Item "$($securityContainer.PSPath)\$($securityProperty.Name)").Value | Should Be ($pluginXml.PluginConfiguration.Resources.Resource.Security.$($securityProperty.Name))
+                }
+            }
+        }
+    }
+
+    Context "Set-Item tests" {
+        It "Set-Item should fail for `$null value" {
+            { Set-Item WSMan:\localhost\Client\TrustedHosts $null } | ShouldBeErrorId "System.ArgumentException,Microsoft.PowerShell.Commands.SetItemCommand"
+        }
+
+        It "Set-Item should fail for <path>" -TestCases @(
+            @{path="WSMan:\"},
+            @{path="WSMan:\localhost"}
+        ) {
+            param ($path)
+            { Set-Item $path "foo" } | ShouldBeErrorId "System.InvalidOperationException,Microsoft.PowerShell.Commands.SetItemCommand"
+        }
+
+        It "Set-Item -WhatIf should work" {
+            $trustedHostsPath = "WSMan:\localhost\Client\TrustedHosts"
+            $trustedHosts = Get-Item $trustedHostsPath
+            Set-Item $trustedHostsPath "hello" -WhatIf
+            (Get-Item $trustedHostsPath).Value | Should Be $trustedHosts.Value
+        }
+
+        It "Set-Item on TrustedHosts should succeed" {
+            try {
+                $trustedHostsPath = "WSMan:\localhost\Client\TrustedHosts\"
+                $trustedHosts = Get-Item $trustedHostsPath
+                Set-Item -Path $trustedHostsPath -Value "hello" -Force
+                (Get-Item $trustedHostsPath).Value | Should Be "hello"
+            }
+            finally {
+                Set-Item $trustedHostsPath $trustedHosts.Value -Force
+            }
+        }
+
+        It "Set-Item on plugin RunAsUser should fail for invalid creds" {
+            $password = ConvertTo-SecureString "My voice is my passport, verify me" -AsPlainText -Force
+            $creds = [pscredential]::new((Get-Random),$password)
+            $exception = { Set-Item $testPluginPath\RunAsUser $creds } | ShouldBeErrorId "System.InvalidOperationException,Microsoft.PowerShell.Commands.SetItemCommand"
+            # make sure it's the error we expect
+            $exception.Exception.Message | Should Match ".*$badCredentialError.*"
+        }
+
+        It "Set-Item and Clear-Item on plugin RunAsUser should succeed for valid creds" {
+            $password = ConvertTo-SecureString $testPass -AsPlainText -Force
+            $creds = [pscredential]::new($testUser,$password)
+            Set-Item $testPluginPath\RunAsUser $creds -WarningAction SilentlyContinue
+            (Get-Item $testPluginPath\RunAsUser).Value | Should Be $testUser
+            (Get-Item $testPluginPath\RunAsPassword).Value | Should Be "System.Security.SecureString"
+            Clear-Item $testPluginPath\RunAsUser -WarningAction SilentlyContinue
+            (Get-Item $testPluginPath\RunAsUser).Value | Should BeNullOrEmpty
+            (Get-Item $testPluginPath\RunAsPassword).Value | Should BeNullOrEmpty
+        }
+
+        It "Set-Item on plugin RunAsUser should fail for invalid password" {
+            $password = ConvertTo-SecureString "My voice is my passport, verify me" -AsPlainText -Force
+            $creds = [pscredential]::new($testUser,$password)
+            $exception = { Set-Item $testPluginPath\RunAsUser $creds } | ShouldBeErrorId "System.InvalidOperationException,Microsoft.PowerShell.Commands.SetItemCommand"
+            # make sure it's the error we expect
+            $exception.Exception.Message | Should Match ".*$badCredentialError.*"
+        }
+
+        It "Set-Item on password without user on plugin should fail for <password>" -TestCases @(
+            @{password=(ConvertTo-SecureString "My voice is my passport, verify me" -AsPlainText -Force)},
+            @{password="hello"}
+        ) {
+            param($password)
+            Clear-Item $testPluginPath\RunAsUser -WarningAction SilentlyContinue
+            { Set-Item $testPluginPath\RunAsPassword $password } | ShouldBeErrorId "System.InvalidOperationException,Microsoft.PowerShell.Commands.SetItemCommand"
+        }
+
+        It "Set-Item on plugin XmlRenderingType property should succeed for '<type>'" -TestCases @(
+            @{type="XmlReader"},
+            @{type="text"},
+            @{type="xMLrEADER"},
+            @{type="TEXT"}
+        ) {
+            param ($type)
+            Set-Item $testPluginPath\XmlRenderingType $type -WarningAction SilentlyContinue
+            (Get-Item $testPluginPath\XmlRenderingType).Value | Should Be $type
+        }
+
+        It "Set-Item on non-existent property should fail" {
+            { Set-Item $testPluginPath\foo "bar" } | ShouldBeErrorId "System.InvalidOperationException,Microsoft.PowerShell.Commands.SetItemCommand"
+        }
+
+        It "Set-Item on plugin Resource '<property>' property with '<value>' should succeed" -TestCases @(
+            @{property="SupportsOptions"; value=$false; expected="False"},
+            @{property="sUPPORTSoPTIONS"; value=$true; expected="true"}
+        ) {
+            param($property, $value, $expected)
+            $resource = Get-ChildItem "$testPluginPath\Resources" | Select-Object -First 1
+            Set-Item "$($resource.PSPath)\$property" $value -WarningAction SilentlyContinue
+            (Get-Item "$($resource.PSPath)\$property").Value | Should Be $expected
+        }
+
+        It "Set-Item on plugin Security Resource '<property>' property with '<value>' should succeed" -TestCases @(
+            @{property="Sddl"; value="O:NSG:BAD:P(A;;GA;;;BA)"},
+            @{property="SDDL"; value="O:NSG:BAD:P(A;;GA;;;BA)(A;;GA;;;IU)(A;;GA;;;RM)S:P(AU;FA;GA;;;WD)(AU;SA;GXGW;;;WD)"}
+        ) {
+            param($property, $value, $expected)
+            $resource = Get-ChildItem "$testPluginPath\Resources" | Select-Object -First 1
+            $security = Get-ChildItem "$($resource.PSPath)\Security" | Select-Object -First 1
+            Set-Item "$($security.PSPath)\$property" $value -WarningAction SilentlyContinue -Force
+            (Get-Item "$($security.PSPath)\$property").Value | Should Be $value
+        }
+
+        It "Set-Item on plugin Security Resource '<property>' property with invalid '<value>' should fail" -TestCases @(
+            @{property="Sddl"; value="foo"},
+            @{property="sDDL"; value="D:P(A;;GA;;;BA)"} # owner missing
+        ) {
+            param($property, $value, $expected)
+            $resource = Get-ChildItem "$testPluginPath\Resources" | Select-Object -First 1
+            $security = Get-ChildItem "$($resource.PSPath)\Security" | Select-Object -First 1
+            { Set-Item "$($security.PSPath)\$property" $value -Force } | ShouldBeErrorId "System.InvalidOperationException,Microsoft.PowerShell.Commands.SetItemCommand"
+        }
+
+        It "Set-Item on plugin InitializationParameters '<property>' property with '<value>' should succeed" -TestCases @(
+            @{property="PSVersion"; value="6.0.0"},
+            @{property="psvERSION"; value="5.1"}
+        ) {
+            param($property, $value)
+            Set-Item "$testPluginPath\InitializationParameters\$property" $value -WarningAction SilentlyContinue
+            (Get-Item "$testPluginPath\InitializationParameters\$property").Value | Should Be $value
+        }
+
+        It "Set-Item on plugin Quotas '<property>' property with '<value>' should succeed" -TestCases @(
+            @{property="IdleTimeoutms"; value=61000},
+            @{property="iDLEtIMEOUTMS"; value=7200000},
+            @{property="MaxShells"; value=1},
+            @{property="mAXsHELLS"; value=2147483647}
+            ) {
+            param($property, $value)
+            Set-Item "$testPluginPath\Quotas\$property" $value -WarningAction SilentlyContinue
+            (Get-Item "$testPluginPath\Quotas\$property").Value | Should Be $value
+        }
+
+        It "Set-Item on plugin Quotas out of range on '<property>' property with '<value>' should fail" -TestCases @(
+            @{property="IdleTimeoutms"; value=59999},
+            @{property="MaxShells"; value=0}
+        ) {
+            param($property, $value)
+            { Set-Item "$testPluginPath\Quotas\$property" $value -WarningAction SilentlyContinue } | ShouldBeErrorId "System.InvalidOperationException,Microsoft.PowerShell.Commands.SetItemCommand"
+        }
+    }
+
+    Context "Clear-Item tests" {
+        It "Clear-Item on <property> should fail" -TestCases @(
+            @{property="Filename"},
+            @{property="Quotas\IdleTimeoutms"},
+            @{property="InitializationParameters\PSVersion"}
+        ) {
+            { Clear-Item "$testPluginPath\$property" -WarningAction SilentlyContinue } | ShouldBeErrorId "System.InvalidOperationException,Microsoft.PowerShell.Commands.ClearItemCommand"
+        }
+    }
+
+    Context "New-Item and Remove-Item tests" {
+        It "New-Item and Remove-Item at root should succeed" -TestCases @(
+            @{name=$env:computername;expected=$env:computername},
+            @{name="${env:computername}\";expected=$env:computername}
+        ) {
+            param($name,$expected)
+            $connections = Get-ChildItem wsman:\
+            $newItem = New-Item WSMan:\$name
+            "WSMan:\$name" | Should Exist
+            (Get-ChildItem wsman:\).Count | Should Be ($connections.Count + 1)
+            # not a .Net type so can't use BeOfType
+            $newItem.PSObject.TypeNames[0] | Should Be "Microsoft.WSMan.Management.WSManConfigContainerElement#ComputerLevel"
+            $newItem.Name | Should Be $expected
+            Remove-Item WSMan:\$name
+            "WSMan:\$name" | Should Not Exist
+        }
+
+        It "New-Item and Remove-Item for a listener" {
+            try {
+                $newListener = New-Item -Path WSMan:\localhost\Listener\ -Address IP:127.0.0.1 -port 6666 -Transport HTTP -Enabled $false -HostName foo -URLPrefix bar -Force
+                $listenerName = $newListener.Name
+                $listenerName | Should Not BeNullOrEmpty
+                $properties = Get-ChildItem "WSMan:\localhost\Listener\$listenerName"
+                $listenerXml = [xml](winrm g winrm/config/listener?Address=IP:127.0.0.1+Transport=HTTP -format:xml)
+                $expectedMissingAttributes = "cfg","xsi","lang"
+                $properties.Count | Should Be (($listenerXml.Listener | Get-Member -Type Properties).Count - $expectedMissingAttributes.Count)
+                foreach ($property in $properties) {
+                    if (-not $property.Name.StartsWith("ListeningOn")) { # this property is represented differently
+                        $property.Value | Should Be $listenerXml.Listener.$($property.Name)
+                    }
+                }
+            }
+            finally {
+                Remove-Item -Path "WSMan:\localhost\Listener\$listenerName" -Force
+                $newListener.PSPath | Should Not Exist
+            }
+        }
+
+        It "New-Item and Remove-Item for a plugin using parameters" {
+            try {
+                $password = ConvertTo-SecureString $testPass -AsPlainText -Force
+                $creds = [pscredential]::new($testUser, $password)
+                $plugin = New-Item -Plugin TestPlugin2 -UseSharedProcess -AutoRestart `
+                    -ProcessIdleTimeoutSec 120 -FileName ${env:windir}\system32\WindowsPowerShell\v1.0\pwrshsip.dll `
+                    -SDKVersion 2 -Resource foo -Capability shell -XMLRenderingType text -Path WSMan:\localhost\plugin `
+                    -RunAsCredential $creds
+                $expectedMissingProperties = @("InitializationParameters")
+                Test-Plugin -Plugin $plugin -expectedMissingProperties $expectedMissingProperties
+            }
+            finally {
+                Remove-Item WSMan:\localhost\Plugin\TestPlugin2\
+                "WSMan:\localhost\Plugin\TestPlugin2" | Should Not Exist
+            }
+        }
+
+        It "New-Item and Remove-Item for a plugin using a file" {
+            $fileXml = @"
+<PlugInConfiguration Name="TestPlugin2" Filename="%windir%\system32\pwrshplugin.dll" SDKVersion="2" XmlRenderingType="text" Enabled="false"
+ Architecture="64" UseSharedProcess="true" ProcessIdleTimeoutSec="0" RunAsUser="" RunAsPassword="" AutoRestart="false" RunAsVirtualAccount="false"
+ RunAsVirtualAccountGroups="" OutputBufferingMode="Block" xmlns="http://schemas.microsoft.com/wbem/wsman/1/config/PluginConfiguration">
+    <InitializationParameters>
+        <Param Name="PSVersion" Value="5.1"></Param>
+    </InitializationParameters>
+    <Resources>
+        <Resource ResourceUri="http://schemas.microsoft.com/powershell/TestPlugin2" SupportsOptions="true" ExactMatch="true">
+            <Security Uri="http://schemas.microsoft.com/powershell/TestPlugin2"
+                Sddl="O:NSG:BAD:P(A;;GA;;;BA)(A;;GA;;;IU)(A;;GA;;;RM)S:P(AU;FA;GA;;;WD)(AU;SA;GXGW;;;WD)" ExactMatch="False"></Security>
+            <Capability Type="Shell"></Capability>
+        </Resource>
+    </Resources>
+    <Quotas MaxIdleTimeoutms="2147483646" MaxConcurrentUsers="2147483646" IdleTimeoutms="6200000" MaxProcessesPerShell="2147483646"
+        MaxMemoryPerShellMB="2147483646" MaxConcurrentCommandsPerShell="2147483646" MaxShells="2147483646" MaxShellsPerUser="2147483646"></Quotas>
+</PlugInConfiguration>
+"@
+            Set-Content -Path $testdrive\plugin.xml -Value $fileXml
+            try {
+                $plugin = New-Item -Path WSMan:\localhost\Plugin -File $testdrive\plugin.xml -Name TestPlugin2
+                Test-Plugin -Plugin $plugin
+            }
+            finally {
+                Remove-Item WSMan:\localhost\Plugin\TestPlugin2\
+                "WSMan:\localhost\Plugin\TestPlugin2\" | Should Not Exist
+            }
+        }
+
+        It "New-Item and Remove-Item for a plugin resource" {
+            try {
+                $resource = New-Item -Path WSMan:\localhost\Plugin\TestPlugin\Resources\ `
+                    -ResourceUri http://foo -Capability shell
+                $resource.PSPath | Should Exist
+                $properties = Get-ChildItem $resource.PSPath
+                ($properties | Where-Object { $_.Name -eq "ResourceUri" }).Value | Should Be "http://foo/"
+                ($properties | Where-Object { $_.Name -eq "Capability" })[0].Value | Should Be "shell"
+            }
+            finally {
+                Remove-Item $resource.PSPath
+                $resource.PSPath | Should Not Exist
+            }
+        }
+
+        It "New-Item and Remove-Item for an initialization parameter" {
+            try {
+                $parameter = New-Item -Path WSMan:\localhost\Plugin\TestPlugin\InitializationParameters `
+                    -ParamName foo -ParamValue bar
+                $parameterObj = Get-Item $parameter.PSPath
+                $parameterObj.Name | Should Be "foo"
+                $parameterObj.Value | Should Be "bar"
+            }
+            finally {
+                Remove-Item $parameter.PSPath
+                $parameter.PSPath | Should Not Exist
+            }
+        }
+
+        It "New-Item and Remove-Item for a security resource" {
+            try {
+                $sddl = "O:NSG:BAD:P(A;;GA;;;BA)"
+                $resource = Get-ChildItem -Path WSMan:\localhost\Plugin\TestPlugin\Resources\ | Select-Object -First 1
+                # remove existing security resource since the folder name is just a hash of the resource uri
+                Get-ChildItem "$($resource.PSPath)\Security" | Remove-Item
+                $security = New-Item "$($resource.PSPath)\Security" -SDDL $sddl -Force
+                $security.PSPath | Should Exist
+                $securityObj = Get-Item $security.PSPath
+                (Get-ChildItem $securityObj.PSPath | Where-Object { $_.Name -eq 'sddl' }).Value | Should Be $sddl
+            }
+            finally {
+                Remove-Item $security.PSPath
+                $security.PSPath | Should Not Exist
+            }
+        }
+    }
+
+    Context "Get-Help tests" {
+        It "Get-Help while in WSMan: drive works" {
+            try {
+                Push-Location WSMan:\localhost
+                Get-Help New-Item | Should Not BeNullOrEmpty
+            }
+            finally {
+                Pop-Location
+            }
+        }
+    }
+}

--- a/test/powershell/engine/ResourceValidation/TestRunner.ps1
+++ b/test/powershell/engine/ResourceValidation/TestRunner.ps1
@@ -38,7 +38,7 @@ function Test-ResourceStrings
         {
             # in the event that the id has a space in it, it is replaced with a '_'
             $classname = $resourcefile.Name -replace ".resx"
-            It "'$classname' should be an available type and the strings should be correct" {
+            It "'$classname' should be an available type and the strings should be correct" -Skip:(!$IsWindows) {
                 # get the type from the assembly
                 $resourceType = $ASSEMBLY.GetType($classname, $false, $true)
                 # the properties themselves are static internals, so we need


### PR DESCRIPTION
added tests for get-item, get-childitem, set-item, new-item remove-item, clear-item, dynamic parameters
merged CoreClr and FullClr code
did not add tests for clientcert handling

Part of https://github.com/PowerShell/PowerShell/issues/4158

Should get line coverage from 50.39% to 72.2%

Lots of error handling code not hit

<!--

If you are a PowerShell Team member, please make sure you choose the Reviewer(s) and Assignee for your PR.
If you are not from the PowerShell Team, you can leave the fields blank and the Maintainers will choose them for you. If you are familiar with the team, feel free to mention some Reviewers yourself.

For more information about the roles of Reviewer and Assignee, refer to [CONTRIBUTING.md](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md).

-->
