### PR TITLE
Rename $IsOSX to $IsMacOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,7 +61,7 @@ gen
 #VS Code files
 .vscode
 
-# OS X
+# macOS
 .DS_Store
 
 # TestsResults

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ If you have any problems building, please consult the developer [FAQ][].
 
 | AppVeyor (Windows)       | Travis CI (Linux) | Travis CI (macOS) | Code Coverage Status |
 |--------------------------|-------------------|-------------------|----------------------|
-| [![av-nightly-image][]][av-nightly-site] | [![linux-nightly-image][]][tv-site] | [![osx-nightly-image][]][tv-site] | [![cc-image][]][cc-site] |
+| [![av-nightly-image][]][av-nightly-site] | [![linux-nightly-image][]][tv-site] | [![macOS-nightly-image][]][tv-site] | [![cc-image][]][cc-site] |
 
 [bd-linux]: docs/building/linux.md
 [bd-windows]: docs/building/windows-core.md
@@ -123,7 +123,7 @@ If you have any problems building, please consult the developer [FAQ][].
 [av-image]: https://ci.appveyor.com/api/projects/status/nsng9iobwa895f98/branch/master?svg=true
 [av-site]: https://ci.appveyor.com/project/PowerShell/powershell
 [linux-nightly-image]: https://jimtru1979.blob.core.windows.net/badges/DailyBuildStatus.Linux.svg
-[osx-nightly-image]: https://jimtru1979.blob.core.windows.net/badges/DailyBuildStatus.OSX.svg
+[macOS-nightly-image]: https://jimtru1979.blob.core.windows.net/badges/DailyBuildStatus.OSX.svg
 [av-nightly-image]: https://ci.appveyor.com/api/projects/status/46yd4jogtm2jodcq?svg=true
 [av-nightly-site]: https://ci.appveyor.com/project/PowerShell/powershell-f975h
 [cc-site]: https://codecov.io/gh/PowerShell/PowerShell

--- a/assets/powershell.1.ronn
+++ b/assets/powershell.1.ronn
@@ -12,7 +12,7 @@ powershell(1) -- command-line shell and .NET REPL
 ## DESCRIPTION
 
 PowerShell is an automation and configuration management platform.
-It consists of a cross-platform (Windows, Linux and OS X)
+It consists of a cross-platform (Windows, Linux and macOS)
 command-line shell and associated scripting language.
 
 ## OPTIONS

--- a/build.psm1
+++ b/build.psm1
@@ -102,12 +102,12 @@ function Get-EnvironmentInformation
 
         $environment += @{'IsCoreCLR' = $true}
         $environment += @{'IsLinux' = $Runtime::IsOSPlatform($OSPlatform::Linux)}
-        $environment += @{'IsOSX' = $Runtime::IsOSPlatform($OSPlatform::OSX)}
+        $environment += @{'IsMacOS' = $Runtime::IsOSPlatform($OSPlatform::OSX)}
         $environment += @{'IsWindows' = $Runtime::IsOSPlatform($OSPlatform::Windows)}
     } catch {
         $environment += @{'IsCoreCLR' = $false}
         $environment += @{'IsLinux' = $false}
-        $environment += @{'IsOSX' = $false}
+        $environment += @{'IsMacOS' = $false}
         $environment += @{'IsWindows' = $true}
     }
 
@@ -352,7 +352,7 @@ function Start-PSBuild {
     # Verify we have all tools in place to do the build
     $precheck = precheck 'dotnet' "Build dependency 'dotnet' not found in PATH. Run Start-PSBootstrap. Also see: https://dotnet.github.io/getting-started/"
 
-    if ($Environment.IsLinux -or $Environment.IsOSX) {
+    if ($Environment.IsLinux -or $Environment.IsMacOS) {
         foreach ($Dependency in 'cmake', 'make', 'g++') {
             $precheck = $precheck -and (precheck $Dependency "Build dependency '$Dependency' not found. Run 'Start-PSBootstrap'.")
         }
@@ -376,7 +376,7 @@ Fix steps:
 
 1. Remove the installed version from:
     - on windows '`$env:LOCALAPPDATA\Microsoft\dotnet'
-    - on osx and linux '`$env:HOME/.dotnet'
+    - on macOS and linux '`$env:HOME/.dotnet'
 2. Run Start-PSBootstrap or Install-Dotnet
 3. Start-PSBuild -Clean
 `n
@@ -441,10 +441,10 @@ Fix steps:
     }
 
     # Build native components
-    if (($Environment.IsLinux -or $Environment.IsOSX) -and -not $SMAOnly) {
+    if (($Environment.IsLinux -or $Environment.IsMacOS) -and -not $SMAOnly) {
         $Ext = if ($Environment.IsLinux) {
             "so"
-        } elseif ($Environment.IsOSX) {
+        } elseif ($Environment.IsMacOS) {
             "dylib"
         }
 
@@ -508,7 +508,7 @@ Fix steps:
     if ($Environment.IsRedHatFamily) {
         # add two symbolic links to system shared libraries that libmi.so is dependent on to handle
         # platform specific changes. This is the only set of platforms needed for this currently
-        # as Ubuntu has these specific library files in the platform and OSX builds for itself
+        # as Ubuntu has these specific library files in the platform and macOS builds for itself
         # against the correct versions.
         if ( ! (test-path "$publishPath/libssl.so.1.0.0")) {
             $null = New-Item -Force -ItemType SymbolicLink -Target "/lib64/libssl.so.10" -Path "$publishPath/libssl.so.1.0.0" -ErrorAction Stop
@@ -592,7 +592,7 @@ function New-PSOptions {
 
     $ConfigWarningMsg = "The passed-in Configuration value '{0}' is not supported on '{1}'. Use '{2}' instead."
     if (-not $Configuration) {
-        $Configuration = if ($Environment.IsLinux -or $Environment.IsOSX) {
+        $Configuration = if ($Environment.IsLinux -or $Environment.IsMacOS) {
             "Linux"
         } elseif ($Environment.IsWindows) {
             "Debug"
@@ -612,7 +612,7 @@ function New-PSOptions {
                 }
             }
             Default {
-                if ($Environment.IsLinux -or $Environment.IsOSX) {
+                if ($Environment.IsLinux -or $Environment.IsMacOS) {
                     $Configuration = "Linux"
                     Write-Warning ($ConfigWarningMsg -f $switch.Current, $Environment.LinuxInfo.PRETTY_NAME, $Configuration)
                 }
@@ -655,7 +655,7 @@ function New-PSOptions {
         }
     }
 
-    $Executable = if ($Environment.IsLinux -or $Environment.IsOSX) {
+    $Executable = if ($Environment.IsLinux -or $Environment.IsMacOS) {
         "powershell"
     } elseif ($Environment.IsWindows) {
         "powershell.exe"
@@ -1078,7 +1078,7 @@ function Start-PSxUnit {
         throw "xUnit tests are only currently supported on Linux / OS X"
     }
 
-    if ($Environment.IsOSX) {
+    if ($Environment.IsMacOS) {
         log "Not yet supported on OS X, pretending they passed..."
         return
     }
@@ -1129,11 +1129,11 @@ function Install-Dotnet {
     $obtainUrl = "https://raw.githubusercontent.com/dotnet/cli/master/scripts/obtain"
 
     # Install for Linux and OS X
-    if ($Environment.IsLinux -or $Environment.IsOSX) {
+    if ($Environment.IsLinux -or $Environment.IsMacOS) {
         # Uninstall all previous dotnet packages
         $uninstallScript = if ($Environment.IsUbuntu) {
             "dotnet-uninstall-debian-packages.sh"
-        } elseif ($Environment.IsOSX) {
+        } elseif ($Environment.IsMacOS) {
             "dotnet-uninstall-pkgs.sh"
         }
 
@@ -1200,7 +1200,7 @@ function Start-PSBootstrap {
     Push-Location $PSScriptRoot/tools
 
     try {
-        if ($Environment.IsLinux -or $Environment.IsOSX) {
+        if ($Environment.IsLinux -or $Environment.IsMacOS) {
             # This allows sudo install to be optional; needed when running in containers / as root
             # Note that when it is null, Invoke-Expression (but not &) must be used to interpolate properly
             $sudo = if (!$NoSudo) { "sudo" }
@@ -1258,7 +1258,7 @@ function Start-PSBootstrap {
                 Start-NativeExecution {
                     Invoke-Expression "$baseCommand $Deps"
                 }
-            } elseif ($Environment.IsOSX) {
+            } elseif ($Environment.IsMacOS) {
                 precheck 'brew' "Bootstrap dependency 'brew' not found, must install Homebrew! See http://brew.sh/"
 
                 # Build tools
@@ -1885,7 +1885,7 @@ function Start-CrossGen {
         }
     } elseif ($Environment.IsLinux) {
         "linux-x64"
-    } elseif ($Environment.IsOSX) {
+    } elseif ($Environment.IsMacOS) {
         "osx-x64"
     }
 
@@ -1914,7 +1914,7 @@ function Start-CrossGen {
          "clrjit.dll"
     } elseif ($Environment.IsLinux) {
         "libclrjit.so"
-    } elseif ($Environment.IsOSX) {
+    } elseif ($Environment.IsMacOS) {
         "libclrjit.dylib"
     }
 

--- a/docker/tests/containerTestCommon.psm1
+++ b/docker/tests/containerTestCommon.psm1
@@ -105,7 +105,7 @@ function Set-RepoName
 function Test-SkipWindows
 {
     [bool] $canRunWindows = (Get-DockerEngineOs) -like 'Windows*'
-    return ($IsLinux -or $IsOSX -or !$canRunWindows)
+    return ($IsLinux -or $IsMacOS -or !$canRunWindows)
 }
 
 function Test-SkipLinux

--- a/docs/learning-powershell/create-powershell-scripts.md
+++ b/docs/learning-powershell/create-powershell-scripts.md
@@ -44,7 +44,7 @@ If you would like to author one script that will return the IP address across Li
 
 ```PowerShell
 # Script to return current IPv4 addresses for Linux, MacOS, or Windows
-$IP = if ($IsLinux -or $IsOSX) {
+$IP = if ($IsLinux -or $IsMacOS) {
     $ipInfo = ifconfig | Select-String 'inet'
     $ipInfo = [regex]::matches($ipInfo,"addr:\b(?:\d{1,3}\.){3}\d{1,3}\b") | ForEach-Object value
     foreach ($ip in $ipInfo) {

--- a/docs/maintainers/releasing.md
+++ b/docs/maintainers/releasing.md
@@ -35,7 +35,7 @@ This is to help track the release preparation work.
      Delete the `docker` branch once the builds succeed.
    - Windows: queue a new build in `PowerShell Windows Docker Build` on VSTS.
 1. Verify the generated docker container images.
-1. [Update the homebrew formula](#homebrew) for the OSX package.
+1. [Update the homebrew formula](#homebrew) for the macOS package.
    This task usually will be taken care of by the community,
    so we can wait for one day or two and see if the homebrew formula has already been updated,
    and only do the update if it hasn't.
@@ -43,7 +43,7 @@ This is to help track the release preparation work.
 ## Building Packages
 
 > Note: Linux and Windows packages are taken care of by our release build pipeline in VSTS,
-while the OSX package needs to be built separately on a macOS.
+while the macOS package needs to be built separately on a macOS.
 
 The release build should be started based on the `release` branch.
 The release Git tag won't be created until all release preparation tasks are done,

--- a/docs/testing-guidelines/TestRoadmap.md
+++ b/docs/testing-guidelines/TestRoadmap.md
@@ -17,8 +17,8 @@ This will provide us much needed visibility in how PowerShell Core is being used
 We already have infrastructure in place to allow us see how PowerShell Core is being used, by collecting telemetry from PowerShell Core, we can improve our confidence as we drive to production quality.
 
 ### Logging
-The code which on Windows create ETW logging has been completely stubbed out on Linux/OSX.
-We should take advantage of the native logging mechanisms on Linux/OSX and implement a logger similar to the ETW logger on Windows using Syslog (or equivalent).
+The code which on Windows create ETW logging has been completely stubbed out on Linux/macOS.
+We should take advantage of the native logging mechanisms on Linux/macOS and implement a logger similar to the ETW logger on Windows using Syslog (or equivalent).
 We could use this data during test runs to identify test gaps.
 Simply by capturing the cmdlets and their parameters which are invoked during test would illuminate the gaps we have in our current tests, and allow us to easily fill them.
 It is not sufficient to support only one platform because we have many tests which determine at runtime whether or not it should run based on OS, so data from Windows will not be the same as that from Linux or MacOS.
@@ -69,7 +69,7 @@ In addition to loopback tests using both WSMan and SSH protocols, we should have
 * Windows Client->Nano Server
 * Windows Client->Linux Server
 * Linux Client -> Windows Server
-* OSX Client -> Nano Client
+* macOS Client -> Nano Client
 * PowerShell Core Client -> Full PowerShell Server
 * Full PowerShell Client -> PowerShell Core Server
 * Downlevel Full PowerShell Client -> PowerShell Core Server

--- a/src/System.Management.Automation/CoreCLR/CorePsPlatform.cs
+++ b/src/System.Management.Automation/CoreCLR/CorePsPlatform.cs
@@ -30,7 +30,7 @@ namespace System.Management.Automation
         }
 
         /// <summary>
-        /// True if the current platform is OS X.
+        /// True if the current platform is macOS.
         /// </summary>
         public static bool IsMacOS
         {
@@ -710,7 +710,7 @@ namespace System.Management.Automation
             {
                 private const string psLib = "libpsl-native";
 
-                // Ansi is a misnomer, it is hardcoded to UTF-8 on Linux and OS X
+                // Ansi is a misnomer, it is hardcoded to UTF-8 on Linux and macOS
 
                 // C bools are 1 byte and so must be marshaled as I1
 

--- a/src/System.Management.Automation/CoreCLR/CorePsPlatform.cs
+++ b/src/System.Management.Automation/CoreCLR/CorePsPlatform.cs
@@ -32,7 +32,7 @@ namespace System.Management.Automation
         /// <summary>
         /// True if the current platform is OS X.
         /// </summary>
-        public static bool IsOSX
+        public static bool IsMacOS
         {
             get
             {
@@ -605,7 +605,7 @@ namespace System.Management.Automation
 
         internal static int NonWindowsGetProcessParentPid(int pid)
         {
-            return IsOSX ? Unix.NativeMethods.GetPPid(pid) : Unix.GetProcFSParentPid(pid);
+            return IsMacOS ? Unix.NativeMethods.GetPPid(pid) : Unix.GetProcFSParentPid(pid);
         }
 
         // Unix specific implementations of required functionality

--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -5138,9 +5138,9 @@ end
                         "Invoke-RestMethod",   "", ScopedItemOptions.ReadOnly | ScopedItemOptions.AllScope),
                     new SessionStateAliasEntry("iwr",
                         "Invoke-WebRequest",   "", ScopedItemOptions.ReadOnly | ScopedItemOptions.AllScope),
-// Porting note: #if !UNIX is used to disable aliases for cmdlets which conflict with Linux / OS X
+// Porting note: #if !UNIX is used to disable aliases for cmdlets which conflict with Linux / macOS
 #if !UNIX
-                    // ac is a native command on OS X
+                    // ac is a native command on macOS
                     new SessionStateAliasEntry("ac",
                         "Add-Content",     "", ScopedItemOptions.ReadOnly | ScopedItemOptions.AllScope),
                     new SessionStateAliasEntry("compare",

--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -4963,8 +4963,8 @@ end
                 ScopedItemOptions.ReadOnly | ScopedItemOptions.AllScope),
 
             new SessionStateVariableEntry(
-                SpecialVariables.IsOSX,
-                Platform.IsOSX,
+                SpecialVariables.IsMacOS,
+                Platform.IsMacOS,
                 String.Empty,
                 ScopedItemOptions.ReadOnly | ScopedItemOptions.AllScope),
 

--- a/src/System.Management.Automation/engine/NativeCommandProcessor.cs
+++ b/src/System.Management.Automation/engine/NativeCommandProcessor.cs
@@ -465,7 +465,7 @@ namespace System.Management.Automation
                     {
                         // UseShellExecute is not properly supported on Unix. It runs the file with '/bin/sh'.
                         // Before the behavior is improved (tracked by dotnet/corefx#19956), we use xdg-open/open as the default programs
-                        string executable = Platform.IsLinux ? "xdg-open" : /* OS X */ "open";
+                        string executable = Platform.IsLinux ? "xdg-open" : /* macOS */ "open";
                         startInfo.Arguments = "\"" + startInfo.FileName + "\" " + startInfo.Arguments;
                         startInfo.FileName = executable;
                         startInfo.UseShellExecute = false;

--- a/src/System.Management.Automation/engine/SpecialVariables.cs
+++ b/src/System.Management.Automation/engine/SpecialVariables.cs
@@ -160,8 +160,8 @@ namespace System.Management.Automation
         internal const string IsLinux = "IsLinux";
         internal static VariablePath IsLinuxPath = new VariablePath("IsLinux");
 
-        internal const string IsOSX = "IsOSX";
-        internal static VariablePath IsOSXPath = new VariablePath("IsOSX");
+        internal const string IsMacOS = "IsMacOS";
+        internal static VariablePath IsMacOSPath = new VariablePath("IsMacOS");
 
         internal const string IsWindows = "IsWindows";
         internal static VariablePath IsWindowsPath = new VariablePath("IsWindows");

--- a/src/System.Management.Automation/help/HelpCommands.cs
+++ b/src/System.Management.Automation/help/HelpCommands.cs
@@ -639,7 +639,7 @@ namespace Microsoft.PowerShell.Commands
                 this.WriteVerbose(string.Format(CultureInfo.InvariantCulture, HelpDisplayStrings.OnlineHelpUri, uriToLaunch.OriginalString));
                 System.Diagnostics.Process browserProcess = new System.Diagnostics.Process();
 #if UNIX
-                browserProcess.StartInfo.FileName = Platform.IsLinux ? "xdg-open" : /* OS X */ "open";
+                browserProcess.StartInfo.FileName = Platform.IsLinux ? "xdg-open" : /* macOS */ "open";
                 browserProcess.StartInfo.Arguments = uriToLaunch.OriginalString;
                 browserProcess.Start();
 #else

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -1332,7 +1332,7 @@ namespace Microsoft.PowerShell.Commands
                 bool invokeDefaultProgram = false;
                 if (Directory.Exists(path))
                 {
-                    // Path points to a directory. We have to use xdg-open/open on Linux/OSX.
+                    // Path points to a directory. We have to use xdg-open/open on Linux/macOS.
                     invokeDefaultProgram = true;
                 }
                 else
@@ -1345,7 +1345,7 @@ namespace Microsoft.PowerShell.Commands
                     catch (Win32Exception ex) when (ex.NativeErrorCode == 13)
                     {
                         // Error code 13 -- Permission denied
-                        // The file is possibly not an executable. We try xdg-open/open on Linux/OSX.
+                        // The file is possibly not an executable. We try xdg-open/open on Linux/macOS.
                         invokeDefaultProgram = true;
                     }
                 }
@@ -1353,7 +1353,7 @@ namespace Microsoft.PowerShell.Commands
                 if (invokeDefaultProgram)
                 {
                     const string quoteFormat = "\"{0}\"";
-                    invokeProcess.StartInfo.FileName = Platform.IsLinux ? "xdg-open" : /* OS X */ "open";
+                    invokeProcess.StartInfo.FileName = Platform.IsLinux ? "xdg-open" : /* macOS */ "open";
                     if (NativeCommandParameterBinder.NeedQuotes(path))
                     {
                         path = string.Format(CultureInfo.InvariantCulture, quoteFormat, path);

--- a/test/csharp/test_CorePsPlatform.cs
+++ b/test/csharp/test_CorePsPlatform.cs
@@ -38,7 +38,7 @@ namespace PSTests
             }
         }
 
-        [Fact(Skip="Bad arguments for OS X")]
+        [Fact(Skip="Bad arguments for macOS")]
         public static void TestGetMachineName()
         {
             var startInfo = new ProcessStartInfo
@@ -61,7 +61,7 @@ namespace PSTests
             }
         }
 
-        [Fact(Skip="Bad arguments for OS X")]
+        [Fact(Skip="Bad arguments for macOS")]
         public static void TestGetFQDN()
         {
             var startInfo = new ProcessStartInfo
@@ -84,7 +84,7 @@ namespace PSTests
             }
         }
 
-        [Fact(Skip="Bad arguments for OS X")]
+        [Fact(Skip="Bad arguments for macOS")]
         public static void TestGetDomainName()
         {
             var startInfo = new ProcessStartInfo

--- a/test/powershell/Language/Classes/Scripting.Classes.BasicParsing.Tests.ps1
+++ b/test/powershell/Language/Classes/Scripting.Classes.BasicParsing.Tests.ps1
@@ -4,7 +4,7 @@
 
 try {
 #
-# CrossGen'ed assemblies cause a hang to happen intermittently when running this test suite in Linux and OSX.
+# CrossGen'ed assemblies cause a hang to happen intermittently when running this test suite in Linux and macOS.
 # The issue has been reported to CoreCLR team. We need to work around it for now with the following approach:
 #  1. For pull request and push commit, build without '-CrossGen' and run the parsing tests
 #  2. For daily build, build with '-CrossGen' but don't run the parsing tests

--- a/test/powershell/Language/Classes/scripting.Classes.inheritance.tests.ps1
+++ b/test/powershell/Language/Classes/scripting.Classes.inheritance.tests.ps1
@@ -4,7 +4,7 @@
 
 try {
 #
-# CrossGen'ed assemblies cause a hang to happen intermittently when running this test suite in Linux and OSX.
+# CrossGen'ed assemblies cause a hang to happen intermittently when running this test suite in Linux and macOS.
 # The issue has been reported to CoreCLR team. We need to work around it for now with the following approach:
 #  1. For pull request and push commit, build without '-CrossGen' and run the parsing tests
 #  2. For daily build, build with '-CrossGen' but don't run the parsing tests

--- a/test/powershell/Language/Parser/Parser.Tests.ps1
+++ b/test/powershell/Language/Parser/Parser.Tests.ps1
@@ -601,7 +601,7 @@ foo``u{2195}abc
     }
 
 	It "Check that a command that uses shell execute can be run from the command line and that no exception is thrown. (line 1702)" {
-		if ( $IsLinux -or $IsOSX ) {
+		if ( $IsLinux -or $IsMacOS ) {
             # because we execute on *nix based on executable bit, and the file name doesn't matter
             # so we can use the same filename as for windows, just make sure it's executable with chmod
             "#!/bin/sh`necho ""Hello World""" | out-file -encoding ASCII $shellfile

--- a/test/powershell/Language/Scripting/NativeExecution/NativeCommandProcessor.Tests.ps1
+++ b/test/powershell/Language/Scripting/NativeExecution/NativeCommandProcessor.Tests.ps1
@@ -176,7 +176,7 @@ Categories=Application;
     }
 
     It "Should open text file without error" -Skip:(!$supportedEnvironment) {
-        if ($IsOSX) {
+        if ($IsMacOS) {
             $expectedTitle = Split-Path $TestFile -Leaf
             open -F -a TextEdit
             $beforeCount = [int]('tell application "TextEdit" to count of windows' | osascript)

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Pester.Commands.Cmdlets.GetCommand.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Pester.Commands.Cmdlets.GetCommand.Tests.ps1
@@ -10,7 +10,7 @@ Describe "Tests Get-Command with relative paths and wildcards" -Tag "CI" {
         $file2 = Setup -f WildCardCommand[B].exe -pass
         #$null = New-Item -ItemType File -Path (Join-Path $TestDrive WildCardCommandA.exe) -ErrorAction Ignore
         #$null = New-Item -ItemType File -Path (Join-Path $TestDRive WildCardCommand[B].exe) -ErrorAction Ignore
-        if ( $IsLinux -or $IsOSX ) {
+        if ( $IsLinux -or $IsMacOS ) {
             /bin/chmod 777 "$file1"
             /bin/chmod 777 "$file2"
         }

--- a/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/CounterTestHelperFunctions.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/CounterTestHelperFunctions.ps1
@@ -288,7 +288,7 @@ function CompareCounterSets
 function SkipCounterTests
 {
     if ([System.Management.Automation.Platform]::IsLinux -or
-        [System.Management.Automation.Platform]::IsOSX -or
+        [System.Management.Automation.Platform]::IsMacOS -or
         [System.Management.Automation.Platform]::IsIoT)
     {
         return $true

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Add-Content.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Add-Content.Tests.ps1
@@ -11,11 +11,11 @@ Describe "Add-Content cmdlet tests" -Tags "CI" {
       $result = get-content -path testdrive:\$file1
       $result | Should BeExactly "ExpectedContent"
     }
-    It "should Add-Content to testdrive:\dynamicfile.txt with dynamic parameters" -Pending:($IsLinux -Or $IsOSX) {#https://github.com/PowerShell/PowerShell/issues/891
+    It "should Add-Content to testdrive:\dynamicfile.txt with dynamic parameters" -Pending:($IsLinux -Or $IsMacOS) {#https://github.com/PowerShell/PowerShell/issues/891
       $result=add-content -path testdrive:\dynamicfile.txt -value "ExpectedContent" -passthru
       $result| Should BeExactly "ExpectedContent"
     }
-    It "should return expected string from testdrive:\dynamicfile.txt" -Pending:($IsLinux -Or $IsOSX) {#https://github.com/PowerShell/PowerShell/issues/891
+    It "should return expected string from testdrive:\dynamicfile.txt" -Pending:($IsLinux -Or $IsMacOS) {#https://github.com/PowerShell/PowerShell/issues/891
       $result = get-content -path testdrive:\dynamicfile.txt
       $result | Should BeExactly "ExpectedContent"
     }
@@ -34,12 +34,12 @@ Describe "Add-Content cmdlet tests" -Tags "CI" {
       } Catch {$_.FullyQualifiedErrorId | Should Be "ParameterArgumentValidationErrorNullNotAllowed,Microsoft.PowerShell.Commands.AddContentCommand"}
     }
     #[BugId(BugDatabase.WindowsOutOfBandReleases, 906022)]
-    It "should throw 'NotSupportedException' when you add-content to an unsupported provider" -Skip:($IsLinux -Or $IsOSX) {
+    It "should throw 'NotSupportedException' when you add-content to an unsupported provider" -Skip:($IsLinux -Or $IsMacOS) {
       Try {add-content -path HKLM:\\software\\microsoft -value "ShouldNotWorkBecausePathIsUnsupported" -ea stop; Throw "Previous statement unexpectedly succeeded..."
       } Catch {$_.FullyQualifiedErrorId | Should Be "NotSupported,Microsoft.PowerShell.Commands.AddContentCommand"}
     }
     #[BugId(BugDatabase.WindowsOutOfBandReleases, 9058182)]
-    It "should be able to pass multiple [string]`$objects to Add-Content through the pipeline to output a dynamic Path file" -Pending:($IsLinux -Or $IsOSX) {#https://github.com/PowerShell/PowerShell/issues/891
+    It "should be able to pass multiple [string]`$objects to Add-Content through the pipeline to output a dynamic Path file" -Pending:($IsLinux -Or $IsMacOS) {#https://github.com/PowerShell/PowerShell/issues/891
       "hello","world"|add-content testdrive:\dynamicfile2.txt
       $result=get-content testdrive:\dynamicfile2.txt
       $result.length |Should be 2

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
@@ -378,7 +378,7 @@ Describe "Hard link and symbolic link tests" -Tags "CI", "RequireAdminOnWindows"
     BeforeAll {
         # on macOS, the /tmp directory is a symlink, so we'll resolve it here
         $TestPath = $TestDrive
-        if ($IsOSX)
+        if ($IsMacOS)
         {
             $item = Get-Item $TestPath
             $dirName = $item.BaseName

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Content.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Content.Tests.ps1
@@ -70,7 +70,7 @@ Describe "Get-Content" -Tags "CI" {
         Pop-Location
     }
     #[BugId(BugDatabase.WindowsOutOfBandReleases, 906022)]
-    It "should throw 'PSNotSupportedException' when you set-content to an unsupported provider" -Skip:($IsLinux -Or $IsOSX) {
+    It "should throw 'PSNotSupportedException' when you set-content to an unsupported provider" -Skip:($IsLinux -Or $IsMacOS) {
         {get-content -path HKLM:\\software\\microsoft -ea stop} | Should Throw "IContentCmdletProvider interface is not implemented"
     }
     It "should Get-Content with a variety of -Tail and -ReadCount values" {#[DRT]

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Process.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Process.Tests.ps1
@@ -9,11 +9,11 @@ Describe "Get-Process" -Tags "CI" {
     BeforeAll {
         $ps = Get-Process
     }
-    It "Should return a type of Object[] for Get-Process cmdlet" -Pending:$IsOSX {
+    It "Should return a type of Object[] for Get-Process cmdlet" -Pending:$IsMacOS {
         ,$ps | Should BeOfType "System.Object[]"
     }
 
-    It "Should have not empty Name flags set for Get-Process object" -Pending:$IsOSX {
+    It "Should have not empty Name flags set for Get-Process object" -Pending:$IsMacOS {
         $ps | foreach-object { $_.Name | Should Not BeNullOrEmpty }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Start-Process.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Start-Process.Tests.ps1
@@ -18,7 +18,7 @@ Describe "Start-Process" -Tags @("Feature") {
     }
 
     # Note that ProcessName may still be `powershell` due to dotnet/corefx#5378
-    # This has been fixed on Linux, but not on OS X
+    # This has been fixed on Linux, but not on macOS
 
     It "Should process arguments without error" {
 	    $process = Start-Process ping -ArgumentList $pingParam -PassThru -RedirectStandardOutput "$TESTDRIVE/output"

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Start-Process.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Start-Process.Tests.ps1
@@ -12,7 +12,7 @@ Describe "Start-Process" -Tags @("Feature") {
         if ($IsWindows) {
             $pingParam = "-n 2 localhost"
         }
-        elseif ($IsLinux -Or $IsOSX) {
+        elseif ($IsLinux -Or $IsMacOS) {
 	        $pingParam = "-c 2 localhost"
         }
     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/ExecutionPolicy.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/ExecutionPolicy.Tests.ps1
@@ -8,7 +8,7 @@ Describe "ExecutionPolicy" -Tags "CI" {
             Get-ExecutionPolicy | Should Be Unrestricted
         }
 
-        It "Should return Microsoft.Powershell.ExecutionPolicy PSObject on Windows" -Skip:($IsLinux -Or $IsOSX) {
+        It "Should return Microsoft.Powershell.ExecutionPolicy PSObject on Windows" -Skip:($IsLinux -Or $IsMacOS) {
             Get-ExecutionPolicy | Should BeOfType Microsoft.Powershell.ExecutionPolicy
         }
     }
@@ -18,7 +18,7 @@ Describe "ExecutionPolicy" -Tags "CI" {
             { Set-ExecutionPolicy Unrestricted } | Should Throw "Operation is not supported on this platform."
         }
 
-        It "Should succeed on Windows" -Skip:($IsLinux -Or $IsOSX) {
+        It "Should succeed on Windows" -Skip:($IsLinux -Or $IsMacOS) {
             # We use the Process scope to avoid affecting the system
             # Unrestricted is assumed "safe", otherwise these tests would not be running
             { Set-ExecutionPolicy -Force -Scope Process -ExecutionPolicy Unrestricted } | Should Not Throw

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/FormatHex.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/FormatHex.Tests.ps1
@@ -38,7 +38,7 @@ Describe "FormatHex" -tags "CI" {
             $certProviderAvailable = $true
         }
 
-        $skipTest = ([System.Management.Automation.Platform]::IsLinux -or [System.Management.Automation.Platform]::IsOSX -or (-not $certProviderAvailable))
+        $skipTest = ([System.Management.Automation.Platform]::IsLinux -or [System.Management.Automation.Platform]::IsMacOS -or (-not $certProviderAvailable))
     }
 
     Context "InputObject Paramater" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Invoke-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Invoke-Item.Tests.ps1
@@ -28,7 +28,7 @@ Describe "Invoke-Item basic tests" -Tags "Feature" {
 
         ## Run this test only on OSX because redirecting stderr of 'xdg-open' results in weird behavior in our Linux CI,
         ## causing this test to fail or the build to hang.
-        It "Should invoke text file '<TestFile>' without error on Mac" -Skip:(!$IsOSX) -TestCases $textFileTestCases {
+        It "Should invoke text file '<TestFile>' without error on Mac" -Skip:(!$IsMacOS) -TestCases $textFileTestCases {
             param($TestFile)
 
             $expectedTitle = Split-Path $TestFile -Leaf

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Invoke-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Invoke-Item.Tests.ps1
@@ -26,7 +26,7 @@ Describe "Invoke-Item basic tests" -Tags "Feature" {
             Remove-Item -Path $redirectErr -Force -ErrorAction SilentlyContinue
         }
 
-        ## Run this test only on OSX because redirecting stderr of 'xdg-open' results in weird behavior in our Linux CI,
+        ## Run this test only on macOS because redirecting stderr of 'xdg-open' results in weird behavior in our Linux CI,
         ## causing this test to fail or the build to hang.
         It "Should invoke text file '<TestFile>' without error on Mac" -Skip:(!$IsMacOS) -TestCases $textFileTestCases {
             param($TestFile)

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -1187,7 +1187,7 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
         
         # Test skipped on macOS pending support for Client Certificate Authentication
         # https://github.com/PowerShell/PowerShell/issues/4650
-        It "Verifies Invoke-WebRequest Certificate Authentication Successful with -Certificate" -Pending:$IsOSX {
+        It "Verifies Invoke-WebRequest Certificate Authentication Successful with -Certificate" -Pending:$IsMacOS {
             $uri = Get-WebListenerUrl -Https -Test 'Cert'
             $certificate = Get-WebListenerClientCertificate
             $result = Invoke-WebRequest -Uri $uri -Certificate $certificate -SkipCertificateCheck | 
@@ -1728,7 +1728,7 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
         
         # Test skipped on macOS pending support for Client Certificate Authentication
         # https://github.com/PowerShell/PowerShell/issues/4650
-        It "Verifies Invoke-RestMethod Certificate Authentication Successful with -Certificate" -Pending:$IsOSX {
+        It "Verifies Invoke-RestMethod Certificate Authentication Successful with -Certificate" -Pending:$IsMacOS {
             $uri = Get-WebListenerUrl -Https -Test 'Cert'
             $certificate = Get-WebListenerClientCertificate
             $result = Invoke-RestMethod -uri $uri -Certificate $certificate -SkipCertificateCheck

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Host.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Host.Tests.ps1
@@ -10,7 +10,7 @@
         )
     }
 
-    It "write-Host works with '<Name>' switch" -TestCases:$testData -Pending:$IsOSX {
+    It "write-Host works with '<Name>' switch" -TestCases:$testData -Pending:$IsMacOS {
         param($Command, $returnCount, $returnValue)
 
         [array]$result = & $powershell -noprofile -c $Command

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Stream.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Stream.Tests.ps1
@@ -83,7 +83,7 @@ Describe "Stream writer tests" -Tags "CI" {
             $ps.Dispose()
         }
 
-       It "Write-Information outputs an information object" -Pending:($IsOSX) {
+       It "Write-Information outputs an information object" -Pending:($IsMacOS) {
             # redirect the streams is sufficient
             $result = Write-Information "Test Message" *>&1
             $result.NativeThreadId | Should Not Be 0

--- a/test/powershell/Modules/PSDesiredStateConfiguration/MOF-Compilation.Tests.ps1
+++ b/test/powershell/Modules/PSDesiredStateConfiguration/MOF-Compilation.Tests.ps1
@@ -10,7 +10,7 @@ Describe "DSC MOF Compilation" -tags "CI" {
         $env:PSModulePath = join-path ([io.path]::GetDirectoryName($powershellexe)) Modules
     }
 
-    It "Should be able to compile a MOF from a basic configuration" -Skip:($IsOSX -or $IsWindows) {
+    It "Should be able to compile a MOF from a basic configuration" -Skip:($IsMacOS -or $IsWindows) {
         [Scriptblock]::Create(@"
         configuration DSCTestConfig
         {
@@ -29,7 +29,7 @@ Describe "DSC MOF Compilation" -tags "CI" {
         Remove-Item -Force -Recurse -Path DSCTestConfig
     }
 
-    It "Should be able to compile a MOF from another basic configuration" -Skip:($IsOSX -or $IsWindows) {
+    It "Should be able to compile a MOF from another basic configuration" -Skip:($IsMacOS -or $IsWindows) {
         [Scriptblock]::Create(@"
         configuration DSCTestConfig
         {
@@ -51,7 +51,7 @@ Describe "DSC MOF Compilation" -tags "CI" {
         Remove-Item -Force -Recurse -Path DSCTestConfig
     }
 
-    It "Should be able to compile a MOF from a complex configuration" -Skip:($IsOSX -or $IsWindows) {
+    It "Should be able to compile a MOF from a complex configuration" -Skip:($IsMacOS -or $IsWindows) {
         [Scriptblock]::Create(@"
 	Configuration WordPressServer{
 

--- a/test/powershell/Modules/PSReadLine/PSReadLine.Tests.ps1
+++ b/test/powershell/Modules/PSReadLine/PSReadLine.Tests.ps1
@@ -13,7 +13,7 @@ Describe "PSReadLine" -tags "CI" {
         $module.Version | Should Be "1.2"
     }
 
-    It "Should use Emacs Bindings on Linux and OS X" -skip:$IsWindows {
+    It "Should use Emacs Bindings on Linux and macOS" -skip:$IsWindows {
         (Get-PSReadLineOption).EditMode | Should Be Emacs
         (Get-PSReadlineKeyHandler | Where-Object { $_.Key -eq "Ctrl+A" }).Function | Should Be BeginningOfLine
     }

--- a/test/powershell/README.md
+++ b/test/powershell/README.md
@@ -35,7 +35,7 @@ Some tests simply must be tied to certain platforms. Use Pester's
 the test only on Windows:
 
 ```powershell
-It "Should do something on Windows" -Skip:($IsLinux -Or $IsOSX) { ... }
+It "Should do something on Windows" -Skip:($IsLinux -Or $IsMacOS) { ... }
 ```
 
 Or only on Linux and OS X:

--- a/test/tools/Modules/HelpersLanguage/HelpersLanguage.psm1
+++ b/test/tools/Modules/HelpersLanguage/HelpersLanguage.psm1
@@ -71,7 +71,7 @@ function ShouldBeParseError
     )
 
     #
-    # CrossGen'ed assemblies cause a hang to happen when running tests with this helper function in Linux and OSX.
+    # CrossGen'ed assemblies cause a hang to happen when running tests with this helper function in Linux and macOS.
     # The issue has been reported to CoreCLR team. We need to work around it for now with the following approach:
     #  1. For pull request and push commit, build without '-CrossGen' and run the parsing tests
     #  2. For nightly build, build with '-CrossGen' but don't run the parsing tests

--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -119,7 +119,7 @@ function Start-PSPackage {
             } else {
                 throw "Building packages for $($Environment.LinuxInfo.PRETTY_NAME) is unsupported!"
             }
-        } elseif ($Environment.IsOSX) {
+        } elseif ($Environment.IsMacOS) {
             "osxpkg", "nupkg"
         } elseif ($Environment.IsWindows) {
             "msi", "nupkg"
@@ -269,7 +269,7 @@ function New-UnixPackage {
             }
         }
         "osxpkg" {
-            if (!$Environment.IsOSX) {
+            if (!$Environment.IsMacOS) {
                 throw ($ErrorMessage -f "OS X")
             }
         }
@@ -316,14 +316,14 @@ function New-UnixPackage {
     # Follow the Filesystem Hierarchy Standard for Linux and OS X
     $Destination = if ($Environment.IsLinux) {
         "/opt/microsoft/powershell/$Suffix"
-    } elseif ($Environment.IsOSX) {
+    } elseif ($Environment.IsMacOS) {
         "/usr/local/microsoft/powershell/$Suffix"
     }
 
     # Destination for symlink to powershell executable
     $Link = if ($Environment.IsLinux) {
         "/usr/bin"
-    } elseif ($Environment.IsOSX) {
+    } elseif ($Environment.IsMacOS) {
         "/usr/local/bin"
     }
 
@@ -358,7 +358,7 @@ function New-UnixPackage {
         # so we move it to make symlink broken
         $symlink_dest = "$Destination/$Name"
         $hack_dest = "./_fpm_symlink_hack_powershell"
-        if ($Environment.IsOSX) {
+        if ($Environment.IsMacOS) {
             if (Test-Path $symlink_dest) {
                 Write-Warning "Move $symlink_dest to $hack_dest (fpm utime bug)"
                 Move-Item $symlink_dest $hack_dest
@@ -503,7 +503,7 @@ function New-UnixPackage {
             $Output = Start-NativeExecution { fpm $Arguments }
         }
     } finally {
-        if ($Environment.IsOSX) {
+        if ($Environment.IsMacOS) {
             # this is continuation of a fpm hack for a weird bug
             if (Test-Path $hack_dest) {
                 Write-Warning "Move $hack_dest to $symlink_dest (fpm utime bug)"
@@ -521,7 +521,7 @@ function New-UnixPackage {
     # Magic to get path output
     $createdPackage = Get-Item (Join-Path $PWD (($Output[-1] -split ":path=>")[-1] -replace '["{}]'))
 
-    if ($Environment.IsOSX) {
+    if ($Environment.IsMacOS) {
         if($pscmdlet.ShouldProcess("Fix package name"))
         {
             # Add the OS information to the OSX package file name.

--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -18,7 +18,7 @@ function Start-PSPackage {
         [ValidatePattern("^powershell")]
         [string]$Name = "powershell",
 
-        # Ubuntu, CentOS, Fedora, OS X, and Windows packages are supported
+        # Ubuntu, CentOS, Fedora, macOS, and Windows packages are supported
         [ValidateSet("deb", "osxpkg", "rpm", "msi", "zip", "AppImage", "nupkg")]
         [string[]]$Type,
 
@@ -270,7 +270,7 @@ function New-UnixPackage {
         }
         "osxpkg" {
             if (!$Environment.IsMacOS) {
-                throw ($ErrorMessage -f "OS X")
+                throw ($ErrorMessage -f "macOS")
             }
         }
     }
@@ -313,7 +313,7 @@ function New-UnixPackage {
         New-StagingFolder -StagingPath $Staging -Name $Name
     }
 
-    # Follow the Filesystem Hierarchy Standard for Linux and OS X
+    # Follow the Filesystem Hierarchy Standard for Linux and macOS
     $Destination = if ($Environment.IsLinux) {
         "/opt/microsoft/powershell/$Suffix"
     } elseif ($Environment.IsMacOS) {
@@ -334,7 +334,7 @@ function New-UnixPackage {
         if ($Environment.IsRedHatFamily) {
             # add two symbolic links to system shared libraries that libmi.so is dependent on to handle
             # platform specific changes. This is the only set of platforms needed for this currently
-            # as Ubuntu has these specific library files in the platform and OSX builds for itself
+            # as Ubuntu has these specific library files in the platform and macOS builds for itself
             # against the correct versions.
             New-Item -Force -ItemType SymbolicLink -Target "/lib64/libssl.so.10" -Path "$Staging/libssl.so.1.0.0" >$null
             New-Item -Force -ItemType SymbolicLink -Target "/lib64/libcrypto.so.10" -Path "$Staging/libcrypto.so.1.0.0" >$null
@@ -354,7 +354,7 @@ function New-UnixPackage {
 
         # there is a weird bug in fpm
         # if the target of the powershell symlink exists, `fpm` aborts
-        # with a `utime` error on OS X.
+        # with a `utime` error on macOS.
         # so we move it to make symlink broken
         $symlink_dest = "$Destination/$Name"
         $hack_dest = "./_fpm_symlink_hack_powershell"
@@ -524,7 +524,7 @@ function New-UnixPackage {
     if ($Environment.IsMacOS) {
         if($pscmdlet.ShouldProcess("Fix package name"))
         {
-            # Add the OS information to the OSX package file name.
+            # Add the OS information to the macOS package file name.
             $packageExt = [System.IO.Path]::GetExtension($createdPackage.Name)
             $packageNameWithoutExt = [System.IO.Path]::GetFileNameWithoutExtension($createdPackage.Name)
 

--- a/tools/travis.ps1
+++ b/tools/travis.ps1
@@ -42,7 +42,7 @@ function Set-DailyBuildBadge
     $storageAccountKey = $Env:TestResultAccountKey
 
     # this is the url referenced in README.MD which displays the badge
-    $platform = if ( $IsOSX ) { "OSX" } else { "Linux" }
+    $platform = if ( $IsLinux ) { "Linux" } else { "OSX" }
     $Url = "https://jimtru1979.blob.core.windows.net/badges/DailyBuildStatus.${platform}.svg"
 
     $body = $content

--- a/tools/travis.ps1
+++ b/tools/travis.ps1
@@ -29,7 +29,7 @@ function Get-DailyBadge
 #
 # the best way to do this would be if travis-ci supported a webcall to get
 # the status of cron_job builds, but it doesn't, so we have this
-# also, since we can have a build on Linux which succeeds and one on OSX which
+# also, since we can have a build on Linux which succeeds and one on macOS which
 # doesn't we'll set the appropriate badge so the the README can pick it up
 function Set-DailyBuildBadge
 {
@@ -133,7 +133,7 @@ else
     $output = Split-Path -Parent (Get-PSOutput -Options (New-PSOptions))
 
     # CrossGen'ed assemblies cause a hang to happen intermittently when running powershell class
-    # basic parsing tests in Linux/OSX. The hang seems to happen when generating dynamic assemblies.
+    # basic parsing tests in Linux/macOS. The hang seems to happen when generating dynamic assemblies.
     # This issue has been reported to CoreCLR team. We need to work around it for now because
     # the Travis CI build failures caused by this is draining our builder resource and severely
     # affect our daily work. The workaround is:


### PR DESCRIPTION
PS-Committee decided we should be consistent with our naming and conform to Apple's use of macOS instead of OSX, however, for readability and consistently we are staying with Pascal casing.

Also renamed instances of variations of `OSX` to `macOS` for consistency in comments/text (separate commit to make it easier to review)

Fix https://github.com/PowerShell/PowerShell/issues/4700