### PR TITLE
Replace 'Windows PowerShell' with 'PowerShell' in resx files

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Diagnostics/resources/GetEventResources.resx
+++ b/src/Microsoft.PowerShell.Commands.Diagnostics/resources/GetEventResources.resx
@@ -268,7 +268,7 @@ The defined template is following:
     <value>This cmdlet can be run only on Microsoft Windows 7 and above.</value>
   </data>
   <data name="Description" xml:space="preserve">
-    <value>This Windows PowerShell snap-in contains Windows Eventing and Performance Counter cmdlets.</value>
+    <value>This PowerShell Core snap-in contains Windows Eventing and Performance Counter cmdlets.</value>
   </data>
   <data name="NoMatchingCounterSetsInFile" xml:space="preserve">
     <value>Cannot find any performance counter sets in the {0} files that match the following: {1}.</value>

--- a/src/Microsoft.PowerShell.Commands.Diagnostics/resources/GetEventResources.resx
+++ b/src/Microsoft.PowerShell.Commands.Diagnostics/resources/GetEventResources.resx
@@ -268,7 +268,7 @@ The defined template is following:
     <value>This cmdlet can be run only on Microsoft Windows 7 and above.</value>
   </data>
   <data name="Description" xml:space="preserve">
-    <value>This PowerShell Core snap-in contains Windows Eventing and Performance Counter cmdlets.</value>
+    <value>This PowerShell snap-in contains Windows Eventing and Performance Counter cmdlets.</value>
   </data>
   <data name="NoMatchingCounterSetsInFile" xml:space="preserve">
     <value>Cannot find any performance counter sets in the {0} files that match the following: {1}.</value>

--- a/src/Microsoft.PowerShell.Commands.Management/resources/ComputerResources.resx
+++ b/src/Microsoft.PowerShell.Commands.Management/resources/ComputerResources.resx
@@ -238,7 +238,7 @@
     <value>Verifying that the computer has been restarted...</value>
   </data>
   <data name="WaitForPowerShell" xml:space="preserve">
-    <value>Waiting for Windows PowerShell connectivity...</value>
+    <value>Waiting for PowerShell Core connectivity...</value>
   </data>
   <data name="WaitForRestartToBegin" xml:space="preserve">
     <value>Waiting for the restart to begin...</value>

--- a/src/Microsoft.PowerShell.Commands.Management/resources/ComputerResources.resx
+++ b/src/Microsoft.PowerShell.Commands.Management/resources/ComputerResources.resx
@@ -238,7 +238,7 @@
     <value>Verifying that the computer has been restarted...</value>
   </data>
   <data name="WaitForPowerShell" xml:space="preserve">
-    <value>Waiting for PowerShell Core connectivity...</value>
+    <value>Waiting for PowerShell connectivity...</value>
   </data>
   <data name="WaitForRestartToBegin" xml:space="preserve">
     <value>Waiting for the restart to begin...</value>

--- a/src/Microsoft.PowerShell.Commands.Management/resources/ManagementMshSnapInResources.resx
+++ b/src/Microsoft.PowerShell.Commands.Management/resources/ManagementMshSnapInResources.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="Description" xml:space="preserve">
-    <value>This PowerShell Core Snap-In contains management cmdlets that are used to manage Windows components.  </value>
+    <value>This PowerShell Snap-In contains management cmdlets that are used to manage Windows components.  </value>
   </data>
   <data name="Vendor" xml:space="preserve">
     <value>Microsoft Corporation</value>

--- a/src/Microsoft.PowerShell.Commands.Management/resources/ManagementMshSnapInResources.resx
+++ b/src/Microsoft.PowerShell.Commands.Management/resources/ManagementMshSnapInResources.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="Description" xml:space="preserve">
-    <value>This Windows PowerShell Snap-In contains management cmdlets that are used to manage Windows components.  </value>
+    <value>This PowerShell Core Snap-In contains management cmdlets that are used to manage Windows components.  </value>
   </data>
   <data name="Vendor" xml:space="preserve">
     <value>Microsoft Corporation</value>

--- a/src/Microsoft.PowerShell.Commands.Management/resources/ServiceResources.resx
+++ b/src/Microsoft.PowerShell.Commands.Management/resources/ServiceResources.resx
@@ -199,6 +199,6 @@
     <value>Service '{1} ({0})' resume failed.</value>
   </data>
   <data name="ComputerAccessDenied" xml:space="preserve">
-    <value>The command cannot be used to configure the service '{0}' because access to computer '{1}' is denied. Run PowerShell Core as admin and run your command again.</value>
+    <value>The command cannot be used to configure the service '{0}' because access to computer '{1}' is denied. Run PowerShell as admin and run your command again.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Management/resources/ServiceResources.resx
+++ b/src/Microsoft.PowerShell.Commands.Management/resources/ServiceResources.resx
@@ -199,6 +199,6 @@
     <value>Service '{1} ({0})' resume failed.</value>
   </data>
   <data name="ComputerAccessDenied" xml:space="preserve">
-    <value>The command cannot be used to configure the service '{0}' because access to computer '{1}' is denied. Run Windows PowerShell as admin and run your command again.</value>
+    <value>The command cannot be used to configure the service '{0}' because access to computer '{1}' is denied. Run PowerShell Core as admin and run your command again.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/Debugger.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/Debugger.resx
@@ -142,7 +142,7 @@
     <value>You cannot debug the default host Runspace using this cmdlet. To debug the default Runspace use the normal debugging commands from the host.</value>
   </data>
   <data name="RunspaceDebuggingNoHostRunspaceOrDebugger" xml:space="preserve">
-    <value>Cannot debug Runspace. The host has no debugger. Try debugging the Runspace inside the Windows PowerShell console or the Windows PowerShell ISE, both of which have built-in debuggers.</value>
+    <value>Cannot debug Runspace. The host has no debugger. Try debugging the Runspace inside the PowerShell Core console or the Visual Studio Code, both of which have built-in debuggers.</value>
   </data>
   <data name="RunspaceDebuggingNoHost" xml:space="preserve">
     <value>Cannot debug Runspace. There is no host or host UI. The debugger requires a host and host UI for debugging.</value>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/Debugger.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/Debugger.resx
@@ -142,7 +142,7 @@
     <value>You cannot debug the default host Runspace using this cmdlet. To debug the default Runspace use the normal debugging commands from the host.</value>
   </data>
   <data name="RunspaceDebuggingNoHostRunspaceOrDebugger" xml:space="preserve">
-    <value>Cannot debug Runspace. The host has no debugger. Try debugging the Runspace inside the PowerShell Core console or the Visual Studio Code, both of which have built-in debuggers.</value>
+    <value>Cannot debug Runspace. The host has no debugger. Try debugging the Runspace inside the PowerShell console or with Visual Studio Code, both of which have built-in debuggers.</value>
   </data>
   <data name="RunspaceDebuggingNoHost" xml:space="preserve">
     <value>Cannot debug Runspace. There is no host or host UI. The debugger requires a host and host UI for debugging.</value>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/FormatAndOut_out_gridview.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/FormatAndOut_out_gridview.resx
@@ -121,7 +121,7 @@
     <value>The data format is not supported by Out-GridView.</value>
   </data>
   <data name="RestartPowerShell" xml:space="preserve">
-    <value>Microsoft .NET Framework 4.5 was installed while one or more PowerShell Core sessions were running. To use the {0} cmdlet, close all PowerShell Core windows, and then open a new PowerShell Core window.</value>
+    <value>Microsoft .NET Framework 4.5 was installed while one or more PowerShell sessions were running. To use the {0} cmdlet, close all PowerShell windows, and then open a new PowerShell window.</value>
   </data>
   <data name="TypeColumnName" xml:space="preserve">
     <value>Type</value>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/FormatAndOut_out_gridview.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/FormatAndOut_out_gridview.resx
@@ -121,7 +121,7 @@
     <value>The data format is not supported by Out-GridView.</value>
   </data>
   <data name="RestartPowerShell" xml:space="preserve">
-    <value>Microsoft .NET Framework 4.5 was installed while one or more Windows PowerShell sessions were running. To use the {0} cmdlet, close all Windows PowerShell windows, and then open a new Windows PowerShell window.</value>
+    <value>Microsoft .NET Framework 4.5 was installed while one or more PowerShell Core sessions were running. To use the {0} cmdlet, close all PowerShell Core windows, and then open a new PowerShell Core window.</value>
   </data>
   <data name="TypeColumnName" xml:space="preserve">
     <value>Type</value>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/ImplicitRemotingStrings.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/ImplicitRemotingStrings.resx
@@ -145,16 +145,16 @@
     <value>Extended type definition has been skipped for the '{0}' type because its name did not match the value of the FormatTypeName parameter.</value>
   </data>
   <data name="ErrorSkippedUnsafeCommandName" xml:space="preserve">
-    <value>Proxy creation has been skipped for the '{0}' command, because Windows PowerShell could not verify the safety of the command name.</value>
+    <value>Proxy creation has been skipped for the '{0}' command, because PowerShell Core could not verify the safety of the command name.</value>
   </data>
   <data name="ErrorSkippedUnsafeParameterName" xml:space="preserve">
-    <value>Proxy creation has been skipped for the '{0}' command, because Windows PowerShell could not verify the safety of a parameter name: '{1}'.</value>
+    <value>Proxy creation has been skipped for the '{0}' command, because PowerShell Core could not verify the safety of a parameter name: '{1}'.</value>
   </data>
   <data name="ErrorSkippedUnsafeParameterSetName" xml:space="preserve">
-    <value>Proxy creation has been skipped for the '{0}' command, because Windows PowerShell could not verify the safety of a parameter set name: '{1}'.</value>
+    <value>Proxy creation has been skipped for the '{0}' command, because PowerShell Core could not verify the safety of a parameter set name: '{1}'.</value>
   </data>
   <data name="ErrorSkippedUnsafeAliasName" xml:space="preserve">
-    <value>Proxy creation has been skipped for the '{0}' command, because Windows PowerShell could not verify the safety of a parameter alias name: '{1}'.</value>
+    <value>Proxy creation has been skipped for the '{0}' command, because PowerShell Core could not verify the safety of a parameter alias name: '{1}'.</value>
   </data>
   <data name="ErrorCommandSkippedBecauseOfShadowing" xml:space="preserve">
     <value>Proxy creation has been skipped for the following command: '{0}', because it would shadow an existing local command.  Use the AllowClobber parameter if you want to shadow existing local commands.</value>
@@ -211,7 +211,7 @@
     <value>Completed.</value>
   </data>
   <data name="CredentialRequestTitle" xml:space="preserve">
-    <value>Windows PowerShell Credential Request</value>
+    <value>PowerShell Core Credential Request</value>
   </data>
   <data name="CredentialRequestBody" xml:space="preserve">
     <value>Enter your credentials for {0}.</value>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/ImplicitRemotingStrings.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/ImplicitRemotingStrings.resx
@@ -145,16 +145,16 @@
     <value>Extended type definition has been skipped for the '{0}' type because its name did not match the value of the FormatTypeName parameter.</value>
   </data>
   <data name="ErrorSkippedUnsafeCommandName" xml:space="preserve">
-    <value>Proxy creation has been skipped for the '{0}' command, because PowerShell Core could not verify the safety of the command name.</value>
+    <value>Proxy creation has been skipped for the '{0}' command, because PowerShell could not verify the safety of the command name.</value>
   </data>
   <data name="ErrorSkippedUnsafeParameterName" xml:space="preserve">
-    <value>Proxy creation has been skipped for the '{0}' command, because PowerShell Core could not verify the safety of a parameter name: '{1}'.</value>
+    <value>Proxy creation has been skipped for the '{0}' command, because PowerShell could not verify the safety of a parameter name: '{1}'.</value>
   </data>
   <data name="ErrorSkippedUnsafeParameterSetName" xml:space="preserve">
-    <value>Proxy creation has been skipped for the '{0}' command, because PowerShell Core could not verify the safety of a parameter set name: '{1}'.</value>
+    <value>Proxy creation has been skipped for the '{0}' command, because PowerShell could not verify the safety of a parameter set name: '{1}'.</value>
   </data>
   <data name="ErrorSkippedUnsafeAliasName" xml:space="preserve">
-    <value>Proxy creation has been skipped for the '{0}' command, because PowerShell Core could not verify the safety of a parameter alias name: '{1}'.</value>
+    <value>Proxy creation has been skipped for the '{0}' command, because PowerShell could not verify the safety of a parameter alias name: '{1}'.</value>
   </data>
   <data name="ErrorCommandSkippedBecauseOfShadowing" xml:space="preserve">
     <value>Proxy creation has been skipped for the following command: '{0}', because it would shadow an existing local command.  Use the AllowClobber parameter if you want to shadow existing local commands.</value>
@@ -211,7 +211,7 @@
     <value>Completed.</value>
   </data>
   <data name="CredentialRequestTitle" xml:space="preserve">
-    <value>PowerShell Core Credential Request</value>
+    <value>PowerShell Credential Request</value>
   </data>
   <data name="CredentialRequestBody" xml:space="preserve">
     <value>Enter your credentials for {0}.</value>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/ImportLocalizedDataStrings.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/ImportLocalizedDataStrings.resx
@@ -124,18 +124,18 @@
     <value>The FileName parameter was not specified. The FileName parameter is required when Import-LocalizedData is not called from a script file.</value>
   </data>
   <data name="ErrorOpeningFile" xml:space="preserve">
-    <value>The following error occurred while PowerShell Core was opening the data file '{0}':
+    <value>The following error occurred while PowerShell was opening the data file '{0}':
 {1}.</value>
   </data>
   <data name="ErrorLoadingDataFile" xml:space="preserve">
-    <value>The following error occurred while PowerShell Core was loading the '{0}' script data file:
+    <value>The following error occurred while PowerShell was loading the '{0}' script data file:
 {1}.</value>
   </data>
   <data name="FileNameParameterCannotHavePath" xml:space="preserve">
     <value>The argument for the FileName parameter should not contain a path.</value>
   </data>
   <data name="CannotFindPsd1File" xml:space="preserve">
-    <value>Cannot find the PowerShell Core data file '{0}' in directory '{1}', or in any parent culture directories.</value>
+    <value>Cannot find the PowerShell data file '{0}' in directory '{1}', or in any parent culture directories.</value>
   </data>
   <data name="CannotDefineSupportedCommand" xml:space="preserve">
     <value>Cannot import localized data. The definition of additional supported commands is not allowed in this language mode.</value>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/ImportLocalizedDataStrings.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/ImportLocalizedDataStrings.resx
@@ -124,18 +124,18 @@
     <value>The FileName parameter was not specified. The FileName parameter is required when Import-LocalizedData is not called from a script file.</value>
   </data>
   <data name="ErrorOpeningFile" xml:space="preserve">
-    <value>The following error occurred while Windows PowerShell was opening the data file '{0}':
+    <value>The following error occurred while PowerShell Core was opening the data file '{0}':
 {1}.</value>
   </data>
   <data name="ErrorLoadingDataFile" xml:space="preserve">
-    <value>The following error occurred while Windows PowerShell was loading the '{0}' script data file:
+    <value>The following error occurred while PowerShell Core was loading the '{0}' script data file:
 {1}.</value>
   </data>
   <data name="FileNameParameterCannotHavePath" xml:space="preserve">
     <value>The argument for the FileName parameter should not contain a path.</value>
   </data>
   <data name="CannotFindPsd1File" xml:space="preserve">
-    <value>Cannot find the Windows PowerShell data file '{0}' in directory '{1}', or in any parent culture directories.</value>
+    <value>Cannot find the PowerShell Core data file '{0}' in directory '{1}', or in any parent culture directories.</value>
   </data>
   <data name="CannotDefineSupportedCommand" xml:space="preserve">
     <value>Cannot import localized data. The definition of additional supported commands is not allowed in this language mode.</value>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/NewObjectStrings.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/NewObjectStrings.resx
@@ -142,6 +142,6 @@
     <value>Cannot create type. Only core types are supported in this language mode.</value>
   </data>
   <data name="ApartmentNotSupported" xml:space="preserve">
-    <value>{0} Please note that Single-Threaded Apartment is not supported in PowerShell.</value>
+    <value>{0} Please note that Single-Threaded Apartment is not supported in PowerShell Core.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/NewObjectStrings.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/NewObjectStrings.resx
@@ -142,6 +142,6 @@
     <value>Cannot create type. Only core types are supported in this language mode.</value>
   </data>
   <data name="ApartmentNotSupported" xml:space="preserve">
-    <value>{0} Please note that Single-Threaded Apartment is not supported in PowerShell Core.</value>
+    <value>{0} Please note that Single-Threaded Apartment is not supported in PowerShell.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/UtilityMshSnapinResources.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/UtilityMshSnapinResources.resx
@@ -118,12 +118,12 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="Description" xml:space="preserve">
-    <value>This Windows PowerShell snap-in contains utility cmdlets that are used to view and organize data in different ways.</value>
+    <value>This PowerShell Core snap-in contains utility cmdlets that are used to view and organize data in different ways.</value>
   </data>
   <data name="Vendor" xml:space="preserve">
     <value>Microsoft Corporation</value>
   </data>
   <data name="Name" xml:space="preserve">
-    <value>Windows PowerShell utility snap-in</value>
+    <value>PowerShell Core utility snap-in</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/UtilityMshSnapinResources.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/UtilityMshSnapinResources.resx
@@ -118,12 +118,12 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="Description" xml:space="preserve">
-    <value>This PowerShell Core snap-in contains utility cmdlets that are used to view and organize data in different ways.</value>
+    <value>This PowerShell snap-in contains utility cmdlets that are used to view and organize data in different ways.</value>
   </data>
   <data name="Vendor" xml:space="preserve">
     <value>Microsoft Corporation</value>
   </data>
   <data name="Name" xml:space="preserve">
-    <value>PowerShell Core utility snap-in</value>
+    <value>PowerShell utility snap-in</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/CommandLineParameterParserStrings.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/CommandLineParameterParserStrings.resx
@@ -141,11 +141,11 @@
 PowerShell[.exe] -Help | -? | /?
 
 -PSConsoleFile
-    Loads the specified PowerShell Core console file. To create a console
-    file, use Export-Console in PowerShell Core.
+    Loads the specified PowerShell console file. To create a console
+    file, use Export-Console in PowerShell.
 
 -Version
-    Starts the specified version of PowerShell Core.
+    Starts the specified version of PowerShell.
 
 -NoLogo
     Hides the copyright banner at startup.
@@ -163,22 +163,22 @@ PowerShell[.exe] -Help | -? | /?
     Uses a single-threaded apartment for the execution thread.
 
 -OutputFormat
-    Determines how output from PowerShell Core is formatted. Valid values
+    Determines how output from PowerShell is formatted. Valid values
     are "Text" (text strings) or "XML" (serialized CLIXML format).
 
 -InputFormat
-    Describes the format of data sent to PowerShell Core. Valid values are
+    Describes the format of data sent to PowerShell. Valid values are
     "Text" (text strings) or "XML" (serialized CLIXML format).
 
 -ConfigurationName
-    Specifies a configuration endpoint in which PowerShell Core is run.
+    Specifies a configuration endpoint in which PowerShell is run.
     This can be any endpoint registered on the local machine including the
-    default PowerShell Core remoting endpoints or a custom endpoint having
+    default PowerShell remoting endpoints or a custom endpoint having
     specific user role capabilities.
 
 -Command
     Executes the specified commands (and any parameters) as though they were
-    typed at the PowerShell Core command prompt, and then exits, unless
+    typed at the PowerShell command prompt, and then exits, unless
     NoExit is specified. The value of Command can be "-", a string. or a
     script block.
 
@@ -186,14 +186,14 @@ PowerShell[.exe] -Help | -? | /?
     input.
 
     Script blocks must be enclosed in braces ({}). You can specify a script
-    block only when running PowerShell.exe in PowerShell Core. The results
+    block only when running PowerShell.exe in PowerShell. The results
     of the script are returned to the parent shell as deserialized XML objects,
     not live objects.
 
     If the value of Command is a string, Command must be the last parameter
     in the command , because any characters typed after the command are
     interpreted as the command arguments.
-       To write a string that runs a PowerShell Core command, use the format:
+       To write a string that runs a PowerShell command, use the format:
     "&amp; {&lt;command&gt;}"
     where the quotation marks indicate a string and the invoke operator (&amp;)
     causes the command to be run.
@@ -249,7 +249,7 @@ EXAMPLES
     <value>Processing -WindowStyle '{0}' failed: {1}.</value>
   </data>
   <data name="InvalidFileArgumentExtension" xml:space="preserve">
-    <value>Processing -File '{0}' failed because the file does not have a '.ps1' extension. Specify a valid PowerShell Core script file name, and then try again.</value>
+    <value>Processing -File '{0}' failed because the file does not have a '.ps1' extension. Specify a valid PowerShell script file name, and then try again.</value>
   </data>
   <data name="ArgumentFileDoesNotExist" xml:space="preserve">
     <value>The argument '{0}' is not recognized as the name of a script file. Check the spelling of the name, or if a path was included, verify that the path is correct and try again.</value>

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/CommandLineParameterParserStrings.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/CommandLineParameterParserStrings.resx
@@ -141,11 +141,11 @@
 PowerShell[.exe] -Help | -? | /?
 
 -PSConsoleFile
-    Loads the specified Windows PowerShell console file. To create a console
-    file, use Export-Console in Windows PowerShell.
+    Loads the specified PowerShell Core console file. To create a console
+    file, use Export-Console in PowerShell Core.
 
 -Version
-    Starts the specified version of Windows PowerShell.
+    Starts the specified version of PowerShell Core.
 
 -NoLogo
     Hides the copyright banner at startup.
@@ -163,22 +163,22 @@ PowerShell[.exe] -Help | -? | /?
     Uses a single-threaded apartment for the execution thread.
 
 -OutputFormat
-    Determines how output from Windows PowerShell is formatted. Valid values
+    Determines how output from PowerShell Core is formatted. Valid values
     are "Text" (text strings) or "XML" (serialized CLIXML format).
 
 -InputFormat
-    Describes the format of data sent to Windows PowerShell. Valid values are
+    Describes the format of data sent to PowerShell Core. Valid values are
     "Text" (text strings) or "XML" (serialized CLIXML format).
 
 -ConfigurationName
-    Specifies a configuration endpoint in which Windows PowerShell is run.
+    Specifies a configuration endpoint in which PowerShell Core is run.
     This can be any endpoint registered on the local machine including the
-    default Windows PowerShell remoting endpoints or a custom endpoint having
+    default PowerShell Core remoting endpoints or a custom endpoint having
     specific user role capabilities.
 
 -Command
     Executes the specified commands (and any parameters) as though they were
-    typed at the Windows PowerShell command prompt, and then exits, unless
+    typed at the PowerShell Core command prompt, and then exits, unless
     NoExit is specified. The value of Command can be "-", a string. or a
     script block.
 
@@ -186,14 +186,14 @@ PowerShell[.exe] -Help | -? | /?
     input.
 
     Script blocks must be enclosed in braces ({}). You can specify a script
-    block only when running PowerShell.exe in Windows PowerShell. The results
+    block only when running PowerShell.exe in PowerShell Core. The results
     of the script are returned to the parent shell as deserialized XML objects,
     not live objects.
 
     If the value of Command is a string, Command must be the last parameter
     in the command , because any characters typed after the command are
     interpreted as the command arguments.
-       To write a string that runs a Windows PowerShell command, use the format:
+       To write a string that runs a PowerShell Core command, use the format:
     "&amp; {&lt;command&gt;}"
     where the quotation marks indicate a string and the invoke operator (&amp;)
     causes the command to be run.
@@ -249,7 +249,7 @@ EXAMPLES
     <value>Processing -WindowStyle '{0}' failed: {1}.</value>
   </data>
   <data name="InvalidFileArgumentExtension" xml:space="preserve">
-    <value>Processing -File '{0}' failed because the file does not have a '.ps1' extension. Specify a valid Windows PowerShell script file name, and then try again.</value>
+    <value>Processing -File '{0}' failed because the file does not have a '.ps1' extension. Specify a valid PowerShell Core script file name, and then try again.</value>
   </data>
   <data name="ArgumentFileDoesNotExist" xml:space="preserve">
     <value>The argument '{0}' is not recognized as the name of a script file. Check the spelling of the name, or if a path was included, verify that the path is correct and try again.</value>

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/ConsoleHostStrings.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/ConsoleHostStrings.resx
@@ -136,11 +136,11 @@
     <value>The shell cannot be started. A failure occurred during initialization:</value>
   </data>
   <data name="UnhandledExceptionShutdownMessage" xml:space="preserve">
-    <value>An error has occurred that was not properly handled. Additional information is shown below. The Windows PowerShell process will exit.</value>
+    <value>An error has occurred that was not properly handled. Additional information is shown below. The PowerShell Core process will exit.</value>
   </data>
   <data name="TranscriptPrologue" xml:space="preserve">
     <value>**********************
-Windows PowerShell transcript start
+PowerShell Core transcript start
 Start time: {0:yyyyMMddHHmmss}
 Username  : {1}\{2}
 Machine   : {3} ({4})
@@ -148,7 +148,7 @@ Machine   : {3} ({4})
   </data>
   <data name="TranscriptEpilogue" xml:space="preserve">
     <value>**********************
-Windows PowerShell transcript end
+PowerShell Core transcript end
 End time: {0:yyyyMMddHHmmss}
 **********************</value>
   </data>
@@ -156,7 +156,7 @@ End time: {0:yyyyMMddHHmmss}
     <value>An instance of the ConsoleHost class has already been created for this process.</value>
   </data>
   <data name="InitialCommandNotExecuted" xml:space="preserve">
-    <value>Command '{0}' could not be run because some Windows PowerShell Snap-Ins did not load.</value>
+    <value>Command '{0}' could not be run because some PowerShell Core Snap-Ins did not load.</value>
   </data>
   <data name="CommandNotExecuted" xml:space="preserve">
     <value>Command '{0}' was not run as the session in which it was intended to run was either closed or broken</value>

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/ConsoleHostStrings.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/ConsoleHostStrings.resx
@@ -136,11 +136,11 @@
     <value>The shell cannot be started. A failure occurred during initialization:</value>
   </data>
   <data name="UnhandledExceptionShutdownMessage" xml:space="preserve">
-    <value>An error has occurred that was not properly handled. Additional information is shown below. The PowerShell Core process will exit.</value>
+    <value>An error has occurred that was not properly handled. Additional information is shown below. The PowerShell process will exit.</value>
   </data>
   <data name="TranscriptPrologue" xml:space="preserve">
     <value>**********************
-PowerShell Core transcript start
+PowerShell transcript start
 Start time: {0:yyyyMMddHHmmss}
 Username  : {1}\{2}
 Machine   : {3} ({4})
@@ -148,7 +148,7 @@ Machine   : {3} ({4})
   </data>
   <data name="TranscriptEpilogue" xml:space="preserve">
     <value>**********************
-PowerShell Core transcript end
+PowerShell transcript end
 End time: {0:yyyyMMddHHmmss}
 **********************</value>
   </data>
@@ -156,7 +156,7 @@ End time: {0:yyyyMMddHHmmss}
     <value>An instance of the ConsoleHost class has already been created for this process.</value>
   </data>
   <data name="InitialCommandNotExecuted" xml:space="preserve">
-    <value>Command '{0}' could not be run because some PowerShell Core Snap-Ins did not load.</value>
+    <value>Command '{0}' could not be run because some PowerShell Snap-Ins did not load.</value>
   </data>
   <data name="CommandNotExecuted" xml:space="preserve">
     <value>Command '{0}' was not run as the session in which it was intended to run was either closed or broken</value>

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/ConsoleHostUserInterfaceStrings.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/ConsoleHostUserInterfaceStrings.resx
@@ -190,6 +190,6 @@
     <value>WARNING: {0}</value>
   </data>
   <data name="ReadFailsOnNonInteractiveFlag" xml:space="preserve">
-    <value>PowerShell Core is in NonInteractive mode. Read and Prompt functionality is not available.</value>
+    <value>PowerShell is in NonInteractive mode. Read and Prompt functionality is not available.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/ConsoleHostUserInterfaceStrings.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/ConsoleHostUserInterfaceStrings.resx
@@ -190,6 +190,6 @@
     <value>WARNING: {0}</value>
   </data>
   <data name="ReadFailsOnNonInteractiveFlag" xml:space="preserve">
-    <value>Windows PowerShell is in NonInteractive mode. Read and Prompt functionality is not available.</value>
+    <value>PowerShell Core is in NonInteractive mode. Read and Prompt functionality is not available.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/HostMshSnapinResources.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/HostMshSnapinResources.resx
@@ -118,12 +118,12 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="Description" xml:space="preserve">
-    <value>This PowerShell Core snap-in contains cmdlets (such as Start-Transcript and Stop-Transcript) that are provided for use with the PowerShell Core console host.</value>
+    <value>This PowerShell snap-in contains cmdlets (such as Start-Transcript and Stop-Transcript) that are provided for use with the PowerShell console host.</value>
   </data>
   <data name="Vendor" xml:space="preserve">
     <value>Microsoft Corporation</value>
   </data>
   <data name="Name" xml:space="preserve">
-    <value>Host PowerShell Core Snap-In.</value>
+    <value>Host PowerShell Snap-In.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/HostMshSnapinResources.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/HostMshSnapinResources.resx
@@ -118,12 +118,12 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="Description" xml:space="preserve">
-    <value>This Windows PowerShell snap-in contains cmdlets (such as Start-Transcript and Stop-Transcript) that are provided for use with the Windows PowerShell console host.</value>
+    <value>This PowerShell Core snap-in contains cmdlets (such as Start-Transcript and Stop-Transcript) that are provided for use with the PowerShell Core console host.</value>
   </data>
   <data name="Vendor" xml:space="preserve">
     <value>Microsoft Corporation</value>
   </data>
   <data name="Name" xml:space="preserve">
-    <value>Host Windows PowerShell Snap-In.</value>
+    <value>Host PowerShell Core Snap-In.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/ManagedEntranceStrings.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/ManagedEntranceStrings.resx
@@ -134,11 +134,11 @@ Copyright (C) Microsoft Corporation. All rights reserved.</value>
 PowerShell[.exe] -Help | -? | /?
 
 -PSConsoleFile
-    Loads the specified Windows PowerShell console file. To create a console
-    file, use Export-Console in Windows PowerShell.
+    Loads the specified PowerShell Core console file. To create a console
+    file, use Export-Console in PowerShell Core.
 
 -Version
-    Starts the specified version of Windows PowerShell.
+    Starts the specified version of PowerShell Core.
     Enter a version number with the parameter, such as "-version 2.0".
 
 -NoLogo
@@ -155,7 +155,7 @@ PowerShell[.exe] -Help | -? | /?
     Start the shell using a multithreaded apartment.
 
 -NoProfile
-    Does not load the Windows PowerShell profile.
+    Does not load the PowerShell Core profile.
 
 -NonInteractive
     Does not present an interactive prompt to the user.
@@ -164,11 +164,11 @@ PowerShell[.exe] -Help | -? | /?
     Present an interactive prompt to the user.
 
 -InputFormat
-    Describes the format of data sent to Windows PowerShell. Valid values are
+    Describes the format of data sent to PowerShell Core. Valid values are
     "Text" (text strings) or "XML" (serialized CLIXML format).
 
 -OutputFormat
-    Determines how output from Windows PowerShell is formatted. Valid values
+    Determines how output from PowerShell Core is formatted. Valid values
     are "Text" (text strings) or "XML" (serialized CLIXML format).
 
 -WindowStyle
@@ -176,13 +176,13 @@ PowerShell[.exe] -Help | -? | /?
 
 -EncodedCommand
     Accepts a base-64-encoded string version of a command. Use this parameter
-    to submit commands to Windows PowerShell that require complex quotation
+    to submit commands to PowerShell Core that require complex quotation
     marks or curly braces.
 
 -ConfigurationName
-    Specifies a configuration endpoint in which Windows PowerShell is run.
+    Specifies a configuration endpoint in which PowerShell Core is run.
     This can be any endpoint registered on the local machine including the
-    default Windows PowerShell remoting endpoints or a custom endpoint having
+    default PowerShell Core remoting endpoints or a custom endpoint having
     specific user role capabilities.
 
 -File
@@ -196,12 +196,12 @@ PowerShell[.exe] -Help | -? | /?
 -ExecutionPolicy
     Sets the default execution policy for the current session and saves it
     in the $env:PSExecutionPolicyPreference environment variable.
-    This parameter does not change the Windows PowerShell execution policy
+    This parameter does not change the PowerShell Core execution policy
     that is set in the registry.
 
 -Command
     Executes the specified commands (and any parameters) as though they were
-    typed at the Windows PowerShell command prompt, and then exits, unless
+    typed at the PowerShell Core command prompt, and then exits, unless
     NoExit is specified. The value of Command can be "-", a string. or a
     script block.
 
@@ -210,14 +210,14 @@ PowerShell[.exe] -Help | -? | /?
 
     If the value of Command is a script block, the script block must be enclosed
     in braces ({}). You can specify a script block only when running PowerShell.exe
-    in Windows PowerShell. The results of the script block are returned to the
+    in PowerShell Core. The results of the script block are returned to the
     parent shell as deserialized XML objects, not live objects.
 
     If the value of Command is a string, Command must be the last parameter
     in the command , because any characters typed after the command are
     interpreted as the command arguments.
 
-    To write a string that runs a Windows PowerShell command, use the format:
+    To write a string that runs a PowerShell Core command, use the format:
     "&amp; {&lt;command&gt;}"
     where the quotation marks indicate a string and the invoke operator (&amp;)
     causes the command to be executed.

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/ManagedEntranceStrings.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/ManagedEntranceStrings.resx
@@ -134,11 +134,11 @@ Copyright (C) Microsoft Corporation. All rights reserved.</value>
 PowerShell[.exe] -Help | -? | /?
 
 -PSConsoleFile
-    Loads the specified PowerShell Core console file. To create a console
-    file, use Export-Console in PowerShell Core.
+    Loads the specified PowerShell console file. To create a console
+    file, use Export-Console in PowerShell.
 
 -Version
-    Starts the specified version of PowerShell Core.
+    Starts the specified version of PowerShell.
     Enter a version number with the parameter, such as "-version 2.0".
 
 -NoLogo
@@ -155,7 +155,7 @@ PowerShell[.exe] -Help | -? | /?
     Start the shell using a multithreaded apartment.
 
 -NoProfile
-    Does not load the PowerShell Core profile.
+    Does not load the PowerShell profile.
 
 -NonInteractive
     Does not present an interactive prompt to the user.
@@ -164,11 +164,11 @@ PowerShell[.exe] -Help | -? | /?
     Present an interactive prompt to the user.
 
 -InputFormat
-    Describes the format of data sent to PowerShell Core. Valid values are
+    Describes the format of data sent to PowerShell. Valid values are
     "Text" (text strings) or "XML" (serialized CLIXML format).
 
 -OutputFormat
-    Determines how output from PowerShell Core is formatted. Valid values
+    Determines how output from PowerShell is formatted. Valid values
     are "Text" (text strings) or "XML" (serialized CLIXML format).
 
 -WindowStyle
@@ -176,13 +176,13 @@ PowerShell[.exe] -Help | -? | /?
 
 -EncodedCommand
     Accepts a base-64-encoded string version of a command. Use this parameter
-    to submit commands to PowerShell Core that require complex quotation
+    to submit commands to PowerShell that require complex quotation
     marks or curly braces.
 
 -ConfigurationName
-    Specifies a configuration endpoint in which PowerShell Core is run.
+    Specifies a configuration endpoint in which PowerShell is run.
     This can be any endpoint registered on the local machine including the
-    default PowerShell Core remoting endpoints or a custom endpoint having
+    default PowerShell remoting endpoints or a custom endpoint having
     specific user role capabilities.
 
 -File
@@ -196,12 +196,12 @@ PowerShell[.exe] -Help | -? | /?
 -ExecutionPolicy
     Sets the default execution policy for the current session and saves it
     in the $env:PSExecutionPolicyPreference environment variable.
-    This parameter does not change the PowerShell Core execution policy
+    This parameter does not change the PowerShell execution policy
     that is set in the registry.
 
 -Command
     Executes the specified commands (and any parameters) as though they were
-    typed at the PowerShell Core command prompt, and then exits, unless
+    typed at the PowerShell command prompt, and then exits, unless
     NoExit is specified. The value of Command can be "-", a string. or a
     script block.
 
@@ -210,14 +210,14 @@ PowerShell[.exe] -Help | -? | /?
 
     If the value of Command is a script block, the script block must be enclosed
     in braces ({}). You can specify a script block only when running PowerShell.exe
-    in PowerShell Core. The results of the script block are returned to the
+    in PowerShell. The results of the script block are returned to the
     parent shell as deserialized XML objects, not live objects.
 
     If the value of Command is a string, Command must be the last parameter
     in the command , because any characters typed after the command are
     interpreted as the command arguments.
 
-    To write a string that runs a PowerShell Core command, use the format:
+    To write a string that runs a PowerShell command, use the format:
     "&amp; {&lt;command&gt;}"
     where the quotation marks indicate a string and the invoke operator (&amp;)
     causes the command to be executed.

--- a/src/Microsoft.PowerShell.ScheduledJob/resources/ScheduledJobErrorStrings.resx
+++ b/src/Microsoft.PowerShell.ScheduledJob/resources/ScheduledJobErrorStrings.resx
@@ -134,7 +134,7 @@
     <value>There is no entry in Task Scheduler for scheduled job definition {0}.  A new Task Scheduler entry has been created for this scheduled job definition.</value>
   </data>
   <data name="CantLoadDefinitionFromStore" xml:space="preserve">
-    <value>Cannot get the {0} scheduled job because it is corrupted or in an irresolvable state. Because it cannot run, PowerShell Core has deleted {0} and its results from the computer. To recreate the scheduled job, use the Register-ScheduledJob cmdlet. For more information about corrupted scheduled jobs, see about_Scheduled_Jobs_Troubleshooting.</value>
+    <value>Cannot get the {0} scheduled job because it is corrupted or in an irresolvable state. Because it cannot run, PowerShell has deleted {0} and its results from the computer. To recreate the scheduled job, use the Register-ScheduledJob cmdlet. For more information about corrupted scheduled jobs, see about_Scheduled_Jobs_Troubleshooting.</value>
     <comment>{0} is the name of the scheduled job definition.</comment>
   </data>
   <data name="CantLoadJobRunFromStore" xml:space="preserve">
@@ -192,7 +192,7 @@
     <value>Scheduled job definition {0}.</value>
   </data>
   <data name="DirectoryNotFoundError" xml:space="preserve">
-    <value>A directory not found error occurred while registering scheduled job definition {0}.  Make sure you are running PowerShell Core with elevated privileges.</value>
+    <value>A directory not found error occurred while registering scheduled job definition {0}.  Make sure you are running PowerShell with elevated privileges.</value>
   </data>
   <data name="ErrorRegisteringDefinitionStore" xml:space="preserve">
     <value>An error occurred while registering scheduled job definition {0}. Cannot add this definition object to the job store.</value>
@@ -231,7 +231,7 @@
     <value>The FilePath parameter is not valid.</value>
   </data>
   <data name="InvalidFilePathFile" xml:space="preserve">
-    <value>Only PowerShell Core script files are allowed for FilePath parameter. Specify a file with .ps1 extension.</value>
+    <value>Only PowerShell script files are allowed for FilePath parameter. Specify a file with .ps1 extension.</value>
   </data>
   <data name="InvalidIdleDuration" xml:space="preserve">
     <value>The IdleDuration parameter cannot have a negative value.</value>
@@ -255,7 +255,7 @@
     <value>The WeeksInterval parameter value must be greater than zero.</value>
   </data>
   <data name="IOFailureOnSetJobDefinition" xml:space="preserve">
-    <value>An I/O failure occurred while updating the scheduled job definition {0}.  This could mean a file is missing or corrupted, either in Task Scheduler or in the PowerShell Core scheduled job store. You might need to create the scheduled job definition again.</value>
+    <value>An I/O failure occurred while updating the scheduled job definition {0}.  This could mean a file is missing or corrupted, either in Task Scheduler or in the PowerShell scheduled job store. You might need to create the scheduled job definition again.</value>
     <comment>{0} is the scheduled job definition name</comment>
   </data>
   <data name="JobAlreadyRunning" xml:space="preserve">
@@ -283,7 +283,7 @@
     <value>No Frequency type has been specified for this job trigger. One of the following job trigger frequencies must be specified: AtStartup, AtLogon, Once, Daily, Weekly.</value>
   </data>
   <data name="NoAccessOnSetJobDefinition" xml:space="preserve">
-    <value>An access denied error occurred while updating the scheduled job definition {0}.  Try running PowerShell Core with elevated user rights; that is, Run as Administrator.</value>
+    <value>An access denied error occurred while updating the scheduled job definition {0}.  Try running PowerShell with elevated user rights; that is, Run as Administrator.</value>
     <comment>{0} is the scheduled job definition name</comment>
   </data>
   <data name="NoAssociatedJobDefinitionForOption" xml:space="preserve">
@@ -320,7 +320,7 @@
     <value>Weekly</value>
   </data>
   <data name="UnauthorizedAccessError" xml:space="preserve">
-    <value>An access denied error occurred when registering scheduled job definition {0}.  Try running PowerShell Core with elevated user rights; that is, Run As Administrator.</value>
+    <value>An access denied error occurred when registering scheduled job definition {0}.  Try running PowerShell with elevated user rights; that is, Run As Administrator.</value>
   </data>
   <data name="UnknownTriggerFrequency" xml:space="preserve">
     <value>Cannot convert a ScheduledJobTrigger object with TriggerFrequency value of {0}.</value>
@@ -334,7 +334,7 @@
 {1} is the inner exception message from .Net serialization, or empty if no exception message.</comment>
   </data>
   <data name="UnsupportedHostFunction" xml:space="preserve">
-    <value>Commands that interact with the host program, such as Write-Host, cannot be included in PowerShell Core scheduled jobs because scheduled jobs do not interact with the host program.  Use an alternate command that does not interact with the host program, such as Write-Output or Out-File.</value>
+    <value>Commands that interact with the host program, such as Write-Host, cannot be included in PowerShell scheduled jobs because scheduled jobs do not interact with the host program.  Use an alternate command that does not interact with the host program, such as Write-Output or Out-File.</value>
   </data>
   <data name="InvalidRepetitionInterval" xml:space="preserve">
     <value>The RepetitionInterval parameter value must be less than or equal to the RepetitionDuration parameter value.</value>

--- a/src/Microsoft.PowerShell.ScheduledJob/resources/ScheduledJobErrorStrings.resx
+++ b/src/Microsoft.PowerShell.ScheduledJob/resources/ScheduledJobErrorStrings.resx
@@ -134,7 +134,7 @@
     <value>There is no entry in Task Scheduler for scheduled job definition {0}.  A new Task Scheduler entry has been created for this scheduled job definition.</value>
   </data>
   <data name="CantLoadDefinitionFromStore" xml:space="preserve">
-    <value>Cannot get the {0} scheduled job because it is corrupted or in an irresolvable state. Because it cannot run, Windows PowerShell has deleted {0} and its results from the computer. To recreate the scheduled job, use the Register-ScheduledJob cmdlet. For more information about corrupted scheduled jobs, see about_Scheduled_Jobs_Troubleshooting.</value>
+    <value>Cannot get the {0} scheduled job because it is corrupted or in an irresolvable state. Because it cannot run, PowerShell Core has deleted {0} and its results from the computer. To recreate the scheduled job, use the Register-ScheduledJob cmdlet. For more information about corrupted scheduled jobs, see about_Scheduled_Jobs_Troubleshooting.</value>
     <comment>{0} is the name of the scheduled job definition.</comment>
   </data>
   <data name="CantLoadJobRunFromStore" xml:space="preserve">
@@ -192,7 +192,7 @@
     <value>Scheduled job definition {0}.</value>
   </data>
   <data name="DirectoryNotFoundError" xml:space="preserve">
-    <value>A directory not found error occurred while registering scheduled job definition {0}.  Make sure you are running Windows PowerShell with elevated privileges.</value>
+    <value>A directory not found error occurred while registering scheduled job definition {0}.  Make sure you are running PowerShell Core with elevated privileges.</value>
   </data>
   <data name="ErrorRegisteringDefinitionStore" xml:space="preserve">
     <value>An error occurred while registering scheduled job definition {0}. Cannot add this definition object to the job store.</value>
@@ -231,7 +231,7 @@
     <value>The FilePath parameter is not valid.</value>
   </data>
   <data name="InvalidFilePathFile" xml:space="preserve">
-    <value>Only Windows PowerShell script files are allowed for FilePath parameter. Specify a file with .ps1 extension.</value>
+    <value>Only PowerShell Core script files are allowed for FilePath parameter. Specify a file with .ps1 extension.</value>
   </data>
   <data name="InvalidIdleDuration" xml:space="preserve">
     <value>The IdleDuration parameter cannot have a negative value.</value>
@@ -255,7 +255,7 @@
     <value>The WeeksInterval parameter value must be greater than zero.</value>
   </data>
   <data name="IOFailureOnSetJobDefinition" xml:space="preserve">
-    <value>An I/O failure occurred while updating the scheduled job definition {0}.  This could mean a file is missing or corrupted, either in Task Scheduler or in the Windows PowerShell scheduled job store. You might need to create the scheduled job definition again.</value>
+    <value>An I/O failure occurred while updating the scheduled job definition {0}.  This could mean a file is missing or corrupted, either in Task Scheduler or in the PowerShell Core scheduled job store. You might need to create the scheduled job definition again.</value>
     <comment>{0} is the scheduled job definition name</comment>
   </data>
   <data name="JobAlreadyRunning" xml:space="preserve">
@@ -283,7 +283,7 @@
     <value>No Frequency type has been specified for this job trigger. One of the following job trigger frequencies must be specified: AtStartup, AtLogon, Once, Daily, Weekly.</value>
   </data>
   <data name="NoAccessOnSetJobDefinition" xml:space="preserve">
-    <value>An access denied error occurred while updating the scheduled job definition {0}.  Try running Windows PowerShell with elevated user rights; that is, Run as Administrator.</value>
+    <value>An access denied error occurred while updating the scheduled job definition {0}.  Try running PowerShell Core with elevated user rights; that is, Run as Administrator.</value>
     <comment>{0} is the scheduled job definition name</comment>
   </data>
   <data name="NoAssociatedJobDefinitionForOption" xml:space="preserve">
@@ -320,7 +320,7 @@
     <value>Weekly</value>
   </data>
   <data name="UnauthorizedAccessError" xml:space="preserve">
-    <value>An access denied error occurred when registering scheduled job definition {0}.  Try running Windows PowerShell with elevated user rights; that is, Run As Administrator.</value>
+    <value>An access denied error occurred when registering scheduled job definition {0}.  Try running PowerShell Core with elevated user rights; that is, Run As Administrator.</value>
   </data>
   <data name="UnknownTriggerFrequency" xml:space="preserve">
     <value>Cannot convert a ScheduledJobTrigger object with TriggerFrequency value of {0}.</value>
@@ -334,7 +334,7 @@
 {1} is the inner exception message from .Net serialization, or empty if no exception message.</comment>
   </data>
   <data name="UnsupportedHostFunction" xml:space="preserve">
-    <value>Commands that interact with the host program, such as Write-Host, cannot be included in Windows PowerShell scheduled jobs because scheduled jobs do not interact with the host program.  Use an alternate command that does not interact with the host program, such as Write-Output or Out-File.</value>
+    <value>Commands that interact with the host program, such as Write-Host, cannot be included in PowerShell Core scheduled jobs because scheduled jobs do not interact with the host program.  Use an alternate command that does not interact with the host program, such as Write-Output or Out-File.</value>
   </data>
   <data name="InvalidRepetitionInterval" xml:space="preserve">
     <value>The RepetitionInterval parameter value must be less than or equal to the RepetitionDuration parameter value.</value>

--- a/src/Microsoft.PowerShell.Security/resources/CertificateProviderStrings.resx
+++ b/src/Microsoft.PowerShell.Security/resources/CertificateProviderStrings.resx
@@ -187,6 +187,6 @@
     <value>The operation is on user root store and UI is not allowed. </value>
   </data>
   <data name="RemoteErrorMessage" xml:space="preserve">
-    <value>. The following error may be a result of user credentials required on the remote machine. See Enable-WSManCredSSP Cmdlet help on how to enable and use CredSSP for delegation with Windows PowerShell remoting. </value>
+    <value>. The following error may be a result of user credentials required on the remote machine. See Enable-WSManCredSSP Cmdlet help on how to enable and use CredSSP for delegation with PowerShell Core remoting. </value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Security/resources/CertificateProviderStrings.resx
+++ b/src/Microsoft.PowerShell.Security/resources/CertificateProviderStrings.resx
@@ -187,6 +187,6 @@
     <value>The operation is on user root store and UI is not allowed. </value>
   </data>
   <data name="RemoteErrorMessage" xml:space="preserve">
-    <value>. The following error may be a result of user credentials required on the remote machine. See Enable-WSManCredSSP Cmdlet help on how to enable and use CredSSP for delegation with PowerShell Core remoting. </value>
+    <value>. The following error may be a result of user credentials required on the remote machine. See Enable-WSManCredSSP Cmdlet help on how to enable and use CredSSP for delegation with PowerShell remoting. </value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Security/resources/ExecutionPolicyCommands.resx
+++ b/src/Microsoft.PowerShell.Security/resources/ExecutionPolicyCommands.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ExecutionPolicyOverridden" xml:space="preserve">
-    <value>PowerShell Core updated your execution policy successfully, but the setting is overridden by a policy defined at a more specific scope.  Due to the override, your shell will retain its current effective execution policy of {0}. Type "Get-ExecutionPolicy -List" to view your execution policy settings. For more information please see "Get-Help Set-ExecutionPolicy".</value>
+    <value>PowerShell updated your execution policy successfully, but the setting is overridden by a policy defined at a more specific scope.  Due to the override, your shell will retain its current effective execution policy of {0}. Type "Get-ExecutionPolicy -List" to view your execution policy settings. For more information please see "Get-Help Set-ExecutionPolicy".</value>
   </data>
   <data name="ExecutionPolicyOverriddenRecommendedAction" xml:space="preserve">
     <value>Contact your system administrator.</value>
@@ -136,6 +136,6 @@
     <value>The execution policy helps protect you from scripts that you do not trust. Changing the execution policy might expose you to the security risks described in the about_Execution_Policies help topic at https://go.microsoft.com/fwlink/?LinkID=135170. Do you want to change the execution policy?</value>
   </data>
   <data name="SetExecutionPolicyAccessDeniedError" xml:space="preserve">
-    <value>{0} To change the execution policy for the default (LocalMachine) scope, start PowerShell Core with the "Run as administrator" option. To change the execution policy for the current user, run "Set-ExecutionPolicy -Scope CurrentUser".</value>
+    <value>{0} To change the execution policy for the default (LocalMachine) scope, start PowerShell with the "Run as administrator" option. To change the execution policy for the current user, run "Set-ExecutionPolicy -Scope CurrentUser".</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Security/resources/ExecutionPolicyCommands.resx
+++ b/src/Microsoft.PowerShell.Security/resources/ExecutionPolicyCommands.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ExecutionPolicyOverridden" xml:space="preserve">
-    <value>Windows PowerShell updated your execution policy successfully, but the setting is overridden by a policy defined at a more specific scope.  Due to the override, your shell will retain its current effective execution policy of {0}. Type "Get-ExecutionPolicy -List" to view your execution policy settings. For more information please see "Get-Help Set-ExecutionPolicy".</value>
+    <value>PowerShell Core updated your execution policy successfully, but the setting is overridden by a policy defined at a more specific scope.  Due to the override, your shell will retain its current effective execution policy of {0}. Type "Get-ExecutionPolicy -List" to view your execution policy settings. For more information please see "Get-Help Set-ExecutionPolicy".</value>
   </data>
   <data name="ExecutionPolicyOverriddenRecommendedAction" xml:space="preserve">
     <value>Contact your system administrator.</value>
@@ -136,6 +136,6 @@
     <value>The execution policy helps protect you from scripts that you do not trust. Changing the execution policy might expose you to the security risks described in the about_Execution_Policies help topic at https://go.microsoft.com/fwlink/?LinkID=135170. Do you want to change the execution policy?</value>
   </data>
   <data name="SetExecutionPolicyAccessDeniedError" xml:space="preserve">
-    <value>{0} To change the execution policy for the default (LocalMachine) scope, start Windows PowerShell with the "Run as administrator" option. To change the execution policy for the current user, run "Set-ExecutionPolicy -Scope CurrentUser".</value>
+    <value>{0} To change the execution policy for the default (LocalMachine) scope, start PowerShell Core with the "Run as administrator" option. To change the execution policy for the current user, run "Set-ExecutionPolicy -Scope CurrentUser".</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Security/resources/SecurityMshSnapinResources.resx
+++ b/src/Microsoft.PowerShell.Security/resources/SecurityMshSnapinResources.resx
@@ -118,12 +118,12 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="Description" xml:space="preserve">
-    <value>This PowerShell Core Snap-In contains cmdlets to manage PowerShell Core security.</value>
+    <value>This PowerShell Snap-In contains cmdlets to manage PowerShell security.</value>
   </data>
   <data name="Vendor" xml:space="preserve">
     <value>Microsoft Corporation</value>
   </data>
   <data name="Name" xml:space="preserve">
-    <value>Security PowerShell Core Snap-In.</value>
+    <value>Security PowerShell Snap-In.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Security/resources/SecurityMshSnapinResources.resx
+++ b/src/Microsoft.PowerShell.Security/resources/SecurityMshSnapinResources.resx
@@ -118,12 +118,12 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="Description" xml:space="preserve">
-    <value>This Windows PowerShell Snap-In contains cmdlets to manage Windows PowerShell security.</value>
+    <value>This PowerShell Core Snap-In contains cmdlets to manage PowerShell Core security.</value>
   </data>
   <data name="Vendor" xml:space="preserve">
     <value>Microsoft Corporation</value>
   </data>
   <data name="Name" xml:space="preserve">
-    <value>Security Windows PowerShell Snap-In.</value>
+    <value>Security PowerShell Core Snap-In.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Security/resources/UtilsStrings.resx
+++ b/src/Microsoft.PowerShell.Security/resources/UtilsStrings.resx
@@ -151,7 +151,7 @@
     <value>Central Access Policy identifier or name is not valid. If specifying an identifier, it must begin with S-1-17. If specifying a name, the policy must be applied on the target machine.</value>
   </data>
   <data name="PromptForCredential_DefaultCaption" xml:space="preserve">
-    <value>Windows PowerShell credential request</value>
+    <value>PowerShell Core credential request</value>
   </data>
   <data name="PromptForCredential_DefaultMessage" xml:space="preserve">
     <value>Enter your credentials.</value>

--- a/src/Microsoft.PowerShell.Security/resources/UtilsStrings.resx
+++ b/src/Microsoft.PowerShell.Security/resources/UtilsStrings.resx
@@ -151,7 +151,7 @@
     <value>Central Access Policy identifier or name is not valid. If specifying an identifier, it must begin with S-1-17. If specifying a name, the policy must be applied on the target machine.</value>
   </data>
   <data name="PromptForCredential_DefaultCaption" xml:space="preserve">
-    <value>PowerShell Core credential request</value>
+    <value>PowerShell credential request</value>
   </data>
   <data name="PromptForCredential_DefaultMessage" xml:space="preserve">
     <value>Enter your credentials.</value>

--- a/src/Microsoft.WSMan.Management/resources/WsManResources.resx
+++ b/src/Microsoft.WSMan.Management/resources/WsManResources.resx
@@ -308,7 +308,7 @@ Do you want to continue?</value>
     <value>This command cannot be used from the current path. Move to root path of the provider using cd\ and run your command again.</value>
   </data>
   <data name="Description" xml:space="preserve">
-    <value>This Windows PowerShell snap-in contains cmdlets (such as Get-WSManInstance and Set-WSManInstance) that are used by the Windows PowerShell host to manage WSMan operations.</value>
+    <value>This PowerShell Core snap-in contains cmdlets (such as Get-WSManInstance and Set-WSManInstance) that are used by the PowerShell Core host to manage WSMan operations.</value>
   </data>
   <data name="LocalHost" xml:space="preserve">
     <value>This command cannot be used to remove the computer 'localhost' because it will always be connected. Give some other connected computer and run your command.</value>

--- a/src/Microsoft.WSMan.Management/resources/WsManResources.resx
+++ b/src/Microsoft.WSMan.Management/resources/WsManResources.resx
@@ -308,7 +308,7 @@ Do you want to continue?</value>
     <value>This command cannot be used from the current path. Move to root path of the provider using cd\ and run your command again.</value>
   </data>
   <data name="Description" xml:space="preserve">
-    <value>This PowerShell Core snap-in contains cmdlets (such as Get-WSManInstance and Set-WSManInstance) that are used by the PowerShell Core host to manage WSMan operations.</value>
+    <value>This PowerShell snap-in contains cmdlets (such as Get-WSManInstance and Set-WSManInstance) that are used by the PowerShell host to manage WSMan operations.</value>
   </data>
   <data name="LocalHost" xml:space="preserve">
     <value>This command cannot be used to remove the computer 'localhost' because it will always be connected. Give some other connected computer and run your command.</value>

--- a/src/System.Management.Automation/resources/AutomationExceptions.resx
+++ b/src/System.Management.Automation/resources/AutomationExceptions.resx
@@ -157,31 +157,31 @@
     <value>A script block that contains a top-level trap statement cannot be converted.</value>
   </data>
   <data name="CantConvertWithUndeclaredVariables" xml:space="preserve">
-    <value>Cannot generate a PowerShell Core object for a ScriptBlock dereferencing variables undeclared in the param(...) block.  Name of undeclared variable: {0}.</value>
+    <value>Cannot generate a PowerShell object for a ScriptBlock dereferencing variables undeclared in the param(...) block.  Name of undeclared variable: {0}.</value>
   </data>
   <data name="CantConvertWithNonConstantExpression" xml:space="preserve">
-    <value>Cannot generate a PowerShell Core object for a ScriptBlock evaluating non-constant expressions. Non-constant expression: {0}.</value>
+    <value>Cannot generate a PowerShell object for a ScriptBlock evaluating non-constant expressions. Non-constant expression: {0}.</value>
   </data>
   <data name="CantConvertWithDynamicExpression" xml:space="preserve">
-    <value>Cannot generate a PowerShell Core object for a ScriptBlock evaluating dynamic expressions. Dynamic expression: {0}.</value>
+    <value>Cannot generate a PowerShell object for a ScriptBlock evaluating dynamic expressions. Dynamic expression: {0}.</value>
   </data>
   <data name="CantConvertWithScriptBlocks" xml:space="preserve">
-    <value>Cannot generate a PowerShell Core object for a ScriptBlock that tries to pass other script blocks inside argument values.</value>
+    <value>Cannot generate a PowerShell object for a ScriptBlock that tries to pass other script blocks inside argument values.</value>
   </data>
   <data name="CantConvertWithCommandInvocations" xml:space="preserve">
-    <value>Cannot generate a PowerShell Core object for a ScriptBlock which invokes pipelines, commands or functions to evaluate arguments of the main pipeline.</value>
+    <value>Cannot generate a PowerShell object for a ScriptBlock which invokes pipelines, commands or functions to evaluate arguments of the main pipeline.</value>
   </data>
   <data name="CantConvertWithDotSourcing" xml:space="preserve">
-    <value>Cannot generate a PowerShell Core object for a ScriptBlock that uses dot sourcing.</value>
+    <value>Cannot generate a PowerShell object for a ScriptBlock that uses dot sourcing.</value>
   </data>
   <data name="CantConvertWithScriptBlockInvocation" xml:space="preserve">
-    <value>Cannot generate a PowerShell Core object for a ScriptBlock that invokes other script blocks.</value>
+    <value>Cannot generate a PowerShell object for a ScriptBlock that invokes other script blocks.</value>
   </data>
   <data name="CanConvertOneOutputErrorRedir" xml:space="preserve">
-    <value>The script block cannot be converted to a PowerShell Core object because it contains forbidden redirection operators.</value>
+    <value>The script block cannot be converted to a PowerShell object because it contains forbidden redirection operators.</value>
   </data>
   <data name="CantConvertScriptBlockWithNoContext" xml:space="preserve">
-    <value>Cannot generate a PowerShell Core object for a ScriptBlock that does not have an associated operation context.</value>
+    <value>Cannot generate a PowerShell object for a ScriptBlock that does not have an associated operation context.</value>
   </data>
   <data name="HaltCommandException" xml:space="preserve">
     <value>The command was stopped by the user.</value>
@@ -193,7 +193,7 @@
     <value>The script block cannot be converted to an open generic type. Define an appropriate closed generic type, and then retry.</value>
   </data>
   <data name="CantConvertPipelineStartsWithExpression" xml:space="preserve">
-    <value>Cannot generate a PowerShell Core object for a ScriptBlock that starts a pipeline with an expression.</value>
+    <value>Cannot generate a PowerShell object for a ScriptBlock that starts a pipeline with an expression.</value>
   </data>
   <data name="CantLoadWorkflowType" xml:space="preserve">
     <value>Cannot create workflow. The type '{0}' from the '{1}' module could not be loaded.</value>

--- a/src/System.Management.Automation/resources/AutomationExceptions.resx
+++ b/src/System.Management.Automation/resources/AutomationExceptions.resx
@@ -157,31 +157,31 @@
     <value>A script block that contains a top-level trap statement cannot be converted.</value>
   </data>
   <data name="CantConvertWithUndeclaredVariables" xml:space="preserve">
-    <value>Cannot generate a Windows PowerShell object for a ScriptBlock dereferencing variables undeclared in the param(...) block.  Name of undeclared variable: {0}.</value>
+    <value>Cannot generate a PowerShell Core object for a ScriptBlock dereferencing variables undeclared in the param(...) block.  Name of undeclared variable: {0}.</value>
   </data>
   <data name="CantConvertWithNonConstantExpression" xml:space="preserve">
-    <value>Cannot generate a Windows PowerShell object for a ScriptBlock evaluating non-constant expressions. Non-constant expression: {0}.</value>
+    <value>Cannot generate a PowerShell Core object for a ScriptBlock evaluating non-constant expressions. Non-constant expression: {0}.</value>
   </data>
   <data name="CantConvertWithDynamicExpression" xml:space="preserve">
-    <value>Cannot generate a Windows PowerShell object for a ScriptBlock evaluating dynamic expressions. Dynamic expression: {0}.</value>
+    <value>Cannot generate a PowerShell Core object for a ScriptBlock evaluating dynamic expressions. Dynamic expression: {0}.</value>
   </data>
   <data name="CantConvertWithScriptBlocks" xml:space="preserve">
-    <value>Cannot generate a Windows PowerShell object for a ScriptBlock that tries to pass other script blocks inside argument values.</value>
+    <value>Cannot generate a PowerShell Core object for a ScriptBlock that tries to pass other script blocks inside argument values.</value>
   </data>
   <data name="CantConvertWithCommandInvocations" xml:space="preserve">
-    <value>Cannot generate a Windows PowerShell object for a ScriptBlock which invokes pipelines, commands or functions to evaluate arguments of the main pipeline.</value>
+    <value>Cannot generate a PowerShell Core object for a ScriptBlock which invokes pipelines, commands or functions to evaluate arguments of the main pipeline.</value>
   </data>
   <data name="CantConvertWithDotSourcing" xml:space="preserve">
-    <value>Cannot generate a Windows PowerShell object for a ScriptBlock that uses dot sourcing.</value>
+    <value>Cannot generate a PowerShell Core object for a ScriptBlock that uses dot sourcing.</value>
   </data>
   <data name="CantConvertWithScriptBlockInvocation" xml:space="preserve">
-    <value>Cannot generate a Windows PowerShell object for a ScriptBlock that invokes other script blocks.</value>
+    <value>Cannot generate a PowerShell Core object for a ScriptBlock that invokes other script blocks.</value>
   </data>
   <data name="CanConvertOneOutputErrorRedir" xml:space="preserve">
-    <value>The script block cannot be converted to a Windows PowerShell object because it contains forbidden redirection operators.</value>
+    <value>The script block cannot be converted to a PowerShell Core object because it contains forbidden redirection operators.</value>
   </data>
   <data name="CantConvertScriptBlockWithNoContext" xml:space="preserve">
-    <value>Cannot generate a Windows PowerShell object for a ScriptBlock that does not have an associated operation context.</value>
+    <value>Cannot generate a PowerShell Core object for a ScriptBlock that does not have an associated operation context.</value>
   </data>
   <data name="HaltCommandException" xml:space="preserve">
     <value>The command was stopped by the user.</value>
@@ -193,7 +193,7 @@
     <value>The script block cannot be converted to an open generic type. Define an appropriate closed generic type, and then retry.</value>
   </data>
   <data name="CantConvertPipelineStartsWithExpression" xml:space="preserve">
-    <value>Cannot generate a Windows PowerShell object for a ScriptBlock that starts a pipeline with an expression.</value>
+    <value>Cannot generate a PowerShell Core object for a ScriptBlock that starts a pipeline with an expression.</value>
   </data>
   <data name="CantLoadWorkflowType" xml:space="preserve">
     <value>Cannot create workflow. The type '{0}' from the '{1}' module could not be loaded.</value>

--- a/src/System.Management.Automation/resources/ConsoleInfoErrorStrings.resx
+++ b/src/System.Management.Automation/resources/ConsoleInfoErrorStrings.resx
@@ -133,7 +133,7 @@
     <value>The console file is not valid because the element {0} is not valid.</value>
   </data>
   <data name="IDNotFound" xml:space="preserve">
-    <value>The console file is not valid because the Windows PowerShell snap-in name is missing.</value>
+    <value>The console file is not valid because the PowerShell Core snap-in name is missing.</value>
   </data>
   <data name="SaveDefaultError" xml:space="preserve">
     <value>Attempting to save a console file with no name. Use Export-Console with the Path parameter to save the console file.</value>
@@ -151,49 +151,49 @@
     <value>The console file name extension is not valid. A console file name extension must be psc1.</value>
   </data>
   <data name="BadMonadVersion" xml:space="preserve">
-    <value>Incorrect Windows PowerShell version {0}. Windows PowerShell version {1} is supported on this computer.</value>
+    <value>Incorrect PowerShell Core version {0}. PowerShell Core version {1} is supported on this computer.</value>
   </data>
   <data name="PSSnapInDoesNotExist" xml:space="preserve">
-    <value>Cannot find any Windows PowerShell snap-in information for {0}.</value>
+    <value>Cannot find any PowerShell Core snap-in information for {0}.</value>
   </data>
   <data name="CannotLoadDefault" xml:space="preserve">
-    <value>This is a system Windows PowerShell snap-in that is loaded by Windows PowerShell.</value>
+    <value>This is a system PowerShell Core snap-in that is loaded by PowerShell Core.</value>
   </data>
   <data name="PSSnapInAlreadyExists" xml:space="preserve">
-    <value>Cannot add Windows PowerShell snap-in {0} because it is already added. Verify the name of the snap-in, and then try again.</value>
+    <value>Cannot add PowerShell Core snap-in {0} because it is already added. Verify the name of the snap-in, and then try again.</value>
   </data>
   <data name="CannotRemovePSSnapIn" xml:space="preserve">
-    <value>Cannot remove the Windows PowerShell snap-in {0} because it is not loaded. Verify the name of the snap-in that you want to remove, and then try again.</value>
+    <value>Cannot remove the PowerShell Core snap-in {0} because it is not loaded. Verify the name of the snap-in that you want to remove, and then try again.</value>
   </data>
   <data name="CannotRemoveDefault" xml:space="preserve">
-    <value>Cannot remove the Windows PowerShell snap-in {0} because it is a system snap-in. Verify the name of the snap-in that you want to remove, and then try again.</value>
+    <value>Cannot remove the PowerShell Core snap-in {0} because it is a system snap-in. Verify the name of the snap-in that you want to remove, and then try again.</value>
   </data>
   <data name="PSSnapInReadError" xml:space="preserve">
-    <value>Cannot load the Windows PowerShell snap-in because an error occurred while reading the registry information for the snap-in.</value>
+    <value>Cannot load the PowerShell Core snap-in because an error occurred while reading the registry information for the snap-in.</value>
   </data>
   <data name="CannotLoadDefaults" xml:space="preserve">
-    <value>An error occurred while attempting to load the system Windows PowerShell snap-ins. Please contact Microsoft Customer Support Services.</value>
+    <value>An error occurred while attempting to load the system PowerShell Core snap-ins. Please contact Microsoft Customer Support Services.</value>
   </data>
   <data name="ConsoleLoadFailure" xml:space="preserve">
     <value>The following errors occurred when loading console {0}: {1}</value>
   </data>
   <data name="PSSnapInLoadFailure" xml:space="preserve">
-    <value>Cannot load Windows PowerShell snap-in {0} because of the following error: {1}</value>
+    <value>Cannot load PowerShell Core snap-in {0} because of the following error: {1}</value>
   </data>
   <data name="PSSnapInLoadWarning" xml:space="preserve">
-    <value>Windows PowerShell snap-in "{0}" loaded with the following warnings: {1}</value>
+    <value>PowerShell Core snap-in "{0}" loaded with the following warnings: {1}</value>
   </data>
   <data name="PSSnapInAssemblyNameMismatch" xml:space="preserve">
-    <value>The Windows PowerShell snap-in module {0} does not have the required Windows PowerShell snap-in strong name {1}.</value>
+    <value>The PowerShell Core snap-in module {0} does not have the required PowerShell Core snap-in strong name {1}.</value>
   </data>
   <data name="PSSnapInDuplicateCmdlets" xml:space="preserve">
-    <value>The cmdlet '{0}' should not occur more than once in Windows PowerShell snap-in '{1}'.</value>
+    <value>The cmdlet '{0}' should not occur more than once in PowerShell Core snap-in '{1}'.</value>
   </data>
   <data name="PSSnapInDuplicateProviders" xml:space="preserve">
-    <value>Windows PowerShell provider '{0}' should not occur more than once in Windows PowerShell snap-in '{1}'.</value>
+    <value>PowerShell Core provider '{0}' should not occur more than once in PowerShell Core snap-in '{1}'.</value>
   </data>
   <data name="AddPSSnapInBadMonadVersion" xml:space="preserve">
-    <value>Windows PowerShell {0} is not supported in the current console. Windows PowerShell {1} is supported in the current console.</value>
+    <value>PowerShell Core {0} is not supported in the current console. PowerShell Core {1} is supported in the current console.</value>
   </data>
   <data name="CmdletNotAvailable" xml:space="preserve">
     <value>The cmdlet is not supported by the custom shell.</value>

--- a/src/System.Management.Automation/resources/ConsoleInfoErrorStrings.resx
+++ b/src/System.Management.Automation/resources/ConsoleInfoErrorStrings.resx
@@ -133,7 +133,7 @@
     <value>The console file is not valid because the element {0} is not valid.</value>
   </data>
   <data name="IDNotFound" xml:space="preserve">
-    <value>The console file is not valid because the PowerShell Core snap-in name is missing.</value>
+    <value>The console file is not valid because the PowerShell snap-in name is missing.</value>
   </data>
   <data name="SaveDefaultError" xml:space="preserve">
     <value>Attempting to save a console file with no name. Use Export-Console with the Path parameter to save the console file.</value>
@@ -151,49 +151,49 @@
     <value>The console file name extension is not valid. A console file name extension must be psc1.</value>
   </data>
   <data name="BadMonadVersion" xml:space="preserve">
-    <value>Incorrect PowerShell Core version {0}. PowerShell Core version {1} is supported on this computer.</value>
+    <value>Incorrect PowerShell version {0}. PowerShell version {1} is supported on this computer.</value>
   </data>
   <data name="PSSnapInDoesNotExist" xml:space="preserve">
-    <value>Cannot find any PowerShell Core snap-in information for {0}.</value>
+    <value>Cannot find any PowerShell snap-in information for {0}.</value>
   </data>
   <data name="CannotLoadDefault" xml:space="preserve">
-    <value>This is a system PowerShell Core snap-in that is loaded by PowerShell Core.</value>
+    <value>This is a system PowerShell snap-in that is loaded by PowerShell.</value>
   </data>
   <data name="PSSnapInAlreadyExists" xml:space="preserve">
-    <value>Cannot add PowerShell Core snap-in {0} because it is already added. Verify the name of the snap-in, and then try again.</value>
+    <value>Cannot add PowerShell snap-in {0} because it is already added. Verify the name of the snap-in, and then try again.</value>
   </data>
   <data name="CannotRemovePSSnapIn" xml:space="preserve">
-    <value>Cannot remove the PowerShell Core snap-in {0} because it is not loaded. Verify the name of the snap-in that you want to remove, and then try again.</value>
+    <value>Cannot remove the PowerShell snap-in {0} because it is not loaded. Verify the name of the snap-in that you want to remove, and then try again.</value>
   </data>
   <data name="CannotRemoveDefault" xml:space="preserve">
-    <value>Cannot remove the PowerShell Core snap-in {0} because it is a system snap-in. Verify the name of the snap-in that you want to remove, and then try again.</value>
+    <value>Cannot remove the PowerShell snap-in {0} because it is a system snap-in. Verify the name of the snap-in that you want to remove, and then try again.</value>
   </data>
   <data name="PSSnapInReadError" xml:space="preserve">
-    <value>Cannot load the PowerShell Core snap-in because an error occurred while reading the registry information for the snap-in.</value>
+    <value>Cannot load the PowerShell snap-in because an error occurred while reading the registry information for the snap-in.</value>
   </data>
   <data name="CannotLoadDefaults" xml:space="preserve">
-    <value>An error occurred while attempting to load the system PowerShell Core snap-ins. Please contact Microsoft Customer Support Services.</value>
+    <value>An error occurred while attempting to load the system PowerShell snap-ins. Please contact Microsoft Customer Support Services.</value>
   </data>
   <data name="ConsoleLoadFailure" xml:space="preserve">
     <value>The following errors occurred when loading console {0}: {1}</value>
   </data>
   <data name="PSSnapInLoadFailure" xml:space="preserve">
-    <value>Cannot load PowerShell Core snap-in {0} because of the following error: {1}</value>
+    <value>Cannot load PowerShell snap-in {0} because of the following error: {1}</value>
   </data>
   <data name="PSSnapInLoadWarning" xml:space="preserve">
-    <value>PowerShell Core snap-in "{0}" loaded with the following warnings: {1}</value>
+    <value>PowerShell snap-in "{0}" loaded with the following warnings: {1}</value>
   </data>
   <data name="PSSnapInAssemblyNameMismatch" xml:space="preserve">
-    <value>The PowerShell Core snap-in module {0} does not have the required PowerShell Core snap-in strong name {1}.</value>
+    <value>The PowerShell snap-in module {0} does not have the required PowerShell snap-in strong name {1}.</value>
   </data>
   <data name="PSSnapInDuplicateCmdlets" xml:space="preserve">
-    <value>The cmdlet '{0}' should not occur more than once in PowerShell Core snap-in '{1}'.</value>
+    <value>The cmdlet '{0}' should not occur more than once in PowerShell snap-in '{1}'.</value>
   </data>
   <data name="PSSnapInDuplicateProviders" xml:space="preserve">
-    <value>PowerShell Core provider '{0}' should not occur more than once in PowerShell Core snap-in '{1}'.</value>
+    <value>PowerShell provider '{0}' should not occur more than once in PowerShell snap-in '{1}'.</value>
   </data>
   <data name="AddPSSnapInBadMonadVersion" xml:space="preserve">
-    <value>PowerShell Core {0} is not supported in the current console. PowerShell Core {1} is supported in the current console.</value>
+    <value>PowerShell {0} is not supported in the current console. PowerShell {1} is supported in the current console.</value>
   </data>
   <data name="CmdletNotAvailable" xml:space="preserve">
     <value>The cmdlet is not supported by the custom shell.</value>

--- a/src/System.Management.Automation/resources/CoreMshSnapinResources.resx
+++ b/src/System.Management.Automation/resources/CoreMshSnapinResources.resx
@@ -118,12 +118,12 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="Description" xml:space="preserve">
-    <value>This PowerShell Core snap-in contains cmdlets used to manage components of PowerShell Core.</value>
+    <value>This PowerShell snap-in contains cmdlets used to manage components of PowerShell.</value>
   </data>
   <data name="Vendor" xml:space="preserve">
     <value>Microsoft Corporation</value>
   </data>
   <data name="Name" xml:space="preserve">
-    <value>Core PowerShell Core snap-in</value>
+    <value>Core PowerShell snap-in</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/CoreMshSnapinResources.resx
+++ b/src/System.Management.Automation/resources/CoreMshSnapinResources.resx
@@ -118,12 +118,12 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="Description" xml:space="preserve">
-    <value>This Windows PowerShell snap-in contains cmdlets used to manage components of Windows PowerShell.</value>
+    <value>This PowerShell Core snap-in contains cmdlets used to manage components of PowerShell Core.</value>
   </data>
   <data name="Vendor" xml:space="preserve">
     <value>Microsoft Corporation</value>
   </data>
   <data name="Name" xml:space="preserve">
-    <value>Core Windows PowerShell snap-in</value>
+    <value>Core PowerShell Core snap-in</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/CredUI.resx
+++ b/src/System.Management.Automation/resources/CredUI.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="PromptForCredential_DefaultCaption" xml:space="preserve">
-    <value>PowerShell Core credential request </value>
+    <value>PowerShell credential request </value>
   </data>
   <data name="PromptForCredential_DefaultMessage" xml:space="preserve">
     <value>Enter your credentials. </value>

--- a/src/System.Management.Automation/resources/CredUI.resx
+++ b/src/System.Management.Automation/resources/CredUI.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="PromptForCredential_DefaultCaption" xml:space="preserve">
-    <value>Windows PowerShell credential request </value>
+    <value>PowerShell Core credential request </value>
   </data>
   <data name="PromptForCredential_DefaultMessage" xml:space="preserve">
     <value>Enter your credentials. </value>

--- a/src/System.Management.Automation/resources/CredentialAttributeStrings.resx
+++ b/src/System.Management.Automation/resources/CredentialAttributeStrings.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="CredentialAttribute_Prompt_Caption" xml:space="preserve">
-    <value>PowerShell Core credential request</value>
+    <value>PowerShell credential request</value>
   </data>
   <data name="CredentialAttribute_Prompt" xml:space="preserve">
     <value>Enter your credentials.</value>

--- a/src/System.Management.Automation/resources/CredentialAttributeStrings.resx
+++ b/src/System.Management.Automation/resources/CredentialAttributeStrings.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="CredentialAttribute_Prompt_Caption" xml:space="preserve">
-    <value>Windows PowerShell credential request</value>
+    <value>PowerShell Core credential request</value>
   </data>
   <data name="CredentialAttribute_Prompt" xml:space="preserve">
     <value>Enter your credentials.</value>

--- a/src/System.Management.Automation/resources/DiscoveryExceptions.resx
+++ b/src/System.Management.Automation/resources/DiscoveryExceptions.resx
@@ -182,7 +182,7 @@ The #requires statement must be in one of the following formats:
     <value>The script '{0}' cannot be run because it contained a "#requires" statement with a shell ID of {1} that is incompatible with the current shell.</value>
   </data>
   <data name="RequiresPSVersionNotCompatible" xml:space="preserve">
-    <value>The script '{0}' cannot be run because it contained a "#requires" statement for Windows PowerShell {1}. The version of Windows PowerShell that is required by the script does not match the currently running version of Windows PowerShell {2}.</value>
+    <value>The script '{0}' cannot be run because it contained a "#requires" statement for PowerShell Core {1}. The version of PowerShell Core that is required by the script does not match the currently running version of PowerShell Core {2}.</value>
   </data>
   <data name="RequiresPSEditionNotCompatible" xml:space="preserve">
     <value>The script '{0}' cannot be run because it contained a "#requires" statement for PowerShell editions '{1}'. The edition of PowerShell that is required by the script does not match the currently running PowerShell {2} edition.</value>
@@ -191,10 +191,10 @@ The #requires statement must be in one of the following formats:
     <value>The script '{0}' cannot be run because the following snap-ins that are specified by the "#requires" statements of the script are missing: {1}.</value>
   </data>
   <data name="RequiresShellIDInvalidForSingleShell" xml:space="preserve">
-    <value>A #requires statement has specified only a shellID. #Requires statements must specify a required Windows PowerShell snap-in when running in Windows PowerShell.</value>
+    <value>A #requires statement has specified only a shellID. #Requires statements must specify a required PowerShell Core snap-in when running in PowerShell Core.</value>
   </data>
   <data name="RequiresElevation" xml:space="preserve">
-    <value>The script '{0}' cannot be run because it contains a "#requires" statement for running as Administrator. The current Windows PowerShell session is not running as Administrator. Start Windows PowerShell by using the Run as Administrator option, and then try running the script again.</value>
+    <value>The script '{0}' cannot be run because it contains a "#requires" statement for running as Administrator. The current PowerShell Core session is not running as Administrator. Start PowerShell Core by using the Run as Administrator option, and then try running the script again.</value>
   </data>
   <data name="PSSnapInNameVersion" xml:space="preserve">
     <value>{0} (Version {1})</value>

--- a/src/System.Management.Automation/resources/DiscoveryExceptions.resx
+++ b/src/System.Management.Automation/resources/DiscoveryExceptions.resx
@@ -182,7 +182,7 @@ The #requires statement must be in one of the following formats:
     <value>The script '{0}' cannot be run because it contained a "#requires" statement with a shell ID of {1} that is incompatible with the current shell.</value>
   </data>
   <data name="RequiresPSVersionNotCompatible" xml:space="preserve">
-    <value>The script '{0}' cannot be run because it contained a "#requires" statement for PowerShell Core {1}. The version of PowerShell Core that is required by the script does not match the currently running version of PowerShell Core {2}.</value>
+    <value>The script '{0}' cannot be run because it contained a "#requires" statement for PowerShell {1}. The version of PowerShell that is required by the script does not match the currently running version of PowerShell {2}.</value>
   </data>
   <data name="RequiresPSEditionNotCompatible" xml:space="preserve">
     <value>The script '{0}' cannot be run because it contained a "#requires" statement for PowerShell editions '{1}'. The edition of PowerShell that is required by the script does not match the currently running PowerShell {2} edition.</value>
@@ -191,10 +191,10 @@ The #requires statement must be in one of the following formats:
     <value>The script '{0}' cannot be run because the following snap-ins that are specified by the "#requires" statements of the script are missing: {1}.</value>
   </data>
   <data name="RequiresShellIDInvalidForSingleShell" xml:space="preserve">
-    <value>A #requires statement has specified only a shellID. #Requires statements must specify a required PowerShell Core snap-in when running in PowerShell Core.</value>
+    <value>A #requires statement has specified only a shellID. #Requires statements must specify a required PowerShell snap-in when running in PowerShell.</value>
   </data>
   <data name="RequiresElevation" xml:space="preserve">
-    <value>The script '{0}' cannot be run because it contains a "#requires" statement for running as Administrator. The current PowerShell Core session is not running as Administrator. Start PowerShell Core by using the Run as Administrator option, and then try running the script again.</value>
+    <value>The script '{0}' cannot be run because it contains a "#requires" statement for running as Administrator. The current PowerShell session is not running as Administrator. Start PowerShell by using the Run as Administrator option, and then try running the script again.</value>
   </data>
   <data name="PSSnapInNameVersion" xml:space="preserve">
     <value>{0} (Version {1})</value>

--- a/src/System.Management.Automation/resources/EventingResources.resx
+++ b/src/System.Management.Automation/resources/EventingResources.resx
@@ -124,10 +124,10 @@
     <value>Cannot register for the specified event. An event with the name '{0}' does not exist.</value>
   </data>
   <data name="WinRTEventsNotSupported" xml:space="preserve">
-    <value>Windows PowerShell cannot subscribe to Windows RT events.</value>
+    <value>PowerShell Core cannot subscribe to Windows RT events.</value>
   </data>
   <data name="ReservedIdentifier" xml:space="preserve">
-    <value>Cannot register for the specified event. The event source identifier '{0}' is reserved for the Windows PowerShell engine.</value>
+    <value>Cannot register for the specified event. The event source identifier '{0}' is reserved for the PowerShell Core engine.</value>
   </data>
   <data name="RemoteOperationNotSupported" xml:space="preserve">
     <value>This operation is not supported on remote instances.</value>

--- a/src/System.Management.Automation/resources/EventingResources.resx
+++ b/src/System.Management.Automation/resources/EventingResources.resx
@@ -124,10 +124,10 @@
     <value>Cannot register for the specified event. An event with the name '{0}' does not exist.</value>
   </data>
   <data name="WinRTEventsNotSupported" xml:space="preserve">
-    <value>PowerShell Core cannot subscribe to Windows RT events.</value>
+    <value>PowerShell cannot subscribe to Windows RT events.</value>
   </data>
   <data name="ReservedIdentifier" xml:space="preserve">
-    <value>Cannot register for the specified event. The event source identifier '{0}' is reserved for the PowerShell Core engine.</value>
+    <value>Cannot register for the specified event. The event source identifier '{0}' is reserved for the PowerShell engine.</value>
   </data>
   <data name="RemoteOperationNotSupported" xml:space="preserve">
     <value>This operation is not supported on remote instances.</value>

--- a/src/System.Management.Automation/resources/HelpDisplayStrings.resx
+++ b/src/System.Management.Automation/resources/HelpDisplayStrings.resx
@@ -334,10 +334,10 @@
     <value>(All)</value>
   </data>
   <data name="CannotMatchModulePattern" xml:space="preserve">
-    <value>No PowerShell Core modules were found that match the following pattern: {0}. Verify the pattern and then try the command again.</value>
+    <value>No PowerShell modules were found that match the following pattern: {0}. Verify the pattern and then try the command again.</value>
   </data>
   <data name="ModuleNotFoundWithFullyQualifiedName" xml:space="preserve">
-    <value>No PowerShell Core modules were found that match the specified FullyQualifiedModule {0}. Verify the FullyQualifiedModule value and then try the command again.</value>
+    <value>No PowerShell modules were found that match the specified FullyQualifiedModule {0}. Verify the FullyQualifiedModule value and then try the command again.</value>
   </data>
   <data name="HelpContentNotFound" xml:space="preserve">
     <value>Help content cannot be found. Make sure the server is available and the help content location is properly defined in the HelpInfo XML.</value>
@@ -466,7 +466,7 @@ To update help again, add the Force parameter to your command.</value>
     <value>The root level element of the help content must be "helpItems".</value>
   </data>
   <data name="UpdateHelpPromptBody" xml:space="preserve">
-    <value>The Update-Help cmdlet downloads the most current Help files for PowerShell Core modules, and installs them on your computer. For more information about the Update-Help cmdlet, see https://go.microsoft.com/fwlink/?LinkId=210614.</value>
+    <value>The Update-Help cmdlet downloads the most current Help files for PowerShell modules, and installs them on your computer. For more information about the Update-Help cmdlet, see https://go.microsoft.com/fwlink/?LinkId=210614.</value>
   </data>
   <data name="UpdateHelpPromptTitle" xml:space="preserve">
     <value>Do you want to run Update-Help?</value>

--- a/src/System.Management.Automation/resources/HelpDisplayStrings.resx
+++ b/src/System.Management.Automation/resources/HelpDisplayStrings.resx
@@ -334,10 +334,10 @@
     <value>(All)</value>
   </data>
   <data name="CannotMatchModulePattern" xml:space="preserve">
-    <value>No Windows PowerShell modules were found that match the following pattern: {0}. Verify the pattern and then try the command again.</value>
+    <value>No PowerShell Core modules were found that match the following pattern: {0}. Verify the pattern and then try the command again.</value>
   </data>
   <data name="ModuleNotFoundWithFullyQualifiedName" xml:space="preserve">
-    <value>No Windows PowerShell modules were found that match the specified FullyQualifiedModule {0}. Verify the FullyQualifiedModule value and then try the command again.</value>
+    <value>No PowerShell Core modules were found that match the specified FullyQualifiedModule {0}. Verify the FullyQualifiedModule value and then try the command again.</value>
   </data>
   <data name="HelpContentNotFound" xml:space="preserve">
     <value>Help content cannot be found. Make sure the server is available and the help content location is properly defined in the HelpInfo XML.</value>
@@ -466,7 +466,7 @@ To update help again, add the Force parameter to your command.</value>
     <value>The root level element of the help content must be "helpItems".</value>
   </data>
   <data name="UpdateHelpPromptBody" xml:space="preserve">
-    <value>The Update-Help cmdlet downloads the most current Help files for Windows PowerShell modules, and installs them on your computer. For more information about the Update-Help cmdlet, see https://go.microsoft.com/fwlink/?LinkId=210614.</value>
+    <value>The Update-Help cmdlet downloads the most current Help files for PowerShell Core modules, and installs them on your computer. For more information about the Update-Help cmdlet, see https://go.microsoft.com/fwlink/?LinkId=210614.</value>
   </data>
   <data name="UpdateHelpPromptTitle" xml:space="preserve">
     <value>Do you want to run Update-Help?</value>

--- a/src/System.Management.Automation/resources/HelpErrors.resx
+++ b/src/System.Management.Automation/resources/HelpErrors.resx
@@ -175,7 +175,7 @@
     <value>Cannot get Help from a remote runspace, because the runspace has not been opened.  Open the runspace by running an implicit remoting command, and then try running the command to get Help again.</value>
   </data>
   <data name="UpdatableHelpRequiresElevation" xml:space="preserve">
-    <value>Access is denied. The command could not update Help topics for the PowerShell Core core modules, or for any modules in the $pshome\Modules directory. To update these Help topics, start PowerShell Core by using the "Run as Administrator" command, and try running Update-Help again.</value>
+    <value>Access is denied. The command could not update Help topics for the PowerShell core modules, or for any modules in the $pshome\Modules directory. To update these Help topics, start PowerShell by using the "Run as Administrator" command, and try running Update-Help again.</value>
   </data>
   <data name="GraphicalHostAssemblyIsNotFound" xml:space="preserve">
     <value>To use the {0}, install Windows PowerShell ISE by using Server Manager, and then restart this application. ({1})</value>

--- a/src/System.Management.Automation/resources/HelpErrors.resx
+++ b/src/System.Management.Automation/resources/HelpErrors.resx
@@ -175,7 +175,7 @@
     <value>Cannot get Help from a remote runspace, because the runspace has not been opened.  Open the runspace by running an implicit remoting command, and then try running the command to get Help again.</value>
   </data>
   <data name="UpdatableHelpRequiresElevation" xml:space="preserve">
-    <value>Access is denied. The command could not update Help topics for the Windows PowerShell core modules, or for any modules in the $pshome\Modules directory. To update these Help topics, start Windows PowerShell by using the "Run as Administrator" command, and try running Update-Help again.</value>
+    <value>Access is denied. The command could not update Help topics for the PowerShell Core core modules, or for any modules in the $pshome\Modules directory. To update these Help topics, start PowerShell Core by using the "Run as Administrator" command, and try running Update-Help again.</value>
   </data>
   <data name="GraphicalHostAssemblyIsNotFound" xml:space="preserve">
     <value>To use the {0}, install Windows PowerShell ISE by using Server Manager, and then restart this application. ({1})</value>

--- a/src/System.Management.Automation/resources/HostInterfaceExceptionsStrings.resx
+++ b/src/System.Management.Automation/resources/HostInterfaceExceptionsStrings.resx
@@ -121,7 +121,7 @@
     <value>An error of type "{0}" has occurred.</value>
   </data>
   <data name="HostFunctionNotImplemented" xml:space="preserve">
-    <value>A command that prompts the user failed because the host program or the command type does not support user interaction. Try a host program that supports user interaction, such as the Windows PowerShell Console or Windows PowerShell ISE, and remove prompt-related commands from command types that do not support user interaction, such as Windows PowerShell workflows.</value>
+    <value>A command that prompts the user failed because the host program or the command type does not support user interaction. Try a host program that supports user interaction, such as the PowerShell Core Console, and remove prompt-related commands from command types that do not support user interaction, such as PowerShell Core workflows.</value>
   </data>
   <data name="HostFunctionPromptNotImplemented" xml:space="preserve">
     <value>A command that prompts the user failed because the host program or the command type does not support user interaction. The host was attempting to request confirmation with the following message: {0}</value>

--- a/src/System.Management.Automation/resources/HostInterfaceExceptionsStrings.resx
+++ b/src/System.Management.Automation/resources/HostInterfaceExceptionsStrings.resx
@@ -121,7 +121,7 @@
     <value>An error of type "{0}" has occurred.</value>
   </data>
   <data name="HostFunctionNotImplemented" xml:space="preserve">
-    <value>A command that prompts the user failed because the host program or the command type does not support user interaction. Try a host program that supports user interaction, such as the PowerShell Console, and remove prompt-related commands from command types that do not support user interaction, such as PowerShell workflows.</value>
+    <value>A command that prompts the user failed because the host program or the command type does not support user interaction. Try a host program that supports user interaction, such as the PowerShell Console, and remove prompt-related commands from command types that do not support user interaction.</value>
   </data>
   <data name="HostFunctionPromptNotImplemented" xml:space="preserve">
     <value>A command that prompts the user failed because the host program or the command type does not support user interaction. The host was attempting to request confirmation with the following message: {0}</value>

--- a/src/System.Management.Automation/resources/HostInterfaceExceptionsStrings.resx
+++ b/src/System.Management.Automation/resources/HostInterfaceExceptionsStrings.resx
@@ -121,7 +121,7 @@
     <value>An error of type "{0}" has occurred.</value>
   </data>
   <data name="HostFunctionNotImplemented" xml:space="preserve">
-    <value>A command that prompts the user failed because the host program or the command type does not support user interaction. Try a host program that supports user interaction, such as the PowerShell Core Console, and remove prompt-related commands from command types that do not support user interaction, such as PowerShell Core workflows.</value>
+    <value>A command that prompts the user failed because the host program or the command type does not support user interaction. Try a host program that supports user interaction, such as the PowerShell Console, and remove prompt-related commands from command types that do not support user interaction, such as PowerShell workflows.</value>
   </data>
   <data name="HostFunctionPromptNotImplemented" xml:space="preserve">
     <value>A command that prompts the user failed because the host program or the command type does not support user interaction. The host was attempting to request confirmation with the following message: {0}</value>

--- a/src/System.Management.Automation/resources/InternalHostUserInterfaceStrings.resx
+++ b/src/System.Management.Automation/resources/InternalHostUserInterfaceStrings.resx
@@ -197,7 +197,7 @@
   </data>
   <data name="TranscriptPrologue" xml:space="preserve">
     <value>**********************
-PowerShell Core transcript start
+PowerShell transcript start
 Start time: {0:yyyyMMddHHmmss}
 Username: {1}
 RunAs User: {2}
@@ -210,7 +210,7 @@ Process ID: {7}
   </data>
   <data name="TranscriptEpilogue" xml:space="preserve">
     <value>**********************
-PowerShell Core transcript end
+PowerShell transcript end
 End time: {0:yyyyMMddHHmmss}
 **********************</value>
   </data>

--- a/src/System.Management.Automation/resources/InternalHostUserInterfaceStrings.resx
+++ b/src/System.Management.Automation/resources/InternalHostUserInterfaceStrings.resx
@@ -197,7 +197,7 @@
   </data>
   <data name="TranscriptPrologue" xml:space="preserve">
     <value>**********************
-Windows PowerShell transcript start
+PowerShell Core transcript start
 Start time: {0:yyyyMMddHHmmss}
 Username: {1}
 RunAs User: {2}
@@ -210,7 +210,7 @@ Process ID: {7}
   </data>
   <data name="TranscriptEpilogue" xml:space="preserve">
     <value>**********************
-Windows PowerShell transcript end
+PowerShell Core transcript end
 End time: {0:yyyyMMddHHmmss}
 **********************</value>
   </data>

--- a/src/System.Management.Automation/resources/Metadata.resx
+++ b/src/System.Management.Automation/resources/Metadata.resx
@@ -223,7 +223,7 @@
     <value>The "{1}" validation script for the argument with value "{0}" did not return a result of True. Determine why the validation script failed, and then try the command again.</value>
   </data>
   <data name="ValidateVersionFailure" xml:space="preserve">
-    <value>The "{0}" argument does not contain a valid Windows PowerShell version. Supply a valid version number and then try the command again.</value>
+    <value>The "{0}" argument does not contain a valid PowerShell Core version. Supply a valid version number and then try the command again.</value>
   </data>
   <data name="ValidateVariableName" xml:space="preserve">
     <value>Cannot validate argument '{0}' because it is not a valid variable name.</value>

--- a/src/System.Management.Automation/resources/Metadata.resx
+++ b/src/System.Management.Automation/resources/Metadata.resx
@@ -223,7 +223,7 @@
     <value>The "{1}" validation script for the argument with value "{0}" did not return a result of True. Determine why the validation script failed, and then try the command again.</value>
   </data>
   <data name="ValidateVersionFailure" xml:space="preserve">
-    <value>The "{0}" argument does not contain a valid PowerShell Core version. Supply a valid version number and then try the command again.</value>
+    <value>The "{0}" argument does not contain a valid PowerShell version. Supply a valid version number and then try the command again.</value>
   </data>
   <data name="ValidateVariableName" xml:space="preserve">
     <value>Cannot validate argument '{0}' because it is not a valid variable name.</value>

--- a/src/System.Management.Automation/resources/Modules.resx
+++ b/src/System.Management.Automation/resources/Modules.resx
@@ -157,7 +157,7 @@
     <value>The module manifest '{0}' could not be processed because it is not a valid PowerShell module manifest file. Remove the elements that are not permitted: {1}</value>
   </data>
   <data name="EmptyModuleManifest" xml:space="preserve">
-    <value>Processing the module manifest file '{0}' did not result in a valid manifest object. Update the file to contain a valid PowerShell Core module manifest. A valid manifest can be created using the New-ModuleManifest cmdlet.</value>
+    <value>Processing the module manifest file '{0}' did not result in a valid manifest object. Update the file to contain a valid PowerShell module manifest. A valid manifest can be created using the New-ModuleManifest cmdlet.</value>
   </data>
   <data name="InvalidModuleManifestMember" xml:space="preserve">
     <value>The '{0}' module cannot be imported because its manifest contains one or more members that are not valid. The valid manifest members are ({1}). Remove the members that are not valid ({2}), then try to import the module again.</value>
@@ -181,7 +181,7 @@
     <value>The version of the Common Language Runtime (CLR) on this computer is '{0}'. The module '{1}' requires a minimum CLR version of '{2}' to run. Verify that you are running the minimum required version of CLR, and then try again.</value>
   </data>
   <data name="ModuleManifestInsufficientPowerShellVersion" xml:space="preserve">
-    <value>The version of PowerShell Core on this computer is '{0}'. The module '{1}' requires a minimum PowerShell Core version of '{2}' to run. Verify that you have the minimum required version of PowerShell Core installed, and then try again.</value>
+    <value>The version of PowerShell on this computer is '{0}'. The module '{1}' requires a minimum PowerShell version of '{2}' to run. Verify that you have the minimum required version of PowerShell installed, and then try again.</value>
   </data>
   <data name="ModuleManifestNestedModulesCantGoWithModuleToProcess" xml:space="preserve">
     <value>The module manifest member 'NestedModules' cannot be used if the 'ModuleToProcess' member is a binary module. Edit the module manifest file at '{0}', and then try again.</value>
@@ -346,10 +346,10 @@
     <value>The module '{0}' requires the following version of the .NET Framework: {1}.  The required version is not installed.</value>
   </data>
   <data name="InvalidPowerShellHostName" xml:space="preserve">
-    <value>The name of the current PowerShell Core host is: '{0}'. The module '{1}' requires the following PowerShell Core host: '{2}'.</value>
+    <value>The name of the current PowerShell host is: '{0}'. The module '{1}' requires the following PowerShell host: '{2}'.</value>
   </data>
   <data name="InvalidPowerShellHostVersion" xml:space="preserve">
-    <value>The current PowerShell Core host is: '{0}' (version {1}). The module '{2}' requires a minimum PowerShell Core host version of '{3}' to run.</value>
+    <value>The current PowerShell host is: '{0}' (version {1}). The module '{2}' requires a minimum PowerShell host version of '{3}' to run.</value>
   </data>
   <data name="ManifestHeaderLine1" xml:space="preserve">
     <value>Module manifest for module '{0}'</value>
@@ -388,7 +388,7 @@
     <value>Description of the functionality provided by this module</value>
   </data>
   <data name="PowerShellVersion" xml:space="preserve">
-    <value>Minimum version of the PowerShell Core engine required by this module</value>
+    <value>Minimum version of the PowerShell engine required by this module</value>
   </data>
   <data name="CLRVersion" xml:space="preserve">
     <value>Minimum version of the common language runtime (CLR) required by this module. {0}</value>
@@ -475,10 +475,10 @@
     <value>Minimum version of Microsoft .NET Framework required by this module. {0}</value>
   </data>
   <data name="PowerShellHostName" xml:space="preserve">
-    <value>Name of the PowerShell Core host required by this module</value>
+    <value>Name of the PowerShell host required by this module</value>
   </data>
   <data name="PowerShellHostVersion" xml:space="preserve">
-    <value>Minimum version of the PowerShell Core host required by this module</value>
+    <value>Minimum version of the PowerShell host required by this module</value>
   </data>
   <data name="LoadingWorkflow" xml:space="preserve">
     <value>Loading workflow {0}</value>
@@ -487,13 +487,13 @@
     <value>HelpInfo URI of this module</value>
   </data>
   <data name="IncludedItemPathFallsOutsideSaveTree" xml:space="preserve">
-    <value>The item {0} that resolves to {1} is not located in the same directory as the module manifest or any of its subdirectories. PowerShell Core looks for items referenced in the manifest only in paths relative to the manifest location. To fix this problem, move the item, and use a relative path to identify its location.</value>
+    <value>The item {0} that resolves to {1} is not located in the same directory as the module manifest or any of its subdirectories. PowerShell looks for items referenced in the manifest only in paths relative to the manifest location. To fix this problem, move the item, and use a relative path to identify its location.</value>
   </data>
   <data name="InvalidWorkflowExtension" xml:space="preserve">
     <value>The workflow file name is not valid because it does not have the required .XAML file name extension. Run the New-ModuleManifest command again specifying a value for the WorkflowsToProcess parameter with this extension.</value>
   </data>
   <data name="ModuleDriveInUse" xml:space="preserve">
-    <value>Because the {0} module is providing the PSDrive in the current PowerShell Core session, no modules were removed. Change the current PSDrive provider, and then try removing modules again.</value>
+    <value>Because the {0} module is providing the PSDrive in the current PowerShell session, no modules were removed. Change the current PSDrive provider, and then try removing modules again.</value>
   </data>
   <data name="InvalidWorkflowExtensionDuringManifestProcessing" xml:space="preserve">
     <value>The workflow file name extension is not valid. The workflow file name {0} that is listed in the WorkflowsToProcess key of the module manifest does not have the required .XAML or .DLL file name extension. Edit the module manifest and correct the workflow file name. If you are using a .DLL file extension, then provide only one assembly name.</value>
@@ -514,7 +514,7 @@
     <value>Wildcard characters are not allowed in members 'ModuleToProcess', 'RootModule', or 'NestedModules' in the module manifest '{0}'.</value>
   </data>
   <data name="CoreModuleCannotBeRemoved" xml:space="preserve">
-    <value>The module '{0}' is a core module for PowerShell Core. Add the Force parameter to your command to remove core modules.</value>
+    <value>The module '{0}' is a core module for PowerShell. Add the Force parameter to your command to remove core modules.</value>
   </data>
   <data name="ModuleManifestCannotContainBothModuleToProcessAndRootModule" xml:space="preserve">
     <value>The module manifest cannot contain both the 'ModuleToProcess' and 'RootModule' members. Change the module manifest file to remove one of these members at '{0}', and then try again.</value>
@@ -535,7 +535,7 @@
     <value>The required module '{0}' was not loaded because no valid module file was found in any module directory.</value>
   </data>
   <data name="MixedModuleOverCimSessionWarning" xml:space="preserve">
-    <value>Some commands from module {0} cannot be imported over a CimSession.  To get all the commands, verify that the remote server has PowerShell Core remote management enabled, and then try adding the PSSession parameter to an Import-Module cmdlet.</value>
+    <value>Some commands from module {0} cannot be imported over a CimSession.  To get all the commands, verify that the remote server has PowerShell remote management enabled, and then try adding the PSSession parameter to an Import-Module cmdlet.</value>
   </data>
   <data name="PsModuleOverCimSessionError" xml:space="preserve">
     <value>The module {0} cannot be imported over a CimSession.  Try using the PSSession parameter of the Import-Module cmdlet.</value>
@@ -625,7 +625,7 @@
     <value>The specified module '{0}' was not found. Update the Name parameter to point to a valid path, and then try again. </value>
   </data>
   <data name="WorkflowModuleNotSupportedInPowerShellCore" xml:space="preserve">
-    <value>Cannot load the workflow module '{0}'. Workflow is not supported in PowerShell Core.</value>
+    <value>Cannot load the workflow module '{0}'. Workflow is not supported in PowerShell.</value>
   </data>
   <data name="PopulatingRepositorySourceLocation" xml:space="preserve">
     <value>Populating RepositorySourceLocation property for module {0}.</value>

--- a/src/System.Management.Automation/resources/Modules.resx
+++ b/src/System.Management.Automation/resources/Modules.resx
@@ -625,7 +625,7 @@
     <value>The specified module '{0}' was not found. Update the Name parameter to point to a valid path, and then try again. </value>
   </data>
   <data name="WorkflowModuleNotSupportedInPowerShellCore" xml:space="preserve">
-    <value>Cannot load the workflow module '{0}'. Workflow is not supported in PowerShell.</value>
+    <value>Cannot load the workflow module '{0}'. Workflow is not supported in PowerShell Core.</value>
   </data>
   <data name="PopulatingRepositorySourceLocation" xml:space="preserve">
     <value>Populating RepositorySourceLocation property for module {0}.</value>

--- a/src/System.Management.Automation/resources/Modules.resx
+++ b/src/System.Management.Automation/resources/Modules.resx
@@ -157,7 +157,7 @@
     <value>The module manifest '{0}' could not be processed because it is not a valid PowerShell module manifest file. Remove the elements that are not permitted: {1}</value>
   </data>
   <data name="EmptyModuleManifest" xml:space="preserve">
-    <value>Processing the module manifest file '{0}' did not result in a valid manifest object. Update the file to contain a valid Windows PowerShell module manifest. A valid manifest can be created using the New-ModuleManifest cmdlet.</value>
+    <value>Processing the module manifest file '{0}' did not result in a valid manifest object. Update the file to contain a valid PowerShell Core module manifest. A valid manifest can be created using the New-ModuleManifest cmdlet.</value>
   </data>
   <data name="InvalidModuleManifestMember" xml:space="preserve">
     <value>The '{0}' module cannot be imported because its manifest contains one or more members that are not valid. The valid manifest members are ({1}). Remove the members that are not valid ({2}), then try to import the module again.</value>
@@ -181,7 +181,7 @@
     <value>The version of the Common Language Runtime (CLR) on this computer is '{0}'. The module '{1}' requires a minimum CLR version of '{2}' to run. Verify that you are running the minimum required version of CLR, and then try again.</value>
   </data>
   <data name="ModuleManifestInsufficientPowerShellVersion" xml:space="preserve">
-    <value>The version of Windows PowerShell on this computer is '{0}'. The module '{1}' requires a minimum Windows PowerShell version of '{2}' to run. Verify that you have the minimum required version of Windows PowerShell installed, and then try again.</value>
+    <value>The version of PowerShell Core on this computer is '{0}'. The module '{1}' requires a minimum PowerShell Core version of '{2}' to run. Verify that you have the minimum required version of PowerShell Core installed, and then try again.</value>
   </data>
   <data name="ModuleManifestNestedModulesCantGoWithModuleToProcess" xml:space="preserve">
     <value>The module manifest member 'NestedModules' cannot be used if the 'ModuleToProcess' member is a binary module. Edit the module manifest file at '{0}', and then try again.</value>
@@ -346,10 +346,10 @@
     <value>The module '{0}' requires the following version of the .NET Framework: {1}.  The required version is not installed.</value>
   </data>
   <data name="InvalidPowerShellHostName" xml:space="preserve">
-    <value>The name of the current Windows PowerShell host is: '{0}'. The module '{1}' requires the following Windows PowerShell host: '{2}'.</value>
+    <value>The name of the current PowerShell Core host is: '{0}'. The module '{1}' requires the following PowerShell Core host: '{2}'.</value>
   </data>
   <data name="InvalidPowerShellHostVersion" xml:space="preserve">
-    <value>The current Windows PowerShell host is: '{0}' (version {1}). The module '{2}' requires a minimum Windows PowerShell host version of '{3}' to run.</value>
+    <value>The current PowerShell Core host is: '{0}' (version {1}). The module '{2}' requires a minimum PowerShell Core host version of '{3}' to run.</value>
   </data>
   <data name="ManifestHeaderLine1" xml:space="preserve">
     <value>Module manifest for module '{0}'</value>
@@ -388,7 +388,7 @@
     <value>Description of the functionality provided by this module</value>
   </data>
   <data name="PowerShellVersion" xml:space="preserve">
-    <value>Minimum version of the Windows PowerShell engine required by this module</value>
+    <value>Minimum version of the PowerShell Core engine required by this module</value>
   </data>
   <data name="CLRVersion" xml:space="preserve">
     <value>Minimum version of the common language runtime (CLR) required by this module. {0}</value>
@@ -475,10 +475,10 @@
     <value>Minimum version of Microsoft .NET Framework required by this module. {0}</value>
   </data>
   <data name="PowerShellHostName" xml:space="preserve">
-    <value>Name of the Windows PowerShell host required by this module</value>
+    <value>Name of the PowerShell Core host required by this module</value>
   </data>
   <data name="PowerShellHostVersion" xml:space="preserve">
-    <value>Minimum version of the Windows PowerShell host required by this module</value>
+    <value>Minimum version of the PowerShell Core host required by this module</value>
   </data>
   <data name="LoadingWorkflow" xml:space="preserve">
     <value>Loading workflow {0}</value>
@@ -487,13 +487,13 @@
     <value>HelpInfo URI of this module</value>
   </data>
   <data name="IncludedItemPathFallsOutsideSaveTree" xml:space="preserve">
-    <value>The item {0} that resolves to {1} is not located in the same directory as the module manifest or any of its subdirectories. Windows PowerShell looks for items referenced in the manifest only in paths relative to the manifest location. To fix this problem, move the item, and use a relative path to identify its location.</value>
+    <value>The item {0} that resolves to {1} is not located in the same directory as the module manifest or any of its subdirectories. PowerShell Core looks for items referenced in the manifest only in paths relative to the manifest location. To fix this problem, move the item, and use a relative path to identify its location.</value>
   </data>
   <data name="InvalidWorkflowExtension" xml:space="preserve">
     <value>The workflow file name is not valid because it does not have the required .XAML file name extension. Run the New-ModuleManifest command again specifying a value for the WorkflowsToProcess parameter with this extension.</value>
   </data>
   <data name="ModuleDriveInUse" xml:space="preserve">
-    <value>Because the {0} module is providing the PSDrive in the current Windows PowerShell session, no modules were removed. Change the current PSDrive provider, and then try removing modules again.</value>
+    <value>Because the {0} module is providing the PSDrive in the current PowerShell Core session, no modules were removed. Change the current PSDrive provider, and then try removing modules again.</value>
   </data>
   <data name="InvalidWorkflowExtensionDuringManifestProcessing" xml:space="preserve">
     <value>The workflow file name extension is not valid. The workflow file name {0} that is listed in the WorkflowsToProcess key of the module manifest does not have the required .XAML or .DLL file name extension. Edit the module manifest and correct the workflow file name. If you are using a .DLL file extension, then provide only one assembly name.</value>
@@ -514,7 +514,7 @@
     <value>Wildcard characters are not allowed in members 'ModuleToProcess', 'RootModule', or 'NestedModules' in the module manifest '{0}'.</value>
   </data>
   <data name="CoreModuleCannotBeRemoved" xml:space="preserve">
-    <value>The module '{0}' is a core module for Windows PowerShell. Add the Force parameter to your command to remove core modules.</value>
+    <value>The module '{0}' is a core module for PowerShell Core. Add the Force parameter to your command to remove core modules.</value>
   </data>
   <data name="ModuleManifestCannotContainBothModuleToProcessAndRootModule" xml:space="preserve">
     <value>The module manifest cannot contain both the 'ModuleToProcess' and 'RootModule' members. Change the module manifest file to remove one of these members at '{0}', and then try again.</value>
@@ -535,7 +535,7 @@
     <value>The required module '{0}' was not loaded because no valid module file was found in any module directory.</value>
   </data>
   <data name="MixedModuleOverCimSessionWarning" xml:space="preserve">
-    <value>Some commands from module {0} cannot be imported over a CimSession.  To get all the commands, verify that the remote server has Windows PowerShell remote management enabled, and then try adding the PSSession parameter to an Import-Module cmdlet.</value>
+    <value>Some commands from module {0} cannot be imported over a CimSession.  To get all the commands, verify that the remote server has PowerShell Core remote management enabled, and then try adding the PSSession parameter to an Import-Module cmdlet.</value>
   </data>
   <data name="PsModuleOverCimSessionError" xml:space="preserve">
     <value>The module {0} cannot be imported over a CimSession.  Try using the PSSession parameter of the Import-Module cmdlet.</value>

--- a/src/System.Management.Automation/resources/MshSnapInCmdletResources.resx
+++ b/src/System.Management.Automation/resources/MshSnapInCmdletResources.resx
@@ -121,15 +121,15 @@
     <value>The operation cannot be performed. The specified cmdlet is not supported in a custom shell.</value>
   </data>
   <data name="NoPSSnapInsFound" xml:space="preserve">
-    <value>No Windows PowerShell snap-ins matching the pattern '{0}' were found. Check the pattern and then try the command again.</value>
+    <value>No PowerShell Core snap-ins matching the pattern '{0}' were found. Check the pattern and then try the command again.</value>
   </data>
   <data name="InvalidPSSnapInName" xml:space="preserve">
-    <value>The format of the specified snap-in name was not valid.  Windows PowerShell snap-in names can only contain alpha-numeric characters, dashes, underscores and periods. Correct the name and then try the operation again.</value>
+    <value>The format of the specified snap-in name was not valid.  PowerShell Core snap-in names can only contain alpha-numeric characters, dashes, underscores and periods. Correct the name and then try the operation again.</value>
   </data>
   <data name="LoadSystemSnapinAsModule" xml:space="preserve">
-    <value>Cannot add Windows PowerShell snap-in {0} because it is a system Windows PowerShell module. Use Import-Module to load the module.</value>
+    <value>Cannot add PowerShell Core snap-in {0} because it is a system PowerShell Core module. Use Import-Module to load the module.</value>
   </data>
   <data name="CustomPSSnapInNotSupportedInPowerShellCore" xml:space="preserve">
-    <value>The custom Windows PowerShell snap-in is not supported in PowerShell Core.</value>
+    <value>The custom PowerShell Core snap-in is not supported in PowerShell Core.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/MshSnapInCmdletResources.resx
+++ b/src/System.Management.Automation/resources/MshSnapInCmdletResources.resx
@@ -121,15 +121,15 @@
     <value>The operation cannot be performed. The specified cmdlet is not supported in a custom shell.</value>
   </data>
   <data name="NoPSSnapInsFound" xml:space="preserve">
-    <value>No PowerShell Core snap-ins matching the pattern '{0}' were found. Check the pattern and then try the command again.</value>
+    <value>No PowerShell snap-ins matching the pattern '{0}' were found. Check the pattern and then try the command again.</value>
   </data>
   <data name="InvalidPSSnapInName" xml:space="preserve">
-    <value>The format of the specified snap-in name was not valid.  PowerShell Core snap-in names can only contain alpha-numeric characters, dashes, underscores and periods. Correct the name and then try the operation again.</value>
+    <value>The format of the specified snap-in name was not valid.  PowerShell snap-in names can only contain alpha-numeric characters, dashes, underscores and periods. Correct the name and then try the operation again.</value>
   </data>
   <data name="LoadSystemSnapinAsModule" xml:space="preserve">
-    <value>Cannot add PowerShell Core snap-in {0} because it is a system PowerShell Core module. Use Import-Module to load the module.</value>
+    <value>Cannot add PowerShell snap-in {0} because it is a system PowerShell module. Use Import-Module to load the module.</value>
   </data>
   <data name="CustomPSSnapInNotSupportedInPowerShellCore" xml:space="preserve">
-    <value>The custom PowerShell Core snap-in is not supported in PowerShell Core.</value>
+    <value>The custom PowerShell snap-in is not supported in PowerShell.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/MshSnapInCmdletResources.resx
+++ b/src/System.Management.Automation/resources/MshSnapInCmdletResources.resx
@@ -130,6 +130,6 @@
     <value>Cannot add PowerShell snap-in {0} because it is a system PowerShell module. Use Import-Module to load the module.</value>
   </data>
   <data name="CustomPSSnapInNotSupportedInPowerShellCore" xml:space="preserve">
-    <value>The custom PowerShell snap-in is not supported in PowerShell.</value>
+    <value>The custom PowerShell snap-in is not supported in PowerShell Core.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/MshSnapinInfo.resx
+++ b/src/System.Management.Automation/resources/MshSnapinInfo.resx
@@ -121,7 +121,7 @@
     <value>Unable to access PowerShell registry information.</value>
   </data>
   <data name="MonadEngineRegistryAccessFailed" xml:space="preserve">
-    <value>Unable to access PowerShell PowerShellEngine registry information.</value>
+    <value>Unable to access PowerShell Engine registry information.</value>
   </data>
   <data name="PublicKeyTokenAccessFailed" xml:space="preserve">
     <value>Unable to access PublicKeyToken information.</value>

--- a/src/System.Management.Automation/resources/MshSnapinInfo.resx
+++ b/src/System.Management.Automation/resources/MshSnapinInfo.resx
@@ -118,19 +118,19 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="MonadRootRegistryAccessFailed" xml:space="preserve">
-    <value>Unable to access Windows PowerShell registry information.</value>
+    <value>Unable to access PowerShell Core registry information.</value>
   </data>
   <data name="MonadEngineRegistryAccessFailed" xml:space="preserve">
-    <value>Unable to access Windows PowerShell PowerShellEngine registry information.</value>
+    <value>Unable to access PowerShell Core PowerShellEngine registry information.</value>
   </data>
   <data name="PublicKeyTokenAccessFailed" xml:space="preserve">
     <value>Unable to access PublicKeyToken information.</value>
   </data>
   <data name="SpecifiedVersionNotFound" xml:space="preserve">
-    <value>Version {0} of Windows PowerShell is not available on this computer.</value>
+    <value>Version {0} of PowerShell Core is not available on this computer.</value>
   </data>
   <data name="MshSnapinDoesNotExist" xml:space="preserve">
-    <value>The Windows PowerShell snap-in '{0}' is not installed on this computer.</value>
+    <value>The PowerShell Core snap-in '{0}' is not installed on this computer.</value>
   </data>
   <data name="MandatoryValueNotPresent" xml:space="preserve">
     <value>The mandatory value {0} is not specified for registry key {1}.</value>
@@ -145,7 +145,7 @@
     <value>Cannot find required information in registry or missing key files.  Cannot load some cmdlets.</value>
   </data>
   <data name="NoMshSnapinPresentForVersion" xml:space="preserve">
-    <value>No snap-ins have been registered for Windows PowerShell version {0}.</value>
+    <value>No snap-ins have been registered for PowerShell Core version {0}.</value>
   </data>
   <data name="ResourceReaderDisposed" xml:space="preserve">
     <value>Cannot retrieve the string resource because the reader has been disposed.</value>
@@ -154,6 +154,6 @@
     <value>Version value {0} is not specified or is incorrect for registry key {1}.</value>
   </data>
   <data name="PSVersionAttributeNotExist" xml:space="preserve">
-    <value>No [PSVersion] attribute was found for Windows PowerShell type {0}. Add a PSVersion attribute to the type using [PSVersion(Windows PowerShell SnapinBase.PSEngineVersion)].</value>
+    <value>No [PSVersion] attribute was found for PowerShell Core type {0}. Add a PSVersion attribute to the type using [PSVersion(PowerShell Core SnapinBase.PSEngineVersion)].</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/MshSnapinInfo.resx
+++ b/src/System.Management.Automation/resources/MshSnapinInfo.resx
@@ -118,19 +118,19 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="MonadRootRegistryAccessFailed" xml:space="preserve">
-    <value>Unable to access PowerShell Core registry information.</value>
+    <value>Unable to access PowerShell registry information.</value>
   </data>
   <data name="MonadEngineRegistryAccessFailed" xml:space="preserve">
-    <value>Unable to access PowerShell Core PowerShellEngine registry information.</value>
+    <value>Unable to access PowerShell PowerShellEngine registry information.</value>
   </data>
   <data name="PublicKeyTokenAccessFailed" xml:space="preserve">
     <value>Unable to access PublicKeyToken information.</value>
   </data>
   <data name="SpecifiedVersionNotFound" xml:space="preserve">
-    <value>Version {0} of PowerShell Core is not available on this computer.</value>
+    <value>Version {0} of PowerShell is not available on this computer.</value>
   </data>
   <data name="MshSnapinDoesNotExist" xml:space="preserve">
-    <value>The PowerShell Core snap-in '{0}' is not installed on this computer.</value>
+    <value>The PowerShell snap-in '{0}' is not installed on this computer.</value>
   </data>
   <data name="MandatoryValueNotPresent" xml:space="preserve">
     <value>The mandatory value {0} is not specified for registry key {1}.</value>
@@ -145,7 +145,7 @@
     <value>Cannot find required information in registry or missing key files.  Cannot load some cmdlets.</value>
   </data>
   <data name="NoMshSnapinPresentForVersion" xml:space="preserve">
-    <value>No snap-ins have been registered for PowerShell Core version {0}.</value>
+    <value>No snap-ins have been registered for PowerShell version {0}.</value>
   </data>
   <data name="ResourceReaderDisposed" xml:space="preserve">
     <value>Cannot retrieve the string resource because the reader has been disposed.</value>
@@ -154,6 +154,6 @@
     <value>Version value {0} is not specified or is incorrect for registry key {1}.</value>
   </data>
   <data name="PSVersionAttributeNotExist" xml:space="preserve">
-    <value>No [PSVersion] attribute was found for PowerShell Core type {0}. Add a PSVersion attribute to the type using [PSVersion(PowerShell Core SnapinBase.PSEngineVersion)].</value>
+    <value>No [PSVersion] attribute was found for PowerShell type {0}. Add a PSVersion attribute to the type using [PSVersion(PowerShell SnapinBase.PSEngineVersion)].</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/ParserStrings.resx
+++ b/src/System.Management.Automation/resources/ParserStrings.resx
@@ -1192,7 +1192,7 @@ ModuleVersion : Version of module to import. If used, ModuleName must represent 
     <value>Exception occurred when post-parsing dynamic keyword '{0}' with details '{1}'.</value>
   </data>
   <data name="WorkflowNotSupportedInPowerShellCore" xml:space="preserve">
-    <value>Workflow is not supported in PowerShell.</value>
+    <value>Workflow is not supported in PowerShell Core.</value>
   </data>
   <data name="MetaConfigurationUsedInRegularConfig" xml:space="preserve">
     <value>Meta Configuration resource {0} is not allowed in the regular configuration. Use meta configuration resources in a configuration with [DscLocalConfigurationManager()] attribute.</value>
@@ -1261,7 +1261,7 @@ ModuleVersion : Version of module to import. If used, ModuleName must represent 
     <value>Variant.GetAccessor cannot handle {0}.</value>
   </data>
   <data name="ConfigurationNotSupportedInPowerShellCore" xml:space="preserve">
-    <value>Configuration keyword is not supported in PowerShell.</value>
+    <value>Configuration keyword is not supported in PowerShell Core.</value>
   </data>
   <data name="MethodHasCodePathNotReturn" xml:space="preserve">
     <value>Not all code path returns value within method.</value>
@@ -1355,7 +1355,7 @@ ModuleVersion : Version of module to import. If used, ModuleName must represent 
 '{1}'.</value>
   </data>
   <data name="CantActivateDocumentInPowerShellCore" xml:space="preserve">
-    <value>Cannot run a document in PowerShell: {0}.</value>
+    <value>Cannot run a document in PowerShell Core: {0}.</value>
   </data>
   <data name="MultipleTypeConstraintsOnMethodParam" xml:space="preserve">
     <value>Multiple type constraints are not allowed on a method parameter.</value>

--- a/src/System.Management.Automation/resources/ParserStrings.resx
+++ b/src/System.Management.Automation/resources/ParserStrings.resx
@@ -850,7 +850,7 @@ Possible matches are</value>
     <value>Flow of control cannot leave a Finally block.</value>
   </data>
   <data name="UnrecoverableParserError" xml:space="preserve">
-    <value>Unrecoverable error in Windows PowerShell.</value>
+    <value>Unrecoverable error in PowerShell Core.</value>
   </data>
   <data name="AstIsReused" xml:space="preserve">
     <value>An AST cannot be used as the child of more than one AST. To use this AST in another AST, call the Copy() method and use its result.</value>
@@ -925,7 +925,7 @@ Possible matches are</value>
     <value>The argument for the Module parameter is not valid. {0}</value>
   </data>
   <data name="RequiresVersionInvalid" xml:space="preserve">
-    <value>The argument for the Version parameter is not valid. Specify a valid Windows PowerShell version, in the format major.minor version.</value>
+    <value>The argument for the Version parameter is not valid. Specify a valid PowerShell Core version, in the format major.minor version.</value>
   </data>
   <data name="RequiresPSEditionInvalid" xml:space="preserve">
     <value>The argument for the {0} parameter is not valid. Specify a valid PowerShell edition.</value>

--- a/src/System.Management.Automation/resources/ParserStrings.resx
+++ b/src/System.Management.Automation/resources/ParserStrings.resx
@@ -850,7 +850,7 @@ Possible matches are</value>
     <value>Flow of control cannot leave a Finally block.</value>
   </data>
   <data name="UnrecoverableParserError" xml:space="preserve">
-    <value>Unrecoverable error in PowerShell Core.</value>
+    <value>Unrecoverable error in PowerShell.</value>
   </data>
   <data name="AstIsReused" xml:space="preserve">
     <value>An AST cannot be used as the child of more than one AST. To use this AST in another AST, call the Copy() method and use its result.</value>
@@ -925,7 +925,7 @@ Possible matches are</value>
     <value>The argument for the Module parameter is not valid. {0}</value>
   </data>
   <data name="RequiresVersionInvalid" xml:space="preserve">
-    <value>The argument for the Version parameter is not valid. Specify a valid PowerShell Core version, in the format major.minor version.</value>
+    <value>The argument for the Version parameter is not valid. Specify a valid PowerShell version, in the format major.minor version.</value>
   </data>
   <data name="RequiresPSEditionInvalid" xml:space="preserve">
     <value>The argument for the {0} parameter is not valid. Specify a valid PowerShell edition.</value>
@@ -1192,7 +1192,7 @@ ModuleVersion : Version of module to import. If used, ModuleName must represent 
     <value>Exception occurred when post-parsing dynamic keyword '{0}' with details '{1}'.</value>
   </data>
   <data name="WorkflowNotSupportedInPowerShellCore" xml:space="preserve">
-    <value>Workflow is not supported in PowerShell Core.</value>
+    <value>Workflow is not supported in PowerShell.</value>
   </data>
   <data name="MetaConfigurationUsedInRegularConfig" xml:space="preserve">
     <value>Meta Configuration resource {0} is not allowed in the regular configuration. Use meta configuration resources in a configuration with [DscLocalConfigurationManager()] attribute.</value>
@@ -1261,7 +1261,7 @@ ModuleVersion : Version of module to import. If used, ModuleName must represent 
     <value>Variant.GetAccessor cannot handle {0}.</value>
   </data>
   <data name="ConfigurationNotSupportedInPowerShellCore" xml:space="preserve">
-    <value>Configuration keyword is not supported in PowerShell Core.</value>
+    <value>Configuration keyword is not supported in PowerShell.</value>
   </data>
   <data name="MethodHasCodePathNotReturn" xml:space="preserve">
     <value>Not all code path returns value within method.</value>
@@ -1355,7 +1355,7 @@ ModuleVersion : Version of module to import. If used, ModuleName must represent 
 '{1}'.</value>
   </data>
   <data name="CantActivateDocumentInPowerShellCore" xml:space="preserve">
-    <value>Cannot run a document in PowerShell Core: {0}.</value>
+    <value>Cannot run a document in PowerShell: {0}.</value>
   </data>
   <data name="MultipleTypeConstraintsOnMethodParam" xml:space="preserve">
     <value>Multiple type constraints are not allowed on a method parameter.</value>

--- a/src/System.Management.Automation/resources/PowerShellStrings.resx
+++ b/src/System.Management.Automation/resources/PowerShellStrings.resx
@@ -142,7 +142,7 @@
     <value>Nested PowerShell instances cannot be invoked asynchronously. Use the Invoke method.</value>
   </data>
   <data name="AsyncResultNotOwned" xml:space="preserve">
-    <value>The {0} object was not created by calling {1} on this Windows PowerShell instance.</value>
+    <value>The {0} object was not created by calling {1} on this PowerShell Core instance.</value>
   </data>
   <data name="ApartmentStateMismatch" xml:space="preserve">
     <value>When the runspace is set to reuse a thread, the apartment state in the invocation settings must match the runspace.</value>
@@ -151,7 +151,7 @@
     <value>When the runspace is set to use the current thread, the apartment state in the invocation settings must match that of the current thread.</value>
   </data>
   <data name="ParameterRequiresCommand" xml:space="preserve">
-    <value>A command is required to add a parameter. A command must be added to the Windows PowerShell instance before adding a parameter.</value>
+    <value>A command is required to add a parameter. A command must be added to the PowerShell Core instance before adding a parameter.</value>
   </data>
   <data name="KeyMustBeString" xml:space="preserve">
     <value>The keys in the dictionary must be strings.</value>
@@ -163,10 +163,10 @@
     <value>You can only begin receiving data on a PSJobProxy instance when it has been created with data streaming disabled. This operation can run only once.</value>
   </data>
   <data name="GetJobForCommandNotSupported" xml:space="preserve">
-    <value>GetJobForCommand is not supported when there is more than one command in the Windows PowerShell instance.</value>
+    <value>GetJobForCommand is not supported when there is more than one command in the PowerShell Core instance.</value>
   </data>
   <data name="GetJobForCommandRequiresACommand" xml:space="preserve">
-    <value>The Command property of a Windows PowerShell object cannot be empty.</value>
+    <value>The Command property of a PowerShell Core object cannot be empty.</value>
   </data>
   <data name="CommandDoesNotWriteJob" xml:space="preserve">
     <value>The PSJobProxy object can only be used for remote commands that return a job object.</value>
@@ -193,16 +193,16 @@
     <value>A job object cannot be reused.</value>
   </data>
   <data name="CannotConnect" xml:space="preserve">
-    <value>This Windows PowerShell object cannot be connected because it is not associated with a remote runspace or runspace pool.</value>
+    <value>This PowerShell Core object cannot be connected because it is not associated with a remote runspace or runspace pool.</value>
   </data>
   <data name="DiscOnSyncCommand" xml:space="preserve">
     <value>The running command has been disconnected but is still running on the remote server.  Reconnect to get command operation status and output data.</value>
   </data>
   <data name="ExecutionDisconnected" xml:space="preserve">
-    <value>The operation cannot be performed because the current Windows PowerShell session is in the Disconnected state.  Connect this Windows PowerShell session, and then either wait for the command to finish, or stop the command.</value>
+    <value>The operation cannot be performed because the current PowerShell Core session is in the Disconnected state.  Connect this PowerShell Core session, and then either wait for the command to finish, or stop the command.</value>
   </data>
   <data name="IsDisconnected" xml:space="preserve">
-    <value>The operation cannot be performed because the current Windows PowerShell session is in the Disconnected state.  Connect this Windows PowerShell session, and then try again.</value>
+    <value>The operation cannot be performed because the current PowerShell Core session is in the Disconnected state.  Connect this PowerShell Core session, and then try again.</value>
   </data>
   <data name="ConnectFailed" xml:space="preserve">
     <value>The connection attempt to the remote command failed.</value>
@@ -215,7 +215,7 @@
     <value>The operation cannot be performed because a command is currently stopping. Wait for the command to complete stopping, and then try the operation again.</value>
   </data>
   <data name="CommandInvokedFromWrongThreadWithoutCommand" xml:space="preserve">
-    <value>There is no Runspace available to run commands in this thread. You can provide one in the DefaultRunspace property of the System.Management.Automation.Runspaces.Runspace type. The current Windows PowerShell instance contains no command to invoke.</value>
+    <value>There is no Runspace available to run commands in this thread. You can provide one in the DefaultRunspace property of the System.Management.Automation.Runspaces.Runspace type. The current PowerShell Core instance contains no command to invoke.</value>
   </data>
   <data name="JobProxyAsJobMustBeTrue" xml:space="preserve">
     <value>A command in which the value of AsJob is equal to false cannot be run through a PSJobProxy.</value>
@@ -226,7 +226,7 @@
     <comment>PSJobProxy is the name of a class and should not be localized</comment>
   </data>
   <data name="NoDefaultRunspaceForPSCreate" xml:space="preserve">
-    <value>A Windows PowerShell object cannot be created that uses the current runspace because there is no current runspace available.  The current runspace might be starting, such as when it is created with an Initial Session State.</value>
+    <value>A PowerShell Core object cannot be created that uses the current runspace because there is no current runspace available.  The current runspace might be starting, such as when it is created with an Initial Session State.</value>
   </data>
   <data name="ProxyJobControlNotSupported" xml:space="preserve">
     <value>PSJobProxy does not support this control method.</value>

--- a/src/System.Management.Automation/resources/PowerShellStrings.resx
+++ b/src/System.Management.Automation/resources/PowerShellStrings.resx
@@ -142,7 +142,7 @@
     <value>Nested PowerShell instances cannot be invoked asynchronously. Use the Invoke method.</value>
   </data>
   <data name="AsyncResultNotOwned" xml:space="preserve">
-    <value>The {0} object was not created by calling {1} on this PowerShell Core instance.</value>
+    <value>The {0} object was not created by calling {1} on this PowerShell instance.</value>
   </data>
   <data name="ApartmentStateMismatch" xml:space="preserve">
     <value>When the runspace is set to reuse a thread, the apartment state in the invocation settings must match the runspace.</value>
@@ -151,7 +151,7 @@
     <value>When the runspace is set to use the current thread, the apartment state in the invocation settings must match that of the current thread.</value>
   </data>
   <data name="ParameterRequiresCommand" xml:space="preserve">
-    <value>A command is required to add a parameter. A command must be added to the PowerShell Core instance before adding a parameter.</value>
+    <value>A command is required to add a parameter. A command must be added to the PowerShell instance before adding a parameter.</value>
   </data>
   <data name="KeyMustBeString" xml:space="preserve">
     <value>The keys in the dictionary must be strings.</value>
@@ -163,10 +163,10 @@
     <value>You can only begin receiving data on a PSJobProxy instance when it has been created with data streaming disabled. This operation can run only once.</value>
   </data>
   <data name="GetJobForCommandNotSupported" xml:space="preserve">
-    <value>GetJobForCommand is not supported when there is more than one command in the PowerShell Core instance.</value>
+    <value>GetJobForCommand is not supported when there is more than one command in the PowerShell instance.</value>
   </data>
   <data name="GetJobForCommandRequiresACommand" xml:space="preserve">
-    <value>The Command property of a PowerShell Core object cannot be empty.</value>
+    <value>The Command property of a PowerShell object cannot be empty.</value>
   </data>
   <data name="CommandDoesNotWriteJob" xml:space="preserve">
     <value>The PSJobProxy object can only be used for remote commands that return a job object.</value>
@@ -193,16 +193,16 @@
     <value>A job object cannot be reused.</value>
   </data>
   <data name="CannotConnect" xml:space="preserve">
-    <value>This PowerShell Core object cannot be connected because it is not associated with a remote runspace or runspace pool.</value>
+    <value>This PowerShell object cannot be connected because it is not associated with a remote runspace or runspace pool.</value>
   </data>
   <data name="DiscOnSyncCommand" xml:space="preserve">
     <value>The running command has been disconnected but is still running on the remote server.  Reconnect to get command operation status and output data.</value>
   </data>
   <data name="ExecutionDisconnected" xml:space="preserve">
-    <value>The operation cannot be performed because the current PowerShell Core session is in the Disconnected state.  Connect this PowerShell Core session, and then either wait for the command to finish, or stop the command.</value>
+    <value>The operation cannot be performed because the current PowerShell session is in the Disconnected state.  Connect this PowerShell session, and then either wait for the command to finish, or stop the command.</value>
   </data>
   <data name="IsDisconnected" xml:space="preserve">
-    <value>The operation cannot be performed because the current PowerShell Core session is in the Disconnected state.  Connect this PowerShell Core session, and then try again.</value>
+    <value>The operation cannot be performed because the current PowerShell session is in the Disconnected state.  Connect this PowerShell session, and then try again.</value>
   </data>
   <data name="ConnectFailed" xml:space="preserve">
     <value>The connection attempt to the remote command failed.</value>
@@ -215,7 +215,7 @@
     <value>The operation cannot be performed because a command is currently stopping. Wait for the command to complete stopping, and then try the operation again.</value>
   </data>
   <data name="CommandInvokedFromWrongThreadWithoutCommand" xml:space="preserve">
-    <value>There is no Runspace available to run commands in this thread. You can provide one in the DefaultRunspace property of the System.Management.Automation.Runspaces.Runspace type. The current PowerShell Core instance contains no command to invoke.</value>
+    <value>There is no Runspace available to run commands in this thread. You can provide one in the DefaultRunspace property of the System.Management.Automation.Runspaces.Runspace type. The current PowerShell instance contains no command to invoke.</value>
   </data>
   <data name="JobProxyAsJobMustBeTrue" xml:space="preserve">
     <value>A command in which the value of AsJob is equal to false cannot be run through a PSJobProxy.</value>
@@ -226,7 +226,7 @@
     <comment>PSJobProxy is the name of a class and should not be localized</comment>
   </data>
   <data name="NoDefaultRunspaceForPSCreate" xml:space="preserve">
-    <value>A PowerShell Core object cannot be created that uses the current runspace because there is no current runspace available.  The current runspace might be starting, such as when it is created with an Initial Session State.</value>
+    <value>A PowerShell object cannot be created that uses the current runspace because there is no current runspace available.  The current runspace might be starting, such as when it is created with an Initial Session State.</value>
   </data>
   <data name="ProxyJobControlNotSupported" xml:space="preserve">
     <value>PSJobProxy does not support this control method.</value>

--- a/src/System.Management.Automation/resources/RemotingErrorIdStrings.resx
+++ b/src/System.Management.Automation/resources/RemotingErrorIdStrings.resx
@@ -657,10 +657,10 @@
     <value>Session configuration "{0}" is not a PowerShell-based shell.</value>
 </data>
   <data name="CSCmdsPowerShellCoreShellNotModifiable" xml:space="preserve">
-    <value>Session configuration "{0}" is a PowerShell-based shell. Please use PowerShell to modify it.</value>
+    <value>Session configuration "{0}" is a PowerShell Core-based shell. Please use PowerShell Core to modify it.</value>
   </data>
   <data name="CSCmdsWindowsPowerShellCoreNotModifiable" xml:space="preserve">
-    <value>Session configuration "{0}" is a PowerShell-based shell. Please use PowerShell to modify it.</value>
+    <value>Session configuration "{0}" is a Windows PowerShell-based shell. Please use Windows PowerShell to modify it.</value>
   </data>
   <data name="CustomShellNotFound" xml:space="preserve">
     <value>No session configuration matches criteria "{0}".</value>
@@ -952,7 +952,7 @@ All WinRM sessions connected to PowerShell session configurations, such as Micro
     <value>A running command could not be found for this PSSession.</value>
   </data>
   <data name="NetFrameWorkV2NotInstalled" xml:space="preserve">
-    <value>The Microsoft .NET Framework 2.0, which is required for PowerShell 2.0, is not installed. Install the .NET Framework 2.0 and retry.</value>
+    <value>The Microsoft .NET Framework 2.0, which is required for Windows PowerShell 2.0, is not installed. Install the .NET Framework 2.0 and retry.</value>
   </data>
   <data name="PipelineFailedWithoutReason" xml:space="preserve">
     <value>The remote pipeline failed.</value>
@@ -1646,7 +1646,7 @@ All WinRM sessions connected to PowerShell session configurations, such as Micro
     <value>The SSH transport process has abruptly terminated causing this remote session to break.</value>
   </data>
   <data name="InvalidProcessorArchitecture" xml:space="preserve">
-    <value>PowerShell does not support WOW64. The binary must match the architecture of the processor.</value>
+    <value>PowerShell Core does not support WOW64. The binary must match the architecture of the processor.</value>
   </data>
   <data name="UnableToInstallPlugin" xml:space="preserve">
       <value>Unable to install plugin {0} to directory {1}.</value>

--- a/src/System.Management.Automation/resources/RemotingErrorIdStrings.resx
+++ b/src/System.Management.Automation/resources/RemotingErrorIdStrings.resx
@@ -172,7 +172,7 @@
     <value>Only administrators can override the Thread Options remotely.</value>
   </data>
   <data name="RemoteHostPromptForCredentialModifiedCaption" xml:space="preserve">
-    <value>PowerShell Core Credential Request: {0}</value>
+    <value>PowerShell Credential Request: {0}</value>
   </data>
   <data name="RemoteHostPromptForCredentialModifiedMessage" xml:space="preserve">
     <value>Warning: A script or application on the remote computer {0} is requesting your credentials. Enter your credentials only if you trust the remote computer and the application or script that is requesting them.
@@ -183,7 +183,7 @@
     <value>A script or application on the remote computer {0} is asking to read a line securely. Enter sensitive information, such as your credentials, only if you trust the remote computer and the application or script that is requesting it.</value>
   </data>
   <data name="RemoteHostGetBufferContents" xml:space="preserve">
-    <value>A script or application on the remote computer {0} is attempting to read the buffer contents on the PowerShell Core host. For security reasons, this is not allowed; the call has been suppressed.</value>
+    <value>A script or application on the remote computer {0} is attempting to read the buffer contents on the PowerShell host. For security reasons, this is not allowed; the call has been suppressed.</value>
   </data>
   <data name="RemoteHostPromptSecureStringPrompt" xml:space="preserve">
     <value>A script or application on the remote computer {0} is sending a prompt request. When you are prompted, enter sensitive information, such as credentials or passwords, only if you trust the remote computer and the application or script that is requesting the data.</value>
@@ -270,7 +270,7 @@
     <value>Error in decoding Maximum runspaces.</value>
   </data>
   <data name="DecodingErrorForPowerShellStateInfo" xml:space="preserve">
-    <value>Error in decoding PowerShell CoreStateInfo.</value>
+    <value>Error in decoding PowerShellStateInfo.</value>
   </data>
   <data name="CantCastPropertyToExpectedType" xml:space="preserve">
     <value>Unexpected type of {0} property (expected {1}, got {2}).</value>
@@ -294,31 +294,31 @@
     <value>The client negotiation timer has expired. The negotiation time-out interval is {0} milliseconds.</value>
   </data>
   <data name="ClientNegotiationFailed" xml:space="preserve">
-    <value>PowerShell Core client does not support the {0} {1} negotiated by the server. Make sure the server is compatible with the build {2} and the protocol version {3} of PowerShell Core.</value>
+    <value>PowerShell client does not support the {0} {1} negotiated by the server. Make sure the server is compatible with the build {2} and the protocol version {3} of PowerShell.</value>
   </data>
   <data name="ClientNotFoundCapabilityProperties" xml:space="preserve">
-    <value>{0}. Negotiation with the server failed. Make sure the server is compatible with the build {1} and the protocol version {2} of PowerShell Core.</value>
+    <value>{0}. Negotiation with the server failed. Make sure the server is compatible with the build {1} and the protocol version {2} of PowerShell.</value>
   </data>
   <data name="ServerRequestedToCloseSession" xml:space="preserve">
     <value>The destination server has sent a request to close the session.</value>
   </data>
   <data name="ServerNegotiationFailed" xml:space="preserve">
-    <value>The server that is running PowerShell Core does not support the {0} {1} negotiated by the client computer. Verify that the client computer is compatible with the build {2} and the protocol version {3} of PowerShell Core.</value>
+    <value>The server that is running PowerShell does not support the {0} {1} negotiated by the client computer. Verify that the client computer is compatible with the build {2} and the protocol version {3} of PowerShell.</value>
   </data>
   <data name="ServerConnectFailedOnNegotiation" xml:space="preserve">
-    <value>The server that is running PowerShell Core does not support connect operations on the {0} {1}  that is negotiated by the client computer. Make sure the client computer is compatible with the build {2} and the protocol version {3} of PowerShell Core.</value>
+    <value>The server that is running PowerShell does not support connect operations on the {0} {1}  that is negotiated by the client computer. Make sure the client computer is compatible with the build {2} and the protocol version {3} of PowerShell.</value>
   </data>
   <data name="ServerConnectFailedOnInputValidation" xml:space="preserve">
-    <value>The server that is running PowerShell Core cannot process the connect operation because the following information is not found or not valid: Client Capability information and Connect RunspacePool information.</value>
+    <value>The server that is running PowerShell cannot process the connect operation because the following information is not found or not valid: Client Capability information and Connect RunspacePool information.</value>
   </data>
   <data name="ServerConnectFailedOnServerStateValidation" xml:space="preserve">
-    <value>The server that is running PowerShell Core cannot process the connect operation because the server has either not been started, or it is shutting down.</value>
+    <value>The server that is running PowerShell cannot process the connect operation because the server has either not been started, or it is shutting down.</value>
   </data>
   <data name="ServerConnectFailedOnMismatchedRunspacePoolProperties" xml:space="preserve">
-    <value>The server that is running PowerShell Core cannot process the connect operation because the server runspace pool properties did not match the client computer specified properties.</value>
+    <value>The server that is running PowerShell cannot process the connect operation because the server runspace pool properties did not match the client computer specified properties.</value>
   </data>
   <data name="ServerNotFoundCapabilityProperties" xml:space="preserve">
-    <value>{0}. Negotiation with the client failed. Make sure the client is compatible with the build {1} and the protocol version {2} of PowerShell Core.</value>
+    <value>{0}. Negotiation with the client failed. Make sure the client is compatible with the build {1} and the protocol version {2} of PowerShell.</value>
   </data>
   <data name="ServerNegotiationTimeout" xml:space="preserve">
     <value>The server negotiation timer has expired. The negotiation time-out interval is {0} milliseconds.</value>
@@ -327,7 +327,7 @@
     <value>The client computer has sent a request to close the session.</value>
   </data>
   <data name="FatalErrorCausingClose" xml:space="preserve">
-    <value>An error has occurred which PowerShell Core cannot handle. A remote session might have ended.</value>
+    <value>An error has occurred which PowerShell cannot handle. A remote session might have ended.</value>
   </data>
   <data name="ClientKeyExchangeFailed" xml:space="preserve">
     <value>The server did not respond with an encrypted session key within the specified time-out period.</value>
@@ -342,7 +342,7 @@
     <value>Attempting to close the session.</value>
   </data>
   <data name="ForceClosed" xml:space="preserve">
-    <value>PowerShell Core cannot close the remote session properly. The session is in an undefined state because it was not opened or connected after being disconnected. PowerShell Core will try to force the session to close on the local computer, but the session might not be closed on the remote computer. To close a remote session properly, first open it or connect it.</value>
+    <value>PowerShell cannot close the remote session properly. The session is in an undefined state because it was not opened or connected after being disconnected. PowerShell will try to force the session to close on the local computer, but the session might not be closed on the remote computer. To close a remote session properly, first open it or connect it.</value>
   </data>
   <data name="CloseFailed" xml:space="preserve">
     <value>Could not close the session.</value>
@@ -459,10 +459,10 @@
     <value>Inter-process communication (IPC) transport does not support connect operations.</value>
   </data>
   <data name="NonExistentInitialSessionStateProvider" xml:space="preserve">
-    <value>An EndpointConfiguration with Id {0} does not exist on the remote server. Contact your PowerShell Core administrator, or the owner or creator of the endpoint configuration.</value>
+    <value>An EndpointConfiguration with Id {0} does not exist on the remote server. Contact your PowerShell administrator, or the owner or creator of the endpoint configuration.</value>
   </data>
   <data name="InitialSessionStateNull" xml:space="preserve">
-    <value>The EndpointConfiguration with the {0} identifier is not in a valid initial session state on the remote computer. Contact your PowerShell Core administrator, or the owner or creator of the endpoint configuration.</value>
+    <value>The EndpointConfiguration with the {0} identifier is not in a valid initial session state on the remote computer. Contact your PowerShell administrator, or the owner or creator of the endpoint configuration.</value>
   </data>
   <data name="MandatoryValueNotPresent" xml:space="preserve">
     <value>The mandatory value {0} is not specified for the {1} registry key.</value>
@@ -471,7 +471,7 @@
     <value>The mandatory value {0} is not in the correct format for registry key {1}. The expected format is 'string'.</value>
   </data>
   <data name="StartupScriptNotCorrect" xml:space="preserve">
-    <value>"{0}" must specify a PowerShell Core script file that ends with extension ".ps1".</value>
+    <value>"{0}" must specify a PowerShell script file that ends with extension ".ps1".</value>
   </data>
   <data name="DuplicateInitializationParameterFound" xml:space="preserve">
     <value>The {0} parameter is already specified in the {1} section. Contact your administrator to make sure that {0} is specified only once.</value>
@@ -552,7 +552,7 @@
     <value>The path specified as the value of the FilePath parameter is not from the FileSystem provider.</value>
   </data>
   <data name="FilePathShouldPS1Extension" xml:space="preserve">
-    <value>The value of the FilePath parameter must be a PowerShell Core script file. Enter the path to a file with a .ps1 file name extension and try the command again.</value>
+    <value>The value of the FilePath parameter must be a PowerShell script file. Enter the path to a file with a .ps1 file name extension and try the command again.</value>
   </data>
   <data name="InvalidComputerName" xml:space="preserve">
     <value>One or more computer names are not valid. If you are trying to pass a URI, use the -ConnectionUri parameter, or pass URI objects instead of strings.</value>
@@ -582,7 +582,7 @@
     <value>Remote Command: {0}, associated with a job that has an ID of "{1}".</value>
   </data>
   <data name="ComputerNameParamNotSupported" xml:space="preserve">
-    <value>The command cannot retrieve the jobs of the specified computers. The ComputerName parameter can be used only with jobs created by using PowerShell Core remoting.</value>
+    <value>The command cannot retrieve the jobs of the specified computers. The ComputerName parameter can be used only with jobs created by using PowerShell remoting.</value>
   </data>
   <data name="RunspaceParamNotSupported" xml:space="preserve">
     <value>The Session parameter can be used only with PSRemotingJob objects.</value>
@@ -654,13 +654,13 @@
     <value>Session configuration "{0}" was not found.</value>
   </data>
   <data name="CSCmdsShellNotPowerShellBased" xml:space="preserve">
-    <value>Session configuration "{0}" is not a PowerShell Core-based shell.</value>
+    <value>Session configuration "{0}" is not a PowerShell-based shell.</value>
 </data>
   <data name="CSCmdsPowerShellCoreShellNotModifiable" xml:space="preserve">
-    <value>Session configuration "{0}" is a PowerShell Core-based shell. Please use PowerShell Core to modify it.</value>
+    <value>Session configuration "{0}" is a PowerShell-based shell. Please use PowerShell to modify it.</value>
   </data>
   <data name="CSCmdsWindowsPowerShellCoreNotModifiable" xml:space="preserve">
-    <value>Session configuration "{0}" is a PowerShell Core-based shell. Please use PowerShell Core to modify it.</value>
+    <value>Session configuration "{0}" is a PowerShell-based shell. Please use PowerShell to modify it.</value>
   </data>
   <data name="CustomShellNotFound" xml:space="preserve">
     <value>No session configuration matches criteria "{0}".</value>
@@ -672,13 +672,13 @@
     <value>Name: {0}</value>
   </data>
   <data name="CSShouldProcessTargetAdminEnable" xml:space="preserve">
-    <value>Name: {0}. This lets administrators remotely run PowerShell Core commands on this computer.</value>
+    <value>Name: {0}. This lets administrators remotely run PowerShell commands on this computer.</value>
   </data>
   <data name="NcsCannotDeleteFile" xml:space="preserve">
     <value>Cannot delete temporary file {0}. Reason for failure: {1}.</value>
   </data>
   <data name="NcsCannotDeleteFileAfterInstall" xml:space="preserve">
-    <value>The new shell was successfully registered, but PowerShell Core cannot delete the temporary file {0}. Reason for failure: {1}.</value>
+    <value>The new shell was successfully registered, but PowerShell cannot delete the temporary file {0}. Reason for failure: {1}.</value>
   </data>
   <data name="NcsCannotWritePluginContent" xml:space="preserve">
     <value>Cannot write the shell configuration data into the temporary file {0}. Reason for failure: {1}.</value>
@@ -687,13 +687,13 @@
     <value>Running command "{0}" to create a new session configuration.</value>
   </data>
   <data name="NcsShouldProcessTargetSDDL" xml:space="preserve">
-    <value>Name: {0} SDDL: {1}. This lets selected users remotely run PowerShell Core commands on this computer.</value>
+    <value>Name: {0} SDDL: {1}. This lets selected users remotely run PowerShell commands on this computer.</value>
   </data>
   <data name="RcsScriptMessageV" xml:space="preserve">
     <value>Running command "{0}" to remove a session configuration.</value>
   </data>
   <data name="GcsScriptMessageV" xml:space="preserve">
-    <value>Running command "{0}" to get PowerShell Core-based session configurations.</value>
+    <value>Running command "{0}" to get PowerShell-based session configurations.</value>
   </data>
   <data name="ScsScriptMessageV" xml:space="preserve">
     <value>Running command "{0}" to update the session configuration properties.</value>
@@ -721,7 +721,7 @@ Do you want to continue?</value>
     <value>Performing operation "{0}".</value>
   </data>
   <data name="EcsShouldProcessTarget" xml:space="preserve">
-    <value>Name: {0} SDDL: {1}. This lets selected users remotely run PowerShell Core commands on this computer.</value>
+    <value>Name: {0} SDDL: {1}. This lets selected users remotely run PowerShell commands on this computer.</value>
   </data>
   <data name="DcsScriptMessageV" xml:space="preserve">
     <value>Running command "{0}" to disable the session configuration.</value>
@@ -737,7 +737,7 @@ Do you want to continue?</value>
     4. Restore the value of the LocalAccountTokenFilterPolicy to 0, which restricts remote access to members of the Administrators group on the computer.</value>
   </data>
   <data name="EDcsRequiresElevation" xml:space="preserve">
-    <value>Access is denied. To run this cmdlet, start PowerShell Core with the "Run as administrator" option.</value>
+    <value>Access is denied. To run this cmdlet, start PowerShell with the "Run as administrator" option.</value>
   </data>
   <data name="RestartWSManServiceMessageV" xml:space="preserve">
     <value>Restarting WinRM service</value>
@@ -846,7 +846,7 @@ Do you want to continue?</value>
     <value>The WriteEvents parameter cannot be used without the Wait parameter.</value>
   </data>
   <data name="PowerShellNotInstalled" xml:space="preserve">
-    <value>PowerShell Core {0} is not installed. Install PowerShell Core {0}, and then try again.</value>
+    <value>PowerShell {0} is not installed. Install PowerShell {0}, and then try again.</value>
   </data>
   <data name="JobManagerRegistrationConstructorError" xml:space="preserve">
     <value>The following type cannot be instantiated because its constructor is not public: {0}.</value>
@@ -933,14 +933,14 @@ Do you want to continue?</value>
     <value>The command cannot find a PSSession that has the name "{0}".</value>
   </data>
   <data name="WinPERemotingNotSupported" xml:space="preserve">
-    <value>PowerShell Core remoting is not supported in the Windows Preinstallation Environment (WinPE).</value>
+    <value>PowerShell remoting is not supported in the Windows Preinstallation Environment (WinPE).</value>
   </data>
   <data name="WinRMRequiresRestart" xml:space="preserve">
     <value>Changes made by {0} cannot take effect until the WinRM service is restarted.</value>
   </data>
   <data name="WinRMRestartWarning" xml:space="preserve">
     <value>{0} may need to restart the WinRM service if a configuration using this name has recently been unregistered, certain system data structures may still be cached. In that case, a restart of WinRM may be required.
-All WinRM sessions connected to PowerShell Core session configurations, such as Microsoft.PowerShell and session configurations that are created with the Register-PSSessionConfiguration cmdlet, are disconnected.</value>
+All WinRM sessions connected to PowerShell session configurations, such as Microsoft.PowerShell and session configurations that are created with the Register-PSSessionConfiguration cmdlet, are disconnected.</value>
   </data>
   <data name="WinRMForceRestartWarning" xml:space="preserve">
     <value>You are running in a remote session and have selected the Force option which means the WinRM service may restart.If the WinRM service restarts then this remote session will be terminated and you will need to create a new session to continue</value>
@@ -952,7 +952,7 @@ All WinRM sessions connected to PowerShell Core session configurations, such as 
     <value>A running command could not be found for this PSSession.</value>
   </data>
   <data name="NetFrameWorkV2NotInstalled" xml:space="preserve">
-    <value>The Microsoft .NET Framework 2.0, which is required for PowerShell Core 2.0, is not installed. Install the .NET Framework 2.0 and retry.</value>
+    <value>The Microsoft .NET Framework 2.0, which is required for PowerShell 2.0, is not installed. Install the .NET Framework 2.0 and retry.</value>
   </data>
   <data name="PipelineFailedWithoutReason" xml:space="preserve">
     <value>The remote pipeline failed.</value>
@@ -1030,7 +1030,7 @@ All WinRM sessions connected to PowerShell Core session configurations, such as 
     <value>Modules to import when applied to a session</value>
   </data>
   <data name="DISCPowerShellVersionComment" xml:space="preserve">
-    <value>Version of the PowerShell Core engine to use when applied to a session</value>
+    <value>Version of the PowerShell engine to use when applied to a session</value>
   </data>
   <data name="DISCProcessorArchitectureComment" xml:space="preserve">
     <value>Processor architecture to use when applied to a session</value>
@@ -1196,7 +1196,7 @@ All WinRM sessions connected to PowerShell Core session configurations, such as 
     <value>The PSSession is in a disconnected state and is not available for connection.</value>
   </data>
   <data name="HyperVModuleNotAvailable" xml:space="preserve">
-    <value>The Hyper-V Module for PowerShell Core is not available on this machine.</value>
+    <value>The Hyper-V Module for PowerShell is not available on this machine.</value>
   </data>
   <data name="CannotCreateProcessInContainer" xml:space="preserve">
     <value>Failed to launch PowerShell process inside container with id {0}.</value>
@@ -1318,7 +1318,7 @@ All WinRM sessions connected to PowerShell Core session configurations, such as 
     <value>One or more jobs are in a suspended or disconnected state, and cannot continue without additional user input.  Specify the -Force parameter to continue to a completed, failed, or stopped state.</value>
   </data>
   <data name="RunAsSessionConfigurationSecurityWarning" xml:space="preserve">
-    <value>When RunAs is enabled in a PowerShell Core session configuration, the Windows security model cannot enforce a security boundary between different user sessions that are created by using this endpoint. Verify that the PowerShell Core runspace configuration is restricted to only the necessary set of cmdlets and capabilities.</value>
+    <value>When RunAs is enabled in a PowerShell session configuration, the Windows security model cannot enforce a security boundary between different user sessions that are created by using this endpoint. Verify that the PowerShell runspace configuration is restricted to only the necessary set of cmdlets and capabilities.</value>
   </data>
   <data name="ForceSuspendJob" xml:space="preserve">
     <value>The job was suspended successfully by adding the Force parameter.</value>
@@ -1333,7 +1333,7 @@ All WinRM sessions connected to PowerShell Core session configurations, such as 
     <value>The workflow job "{0}" was stopped. Receive-Job is only displaying partial results.</value>
   </data>
   <data name="EndpointDoesNotSupportDisconnect" xml:space="preserve">
-    <value>Disconnected sessions are supported only when the remote computer is running PowerShell Core 3.0 or a later version of PowerShell Core.</value>
+    <value>Disconnected sessions are supported only when the remote computer is running PowerShell 3.0 or a later version of PowerShell.</value>
   </data>
   <data name="ThrottlingJobFlowControlMemoryWarning" xml:space="preserve">
     <value>Memory usage of a cmdlet has exceeded a warning level. To avoid this situation, try one of the following: 1) Lower the rate at which CIM operations produce data (for example, by passing a low value to the ThrottleLimit parameter), 2) Increase the rate at which data is consumed by downstream cmdlets, or 3) Use the Invoke-Command cmdlet to run the whole pipeline on the server. The cmdlet that exceeded a warning level of memory usage was started by the following command line: {0}</value>
@@ -1342,7 +1342,7 @@ All WinRM sessions connected to PowerShell Core session configurations, such as 
     <value>PSSession {0} was created using the EnableNetworkAccess parameter and can only be reconnected from the local computer.</value>
   </data>
   <data name="RemoteHostDoesNotSupportPushRunspace" xml:space="preserve">
-    <value>You are currently in a PowerShell Core PSSession and cannot use the Enter-PSSession cmdlet to enter another PSSession.</value>
+    <value>You are currently in a PowerShell PSSession and cannot use the Enter-PSSession cmdlet to enter another PSSession.</value>
   </data>
   <data name="CannotStartJobInconsistentLanguageMode" xml:space="preserve">
     <value>Cannot start job. The language mode for this session is incompatible with the system-wide language mode.</value>
@@ -1354,7 +1354,7 @@ All WinRM sessions connected to PowerShell Core session configurations, such as 
     <value>Cannot exit a nested pipeline because the pipeline is not in the nested state.</value>
   </data>
   <data name="PowerShellInvokerInvalidState" xml:space="preserve">
-    <value>The PowerShell Core server session is not in a valid state for running nested commands.  No nested commands can be run in this session.</value>
+    <value>The PowerShell server session is not in a valid state for running nested commands.  No nested commands can be run in this session.</value>
   </data>
   <data name="CannotInvokeNestedCommandNestedCommandRunning" xml:space="preserve">
     <value>Cannot invoke a nested command on the remote session because a nested command is already running.</value>
@@ -1366,7 +1366,7 @@ All WinRM sessions connected to PowerShell Core session configurations, such as 
     <value>The remote session command is currently stopped in the debugger.  Use the Enter-PSSession cmdlet to connect interactively to the remote session and automatically enter into the console debugger.</value>
   </data>
   <data name="RemoteDebuggingEndpointVersionError" xml:space="preserve">
-    <value>The remote session to which you are connected does not support remote debugging. You must connect to a remote computer that is running PowerShell Core {0} or greater.</value>
+    <value>The remote session to which you are connected does not support remote debugging. You must connect to a remote computer that is running PowerShell {0} or greater.</value>
   </data>
   <data name="ICMInvalidSessionState" xml:space="preserve">
     <value>Because the session state for session {0}, {1}, {2} is not equal to Open, you cannot run a command in the session.  The session state is {3}.</value>
@@ -1408,13 +1408,13 @@ All WinRM sessions connected to PowerShell Core session configurations, such as 
     <value>The Named Pipe server listener used for process attach is already running.</value>
   </data>
   <data name="EnterPSHostProcessCantEnterSameProcess" xml:space="preserve">
-    <value>Enter-PSHostProcess does not support entering the same PowerShell Core session it is running in.</value>
+    <value>Enter-PSHostProcess does not support entering the same PowerShell session it is running in.</value>
   </data>
   <data name="EnterPSHostProcessMultipleProcessesFoundWithName" xml:space="preserve">
     <value>Multiple processes were found with this name {0}. Use the process Id to specify a single process to enter.</value>
   </data>
   <data name="EnterPSHostProcessNoPowerShell" xml:space="preserve">
-    <value>Cannot enter process {0} because it has not loaded the PowerShell Core engine.</value>
+    <value>Cannot enter process {0} because it has not loaded the PowerShell engine.</value>
   </data>
   <data name="EnterPSHostProcessNoProcessFoundWithId" xml:space="preserve">
     <value>No process was found with Id: {0}.</value>
@@ -1646,13 +1646,13 @@ All WinRM sessions connected to PowerShell Core session configurations, such as 
     <value>The SSH transport process has abruptly terminated causing this remote session to break.</value>
   </data>
   <data name="InvalidProcessorArchitecture" xml:space="preserve">
-    <value>PowerShell Core does not support WOW64. The binary must match the architecture of the processor.</value>
+    <value>PowerShell does not support WOW64. The binary must match the architecture of the processor.</value>
   </data>
   <data name="UnableToInstallPlugin" xml:space="preserve">
       <value>Unable to install plugin {0} to directory {1}.</value>
   </data>
   <data name="PluginDllMissing" xml:space="preserve">
-      <value>The WinRM plugin DLL {0} is missing for PowerShell Core. Please run Enable-PSRemoting and then retry this command.</value>
+      <value>The WinRM plugin DLL {0} is missing for PowerShell. Please run Enable-PSRemoting and then retry this command.</value>
   </data>
   <data name="WSManClientDllNotAvailable" xml:space="preserve">
     <value>This parameter set requires WSMan, and no supported WSMan client library was found. WSMan is either not installed or unavailable for this system.</value>

--- a/src/System.Management.Automation/resources/RemotingErrorIdStrings.resx
+++ b/src/System.Management.Automation/resources/RemotingErrorIdStrings.resx
@@ -172,7 +172,7 @@
     <value>Only administrators can override the Thread Options remotely.</value>
   </data>
   <data name="RemoteHostPromptForCredentialModifiedCaption" xml:space="preserve">
-    <value>Windows PowerShell Credential Request: {0}</value>
+    <value>PowerShell Core Credential Request: {0}</value>
   </data>
   <data name="RemoteHostPromptForCredentialModifiedMessage" xml:space="preserve">
     <value>Warning: A script or application on the remote computer {0} is requesting your credentials. Enter your credentials only if you trust the remote computer and the application or script that is requesting them.
@@ -183,7 +183,7 @@
     <value>A script or application on the remote computer {0} is asking to read a line securely. Enter sensitive information, such as your credentials, only if you trust the remote computer and the application or script that is requesting it.</value>
   </data>
   <data name="RemoteHostGetBufferContents" xml:space="preserve">
-    <value>A script or application on the remote computer {0} is attempting to read the buffer contents on the Windows PowerShell host. For security reasons, this is not allowed; the call has been suppressed.</value>
+    <value>A script or application on the remote computer {0} is attempting to read the buffer contents on the PowerShell Core host. For security reasons, this is not allowed; the call has been suppressed.</value>
   </data>
   <data name="RemoteHostPromptSecureStringPrompt" xml:space="preserve">
     <value>A script or application on the remote computer {0} is sending a prompt request. When you are prompted, enter sensitive information, such as credentials or passwords, only if you trust the remote computer and the application or script that is requesting the data.</value>
@@ -270,7 +270,7 @@
     <value>Error in decoding Maximum runspaces.</value>
   </data>
   <data name="DecodingErrorForPowerShellStateInfo" xml:space="preserve">
-    <value>Error in decoding Windows PowerShellStateInfo.</value>
+    <value>Error in decoding PowerShell CoreStateInfo.</value>
   </data>
   <data name="CantCastPropertyToExpectedType" xml:space="preserve">
     <value>Unexpected type of {0} property (expected {1}, got {2}).</value>
@@ -294,31 +294,31 @@
     <value>The client negotiation timer has expired. The negotiation time-out interval is {0} milliseconds.</value>
   </data>
   <data name="ClientNegotiationFailed" xml:space="preserve">
-    <value>Windows PowerShell client does not support the {0} {1} negotiated by the server. Make sure the server is compatible with the build {2} and the protocol version {3} of Windows PowerShell.</value>
+    <value>PowerShell Core client does not support the {0} {1} negotiated by the server. Make sure the server is compatible with the build {2} and the protocol version {3} of PowerShell Core.</value>
   </data>
   <data name="ClientNotFoundCapabilityProperties" xml:space="preserve">
-    <value>{0}. Negotiation with the server failed. Make sure the server is compatible with the build {1} and the protocol version {2} of Windows PowerShell.</value>
+    <value>{0}. Negotiation with the server failed. Make sure the server is compatible with the build {1} and the protocol version {2} of PowerShell Core.</value>
   </data>
   <data name="ServerRequestedToCloseSession" xml:space="preserve">
     <value>The destination server has sent a request to close the session.</value>
   </data>
   <data name="ServerNegotiationFailed" xml:space="preserve">
-    <value>The server that is running Windows PowerShell does not support the {0} {1} negotiated by the client computer. Verify that the client computer is compatible with the build {2} and the protocol version {3} of Windows PowerShell.</value>
+    <value>The server that is running PowerShell Core does not support the {0} {1} negotiated by the client computer. Verify that the client computer is compatible with the build {2} and the protocol version {3} of PowerShell Core.</value>
   </data>
   <data name="ServerConnectFailedOnNegotiation" xml:space="preserve">
-    <value>The server that is running Windows PowerShell does not support connect operations on the {0} {1}  that is negotiated by the client computer. Make sure the client computer is compatible with the build {2} and the protocol version {3} of Windows PowerShell.</value>
+    <value>The server that is running PowerShell Core does not support connect operations on the {0} {1}  that is negotiated by the client computer. Make sure the client computer is compatible with the build {2} and the protocol version {3} of PowerShell Core.</value>
   </data>
   <data name="ServerConnectFailedOnInputValidation" xml:space="preserve">
-    <value>The server that is running Windows PowerShell cannot process the connect operation because the following information is not found or not valid: Client Capability information and Connect RunspacePool information.</value>
+    <value>The server that is running PowerShell Core cannot process the connect operation because the following information is not found or not valid: Client Capability information and Connect RunspacePool information.</value>
   </data>
   <data name="ServerConnectFailedOnServerStateValidation" xml:space="preserve">
-    <value>The server that is running Windows PowerShell cannot process the connect operation because the server has either not been started, or it is shutting down.</value>
+    <value>The server that is running PowerShell Core cannot process the connect operation because the server has either not been started, or it is shutting down.</value>
   </data>
   <data name="ServerConnectFailedOnMismatchedRunspacePoolProperties" xml:space="preserve">
-    <value>The server that is running Windows PowerShell cannot process the connect operation because the server runspace pool properties did not match the client computer specified properties.</value>
+    <value>The server that is running PowerShell Core cannot process the connect operation because the server runspace pool properties did not match the client computer specified properties.</value>
   </data>
   <data name="ServerNotFoundCapabilityProperties" xml:space="preserve">
-    <value>{0}. Negotiation with the client failed. Make sure the client is compatible with the build {1} and the protocol version {2} of Windows PowerShell.</value>
+    <value>{0}. Negotiation with the client failed. Make sure the client is compatible with the build {1} and the protocol version {2} of PowerShell Core.</value>
   </data>
   <data name="ServerNegotiationTimeout" xml:space="preserve">
     <value>The server negotiation timer has expired. The negotiation time-out interval is {0} milliseconds.</value>
@@ -327,7 +327,7 @@
     <value>The client computer has sent a request to close the session.</value>
   </data>
   <data name="FatalErrorCausingClose" xml:space="preserve">
-    <value>An error has occurred which Windows PowerShell cannot handle. A remote session might have ended.</value>
+    <value>An error has occurred which PowerShell Core cannot handle. A remote session might have ended.</value>
   </data>
   <data name="ClientKeyExchangeFailed" xml:space="preserve">
     <value>The server did not respond with an encrypted session key within the specified time-out period.</value>
@@ -342,7 +342,7 @@
     <value>Attempting to close the session.</value>
   </data>
   <data name="ForceClosed" xml:space="preserve">
-    <value>Windows PowerShell cannot close the remote session properly. The session is in an undefined state because it was not opened or connected after being disconnected. Windows PowerShell will try to force the session to close on the local computer, but the session might not be closed on the remote computer. To close a remote session properly, first open it or connect it.</value>
+    <value>PowerShell Core cannot close the remote session properly. The session is in an undefined state because it was not opened or connected after being disconnected. PowerShell Core will try to force the session to close on the local computer, but the session might not be closed on the remote computer. To close a remote session properly, first open it or connect it.</value>
   </data>
   <data name="CloseFailed" xml:space="preserve">
     <value>Could not close the session.</value>
@@ -459,10 +459,10 @@
     <value>Inter-process communication (IPC) transport does not support connect operations.</value>
   </data>
   <data name="NonExistentInitialSessionStateProvider" xml:space="preserve">
-    <value>An EndpointConfiguration with Id {0} does not exist on the remote server. Contact your Windows PowerShell administrator, or the owner or creator of the endpoint configuration.</value>
+    <value>An EndpointConfiguration with Id {0} does not exist on the remote server. Contact your PowerShell Core administrator, or the owner or creator of the endpoint configuration.</value>
   </data>
   <data name="InitialSessionStateNull" xml:space="preserve">
-    <value>The EndpointConfiguration with the {0} identifier is not in a valid initial session state on the remote computer. Contact your Windows PowerShell administrator, or the owner or creator of the endpoint configuration.</value>
+    <value>The EndpointConfiguration with the {0} identifier is not in a valid initial session state on the remote computer. Contact your PowerShell Core administrator, or the owner or creator of the endpoint configuration.</value>
   </data>
   <data name="MandatoryValueNotPresent" xml:space="preserve">
     <value>The mandatory value {0} is not specified for the {1} registry key.</value>
@@ -471,7 +471,7 @@
     <value>The mandatory value {0} is not in the correct format for registry key {1}. The expected format is 'string'.</value>
   </data>
   <data name="StartupScriptNotCorrect" xml:space="preserve">
-    <value>"{0}" must specify a Windows PowerShell script file that ends with extension ".ps1".</value>
+    <value>"{0}" must specify a PowerShell Core script file that ends with extension ".ps1".</value>
   </data>
   <data name="DuplicateInitializationParameterFound" xml:space="preserve">
     <value>The {0} parameter is already specified in the {1} section. Contact your administrator to make sure that {0} is specified only once.</value>
@@ -552,7 +552,7 @@
     <value>The path specified as the value of the FilePath parameter is not from the FileSystem provider.</value>
   </data>
   <data name="FilePathShouldPS1Extension" xml:space="preserve">
-    <value>The value of the FilePath parameter must be a Windows PowerShell script file. Enter the path to a file with a .ps1 file name extension and try the command again.</value>
+    <value>The value of the FilePath parameter must be a PowerShell Core script file. Enter the path to a file with a .ps1 file name extension and try the command again.</value>
   </data>
   <data name="InvalidComputerName" xml:space="preserve">
     <value>One or more computer names are not valid. If you are trying to pass a URI, use the -ConnectionUri parameter, or pass URI objects instead of strings.</value>
@@ -582,7 +582,7 @@
     <value>Remote Command: {0}, associated with a job that has an ID of "{1}".</value>
   </data>
   <data name="ComputerNameParamNotSupported" xml:space="preserve">
-    <value>The command cannot retrieve the jobs of the specified computers. The ComputerName parameter can be used only with jobs created by using Windows PowerShell remoting.</value>
+    <value>The command cannot retrieve the jobs of the specified computers. The ComputerName parameter can be used only with jobs created by using PowerShell Core remoting.</value>
   </data>
   <data name="RunspaceParamNotSupported" xml:space="preserve">
     <value>The Session parameter can be used only with PSRemotingJob objects.</value>
@@ -654,13 +654,13 @@
     <value>Session configuration "{0}" was not found.</value>
   </data>
   <data name="CSCmdsShellNotPowerShellBased" xml:space="preserve">
-    <value>Session configuration "{0}" is not a Windows PowerShell-based shell.</value>
+    <value>Session configuration "{0}" is not a PowerShell Core-based shell.</value>
 </data>
   <data name="CSCmdsPowerShellCoreShellNotModifiable" xml:space="preserve">
     <value>Session configuration "{0}" is a PowerShell Core-based shell. Please use PowerShell Core to modify it.</value>
   </data>
   <data name="CSCmdsWindowsPowerShellCoreNotModifiable" xml:space="preserve">
-    <value>Session configuration "{0}" is a Windows PowerShell-based shell. Please use Windows PowerShell to modify it.</value>
+    <value>Session configuration "{0}" is a PowerShell Core-based shell. Please use PowerShell Core to modify it.</value>
   </data>
   <data name="CustomShellNotFound" xml:space="preserve">
     <value>No session configuration matches criteria "{0}".</value>
@@ -672,13 +672,13 @@
     <value>Name: {0}</value>
   </data>
   <data name="CSShouldProcessTargetAdminEnable" xml:space="preserve">
-    <value>Name: {0}. This lets administrators remotely run Windows PowerShell commands on this computer.</value>
+    <value>Name: {0}. This lets administrators remotely run PowerShell Core commands on this computer.</value>
   </data>
   <data name="NcsCannotDeleteFile" xml:space="preserve">
     <value>Cannot delete temporary file {0}. Reason for failure: {1}.</value>
   </data>
   <data name="NcsCannotDeleteFileAfterInstall" xml:space="preserve">
-    <value>The new shell was successfully registered, but Windows PowerShell cannot delete the temporary file {0}. Reason for failure: {1}.</value>
+    <value>The new shell was successfully registered, but PowerShell Core cannot delete the temporary file {0}. Reason for failure: {1}.</value>
   </data>
   <data name="NcsCannotWritePluginContent" xml:space="preserve">
     <value>Cannot write the shell configuration data into the temporary file {0}. Reason for failure: {1}.</value>
@@ -687,13 +687,13 @@
     <value>Running command "{0}" to create a new session configuration.</value>
   </data>
   <data name="NcsShouldProcessTargetSDDL" xml:space="preserve">
-    <value>Name: {0} SDDL: {1}. This lets selected users remotely run Windows PowerShell commands on this computer.</value>
+    <value>Name: {0} SDDL: {1}. This lets selected users remotely run PowerShell Core commands on this computer.</value>
   </data>
   <data name="RcsScriptMessageV" xml:space="preserve">
     <value>Running command "{0}" to remove a session configuration.</value>
   </data>
   <data name="GcsScriptMessageV" xml:space="preserve">
-    <value>Running command "{0}" to get Windows PowerShell-based session configurations.</value>
+    <value>Running command "{0}" to get PowerShell Core-based session configurations.</value>
   </data>
   <data name="ScsScriptMessageV" xml:space="preserve">
     <value>Running command "{0}" to update the session configuration properties.</value>
@@ -721,7 +721,7 @@ Do you want to continue?</value>
     <value>Performing operation "{0}".</value>
   </data>
   <data name="EcsShouldProcessTarget" xml:space="preserve">
-    <value>Name: {0} SDDL: {1}. This lets selected users remotely run Windows PowerShell commands on this computer.</value>
+    <value>Name: {0} SDDL: {1}. This lets selected users remotely run PowerShell Core commands on this computer.</value>
   </data>
   <data name="DcsScriptMessageV" xml:space="preserve">
     <value>Running command "{0}" to disable the session configuration.</value>
@@ -737,7 +737,7 @@ Do you want to continue?</value>
     4. Restore the value of the LocalAccountTokenFilterPolicy to 0, which restricts remote access to members of the Administrators group on the computer.</value>
   </data>
   <data name="EDcsRequiresElevation" xml:space="preserve">
-    <value>Access is denied. To run this cmdlet, start Windows PowerShell with the "Run as administrator" option.</value>
+    <value>Access is denied. To run this cmdlet, start PowerShell Core with the "Run as administrator" option.</value>
   </data>
   <data name="RestartWSManServiceMessageV" xml:space="preserve">
     <value>Restarting WinRM service</value>
@@ -846,7 +846,7 @@ Do you want to continue?</value>
     <value>The WriteEvents parameter cannot be used without the Wait parameter.</value>
   </data>
   <data name="PowerShellNotInstalled" xml:space="preserve">
-    <value>Windows PowerShell {0} is not installed. Install Windows PowerShell {0}, and then try again.</value>
+    <value>PowerShell Core {0} is not installed. Install PowerShell Core {0}, and then try again.</value>
   </data>
   <data name="JobManagerRegistrationConstructorError" xml:space="preserve">
     <value>The following type cannot be instantiated because its constructor is not public: {0}.</value>
@@ -933,14 +933,14 @@ Do you want to continue?</value>
     <value>The command cannot find a PSSession that has the name "{0}".</value>
   </data>
   <data name="WinPERemotingNotSupported" xml:space="preserve">
-    <value>Windows PowerShell remoting is not supported in the Windows Preinstallation Environment (WinPE).</value>
+    <value>PowerShell Core remoting is not supported in the Windows Preinstallation Environment (WinPE).</value>
   </data>
   <data name="WinRMRequiresRestart" xml:space="preserve">
     <value>Changes made by {0} cannot take effect until the WinRM service is restarted.</value>
   </data>
   <data name="WinRMRestartWarning" xml:space="preserve">
     <value>{0} may need to restart the WinRM service if a configuration using this name has recently been unregistered, certain system data structures may still be cached. In that case, a restart of WinRM may be required.
-All WinRM sessions connected to Windows PowerShell session configurations, such as Microsoft.PowerShell and session configurations that are created with the Register-PSSessionConfiguration cmdlet, are disconnected.</value>
+All WinRM sessions connected to PowerShell Core session configurations, such as Microsoft.PowerShell and session configurations that are created with the Register-PSSessionConfiguration cmdlet, are disconnected.</value>
   </data>
   <data name="WinRMForceRestartWarning" xml:space="preserve">
     <value>You are running in a remote session and have selected the Force option which means the WinRM service may restart.If the WinRM service restarts then this remote session will be terminated and you will need to create a new session to continue</value>
@@ -952,7 +952,7 @@ All WinRM sessions connected to Windows PowerShell session configurations, such 
     <value>A running command could not be found for this PSSession.</value>
   </data>
   <data name="NetFrameWorkV2NotInstalled" xml:space="preserve">
-    <value>The Microsoft .NET Framework 2.0, which is required for Windows PowerShell 2.0, is not installed. Install the .NET Framework 2.0 and retry.</value>
+    <value>The Microsoft .NET Framework 2.0, which is required for PowerShell Core 2.0, is not installed. Install the .NET Framework 2.0 and retry.</value>
   </data>
   <data name="PipelineFailedWithoutReason" xml:space="preserve">
     <value>The remote pipeline failed.</value>
@@ -1030,7 +1030,7 @@ All WinRM sessions connected to Windows PowerShell session configurations, such 
     <value>Modules to import when applied to a session</value>
   </data>
   <data name="DISCPowerShellVersionComment" xml:space="preserve">
-    <value>Version of the Windows PowerShell engine to use when applied to a session</value>
+    <value>Version of the PowerShell Core engine to use when applied to a session</value>
   </data>
   <data name="DISCProcessorArchitectureComment" xml:space="preserve">
     <value>Processor architecture to use when applied to a session</value>
@@ -1196,7 +1196,7 @@ All WinRM sessions connected to Windows PowerShell session configurations, such 
     <value>The PSSession is in a disconnected state and is not available for connection.</value>
   </data>
   <data name="HyperVModuleNotAvailable" xml:space="preserve">
-    <value>The Hyper-V Module for Windows PowerShell is not available on this machine.</value>
+    <value>The Hyper-V Module for PowerShell Core is not available on this machine.</value>
   </data>
   <data name="CannotCreateProcessInContainer" xml:space="preserve">
     <value>Failed to launch PowerShell process inside container with id {0}.</value>
@@ -1318,7 +1318,7 @@ All WinRM sessions connected to Windows PowerShell session configurations, such 
     <value>One or more jobs are in a suspended or disconnected state, and cannot continue without additional user input.  Specify the -Force parameter to continue to a completed, failed, or stopped state.</value>
   </data>
   <data name="RunAsSessionConfigurationSecurityWarning" xml:space="preserve">
-    <value>When RunAs is enabled in a Windows PowerShell session configuration, the Windows security model cannot enforce a security boundary between different user sessions that are created by using this endpoint. Verify that the Windows PowerShell runspace configuration is restricted to only the necessary set of cmdlets and capabilities.</value>
+    <value>When RunAs is enabled in a PowerShell Core session configuration, the Windows security model cannot enforce a security boundary between different user sessions that are created by using this endpoint. Verify that the PowerShell Core runspace configuration is restricted to only the necessary set of cmdlets and capabilities.</value>
   </data>
   <data name="ForceSuspendJob" xml:space="preserve">
     <value>The job was suspended successfully by adding the Force parameter.</value>
@@ -1333,7 +1333,7 @@ All WinRM sessions connected to Windows PowerShell session configurations, such 
     <value>The workflow job "{0}" was stopped. Receive-Job is only displaying partial results.</value>
   </data>
   <data name="EndpointDoesNotSupportDisconnect" xml:space="preserve">
-    <value>Disconnected sessions are supported only when the remote computer is running Windows PowerShell 3.0 or a later version of Windows PowerShell.</value>
+    <value>Disconnected sessions are supported only when the remote computer is running PowerShell Core 3.0 or a later version of PowerShell Core.</value>
   </data>
   <data name="ThrottlingJobFlowControlMemoryWarning" xml:space="preserve">
     <value>Memory usage of a cmdlet has exceeded a warning level. To avoid this situation, try one of the following: 1) Lower the rate at which CIM operations produce data (for example, by passing a low value to the ThrottleLimit parameter), 2) Increase the rate at which data is consumed by downstream cmdlets, or 3) Use the Invoke-Command cmdlet to run the whole pipeline on the server. The cmdlet that exceeded a warning level of memory usage was started by the following command line: {0}</value>
@@ -1342,7 +1342,7 @@ All WinRM sessions connected to Windows PowerShell session configurations, such 
     <value>PSSession {0} was created using the EnableNetworkAccess parameter and can only be reconnected from the local computer.</value>
   </data>
   <data name="RemoteHostDoesNotSupportPushRunspace" xml:space="preserve">
-    <value>You are currently in a Windows PowerShell PSSession and cannot use the Enter-PSSession cmdlet to enter another PSSession.</value>
+    <value>You are currently in a PowerShell Core PSSession and cannot use the Enter-PSSession cmdlet to enter another PSSession.</value>
   </data>
   <data name="CannotStartJobInconsistentLanguageMode" xml:space="preserve">
     <value>Cannot start job. The language mode for this session is incompatible with the system-wide language mode.</value>
@@ -1354,7 +1354,7 @@ All WinRM sessions connected to Windows PowerShell session configurations, such 
     <value>Cannot exit a nested pipeline because the pipeline is not in the nested state.</value>
   </data>
   <data name="PowerShellInvokerInvalidState" xml:space="preserve">
-    <value>The Windows PowerShell server session is not in a valid state for running nested commands.  No nested commands can be run in this session.</value>
+    <value>The PowerShell Core server session is not in a valid state for running nested commands.  No nested commands can be run in this session.</value>
   </data>
   <data name="CannotInvokeNestedCommandNestedCommandRunning" xml:space="preserve">
     <value>Cannot invoke a nested command on the remote session because a nested command is already running.</value>
@@ -1366,7 +1366,7 @@ All WinRM sessions connected to Windows PowerShell session configurations, such 
     <value>The remote session command is currently stopped in the debugger.  Use the Enter-PSSession cmdlet to connect interactively to the remote session and automatically enter into the console debugger.</value>
   </data>
   <data name="RemoteDebuggingEndpointVersionError" xml:space="preserve">
-    <value>The remote session to which you are connected does not support remote debugging. You must connect to a remote computer that is running Windows PowerShell {0} or greater.</value>
+    <value>The remote session to which you are connected does not support remote debugging. You must connect to a remote computer that is running PowerShell Core {0} or greater.</value>
   </data>
   <data name="ICMInvalidSessionState" xml:space="preserve">
     <value>Because the session state for session {0}, {1}, {2} is not equal to Open, you cannot run a command in the session.  The session state is {3}.</value>
@@ -1408,13 +1408,13 @@ All WinRM sessions connected to Windows PowerShell session configurations, such 
     <value>The Named Pipe server listener used for process attach is already running.</value>
   </data>
   <data name="EnterPSHostProcessCantEnterSameProcess" xml:space="preserve">
-    <value>Enter-PSHostProcess does not support entering the same Windows PowerShell session it is running in.</value>
+    <value>Enter-PSHostProcess does not support entering the same PowerShell Core session it is running in.</value>
   </data>
   <data name="EnterPSHostProcessMultipleProcessesFoundWithName" xml:space="preserve">
     <value>Multiple processes were found with this name {0}. Use the process Id to specify a single process to enter.</value>
   </data>
   <data name="EnterPSHostProcessNoPowerShell" xml:space="preserve">
-    <value>Cannot enter process {0} because it has not loaded the Windows PowerShell engine.</value>
+    <value>Cannot enter process {0} because it has not loaded the PowerShell Core engine.</value>
   </data>
   <data name="EnterPSHostProcessNoProcessFoundWithId" xml:space="preserve">
     <value>No process was found with Id: {0}.</value>

--- a/src/System.Management.Automation/resources/RunspaceInit.resx
+++ b/src/System.Management.Automation/resources/RunspaceInit.resx
@@ -130,7 +130,7 @@
     <value>The run objects available to cmdlets</value>
   </data>
   <data name="PSVersionTableDescription" xml:space="preserve">
-    <value>Version information for current Windows PowerShell session</value>
+    <value>Version information for current PowerShell Core session</value>
   </data>
   <data name="PIDDescription" xml:space="preserve">
     <value>Current process ID</value>
@@ -199,10 +199,10 @@
     <value>Displays errors with a description of the error class</value>
   </data>
   <data name="DollarPSCultureDescription" xml:space="preserve">
-    <value>Culture of the current Windows PowerShell session</value>
+    <value>Culture of the current PowerShell Core session</value>
   </data>
   <data name="DollarPSUICultureDescription" xml:space="preserve">
-    <value>UI culture of the current Windows PowerShell session</value>
+    <value>UI culture of the current PowerShell Core session</value>
   </data>
   <data name="PSDefaultParameterValuesDescription" xml:space="preserve">
     <value>Variable to hold all default &lt;cmdlet:parameter, value&gt; pairs</value>

--- a/src/System.Management.Automation/resources/RunspaceInit.resx
+++ b/src/System.Management.Automation/resources/RunspaceInit.resx
@@ -130,7 +130,7 @@
     <value>The run objects available to cmdlets</value>
   </data>
   <data name="PSVersionTableDescription" xml:space="preserve">
-    <value>Version information for current PowerShell Core session</value>
+    <value>Version information for current PowerShell session</value>
   </data>
   <data name="PIDDescription" xml:space="preserve">
     <value>Current process ID</value>
@@ -199,10 +199,10 @@
     <value>Displays errors with a description of the error class</value>
   </data>
   <data name="DollarPSCultureDescription" xml:space="preserve">
-    <value>Culture of the current PowerShell Core session</value>
+    <value>Culture of the current PowerShell session</value>
   </data>
   <data name="DollarPSUICultureDescription" xml:space="preserve">
-    <value>UI culture of the current PowerShell Core session</value>
+    <value>UI culture of the current PowerShell session</value>
   </data>
   <data name="PSDefaultParameterValuesDescription" xml:space="preserve">
     <value>Variable to hold all default &lt;cmdlet:parameter, value&gt; pairs</value>

--- a/src/System.Management.Automation/resources/RunspacePoolStrings.resx
+++ b/src/System.Management.Automation/resources/RunspacePoolStrings.resx
@@ -160,7 +160,7 @@
     <value>The Disconnect operation is not supported on the server.  The server must be running Windows PowerShell 3.0 or greater for remote runspace pool disconnection support.</value>
   </data>
   <data name="CannotReconstructCommands" xml:space="preserve">
-    <value>This runspace pool {0} is not configured to provide disconnected PowerShell Core objects for commands running on the remote server.  Use the RunspacePool class GetRunspacePools() static method to query the server and return runspace pool objects that are configured to do this.</value>
+    <value>This runspace pool {0} is not configured to provide disconnected PowerShell objects for commands running on the remote server.  Use the RunspacePool class GetRunspacePools() static method to query the server and return runspace pool objects that are configured to do this.</value>
   </data>
   <data name="CannotConnect" xml:space="preserve">
     <value>This runspace pool cannot be connected because the corresponding server side runspace pool is connected to another client.</value>

--- a/src/System.Management.Automation/resources/RunspacePoolStrings.resx
+++ b/src/System.Management.Automation/resources/RunspacePoolStrings.resx
@@ -160,7 +160,7 @@
     <value>The Disconnect operation is not supported on the server.  The server must be running Windows PowerShell 3.0 or greater for remote runspace pool disconnection support.</value>
   </data>
   <data name="CannotReconstructCommands" xml:space="preserve">
-    <value>This runspace pool {0} is not configured to provide disconnected Windows PowerShell objects for commands running on the remote server.  Use the RunspacePool class GetRunspacePools() static method to query the server and return runspace pool objects that are configured to do this.</value>
+    <value>This runspace pool {0} is not configured to provide disconnected PowerShell Core objects for commands running on the remote server.  Use the RunspacePool class GetRunspacePools() static method to query the server and return runspace pool objects that are configured to do this.</value>
   </data>
   <data name="CannotConnect" xml:space="preserve">
     <value>This runspace pool cannot be connected because the corresponding server side runspace pool is connected to another client.</value>

--- a/src/System.Management.Automation/resources/RunspaceStrings.resx
+++ b/src/System.Management.Automation/resources/RunspaceStrings.resx
@@ -237,7 +237,7 @@
 </value>
   </data>
   <data name="RunningCmdDebugStop" xml:space="preserve">
-    <value>You have entered a session that is currently stopped at a debug breakpoint inside a running command or script.  Use the PowerShell Core command line debugger to continue debugging.
+    <value>You have entered a session that is currently stopped at a debug breakpoint inside a running command or script.  Use the PowerShell command line debugger to continue debugging.
 </value>
   </data>
   <data name="RunspaceNotLocal" xml:space="preserve">

--- a/src/System.Management.Automation/resources/RunspaceStrings.resx
+++ b/src/System.Management.Automation/resources/RunspaceStrings.resx
@@ -237,7 +237,7 @@
 </value>
   </data>
   <data name="RunningCmdDebugStop" xml:space="preserve">
-    <value>You have entered a session that is currently stopped at a debug breakpoint inside a running command or script.  Use the Windows PowerShell command line debugger to continue debugging.
+    <value>You have entered a session that is currently stopped at a debug breakpoint inside a running command or script.  Use the PowerShell Core command line debugger to continue debugging.
 </value>
   </data>
   <data name="RunspaceNotLocal" xml:space="preserve">

--- a/src/System.Management.Automation/resources/Serialization.resx
+++ b/src/System.Management.Automation/resources/Serialization.resx
@@ -178,7 +178,7 @@
     <value>The key type {0} is not valid. The PSPrimitiveDictionary class accepts only keys of the type System.String.</value>
   </data>
   <data name="PrimitiveHashtableInvalidValue" xml:space="preserve">
-    <value>The type of the value {0} is not valid. The PSPrimitiveDictionary class accepts only values of types that are fully serializable over PowerShell Core remoting. See the Help topic about_Remoting for a list of fully-serializable types.</value>
+    <value>The type of the value {0} is not valid. The PSPrimitiveDictionary class accepts only values of types that are fully serializable over PowerShell remoting. See the Help topic about_Remoting for a list of fully-serializable types.</value>
   </data>
   <data name="InvalidKey" xml:space="preserve">
     <value>Could not decrypt data. The data was not encrypted with this key.</value>

--- a/src/System.Management.Automation/resources/Serialization.resx
+++ b/src/System.Management.Automation/resources/Serialization.resx
@@ -178,7 +178,7 @@
     <value>The key type {0} is not valid. The PSPrimitiveDictionary class accepts only keys of the type System.String.</value>
   </data>
   <data name="PrimitiveHashtableInvalidValue" xml:space="preserve">
-    <value>The type of the value {0} is not valid. The PSPrimitiveDictionary class accepts only values of types that are fully serializable over Windows PowerShell remoting. See the Help topic about_Remoting for a list of fully-serializable types.</value>
+    <value>The type of the value {0} is not valid. The PSPrimitiveDictionary class accepts only values of types that are fully serializable over PowerShell Core remoting. See the Help topic about_Remoting for a list of fully-serializable types.</value>
   </data>
   <data name="InvalidKey" xml:space="preserve">
     <value>Could not decrypt data. The data was not encrypted with this key.</value>

--- a/src/System.Management.Automation/resources/SessionStateStrings.resx
+++ b/src/System.Management.Automation/resources/SessionStateStrings.resx
@@ -451,7 +451,7 @@
     <value>Cannot find a provider with the name '{0}'.</value>
   </data>
   <data name="ProviderNotFoundBadFormat" xml:space="preserve">
-    <value>Cannot find a provider with the name '{0}'. The name is not in the proper format. A provider name can only be alphanumeric characters, or a PowerShell Core snap-in name that is followed by a single '\', followed by alphanumeric characters.</value>
+    <value>Cannot find a provider with the name '{0}'. The name is not in the proper format. A provider name can only be alphanumeric characters, or a PowerShell snap-in name that is followed by a single '\', followed by alphanumeric characters.</value>
   </data>
   <data name="ProviderNameAmbiguous" xml:space="preserve">
     <value>'{0}' resolved to more than one provider name. Possible matches include:{1}.</value>

--- a/src/System.Management.Automation/resources/SessionStateStrings.resx
+++ b/src/System.Management.Automation/resources/SessionStateStrings.resx
@@ -451,7 +451,7 @@
     <value>Cannot find a provider with the name '{0}'.</value>
   </data>
   <data name="ProviderNotFoundBadFormat" xml:space="preserve">
-    <value>Cannot find a provider with the name '{0}'. The name is not in the proper format. A provider name can only be alphanumeric characters, or a Windows PowerShell snap-in name that is followed by a single '\', followed by alphanumeric characters.</value>
+    <value>Cannot find a provider with the name '{0}'. The name is not in the proper format. A provider name can only be alphanumeric characters, or a PowerShell Core snap-in name that is followed by a single '\', followed by alphanumeric characters.</value>
   </data>
   <data name="ProviderNameAmbiguous" xml:space="preserve">
     <value>'{0}' resolved to more than one provider name. Possible matches include:{1}.</value>

--- a/src/System.Management.Automation/resources/SuggestionStrings.resx
+++ b/src/System.Management.Automation/resources/SuggestionStrings.resx
@@ -124,7 +124,7 @@
     <value>The Use-Transaction cmdlet is intended for scripting of transaction-enabled .NET objects. Its ScriptBlock should contain nothing else.</value>
   </data>
   <data name="Suggestion_CommandExistsInCurrentDirectory" xml:space="preserve">
-    <value>The command {0} was not found, but does exist in the current location. Windows PowerShell does not load commands from the current location by default. If you trust this command, instead type: "{1}". See "get-help about_Command_Precedence" for more details.</value>
+    <value>The command {0} was not found, but does exist in the current location. PowerShell Core does not load commands from the current location by default. If you trust this command, instead type: "{1}". See "get-help about_Command_Precedence" for more details.</value>
   </data>
   <data name="RuleMustBeScriptBlock" xml:space="preserve">
     <value>Rule must be a ScriptBlock for dynamic match types.</value>

--- a/src/System.Management.Automation/resources/SuggestionStrings.resx
+++ b/src/System.Management.Automation/resources/SuggestionStrings.resx
@@ -124,7 +124,7 @@
     <value>The Use-Transaction cmdlet is intended for scripting of transaction-enabled .NET objects. Its ScriptBlock should contain nothing else.</value>
   </data>
   <data name="Suggestion_CommandExistsInCurrentDirectory" xml:space="preserve">
-    <value>The command {0} was not found, but does exist in the current location. PowerShell Core does not load commands from the current location by default. If you trust this command, instead type: "{1}". See "get-help about_Command_Precedence" for more details.</value>
+    <value>The command {0} was not found, but does exist in the current location. PowerShell does not load commands from the current location by default. If you trust this command, instead type: "{1}". See "get-help about_Command_Precedence" for more details.</value>
   </data>
   <data name="RuleMustBeScriptBlock" xml:space="preserve">
     <value>Rule must be a ScriptBlock for dynamic match types.</value>

--- a/src/System.Management.Automation/resources/TypesXmlStrings.resx
+++ b/src/System.Management.Automation/resources/TypesXmlStrings.resx
@@ -160,7 +160,7 @@
     <value>Cannot create an instance of the type converter for type {0} due to exception: {1}.</value>
   </data>
   <data name="UnableToInstantiateTypeAdapter" xml:space="preserve">
-    <value>Windows PowerShell cannot create an instance of the type adapter for the type {0} because of the following exception: {1}.</value>
+    <value>PowerShell Core cannot create an instance of the type adapter for the type {0} because of the following exception: {1}.</value>
   </data>
   <data name="InvalidAdaptedType" xml:space="preserve">
     <value>The adapted type "{0}" is not valid.</value>

--- a/src/System.Management.Automation/resources/TypesXmlStrings.resx
+++ b/src/System.Management.Automation/resources/TypesXmlStrings.resx
@@ -160,7 +160,7 @@
     <value>Cannot create an instance of the type converter for type {0} due to exception: {1}.</value>
   </data>
   <data name="UnableToInstantiateTypeAdapter" xml:space="preserve">
-    <value>PowerShell Core cannot create an instance of the type adapter for the type {0} because of the following exception: {1}.</value>
+    <value>PowerShell cannot create an instance of the type adapter for the type {0} because of the following exception: {1}.</value>
   </data>
   <data name="InvalidAdaptedType" xml:space="preserve">
     <value>The adapted type "{0}" is not valid.</value>

--- a/test/powershell/Modules/Microsoft.Powershell.Host/Start-Transcript.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.Powershell.Host/Start-Transcript.Tests.ps1
@@ -133,7 +133,7 @@ Describe "Start-Transcript, Stop-Transcript tests" -tags "CI" {
 
         Test-Path $transcriptFilePath | Should be $true
         $transcriptFilePath | Should contain "Before Dispose"
-        $transcriptFilePath | Should contain "PowerShell Core transcript end"
+        $transcriptFilePath | Should contain "PowerShell transcript end"
     }
 
 }

--- a/test/powershell/Modules/Microsoft.Powershell.Host/Start-Transcript.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.Powershell.Host/Start-Transcript.Tests.ps1
@@ -133,7 +133,7 @@ Describe "Start-Transcript, Stop-Transcript tests" -tags "CI" {
 
         Test-Path $transcriptFilePath | Should be $true
         $transcriptFilePath | Should contain "Before Dispose"
-        $transcriptFilePath | Should contain "Windows PowerShell transcript end"
+        $transcriptFilePath | Should contain "PowerShell Core transcript end"
     }
 
 }


### PR DESCRIPTION
Address #3345 

## Motivation

After removing FullCLR from the repo we can clean up message strings and replace 'Windows PowerShell' with 'PowerShell' in resx files.

## Fix

Find and replace 'Windows PowerShell' with 'PowerShell' in .resx files. Then revert some replacements (related workflows, "Windows PowerShell 3.0 and higher" and so on).

## Additional considerations

The PR doesn't address *.cs files (which have 'Windows PowerShell' strings in comments).
