### PR TITLE
Correct %c format in Get-Date -UFormat

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetDateCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetDateCommand.cs
@@ -369,9 +369,7 @@ namespace Microsoft.PowerShell.Commands
                             break;
 
                         case 'c':
-                            sb.Append("{0:ddd} {0:MMM} ");
-                            sb.Append(StringUtil.Format("{0,2} ", dateTime.Day));
-                            sb.Append("{0:HH}:{0:mm}:{0:ss} {0:yyyy}");
+                            sb.Append("{0:ddd} {0:MMM} {0:dd} {0:HH}:{0:mm}:{0:ss} {0:yyyy}");
                             break;
 
                         case 'D':

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Date.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Date.Tests.ps1
@@ -30,7 +30,7 @@ Describe "Get-Date DRT Unit Tests" -Tags "CI" {
     }
 
     It "using -uformat 'aAbBcCdDehHIjmMpr' produces the correct output" {
-        Get-date -Date 1/1/0030 -uformat %a%A%b%B%c%C%d%D%e%h%H%I%j%m%M%p%r | Should be "TueTuesdayJanJanuaryTue Jan  1 00:00:00 003000101/01/30 1Jan001210100AM12:00:00 AM"
+        Get-date -Date 1/1/0030 -uformat %a%A%b%B%c%C%d%D%e%h%H%I%j%m%M%p%r | Should be "TueTuesdayJanJanuaryTue Jan 01 00:00:00 003000101/01/30 1Jan001210100AM12:00:00 AM"
     }
 
     It "using -uformat 'StTuUVwWxXyYZ' produces the correct output" {


### PR DESCRIPTION
Related #4750.

Add leading zero: now day of the month is from 01 through 31.

Before fix:
```powershell
>Get-Date -UFormat %c
Thu Sep 7 17:49:48 2017
```
After the fix:
```powershell
>Get-Date -UFormat %c
Thu Sep 07 17:49:48 2017
```


