### PR TITLE
Enable ApartmentState support

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/new-object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/new-object.cs
@@ -366,7 +366,6 @@ namespace Microsoft.PowerShell.Commands
             return result;
         }
 
-#if !CORECLR
         private class ComCreateInfo
         {
             public Object objectCreated;
@@ -405,7 +404,6 @@ namespace Microsoft.PowerShell.Commands
                 info.success = false;
             }
         }
-#endif
 
         private object CreateComObject()
         {
@@ -428,13 +426,6 @@ namespace Microsoft.PowerShell.Commands
                 //Check Error Code to see if Error is because of Com apartment Mismatch.
                 if (e.HResult == RPC_E_CHANGED_MODE)
                 {
-#if CORECLR
-                    ThrowTerminatingError(
-                        new ErrorRecord(
-                            new COMException(StringUtil.Format(NewObjectStrings.ApartmentNotSupported, e.Message), e),
-                            "NoCOMClassIdentified",
-                            ErrorCategory.ResourceUnavailable, null));
-#else
                     createInfo = new ComCreateInfo();
 
                     Thread thread = new Thread(new ParameterizedThreadStart(STAComCreateThreadProc));
@@ -451,7 +442,6 @@ namespace Microsoft.PowerShell.Commands
                     ThrowTerminatingError(
                              new ErrorRecord(createInfo.e, "NoCOMClassIdentified",
                                                     ErrorCategory.ResourceUnavailable, null));
-#endif
                 }
                 else
                 {

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
@@ -432,13 +432,8 @@ namespace Microsoft.PowerShell
                 }
                 else
                 {
-#if CORECLR
-                    // Nano doesn't support STA COM apartment, so on Nano powershell has to use MTA as the default.
-                    return false;
-#else
                     // Win8: 182409 PowerShell 3.0 should run in STA mode by default
                     return true;
-#endif
                 }
             }
         }
@@ -736,7 +731,6 @@ namespace Microsoft.PowerShell
                         break;
                     }
                 }
-#if !CORECLR  // explicit setting of the ApartmentState Not supported on NanoServer
                 else if (MatchSwitch(switchKey, "sta", "s"))
                 {
                     if (_staMode.HasValue)
@@ -763,7 +757,6 @@ namespace Microsoft.PowerShell
 
                     _staMode = false;
                 }
-#endif
                 else
                 {
                     // The first parameter we fail to recognize marks the beginning of the file string.

--- a/src/Microsoft.PowerShell.PSReadLine/ReadLine.cs
+++ b/src/Microsoft.PowerShell.PSReadLine/ReadLine.cs
@@ -713,9 +713,6 @@ namespace Microsoft.PowerShell
 
         private static void ExecuteOnSTAThread(Action action)
         {
-#if CORECLR
-            action();
-#else
             if (Thread.CurrentThread.GetApartmentState() == ApartmentState.STA)
             {
                 action();
@@ -743,7 +740,6 @@ namespace Microsoft.PowerShell
             {
                 throw exception;
             }
-#endif
         }
 
         #region Miscellaneous bindable functions

--- a/src/Microsoft.WSMan.Management/CredSSP.cs
+++ b/src/Microsoft.WSMan.Management/CredSSP.cs
@@ -18,9 +18,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Security;
 using System.Threading;
-#if CORECLR
 using System.Xml.XPath;
-#endif
 
 using Dbg = System.Management.Automation;
 
@@ -335,15 +333,6 @@ namespace Microsoft.WSMan.Management
         /// </summary>
         protected override void BeginProcessing()
         {
-#if !CORECLR
-            if (Environment.OSVersion.Version.Major < 6)
-            {
-                //OS is XP/Win2k3. Throw error.
-                WSManHelper helper = new WSManHelper(this);
-                string message = helper.FormatResourceMsgFromResourcetext("CmdletNotAvailable");
-                throw new InvalidOperationException(message);
-            }
-#endif
             //If not running elevated, then throw an "elevation required" error message.
             WSManHelper.ThrowIfNotAdministrator();
 
@@ -453,14 +442,6 @@ namespace Microsoft.WSMan.Management
             //If not running elevated, then throw an "elevation required" error message.
             WSManHelper.ThrowIfNotAdministrator();
             helper = new WSManHelper(this);
-#if !CORECLR
-            if (Environment.OSVersion.Version.Major < 6)
-            {
-                //OS is XP/Win2k3. Throw error.
-                string message = helper.FormatResourceMsgFromResourcetext("CmdletNotAvailable");
-                throw new InvalidOperationException(message);
-            }
-#endif
 
             // DelegateComputer cannot be specified when Role is other than client
             if ((delegatecomputer != null) && !Role.Equals(Client, StringComparison.OrdinalIgnoreCase))
@@ -725,11 +706,7 @@ namespace Microsoft.WSMan.Management
                 //open the registry key.If key is not present,create a new one
                 Credential_Delegation_Key = rootKey.OpenSubKey(Registry_Path_Credentials_Delegation, true);
                 if (Credential_Delegation_Key == null)
-                    Credential_Delegation_Key = rootKey.CreateSubKey(Registry_Path_Credentials_Delegation
-#if !CORECLR
-                        , RegistryKeyPermissionCheck.ReadWriteSubTree
-#endif
-                        );
+                    Credential_Delegation_Key = rootKey.CreateSubKey(Registry_Path_Credentials_Delegation);
 
                 Credential_Delegation_Key.SetValue(helper.Key_Allow_Fresh_Credentials, 1, RegistryValueKind.DWord);
                 Credential_Delegation_Key.SetValue(helper.Key_Concatenate_Defaults_AllowFresh, 1, RegistryValueKind.DWord);
@@ -737,11 +714,7 @@ namespace Microsoft.WSMan.Management
                 // add the delegate value
                 Allow_Fresh_Credential_Key = rootKey.OpenSubKey(Registry_Path_Credentials_Delegation + @"\" + helper.Key_Allow_Fresh_Credentials, true);
                 if (Allow_Fresh_Credential_Key == null)
-                    Allow_Fresh_Credential_Key = rootKey.CreateSubKey(Registry_Path_Credentials_Delegation + @"\" + helper.Key_Allow_Fresh_Credentials
-#if !CORECLR
-                        , RegistryKeyPermissionCheck.ReadWriteSubTree
-#endif
-                        );
+                    Allow_Fresh_Credential_Key = rootKey.CreateSubKey(Registry_Path_Credentials_Delegation + @"\" + helper.Key_Allow_Fresh_Credentials);
 
                 if (Allow_Fresh_Credential_Key != null)
                 {
@@ -890,14 +863,6 @@ namespace Microsoft.WSMan.Management
             WSManHelper.ThrowIfNotAdministrator();
 
             helper = new WSManHelper(this);
-#if !CORECLR
-            if (Environment.OSVersion.Version.Major < 6)
-            {
-                //OS is XP/Win2k3. Throw error.
-                string message = helper.FormatResourceMsgFromResourcetext("CmdletNotAvailable");
-                throw new InvalidOperationException(message);
-            }
-#endif
 
             IWSManSession m_SessionObj = null;
             try

--- a/src/Microsoft.WSMan.Management/Interop.cs
+++ b/src/Microsoft.WSMan.Management/Interop.cs
@@ -181,15 +181,10 @@ namespace Microsoft.WSMan.Management
     [Guid("190D8637-5CD3-496D-AD24-69636BB5A3B5")]
     [ComImport]
     [TypeLibType((short)4304)]
-#if CORECLR
     [InterfaceTypeAttribute(ComInterfaceType.InterfaceIsIUnknown)]
-#else
-    [InterfaceTypeAttribute(ComInterfaceType.InterfaceIsIDispatch)]
-#endif
 
     public interface IWSMan
     {
-#if CORECLR
         [return: MarshalAs(UnmanagedType.IUnknown)]
         object GetTypeInfoCount();
 
@@ -201,30 +196,20 @@ namespace Microsoft.WSMan.Management
 
         [return: MarshalAs(UnmanagedType.IUnknown)]
         object Invoke();
-#endif
 
         /// <summary><para><c>CreateSession</c> method of <c>IWSMan</c> interface.</para></summary>
         /// <remarks><para>An original IDL definition of <c>CreateSession</c> method was the following:  <c>HRESULT CreateSession ([optional, defaultvalue("")] BSTR connection, [optional, defaultvalue(0)] long flags, [optional] IDispatch* connectionOptions, [out, retval] IDispatch** ReturnValue)</c>;</para></remarks>
         // IDL: HRESULT CreateSession ([optional, defaultvalue("")] BSTR connection, [optional, defaultvalue(0)] long flags, [optional] IDispatch* connectionOptions, [out, retval] IDispatch** ReturnValue);
 
         [DispId(1)]
-#if CORECLR
         [return: MarshalAs(UnmanagedType.IUnknown)]
         object CreateSession([MarshalAs(UnmanagedType.BStr)] string connection, int flags, [MarshalAs(UnmanagedType.IUnknown)] object connectionOptions);
-#else
-        [return: MarshalAs(UnmanagedType.IDispatch)]
-        object CreateSession([MarshalAs(UnmanagedType.BStr)] string connection, int flags, [MarshalAs(UnmanagedType.IDispatch)] object connectionOptions);
-#endif
         /// <summary><para><c>CreateConnectionOptions</c> method of <c>IWSMan</c> interface.</para></summary>
         /// <remarks><para>An original IDL definition of <c>CreateConnectionOptions</c> method was the following:  <c>HRESULT CreateConnectionOptions ([out, retval] IDispatch** ReturnValue)</c>;</para></remarks>
         // IDL: HRESULT CreateConnectionOptions ([out, retval] IDispatch** ReturnValue);
         //
         [DispId(2)]
-#if CORECLR
         [return: MarshalAs(UnmanagedType.IUnknown)]
-#else
-        [return: MarshalAs(UnmanagedType.IDispatch)]
-#endif
         object CreateConnectionOptions();
 
         /// <summary><para><c>CommandLine</c> property of <c>IWSMan</c> interface.</para></summary>
@@ -263,15 +248,10 @@ namespace Microsoft.WSMan.Management
     [Guid("F704E861-9E52-464F-B786-DA5EB2320FDD")]
     [ComImport]
     [TypeLibType((short)4288)]
-#if CORECLR
     [InterfaceTypeAttribute(ComInterfaceType.InterfaceIsIUnknown)]
-#else
-    [InterfaceTypeAttribute(ComInterfaceType.InterfaceIsIDispatch)]
-#endif
     [SuppressMessage("Microsoft.Design", "CA1044:PropertiesShouldNotBeWriteOnly")]
     public interface IWSManConnectionOptions
     {
-#if CORECLR
         [return: MarshalAs(UnmanagedType.IUnknown)]
         object GetTypeInfoCount();
 
@@ -283,7 +263,6 @@ namespace Microsoft.WSMan.Management
 
         [return: MarshalAs(UnmanagedType.IUnknown)]
         object Invoke();
-#endif
         /// <summary><para><c>UserName</c> property of <c>IWSManConnectionOptions</c> interface.</para></summary>
         /// <remarks><para>An original IDL definition of <c>UserName</c> property was the following:  <c>BSTR UserName</c>;</para></remarks>
         // IDL: BSTR UserName;
@@ -320,11 +299,7 @@ namespace Microsoft.WSMan.Management
     [Guid("EF43EDF7-2A48-4d93-9526-8BD6AB6D4A6B")]
     [ComImport]
     [TypeLibType((short)4288)]
-#if CORECLR
     [InterfaceTypeAttribute(ComInterfaceType.InterfaceIsIUnknown)]
-#else
-    [InterfaceTypeAttribute(ComInterfaceType.InterfaceIsIDispatch)]
-#endif
     [SuppressMessage("Microsoft.Naming", "CA1711:IdentifiersShouldNotHaveIncorrectSuffix")]
     public interface IWSManConnectionOptionsEx : IWSManConnectionOptions
     {
@@ -345,11 +320,7 @@ namespace Microsoft.WSMan.Management
     [Guid("F500C9EC-24EE-48ab-B38D-FC9A164C658E")]
     [ComImport]
     [TypeLibType((short)4288)]
-#if CORECLR
     [InterfaceTypeAttribute(ComInterfaceType.InterfaceIsIUnknown)]
-#else
-    [InterfaceTypeAttribute(ComInterfaceType.InterfaceIsIDispatch)]
-#endif
     public interface IWSManConnectionOptionsEx2 : IWSManConnectionOptionsEx
     {
         /// <summary><para><c>SetProxy</c> method of <c>IWSManConnectionOptionsEx2</c> interface.</para></summary>
@@ -396,15 +367,10 @@ namespace Microsoft.WSMan.Management
     [Guid("F3457CA9-ABB9-4FA5-B850-90E8CA300E7F")]
     [ComImport]
     [TypeLibType((short)4288)]
-#if CORECLR
     [InterfaceTypeAttribute(ComInterfaceType.InterfaceIsIUnknown)]
-#else
-    [InterfaceTypeAttribute(ComInterfaceType.InterfaceIsIDispatch)]
-#endif
 
     public interface IWSManEnumerator
     {
-#if CORECLR
         [return: MarshalAs(UnmanagedType.IUnknown)]
         object GetTypeInfoCount();
 
@@ -416,7 +382,6 @@ namespace Microsoft.WSMan.Management
 
         [return: MarshalAs(UnmanagedType.IUnknown)]
         object Invoke();
-#endif
 
         /// <summary><para><c>ReadItem</c> method of <c>IWSManEnumerator</c> interface.</para></summary>
         /// <remarks><para>An original IDL definition of <c>ReadItem</c> method was the following:  <c>HRESULT ReadItem ([out, retval] BSTR* ReturnValue)</c>;</para></remarks>
@@ -460,18 +425,13 @@ namespace Microsoft.WSMan.Management
     [ComImport]
     [TypeLibType((short)4304)]
     [SuppressMessage("Microsoft.Naming", "CA1711:IdentifiersShouldNotHaveIncorrectSuffix")]
-#if CORECLR
     [InterfaceTypeAttribute(ComInterfaceType.InterfaceIsIUnknown)]
-#else
-    [InterfaceTypeAttribute(ComInterfaceType.InterfaceIsIDispatch)]
-#endif
     [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "str")]
     [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Cred")]
     [SuppressMessage("Microsoft.Naming", "CA1702:CompoundWordsShouldBeCasedCorrectly", MessageId = "Username")]
     [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Error")]
     public interface IWSManEx
     {
-#if CORECLR
         [return: MarshalAs(UnmanagedType.IUnknown)]
         object GetTypeInfoCount();
 
@@ -483,32 +443,21 @@ namespace Microsoft.WSMan.Management
 
         [return: MarshalAs(UnmanagedType.IUnknown)]
         object Invoke();
-#endif
 
         /// <summary><para><c>CreateSession</c> method of <c>IWSManEx</c> interface.</para></summary>
         /// <remarks><para>An original IDL definition of <c>CreateSession</c> method was the following:  <c>HRESULT CreateSession ([optional, defaultvalue("")] BSTR connection, [optional, defaultvalue(0)] long flags, [optional] IDispatch* connectionOptions, [out, retval] IDispatch** ReturnValue)</c>;</para></remarks>
         // IDL: HRESULT CreateSession ([optional, defaultvalue("")] BSTR connection, [optional, defaultvalue(0)] long flags, [optional] IDispatch* connectionOptions, [out, retval] IDispatch** ReturnValue);
 
         [DispId(1)]
-#if CORECLR
         [return: MarshalAs(UnmanagedType.IUnknown)]
         object CreateSession([MarshalAs(UnmanagedType.BStr)] string connection, int flags, [MarshalAs(UnmanagedType.IUnknown)] object connectionOptions);
-#else
-        [return: MarshalAs(UnmanagedType.IDispatch)]
-        object CreateSession([MarshalAs(UnmanagedType.BStr)] string connection, int flags, [MarshalAs(UnmanagedType.IDispatch)] object connectionOptions);
-#endif
-
 
         /// <summary><para><c>CreateConnectionOptions</c> method of <c>IWSManEx</c> interface.</para></summary>
         /// <remarks><para>An original IDL definition of <c>CreateConnectionOptions</c> method was the following:  <c>HRESULT CreateConnectionOptions ([out, retval] IDispatch** ReturnValue)</c>;</para></remarks>
         // IDL: HRESULT CreateConnectionOptions ([out, retval] IDispatch** ReturnValue);
 
         [DispId(2)]
-#if CORECLR
         [return: MarshalAs(UnmanagedType.IUnknown)]
-#else
-        [return: MarshalAs(UnmanagedType.IDispatch)]
-#endif
         object CreateConnectionOptions();
 
 
@@ -548,11 +497,7 @@ namespace Microsoft.WSMan.Management
 
         [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "str")]
         [DispId(5)]
-#if CORECLR
         [return: MarshalAs(UnmanagedType.IUnknown)]
-#else
-        [return: MarshalAs(UnmanagedType.IDispatch)]
-#endif
         object CreateResourceLocator([MarshalAs(UnmanagedType.BStr)] string strResourceLocator);
 
         /// <summary><para><c>SessionFlagUTF8</c> method of <c>IWSManEx</c> interface.</para></summary>
@@ -723,16 +668,9 @@ namespace Microsoft.WSMan.Management
     [Guid("A7A1BA28-DE41-466A-AD0A-C4059EAD7428")]
     [ComImport]
     [TypeLibType((short)4288)]
-#if CORECLR
     [InterfaceTypeAttribute(ComInterfaceType.InterfaceIsIUnknown)]
-#else
-    [InterfaceTypeAttribute(ComInterfaceType.InterfaceIsIDispatch)]
-#endif
-
-
     public interface IWSManResourceLocator
     {
-#if CORECLR
         [return: MarshalAs(UnmanagedType.IUnknown)]
         object GetTypeInfoCount();
 
@@ -744,7 +682,7 @@ namespace Microsoft.WSMan.Management
 
         [return: MarshalAs(UnmanagedType.IUnknown)]
         object Invoke();
-#endif
+
         /// <summary><para><c>resourceUri</c> property of <c>IWSManResourceLocator</c> interface.  </para><para>Set the resource URI. Must contain path only -- query string is not allowed here.</para></summary>
         /// <remarks><para>An original IDL definition of <c>resourceUri</c> property was the following:  <c>BSTR resourceUri</c>;</para></remarks>
         // Set the resource URI. Must contain path only -- query string is not allowed here.
@@ -892,19 +830,13 @@ namespace Microsoft.WSMan.Management
     [Guid("FC84FC58-1286-40C4-9DA0-C8EF6EC241E0")]
     [ComImport]
     [TypeLibType((short)4288)]
-#if CORECLR
     [InterfaceTypeAttribute(ComInterfaceType.InterfaceIsIUnknown)]
-#else
-    [InterfaceTypeAttribute(ComInterfaceType.InterfaceIsIDispatch)]
-#endif
-
     [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Error")]
     [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get")]
     [SuppressMessage("Microsoft.Design", "CA1054:UriParametersShouldNotBeStrings", MessageId = "0#")]
     [SuppressMessage("Microsoft.Naming", "CA1709:IdentifiersShouldBeCasedCorrectly", MessageId = "URI")]
     public interface IWSManSession
     {
-#if CORECLR
         [return: MarshalAs(UnmanagedType.IUnknown)]
         object GetTypeInfoCount();
 
@@ -916,7 +848,6 @@ namespace Microsoft.WSMan.Management
 
         [return: MarshalAs(UnmanagedType.IUnknown)]
         object Invoke();
-#endif
 
         /// <summary><para><c>Get</c> method of <c>IWSManSession</c> interface.</para></summary>
         /// <remarks><para>An original IDL definition of <c>Get</c> method was the following:  <c>HRESULT Get (VARIANT resourceUri, [optional, defaultvalue(0)] long flags, [out, retval] BSTR* ReturnValue)</c>;</para></remarks>
@@ -971,11 +902,7 @@ namespace Microsoft.WSMan.Management
         // IDL: HRESULT Enumerate (VARIANT resourceUri, [optional, defaultvalue("")] BSTR filter, [optional, defaultvalue("")] BSTR dialect, [optional, defaultvalue(0)] long flags, [out, retval] IDispatch** ReturnValue);
 
         [DispId(6)]
-#if CORECLR
         [return: MarshalAs(UnmanagedType.IUnknown)]
-#else
-        [return: MarshalAs(UnmanagedType.IDispatch)]
-#endif
         object Enumerate(object resourceUri, [MarshalAs(UnmanagedType.BStr)] string filter, [MarshalAs(UnmanagedType.BStr)] string dialect, int flags);
 
         /// <summary><para><c>Identify</c> method of <c>IWSManSession</c> interface.</para></summary>
@@ -1043,15 +970,10 @@ namespace Microsoft.WSMan.Management
     [Guid("EFFAEAD7-7EC8-4716-B9BE-F2E7E9FB4ADB")]
     [ComImport]
     [TypeLibType((short)400)]
-#if CORECLR
     [InterfaceTypeAttribute(ComInterfaceType.InterfaceIsIUnknown)]
-#else
-    [InterfaceTypeAttribute(ComInterfaceType.InterfaceIsIDispatch)]
-#endif
     [SuppressMessage("Microsoft.Design", "CA1040:AvoidEmptyInterfaces")]
     public interface IWSManResourceLocatorInternal
     {
-#if CORECLR
         [return: MarshalAs(UnmanagedType.IUnknown)]
         object GetTypeInfoCount();
 
@@ -1063,7 +985,6 @@ namespace Microsoft.WSMan.Management
 
         [return: MarshalAs(UnmanagedType.IUnknown)]
         object Invoke();
-#endif
     }
 
     #endregion IWSManResourceLocatorInternal
@@ -1072,11 +993,7 @@ namespace Microsoft.WSMan.Management
     /// <summary><para><c>WSMan</c> interface.</para></summary>
     [Guid("BCED617B-EC03-420b-8508-977DC7A686BD")]
     [ComImport]
-#if CORECLR
     [ClassInterface(ClassInterfaceType.None)]
-#else
-    [ClassInterface(ClassInterfaceType.AutoDual)]
-#endif
     public class WSManClass
     {
     }

--- a/src/Microsoft.WSMan.Management/Microsoft.WSMan.Management.csproj
+++ b/src/Microsoft.WSMan.Management/Microsoft.WSMan.Management.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <ProjectReference Include="..\System.Management.Automation\System.Management.Automation.csproj" />
     <ProjectReference Include="..\Microsoft.WSMan.Runtime\Microsoft.WSMan.Runtime.csproj" />
+    <PackageReference Include="System.ServiceProcess.ServiceController" Version="4.4.0" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/Microsoft.WSMan.Management/WsManHelper.cs
+++ b/src/Microsoft.WSMan.Management/WsManHelper.cs
@@ -17,9 +17,7 @@ using Microsoft.Win32;
 using System.Management.Automation;
 using System.Management.Automation.Provider;
 using System.Threading;
-#if CORECLR
 using System.Xml.XPath;
-#endif
 
 namespace Microsoft.WSMan.Management
 {
@@ -1009,17 +1007,11 @@ namespace Microsoft.WSMan.Management
             {
                 RegistryKey rGPOLocalMachineKey = Registry.LocalMachine.OpenSubKey(
                     Registry_Path_Credentials_Delegation + @"\CredentialsDelegation",
-#if !CORECLR
-                    RegistryKeyPermissionCheck.ReadWriteSubTree,
-#endif
-                    System.Security.AccessControl.RegistryRights.FullControl);
+                        System.Security.AccessControl.RegistryRights.FullControl);
 
                 if (rGPOLocalMachineKey != null)
                 {
                     rGPOLocalMachineKey = rGPOLocalMachineKey.OpenSubKey(Key_Allow_Fresh_Credentials,
-#if !CORECLR
-                        RegistryKeyPermissionCheck.ReadWriteSubTree,
-#endif
                         System.Security.AccessControl.RegistryRights.FullControl);
                     if (rGPOLocalMachineKey == null)
                     {
@@ -1078,11 +1070,7 @@ namespace Microsoft.WSMan.Management
             try
             {
                 string filepath = System.Environment.ExpandEnvironmentVariables("%Windir%") + "\\System32\\Winrm\\" +
-#if CORECLR
                     "0409" /* TODO: don't assume it is always English on CSS? */
-#else
-                    String.Concat("0", String.Format(CultureInfo.CurrentCulture, "{0:x2}", checked((uint)CultureInfo.CurrentUICulture.LCID)))
-#endif
                     + "\\" + "winrm.ini";
                 if (File.Exists(filepath))
                 {

--- a/src/System.Management.Automation/CoreCLR/CorePsStub.cs
+++ b/src/System.Management.Automation/CoreCLR/CorePsStub.cs
@@ -133,26 +133,6 @@ namespace System.Management.Automation
     }
 
     #endregion PSTransaction
-
-    #region ApartmentState
-
-    internal enum ApartmentState
-    {
-        //
-        // Summary:
-        //     The System.Threading.Thread will create and enter a single-threaded apartment.
-        STA = 0,
-        //
-        // Summary:
-        //     The System.Threading.Thread will create and enter a multithreaded apartment.
-        MTA = 1,
-        //
-        // Summary:
-        //     The System.Threading.Thread.ApartmentState property has not been set.
-        Unknown = 2
-    }
-
-    #endregion ApartmentState
 }
 
 namespace System.Management.Automation.Internal

--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -2100,9 +2100,7 @@ namespace System.Management.Automation.Runspaces
             ss.UseFullLanguageModeInDebugger = this.UseFullLanguageModeInDebugger;
             ss.ThreadOptions = this.ThreadOptions;
             ss.ThrowOnRunspaceOpenError = this.ThrowOnRunspaceOpenError;
-#if !CORECLR // No ApartmentState In CoreCLR
             ss.ApartmentState = this.ApartmentState;
-#endif
 
             foreach (ModuleSpecification modSpec in this.ModuleSpecificationsToImport)
             {
@@ -2247,13 +2245,10 @@ namespace System.Management.Automation.Runspaces
         /// </summary>
         public bool UseFullLanguageModeInDebugger { get; set; } = false;
 
-#if !CORECLR // No ApartmentState In CoreCLR
         /// <summary>
         /// ApartmentState of the thread used to execute commands
         /// </summary>
         public ApartmentState ApartmentState { get; set; } = Runspace.DefaultApartmentState;
-
-#endif
 
         /// <summary>
         /// This property determines whether a new thread is create for each invocation of a command

--- a/src/System.Management.Automation/engine/hostifaces/Connection.cs
+++ b/src/System.Management.Automation/engine/hostifaces/Connection.cs
@@ -557,7 +557,6 @@ namespace System.Management.Automation.Runspaces
             }
         }
 
-#if !CORECLR // No ApartmentState In CoreCLR
         internal const ApartmentState DefaultApartmentState = ApartmentState.Unknown;
 
         /// <summary>
@@ -587,7 +586,6 @@ namespace System.Management.Automation.Runspaces
             }
         }
         private ApartmentState apartmentState = Runspace.DefaultApartmentState;
-#endif
 
         /// <summary>
         /// This property determines whether a new thread is create for each invocation
@@ -650,12 +648,7 @@ namespace System.Management.Automation.Runspaces
         /// <summary>
         /// RunspaceConfiguration information for this runspace.
         /// </summary>
-#if CORECLR
-        internal
-#else
-        public
-#endif
-        abstract RunspaceConfiguration RunspaceConfiguration
+        internal abstract RunspaceConfiguration RunspaceConfiguration
         {
             get;
         }

--- a/src/System.Management.Automation/engine/hostifaces/ConnectionBase.cs
+++ b/src/System.Management.Automation/engine/hostifaces/ConnectionBase.cs
@@ -84,10 +84,7 @@ namespace System.Management.Automation.Runspaces
             Host = host;
             InitialSessionState = initialSessionState.Clone();
             this.ThreadOptions = initialSessionState.ThreadOptions;
-
-#if !CORECLR // No ApartmentState In CoreCLR
             this.ApartmentState = initialSessionState.ApartmentState;
-#endif
         }
 
         /// <summary>
@@ -131,10 +128,7 @@ namespace System.Management.Automation.Runspaces
                 InitialSessionState = initialSessionState.Clone();
             }
             this.ThreadOptions = initialSessionState.ThreadOptions;
-
-#if !CORECLR // No ApartmentState In CoreCLR
             this.ApartmentState = initialSessionState.ApartmentState;
-#endif
         }
 
         /// <summary>
@@ -145,12 +139,7 @@ namespace System.Management.Automation.Runspaces
         /// <summary>
         /// runspaceConfiguration information for this runspace
         /// </summary>
-#if CORECLR
-        internal
-#else
-        public
-#endif
-        override RunspaceConfiguration RunspaceConfiguration { get; }
+        internal override RunspaceConfiguration RunspaceConfiguration { get; }
 
         /// <summary>
         /// runspaceConfiguration information for this runspace
@@ -942,7 +931,6 @@ namespace System.Management.Automation.Runspaces
                     waitHandles[i] = runningPipelines[i].PipelineFinishedEvent;
                 }
 
-#if !CORECLR    // No ApartmentState.STA In CoreCLR
                 // WaitAll for multiple handles on a STA (single-thread apartment) thread is not supported as WaitAll will prevent the message pump to run
                 if (runningPipelines.Length > 1 && Thread.CurrentThread.GetApartmentState() == ApartmentState.STA)
                 {
@@ -962,7 +950,6 @@ namespace System.Management.Automation.Runspaces
                         return waitAllIsDone.WaitOne();
                     }
                 }
-#endif
                 return WaitHandle.WaitAll(waitHandles);
             }
             else

--- a/src/System.Management.Automation/engine/hostifaces/LocalConnection.cs
+++ b/src/System.Management.Automation/engine/hostifaces/LocalConnection.cs
@@ -165,15 +165,11 @@ namespace System.Management.Automation.Runspaces
                     {
                         if (this.RunspaceStateInfo.State != RunspaceState.BeforeOpen)
                         {
-#if CORECLR                 // No ApartmentState.STA Support In CoreCLR
-                            bool allowed = value == PSThreadOptions.ReuseThread;
-#else
                             // if the runspace is already opened we only allow changing the options if
                             // the apartment state is MTA and the new value is ReuseThread
                             bool allowed = (this.ApartmentState == ApartmentState.MTA || this.ApartmentState == ApartmentState.Unknown) // Unknown is the same as MTA
                                            &&
                                            value == PSThreadOptions.ReuseThread;
-#endif
 
                             if (!allowed)
                             {
@@ -798,11 +794,7 @@ namespace System.Management.Automation.Runspaces
         {
             if (_pipelineThread == null)
             {
-#if CORECLR     // No ApartmentState In CoreCLR
-                _pipelineThread = new PipelineThread();
-#else
                 _pipelineThread = new PipelineThread(this.ApartmentState);
-#endif
             }
 
             return _pipelineThread;

--- a/src/System.Management.Automation/engine/hostifaces/LocalPipeline.cs
+++ b/src/System.Management.Automation/engine/hostifaces/LocalPipeline.cs
@@ -156,6 +156,7 @@ namespace System.Management.Automation.Runspaces
                         Thread invokeThread = new Thread(new ThreadStart(this.InvokeThreadProc), MaxStack);
                         SetupInvokeThread(invokeThread, true);
 
+#if !UNIX
                         ApartmentState apartmentState;
 
                         if (InvocationSettings != null && InvocationSettings.ApartmentState != ApartmentState.Unknown)
@@ -171,6 +172,7 @@ namespace System.Management.Automation.Runspaces
                         {
                             invokeThread.SetApartmentState(apartmentState);
                         }
+#endif
                         invokeThread.Start();
 
                         break;
@@ -247,44 +249,9 @@ namespace System.Management.Automation.Runspaces
         {
             get
             {
-                int i = ReadRegistryInt("PipelineMaxStackSizeMB", 10);  // TODO: move to startupconfig
-                if (i < 10)
-                    i = 10; // minimum 10MB
-                else if (i > 100)
-                    i = 100; // maximum 100MB
-                return i * 1000000;
+                // TODO: move this to startupconfig is needed.  This number is in bytes.
+                return 10000000;
             }
-        }
-
-        internal static int ReadRegistryInt(string policyValueName, int defaultValue)
-        {
-            RegistryKey key;
-            try
-            {
-                key = Registry.LocalMachine.OpenSubKey(Utils.GetRegistryConfigurationPrefix());
-            }
-            catch (System.Security.SecurityException)
-            {
-                return defaultValue;
-            }
-            if (null == key)
-                return defaultValue;
-
-            object temp;
-            try
-            {
-                temp = key.GetValue(policyValueName);
-            }
-            catch (System.Security.SecurityException)
-            {
-                return defaultValue;
-            }
-            if (!(temp is int))
-            {
-                return defaultValue;
-            }
-            int i = (int)temp;
-            return i;
         }
 
         ///<summary>

--- a/src/System.Management.Automation/engine/hostifaces/PowerShell.cs
+++ b/src/System.Management.Automation/engine/hostifaces/PowerShell.cs
@@ -325,9 +325,7 @@ namespace System.Management.Automation
         /// </summary>
         public PSInvocationSettings()
         {
-#if !CORECLR // No ApartmentState In CoreCLR
             this.ApartmentState = ApartmentState.Unknown;
-#endif
             _host = null;
             RemoteStreamOptions = 0;
             AddToHistory = false;
@@ -336,13 +334,11 @@ namespace System.Management.Automation
 
         #endregion
 
-#if !CORECLR // No ApartmentState In CoreCLR
         /// <summary>
         /// ApartmentState of the thread in which the command
         /// is executed.
         /// </summary>
         public ApartmentState ApartmentState { get; set; }
-#endif
 
         /// <summary>
         /// Host to use with the Runspace when the command is
@@ -4221,9 +4217,7 @@ namespace System.Management.Automation
                 {
                     if (null != pool)
                     {
-#if !CORECLR            // No ApartmentState In CoreCLR
                         VerifyThreadSettings(settings, pool.ApartmentState, pool.ThreadOptions, false);
-#endif
                         // getting the runspace asynchronously so that Stop can be supported from a different
                         // thread.
                         _worker.GetRunspaceAsyncResult = pool.BeginGetRunspace(null, null);
@@ -4235,9 +4229,7 @@ namespace System.Management.Automation
                         rsToUse = _rsConnection as Runspace;
                         if (null != rsToUse)
                         {
-#if !CORECLR                // No ApartmentState In CoreCLR
                             VerifyThreadSettings(settings, rsToUse.ApartmentState, rsToUse.ThreadOptions, false);
-#endif
                             if (rsToUse.RunspaceStateInfo.State != RunspaceState.Opened)
                             {
                                 string message = StringUtil.Format(PowerShellStrings.InvalidRunspaceState, RunspaceState.Opened, rsToUse.RunspaceStateInfo.State);
@@ -4505,9 +4497,7 @@ namespace System.Management.Automation
                 {
                     if (null != pool)
                     {
-#if !CORECLR            // No ApartmentState In CoreCLR
                         VerifyThreadSettings(settings, pool.ApartmentState, pool.ThreadOptions, pool.IsRemote);
-#endif
                         pool.AssertPoolIsOpen();
 
                         // for executing in a remote runspace pool case
@@ -4581,9 +4571,7 @@ namespace System.Management.Automation
                         LocalRunspace rs = _rsConnection as LocalRunspace;
                         if (null != rs)
                         {
-#if !CORECLR                // No ApartmentState In CoreCLR
                             VerifyThreadSettings(settings, rs.ApartmentState, rs.ThreadOptions, false);
-#endif
                             if (rs.RunspaceStateInfo.State != RunspaceState.Opened)
                             {
                                 string message = StringUtil.Format(PowerShellStrings.InvalidRunspaceState, RunspaceState.Opened, rs.RunspaceStateInfo.State);
@@ -4630,7 +4618,6 @@ namespace System.Management.Automation
             return _invokeAsyncResult;
         }
 
-#if !CORECLR // No ApartmentState In CoreCLR
         /// <summary>
         /// Verifies the settings for ThreadOptions and ApartmentState
         /// </summary>
@@ -4665,7 +4652,6 @@ namespace System.Management.Automation
                 }
             }
         }
-#endif
 
         /// <summary>
         ///

--- a/src/System.Management.Automation/engine/hostifaces/RunspacePool.cs
+++ b/src/System.Management.Automation/engine/hostifaces/RunspacePool.cs
@@ -1265,7 +1265,6 @@ namespace System.Management.Automation.Runspaces
             }
         }
 
-#if !CORECLR // No ApartmentState In CoreCLR
         /// <summary>
         /// ApartmentState of the thread used to execute commands within this RunspacePool
         /// </summary>
@@ -1292,7 +1291,6 @@ namespace System.Management.Automation.Runspaces
                 _internalPool.ApartmentState = value;
             }
         }
-#endif
 
         /// <summary>
         /// Gets Runspace asynchronously from the runspace pool. The caller

--- a/src/System.Management.Automation/engine/hostifaces/RunspacePoolInternal.cs
+++ b/src/System.Management.Automation/engine/hostifaces/RunspacePoolInternal.cs
@@ -143,10 +143,7 @@ namespace System.Management.Automation.Runspaces.Internal
             _initialSessionState = initialSessionState.Clone();
             this.host = host;
             ThreadOptions = initialSessionState.ThreadOptions;
-#if !CORECLR
-            // No ApartmentState In CoreCLR
             this.ApartmentState = initialSessionState.ApartmentState;
-#endif
             pool = new Stack<Runspace>();
             runspaceRequestQueue = new Queue<GetRunspaceAsyncResult>();
             ultimateRequestQueue = new Queue<GetRunspaceAsyncResult>();
@@ -872,7 +869,6 @@ namespace System.Management.Automation.Runspaces.Internal
         /// </remarks>
         internal PSThreadOptions ThreadOptions { get; set; } = PSThreadOptions.Default;
 
-#if !CORECLR // No ApartmentState In CoreCLR
         /// <summary>
         /// The value of this property is propagated to all the Runspaces in this pool
         /// </summary>
@@ -880,7 +876,6 @@ namespace System.Management.Automation.Runspaces.Internal
         /// Any updates to the value of this property must be done before the RunspacePool is opened
         /// </remarks>
         internal ApartmentState ApartmentState { get; set; } = Runspace.DefaultApartmentState;
-#endif
 
         /// <summary>
         /// Gets Runspace asynchronously from the runspace pool. The caller
@@ -1289,9 +1284,7 @@ namespace System.Management.Automation.Runspaces.Internal
             }
 
             result.ThreadOptions = this.ThreadOptions == PSThreadOptions.Default ? PSThreadOptions.ReuseThread : this.ThreadOptions;
-#if !CORECLR // No ApartmentState In CoreCLR
             result.ApartmentState = this.ApartmentState;
-#endif
 
             this.PropagateApplicationPrivateData(result);
 

--- a/src/System.Management.Automation/engine/remoting/client/remoterunspace.cs
+++ b/src/System.Management.Automation/engine/remoting/client/remoterunspace.cs
@@ -554,9 +554,7 @@ namespace System.Management.Automation
             try
             {
                 RunspacePool.ThreadOptions = this.ThreadOptions;
-#if !CORECLR // No ApartmentState In CoreCLR
                 RunspacePool.ApartmentState = this.ApartmentState;
-#endif
                 RunspacePool.Open();
             }
             catch (InvalidRunspacePoolStateException e)

--- a/src/System.Management.Automation/engine/remoting/commands/CustomShellCommands.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/CustomShellCommands.cs
@@ -1089,7 +1089,6 @@ else
                     maxObjectSizeMB.Value,
                     Environment.NewLine));
             }
-#if !CORECLR // No ApartmentState In CoreCLR
             if (threadAptState.HasValue)
             {
                 initParameters.Append(string.Format(CultureInfo.InvariantCulture,
@@ -1098,7 +1097,6 @@ else
                     threadAptState.Value,
                     Environment.NewLine));
             }
-#endif
             if (threadOptions.HasValue)
             {
                 initParameters.Append(string.Format(CultureInfo.InvariantCulture,
@@ -2135,7 +2133,6 @@ else
         internal PSCredential runAsCredential;
         internal bool isRunAsCredentialSpecified;
 
-#if !CORECLR // No ApartmentState In CoreCLR
         /// <summary>
         /// ApartmentState of the Runspace created for the shell.
         /// </summary>
@@ -2155,7 +2152,6 @@ else
             set { threadAptState = value; }
         }
         internal Nullable<ApartmentState> threadAptState;
-#endif
 
         /// <summary>
         /// ThreadOptions of the Runspace created for the shell.
@@ -3286,9 +3282,7 @@ Set-PSSessionConfiguration $args[0] $args[1] $args[2] $args[3] $args[4] $args[5]
             ConfigurationDataFromXML.MAXRCVDOBJSIZETOKEN,
             ConfigurationDataFromXML.MAXRCVDCMDSIZETOKEN,
             ConfigurationDataFromXML.THREADOPTIONSTOKEN,
-#if !CORECLR // No ApartmentState In CoreCLR
             ConfigurationDataFromXML.THREADAPTSTATETOKEN,
-#endif
             ConfigurationDataFromXML.PSVERSIONTOKEN,
             ConfigurationDataFromXML.MAXPSVERSIONTOKEN,
             ConfigurationDataFromXML.SESSIONCONFIGTOKEN,
@@ -3954,12 +3948,10 @@ Set-PSSessionConfiguration $args[0] $args[1] $args[2] $args[3] $args[4] $args[5]
                 result.Properties.Add(new PSNoteProperty(ConfigurationDataFromXML.MAXRCVDOBJSIZETOKEN, input));
             }
 
-#if !CORECLR // No ApartmentState In CoreCLR
             if (threadAptState.HasValue)
             {
                 result.Properties.Add(new PSNoteProperty(ConfigurationDataFromXML.THREADAPTSTATETOKEN, threadAptState.Value));
             }
-#endif
 
             if (threadOptions.HasValue)
             {

--- a/src/System.Management.Automation/engine/remoting/common/RunspaceConnectionInfo.cs
+++ b/src/System.Management.Automation/engine/remoting/common/RunspaceConnectionInfo.cs
@@ -3300,16 +3300,6 @@ namespace System.Management.Automation.Runspaces
         /// </summary>
         private void RunOnMTAThread(ThreadStart threadProc)
         {
-            //
-            // By default, non-OneCore PowerShell is launched with ApartmentState being STA.
-            // In this case, we need to create a separate thread, set its ApartmentState to MTA,
-            // and do the work.
-            //
-            // For OneCore PowerShell, its ApartmentState is always MTA.
-            //        
-#if CORECLR
-            threadProc();
-#else
             if (Thread.CurrentThread.GetApartmentState() == ApartmentState.MTA)
             {
                 threadProc();
@@ -3322,7 +3312,6 @@ namespace System.Management.Automation.Runspaces
                 executionThread.Start();
                 executionThread.Join();
             }
-#endif
         }
 
         /// <summary>

--- a/src/System.Management.Automation/engine/remoting/common/WireDataFormat/EncodeAndDecode.cs
+++ b/src/System.Management.Automation/engine/remoting/common/WireDataFormat/EncodeAndDecode.cs
@@ -677,11 +677,7 @@ namespace System.Management.Automation
             dataAsPSObject.Properties.Add(new PSNoteProperty(RemoteDataNameStrings.MinRunspaces, minRunspaces));
             dataAsPSObject.Properties.Add(new PSNoteProperty(RemoteDataNameStrings.MaxRunspaces, maxRunspaces));
             dataAsPSObject.Properties.Add(new PSNoteProperty(RemoteDataNameStrings.ThreadOptions, runspacePool.ThreadOptions));
-#if CORECLR // No ApartmentState In CoreCLR, default to MTA for outgoing objects
-            ApartmentState poolState = ApartmentState.MTA;
-#else
             ApartmentState poolState = runspacePool.ApartmentState;
-#endif
             dataAsPSObject.Properties.Add(new PSNoteProperty(RemoteDataNameStrings.ApartmentState, poolState));
             dataAsPSObject.Properties.Add(new PSNoteProperty(RemoteDataNameStrings.ApplicationArguments, applicationArguments));
 
@@ -1112,12 +1108,7 @@ namespace System.Management.Automation
             {
                 hostInfo = new HostInfo(null);
                 hostInfo.UseRunspaceHost = true;
-
-#if CORECLR // No ApartmentState In CoreCLR, default to MTA for outgoing objects
-                ApartmentState passedApartmentState = ApartmentState.MTA;
-#else
                 ApartmentState passedApartmentState = rsPool.ApartmentState;
-#endif
                 dataAsPSObject.Properties.Add(new PSNoteProperty(RemoteDataNameStrings.ApartmentState, passedApartmentState));
                 dataAsPSObject.Properties.Add(new PSNoteProperty(RemoteDataNameStrings.RemoteStreamOptions, RemoteStreamOptions.AddInvocationInfo));
                 dataAsPSObject.Properties.Add(new PSNoteProperty(RemoteDataNameStrings.AddToHistory, false));
@@ -1130,11 +1121,7 @@ namespace System.Management.Automation
                     hostInfo.UseRunspaceHost = true;
                 }
 
-#if CORECLR // No ApartmentState In CoreCLR, default to MTA for outgoing objects
-                ApartmentState passedApartmentState = ApartmentState.MTA;
-#else
                 ApartmentState passedApartmentState = settings.ApartmentState;
-#endif
                 dataAsPSObject.Properties.Add(new PSNoteProperty(RemoteDataNameStrings.ApartmentState, passedApartmentState));
                 dataAsPSObject.Properties.Add(new PSNoteProperty(RemoteDataNameStrings.RemoteStreamOptions, settings.RemoteStreamOptions));
                 dataAsPSObject.Properties.Add(new PSNoteProperty(RemoteDataNameStrings.AddToHistory, settings.AddToHistory));
@@ -2341,7 +2328,6 @@ namespace System.Management.Automation
             return GetPropertyValue<bool>(dataAsPSObject, RemoteDataNameStrings.IsNested);
         }
 
-#if !CORECLR // No ApartmentState In CoreCLR
         /// <summary>
         /// Gets the invocation settings information from the message
         /// </summary>
@@ -2352,7 +2338,7 @@ namespace System.Management.Automation
             PSObject dataAsPSObject = PSObject.AsPSObject(data);
             return GetPropertyValue<ApartmentState>(dataAsPSObject, RemoteDataNameStrings.ApartmentState);
         }
-#endif
+
         /// <summary>
         /// Gets the stream options from the message
         /// </summary>
@@ -2401,7 +2387,7 @@ namespace System.Management.Automation
                 //
                 // So just return the CurrentTimeZone.
 
-#if !CORECLR // TimeZone Not In CoreCLR
+#if !CORECLR // TimeZone deprecated, need to change to TimeZoneInfo
                 result.TimeZone = TimeZone.CurrentTimeZone;
 #endif
             }

--- a/src/System.Management.Automation/engine/remoting/common/WireDataFormat/EncodeAndDecode.cs
+++ b/src/System.Management.Automation/engine/remoting/common/WireDataFormat/EncodeAndDecode.cs
@@ -2387,7 +2387,7 @@ namespace System.Management.Automation
                 //
                 // So just return the CurrentTimeZone.
 
-#if !CORECLR // TimeZone deprecated, need to change to TimeZoneInfo
+#if !CORECLR // TODO: TimeZone deprecated, need to change to TimeZoneInfo.  Affects serialization, remoting, and backwards compatibility.
                 result.TimeZone = TimeZone.CurrentTimeZone;
 #endif
             }

--- a/src/System.Management.Automation/engine/remoting/fanin/InitialSessionStateProvider.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/InitialSessionStateProvider.cs
@@ -44,9 +44,7 @@ namespace System.Management.Automation.Remoting
         internal const string MAXRCVDCMDSIZETOKEN = "psmaximumreceiveddatasizepercommandmb";
         internal const string MAXRCVDCMDSIZETOKEN_CamelCase = "PSMaximumReceivedDataSizePerCommandMB";
         internal const string THREADOPTIONSTOKEN = "pssessionthreadoptions";
-#if !CORECLR // No ApartmentState In CoreCLR
         internal const string THREADAPTSTATETOKEN = "pssessionthreadapartmentstate";
-#endif
         internal const string SESSIONCONFIGTOKEN = "sessionconfigurationdata";
         internal const string PSVERSIONTOKEN = "PSVersion";
         internal const string MAXPSVERSIONTOKEN = "MaxPSVersion";
@@ -72,10 +70,7 @@ namespace System.Management.Automation.Remoting
         internal Nullable<int> MaxReceivedCommandSizeMB;
         // Used to set properties on the RunspacePool created for this shell.
         internal Nullable<PSThreadOptions> ShellThreadOptions;
-
-#if !CORECLR // No ApartmentState In CoreCLR
         internal Nullable<System.Threading.ApartmentState> ShellThreadApartmentState;
-#endif
         internal PSSessionConfigurationData SessionConfigurationData;
         internal string ConfigFilePath;
 
@@ -131,13 +126,11 @@ namespace System.Management.Automation.Remoting
                     ShellThreadOptions = (PSThreadOptions)LanguagePrimitives.ConvertTo(
                         optionValue, typeof(PSThreadOptions), CultureInfo.InvariantCulture);
                     break;
-#if !CORECLR // No ApartmentState In CoreCLR
                 case THREADAPTSTATETOKEN:
                     AssertValueNotAssigned(THREADAPTSTATETOKEN, ShellThreadApartmentState);
                     ShellThreadApartmentState = (System.Threading.ApartmentState)LanguagePrimitives.ConvertTo(
                         optionValue, typeof(System.Threading.ApartmentState), CultureInfo.InvariantCulture);
                     break;
-#endif
                 case SESSIONCONFIGTOKEN:
                     {
                         AssertValueNotAssigned(SESSIONCONFIGTOKEN, SessionConfigurationData);
@@ -252,9 +245,7 @@ namespace System.Management.Automation.Remoting
             readerSettings.IgnoreProcessingInstructions = true;
             readerSettings.MaxCharactersInDocument = 10000;
             readerSettings.ConformanceLevel = ConformanceLevel.Fragment;
-#if !CORECLR // No XmlReaderSettings.XmlResolver in CoreCLR
             readerSettings.XmlResolver = null;
-#endif
 
             using (XmlReader reader = XmlReader.Create(new StringReader(initializationParameters), readerSettings))
             {

--- a/src/System.Management.Automation/engine/remoting/server/ServerPowerShellDriver.cs
+++ b/src/System.Management.Automation/engine/remoting/server/ServerPowerShellDriver.cs
@@ -38,9 +38,7 @@ namespace System.Management.Automation
         private bool _addToHistory;
         private ServerRemoteHost _remoteHost;   // the server remote host instance
                                                 // associated with this powershell
-#if !CORECLR // No ApartmentState In CoreCLR
         private ApartmentState apartmentState;  // apartment state for this powershell
-#endif
 
         private IRSPDriverInvoke _psDriverInvoker;  // Handles nested invocation of PS drivers.
 
@@ -48,7 +46,6 @@ namespace System.Management.Automation
 
         #region Constructors
 
-#if !CORECLR
         /// <summary>
         /// Default constructor for creating ServerPowerShellDrivers
         /// </summary>
@@ -78,66 +75,7 @@ namespace System.Management.Automation
                    apartmentState, hostInfo, streamOptions, addToHistory, rsToUse, null)
         {
         }
-#else
-        /// <summary>
-        /// Default constructor for creating ServerPowerShellDrivers
-        /// </summary>
-        /// <param name="powershell">decoded powershell object</param>
-        /// <param name="extraPowerShell">extra pipeline to be run after <paramref name="powershell"/> completes</param>
-        /// <param name="noInput">whether there is input for this powershell</param>
-        /// <param name="clientPowerShellId">the client powershell id</param>
-        /// <param name="clientRunspacePoolId">the client runspacepool id</param>
-        /// <param name="runspacePoolDriver">runspace pool driver
-        /// which is creating this powershell driver</param>
-        /// <param name="hostInfo">host info using which the host for
-        /// this powershell will be constructed</param>
-        /// <param name="streamOptions">serialization options for the streams in this powershell</param>
-        /// <param name="addToHistory">
-        /// true if the command is to be added to history list of the runspace. false, otherwise.
-        /// </param>
-        /// <param name="rsToUse">
-        /// If not null, this Runspace will be used to invoke Powershell.
-        /// If null, the RunspacePool pointed by <paramref name="runspacePoolDriver"/> will be used.
-        /// </param>
-        internal ServerPowerShellDriver(PowerShell powershell, PowerShell extraPowerShell, bool noInput, Guid clientPowerShellId,
-           Guid clientRunspacePoolId, ServerRunspacePoolDriver runspacePoolDriver,
-           HostInfo hostInfo, RemoteStreamOptions streamOptions,
-           bool addToHistory, Runspace rsToUse)
-            : this(powershell, extraPowerShell, noInput, clientPowerShellId, clientRunspacePoolId, runspacePoolDriver,
-                   hostInfo, streamOptions, addToHistory, rsToUse, null)
-        {
-        }
-#endif
 
-#if CORECLR
-        /// <summary>
-        /// Default constructor for creating ServerPowerShellDrivers
-        /// </summary>
-        /// <param name="powershell">decoded powershell object</param>
-        /// <param name="extraPowerShell">extra pipeline to be run after <paramref name="powershell"/> completes</param>
-        /// <param name="noInput">whether there is input for this powershell</param>
-        /// <param name="clientPowerShellId">the client powershell id</param>
-        /// <param name="clientRunspacePoolId">the client runspacepool id</param>
-        /// <param name="runspacePoolDriver">runspace pool driver
-        /// which is creating this powershell driver</param>
-        /// <param name="hostInfo">host info using which the host for
-        /// this powershell will be constructed</param>
-        /// <param name="streamOptions">serialization options for the streams in this powershell</param>
-        /// <param name="addToHistory">
-        /// true if the command is to be added to history list of the runspace. false, otherwise.
-        /// </param>
-        /// <param name="rsToUse">
-        /// If not null, this Runspace will be used to invoke Powershell.
-        /// If null, the RunspacePool pointed by <paramref name="runspacePoolDriver"/> will be used.
-        /// </param>
-        /// <param name="output">
-        /// If not null, this is used as another source of output sent to the client.
-        /// </param>
-        internal ServerPowerShellDriver(PowerShell powershell, PowerShell extraPowerShell, bool noInput, Guid clientPowerShellId,
-            Guid clientRunspacePoolId, ServerRunspacePoolDriver runspacePoolDriver,
-            HostInfo hostInfo, RemoteStreamOptions streamOptions,
-            bool addToHistory, Runspace rsToUse, PSDataCollection<PSObject> output)
-#else
         /// <summary>
         /// Default constructor for creating ServerPowerShellDrivers
         /// </summary>
@@ -166,14 +104,11 @@ namespace System.Management.Automation
             Guid clientRunspacePoolId, ServerRunspacePoolDriver runspacePoolDriver,
             ApartmentState apartmentState, HostInfo hostInfo, RemoteStreamOptions streamOptions,
             bool addToHistory, Runspace rsToUse, PSDataCollection<PSObject> output)
-#endif
         {
             InstanceId = clientPowerShellId;
             RunspacePoolId = clientRunspacePoolId;
             RemoteStreamOptions = streamOptions;
-#if !CORECLR // No ApartmentState In CoreCLR
             this.apartmentState = apartmentState;
-#endif
             LocalPowerShell = powershell;
             _extraPowerShell = extraPowerShell;
             _localPowerShellOutput = new PSDataCollection<PSObject>();
@@ -291,9 +226,7 @@ namespace System.Management.Automation
             }
 
             PSInvocationSettings settings = new PSInvocationSettings();
-#if !CORECLR // No ApartmentState In CoreCLR
             settings.ApartmentState = apartmentState;
-#endif
             settings.Host = _remoteHost;
 
             // Flow the impersonation policy to pipeline execution thread

--- a/src/System.Management.Automation/engine/remoting/server/ServerRunspacePoolDriver.cs
+++ b/src/System.Management.Automation/engine/remoting/server/ServerRunspacePoolDriver.cs
@@ -93,47 +93,6 @@ namespace System.Management.Automation
 
         #region Constructors
 
-
-#if CORECLR // No ApartmentState In CoreCLR
-        /// <summary>
-        /// Creates the runspace pool driver
-        /// </summary>
-        /// <param name="clientRunspacePoolId">client runspace pool id to associate</param>
-        /// <param name="transportManager">transport manager associated with this
-        /// runspace pool driver</param>
-        /// <param name="maxRunspaces">maximum runspaces to open</param>
-        /// <param name="minRunspaces">minimum runspaces to open</param>
-        /// <param name="threadOptions">threading options for the runspaces in the pool</param>
-        /// <param name="hostInfo">host information about client side host</param>
-        /// <param name="configData">
-        /// Contains:
-        /// 1. Script to run after a RunspacePool/Runspace is created in this session.
-        /// For RunspacePool case, every newly created Runspace (in the pool) will run
-        /// this script.
-        /// 2. ThreadOptions for RunspacePool/Runspace
-        /// 3. ThreadApartment for RunspacePool/Runspace
-        /// </param>
-        /// <param name="initialSessionState">configuration of the runspace</param>
-        /// <param name="applicationPrivateData">application private data</param>
-        /// <param name="isAdministrator">True if the driver is being created by an administrator</param>
-        /// <param name="serverCapability">server capability reported to the client during negotiation (not the actual capability)</param>
-        /// <param name="psClientVersion">Client PowerShell version.</param>
-        /// <param name="configurationName">Optional endpoint configuration name to create a pushed configured runspace.</param>
-        internal ServerRunspacePoolDriver(
-            Guid clientRunspacePoolId,
-            int minRunspaces,
-            int maxRunspaces,
-            PSThreadOptions threadOptions,
-            HostInfo hostInfo,
-            InitialSessionState initialSessionState,
-            PSPrimitiveDictionary applicationPrivateData,
-            ConfigurationDataFromXML configData,
-            AbstractServerSessionTransportManager transportManager,
-            bool isAdministrator,
-            RemoteSessionCapability serverCapability,
-            Version psClientVersion,
-            string configurationName)
-#else
         /// <summary>
         /// Creates the runspace pool driver
         /// </summary>
@@ -174,7 +133,6 @@ namespace System.Management.Automation
             RemoteSessionCapability serverCapability,
             Version psClientVersion,
             string configurationName)
-#endif
         {
             Dbg.Assert(null != configData, "ConfigurationData cannot be null");
 
@@ -212,7 +170,6 @@ namespace System.Management.Automation
                 RunspacePool.ThreadOptions = threadOptions;
             }
 
-#if !CORECLR // No ApartmentState In CoreCLR
             // Set Thread ApartmentState for this RunspacePool
             ApartmentState serverApartmentState = configData.ShellThreadApartmentState.HasValue ? configData.ShellThreadApartmentState.Value : Runspace.DefaultApartmentState;
 
@@ -224,7 +181,6 @@ namespace System.Management.Automation
             {
                 RunspacePool.ApartmentState = apartmentState;
             }
-#endif
 
             // If we have a runspace pool with a single runspace then we can run nested pipelines on
             // on it in a single pipeline invoke thread.
@@ -575,9 +531,7 @@ namespace System.Management.Automation
                 Guid.Empty,
                 this.InstanceId,
                 this,
-#if !CORECLR // No ApartmentState In CoreCLR
                 args.Runspace.ApartmentState,
-#endif
                 hostInfo,
                 RemoteStreamOptions.AddInvocationInfo,
                 false,
@@ -758,9 +712,7 @@ namespace System.Management.Automation
             // invoked from within the driver
             HostInfo hostInfo = RemotingDecoder.GetHostInfo(data.Data);
 
-#if !CORECLR // No ApartmentState In CoreCLR
             ApartmentState apartmentState = RemotingDecoder.GetApartmentState(data.Data);
-#endif
 
             RemoteStreamOptions streamOptions = RemotingDecoder.GetRemoteStreamOptions(data.Data);
             PowerShell powershell = RemotingDecoder.GetPowerShell(data.Data);
@@ -822,9 +774,7 @@ namespace System.Management.Automation
                         data.PowerShellId,
                         data.RunspacePoolId,
                         this,
-#if !CORECLR // No ApartmentState In CoreCLR
                         apartmentState,
-#endif
                         hostInfo,
                         streamOptions,
                         addToHistory,
@@ -881,9 +831,7 @@ namespace System.Management.Automation
                             data.PowerShellId,
                             data.RunspacePoolId,
                             this,
-#if !CORECLR // No ApartmentState In CoreCLR
                             apartmentState,
-#endif
                             hostInfo,
                             streamOptions,
                             addToHistory,
@@ -902,9 +850,7 @@ namespace System.Management.Automation
                             data.PowerShellId,
                             data.RunspacePoolId,
                             this,
-#if !CORECLR // No ApartmentState In CoreCLR
                             apartmentState,
-#endif
                             _remoteHost,
                             hostInfo,
                             streamOptions,
@@ -935,9 +881,7 @@ namespace System.Management.Automation
                             data.PowerShellId,
                             data.RunspacePoolId,
                             this,
-#if !CORECLR // No ApartmentState In CoreCLR
                             apartmentState,
-#endif
                             hostInfo,
                             streamOptions,
                             addToHistory,
@@ -969,9 +913,7 @@ namespace System.Management.Automation
                 data.PowerShellId,
                 data.RunspacePoolId,
                 this,
-#if !CORECLR // No ApartmentState In CoreCLR
                 apartmentState,
-#endif
                 hostInfo,
                 streamOptions,
                 addToHistory,
@@ -1081,9 +1023,7 @@ namespace System.Management.Automation
                     data.PowerShellId,
                     data.RunspacePoolId,
                     this,
-#if !CORECLR // No ApartmentState In CoreCLR
                     ApartmentState.Unknown,
-#endif
                     useRunspaceHost,
                     0 /* stream options */,
                     false /* addToHistory */,
@@ -1220,9 +1160,7 @@ namespace System.Management.Automation
                 powershellId,
                 runspacePoolId,
                 this,
-#if !CORECLR // No ApartmentState In CoreCLR
                 ApartmentState.MTA,
-#endif
                 hostInfo,
                 streamOptions,
                 addToHistory,
@@ -2489,9 +2427,7 @@ namespace System.Management.Automation
             Guid powershellId,
             Guid runspacePoolId,
             ServerRunspacePoolDriver runspacePoolDriver,
-#if !CORECLR // No ApartmentState In CoreCLR
             ApartmentState apartmentState,
-#endif
             ServerRemoteHost remoteHost,
             HostInfo hostInfo,
             RemoteStreamOptions streamOptions,
@@ -2527,9 +2463,7 @@ namespace System.Management.Automation
                     powershellId,
                     runspacePoolId,
                     runspacePoolDriver,
-#if !CORECLR // No ApartmentState In CoreCLR
                     apartmentState,
-#endif
                     hostInfo,
                     streamOptions,
                     addToHistory,

--- a/src/System.Management.Automation/engine/remoting/server/ServerSteppablePipelineDriver.cs
+++ b/src/System.Management.Automation/engine/remoting/server/ServerSteppablePipelineDriver.cs
@@ -76,9 +76,7 @@ namespace System.Management.Automation
         // was created
         private bool _addToHistory;
         // associated with this powershell
-#if !CORECLR // No ApartmentState In CoreCLR
         private ApartmentState apartmentState;  // apartment state for this powershell
-#endif
 
         // pipeline that runs the actual command.
         private ServerSteppablePipelineSubscriber _eventSubscriber;
@@ -86,36 +84,6 @@ namespace System.Management.Automation
 
         #endregion
 
-#if CORECLR // No ApartmentState In CoreCLR
-        /// <summary>
-        /// Default constructor for creating ServerSteppablePipelineDriver...Used by server to concurrently
-        /// run 2 pipelines.
-        /// </summary>
-        /// <param name="powershell">decoded powershell object</param>
-        /// <param name="noInput">whether there is input for this powershell</param>
-        /// <param name="clientPowerShellId">the client powershell id</param>
-        /// <param name="clientRunspacePoolId">the client runspacepool id</param>
-        /// <param name="runspacePoolDriver">runspace pool driver
-        /// which is creating this powershell driver</param>
-        /// <param name="hostInfo">host info using which the host for
-        /// this powershell will be constructed</param>
-        /// <param name="streamOptions">serialization options for the streams in this powershell</param>
-        /// <param name="addToHistory">
-        /// true if the command is to be added to history list of the runspace. false, otherwise.
-        /// </param>
-        /// <param name="rsToUse">
-        /// If not null, this Runspace will be used to invoke Powershell.
-        /// If null, the RunspacePool pointed by <paramref name="runspacePoolDriver"/> will be used.
-        /// </param>
-        /// <param name="eventSubscriber">
-        /// Steppable pipeline event subscriber
-        /// </param>
-        /// <param name="powershellInput">input collection of the PowerShell pipeline</param>
-        internal ServerSteppablePipelineDriver(PowerShell powershell, bool noInput, Guid clientPowerShellId,
-            Guid clientRunspacePoolId, ServerRunspacePoolDriver runspacePoolDriver,
-            HostInfo hostInfo, RemoteStreamOptions streamOptions,
-            bool addToHistory, Runspace rsToUse, ServerSteppablePipelineSubscriber eventSubscriber, PSDataCollection<object> powershellInput)
-#else
         /// <summary>
         /// Default constructor for creating ServerSteppablePipelineDriver...Used by server to concurrently
         /// run 2 pipelines.
@@ -145,15 +113,12 @@ namespace System.Management.Automation
             Guid clientRunspacePoolId, ServerRunspacePoolDriver runspacePoolDriver,
             ApartmentState apartmentState, HostInfo hostInfo, RemoteStreamOptions streamOptions,
             bool addToHistory, Runspace rsToUse, ServerSteppablePipelineSubscriber eventSubscriber, PSDataCollection<object> powershellInput)
-#endif
         {
             LocalPowerShell = powershell;
             InstanceId = clientPowerShellId;
             RunspacePoolId = clientRunspacePoolId;
             RemoteStreamOptions = streamOptions;
-#if !CORECLR // No ApartmentState In CoreCLR
             this.apartmentState = apartmentState;
-#endif
             NoInput = noInput;
             _addToHistory = addToHistory;
             _eventSubscriber = eventSubscriber;

--- a/src/System.Management.Automation/engine/remoting/server/serverremotesession.cs
+++ b/src/System.Management.Automation/engine/remoting/server/serverremotesession.cs
@@ -856,9 +856,7 @@ namespace System.Management.Automation.Remoting
             int minRunspaces = RemotingDecoder.GetMinRunspaces(rcvdData.Data);
             int maxRunspaces = RemotingDecoder.GetMaxRunspaces(rcvdData.Data);
             PSThreadOptions threadOptions = RemotingDecoder.GetThreadOptions(rcvdData.Data);
-#if !CORECLR // No ApartmentState In CoreCLR
             ApartmentState apartmentState = RemotingDecoder.GetApartmentState(rcvdData.Data);
-#endif
             HostInfo hostInfo = RemotingDecoder.GetHostInfo(rcvdData.Data);
 
             if (_runspacePoolDriver != null)
@@ -878,9 +876,7 @@ namespace System.Management.Automation.Remoting
                 minRunspaces,
                 maxRunspaces,
                 threadOptions,
-#if !CORECLR // No ApartmentState In CoreCLR
                 apartmentState,
-#endif
                 hostInfo,
                 rsSessionStateToUse,
                 applicationPrivateData,

--- a/test/powershell/Host/ConsoleHost.Tests.ps1
+++ b/test/powershell/Host/ConsoleHost.Tests.ps1
@@ -509,6 +509,18 @@ foo
             }
         }
     }
+
+    Context "Set ApartmentState" {
+        It "powershell starts with <ApartmentState>" -TestCases @(
+            @{ApartmentState = "STA"},
+            @{ApartmentState = "MTA"}
+        ) {
+            param($ApartmentState)
+
+            $cmdline = "powershell -noprofile -nologo -$ApartmentState -command [System.Threading.Thread]::CurrentThread.ApartmentState"
+            Invoke-Expression $cmdline | Should BeExactly $ApartmentState
+        }
+    }
 }
 
 Describe "WindowStyle argument" -Tag Feature {


### PR DESCRIPTION
WSManConfigProvider doesn't work once this is enabled if starting powershell with `-sta`, it does work if using `-mta`.  The same/similar WSManConfigProvider code works fine under Windows PowerShell 5.1 with `sta` or `mta`.  We shouldn't have to change the WSManConfigProvider code which relies on underlying non-thread safe COM objects, but need some help debugging this.

Fix #4350 
