### PR TITLE
Mitigate intermittent failures in access denied tests.

### DIFF
--- a/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
@@ -213,20 +213,20 @@ Describe "Basic FileSystem Provider Tests" -Tags "CI" {
         }
 
         It "Access-denied test for '<cmdline>" -Skip:(-not $IsWindows) -TestCases @(
-            # NOTE: ensure the testId parameter is unique for each test case; it is used to generate a unique error and done file name.
-            @{cmdline = "Get-Item $protectedPath2"; expectedError = "ItemExistsUnauthorizedAccessError,Microsoft.PowerShell.Commands.GetItemCommand"; testId = 'GetItem'}
-            @{cmdline = "Get-ChildItem $protectedPath"; expectedError = "DirUnauthorizedAccessError,Microsoft.PowerShell.Commands.GetChildItemCommand"; testId = 'GetChildItem'}
-            @{cmdline = "New-Item -Type File -Path $newItemPath"; expectedError = "NewItemUnauthorizedAccessError,Microsoft.PowerShell.Commands.NewItemCommand"; testId = 'NewItem'}
-            @{cmdline = "Rename-Item -Path $protectedPath -NewName bar"; expectedError = "RenameItemIOError,Microsoft.PowerShell.Commands.RenameItemCommand"; testId = 'RenameItem'},
-            @{cmdline = "Move-Item -Path $protectedPath -Destination bar"; expectedError = "MoveDirectoryItemIOError,Microsoft.PowerShell.Commands.MoveItemCommand";  testId = 'MoveItem'},
-            @{cmdline = "Remove-Item -Path $protectedPath"; expectedError = "RemoveItemUnauthorizedAccessError,Microsoft.PowerShell.Commands.RemoveItemCommand"; testId = 'RemoveItem'}
+            # NOTE: ensure the fileNameBase parameter is unique for each test case; it is used to generate a unique error and done file name.
+            @{cmdline = "Get-Item $protectedPath2"; expectedError = "ItemExistsUnauthorizedAccessError,Microsoft.PowerShell.Commands.GetItemCommand"; fileNameBase = 'GetItem'}
+            @{cmdline = "Get-ChildItem $protectedPath"; expectedError = "DirUnauthorizedAccessError,Microsoft.PowerShell.Commands.GetChildItemCommand"; fileNameBase = 'GetChildItem'}
+            @{cmdline = "New-Item -Type File -Path $newItemPath"; expectedError = "NewItemUnauthorizedAccessError,Microsoft.PowerShell.Commands.NewItemCommand"; fileNameBase = 'NewItem'}
+            @{cmdline = "Rename-Item -Path $protectedPath -NewName bar"; expectedError = "RenameItemIOError,Microsoft.PowerShell.Commands.RenameItemCommand"; fileNameBase = 'RenameItem'},
+            @{cmdline = "Move-Item -Path $protectedPath -Destination bar"; expectedError = "MoveDirectoryItemIOError,Microsoft.PowerShell.Commands.MoveItemCommand";  fileNameBase = 'MoveItem'},
+            @{cmdline = "Remove-Item -Path $protectedPath"; expectedError = "RemoveItemUnauthorizedAccessError,Microsoft.PowerShell.Commands.RemoveItemCommand"; fileNameBase = 'RemoveItem'}
         ) {
-            param ($cmdline, $expectedError, $testId)
+            param ($cmdline, $expectedError, $fileNameBase)
 
-            $errFile = Join-Path -Path $TestDrive -ChildPath "$testId.error.txt"
-            $doneFile = Join-Path -Path $TestDrive -Childpath "$testId.done.txt"
+            $errFile = Join-Path -Path $TestDrive -ChildPath "$fileNameBase.error.txt"
+            $doneFile = Join-Path -Path $TestDrive -Childpath "$fileNameBase.done.txt"
             # Seed the error file with text indicating a timeout waiting for the command.
-            "Test $testId timeout waiting for $cmdLine" | Set-Content -Path $errFile
+            "Test timeout waiting for $cmdLine" | Set-Content -Path $errFile
 
             runas.exe /trustlevel:0x20000 "$powershell -nop -c try { $cmdline -ErrorAction Stop } catch { `$_.FullyQualifiedErrorId | Out-File $errFile }; New-Item -Type File -Path $doneFile"
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
@@ -213,6 +213,7 @@ Describe "Basic FileSystem Provider Tests" -Tags "CI" {
         }
 
         It "Access-denied test for '<cmdline>" -Skip:(-not $IsWindows) -TestCases @(
+            # NOTE: ensure the testId parameter is unique for each test case; it is used to generate a unique error and done file name.
             @{cmdline = "Get-Item $protectedPath2"; expectedError = "ItemExistsUnauthorizedAccessError,Microsoft.PowerShell.Commands.GetItemCommand"; testId = 'GetItem'}
             @{cmdline = "Get-ChildItem $protectedPath"; expectedError = "DirUnauthorizedAccessError,Microsoft.PowerShell.Commands.GetChildItemCommand"; testId = 'GetChildItem'}
             @{cmdline = "New-Item -Type File -Path $newItemPath"; expectedError = "NewItemUnauthorizedAccessError,Microsoft.PowerShell.Commands.NewItemCommand"; testId = 'NewItem'}
@@ -235,7 +236,6 @@ Describe "Basic FileSystem Provider Tests" -Tags "CI" {
                 Start-Sleep -Milliseconds 100
             }
 
-            $errFile | Should Exist
             $err = Get-Content $errFile
             $err | Should Be $expectedError
         }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
@@ -214,17 +214,21 @@ Describe "Basic FileSystem Provider Tests" -Tags "CI" {
 
         It "Access-denied test for '<cmdline>" -Skip:(-not $IsWindows) -TestCases @(
             # NOTE: ensure the fileNameBase parameter is unique for each test case; it is used to generate a unique error and done file name.
-            @{cmdline = "Get-Item $protectedPath2"; expectedError = "ItemExistsUnauthorizedAccessError,Microsoft.PowerShell.Commands.GetItemCommand"; fileNameBase = 'GetItem'}
-            @{cmdline = "Get-ChildItem $protectedPath"; expectedError = "DirUnauthorizedAccessError,Microsoft.PowerShell.Commands.GetChildItemCommand"; fileNameBase = 'GetChildItem'}
-            @{cmdline = "New-Item -Type File -Path $newItemPath"; expectedError = "NewItemUnauthorizedAccessError,Microsoft.PowerShell.Commands.NewItemCommand"; fileNameBase = 'NewItem'}
-            @{cmdline = "Rename-Item -Path $protectedPath -NewName bar"; expectedError = "RenameItemIOError,Microsoft.PowerShell.Commands.RenameItemCommand"; fileNameBase = 'RenameItem'},
-            @{cmdline = "Move-Item -Path $protectedPath -Destination bar"; expectedError = "MoveDirectoryItemIOError,Microsoft.PowerShell.Commands.MoveItemCommand";  fileNameBase = 'MoveItem'},
-            @{cmdline = "Remove-Item -Path $protectedPath"; expectedError = "RemoveItemUnauthorizedAccessError,Microsoft.PowerShell.Commands.RemoveItemCommand"; fileNameBase = 'RemoveItem'}
+            @{cmdline = "Get-Item $protectedPath2"; expectedError = "ItemExistsUnauthorizedAccessError,Microsoft.PowerShell.Commands.GetItemCommand"}
+            @{cmdline = "Get-ChildItem $protectedPath"; expectedError = "DirUnauthorizedAccessError,Microsoft.PowerShell.Commands.GetChildItemCommand"}
+            @{cmdline = "New-Item -Type File -Path $newItemPath"; expectedError = "NewItemUnauthorizedAccessError,Microsoft.PowerShell.Commands.NewItemCommand"}
+            @{cmdline = "Rename-Item -Path $protectedPath -NewName bar"; expectedError = "RenameItemIOError,Microsoft.PowerShell.Commands.RenameItemCommand"},
+            @{cmdline = "Move-Item -Path $protectedPath -Destination bar"; expectedError = "MoveDirectoryItemIOError,Microsoft.PowerShell.Commands.MoveItemCommand"},
+            @{cmdline = "Remove-Item -Path $protectedPath"; expectedError = "RemoveItemUnauthorizedAccessError,Microsoft.PowerShell.Commands.RemoveItemCommand"}
         ) {
-            param ($cmdline, $expectedError, $fileNameBase)
+            param ($cmdline, $expectedError)
 
+            # generate a filename to use for the error and done text files to avoid test output collision
+            # when a timeout occurs waiting for powershell.
+            $fileNameBase = ([string] $cmdline).GetHashCode().ToString()
             $errFile = Join-Path -Path $TestDrive -ChildPath "$fileNameBase.error.txt"
             $doneFile = Join-Path -Path $TestDrive -Childpath "$fileNameBase.done.txt"
+
             # Seed the error file with text indicating a timeout waiting for the command.
             "Test timeout waiting for $cmdLine" | Set-Content -Path $errFile
 


### PR DESCRIPTION
Fix https://github.com/PowerShell/PowerShell/issues/4561

This change mitigates intermittent timeout failures in the access denied tests as well as fixes unintended cross-test dependencies.  If PowerShell takes longer that 10 seconds to complete a race can cause the subsequent test to pick up the output file of the previous test and fail (i.e., the expected output error file already exists from the previous test because it was created by the long running PowerShell process after the second test started.)  Worse case, the failure cascades causing the race to propogate through the remaining tests in the set.

The fix is two fold:
1: Increase the timeout for waiting for the launched powershell process. (mitigation)
2: Ensure each uses a unique name for the error and done files to avoid polluting the next test.