### PR TITLE
Add tests for  Get-Content -Tail  parameter

### DIFF
--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Content.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Content.Tests.ps1
@@ -79,7 +79,17 @@ Describe "Get-Content" -Tags "CI" {
     It 'Verifies using -Tail and -TotalCount together reports a TailAndHeadCannotCoexist error' {
         { Get-Content -Path Variable:\PSHOME -Tail 1 -TotalCount 5 -ErrorAction Stop} | ShouldBeErrorId 'TailAndHeadCannotCoexist,Microsoft.PowerShell.Commands.GetContentCommand'
     }
-    It 'Verifies -Tail with content that uses an uncommon encoding' {
+    It 'Verifies -Tail with content that uses an explicit encoding' -TestCases @(
+        @{EncodingName = 'String'},
+        @{EncodingName = 'Unicode'},
+        @{EncodingName = 'BigEndianUnicode'},
+        @{EncodingName = 'UTF8'},
+        @{EncodingName = 'UTF7'},
+        @{EncodingName = 'UTF32'},
+        @{EncodingName = 'Ascii'}
+        ){
+        param($EncodingName)
+
         $content = @"
 one
 two
@@ -89,12 +99,13 @@ baz
 "@
         $expected = 'foo'
         $tailCount = 3
+        [Microsoft.PowerShell.Commands.FileSystemCmdletProviderEncoding] $encoding = $EncodingName
 
         $testPath = Join-Path -Path $TestDrive -ChildPath 'TailWithEncoding.txt'
-        $content | Set-Content -Path $testPath -Encoding BigEndianUnicode
+        $content | Set-Content -Path $testPath -Encoding $encoding
         $expected = 'foo'
 
-        $actual = Get-Content -Path $testPath -Tail $tailCount -Encoding BigEndianUnicode
+        $actual = Get-Content -Path $testPath -Tail $tailCount -Encoding $encoding
         $actual.GetType() | Should Be "System.Object[]"
         $actual.Length | Should Be $tailCount
         $actual[0] | Should Be $expected

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Content.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Content.Tests.ps1
@@ -77,7 +77,7 @@ Describe "Get-Content" -Tags "CI" {
         {Get-Content -Path Variable:\PSHOME -Tail 1 -ErrorAction Stop} | ShouldBeErrorId 'TailNotSupported,Microsoft.PowerShell.Commands.GetContentCommand'
     }
     It 'Verifies using -Tail and -TotalCount together reports a TailAndHeadCannotCoexist error' {
-            { Get-Content -Path Variable:\PSHOME -Tail 1 -TotalCount 5 -ErrorAction Stop} | ShouldBeErrorId 'TailAndHeadCannotCoexist,Microsoft.PowerShell.Commands.GetContentCommand'
+        { Get-Content -Path Variable:\PSHOME -Tail 1 -TotalCount 5 -ErrorAction Stop} | ShouldBeErrorId 'TailAndHeadCannotCoexist,Microsoft.PowerShell.Commands.GetContentCommand'
     }
     It 'Verifies -Tail with content that uses an uncommon encoding' {
         $content = @"

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Content.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Content.Tests.ps1
@@ -95,7 +95,7 @@ baz
         $expected = 'foo'
 
         $actual = Get-Content -Path $testPath -Tail $tailCount -Encoding BigEndianUnicode
-        ,$actual | Should BeOfType "System.Object[]"
+        $actual.GetType() | Should Be "System.Object[]"
         $actual.Length | Should Be $tailCount
         $actual[0] | Should Be $expected
     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Content.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Content.Tests.ps1
@@ -100,10 +100,7 @@ baz
         $content | Set-Content -Path $testPath -Encoding BigEndianUnicode
         $expected = 'foo'
 
-        $testPath   = Join-Path -Path $TestDrive -ChildPath 'TailWithEncoding.txt'
-        $content | Set-Content -Path $testPath -Encoding BigEndianUnicode
         $actual = Get-Content -Path $testPath -Tail 3 -Encoding BigEndianUnicode
-
         $actual | Should Be $expected
     }
     It "should Get-Content with a variety of -Tail and -ReadCount values" {#[DRT]

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Content.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Content.Tests.ps1
@@ -71,23 +71,13 @@ Describe "Get-Content" -Tags "CI" {
     }
     #[BugId(BugDatabase.WindowsOutOfBandReleases, 906022)]
     It "should throw 'PSNotSupportedException' when you set-content to an unsupported provider" -Skip:($IsLinux -Or $IsMacOS) {
-        {get-content -path HKLM:\\software\\microsoft -ea stop} | Should Throw "IContentCmdletProvider interface is not implemented"
+        {Get-Content -path HKLM:\\software\\microsoft -ea stop} | Should Throw "IContentCmdletProvider interface is not implemented"
     }
     It 'Verifies -Tail reports a TailNotSupported error for unsupported providers' {
-        try {
-            Get-Content -Path Variable:\PSHOME -Tail 1 -ErrorAction Stop
-        }
-        catch {
-            $_.FullyQualifiedErrorId | Should Be 'TailNotSupported,Microsoft.PowerShell.Commands.GetContentCommand'
-        }
+        {Get-Content -Path Variable:\PSHOME -Tail 1 -ErrorAction Stop} | ShouldBeErrorId 'TailNotSupported,Microsoft.PowerShell.Commands.GetContentCommand'
     }
     It 'Verifies using -Tail and -TotalCount together reports a TailAndHeadCannotCoexist error' {
-        try {
-            Get-Content -Path Variable:\PSHOME -Tail 1 -TotalCount 5 -ErrorAction Stop
-        }
-        catch {
-            $_.FullyQualifiedErrorId | Should Be 'TailAndHeadCannotCoexist,Microsoft.PowerShell.Commands.GetContentCommand'
-        }
+            { Get-Content -Path Variable:\PSHOME -Tail 1 -TotalCount 5 -ErrorAction Stop} | ShouldBeErrorId 'TailAndHeadCannotCoexist,Microsoft.PowerShell.Commands.GetContentCommand'
     }
     It 'Verifies -Tail with content that uses an uncommon encoding' {
         $content = @"

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Content.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Content.Tests.ps1
@@ -71,7 +71,7 @@ Describe "Get-Content" -Tags "CI" {
     }
     #[BugId(BugDatabase.WindowsOutOfBandReleases, 906022)]
     It "should throw 'PSNotSupportedException' when you set-content to an unsupported provider" -Skip:($IsLinux -Or $IsMacOS) {
-        {Get-Content -path HKLM:\\software\\microsoft -ea stop} | Should Throw "IContentCmdletProvider interface is not implemented"
+        {get-content -path HKLM:\\software\\microsoft -ea stop} | Should Throw "IContentCmdletProvider interface is not implemented"
     }
     It 'Verifies -Tail reports a TailNotSupported error for unsupported providers' {
         {Get-Content -Path Variable:\PSHOME -Tail 1 -ErrorAction Stop} | ShouldBeErrorId 'TailNotSupported,Microsoft.PowerShell.Commands.GetContentCommand'
@@ -90,7 +90,7 @@ baz
         $expected = 'foo'
         $tailCount = 3
 
-        $testPath   = Join-Path -Path $TestDrive -ChildPath 'TailWithEncoding.txt'
+        $testPath = Join-Path -Path $TestDrive -ChildPath 'TailWithEncoding.txt'
         $content | Set-Content -Path $testPath -Encoding BigEndianUnicode
         $expected = 'foo'
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Content.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Content.Tests.ps1
@@ -91,17 +91,23 @@ Describe "Get-Content" -Tags "CI" {
     }
     It 'Verifies -Tail with content that uses an uncommon encoding' {
         $content = @"
+one
+two
 foo
 bar
 baz
 "@
+        $expected = 'foo'
+        $tailCount = 3
 
         $testPath   = Join-Path -Path $TestDrive -ChildPath 'TailWithEncoding.txt'
         $content | Set-Content -Path $testPath -Encoding BigEndianUnicode
         $expected = 'foo'
 
-        $actual = Get-Content -Path $testPath -Tail 3 -Encoding BigEndianUnicode
-        $actual | Should Be $expected
+        $actual = Get-Content -Path $testPath -Tail $tailCount -Encoding BigEndianUnicode
+        ,$actual | Should BeOfType "System.Object[]"
+        $actual.Length | Should Be $tailCount
+        $actual[0] | Should Be $expected
     }
     It "should Get-Content with a variety of -Tail and -ReadCount values" {#[DRT]
         set-content -path $testPath "Hello,World","Hello2,World2","Hello3,World3","Hello4,World4"


### PR DESCRIPTION
This change adds Get-Content tests (see https://github.com/PowerShell/PowerShell/issues/4150)
Three conditions are tested:
1: Specifying -Tail and -TotalCount (invalid parameter combination)
2: Specifying -Tail for a provider that is not supported.
3: Ensuring -Tail works with a non-default Encoding.