### PR TITLE
Fix tests that incorrectly use ShouldBeErrorId

### DIFF
--- a/test/powershell/Language/Operators/ComparisonOperator.Tests.ps1
+++ b/test/powershell/Language/Operators/ComparisonOperator.Tests.ps1
@@ -50,13 +50,13 @@ Describe "ComparisonOperator" -tag "CI" {
     }
 
     It "Should return error if right hand is not a valid type: 'hello' <operator> <type>" -TestCases @(
-        @{operator = "-is"; type = "'foo'"; expected='RuntimeException,Microsoft.PowerShell.Commands.InvokeExpressionCommand'},
-        @{operator = "-isnot"; type = "'foo'"; expected='RuntimeException,Microsoft.PowerShell.Commands.InvokeExpressionCommand'},
-        @{operator = "-is"; type = "[foo]"; expected='TypeNotFound,Microsoft.PowerShell.Commands.InvokeExpressionCommand'},
-        @{operator = "-isnot"; type = "[foo]"; expected='TypeNotFound,Microsoft.PowerShell.Commands.InvokeExpressionCommand'}
+        @{operator = "-is"; type = "'foo'"; expectedError='RuntimeException,Microsoft.PowerShell.Commands.InvokeExpressionCommand'},
+        @{operator = "-isnot"; type = "'foo'"; expectedError='RuntimeException,Microsoft.PowerShell.Commands.InvokeExpressionCommand'},
+        @{operator = "-is"; type = "[foo]"; expectedError='TypeNotFound,Microsoft.PowerShell.Commands.InvokeExpressionCommand'},
+        @{operator = "-isnot"; type = "[foo]"; expectedError='TypeNotFound,Microsoft.PowerShell.Commands.InvokeExpressionCommand'}
     ) {
-        param($operator, $type, $expected)
-        { Invoke-Expression "'Hello' $operator $type" } | ShouldBeErrorId $expected
+        param($operator, $type, $expectedError)
+        { Invoke-Expression "'Hello' $operator $type" } | ShouldBeErrorId $expectedError
     }
 
     It "Should succeed in comparing type: <lhs> <operator> <rhs>" -TestCases @(

--- a/test/powershell/Language/Operators/ComparisonOperator.Tests.ps1
+++ b/test/powershell/Language/Operators/ComparisonOperator.Tests.ps1
@@ -50,9 +50,9 @@ Describe "ComparisonOperator" -tag "CI" {
     }
 
     It "Should return error if right hand is not a valid type: 'hello' <operator> <type>" -TestCases @(
-        @{operator = "-is"; type = "'foo'"; expectedError='RuntimeException,Microsoft.PowerShell.Commands.InvokeExpressionCommand'},
+        @{operator = "-is"; type = "'foo'";    expectedError='RuntimeException,Microsoft.PowerShell.Commands.InvokeExpressionCommand'},
         @{operator = "-isnot"; type = "'foo'"; expectedError='RuntimeException,Microsoft.PowerShell.Commands.InvokeExpressionCommand'},
-        @{operator = "-is"; type = "[foo]"; expectedError='TypeNotFound,Microsoft.PowerShell.Commands.InvokeExpressionCommand'},
+        @{operator = "-is"; type = "[foo]";    expectedError='TypeNotFound,Microsoft.PowerShell.Commands.InvokeExpressionCommand'},
         @{operator = "-isnot"; type = "[foo]"; expectedError='TypeNotFound,Microsoft.PowerShell.Commands.InvokeExpressionCommand'}
     ) {
         param($operator, $type, $expectedError)

--- a/test/powershell/Language/Operators/ComparisonOperator.Tests.ps1
+++ b/test/powershell/Language/Operators/ComparisonOperator.Tests.ps1
@@ -56,7 +56,7 @@ Describe "ComparisonOperator" -tag "CI" {
         @{operator = "-isnot"; type = "[foo]"}
     ) {
         param($operator, $type)
-        { Invoke-Expression "'Hello' $operator $type" | Should Be ErrorId "RuntimeException" }
+        { Invoke-Expression "'Hello' $operator $type" | ShouldBeErrorId "RuntimeException" }
     }
 
     It "Should succeed in comparing type: <lhs> <operator> <rhs>" -TestCases @(

--- a/test/powershell/Language/Operators/ComparisonOperator.Tests.ps1
+++ b/test/powershell/Language/Operators/ComparisonOperator.Tests.ps1
@@ -50,13 +50,13 @@ Describe "ComparisonOperator" -tag "CI" {
     }
 
     It "Should return error if right hand is not a valid type: 'hello' <operator> <type>" -TestCases @(
-        @{operator = "-is"; type = "'foo'"},
-        @{operator = "-isnot"; type = "'foo'"},
-        @{operator = "-is"; type = "[foo]"},
-        @{operator = "-isnot"; type = "[foo]"}
+        @{operator = "-is"; type = "'foo'"; expected='RuntimeException,Microsoft.PowerShell.Commands.InvokeExpressionCommand'},
+        @{operator = "-isnot"; type = "'foo'"; expected='RuntimeException,Microsoft.PowerShell.Commands.InvokeExpressionCommand'},
+        @{operator = "-is"; type = "[foo]"; expected='TypeNotFound,Microsoft.PowerShell.Commands.InvokeExpressionCommand'},
+        @{operator = "-isnot"; type = "[foo]"; expected='TypeNotFound,Microsoft.PowerShell.Commands.InvokeExpressionCommand'}
     ) {
-        param($operator, $type)
-        { Invoke-Expression "'Hello' $operator $type" | ShouldBeErrorId "RuntimeException" }
+        param($operator, $type, $expected)
+        { Invoke-Expression "'Hello' $operator $type" } | ShouldBeErrorId $expected
     }
 
     It "Should succeed in comparing type: <lhs> <operator> <rhs>" -TestCases @(

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/xml.tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/xml.tests.ps1
@@ -55,19 +55,19 @@
         }
 
         It "non filesystem path using <parameter>" -TestCases @(
-            @{parameter="literalPath"},
-            @{parameter="path"}
+            @{parameter="literalPath"; expectedError='ProcessingFile,Microsoft.PowerShell.Commands.SelectXmlCommand'},
+            @{parameter="path"; expectedError='PathNotFound,Microsoft.PowerShell.Commands.SelectXmlCommand'}
         ) {
-            param($parameter)
-            $__data = "abcdefg"
-            $params = @{$parameter="variable:__data"}
-            { Select-XML @params "Root" | ShouldBeErrorId 'ProcessingFile,Microsoft.PowerShell.Commands.SelectXmlCommand' }
+            param($parameter, $expectedError)
+            $file = Join-Path -Path $testDrive -ChildPath 'abcdefg'
+            $params = @{$parameter=$file}
+            { Select-XML @params "Root" -ErrorAction Stop} | ShouldBeErrorId $expectedError
         }
 
         It "Invalid xml file" {
             $testfile = "$testdrive/test.xml"
             Set-Content -Path $testfile -Value "<a><b>"
-            { Select-Xml -Path $testfile -XPath foo | ShouldBeErrorId 'ProcessingFile,Microsoft.PowerShell.Commands.SelectXmlCommand' }
+            { Select-Xml -Path $testfile -XPath foo -ErrorAction Stop} | ShouldBeErrorId 'ProcessingFile,Microsoft.PowerShell.Commands.SelectXmlCommand'
         }
 
         It "-xml works with inputstream" {
@@ -80,11 +80,11 @@
 
         It "Returns error for invalid xmlnamespace" {
             [xml]$xml = "<a xmlns='bar'><b xmlns:b='foo'>hello</b><c>world</c></a>"
-            { Select-Xml -Xml $xml -XPath foo -Namespace @{c=$null} | ShouldBeErrorId "PrefixError,Microsoft.PowerShell.Commands.SelectXmlCommand" }
+            { Select-Xml -Xml $xml -XPath foo -Namespace @{c=$null} -ErrorAction Stop } | ShouldBeErrorId "PrefixError,Microsoft.PowerShell.Commands.SelectXmlCommand"
         }
 
         It "Returns error for invalid content" {
-            { Select-Xml -Content "hello" -XPath foo | ShouldBeErrorId "InvalidCastToXmlDocument,Microsoft.PowerShell.Commands.SelectXmlCommand" }
+            { Select-Xml -Content "hello" -XPath foo -ErrorAction Stop} | ShouldBeErrorId "InvalidCastToXmlDocument,Microsoft.PowerShell.Commands.SelectXmlCommand"
         }
 
         It "ToString() works correctly on nested node" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/xml.tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/xml.tests.ps1
@@ -61,7 +61,7 @@
             param($parameter)
             $__data = "abcdefg"
             $params = @{$parameter="variable:__data"}
-            { Select-XML @params "Root" | Should BeErrorId 'ProcessingFile,Microsoft.PowerShell.Commands.SelectXmlCommand' }
+            { Select-XML @params "Root" | ShouldBeErrorId 'ProcessingFile,Microsoft.PowerShell.Commands.SelectXmlCommand' }
         }
 
         It "Invalid xml file" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/xml.tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/xml.tests.ps1
@@ -54,9 +54,9 @@
             }
         }
 
-        It "non filesystem path using <parameter>" -TestCases @(
+        It "Verifies a non filesystem path using <parameter> should fail" -TestCases @(
             @{parameter="literalPath"; expectedError='ProcessingFile,Microsoft.PowerShell.Commands.SelectXmlCommand'},
-            @{parameter="path"; expectedError='ProcessingFile,Microsoft.PowerShell.Commands.SelectXmlCommand'}
+            @{parameter="path";        expectedError='ProcessingFile,Microsoft.PowerShell.Commands.SelectXmlCommand'}
         ) {
             param($parameter, $expectedError)
             try

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/xml.tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/xml.tests.ps1
@@ -56,18 +56,30 @@
 
         It "non filesystem path using <parameter>" -TestCases @(
             @{parameter="literalPath"; expectedError='ProcessingFile,Microsoft.PowerShell.Commands.SelectXmlCommand'},
-            @{parameter="path"; expectedError='PathNotFound,Microsoft.PowerShell.Commands.SelectXmlCommand'}
+            @{parameter="path"; expectedError='ProcessingFile,Microsoft.PowerShell.Commands.SelectXmlCommand'}
         ) {
             param($parameter, $expectedError)
-            $file = Join-Path -Path $testDrive -ChildPath 'abcdefg'
-            $params = @{$parameter=$file}
-            { Select-XML @params "Root" -ErrorAction Stop} | ShouldBeErrorId $expectedError
+            try
+            {
+                $env:xmltestfile = '<a><b>'
+                $file = 'env:xmltestfile'
+                $params = @{$parameter=$file}
+                $err = $null
+                Select-XML @params "Root" -ErrorVariable err
+                $err.FullyQualifiedErrorId | Should Be $expectedError
+            }
+            finally
+            {
+                Remove-Item -Path 'env:xmltestfile'
+            }
         }
 
         It "Invalid xml file" {
             $testfile = "$testdrive/test.xml"
             Set-Content -Path $testfile -Value "<a><b>"
-            { Select-Xml -Path $testfile -XPath foo -ErrorAction Stop} | ShouldBeErrorId 'ProcessingFile,Microsoft.PowerShell.Commands.SelectXmlCommand'
+            $err = $null
+            Select-Xml -Path $testfile -XPath foo -ErrorVariable err
+            $err.FullyQualifiedErrorId | Should Be 'ProcessingFile,Microsoft.PowerShell.Commands.SelectXmlCommand'
         }
 
         It "-xml works with inputstream" {
@@ -79,12 +91,16 @@
         }
 
         It "Returns error for invalid xmlnamespace" {
+            $err = $null
             [xml]$xml = "<a xmlns='bar'><b xmlns:b='foo'>hello</b><c>world</c></a>"
-            { Select-Xml -Xml $xml -XPath foo -Namespace @{c=$null} -ErrorAction Stop } | ShouldBeErrorId "PrefixError,Microsoft.PowerShell.Commands.SelectXmlCommand"
+            Select-Xml -Xml $xml -XPath foo -Namespace @{c=$null} -ErrorVariable err
+            $err.FullyQualifiedErrorId | Should Be 'PrefixError,Microsoft.PowerShell.Commands.SelectXmlCommand'
         }
 
         It "Returns error for invalid content" {
-            { Select-Xml -Content "hello" -XPath foo -ErrorAction Stop} | ShouldBeErrorId "InvalidCastToXmlDocument,Microsoft.PowerShell.Commands.SelectXmlCommand"
+            $err = $null
+            Select-Xml -Content "hello" -XPath foo -ErrorVariable err
+            $err.FullyQualifiedErrorId | Should Be 'InvalidCastToXmlDocument,Microsoft.PowerShell.Commands.SelectXmlCommand'
         }
 
         It "ToString() works correctly on nested node" {


### PR DESCRIPTION
Various tests were using ShouldBeErrorId incorrectly.  The change fixes all found occurrences and, when needed, fix the tests that do not work.