### PR TITLE
added CDXML CIM datetime test

### DIFF
--- a/test/powershell/engine/Cdxml/Cdxml.Tests.ps1
+++ b/test/powershell/engine/Cdxml/Cdxml.Tests.ps1
@@ -55,7 +55,12 @@ Describe "Cdxml cmdlets are supported" -Tag CI,RequireAdminOnWindows {
         # create the class and instances
         # and track the exitcode for the compilation of the mof file
         # if there's a problem, there's no reason to keep going
-        $result = MofComp.exe ${script:createMof}
+        $testMof = Get-Content -Path ${script:createmof} -Raw
+        $currentTimeZone = [System.TimeZoneInfo]::Local
+        $UTCOffset = ($currentTimeZone.GetUtcOffset([datetime]::new(2008, 01, 01, 0, 0, 0))).TotalMinutes.ToString()
+        $testMof = $testMof.Replace("<UTCOffSet>", $UTCOffset)
+        Set-Content -Path $testDrive\testmof.mof -Value $testMof
+        $result = MofComp.exe $testDrive\testmof.mof
         $script:MofCompReturnCode = $LASTEXITCODE
         if ( $script:MofCompReturnCode -ne 0 ) {
             return
@@ -117,6 +122,12 @@ Describe "Cdxml cmdlets are supported" -Tag CI,RequireAdminOnWindows {
             $result = 1,2,4 | foreach-object { [pscustomobject]@{ id = $_ } } | Get-CimTest
             @($result).Count | should be 3
             ( $result.id | sort-object ) -join "," | Should be "1,2,4"
+        }
+
+        It "The Get-CimTest cmdlet should retrieve an object by datetime" @ItSkipOrPending {
+            $result = Get-CimTest -DateTime ([datetime]::new(2008,01,01,0,0,0))
+            @($result).Count | Should Be 1
+            $result.field1 | Should Be "instance 1"
         }
 
         It "The Get-CimTest cmdlet should return the proper error if the instance does not exist" @ItSkipOrPending {

--- a/test/powershell/engine/Cdxml/Cdxml.Tests.ps1
+++ b/test/powershell/engine/Cdxml/Cdxml.Tests.ps1
@@ -43,7 +43,7 @@ Describe "Cdxml cmdlets are supported" -Tag CI,RequireAdminOnWindows {
             if ( Test-CimTestInstance ) {
                 Get-CimInstance @CimCmdletArgs | Remove-CimInstance
             }
-            # if there's a failure with mofcomp then we will have trouble 
+            # if there's a failure with mofcomp then we will have trouble
             # executing the tests. Keep track of the exit code
             $result = MofComp.exe $deleteMof
             $script:MofCompReturnCode = $LASTEXITCODE
@@ -57,6 +57,8 @@ Describe "Cdxml cmdlets are supported" -Tag CI,RequireAdminOnWindows {
         # if there's a problem, there's no reason to keep going
         $testMof = Get-Content -Path ${script:createmof} -Raw
         $currentTimeZone = [System.TimeZoneInfo]::Local
+
+        # this date is simply the same one used in the test mof
         $UTCOffset = ($currentTimeZone.GetUtcOffset([datetime]::new(2008, 01, 01, 0, 0, 0))).TotalMinutes.ToString()
         $testMof = $testMof.Replace("<UTCOffSet>", $UTCOffset)
         Set-Content -Path $testDrive\testmof.mof -Value $testMof

--- a/test/powershell/engine/Cdxml/assets/CimTest/CimTest.cdxml
+++ b/test/powershell/engine/Cdxml/assets/CimTest/CimTest.cdxml
@@ -18,6 +18,12 @@
               <CmdletParameterMetadata ValueFromPipelineByPropertyName="true" CmdletParameterSets="Id" />
             </RegularQuery>
           </Property>
+          <Property PropertyName="DateTime">
+            <Type PSType="System.DateTime" />
+            <RegularQuery>
+              <CmdletParameterMetadata PSName="DateTime" ValueFromPipelineByPropertyName="false" CmdletParameterSets="DateTime" />
+            </RegularQuery>
+          </Property>
         </QueryableProperties>
       </GetCmdletParameters>
 

--- a/test/powershell/engine/Cdxml/assets/CimTest/CreateCimTest.mof
+++ b/test/powershell/engine/Cdxml/assets/CimTest/CreateCimTest.mof
@@ -32,6 +32,7 @@ class PSCore_Test1
     [key] string id;
     string field1;
     sint32 field2;
+    datetime datetime;
     PSCore_subclass subclass;
 };
 
@@ -40,6 +41,7 @@ instance of PSCore_Test1
     id = "1";
     field1 = "instance 1";
     field2 = -1;
+    datetime = "20080101000000.000000<UTCOffSet>";
     subclass = instance of PSCore_subclass{Id="10";subfield1="yup";subfield2=200;};
 };
 


### PR DESCRIPTION
Part of https://github.com/PowerShell/PowerShell/issues/4169

Adds coverage to https://codecov.io/gh/PowerShell/PowerShell/src/ee0bb15b71738eb4ab67cd81d3deca182417116c/src/System.Management.Automation/utils/ClrFacade.cs

To make sure the test runs successfully on any machine in any timezone, needed to create the test mof during runtime with current UTC offset