### PR TITLE
fix set-service failing test

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Service.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Service.cs
@@ -2015,10 +2015,11 @@ namespace Microsoft.PowerShell.Commands
                         dwStartType = NativeMethods.SERVICE_DISABLED;
                         break;
                     default:
-                        Diagnostics.Assert(
-                            ((ServiceStartMode)(-1)) == StartupType,
-                            "bad StartupType");
-                        break;
+                        WriteNonTerminatingError(StartupType.ToString(), DisplayName, Name,
+                            new ArgumentException(), "CouldNotNewService",
+                            ServiceResources.UnsupportedStartupType,
+                            ErrorCategory.InvalidArgument);
+                        return;
                 }
 
                 // set up the double-null-terminated lpDependencies parameter

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Service.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Service.cs
@@ -1683,7 +1683,7 @@ namespace Microsoft.PowerShell.Commands
                         {
                             DWORD dwStartType = NativeMethods.SERVICE_NO_CHANGE;
                             if ((ServiceStartMode)(-1) != StartupType &&
-                                !NativeMethods.GetNativeStartupType(StartupType, out dwStartType))
+                                !NativeMethods.TryGetNativeStartupType(StartupType, out dwStartType))
                             {
                                 WriteNonTerminatingError(StartupType.ToString(), "Set-Service", Name,
                                     new ArgumentException(), "CouldNotSetService",
@@ -1992,8 +1992,7 @@ namespace Microsoft.PowerShell.Commands
                         ErrorCategory.PermissionDenied);
                     return;
                 }
-                DWORD dwStartType = NativeMethods.SERVICE_NO_CHANGE;
-                if (! NativeMethods.GetNativeStartupType(StartupType, out dwStartType))
+                if (!NativeMethods.TryGetNativeStartupType(StartupType, out DWORD dwStartType))
                 {
                     WriteNonTerminatingError(StartupType.ToString(), "New-Service", Name,
                         new ArgumentException(), "CouldNotNewService",
@@ -2403,7 +2402,7 @@ namespace Microsoft.PowerShell.Commands
         /// <returns>
         /// If a supported StartupType is provided, funciton returns true, otherwise false.
         /// </returns>
-        internal static bool GetNativeStartupType(ServiceStartMode StartupType, out DWORD dwStartType)
+        internal static bool TryGetNativeStartupType(ServiceStartMode StartupType, out DWORD dwStartType)
         {
             bool success = true;
             dwStartType = NativeMethods.SERVICE_NO_CHANGE;

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Service.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Service.cs
@@ -1682,8 +1682,7 @@ namespace Microsoft.PowerShell.Commands
                             || (ServiceStartMode)(-1) != StartupType)
                         {
                             DWORD dwStartType = NativeMethods.SERVICE_NO_CHANGE;
-                            if ((ServiceStartMode)(-1) != StartupType &&
-                                !NativeMethods.TryGetNativeStartupType(StartupType, out dwStartType))
+                            if (!NativeMethods.TryGetNativeStartupType(StartupType, out dwStartType))
                             {
                                 WriteNonTerminatingError(StartupType.ToString(), "Set-Service", Name,
                                     new ArgumentException(), "CouldNotSetService",
@@ -2416,6 +2415,9 @@ namespace Microsoft.PowerShell.Commands
                     break;
                 case ServiceStartMode.Disabled:
                     dwStartType = NativeMethods.SERVICE_DISABLED;
+                    break;
+                case (ServiceStartMode)(-1):
+                    dwStartType = NativeMethods.SERVICE_NO_CHANGE;
                     break;
                 default:
                     success = false;

--- a/src/Microsoft.PowerShell.Commands.Management/resources/ServiceResources.resx
+++ b/src/Microsoft.PowerShell.Commands.Management/resources/ServiceResources.resx
@@ -202,6 +202,6 @@
     <value>The command cannot be used to configure the service '{0}' because access to computer '{1}' is denied. Run PowerShell as admin and run your command again.</value>
   </data>
   <data name="UnsupportedStartupType" xml:space="preserve">
-    <value>The startup type '{0}' is not supported by New-Service.</value>
+    <value>The startup type '{0}' is not supported by {1}.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Management/resources/ServiceResources.resx
+++ b/src/Microsoft.PowerShell.Commands.Management/resources/ServiceResources.resx
@@ -201,4 +201,7 @@
   <data name="ComputerAccessDenied" xml:space="preserve">
     <value>The command cannot be used to configure the service '{0}' because access to computer '{1}' is denied. Run PowerShell as admin and run your command again.</value>
   </data>
+  <data name="UnsupportedStartupType" xml:space="preserve">
+    <value>The startup type '{0}' is not supported by New-Service.</value>
+  </data>
 </root>

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Service.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Service.Tests.ps1
@@ -163,8 +163,7 @@ Describe "Set/New-Service cmdlet tests" -Tags "Feature", "RequireAdminOnWindows"
             [System.Management.Automation.PSCredential]::new("username", 
             (ConvertTo-SecureString "PlainTextPassword" -AsPlainText -Force)))
         },
-        # This test case fails due to #4803. Disabled for now.
-        # @{name = 'badstarttype'; parameter = "StartupType"; value = "System"},
+        @{name = 'badstarttype'; parameter = "StartupType"; value = "System"},
         @{name = 'winmgmt'     ; parameter = "DisplayName"; value = "foo"}
     ) {
         param($name, $parameter, $value)

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Service.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Service.Tests.ps1
@@ -42,7 +42,7 @@ Describe "Set/New-Service cmdlet tests" -Tags "Feature", "RequireAdminOnWindows"
 
     It "Set-Service parameter validation for invalid values: <script>" -TestCases @(
         @{
-            script  = {Set-Service foo -StartupType bar};
+            script  = {Set-Service foo -StartupType bar -ErrorAction Stop};
             errorid = "CannotConvertArgumentNoMessage,Microsoft.PowerShell.Commands.SetServiceCommand"
         }
     ) {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Service.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Service.Tests.ps1
@@ -22,15 +22,18 @@ Describe "Set/New-Service cmdlet tests" -Tags "Feature", "RequireAdminOnWindows"
         @{parameter = "Status"      ; value = "Running"},
         @{parameter = "Status"      ; value = "Stopped"},
         @{parameter = "Status"      ; value = "Paused"},
-        @{parameter = "InputObject" ; value = (Get-Service | Select-Object -First 1)},
+        @{parameter = "InputObject" ; script = {Get-Service | Select-Object -First 1}},
         # cmdlet inherits this property, but it's not exposed as parameter so it should be $null
         @{parameter = "Include"     ; value = "foo", "bar" ; expectedNull = $true},
         # cmdlet inherits this property, but it's not exposed as parameter so it should be $null
         @{parameter = "Exclude"     ; value = "foo", "bar" ; expectedNull = $true}
     ) {
-        param($parameter, $value, $expectedNull)
+        param($parameter, $value, $script, $expectedNull)
 
         $setServiceCommand = [Microsoft.PowerShell.Commands.SetServiceCommand]::new()
+        if ($script -ne $Null) {
+            $value = & $script
+        }
         $setServiceCommand.$parameter = $value
         if ($expectedNull -eq $true) {
             $setServiceCommand.$parameter | Should BeNullOrEmpty


### PR DESCRIPTION
missed -ErrorAction Stop
changed new-service to return error when given unsupported startuptype

Fix https://github.com/PowerShell/PowerShell/issues/4800
Fix https://github.com/PowerShell/PowerShell/issues/4803
<!--

If you are a PowerShell Team member, please make sure you choose the Reviewer(s) and Assignee for your PR.
If you are not from the PowerShell Team, you can leave the fields blank and the Maintainers will choose them for you. If you are familiar with the team, feel free to mention some Reviewers yourself.

For more information about the roles of Reviewer and Assignee, refer to [CONTRIBUTING.md](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md).

-->