### PR TITLE
Disable a failing test case in AppVeyor daily test run

### DIFF
--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Service.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Service.Tests.ps1
@@ -163,7 +163,8 @@ Describe "Set/New-Service cmdlet tests" -Tags "Feature", "RequireAdminOnWindows"
             [System.Management.Automation.PSCredential]::new("username", 
             (ConvertTo-SecureString "PlainTextPassword" -AsPlainText -Force)))
         },
-        @{name = 'badstarttype'; parameter = "StartupType"; value = "System"},
+        # This test case fails due to #4803. Disabled for now.
+        # @{name = 'badstarttype'; parameter = "StartupType"; value = "System"},
         @{name = 'winmgmt'     ; parameter = "DisplayName"; value = "foo"}
     ) {
         param($name, $parameter, $value)


### PR DESCRIPTION
See https://ci.appveyor.com/project/PowerShell/powershell-f975h
```
 [-] New-Service with bad parameters will fail for 'badstarttype' where 'StartupType' = 'System' 78ms
   Expected string length 66 but was 13. Strings differ at index 0.
   Expected: {CouldNotNewService,Microsoft.PowerShell.Commands.NewServiceCommand}
   But was:  {No Exception!}
   -----------^
   at line: 65 in C:\projects\powershell-f975h\test\tools\Modules\HelpersCommon\HelpersCommon.psm1
   65:             $_.FullyQualifiedErrorId | Should Be $FullyQualifiedErrorId | Out-Null
```
It's tracked by https://github.com/PowerShell/PowerShell/issues/4803. So for now we will disable the test case.