### PR TITLE
Update docs for beta.7 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,15 +43,15 @@ You can download and install a PowerShell package for any of the following platf
 | Docker                             |                        | [Instructions][in-docker]     |
 | Kali Linux                         | [.deb][rl-ubuntu16]    | [Instructions][in-kali]
 
-[rl-windows10]: https://github.com/PowerShell/PowerShell/releases/download/v6.0.0-beta.6/PowerShell-6.0.0-beta.6-win10-win2016-x64.msi
-[rl-windows81]: https://github.com/PowerShell/PowerShell/releases/download/v6.0.0-beta.6/PowerShell-6.0.0-beta.6-win81-win2012r2-x64.msi
-[rl-windows7-64]: https://github.com/PowerShell/PowerShell/releases/download/v6.0.0-beta.6/PowerShell-6.0.0-beta.6-win7-win2008r2-x64.msi
-[rl-windows7-86]: https://github.com/PowerShell/PowerShell/releases/download/v6.0.0-beta.6/PowerShell-6.0.0-beta.6-win7-x86.msi
-[rl-ubuntu16]: https://github.com/PowerShell/PowerShell/releases/download/v6.0.0-beta.6/powershell_6.0.0-beta.6-1ubuntu1.16.04.1_amd64.deb
-[rl-ubuntu14]: https://github.com/PowerShell/PowerShell/releases/download/v6.0.0-beta.6/powershell_6.0.0-beta.6-1ubuntu1.14.04.1_amd64.deb
-[rl-centos]: https://github.com/PowerShell/PowerShell/releases/download/v6.0.0-beta.6/powershell-6.0.0_beta.6-1.el7.x86_64.rpm
-[rl-ai]: https://github.com/PowerShell/PowerShell/releases/download/v6.0.0-beta.6/PowerShell-6.0.0-beta.6-x86_64.AppImage
-[rl-macos]: https://github.com/PowerShell/PowerShell/releases/download/v6.0.0-beta.6/powershell-6.0.0-beta.6-osx.10.12-x64.pkg
+[rl-windows10]: https://github.com/PowerShell/PowerShell/releases/download/v6.0.0-beta.7/PowerShell-6.0.0-beta.7-win10-win2016-x64.msi
+[rl-windows81]: https://github.com/PowerShell/PowerShell/releases/download/v6.0.0-beta.7/PowerShell-6.0.0-beta.7-win81-win2012r2-x64.msi
+[rl-windows7-64]: https://github.com/PowerShell/PowerShell/releases/download/v6.0.0-beta.7/PowerShell-6.0.0-beta.7-win7-win2008r2-x64.msi
+[rl-windows7-86]: https://github.com/PowerShell/PowerShell/releases/download/v6.0.0-beta.7/PowerShell-6.0.0-beta.7-win7-x86.msi
+[rl-ubuntu16]: https://github.com/PowerShell/PowerShell/releases/download/v6.0.0-beta.7/powershell_6.0.0-beta.7-1ubuntu1.16.04.1_amd64.deb
+[rl-ubuntu14]: https://github.com/PowerShell/PowerShell/releases/download/v6.0.0-beta.7/powershell_6.0.0-beta.7-1ubuntu1.14.04.1_amd64.deb
+[rl-centos]: https://github.com/PowerShell/PowerShell/releases/download/v6.0.0-beta.7/powershell-6.0.0_beta.7-1.el7.x86_64.rpm
+[rl-ai]: https://github.com/PowerShell/PowerShell/releases/download/v6.0.0-beta.7/PowerShell-6.0.0-beta.7-x86_64.AppImage
+[rl-macos]: https://github.com/PowerShell/PowerShell/releases/download/v6.0.0-beta.7/powershell-6.0.0-beta.7-osx.10.12-x64.pkg
 [rl-opensuse421]: https://github.com/PowerShell/PowerShell/releases/download/v6.0.0-beta.6/powershell-6.0.0_beta.6-1.suse.42.1.x86_64.rpm
 
 [installation]: docs/installation

--- a/docker/release/amazonlinux/Dockerfile
+++ b/docker/release/amazonlinux/Dockerfile
@@ -2,7 +2,7 @@
 
 FROM amazonlinux:latest
 
-ARG POWERSHELL_VERSION=6.0.0-beta.6
+ARG POWERSHELL_VERSION=6.0.0-beta.7
 ARG IMAGE_NAME=microsoft/powershell:amazonlinux
 
 LABEL maintainer="PowerShell Team <powershellteam@hotmail.com>" \

--- a/docker/release/centos7/Dockerfile
+++ b/docker/release/centos7/Dockerfile
@@ -2,7 +2,7 @@
 
 FROM centos:7
 
-ARG POWERSHELL_VERSION=6.0.0-beta.6
+ARG POWERSHELL_VERSION=6.0.0-beta.7
 ARG IMAGE_NAME=microsoft/powershell:centos7
 
 LABEL maintainer="PowerShell Team <powershellteam@hotmail.com>" \

--- a/docker/release/fedora24/Dockerfile
+++ b/docker/release/fedora24/Dockerfile
@@ -3,9 +3,9 @@ FROM fedora:24
 # TODO: Until a release of PowerShell for Fedora 24 is available,
 # this Dockerfile installs the CentOS 7 version for compatibility.
 
-ARG POWERSHELL_VERSION=6.0.0-beta.6
-ARG POWERSHELL_RELEASE=v6.0.0-beta.6
-ARG POWERSHELL_PACKAGE=powershell-6.0.0_beta.6-1.el7.x86_64.rpm
+ARG POWERSHELL_VERSION=6.0.0-beta.7
+ARG POWERSHELL_RELEASE=v6.0.0-beta.7
+ARG POWERSHELL_PACKAGE=powershell-6.0.0_beta.7-1.el7.x86_64.rpm
 ARG IMAGE_NAME=microsoft/powershell:fedora24
 
 LABEL maintainer="PowerShell Team <powershellteam@hotmail.com>" \

--- a/docker/release/nanoserver-insider/Dockerfile
+++ b/docker/release/nanoserver-insider/Dockerfile
@@ -10,7 +10,7 @@ ARG NanoServerRepo=microsoft/nanoserver-insider
 FROM ${WindowsServerCoreRepo}:$WindowsServerCoreVersion  AS installer-env
 
 # Arguments for installing powershell, must be defined in the container they are used
-ARG PS_VERSION=6.0.0-beta.6
+ARG PS_VERSION=6.0.0-beta.7
 
 ENV PS_DOWNLOAD_URL https://github.com/PowerShell/PowerShell/releases/download/v$PS_VERSION/PowerShell-$PS_VERSION-win10-win2016-x64.zip
 
@@ -23,7 +23,7 @@ RUN Expand-Archive powershell.zip -DestinationPath \PowerShell
 FROM ${NanoServerRepo}:$NanoServerVersion
 
 ARG VCS_REF="none"
-ARG PS_VERSION=6.0.0-beta.6
+ARG PS_VERSION=6.0.0-beta.7
 ARG IMAGE_NAME=microsoft/nanoserver-insider-powershell
 
 LABEL maintainer="PowerShell Team <powershellteam@hotmail.com>" `

--- a/docker/release/nanoserver/Dockerfile
+++ b/docker/release/nanoserver/Dockerfile
@@ -1,8 +1,8 @@
 # escape=`
 FROM microsoft/nanoserver:latest
 
-ARG POWERSHELL_ZIP=https://github.com/PowerShell/PowerShell/releases/download/v6.0.0-beta.6/PowerShell-6.0.0-beta.6-win10-win2016-x64.zip
-ARG POWERSHELL_VERSION=6.0.0-beta.6
+ARG POWERSHELL_ZIP=https://github.com/PowerShell/PowerShell/releases/download/v6.0.0-beta.7/PowerShell-6.0.0-beta.7-win10-win2016-x64.zip
+ARG POWERSHELL_VERSION=6.0.0-beta.7
 ARG IMAGE_NAME=microsoft/powershell:nanoserver
 
 LABEL maintainer="PowerShell Team <powershellteam@hotmail.com>" `

--- a/docker/release/ubuntu14.04/Dockerfile
+++ b/docker/release/ubuntu14.04/Dockerfile
@@ -2,7 +2,7 @@
 
 FROM ubuntu:trusty
 
-ARG POWERSHELL_VERSION=6.0.0-beta.6
+ARG POWERSHELL_VERSION=6.0.0-beta.7
 ARG IMAGE_NAME=microsoft/powershell:ubuntu14.04
 
 LABEL maintainer="PowerShell Team <powershellteam@hotmail.com>" \

--- a/docker/release/ubuntu16.04/Dockerfile
+++ b/docker/release/ubuntu16.04/Dockerfile
@@ -2,7 +2,7 @@
 
 FROM ubuntu:xenial
 
-ARG POWERSHELL_VERSION=6.0.0-beta.6
+ARG POWERSHELL_VERSION=6.0.0-beta.7
 ARG IMAGE_NAME=microsoft/powershell:ubuntu16.04
 
 LABEL maintainer="PowerShell Team <powershellteam@hotmail.com>" \

--- a/docker/release/windowsservercore/Dockerfile
+++ b/docker/release/windowsservercore/Dockerfile
@@ -1,8 +1,8 @@
 # escape=`
 FROM microsoft/windowsservercore:latest
 
-ARG POWERSHELL_MSI=https://github.com/PowerShell/PowerShell/releases/download/v6.0.0-beta.6/PowerShell-6.0.0-beta.6-win10-win2016-x64.msi
-ARG POWERSHELL_VERSION=6.0.0-beta.6
+ARG POWERSHELL_MSI=https://github.com/PowerShell/PowerShell/releases/download/v6.0.0-beta.7/PowerShell-6.0.0-beta.7-win10-win2016-x64.msi
+ARG POWERSHELL_VERSION=6.0.0-beta.7
 ARG IMAGE_NAME=microsoft/powershell:windowsservercore
 
 LABEL maintainer="PowerShell Team <powershellteam@hotmail.com>" `

--- a/docs/installation/linux.md
+++ b/docs/installation/linux.md
@@ -55,13 +55,13 @@ from then on, you just need to use `sudo apt-get upgrade powershell` to update i
 ### Installation via Direct Download
 
 Using [Ubuntu 14.04][], download the Debian package
-`powershell_6.0.0-beta.6-1ubuntu1.14.04.1_amd64.deb`
+`powershell_6.0.0-beta.7-1ubuntu1.14.04.1_amd64.deb`
 from the [releases][] page onto the Ubuntu machine.
 
 Then execute the following in the terminal:
 
 ```sh
-sudo dpkg -i powershell_6.0.0-beta.6-1ubuntu1.14.04.1_amd64.deb
+sudo dpkg -i powershell_6.0.0-beta.7-1ubuntu1.14.04.1_amd64.deb
 sudo apt-get install -f
 ```
 
@@ -107,13 +107,13 @@ from then on, you just need to use `sudo apt-get upgrade powershell` to update i
 ### Installation via Direct Download - Ubuntu 16.04
 
 Using [Ubuntu 16.04][], download the Debian package
-`powershell_6.0.0-beta.6-1ubuntu1.16.04.1_amd64.deb`
+`powershell_6.0.0-beta.7-1ubuntu1.16.04.1_amd64.deb`
 from the [releases][] page onto the Ubuntu machine.
 
 Then execute the following in the terminal:
 
 ```sh
-sudo dpkg -i powershell_6.0.0-beta.6-1ubuntu1.16.04.1_amd64.deb
+sudo dpkg -i powershell_6.0.0-beta.7-1ubuntu1.16.04.1_amd64.deb
 sudo apt-get install -f
 ```
 
@@ -160,13 +160,13 @@ from then on, you just need to use `sudo apt-get upgrade powershell` to update i
 ### Installation via Direct Download - Debian 8
 
 Download the Debian package
-`powershell_6.0.0-beta.6-1ubuntu1.14.04.1_amd64.deb`
+`powershell_6.0.0-beta.7-1ubuntu1.14.04.1_amd64.deb`
 from the [releases][] page onto the Debian machine.
 
 Then execute the following in the terminal:
 
 ```sh
-sudo dpkg -i powershell_6.0.0-beta.6-1ubuntu1.14.04.1_amd64.deb
+sudo dpkg -i powershell_6.0.0-beta.7-1ubuntu1.14.04.1_amd64.deb
 sudo apt-get install -f
 ```
 
@@ -205,19 +205,19 @@ you just need to use `sudo yum update powershell` to update PowerShell.
 ### Installation via Direct Download - CentOS 7
 
 Using [CentOS 7][], download the RPM package
-`powershell-6.0.0_beta.6-1.el7.x86_64.rpm`
+`powershell-6.0.0_beta.7-1.el7.x86_64.rpm`
 from the [releases][] page onto the CentOS machine.
 
 Then execute the following in the terminal:
 
 ```sh
-sudo yum install ./powershell-6.0.0_beta.6-1.el7.x86_64.rpm
+sudo yum install ./powershell-6.0.0_beta.7-1.el7.x86_64.rpm
 ```
 
 You can also install the RPM without the intermediate step of downloading it:
 
 ```sh
-sudo yum install https://github.com/PowerShell/PowerShell/releases/download/v6.0.0-beta.6/powershell-6.0.0_beta.6-1.el7.x86_64.rpm
+sudo yum install https://github.com/PowerShell/PowerShell/releases/download/v6.0.0-beta.7/powershell-6.0.0_beta.7-1.el7.x86_64.rpm
 ```
 
 ### Uninstallation - CentOS 7
@@ -251,19 +251,19 @@ you just need to use `sudo yum update powershell` to update PowerShell.
 ### Installation via Direct Download - Red Hat Enterprise Linux (RHEL) 7
 
 Download the RPM package
-`powershell-6.0.0_beta.6-1.el7.x86_64.rpm`
+`powershell-6.0.0_beta.7-1.el7.x86_64.rpm`
 from the [releases][] page onto the Red Hat Enterprise Linux machine.
 
 Then execute the following in the terminal:
 
 ```sh
-sudo yum install ./powershell-6.0.0_beta.6-1.el7.x86_64.rpm
+sudo yum install ./powershell-6.0.0_beta.7-1.el7.x86_64.rpm
 ```
 
 You can also install the RPM without the intermediate step of downloading it:
 
 ```sh
-sudo yum install https://github.com/PowerShell/PowerShell/releases/download/v6.0.0-beta.6/powershell-6.0.0_beta.6-1.el7.x86_64.rpm
+sudo yum install https://github.com/PowerShell/PowerShell/releases/download/v6.0.0-beta.7/powershell-6.0.0_beta.7-1.el7.x86_64.rpm
 ```
 
 ### Uninstallation - Red Hat Enterprise Linux (RHEL) 7
@@ -319,14 +319,14 @@ For more information on installing packages from the AUR, see the [Arch Linux wi
 ## Linux AppImage
 
 Using a recent Linux distribution,
-download the AppImage `PowerShell-6.0.0-beta.6-x86_64.AppImage`
+download the AppImage `PowerShell-6.0.0-beta.7-x86_64.AppImage`
 from the [releases][] page onto the Linux machine.
 
 Then execute the following in the terminal:
 
 ```bash
-chmod a+x PowerShell-6.0.0-beta.6-x86_64.AppImage
-./PowerShell-6.0.0-beta.6-x86_64.AppImage
+chmod a+x PowerShell-6.0.0-beta.7-x86_64.AppImage
+./PowerShell-6.0.0-beta.7-x86_64.AppImage
 ```
 
 The [AppImage][] lets you run PowerShell without installing it.
@@ -374,14 +374,14 @@ brew cask reinstall powershell
 ### Installation via Direct Download - macOS 10.12
 
 Using macOS 10.12, download the PKG package
-`powershell-6.0.0-beta.6-osx.10.12-x64.pkg`
+`powershell-6.0.0-beta.7-osx.10.12-x64.pkg`
 from the [releases][] page onto the macOS machine.
 
 Either double-click the file and follow the prompts,
 or install it from the terminal:
 
 ```sh
-sudo installer -pkg powershell-6.0.0-beta.6-osx.10.12-x64.pkg -target /
+sudo installer -pkg powershell-6.0.0-beta.7-osx.10.12-x64.pkg -target /
 ```
 
 ### Uninstallation - macOS 10.12
@@ -461,7 +461,7 @@ wget http://security.debian.org/debian-security/pool/updates/main/o/openssl/libs
 dpkg -i libssl1.0.0_1.0.1t-1+deb8u6_amd64.deb
 
 # Install PowerShell
-dpkg -i powershell_6.0.0-beta.6-1ubuntu1.16.04.1_amd64.deb
+dpkg -i powershell_6.0.0-beta.7-1ubuntu1.16.04.1_amd64.deb
 
 # Start PowerShell
 powershell
@@ -471,24 +471,24 @@ powershell
 
 ```sh
 # Grab the latest App Image
-wget https://github.com/PowerShell/PowerShell/releases/download/v6.0.0-beta.6/PowerShell-6.0.0-beta.6-x86_64.AppImage
+wget https://github.com/PowerShell/PowerShell/releases/download/v6.0.0-beta.7/PowerShell-6.0.0-beta.7-x86_64.AppImage
 
 # Make executable
-chmod a+x PowerShell-6.0.0-beta.6-x86_64.AppImage
+chmod a+x PowerShell-6.0.0-beta.7-x86_64.AppImage
 
 # Start PowerShell
-./PowerShell-6.0.0-beta.6-x86_64.AppImage
+./PowerShell-6.0.0-beta.7-x86_64.AppImage
 ```
 
 ### Uninstallation - Kali
 
 ```sh
-dpkg -r powershell_6.0.0-beta.6-1ubuntu1.16.04.1_amd64
+dpkg -r powershell_6.0.0-beta.7-1ubuntu1.16.04.1_amd64
 ```
 
 ## Paths
 
-* `$PSHOME` is `/opt/microsoft/powershell/6.0.0-beta.6/`
+* `$PSHOME` is `/opt/microsoft/powershell/6.0.0-beta.7/`
 * User profiles will be read from `~/.config/powershell/profile.ps1`
 * Default profiles will be read from `$PSHOME/profile.ps1`
 * User modules will be read from `~/.local/share/powershell/Modules`
@@ -503,7 +503,7 @@ On Linux and macOS, the [XDG Base Directory Specification][xdg-bds] is respected
 
 Note that because macOS is a derivation of BSD,
 instead of `/opt`, the prefix used is `/usr/local`.
-Thus, `$PSHOME` is `/usr/local/microsoft/powershell/6.0.0-beta.6/`,
+Thus, `$PSHOME` is `/usr/local/microsoft/powershell/6.0.0-beta.7/`,
 and the symlink is placed at `/usr/local/bin/powershell`.
 
 [releases]: https://github.com/PowerShell/PowerShell/releases/latest

--- a/tools/download.sh
+++ b/tools/download.sh
@@ -9,11 +9,11 @@ trap '
 
 get_url() {
     fork=$2
-    release=v6.0.0-beta.6
-    echo "https://github.com/$fork/PowerShell/releases/download/$release/$1"
+    echo "https://github.com/$fork/PowerShell/releases/download/$3/$1"
 }
 
 fork="PowerShell"
+release=v6.0.0-beta.7
 # Get OS specific asset ID and package name
 case "$OSTYPE" in
     linux*)
@@ -26,7 +26,7 @@ case "$OSTYPE" in
                     sudo yum install -y curl
                 fi
 
-                package=powershell-6.0.0_beta.6-1.el7.x86_64.rpm
+                package=powershell-6.0.0_beta.7-1.el7.x86_64.rpm
                 ;;
             ubuntu)
                 if ! hash curl 2>/dev/null; then
@@ -36,10 +36,10 @@ case "$OSTYPE" in
 
                 case "$VERSION_ID" in
                     14.04)
-                        package=powershell_6.0.0-beta.6-1ubuntu1.14.04.1_amd64.deb
+                        package=powershell_6.0.0-beta.7-1ubuntu1.14.04.1_amd64.deb
                         ;;
                     16.04)
-                        package=powershell_6.0.0-beta.6-1ubuntu1.16.04.1_amd64.deb
+                        package=powershell_6.0.0-beta.7-1ubuntu1.16.04.1_amd64.deb
                         ;;
                     *)
                         echo "Ubuntu $VERSION_ID is not supported!" >&2
@@ -56,6 +56,7 @@ case "$OSTYPE" in
                 case "$VERSION_ID" in
                     42.1)
                         package=powershell-6.0.0_beta.6-1.suse.42.1.x86_64.rpm
+                        release=v6.0.0-beta.6
                         ;;
                     *)
                         echo "OpenSUSE $VERSION_ID is not supported!" >&2
@@ -69,7 +70,7 @@ case "$OSTYPE" in
         ;;
     darwin*)
         # We don't check for curl as macOS should have a system version
-        package=powershell-6.0.0-beta.6-osx.10.12-x64.pkg
+        package=powershell-6.0.0-beta.7-osx.10.12-x64.pkg
         ;;
     *)
         echo "$OSTYPE is not supported!" >&2
@@ -77,7 +78,7 @@ case "$OSTYPE" in
         ;;
 esac
 
-curl -L -o "$package" $(get_url "$package" "$fork")
+curl -L -o "$package" $(get_url "$package" "$fork" "$release")
 
 if [[ ! -r "$package" ]]; then
     echo "ERROR: $package failed to download! Aborting..." >&2


### PR DESCRIPTION
Leave OpenSuse42.1 related package strings to point to beta.6, because we won't be able to publish a new package for 42.1 anymore.