### PR TITLE
Skip Certificate Authentication tests on CentOS and Mac

### DIFF
--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -415,6 +415,12 @@ $redirectTests = @(
     @{redirectType = 'RedirectKeepVerb'; redirectedMethod='GET'} # Synonym for TemporaryRedirect
 )
 
+$PendingCertificateTest = $false
+# we can't check for Certificate on MacOS and Centos libcurl (currently 7.29.0) returns the following error:
+# The handler does not support client authentication certificates with this combination of libcurl (7.29.0) and its SSL backend ("NSS/3.21 Basic ECC")
+if ( $IsMacOS ) { $PendingCertificateTest = $true }
+if ( test-path /etc/centos-release ) { $PendingCertificateTest = $true }
+
 Describe "Invoke-WebRequest tests" -Tags "Feature" {
 
     BeforeAll {
@@ -1219,9 +1225,9 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
             $result.Status | Should Be 'FAILED'
         }
         
-        # Test skipped on macOS pending support for Client Certificate Authentication
+        # Test skipped on macOS and CentOS pending support for Client Certificate Authentication
         # https://github.com/PowerShell/PowerShell/issues/4650
-        It "Verifies Invoke-WebRequest Certificate Authentication Successful with -Certificate" -Pending:$IsMacOS {
+        It "Verifies Invoke-WebRequest Certificate Authentication Successful with -Certificate" -Pending:$PendingCertificateTest {
             $uri = Get-WebListenerUrl -Https -Test 'Cert'
             $certificate = Get-WebListenerClientCertificate
             $result = Invoke-WebRequest -Uri $uri -Certificate $certificate -SkipCertificateCheck | 
@@ -1793,9 +1799,9 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
             $result.Status | Should Be 'FAILED'
         }
         
-        # Test skipped on macOS pending support for Client Certificate Authentication
+        # Test skipped on macOS and CentOS pending support for Client Certificate Authentication
         # https://github.com/PowerShell/PowerShell/issues/4650
-        It "Verifies Invoke-RestMethod Certificate Authentication Successful with -Certificate" -Pending:$IsMacOS {
+        It "Verifies Invoke-RestMethod Certificate Authentication Successful with -Certificate" -Pending:$PendingCertificateTest {
             $uri = Get-WebListenerUrl -Https -Test 'Cert'
             $certificate = Get-WebListenerClientCertificate
             $result = Invoke-RestMethod -uri $uri -Certificate $certificate -SkipCertificateCheck


### PR DESCRIPTION
These two tests have been failing on CentOS for some time. It is because the available libcurl library does not support client authentication certificates. Marking them as Pending for both CentOS and MacOS
