### PR TITLE
Exclude directories from -Path in Select-String

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
@@ -1347,6 +1347,11 @@ namespace Microsoft.PowerShell.Commands
             {
                 foreach (string filename in expandedPaths)
                 {
+                    if (System.IO.Directory.Exists(filename))
+                    {
+                        continue;
+                    }
+
                     bool foundMatch = ProcessFile(filename);
                     if (_quiet && foundMatch)
                         return;

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
@@ -1347,7 +1347,7 @@ namespace Microsoft.PowerShell.Commands
             {
                 foreach (string filename in expandedPaths)
                 {
-                    if (System.IO.Directory.Exists(filename))
+                    if (Directory.Exists(filename))
                     {
                         continue;
                     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/string.tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/string.tests.ps1
@@ -10,7 +10,7 @@
             $fileNameWithDots = $fileName.FullName.Replace("\", "\.\")
 
             $subDirName = Join-Path $TestDrive 'selectSubDir'
-            New-Item -Path $subDirName -ItemType Directory > $null
+            New-Item -Path $subDirName -ItemType Directory -Force > $null
             $pathWithoutWildcard = $TestDrive
             $pathWithWildcard = Join-Path $TestDrive '*'
 
@@ -30,11 +30,11 @@
         }
 
         It "Select-String does not throw on subdirectory (path without wildcard)" {
-            { select-string -Path  $pathWithoutWildcard "noExists" } | Should Not Throw
+            { select-string -Path  $pathWithoutWildcard "noExists" -ErrorAction Stop } | Should Not Throw
         }
 
         It "Select-String does not throw on subdirectory (path with wildcard)" {
-            { select-string -Path  $pathWithWildcard "noExists" } | Should Not Throw
+            { select-string -Path  $pathWithWildcard "noExists" -ErrorAction Stop } | Should Not Throw
         }
 
         It "LiteralPath with relative path" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/string.tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/string.tests.ps1
@@ -9,6 +9,11 @@
 
             $fileNameWithDots = $fileName.FullName.Replace("\", "\.\")
 
+            $subDirName = Join-Path $TestDrive 'selectSubDir'
+            New-Item -Path $subDirName -ItemType Directory > $null
+            $pathWithoutWildcard = $TestDrive
+            $pathWithWildcard = Join-Path $TestDrive '*'
+
             $tempFile = New-TemporaryFile
             "abc" | Out-File -LiteralPath $tempFile.fullname
 	        "bcd" | Out-File -LiteralPath $tempFile.fullname -Append
@@ -22,6 +27,14 @@
         AfterAll {
             Remove-Item $tempFile -Force -ErrorAction SilentlyContinue
             Pop-Location
+        }
+
+        It "Select-String does not throw on subdirectory (path without wildcard)" {
+            { select-string -Path  $pathWithoutWildcard "noExists" } | Should Not Throw
+        }
+
+        It "Select-String does not throw on subdirectory (path with wildcard)" {
+            { select-string -Path  $pathWithWildcard "noExists" } | Should Not Throw
         }
 
         It "LiteralPath with relative path" {


### PR DESCRIPTION
Fix #4820.

Select-String can search in files only so we should skip directory
objects.
