### PR TITLE
Make the build output the WiX compilation log if it failed.

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -1831,9 +1831,9 @@ function New-MSIPackage
         Write-Error -Message "Package already exists, use -Force to overwrite, path:  $msiLocationPath" -ErrorAction Stop
     }
 
-    & $wixHeatExePath dir  $ProductSourcePath -dr  $productVersionWithName -cg $productVersionWithName -gg -sfrag -srd -scom -sreg -out $wixFragmentPath -var env.ProductSourcePath -v | Write-Verbose
-    & $wixCandleExePath  "$ProductWxsPath"  "$wixFragmentPath" -out (Join-Path "$env:Temp" "\\") -ext WixUIExtension -ext WixUtilExtension -arch x64 -v | Write-Verbose
-    & $wixLightExePath -out $msiLocationPath $wixObjProductPath $wixObjFragmentPath -ext WixUIExtension -ext WixUtilExtension -dWixUILicenseRtf="$LicenseFilePath" -v | Write-Verbose
+    $WiXHeatLog = & $wixHeatExePath dir  $ProductSourcePath -dr  $productVersionWithName -cg $productVersionWithName -gg -sfrag -srd -scom -sreg -out $wixFragmentPath -var env.ProductSourcePath -v
+    $WiXCandleLog = & $wixCandleExePath  "$ProductWxsPath"  "$wixFragmentPath" -out (Join-Path "$env:Temp" "\\") -ext WixUIExtension -ext WixUtilExtension -arch x64 -v
+    $WiXLightLog = & $wixLightExePath -out $msiLocationPath $wixObjProductPath $wixObjFragmentPath -ext WixUIExtension -ext WixUtilExtension -dWixUILicenseRtf="$LicenseFilePath" -v
 
     Remove-Item -ErrorAction SilentlyContinue *.wixpdb -Force
 
@@ -1844,6 +1844,9 @@ function New-MSIPackage
     }
     else
     {
+        $WiXHeatLog   | Out-String | Write-Verbose
+        $WiXCandleLog | Out-String | Write-Verbose
+        $WiXLightLog  | Out-String | Write-Verbose
         throw "Failed to create $msiLocationPath"
     }
 }

--- a/build.psm1
+++ b/build.psm1
@@ -1844,9 +1844,9 @@ function New-MSIPackage
     }
     else
     {
-        $WiXHeatLog   | Out-String | Write-Verbose
-        $WiXCandleLog | Out-String | Write-Verbose
-        $WiXLightLog  | Out-String | Write-Verbose
+        $WiXHeatLog   | Out-String | Write-Verbose -Verbose
+        $WiXCandleLog | Out-String | Write-Verbose -Verbose
+        $WiXLightLog  | Out-String | Write-Verbose -Verbose
         throw "Failed to create $msiLocationPath"
     }
 }


### PR DESCRIPTION
Although PR #4795 fixed the main issue of #4760 (to make the build red if there is a `WiX` compilation error), it did not fix the problem that currently the `WiX` log is not outputted at all and therefore one cannot see the compilation error in the log. This PR fixes this and outputs the `WiX` log only if no `MSI` could be produced because the `WiX` log is quite verbose (around 250 lines) and would be unnecessary noise in a green build.

The reason why the log is currently not displayed in the log is because the resulting object is piped directly to `Write-Verbose` but is of type array and therefore needs to be converted to a string using `Out-String` beforehand.