### PR TITLE
Build powershell core using the generic RID 'linux-x64'

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -638,17 +638,19 @@ function New-PSOptions {
         if ($Environment.IsLinux) {
             $Runtime = "linux-x64"
         } else {
-            $Runtime = dotnet --info | ForEach-Object {
+            $RID = dotnet --info | ForEach-Object {
                 if ($_ -match "RID") {
                     $_ -split "\s+" | Select-Object -Last 1
                 }
             }
 
-            # We plan to release packages targetting win7-x64 and win7-x86 RIDs,
-            # which supports all supported windows platforms.
-            # So we, will change the RID to win7-<arch>
             if ($Environment.IsWindows) {
-                $Runtime = $Runtime -replace "win\d+", "win7"
+                # We plan to release packages targetting win7-x64 and win7-x86 RIDs,
+                # which supports all supported windows platforms.
+                # So we, will change the RID to win7-<arch>
+                $Runtime = $RID -replace "win\d+", "win7"
+            } else {
+                $Runtime = $RID
             }
         }
 

--- a/build.psm1
+++ b/build.psm1
@@ -290,18 +290,12 @@ function Start-PSBuild {
 
         # These runtimes must match those in project.json
         # We do not use ValidateScript since we want tab completion
-        [ValidateSet("ubuntu.14.04-x64",
-                     "ubuntu.16.04-x64",
-                     "debian.8-x64",
-                     "centos.7-x64",
-                     "fedora.24-x64",
-                     "win7-x64",
+        [ValidateSet("win7-x64",
                      "win7-x86",
                      "win81-x64",
                      "win10-x64",
                      "osx.10.12-x64",
-                     "opensuse.13.2-x64",
-                     "opensuse.42.1-x64",
+                     "linux-x64",
                      "linux-arm")]
         [string]$Runtime,
 
@@ -589,18 +583,12 @@ function New-PSOptions {
         # These are duplicated from Start-PSBuild
         # We do not use ValidateScript since we want tab completion
         [ValidateSet("",
-                     "ubuntu.14.04-x64",
-                     "ubuntu.16.04-x64",
-                     "debian.8-x64",
-                     "centos.7-x64",
-                     "fedora.24-x64",
                      "win7-x86",
                      "win7-x64",
                      "win81-x64",
                      "win10-x64",
                      "osx.10.12-x64",
-                     "opensuse.13.2-x64",
-                     "opensuse.42.1-x64",
+                     "linux-x64",
                      "linux-arm")]
         [string]$Runtime,
 
@@ -659,17 +647,21 @@ function New-PSOptions {
     }
 
     if (-not $Runtime) {
-        $Runtime = dotnet --info | ForEach-Object {
-            if ($_ -match "RID") {
-                $_ -split "\s+" | Select-Object -Last 1
+        if ($Environment.IsLinux) {
+            $Runtime = "linux-x64"
+        } else {
+            $Runtime = dotnet --info | ForEach-Object {
+                if ($_ -match "RID") {
+                    $_ -split "\s+" | Select-Object -Last 1
+                }
             }
-        }
 
-        # We plan to release packages targetting win7-x64 and win7-x86 RIDs,
-        # which supports all supported windows platforms.
-        # So we, will change the RID to win7-<arch>
-        if ($Environment.IsWindows) {
-            $Runtime = $Runtime -replace "win\d+", "win7"
+            # We plan to release packages targetting win7-x64 and win7-x86 RIDs,
+            # which supports all supported windows platforms.
+            # So we, will change the RID to win7-<arch>
+            if ($Environment.IsWindows) {
+                $Runtime = $Runtime -replace "win\d+", "win7"
+            }
         }
 
         if (-not $Runtime) {
@@ -851,7 +843,7 @@ function Start-PSPester {
     {
         $Path += "$PSScriptRoot/tools/failingTests"
     }
-    
+
     # we need to do few checks and if user didn't provide $ExcludeTag explicitly, we should alternate the default
     if ($Unelevate)
     {
@@ -1866,18 +1858,12 @@ function Start-CrossGen {
         $PublishPath,
 
         [Parameter(Mandatory=$true)]
-        [ValidateSet("ubuntu.14.04-x64",
-                     "ubuntu.16.04-x64",
-                     "debian.8-x64",
-                     "centos.7-x64",
-                     "fedora.24-x64",
-                     "win7-x86",
+        [ValidateSet("win7-x86",
                      "win7-x64",
                      "win81-x64",
                      "win10-x64",
                      "osx.10.12-x64",
-                     "opensuse.13.2-x64",
-                     "opensuse.42.1-x64",
+                     "linux-x64",
                      "linux-arm")]
         [string]
         $Runtime

--- a/build.psm1
+++ b/build.psm1
@@ -160,14 +160,6 @@ if ( $env:PSModulePath -notcontains $TestModulePath ) {
     $env:PSModulePath = $TestModulePath+$TestModulePathSeparator+$($env:PSModulePath)
 }
 
-#
-# At the moment, we just support x64 builds. When we support x86 builds, this
-# check may need to verify the SDK for the specified architecture.
-#
-function Get-Win10SDKBinDir {
-    return "${env:ProgramFiles(x86)}\Windows Kits\10\bin\x64"
-}
-
 function Test-Win10SDK {
     # The Windows 10 SDK is installed to "${env:ProgramFiles(x86)}\Windows Kits\10\bin\x64",
     # but the directory may exist even if the SDK has not been installed.
@@ -292,8 +284,6 @@ function Start-PSBuild {
         # We do not use ValidateScript since we want tab completion
         [ValidateSet("win7-x64",
                      "win7-x86",
-                     "win81-x64",
-                     "win10-x64",
                      "osx.10.12-x64",
                      "linux-x64",
                      "linux-arm")]
@@ -585,8 +575,6 @@ function New-PSOptions {
         [ValidateSet("",
                      "win7-x86",
                      "win7-x64",
-                     "win81-x64",
-                     "win10-x64",
                      "osx.10.12-x64",
                      "linux-x64",
                      "linux-arm")]
@@ -1860,8 +1848,6 @@ function Start-CrossGen {
         [Parameter(Mandatory=$true)]
         [ValidateSet("win7-x86",
                      "win7-x64",
-                     "win81-x64",
-                     "win10-x64",
                      "osx.10.12-x64",
                      "linux-x64",
                      "linux-arm")]

--- a/src/ResGen/ResGen.csproj
+++ b/src/ResGen/ResGen.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <AssemblyName>resgen</AssemblyName>
     <OutputType>Exe</OutputType>
-    <RuntimeIdentifiers>ubuntu.16.10-x64;ubuntu.16.04-x64;ubuntu.14.04-x64;debian.8-x64;centos.7-x64;fedora.24-x64;win7-x86;win7-x64;win81-x64;win10-x64;osx.10.12-x64;opensuse.13.2-x64;opensuse.42.1-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win7-x86;win7-x64;win81-x64;win10-x64;osx.10.12-x64;linux-x64</RuntimeIdentifiers>
   </PropertyGroup>
 
 </Project>

--- a/src/ResGen/ResGen.csproj
+++ b/src/ResGen/ResGen.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <AssemblyName>resgen</AssemblyName>
     <OutputType>Exe</OutputType>
-    <RuntimeIdentifiers>win7-x86;win7-x64;win81-x64;win10-x64;osx.10.12-x64;linux-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win7-x86;win7-x64;osx.10.12-x64;linux-x64</RuntimeIdentifiers>
   </PropertyGroup>
 
 </Project>

--- a/src/TypeCatalogGen/TypeCatalogGen.csproj
+++ b/src/TypeCatalogGen/TypeCatalogGen.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <AssemblyName>TypeCatalogGen</AssemblyName>
     <OutputType>Exe</OutputType>
-    <RuntimeIdentifiers>win7-x86;win7-x64;win81-x64;win10-x64;osx.10.12-x64;linux-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win7-x86;win7-x64;osx.10.12-x64;linux-x64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/src/TypeCatalogGen/TypeCatalogGen.csproj
+++ b/src/TypeCatalogGen/TypeCatalogGen.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <AssemblyName>TypeCatalogGen</AssemblyName>
     <OutputType>Exe</OutputType>
-    <RuntimeIdentifiers>ubuntu.14.04-x64;ubuntu.16.04-x64;ubuntu.16.10-x64;debian.8-x64;centos.7-x64;fedora.24-x64;win7-x86;win7-x64;win81-x64;win10-x64;osx.10.12-x64;opensuse.13.2-x64;opensuse.42.1-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win7-x86;win7-x64;win81-x64;win10-x64;osx.10.12-x64;linux-x64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/src/powershell-unix/powershell-unix.csproj
+++ b/src/powershell-unix/powershell-unix.csproj
@@ -6,7 +6,7 @@
     <Description>PowerShell top-level project with .NET CLI host</Description>
     <AssemblyName>powershell</AssemblyName>
     <OutputType>Exe</OutputType>
-    <RuntimeIdentifiers>ubuntu.14.04-x64;ubuntu.16.04-x64;ubuntu.16.10-x64;debian.8-x64;centos.7-x64;fedora.24-x64;osx.10.12-x64;opensuse.13.2-x64;opensuse.42.1-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>linux-x64;osx.10.12-x64;</RuntimeIdentifiers>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/powershell-win-core/powershell-win-core.csproj
+++ b/src/powershell-win-core/powershell-win-core.csproj
@@ -6,7 +6,7 @@
     <Description>PowerShell Core on Windows top-level project</Description>
     <AssemblyName>powershell</AssemblyName>
     <OutputType>Exe</OutputType>
-    <RuntimeIdentifiers>win7-x86;win7-x64;win81-x64;win10-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win7-x86;win7-x64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/PSReadLine/PSReadLine.tests.csproj
+++ b/test/PSReadLine/PSReadLine.tests.csproj
@@ -6,7 +6,7 @@
     <Description>PSReadLine basic tests</Description>
     <AssemblyName>TestPSReadLine</AssemblyName>
     <OutputType>Exe</OutputType>
-    <RuntimeIdentifiers>win7-x86;win7-x64;win10-x64;osx.10.12-x64;linux-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win7-x86;win7-x64;osx.10.12-x64;linux-x64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/PSReadLine/PSReadLine.tests.csproj
+++ b/test/PSReadLine/PSReadLine.tests.csproj
@@ -6,7 +6,7 @@
     <Description>PSReadLine basic tests</Description>
     <AssemblyName>TestPSReadLine</AssemblyName>
     <OutputType>Exe</OutputType>
-    <RuntimeIdentifiers>ubuntu.14.04-x64;ubuntu.16.04-x64;centos.7-x64;fedora.24-x64;win7-x86;win7-x64;win10-x64;osx.10.12-x64;opensuse.13.2-x64;opensuse.42.1-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win7-x86;win7-x64;win10-x64;osx.10.12-x64;linux-x64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/csharp/csharp.tests.csproj
+++ b/test/csharp/csharp.tests.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <Description>PowerShell On Linux xUnit Tests</Description>
     <AssemblyName>powershell-tests</AssemblyName>
-    <RuntimeIdentifiers>win7-x86;win7-x64;win81-x64;win10-x64;osx.10.12-x64;linux-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win7-x86;win7-x64;osx.10.12-x64;linux-x64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/csharp/csharp.tests.csproj
+++ b/test/csharp/csharp.tests.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <Description>PowerShell On Linux xUnit Tests</Description>
     <AssemblyName>powershell-tests</AssemblyName>
-    <RuntimeIdentifiers>ubuntu.14.04-x64;ubuntu.16.04-x64;debian.8-x64;centos.7-x64;fedora.24-x64;win7-x86;win7-x64;win81-x64;win10-x64;osx.10.12-x64;opensuse.13.2-x64;opensuse.42.1-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win7-x86;win7-x64;win81-x64;win10-x64;osx.10.12-x64;linux-x64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/tools/TestExe/TestExe.csproj
+++ b/test/tools/TestExe/TestExe.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <AssemblyName>testexe</AssemblyName>
     <OutputType>Exe</OutputType>
-    <RuntimeIdentifiers>ubuntu.16.04-x64;ubuntu.14.04-x64;debian.8-x64;centos.7-x64;fedora.24-x64;win7-x86;win7-x64;win81-x64;win10-x64;osx.10.12-x64;opensuse.13.2-x64;opensuse.42.1-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win7-x86;win7-x64;win81-x64;win10-x64;osx.10.12-x64;linux-x64</RuntimeIdentifiers>
   </PropertyGroup>
 
 </Project>

--- a/test/tools/TestExe/TestExe.csproj
+++ b/test/tools/TestExe/TestExe.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <AssemblyName>testexe</AssemblyName>
     <OutputType>Exe</OutputType>
-    <RuntimeIdentifiers>win7-x86;win7-x64;win81-x64;win10-x64;osx.10.12-x64;linux-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win7-x86;win7-x64;osx.10.12-x64;linux-x64</RuntimeIdentifiers>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Initial PR for #3961, to get the ball rolling.
- [x] Update build so it can build and publish for the runtime linux-x64

Now that openSUSE.42.1 is decommissioned, comparing to updating our build to support SUSE 42.2, it's better to spend our effort on moving toward the generic Linux package.

This PR focuses on enabling build/publish with 'linux-x64'. I also removed `win10-x64` and `win81-x64` RID's given that we produce a single windows package now.
I tried `Start-PSPackage` on Ubuntu after building with the changes of this PR, and the generated package works fine.

The next step is to figure out how to generate single DEB/RPM packages that work for all supported Linux distros.