### PR TITLE
Updated default ModuleVersion in ModuleManifest

### DIFF
--- a/src/System.Management.Automation/engine/Modules/NewModuleManifestCommand.cs
+++ b/src/System.Management.Automation/engine/Modules/NewModuleManifestCommand.cs
@@ -123,7 +123,7 @@ namespace Microsoft.PowerShell.Commands
             get { return _moduleVersion; }
             set { _moduleVersion = value; }
         }
-        private Version _moduleVersion = new Version(1, 0);
+        private Version _moduleVersion = new Version(0, 0, 1);
 
         /// <summary>
         /// Set the module description

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Import-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Import-Module.Tests.ps1
@@ -53,8 +53,8 @@ Describe "Import-Module with ScriptsToProcess" -Tags "CI" {
     $testCases = @(
             @{ TestNameSuffix = 'for top-level module'; ipmoParms =  @{'Name'='.\module1.psd1'}; Expected = '1' }
             @{ TestNameSuffix = 'for top-level and nested module'; ipmoParms =  @{'Name'='.\module2.psd1'}; Expected = '21' }
-            @{ TestNameSuffix = 'for top-level module when -Version is specified'; ipmoParms =  @{'Name'='.\module1.psd1'; 'Version'='1.0'}; Expected = '1' }
-            @{ TestNameSuffix = 'for top-level and nested module when -Version is specified'; ipmoParms =  @{'Name'='.\module2.psd1'; 'Version'='1.0'}; Expected = '21' }
+            @{ TestNameSuffix = 'for top-level module when -Version is specified'; ipmoParms =  @{'Name'='.\module1.psd1'; 'Version'='0.0.1'}; Expected = '1' }
+            @{ TestNameSuffix = 'for top-level and nested module when -Version is specified'; ipmoParms =  @{'Name'='.\module2.psd1'; 'Version'='0.0.1'}; Expected = '21' }
         )
 
     It "Verify ScriptsToProcess are executed <TestNameSuffix>" -TestCases $testCases {


### PR DESCRIPTION
<!--

If you are a PowerShell Team member, please make sure you choose the Reviewer(s) and Assignee for your PR.
If you are not from the PowerShell Team, you can leave the fields blank and the Maintainers will choose them for you. If you are familiar with the team, feel free to mention some Reviewers yourself.

For more information about the roles of Reviewer and Assignee, refer to [CONTRIBUTING.md](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md).

-->

This pull request updates the New-ModuleManifest command to generate a ModuleVersion manifest property with 0.0.1 instead of 1.0. specified by the discussion in #4823.
