### PR TITLE
Added functionality to set credientials on Set-Service command

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Service.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Service.cs
@@ -1472,12 +1472,7 @@ namespace Microsoft.PowerShell.Commands
         /// <value></value>
         [Parameter]
         [Credential()]
-        public PSCredential Credential
-        {
-            get { return credential; }
-            set { credential = value; }
-        }
-        internal PSCredential credential = null;
+        public PSCredential Credential { get; set; }
 
 
 
@@ -1693,7 +1688,7 @@ namespace Microsoft.PowerShell.Commands
                             continue;
                         }
 
-                        // modify startup type or display name or credential
+                        // Modify startup type or display name or credential
                         if (!String.IsNullOrEmpty(DisplayName)
                             || (ServiceStartMode)(-1) != StartupType || null != Credential) 
                         {
@@ -1716,7 +1711,6 @@ namespace Microsoft.PowerShell.Commands
                                     break;
                             }
 
-                            // set up the Credential parameter
                             string username = null;
                             if (null != Credential)
                             {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Service.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Service.Tests.ps1
@@ -110,7 +110,7 @@ Describe "Set/New-Service cmdlet tests" -Tags "Feature", "RequireAdminOnWindows"
         $newServiceCommand.$parameter | Should Be $value
     }
 
-    It "Set-Service can create a new service called '<name>' and change the credentials" -TestCases @(
+    It "Set-Service can change credentials of a service" -TestCases @(
         @{name = "testsetcredential"; 
             startCredential = [System.Management.Automation.PSCredential]::new(".\Guest", 
                 (ConvertTo-SecureString "PlainTextPassword" -AsPlainText -Force)); 
@@ -136,9 +136,9 @@ Describe "Set/New-Service cmdlet tests" -Tags "Feature", "RequireAdminOnWindows"
             $service.StartName | Should Be $endCredential.UserName
         }
         finally {
-            $service = Get-CimInstance Win32_Service -Filter "name='$name'"
+            $service = Get-CimInstance Win32_Service -Filter "name='$name'" -ErrorAction SilentlyContinue
             if ($service -ne $null) {
-                $service | Remove-CimInstance
+                $service | Remove-CimInstance -ErrorAction SilentlyContinue
             }
         }
     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Service.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Service.Tests.ps1
@@ -111,7 +111,6 @@ Describe "Set/New-Service cmdlet tests" -Tags "Feature", "RequireAdminOnWindows"
     }
 
     It "Set-Service can change credentials of a service" {
-        param()
         try {
             $startUsername = "user1"
             $endUsername = "user2"

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Service.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Service.Tests.ps1
@@ -129,19 +129,14 @@ Describe "Set/New-Service cmdlet tests" -Tags "Feature", "RequireAdminOnWindows"
             $service = New-Service @parameters
             $service | Should Not BeNullOrEmpty
             $service = Get-CimInstance Win32_Service -Filter "name='$name'"
-            $service | Should Not BeNullOrEmpty
-            $service.StartName | Should Be $creds.UserName
+            $service.StartName | Should BeExactly $creds.UserName
             $creds = [pscredential]::new(".\$endUsername", $password)
             Set-Service -Name $name -Credential $creds
             $service = Get-CimInstance Win32_Service -Filter "name='$name'"
-            $service | Should Not BeNullOrEmpty
-            $service.StartName | Should Be $creds.UserName
+            $service.StartName | Should BeExactly $creds.UserName
         }
         finally {
-            $service = Get-CimInstance Win32_Service -Filter "name='$name'" -ErrorAction SilentlyContinue
-            if ($service -ne $null) {
-                $service | Remove-CimInstance -ErrorAction SilentlyContinue
-            }
+            Get-CimInstance Win32_Service -Filter "name='$name'" | Remove-CimInstance -ErrorAction SilentlyContinue
             $null = net user $startUsername /delete
             $null = net user $endUsername /delete
         }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Service.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Service.Tests.ps1
@@ -112,9 +112,9 @@ Describe "Set/New-Service cmdlet tests" -Tags "Feature", "RequireAdminOnWindows"
 
     It "Set-Service can create a new service called '<name>' and change the credentials" -TestCases @(
         @{name = "testsetcredential"; 
-            startCredential = [System.Management.Automation.PSCredential]::new("username", 
+            startCredential = [System.Management.Automation.PSCredential]::new(".\Guest", 
                 (ConvertTo-SecureString "PlainTextPassword" -AsPlainText -Force)); 
-            endCredential = [System.Management.Automation.PSCredential]::new("username2", 
+            endCredential = [System.Management.Automation.PSCredential]::new(".\Administrator", 
                 (ConvertTo-SecureString "PlainTextPassword" -AsPlainText -Force))}
     ) {
         param($name, $startCredential, $endCredential)


### PR DESCRIPTION
Added functionality to set credientials on `Set-Service` command.
Using this you can now specifiy the `-Credential` parameter which makes the service you have specfied change the log-on account.

Issue #4843 
