### PR TITLE
Void codemethod call should not crash

### DIFF
--- a/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
+++ b/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
@@ -6571,7 +6571,7 @@ namespace System.Management.Automation.Language
                 Expression expr = InvokeMethod(codeMethod.CodeReference, null, args.Prepend(target).ToArray(), false, MethodInvocationType.Ordinary);
                 if (codeMethod.CodeReference.ReturnType == typeof(void))
                 {
-                    expr = Expression.Block(expr, Expression.Default(typeof(object)));
+                    expr = Expression.Block(expr, ExpressionCache.AutomationNullConstant);
                 }
                 else
                 {

--- a/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
+++ b/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
@@ -6568,9 +6568,16 @@ namespace System.Management.Automation.Language
             var codeMethod = methodInfo as PSCodeMethod;
             if (codeMethod != null)
             {
-                return new DynamicMetaObject(
-                    InvokeMethod(codeMethod.CodeReference, null, args.Prepend(target).ToArray(), false, MethodInvocationType.Ordinary)
-                    .Cast(typeof(object)), restrictions).WriteToDebugLog(this);
+                Expression expr = InvokeMethod(codeMethod.CodeReference, null, args.Prepend(target).ToArray(), false, MethodInvocationType.Ordinary);
+                if (codeMethod.CodeReference.ReturnType == typeof(void))
+                {
+                    expr = Expression.Block(expr, Expression.Default(typeof(object)));
+                }
+                else
+                {
+                    expr = expr.Cast(typeof(object));
+                }
+                return new DynamicMetaObject(expr, restrictions).WriteToDebugLog(this);
             }
 
             var parameterizedProperty = methodInfo as PSParameterizedProperty;

--- a/test/powershell/engine/ETS/Adapter.Tests.ps1
+++ b/test/powershell/engine/ETS/Adapter.Tests.ps1
@@ -79,6 +79,39 @@ Describe "Adapter Tests" -tags "CI" {
         $val  = $doc.ToString()
         $val | Should Be "book"
     }
+
+    It "Calls CodeMethod with void result" {
+
+        class TestCodeMethodInvokationWithVoidReturn {
+            [int] $CallCounter
+
+            static [int] IntMethodCM([PSObject] $self) {
+                return $self.CallCounter
+            }
+
+            static [void] VoidMethodCM([PSObject] $self) {
+                $self.CallCounter++
+            }
+
+            static [Reflection.MethodInfo] GetMethodInfo([string] $name) {
+                return [TestCodeMethodInvokationWithVoidReturn].GetMethod($name)
+            }
+        }
+
+        Update-TypeData -Force -TypeName TestCodeMethodInvokationWithVoidReturn -MemberType CodeMethod -MemberName IntMethod -Value ([TestCodeMethodInvokationWithVoidReturn]::GetMethodInfo('IntMethodCM'))
+        Update-TypeData -Force -TypeName TestCodeMethodInvokationWithVoidReturn -MemberType CodeMethod -MemberName VoidMethod -Value ([TestCodeMethodInvokationWithVoidReturn]::GetMethodInfo('VoidMethodCM'))
+        try {
+            $o = [TestCodeMethodInvokationWithVoidReturn]::new()
+            $o.CallCounter | Should Be 0
+            $o.VoidMethod()
+            $o.CallCounter | Should be 1
+
+            $o.IntMethod() | Should be 1
+        }
+        finally {
+            Remove-TypeData TestCodeMethodInvokationWithVoidReturn
+        }
+    }
 }
 
 Describe "Adapter XML Tests" -tags "CI" {


### PR DESCRIPTION
Fixes #4826 

Adding a check if the method to be called is void, and in that case wrap it in a block that returns null.

Looking at some other code, there seems to be a `CSharpBinderFlags.ResultDiscarded` when they to this in C#. Can reviewers please check if this or something similar needs to be used here?



