### PR TITLE
Initialize Headers Dictionary Only Once

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebResponseHelper.CoreClr.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebResponseHelper.CoreClr.cs
@@ -4,6 +4,8 @@
 Copyright (c) Microsoft Corporation.  All rights reserved.
 --********************************************************************/
 
+using System;
+using System.Collections.Generic;
 using System.Net.Http;
 using System.Globalization;
 
@@ -15,6 +17,24 @@ namespace Microsoft.PowerShell.Commands
         {
             string characterSet = response.Content.Headers.ContentType.CharSet;
             return characterSet;
+        }
+        
+        internal static Dictionary<string, IEnumerable<string>> GetHeadersDictionary(HttpResponseMessage response)
+        {
+            var headers = new Dictionary<string, IEnumerable<string>>(StringComparer.OrdinalIgnoreCase);
+            foreach (var entry in response.Headers)
+            {
+                headers[entry.Key] = entry.Value;
+            }
+            if (response.Content != null)
+            {
+                foreach (var entry in response.Content.Headers)
+                {
+                    headers[entry.Key] = entry.Value;
+                }
+            }
+
+            return headers;
         }
 
         internal static string GetProtocol(HttpResponseMessage response)

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebResponseHelper.CoreClr.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebResponseHelper.CoreClr.cs
@@ -26,6 +26,10 @@ namespace Microsoft.PowerShell.Commands
             {
                 headers[entry.Key] = entry.Value;
             }
+            // In CoreFX, HttpResponseMessage separates content related headers, such as Content-Type to 
+            // HttpResponseMessage.Content.Headers. The remaining headers are in HttpResponseMessage.Headers.
+            // The keys in both should be unique with no duplicates between them.
+            // Added for backwards compatibility with PowerShell 5.1 and earlier.
             if (response.Content != null)
             {
                 foreach (var entry in response.Content.Headers)

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebResponseObject.CoreClr.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebResponseObject.CoreClr.cs
@@ -33,18 +33,7 @@ namespace Microsoft.PowerShell.Commands
             {
                 if(_headers == null)
                 {
-                    _headers = new Dictionary<string, IEnumerable<string>>(StringComparer.OrdinalIgnoreCase);
-                    foreach (var entry in BaseResponse.Headers)
-                    {
-                        _headers[entry.Key] = entry.Value;
-                    }
-                    if (BaseResponse.Content != null)
-                    {
-                        foreach (var entry in BaseResponse.Content.Headers)
-                        {
-                            _headers[entry.Key] = entry.Value;
-                        }
-                    }
+                    _headers = WebResponseHelper.GetHeadersDictionary(BaseResponse);
                 }
 
                 return _headers;

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebResponseObject.CoreClr.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebResponseObject.CoreClr.cs
@@ -31,27 +31,27 @@ namespace Microsoft.PowerShell.Commands
         {
             get
             {
-                if(headers == null)
+                if(_headers == null)
                 {
-                    headers = new Dictionary<string, IEnumerable<string>>(StringComparer.OrdinalIgnoreCase);
+                    _headers = new Dictionary<string, IEnumerable<string>>(StringComparer.OrdinalIgnoreCase);
                     foreach (var entry in BaseResponse.Headers)
                     {
-                        headers[entry.Key] = entry.Value;
+                        _headers[entry.Key] = entry.Value;
                     }
                     if (BaseResponse.Content != null)
                     {
                         foreach (var entry in BaseResponse.Content.Headers)
                         {
-                            headers[entry.Key] = entry.Value;
+                            _headers[entry.Key] = entry.Value;
                         }
                     }
                 }
 
-                return headers;
+                return _headers;
             }
         }
 
-        private Dictionary<string, IEnumerable<string>> headers = null;
+        private Dictionary<string, IEnumerable<string>> _headers = null;
         
         /// <summary>
         /// gets the RelationLink property

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebResponseObject.CoreClr.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebResponseObject.CoreClr.cs
@@ -31,16 +31,19 @@ namespace Microsoft.PowerShell.Commands
         {
             get
             {
-                var headers = new Dictionary<string, IEnumerable<string>>(StringComparer.OrdinalIgnoreCase);
-                foreach (var entry in BaseResponse.Headers)
+                if(headers == null)
                 {
-                    headers[entry.Key] = entry.Value;
-                }
-                if (BaseResponse.Content != null)
-                {
-                    foreach (var entry in BaseResponse.Content.Headers)
+                    headers = new Dictionary<string, IEnumerable<string>>(StringComparer.OrdinalIgnoreCase);
+                    foreach (var entry in BaseResponse.Headers)
                     {
                         headers[entry.Key] = entry.Value;
+                    }
+                    if (BaseResponse.Content != null)
+                    {
+                        foreach (var entry in BaseResponse.Content.Headers)
+                        {
+                            headers[entry.Key] = entry.Value;
+                        }
                     }
                 }
 
@@ -48,6 +51,8 @@ namespace Microsoft.PowerShell.Commands
             }
         }
 
+        private Dictionary<string, IEnumerable<string>> headers = null;
+        
         /// <summary>
         /// gets the RelationLink property
         /// </summary>


### PR DESCRIPTION
Switch the `WebResponseObject.Headers` Dictionary to initialize once instead of creating a new dictionary on every get. Moved logic to `WebResponseHelper.GetHeadersDictionary()` as this code will be reused outside of `WebResponseObject`.

Closes #3842 

This changes internal functionality only. Existing tests for the `Headers` property are sufficient.
