### PR TITLE
reduce output of pester for CI

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -1018,7 +1018,14 @@ function Start-PSPester {
                 try
                 {
                     $Command += "|Export-Clixml -Path '$passThruFile' -Force"
-                    Start-NativeExecution -sb {& $powershell -noprofile -c $Command} | ForEach-Object { Write-Host $_}
+                    if ($Terse)
+                    {
+                        Start-NativeExecution -sb {& $powershell -noprofile -c $Command} | ForEach-Object { Write-Terse $_}
+                    }
+                    else
+                    {
+                        Start-NativeExecution -sb {& $powershell -noprofile -c $Command} | ForEach-Object { Write-Host $_}
+                    }
                     Import-Clixml -Path $passThruFile | Where-Object {$_.TotalCount -is [Int32]}
                 }
                 finally

--- a/tools/appveyor.psm1
+++ b/tools/appveyor.psm1
@@ -348,11 +348,11 @@ function Invoke-AppVeyorTest
         Remove-Item -Force ${telemetrySemaphoreFilepath}
     }
 
-    Start-PSPester -bindir $env:CoreOutput -outputFile $testResultsNonAdminFile -Unelevate -Tag @() -ExcludeTag ($ExcludeTag + @('RequireAdminOnWindows'))
+    Start-PSPester -Terse -bindir $env:CoreOutput -outputFile $testResultsNonAdminFile -Unelevate -Tag @() -ExcludeTag ($ExcludeTag + @('RequireAdminOnWindows'))
     Write-Host -Foreground Green 'Upload CoreCLR Non-Admin test results'
     Update-AppVeyorTestResults -resultsFile $testResultsNonAdminFile
 
-    Start-PSPester -bindir $env:CoreOutput -outputFile $testResultsAdminFile -Tag @('RequireAdminOnWindows') -ExcludeTag $ExcludeTag
+    Start-PSPester -Terse -bindir $env:CoreOutput -outputFile $testResultsAdminFile -Tag @('RequireAdminOnWindows') -ExcludeTag $ExcludeTag
     Write-Host -Foreground Green 'Upload CoreCLR Admin test results'
     Update-AppVeyorTestResults -resultsFile $testResultsAdminFile
 

--- a/tools/travis.ps1
+++ b/tools/travis.ps1
@@ -158,6 +158,7 @@ else
     $pesterParam = @{ 
         'binDir'   = $output 
         'PassThru' = $true
+        'Terse'    = $true
     }
 
     if ($isFullBuild) {


### PR DESCRIPTION
added `-terse` switch to Start-PSPester to reduce output and suppress progress
update CI scripts to use new switch

example output:
```none
Describing Adapter Tests
+++++++++
Describing Adapter XML Tests
   Context Can set XML node property to non-string object
++++++++++
Describing DataRow and DataRowView Adapter tests
   Context DataRow Adapter tests
++
   Context DataRowView Adapter tests
++
Describing CIM Objects are adapted properly
+++++++++++++++
Describing Online help tests for PowerShell Core Cmdlets
!+++!+!+!+++++!++++++++++++!+++++!++++++++!++++++++++++++!+++++!++++++!++++++++++++++!+++!+++++!+++++++++++++!++!!++++++!+!!!!!!++++++++++!++!++!++!++++++++!!+!+++++++!+!+++!+++!+++++++++++++++++++++!++!++++++!++++++++!+++++!+++!+!++++++!+++++++!!+++!!+!!!!!+!!!+!++!!+!!!!+!++!!!++!+!!!!!!!+++!++!!++++++++!!+++!!!+!!!!!!!!!!!!!!!++++++
```

Runtime (on my laptop) went from 201.22s to 144.89s
<!--

If you are a PowerShell Team member, please make sure you choose the Reviewer(s) and Assignee for your PR.
If you are not from the PowerShell Team, you can leave the fields blank and the Maintainers will choose them for you. If you are familiar with the team, feel free to mention some Reviewers yourself.

For more information about the roles of Reviewer and Assignee, refer to [CONTRIBUTING.md](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md).

-->
