### PR TITLE
Only run resource validation tests on Windows, otherwise skip them.

### DIFF
--- a/test/powershell/engine/ResourceValidation/CimCmdletsResources.Tests.ps1
+++ b/test/powershell/engine/ResourceValidation/CimCmdletsResources.Tests.ps1
@@ -6,7 +6,10 @@ $assemblyName = "Microsoft.Management.Infrastructure.CimCmdlets"
 # entries in the csproj for the assembly
 $excludeList = @()
 # load the module since it isn't there by default
-import-module CimCmdlets
+if ( $IsWindows )
+{
+    import-module CimCmdlets
+}
 
 # run the tests
 Test-ResourceStrings -AssemblyName $AssemblyName -ExcludeList $excludeList

--- a/test/powershell/engine/ResourceValidation/TestRunner.ps1
+++ b/test/powershell/engine/ResourceValidation/TestRunner.ps1
@@ -38,7 +38,7 @@ function Test-ResourceStrings
         {
             # in the event that the id has a space in it, it is replaced with a '_'
             $classname = $resourcefile.Name -replace ".resx"
-            It "'$classname' should be an available type and the strings should be correct" {
+            It "'$classname' should be an available type and the strings should be correct" -Skip:(!$IsWindows) {
                 # get the type from the assembly
                 $resourceType = $ASSEMBLY.GetType($classname, $false, $true)
                 # the properties themselves are static internals, so we need

--- a/test/powershell/engine/ResourceValidation/WSManResources.Tests.ps1
+++ b/test/powershell/engine/ResourceValidation/WSManResources.Tests.ps1
@@ -6,17 +6,9 @@ $assemblyName = "Microsoft.WSMan.Management"
 # entries in the csproj for the assembly
 $excludeList = @()
 # load the module since it isn't there by default
-import-module Microsoft.WSMan.Management
-
-
-try {
-    if ( ! $IsWindows ) 
-    {
-        $PSDefaultParameterValues["it:skip"] = $true
-    }
-    # run the tests
-    Test-ResourceStrings -AssemblyName $AssemblyName -ExcludeList $excludeList
+if ( $IsWindows ) {
+    import-module Microsoft.WSMan.Management
 }
-finally {
-    $PSDefaultParameterValues.Remove("it:skip")
-}
+
+# run the tests
+Test-ResourceStrings -AssemblyName $AssemblyName -ExcludeList $excludeList


### PR DESCRIPTION
This is a global change rather than in the single WSMan tests. Since we don't have different resources based on platform, we can test on Windows only. If we have resources on non-Windows only then this will need to be a bit more complicated
