### PR TITLE
allow * to be used in registry path for remove-item

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Navigation.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Navigation.cs
@@ -3266,6 +3266,10 @@ namespace Microsoft.PowerShell.Commands
                     {
                         // not a directory
                     }
+                    catch (System.ArgumentException)
+                    {
+                        // invalid characters (like asterisk) for a file path, but valid for other paths (like registry)
+                    }
 
                     if (!treatAsFile && !Recurse && hasChildren)
                     {

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Navigation.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Navigation.cs
@@ -3107,6 +3107,18 @@ namespace Microsoft.PowerShell.Commands
                     try
                     {
                         resolvedPSPaths = SessionState.Path.GetResolvedPSPathFromPSPath(path, currentContext);
+                        if (null != LiteralPath && 0 == resolvedPSPaths.Count)
+                        {
+                            ItemNotFoundException pathNotFound =
+                                new ItemNotFoundException(
+                                    path,
+                                    "PathNotFound",
+                                    SessionStateStrings.PathNotFound);
+                            WriteError(new ErrorRecord(
+                                pathNotFound.ErrorRecord,
+                                pathNotFound));
+                            continue;
+                        }
                     }
                     finally
                     {
@@ -3253,22 +3265,23 @@ namespace Microsoft.PowerShell.Commands
 
                     bool shouldRecurse = Recurse;
                     bool treatAsFile = false;
-                    try
+
+                    // only check if path is a directory using DirectoryInfo if using FileSystemProvider
+                    if (resolvedPath.Provider.Name.Equals(FileSystemProvider.ProviderName, StringComparison.OrdinalIgnoreCase))
                     {
-                        System.IO.DirectoryInfo di = new System.IO.DirectoryInfo(providerPath);
-                        if (di != null && (di.Attributes & System.IO.FileAttributes.ReparsePoint) != 0)
+                        try
                         {
-                            shouldRecurse = false;
-                            treatAsFile = true;
+                            System.IO.DirectoryInfo di = new System.IO.DirectoryInfo(providerPath);
+                            if (di != null && (di.Attributes & System.IO.FileAttributes.ReparsePoint) != 0)
+                            {
+                                shouldRecurse = false;
+                                treatAsFile = true;
+                            }
                         }
-                    }
-                    catch (System.IO.FileNotFoundException)
-                    {
-                        // not a directory
-                    }
-                    catch (System.ArgumentException)
-                    {
-                        // invalid characters (like asterisk) for a file path, but valid for other paths (like registry)
+                        catch (System.IO.FileNotFoundException)
+                        {
+                            // not a directory
+                        }
                     }
 
                     if (!treatAsFile && !Recurse && hasChildren)

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
@@ -370,6 +370,10 @@ Describe "Handling of globbing patterns" -Tags "CI" {
             Copy-Item -LiteralPath $file.FullName -Destination $newPath
             Test-Path -LiteralPath $newPath | Should Be $true
         }
+
+        It "Remove-Item -LiteralPath should fail if it contains asterisk" {
+            { Remove-Item -LiteralPath ./foo*.txt -ErrorAction Stop } | ShouldBeErrorId "PathNotFound,Microsoft.PowerShell.Commands.RemoveItemCommand"
+        }
     }
 }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Registry.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Registry.Tests.ps1
@@ -469,6 +469,22 @@ Describe "Extended Registry Provider Tests" -Tags @("Feature", "RequireAdminOnWi
             $result."$testPropertyName" | Should Be $testPropertyValue
         }
     }
+
+    Context "Validate -LiteralPath" {
+        It "Verify New-Item and Remove-Item work with asterisk" {
+            try {
+                $tempPath = "HKCU:\_tmp"
+                $testPath = "$tempPath\*\sub"
+                New-Item -Force $testPath
+                $testPath | Should Exist
+                Remove-Item -LiteralPath $testPath
+                $testPath | Should Not Exist
+            }
+            finally {
+                Remove-Item -Recurse $tempPath
+            }
+        }
+    }
 }
 
 } finally {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Registry.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Registry.Tests.ps1
@@ -475,13 +475,13 @@ Describe "Extended Registry Provider Tests" -Tags @("Feature", "RequireAdminOnWi
             try {
                 $tempPath = "HKCU:\_tmp"
                 $testPath = "$tempPath\*\sub"
-                New-Item -Force $testPath
+                $null = New-Item -Force $testPath
                 $testPath | Should Exist
                 Remove-Item -LiteralPath $testPath
                 $testPath | Should Not Exist
             }
             finally {
-                Remove-Item -Recurse $tempPath
+                Remove-Item -Recurse $tempPath -ErrorAction SilentlyContinue
             }
         }
     }

--- a/test/powershell/Modules/Microsoft.WSMan.Management/ConfigProvider.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.WSMan.Management/ConfigProvider.Tests.ps1
@@ -292,11 +292,11 @@ Describe "WSMan Config Provider" -Tag Feature,RequireAdminOnWindows {
                 # not a .Net type so can't use BeOfType
                 $newItem.PSObject.TypeNames[0] | Should Be "Microsoft.WSMan.Management.WSManConfigContainerElement#ComputerLevel"
                 $newItem.Name | Should Be $expected
-                Remove-Item WSMan:\$name
+                Remove-Item WSMan:\$name -Recurse -Force
                 "WSMan:\$name" | Should Not Exist
             }
             finally {
-                Remove-Item WSMan:\$name -Force -ErrorAction SilentlyContinue
+                Remove-Item WSMan:\$name -Recurse -Force -ErrorAction SilentlyContinue
             }
         }
 
@@ -314,11 +314,11 @@ Describe "WSMan Config Provider" -Tag Feature,RequireAdminOnWindows {
                         $property.Value | Should Be $listenerXml.Listener.$($property.Name)
                     }
                 }
-                Remove-Item -Path "WSMan:\localhost\Listener\$listenerName" -Force
+                Remove-Item -Path "WSMan:\localhost\Listener\$listenerName" -Recurse -Force
                 $newListener.PSPath | Should Not Exist
             }
             finally {
-                Remove-Item -Path "WSMan:\localhost\Listener\$listenerName" -Force -ErrorAction SilentlyContinue
+                Remove-Item -Path "WSMan:\localhost\Listener\$listenerName" -Recurse -Force -ErrorAction SilentlyContinue
             }
         }
 
@@ -332,11 +332,11 @@ Describe "WSMan Config Provider" -Tag Feature,RequireAdminOnWindows {
                     -RunAsCredential $creds
                 $expectedMissingProperties = @("InitializationParameters")
                 Test-Plugin -Plugin $plugin -expectedMissingProperties $expectedMissingProperties
-                Remove-Item WSMan:\localhost\Plugin\TestPlugin2\
+                Remove-Item WSMan:\localhost\Plugin\TestPlugin2\ -Recurse -Force
                 "WSMan:\localhost\Plugin\TestPlugin2" | Should Not Exist
             }
             finally {
-                Remove-Item WSMan:\localhost\Plugin\TestPlugin2\ -Force -ErrorAction SilentlyContinue
+                Remove-Item WSMan:\localhost\Plugin\TestPlugin2\ -Recurse -Force -ErrorAction SilentlyContinue
             }
         }
 
@@ -363,11 +363,11 @@ Describe "WSMan Config Provider" -Tag Feature,RequireAdminOnWindows {
             try {
                 $plugin = New-Item -Path WSMan:\localhost\Plugin -File $testdrive\plugin.xml -Name TestPlugin2
                 Test-Plugin -Plugin $plugin
-                Remove-Item WSMan:\localhost\Plugin\TestPlugin2\
+                Remove-Item WSMan:\localhost\Plugin\TestPlugin2\ -Recurse -Force
                 "WSMan:\localhost\Plugin\TestPlugin2\" | Should Not Exist
             }
             finally {
-                Remove-Item "WSMan:\localhost\Plugin\TestPlugin2\" -Force -ErrorAction SilentlyContinue
+                Remove-Item "WSMan:\localhost\Plugin\TestPlugin2\" -Recurse -Force -ErrorAction SilentlyContinue
             }
         }
 
@@ -379,11 +379,11 @@ Describe "WSMan Config Provider" -Tag Feature,RequireAdminOnWindows {
                 $properties = Get-ChildItem $resource.PSPath
                 ($properties | Where-Object { $_.Name -eq "ResourceUri" }).Value | Should Be "http://foo/"
                 ($properties | Where-Object { $_.Name -eq "Capability" })[0].Value | Should Be "shell"
-                Remove-Item $resource.PSPath
+                Remove-Item $resource.PSPath -Recurse -Force
                 $resource.PSPath | Should Not Exist
             }
             finally {
-                Remove-Item $resource.PSPath -Force -ErrorAction SilentlyContinue
+                Remove-Item $resource.PSPath -Recurse -Force -ErrorAction SilentlyContinue
             }
         }
 
@@ -394,7 +394,7 @@ Describe "WSMan Config Provider" -Tag Feature,RequireAdminOnWindows {
                 $parameterObj = Get-Item $parameter.PSPath
                 $parameterObj.Name | Should Be "foo"
                 $parameterObj.Value | Should Be "bar"
-                Remove-Item $parameter.PSPath
+                Remove-Item $parameter.PSPath -Force
                 $parameter.PSPath | Should Not Exist
             }
             finally {
@@ -407,16 +407,16 @@ Describe "WSMan Config Provider" -Tag Feature,RequireAdminOnWindows {
                 $sddl = "O:NSG:BAD:P(A;;GA;;;BA)"
                 $resource = Get-ChildItem -Path WSMan:\localhost\Plugin\TestPlugin\Resources\ | Select-Object -First 1
                 # remove existing security resource since the folder name is just a hash of the resource uri
-                Get-ChildItem "$($resource.PSPath)\Security" | Remove-Item
+                Get-ChildItem "$($resource.PSPath)\Security" | Remove-Item -Recurse -Force
                 $security = New-Item "$($resource.PSPath)\Security" -SDDL $sddl -Force
                 $security.PSPath | Should Exist
                 $securityObj = Get-Item $security.PSPath
                 (Get-ChildItem $securityObj.PSPath | Where-Object { $_.Name -eq 'sddl' }).Value | Should Be $sddl
-                Remove-Item $security.PSPath
+                Remove-Item $security.PSPath -Recurse -Force
                 $security.PSPath | Should Not Exist
             }
             finally {
-                Remove-Item $security.PSPath -Force -ErrorAction SilentlyContinue
+                Remove-Item $security.PSPath -Recurse -Force -ErrorAction SilentlyContinue
             }
         }
     }


### PR DESCRIPTION
Code is creating a DirectoryInfo instance to determine if the path is a directory or file, but it fails because `*` is not allowed, however, `*` is a valid character in a registry path.  Fix is to catch this exception and ignore it.  This means that using `-literalpath` with an asterisk and the filesystem provider will now return an error rather than returning quietly.

Fix https://github.com/PowerShell/PowerShell/issues/4704
Fix https://github.com/PowerShell/PowerShell/issues/4330

<!--

If you are a PowerShell Team member, please make sure you choose the Reviewer(s) and Assignee for your PR.
If you are not from the PowerShell Team, you can leave the fields blank and the Maintainers will choose them for you. If you are familiar with the team, feel free to mention some Reviewers yourself.

For more information about the roles of Reviewer and Assignee, refer to [CONTRIBUTING.md](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md).

-->
