### PR TITLE
Add the timezone offset correctly

### DIFF
--- a/test/powershell/engine/Cdxml/Cdxml.Tests.ps1
+++ b/test/powershell/engine/Cdxml/Cdxml.Tests.ps1
@@ -59,7 +59,10 @@ Describe "Cdxml cmdlets are supported" -Tag CI,RequireAdminOnWindows {
         $currentTimeZone = [System.TimeZoneInfo]::Local
 
         # this date is simply the same one used in the test mof
-        $UTCOffset = ($currentTimeZone.GetUtcOffset([datetime]::new(2008, 01, 01, 0, 0, 0))).TotalMinutes.ToString()
+        # the minutes must be padded to 3 digits proceeded by a '+' or '-'
+        # when east of UTC 0 we must add a '+'
+        $offsetMinutes = ($currentTimeZone.GetUtcOffset([datetime]::new(2008, 01, 01, 0, 0, 0))).TotalMinutes
+        $UTCOffset = "{0:+000;-000}" -f $offsetMinutes
         $testMof = $testMof.Replace("<UTCOffSet>", $UTCOffset)
         Set-Content -Path $testDrive\testmof.mof -Value $testMof
         $result = MofComp.exe $testDrive\testmof.mof


### PR DESCRIPTION
It must be padded to 3 digits and prepended with either '-' or '+'

The test creates a cim instance of a test class which includes the time and timezone offset. This must be a string which ends with "+" or "-" followed by the digits which represents the offset in minutes from UTC. The issue with the original code was that sometimes there would be only 1 (0) or 2 digits (60) depending on where the test was run (reflected by the TZ offset from UTC). Our code coverage runs are on an azure instance which UTZ offset of 0, so the representation of time was faulty.

This fix ensures that there are always a "+" or "-" and 3 digits in the TZ offset representation