### PR TITLE
Enable transcription of native commands on non-Windows

### DIFF
--- a/src/System.Management.Automation/engine/NativeCommandProcessor.cs
+++ b/src/System.Management.Automation/engine/NativeCommandProcessor.cs
@@ -401,9 +401,9 @@ namespace System.Management.Automation
             // we have to see if the redirection is actually being done at the topmost level or not.
 
             // Calculate if input and output are redirected.
-            bool redirectOutput = true;
-            bool redirectError = true;
-            bool redirectInput = this.Command.MyInvocation.ExpectingInput;
+            bool redirectOutput;
+            bool redirectError;
+            bool redirectInput;
 
             _startPosition = new Host.Coordinates();
 
@@ -1290,7 +1290,10 @@ namespace System.Management.Automation
                     redirectError = true;
                 }
             }
-            else if (_isTranscribing && (false == s_supportScreenScrape))
+
+            // if screen scraping isn't supported, we enable redirection so that the output is still transcribed
+            // as redirected output is always transcribed
+            if (_isTranscribing && (false == s_supportScreenScrape))
             {
                 redirectOutput = true;
                 redirectError = true;

--- a/src/System.Management.Automation/engine/NativeCommandProcessor.cs
+++ b/src/System.Management.Automation/engine/NativeCommandProcessor.cs
@@ -375,8 +375,8 @@ namespace System.Management.Automation
         /// </summary>
         private BlockingCollection<ProcessOutputObject> _nativeProcessOutputQueue;
 
-        private static bool? s_supportScreenScrape = null;
-        private bool _isTranscribing;
+        private static bool s_supportScreenScrape = false;
+        private bool _isTranscribing = false;
         private Host.Coordinates _startPosition;
 
         /// <summary>
@@ -407,18 +407,16 @@ namespace System.Management.Automation
 
             _startPosition = new Host.Coordinates();
 
-            if (null == s_supportScreenScrape)
+            try
             {
-                try
-                {
-                    Host.BufferCell[,] bufferContents = this.Command.Context.EngineHostInterface.UI.RawUI.GetBufferContents(
-                        new Host.Rectangle(_startPosition, _startPosition));
-                    s_supportScreenScrape = true;
-                }
-                catch (NotImplementedException)
-                {
-                    s_supportScreenScrape = false;
-                }
+                _startPosition = this.Command.Context.EngineHostInterface.UI.RawUI.CursorPosition;
+                Host.BufferCell[,] bufferContents = this.Command.Context.EngineHostInterface.UI.RawUI.GetBufferContents(
+                    new Host.Rectangle(_startPosition, _startPosition));
+                s_supportScreenScrape = true;
+            }
+            catch (Exception)
+            {
+                // screen scraping not supported on non-Windows or as job
             }
 
             CalculateIORedirection(out redirectOutput, out redirectError, out redirectInput);

--- a/test/powershell/Modules/Microsoft.Powershell.Host/Start-Transcript.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.Powershell.Host/Start-Transcript.Tests.ps1
@@ -107,7 +107,7 @@ Describe "Start-Transcript, Stop-Transcript tests" -tags "CI" {
         ValidateTranscription -scriptToExecute $script -outputFilePath $null -expectedError $expectedError
     }
     It "Transcription should remain active if other runspace in the host get closed" {
-        try{
+        try {
             $ps = [powershell]::Create()
             $ps.addscript("Start-Transcript -path $transcriptFilePath").Invoke()
             $ps.addscript('$rs = [system.management.automation.runspaces.runspacefactory]::CreateRunspace()').Invoke()
@@ -115,12 +115,11 @@ Describe "Start-Transcript, Stop-Transcript tests" -tags "CI" {
             $ps.addscript('$rs.Dispose()').Invoke()
             $ps.addscript('Write-Host "After Dispose"').Invoke()
             $ps.addscript("Stop-Transcript").Invoke()
-            } finally {
-                if ($null -ne $ps) {
-                    $ps.Dispose()
-                }
+        } finally {
+            if ($null -ne $ps) {
+                $ps.Dispose()
             }
-
+        }
 
         Test-Path $transcriptFilePath | Should be $true
         $transcriptFilePath | Should contain "After Dispose"
@@ -136,4 +135,19 @@ Describe "Start-Transcript, Stop-Transcript tests" -tags "CI" {
         $transcriptFilePath | Should contain "PowerShell transcript end"
     }
 
+    It "Transcription should record native command output" {
+        try {
+            $ps = [powershell]::Create()
+            $ps.addscript("Start-Transcript -path $transcriptFilePath").Invoke()
+            $ps.addscript("hostname").Invoke()
+            $ps.addscript("Stop-Transcript").Invoke()
+        } finally {
+            if ($null -ne $ps) {
+                $ps.Dispose()
+            }
+        }
+        Test-Path $transcriptFilePath | Should be $true
+        $machineName = [System.Environment]::MachineName
+        $transcriptFilePath | Should contain $machineName
+    }
 }

--- a/test/powershell/Modules/Microsoft.Powershell.Host/Start-Transcript.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.Powershell.Host/Start-Transcript.Tests.ps1
@@ -136,17 +136,13 @@ Describe "Start-Transcript, Stop-Transcript tests" -tags "CI" {
     }
 
     It "Transcription should record native command output" {
-        try {
-            $ps = [powershell]::Create()
-            $ps.addscript("Start-Transcript -path $transcriptFilePath").Invoke()
-            $ps.addscript("hostname").Invoke()
-            $ps.addscript("Stop-Transcript").Invoke()
-        } finally {
-            if ($null -ne $ps) {
-                $ps.Dispose()
-            }
-        }
+        $script = {
+            Start-Transcript -Path $transcriptFilePath
+            hostname
+            Stop-Transcript }
+        & $script
         Test-Path $transcriptFilePath | Should be $true
+
         $machineName = [System.Environment]::MachineName
         $transcriptFilePath | Should contain $machineName
     }

--- a/test/powershell/engine/Job/Jobs.Tests.ps1
+++ b/test/powershell/engine/Job/Jobs.Tests.ps1
@@ -17,6 +17,21 @@ Describe 'Basic Job Tests' -Tags 'CI' {
         Receive-Job $job -wait | should be 1
     }
 
+    It "Create job with native command" {
+        try {
+            $nativeJob = Start-job { powershell -c 1+1 }
+            $nativeJob | Wait-Job
+            $nativeJob.State | Should BeExactly "Completed"
+            $nativeJob.HasMoreData | Should Be $true
+            Receive-Job $nativeJob | Should BeExactly 2
+            Remove-Job $nativeJob
+            { Get-Job $nativeJob -ErrorAction Stop } | ShouldBeErrorId "JobWithSpecifiedNameNotFound,Microsoft.PowerShell.Commands.GetJobCommand"
+        }
+        finally {
+            Remove-Job $nativeJob -Force -ErrorAction SilentlyContinue
+        }
+    }
+
     AfterAll {
         Remove-Job $job -Force
     }


### PR DESCRIPTION
Transcription was relying on reading the screen buffer to record output from native commands.
This resulted in an unhandled exception calling an unimplemented api on non-Windows.
Fix is to default to using redirected output if reading the screen buffer is not supported.

Fix https://github.com/PowerShell/PowerShell/issues/1920

<!--

If you are a PowerShell Team member, please make sure you choose the Reviewer(s) and Assignee for your PR.
If you are not from the PowerShell Team, you can leave the fields blank and the Maintainers will choose them for you. If you are familiar with the team, feel free to mention some Reviewers yourself.

For more information about the roles of Reviewer and Assignee, refer to [CONTRIBUTING.md](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md).

-->