### PR TITLE
Add ResponseHeadersVariable Parameter to Invoke-RestMethod

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/InvokeRestMethodCommand.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/InvokeRestMethodCommand.Common.cs
@@ -60,6 +60,13 @@ namespace Microsoft.PowerShell.Commands
             set { base._maximumFollowRelLink = value; }
         }
 
+        /// <summary>
+        /// Gets or sets the ResponseHeadersVariable property.
+        /// </summary>
+        [Parameter]
+        [Alias("HV")]
+        public string ResponseHeadersVariable { get; set; }
+
         #endregion Parameters
 
         #region Helper Methods

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/InvokeRestMethodCommand.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/InvokeRestMethodCommand.Common.cs
@@ -64,7 +64,7 @@ namespace Microsoft.PowerShell.Commands
         /// Gets or sets the ResponseHeadersVariable property.
         /// </summary>
         [Parameter]
-        [Alias("HV")]
+        [Alias("RHV")]
         public string ResponseHeadersVariable { get; set; }
 
         #endregion Parameters

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/InvokeRestMethodCommand.CoreClr.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/InvokeRestMethodCommand.CoreClr.cs
@@ -95,6 +95,12 @@ namespace Microsoft.PowerShell.Commands
                 {
                     StreamHelper.SaveStreamToFile(responseStream, QualifiedOutFile, this);
                 }
+
+                if (!String.IsNullOrEmpty(ResponseHeadersVariable))
+                {
+                    PSVariableIntrinsics vi = SessionState.PSVariable;
+                    vi.Set(ResponseHeadersVariable, WebResponseHelper.GetHeadersDictionary(response));
+                }
             }
         }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -2080,14 +2080,7 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
             $headers.'Content-Type' | Should Be 'text/html; charset=utf-8'
             $headers.Server | Should Be 'Kestrel'
         }
-        It "Verifies Invoke-RestMethod supports -HV alias" {
-            $uri = Get-WebListenerUrl -Test '/'
-            $response = Invoke-RestMethod -Uri $uri -HV 'headers'
-
-            $headers | Should Not BeNullOrEmpty
-            $headers.'Content-Type' | Should Be 'text/html; charset=utf-8'
-            $headers.Server | Should Be 'Kestrel'
-        }
+        
         It "Verifies Invoke-RestMethod supports -ResponseHeadersVariable overwriting existing variable" {
             $uri = Get-WebListenerUrl -Test '/'
             $headers = 'prexisting'

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -2076,7 +2076,6 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
             $uri = Get-WebListenerUrl -Test '/'
             $response = Invoke-RestMethod -Uri $uri -ResponseHeadersVariable 'headers'
 
-            $headers | Should Not BeNullOrEmpty
             $headers.'Content-Type' | Should Be 'text/html; charset=utf-8'
             $headers.Server | Should Be 'Kestrel'
         }
@@ -2087,7 +2086,6 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
             $response = Invoke-RestMethod -Uri $uri -ResponseHeadersVariable 'headers'
 
             $headers | Should Not Be 'prexisting'
-            $headers | Should Not BeNullOrEmpty
             $headers.'Content-Type' | Should Be 'text/html; charset=utf-8'
             $headers.Server | Should Be 'Kestrel'
         }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -2071,6 +2071,35 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
 
     #endregion charset encoding tests
 
+    Context 'Invoke-RestMethod ResponseHeadersVariable Tests' {
+        It "Verifies Invoke-RestMethod supports -ResponseHeadersVariable" {
+            $uri = Get-WebListenerUrl -Test '/'
+            $response = Invoke-RestMethod -Uri $uri -ResponseHeadersVariable 'headers'
+
+            $headers | Should Not BeNullOrEmpty
+            $headers.'Content-Type' | Should Be 'text/html; charset=utf-8'
+            $headers.Server | Should Be 'Kestrel'
+        }
+        It "Verifies Invoke-RestMethod supports -HV alias" {
+            $uri = Get-WebListenerUrl -Test '/'
+            $response = Invoke-RestMethod -Uri $uri -HV 'headers'
+
+            $headers | Should Not BeNullOrEmpty
+            $headers.'Content-Type' | Should Be 'text/html; charset=utf-8'
+            $headers.Server | Should Be 'Kestrel'
+        }
+        It "Verifies Invoke-RestMethod supports -ResponseHeadersVariable overwriting existing variable" {
+            $uri = Get-WebListenerUrl -Test '/'
+            $headers = 'prexisting'
+            $response = Invoke-RestMethod -Uri $uri -ResponseHeadersVariable 'headers'
+
+            $headers | Should Not Be 'prexisting'
+            $headers | Should Not BeNullOrEmpty
+            $headers.'Content-Type' | Should Be 'text/html; charset=utf-8'
+            $headers.Server | Should Be 'Kestrel'
+        }
+    }
+
     BeforeEach {
         if ($env:http_proxy) {
             $savedHttpProxy = $env:http_proxy


### PR DESCRIPTION
closes #4845

* Adds `-ResponseHeadersVariable` parameter to Invoke-RestMethod
* Adds `-RHV` alias for the parameter
* A variable with the provided name is created in the calling scope which contains the HTTP Response Headers as a dictionary constructed in the same manner `WebResponseObject.Headers` is constructed for `Invoke-WebRequest`
* Add tests for the parameter

# Documentation Needed
The new parameter will need to be documented.
