### PR TITLE
fix tests not setting back $psdefaultparametervalues back correctly

### DIFF
--- a/test/powershell/Language/Parser/RedirectionOperator.Tests.ps1
+++ b/test/powershell/Language/Parser/RedirectionOperator.Tests.ps1
@@ -18,7 +18,7 @@ Describe "Redirection operator now supports encoding changes" -Tags "CI" {
     }
     AfterAll {
         # be sure to tidy up afterwards
-        $psDefaultParameterValues = $oldDefaultParameterValues
+        $global:psDefaultParameterValues = $oldDefaultParameterValues
     }
     BeforeEach {
         # start each test with a clean plate!

--- a/test/powershell/Language/Parser/RedirectionOperator.Tests.ps1
+++ b/test/powershell/Language/Parser/RedirectionOperator.Tests.ps1
@@ -13,7 +13,7 @@ Describe "Redirection operator now supports encoding changes" -Tags "CI" {
         # If out-file -encoding happens to have a default, be sure to
         # save it away
         $SavedValue = $null
-        $oldDefaultParameterValues = $psDefaultParameterValues
+        $oldDefaultParameterValues = $psDefaultParameterValues.Clone()
         $psDefaultParameterValues = @{}
     }
     AfterAll {

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/CertificateProvider.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/CertificateProvider.Tests.ps1
@@ -36,7 +36,7 @@ Describe "Certificate Provider tests" -Tags "CI" {
     AfterAll {
         if(!$IsWindows)
         {
-            $PSdefaultParameterValues = $defaultParamValues
+            $global:PSdefaultParameterValues = $defaultParamValues
         }
     }
 
@@ -98,7 +98,7 @@ Describe "Certificate Provider tests" -Tags "Feature" {
         }
         else
         {
-            $PSdefaultParameterValues = $defaultParamValues
+            $global:PSdefaultParameterValues = $defaultParamValues
         }
     }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/CmsMessage.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/CmsMessage.Tests.ps1
@@ -81,7 +81,7 @@ Describe "CmsMessage cmdlets thorough tests" -Tags "Feature" {
         }
         else
         {
-            $PSdefaultParameterValues = $defaultParamValues
+            $global:PSdefaultParameterValues = $defaultParamValues
         }
     }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/SecureString.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/SecureString.Tests.ps1
@@ -8,7 +8,7 @@ Describe "SecureString conversion tests" -Tags "CI" {
         if ( ! $IsWindows ) { $PSdefaultParameterValues["it:pending"] = $true }
     }
     AfterAll {
-        $PSdefaultParameterValues = $defaultParamValues
+        $global:PSdefaultParameterValues = $defaultParamValues
     }
 
     It "using null arguments to ConvertFrom-SecureString produces an exception" {


### PR DESCRIPTION
Due to how Pester works, when $psdefaultparametervalues is first set, it is set at global scope so needs to be reset back in global scope

<!--

If you are a PowerShell Team member, please make sure you choose the Reviewer(s) and Assignee for your PR.
If you are not from the PowerShell Team, you can leave the fields blank and the Maintainers will choose them for you. If you are familiar with the team, feel free to mention some Reviewers yourself.

For more information about the roles of Reviewer and Assignee, refer to [CONTRIBUTING.md](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md).

-->
