### PR TITLE
add get-help tests for alias

### DIFF
--- a/test/powershell/engine/Help/HelpSystem.Tests.ps1
+++ b/test/powershell/engine/Help/HelpSystem.Tests.ps1
@@ -272,5 +272,29 @@ Describe "Get-Help should find pattern help files" -Tags "CI" {
         )
         $command.Invoke() | Should Be $result
     }
+}
+
+  Describe "Get-Help should find pattern alias" -Tags "CI" {
+    # Remove test alias
+    AfterAll {
+        Remove-Item alias:\testAlias1
+    }
+    
+    It "Get-Help should find alias as command" {
+       (Get-Help where).Name | Should BeExactly "Where-Object"
+    }
+
+    It "Get-Help should find alias with ? pattern" {
+       $help = Get-Help wher?
+       $help.Category | Should BeExactly "Alias"
+       $help.Synopsis | Should BeExactly "Where-Object"
+    }
+
+    It "Get-Help should find alias with * pattern" {
+       Set-Alias -Name testAlias1 -Value Where-Object
+       $help = Get-Help testAlias1*
+       $help.Category | Should BeExactly "Alias"
+       $help.Synopsis | Should BeExactly "Where-Object"
+    }
 
 }


### PR DESCRIPTION
this is to resolve #4167

added help alias tests.

For other concerns of the issue:

1. SaveTests are located at UpdatableHelpSystem.Tests.ps1

2. Major methods of HelpProviderWithCache are never implemented as all the classes derived from the class have implemented override methods of SearchHelp and ExactMatchHelp:

\src\System.Management.Automation\help\CommandHelpProvider.cs(30):    internal class CommandHelpProvider : HelpProviderWithCache
\src\System.Management.Automation\help\DscResourceHelpProvider.cs(15):    internal class DscResourceHelpProvider : HelpProviderWithCache
\src\System.Management.Automation\help\HelpFileHelpProvider.cs(24):    internal class HelpFileHelpProvider : HelpProviderWithCache
\src\System.Management.Automation\help\HelpProviderWithFullCache.cs(20):    internal abstract class HelpProviderWithFullCache : HelpProviderWithCache
\src\System.Management.Automation\help\ProviderHelpProvider.cs(22):    internal class ProviderHelpProvider : HelpProviderWithCache
\src\System.Management.Automation\help\PSClassHelpProvider.cs(15): 	internal class PSClassHelpProvider : HelpProviderWithCache