### PR TITLE
Create generic Linux-x64 packages that are portable to all supported Linux distros

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -262,6 +262,63 @@ cmd.exe /C cd /d "$location" "&" "$($vcPath)\vcvarsall.bat" "$Arch" "&" cmake "$
     }
 }
 
+function Start-BuildNativeUnixBinaries {
+    param (
+        [switch] $BuildLinuxArm
+    )
+
+    if (-not $Environment.IsLinux -and -not $Environment.IsMacOS) {
+        Write-Warning -Message "'Start-BuildNativeUnixBinaries' is only supported on Linux/macOS platforms"
+        return
+    }
+
+    # Verify we have all tools in place to do the build
+    foreach ($Dependency in 'cmake', 'make', 'g++') {
+        $precheck = $precheck -and (precheck $Dependency "Build dependency '$Dependency' not found. Run 'Start-PSBootstrap'.")
+    }
+
+    if ($BuildLinuxArm) {
+        foreach ($Dependency in 'arm-linux-gnueabihf-gcc', 'arm-linux-gnueabihf-g++') {
+            $precheck = $precheck -and (precheck $Dependency "Build dependency '$Dependency' not found. Run 'Start-PSBootstrap'.")
+        }
+    }
+
+    # Abort if any precheck failed
+    if (-not $precheck) {
+        return
+    }
+
+    # Build native components
+    $Ext = if ($Environment.IsLinux) {
+        "so"
+    } elseif ($Environment.IsMacOS) {
+        "dylib"
+    }
+
+    $Native = "$PSScriptRoot/src/libpsl-native"
+    $Lib = "$PSScriptRoot/src/powershell-unix/libpsl-native.$Ext"
+    log "Start building $Lib"
+
+    try {
+        Push-Location $Native
+        if ($Runtime -eq "linux-arm") {
+            Start-NativeExecution { cmake -DCMAKE_TOOLCHAIN_FILE="./arm.toolchain.cmake" . }
+            Start-NativeExecution { make -j }
+        }
+        else {
+            Start-NativeExecution { cmake -DCMAKE_BUILD_TYPE=Debug . }
+            Start-NativeExecution { make -j }
+            Start-NativeExecution { ctest --verbose }
+        }
+    } finally {
+        Pop-Location
+    }
+
+    if (-not (Test-Path $Lib)) {
+        throw "Compilation of $Lib failed"
+    }
+}
+
 function Start-PSBuild {
     [CmdletBinding()]
     param(
@@ -298,6 +355,10 @@ function Start-PSBuild {
         [ValidateNotNullOrEmpty()]
         [string]$ReleaseTag
     )
+
+    if ($Runtime -eq "linux-arm" -and -not $Environment.IsUbuntu) {
+        throw "Cross compiling for linux-arm is only supported on Ubuntu environment"
+    }
 
     function Stop-DevPowerShell {
         Get-Process powershell* |
@@ -339,22 +400,8 @@ function Start-PSBuild {
     # Add .NET CLI tools to PATH
     Find-Dotnet
 
-    # Verify we have all tools in place to do the build
+    # Verify we have .NET SDK in place to do the build, and abort if the precheck failed
     $precheck = precheck 'dotnet' "Build dependency 'dotnet' not found in PATH. Run Start-PSBootstrap. Also see: https://dotnet.github.io/getting-started/"
-
-    if ($Environment.IsLinux -or $Environment.IsMacOS) {
-        foreach ($Dependency in 'cmake', 'make', 'g++') {
-            $precheck = $precheck -and (precheck $Dependency "Build dependency '$Dependency' not found. Run 'Start-PSBootstrap'.")
-        }
-    }
-
-    if ($RunTime -eq "linux-arm") {
-        foreach ($Dependency in 'arm-linux-gnueabihf-gcc', 'arm-linux-gnueabihf-g++') {
-            $precheck = $precheck -and (precheck $Dependency "Build dependency '$Dependency' not found. Run 'Start-PSBootstrap'.")
-        }
-    }
-
-    # Abort if any precheck failed
     if (-not $precheck) {
         return
     }
@@ -439,38 +486,6 @@ Fix steps:
     if ($ResGen -or -not (Test-Path "$PSScriptRoot/src/Microsoft.PowerShell.ConsoleHost/gen")) {
         log "Run ResGen (generating C# bindings for resx files)"
         Start-ResGen
-    }
-
-    # Build native components
-    if (($Environment.IsLinux -or $Environment.IsMacOS) -and -not $SMAOnly) {
-        $Ext = if ($Environment.IsLinux) {
-            "so"
-        } elseif ($Environment.IsMacOS) {
-            "dylib"
-        }
-
-        $Native = "$PSScriptRoot/src/libpsl-native"
-        $Lib = "$($Options.Top)/libpsl-native.$Ext"
-        log "Start building $Lib"
-
-        try {
-            Push-Location $Native
-            if ($Runtime -eq "linux-arm") {
-                Start-NativeExecution { cmake -DCMAKE_TOOLCHAIN_FILE="./arm.toolchain.cmake" . }
-                Start-NativeExecution { make -j }
-            }
-            else {
-                Start-NativeExecution { cmake -DCMAKE_BUILD_TYPE=Debug . }
-                Start-NativeExecution { make -j }
-                Start-NativeExecution { ctest --verbose }
-            }
-        } finally {
-            Pop-Location
-        }
-
-        if (-not (Test-Path $Lib)) {
-            throw "Compilation of $Lib failed"
-        }
     }
 
     # handle TypeGen

--- a/build.psm1
+++ b/build.psm1
@@ -272,7 +272,12 @@ function Start-BuildNativeUnixBinaries {
         return
     }
 
+    if ($BuildLinuxArm -and -not $Environment.IsUbuntu) {
+        throw "Cross compiling for linux-arm is only supported on Ubuntu environment"
+    }
+
     # Verify we have all tools in place to do the build
+    $precheck = $true
     foreach ($Dependency in 'cmake', 'make', 'g++') {
         $precheck = $precheck -and (precheck $Dependency "Build dependency '$Dependency' not found. Run 'Start-PSBootstrap'.")
     }
@@ -299,9 +304,11 @@ function Start-BuildNativeUnixBinaries {
     $Lib = "$PSScriptRoot/src/powershell-unix/libpsl-native.$Ext"
     log "Start building $Lib"
 
+    git clean -qfdX $Native
+
     try {
         Push-Location $Native
-        if ($Runtime -eq "linux-arm") {
+        if ($BuildLinuxArm) {
             Start-NativeExecution { cmake -DCMAKE_TOOLCHAIN_FILE="./arm.toolchain.cmake" . }
             Start-NativeExecution { make -j }
         }

--- a/src/powershell-unix/powershell-unix.csproj
+++ b/src/powershell-unix/powershell-unix.csproj
@@ -28,6 +28,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="libpsl" Version="6.0.0-*" />
     <PackageReference Include="psrp" Version="1.1.0-*" />
     <PackageReference Include="PSDesiredStateConfiguration" Version="1.0.0-alpha01" />
     <PackageReference Include="PowerShellHelpFiles" Version="1.0.0-alpha01" />

--- a/src/powershell-unix/powershell-unix.csproj
+++ b/src/powershell-unix/powershell-unix.csproj
@@ -16,7 +16,7 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
     </Content>
-    <Content Include="*.so;*.dylib;..\..\license_thirdparty_proprietary.txt;..\..\powershell.version;..\..\DELETE_ME_TO_DISABLE_CONSOLEHOST_TELEMETRY">
+    <Content Include="..\..\license_thirdparty_proprietary.txt;..\..\powershell.version;..\..\DELETE_ME_TO_DISABLE_CONSOLEHOST_TELEMETRY">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
     </Content>

--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -246,10 +246,6 @@ function New-UnixPackage {
         [Parameter(Mandatory)]
         [string]$Version,
 
-        # Package iteration version (rarely changed)
-        # This is a string because strings are appended to it
-        [string]$Iteration = "1",
-
         [Switch]
         $Force
     )

--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -30,7 +30,7 @@ function Start-PSPackage {
         [Switch] $Force,
 
         [Switch] $IncludeSymbols,
-        
+
         [Switch] $SkipReleaseChecks
     )
 
@@ -43,11 +43,9 @@ function Start-PSPackage {
         New-PSOptions -Configuration "Release" -WarningAction SilentlyContinue | ForEach-Object { $_.Runtime, $_.Configuration }
     }
 
-    # We convert the runtime to win7-x64 or win7-x86 to build the universal windows package.
     if($Environment.IsWindows) {
-        $Runtime = $Runtime -replace "win\d+", "win7"
-
-        # Build the name suffix for win-plat packages
+        # Runtime will always be win7-x64 or win7-x86 on Windows.
+        # Build the name suffix for universal win-plat packages.
         $NameSuffix = $Runtime -replace 'win\d+', 'win'
     }
 
@@ -134,7 +132,7 @@ function Start-PSPackage {
     }
     log "Packaging Type: $Type"
 
-    # Add the symbols to the suffix 
+    # Add the symbols to the suffix
     # if symbols are specified to be included
     if($IncludeSymbols.IsPresent -and $NameSuffix) {
         $NameSuffix = "symbols-$NameSuffix"
@@ -186,7 +184,7 @@ function Start-PSPackage {
             {
                 throw "AppImage does not support packaging '-IncludeSymbols'"
             }
-            
+
             if ($Environment.IsUbuntu14) {
                 $null = Start-NativeExecution { bash -iex "$PSScriptRoot/../appimage.sh" }
                 $appImage = Get-Item PowerShell-*.AppImage
@@ -260,14 +258,14 @@ function New-UnixPackage {
     $ErrorMessage = "Must be on {0} to build '$Type' packages!"
     switch ($Type) {
         "deb" {
-            $WarningMessage = "Building for Ubuntu {0}.04!"
+            $verboseMsg = "Building for Ubuntu {0}.04!"
             if (!$Environment.IsUbuntu) {
-                    throw ($ErrorMessage -f "Ubuntu")
-                } elseif ($Environment.IsUbuntu14) {
-                    Write-Warning ($WarningMessage -f "14")
-                } elseif ($Environment.IsUbuntu16) {
-                    Write-Warning ($WarningMessage -f "16")
-                }
+                throw ($ErrorMessage -f "Ubuntu")
+            } elseif ($Environment.IsUbuntu14) {
+                Write-Verbose ($verboseMsg -f "14")
+            } elseif ($Environment.IsUbuntu16) {
+                Write-Verbose ($verboseMsg -f "16")
+            }
         }
         "rpm" {
             if (!$Environment.IsRedHatFamily) {
@@ -309,7 +307,7 @@ function New-UnixPackage {
     # Suffix is used for side-by-side package installation
     $Suffix = $Name -replace "^powershell"
     if (!$Suffix) {
-        Write-Warning "Suffix not given, building primary PowerShell package!"
+        Write-Verbose "Suffix not given, building primary PowerShell package!"
         $Suffix = $Version
     }
 
@@ -408,73 +406,28 @@ function New-UnixPackage {
             "libc6",
             "libcurl3",
             "libgcc1",
-            "libssl1.0.0",
+            "libgssapi-krb5-2",
+            "liblttng-ust0",
             "libstdc++6",
-            "libtinfo5",
             "libunwind8",
             "libuuid1",
-            "zlib1g"
+            "zlib1g",
+            "libssl1.0.0",
+            "libicu-dev"
         )
-        # Please note the different libicu package dependency!
-        if ($Environment.IsUbuntu14) {
-            $Dependencies += "libicu52"
-        } elseif ($Environment.IsUbuntu16) {
-            $Dependencies += "libicu55"
-        }
     } elseif ($Environment.IsRedHatFamily) {
         $Dependencies = @(
-            "glibc",
-            "libicu",
-            "openssl",
             "libunwind",
-            "uuid",
-            "zlib"
+            "libcurl",
+            "openssl-libs",
+            "libicu"
         )
-
-        if($Environment.IsFedora -or $Environment.IsCentOS)
-        {
-            $Dependencies += "libcurl"
-            $Dependencies += "libgcc"
-            $Dependencies += "libstdc++"
-            $Dependencies += "ncurses-base"
-        }
-
-        if($Environment.IsOpenSUSE)
-        {
-            $Dependencies += "libgcc_s1"
-            $Dependencies += "libstdc++6"
-        }
     }
-
-    # iteration is "debian_revision"
-    # usage of this to differentiate distributions is allowed by non-standard
-    if ($Environment.IsUbuntu14) {
-        $Iteration += "ubuntu1.14.04.1"
-    } elseif ($Environment.IsUbuntu16) {
-        $Iteration += "ubuntu1.16.04.1"
-    }
-
-    # We currently only support:
-    # CentOS 7
-    # Fedora 24+
-    # OpenSUSE 42.1 (13.2 might build but is EOL)
-    # Also SEE: https://fedoraproject.org/wiki/Packaging:DistTag
-    if ($Environment.IsCentOS) {
-        $rpm_dist = "el7"
-    } elseif ($Environment.IsFedora) {
-        $version_id = $Environment.LinuxInfo.VERSION_ID
-        $rpm_dist = "fedora.$version_id"
-    } elseif ($Environment.IsOpenSUSE) {
-        $version_id = $Environment.LinuxInfo.VERSION_ID
-        $rpm_dist = "suse.$version_id"
-    }
-
 
     $Arguments = @(
         "--force", "--verbose",
         "--name", $Name,
         "--version", $Version,
-        "--iteration", $Iteration,
         "--maintainer", "PowerShell Team <PowerShellTeam@hotmail.com>",
         "--vendor", "Microsoft Corporation",
         "--url", "https://microsoft.com/powershell",
@@ -485,7 +438,7 @@ function New-UnixPackage {
         "-s", "dir"
     )
     if ($Environment.IsRedHatFamily) {
-        $Arguments += @("--rpm-dist", $rpm_dist)
+        $Arguments += @("--rpm-dist", "rhel.7")
         $Arguments += @("--rpm-os", "linux")
     }
     foreach ($Dependency in $Dependencies) {
@@ -504,8 +457,7 @@ function New-UnixPackage {
     )
     # Build package
     try {
-        if($pscmdlet.ShouldProcess("Create $type package"))
-        {
+        if($pscmdlet.ShouldProcess("Create $type package")) {
             $Output = Start-NativeExecution { fpm $Arguments }
         }
     } finally {


### PR DESCRIPTION
Update build and package scripts to create portable Linux packages.
Fix the second task of #3961
- [x] Update packaging script to package native binaries published and remove unneeded dependencies

Help Needed
--------------
**I need help from the team to verify the single DEB/RPM package on different distros.**

Background Information
--------------------
- "RID `Linux-x64` isn't any different from `Ubuntu.16.04-x64`. The change we've made to enable the portable Linux-x64 rid was that we dynamically load OpenSSL and ICU libraries at runtime and we can also handle few missing APIs in various versions of CURL, so we can handle subtle differences between the distros. We don't build any distro specific binaries, so the `dotnet publish` publishes the same files when using those 2 RIDs respectively." See https://github.com/PowerShell/PowerShell/issues/3961#issuecomment-330796735

- "if you build the libpsl-native.so on CentOS 7, then it should be as portable as the dotnet stuff (we build it on CentOS 7 to ensure that it doesn't depend on newer glibc)." See https://github.com/PowerShell/PowerShell/issues/3961#issuecomment-331009082

Therefore, we need to use the `Linux-x64` `libpsl-native.so` built on CentOS 7 for all Linux distros. The way to do that is to create nuget package for `libpsl` and consume it from our build.

Native Dependencies of `dotnet-runtime-2.0.0` packages
--------------------------------------------------------------
The dependencies below were got by inspecting the `dotnet-runtime-2.0.0` packages (You can get those packages from https://www.microsoft.com/net/download/linux).
### DEB
- Ubuntu 16.04 depends
   - libc6, libcurl3, libgcc1, libgssapi-krb5-2, liblttng-ust0, libstdc++6, libunwind8, libuuid1, zlib1g, libssl1.0.0, libicu55
- Ubuntu 14.04 depends
   - libc6, libcurl3, libgcc1, libgssapi-krb5-2, liblttng-ust0, libstdc++6, libunwind8, libuuid1, zlib1g, libssl1.0.0, libicu52
- Ubuntu 17.04 depends
   - libc6, libcurl3, libgcc1, libgssapi-krb5-2, liblttng-ust0, libstdc++6, libunwind8, libuuid1, zlib1g, libssl1.0.0, libicu57
- Debian-stretch (9) depends
   - libc6, libcurl3, libgcc1, libgssapi-krb5-2, liblttng-ust0, libstdc++6, libunwind8, libuuid1, zlib1g, libssl1.0.2, libicu57
- Debian-jessie (8) depends
   - libc6, libcurl3, libgcc1, libgssapi-krb5-2, liblttng-ust0, libstdc++6, libunwind8, libuuid1, zlib1g, libssl1.0.0, libicu52

### RPM
- CentOS 7/Oracle Linux 7/openSUSE depend
   - openssl-libs, libcurl
   - However, when installing `dotnet-sdk-2.0.0`, two more packages are required to be manually installed: libunwind, libicu.
- Fedora 26
   - openssl-libs, libcurl
   - However, when installing `dotnet-sdk-2.0.0`, three more packages are required to be manually installed: libunwind, libicu, compat-openssl10

As shown above:
The only difference in DEB world is libicu (libicu52, libicu55, libicu57).
The only difference in RPM world is that Fedora needs `compat-openssl10` (see https://www.microsoft.com/net/core#linuxfedora). **`compat-openssl10` might be required only for dotnet-sdk toolings, but I'm not sure.**

Major Changes
-----------------
- Move the Unix native component build out of `Start-PSBuild` to `Start-BuildNativeUnixBinaries`
- Pack `libps1-native` into a nuget package `libpsl`. It includes binaries for `linux-x64`, `linux-arm` and `osx`. **NOTE:** the `linux-x64` version `libps1-native.so` is built on CentOS 7.
- Update the package script to use the correct dependencies and also use names for .deb and .rpm names.
   - **NOTE1:** for DEB, since `libicu` is different on different distros, I decided to use `libicu-dev` which will pull in the correct packages for `libicu` for different distros.
   - **NOTE2:** for RPM, since `compat-openssl10` is only available to Fedora, I don't include it in the dependencies. We can do the same as .NET Core (https://www.microsoft.com/net/core#linuxfedora), asking Fedora users to install `compat-openssl10` manually.
   - **NOTE3:** the updated package names are: `powershell_6.0.0-beta.20_amd64.deb` and `powershell-6.0.0_beta.22-1.rhel.7.x86_64.rpm`. I use `rhel.7` because dotnet-runtime-2.0.0 use it in the name `dotnet-runtime-2.0.0-rhel.7-x64.rpm`.

Distros that I have verified
-----------------------------
1. DEB package built from Ubuntu.16.04
    - Works on Ubuntu.16.04 and Ubuntu.14.04
    - Haven't tried on Ubuntu.17.04, Debian 8 and Debian 9
2. RPM package built from CentOS 7
    - Works on CentOS7, openSUSE.42.2
       - **Attention:** installing RPM on openSUSE has the same issue as `dotnet-runtime-2.0.0` package. It's quoted below from https://www.microsoft.com/net/core#linuxopensuse.
       - Haven't tried on other RedHat distros
> "Note: When installing the SDK, SUSE and OpenSUSE may report that nothing provides libcurl. libcurl should already be installed on supported versions of both distros. Run zypper search libcurl to confirm. The error will present 2 'solutions'. Choose 'Solution 2' to continue installing .NET Core." 
