### PR TITLE
Change UserAgent App WindowsPowerShell -> PowerShell

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/PSUserAgent.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/PSUserAgent.cs
@@ -113,7 +113,7 @@ namespace Microsoft.PowerShell.Commands
             get
             {
                 string app = string.Format(CultureInfo.InvariantCulture,
-                    "WindowsPowerShell/{0}", PSVersionInfo.PSVersion);
+                    "PowerShell/{0}", PSVersionInfo.PSVersion);
                 return (app);
             }
         }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -465,7 +465,7 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
 
         # Validate response content
         $jsonContent = $result.Output.Content | ConvertFrom-Json
-        $jsonContent.headers.'User-Agent' | Should Be $DefaultUserAgent
+        $jsonContent.headers.'User-Agent' | Should Match '(?<!Windows)PowerShell\/\d+\.\d+\.\d+.*'
     }
 
     It "Invoke-WebRequest returns headers dictionary" {
@@ -1326,7 +1326,7 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
         $result = ExecuteWebCommand -command $command
 
         # Validate response
-        $result.Output.headers.'User-Agent' | Should Be $DefaultUserAgent
+        $result.Output.headers.'User-Agent' | Should Be '(?<!Windows)PowerShell\/\d+\.\d+\.\d+.*'
     }
 
     It "Invoke-RestMethod returns headers dictionary" {
@@ -2187,12 +2187,5 @@ Describe "Web cmdlets tests using the cmdlet's aliases" -Tags "CI" {
     It "Execute Invoke-RestMethod" {
         $result = irm "http://localhost:8082/PowerShell?test=response&output={%22hello%22:%22world%22}&contenttype=application/json" -TimeoutSec 5
         $result.Hello | Should Be "world"
-    }
-}
-
-Describe "PSUserAgent Tests" -Tags "CI" {
-    It "App Should Match ^PowerShell/\d+\.\d+\.\d+.*" {
-        $app = [Microsoft.PowerShell.Commands.PSUserAgent].GetProperty('App',@('Static','NonPublic')).GetValue($null,$null) 
-        $app | Should Match '^PowerShell/\d+\.\d+\.\d+.*'
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -463,7 +463,7 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
 
         # Validate response content
         $jsonContent = $result.Output.Content | ConvertFrom-Json
-        $jsonContent.headers.'User-Agent' | Should Match '(?<!Windows)PowerShell\/\d+\.\d+\.\d+.*'
+        $jsonContent.headers.'User-Agent' | Should MatchExactly '(?<!Windows)PowerShell\/\d+\.\d+\.\d+.*'
     }
 
     It "Invoke-WebRequest returns headers dictionary" {
@@ -1317,7 +1317,7 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
         $result = ExecuteWebCommand -command $command
 
         # Validate response
-        $result.Output.headers.'User-Agent' | Should Match '(?<!Windows)PowerShell\/\d+\.\d+\.\d+.*'
+        $result.Output.headers.'User-Agent' | Should MatchExactly '(?<!Windows)PowerShell\/\d+\.\d+\.\d+.*'
     }
 
     It "Invoke-RestMethod returns headers dictionary" {
@@ -1427,7 +1427,7 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
         $result = ExecuteWebCommand -command $command
 
         # Validate response
-        $result.Output.headers.'User-Agent' | Should Match '(?<!Windows)PowerShell\/\d+\.\d+\.\d+.*'
+        $result.Output.headers.'User-Agent' | Should MatchExactly '(?<!Windows)PowerShell\/\d+\.\d+\.\d+.*'
     }
 
     # Perform the following operation for Invoke-RestMethod

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -421,14 +421,13 @@ $PendingCertificateTest = $false
 if ( $IsMacOS ) { $PendingCertificateTest = $true }
 if ( test-path /etc/centos-release ) { $PendingCertificateTest = $true }
 
-# Get the default UserAgent through reflection
-$DefaultUserAgent = [Microsoft.PowerShell.Commands.PSUserAgent].GetProperty('UserAgent',@('Static','NonPublic')).GetValue($null,$null)
-
 Describe "Invoke-WebRequest tests" -Tags "Feature" {
 
     BeforeAll {
         $response = Start-HttpListener -Port 8080
         $WebListener = Start-WebListener
+        # Get the default UserAgent through reflection
+        $DefaultUserAgent = [Microsoft.PowerShell.Commands.PSUserAgent].GetProperty('UserAgent',@('Static','NonPublic')).GetValue($null,$null)
     }
 
     AfterAll {
@@ -1310,6 +1309,8 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
     BeforeAll {
         $response = Start-HttpListener -Port 8081
         $WebListener = Start-WebListener
+        # Get the default UserAgent through reflection
+        $DefaultUserAgent = [Microsoft.PowerShell.Commands.PSUserAgent].GetProperty('UserAgent',@('Static','NonPublic')).GetValue($null,$null)
     }
 
     AfterAll {
@@ -2186,5 +2187,12 @@ Describe "Web cmdlets tests using the cmdlet's aliases" -Tags "CI" {
     It "Execute Invoke-RestMethod" {
         $result = irm "http://localhost:8082/PowerShell?test=response&output={%22hello%22:%22world%22}&contenttype=application/json" -TimeoutSec 5
         $result.Hello | Should Be "world"
+    }
+}
+
+Describe "PSUserAgent Tests" {
+    It "App Should Match ^PowerShell/\d+\.\d+\.\d+.*" {
+        $app = [Microsoft.PowerShell.Commands.PSUserAgent].GetProperty('App',@('Static','NonPublic')).GetValue($null,$null) 
+        $app | Should Match '^PowerShell/\d+\.\d+\.\d+.*'
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -421,6 +421,9 @@ $PendingCertificateTest = $false
 if ( $IsMacOS ) { $PendingCertificateTest = $true }
 if ( test-path /etc/centos-release ) { $PendingCertificateTest = $true }
 
+# Get the default UserAgent through reflection
+$DefaultUserAgent = [Microsoft.PowerShell.Commands.PSUserAgent].GetProperty('UserAgent',@('Static','NonPublic')).GetValue($null,$null)
+
 Describe "Invoke-WebRequest tests" -Tags "Feature" {
 
     BeforeAll {
@@ -463,7 +466,7 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
 
         # Validate response content
         $jsonContent = $result.Output.Content | ConvertFrom-Json
-        $jsonContent.headers.'User-Agent' | Should Match "PowerShell"
+        $jsonContent.headers.'User-Agent' | Should Be $DefaultUserAgent
     }
 
     It "Invoke-WebRequest returns headers dictionary" {
@@ -477,7 +480,7 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
         # Validate response content
         $jsonContent = $result.Output.Content | ConvertFrom-Json
         $jsonContent.headers.Host | Should Be $Uri.Authority
-        $jsonContent.headers.'User-Agent' | Should Match "PowerShell"
+        $jsonContent.headers.'User-Agent' | Should Be $DefaultUserAgent
     }
 
     It "Validate Invoke-WebRequest -DisableKeepAlive" {
@@ -503,7 +506,7 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
         # Validate response content
         $jsonContent = $result.Output.Content | ConvertFrom-Json
         $jsonContent.headers.Host | Should Match $uri.Authority
-        $jsonContent.headers.'User-Agent' | Should Match "PowerShell"
+        $jsonContent.headers.'User-Agent' | Should Be $DefaultUserAgent
     }
 
     It "Validate Invoke-WebRequest error for -MaximumRedirection" {
@@ -584,7 +587,7 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
         # Validate response content
         $jsonContent = $result.Output.Content | ConvertFrom-Json
         $jsonContent.headers.Host | Should Be $uri.Authority
-        $jsonContent.headers.'User-Agent' | Should Match "PowerShell"
+        $jsonContent.headers.'User-Agent' | Should Be $DefaultUserAgent
     }
 
     It "Invoke-WebRequest validate timeout option" {
@@ -658,7 +661,7 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
                 # Validate response content
                 $jsonContent = $result.Output.Content | ConvertFrom-Json
                 $jsonContent.url | Should Match $uri
-                $jsonContent.headers.'User-Agent' | Should Match "PowerShell"
+                $jsonContent.headers.'User-Agent' | Should Be $DefaultUserAgent
 
                 # For a GET request, there is no data property to validate.
                 if ($method -ne "GET")
@@ -720,7 +723,7 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
         $result = ExecuteRequestWithOutFile -cmdletName "Invoke-WebRequest" -uri $uri
         $jsonContent = $result.Output | ConvertFrom-Json
         $jsonContent.headers.Host | Should Be $uri.Authority
-        $jsonContent.headers.'User-Agent' | Should Match "PowerShell"
+        $jsonContent.headers.'User-Agent' | Should Be $DefaultUserAgent
     }
 
     It "Validate Invoke-WebRequest handles missing Content-Type in response header" {
@@ -1322,7 +1325,7 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
         $result = ExecuteWebCommand -command $command
 
         # Validate response
-        $result.Output.headers.'User-Agent' | Should Match "PowerShell"
+        $result.Output.headers.'User-Agent' | Should Be $DefaultUserAgent
     }
 
     It "Invoke-RestMethod returns headers dictionary" {
@@ -1334,7 +1337,7 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
 
         # Validate response
         $result.Output.headers.Host | Should Be $Uri.Authority
-        $result.Output.headers.'User-Agent' | Should Match "PowerShell"
+        $result.Output.headers.'User-Agent' | Should Be $DefaultUserAgent
     }
 
     It "Validate Invoke-RestMethod -DisableKeepAlive" {
@@ -1347,7 +1350,7 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
 
         # Validate response
         $result.Output.headers.Host | Should Be $uri.Authority
-        $result.Output.headers.'User-Agent' | Should Match "PowerShell"
+        $result.Output.headers.'User-Agent' | Should Be $DefaultUserAgent
         $result.Output.Headers.Connection | Should Be "Close"
     }
 
@@ -1360,7 +1363,7 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
 
         # Validate response
         $result.Output.headers.Host | Should Match $uri.Authority
-        $result.Output.headers.'User-Agent' | Should Match "PowerShell"
+        $result.Output.headers.'User-Agent' | Should Be $DefaultUserAgent
     }
 
     It "Validate Invoke-RestMethod error for -MaximumRedirection" {
@@ -1435,7 +1438,7 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
         $result = ExecuteWebCommand -command $command
 
         # Validate response
-        $result.Output.headers.'User-Agent' | Should Match "PowerShell"
+        $result.Output.headers.'User-Agent' | Should Be $DefaultUserAgent
     }
 
     # Perform the following operation for Invoke-RestMethod
@@ -1497,7 +1500,7 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
 
                 # Validate response
                 $result.Output.url | Should Match $uri
-                $result.Output.headers.'User-Agent' | Should Match "PowerShell"
+                $result.Output.headers.'User-Agent' | Should Be $DefaultUserAgent
 
                 # For a GET request, there is no data property to validate.
                 if ($method -ne "GET")
@@ -1525,7 +1528,7 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
 
         # Validate response
         $result.Output.url | Should Match $uri
-        $result.Output.headers.'User-Agent' | Should Match "PowerShell"
+        $result.Output.headers.'User-Agent' | Should Be $DefaultUserAgent
         $result.Output.Headers.Connection | Should Be "Close"
     }
 
@@ -1560,7 +1563,7 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
         $result = ExecuteRequestWithOutFile -cmdletName "Invoke-RestMethod" -uri $uri
         $jsonContent = $result.Output | ConvertFrom-Json
         $jsonContent.headers.Host | Should Be $uri.Authority
-        $jsonContent.headers.'User-Agent' | Should Match "PowerShell"
+        $jsonContent.headers.'User-Agent' | Should Be $DefaultUserAgent
     }
 
     It "Validate Invoke-RestMethod handles missing Content-Type in response header" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -426,8 +426,6 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
     BeforeAll {
         $response = Start-HttpListener -Port 8080
         $WebListener = Start-WebListener
-        # Get the default UserAgent through reflection
-        $DefaultUserAgent = [Microsoft.PowerShell.Commands.PSUserAgent].GetProperty('UserAgent',@('Static','NonPublic')).GetValue($null,$null)
     }
 
     AfterAll {
@@ -479,7 +477,6 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
         # Validate response content
         $jsonContent = $result.Output.Content | ConvertFrom-Json
         $jsonContent.headers.Host | Should Be $Uri.Authority
-        $jsonContent.headers.'User-Agent' | Should Be $DefaultUserAgent
     }
 
     It "Validate Invoke-WebRequest -DisableKeepAlive" {
@@ -505,7 +502,6 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
         # Validate response content
         $jsonContent = $result.Output.Content | ConvertFrom-Json
         $jsonContent.headers.Host | Should Match $uri.Authority
-        $jsonContent.headers.'User-Agent' | Should Be $DefaultUserAgent
     }
 
     It "Validate Invoke-WebRequest error for -MaximumRedirection" {
@@ -586,7 +582,6 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
         # Validate response content
         $jsonContent = $result.Output.Content | ConvertFrom-Json
         $jsonContent.headers.Host | Should Be $uri.Authority
-        $jsonContent.headers.'User-Agent' | Should Be $DefaultUserAgent
     }
 
     It "Invoke-WebRequest validate timeout option" {
@@ -660,7 +655,6 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
                 # Validate response content
                 $jsonContent = $result.Output.Content | ConvertFrom-Json
                 $jsonContent.url | Should Match $uri
-                $jsonContent.headers.'User-Agent' | Should Be $DefaultUserAgent
 
                 # For a GET request, there is no data property to validate.
                 if ($method -ne "GET")
@@ -722,7 +716,6 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
         $result = ExecuteRequestWithOutFile -cmdletName "Invoke-WebRequest" -uri $uri
         $jsonContent = $result.Output | ConvertFrom-Json
         $jsonContent.headers.Host | Should Be $uri.Authority
-        $jsonContent.headers.'User-Agent' | Should Be $DefaultUserAgent
     }
 
     It "Validate Invoke-WebRequest handles missing Content-Type in response header" {
@@ -1309,8 +1302,6 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
     BeforeAll {
         $response = Start-HttpListener -Port 8081
         $WebListener = Start-WebListener
-        # Get the default UserAgent through reflection
-        $DefaultUserAgent = [Microsoft.PowerShell.Commands.PSUserAgent].GetProperty('UserAgent',@('Static','NonPublic')).GetValue($null,$null)
     }
 
     AfterAll {
@@ -1326,7 +1317,7 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
         $result = ExecuteWebCommand -command $command
 
         # Validate response
-        $result.Output.headers.'User-Agent' | Should Be '(?<!Windows)PowerShell\/\d+\.\d+\.\d+.*'
+        $result.Output.headers.'User-Agent' | Should Match '(?<!Windows)PowerShell\/\d+\.\d+\.\d+.*'
     }
 
     It "Invoke-RestMethod returns headers dictionary" {
@@ -1338,7 +1329,6 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
 
         # Validate response
         $result.Output.headers.Host | Should Be $Uri.Authority
-        $result.Output.headers.'User-Agent' | Should Be $DefaultUserAgent
     }
 
     It "Validate Invoke-RestMethod -DisableKeepAlive" {
@@ -1351,7 +1341,6 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
 
         # Validate response
         $result.Output.headers.Host | Should Be $uri.Authority
-        $result.Output.headers.'User-Agent' | Should Be $DefaultUserAgent
         $result.Output.Headers.Connection | Should Be "Close"
     }
 
@@ -1364,7 +1353,6 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
 
         # Validate response
         $result.Output.headers.Host | Should Match $uri.Authority
-        $result.Output.headers.'User-Agent' | Should Be $DefaultUserAgent
     }
 
     It "Validate Invoke-RestMethod error for -MaximumRedirection" {
@@ -1439,7 +1427,7 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
         $result = ExecuteWebCommand -command $command
 
         # Validate response
-        $result.Output.headers.'User-Agent' | Should Be $DefaultUserAgent
+        $result.Output.headers.'User-Agent' | Should Match '(?<!Windows)PowerShell\/\d+\.\d+\.\d+.*'
     }
 
     # Perform the following operation for Invoke-RestMethod
@@ -1501,7 +1489,6 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
 
                 # Validate response
                 $result.Output.url | Should Match $uri
-                $result.Output.headers.'User-Agent' | Should Be $DefaultUserAgent
 
                 # For a GET request, there is no data property to validate.
                 if ($method -ne "GET")
@@ -1529,7 +1516,6 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
 
         # Validate response
         $result.Output.url | Should Match $uri
-        $result.Output.headers.'User-Agent' | Should Be $DefaultUserAgent
         $result.Output.Headers.Connection | Should Be "Close"
     }
 
@@ -1564,7 +1550,6 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
         $result = ExecuteRequestWithOutFile -cmdletName "Invoke-RestMethod" -uri $uri
         $jsonContent = $result.Output | ConvertFrom-Json
         $jsonContent.headers.Host | Should Be $uri.Authority
-        $jsonContent.headers.'User-Agent' | Should Be $DefaultUserAgent
     }
 
     It "Validate Invoke-RestMethod handles missing Content-Type in response header" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -2190,7 +2190,7 @@ Describe "Web cmdlets tests using the cmdlet's aliases" -Tags "CI" {
     }
 }
 
-Describe "PSUserAgent Tests" {
+Describe "PSUserAgent Tests" -Tags "CI" {
     It "App Should Match ^PowerShell/\d+\.\d+\.\d+.*" {
         $app = [Microsoft.PowerShell.Commands.PSUserAgent].GetProperty('App',@('Static','NonPublic')).GetValue($null,$null) 
         $app | Should Match '^PowerShell/\d+\.\d+\.\d+.*'

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -463,7 +463,7 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
 
         # Validate response content
         $jsonContent = $result.Output.Content | ConvertFrom-Json
-        $jsonContent.headers.'User-Agent' | Should Match "WindowsPowerShell"
+        $jsonContent.headers.'User-Agent' | Should Match "PowerShell"
     }
 
     It "Invoke-WebRequest returns headers dictionary" {
@@ -477,7 +477,7 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
         # Validate response content
         $jsonContent = $result.Output.Content | ConvertFrom-Json
         $jsonContent.headers.Host | Should Be $Uri.Authority
-        $jsonContent.headers.'User-Agent' | Should Match "WindowsPowerShell"
+        $jsonContent.headers.'User-Agent' | Should Match "PowerShell"
     }
 
     It "Validate Invoke-WebRequest -DisableKeepAlive" {
@@ -503,7 +503,7 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
         # Validate response content
         $jsonContent = $result.Output.Content | ConvertFrom-Json
         $jsonContent.headers.Host | Should Match $uri.Authority
-        $jsonContent.headers.'User-Agent' | Should Match "WindowsPowerShell"
+        $jsonContent.headers.'User-Agent' | Should Match "PowerShell"
     }
 
     It "Validate Invoke-WebRequest error for -MaximumRedirection" {
@@ -584,7 +584,7 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
         # Validate response content
         $jsonContent = $result.Output.Content | ConvertFrom-Json
         $jsonContent.headers.Host | Should Be $uri.Authority
-        $jsonContent.headers.'User-Agent' | Should Match "WindowsPowerShell"
+        $jsonContent.headers.'User-Agent' | Should Match "PowerShell"
     }
 
     It "Invoke-WebRequest validate timeout option" {
@@ -658,7 +658,7 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
                 # Validate response content
                 $jsonContent = $result.Output.Content | ConvertFrom-Json
                 $jsonContent.url | Should Match $uri
-                $jsonContent.headers.'User-Agent' | Should Match "WindowsPowerShell"
+                $jsonContent.headers.'User-Agent' | Should Match "PowerShell"
 
                 # For a GET request, there is no data property to validate.
                 if ($method -ne "GET")
@@ -720,7 +720,7 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
         $result = ExecuteRequestWithOutFile -cmdletName "Invoke-WebRequest" -uri $uri
         $jsonContent = $result.Output | ConvertFrom-Json
         $jsonContent.headers.Host | Should Be $uri.Authority
-        $jsonContent.headers.'User-Agent' | Should Match "WindowsPowerShell"
+        $jsonContent.headers.'User-Agent' | Should Match "PowerShell"
     }
 
     It "Validate Invoke-WebRequest handles missing Content-Type in response header" {
@@ -1322,7 +1322,7 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
         $result = ExecuteWebCommand -command $command
 
         # Validate response
-        $result.Output.headers.'User-Agent' | Should Match "WindowsPowerShell"
+        $result.Output.headers.'User-Agent' | Should Match "PowerShell"
     }
 
     It "Invoke-RestMethod returns headers dictionary" {
@@ -1334,7 +1334,7 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
 
         # Validate response
         $result.Output.headers.Host | Should Be $Uri.Authority
-        $result.Output.headers.'User-Agent' | Should Match "WindowsPowerShell"
+        $result.Output.headers.'User-Agent' | Should Match "PowerShell"
     }
 
     It "Validate Invoke-RestMethod -DisableKeepAlive" {
@@ -1347,7 +1347,7 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
 
         # Validate response
         $result.Output.headers.Host | Should Be $uri.Authority
-        $result.Output.headers.'User-Agent' | Should Match "WindowsPowerShell"
+        $result.Output.headers.'User-Agent' | Should Match "PowerShell"
         $result.Output.Headers.Connection | Should Be "Close"
     }
 
@@ -1360,7 +1360,7 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
 
         # Validate response
         $result.Output.headers.Host | Should Match $uri.Authority
-        $result.Output.headers.'User-Agent' | Should Match "WindowsPowerShell"
+        $result.Output.headers.'User-Agent' | Should Match "PowerShell"
     }
 
     It "Validate Invoke-RestMethod error for -MaximumRedirection" {
@@ -1435,7 +1435,7 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
         $result = ExecuteWebCommand -command $command
 
         # Validate response
-        $result.Output.headers.'User-Agent' | Should Match "WindowsPowerShell"
+        $result.Output.headers.'User-Agent' | Should Match "PowerShell"
     }
 
     # Perform the following operation for Invoke-RestMethod
@@ -1497,7 +1497,7 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
 
                 # Validate response
                 $result.Output.url | Should Match $uri
-                $result.Output.headers.'User-Agent' | Should Match "WindowsPowerShell"
+                $result.Output.headers.'User-Agent' | Should Match "PowerShell"
 
                 # For a GET request, there is no data property to validate.
                 if ($method -ne "GET")
@@ -1525,7 +1525,7 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
 
         # Validate response
         $result.Output.url | Should Match $uri
-        $result.Output.headers.'User-Agent' | Should Match "WindowsPowerShell"
+        $result.Output.headers.'User-Agent' | Should Match "PowerShell"
         $result.Output.Headers.Connection | Should Be "Close"
     }
 
@@ -1560,7 +1560,7 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
         $result = ExecuteRequestWithOutFile -cmdletName "Invoke-RestMethod" -uri $uri
         $jsonContent = $result.Output | ConvertFrom-Json
         $jsonContent.headers.Host | Should Be $uri.Authority
-        $jsonContent.headers.'User-Agent' | Should Match "WindowsPowerShell"
+        $jsonContent.headers.'User-Agent' | Should Match "PowerShell"
     }
 
     It "Validate Invoke-RestMethod handles missing Content-Type in response header" {


### PR DESCRIPTION
fixes #4911

* renames the App portion of the user agent to `PowerShell`
* Adjusts tests. 
