### PR TITLE
Fix TestValue in Get-WebListenerUrl to Avoid // Urls

### DIFF
--- a/test/tools/Modules/WebListener/WebListener.psm1
+++ b/test/tools/Modules/WebListener/WebListener.psm1
@@ -141,7 +141,16 @@ function Get-WebListenerUrl {
             $Uri.Port = $runningListener.HttpsPort
             $Uri.Scheme = 'Https'
         }
-        $Uri.Path = '{0}/{1}' -f $Test, $TestValue
+
+        if ($TestValue)
+        {
+            $Uri.Path = '{0}/{1}' -f $Test, $TestValue
+        }
+        else 
+        {
+            $Uri.Path = $Test
+        }
+
         return [Uri]$Uri.ToString()
     }
 }


### PR DESCRIPTION
fixes #4919 

* Adds logic in `Get-WebListenerUrl` to only apply the `TestValue` part of the path if it was supplied
