### PR TITLE
Exclude -Comobject parameter of New-Object cmdlet on unsupported platforms

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/new-object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/new-object.cs
@@ -31,12 +31,12 @@ namespace Microsoft.PowerShell.Commands
         [Parameter(ParameterSetName = netSetName, Mandatory = true, Position = 0)]
         public string TypeName { get; set; } = null;
 
-
+#if !UNIX
         private Guid _comObjectClsId = Guid.Empty;
         /// <summary> the ProgID of the Com object</summary>
         [Parameter(ParameterSetName = "Com", Mandatory = true, Position = 0)]
         public string ComObject { get; set; } = null;
-
+#endif
 
         /// <summary>
         /// The parameters for the constructor
@@ -245,8 +245,15 @@ namespace Microsoft.PowerShell.Commands
                      "CannotFindAppropriateCtor",
                      ErrorCategory.ObjectNotFound, null));
             }
+#if !UNIX
             else // Parameterset -Com
             {
+                if (!Platform.IsWindowsDesktop)
+                {
+                    Exception exc = new NotSupportedException(NewObjectStrings.ComObjectPlatformIsNotSupported);
+                    ThrowTerminatingError(new ErrorRecord(exc, "ComObjectPlatformIsNotSupported", ErrorCategory.NotImplemented, null));
+                }
+
                 int result = NewObjectNativeMethods.CLSIDFromProgID(ComObject, out _comObjectClsId);
 
                 // If we're in ConstrainedLanguage, do additional restrictions
@@ -295,6 +302,7 @@ namespace Microsoft.PowerShell.Commands
                 }
                 WriteObject(comObject);
             }
+#endif
         }//protected override void BeginProcessing()
 
         #endregion Overrides
@@ -407,6 +415,7 @@ namespace Microsoft.PowerShell.Commands
         }
 #endif
 
+#if !UNIX
         private object CreateComObject()
         {
             Type type = null;
@@ -465,7 +474,7 @@ namespace Microsoft.PowerShell.Commands
                 return null;
             }
         }
-
+#endif
         #endregion Com
 
         // HResult code '-2147417850' - Cannot change thread mode after it is set.

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/new-object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/new-object.cs
@@ -248,12 +248,6 @@ namespace Microsoft.PowerShell.Commands
 #if !UNIX
             else // Parameterset -Com
             {
-                if (!Platform.IsWindowsDesktop)
-                {
-                    Exception exc = new NotSupportedException(NewObjectStrings.ComObjectPlatformIsNotSupported);
-                    ThrowTerminatingError(new ErrorRecord(exc, "ComObjectPlatformIsNotSupported", ErrorCategory.NotImplemented, null));
-                }
-
                 int result = NewObjectNativeMethods.CLSIDFromProgID(ComObject, out _comObjectClsId);
 
                 // If we're in ConstrainedLanguage, do additional restrictions
@@ -307,6 +301,7 @@ namespace Microsoft.PowerShell.Commands
 
         #endregion Overrides
 
+#if !UNIX
         #region Com
 
         private object SafeCreateInstance(Type t, object[] args)
@@ -415,7 +410,6 @@ namespace Microsoft.PowerShell.Commands
         }
 #endif
 
-#if !UNIX
         private object CreateComObject()
         {
             Type type = null;
@@ -474,8 +468,9 @@ namespace Microsoft.PowerShell.Commands
                 return null;
             }
         }
-#endif
+
         #endregion Com
+#endif
 
         // HResult code '-2147417850' - Cannot change thread mode after it is set.
         private const int RPC_E_CHANGED_MODE = unchecked((int)0x80010106);

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/NewObjectStrings.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/NewObjectStrings.resx
@@ -144,4 +144,7 @@
   <data name="ApartmentNotSupported" xml:space="preserve">
     <value>{0} Please note that Single-Threaded Apartment is not supported in PowerShell Core.</value>
   </data>
+  <data name="ComObjectPlatformIsNotSupported" xml:space="preserve">
+    <value>Parameter 'ComObject' is not supported on the platform.</value>
+  </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/NewObjectStrings.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/NewObjectStrings.resx
@@ -144,7 +144,4 @@
   <data name="ApartmentNotSupported" xml:space="preserve">
     <value>{0} Please note that Single-Threaded Apartment is not supported in PowerShell Core.</value>
   </data>
-  <data name="ComObjectPlatformIsNotSupported" xml:space="preserve">
-    <value>Parameter 'ComObject' is not supported on the platform.</value>
-  </data>
 </root>

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/New-Object.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/New-Object.Tests.ps1
@@ -1,4 +1,15 @@
 Describe "New-Object" -Tags "CI" {
+    It "Support 'ComObject' parameter on platforms" {
+        if ($IsLinux -or $IsMacOs ) {
+            { New-Object -ComObject "Shell.Application" } | ShouldBeErrorId "NamedParameterNotFound,Microsoft.PowerShell.Commands.NewObjectCommand"
+        } elseif (![System.Management.Automation.Platform]::IsWindowsDesktop) {
+            # Windows Core and IoT
+            { New-Object -ComObject "Shell.Application" } | ShouldBeErrorId "ComObjectPlatformIsNotSupported,Microsoft.PowerShell.Commands.NewObjectCommand"
+        } elseif ($IsWindows) {
+            { New-Object -ComObject "Shell.Application" } | Should Not Throw
+        }
+    }
+
     It "should create an object with 4 fields" {
         $o = New-Object psobject
         $val = $o.GetType()

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/New-Object.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/New-Object.Tests.ps1
@@ -3,7 +3,8 @@ Describe "New-Object" -Tags "CI" {
         if ($IsLinux -or $IsMacOs ) {
             { New-Object -ComObject "Shell.Application" } | ShouldBeErrorId "NamedParameterNotFound,Microsoft.PowerShell.Commands.NewObjectCommand"
         } else {
-            { New-Object -ComObject "Shell.Application" } | Should Not Throw
+            # It works on NanoServer and IoT too
+            (Get-Command "New-Object").Parameters.ContainsKey("ComObject") | Should Be $true
         }
     }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/New-Object.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/New-Object.Tests.ps1
@@ -2,10 +2,7 @@ Describe "New-Object" -Tags "CI" {
     It "Support 'ComObject' parameter on platforms" {
         if ($IsLinux -or $IsMacOs ) {
             { New-Object -ComObject "Shell.Application" } | ShouldBeErrorId "NamedParameterNotFound,Microsoft.PowerShell.Commands.NewObjectCommand"
-        } elseif (![System.Management.Automation.Platform]::IsWindowsDesktop) {
-            # Windows Core and IoT
-            { New-Object -ComObject "Shell.Application" } | ShouldBeErrorId "ComObjectPlatformIsNotSupported,Microsoft.PowerShell.Commands.NewObjectCommand"
-        } elseif ($IsWindows) {
+        } else {
             { New-Object -ComObject "Shell.Application" } | Should Not Throw
         }
     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/New-Object.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/New-Object.Tests.ps1
@@ -1,17 +1,17 @@
 Describe "New-Object" -Tags "CI" {
     It "should create an object with 4 fields" {
         $o = New-Object psobject
-	    $val = $o.GetType()
+        $val = $o.GetType()
 
-	    $val.IsPublic       | Should Not BeNullOrEmpty
-	    $val.Name           | Should Not BeNullOrEmpty
-	    $val.IsSerializable | Should Not BeNullOrEmpty
-	    $val.BaseType       | Should Not BeNullOrEmpty
+        $val.IsPublic       | Should Not BeNullOrEmpty
+        $val.Name           | Should Not BeNullOrEmpty
+        $val.IsSerializable | Should Not BeNullOrEmpty
+        $val.BaseType       | Should Not BeNullOrEmpty
 
-	    $val.IsPublic       | Should Be $true
-	    $val.IsSerializable | Should Be $false
-	    $val.Name           | Should Be 'PSCustomObject'
-	    $val.BaseType       | Should Be 'System.Object'
+        $val.IsPublic       | Should Be $true
+        $val.IsSerializable | Should Be $false
+        $val.Name           | Should Be 'PSCustomObject'
+        $val.BaseType       | Should Be 'System.Object'
     }
 
     It "should create an object with using Property switch" {
@@ -19,185 +19,185 @@ Describe "New-Object" -Tags "CI" {
             FirstVal = 'test1'
             SecondVal = 'test2'
         }
-	    $o = New-Object psobject -Property $hash
+        $o = New-Object psobject -Property $hash
 
-	    $o.FirstVal     | Should Be 'test1'
-	    $o.SecondVal    | Should Be 'test2'
+        $o.FirstVal     | Should Be 'test1'
+        $o.SecondVal    | Should Be 'test2'
     }
 
     It "should create a .Net object with using ArgumentList switch" {
-	    $o = New-Object -TypeName System.Version -ArgumentList "1.2.3.4"
+        $o = New-Object -TypeName System.Version -ArgumentList "1.2.3.4"
         $o.GetType() | Should Be ([System.Version])
 
-	    $o      | Should Be "1.2.3.4"
+        $o      | Should Be "1.2.3.4"
     }
 }
 
 Describe "New-Object DRT basic functionality" -Tags "CI" {
-	It "New-Object with int array should work"{
-		$result = New-Object -TypeName int[] -Arg 10
-		$result.Count | Should Be 10
-	}
+    It "New-Object with int array should work"{
+        $result = New-Object -TypeName int[] -Arg 10
+        $result.Count | Should Be 10
+    }
 
-	It "New-Object with char should work"{
-		$result = New-Object -TypeName char
-		$result.Count | Should Be 1
-		$defaultChar = [char]0
-		([char]$result) | Should Be $defaultChar
-	}
+    It "New-Object with char should work"{
+        $result = New-Object -TypeName char
+        $result.Count | Should Be 1
+        $defaultChar = [char]0
+        ([char]$result) | Should Be $defaultChar
+    }
 
-	It "New-Object with default Coordinates should work"{
-		$result = New-Object -TypeName System.Management.Automation.Host.Coordinates
-		$result.Count | Should Be 1
-		$result.X | Should Be 0
-		$result.Y | Should Be 0
-	}
+    It "New-Object with default Coordinates should work"{
+        $result = New-Object -TypeName System.Management.Automation.Host.Coordinates
+        $result.Count | Should Be 1
+        $result.X | Should Be 0
+        $result.Y | Should Be 0
+    }
 
-	It "New-Object with specified Coordinates should work"{
-		$result = New-Object -TypeName System.Management.Automation.Host.Coordinates -ArgumentList 1,2
-		$result.Count | Should Be 1
-		$result.X | Should Be 1
-		$result.Y | Should Be 2
-	}
+    It "New-Object with specified Coordinates should work"{
+        $result = New-Object -TypeName System.Management.Automation.Host.Coordinates -ArgumentList 1,2
+        $result.Count | Should Be 1
+        $result.X | Should Be 1
+        $result.Y | Should Be 2
+    }
 
-	It "New-Object with Employ should work"{
-		if(-not ([System.Management.Automation.PSTypeName]'Employee').Type)
-		{
-			Add-Type -TypeDefinition "public class Employee{public Employee(string firstName,string lastName,int yearsInMS){FirstName = firstName;LastName=lastName;YearsInMS = yearsInMS;}public string FirstName;public string LastName;public int YearsInMS;}"
-		}
-		$result = New-Object -TypeName Employee -ArgumentList "Mary", "Soe", 11
-		$result.Count | Should Be 1
-		$result.FirstName | Should Be "Mary"
-		$result.LastName | Should Be "Soe"
-		$result.YearsInMS | Should Be 11
-	}
+    It "New-Object with Employ should work"{
+        if(-not ([System.Management.Automation.PSTypeName]'Employee').Type)
+        {
+            Add-Type -TypeDefinition "public class Employee{public Employee(string firstName,string lastName,int yearsInMS){FirstName = firstName;LastName=lastName;YearsInMS = yearsInMS;}public string FirstName;public string LastName;public int YearsInMS;}"
+        }
+        $result = New-Object -TypeName Employee -ArgumentList "Mary", "Soe", 11
+        $result.Count | Should Be 1
+        $result.FirstName | Should Be "Mary"
+        $result.LastName | Should Be "Soe"
+        $result.YearsInMS | Should Be 11
+    }
 
-	It "New-Object with invalid type should throw Exception"{
-		try
-		{
-			New-Object -TypeName LiarType -EA Stop
-			Throw "Execution OK"
-		}
-		catch
-		{
-			$_.CategoryInfo| Should Match "PSArgumentException"
-			$_.FullyQualifiedErrorId | Should be "TypeNotFound,Microsoft.PowerShell.Commands.NewObjectCommand"
-		}
-	}
+    It "New-Object with invalid type should throw Exception"{
+        try
+        {
+            New-Object -TypeName LiarType -EA Stop
+            Throw "Execution OK"
+        }
+        catch
+        {
+            $_.CategoryInfo| Should Match "PSArgumentException"
+            $_.FullyQualifiedErrorId | Should be "TypeNotFound,Microsoft.PowerShell.Commands.NewObjectCommand"
+        }
+    }
 
-	It "New-Object with invalid argument should throw Exception"{
-		try
-		{
-			New-Object -TypeName System.Management.Automation.PSVariable -ArgumentList "A", 1, None, "asd" -EA Stop
-			Throw "Execution OK"
-		}
-		catch
-		{
-			$_.CategoryInfo| Should Match "MethodException"
-			$_.FullyQualifiedErrorId | Should be "ConstructorInvokedThrowException,Microsoft.PowerShell.Commands.NewObjectCommand"
-		}
-	}
+    It "New-Object with invalid argument should throw Exception"{
+        try
+        {
+            New-Object -TypeName System.Management.Automation.PSVariable -ArgumentList "A", 1, None, "asd" -EA Stop
+            Throw "Execution OK"
+        }
+        catch
+        {
+            $_.CategoryInfo| Should Match "MethodException"
+            $_.FullyQualifiedErrorId | Should be "ConstructorInvokedThrowException,Microsoft.PowerShell.Commands.NewObjectCommand"
+        }
+    }
 
-	It "New-Object with abstract class should throw Exception"{
-		Add-Type -TypeDefinition "public abstract class AbstractEmployee{public AbstractEmployee(){}}"
-		try
-		{
-			New-Object -TypeName AbstractEmployee -EA Stop
-			Throw "Execution OK"
-		}
-		catch
-		{
-			$_.CategoryInfo| Should Match "MethodInvocationException"
-			$_.FullyQualifiedErrorId | Should be "ConstructorInvokedThrowException,Microsoft.PowerShell.Commands.NewObjectCommand"
-		}
-	}
+    It "New-Object with abstract class should throw Exception"{
+        Add-Type -TypeDefinition "public abstract class AbstractEmployee{public AbstractEmployee(){}}"
+        try
+        {
+            New-Object -TypeName AbstractEmployee -EA Stop
+            Throw "Execution OK"
+        }
+        catch
+        {
+            $_.CategoryInfo| Should Match "MethodInvocationException"
+            $_.FullyQualifiedErrorId | Should be "ConstructorInvokedThrowException,Microsoft.PowerShell.Commands.NewObjectCommand"
+        }
+    }
 
-	It "New-Object with bad argument for class constructor should throw Exception"{
-		if(-not ([System.Management.Automation.PSTypeName]'Employee').Type)
-		{
-			Add-Type -TypeDefinition "public class Employee{public Employee(string firstName,string lastName,int yearsInMS){FirstName = firstName;LastName=lastName;YearsInMS = yearsInMS;}public string FirstName;public string LastName;public int YearsInMS;}"
-		}
-		try
-		{
-			New-Object -TypeName Employee -ArgumentList 11 -EA Stop
-			Throw "Execution OK"
-		}
-		catch
-		{
-			$_.CategoryInfo| Should Match "MethodException"
-			$_.FullyQualifiedErrorId | Should be "ConstructorInvokedThrowException,Microsoft.PowerShell.Commands.NewObjectCommand"
-		}
-	}
+    It "New-Object with bad argument for class constructor should throw Exception"{
+        if(-not ([System.Management.Automation.PSTypeName]'Employee').Type)
+        {
+            Add-Type -TypeDefinition "public class Employee{public Employee(string firstName,string lastName,int yearsInMS){FirstName = firstName;LastName=lastName;YearsInMS = yearsInMS;}public string FirstName;public string LastName;public int YearsInMS;}"
+        }
+        try
+        {
+            New-Object -TypeName Employee -ArgumentList 11 -EA Stop
+            Throw "Execution OK"
+        }
+        catch
+        {
+            $_.CategoryInfo| Should Match "MethodException"
+            $_.FullyQualifiedErrorId | Should be "ConstructorInvokedThrowException,Microsoft.PowerShell.Commands.NewObjectCommand"
+        }
+    }
 
-	#This case will throw "Execution OK" now, just mark as pending now
-	It "New-Object with not init class constructor should throw Exception" -Pending{
-		if(-not ([System.Management.Automation.PSTypeName]'Employee').Type)
-		{
-			Add-Type -TypeDefinition "public class Employee{public Employee(string firstName,string lastName,int yearsInMS){FirstName = firstName;LastName=lastName;YearsInMS = yearsInMS;}public string FirstName;public string LastName;public int YearsInMS;}"
-		}
-		try
-		{
-			New-Object -TypeName Employee -EA Stop
-			Throw "Execution OK"
-		}
-		catch
-		{
-			$_.FullyQualifiedErrorId | Should be "CannotFindAppropriateCtor,Microsoft.PowerShell.Commands.NewObjectCommand"
-		}
-	}
+    #This case will throw "Execution OK" now, just mark as pending now
+    It "New-Object with not init class constructor should throw Exception" -Pending{
+        if(-not ([System.Management.Automation.PSTypeName]'Employee').Type)
+        {
+            Add-Type -TypeDefinition "public class Employee{public Employee(string firstName,string lastName,int yearsInMS){FirstName = firstName;LastName=lastName;YearsInMS = yearsInMS;}public string FirstName;public string LastName;public int YearsInMS;}"
+        }
+        try
+        {
+            New-Object -TypeName Employee -EA Stop
+            Throw "Execution OK"
+        }
+        catch
+        {
+            $_.FullyQualifiedErrorId | Should be "CannotFindAppropriateCtor,Microsoft.PowerShell.Commands.NewObjectCommand"
+        }
+    }
 
-	It "New-Object with Private Nested class should throw Exception"{
-		Add-Type -TypeDefinition "public class WeirdEmployee{public WeirdEmployee(){}private class PrivateNestedWeirdEmployee{public PrivateNestedWeirdEmployee(){}}}"
-		try
-		{
-			New-Object -TypeName WeirdEmployee+PrivateNestedWeirdEmployee -EA Stop
-			Throw "Execution OK"
-		}
-		catch
-		{
-			$_.CategoryInfo| Should Match "PSArgumentException"
-			$_.FullyQualifiedErrorId | Should be "TypeNotFound,Microsoft.PowerShell.Commands.NewObjectCommand"
-		}
-	}
+    It "New-Object with Private Nested class should throw Exception"{
+        Add-Type -TypeDefinition "public class WeirdEmployee{public WeirdEmployee(){}private class PrivateNestedWeirdEmployee{public PrivateNestedWeirdEmployee(){}}}"
+        try
+        {
+            New-Object -TypeName WeirdEmployee+PrivateNestedWeirdEmployee -EA Stop
+            Throw "Execution OK"
+        }
+        catch
+        {
+            $_.CategoryInfo| Should Match "PSArgumentException"
+            $_.FullyQualifiedErrorId | Should be "TypeNotFound,Microsoft.PowerShell.Commands.NewObjectCommand"
+        }
+    }
 
-	It "New-Object with TypeName and Property parameter should work"{
-		$result = New-Object -TypeName PSObject -property @{foo=123}
-		$result.foo | Should Be 123
-	}
+    It "New-Object with TypeName and Property parameter should work"{
+        $result = New-Object -TypeName PSObject -property @{foo=123}
+        $result.foo | Should Be 123
+    }
 }
 
-try 
+try
 {
     $defaultParamValues = $PSdefaultParameterValues.Clone()
     $PSDefaultParameterValues["it:skip"] = ![System.Management.Automation.Platform]::IsWindowsDesktop
 
-	Describe "New-Object COM functionality" -Tags "CI" {
-		$testCases = @(
-			@{
-				Name   = 'Microsoft.Update.AutoUpdate'
-				Property = 'Settings'
-				Type = 'Object'
-			}
-			@{
-				Name   = 'Microsoft.Update.SystemInfo'
-				Property = 'RebootRequired'
-				Type = 'Bool'
-			}
-		)
+    Describe "New-Object COM functionality" -Tags "CI" {
+        $testCases = @(
+            @{
+                Name   = 'Microsoft.Update.AutoUpdate'
+                Property = 'Settings'
+                Type = 'Object'
+            }
+            @{
+                Name   = 'Microsoft.Update.SystemInfo'
+                Property = 'RebootRequired'
+                Type = 'Bool'
+            }
+        )
 
-		It "Should be able to create <Name> with property <Property> of Type <Type>" -TestCases $testCases {
-			param($Name, $Property, $Type)
-			$comObject = New-Object -ComObject $name
-			$comObject.$Property | should not be $null
-			$comObject.$Property | should beoftype $Type
-		}
+        It "Should be able to create <Name> with property <Property> of Type <Type>" -TestCases $testCases {
+            param($Name, $Property, $Type)
+            $comObject = New-Object -ComObject $name
+            $comObject.$Property | should not be $null
+            $comObject.$Property | should beoftype $Type
+        }
 
-		It "Should fail with correct error when creating a COM object that dose not exist" {
-			{New-Object -ComObject 'doesnotexist'} | shouldBeErrorId 'NoCOMClassIdentified,Microsoft.PowerShell.Commands.NewObjectCommand'
-		}
-	}
-} 
-finally 
+        It "Should fail with correct error when creating a COM object that dose not exist" {
+            {New-Object -ComObject 'doesnotexist'} | shouldBeErrorId 'NoCOMClassIdentified,Microsoft.PowerShell.Commands.NewObjectCommand'
+        }
+    }
+}
+finally
 {
     $global:PSdefaultParameterValues = $defaultParamValues
 }


### PR DESCRIPTION
Fix #4897.

New-Object -Comobject is not supported on
- Linux and MacOs - fix is remove the code.
- Windows Core and IoT - fix is throw `NotSupportedException` exception.

First commit reformat test file.