### PR TITLE
Fix credential scan issues

### DIFF
--- a/demos/Azure/Azure-Demo.ps1
+++ b/demos/Azure/Azure-Demo.ps1
@@ -28,6 +28,8 @@ New-AzureRmResourceGroup -Name $resourceGroupName -Location "West US"
 ### http://armviz.io/#/?load=https:%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2F101-vm-simple-linux%2Fazuredeploy.json
 $dnsLabelPrefix = $resourceGroupName | ForEach-Object tolower
 $dnsLabelPrefix
+
+#[SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Demo/doc secret.")]
 $password = ConvertTo-SecureString -String "PowerShellRocks!" -AsPlainText -Force
 New-AzureRmResourceGroupDeployment -ResourceGroupName $resourceGroupName -TemplateFile ./Compute-Linux.json -adminUserName psuser -adminPassword $password -dnsLabelPrefix $dnsLabelPrefix
 

--- a/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalUser.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalUser.Tests.ps1
@@ -376,6 +376,7 @@ try {
         }
 
         It "Can set PasswordNeverExpires to create a user with null for PasswordExpires date" {
+            #[SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Demo/doc/test secret.")]
             $result = New-LocalUser TestUserNew1 -Password (ConvertTo-SecureString "p@ssw0rd" -Asplaintext -Force) -PasswordNeverExpires
 
             $result.Name | Should BeExactly TestUserNew1
@@ -781,6 +782,7 @@ try {
         }
 
         It 'Can use PasswordNeverExpires:$true to null a PasswordExpires date' {
+            #[SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Demo/doc/test secret.")]
             $user = New-LocalUser TestUserSet2 -Password (ConvertTo-SecureString "p@ssw0rd" -Asplaintext -Force)
             $user | Set-LocalUser -PasswordNeverExpires:$true
             $result = Get-LocalUser TestUserSet2
@@ -790,6 +792,7 @@ try {
         }
 
         It 'Can use PasswordNeverExpires:$false to activate a PasswordExpires date' {
+            #[SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Demo/doc/test secret.")]
             $user = New-LocalUser TestUserSet2 -Password (ConvertTo-SecureString "p@ssw0rd" -Asplaintext -Force) -PasswordNeverExpires
             $user | Set-LocalUser -PasswordNeverExpires:$false
             $result = Get-LocalUser TestUserSet2

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Service.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Service.Tests.ps1
@@ -103,6 +103,7 @@ Describe "Set/New/Remove-Service cmdlet tests" -Tags "Feature", "RequireAdminOnW
         @{parameter = "StartupType"    ; value = "System"},
         @{parameter = "Credential"     ; value = (
                 [System.Management.Automation.PSCredential]::new("username", 
+                    #[SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Demo/doc/test secret.")]
                     (ConvertTo-SecureString "PlainTextPassword" -AsPlainText -Force)))
         }
         @{parameter = "DependsOn"      ; value = "foo", "bar"}
@@ -257,6 +258,7 @@ Describe "Set/New/Remove-Service cmdlet tests" -Tags "Feature", "RequireAdminOnW
     It "Using bad parameters will fail for '<name>' where '<parameter>' = '<value>'" -TestCases @(
         @{cmdlet="New-Service"; name = 'credtest'    ; parameter = "Credential" ; value = (
             [System.Management.Automation.PSCredential]::new("username", 
+            #[SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Demo/doc/test secret.")]
             (ConvertTo-SecureString "PlainTextPassword" -AsPlainText -Force)));
             errorid = "CouldNotNewService,Microsoft.PowerShell.Commands.NewServiceCommand"},
         @{cmdlet="New-Service"; name = 'badstarttype'; parameter = "StartupType"; value = "System";

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/GetCredential.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/GetCredential.Tests.ps1
@@ -90,6 +90,7 @@ Describe "Get-Credential Test" -tag "CI" {
         $th.ui.Streams.Prompt[-1] | Should Match "Credential:[^:]+:[^:]+"
     }
     it "Get-Credential `$credential" {
+        #[SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Demo/doc/test secret.")]
         $password = ConvertTo-SecureString -String "CredTest" -AsPlainText -Force
         $credential = [pscredential]::new("John", $password)
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/TestData/CatalogTestData/CatalogTestFile2.xml
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/TestData/CatalogTestData/CatalogTestFile2.xml
@@ -1,7 +1,8 @@
 <MachineInventory aliasing="True">
      <Machine machineRole="Server">
         <Accounts>
-          <LocalAdmin user="root" password="Bull_dog1" />
+          <!--[SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Demo/doc/test secret.")] -->
+          <LocalAdmin user="root" password="PowerShellRocks!" />
         </Accounts>
         <BMCMachine>No</BMCMachine>
         <BranchName>Linux</BranchName>

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-SecureString.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-SecureString.Tests.ps1
@@ -1,8 +1,9 @@
-Describe "ConvertTo-SecureString" -Tags "CI" {
+	Describe "ConvertTo--SecureString" -Tags "CI" {
 
-    Context "Checking return types of ConvertTo-SecureString" {
+    Context "Checking return types of ConvertTo--SecureString" {
 
 	It "Should return System.Security.SecureString after converting plaintext variable"{
+        #[SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Demo/doc/test secret.")]
 	    $PesterTestConvert = (ConvertTo-SecureString "plaintextpester" -AsPlainText -force)
 	    $PesterTestConvert | Should BeOfType securestring
 

--- a/test/powershell/Modules/Microsoft.WSMan.Management/ConfigProvider.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.WSMan.Management/ConfigProvider.Tests.ps1
@@ -158,6 +158,7 @@ Describe "WSMan Config Provider" -Tag Feature,RequireAdminOnWindows {
         }
 
         It "Set-Item on plugin RunAsUser should fail for invalid creds" {
+            #[SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Demo/doc/test secret.")]
             $password = ConvertTo-SecureString "My voice is my passport, verify me" -AsPlainText -Force
             $creds = [pscredential]::new((Get-Random),$password)
             $exception = { Set-Item $testPluginPath\RunAsUser $creds } | ShouldBeErrorId "System.InvalidOperationException,Microsoft.PowerShell.Commands.SetItemCommand"
@@ -176,6 +177,7 @@ Describe "WSMan Config Provider" -Tag Feature,RequireAdminOnWindows {
         }
 
         It "Set-Item on plugin RunAsUser should fail for invalid password" {
+            #[SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Demo/doc/test secret.")]
             $password = ConvertTo-SecureString "My voice is my passport, verify me" -AsPlainText -Force
             $creds = [pscredential]::new($testUser,$password)
             $exception = { Set-Item $testPluginPath\RunAsUser $creds } | ShouldBeErrorId "System.InvalidOperationException,Microsoft.PowerShell.Commands.SetItemCommand"
@@ -183,6 +185,7 @@ Describe "WSMan Config Provider" -Tag Feature,RequireAdminOnWindows {
         }
 
         It "Set-Item on password without user on plugin should fail for <password>" -TestCases @(
+            #[SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Demo/doc/test secret.")]
             @{password=(ConvertTo-SecureString "My voice is my passport, verify me" -AsPlainText -Force)},
             @{password="hello"}
         ) {

--- a/test/powershell/engine/Api/Serialization.Tests.ps1
+++ b/test/powershell/engine/Api/Serialization.Tests.ps1
@@ -83,6 +83,7 @@ Describe "Serialization Tests" -tags "CI" {
     }
 
     It 'Test SecureString serialize and deserialize work as expected.' {
+        #[SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Demo/doc/test secret.")]
         $inputObject = Convertto-Securestring -String "PowerShellRocks!" -AsPlainText -Force
         SerializeAndDeserialize($inputObject).Length | Should be $inputObject.Length
 

--- a/tools/credScan/suppress.json
+++ b/tools/credScan/suppress.json
@@ -1,0 +1,13 @@
+{
+    "tool": "Credential Scanner",
+    "suppressions": [
+      {
+       "file": "\\test\\tools\\Modules\\WebListener\\ClientCert.pfx", 
+        "_justification": "Test certificate with private key"
+      },
+      {
+        "file": "\\test\\tools\\Modules\\WebListener\\ServerCert.pfx", 
+         "_justification": "Test certificate with private key"
+       }
+     ]  
+}


### PR DESCRIPTION
Add suppression for lines with secrets.
Add suppressions for files which are secrets.
This will be consumed in the VSTS daily build.

Renamed tests with `ConvertTo-SecureString` to avoid false positives