### PR TITLE
Platform should return cross platform values under PSUserAgent

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/PSUserAgent.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/PSUserAgent.cs
@@ -122,7 +122,8 @@ namespace Microsoft.PowerShell.Commands
         {
             get
             {
-                return ("Windows NT");
+                OperatingSystem osInfo = Environment.OSVersion;
+                return (osInfo.Platform.ToString());
             }
         }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Environment-Variables.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Environment-Variables.Tests.ps1
@@ -40,4 +40,10 @@ Describe "Environment-Variables" -Tags "CI" {
 	$ENV:TESTENVIRONMENTVARIABLE | Should Be $expected
 
     }
+
+    It "User Agent should reflect current plafformID" {
+    $bingdings = [System.Reflection.BindingFlags]::NonPublic -bxor [System.Reflection.BindingFlags]::Static
+    $platform = [Microsoft.PowerShell.Commands.PSUserAgent].GetProperty('Platform',$bingdings).GetValue($null,$null)
+    $platform | Should BeExactly $PSVersionTable.platform
+    }
 }


### PR DESCRIPTION
resolve #4913 
Repro:
$bingdings = [System.Reflection.BindingFlags]::NonPublic -bxor [System.Reflection.BindingFlags]::Static
[Microsoft.PowerShell.Commands.PSUserAgent].GetProperty('Platform',$bingdings).GetValue($null,$null)

Before fix: 
the returned string is fixed to "WindowsNT"

After fix:
the returned string is the current OS's platformID