### PR TITLE
Replace httpbin.org/gzip Tests with WebListener and Re-Enable Deflate Tests

### DIFF
--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -592,29 +592,22 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
     # gzip Returns gzip-encoded data.
     # deflate Returns deflate-encoded data.
     # $dataEncodings = @("Chunked", "Compress", "Deflate", "GZip", "Identity")
-    #                 Note: These are the supported options, but we do not have a web service to test them all.
-    # $dataEncodings = @("gzip", "deflate") --> Currently there is a bug for deflate encoding. Please see '7976639:Invoke-WebRequest does not support -TransferEncoding deflate' for more info.
-    $dataEncodings = @("gzip")
-    foreach ($data in $dataEncodings)
-    {
-        It "Invoke-WebRequest supports request that returns $data-encoded data." {
+    # Note: These are the supported options, but we do not have a web service to test them all.
+    It "Invoke-WebRequest supports request that returns <DataEncoding>-encoded data." -TestCases @(
+        @{ DataEncoding = "gzip"}
+        @{ DataEncoding = "deflate"}
+    ) {
+        param($dataEncoding)
+        $uri = Get-WebListenerUrl -Test 'Compression' -TestValue $dataEncoding
+        $command = "Invoke-WebRequest -Uri '$uri'"
 
-            $command = "Invoke-WebRequest -Uri http://httpbin.org/$data -TimeoutSec 5"
+        $result = ExecuteWebCommand -command $command
+        ValidateResponse -response $result
 
-            $result = ExecuteWebCommand -command $command
-            ValidateResponse -response $result
-
-            # Validate response content
-            $jsonContent = $result.Output.Content | ConvertFrom-Json
-            if ($data -eq "gzip")
-            {
-                $jsonContent.gzipped | Should Match $true
-            }
-            else
-            {
-                $jsonContent.deflated | Should Match $true
-            }
-        }
+        # Validate response content
+        $result.Output.Headers.'Content-Encoding'[0] | Should Be $dataEncoding
+        $jsonContent = $result.Output.Content | ConvertFrom-Json        
+        $jsonContent.Headers.Host | Should Be $uri.Authority
     }
 
     # Perform the following operation for Invoke-WebRequest using the following content types: "text/plain", "application/xml", "application/xml"
@@ -1433,27 +1426,18 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
     # gzip Returns gzip-encoded data.
     # deflate Returns deflate-encoded data.
     # $dataEncodings = @("Chunked", "Compress", "Deflate", "GZip", "Identity")
-    #                 Note: These are the supported options, but we do not have a web service to test them all.
-    # $dataEncodings = @("gzip", "deflate") --> Currently there is a bug for deflate encoding. Please see '7976639:Invoke-RestMethod does not support -TransferEncoding deflate' for more info.
-    $dataEncodings = @("gzip")
-    foreach ($data in $dataEncodings)
-    {
-        It "Invoke-RestMethod supports request that returns $data-encoded data." {
+    # Note: These are the supported options, but we do not have a web service to test them all.
+    It "Invoke-RestMethod supports request that returns <DataEncoding>-encoded data." -TestCases @(
+        @{ DataEncoding = "gzip"}
+        @{ DataEncoding = "deflate"}
+    ) {
+        param($dataEncoding)
+        $uri = Get-WebListenerUrl -Test 'Compression' -TestValue $dataEncoding
+        $result = Invoke-RestMethod -Uri $uri -ResponseHeadersVariable 'headers'
 
-            $command = "Invoke-RestMethod -Uri http://httpbin.org/$data -TimeoutSec 5"
-
-            $result = ExecuteWebCommand -command $command
-
-            # Validate response
-            if ($data -eq "gzip")
-            {
-                $result.Output.gzipped | Should Match $true
-            }
-            else
-            {
-                $result.Output.deflated | Should Match $true
-            }
-        }
+        # Validate response content
+        $headers.'Content-Encoding'[0] | Should Be $dataEncoding      
+        $result.Headers.Host | Should Be $uri.Authority
     }
 
     # Perform the following operation for Invoke-RestMethod using the following content types: "text/plain", "application/xml", "application/xml"

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -605,9 +605,9 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
         ValidateResponse -response $result
 
         # Validate response content
-        $result.Output.Headers.'Content-Encoding'[0] | Should Be $dataEncoding
+        $result.Output.Headers.'Content-Encoding'[0] | Should BeExactly $dataEncoding
         $jsonContent = $result.Output.Content | ConvertFrom-Json        
-        $jsonContent.Headers.Host | Should Be $uri.Authority
+        $jsonContent.Headers.Host | Should BeExactly $uri.Authority
     }
 
     # Perform the following operation for Invoke-WebRequest using the following content types: "text/plain", "application/xml", "application/xml"
@@ -1436,8 +1436,8 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
         $result = Invoke-RestMethod -Uri $uri -ResponseHeadersVariable 'headers'
 
         # Validate response content
-        $headers.'Content-Encoding'[0] | Should Be $dataEncoding      
-        $result.Headers.Host | Should Be $uri.Authority
+        $headers.'Content-Encoding'[0] | Should BeExactly $dataEncoding      
+        $result.Headers.Host | Should BeExactly $uri.Authority
     }
 
     # Perform the following operation for Invoke-RestMethod using the following content types: "text/plain", "application/xml", "application/xml"

--- a/test/tools/Modules/WebListener/WebListener.psm1
+++ b/test/tools/Modules/WebListener/WebListener.psm1
@@ -114,6 +114,7 @@ function Get-WebListenerUrl {
         [switch]$Https,
         [ValidateSet(
             'Cert',
+            'Compression',
             'Delay',
             'Encoding',
             'Get',

--- a/test/tools/WebListener/Controllers/CompressionController.cs
+++ b/test/tools/WebListener/Controllers/CompressionController.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using mvc.Models;
+
+namespace mvc.Controllers
+{
+    public class CompressionController : Controller
+    {
+        public ActionResult Index()
+        {
+            string url = "/Compression/Gzip";
+            ViewData["Url"] = url;
+            Response.Redirect(url, false);
+            return View("~/Views/Redirect/Index.cshtml");
+        }
+
+        [GzipFilter]
+        public JsonResult Gzip()
+        {
+            var getController = new GetController();
+            getController.ControllerContext = this.ControllerContext;            
+            return getController.Index();
+        }
+
+        [DeflateFilter]
+        public JsonResult Deflate()
+        {
+            var getController = new GetController();
+            getController.ControllerContext = this.ControllerContext;            
+            return getController.Index();
+        }
+
+        public IActionResult Error()
+        {
+            return View(new ErrorViewModel { RequestId = Activity.Current?.Id ?? HttpContext.TraceIdentifier });
+        }
+    }
+}

--- a/test/tools/WebListener/DeflateFilter.cs
+++ b/test/tools/WebListener/DeflateFilter.cs
@@ -1,0 +1,30 @@
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace mvc.Controllers
+{
+    internal sealed class DeflateFilter : ResultFilterAttribute
+    {
+        public override async Task OnResultExecutionAsync( ResultExecutingContext context, ResultExecutionDelegate next)
+        {
+            var httpContext = context.HttpContext;
+            using (var memoryStream = new MemoryStream())
+            {
+                var responseStream = httpContext.Response.Body;
+                httpContext.Response.Body = memoryStream;
+
+                await next();
+
+                using (var compressedStream = new DeflateStream(responseStream, CompressionLevel.Fastest))
+                {
+                    httpContext.Response.Headers.Add("Content-Encoding", new [] { "deflate" });
+                    memoryStream.Seek(0, SeekOrigin.Begin);
+                    await memoryStream.CopyToAsync(compressedStream);
+                }
+            }
+        }
+    }
+}

--- a/test/tools/WebListener/GzipFilter.cs
+++ b/test/tools/WebListener/GzipFilter.cs
@@ -1,0 +1,30 @@
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace mvc.Controllers
+{
+    internal sealed class GzipFilter : ResultFilterAttribute
+    {
+        public override async Task OnResultExecutionAsync( ResultExecutingContext context, ResultExecutionDelegate next)
+        {
+            var httpContext = context.HttpContext;
+            using (var memoryStream = new MemoryStream())
+            {
+                var responseStream = httpContext.Response.Body;
+                httpContext.Response.Body = memoryStream;
+
+                await next();
+
+                using (var compressedStream = new GZipStream(responseStream, CompressionLevel.Fastest))
+                {
+                    httpContext.Response.Headers.Add("Content-Encoding", new [] { "gzip" });
+                    memoryStream.Seek(0, SeekOrigin.Begin);
+                    await memoryStream.CopyToAsync(compressedStream);
+                }
+            }
+        }
+    }
+}

--- a/test/tools/WebListener/README.md
+++ b/test/tools/WebListener/README.md
@@ -59,6 +59,46 @@ Response when certificate is not provided in request:
 }
 ```
 
+## /Compression/Deflate/
+Returns the same results as the Get test with deflate compression.
+
+```powershell
+$uri = Get-WebListenerUrl -Test 'Compression' -TestValue 'Deflate'
+Invoke-RestMethod -Uri $uri -Headers $headers
+```
+
+```json
+{
+  "args": {},
+  "origin": "127.0.0.1",
+  "headers": {
+    "User-Agent": "Mozilla/5.0 (Windows NT; Windows NT 10.0; en-US) WindowsPowerShell/5.1.15063.608",
+    "Host": "localhost:8083"
+  },
+  "url": "http://localhost:8083/Compression/Deflate"
+}
+```
+
+## /Compression/Gzip/
+Returns the same results as the Get test with gzip compression.
+
+```powershell
+$uri = Get-WebListenerUrl -Test 'Compression' -TestValue 'Gzip'
+Invoke-RestMethod -Uri $uri -Headers $headers
+```
+
+```json
+{
+  "args": {},
+  "origin": "127.0.0.1",
+  "headers": {
+    "User-Agent": "Mozilla/5.0 (Windows NT; Windows NT 10.0; en-US) WindowsPowerShell/5.1.15063.608",
+    "Host": "localhost:8083"
+  },
+  "url": "http://localhost:8083/Compression/Gzip"
+}
+```
+
 ## /Delay/
 
 Returns the same results as the Get test. If a number is supplied, the server will wait that many seconds before returning a response. This can be used to test timeouts.

--- a/test/tools/WebListener/README.md
+++ b/test/tools/WebListener/README.md
@@ -72,7 +72,7 @@ Invoke-RestMethod -Uri $uri -Headers $headers
   "args": {},
   "origin": "127.0.0.1",
   "headers": {
-    "User-Agent": "Mozilla/5.0 (Windows NT; Windows NT 10.0; en-US) WindowsPowerShell/5.1.15063.608",
+    "User-Agent": "Mozilla/5.0 (Windows NT; Microsoft Windows 10.0.15063 ; en-US) PowerShell/6.0.0",
     "Host": "localhost:8083"
   },
   "url": "http://localhost:8083/Compression/Deflate"
@@ -92,7 +92,7 @@ Invoke-RestMethod -Uri $uri -Headers $headers
   "args": {},
   "origin": "127.0.0.1",
   "headers": {
-    "User-Agent": "Mozilla/5.0 (Windows NT; Windows NT 10.0; en-US) WindowsPowerShell/5.1.15063.608",
+    "User-Agent": "Mozilla/5.0 (Windows NT; Microsoft Windows 10.0.15063 ; en-US) PowerShell/6.0.0",
     "Host": "localhost:8083"
   },
   "url": "http://localhost:8083/Compression/Gzip"

--- a/test/tools/WebListener/Views/Home/Index.cshtml
+++ b/test/tools/WebListener/Views/Home/Index.cshtml
@@ -2,6 +2,8 @@
 <ul>
     <li><a href="/">/</a> - This page</li>
     <li><a href="/Cert/">/Cert/</a> - Client Certificate Details</li>
+    <li><a href="/Compression/Deflate/">/Compression/Deflate/</a> - Returns deflate compressed response</li>
+    <li><a href="/Compression/GZip/">/Compression/Gzip/</a> - Returns gzip compressed response</li>
     <li><a href="/Delay/">/Delay/{seconds}</a> - Delays response for <i>seconds</i> seconds.</li>
     <li><a href="/Encoding/Utf8/">/Encoding/Utf8/</a> - Returns page containing UTF-8 data.</li>
     <li><a href="/Get/">/Get/</a> - Emulates functionality of https://httpbin.org/get by returning GET headers, Arguments, and Request URL</li>


### PR DESCRIPTION
* Add `Compression/Gzip` test to WebListener
* Add `Compression/Deflate` test to WebListener
* Replace tests using httpbin.org/gzip with WebListener
* Re-enable testing for Deflate
* Converted tests to `-TestCase` from `foreach`

I have no idea what ''7976639:Invoke-WebRequest does not support -TransferEncoding deflate'' and "7976639:Invoke-RestMethod does not support -TransferEncoding deflate" are, but in my limited testing it appears to no longer be true.

reference #2504 