### PR TITLE
remove unnecessary error messages from output

### DIFF
--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Export-Alias.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Export-Alias.Tests.ps1
@@ -5,8 +5,8 @@ Describe "Export-Alias DRT Unit Tests" -Tags "CI" {
 		$testAliases        = "TestAliases"
     	$fulltestpath       = Join-Path -Path $testAliasDirectory -ChildPath $testAliases
 
-		remove-item alias:abcd* -force
-		remove-item alias:ijkl* -force
+		remove-item alias:abcd* -force -ErrorAction SilentlyContinue
+		remove-item alias:ijkl* -force -ErrorAction SilentlyContinue
 		set-alias abcd01 efgh01
 		set-alias abcd02 efgh02
 		set-alias abcd03 efgh03
@@ -18,8 +18,8 @@ Describe "Export-Alias DRT Unit Tests" -Tags "CI" {
 	}
 
 	AfterAll {
-		remove-item alias:abcd* -force
-		remove-item alias:ijkl* -force
+		remove-item alias:abcd* -force -ErrorAction SilentlyContinue
+		remove-item alias:ijkl* -force -ErrorAction SilentlyContinue
 	}
 
     BeforeEach {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Import-Alias.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Import-Alias.Tests.ps1
@@ -5,8 +5,8 @@ Describe "Import-Alias DRT Unit Tests" -Tags "CI" {
 
     BeforeEach {
 		New-Item -Path $testAliasDirectory -ItemType Directory -Force
-		remove-item alias:abcd* -force
-		remove-item alias:ijkl* -force
+		remove-item alias:abcd* -force -ErrorAction SilentlyContinue
+		remove-item alias:ijkl* -force -ErrorAction SilentlyContinue
 		set-alias abcd01 efgh01
 		set-alias abcd02 efgh02
 		set-alias abcd03 efgh03
@@ -18,7 +18,7 @@ Describe "Import-Alias DRT Unit Tests" -Tags "CI" {
     }
 
 	AfterEach {
-		Remove-Item -Path $testAliasDirectory -Recurse -Force
+		Remove-Item -Path $testAliasDirectory -Recurse -Force -ErrorAction SilentlyContinue
 	}
 
 	It "Import-Alias Resolve To Multiple will throw PSInvalidOperationException" {

--- a/test/powershell/engine/Help/HelpSystem.Tests.ps1
+++ b/test/powershell/engine/Help/HelpSystem.Tests.ps1
@@ -219,7 +219,7 @@ Describe "Get-Help should find help info within help files" -Tags @('CI', 'Requi
         {
             $null = New-Item -ItemType Directory -Path $helpFolderPath -ErrorAction SilentlyContinue
         }
-        
+
         try
         {
             $null = New-Item -ItemType File -Path $helpFilePath -Value "about_test" -ErrorAction SilentlyContinue
@@ -234,11 +234,11 @@ Describe "Get-Help should find help info within help files" -Tags @('CI', 'Requi
 }
 
 Describe "Get-Help should find pattern help files" -Tags "CI" {
-    
-    # There is a bug specific to Travis CI that hangs the test if "get-help" is used to search pattern string. This doesn't repro locally. 
+
+    # There is a bug specific to Travis CI that hangs the test if "get-help" is used to search pattern string. This doesn't repro locally.
     # This occurs even if Unix system just returns "Directory.GetFiles(path, pattern);" as the windows' code does.
     # Since there's currently no way to get the vm from Travis CI and the test PASSES locally on both Ubuntu and MacOS, excluding pattern test under Unix system.
-  
+
   BeforeAll {
     $helpFile1 = "about_testCase1.help.txt"
     $helpFile2 = "about_testCase.2.help.txt"
@@ -249,7 +249,7 @@ Describe "Get-Help should find pattern help files" -Tags "CI" {
     $null = New-Item -ItemType Directory -Path $helpFolderPath -ErrorAction SilentlyContinue -Force
     # Create at least one help file matches "about*" pattern
     $null = New-Item -ItemType File -Path $helpFilePath1 -Value "about_test1" -ErrorAction SilentlyContinue
-    $null = New-Item -ItemType File -Path $helpFilePath2 -Value "about_test2" -ErrorAction SilentlyContinue 
+    $null = New-Item -ItemType File -Path $helpFilePath2 -Value "about_test2" -ErrorAction SilentlyContinue
   }
 
   # Remove the test files
@@ -277,9 +277,9 @@ Describe "Get-Help should find pattern help files" -Tags "CI" {
   Describe "Get-Help should find pattern alias" -Tags "CI" {
     # Remove test alias
     AfterAll {
-        Remove-Item alias:\testAlias1
+        Remove-Item alias:\testAlias1 -ErrorAction SilentlyContinue
     }
-    
+
     It "Get-Help should find alias as command" {
        (Get-Help where).Name | Should BeExactly "Where-Object"
     }


### PR DESCRIPTION
In some CI runs, I see error in the output from setup or cleanup and not from the tests themselves.  Cleaning this up so it's easier to spot real issues in the output.

Looks like VSCode also cleaned up some trailing whitespace

<!--

If you are a PowerShell Team member, please make sure you choose the Reviewer(s) and Assignee for your PR.
If you are not from the PowerShell Team, you can leave the fields blank and the Maintainers will choose them for you. If you are familiar with the team, feel free to mention some Reviewers yourself.

For more information about the roles of Reviewer and Assignee, refer to [CONTRIBUTING.md](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md).

-->
