### PR TITLE
Suppress the output of building test tools in 'Compress-TestContent'

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -567,7 +567,7 @@ function Compress-TestContent {
         $Destination
     )
 
-    Publish-PSTestTools
+    $null = Publish-PSTestTools
     $powerShellTestRoot =  Join-Path $PSScriptRoot 'test'
     Add-Type -AssemblyName System.IO.Compression.FileSystem
 


### PR DESCRIPTION
When uploading CodeCoverage artifacts, `Compress-TestContent` is called which calls `Publish-PSTestTools` to build test tools. The build output was captured by `$codeCoverageArtifacts` which causes `Push-AppveyorArtifact` to spit out a lot of errors. See https://ci.appveyor.com/project/PowerShell/powershell-f975h/build/6.0.0-beta.7-428#L3630

The fix is to suppress build output in `Compress-TestContent`. Fix #4924