### PR TITLE
fix `powershell -version` and help

### DIFF
--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
@@ -400,15 +400,9 @@ namespace Microsoft.PowerShell
 
         private void ShowHelp()
         {
+            Dbg.Assert(_helpText != null, "_helpText should not be null");
             _hostUI.WriteLine("");
-            if (_helpText == null)
-            {
-                _hostUI.WriteLine(CommandLineParameterParserStrings.DefaultHelp);
-            }
-            else
-            {
-                _hostUI.Write(_helpText);
-            }
+            _hostUI.Write(_helpText);
             _hostUI.WriteLine("");
         }
 
@@ -548,17 +542,9 @@ namespace Microsoft.PowerShell
                     _noInteractive = true;
                     _skipUserInit = true;
                     _noExit = false;
-
-                    ++i;
-                    if (i < args.Length)
-                    {
-                        _showVersion = false;
-                        WriteCommandLineError(string.Format(CultureInfo.CurrentCulture, CommandLineParameterParserStrings.DeprecatedVersionParameter,args[i]));
-                    }
                     break;
                 }
-
-                if (MatchSwitch(switchKey, "help", "h") || MatchSwitch(switchKey, "?", "?"))
+                else if (MatchSwitch(switchKey, "help", "h") || MatchSwitch(switchKey, "?", "?"))
                 {
                     _showHelp = true;
                     _abortStartup = true;

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
@@ -552,11 +552,11 @@ namespace Microsoft.PowerShell
                     ++i;
                     if (i < args.Length)
                     {
+                        _showVersion = false;
                         WriteCommandLineError(string.Format(CultureInfo.CurrentCulture, CommandLineParameterParserStrings.DeprecatedVersionParameter,args[i]));
                     }
                     break;
                 }
-
 
                 if (MatchSwitch(switchKey, "help", "h") || MatchSwitch(switchKey, "?", "?"))
                 {

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
@@ -200,7 +200,7 @@ namespace Microsoft.PowerShell
                     // Alternatively, we could call s_theConsoleHost.UI.WriteLine(s_theConsoleHost.Version.ToString());
                     // or start up the engine and retrieve the information via $psversiontable.GitCommitId
                     // but this returns the semantic version and avoids executing a script
-                    s_theConsoleHost.UI.WriteLine("powershell " + PSVersionInfo.GitCommitId);
+                    s_theConsoleHost.UI.WriteLine("PowerShell " + PSVersionInfo.GitCommitId);
                     return 0;
                 }
 

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/CommandLineParameterParserStrings.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/CommandLineParameterParserStrings.resx
@@ -273,6 +273,6 @@ EXAMPLES
     <value>Invalid argument '{0}', did you mean:</value>
   </data>
   <data name="DeprecatedVersionParameter" xml:space="preserve">
-    <value>Usage of '-Version {0}' is not supported. '-Version' currently only returns the current PowerShell version.</value>
+    <value>Unsupported value '{0}' passed to `-Version`. '-Version' only returns the current PowerShell version and must be used standalone.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/CommandLineParameterParserStrings.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/CommandLineParameterParserStrings.resx
@@ -129,89 +129,6 @@
   <data name="UnknownParameter" xml:space="preserve">
     <value>Unrecognized parameter: '{0}'.</value>
   </data>
-  <data name="DefaultHelp" xml:space="preserve">
-    <value>PowerShell[.exe] [-PSConsoleFile &lt;file&gt; | -Version &lt;version&gt;]
-    [-NoLogo] [-NoExit] [-NoProfile] [-NonInteractive] [-STA]
-    [-OutputFormat {Text | XML}] [-InputFormat {Text | XML}]
-    [-ConfigurationName &lt;string&gt;]
-    [-File fileName [arguments...]] [-ExecutionPolicy &lt;ExecutionPolicy&gt;]
-    [-Command { - | &lt;script-block&gt; [-args &lt;arg-array&gt;]
-                  | &lt;string&gt; [&lt;CommandParameters&gt;] } ]
-
-PowerShell[.exe] -Help | -? | /?
-
--PSConsoleFile
-    Loads the specified PowerShell console file. To create a console
-    file, use Export-Console in PowerShell.
-
--Version
-    Starts the specified version of PowerShell.
-
--NoLogo
-    Hides the copyright banner at startup.
-
--NoExit
-    Does not exit after running startup commands.
-
--NoProfile
-    Does not use the user profile.
-
--NonInteractive
-    Does not present an interactive prompt to the user.
-
--STA
-    Uses a single-threaded apartment for the execution thread.
-
--OutputFormat
-    Determines how output from PowerShell is formatted. Valid values
-    are "Text" (text strings) or "XML" (serialized CLIXML format).
-
--InputFormat
-    Describes the format of data sent to PowerShell. Valid values are
-    "Text" (text strings) or "XML" (serialized CLIXML format).
-
--ConfigurationName
-    Specifies a configuration endpoint in which PowerShell is run.
-    This can be any endpoint registered on the local machine including the
-    default PowerShell remoting endpoints or a custom endpoint having
-    specific user role capabilities.
-
--Command
-    Executes the specified commands (and any parameters) as though they were
-    typed at the PowerShell command prompt, and then exits, unless
-    NoExit is specified. The value of Command can be "-", a string. or a
-    script block.
-
-    If the value of Command is "-", the command text is read from standard
-    input.
-
-    Script blocks must be enclosed in braces ({}). You can specify a script
-    block only when running PowerShell.exe in PowerShell. The results
-    of the script are returned to the parent shell as deserialized XML objects,
-    not live objects.
-
-    If the value of Command is a string, Command must be the last parameter
-    in the command , because any characters typed after the command are
-    interpreted as the command arguments.
-       To write a string that runs a PowerShell command, use the format:
-    "&amp; {&lt;command&gt;}"
-    where the quotation marks indicate a string and the invoke operator (&amp;)
-    causes the command to be run.
-
--Help, -?, /?
-    Shows this message. If you are typing a PowerShell.exe command in Windows
-    PowerShell, prepend the command parameters with a hyphen (-), not a forward
-    slash (/). You can use either a hyphen or forward slash in Cmd.exe.
-
-
-EXAMPLES
-    PowerShell -PSConsoleFile SqlSnapin.Psc1
-    PowerShell -version 1.0 -NoLogo -InputFormat text -OutputFormat XML
-    PowerShell -ConfigurationName AdminRoles
-    PowerShell -Command {Get-EventLog -LogName security}
-    PowerShell -Command "&amp; {Get-EventLog -LogName security}"
-</value>
-  </data>
   <data name="TooManyParametersToCommand" xml:space="preserve">
     <value>'-' was specified with the -Command parameter; no other arguments to -Command are permitted.</value>
   </data>
@@ -271,8 +188,5 @@ EXAMPLES
   </data>
   <data name="InvalidArgument" xml:space="preserve">
     <value>Invalid argument '{0}', did you mean:</value>
-  </data>
-  <data name="DeprecatedVersionParameter" xml:space="preserve">
-    <value>Unsupported value '{0}' passed to `-Version`. '-Version' only returns the current PowerShell version and must be used standalone.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/ManagedEntranceStrings.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/ManagedEntranceStrings.resx
@@ -122,8 +122,8 @@
 Copyright (C) Microsoft Corporation. All rights reserved.</value>
   </data>
   <data name="ShellHelp" xml:space="preserve">
-    <value>PowerShell[.exe] [-PSConsoleFile &lt;file&gt; | -Version &lt;version&gt;]
-    [-NoLogo] [-NoExit] [-Sta] [-Mta] [-NoProfile] [-NonInteractive] [-Interactive]
+    <value>PowerShell[.exe] [-Version] [-NoLogo] [-NoExit]
+    [-NoProfile] [-NonInteractive] [-Interactive]
     [-InputFormat {Text | XML}] [-OutputFormat {Text | XML}]
     [-WindowStyle &lt;style&gt;] [-EncodedCommand &lt;Base64EncodedCommand&gt;]
     [-ConfigurationName &lt;string&gt;]
@@ -133,26 +133,15 @@ Copyright (C) Microsoft Corporation. All rights reserved.</value>
 
 PowerShell[.exe] -Help | -? | /?
 
--PSConsoleFile
-    Loads the specified PowerShell console file. To create a console
-    file, use Export-Console in PowerShell.
-
 -Version
-    Starts the specified version of PowerShell.
-    Enter a version number with the parameter, such as "-version 2.0".
+    Shows the version of PowerShell and exits.
+    Additional arguments are ignored.
 
 -NoLogo
     Hides the copyright banner at startup.
 
 -NoExit
     Does not exit after running startup commands.
-
--Sta
-    Starts the shell using a single-threaded apartment.
-    Single-threaded apartment (STA) is the default.
-
--Mta
-    Start the shell using a multithreaded apartment.
 
 -NoProfile
     Does not load the PowerShell profile.
@@ -228,8 +217,7 @@ PowerShell[.exe] -Help | -? | /?
     slash (/). You can use either a hyphen or forward slash in Cmd.exe.
 
 EXAMPLES
-    PowerShell -PSConsoleFile SqlSnapIn.Psc1
-    PowerShell -version 2.0 -NoLogo -InputFormat text -OutputFormat XML
+    PowerShell -Version
     PowerShell -ConfigurationName AdminRoles
     PowerShell -Command {Get-EventLog -LogName security}
     PowerShell -Command "&amp; {Get-EventLog -LogName security}"
@@ -239,6 +227,6 @@ EXAMPLES
     $command = 'dir "c:\program files" '
     $bytes = [System.Text.Encoding]::Unicode.GetBytes($command)
     $encodedCommand = [Convert]::ToBase64String($bytes)
-    powershell.exe -encodedCommand $encodedCommand</value>
+    powershell -encodedCommand $encodedCommand</value>
   </data>
 </root>

--- a/test/powershell/Host/ConsoleHost.Tests.ps1
+++ b/test/powershell/Host/ConsoleHost.Tests.ps1
@@ -165,20 +165,15 @@ Describe "ConsoleHost unit tests" -tags "Feature" {
             $actual | Should Be $expected
         }
 
-        It "-Version should return the engine version" {
-            $currentVersion = "powershell " + $PSVersionTable.GitCommitId.ToString()
-            $observed = & $powershell -version
-            $observed | should be $currentVersion
-        }
-
-        It "-Version should write an error if a value is present: <value>" -TestCases @(
-            @{value="2"},
-            @{value="-command 1-1"}
+        It "-Version should return the engine version using: -version <value>" -TestCases @(
+            @{value = ""},
+            @{value = "2"},
+            @{value = "-command 1-1"}
         ) {
-            param($value)
+            $currentVersion = "powershell " + $PSVersionTable.GitCommitId.ToString()
             $observed = & $powershell -version $value 2>&1
-            $observed | Should Match $value
-            $LASTEXITCODE | Should Be $ExitCodeBadCommandLineParameter
+            $observed | should be $currentVersion
+            $LASTEXITCODE | Should Be 0
         }
 
         It "-File should be default parameter" {

--- a/test/powershell/Host/ConsoleHost.Tests.ps1
+++ b/test/powershell/Host/ConsoleHost.Tests.ps1
@@ -173,11 +173,9 @@ Describe "ConsoleHost unit tests" -tags "Feature" {
 
         It "-Version should write an error if a value is present" {
             $versionValue = "abrakadabra"
-            $tempFile = Join-Path $testdrive "expectedError.txt"
-            $observed = & $powershell -version $versionValue > $tempFile
-            $expectedError = (Get-Content $tempFile)[0]
-
-            $expectedError | Should Match $versionValue
+            $observed = & $powershell -version $versionValue 2>&1
+            $observed | Should Match $versionValue
+            $LASTEXITCODE | Should Be $ExitCodeBadCommandLineParameter
         }
 
         It "-File should be default parameter" {

--- a/test/powershell/Host/ConsoleHost.Tests.ps1
+++ b/test/powershell/Host/ConsoleHost.Tests.ps1
@@ -171,13 +171,6 @@ Describe "ConsoleHost unit tests" -tags "Feature" {
             $observed | should be $currentVersion
         }
 
-        It "-Version should ignore other parameters" {
-            $currentVersion = "powershell " + $PSVersionTable.GitCommitId.ToString()
-            $observed = & $powershell -version -command get-date
-            # no extraneous output
-            $observed | should be $currentVersion
-        }
-
         It "-Version should write an error if a value is present" {
             $versionValue = "abrakadabra"
             $tempFile = Join-Path $testdrive "expectedError.txt"

--- a/test/powershell/Host/ConsoleHost.Tests.ps1
+++ b/test/powershell/Host/ConsoleHost.Tests.ps1
@@ -171,10 +171,13 @@ Describe "ConsoleHost unit tests" -tags "Feature" {
             $observed | should be $currentVersion
         }
 
-        It "-Version should write an error if a value is present" {
-            $versionValue = "abrakadabra"
-            $observed = & $powershell -version $versionValue 2>&1
-            $observed | Should Match $versionValue
+        It "-Version should write an error if a value is present: <value>" -TestCases @(
+            @{value="2"},
+            @{value="-command 1-1"}
+        ) {
+            param($value)
+            $observed = & $powershell -version $value 2>&1
+            $observed | Should Match $value
             $LASTEXITCODE | Should Be $ExitCodeBadCommandLineParameter
         }
 


### PR DESCRIPTION
`PowerShell -v` behavior updated to align with other tools like git, curl, and bash where args after `-v` are silently ignored.

Built-in help updated to reflect changes we've made to the console host in PSCore6 removing unsupported parameters.

Doc update aligned with these changes (and general cleanup of parameters we don't support in PSCore6) https://github.com/PowerShell/PowerShell-Docs/pull/1707
<!--

If you are a PowerShell Team member, please make sure you choose the Reviewer(s) and Assignee for your PR.
If you are not from the PowerShell Team, you can leave the fields blank and the Maintainers will choose them for you. If you are familiar with the team, feel free to mention some Reviewers yourself.

For more information about the roles of Reviewer and Assignee, refer to [CONTRIBUTING.md](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md).

-->
