### PR TITLE
enable support of folders and files with colon in name on Unix

### DIFF
--- a/src/System.Management.Automation/namespaces/LocationGlobber.cs
+++ b/src/System.Management.Automation/namespaces/LocationGlobber.cs
@@ -1665,13 +1665,15 @@ namespace System.Management.Automation
 
                 if (index > 0)
                 {
-                    int separator = path.IndexOf(StringLiterals.DefaultPathSeparator, 0, index);
+                    // see if there are any path separators before the colon which would mean the
+                    // colon is part of a file or folder name and not a drive: ./foo:bar vs foo:bar
+                    int separator = path.IndexOf(StringLiterals.DefaultPathSeparator, 0, index-1);
                     if (separator == -1)
                     {
-                        separator = path.IndexOf(StringLiterals.AlternatePathSeparator, 0, index);
+                        separator = path.IndexOf(StringLiterals.AlternatePathSeparator, 0, index-1);
                     }
                     if (separator == -1 || index < separator)
-                    {                        
+                    {
                         // We must have a drive specified
                         result = true;
                     }

--- a/src/System.Management.Automation/namespaces/LocationGlobber.cs
+++ b/src/System.Management.Automation/namespaces/LocationGlobber.cs
@@ -1649,7 +1649,6 @@ namespace System.Management.Automation
                 }
 
                 int index = path.IndexOf(":", StringComparison.Ordinal);
-                int separator = path.IndexOf(StringLiterals.DefaultPathSeparatorString, StringComparison.Ordinal);
 
                 if (index == -1)
                 {
@@ -1664,11 +1663,18 @@ namespace System.Management.Automation
                 // must assume that it is part of the path, and not
                 // delimiting the drive name.
 
-                if (index > 0 && index < separator)
+                if (index > 0)
                 {
-                    // We must have a drive specified
-
-                    result = true;
+                    int separator = path.IndexOf(StringLiterals.DefaultPathSeparator, 0, index);
+                    if (separator == -1)
+                    {
+                        separator = path.IndexOf(StringLiterals.AlternatePathSeparator, 0, index);
+                    }
+                    if (separator == -1 || index < separator)
+                    {                        
+                        // We must have a drive specified
+                        result = true;
+                    }
                 }
             } while (false);
 
@@ -3408,19 +3414,24 @@ namespace System.Management.Automation
             // Find the drive separator only if it's before a path separator
 
             int index = path.IndexOf(":", StringComparison.Ordinal);
-            int separator = path.IndexOf(StringLiterals.DefaultPathSeparatorString, StringComparison.Ordinal);
-
-            if (index != -1 && index < separator)
+            if (index != -1)
             {
-                // Remove the \ or / if it follows the drive indicator
-
-                if (path[index + 1] == '\\' ||
-                    path[index + 1] == '/')
+                int separator = path.IndexOf(StringLiterals.DefaultPathSeparator, 0, index);
+                if (separator == -1)
                 {
-                    ++index;
+                    separator = path.IndexOf(StringLiterals.AlternatePathSeparator, 0, index);
                 }
+                if (separator == -1 || index < separator)
+                {
+                    // Remove the \ or / if it follows the drive indicator
+                    if (path[index + 1] == '\\' ||
+                        path[index + 1] == '/')
+                    {
+                        ++index;
+                    }
 
-                result = path.Substring(index + 1);
+                    result = path.Substring(index + 1);
+                }
             }
 
             return result;

--- a/src/System.Management.Automation/namespaces/LocationGlobber.cs
+++ b/src/System.Management.Automation/namespaces/LocationGlobber.cs
@@ -1649,6 +1649,7 @@ namespace System.Management.Automation
                 }
 
                 int index = path.IndexOf(":", StringComparison.Ordinal);
+                int separator = path.IndexOf(StringLiterals.DefaultPathSeparatorString, StringComparison.Ordinal);
 
                 if (index == -1)
                 {
@@ -1663,7 +1664,7 @@ namespace System.Management.Automation
                 // must assume that it is part of the path, and not
                 // delimiting the drive name.
 
-                if (index > 0)
+                if (index > 0 && index < separator)
                 {
                     // We must have a drive specified
 
@@ -3404,11 +3405,12 @@ namespace System.Management.Automation
 
             string result = path;
 
-            // Find the drive separator
+            // Find the drive separator only if it's before a path separator
 
             int index = path.IndexOf(":", StringComparison.Ordinal);
+            int separator = path.IndexOf(StringLiterals.DefaultPathSeparatorString, StringComparison.Ordinal);
 
-            if (index != -1)
+            if (index != -1 && index < separator)
             {
                 // Remove the \ or / if it follows the drive indicator
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
@@ -200,21 +200,41 @@ Describe "Basic FileSystem Provider Tests" -Tags "CI" {
              }
          }
 
-         It "Set-Location on Unix succeeds with folder with colon" -Skip:($IsWindows) {
-             New-Item -Path "$testdrive\hello:world" -ItemType Directory > $null
-             Set-Location "$testdrive"
-             Set-Location ".\hello:world"
-             (Get-Location).Path | Should Be "$testdrive/hello:world"
+         It "Set-Location on Unix succeeds with folder with colon: <path>" -Skip:($IsWindows) -TestCases @(
+             @{path="\hello:world"},
+             @{path="\:world"},
+             @{path="/hello:"}
+         ) {
+            param($path)
+            try {
+                New-Item -Path "$testdrive$path" -ItemType Directory > $null
+                Set-Location "$testdrive"
+                Set-Location ".$path"
+                (Get-Location).Path | Should Be "$testdrive/$($path.Substring(1,$path.Length-1))"
+            }
+            finally {
+                Remove-Item -Path "$testdrive$path" -ErrorAction SilentlyContinue
+            }
          }
 
-         It "Get-Content on Unix succeeds with folder and file with colon" -Skip:($IsWindows) {
-            $testPath = "$testdrive/hello:world"
-            New-Item -Path $testPath -ItemType Directory > $null
-            Set-Content -Path "$testPath\foo:bar.txt" -Value "Hello"
-            $files = Get-ChildItem "$testPath"
-            $files.Count | Should Be 1
-            $files[0].Name | Should BeExactly "foo:bar.txt"
-            $files[0] | Get-Content | Should BeExactly "Hello"
+         It "Get-Content on Unix succeeds with folder and file with colon: <path>" -Skip:($IsWindows) -TestCases @(
+             @{path="\foo:bar.txt"},
+             @{path="/foo:"},
+             @{path="\:bar"}
+         ) {
+            param($path)
+            try {
+                $testPath = "$testdrive/hello:world"
+                New-Item -Path "$testPath" -ItemType Directory > $null
+                Set-Content -Path "$testPath$path" -Value "Hello"
+                $files = Get-ChildItem "$testPath"
+                $files.Count | Should Be 1
+                $files[0].Name | Should BeExactly $path.Substring(1,$path.Length-1)
+                $files[0] | Get-Content | Should BeExactly "Hello"
+            }
+            finally {
+                Remove-Item -Path $testPath -Recurse -Force -ErrorAction SilentlyContinue
+            }
          }
     }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
@@ -199,6 +199,23 @@ Describe "Basic FileSystem Provider Tests" -Tags "CI" {
                 New-Item -Path $testFile -ItemType File -Force -ErrorAction SilentlyContinue
              }
          }
+
+         It "Set-Location on Unix succeeds with folder with colon" -Skip:($IsWindows) {
+             New-Item -Path "$testdrive/hello:world" -ItemType Directory > $null
+             Set-Location "$testdrive"
+             Set-Location "./hello:world"
+             (Get-Location).Path | Should Be "$testdrive/hello:world"
+         }
+
+         It "Get-Content on Unix succeeds with folder and file with colon" -Skip:($IsWindows) {
+            $testPath = "$testdrive/hello:world"
+            New-Item -Path $testPath -ItemType Directory > $null
+            Set-Content -Path "$testPath/foo:bar.txt" -Value "Hello"
+            $files = Get-ChildItem "$testPath"
+            $files.Count | Should Be 1
+            $files[0].Name | Should BeExactly "foo:bar.txt"
+            $files[0] | Get-Content | Should BeExactly "Hello"
+         }
     }
 
     Context "Validate behavior when access is denied" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
@@ -201,16 +201,16 @@ Describe "Basic FileSystem Provider Tests" -Tags "CI" {
          }
 
          It "Set-Location on Unix succeeds with folder with colon" -Skip:($IsWindows) {
-             New-Item -Path "$testdrive/hello:world" -ItemType Directory > $null
+             New-Item -Path "$testdrive\hello:world" -ItemType Directory > $null
              Set-Location "$testdrive"
-             Set-Location "./hello:world"
+             Set-Location ".\hello:world"
              (Get-Location).Path | Should Be "$testdrive/hello:world"
          }
 
          It "Get-Content on Unix succeeds with folder and file with colon" -Skip:($IsWindows) {
             $testPath = "$testdrive/hello:world"
             New-Item -Path $testPath -ItemType Directory > $null
-            Set-Content -Path "$testPath/foo:bar.txt" -Value "Hello"
+            Set-Content -Path "$testPath\foo:bar.txt" -Value "Hello"
             $files = Get-ChildItem "$testPath"
             $files.Count | Should Be 1
             $files[0].Name | Should BeExactly "foo:bar.txt"


### PR DESCRIPTION
allow colons if it shows up after a path separator

fix https://github.com/PowerShell/PowerShell/issues/4889
<!--

If you are a PowerShell Team member, please make sure you choose the Reviewer(s) and Assignee for your PR.
If you are not from the PowerShell Team, you can leave the fields blank and the Maintainers will choose them for you. If you are familiar with the team, feel free to mention some Reviewers yourself.

For more information about the roles of Reviewer and Assignee, refer to [CONTRIBUTING.md](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md).

-->