### PR TITLE
properly escape trailing backslash so that it doesn't end up escaping the quotes

### DIFF
--- a/src/System.Management.Automation/engine/NativeCommandParameterBinder.cs
+++ b/src/System.Management.Automation/engine/NativeCommandParameterBinder.cs
@@ -197,25 +197,11 @@ namespace System.Management.Automation
                         {
                             _arguments.Append('"');
                             // need to escape all trailing backslashes so the native command receives it correctly
-                            if (arg.EndsWith('\\'))
+                            // according to http://www.daviddeley.com/autohotkey/parameters/parameters.htm#WINCRULESDOC
+                            _arguments.Append(arg);
+                            for (int i = arg.Length-1; i >= 0 && arg[i] == '\\'; i--)
                             {
-                                // find index of last character that isn't a backslash
-                                var chars = arg.ToCharArray();
-                                int index = 0;
-                                for (int i = chars.Length-1; i > 0; i--)
-                                {
-                                    if (chars[i] != '\\')
-                                    {
-                                        index = i;
-                                        break;
-                                    }
-                                }
-                                _arguments.Append(arg.Substring(0, index));
-                                _arguments.Append(arg.Substring(index).Replace("\\","\\\\"));
-                            }
-                            else
-                            {
-                                _arguments.Append(arg);
+                                _arguments.Append('\\');
                             }
                             _arguments.Append('"');
                         }

--- a/src/System.Management.Automation/engine/NativeCommandParameterBinder.cs
+++ b/src/System.Management.Automation/engine/NativeCommandParameterBinder.cs
@@ -196,16 +196,28 @@ namespace System.Management.Automation
                         if (NeedQuotes(arg))
                         {
                             _arguments.Append('"');
-                            _arguments.Append(arg);
-                            // if trailing backslash, we need to escape it so that it doesn't escape the quotes
+                            // need to escape all trailing backslashes so the native command receives it correctly
                             if (arg.EndsWith('\\'))
                             {
-                                _arguments.Append("\\\"");
+                                // find index of last character that isn't a backslash
+                                var chars = arg.ToCharArray();
+                                int index = 0;
+                                for (int i = chars.Length-1; i > 0; i--)
+                                {
+                                    if (chars[i] != '\\')
+                                    {
+                                        index = i;
+                                        break;
+                                    }
+                                }
+                                _arguments.Append(arg.Substring(0, index));
+                                _arguments.Append(arg.Substring(index).Replace("\\","\\\\"));
                             }
                             else
                             {
-                                _arguments.Append('"');
+                                _arguments.Append(arg);
                             }
+                            _arguments.Append('"');
                         }
                         else
                         {

--- a/src/System.Management.Automation/engine/NativeCommandParameterBinder.cs
+++ b/src/System.Management.Automation/engine/NativeCommandParameterBinder.cs
@@ -197,7 +197,15 @@ namespace System.Management.Automation
                         {
                             _arguments.Append('"');
                             _arguments.Append(arg);
-                            _arguments.Append('"');
+                            // if trailing backslash, we need to escape it so that it doesn't escape the quotes
+                            if (arg.EndsWith('\\'))
+                            {
+                                _arguments.Append("\\\"");
+                            }
+                            else
+                            {
+                                _arguments.Append('"');
+                            }
                         }
                         else
                         {

--- a/test/powershell/Language/Scripting/NativeExecution/NativeCommandArguments.Tests.ps1
+++ b/test/powershell/Language/Scripting/NativeExecution/NativeCommandArguments.Tests.ps1
@@ -8,7 +8,7 @@ Describe "Native Command Arguments" -tags "CI" {
     It "Should handle quoted spaces correctly" {
         $a = 'a"b c"d'
         $lines = testexe -echoargs $a 'a"b c"d' a"b c"d
-        ($lines | measure).Count | Should Be 3
+        $lines.Count | Should Be 3
         $lines[0] | Should Be 'Arg 0 is <ab cd>'
         $lines[1] | Should Be 'Arg 1 is <ab cd>'
         $lines[2] | Should Be 'Arg 2 is <ab cd>'
@@ -27,15 +27,20 @@ Describe "Native Command Arguments" -tags "CI" {
     # looking at how it got the arguments.
     It "Should handle spaces between escaped quotes" {
         $lines = testexe -echoargs 'a\"b c\"d' "a\`"b c\`"d"
-        ($lines | measure).Count | Should Be 2
+        $lines.Count | Should Be 2
         $lines[0] | Should Be 'Arg 0 is <a"b c"d>'
         $lines[1] | Should Be 'Arg 1 is <a"b c"d>'
     }
 
-    It "Should correctly quote paths with spaces" {
-        $lines = testexe -echoargs '.\test 1\' ".\test 2\"
-        ($lines | measure).Count | Should Be 2
-        $lines[0] | Should Be 'Arg 0 is <.\test 1\>'
-        $lines[1] | Should Be 'Arg 1 is <.\test 2\>'
+    It "Should correctly quote paths with spaces: <arguments>" -TestCases @(
+        @{arguments = "'.\test 1\' `".\test 2\`""  ; expected = @(".\test 1\",".\test 2\")},
+        @{arguments = "'.\test 1\\\' `".\test 2\\`""; expected = @(".\test 1\\\",".\test 2\\")}
+    ) {
+        param($arguments, $expected)
+        $lines = Invoke-Expression "testexe -echoargs $arguments"
+        $lines.Count | Should Be $expected.Count
+        for ($i = 0; $i -lt $lines.Count; $i++) {
+            $lines[$i] | Should Be "Arg $i is <$($expected[$i])>"
+        }
     }
 }

--- a/test/powershell/Language/Scripting/NativeExecution/NativeCommandArguments.Tests.ps1
+++ b/test/powershell/Language/Scripting/NativeExecution/NativeCommandArguments.Tests.ps1
@@ -31,4 +31,11 @@ Describe "Native Command Arguments" -tags "CI" {
         $lines[0] | Should Be 'Arg 0 is <a"b c"d>'
         $lines[1] | Should Be 'Arg 1 is <a"b c"d>'
     }
+
+    It "Should correctly quote paths with spaces" {
+        $lines = testexe -echoargs '.\test 1\' '.\test 2\'
+        ($lines | measure).Count | Should Be 2
+        $lines[0] | Should Be 'Arg 0 is <.\test 1\>'
+        $lines[1] | Should Be 'Arg 1 is <.\test 2\>'
+    }
 }

--- a/test/powershell/Language/Scripting/NativeExecution/NativeCommandArguments.Tests.ps1
+++ b/test/powershell/Language/Scripting/NativeExecution/NativeCommandArguments.Tests.ps1
@@ -33,7 +33,7 @@ Describe "Native Command Arguments" -tags "CI" {
     }
 
     It "Should correctly quote paths with spaces" {
-        $lines = testexe -echoargs '.\test 1\' '.\test 2\'
+        $lines = testexe -echoargs '.\test 1\' ".\test 2\"
         ($lines | measure).Count | Should Be 2
         $lines[0] | Should Be 'Arg 0 is <.\test 1\>'
         $lines[1] | Should Be 'Arg 1 is <.\test 2\>'


### PR DESCRIPTION
When we create the arg string, an arg of `.\test 1\` ends up being `".\test 1\"` which is stored in StartInfo.Arguments which then corefx [passes as-is](https://github.com/dotnet/corefx/blob/93c5f5d795a464c18d96da47bcb5b2f7f571d26a/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Win32.cs#L48) to SHELLEXECUTEINFO.

The native command receives the arg as `.\test 1"` as the last `\"` is treated as escaping the quotes.  Fix is to add an extra backslash to escape the last enclosing quote.

Fix https://github.com/PowerShell/PowerShell/issues/4358

<!--

If you are a PowerShell Team member, please make sure you choose the Reviewer(s) and Assignee for your PR.
If you are not from the PowerShell Team, you can leave the fields blank and the Maintainers will choose them for you. If you are familiar with the team, feel free to mention some Reviewers yourself.

For more information about the roles of Reviewer and Assignee, refer to [CONTRIBUTING.md](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md).

-->
