### PR TITLE
Update version of PSDesiredStateConfiguration in project files

### DIFF
--- a/src/powershell-unix/powershell-unix.csproj
+++ b/src/powershell-unix/powershell-unix.csproj
@@ -30,7 +30,7 @@
   <ItemGroup>
     <PackageReference Include="libpsl" Version="6.0.0-*" />
     <PackageReference Include="psrp" Version="1.1.0-*" />
-    <PackageReference Include="PSDesiredStateConfiguration" Version="1.0.0-alpha01" />
+    <PackageReference Include="PSDesiredStateConfiguration" Version="6.0.0-beta.8" />
     <PackageReference Include="PowerShellHelpFiles" Version="1.0.0-alpha01" />
   </ItemGroup>
 

--- a/src/powershell-win-core/powershell-win-core.csproj
+++ b/src/powershell-win-core/powershell-win-core.csproj
@@ -34,7 +34,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="PSDesiredStateConfiguration" Version="1.0.0-alpha01" />
+    <PackageReference Include="PSDesiredStateConfiguration" Version="6.0.0-beta.8" />
     <PackageReference Include="PowerShellHelpFiles" Version="1.0.0-alpha01" />
     <PackageReference Include="psrp.windows" Version="6.0.0-beta.2" />
   </ItemGroup>


### PR DESCRIPTION
This PR has the project dependency changes for updating version of PSDesiredStateConfiguration module. The module has been fixed to enable Dsc configuration compilation on Windows with PowerShell 6.0.0.0

Resolves #4570 