### PR TITLE
Add Get-WebListenerUrl Based Examples to WebListener README.md

### DIFF
--- a/test/tools/WebListener/README.md
+++ b/test/tools/WebListener/README.md
@@ -38,6 +38,11 @@ Returns a static HTML page containing links and descriptions of the available te
 
 Returns a JSON object containing the details of the Client Certificate if one is provided in the request.
 
+```powershell
+$uri = Get-WebListenerUrl -Test 'Compression' -Https -Certificate $certificate
+Invoke-RestMethod -Uri $uri
+```
+
 Response when certificate is provided in request:
 ```json
 {
@@ -64,7 +69,7 @@ Returns the same results as the Get test with deflate compression.
 
 ```powershell
 $uri = Get-WebListenerUrl -Test 'Compression' -TestValue 'Deflate'
-Invoke-RestMethod -Uri $uri -Headers $headers
+Invoke-RestMethod -Uri $uri
 ```
 
 ```json
@@ -84,7 +89,7 @@ Returns the same results as the Get test with gzip compression.
 
 ```powershell
 $uri = Get-WebListenerUrl -Test 'Compression' -TestValue 'Gzip'
-Invoke-RestMethod -Uri $uri -Headers $headers
+Invoke-RestMethod -Uri $uri
 ```
 
 ```json
@@ -104,7 +109,8 @@ Invoke-RestMethod -Uri $uri -Headers $headers
 Returns the same results as the Get test. If a number is supplied, the server will wait that many seconds before returning a response. This can be used to test timeouts.
 
 ```powershell
-Invoke-WebRequest -Uri 'http://localhost:8083/Delay/5'
+$uri = Get-WebListenerUrl -Test 'Delay' -TestValue '5'
+Invoke-RestMethod -Uri $uri
 ```
 
 After 5 Seconds:
@@ -127,13 +133,19 @@ After 5 Seconds:
 
 Returns page containing UTF-8 data.
 
+```powershell
+$uri = Get-WebListenerUrl -Test 'Encoding' -TestValue 'Utf8'
+Invoke-RestMethod -Uri $uri
+```
+
 
 ## /Get/
 
 Returns a JSON object containing the Request URL, Request Headers, GET Query Fields and Values, and Origin IP. This emulates the functionality of [HttpBin's get test](https://httpbin.org/get).
 
 ```powershell
-Invoke-WebRequest -Uri 'http://localhost:8083/Get/' -Body @{TestField = 'TestValue'}
+$uri = Get-WebListenerUrl -Test 'Get'
+Invoke-RestMethod -Uri $uri -Body @{TestField = 'TestValue'}
 ```
 
 ```json
@@ -158,6 +170,11 @@ Provides an HTML form for `multipart/form-data` submission.
 
 ### POST
 Accepts a `multipart/form-data` submission and returns a JSON object containing information about the submission including the items and files submitted.
+
+```powershell
+$uri = Get-WebListenerUrl -Test 'Multipart'
+Invoke-RestMethod -Uri $uri -Body $multipartData -Method 'POST'
+```
 
 ```json
 {
@@ -199,7 +216,13 @@ Accepts a `multipart/form-data` submission and returns a JSON object containing 
 
 Will 302 redirect to `/Get/`. If a number is supplied, redirect will occur that many times. Can be used to test maximum redirects.
 
+```powershell
+$uri = Get-WebListenerUrl -Test 'Redirect' -TestValue '2'
+Invoke-RestMethod -Uri $uri
+```
+
 Request 1:
+
 ```none
 GET http://localhost:8083/Redirect/2 HTTP/1.1
 Connection: Keep-Alive
@@ -208,6 +231,7 @@ Host: localhost:8083
 ```
 
 Response 1:
+
 ```none
 HTTP/1.1 302 Found
 Date: Fri, 15 Sep 2017 10:46:41 GMT

--- a/test/tools/WebListener/README.md
+++ b/test/tools/WebListener/README.md
@@ -39,8 +39,9 @@ Returns a static HTML page containing links and descriptions of the available te
 Returns a JSON object containing the details of the Client Certificate if one is provided in the request.
 
 ```powershell
-$uri = Get-WebListenerUrl -Test 'Compression' -Https -Certificate $certificate
-Invoke-RestMethod -Uri $uri
+$certificate = Get-WebListenerClientCertificate
+$uri = Get-WebListenerUrl -Test 'Cert' -Https 
+Invoke-RestMethod -Uri $uri -Certificate $certificate
 ```
 
 Response when certificate is provided in request:


### PR DESCRIPTION
closes #4918

* Switches from URL Examples to Get-WebListenerUrl
* Minor formatting
* Correct the Compression examples

@dantraMSFT As requested in #4905 