### PR TITLE
Make Get-ChildItem honor Depth parameter with Include/Exclude

### DIFF
--- a/src/System.Management.Automation/engine/SessionStateContainer.cs
+++ b/src/System.Management.Automation/engine/SessionStateContainer.cs
@@ -1593,7 +1593,7 @@ namespace System.Management.Automation
                             }
 
                             int unUsedChildrenNotMatchingFilterCriteria = 0;
-                            ProcessPathItems(providerInstance, providerPath, recurse, context, out unUsedChildrenNotMatchingFilterCriteria, ProcessMode.Enumerate);
+                            ProcessPathItems(providerInstance, providerPath, recurse, context, out unUsedChildrenNotMatchingFilterCriteria, ProcessMode.Enumerate, depth: depth);
                         }
                     }
                     else
@@ -1836,6 +1836,10 @@ namespace System.Management.Automation
         ///
         /// <param name="skipIsItemContainerCheck">a hint used to skip IsItemContainer checks</param>
         ///
+        /// <param name="depth">
+        /// Limits the depth of recursion; uint.MaxValue performs full recursion.
+        /// </param>
+        ///
         /// <exception cref="ProviderNotFoundException">
         /// If the <paramref name="path"/> refers to a provider that could not be found.
         /// </exception>
@@ -1860,7 +1864,8 @@ namespace System.Management.Automation
             CmdletProviderContext context,
             out int childrenNotMatchingFilterCriteria,
             ProcessMode processMode = ProcessMode.Enumerate,
-            bool skipIsItemContainerCheck = false)
+            bool skipIsItemContainerCheck = false,
+            uint depth = uint.MaxValue)
         {
             ContainerCmdletProvider containerCmdletProvider = GetContainerProviderInstance(providerInstance);
             childrenNotMatchingFilterCriteria = 0;
@@ -2016,7 +2021,7 @@ namespace System.Management.Automation
                     }
 
                     // Now recurse if it is a container
-                    if (recurse && IsPathContainer(providerInstance, qualifiedPath, context))
+                    if (recurse && IsPathContainer(providerInstance, qualifiedPath, context) && depth > 0)
                     {
                         // Making sure to obey the StopProcessing.
                         if (context.Stopping)
@@ -2024,7 +2029,7 @@ namespace System.Management.Automation
                             return;
                         }
                         // The item is a container so recurse into it.
-                        ProcessPathItems(providerInstance, qualifiedPath, recurse, context, out childrenNotMatchingFilterCriteria, processMode, skipIsItemContainerCheck: true);
+                        ProcessPathItems(providerInstance, qualifiedPath, recurse, context, out childrenNotMatchingFilterCriteria, processMode, skipIsItemContainerCheck: true, depth: depth - 1);
                     }
                 } // for each childName
             }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ChildItem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ChildItem.Tests.ps1
@@ -9,13 +9,15 @@ Describe "Get-ChildItem" -Tags "CI" {
             $item_c = "c283d143-2116-4809-bf11-4f7d61613f92"
             $item_D = "D39B4FD9-3E1D-4DD5-8718-22FE2C934CE3"
             $item_E = "EE150FEB-0F21-4AFF-8066-AF59E925810C"
-            $item_F = ".F81D8514-8862-4227-B041-0529B1656A43" 
+            $item_F = ".F81D8514-8862-4227-B041-0529B1656A43"
+            $item_G = "5560A62F-74F1-4FAE-9A23-F4EBD90D2676" 
             $null = New-Item -Path $TestDrive -Name $item_a -ItemType "File" -Force
             $null = New-Item -Path $TestDrive -Name $item_B -ItemType "File" -Force
             $null = New-Item -Path $TestDrive -Name $item_c -ItemType "File" -Force
             $null = New-Item -Path $TestDrive -Name $item_D -ItemType "File" -Force
             $null = New-Item -Path $TestDrive -Name $item_E -ItemType "Directory" -Force
             $null = New-Item -Path $TestDrive -Name $item_F -ItemType "File" -Force | ForEach-Object {$_.Attributes = "hidden"}
+            $null = New-Item -Path (Join-Path -Path $TestDrive -ChildPath $item_E) -Name $item_G -ItemType "File" -Force
         }
 
         It "Should list the contents of the current folder" {
@@ -65,6 +67,18 @@ Describe "Get-ChildItem" -Tags "CI" {
             $file | Should Not BeNullOrEmpty
             $file.Count | Should be 1
             $file.Name | Should be $item_F
+        }
+
+        It "Should list items in current directory only with depth set to 0" {
+            (Get-ChildItem -Path $TestDrive -Depth 0).Count | Should Be 5
+            (Get-ChildItem -Path $TestDrive -Depth 0 -Include *).Count | Should Be 5
+            (Get-ChildItem -Path $TestDrive -Depth 0 -Exclude IntentionallyNonexistent).Count | Should Be 5
+        }
+
+        It "Should return items recursively when using 'Include' or 'Exclude' parameters" {
+            (Get-ChildItem -Path $TestDrive -Depth 1).Count | Should Be 6
+            (Get-ChildItem -Path $TestDrive -Depth 1 -Include $item_G).Count | Should Be 1
+            (Get-ChildItem -Path $TestDrive -Depth 1 -Exclude $item_a).Count | Should Be 5
         }
     }
 


### PR DESCRIPTION
Addresses issue #3726 by adding decrementing depth to ProcessPathItems.

Includes tests specifically for the examples listed in the issue and also testing that recursion still works when excluding or including a string.
