### PR TITLE
removed accidental leading whitespace from resx string

### DIFF
--- a/src/System.Management.Automation/resources/DiscoveryExceptions.resx
+++ b/src/System.Management.Automation/resources/DiscoveryExceptions.resx
@@ -137,7 +137,7 @@
   </data>
   <data name="CommandNotFoundException" xml:space="preserve">
     <value>The term '{0}' is not recognized as the name of a cmdlet, function, script file, or operable program.
-      Check the spelling of the name, or if a path was included, verify that the path is correct and try again.</value>
+Check the spelling of the name, or if a path was included, verify that the path is correct and try again.</value>
   </data>
   <data name="CmdletNotFoundException" xml:space="preserve">
     <value>Argument '{0}' is not recognized as a cmdlet: {1}</value>


### PR DESCRIPTION
fix from https://github.com/PowerShell/PowerShell/pull/4934
<!--

If you are a PowerShell Team member, please make sure you choose the Reviewer(s) and Assignee for your PR.
If you are not from the PowerShell Team, you can leave the fields blank and the Maintainers will choose them for you. If you are familiar with the team, feel free to mention some Reviewers yourself.

For more information about the roles of Reviewer and Assignee, refer to [CONTRIBUTING.md](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md).

-->
