### PR TITLE
Fix for Linux platform PowerShell exit on error during SSH remoting connection

### DIFF
--- a/src/System.Management.Automation/engine/remoting/fanin/OutOfProcTransportManager.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/OutOfProcTransportManager.cs
@@ -1488,18 +1488,23 @@ namespace System.Management.Automation.Remoting.Client
             var stdErrReader = _stdErrReader;
             if (stdErrReader != null) { stdErrReader.Dispose(); }
 
-            try
+            var sshProcessId = _sshProcessId;
+            _sshProcessId = 0;
+            if (sshProcessId != 0)
             {
-                var sshProcess = System.Diagnostics.Process.GetProcessById(_sshProcessId);
-                if ((sshProcess != null) && !sshProcess.HasExited)
+                try
                 {
-                    sshProcess.Kill();
+                    var sshProcess = System.Diagnostics.Process.GetProcessById(sshProcessId);
+                    if ((sshProcess != null) && (sshProcess.Handle != IntPtr.Zero) && !sshProcess.HasExited)
+                    {
+                        sshProcess.Kill();
+                    }
                 }
+                catch (ArgumentException) { }
+                catch (InvalidOperationException) { }
+                catch (NotSupportedException) { }
+                catch (System.ComponentModel.Win32Exception) { }
             }
-            catch (ArgumentException) { }
-            catch (InvalidOperationException) { }
-            catch (NotSupportedException) { }
-            catch (System.ComponentModel.Win32Exception) { }
         }
 
         private void StartErrorThread(

--- a/src/System.Management.Automation/engine/remoting/fanin/OutOfProcTransportManager.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/OutOfProcTransportManager.cs
@@ -1488,6 +1488,9 @@ namespace System.Management.Automation.Remoting.Client
             var stdErrReader = _stdErrReader;
             if (stdErrReader != null) { stdErrReader.Dispose(); }
 
+            // The CloseConnection() method can be called multiple times from multiple places.
+            // Set the _sshProcessId to zero here so that we go through the work of finding
+            // and terminating the SSH process just once.
             var sshProcessId = _sshProcessId;
             _sshProcessId = 0;
             if (sshProcessId != 0)


### PR DESCRIPTION
This fixes addresses issue #4940.

The problem is that the connection clean up code in SSHClientSessionTransportManager would try to terminate a process with id == 0, which is the initial value for the _sshProcessId field when no SSH process has been created yet.  For both Linux and Windows platforms process id of zero is a special process and should not be terminated.  Fortunately those processes are not terminated by the existing code but on Linux platforms the PowerShell parent process exits immediately.

The fix is to add checks that the SSH process has been created and is valid before terminating it during connection cleanup.