### PR TITLE
enable using filesystem from a UNC location

### DIFF
--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -98,7 +98,15 @@ namespace Microsoft.PowerShell.Commands
         ///
         private static string NormalizePath(string path)
         {
-            return path.Replace(StringLiterals.AlternatePathSeparator, StringLiterals.DefaultPathSeparator);
+            path = path.Replace(StringLiterals.AlternatePathSeparator, StringLiterals.DefaultPathSeparator);
+#if !UNIX
+            // since this is an absolute path, if it starts with a single backslash, we need to add another to make it a UNC path
+            if (path.Length >= 2 && path[0] == StringLiterals.DefaultPathSeparator && path[1] != StringLiterals.DefaultPathSeparator)
+            {
+                path = StringLiterals.DefaultPathSeparatorString + path;
+            }
+#endif
+            return path;
         } // NormalizePath
 
 

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -98,15 +98,7 @@ namespace Microsoft.PowerShell.Commands
         ///
         private static string NormalizePath(string path)
         {
-            path = path.Replace(StringLiterals.AlternatePathSeparator, StringLiterals.DefaultPathSeparator);
-#if !UNIX
-            // since this is an absolute path, if it starts with a single backslash, we need to add another to make it a UNC path
-            if (path.Length >= 2 && path[0] == StringLiterals.DefaultPathSeparator && path[1] != StringLiterals.DefaultPathSeparator)
-            {
-                path = StringLiterals.DefaultPathSeparatorString + path;
-            }
-#endif
-            return path;
+            return path.Replace(StringLiterals.AlternatePathSeparator, StringLiterals.DefaultPathSeparator);
         } // NormalizePath
 
 
@@ -4825,6 +4817,13 @@ namespace Microsoft.PowerShell.Commands
             {
                 parentPath = EnsureDriveIsRooted(parentPath);
             }
+#if !UNIX
+            else if (parentPath.Equals(StringLiterals.DefaultPathSeparatorString, StringComparison.Ordinal))
+            {
+                // make sure we return two backslashes so it still results in a UNC path
+                parentPath = "\\\\";
+            }
+#endif
             return parentPath;
         } // GetParentPath
 

--- a/src/System.Management.Automation/namespaces/NavigationProviderBase.cs
+++ b/src/System.Management.Automation/namespaces/NavigationProviderBase.cs
@@ -426,9 +426,10 @@ namespace System.Management.Automation.Provider
                     StringBuilder builder = new StringBuilder(parent, parent.Length + child.Length + 1);
 #if !UNIX
                     // On Windows, if we have a single backslash for the parent, it's a UNC path so we need to add another backslash back
-                    if (String.Compare(parent, StringLiterals.DefaultPathSeparatorString, StringComparison.Ordinal) == 0)
+                    if (this.ProviderInfo.FullName.Equals(@"Microsoft.PowerShell.Core\FileSystem", StringComparison.OrdinalIgnoreCase) &&
+                        String.Compare(parent, StringLiterals.DefaultPathSeparatorString, StringComparison.Ordinal) == 0)
                     {
-                        builder.Append('\\');
+                        builder.Append(StringLiterals.DefaultPathSeparator);
                     }
 #endif
 

--- a/src/System.Management.Automation/namespaces/NavigationProviderBase.cs
+++ b/src/System.Management.Automation/namespaces/NavigationProviderBase.cs
@@ -424,14 +424,6 @@ namespace System.Management.Automation.Provider
                     // Joins the paths
 
                     StringBuilder builder = new StringBuilder(parent, parent.Length + child.Length + 1);
-#if !UNIX
-                    // On Windows, if we have a single backslash for the parent, it's a UNC path so we need to add another backslash back
-                    if (this.ProviderInfo.FullName.Equals(@"Microsoft.PowerShell.Core\FileSystem", StringComparison.OrdinalIgnoreCase) &&
-                        String.Compare(parent, StringLiterals.DefaultPathSeparatorString, StringComparison.Ordinal) == 0)
-                    {
-                        builder.Append(StringLiterals.DefaultPathSeparator);
-                    }
-#endif
 
                     if (parent.EndsWith(StringLiterals.DefaultPathSeparatorString, StringComparison.Ordinal))
                     {

--- a/src/System.Management.Automation/namespaces/NavigationProviderBase.cs
+++ b/src/System.Management.Automation/namespaces/NavigationProviderBase.cs
@@ -424,6 +424,13 @@ namespace System.Management.Automation.Provider
                     // Joins the paths
 
                     StringBuilder builder = new StringBuilder(parent, parent.Length + child.Length + 1);
+#if !UNIX
+                    // On Windows, if we have a single backslash for the parent, it's a UNC path so we need to add another backslash back
+                    if (String.Compare(parent, StringLiterals.DefaultPathSeparatorString, StringComparison.Ordinal) == 0)
+                    {
+                        builder.Append('\\');
+                    }
+#endif
 
                     if (parent.EndsWith(StringLiterals.DefaultPathSeparatorString, StringComparison.Ordinal))
                     {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
@@ -1303,17 +1303,22 @@ Describe "Extended FileSystem Path/Location Cmdlet Provider Tests" -Tags "Featur
 }
 
 Describe "UNC paths" -Tags 'CI' {
-    It "Can Get-ChildItems from a UNC location" -Skip:(!$IsWindows) {
+    It "Can Get-ChildItems from a UNC location using <cmdlet>" -Skip:(!$IsWindows) -TestCases @(
+        @{cmdlet="Push-Location"},
+        @{cmdlet="Set-Location"}
+    ) {
+        param($cmdlet)
+        $originalLocation = Get-Location
         try {
             $systemDrive = ($env:SystemDrive).Replace(":","$")
             $testPath = Join-Path "\\localhost" $systemDrive
-            Push-Location $testPath
+            & $cmdlet $testPath
             Get-Location | Should BeExactly "Microsoft.PowerShell.Core\FileSystem::$testPath"
             $children = { Get-ChildItem -ErrorAction Stop } | Should Not Throw
             $children.Count | Should BeGreaterThan 0
         }
         finally {
-            Pop-Location
+            Set-Location $originalLocation
         }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
@@ -1301,3 +1301,19 @@ Describe "Extended FileSystem Path/Location Cmdlet Provider Tests" -Tags "Featur
         }
     }
 }
+
+Describe "UNC paths" -Tags 'CI' {
+    It "Can Get-ChildItems from a UNC location" -Skip:(!$IsWindows) {
+        try {
+            $systemDrive = ($env:SystemDrive).Replace(":","$")
+            $testPath = Join-Path "\\localhost" $systemDrive
+            Push-Location $testPath
+            Get-Location | Should BeExactly "Microsoft.PowerShell.Core\FileSystem::$testPath"
+            $children = { Get-ChildItem -ErrorAction Stop } | Should Not Throw
+            $children.Count | Should BeGreaterThan 0
+        }
+        finally {
+            Pop-Location
+        }
+    }
+}


### PR DESCRIPTION
The problem is while validating the path, it splits `\\server\share\folder` by the backslash so the root is just `\` and the path ends up being `\server\share\folder` which isn't valid.  Fix is on Windows to add extra slash if the root is `\`

Fix https://github.com/PowerShell/PowerShell/issues/4990

<!--

If you are a PowerShell Team member, please make sure you choose the Reviewer(s) and Assignee for your PR.
If you are not from the PowerShell Team, you can leave the fields blank and the Maintainers will choose them for you. If you are familiar with the team, feel free to mention some Reviewers yourself.

For more information about the roles of Reviewer and Assignee, refer to [CONTRIBUTING.md](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md).

-->
