### PR TITLE
increase timing on test service for webcmdlet timeout test to make it more robust

### DIFF
--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -359,7 +359,7 @@ function ExecuteRestMethod
     return $result
 }
 
-function GetMultipartBody 
+function GetMultipartBody
 {
     param
     (
@@ -389,7 +389,7 @@ function GetMultipartBody
         $multipartContent.Add($fileContent)
     }
     # unary comma required to prevent $multipartContent from being unwrapped/enumerated
-    return ,$multipartContent 
+    return ,$multipartContent
 }
 
 <#
@@ -527,7 +527,7 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
 
     It "Invoke-WebRequest validate timeout option" {
 
-        $uri = Get-WebListenerUrl -Test 'Delay' -TestValue '5'
+        $uri = Get-WebListenerUrl -Test 'Delay' -TestValue '6'
         $command = "Invoke-WebRequest -Uri '$uri' -TimeoutSec 5"
 
         $result = ExecuteWebCommand -command $command
@@ -1190,42 +1190,42 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
             $command = "Invoke-WebRequest -Uri '$Uri'"
             $result = ExecuteWebCommand -command $command
             $result.Error.FullyQualifiedErrorId | Should Be "WebCmdletWebResponseException,Microsoft.PowerShell.Commands.InvokeWebRequestCommand"
-            
+
             # validate that no exception is thrown for URI with expired certificate when using -SkipCertificateCheck option
             $Uri = Get-WebListenerUrl -Https
             $command = "Invoke-WebRequest -Uri '$Uri' -SkipCertificateCheck"
             $result = ExecuteWebCommand -command $command
             $result.Error | Should BeNullOrEmpty
         }
-        
+
         It "Validate Invoke-WebRequest returns native HTTPS error message in exception" {
             $uri = Get-WebListenerUrl -Https
             $command = "Invoke-WebRequest -Uri '$uri'"
             $result = ExecuteWebCommand -command $command
-            
+
             # need to check against inner exception since Linux and Windows uses different HTTP client libraries so errors aren't the same
             $result.Error.ErrorDetails.Message | Should Match $result.Error.Exception.InnerException.Message
             $result.Error.FullyQualifiedErrorId | Should Be "WebCmdletWebResponseException,Microsoft.PowerShell.Commands.InvokeWebRequestCommand"
         }
-        
+
         It "Verifies Invoke-WebRequest Certificate Authentication Fails without -Certificate"  {
             $uri = Get-WebListenerUrl -Https -Test 'Cert'
-            $result = Invoke-WebRequest -Uri $uri -SkipCertificateCheck | 
+            $result = Invoke-WebRequest -Uri $uri -SkipCertificateCheck |
                 Select-Object -ExpandProperty Content |
                 ConvertFrom-Json
-            
+
             $result.Status | Should Be 'FAILED'
         }
-        
+
         # Test skipped on macOS and CentOS pending support for Client Certificate Authentication
         # https://github.com/PowerShell/PowerShell/issues/4650
         It "Verifies Invoke-WebRequest Certificate Authentication Successful with -Certificate" -Pending:$PendingCertificateTest {
             $uri = Get-WebListenerUrl -Https -Test 'Cert'
             $certificate = Get-WebListenerClientCertificate
-            $result = Invoke-WebRequest -Uri $uri -Certificate $certificate -SkipCertificateCheck | 
+            $result = Invoke-WebRequest -Uri $uri -Certificate $certificate -SkipCertificateCheck |
                 Select-Object -ExpandProperty Content |
                 ConvertFrom-Json
-            
+
             $result.Status | Should Be 'OK'
             $result.Thumbprint | Should Be $certificate.Thumbprint
         }
@@ -1365,7 +1365,7 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
         $uri = Get-WebListenerUrl -Test 'Encoding' -TestValue 'Utf8'
         $command = "Invoke-RestMethod -Uri '$uri'"
 
-        $result = ExecuteWebCommand -command $command        
+        $result = ExecuteWebCommand -command $command
         $Result.Output | Should Match '⡌⠁⠧⠑ ⠼⠁⠒  ⡍⠜⠇⠑⠹⠰⠎ ⡣⠕⠌'
     }
 
@@ -1757,37 +1757,37 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
             $command = "Invoke-RestMethod -Uri '$uri' -Method HEAD"
             $result = ExecuteWebCommand -command $command
             $result.Error.FullyQualifiedErrorId | Should Be "WebCmdletWebResponseException,Microsoft.PowerShell.Commands.InvokeRestMethodCommand"
-            
+
             # validate that no exception is thrown for URI with expired certificate when using -SkipCertificateCheck option
             $command = "Invoke-RestMethod -Uri '$uri' -SkipCertificateCheck -Method HEAD"
             $result = ExecuteWebCommand -command $command
             $result.Error | Should BeNullOrEmpty
         }
-        
+
         It "Validate Invoke-RestMethod returns native HTTPS error message in exception" {
             $uri = Get-WebListenerUrl -Https
             $command = "Invoke-RestMethod -Uri '$uri'"
             $result = ExecuteWebCommand -command $command
-            
+
             # need to check against inner exception since Linux and Windows uses different HTTP client libraries so errors aren't the same
             $result.Error.ErrorDetails.Message | Should Match $result.Error.Exception.InnerException.Message
             $result.Error.FullyQualifiedErrorId | Should Be "WebCmdletWebResponseException,Microsoft.PowerShell.Commands.InvokeRestMethodCommand"
         }
-        
+
         It "Verifies Invoke-RestMethod Certificate Authentication Fails without -Certificate" {
             $uri = Get-WebListenerUrl -Https -Test 'Cert'
             $result = Invoke-RestMethod -Uri $uri -SkipCertificateCheck
-            
+
             $result.Status | Should Be 'FAILED'
         }
-        
+
         # Test skipped on macOS and CentOS pending support for Client Certificate Authentication
         # https://github.com/PowerShell/PowerShell/issues/4650
         It "Verifies Invoke-RestMethod Certificate Authentication Successful with -Certificate" -Pending:$PendingCertificateTest {
             $uri = Get-WebListenerUrl -Https -Test 'Cert'
             $certificate = Get-WebListenerClientCertificate
             $result = Invoke-RestMethod -uri $uri -Certificate $certificate -SkipCertificateCheck
-            
+
             $result.Status | Should Be 'OK'
             $result.Thumbprint | Should Be $certificate.Thumbprint
         }
@@ -2051,7 +2051,7 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
             $headers.'Content-Type' | Should Be 'text/html; charset=utf-8'
             $headers.Server | Should Be 'Kestrel'
         }
-        
+
         It "Verifies Invoke-RestMethod supports -ResponseHeadersVariable overwriting existing variable" {
             $uri = Get-WebListenerUrl -Test '/'
             $headers = 'prexisting'


### PR DESCRIPTION
Test service had a delay of 5s while the test had a timeout of 5s, there's a small window where the delay expires before the timeout invalidating the test.
Fix is to increase the delay to 6s allowing for the timeout to succeed.

VSCode removed a bunch of trailing whitespace.

<!--

If you are a PowerShell Team member, please make sure you choose the Reviewer(s) and Assignee for your PR.
If you are not from the PowerShell Team, you can leave the fields blank and the Maintainers will choose them for you. If you are familiar with the team, feel free to mention some Reviewers yourself.

For more information about the roles of Reviewer and Assignee, refer to [CONTRIBUTING.md](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md).

-->
