### PR TITLE
SetServiceCommand: Add positional parameter attribute

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Service.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Service.cs
@@ -1436,7 +1436,7 @@ namespace Microsoft.PowerShell.Commands
         /// service name
         /// </summary>
         /// <value></value>
-        [Parameter(Position = 0, Mandatory = true, ValueFromPipeline = true, ValueFromPipelineByPropertyName = true, ParameterSetName = "Name")]
+        [Parameter(Mandatory = true, ParameterSetName = "Name", Position = 0, ValueFromPipeline = true, ValueFromPipelineByPropertyName = true)]
         [Alias("ServiceName", "SN")]
         public new String Name
         {
@@ -1448,6 +1448,14 @@ namespace Microsoft.PowerShell.Commands
         }
         internal String serviceName = null;
 
+        /// <summary>
+        /// The following is the definition of the input parameter "InputObject".
+        /// Specifies a ServiceController object that represents the service to change.
+        /// Enter a variable that contains the objects or type a command or expression
+        /// that gets the objects.
+        /// </summary>
+        [Parameter(Mandatory = true, ParameterSetName = "InputObject", Position = 0, ValueFromPipeline = true)]
+        public new ServiceController InputObject { get; set; }
 
         /// <summary>
         /// The following is the definition of the input parameter "DisplayName".
@@ -1538,16 +1546,6 @@ namespace Microsoft.PowerShell.Commands
             }
         }
         internal string serviceStatus = null;
-
-        /// <summary>
-        /// The following is the definition of the input parameter "InputObject".
-        /// Specifies ServiceController object representing the services to be stopped.
-        /// Enter a variable that contains the objects or type a command or expression
-        /// that gets the objects.
-        /// </summary>
-        [Parameter(ValueFromPipeline = true,
-                   ParameterSetName = "InputObject")]
-        public new ServiceController InputObject { get; set; }
 
         /// <summary>
         /// This is not a parameter for this cmdlet.
@@ -1688,7 +1686,7 @@ namespace Microsoft.PowerShell.Commands
 
                         // Modify startup type or display name or credential
                         if (!String.IsNullOrEmpty(DisplayName)
-                            || (ServiceStartMode)(-1) != StartupType || null != Credential) 
+                            || (ServiceStartMode)(-1) != StartupType || null != Credential)
                         {
                             DWORD dwStartType = NativeMethods.SERVICE_NO_CHANGE;
                             if (!NativeMethods.TryGetNativeStartupType(StartupType, out dwStartType))


### PR DESCRIPTION
Added a positional parameter attribute to the InputObject parameter,
giving Set-Service behavior similar to the other *-Service cmdlets.

Closes #4916.

<!--

If you are a PowerShell Team member, please make sure you choose the Reviewer(s) and Assignee for your PR.
If you are not from the PowerShell Team, you can leave the fields blank and the Maintainers will choose them for you. If you are familiar with the team, feel free to mention some Reviewers yourself.

For more information about the roles of Reviewer and Assignee, refer to [CONTRIBUTING.md](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md).

-->
