### PR TITLE
treat .rtf files as binary so EOL don't get changed

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 CHANGELOG.md merge=union
 * text=auto
 *.png binary
+*.rtf binary


### PR DESCRIPTION
with the change in .gitattributes, this file was being treated as text so git on Linux kept trying to autocorrect the EOL to LF (thus showing up as a modified file).  Since this file is primarily used in our .msi pkg on Windows, we should retain CRLF EOL.  updated .gitattributes to treat .rtf files as binary.

<!--

If you are a PowerShell Team member, please make sure you choose the Reviewer(s) and Assignee for your PR.
If you are not from the PowerShell Team, you can leave the fields blank and the Maintainers will choose them for you. If you are familiar with the team, feel free to mention some Reviewers yourself.

For more information about the roles of Reviewer and Assignee, refer to [CONTRIBUTING.md](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md).

-->
