### PR TITLE
Fix powershell to update the PATH environment variable only if PATH exists

### DIFF
--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
@@ -136,10 +136,13 @@ namespace Microsoft.PowerShell
 
             // put PSHOME in front of PATH so that calling `powershell` within `powershell` always starts the same running version
             string path = Environment.GetEnvironmentVariable("PATH");
-            string pshome = Utils.DefaultPowerShellAppBase;
-            if (!path.Contains(pshome))
+            if (path != null)
             {
-                Environment.SetEnvironmentVariable("PATH", pshome + Path.PathSeparator + path);
+                string pshome = Utils.DefaultPowerShellAppBase;
+                if (!path.Contains(pshome))
+                {
+                    Environment.SetEnvironmentVariable("PATH", pshome + Path.PathSeparator + path);
+                }
             }
 
             try

--- a/test/powershell/Host/ConsoleHost.Tests.ps1
+++ b/test/powershell/Host/ConsoleHost.Tests.ps1
@@ -238,7 +238,7 @@ Describe "ConsoleHost unit tests" -tags "Feature" {
             $observed | Should Be $BoolValue
         }
 
-        It "-File should return exit code from script"  -TestCases @(
+        It "-File '<filename>' should return exit code from script"  -TestCases @(
             @{Filename = "test.ps1"},
             @{Filename = "test"}
         ) {
@@ -489,6 +489,10 @@ foo
     Context "PATH environment variable" {
         It "`$PSHOME should be in front so that powershell.exe starts current running PowerShell" {
             powershell -v | Should Match $psversiontable.GitCommitId
+        }
+
+        It "powershell starts if PATH is not set" -Skip:($IsWindows) {
+            bash -c "unset PATH;$powershell -c '1+1'" | Should BeExactly 2
         }
     }
 


### PR DESCRIPTION
Linux service calling powershell may not have PATH set
only use PATH if it's not null
also fixed a test case using -TestCases without unique test name

Fix https://github.com/PowerShell/PowerShell/issues/5019

<!--

If you are a PowerShell Team member, please make sure you choose the Reviewer(s) and Assignee for your PR.
If you are not from the PowerShell Team, you can leave the fields blank and the Maintainers will choose them for you. If you are familiar with the team, feel free to mention some Reviewers yourself.

For more information about the roles of Reviewer and Assignee, refer to [CONTRIBUTING.md](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md).

-->