### PR TITLE
Update docs for beta.8 release

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -557,8 +557,10 @@ sample-dotnet2
 
 #region docs/installation/linux.md Overrides
  - docs/installation/linux.md
+libcurl
 OpenSUSE
 TravisEz13
+zypper
 #endregion
 
 #region docs/installation/windows.md Overrides

--- a/README.md
+++ b/README.md
@@ -29,39 +29,49 @@ You can download and install a PowerShell package for any of the following platf
 | ---------------------------------- | ---------------------- | ----------------------------- |
 | Windows (x64)                      | [.msi][rl-windows-64]  | [Instructions][in-windows]    |
 | Windows (x86)                      | [.msi][rl-windows-86]  | [Instructions][in-windows]    |
+| Ubuntu 17.04                       | [.deb][rl-ubuntu17]    | [Instructions][in-ubuntu17]   |
 | Ubuntu 16.04                       | [.deb][rl-ubuntu16]    | [Instructions][in-ubuntu16]   |
 | Ubuntu 14.04                       | [.deb][rl-ubuntu14]    | [Instructions][in-ubuntu14]   |
-| Debian 8                           | [.deb][rl-ubuntu14]    | [Instructions][in-deb8]       |
+| Debian 8                           | [.deb][rl-debian8]     | [Instructions][in-deb8]       |
+| Debian 9                           | [.deb][rl-debian9]     | [Instructions][in-deb9]       |
 | CentOS 7                           | [.rpm][rl-centos]      | [Instructions][in-centos]     |
 | Red Hat Enterprise Linux 7         | [.rpm][rl-centos]      | [Instructions][in-rhel7]      |
-| OpenSUSE 42.1                      | [.rpm][rl-opensuse421] | [Instructions][in-opensuse421]|
+| OpenSUSE 42.2                      | [.rpm][rl-centos]      | [Instructions][in-opensuse422]|
+| Fedora 25                          | [.rpm][rl-centos]      | [Instructions][in-fedora25]   |
+| Fedora 26                          | [.rpm][rl-centos]      | [Instructions][in-fedora26]   |
 | Arch Linux                         |                        | [Instructions][in-archlinux]  |
 | Many Linux distributions           | [.AppImage][rl-ai]     | [Instructions][in-appimage]   |
 | macOS 10.12                        | [.pkg][rl-macos]       | [Instructions][in-macos]      |
 | Docker                             |                        | [Instructions][in-docker]     |
 | Kali Linux                         | [.deb][rl-ubuntu16]    | [Instructions][in-kali]
 
-[rl-windows-64]: https://github.com/PowerShell/PowerShell/releases/download/v6.0.0-beta.7/PowerShell-6.0.0-beta.7-win-x64.msi
-[rl-windows-86]: https://github.com/PowerShell/PowerShell/releases/download/v6.0.0-beta.7/PowerShell-6.0.0-beta.7-win-x86.msi
-[rl-ubuntu16]: https://github.com/PowerShell/PowerShell/releases/download/v6.0.0-beta.7/powershell_6.0.0-beta.7-1ubuntu1.16.04.1_amd64.deb
-[rl-ubuntu14]: https://github.com/PowerShell/PowerShell/releases/download/v6.0.0-beta.7/powershell_6.0.0-beta.7-1ubuntu1.14.04.1_amd64.deb
-[rl-centos]: https://github.com/PowerShell/PowerShell/releases/download/v6.0.0-beta.7/powershell-6.0.0_beta.7-1.el7.x86_64.rpm
-[rl-ai]: https://github.com/PowerShell/PowerShell/releases/download/v6.0.0-beta.7/PowerShell-6.0.0-beta.7-x86_64.AppImage
-[rl-macos]: https://github.com/PowerShell/PowerShell/releases/download/v6.0.0-beta.7/powershell-6.0.0-beta.7-osx.10.12-x64.pkg
-[rl-opensuse421]: https://github.com/PowerShell/PowerShell/releases/download/v6.0.0-beta.6/powershell-6.0.0_beta.6-1.suse.42.1.x86_64.rpm
+[rl-windows-64]: https://github.com/PowerShell/PowerShell/releases/download/v6.0.0-beta.8/PowerShell-6.0.0-beta.8-win-x64.msi
+[rl-windows-86]: https://github.com/PowerShell/PowerShell/releases/download/v6.0.0-beta.8/PowerShell-6.0.0-beta.8-win-x86.msi
+[rl-ubuntu17]: https://github.com/PowerShell/PowerShell/releases/download/v6.0.0-beta.8/powershell_6.0.0-beta.8-1.ubuntu.17.04_amd64.deb
+[rl-ubuntu16]: https://github.com/PowerShell/PowerShell/releases/download/v6.0.0-beta.8/powershell_6.0.0-beta.8-1.ubuntu.16.04_amd64.deb
+[rl-ubuntu14]: https://github.com/PowerShell/PowerShell/releases/download/v6.0.0-beta.8/powershell_6.0.0-beta.8-1.ubuntu.14.04_amd64.deb
+[rl-debian8]: https://github.com/PowerShell/PowerShell/releases/download/v6.0.0-beta.8/powershell_6.0.0-beta.8-1.debian.8_amd64.deb
+[rl-debian9]: https://github.com/PowerShell/PowerShell/releases/download/v6.0.0-beta.8/powershell_6.0.0-beta.8-1.debian.9_amd64.deb
+[rl-centos]: https://github.com/PowerShell/PowerShell/releases/download/v6.0.0-beta.8/powershell-6.0.0_beta.8-1.el7.x86_64.rpm
+[rl-ai]: https://github.com/PowerShell/PowerShell/releases/download/v6.0.0-beta.8/PowerShell-6.0.0-beta.8-x86_64.AppImage
+[rl-macos]: https://github.com/PowerShell/PowerShell/releases/download/v6.0.0-beta.8/powershell-6.0.0-beta.8-osx.10.12-x64.pkg
 
 [installation]: docs/installation
 [in-windows]: docs/installation/windows.md#msi
 [in-ubuntu14]: docs/installation/linux.md#ubuntu-1404
 [in-ubuntu16]: docs/installation/linux.md#ubuntu-1604
+[in-ubuntu17]: docs/installation/linux.md#ubuntu-1704
 [in-deb8]: docs/installation/linux.md#debian-8
+[in-deb9]: docs/installation/linux.md#debian-9
 [in-centos]: docs/installation/linux.md#centos-7
 [in-rhel7]: docs/installation/linux.md#red-hat-enterprise-linux-rhel-7
+[in-opensuse422]: docs/installation/linux.md#opensuse-422
+[in-fedora25]: docs/installation/linux.md#fedora-25
+[in-fedora26]: docs/installation/linux.md#fedora-26
 [in-archlinux]: docs/installation/linux.md#arch-linux
 [in-appimage]: docs/installation/linux.md#linux-appimage
 [in-macos]: docs/installation/linux.md#macos-1012
 [in-docker]: docker
-[in-opensuse421]: docs/installation/linux.md#opensuse-421
 [in-kali]: docs/installation/linux.md#kali
 
 To install a specific version, visit [releases](https://github.com/PowerShell/PowerShell/releases).

--- a/docker/release/amazonlinux/Dockerfile
+++ b/docker/release/amazonlinux/Dockerfile
@@ -2,7 +2,7 @@
 
 FROM amazonlinux:latest
 
-ARG POWERSHELL_VERSION=6.0.0-beta.7
+ARG POWERSHELL_VERSION=6.0.0-beta.8
 ARG IMAGE_NAME=microsoft/powershell:amazonlinux
 
 LABEL maintainer="PowerShell Team <powershellteam@hotmail.com>" \

--- a/docker/release/centos7/Dockerfile
+++ b/docker/release/centos7/Dockerfile
@@ -2,7 +2,7 @@
 
 FROM centos:7
 
-ARG POWERSHELL_VERSION=6.0.0-beta.7
+ARG POWERSHELL_VERSION=6.0.0-beta.8
 ARG IMAGE_NAME=microsoft/powershell:centos7
 
 LABEL maintainer="PowerShell Team <powershellteam@hotmail.com>" \

--- a/docker/release/fedora24/Dockerfile
+++ b/docker/release/fedora24/Dockerfile
@@ -3,9 +3,9 @@ FROM fedora:24
 # TODO: Until a release of PowerShell for Fedora 24 is available,
 # this Dockerfile installs the CentOS 7 version for compatibility.
 
-ARG POWERSHELL_VERSION=6.0.0-beta.7
-ARG POWERSHELL_RELEASE=v6.0.0-beta.7
-ARG POWERSHELL_PACKAGE=powershell-6.0.0_beta.7-1.el7.x86_64.rpm
+ARG POWERSHELL_VERSION=6.0.0-beta.8
+ARG POWERSHELL_RELEASE=v6.0.0-beta.8
+ARG POWERSHELL_PACKAGE=powershell-6.0.0_beta.8-1.rhel.7.x86_64.rpm
 ARG IMAGE_NAME=microsoft/powershell:fedora24
 
 LABEL maintainer="PowerShell Team <powershellteam@hotmail.com>" \

--- a/docker/release/nanoserver-insider/Dockerfile
+++ b/docker/release/nanoserver-insider/Dockerfile
@@ -10,7 +10,7 @@ ARG NanoServerRepo=microsoft/nanoserver-insider
 FROM ${WindowsServerCoreRepo}:$WindowsServerCoreVersion  AS installer-env
 
 # Arguments for installing powershell, must be defined in the container they are used
-ARG PS_VERSION=6.0.0-beta.7
+ARG PS_VERSION=6.0.0-beta.8
 
 ENV PS_DOWNLOAD_URL https://github.com/PowerShell/PowerShell/releases/download/v$PS_VERSION/PowerShell-$PS_VERSION-win-x64.zip
 
@@ -23,7 +23,7 @@ RUN Expand-Archive powershell.zip -DestinationPath \PowerShell
 FROM ${NanoServerRepo}:$NanoServerVersion
 
 ARG VCS_REF="none"
-ARG PS_VERSION=6.0.0-beta.7
+ARG PS_VERSION=6.0.0-beta.8
 ARG IMAGE_NAME=microsoft/nanoserver-insider-powershell
 
 LABEL maintainer="PowerShell Team <powershellteam@hotmail.com>" `

--- a/docker/release/nanoserver/Dockerfile
+++ b/docker/release/nanoserver/Dockerfile
@@ -1,8 +1,8 @@
 # escape=`
 FROM microsoft/nanoserver:latest
 
-ARG POWERSHELL_ZIP=https://github.com/PowerShell/PowerShell/releases/download/v6.0.0-beta.7/PowerShell-6.0.0-beta.7-win-x64.zip
-ARG POWERSHELL_VERSION=6.0.0-beta.7
+ARG POWERSHELL_ZIP=https://github.com/PowerShell/PowerShell/releases/download/v6.0.0-beta.8/PowerShell-6.0.0-beta.8-win-x64.zip
+ARG POWERSHELL_VERSION=6.0.0-beta.8
 ARG IMAGE_NAME=microsoft/powershell:nanoserver
 
 LABEL maintainer="PowerShell Team <powershellteam@hotmail.com>" `

--- a/docker/release/opensuse42.2/Dockerfile
+++ b/docker/release/opensuse42.2/Dockerfile
@@ -1,10 +1,10 @@
 # Docker image file that describes an OpenSUSE 42.1 (AKA leap 42.1) image with PowerShell installed from PowerShell Release
 FROM opensuse:42.2
 
-ARG POWERSHELL_VERSION=6.0.0_beta.6
-ARG POWERSHELL_RELEASE=v6.0.0-beta.6
+ARG POWERSHELL_VERSION=6.0.0_beta.8
+ARG POWERSHELL_RELEASE=v6.0.0-beta.8
 ARG FORK=PowerShell
-ARG POWERSHELL_PACKAGE=powershell-$POWERSHELL_VERSION-1.suse.42.1.x86_64.rpm
+ARG POWERSHELL_PACKAGE=powershell-6.0.0_beta.8-1.rhel.7.x86_64.rpm
 ARG IMAGE_NAME=microsoft/powershell:opensuse42.2
 
 LABEL maintainer="PowerShell Team <powershellteam@hotmail.com>" \

--- a/docker/release/ubuntu14.04/Dockerfile
+++ b/docker/release/ubuntu14.04/Dockerfile
@@ -2,7 +2,7 @@
 
 FROM ubuntu:trusty
 
-ARG POWERSHELL_VERSION=6.0.0-beta.7
+ARG POWERSHELL_VERSION=6.0.0-beta.8
 ARG IMAGE_NAME=microsoft/powershell:ubuntu14.04
 
 LABEL maintainer="PowerShell Team <powershellteam@hotmail.com>" \

--- a/docker/release/ubuntu16.04/Dockerfile
+++ b/docker/release/ubuntu16.04/Dockerfile
@@ -2,7 +2,7 @@
 
 FROM ubuntu:xenial
 
-ARG POWERSHELL_VERSION=6.0.0-beta.7
+ARG POWERSHELL_VERSION=6.0.0-beta.8
 ARG IMAGE_NAME=microsoft/powershell:ubuntu16.04
 
 LABEL maintainer="PowerShell Team <powershellteam@hotmail.com>" \

--- a/docker/release/windowsservercore/Dockerfile
+++ b/docker/release/windowsservercore/Dockerfile
@@ -1,8 +1,8 @@
 # escape=`
 FROM microsoft/windowsservercore:latest
 
-ARG POWERSHELL_MSI=https://github.com/PowerShell/PowerShell/releases/download/v6.0.0-beta.7/PowerShell-6.0.0-beta.7-win-x64.msi
-ARG POWERSHELL_VERSION=6.0.0-beta.7
+ARG POWERSHELL_MSI=https://github.com/PowerShell/PowerShell/releases/download/v6.0.0-beta.8/PowerShell-6.0.0-beta.8-win-x64.msi
+ARG POWERSHELL_VERSION=6.0.0-beta.8
 ARG IMAGE_NAME=microsoft/powershell:windowsservercore
 
 LABEL maintainer="PowerShell Team <powershellteam@hotmail.com>" `

--- a/docs/installation/linux.md
+++ b/docs/installation/linux.md
@@ -1,7 +1,8 @@
 # Package installation instructions
 
-Supports [Ubuntu 14.04][u14], [Ubuntu 16.04][u16], [Debian 8][deb8],
-[CentOS 7][cos], [Red Hat Enterprise Linux (RHEL) 7][rhel7], [Arch Linux][arch], [many Linux distributions (AppImage)][lai], and [macOS 10.12][mac].
+Supports [Ubuntu 14.04][u14], [Ubuntu 16.04][u16], [Ubuntu 17.04][u17], [Debian 8][deb8], [Debian 9][deb9],
+[CentOS 7][cos], [Red Hat Enterprise Linux (RHEL) 7][rhel7], [OpenSUSE 42.2][opensuse], [Fedora 25][fed25],
+[Fedora 26][fed26], [Arch Linux][arch], [many Linux distributions (AppImage)][lai], and [macOS 10.12][mac].
 All packages are available on our GitHub [releases][] page.
 
 All of these steps can be done automatically by the [`download.sh`][download] script.
@@ -17,9 +18,14 @@ Once the package is installed, run `powershell` from a terminal.
 
 [u14]: #ubuntu-1404
 [u16]: #ubuntu-1604
+[u17]: #ubuntu-1704
 [deb8]: #debian-8
+[deb9]: #debian-9
 [cos]: #centos-7
 [rhel7]: #red-hat-enterprise-linux-rhel-7
+[opensuse]: #opensuse-422
+[fed25]: #fedora-25
+[fed26]: #fedora-26
 [arch]: #arch-linux
 [lai]: #linux-appimage
 [mac]: #macos-1012
@@ -39,7 +45,7 @@ curl https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
 # Register the Microsoft Ubuntu repository
 curl https://packages.microsoft.com/config/ubuntu/14.04/prod.list | sudo tee /etc/apt/sources.list.d/microsoft.list
 
-# Update apt-get
+# Update the list of products
 sudo apt-get update
 
 # Install PowerShell
@@ -52,16 +58,16 @@ powershell
 After registering the Microsoft repository once as superuser,
 from then on, you just need to use `sudo apt-get upgrade powershell` to update it.
 
-### Installation via Direct Download
+### Installation via Direct Download - Ubuntu 14.04
 
-Using [Ubuntu 14.04][], download the Debian package
-`powershell_6.0.0-beta.7-1ubuntu1.14.04.1_amd64.deb`
+Download the Debian package
+`powershell_6.0.0-beta.8-1.ubuntu.14.04_amd64.deb`
 from the [releases][] page onto the Ubuntu machine.
 
 Then execute the following in the terminal:
 
 ```sh
-sudo dpkg -i powershell_6.0.0-beta.7-1ubuntu1.14.04.1_amd64.deb
+sudo dpkg -i powershell_6.0.0-beta.8-1.ubuntu.14.04_amd64.deb
 sudo apt-get install -f
 ```
 
@@ -74,8 +80,6 @@ sudo apt-get install -f
 ```sh
 sudo apt-get remove powershell
 ```
-
-[Ubuntu 14.04]: http://releases.ubuntu.com/14.04/
 
 ## Ubuntu 16.04
 
@@ -91,7 +95,7 @@ curl https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
 # Register the Microsoft Ubuntu repository
 curl https://packages.microsoft.com/config/ubuntu/16.04/prod.list | sudo tee /etc/apt/sources.list.d/microsoft.list
 
-# Update apt-get
+# Update the list of products
 sudo apt-get update
 
 # Install PowerShell
@@ -106,14 +110,14 @@ from then on, you just need to use `sudo apt-get upgrade powershell` to update i
 
 ### Installation via Direct Download - Ubuntu 16.04
 
-Using [Ubuntu 16.04][], download the Debian package
-`powershell_6.0.0-beta.7-1ubuntu1.16.04.1_amd64.deb`
+Download the Debian package
+`powershell_6.0.0-beta.8-1.ubuntu.16.04_amd64.deb`
 from the [releases][] page onto the Ubuntu machine.
 
 Then execute the following in the terminal:
 
 ```sh
-sudo dpkg -i powershell_6.0.0-beta.7-1ubuntu1.16.04.1_amd64.deb
+sudo dpkg -i powershell_6.0.0-beta.8-1.ubuntu.16.04_amd64.deb
 sudo apt-get install -f
 ```
 
@@ -127,7 +131,55 @@ sudo apt-get install -f
 sudo apt-get remove powershell
 ```
 
-[Ubuntu 16.04]: http://releases.ubuntu.com/16.04/
+## Ubuntu 17.04
+
+### Installation via Package Repository - Ubuntu 17.04
+
+PowerShell Core, for Linux, is published to package repositories for easy installation (and updates).
+This is the preferred method.
+
+```sh
+# Import the public repository GPG keys
+curl https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
+
+# Register the Microsoft Ubuntu repository
+curl https://packages.microsoft.com/config/ubuntu/17.04/prod.list | sudo tee /etc/apt/sources.list.d/microsoft.list
+
+# Update the list of products
+sudo apt-get update
+
+# Install PowerShell
+sudo apt-get install -y powershell
+
+# Start PowerShell
+powershell
+```
+
+After registering the Microsoft repository once as superuser,
+from then on, you just need to use `sudo apt-get upgrade powershell` to update it.
+
+### Installation via Direct Download - Ubuntu 17.04
+
+Download the Debian package
+`powershell_6.0.0-beta.8-1.ubuntu.17.04_amd64.deb`
+from the [releases][] page onto the Ubuntu machine.
+
+Then execute the following in the terminal:
+
+```sh
+sudo dpkg -i powershell_6.0.0-beta.8-1.ubuntu.17.04_amd64.deb
+sudo apt-get install -f
+```
+
+> Please note that `dpkg -i` will fail with unmet dependencies;
+> the next command, `apt-get install -f` resolves these
+> and then finishes configuring the PowerShell package.
+
+### Uninstallation - Ubuntu 17.04
+
+```sh
+sudo apt-get remove powershell
+```
 
 ## Debian 8
 
@@ -135,16 +187,19 @@ sudo apt-get remove powershell
 
 PowerShell Core, for Linux, is published to package repositories for easy installation (and updates).
 This is the preferred method.
-Note that these instructions are the same as for Ubuntu 14.04 as we have validated the same package works on Debian 8.
 
 ```sh
+# Install system components
+sudo apt-get update
+sudo apt-get install curl apt-transport-https
+
 # Import the public repository GPG keys
 curl https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
 
-# Register the Microsoft repository
-curl https://packages.microsoft.com/config/ubuntu/14.04/prod.list | sudo tee /etc/apt/sources.list.d/microsoft.list
+# Register the Microsoft Product feed
+sudo sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-debian-jessie-prod jessie main" > /etc/apt/sources.list.d/microsoft.list'
 
-# Update apt-get
+# Update the list of products
 sudo apt-get update
 
 # Install PowerShell
@@ -160,13 +215,13 @@ from then on, you just need to use `sudo apt-get upgrade powershell` to update i
 ### Installation via Direct Download - Debian 8
 
 Download the Debian package
-`powershell_6.0.0-beta.7-1ubuntu1.14.04.1_amd64.deb`
+`powershell_6.0.0-beta.8-1.debian.8_amd64.deb`
 from the [releases][] page onto the Debian machine.
 
 Then execute the following in the terminal:
 
 ```sh
-sudo dpkg -i powershell_6.0.0-beta.7-1ubuntu1.14.04.1_amd64.deb
+sudo dpkg -i powershell_6.0.0-beta.8-1.debian.8_amd64.deb
 sudo apt-get install -f
 ```
 
@@ -175,6 +230,60 @@ sudo apt-get install -f
 > and then finishes configuring the PowerShell package.
 
 ### Uninstallation - Debian 8
+
+```sh
+sudo apt-get remove powershell
+```
+
+## Debian 9
+
+### Installation via Package Repository - Debian 9
+
+PowerShell Core, for Linux, is published to package repositories for easy installation (and updates).
+This is the preferred method.
+
+```sh
+# Install system components
+sudo apt-get update
+sudo apt-get install curl gnupg apt-transport-https
+
+# Import the public repository GPG keys
+curl https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
+
+# Register the Microsoft Product feed
+sudo sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-debian-stretch-prod stretch main" > /etc/apt/sources.list.d/microsoft.list'
+
+# Update the list of products
+sudo apt-get update
+
+# Install PowerShell
+sudo apt-get install -y powershell
+
+# Start PowerShell
+powershell
+```
+
+After registering the Microsoft repository once as superuser,
+from then on, you just need to use `sudo apt-get upgrade powershell` to update it.
+
+### Installation via Direct Download - Debian 9
+
+Download the Debian package
+`powershell_6.0.0-beta.8-1.debian.9_amd64.deb`
+from the [releases][] page onto the Debian machine.
+
+Then execute the following in the terminal:
+
+```sh
+sudo dpkg -i powershell_6.0.0-beta.8-1.debian.9_amd64.deb
+sudo apt-get install -f
+```
+
+> Please note that `dpkg -i` will fail with unmet dependencies;
+> the next command, `apt-get install -f` resolves these
+> and then finishes configuring the PowerShell package.
+
+### Uninstallation - Debian 9
 
 ```sh
 sudo apt-get remove powershell
@@ -205,19 +314,19 @@ you just need to use `sudo yum update powershell` to update PowerShell.
 ### Installation via Direct Download - CentOS 7
 
 Using [CentOS 7][], download the RPM package
-`powershell-6.0.0_beta.7-1.el7.x86_64.rpm`
+`powershell-6.0.0_beta.8-1.rhel.7.x86_64.rpm`
 from the [releases][] page onto the CentOS machine.
 
 Then execute the following in the terminal:
 
 ```sh
-sudo yum install ./powershell-6.0.0_beta.7-1.el7.x86_64.rpm
+sudo yum install powershell-6.0.0_beta.8-1.rhel.7.x86_64.rpm
 ```
 
 You can also install the RPM without the intermediate step of downloading it:
 
 ```sh
-sudo yum install https://github.com/PowerShell/PowerShell/releases/download/v6.0.0-beta.7/powershell-6.0.0_beta.7-1.el7.x86_64.rpm
+sudo yum install https://github.com/PowerShell/PowerShell/releases/download/v6.0.0-beta.8/powershell-6.0.0_beta.8-1.rhel.7.x86_64.rpm
 ```
 
 ### Uninstallation - CentOS 7
@@ -251,19 +360,19 @@ you just need to use `sudo yum update powershell` to update PowerShell.
 ### Installation via Direct Download - Red Hat Enterprise Linux (RHEL) 7
 
 Download the RPM package
-`powershell-6.0.0_beta.7-1.el7.x86_64.rpm`
+`powershell-6.0.0_beta.8-1.rhel.7.x86_64.rpm`
 from the [releases][] page onto the Red Hat Enterprise Linux machine.
 
 Then execute the following in the terminal:
 
 ```sh
-sudo yum install ./powershell-6.0.0_beta.7-1.el7.x86_64.rpm
+sudo yum install powershell-6.0.0_beta.8-1.rhel.7.x86_64.rpm
 ```
 
 You can also install the RPM without the intermediate step of downloading it:
 
 ```sh
-sudo yum install https://github.com/PowerShell/PowerShell/releases/download/v6.0.0-beta.7/powershell-6.0.0_beta.7-1.el7.x86_64.rpm
+sudo yum install https://github.com/PowerShell/PowerShell/releases/download/v6.0.0-beta.8/powershell-6.0.0_beta.8-1.rhel.7.x86_64.rpm
 ```
 
 ### Uninstallation - Red Hat Enterprise Linux (RHEL) 7
@@ -272,37 +381,157 @@ sudo yum install https://github.com/PowerShell/PowerShell/releases/download/v6.0
 sudo yum remove powershell
 ```
 
-## OpenSUSE 42.1
+## OpenSUSE 42.2
 
-Installation instruction for OpenSUSE 42.1.
+> **Note:** When installing PowerShell Core, OpenSUSE may report that nothing provides libcurl.
+libcurl should already be installed on supported versions of OpenSUSE.
+Run zypper search libcurl to confirm.
+The error will present 2 'solutions'. Choose 'Solution 2' to continue installing PowerShell Core.
 
-### Installation via Direct Download - OpenSUSE 42.1
+### Installation via Package Repository (preferred) - OpenSUSE 42.2
 
-Using [OpenSUSE 42.1][], download the RPM package
-`powershell-6.0.0_beta.6-1.suse.42.1.x86_64.rpm`
+PowerShell Core for Linux is published to official Microsoft repositories for easy installation (and updates).
+
+```sh
+# Register the Microsoft signature key
+sudo rpm --import https://packages.microsoft.com/keys/microsoft.asc
+
+# Add the Microsoft Product feed
+curl https://packages.microsoft.com/config/rhel/7/prod.repo | sudo tee /etc/zypp/repos.d/microsoft.repo
+
+# Update the list of products
+sudo zypper update
+
+# Install PowerShell
+sudo zypper install powershell
+
+# Start PowerShell
+powershell
+```
+
+### Installation via Direct Download - OpenSUSE 42.2
+
+Download the RPM package `powershell-6.0.0_beta.8-1.rhel.7.x86_64.rpm`
 from the [releases][] page onto the OpenSUSE machine.
-
-Then execute the following in the terminal:
 
 ```sh
 sudo rpm --import https://packages.microsoft.com/keys/microsoft.asc
-sudo zypper install ./powershell-6.0.0_beta.6-1.suse.42.1.x86_64.rpm
+sudo zypper install powershell-6.0.0_beta.8-1.rhel.7.x86_64.rpm
 ```
 
 You can also install the RPM without the intermediate step of downloading it:
 
 ```sh
 sudo rpm --import https://packages.microsoft.com/keys/microsoft.asc
-sudo zypper install https://github.com/PowerShell/PowerShell/releases/download/v6.0.0-beta.6/powershell-6.0.0_beta.6-1.suse.42.1.x86_64.rpm
+sudo zypper install https://github.com/PowerShell/PowerShell/releases/download/v6.0.0-beta.8/powershell-6.0.0_beta.8-1.rhel.7.x86_64.rpm
 ```
 
-### Uninstallation - OpenSUSE 42.1
+### Uninstallation - OpenSUSE 42.2
 
 ```sh
 sudo zypper remove powershell
 ```
 
-[OpenSUSE 42.1]: https://software.opensuse.org/421/en
+## Fedora 25
+
+### Installation via Package Repository (preferred) - Fedora 25
+
+PowerShell Core for Linux is published to official Microsoft repositories for easy installation (and updates).
+
+```sh
+# Register the Microsoft signature key
+sudo rpm --import https://packages.microsoft.com/keys/microsoft.asc
+
+# Register the Microsoft RedHat repository
+curl https://packages.microsoft.com/config/rhel/7/prod.repo | sudo tee /etc/yum.repos.d/microsoft.repo
+
+# Update the list of products
+sudo dnf update
+
+# Install PowerShell
+sudo dnf install -y powershell
+
+# Start PowerShell
+powershell
+```
+
+### Installation via Direct Download - Fedora 25
+
+Download the RPM package
+`powershell-6.0.0_beta.8-1.rhel.7.x86_64.rpm`
+from the [releases][] page onto the Red Hat Enterprise Linux machine.
+
+Then execute the following in the terminal:
+
+```sh
+sudo dnf install powershell-6.0.0_beta.8-1.rhel.7.x86_64.rpm
+```
+
+You can also install the RPM without the intermediate step of downloading it:
+
+```sh
+sudo dnf install https://github.com/PowerShell/PowerShell/releases/download/v6.0.0-beta.8/powershell-6.0.0_beta.8-1.rhel.7.x86_64.rpm
+```
+
+### Uninstallation - Fedora 25
+
+```sh
+sudo dnf remove powershell
+```
+
+## Fedora 26
+
+### Installation via Package Repository (preferred) - Fedora 26
+
+PowerShell Core for Linux is published to official Microsoft repositories for easy installation (and updates).
+
+```sh
+# Register the Microsoft signature key
+sudo rpm --import https://packages.microsoft.com/keys/microsoft.asc
+
+# Register the Microsoft RedHat repository
+curl https://packages.microsoft.com/config/rhel/7/prod.repo | sudo tee /etc/yum.repos.d/microsoft.repo
+
+# Update the list of products
+sudo dnf update
+
+# Install a system component
+sudo dnf install compat-openssl10
+
+# Install PowerShell
+sudo dnf install -y powershell
+
+# Start PowerShell
+powershell
+```
+
+### Installation via Direct Download - Fedora 26
+
+Download the RPM package
+`powershell-6.0.0_beta.8-1.rhel.7.x86_64.rpm`
+from the [releases][] page onto the Red Hat Enterprise Linux machine.
+
+Then execute the following in the terminal:
+
+```sh
+sudo dnf update
+sudo dnf install compat-openssl10
+sudo dnf install powershell-6.0.0_beta.8-1.rhel.7.x86_64.rpm
+```
+
+You can also install the RPM without the intermediate step of downloading it:
+
+```sh
+sudo dnf update
+sudo dnf install compat-openssl10
+sudo dnf install https://github.com/PowerShell/PowerShell/releases/download/v6.0.0-beta.8/powershell-6.0.0_beta.8-1.rhel.7.x86_64.rpm
+```
+
+### Uninstallation - Fedora 26
+
+```sh
+sudo dnf remove powershell
+```
 
 ## Arch Linux
 
@@ -319,14 +548,14 @@ For more information on installing packages from the AUR, see the [Arch Linux wi
 ## Linux AppImage
 
 Using a recent Linux distribution,
-download the AppImage `PowerShell-6.0.0-beta.7-x86_64.AppImage`
+download the AppImage `PowerShell-6.0.0-beta.8-x86_64.AppImage`
 from the [releases][] page onto the Linux machine.
 
 Then execute the following in the terminal:
 
 ```bash
-chmod a+x PowerShell-6.0.0-beta.7-x86_64.AppImage
-./PowerShell-6.0.0-beta.7-x86_64.AppImage
+chmod a+x PowerShell-6.0.0-beta.8-x86_64.AppImage
+./PowerShell-6.0.0-beta.8-x86_64.AppImage
 ```
 
 The [AppImage][] lets you run PowerShell without installing it.
@@ -374,14 +603,14 @@ brew cask reinstall powershell
 ### Installation via Direct Download - macOS 10.12
 
 Using macOS 10.12, download the PKG package
-`powershell-6.0.0-beta.7-osx.10.12-x64.pkg`
+`powershell-6.0.0-beta.8-osx.10.12-x64.pkg`
 from the [releases][] page onto the macOS machine.
 
 Either double-click the file and follow the prompts,
 or install it from the terminal:
 
 ```sh
-sudo installer -pkg powershell-6.0.0-beta.7-osx.10.12-x64.pkg -target /
+sudo installer -pkg powershell-6.0.0-beta.8-osx.10.12-x64.pkg -target /
 ```
 
 ### Uninstallation - macOS 10.12
@@ -461,7 +690,7 @@ wget http://security.debian.org/debian-security/pool/updates/main/o/openssl/libs
 dpkg -i libssl1.0.0_1.0.1t-1+deb8u6_amd64.deb
 
 # Install PowerShell
-dpkg -i powershell_6.0.0-beta.7-1ubuntu1.16.04.1_amd64.deb
+dpkg -i powershell_6.0.0-beta.8-1.ubuntu.16.04_amd64.deb
 
 # Start PowerShell
 powershell
@@ -471,24 +700,24 @@ powershell
 
 ```sh
 # Grab the latest App Image
-wget https://github.com/PowerShell/PowerShell/releases/download/v6.0.0-beta.7/PowerShell-6.0.0-beta.7-x86_64.AppImage
+wget https://github.com/PowerShell/PowerShell/releases/download/v6.0.0-beta.8/PowerShell-6.0.0-beta.8-x86_64.AppImage
 
 # Make executable
-chmod a+x PowerShell-6.0.0-beta.7-x86_64.AppImage
+chmod a+x PowerShell-6.0.0-beta.8-x86_64.AppImage
 
 # Start PowerShell
-./PowerShell-6.0.0-beta.7-x86_64.AppImage
+./PowerShell-6.0.0-beta.8-x86_64.AppImage
 ```
 
 ### Uninstallation - Kali
 
 ```sh
-dpkg -r powershell_6.0.0-beta.7-1ubuntu1.16.04.1_amd64
+dpkg -r powershell_6.0.0-beta.8-1.ubuntu.16.04_amd64.deb
 ```
 
 ## Paths
 
-* `$PSHOME` is `/opt/microsoft/powershell/6.0.0-beta.7/`
+* `$PSHOME` is `/opt/microsoft/powershell/6.0.0-beta.8/`
 * User profiles will be read from `~/.config/powershell/profile.ps1`
 * Default profiles will be read from `$PSHOME/profile.ps1`
 * User modules will be read from `~/.local/share/powershell/Modules`
@@ -503,7 +732,7 @@ On Linux and macOS, the [XDG Base Directory Specification][xdg-bds] is respected
 
 Note that because macOS is a derivation of BSD,
 instead of `/opt`, the prefix used is `/usr/local`.
-Thus, `$PSHOME` is `/usr/local/microsoft/powershell/6.0.0-beta.7/`,
+Thus, `$PSHOME` is `/usr/local/microsoft/powershell/6.0.0-beta.8/`,
 and the symlink is placed at `/usr/local/bin/powershell`.
 
 [releases]: https://github.com/PowerShell/PowerShell/releases/latest

--- a/tools/download.sh
+++ b/tools/download.sh
@@ -13,7 +13,7 @@ get_url() {
 }
 
 fork="PowerShell"
-release=v6.0.0-beta.7
+release=v6.0.0-beta.8
 # Get OS specific asset ID and package name
 case "$OSTYPE" in
     linux*)
@@ -26,7 +26,7 @@ case "$OSTYPE" in
                     sudo yum install -y curl
                 fi
 
-                package=powershell-6.0.0_beta.7-1.el7.x86_64.rpm
+                powershell-6.0.0_beta.8-1.rhel.7.x86_64.rpm
                 ;;
             ubuntu)
                 if ! hash curl 2>/dev/null; then
@@ -36,10 +36,10 @@ case "$OSTYPE" in
 
                 case "$VERSION_ID" in
                     14.04)
-                        package=powershell_6.0.0-beta.7-1ubuntu1.14.04.1_amd64.deb
+                        package=powershell_6.0.0-beta.8-1.ubuntu.14.04_amd64.deb
                         ;;
                     16.04)
-                        package=powershell_6.0.0-beta.7-1ubuntu1.16.04.1_amd64.deb
+                        package=powershell_6.0.0-beta.8-1.ubuntu.16.04_amd64.deb
                         ;;
                     *)
                         echo "Ubuntu $VERSION_ID is not supported!" >&2
@@ -70,7 +70,7 @@ case "$OSTYPE" in
         ;;
     darwin*)
         # We don't check for curl as macOS should have a system version
-        package=powershell-6.0.0-beta.7-osx.10.12-x64.pkg
+        package=powershell-6.0.0-beta.8-osx.10.12-x64.pkg
         ;;
     *)
         echo "$OSTYPE is not supported!" >&2


### PR DESCRIPTION
A manual step is required for install powershell on openSUSE (same as `dotnet-sdk-2.0.0`), so the current script that automatically set up powershell on OpenSUSE doesn't work. Filed #5023 to track this.
Two scripts are affected:
- tools/download.sh
   It will continue to install the beta.6 powershell openSUSE package.
- tools/installpsh-suse.sh
   It's already broken since beta.7, because we stopped publishing suse.42.1 package in beta.7 due its end of lifecycle.