### PR TITLE
Make SemanticVersion compatible with SemVer 2.0

### DIFF
--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/DotNetTypes_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/DotNetTypes_format_ps1xml.cs
@@ -44,6 +44,14 @@ namespace System.Management.Automation.Runspaces
                 ViewsOf_System_Version());
 
             yield return new ExtendedTypeDefinition(
+                "System.Version#IncludeLabel",
+                ViewsOf_System_Version_With_Label());
+
+            yield return new ExtendedTypeDefinition(
+                "System.Management.Automation.SemanticVersion",
+                ViewsOf_Semantic_Version_With_Label());
+
+            yield return new ExtendedTypeDefinition(
                 "System.Drawing.Printing.PrintDocument",
                 ViewsOf_System_Drawing_Printing_PrintDocument());
 
@@ -474,6 +482,46 @@ namespace System.Management.Automation.Runspaces
                         .AddPropertyColumn("Minor")
                         .AddPropertyColumn("Build")
                         .AddPropertyColumn("Revision")
+                    .EndRowDefinition()
+                .EndTable());
+        }
+
+        private static IEnumerable<FormatViewDefinition> ViewsOf_System_Version_With_Label()
+        {
+            yield return new FormatViewDefinition("System.Version",
+                TableControl.Create()
+                    .AddHeader(width: 6)
+                    .AddHeader(width: 6)
+                    .AddHeader(width: 6)
+                    .AddHeader(width: 8)
+                    .AddHeader(width: 26)
+                    .AddHeader(width: 27)
+                    .StartRowDefinition()
+                        .AddPropertyColumn("Major")
+                        .AddPropertyColumn("Minor")
+                        .AddPropertyColumn("Build")
+                        .AddPropertyColumn("Revision")
+                        .AddPropertyColumn("PSSemanticVersionPreLabel")
+                        .AddPropertyColumn("PSSemanticVersionBuildLabel")
+                    .EndRowDefinition()
+                .EndTable());
+        }
+
+        private static IEnumerable<FormatViewDefinition> ViewsOf_Semantic_Version_With_Label()
+        {
+            yield return new FormatViewDefinition("System.Management.Automation.SemanticVersion",
+                TableControl.Create()
+                    .AddHeader(width: 6)
+                    .AddHeader(width: 6)
+                    .AddHeader(width: 6)
+                    .AddHeader(width: 9)
+                    .AddHeader(width: 11)
+                    .StartRowDefinition()
+                        .AddPropertyColumn("Major")
+                        .AddPropertyColumn("Minor")
+                        .AddPropertyColumn("Patch")
+                        .AddPropertyColumn("PreLabel")
+                        .AddPropertyColumn("BuildLabel")
                     .EndRowDefinition()
                 .EndTable());
         }

--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/DotNetTypes_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/DotNetTypes_format_ps1xml.cs
@@ -501,8 +501,8 @@ namespace System.Management.Automation.Runspaces
                         .AddPropertyColumn("Minor")
                         .AddPropertyColumn("Build")
                         .AddPropertyColumn("Revision")
-                        .AddPropertyColumn("PSSemanticVersionPreLabel")
-                        .AddPropertyColumn("PSSemanticVersionBuildLabel")
+                        .AddPropertyColumn("PSSemVerPreReleaseLabel")
+                        .AddPropertyColumn("PSSemVerBuildLabel")
                     .EndRowDefinition()
                 .EndTable());
         }
@@ -520,7 +520,7 @@ namespace System.Management.Automation.Runspaces
                         .AddPropertyColumn("Major")
                         .AddPropertyColumn("Minor")
                         .AddPropertyColumn("Patch")
-                        .AddPropertyColumn("PreLabel")
+                        .AddPropertyColumn("PreReleaseLabel")
                         .AddPropertyColumn("BuildLabel")
                     .EndRowDefinition()
                 .EndTable());

--- a/src/System.Management.Automation/engine/PSVersionInfo.cs
+++ b/src/System.Management.Automation/engine/PSVersionInfo.cs
@@ -780,8 +780,20 @@ namespace System.Management.Automation
         /// </summary>
         public static int Compare(SemanticVersion versionA, SemanticVersion versionB)
         {
-            if (versionA == null) return -1;
-            return versionA.CompareTo(versionB);
+            if (versionA != null) {
+                if (versionB != null)
+                {
+                    return versionA.CompareTo(versionB);
+                }
+                return 1;
+            }
+
+            if (versionB != null)
+            {
+                return -1;
+            }
+
+            return 0;
         }
 
         /// <summary>
@@ -849,7 +861,7 @@ namespace System.Management.Automation
         /// </summary>
         public override int GetHashCode()
         {
-            return versionString.GetHashCode();
+            return this.ToString().GetHashCode();
         }
 
         /// <summary>
@@ -907,7 +919,15 @@ namespace System.Management.Automation
 
         private static int ComparePreLabel(string preLabel1, string preLabel2)
         {
-            // Symver 2.0 standard p.9 - Pre-release versions have a lower precedence than the associated normal version.
+            // Symver 2.0 standard p.9
+            // Pre-release versions have a lower precedence than the associated normal version.
+            // Comparing each dot separated identifier from left to right
+            // until a difference is found as follows:
+            //     identifiers consisting of only digits are compared numerically
+            //     and identifiers with letters or hyphens are compared lexically in ASCII sort order.
+            // Numeric identifiers always have lower precedence than non-numeric identifiers.
+            // A larger set of pre-release fields has a higher precedence than a smaller set,
+            // if all of the preceding identifiers are equal.
             if (String.IsNullOrEmpty(preLabel1)) { return String.IsNullOrEmpty(preLabel2) ? 0 : 1; }
             if (String.IsNullOrEmpty(preLabel2)) { return -1; }
 

--- a/src/System.Management.Automation/engine/PSVersionInfo.cs
+++ b/src/System.Management.Automation/engine/PSVersionInfo.cs
@@ -389,8 +389,8 @@ namespace System.Management.Automation
         private const string VersionSansRegEx = @"^(?<major>\d+)(\.(?<minor>\d+))?(\.(?<patch>\d+))?$";
         private const string LabelRegEx = @"^((?<preLabel>[0-9A-Za-z][0-9A-Za-z\-\.]*))?(\+(?<buildLabel>[0-9A-Za-z][0-9A-Za-z\-\.]*))?$";
         private const string LabelUnitRegEx = @"^[0-9A-Za-z][0-9A-Za-z\-\.]*$";
-        private const string PreLabelPropertyName = "PSSemanticVersionPreLabel";
-        private const string BuildLabelPropertyName = "PSSemanticVersionBuildLabel";
+        private const string PreLabelPropertyName = "PSSemVerPreReleaseLabel";
+        private const string BuildLabelPropertyName = "PSSemVerBuildLabel";
         private const string TypeNameForVersionWithLabel = "System.Version#IncludeLabel";
         private string versionString;
 
@@ -417,20 +417,20 @@ namespace System.Management.Automation
         /// <param name="major">The major version</param>
         /// <param name="minor">The minor version</param>
         /// <param name="patch">The patch version</param>
-        /// <param name="preLabel">The preLabel for the version</param>
-        /// <param name="buildLabel">The buildLabel for the version</param>
+        /// <param name="preReleaseLabel">The pre-release label for the version</param>
+        /// <param name="buildLabel">The build metadata for the version</param>
         /// <exception cref="FormatException">
-        /// If <paramref name="preLabel"/> don't match 'LabelUnitRegEx'.
+        /// If <paramref name="preReleaseLabel"/> don't match 'LabelUnitRegEx'.
         /// If <paramref name="buildLabel"/> don't match 'LabelUnitRegEx'.
         /// </exception>
-        public SemanticVersion(int major, int minor, int patch, string preLabel, string buildLabel)
+        public SemanticVersion(int major, int minor, int patch, string preReleaseLabel, string buildLabel)
             : this(major, minor, patch)
         {
-            if (!string.IsNullOrEmpty(preLabel))
+            if (!string.IsNullOrEmpty(preReleaseLabel))
             {
-                if (!Regex.IsMatch(preLabel, LabelUnitRegEx)) throw new FormatException(nameof(preLabel));
+                if (!Regex.IsMatch(preReleaseLabel, LabelUnitRegEx)) throw new FormatException(nameof(preReleaseLabel));
 
-                PreReleaseLabel = preLabel;
+                PreReleaseLabel = preReleaseLabel;
             }
 
             if (!string.IsNullOrEmpty(buildLabel))
@@ -665,7 +665,7 @@ namespace System.Management.Automation
 
             if (dashIndex > plusIndex)
             {
-                // 'preLabel' can contains dashes.
+                // 'PreReleaseLabel' can contains dashes.
                 if (plusIndex == -1)
                 {
                     // No buildLabel: buildLabel == null
@@ -675,7 +675,7 @@ namespace System.Management.Automation
                 }
                 else
                 {
-                    // No preLabel: preLabel == null
+                    // No PreReleaseLabel: preLabel == null
                     // Format is 'major.minor.patch+BuildLabel'
                     buildLabel = version.Substring(plusIndex+1);
                     versionSansLabel = version.Substring(0, plusIndex);
@@ -705,7 +705,7 @@ namespace System.Management.Automation
                 (plusIndex != - 1 && String.IsNullOrEmpty(buildLabel)) ||
                 String.IsNullOrEmpty(versionSansLabel))
             {
-                // We have dash and no preLabel or
+                // We have dash and no preReleaseLabel  or
                 // we have plus and no buildLabel or
                 // we have no main version part (versionSansLabel==null)
                 result.SetFailure(ParseFailureKind.FormatException);
@@ -780,12 +780,9 @@ namespace System.Management.Automation
         /// </summary>
         public static int Compare(SemanticVersion versionA, SemanticVersion versionB)
         {
-            if (versionA != null) {
-                if (versionB != null)
-                {
-                    return versionA.CompareTo(versionB);
-                }
-                return 1;
+            if (versionA != null)
+            {
+                return versionA.CompareTo(versionB);
             }
 
             if (versionB != null)

--- a/src/System.Management.Automation/engine/PSVersionInfo.cs
+++ b/src/System.Management.Automation/engine/PSVersionInfo.cs
@@ -386,9 +386,9 @@ namespace System.Management.Automation
     /// </summary>
     public sealed class SemanticVersion : IComparable, IComparable<SemanticVersion>, IEquatable<SemanticVersion>
     {
-        private const string s_VersionSansRegEx = @"^(?<major>\d+)(\.(?<minor>\d+))?(\.(?<patch>\d+))?$";
-        private const string s_LabelRegEx = @"^((?<preLabel>[0-9A-Za-z][0-9A-Za-z\-\.]*))?(\+(?<buildLabel>[0-9A-Za-z][0-9A-Za-z\-\.]*))?$";
-        private const string s_LabelUnitRegEx = @"^[0-9A-Za-z][0-9A-Za-z\-\.]*?$";
+        private const string VersionSansRegEx = @"^(?<major>\d+)(\.(?<minor>\d+))?(\.(?<patch>\d+))?$";
+        private const string LabelRegEx = @"^((?<preLabel>[0-9A-Za-z][0-9A-Za-z\-\.]*))?(\+(?<buildLabel>[0-9A-Za-z][0-9A-Za-z\-\.]*))?$";
+        private const string LabelUnitRegEx = @"^[0-9A-Za-z][0-9A-Za-z\-\.]*?$";
         private const string PreLabelPropertyName = "PSSemanticVersionPreLabel";
         private const string BuildLabelPropertyName = "PSSemanticVersionBuildLabel";
         private const string TypeNameForVersionWithLabel = "System.Version#IncludeLabel";
@@ -428,14 +428,14 @@ namespace System.Management.Automation
         {
             if (!string.IsNullOrEmpty(preLabel))
             {
-                if (!Regex.IsMatch(preLabel, s_LabelUnitRegEx)) throw new FormatException(nameof(preLabel));
+                if (!Regex.IsMatch(preLabel, LabelUnitRegEx)) throw new FormatException(nameof(preLabel));
 
                 PreLabel = preLabel;
             }
 
             if (!string.IsNullOrEmpty(buildLabel))
             {
-                if (!Regex.IsMatch(buildLabel, s_LabelUnitRegEx)) throw new FormatException(nameof(buildLabel));
+                if (!Regex.IsMatch(buildLabel, LabelUnitRegEx)) throw new FormatException(nameof(buildLabel));
 
                 BuildLabel = buildLabel;
             }
@@ -460,7 +460,7 @@ namespace System.Management.Automation
             // 2) 'label' starts with letter or digit.
             if (!string.IsNullOrEmpty(label))
             {
-                var match = Regex.Match(label, s_LabelRegEx);
+                var match = Regex.Match(label, LabelRegEx);
                 if (!match.Success) throw new FormatException(nameof(label));
 
                 PreLabel = match.Groups["preLabel"].Value;
@@ -713,7 +713,7 @@ namespace System.Management.Automation
                 return false;
             }
 
-            var match = Regex.Match(versionSansLabel, s_VersionSansRegEx);
+            var match = Regex.Match(versionSansLabel, VersionSansRegEx);
             if (!match.Success)
             {
                 result.SetFailure(ParseFailureKind.FormatException);
@@ -738,8 +738,8 @@ namespace System.Management.Automation
                 return false;
             }
 
-            if (preLabel != null && !Regex.IsMatch(preLabel, s_LabelUnitRegEx) ||
-               (buildLabel != null && !Regex.IsMatch(buildLabel, s_LabelUnitRegEx)))
+            if (preLabel != null && !Regex.IsMatch(preLabel, LabelUnitRegEx) ||
+               (buildLabel != null && !Regex.IsMatch(buildLabel, LabelUnitRegEx)))
             {
                 result.SetFailure(ParseFailureKind.FormatException);
                 return false;

--- a/src/System.Management.Automation/engine/PSVersionInfo.cs
+++ b/src/System.Management.Automation/engine/PSVersionInfo.cs
@@ -822,12 +822,6 @@ namespace System.Management.Automation
             if (Patch != value.Patch)
                 return Patch > value.Patch ? 1 : -1;
 
-            if (PreLabel == null)
-                return value.PreLabel == null ? 0 : 1;
-
-            if (value.PreLabel == null)
-                return -1;
-
             // SymVer 2.0 standard requires to ignore 'BuildLabel' (Build metadata).
             return ComparePreLabel(this.PreLabel, value.PreLabel);
         }
@@ -914,6 +908,7 @@ namespace System.Management.Automation
 
         private static int ComparePreLabel(string preLabel1, string preLabel2)
         {
+            // Symver 2.0 standard p.9 - Pre-release versions have a lower precedence than the associated normal version.
             if (String.IsNullOrEmpty(preLabel1)) { return String.IsNullOrEmpty(preLabel2) ? 0 : 1; }
             if (String.IsNullOrEmpty(preLabel2)) { return -1; }
 

--- a/src/System.Management.Automation/engine/Types_Ps1Xml.cs
+++ b/src/System.Management.Automation/engine/Types_Ps1Xml.cs
@@ -1982,6 +1982,22 @@ namespace System.Management.Automation.Runspaces
             var td251 = new TypeData(@"Deserialized.System.Management.Automation.DebuggerCommandResults", true);
             td251.TargetTypeForDeserialization = typeof(Microsoft.PowerShell.DeserializingTypeConverter);
             yield return td251;
+
+            var td252 = new TypeData(@"System.Version#IncludeLabel", true);
+            td252.Members.Add("ToString",
+                new ScriptMethodData(@"ToString", GetScriptBlock(@"
+          $suffix = """"
+          if (![String]::IsNullOrEmpty($this.PSSemanticVersionPreLabel))
+          {
+              $suffix = ""-""+$this.PSSemanticVersionPreLabel
+          }
+          if (![String]::IsNullOrEmpty($this.PSSemanticVersionBuildLabel))
+          {
+              $suffix += ""+""+$this.PSSemanticVersionBuildLabel
+          }
+          ""$($this.Major).$($this.Minor).$($this.Build)""+$suffix
+            ")));
+            yield return td252;
         }
     }
 }

--- a/src/System.Management.Automation/engine/Types_Ps1Xml.cs
+++ b/src/System.Management.Automation/engine/Types_Ps1Xml.cs
@@ -1987,13 +1987,13 @@ namespace System.Management.Automation.Runspaces
             td252.Members.Add("ToString",
                 new ScriptMethodData(@"ToString", GetScriptBlock(@"
           $suffix = """"
-          if (![String]::IsNullOrEmpty($this.PSSemanticVersionPreLabel))
+          if (![String]::IsNullOrEmpty($this.PSSemVerPreReleaseLabel))
           {
-              $suffix = ""-""+$this.PSSemanticVersionPreLabel
+              $suffix = ""-""+$this.PSSemVerPreReleaseLabel
           }
-          if (![String]::IsNullOrEmpty($this.PSSemanticVersionBuildLabel))
+          if (![String]::IsNullOrEmpty($this.PSSemVerBuildLabel))
           {
-              $suffix += ""+""+$this.PSSemanticVersionBuildLabel
+              $suffix += ""+""+$this.PSSemVerBuildLabel
           }
           ""$($this.Major).$($this.Minor).$($this.Build)""+$suffix
             ")));

--- a/test/powershell/engine/Basic/SemanticVersion.Tests.ps1
+++ b/test/powershell/engine/Basic/SemanticVersion.Tests.ps1
@@ -75,8 +75,8 @@ Describe "SemanticVersion api tests" -Tags 'CI' {
             $v2.Major | Should Be 3
             $v2.Minor | Should Be 2
             $v2.Build | Should Be 1
-            $v2.PSSemanticVersionPreLabel | Should Be "prerelease"
-            $v2.PSSemanticVersionBuildLabel | Should Be "meta"
+            $v2.PSSemVerPreReleaseLabel | Should Be "prerelease"
+            $v2.PSSemVerBuildLabel | Should Be "meta"
             $v2.ToString() | Should Be "3.2.1-prerelease+meta"
         }
 

--- a/test/powershell/engine/Basic/SemanticVersion.Tests.ps1
+++ b/test/powershell/engine/Basic/SemanticVersion.Tests.ps1
@@ -8,7 +8,7 @@ Describe "SemanticVersion api tests" -Tags 'CI' {
             $v.Major | Should Be 1
             $v.Minor | Should Be 2
             $v.Patch | Should Be 3
-            $v.PreLabel | Should Be "Alpha-super.3"
+            $v.PreReleaseLabel | Should Be "Alpha-super.3"
             $v.BuildLabel | Should Be "BLD.a1-xxx.03"
             $v.ToString() | Should Be "1.2.3-Alpha-super.3+BLD.a1-xxx.03"
 
@@ -16,7 +16,7 @@ Describe "SemanticVersion api tests" -Tags 'CI' {
             $v.Major | Should Be 1
             $v.Minor | Should Be 0
             $v.Patch | Should Be 0
-            $v.PreLabel | Should BeNullOrEmpty
+            $v.PreReleaseLabel | Should BeNullOrEmpty
             $v.BuildLabel | Should BeNullOrEmpty
             $v.ToString() | Should Be "1.0.0"
 
@@ -24,7 +24,7 @@ Describe "SemanticVersion api tests" -Tags 'CI' {
             $v.Major | Should Be 3
             $v.Minor | Should Be 0
             $v.Patch | Should Be 0
-            $v.PreLabel | Should BeNullOrEmpty
+            $v.PreReleaseLabel | Should BeNullOrEmpty
             $v.BuildLabel | Should BeNullOrEmpty
             $v.ToString() | Should Be "3.0.0"
 
@@ -32,7 +32,7 @@ Describe "SemanticVersion api tests" -Tags 'CI' {
             $v.Major | Should Be 2
             $v.Minor | Should Be 0
             $v.Patch | Should Be 0
-            $v.PreLabel | Should BeNullOrEmpty
+            $v.PreReleaseLabel | Should BeNullOrEmpty
             $v.BuildLabel | Should BeNullOrEmpty
             $v.ToString() | Should Be "2.0.0"
         }

--- a/test/powershell/engine/Basic/SemanticVersion.Tests.ps1
+++ b/test/powershell/engine/Basic/SemanticVersion.Tests.ps1
@@ -2,45 +2,55 @@ using namespace System.Management.Automation
 using namespace System.Management.Automation.Language
 
 Describe "SemanticVersion api tests" -Tags 'CI' {
-    Context "constructing valid versions" {
-        It "string argument constructor" {
-            $v = [SemanticVersion]::new("1.2.3-alpha")
+    Context "Constructing valid versions" {
+        It "String argument constructor" {
+            $v = [SemanticVersion]::new("1.2.3-Alpha-super.3+BLD.a1-xxx.03")
             $v.Major | Should Be 1
             $v.Minor | Should Be 2
             $v.Patch | Should Be 3
-            $v.Label | Should Be "alpha"
-            $v.ToString() | Should Be "1.2.3-alpha"
+            $v.PreLabel | Should Be "Alpha-super.3"
+            $v.BuildLabel | Should Be "BLD.a1-xxx.03"
+            $v.ToString() | Should Be "1.2.3-Alpha-super.3+BLD.a1-xxx.03"
 
             $v = [SemanticVersion]::new("1.0.0")
             $v.Major | Should Be 1
             $v.Minor | Should Be 0
             $v.Patch | Should Be 0
-            $v.Label | Should BeNullOrEmpty
+            $v.PreLabel | Should BeNullOrEmpty
+            $v.BuildLabel | Should BeNullOrEmpty
             $v.ToString() | Should Be "1.0.0"
 
             $v = [SemanticVersion]::new("3.0")
             $v.Major | Should Be 3
             $v.Minor | Should Be 0
             $v.Patch | Should Be 0
-            $v.Label | Should BeNullOrEmpty
+            $v.PreLabel | Should BeNullOrEmpty
+            $v.BuildLabel | Should BeNullOrEmpty
             $v.ToString() | Should Be "3.0.0"
 
             $v = [SemanticVersion]::new("2")
             $v.Major | Should Be 2
             $v.Minor | Should Be 0
             $v.Patch | Should Be 0
-            $v.Label | Should BeNullOrEmpty
+            $v.PreLabel | Should BeNullOrEmpty
+            $v.BuildLabel | Should BeNullOrEmpty
             $v.ToString() | Should Be "2.0.0"
         }
 
-	    # After the above test, we trust the properties and rely on ToString for validation
+        # After the above test, we trust the properties and rely on ToString for validation
 
-        It "int args constructor" {
+        It "Int args constructor" {
             $v = [SemanticVersion]::new(1, 0, 0)
             $v.ToString() | Should Be "1.0.0"
 
             $v = [SemanticVersion]::new(3, 2, 0, "beta.1")
             $v.ToString() | Should Be "3.2.0-beta.1"
+
+            $v = [SemanticVersion]::new(3, 2, 0, "beta.1+meta")
+            $v.ToString() | Should Be "3.2.0-beta.1+meta"
+
+            $v = [SemanticVersion]::new(3, 2, 0, "beta.1", "meta")
+            $v.ToString() | Should Be "3.2.0-beta.1+meta"
 
             $v = [SemanticVersion]::new(3, 1)
             $v.ToString() | Should Be "3.1.0"
@@ -49,7 +59,7 @@ Describe "SemanticVersion api tests" -Tags 'CI' {
             $v.ToString() | Should Be "3.0.0"
         }
 
-        It "version arg constructor" {
+        It "Version arg constructor" {
             $v = [SemanticVersion]::new([Version]::new(1, 2))
             $v.ToString() | Should Be '1.2.0'
 
@@ -57,37 +67,63 @@ Describe "SemanticVersion api tests" -Tags 'CI' {
             $v.ToString() | Should Be '1.2.3'
         }
 
-        It "semantic version can round trip through version" {
-            $v1 = [SemanticVersion]::new(3, 2, 1, "prerelease")
+        It "Can covert to 'Version' type" {
+            $v1 = [SemanticVersion]::new(3, 2, 1, "prerelease", "meta")
+            $v2 = [Version]$v1
+            $v2.GetType() | Should Be "Version"
+            $v2.PSobject.TypeNames[0] | Should Be "System.Version#IncludeLabel"
+            $v2.Major | Should Be 3
+            $v2.Minor | Should Be 2
+            $v2.Build | Should Be 1
+            $v2.PSSemanticVersionPreLabel | Should Be "prerelease"
+            $v2.PSSemanticVersionBuildLabel | Should Be "meta"
+            $v2.ToString() | Should Be "3.2.1-prerelease+meta"
+        }
+
+        It "Semantic version can round trip through version" {
+            $v1 = [SemanticVersion]::new(3, 2, 1, "prerelease", "meta")
             $v2 = [SemanticVersion]::new([Version]$v1)
-            $v2.ToString() | Should Be "3.2.1-prerelease"
+            $v2.ToString() | Should Be "3.2.1-prerelease+meta"
         }
     }
 
     Context "Comparisons" {
-        $v1_0_0 = [SemanticVersion]::new(1, 0, 0)
-        $v1_1_0 = [SemanticVersion]::new(1, 1, 0)
-        $v1_1_1 = [SemanticVersion]::new(1, 1, 1)
-        $v2_1_0 = [SemanticVersion]::new(2, 1, 0)
-        $v1_0_0_alpha = [SemanticVersion]::new(1, 0, 0, "alpha")
-        $v1_0_0_beta = [SemanticVersion]::new(1, 0, 0, "beta")
+        BeforeAll {
+            $v1_0_0 = [SemanticVersion]::new(1, 0, 0)
+            $v1_1_0 = [SemanticVersion]::new(1, 1, 0)
+            $v1_1_1 = [SemanticVersion]::new(1, 1, 1)
+            $v2_1_0 = [SemanticVersion]::new(2, 1, 0)
+            $v1_0_0_alpha = [SemanticVersion]::new(1, 0, 0, "alpha.1.1")
+            $v1_0_0_alpha2 = [SemanticVersion]::new(1, 0, 0, "alpha.1.2")
+            $v1_0_0_beta = [SemanticVersion]::new(1, 0, 0, "beta")
+            $v1_0_0_betaBuild = [SemanticVersion]::new(1, 0, 0, "beta", "BUILD")
 
-        $testCases = @(
-            @{ lhs = $v1_0_0; rhs = $v1_1_0 }
-            @{ lhs = $v1_0_0; rhs = $v1_1_1 }
-            @{ lhs = $v1_1_0; rhs = $v1_1_1 }
-            @{ lhs = $v1_0_0; rhs = $v2_1_0 }
-            @{ lhs = $v1_0_0_alpha; rhs = $v1_0_0_beta }
-            @{ lhs = $v1_0_0_alpha; rhs = $v1_0_0 }
-            @{ lhs = $v1_0_0_beta; rhs = $v1_0_0 }
-            @{ lhs = $v2_1_0; rhs = "3.0"}
-            @{ lhs = "1.5"; rhs = $v2_1_0}
-        )
+            $testCases = @(
+                @{ lhs = $v1_0_0; rhs = $v1_1_0 }
+                @{ lhs = $v1_0_0; rhs = $v1_1_1 }
+                @{ lhs = $v1_1_0; rhs = $v1_1_1 }
+                @{ lhs = $v1_0_0; rhs = $v2_1_0 }
+                @{ lhs = $v1_0_0_alpha; rhs = $v1_0_0_beta }
+                @{ lhs = $v1_0_0_alpha; rhs = $v1_0_0_alpha2 }
+                @{ lhs = $v1_0_0_alpha; rhs = $v1_0_0 }
+                @{ lhs = $v1_0_0_beta; rhs = $v1_0_0 }
+                @{ lhs = $v2_1_0; rhs = "3.0"}
+                @{ lhs = "1.5"; rhs = $v2_1_0}
+            )
+        }
+
+        It "Build meta should be ignored" {
+            $v1_0_0_beta -eq $v1_0_0_betaBuild | Should Be $true
+            $v1_0_0_betaBuild -lt $v1_0_0_beta | Should Be $false
+            $v1_0_0_beta -lt $v1_0_0_betaBuild | Should Be $false
+        }
+
         It "<lhs> less than <rhs>" -TestCases $testCases {
             param($lhs, $rhs)
             $lhs -lt $rhs | Should Be $true
             $rhs -lt $lhs | Should Be $false
         }
+
         It "<lhs> less than or equal <rhs>" -TestCases $testCases {
             param($lhs, $rhs)
             $lhs -le $rhs | Should Be $true
@@ -95,11 +131,13 @@ Describe "SemanticVersion api tests" -Tags 'CI' {
             $lhs -le $lhs | Should Be $true
             $rhs -le $rhs | Should Be $true
         }
+
         It "<lhs> greater than <rhs>" -TestCases $testCases {
             param($lhs, $rhs)
             $lhs -gt $rhs | Should Be $false
             $rhs -gt $lhs | Should Be $true
         }
+
         It "<lhs> greater than or equal <rhs>" -TestCases $testCases {
             param($lhs, $rhs)
             $lhs -ge $rhs | Should Be $false
@@ -108,11 +146,10 @@ Describe "SemanticVersion api tests" -Tags 'CI' {
             $rhs -ge $rhs | Should Be $true
         }
 
-        $testCases = @(
+        It "Equality <operand>" -TestCases @(
             @{ operand = $v1_0_0 }
             @{ operand = $v1_0_0_alpha }
-        )
-        It "Equality <operand>" -TestCases $testCases {
+        ) {
             param($operand)
             $operand -eq $operand | Should Be $true
             $operand -ne $operand | Should Be $false
@@ -134,84 +171,67 @@ Describe "SemanticVersion api tests" -Tags 'CI' {
         }
     }
 
-    Context "error handling" {
+    Context "Error handling" {
 
-        # The specific errors aren't too useful here, but noted in comments
-        # so when we pick up a version of Pester that will let us check FullyQualifiedErrorId,
-        # it's easier to tweak the tests
-
-        $testCases = @(
-            @{ expectedResult = $false; version = $null  }
-            @{ expectedResult = $false; version = [NullString]::Value }
-            @{ expectedResult = $false; version = "" }
-            @{ expectedResult = $false; version = "1.0.0-" }
-            @{ expectedResult = $false; version = "-" }
-            @{ expectedResult = $false; version = "." }
-            @{ expectedResult = $false; version = "-alpha" }
-	        @{ expectedResult = $false; version = "1..0" }
-	        @{ expectedResult = $false; version = "1.0.-alpha" }
-	        @{ expectedResult = $false; version = "1.0." }
-	        @{ expectedResult = $false; version = ".0.0" }
-        )
-
-        It "parts of version missing" -TestCases $testCases {
-            param($version, $expectedResult)
-            { [SemanticVersion]::new($version) } | Should Throw # PSArgumentException
-            { [SemanticVersion]::Parse($version) } | Should Throw # PSArgumentException
-            $semVer = $null
-            [SemanticVersion]::TryParse($_, [ref]$semVer) | Should Be $expectedResult
-            $semVer | Should Be $null
-        }
-
-        $testCases = @(
-            @{ expectedResult = $false; version = "-1.0.0"  }
-            @{ expectedResult = $false; version = "1.-1.0"  }
-            @{ expectedResult = $false; version = "1.0.-1"  }
-        )
-
-        It "range check of versions: <version>" -TestCases $testCases {
-            param($version, $expectedResult)
-            { [SemanticVersion]::new($version) } | Should Throw # PSArgumentException
-            { [SemanticVersion]::Parse($version) } | Should Throw # PSArgumentException
-            $semVer = $null
-            [SemanticVersion]::TryParse($_, [ref]$semVer) | Should Be $expectedResult
-            $semVer | Should Be $null
-        }
-
-        $testCases = @(
-            @{ expectedResult = $false; version = "aa.0.0"  }
-            @{ expectedResult = $false; version = "1.bb.0"  }
-            @{ expectedResult = $false; version = "1.0.cc"  }
-        )
-
-        It "format errors: <version>" -TestCases $testCases {
-            param($version, $expectedResult)
-            { [SemanticVersion]::new($version) } | Should Throw # PSArgumentException
-            { [SemanticVersion]::Parse($version) } | Should Throw # PSArgumentException
+        It "<name>: '<version>'" -TestCases @(
+            @{ name = "Missing parts: 'null'";       errorId = "PSArgumentNullException";expectedResult = $false; version = $null  }
+            @{ name = "Missing parts: 'NullString'"; errorId = "PSArgumentNullException";expectedResult = $false; version = [NullString]::Value }
+            @{ name = "Missing parts: 'EmptyString'";errorId = "FormatException";    expectedResult = $false; version = "" }
+            @{ name = "Missing parts";               errorId = "FormatException";    expectedResult = $false; version = "-" }
+            @{ name = "Missing parts";               errorId = "FormatException";    expectedResult = $false; version = "." }
+            @{ name = "Missing parts";               errorId = "FormatException";    expectedResult = $false; version = "+" }
+            @{ name = "Missing parts";               errorId = "FormatException";    expectedResult = $false; version = "-alpha" }
+            @{ name = "Missing parts";               errorId = "FormatException";    expectedResult = $false; version = "1..0" }
+            @{ name = "Missing parts";               errorId = "FormatException";    expectedResult = $false; version = "1.0.-alpha" }
+            @{ name = "Missing parts";               errorId = "FormatException";    expectedResult = $false; version = "1.0.+alpha" }
+            @{ name = "Missing parts";               errorId = "FormatException";    expectedResult = $false; version = "1.0.0-alpha+" }
+            @{ name = "Missing parts";               errorId = "FormatException";    expectedResult = $false; version = "1.0.0-+" }
+            @{ name = "Missing parts";               errorId = "FormatException";    expectedResult = $false; version = "1.0.0+-" }
+            @{ name = "Missing parts";               errorId = "FormatException";    expectedResult = $false; version = "1.0.0+" }
+            @{ name = "Missing parts";               errorId = "FormatException";    expectedResult = $false; version = "1.0.0-" }
+            @{ name = "Missing parts";               errorId = "FormatException";    expectedResult = $false; version = "1.0.0." }
+            @{ name = "Missing parts";               errorId = "FormatException";    expectedResult = $false; version = "1.0." }
+            @{ name = "Missing parts";               errorId = "FormatException";    expectedResult = $false; version = "1.0.." }
+            @{ name = "Missing parts";               errorId = "FormatException";    expectedResult = $false; version = ".0.0" }
+            @{ name = "Range check of versions";     errorId = "FormatException";    expectedResult = $false; version = "-1.0.0"  }
+            @{ name = "Range check of versions";     errorId = "FormatException";    expectedResult = $false; version = "1.-1.0"  }
+            @{ name = "Range check of versions";     errorId = "FormatException";    expectedResult = $false; version = "1.0.-1"  }
+            @{ name = "Format errors";               errorId = "FormatException";    expectedResult = $false; version = "aa.0.0"  }
+            @{ name = "Format errors";               errorId = "FormatException";    expectedResult = $false; version = "1.bb.0"  }
+            @{ name = "Format errors";               errorId = "FormatException";    expectedResult = $false; version = "1.0.cc"  }
+        ) {
+            param($version, $expectedResult, $errorId)
+            { [SemanticVersion]::new($version) } | ShouldBeErrorId $errorId
+            if ($version -eq $null) {
+                # PowerShell convert $null to Empty string
+                { [SemanticVersion]::Parse($version) } | ShouldBeErrorId "FormatException"
+            } else {
+                { [SemanticVersion]::Parse($version) } | ShouldBeErrorId $errorId
+            }
             $semVer = $null
             [SemanticVersion]::TryParse($_, [ref]$semVer) | Should Be $expectedResult
             $semVer | Should Be $null
         }
 
         It "Negative version arguments" {
-            { [SemanticVersion]::new(-1, 0) } | Should Throw # PSArgumentException
-            { [SemanticVersion]::new(1, -1) } | Should Throw # PSArgumentException
-            { [SemanticVersion]::new(1, 1, -1) } | Should Throw # PSArgumentException
+            { [SemanticVersion]::new(-1, 0) } | ShouldBeErrorId "PSArgumentException"
+            { [SemanticVersion]::new(1, -1) } | ShouldBeErrorId "PSArgumentException"
+            { [SemanticVersion]::new(1, 1, -1) } | ShouldBeErrorId "PSArgumentException"
         }
 
-        It "Incompatible version throws" {
+        It "Incompatible 'Version' throws" {
             # Revision isn't supported
-            { [SemanticVersion]::new([Version]::new(0, 0, 0, 4)) } | Should Throw # PSArgumentException
-            { [SemanticVersion]::new([Version]::new("1.2.3.4")) } | Should Throw # PSArgumentException
+            { [SemanticVersion]::new([Version]::new(0, 0, 0, 4)) } | ShouldBeErrorId "PSArgumentException"
+            { [SemanticVersion]::new([Version]::new("1.2.3.4")) } | ShouldBeErrorId "PSArgumentException"
         }
     }
 
     Context "Serialization" {
         $testCases = @(
-            @{ expectedResult = "1.0.0"; semver = [SemanticVersion]::new(1, 0, 0) }
-            @{ expectedResult = "1.0.1"; semver = [SemanticVersion]::new(1, 0, 1) }
-            @{ expectedResult = "1.0.0-alpha"; semver = [SemanticVersion]::new(1, 0, 0, "alpha") }
-            @{ expectedResult = "1.0.0-beta"; semver = [SemanticVersion]::new(1, 0, 0, "beta") }
+            @{ errorId = "PSArgumentException"; expectedResult = "1.0.0"; semver = [SemanticVersion]::new(1, 0, 0) }
+            @{ errorId = "PSArgumentException"; expectedResult = "1.0.1"; semver = [SemanticVersion]::new(1, 0, 1) }
+            @{ errorId = "PSArgumentException"; expectedResult = "1.0.0-alpha"; semver = [SemanticVersion]::new(1, 0, 0, "alpha") }
+            @{ errorId = "PSArgumentException"; expectedResult = "1.0.0-Alpha-super.3+BLD.a1-xxx.03"; semver = [SemanticVersion]::new(1, 0, 0, "Alpha-super.3+BLD.a1-xxx.03") }
         )
         It "Can round trip: <semver>" -TestCases $testCases {
             param($semver, $expectedResult)


### PR DESCRIPTION
Fix #5004 

### Fix description

Made compatible with SymVer 2.0 http://semver.org/ (p.10)
Fixed comparisons
Refactored tests 
Added new tests

### Additional information
Useful sample https://github.com/maxhauser/semver/blob/master/src/Semver/SemVersion.cs
Related #2983
