### PR TITLE
fix detection of whether `-LiteralPath` was used to suppress wildcardexpansion for navigation cmdlets

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/Navigation.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/Navigation.cs
@@ -3107,7 +3107,7 @@ namespace Microsoft.PowerShell.Commands
                     try
                     {
                         resolvedPSPaths = SessionState.Path.GetResolvedPSPathFromPSPath(path, currentContext);
-                        if (null != LiteralPath && 0 == resolvedPSPaths.Count)
+                        if (true == SuppressWildcardExpansion && 0 == resolvedPSPaths.Count)
                         {
                             ItemNotFoundException pathNotFound =
                                 new ItemNotFoundException(

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
@@ -1031,8 +1031,13 @@ Describe "Extended FileSystem Item/Content Cmdlet Provider Tests" -Tags "Feature
             $result | Should BeNullOrEmpty
         }
 
-        It "Verify no error if wildcard doesn't match" {
-            { Remove-Item "TestDrive:\*.foo" } | Should Not Throw
+        It "Verify no error if wildcard doesn't match: <path>" -TestCases @(
+            @{path="TestDrive:\*.foo"},
+            @{path="TestDrive:\[z]"},
+            @{path="TestDrive:\z.*"}
+        ) {
+            param($path)
+            { Remove-Item $path } | Should Not Throw
         }
     }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
@@ -370,9 +370,24 @@ Describe "Handling of globbing patterns" -Tags "CI" {
             Copy-Item -LiteralPath $file.FullName -Destination $newPath
             Test-Path -LiteralPath $newPath | Should Be $true
         }
+    }
 
-        It "Remove-Item -LiteralPath should fail if it contains asterisk" {
+    Context "Handle asterisks in name" {
+        It "Remove-Item -LiteralPath should fail if it contains asterisk and file doesn't exist" {
             { Remove-Item -LiteralPath ./foo*.txt -ErrorAction Stop } | ShouldBeErrorId "PathNotFound,Microsoft.PowerShell.Commands.RemoveItemCommand"
+        }
+
+        It "Remove-Item -LiteralPath should succeed for file with asterisk in name" {
+            $testPath = "$testdrive\foo*"
+            $testPath2 = "$testdrive\foo*2"
+            New-Item -Path $testPath -ItemType File
+            New-Item -Path $testPath2 -ItemType File
+            Test-Path -LiteralPath $testPath | Should Be $true
+            Test-Path -LiteralPath $testPath2 | Should Be $true
+            { Remove-Item -LiteralPath $testPath } | Should Not Throw
+            Test-Path -LiteralPath $testPath | Should Be $false
+            # make sure wildcard wasn't applied so this file should still exist
+            Test-Path -LiteralPath $testPath2 | Should Be $true
         }
     }
 }
@@ -989,7 +1004,7 @@ Describe "Extended FileSystem Item/Content Cmdlet Provider Tests" -Tags "Feature
 
         It "Verify Filter" {
             Remove-Item "TestDrive:\*" -Filter "*.txt"
-            $result = Get-Item "*.txt"
+            $result = Get-Item "TestDrive:\*.txt"
             $result | Should BeNullOrEmpty
         }
 
@@ -1008,6 +1023,16 @@ Describe "Extended FileSystem Item/Content Cmdlet Provider Tests" -Tags "Feature
             $file2 = Get-Item $testFile2 -ErrorAction SilentlyContinue
             $file1 | Should BeNullOrEmpty
             $file2.Name | Should Be $testFile2
+        }
+
+        It "Verify Path can accept wildcard" {
+            Remove-Item "TestDrive:\*.txt" -Recurse -Force
+            $result = Get-ChildItem "TestDrive:\*.txt"
+            $result | Should BeNullOrEmpty
+        }
+
+        It "Verify no error if wildcard doesn't match" {
+            { Remove-Item "TestDrive:\*.foo" } | Should Not Throw
         }
     }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
@@ -377,7 +377,7 @@ Describe "Handling of globbing patterns" -Tags "CI" {
             { Remove-Item -LiteralPath ./foo*.txt -ErrorAction Stop } | ShouldBeErrorId "PathNotFound,Microsoft.PowerShell.Commands.RemoveItemCommand"
         }
 
-        It "Remove-Item -LiteralPath should succeed for file with asterisk in name" {
+        It "Remove-Item -LiteralPath should succeed for file with asterisk in name" -Skip:($IsWindows) {
             $testPath = "$testdrive\foo*"
             $testPath2 = "$testdrive\foo*2"
             New-Item -Path $testPath -ItemType File


### PR DESCRIPTION
Fix https://github.com/PowerShell/PowerShell/issues/5031
<!--

If you are a PowerShell Team member, please make sure you choose the Reviewer(s) and Assignee for your PR.
If you are not from the PowerShell Team, you can leave the fields blank and the Maintainers will choose them for you. If you are familiar with the team, feel free to mention some Reviewers yourself.

For more information about the roles of Reviewer and Assignee, refer to [CONTRIBUTING.md](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md).

-->