### PR TITLE
Add -AsHashtable switch to ConvertFrom-Json for issue #3623

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/InvokeRestMethodCommand.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/InvokeRestMethodCommand.Common.cs
@@ -171,7 +171,7 @@ namespace Microsoft.PowerShell.Commands
             try
             {
                 ErrorRecord error;
-                obj = JsonObject.ConvertFromJson(json, false, out error);
+                obj = JsonObject.ConvertFromJson(json, out error);
 
                 if (error != null)
                 {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/InvokeRestMethodCommand.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/InvokeRestMethodCommand.Common.cs
@@ -171,7 +171,7 @@ namespace Microsoft.PowerShell.Commands
             try
             {
                 ErrorRecord error;
-                obj = JsonObject.ConvertFromJson(json, out error);
+                obj = JsonObject.ConvertFromJson(json, false, out error);
 
                 if (error != null)
                 {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -335,7 +335,7 @@ namespace Microsoft.PowerShell.Commands
                         {
                             if (Directory.Exists(providerPaths[0]))
                             {
-                                errorRecord = GetValidationError(WebCmdletStrings.DirecotryPathSpecified,
+                                errorRecord = GetValidationError(WebCmdletStrings.DirectoryPathSpecified,
                                                                  "WebCmdletInFileNotFilePathException", InFile);
                             }
                             _originalFilePath = InFile;

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/ConvertFromJsonCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/ConvertFromJsonCommand.cs
@@ -34,7 +34,6 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Returned data structure is a Hashtable instead a CustomPSObject.
         /// </summary>
-        [Parameter(Mandatory = false)]
         public SwitchParameter AsHashtable { get; set; }
 
         #endregion parameters

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/ConvertFromJsonCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/ConvertFromJsonCommand.cs
@@ -34,6 +34,7 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Returned data structure is a Hashtable instead a CustomPSObject.
         /// </summary>
+        [Parameter()]
         public SwitchParameter AsHashtable { get; set; }
 
         #endregion parameters

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/ConvertFromJsonCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/ConvertFromJsonCommand.cs
@@ -20,16 +20,22 @@ namespace Microsoft.PowerShell.Commands
         #region parameters
 
         /// <summary>
-        /// gets or sets the InputString property
+        /// Gets or sets the InputString property.
         /// </summary>
         [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true)]
         [AllowEmptyString]
         public string InputObject { get; set; }
 
         /// <summary>
-        /// inputObjectBuffer buffers all InputObjet contents available in the pipeline.
+        /// InputObjectBuffer buffers all InputObject contents available in the pipeline.
         /// </summary>
         private List<string> _inputObjectBuffer = new List<string>();
+
+        /// <summary>
+        /// Returned data structure is a Hashtable instead a CustomPSObject.
+        /// </summary>
+        [Parameter(Mandatory = false)]
+        public SwitchParameter AsHashtable { get; set; }
 
         #endregion parameters
 
@@ -44,7 +50,7 @@ namespace Microsoft.PowerShell.Commands
         }
 
         /// <summary>
-        /// the main execution method for the convertfrom-json command
+        /// The main execution method for the ConvertFrom-Json command.
         /// </summary>
         protected override void EndProcessing()
         {
@@ -95,7 +101,7 @@ namespace Microsoft.PowerShell.Commands
         private bool ConvertFromJsonHelper(string input)
         {
             ErrorRecord error = null;
-            object result = JsonObject.ConvertFromJson(input, out error);
+            object result = JsonObject.ConvertFromJson(input, AsHashtable.IsPresent, out error);
 
             if (error != null)
             {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/JsonObject.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/JsonObject.cs
@@ -121,6 +121,18 @@ namespace Microsoft.PowerShell.Commands
             PSObject result = new PSObject();
             foreach (var entry in entries)
             {
+                if (string.IsNullOrEmpty(entry.Key))
+                {
+                    string errorMsg = string.Format(CultureInfo.InvariantCulture,
+                                                    WebCmdletStrings.EmptyKeyInJsonString);
+                    error = new ErrorRecord(
+                        new InvalidOperationException(errorMsg),
+                        "EmptyKeyInJsonString",
+                        ErrorCategory.InvalidOperation,
+                        null);
+                    return null;
+                }
+
                 PSPropertyInfo property = result.Properties[entry.Key];
                 if (property != null)
                 {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/JsonObject.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/JsonObject.cs
@@ -27,6 +27,18 @@ namespace Microsoft.PowerShell.Commands
         private const int maxDepthAllowed = 100;
 
         /// <summary>
+        /// Convert a Json string back to an object of type PSObject.
+        /// </summary>
+        /// <param name="input"></param>
+        /// <param name="error"></param>
+        /// <returns>A PSObject.</returns>
+        [SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly")]
+        public static object ConvertFromJson(string input, out ErrorRecord error)
+        {
+            return ConvertFromJson(input, false, out error);
+        }
+
+        /// <summary>
         /// Convert a Json string back to an object of type PSObject or Hashtable depending on parameter <paramref name="returnHashTable"/>.
         /// </summary>
         /// <param name="input"></param>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/WebCmdletStrings.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/WebCmdletStrings.resx
@@ -133,7 +133,10 @@
     <value>The provided JSON includes a property whose name is an empty string, this is only supported using the -AsHashTable switch.</value>
   </data>
   <data name="DuplicateKeysInJsonString" xml:space="preserve">
-    <value>Cannot convert the JSON string because a dictionary that was converted from the string contains the duplicated keys '{0}' and '{1}'.</value>
+    <value>Cannot convert the JSON string because a dictionary that was converted from the string contains the duplicated key '{0}'.</value>
+  </data>
+  <data name="KeysWithDifferentCasingInJsonString" xml:space="preserve">
+    <value>Cannot convert the JSON string because a PSObject does not support keys with different casing. Please use the -AsHashTable switch instead. The key that was attempted to be added to the exisiting key '{0}' was '{1}'.</value>
   </data>
   <data name="ExtendedProfileRequired" xml:space="preserve">
     <value>The ConvertTo-Json and ConvertFrom-Json cmdlets require the installation of the .NET Client Profile, sometimes called the .NET extended profile.</value>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/WebCmdletStrings.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/WebCmdletStrings.resx
@@ -136,7 +136,7 @@
     <value>Cannot convert the JSON string because a dictionary that was converted from the string contains the duplicated key '{0}'.</value>
   </data>
   <data name="KeysWithDifferentCasingInJsonString" xml:space="preserve">
-    <value>Cannot convert the JSON string because a PSObject does not support keys with different casing. Please use the -AsHashTable switch instead. The key that was attempted to be added to the exisiting key '{0}' was '{1}'.</value>
+    <value>Cannot convert the JSON string because it contains keys with different casing. Please use the -AsHashTable switch instead. The key that was attempted to be added to the exisiting key '{0}' was '{1}'.</value>
   </data>
   <data name="ExtendedProfileRequired" xml:space="preserve">
     <value>The ConvertTo-Json and ConvertFrom-Json cmdlets require the installation of the .NET Client Profile, sometimes called the .NET extended profile.</value>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/WebCmdletStrings.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/WebCmdletStrings.resx
@@ -130,7 +130,7 @@
     <value>Path '{0}' resolves to a directory. Specify a path including a file name, and then retry the command.</value>
   </data>
   <data name="EmptyKeyInJsonString" xml:space="preserve">
-    <value>The provided json includes a property whose name is an empty string, this is only supported using the -AsHashTable switch.</value>
+    <value>The provided JSON includes a property whose name is an empty string, this is only supported using the -AsHashTable switch.</value>
   </data>
   <data name="DuplicateKeysInJsonString" xml:space="preserve">
     <value>Cannot convert the JSON string because a dictionary that was converted from the string contains the duplicated keys '{0}' and '{1}'.</value>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/WebCmdletStrings.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/WebCmdletStrings.resx
@@ -126,8 +126,11 @@
   <data name="CredentialConflict" xml:space="preserve">
     <value>The cmdlet cannot run because the following conflicting parameters are specified: Credential and UseDefaultCredentials. Specify either Credential or UseDefaultCredentials, then retry.</value>
   </data>
-  <data name="DirecotryPathSpecified" xml:space="preserve">
+  <data name="DirectoryPathSpecified" xml:space="preserve">
     <value>Path '{0}' resolves to a directory. Specify a path including a file name, and then retry the command.</value>
+  </data>
+  <data name="EmptyKeyInJsonString" xml:space="preserve">
+    <value>The provided json includes a property whose name is an empty string, this is only supported using the -AsHashTable switch.</value>
   </data>
   <data name="DuplicateKeysInJsonString" xml:space="preserve">
     <value>Cannot convert the JSON string because a dictionary that was converted from the string contains the duplicated keys '{0}' and '{1}'.</value>

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertFrom-Json.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertFrom-Json.Tests.ps1
@@ -1,16 +1,19 @@
 Describe 'ConvertFrom-Json' -tags "CI" {
     
-    $testCasesWithAndWithoutAsHashtableSwitch = @(
-        @{ AsHashtable = $true  }
-        @{ AsHashtable = $false }
-    )
+    BeforeAll {
+        $testCasesWithAndWithoutAsHashtableSwitch = @(
+            @{ AsHashtable = $true  }
+            @{ AsHashtable = $false }
+        )
+    }
 
-    It 'can convert a single-line object with AsHashtable switch set to <AsHashtable>' -TestCase $testCasesWithAndWithoutAsHashtableSwitch {
+
+    It 'Can convert a single-line object with AsHashtable switch set to <AsHashtable>' -TestCase $testCasesWithAndWithoutAsHashtableSwitch {
         Param($AsHashtable)
         ('{"a" : "1"}' | ConvertFrom-Json -AsHashtable:$AsHashtable).a | Should Be 1
     }
 
-    It 'can convert one string-per-object with AsHashtable switch set to <AsHashtable>' -TestCase $testCasesWithAndWithoutAsHashtableSwitch {
+    It 'Can convert one string-per-object with AsHashtable switch set to <AsHashtable>' -TestCase $testCasesWithAndWithoutAsHashtableSwitch {
         Param($AsHashtable)
         $json = @('{"a" : "1"}', '{"a" : "x"}') | ConvertFrom-Json -AsHashtable:$AsHashtable
         $json.Count | Should Be 2
@@ -21,7 +24,7 @@ Describe 'ConvertFrom-Json' -tags "CI" {
         }
     }
 
-    It 'can convert multi-line object with AsHashtable switch set to <AsHashtable>' -TestCase $testCasesWithAndWithoutAsHashtableSwitch {
+    It 'Can convert multi-line object with AsHashtable switch set to <AsHashtable>' -TestCase $testCasesWithAndWithoutAsHashtableSwitch {
         Param($AsHashtable)
         $json = @('{"a" :', '"x"}') | ConvertFrom-Json -AsHashtable:$AsHashtable
         $json.a | Should Be 'x'

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertFrom-Json.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertFrom-Json.Tests.ps1
@@ -1,16 +1,33 @@
 Describe 'ConvertFrom-Json' -tags "CI" {
-    It 'can convert a single-line object' {
-        ('{"a" : "1"}' | ConvertFrom-Json).a | Should Be 1
+    
+    $testCasesWithAndWithoutAsHashtableSwitch = @(
+        @{ AsHashtable = $true  }
+        @{ AsHashtable = $false }
+    )
+
+    It 'can convert a single-line object with AsHashtable switch set to <AsHashtable>' -TestCase $testCasesWithAndWithoutAsHashtableSwitch {
+        Param($AsHashtable)
+        ('{"a" : "1"}' | ConvertFrom-Json -AsHashtable:$AsHashtable).a | Should Be 1
     }
 
-    It 'can convert one string-per-object' {
-        $json = @('{"a" : "1"}', '{"a" : "x"}') | ConvertFrom-Json
+    It 'can convert one string-per-object with AsHashtable switch set to <AsHashtable>' -TestCase $testCasesWithAndWithoutAsHashtableSwitch {
+        Param($AsHashtable)
+        $json = @('{"a" : "1"}', '{"a" : "x"}') | ConvertFrom-Json -AsHashtable:$AsHashtable
         $json.Count | Should Be 2
         $json[1].a | Should Be 'x'
+        if ($AsHashtable)
+        {
+            $json | Should BeOfType Hashtable
+        }
     }
 
-    It 'can convert multi-line object' {
-        $json = @('{"a" :', '"x"}') | ConvertFrom-Json
+    It 'can convert multi-line object with AsHashtable switch set to <AsHashtable>' -TestCase $testCasesWithAndWithoutAsHashtableSwitch {
+        Param($AsHashtable)
+        $json = @('{"a" :', '"x"}') | ConvertFrom-Json -AsHashtable:$AsHashtable
         $json.a | Should Be 'x'
+        if ($AsHashtable)
+        {
+            $json | Should BeOfType Hashtable
+        }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/JsonObject.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/JsonObject.Tests.ps1
@@ -32,14 +32,14 @@
     }
 
     $jsonWithEmptyKey = '{"": "Value"}'
-    It 'throw InvalidOperationException for string ''jsonWithEmptyKey'' with empty key name' {
+    It 'throw InvalidOperationException when json contains empty key name' {
         $errorRecord = $null
         [Microsoft.PowerShell.Commands.JsonObject]::ConvertFromJson($jsonWithEmptyKey, [ref]$errorRecord)
-        $errorRecord.Exception | Should Be InvalidOperationException
+        $errorRecord.Exception.GetType() | Should Be System.InvalidOperationException
         $errorRecord.FullyQualifiedErrorId | Should Be EmptyKeyInJsonString
     }
 
-    It 'not throw for string ''jsonWithEmptyKey'' with empty key name when returnHashTable is used' {
+    It 'not throw when json contains empty key na' {
         $errorRecord = $null
         $result = [Microsoft.PowerShell.Commands.JsonObject]::ConvertFromJson($jsonWithEmptyKey, $true, [ref]$errorRecord)
         $result | Should Not Be $null

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/JsonObject.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/JsonObject.Tests.ps1
@@ -43,6 +43,8 @@
             $errorRecord = $null
             $result = [Microsoft.PowerShell.Commands.JsonObject]::ConvertFromJson($jsonWithEmptyKey, $true, [ref]$errorRecord)
             $result | Should Not Be $null
+            $result.Count | Should Be 1
+            $result.$('') | Should Be 'Value'
         }
     }
 
@@ -58,6 +60,9 @@
             $errorRecord = $null
             $result = [Microsoft.PowerShell.Commands.JsonObject]::ConvertFromJson($jsonContainingKeysWithDifferentCasing, $true, [ref]$errorRecord)
             $result | Should Not Be $null
+            $result.Count | Should Be 2
+            $result.key1  | Should Be 'Value1'
+            $result.Key1  | Should Be 'Value2'
         }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/JsonObject.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/JsonObject.Tests.ps1
@@ -44,7 +44,7 @@
             $result = [Microsoft.PowerShell.Commands.JsonObject]::ConvertFromJson($jsonWithEmptyKey, $true, [ref]$errorRecord)
             $result | Should Not Be $null
             $result.Count | Should Be 1
-            $result.$('') | Should Be 'Value'
+            $result.'' | Should Be 'Value'
         }
     }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/JsonObject.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/JsonObject.Tests.ps1
@@ -2,6 +2,7 @@
 
     BeforeAll {
         $jsonWithEmptyKey = '{"": "Value"}'
+        $jsonContainingKeysWithDifferentCasing = '{"key1": "Value1", "Key1": "Value2"}'
     }
 
     It 'No error for valid string ''<name>'' with -ReturnHashTable:$<ReturnHashTable>' -TestCase @(
@@ -30,16 +31,33 @@
         $errRecord = $null
         { [Microsoft.PowerShell.Commands.JsonObject]::ConvertFromJson($str, $ReturnHashTable, [ref]$errRecord) } | ShouldBeErrorId "ArgumentException"
     }
-    
-    It 'Throw InvalidOperationException when json contains empty key name' {
-        $errorRecord = $null
-        [Microsoft.PowerShell.Commands.JsonObject]::ConvertFromJson($jsonWithEmptyKey, [ref]$errorRecord)
-        $errorRecord.FullyQualifiedErrorId | Should Be 'EmptyKeyInJsonString'
+
+    Context 'Empty key name' {    
+        It 'Throw InvalidOperationException when json contains empty key name' {
+            $errorRecord = $null
+            [Microsoft.PowerShell.Commands.JsonObject]::ConvertFromJson($jsonWithEmptyKey, [ref]$errorRecord)
+            $errorRecord.FullyQualifiedErrorId | Should Be 'EmptyKeyInJsonString'
+        }
+
+        It 'Not throw when json contains empty key name when ReturnHashTable is true' {
+            $errorRecord = $null
+            $result = [Microsoft.PowerShell.Commands.JsonObject]::ConvertFromJson($jsonWithEmptyKey, $true, [ref]$errorRecord)
+            $result | Should Not Be $null
+        }
     }
 
-    It 'Not throw when json contains empty key na' {
-        $errorRecord = $null
-        $result = [Microsoft.PowerShell.Commands.JsonObject]::ConvertFromJson($jsonWithEmptyKey, $true, [ref]$errorRecord)
-        $result | Should Not Be $null
+    Context 'Keys with different casing ' {
+        
+        It 'Throw InvalidOperationException when json contains key with different casing' {
+            $errorRecord = $null
+            [Microsoft.PowerShell.Commands.JsonObject]::ConvertFromJson($jsonContainingKeysWithDifferentCasing, [ref]$errorRecord)
+            $errorRecord.FullyQualifiedErrorId | Should Be 'KeysWithDifferentCasingInJsonString'
+        }
+
+        It 'Not throw when json contains key (same casing) when ReturnHashTable is true' {
+            $errorRecord = $null
+            $result = [Microsoft.PowerShell.Commands.JsonObject]::ConvertFromJson($jsonContainingKeysWithDifferentCasing, $true, [ref]$errorRecord)
+            $result | Should Not Be $null
+        }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/JsonObject.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/JsonObject.Tests.ps1
@@ -1,6 +1,11 @@
 ﻿Describe 'Unit tests for JsonObject' -tags "CI" {
 
-    $validStrings = @(
+    BeforeAll {
+        $jsonWithEmptyKey = '{"": "Value"}'
+    }
+
+
+    It 'No error for valid string ''<name>'' with -ReturnHashTable:$<ReturnHashTable>' -TestCase @(
         @{ name = "null";   str = $null;   ReturnHashTable = $true  }
         @{ name = "empty";  str = "";      ReturnHashTable = $true  }
         @{ name = "spaces"; str = "  ";    ReturnHashTable = $true  }
@@ -9,37 +14,31 @@
         @{ name = "empty";  str = "";      ReturnHashTable = $false }
         @{ name = "spaces"; str = "  ";    ReturnHashTable = $false }
         @{ name = "object"; str = "{a:1}"; ReturnHashTable = $false }
-    )
-
-    It 'no error for valid string ''<name>'' with -ReturnHashTable:$<ReturnHashTable>' -TestCase $validStrings {
+    ) {
         param ($str, $ReturnHashTable)
         $errRecord = $null
         [Microsoft.PowerShell.Commands.JsonObject]::ConvertFromJson($str, $ReturnHashTable, [ref]$errRecord)
         $errRecord | Should BeNullOrEmpty
     }
 
-    $invalidStrings = @(
+    It 'Throw ArgumentException for invalid string ''<name>'' with -ReturnHashTable:$<ReturnHashTable>' -TestCase @(
         @{ name = "plain text"; str = "plaintext"; ReturnHashTable = $true  }
         @{ name = "part";       str = '{"a" :';    ReturnHashTable = $true  }
         @{ name = "plain text"; str = "plaintext"; ReturnHashTable = $false }
         @{ name = "part";       str = '{"a" :';    ReturnHashTable = $false }
-    )
-
-    It 'throw ArgumentException for invalid string ''<name>'' with -ReturnHashTable:$<ReturnHashTable>' -TestCase $invalidStrings  {
+    )  {
         param ($str, $ReturnHashTable)
         $errRecord = $null
         { [Microsoft.PowerShell.Commands.JsonObject]::ConvertFromJson($str, $ReturnHashTable, [ref]$errRecord) } | ShouldBeErrorId "ArgumentException"
     }
-
-    $jsonWithEmptyKey = '{"": "Value"}'
-    It 'throw InvalidOperationException when json contains empty key name' {
+    
+    It 'Throw InvalidOperationException when json contains empty key name' {
         $errorRecord = $null
         [Microsoft.PowerShell.Commands.JsonObject]::ConvertFromJson($jsonWithEmptyKey, [ref]$errorRecord)
-        $errorRecord.Exception.GetType() | Should Be System.InvalidOperationException
-        $errorRecord.FullyQualifiedErrorId | Should Be EmptyKeyInJsonString
+        $errorRecord.FullyQualifiedErrorId | Should Be 'EmptyKeyInJsonString'
     }
 
-    It 'not throw when json contains empty key na' {
+    It 'Not throw when json contains empty key na' {
         $errorRecord = $null
         $result = [Microsoft.PowerShell.Commands.JsonObject]::ConvertFromJson($jsonWithEmptyKey, $true, [ref]$errorRecord)
         $result | Should Not Be $null

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/JsonObject.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/JsonObject.Tests.ps1
@@ -30,4 +30,18 @@
         $errRecord = $null
         { [Microsoft.PowerShell.Commands.JsonObject]::ConvertFromJson($str, $ReturnHashTable, [ref]$errRecord) } | ShouldBeErrorId "ArgumentException"
     }
+
+    $jsonWithEmptyKey = '{"": "Value"}'
+    It 'throw InvalidOperationException for string ''jsonWithEmptyKey'' with empty key name' {
+        $errorRecord = $null
+        [Microsoft.PowerShell.Commands.JsonObject]::ConvertFromJson($jsonWithEmptyKey, [ref]$errorRecord)
+        $errorRecord.Exception | Should Be InvalidOperationException
+        $errorRecord.FullyQualifiedErrorId | Should Be EmptyKeyInJsonString
+    }
+
+    It 'not throw for string ''jsonWithEmptyKey'' with empty key name when returnHashTable is used' {
+        $errorRecord = $null
+        $result = [Microsoft.PowerShell.Commands.JsonObject]::ConvertFromJson($jsonWithEmptyKey, $true, [ref]$errorRecord)
+        $result | Should Not Be $null
+    }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/JsonObject.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/JsonObject.Tests.ps1
@@ -4,7 +4,6 @@
         $jsonWithEmptyKey = '{"": "Value"}'
     }
 
-
     It 'No error for valid string ''<name>'' with -ReturnHashTable:$<ReturnHashTable>' -TestCase @(
         @{ name = "null";   str = $null;   ReturnHashTable = $true  }
         @{ name = "empty";  str = "";      ReturnHashTable = $true  }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/JsonObject.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/JsonObject.Tests.ps1
@@ -1,9 +1,11 @@
 ﻿Describe 'Unit tests for JsonObject' -tags "CI" {
 
     $validStrings = @(
+        @{ name = "null";   str = $null;   ReturnHashTable = $true  }
         @{ name = "empty";  str = "";      ReturnHashTable = $true  }
         @{ name = "spaces"; str = "  ";    ReturnHashTable = $true  }
         @{ name = "object"; str = "{a:1}"; ReturnHashTable = $true  }
+        @{ name = "null";   str = $null;   ReturnHashTable = $false }
         @{ name = "empty";  str = "";      ReturnHashTable = $false }
         @{ name = "spaces"; str = "  ";    ReturnHashTable = $false }
         @{ name = "object"; str = "{a:1}"; ReturnHashTable = $false }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/JsonObject.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/JsonObject.Tests.ps1
@@ -1,7 +1,5 @@
 ﻿Describe 'Unit tests for JsonObject' -tags "CI" {
 
-    $TestCasesForReturnHashTableParameter = @($true, $false)
-
     $validStrings = @(
         @{ name = "empty";  str = "";      ReturnHashTable = $true  }
         @{ name = "spaces"; str = "  ";    ReturnHashTable = $true  }
@@ -11,7 +9,7 @@
         @{ name = "object"; str = "{a:1}"; ReturnHashTable = $false }
     )
 
-    It 'no error for valid string - <name> when ReturnHashTable is <ReturnHashTable>' -TestCase $validStrings {
+    It 'no error for valid string ''<name>'' with -ReturnHashTable:$<ReturnHashTable>' -TestCase $validStrings {
         param ($str, $ReturnHashTable)
         $errRecord = $null
         [Microsoft.PowerShell.Commands.JsonObject]::ConvertFromJson($str, $ReturnHashTable, [ref]$errRecord)
@@ -25,7 +23,7 @@
         @{ name = "part";       str = '{"a" :';    ReturnHashTable = $false }
     )
 
-    It 'throw ArgumentException for invalid string - <name> when ReturnHashTable is <ReturnHashTable>' -TestCase $invalidStrings  {
+    It 'throw ArgumentException for invalid string ''<name>'' with -ReturnHashTable:$<ReturnHashTable>' -TestCase $invalidStrings  {
         param ($str, $ReturnHashTable)
         $errRecord = $null
         { [Microsoft.PowerShell.Commands.JsonObject]::ConvertFromJson($str, $ReturnHashTable, [ref]$errRecord) } | ShouldBeErrorId "ArgumentException"

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/JsonObject.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/JsonObject.Tests.ps1
@@ -1,46 +1,33 @@
 ﻿Describe 'Unit tests for JsonObject' -tags "CI" {
 
-    function ShouldThrow
-    {
-        param (
-            [Parameter(ValueFromPipeline = $true)]
-            $InputObject,
-            [Parameter(Position = 0)]
-            $ExpectedException
-        )
-
-        try
-        {
-            & $InputObject
-            throw "Should throw exception"
-        }
-        catch
-        {
-            $_.FullyQualifiedErrorId | should be $ExpectedException
-        }
-    }
+    $TestCasesForReturnHashTableParameter = @($true, $false)
 
     $validStrings = @(
-        @{ name = "empty"; str = "" }
-        @{ name = "spaces"; str = "  " }
-        @{ name = "object"; str = "{a:1}" }
+        @{ name = "empty";  str = "";      ReturnHashTable = $true  }
+        @{ name = "spaces"; str = "  ";    ReturnHashTable = $true  }
+        @{ name = "object"; str = "{a:1}"; ReturnHashTable = $true  }
+        @{ name = "empty";  str = "";      ReturnHashTable = $false }
+        @{ name = "spaces"; str = "  ";    ReturnHashTable = $false }
+        @{ name = "object"; str = "{a:1}"; ReturnHashTable = $false }
     )
 
-    It 'no error for valid string - <name>' -TestCase $validStrings {
-        param ($str)
+    It 'no error for valid string - <name> when ReturnHashTable is <ReturnHashTable>' -TestCase $validStrings {
+        param ($str, $ReturnHashTable)
         $errRecord = $null
-        [Microsoft.PowerShell.Commands.JsonObject]::ConvertFromJson($str, [ref]$errRecord)
+        [Microsoft.PowerShell.Commands.JsonObject]::ConvertFromJson($str, $ReturnHashTable, [ref]$errRecord)
         $errRecord | Should BeNullOrEmpty
     }
 
     $invalidStrings = @(
-        @{ name = "plain text"; str = "plaintext" }
-        @{ name = "part"; str = '{"a" :' }
+        @{ name = "plain text"; str = "plaintext"; ReturnHashTable = $true  }
+        @{ name = "part";       str = '{"a" :';    ReturnHashTable = $true  }
+        @{ name = "plain text"; str = "plaintext"; ReturnHashTable = $false }
+        @{ name = "part";       str = '{"a" :';    ReturnHashTable = $false }
     )
 
-    It 'throw ArgumentException for invalid string - <name>' -TestCase $invalidStrings  {
-        param ($str)
+    It 'throw ArgumentException for invalid string - <name> when ReturnHashTable is <ReturnHashTable>' -TestCase $invalidStrings  {
+        param ($str, $ReturnHashTable)
         $errRecord = $null
-        { [Microsoft.PowerShell.Commands.JsonObject]::ConvertFromJson($str, [ref]$errRecord) } | ShouldThrow 'ArgumentException'
+        { [Microsoft.PowerShell.Commands.JsonObject]::ConvertFromJson($str, $ReturnHashTable, [ref]$errRecord) } | ShouldBeErrorId "ArgumentException"
     }
 }


### PR DESCRIPTION
Address https://github.com/PowerShell/PowerShell/issues/3623.

Implementation symmetric to traditional code path that returns a `PSCustomObject`. Code is shared on the top level but 2 low level methods were difficult to share, therefore 2 separate but similar methods were created for HashTables.
All existing tests related to this change were adapted to also test against this new switch and were slightly improved. 

Update (@TravisEz13):
`-AsHashtable` is an existing pattern used in `Group-Object`