### PR TITLE
Update script to get PSVersion from $PSVersionTable

### DIFF
--- a/src/powershell-native/Install-PowerShellRemoting.ps1
+++ b/src/powershell-native/Install-PowerShellRemoting.ps1
@@ -15,11 +15,7 @@ param
 (
     [parameter(Mandatory = $true, ParameterSetName = "ByPath")]
     [string]
-    $PowerShellHome,
-
-    [parameter(Mandatory = $true, ParameterSetName = "ByPath")]
-    [string]
-    $PowerShellVersion = "6.0.0-alpha.8"
+    $PowerShellHome
 )
 
 function Register-WinRmPlugin
@@ -123,16 +119,16 @@ if (! ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity
 if ($PsCmdlet.ParameterSetName -eq "ByPath")
 {
     $targetPsHome = $PowerShellHome
-    $targetPsVersion = $PowershellVersion
+    $targetPsVersion = & "$targetPsHome\powershell" -NoProfile -Command '$PSVersionTable.PSVersion.ToString()'
 }
 else
 {
     ## Get the PSHome and PSVersion using the current powershell instance
     $targetPsHome = $PSHOME
     $targetPsVersion = $PSVersionTable.PSVersion.ToString()
-
-    Write-Verbose "Using PowerShell Version: $targetPsVersion" -Verbose
 }
+
+Write-Verbose "Using PowerShell Version: $targetPsVersion" -Verbose
 
 $pluginBasePath = Join-Path "$env:WINDIR\System32\PowerShell" $targetPsVersion
 

--- a/src/powershell-native/Install-PowerShellRemoting.ps1
+++ b/src/powershell-native/Install-PowerShellRemoting.ps1
@@ -2,10 +2,14 @@
 #
 # Registers the WinRM endpoint for this instance of PowerShell.
 #
+# If the parameters '-PowerShellHome' were specified, it means that the script will be registering
+# an instance of PowerShell from another instance of PowerShell.
+#
+# If no parameter is specified, it means that this instance of PowerShell is registering itself.
+#
 # Assumptions:
-#     1. This script is run from within the PowerShell that it will register as a WinRM endpoint.
-#     2. The CoreCLR and the the PowerShell assemblies are side-by-side in $PSHOME
-#     3. Plugins are registered by version number. Only one plugin can be automatically registered
+#     1. The CoreCLR and the the PowerShell assemblies are side-by-side in $PSHOME
+#     2. Plugins are registered by version number. Only one plugin can be automatically registered
 #        per PowerShell version. However, multiple endpoints may be manually registered for a given
 #        plugin.
 #
@@ -32,7 +36,7 @@ function Register-WinRmPlugin
         $pluginAbsolutePath,
 
         #
-        # Expected Example: microsoft.powershell-core.6.0
+        # Expected Example: powershell.6.0.0-beta.3
         #
         [string]
         [parameter(Mandatory=$true)]
@@ -69,9 +73,6 @@ function Register-WinRmPlugin
 
     Write-Verbose "Performing WinRM registration with: $fileName"
     reg.exe import .\$fileName
-
-    # Clean up
-#    Remove-Item .\$fileName
 }
 
 function Generate-PluginConfigFile
@@ -109,13 +110,6 @@ if (! ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity
     Break
 }
 
-#
-# If the parameters were specified, it means that the script will be registering
-# an instance of PowerShell from another instance of PowerShell.
-#
-# If no parameters are specified, it means that this instance of PowerShell is
-# registering itself.
-#
 if ($PsCmdlet.ParameterSetName -eq "ByPath")
 {
     $targetPsHome = $PowerShellHome

--- a/src/powershell-native/Install-PowerShellRemoting.ps1
+++ b/src/powershell-native/Install-PowerShellRemoting.ps1
@@ -74,6 +74,7 @@ function Register-WinRmPlugin
     Write-Verbose "Performing WinRM registration with: $fileName"
     reg.exe import .\$fileName
 
+    # Clean up
     Remove-Item .\$fileName
 }
 

--- a/src/powershell-native/Install-PowerShellRemoting.ps1
+++ b/src/powershell-native/Install-PowerShellRemoting.ps1
@@ -10,15 +10,14 @@
 #        plugin.
 #
 #####################################################################################################
+[CmdletBinding(DefaultParameterSetName = "NotByPath")]
 param
 (
-    [parameter(ParameterSetName = "ByPath")]
-    [ValidateNotNullOrEmpty()]
+    [parameter(Mandatory = $true, ParameterSetName = "ByPath")]
     [string]
     $PowerShellHome,
 
-    [parameter(ParameterSetName = "ByPath")]
-    [ValidateNotNullOrEmpty()]
+    [parameter(Mandatory = $true, ParameterSetName = "ByPath")]
     [string]
     $PowerShellVersion = "6.0.0-alpha.8"
 )
@@ -128,21 +127,9 @@ if ($PsCmdlet.ParameterSetName -eq "ByPath")
 }
 else
 {
+    ## Get the PSHome and PSVersion using the current powershell instance
     $targetPsHome = $PSHOME
-
-    # Parse the version string from the version file so that users do not have
-    # to enter it manually.
-    $targetPsVersionFilePath = Join-Path $targetPsHome "Powershell.Version"
-    $versionString = (Get-Content $targetPsVersionFilePath).Trim()
-    if($versionString.StartsWith("v"))
-    {
-        $versionString = $versionString.substring(1)
-    }
-    $index = $versionString.LastIndexOf(".")
-    $version = $versionString.Substring(0,$index)
-    $revision = $versionString.Substring($index).split("-")
-    $version= $version + $revision[0]
-    $targetPsVersion = $version
+    $targetPsVersion = $PSVersionTable.PSVersion.ToString()
 
     Write-Verbose "Using PowerShell Version: $targetPsVersion" -Verbose
 }

--- a/src/powershell-native/Install-PowerShellRemoting.ps1
+++ b/src/powershell-native/Install-PowerShellRemoting.ps1
@@ -73,6 +73,8 @@ function Register-WinRmPlugin
 
     Write-Verbose "Performing WinRM registration with: $fileName"
     reg.exe import .\$fileName
+
+    Remove-Item .\$fileName
 }
 
 function Generate-PluginConfigFile


### PR DESCRIPTION
The file `powershell.version` has been removed as we now figure out `PSVersion` and `GitCommitId` from the `ProductVersion` of `S,M.A.dll`. Update the script to get the PSVersion directly from `$PSVersionTable.PSVersion`.