### PR TITLE
Test fixes and code coverage automation fixes.

### DIFF
--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -119,21 +119,6 @@ Describe "TabCompletion" -Tags CI {
         $res.CompletionMatches[0].CompletionText | Should Be 'namespace'
     }
 
-    It 'Should complete about help topic' {
-
-        $aboutHelpPath = Join-Path $PSHOME (Get-Culture).Name
-
-        ## If help content does not exist, tab completion will not work. So update it first.
-        if(-not (Test-Path (Join-Path $aboutHelpPath "about_Splatting.help.txt")))
-        {
-            Update-Help -Force -ErrorAction SilentlyContinue
-        }
-
-        $res = TabExpansion2 -inputScript 'get-help about_spla' -cursorColumn 'get-help about_spla'.Length
-        $res.CompletionMatches.Count | Should Be 1
-        $res.CompletionMatches[0].CompletionText | Should BeExactly 'about_Splatting'
-    }
-
     Context NativeCommand {
         BeforeAll {
             $nativeCommand = (Get-Command -CommandType Application -TotalCount 1).Name
@@ -467,7 +452,6 @@ Describe "TabCompletion" -Tags CI {
             $beforeTab = "\\localhost\$homeDrive\wind"
             $afterTab = "& '\\localhost\$homeDrive\Windows'"
             $res = TabExpansion2 -inputScript $beforeTab -cursorColumn $beforeTab.Length
-            $res.CompletionMatches.Count | Should BeExactly 1
             $res.CompletionMatches[0].CompletionText | Should Be $afterTab
         }
 
@@ -496,7 +480,6 @@ Describe "TabCompletion" -Tags CI {
                 $afterTab = 'filesystem::/usr' -f $env:SystemDrive
             }
             $res = TabExpansion2 -inputScript $beforeTab -cursorColumn $beforeTab.Length
-            $res.CompletionMatches.Count | Should BeExactly 1
             $res.CompletionMatches[0].CompletionText | Should Be $afterTab
         }
 
@@ -1066,5 +1049,23 @@ Describe "WSMan Config Provider tab complete tests" -Tags Feature,RequireAdminOn
     ) {
         # https://github.com/PowerShell/PowerShell/issues/4744
         # TODO: move to test cases above once working
+    }
+}
+
+Describe "TabCompletion tests requiring elevation" -Tags Feature,RequireAdminOnWindows {
+
+    It 'Should complete about help topic' {
+
+        $aboutHelpPath = Join-Path $PSHOME (Get-Culture).Name
+
+        ## If help content does not exist, tab completion will not work. So update it first.
+        if (-not (Test-Path (Join-Path $aboutHelpPath "about_Splatting.help.txt")))
+        {
+            Update-Help -Force -ErrorAction SilentlyContinue
+        }
+
+        $res = TabExpansion2 -inputScript 'get-help about_spla' -cursorColumn 'get-help about_spla'.Length
+        $res.CompletionMatches.Count | Should Be 1
+        $res.CompletionMatches[0].CompletionText | Should BeExactly 'about_Splatting'
     }
 }

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -119,6 +119,8 @@ Describe "TabCompletion" -Tags CI {
         $res.CompletionMatches[0].CompletionText | Should Be 'namespace'
     }
 
+
+
     Context NativeCommand {
         BeforeAll {
             $nativeCommand = (Get-Command -CommandType Application -TotalCount 1).Name
@@ -452,6 +454,7 @@ Describe "TabCompletion" -Tags CI {
             $beforeTab = "\\localhost\$homeDrive\wind"
             $afterTab = "& '\\localhost\$homeDrive\Windows'"
             $res = TabExpansion2 -inputScript $beforeTab -cursorColumn $beforeTab.Length
+            $res.CompletionMatches.Count | Should BeGreaterThan 0
             $res.CompletionMatches[0].CompletionText | Should Be $afterTab
         }
 
@@ -480,6 +483,7 @@ Describe "TabCompletion" -Tags CI {
                 $afterTab = 'filesystem::/usr' -f $env:SystemDrive
             }
             $res = TabExpansion2 -inputScript $beforeTab -cursorColumn $beforeTab.Length
+            $res.CompletionMatches.Count | Should BeGreaterThan 0
             $res.CompletionMatches[0].CompletionText | Should Be $afterTab
         }
 
@@ -1065,7 +1069,7 @@ Describe "TabCompletion tests requiring elevation" -Tags Feature,RequireAdminOnW
         }
 
         $res = TabExpansion2 -inputScript 'get-help about_spla' -cursorColumn 'get-help about_spla'.Length
-        $res.CompletionMatches.Count | Should Be 1
+        $res.CompletionMatches.Count | Should BeGreaterThan 0
         $res.CompletionMatches[0].CompletionText | Should BeExactly 'about_Splatting'
     }
 }

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -120,8 +120,17 @@ Describe "TabCompletion" -Tags CI {
     }
 
     It 'Should complete about help topic' {
+
+        $aboutHelpPath = Join-Path $PSHOME (Get-Culture).Name
+
+        ## If help content does not exist, tab completion will not work. So update it first.
+        if(-not (Test-Path (Join-Path $aboutHelpPath "about_Splatting.help.txt")))
+        {
+            Update-Help -Force -ErrorAction SilentlyContinue
+        }
+
         $res = TabExpansion2 -inputScript 'get-help about_spla' -cursorColumn 'get-help about_spla'.Length
-        $res.CompletionMatches.Count | Should BeGreaterThan 0
+        $res.CompletionMatches.Count | Should Be 1
         $res.CompletionMatches[0].CompletionText | Should BeExactly 'about_Splatting'
     }
 

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -119,7 +119,11 @@ Describe "TabCompletion" -Tags CI {
         $res.CompletionMatches[0].CompletionText | Should Be 'namespace'
     }
 
-
+    It 'Should complete about help topic' {
+        $res = TabExpansion2 -inputScript 'get-help about_spla' -cursorColumn 'get-help about_spla'.Length
+        $res.CompletionMatches.Count | Should BeGreaterThan 0
+        $res.CompletionMatches[0].CompletionText | Should BeExactly 'about_Splatting'
+    }
 
     Context NativeCommand {
         BeforeAll {
@@ -420,7 +424,8 @@ Describe "TabCompletion" -Tags CI {
                 @{ inputStr = '$global:max'; expected = '$global:MaximumHistoryCount'; setup = $null }
                 @{ inputStr = '$PSMod'; expected = '$PSModuleAutoLoadingPreference'; setup = $null }
                 ## tab completion for variable in path
-                @{ inputStr = 'cd $pshome\Modu'; expected = Join-Path $PSHOME 'Modules'; setup = $null }
+                ## if $PSHOME contains a space tabcompletion adds ' around the path
+                @{ inputStr = 'cd $pshome\Modu'; expected = if($PSHOME.Contains(' ')) { "'$(Join-Path $PSHOME 'Modules')'" } else { Join-Path $PSHOME 'Modules' }; setup = $null }
                 @{ inputStr = 'cd "$pshome\Modu"'; expected = "`"$(Join-Path $PSHOME 'Modules')`""; setup = $null }
                 @{ inputStr = '$PSHOME\System.Management.Au'; expected = Join-Path $PSHOME 'System.Management.Automation.dll'; setup = $null }
                 @{ inputStr = '"$PSHOME\System.Management.Au"'; expected = "`"$(Join-Path $PSHOME 'System.Management.Automation.dll')`""; setup = $null }
@@ -901,13 +906,13 @@ dir -Recurse `
                 @{ inputStr = 'Get-CimInstance Win32_Process | ?{ $_.ProcessId -eq $Pid } | Get-CimAssociatedInstance -ResultClassName Win32_ComputerS'; expected = 'Win32_ComputerSystem' }
                 @{ inputStr = 'Get-CimInstance -Namespace root/Interop -ClassName Win32_PowerSupplyP'; expected = 'Win32_PowerSupplyProfile' }
                 @{ inputStr = 'Get-CimInstance __NAMESP'; expected = '__NAMESPACE' }
-                @{ inputStr = 'Get-CimInstance -Namespace root/Int'; expected = 'root/Interop' }
+                @{ inputStr = 'Get-CimInstance -Namespace root/Inter'; expected = 'root/Interop' }
                 @{ inputStr = 'Get-CimInstance -Namespace root/Int*ro'; expected = 'root/Interop' }
                 @{ inputStr = 'Get-CimInstance -Namespace root/Interop/'; expected = 'root/Interop/ms_409' }
-                @{ inputStr = 'New-CimInstance -Namespace root/Int'; expected = 'root/Interop' }
-                @{ inputStr = 'Invoke-CimMethod -Namespace root/Int'; expected = 'root/Interop' }
-                @{ inputStr = 'Get-CimClass -Namespace root/Int'; expected = 'root/Interop' }
-                @{ inputStr = 'Register-CimIndicationEvent -Namespace root/Int'; expected = 'root/Interop' }
+                @{ inputStr = 'New-CimInstance -Namespace root/Inter'; expected = 'root/Interop' }
+                @{ inputStr = 'Invoke-CimMethod -Namespace root/Inter'; expected = 'root/Interop' }
+                @{ inputStr = 'Get-CimClass -Namespace root/Inter'; expected = 'root/Interop' }
+                @{ inputStr = 'Register-CimIndicationEvent -Namespace root/Inter'; expected = 'root/Interop' }
                 @{ inputStr = '[Microsoft.Management.Infrastructure.CimClass]$c = $null; $c.CimClassNam'; expected = 'CimClassName' }
                 @{ inputStr = '[Microsoft.Management.Infrastructure.CimClass]$c = $null; $c.CimClassName.Substrin'; expected = 'Substring(' }
                 @{ inputStr = 'Get-CimInstance -ClassName Win32_Process | %{ $_.ExecutableP'; expected = 'ExecutablePath' }
@@ -1053,23 +1058,5 @@ Describe "WSMan Config Provider tab complete tests" -Tags Feature,RequireAdminOn
     ) {
         # https://github.com/PowerShell/PowerShell/issues/4744
         # TODO: move to test cases above once working
-    }
-}
-
-Describe "TabCompletion tests requiring elevation" -Tags Feature,RequireAdminOnWindows {
-
-    It 'Should complete about help topic' {
-
-        $aboutHelpPath = Join-Path $PSHOME (Get-Culture).Name
-
-        ## If help content does not exist, tab completion will not work. So update it first.
-        if (-not (Test-Path (Join-Path $aboutHelpPath "about_Splatting.help.txt")))
-        {
-            Update-Help -Force -ErrorAction SilentlyContinue
-        }
-
-        $res = TabExpansion2 -inputScript 'get-help about_spla' -cursorColumn 'get-help about_spla'.Length
-        $res.CompletionMatches.Count | Should BeGreaterThan 0
-        $res.CompletionMatches[0].CompletionText | Should BeExactly 'about_Splatting'
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Process.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Process.Tests.ps1
@@ -1,6 +1,6 @@
 Describe "Get-Process for admin" -Tags @('CI', 'RequireAdminOnWindows') {
     It "Should support -IncludeUserName" {
-        (Get-Process powershell -IncludeUserName | Select-Object -First 1).UserName | Should Match $env:USERNAME
+        (Get-Process -Id $pid -IncludeUserName).UserName | Should Match $env:USERNAME
     }
 }
 

--- a/test/powershell/Modules/Microsoft.WSMan.Management/CredSSP.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.WSMan.Management/CredSSP.Tests.ps1
@@ -10,7 +10,7 @@ Describe "CredSSP cmdlet tests" -Tags 'Feature','RequireAdminOnWindows' {
         {
             $PSDefaultParameterValues["it:skip"] = $true
         }
-        else 
+        else
         {
             if ([System.Globalization.CultureInfo]::CurrentCulture.Name -ne "en-US")
             {
@@ -18,7 +18,7 @@ Describe "CredSSP cmdlet tests" -Tags 'Feature','RequireAdminOnWindows' {
             }
         }
     }
-    
+
     AfterAll {
         $global:PSDefaultParameterValues = $originalDefaultParameterValues
     }

--- a/test/powershell/engine/Api/ProxyCommand.Tests.ps1
+++ b/test/powershell/engine/Api/ProxyCommand.Tests.ps1
@@ -82,7 +82,25 @@ Describe 'ProxyCommand Tests' -Tags "CI" {
         Set-Item -Path function:\TestHelpComment -Value $bodySB
         $newHelpObj = Get-Help TestHelpComment -Full
 
-        $helpObj.Synopsis | Should Be $newHelpObj.Synopsis
+        if($helpObj.Synopsis.Contains("`r`n"))
+        {
+            $helpObjText = ($helpObj.Synopsis).replace("`r`n", [System.Environment]::NewLine).trim()
+        }
+        else
+        {
+            $helpObjText = ($helpObj.Synopsis).replace("`n", [System.Environment]::NewLine).trim()
+        }
+
+        if($newHelpObj.Synopsis.Contains("`r`n"))
+        {
+            $newHelpObjText = ($newHelpObj.Synopsis).replace("`r`n", [System.Environment]::NewLine).trim()
+        }
+        else
+        {
+            $newHelpObjText = ($newHelpObj.Synopsis).replace("`n", [System.Environment]::NewLine).trim()
+        }
+
+        $helpObjText | Should Be $newHelpObjText
         $oldDespText = GetSectionText $helpObj.description
         $newDespText = GetSectionText $newHelpObj.description
         $oldDespText | Should Be $newDespText

--- a/test/powershell/engine/Api/ProxyCommand.Tests.ps1
+++ b/test/powershell/engine/Api/ProxyCommand.Tests.ps1
@@ -3,6 +3,21 @@ using namespace System.Collections.ObjectModel
 
 Describe 'ProxyCommand Tests' -Tags "CI" {
     BeforeAll {
+        function NormalizeCRLF {
+            param ($helpObj)
+
+            if($helpObj.Synopsis.Contains("`r`n"))
+            {
+                $helpObjText = ($helpObj.Synopsis).replace("`r`n", [System.Environment]::NewLine).trim()
+            }
+            else
+            {
+                $helpObjText = ($helpObj.Synopsis).replace("`n", [System.Environment]::NewLine).trim()
+            }
+
+            return $helpObjText
+        }
+
         function GetSectionText {
             param ($object)
             $texts = $object | Out-String -Stream | ForEach-Object {
@@ -82,23 +97,8 @@ Describe 'ProxyCommand Tests' -Tags "CI" {
         Set-Item -Path function:\TestHelpComment -Value $bodySB
         $newHelpObj = Get-Help TestHelpComment -Full
 
-        if($helpObj.Synopsis.Contains("`r`n"))
-        {
-            $helpObjText = ($helpObj.Synopsis).replace("`r`n", [System.Environment]::NewLine).trim()
-        }
-        else
-        {
-            $helpObjText = ($helpObj.Synopsis).replace("`n", [System.Environment]::NewLine).trim()
-        }
-
-        if($newHelpObj.Synopsis.Contains("`r`n"))
-        {
-            $newHelpObjText = ($newHelpObj.Synopsis).replace("`r`n", [System.Environment]::NewLine).trim()
-        }
-        else
-        {
-            $newHelpObjText = ($newHelpObj.Synopsis).replace("`n", [System.Environment]::NewLine).trim()
-        }
+        $helpObjText = NormalizeCRLF -helpObj $helpObj
+        $newHelpObjText = NormalizeCRLF -helpObj $newHelpObj
 
         $helpObjText | Should Be $newHelpObjText
         $oldDespText = GetSectionText $helpObj.description

--- a/test/powershell/engine/Help/HelpSystem.Tests.ps1
+++ b/test/powershell/engine/Help/HelpSystem.Tests.ps1
@@ -188,10 +188,14 @@ Describe "Validate about_help.txt under culture specific folder works" -Tags @('
         New-ModuleManifest -Path $modulePath\test.psd1 -RootModule test.psm1
         Set-Content -Path $modulePath\test.psm1 -Value "function foo{}"
         Set-Content -Path $modulePath\en-US\about_testhelp.help.txt -Value "Hello" -NoNewline
+        ## This is needed for getting about topics. We use -Force, so we always update.
+        Update-Help -Force
     }
 
     AfterAll {
         Remove-Item $modulePath -Recurse -Force
+        # Remove all the help content.
+        Get-ChildItem -Path $PSHOME -Include @('about_*.txt', "*help.xml") -Recurse | Remove-Item -Force -ErrorAction SilentlyContinue
     }
 
     It "Get-Help should return help text and not multiple HelpInfo objects when help is under `$pshome path" {

--- a/test/powershell/engine/Help/UpdatableHelpSystem.Tests.ps1
+++ b/test/powershell/engine/Help/UpdatableHelpSystem.Tests.ps1
@@ -178,7 +178,7 @@ function RunUpdateHelpTests
             It "Validate Update-Help for module '$moduleName'" -Pending:$Pending {
 
                 # If the help file is already installed, delete it.
-                Get-ChildItem $testCases[$moduleName].HelpInstallationPath -Include @("about_*.txt","*help.xml") -Recurse -ea SilentlyContinue |
+                Get-ChildItem $testCases[$moduleName].HelpInstallationPath -Include @("*help.xml") -Recurse -ea SilentlyContinue |
                     Remove-Item -Force -ErrorAction SilentlyContinue
 
                 if ((Get-UICulture).Name -ne "en-Us")

--- a/test/powershell/engine/Remoting/SSHRemotingAPI.Tests.ps1
+++ b/test/powershell/engine/Remoting/SSHRemotingAPI.Tests.ps1
@@ -4,7 +4,7 @@ Describe "SSH Remoting API Tests" -Tags "Feature" {
 
         BeforeAll {
             ## Skip the test if ssh.exe is not present.
-            $skipTest = (Get-Command 'ssh.exe' -ErrorAction SilentlyContinue) -eq $null
+            $skipTest = (Get-Command 'ssh' -ErrorAction SilentlyContinue) -eq $null
         }
 
         AfterEach {

--- a/test/powershell/engine/Remoting/SSHRemotingAPI.Tests.ps1
+++ b/test/powershell/engine/Remoting/SSHRemotingAPI.Tests.ps1
@@ -3,8 +3,8 @@ Describe "SSH Remoting API Tests" -Tags "Feature" {
     Context "SSHConnectionInfo Class Tests" {
 
         BeforeAll {
-            ## Skip the test if ssh.exe is not present.
-            $skipTest = (Get-Command 'ssh' -ErrorAction SilentlyContinue) -eq $null
+            ## Skip the test if ssh is not present.
+            $skipTest = (Get-Command 'ssh' -CommandType Application -ErrorAction SilentlyContinue) -eq $null
         }
 
         AfterEach {

--- a/test/powershell/engine/Remoting/SSHRemotingAPI.Tests.ps1
+++ b/test/powershell/engine/Remoting/SSHRemotingAPI.Tests.ps1
@@ -2,6 +2,11 @@ Describe "SSH Remoting API Tests" -Tags "Feature" {
 
     Context "SSHConnectionInfo Class Tests" {
 
+        BeforeAll {
+            ## Skip the test if ssh.exe is not present.
+            $skipTest = (Get-Command 'ssh.exe' -ErrorAction SilentlyContinue) -eq $null
+        }
+
         AfterEach {
             if ($null -ne $rs) {
                 $rs.Dispose()
@@ -17,7 +22,7 @@ Describe "SSH Remoting API Tests" -Tags "Feature" {
                 0) } | ShouldBeErrorId "PSArgumentNullException"
         }
 
-        It "SSHConnectionInfo should throw file not found exception for invalid key file path" {
+        It "SSHConnectionInfo should throw file not found exception for invalid key file path" -Skip:$skipTest {
 
             try
             {
@@ -29,7 +34,7 @@ Describe "SSH Remoting API Tests" -Tags "Feature" {
 
                 $rs = [runspacefactory]::CreateRunspace($sshConnectionInfo)
                 $rs.Open()
-                
+
                 throw "No Exception!"
             }
             catch
@@ -39,7 +44,7 @@ Describe "SSH Remoting API Tests" -Tags "Feature" {
         }
 
         It "SSHConnectionInfo should throw argument exception for invalid port (non 16bit uint)" {
-            try 
+            try
             {
                 $sshConnectionInfo = [System.Management.Automation.Runspaces.SSHConnectionInfo]::new(
                     "UserName",
@@ -49,7 +54,7 @@ Describe "SSH Remoting API Tests" -Tags "Feature" {
 
                 $rs = [runspacefactory]::CreateRunspace($sshConnectionInfo)
                 $rs.Open()
-                
+
                 throw "No Exception!"
             }
             catch

--- a/test/tools/CodeCoverageAutomation/Start-CodeCoverageRun.ps1
+++ b/test/tools/CodeCoverageAutomation/Start-CodeCoverageRun.ps1
@@ -197,6 +197,21 @@ try
     Expand-Archive -path $OpenCoverZipFilePath -destinationpath $openCoverPath -Force
     Write-LogPassThru -Message "Expansion complete."
 
+    if(Test-Path $elevatedLogs)
+    {
+        Remove-Item -Force -Recurse $elevatedLogs
+    }
+
+    if(Test-Path $unelevatedLogs)
+    {
+        Remove-Item -Force -Recurse $unelevatedLogs
+    }
+
+    if(Test-Path $outputLog)
+    {
+        Remove-Item $outputLog -Force -ErrorAction SilentlyContinue
+    }
+
     Import-Module "$openCoverPath\OpenCover" -Force
     Install-OpenCover -TargetDirectory $openCoverTargetDirectory -force
     Write-LogPassThru -Message "OpenCover installed."
@@ -259,8 +274,8 @@ try
         Write-LogPassThru -Message "git operation 'set sparse-checkout' returned $LASTEXITCODE"
 
         Write-LogPassThru -Message "pulling sparse repo"
-        "src" | Out-File -Encoding ascii .git\info\sparse-checkout
-        "assets" | Out-File -Encoding ascii .git\info\ -Append
+        "src" | Out-File -Encoding ascii .git\info\sparse-checkout -Force
+        "assets" | Out-File -Encoding ascii .git\info\sparse-checkout -Append
         & $gitexe pull origin master
         Write-LogPassThru -Message "git operation 'pull' returned $LASTEXITCODE"
 
@@ -276,10 +291,6 @@ try
     $openCoverParams | Out-String | Write-LogPassThru
     Write-LogPassThru -Message "Starting test run."
 
-    if(Test-Path $outputLog)
-    {
-        Remove-Item $outputLog -Force -ErrorAction SilentlyContinue
-    }
     # now invoke opencover
     Invoke-OpenCover @openCoverParams
 

--- a/test/tools/CodeCoverageAutomation/Start-CodeCoverageRun.ps1
+++ b/test/tools/CodeCoverageAutomation/Start-CodeCoverageRun.ps1
@@ -54,7 +54,7 @@ function ConvertTo-CodeCovJson
     $progress=0
     foreach($f in $keys)
     {
-        Write-Progress -Id 1 -Activity "Converting to JSON" -Status 'Converting' -PercentComplete ($progress * 100 / $keys.Count) 
+        Write-Progress -Id 1 -Activity "Converting to JSON" -Status 'Converting' -PercentComplete ($progress * 100 / $keys.Count)
         $fileCoverage = GetSequencePointsForFile -fileId $f
         $fileName = $Script:fileTable[$f]
         $previousFileCoverage = $totalCoverage.coverage.${fileName}
@@ -151,24 +151,50 @@ try
 
     $oldErrorActionPreference = $ErrorActionPreference
     $ErrorActionPreference = 'Stop'
+    $oldProgressPreference = $ProgressPreference
+    $ProgressPreference = 'SilentlyContinue'
     Write-LogPassThru -Message "Starting downloads."
+
+    $CoverageZipFilePath = "$outputBaseFolder\PSCodeCoverage.zip"
+    if(Test-Path $CoverageZipFilePath)
+    {
+        Remove-Item $CoverageZipFilePath -Force
+    }
     Invoke-WebRequest -uri $codeCoverageZip -outfile "$outputBaseFolder\PSCodeCoverage.zip"
-    Invoke-WebRequest -uri $testContentZip -outfile "$outputBaseFolder\tests.zip"
-    Invoke-WebRequest -uri $openCoverZip -outfile "$outputBaseFolder\OpenCover.zip"
+
+    $TestsZipFilePath = "$outputBaseFolder\tests.zip"
+    if(Test-Path $TestsZipFilePath)
+    {
+        Remove-Item $TestsZipFilePath -Force
+    }
+    Invoke-WebRequest -uri $testContentZip -outfile $TestsZipFilePath
+
+    $OpenCoverZipFilePath = "$outputBaseFolder\OpenCover.zip"
+    if(Test-Path $OpenCoverZipFilePath)
+    {
+        Remove-Item $OpenCoverZipFilePath -Force
+    }
+    Invoke-WebRequest -uri $openCoverZip -outfile $OpenCoverZipFilePath
+
     Write-LogPassThru -Message "Downloads complete. Starting expansion"
 
-    Expand-Archive -path "$outputBaseFolder\PSCodeCoverage.zip" -destinationpath "$psBinPath" -Force
-    Expand-Archive -path "$outputBaseFolder\tests.zip" -destinationpath $testRootPath -Force
-    Expand-Archive -path "$outputBaseFolder\OpenCover.zip" -destinationpath $openCoverPath -Force
+    if(Test-Path $psBinPath)
+    {
+        Remove-Item -Force -Recurse $psBinPath
+    }
+    Expand-Archive -path $CoverageZipFilePath -destinationpath "$psBinPath" -Force
 
-    ## Download Coveralls.net uploader
-    $coverallsToolsUrl = 'https://github.com/csMACnz/coveralls.net/releases/download/0.7.0/coveralls.net.0.7.0.nupkg'
-    $coverallsPath = "$outputBaseFolder\coveralls"
+    if(Test-Path $testRootPath)
+    {
+        Remove-Item -Force -Recurse $testRootPath
+    }
+    Expand-Archive -path $TestsZipFilePath -destinationpath $testRootPath -Force
 
-    ## Saving the nupkg as zip so we can expand it.
-    Invoke-WebRequest -uri $coverallsToolsUrl -outfile "$outputBaseFolder\coveralls.zip"
-    Expand-Archive -Path "$outputBaseFolder\coveralls.zip" -DestinationPath $coverallsPath -Force
-
+    if(Test-Path $openCoverPath)
+    {
+        Remove-Item -Force -Recurse $openCoverPath
+    }
+    Expand-Archive -path $OpenCoverZipFilePath -destinationpath $openCoverPath -Force
     Write-LogPassThru -Message "Expansion complete."
 
     Import-Module "$openCoverPath\OpenCover" -Force
@@ -216,6 +242,10 @@ try
         {
             remove-item -force -recurse "${outputBaseFolder}/src"
         }
+        if ( Test-Path "$outputBaseFolder/assests" )
+        {
+            remove-item -force -recurse "${outputBaseFolder}/assets"
+        }
         Write-LogPassThru -Message "initializing repo in $outputBaseFolder"
         & $gitexe init
         Write-LogPassThru -Message "git operation 'init' returned $LASTEXITCODE"
@@ -230,6 +260,7 @@ try
 
         Write-LogPassThru -Message "pulling sparse repo"
         "src" | out-file -encoding ascii .git\info\sparse-checkout
+        "assets" | out-file -encoding ascii .git\info\ -Append
         & $gitexe pull origin master
         Write-LogPassThru -Message "git operation 'pull' returned $LASTEXITCODE"
 
@@ -261,28 +292,8 @@ try
 
     Write-LogPassThru -Message $commitId
 
-    $coverallsPath = "$outputBaseFolder\coveralls"
-
     $commitInfo = Invoke-RestMethod -Method Get "https://api.github.com/repos/powershell/powershell/git/commits/$commitId"
     $message = ($commitInfo.message).replace("`n", " ")
-    $author = $commitInfo.author.name
-    $email = $commitInfo.author.email
-
-    $coverallsExe = Join-Path $coverallsPath "tools\csmacnz.Coveralls.exe"
-    $coverallsParams = @("--opencover",
-        "-i $outputLog",
-        "--repoToken $coverallsToken",
-        "--commitId $commitId",
-        "--commitBranch master",
-        "--commitAuthor `"$author`"",
-        "--commitEmail $email",
-        "--commitMessage `"$message`""
-    )
-
-    $coverallsParams | ForEach-Object { Write-LogPassThru -Message $_ }
-
-    Write-LogPassThru -Message "Uploading to CoverAlls"
-    & $coverallsExe """$coverallsParams"""
 
     Write-LogPassThru -Message "Uploading to CodeCov"
     if ( test-path $outputLog ) {
@@ -303,7 +314,7 @@ finally
 {
     # the powershell execution should be done, be sure that there are no PowerShell test executables running because
     # they will cause subsequent coverage runs to behave poorly. Make sure that the path is properly formatted, and
-    # we need to use like rather than match because on Windows, there will be "\" as path separators which would need 
+    # we need to use like rather than match because on Windows, there will be "\" as path separators which would need
     # escaping for -match
     $ResolvedPSBinPath = (Resolve-Path ${psbinpath}).Path
     Get-Process PowerShell | Where-Object { $_.Path -like "*${ResolvedPSBinPath}*" } | Stop-Process -Force -ErrorAction Continue
@@ -328,4 +339,5 @@ finally
     ## Disable the cleanup till we stabilize.
     #Remove-Item -recurse -force -path $outputBaseFolder
     $ErrorActionPreference = $oldErrorActionPreference
+    $ProgressPreference = $oldProgressPreference
 }

--- a/test/tools/CodeCoverageAutomation/Start-CodeCoverageRun.ps1
+++ b/test/tools/CodeCoverageAutomation/Start-CodeCoverageRun.ps1
@@ -77,7 +77,7 @@ function ConvertTo-CodeCovJson
 
     Write-Progress -Id 1 -Completed -Activity "Converting to JSON"
 
-    $totalCoverage | ConvertTo-Json -Depth 5 -Compress | out-file $DestinationPath -Encoding ascii
+    $totalCoverage | ConvertTo-Json -Depth 5 -Compress | Out-File $DestinationPath -Encoding ascii
 }
 
 function Write-LogPassThru
@@ -236,15 +236,15 @@ try
         # clean up partial repo clone before starting
         if ( Test-Path "$outputBaseFolder/.git" )
         {
-            remove-item -force -recurse "${outputBaseFolder}/.git"
+            Remove-Item -Force -Recurse "${outputBaseFolder}/.git"
         }
         if ( Test-Path "$outputBaseFolder/src" )
         {
-            remove-item -force -recurse "${outputBaseFolder}/src"
+            Remove-Item -Force -Recurse "${outputBaseFolder}/src"
         }
         if ( Test-Path "$outputBaseFolder/assests" )
         {
-            remove-item -force -recurse "${outputBaseFolder}/assets"
+            Remove-Item -Force -Recurse "${outputBaseFolder}/assets"
         }
         Write-LogPassThru -Message "initializing repo in $outputBaseFolder"
         & $gitexe init
@@ -259,8 +259,8 @@ try
         Write-LogPassThru -Message "git operation 'set sparse-checkout' returned $LASTEXITCODE"
 
         Write-LogPassThru -Message "pulling sparse repo"
-        "src" | out-file -encoding ascii .git\info\sparse-checkout
-        "assets" | out-file -encoding ascii .git\info\ -Append
+        "src" | Out-File -Encoding ascii .git\info\sparse-checkout
+        "assets" | Out-File -Encoding ascii .git\info\ -Append
         & $gitexe pull origin master
         Write-LogPassThru -Message "git operation 'pull' returned $LASTEXITCODE"
 
@@ -296,7 +296,7 @@ try
     $message = ($commitInfo.message).replace("`n", " ")
 
     Write-LogPassThru -Message "Uploading to CodeCov"
-    if ( test-path $outputLog ) {
+    if ( Test-Path $outputLog ) {
         ConvertTo-CodeCovJson -Path $outputLog -DestinationPath $jsonFile
         Push-CodeCovData -file $jsonFile -CommitID $commitId -token $codecovToken -Branch 'master'
 

--- a/test/tools/OpenCover/OpenCover.psm1
+++ b/test/tools/OpenCover/OpenCover.psm1
@@ -664,8 +664,10 @@ function Invoke-OpenCover
     # create the arguments for OpenCover
 
     $updatedEnvPath = "${PowerShellExeDirectory}\Modules;$TestToolsModulesPath"
+    $testToolsExePath = (Resolve-Path(Join-Path $TestPath -ChildPath "..\tools\TestExe\bin")).Path
+    $updatedProcessEnvPath = "${testToolsExePath};${env:PATH}"
 
-    $startupArgs =  "Set-ExecutionPolicy Bypass -Force -Scope Process; `$env:PSModulePath = '${updatedEnvPath}';"
+    $startupArgs =  "Set-ExecutionPolicy Bypass -Force -Scope Process; `$env:PSModulePath = '${updatedEnvPath}'; `$env:Path = '${updatedProcessEnvPath}'"
     $targetArgs = "${startupArgs}", "Invoke-Pester","${TestPath}","-OutputFormat $PesterLogFormat"
 
     if ( $CIOnly )


### PR DESCRIPTION
* About help test needed `Update-Help`
* Tab completion tests were too stringent. There can be more than 1 matches.
* Get-Process test should use $PID.
* Improvements to Start-CodeCoverage script with respect to clean up and progress preference. 
* Removed code for uploading data to coveralls.
* Added testexe path to $env:PATH 