### PR TITLE
Add Authentication Parameter to Web Cmdlets for Basic and OAuth

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -89,7 +89,7 @@ namespace Microsoft.PowerShell.Commands
         #region Authorization and Credentials
 
         /// <summary>
-        /// gets or sets the AllowUnencryptedAuthentication property
+        /// Gets or sets the AllowUnencryptedAuthentication property
         /// </summary>
         [Parameter]
         public virtual SwitchParameter AllowUnencryptedAuthentication { get; set; }
@@ -138,7 +138,7 @@ namespace Microsoft.PowerShell.Commands
         public virtual SwitchParameter SkipCertificateCheck { get; set; }
 
         /// <summary>
-        /// gets or sets the Token property. Token is required by Authentication OAuth and Bearer.
+        /// Gets or sets the Token property. Token is required by Authentication OAuth and Bearer.
         /// </summary>
         [Parameter]
         public virtual SecureString Token { get; set; }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -63,32 +63,32 @@ namespace Microsoft.PowerShell.Commands
         #region Authorization and Credentials
 
         /// <summary>
-        /// gets or sets the AllowUnencryptedAuthorization property
+        /// gets or sets the AllowUnencryptedAuthentication property
         /// </summary>
         [Parameter]
-        public virtual SwitchParameter AllowUnencryptedAuthorization { get; set; }
+        public virtual SwitchParameter AllowUnencryptedAuthentication { get; set; }
 
         /// <summary>
-        /// Gets or sets the Authorization property used to determin the Authorization method for the web session. 
-        /// Authorization does not work with UseDefaultCredentials.
-        /// Authorization over unencrypted sessions requires AllowUnencryptedAuthorization.
+        /// Gets or sets the Authentication property used to determin the Authentication method for the web session. 
+        /// Authentication does not work with UseDefaultCredentials.
+        /// Authentication over unencrypted sessions requires AllowUnencryptedAuthentication.
         /// Basic: Requires Credential
         /// OAuth/Bearer: Requires Token
         /// </summary>
         [Parameter]
         [ValidateSet("Basic","Bearer","OAuth")]
-        public virtual string Authorization 
+        public virtual string Authentication 
         { 
             get
             {
-                return _authorization;
+                return _authentication;
             } 
             set
             {
-                _authorization = value.ToLower();
+                _authentication = value.ToLower();
             }
         }
-        private string _authorization;
+        private string _authentication;
         
         /// <summary>
         /// gets or sets the Credential property
@@ -124,7 +124,7 @@ namespace Microsoft.PowerShell.Commands
         public virtual SwitchParameter SkipCertificateCheck { get; set; }
 
         /// <summary>
-        /// gets or sets the Token property. Token is required by Authorization OAuth and Bearer.
+        /// gets or sets the Token property. Token is required by Authentication OAuth and Bearer.
         /// </summary>
         [Parameter]
         public virtual SecureString Token { get; set; }
@@ -309,35 +309,35 @@ namespace Microsoft.PowerShell.Commands
                 ThrowTerminatingError(error);
             }
 
-            // Authorization
-            if (UseDefaultCredentials && (null != Authorization))
+            // Authentication
+            if (UseDefaultCredentials && (null != Authentication))
             {
-                ErrorRecord error = GetValidationError(WebCmdletStrings.AuthorizationConflict,
-                                                       "WebCmdletAuthorizationConflictException");
+                ErrorRecord error = GetValidationError(WebCmdletStrings.AuthenticationConflict,
+                                                       "WebCmdletAuthenticationConflictException");
                 ThrowTerminatingError(error);
             }
-            if ((null != Authorization) && (null != Token) && (null != Credential))
+            if ((null != Authentication) && (null != Token) && (null != Credential))
             {
-                ErrorRecord error = GetValidationError(WebCmdletStrings.AuthorizationTokenConflict,
-                                                       "WebCmdletAuthorizationTokenConflictException");
+                ErrorRecord error = GetValidationError(WebCmdletStrings.AuthenticationTokenConflict,
+                                                       "WebCmdletAuthenticationTokenConflictException");
                 ThrowTerminatingError(error);
             }
-            if ((Authorization == "basic") && (null == Credential))
+            if ((Authentication == "basic") && (null == Credential))
             {
-                ErrorRecord error = GetValidationError(WebCmdletStrings.AuthorizationCredentialNotSupplied,
-                                                       "WebCmdletAuthorizationCredentialNotSuppliedException");
+                ErrorRecord error = GetValidationError(WebCmdletStrings.AuthenticationCredentialNotSupplied,
+                                                       "WebCmdletAuthenticationCredentialNotSuppliedException");
                 ThrowTerminatingError(error);
             }
-            if ((Authorization == "oauth" || Authorization == "bearer") && (null == Token))
+            if ((Authentication == "oauth" || Authentication == "bearer") && (null == Token))
             {
-                ErrorRecord error = GetValidationError(WebCmdletStrings.AuthorizationTokenNotSupplied,
-                                                       "WebCmdletAuthorizationTokenNotSuppliedException");
+                ErrorRecord error = GetValidationError(WebCmdletStrings.AuthenticationTokenNotSupplied,
+                                                       "WebCmdletAuthenticationTokenNotSuppliedException");
                 ThrowTerminatingError(error);
             }
-            if (!AllowUnencryptedAuthorization && (null != Authorization) && (Uri.Scheme != "https"))
+            if (!AllowUnencryptedAuthentication && (null != Authentication) && (Uri.Scheme != "https"))
             {
-                ErrorRecord error = GetValidationError(WebCmdletStrings.AllowUnencryptedAuthorizationRequired,
-                                                       "WebCmdletAllowUnencryptedAuthorizationRequiredException");
+                ErrorRecord error = GetValidationError(WebCmdletStrings.AllowUnencryptedAuthenticationRequired,
+                                                       "WebCmdletAllowUnencryptedAuthenticationRequiredException");
                 ThrowTerminatingError(error);
             }
 
@@ -456,7 +456,7 @@ namespace Microsoft.PowerShell.Commands
             //
             // handle credentials
             //
-            if (null != Credential && null == Authorization)
+            if (null != Credential && null == Authentication)
             {
                 // get the relevant NetworkCredential
                 NetworkCredential netCred = Credential.GetNetworkCredential();
@@ -465,9 +465,9 @@ namespace Microsoft.PowerShell.Commands
                 // supplying a credential overrides the UseDefaultCredentials setting
                 WebSession.UseDefaultCredentials = false;
             }
-            else if ((null != Credential || null!= Token) && null != Authorization)
+            else if ((null != Credential || null!= Token) && null != Authentication)
             {
-                ProcessAuthorization();
+                ProcessAuthentication();
             }
             else if (UseDefaultCredentials)
             {
@@ -749,19 +749,19 @@ namespace Microsoft.PowerShell.Commands
             return String.Format("Bearer {0}", new NetworkCredential(String.Empty, Token).Password);
         }
 
-        private void ProcessAuthorization()
+        private void ProcessAuthentication()
         {
-            if(Authorization == "basic")
+            if(Authentication == "basic")
             {
                 WebSession.Headers["Authorization"] = GetBasicAuthorizationHeader();
             }
-            else if (Authorization == "bearer" || Authorization == "oauth")
+            else if (Authentication == "bearer" || Authentication == "oauth")
             {
                 WebSession.Headers["Authorization"] = GetBearerAuthorizationHeader();
             }
             else
             {
-                Diagnostics.Assert(false, String.Format("Unrecognized Authorization value: {0}", Authorization));
+                Diagnostics.Assert(false, String.Format("Unrecognized Authentication value: {0}", Authentication));
             }
         }
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -102,7 +102,7 @@ namespace Microsoft.PowerShell.Commands
         /// OAuth/Bearer: Requires Token
         /// </summary>
         [Parameter]
-        public virtual WebAuthenticationType Authentication { get; set; }
+        public virtual WebAuthenticationType Authentication { get; set; } = WebAuthenticationType.None;
         
         /// <summary>
         /// gets or sets the Credential property

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -472,10 +472,6 @@ namespace Microsoft.PowerShell.Commands
             //
             if (null != Credential && Authentication == WebAuthenticationType.None)
             {
-                if (Uri.Scheme != "https" && !AllowUnencryptedAuthentication)
-                {
-                    WriteWarning(WebCmdletStrings.UnencryptedCredentialWarning);
-                }
                 // get the relevant NetworkCredential
                 NetworkCredential netCred = Credential.GetNetworkCredential();
                 WebSession.Credentials = netCred;

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -4,7 +4,6 @@ Copyright (c) Microsoft Corporation.  All rights reserved.
 
 using System;
 using System.Collections.ObjectModel;
-using System.Diagnostics;
 using System.Management.Automation;
 using System.Net;
 using System.IO;
@@ -70,7 +69,11 @@ namespace Microsoft.PowerShell.Commands
         public virtual SwitchParameter AllowUnencryptedAuthorization { get; set; }
 
         /// <summary>
-        /// Gets or sets the Authorization property used to determin the Authorization method for the web session.!--
+        /// Gets or sets the Authorization property used to determin the Authorization method for the web session. 
+        /// Authorization does not work with UseDefaultCredentials.
+        /// Authorization over unencrypted sessions requires AllowUnencryptedAuthorization.
+        /// Basic: Requires Credential
+        /// OAuth/Bearer: Requires Token
         /// </summary>
         [Parameter]
         [ValidateSet("Basic","Bearer","OAuth")]
@@ -121,7 +124,7 @@ namespace Microsoft.PowerShell.Commands
         public virtual SwitchParameter SkipCertificateCheck { get; set; }
 
         /// <summary>
-        /// gets or sets the Token property
+        /// gets or sets the Token property. Token is required by Authorization OAuth and Bearer.
         /// </summary>
         [Parameter]
         public virtual SecureString Token { get; set; }
@@ -758,7 +761,7 @@ namespace Microsoft.PowerShell.Commands
             }
             else
             {
-                Debug.Assert(false, String.Format("Unrecognized Authorization value: {0}", Authorization));
+                Diagnostics.Assert(false, String.Format("Unrecognized Authorization value: {0}", Authorization));
             }
         }
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -472,6 +472,10 @@ namespace Microsoft.PowerShell.Commands
             //
             if (null != Credential && Authentication == WebAuthenticationType.None)
             {
+                if (Uri.Scheme != "https" && !AllowUnencryptedAuthentication)
+                {
+                    WriteWarning(WebCmdletStrings.UnencryptedCredentialWarning);
+                }
                 // get the relevant NetworkCredential
                 NetworkCredential netCred = Credential.GetNetworkCredential();
                 WebSession.Credentials = netCred;

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/WebCmdletStrings.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/WebCmdletStrings.resx
@@ -120,6 +120,21 @@
   <data name="AccessDenied" xml:space="preserve">
     <value>Access to the path '{0}' is denied.</value>
   </data>
+  <data name="AllowUnencryptedAuthorizationRequired" xml:space="preserve">
+    <value>The cmdlet cannot protect plain text secrets sent over unencrypted connections. To supress this warning and send plain text secrets over unencrypted networks, reissue the command specifying the AllowUnencryptedAuthorization parameter.</value>
+  </data>
+  <data name="AuthorizationConflict" xml:space="preserve">
+    <value>The cmdlet cannot run because the following conflicting parameters are specified: Authorization and UseDefaultCredentials. Authorization does not support Default Credentials. Specify either Authorization or UseDefaultCredentials, then retry.</value>
+  </data>
+  <data name="AuthorizationCredentialNotSupplied" xml:space="preserve">
+    <value>The cmdlet cannot run because the following parameter is not specified: Credential. The supplied Authorization type requires a Credential. Specify Credential, then retry.</value>
+  </data>
+    <data name="AuthorizationTokenNotSupplied" xml:space="preserve">
+    <value>The cmdlet cannot run because the following parameter is not specified: Token. The supplied Authorization type requires a Token. Specify Token, then retry.</value>
+  </data>
+  <data name="AuthorizationTokenConflict" xml:space="preserve">
+    <value>The cmdlet cannot run because the following conflicting parameters are specified: Credential and Token. Specify either Credential or Token, then retry.</value>
+  </data>
   <data name="BodyConflict" xml:space="preserve">
     <value>The cmdlet cannot run because the following conflicting parameters are specified: Body and InFile. Specify either Body or Infile, then retry.  </value>
   </data>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/WebCmdletStrings.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/WebCmdletStrings.resx
@@ -120,19 +120,19 @@
   <data name="AccessDenied" xml:space="preserve">
     <value>Access to the path '{0}' is denied.</value>
   </data>
-  <data name="AllowUnencryptedAuthorizationRequired" xml:space="preserve">
-    <value>The cmdlet cannot protect plain text secrets sent over unencrypted connections. To supress this warning and send plain text secrets over unencrypted networks, reissue the command specifying the AllowUnencryptedAuthorization parameter.</value>
+  <data name="AllowUnencryptedAuthenticationRequired" xml:space="preserve">
+    <value>The cmdlet cannot protect plain text secrets sent over unencrypted connections. To supress this warning and send plain text secrets over unencrypted networks, reissue the command specifying the AllowUnencryptedAuthentication parameter.</value>
   </data>
-  <data name="AuthorizationConflict" xml:space="preserve">
-    <value>The cmdlet cannot run because the following conflicting parameters are specified: Authorization and UseDefaultCredentials. Authorization does not support Default Credentials. Specify either Authorization or UseDefaultCredentials, then retry.</value>
+  <data name="AuthenticationConflict" xml:space="preserve">
+    <value>The cmdlet cannot run because the following conflicting parameters are specified: Authentication and UseDefaultCredentials. Authentication does not support Default Credentials. Specify either Authentication or UseDefaultCredentials, then retry.</value>
   </data>
-  <data name="AuthorizationCredentialNotSupplied" xml:space="preserve">
-    <value>The cmdlet cannot run because the following parameter is not specified: Credential. The supplied Authorization type requires a Credential. Specify Credential, then retry.</value>
+  <data name="AuthenticationCredentialNotSupplied" xml:space="preserve">
+    <value>The cmdlet cannot run because the following parameter is not specified: Credential. The supplied Authentication type requires a Credential. Specify Credential, then retry.</value>
   </data>
-    <data name="AuthorizationTokenNotSupplied" xml:space="preserve">
-    <value>The cmdlet cannot run because the following parameter is not specified: Token. The supplied Authorization type requires a Token. Specify Token, then retry.</value>
+    <data name="AuthenticationTokenNotSupplied" xml:space="preserve">
+    <value>The cmdlet cannot run because the following parameter is not specified: Token. The supplied Authentication type requires a Token. Specify Token, then retry.</value>
   </data>
-  <data name="AuthorizationTokenConflict" xml:space="preserve">
+  <data name="AuthenticationTokenConflict" xml:space="preserve">
     <value>The cmdlet cannot run because the following conflicting parameters are specified: Credential and Token. Specify either Credential or Token, then retry.</value>
   </data>
   <data name="BodyConflict" xml:space="preserve">

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/WebCmdletStrings.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/WebCmdletStrings.resx
@@ -198,9 +198,6 @@
   <data name="ThumbprintNotFound" xml:space="preserve">
     <value>Unable to retrieve certificates because the thumbprint is not valid. Verify the thumbprint and retry. </value>
   </data>
-    <data name="UnencryptedCredentialWarning" xml:space="preserve">
-    <value>The cmdlet cannot protect plain text secrets sent over unencrypted connections. To supress this warning reissue the command with a Uri that beings with 'https://' or specify the AllowUnencryptedAuthentication parameter.</value>
-  </data>
   <data name="WriteRequestComplete" xml:space="preserve">
     <value>Writing web request completed. (Number of bytes remaining: {0})</value>
   </data>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/WebCmdletStrings.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/WebCmdletStrings.resx
@@ -198,6 +198,9 @@
   <data name="ThumbprintNotFound" xml:space="preserve">
     <value>Unable to retrieve certificates because the thumbprint is not valid. Verify the thumbprint and retry. </value>
   </data>
+    <data name="UnencryptedCredentialWarning" xml:space="preserve">
+    <value>The cmdlet cannot protect plain text secrets sent over unencrypted connections. To supress this warning reissue the command with a Uri that beings with 'https://' or specify the AllowUnencryptedAuthentication parameter.</value>
+  </data>
   <data name="WriteRequestComplete" xml:space="preserve">
     <value>Writing web request completed. (Number of bytes remaining: {0})</value>
   </data>

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -1381,7 +1381,7 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
             { Invoke-WebRequest @params } | ShouldBeErrorId "WebCmdletAllowUnencryptedAuthenticationRequiredException,Microsoft.PowerShell.Commands.InvokeWebRequestCommand"
         }
 
-        It "Verifies Invoke-WebRequest -Authentication Can us HTTP with -AllowUnencryptedAuthentication" {
+        It "Verifies Invoke-WebRequest -Authentication Can use HTTP with -AllowUnencryptedAuthentication" {
             $params = @{
                 Uri = $httpUri
                 Token = $token
@@ -1392,6 +1392,31 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
             $result = $response.Content | ConvertFrom-Json
 
             $result.Headers.Authorization | Should BeExactly "Bearer testpassword"
+        }
+
+        It "Verifies Invoke-WebRequest -Credential produces a warning on HTTP requests" {
+            $params = @{
+                Uri = $httpUri
+                Credential = $credential
+                WarningVariable = 'warnings'
+                WarningAction =  'SilentlyContinue'
+            }
+            $Response = Invoke-WebRequest @params
+
+            $warnings.Count | should be 1
+        }
+
+        It "Verifies Invoke-WebRequest -Credential suppresses a warning on HTTP requests with -AllowUnencryptedAuthentication " {
+            $params = @{
+                Uri = $httpUri
+                Credential = $credential
+                WarningVariable = 'warnings'
+                WarningAction =  'SilentlyContinue'
+                AllowUnencryptedAuthentication = $true
+            }
+            $Response = Invoke-WebRequest @params
+
+            $warnings.Count | should be 0
         }
     }
 
@@ -2299,7 +2324,7 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
             { Invoke-RestMethod @params } | ShouldBeErrorId "WebCmdletAllowUnencryptedAuthenticationRequiredException,Microsoft.PowerShell.Commands.InvokeRestMethodCommand"
         }
 
-        It "Verifies Invoke-RestMethod -Authentication Can us HTTP with -AllowUnencryptedAuthentication" {
+        It "Verifies Invoke-RestMethod -Authentication Can use HTTP with -AllowUnencryptedAuthentication" {
             $params = @{
                 Uri = $httpUri
                 Token = $token
@@ -2309,6 +2334,31 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
             $result = Invoke-RestMethod @params
 
             $result.Headers.Authorization | Should BeExactly "Bearer testpassword"
+        }
+
+        It "Verifies Invoke-RestMethod -Credential produces a warning on HTTP requests" {
+            $params = @{
+                Uri = $httpUri
+                Credential = $credential
+                WarningVariable = 'warnings'
+                WarningAction =  'SilentlyContinue'
+            }
+            $Response = Invoke-RestMethod @params
+
+            $warnings.Count | should be 1
+        }
+
+        It "Verifies Invoke-RestMethod -Credential suppresses a warning on HTTP requests with -AllowUnencryptedAuthentication " {
+            $params = @{
+                Uri = $httpUri
+                Credential = $credential
+                WarningVariable = 'warnings'
+                WarningAction =  'SilentlyContinue'
+                AllowUnencryptedAuthentication = $true
+            }
+            $Response = Invoke-RestMethod @params
+
+            $warnings.Count | should be 0
         }
     }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -1286,7 +1286,7 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
         }
     }
 
-    Context "Invoke-WebRequest -Authorization tests" {
+    Context "Invoke-WebRequest -Authentication tests" {
         BeforeAll {
             #[SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Demo/doc/test secret.")]
             $token = "testpassword" | ConvertTo-SecureString -AsPlainText -Force
@@ -1294,15 +1294,15 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
             $httpUri = Get-WebListenerUrl -Test 'Get'
             $httpsUri = Get-WebListenerUrl -Test 'Get' -Https
             $testCases = @(
-                @{authorization = "bearer"}
-                @{authorization = "OAuth"}
+                @{Authentication = "bearer"}
+                @{Authentication = "OAuth"}
             )
         }
 
-        It "Verifies Invoke-WebRequest -Authorization Basic" {
+        It "Verifies Invoke-WebRequest -Authentication Basic" {
             $params = @{
                 Uri = $httpsUri
-                Authorization = "Basic"
+                Authentication = "Basic"
                 Credential = $credential
                 SkipCertificateCheck = $true
             }
@@ -1312,11 +1312,11 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
             $result.Headers.Authorization | Should BeExactly "Basic dGVzdHVzZXI6dGVzdHBhc3N3b3Jk"
         }
 
-        It "Verifies Invoke-WebRequest -Authorization <authorization>" -TestCases $testCases {
-            param($authorization)
+        It "Verifies Invoke-WebRequest -Authentication <Authentication>" -TestCases $testCases {
+            param($Authentication)
             $params = @{
                 Uri = $httpsUri
-                Authorization = $authorization 
+                Authentication = $Authentication 
                 Token = $token
                 SkipCertificateCheck = $true
             }
@@ -1326,67 +1326,67 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
             $result.Headers.Authorization | Should BeExactly "Bearer testpassword"
         }
 
-        It "Verifies Invoke-WebRequest -Authorization does not support -UseDefaultCredentials" {
+        It "Verifies Invoke-WebRequest -Authentication does not support -UseDefaultCredentials" {
             $params = @{
                 Uri = $httpsUri
                 Token = $token
-                Authorization = "OAuth"
+                Authentication = "OAuth"
                 UseDefaultCredentials = $true
                 ErrorAction = 'Stop'
                 SkipCertificateCheck = $true
             }
-            { Invoke-WebRequest @params } | ShouldBeErrorId "WebCmdletAuthorizationConflictException,Microsoft.PowerShell.Commands.InvokeWebRequestCommand"
+            { Invoke-WebRequest @params } | ShouldBeErrorId "WebCmdletAuthenticationConflictException,Microsoft.PowerShell.Commands.InvokeWebRequestCommand"
         }
 
-        It "Verifies Invoke-WebRequest -Authorization does not support Both -Credential and -Token" {
+        It "Verifies Invoke-WebRequest -Authentication does not support Both -Credential and -Token" {
             $params = @{
                 Uri = $httpsUri
                 Token = $token
                 Credential = $credential
-                Authorization = "OAuth"
+                Authentication = "OAuth"
                 ErrorAction = 'Stop'
                 SkipCertificateCheck = $true
             }
-            { Invoke-WebRequest @params } | ShouldBeErrorId "WebCmdletAuthorizationTokenConflictException,Microsoft.PowerShell.Commands.InvokeWebRequestCommand"
+            { Invoke-WebRequest @params } | ShouldBeErrorId "WebCmdletAuthenticationTokenConflictException,Microsoft.PowerShell.Commands.InvokeWebRequestCommand"
         }
 
-        It "Verifies Invoke-WebRequest -Authorization <authorization> requires -Token" -TestCases $testCases {
-            param($authorization)
+        It "Verifies Invoke-WebRequest -Authentication <Authentication> requires -Token" -TestCases $testCases {
+            param($Authentication)
             $params = @{
                 Uri = $httpsUri
-                Authorization = $authorization
+                Authentication = $Authentication
                 ErrorAction = 'Stop'
                 SkipCertificateCheck = $true
             }
-            { Invoke-WebRequest @params } | ShouldBeErrorId "WebCmdletAuthorizationTokenNotSuppliedException,Microsoft.PowerShell.Commands.InvokeWebRequestCommand"
+            { Invoke-WebRequest @params } | ShouldBeErrorId "WebCmdletAuthenticationTokenNotSuppliedException,Microsoft.PowerShell.Commands.InvokeWebRequestCommand"
         }
 
-        It "Verifies Invoke-WebRequest -Authorization Basic requires -Credential" {
+        It "Verifies Invoke-WebRequest -Authentication Basic requires -Credential" {
             $params = @{
                 Uri = $httpsUri
-                Authorization = "Basic"
+                Authentication = "Basic"
                 ErrorAction = 'Stop'
                 SkipCertificateCheck = $true
             }
-            { Invoke-WebRequest @params } | ShouldBeErrorId "WebCmdletAuthorizationCredentialNotSuppliedException,Microsoft.PowerShell.Commands.InvokeWebRequestCommand"
+            { Invoke-WebRequest @params } | ShouldBeErrorId "WebCmdletAuthenticationCredentialNotSuppliedException,Microsoft.PowerShell.Commands.InvokeWebRequestCommand"
         }
 
-        It "Verifies Invoke-WebRequest -Authorization Requires HTTPS" {
+        It "Verifies Invoke-WebRequest -Authentication Requires HTTPS" {
             $params = @{
                 Uri = $httpUri
                 Token = $token
-                Authorization = "OAuth"
+                Authentication = "OAuth"
                 ErrorAction = 'Stop'
             }
-            { Invoke-WebRequest @params } | ShouldBeErrorId "WebCmdletAllowUnencryptedAuthorizationRequiredException,Microsoft.PowerShell.Commands.InvokeWebRequestCommand"
+            { Invoke-WebRequest @params } | ShouldBeErrorId "WebCmdletAllowUnencryptedAuthenticationRequiredException,Microsoft.PowerShell.Commands.InvokeWebRequestCommand"
         }
 
-        It "Verifies Invoke-WebRequest -Authorization Can us HTTP with -AllowUnencryptedAuthorization" {
+        It "Verifies Invoke-WebRequest -Authentication Can us HTTP with -AllowUnencryptedAuthentication" {
             $params = @{
                 Uri = $httpUri
                 Token = $token
-                Authorization = "OAuth"
-                AllowUnencryptedAuthorization = $true
+                Authentication = "OAuth"
+                AllowUnencryptedAuthentication = $true
             }
             $Response = Invoke-WebRequest @params
             $result = $response.Content | ConvertFrom-Json
@@ -2206,7 +2206,7 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
         }
     }
 
-    Context "Invoke-RestMethod -Authorization tests" {
+    Context "Invoke-RestMethod -Authentication tests" {
         BeforeAll {
             #[SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Demo/doc/test secret.")]
             $token = "testpassword" | ConvertTo-SecureString -AsPlainText -Force
@@ -2214,15 +2214,15 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
             $httpUri = Get-WebListenerUrl -Test 'Get'
             $httpsUri = Get-WebListenerUrl -Test 'Get' -Https
             $testCases = @(
-                @{authorization = "bearer"}
-                @{authorization = "OAuth"}
+                @{Authentication = "bearer"}
+                @{Authentication = "OAuth"}
             )
         }
 
-        It "Verifies Invoke-RestMethod -Authorization Basic" {
+        It "Verifies Invoke-RestMethod -Authentication Basic" {
             $params = @{
                 Uri = $httpsUri
-                Authorization = "Basic"
+                Authentication = "Basic"
                 Credential = $credential
                 SkipCertificateCheck = $true
             }
@@ -2231,11 +2231,11 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
             $result.Headers.Authorization | Should BeExactly "Basic dGVzdHVzZXI6dGVzdHBhc3N3b3Jk"
         }
 
-        It "Verifies Invoke-RestMethod -Authorization <authorization>" -TestCases $testCases {
-            param($authorization)
+        It "Verifies Invoke-RestMethod -Authentication <Authentication>" -TestCases $testCases {
+            param($Authentication)
             $params = @{
                 Uri = $httpsUri
-                Authorization = $authorization 
+                Authentication = $Authentication 
                 Token = $token
                 SkipCertificateCheck = $true
             }
@@ -2244,67 +2244,67 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
             $result.Headers.Authorization | Should BeExactly "Bearer testpassword"
         }
 
-        It "Verifies Invoke-RestMethod -Authorization does not support -UseDefaultCredentials" {
+        It "Verifies Invoke-RestMethod -Authentication does not support -UseDefaultCredentials" {
             $params = @{
                 Uri = $httpsUri
                 Token = $token
-                Authorization = "OAuth"
+                Authentication = "OAuth"
                 UseDefaultCredentials = $true
                 ErrorAction = 'Stop'
                 SkipCertificateCheck = $true
             }
-            { Invoke-RestMethod @params } | ShouldBeErrorId "WebCmdletAuthorizationConflictException,Microsoft.PowerShell.Commands.InvokeRestMethodCommand"
+            { Invoke-RestMethod @params } | ShouldBeErrorId "WebCmdletAuthenticationConflictException,Microsoft.PowerShell.Commands.InvokeRestMethodCommand"
         }
 
-        It "Verifies Invoke-RestMethod -Authorization does not support Both -Credential and -Token" {
+        It "Verifies Invoke-RestMethod -Authentication does not support Both -Credential and -Token" {
             $params = @{
                 Uri = $httpsUri
                 Token = $token
                 Credential = $credential
-                Authorization = "OAuth"
+                Authentication = "OAuth"
                 ErrorAction = 'Stop'
                 SkipCertificateCheck = $true
             }
-            { Invoke-RestMethod @params } | ShouldBeErrorId "WebCmdletAuthorizationTokenConflictException,Microsoft.PowerShell.Commands.InvokeRestMethodCommand"
+            { Invoke-RestMethod @params } | ShouldBeErrorId "WebCmdletAuthenticationTokenConflictException,Microsoft.PowerShell.Commands.InvokeRestMethodCommand"
         }
 
-        It "Verifies Invoke-RestMethod -Authorization <authorization> requires -Token" -TestCases $testCases {
-            param($authorization)
+        It "Verifies Invoke-RestMethod -Authentication <Authentication> requires -Token" -TestCases $testCases {
+            param($Authentication)
             $params = @{
                 Uri = $httpsUri
-                Authorization = $authorization
+                Authentication = $Authentication
                 ErrorAction = 'Stop'
                 SkipCertificateCheck = $true
             }
-            { Invoke-RestMethod @params } | ShouldBeErrorId "WebCmdletAuthorizationTokenNotSuppliedException,Microsoft.PowerShell.Commands.InvokeRestMethodCommand"
+            { Invoke-RestMethod @params } | ShouldBeErrorId "WebCmdletAuthenticationTokenNotSuppliedException,Microsoft.PowerShell.Commands.InvokeRestMethodCommand"
         }
 
-        It "Verifies Invoke-RestMethod -Authorization Basic requires -Credential" {
+        It "Verifies Invoke-RestMethod -Authentication Basic requires -Credential" {
             $params = @{
                 Uri = $httpsUri
-                Authorization = "Basic"
+                Authentication = "Basic"
                 ErrorAction = 'Stop'
                 SkipCertificateCheck = $true
             }
-            { Invoke-RestMethod @params } | ShouldBeErrorId "WebCmdletAuthorizationCredentialNotSuppliedException,Microsoft.PowerShell.Commands.InvokeRestMethodCommand"
+            { Invoke-RestMethod @params } | ShouldBeErrorId "WebCmdletAuthenticationCredentialNotSuppliedException,Microsoft.PowerShell.Commands.InvokeRestMethodCommand"
         }
 
-        It "Verifies Invoke-RestMethod -Authorization Requires HTTPS" {
+        It "Verifies Invoke-RestMethod -Authentication Requires HTTPS" {
             $params = @{
                 Uri = $httpUri
                 Token = $token
-                Authorization = "OAuth"
+                Authentication = "OAuth"
                 ErrorAction = 'Stop'
             }
-            { Invoke-RestMethod @params } | ShouldBeErrorId "WebCmdletAllowUnencryptedAuthorizationRequiredException,Microsoft.PowerShell.Commands.InvokeRestMethodCommand"
+            { Invoke-RestMethod @params } | ShouldBeErrorId "WebCmdletAllowUnencryptedAuthenticationRequiredException,Microsoft.PowerShell.Commands.InvokeRestMethodCommand"
         }
 
-        It "Verifies Invoke-RestMethod -Authorization Can us HTTP with -AllowUnencryptedAuthorization" {
+        It "Verifies Invoke-RestMethod -Authentication Can us HTTP with -AllowUnencryptedAuthentication" {
             $params = @{
                 Uri = $httpUri
                 Token = $token
-                Authorization = "OAuth"
-                AllowUnencryptedAuthorization = $true
+                Authentication = "OAuth"
+                AllowUnencryptedAuthentication = $true
             }
             $result = Invoke-RestMethod @params
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -1393,31 +1393,6 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
 
             $result.Headers.Authorization | Should BeExactly "Bearer testpassword"
         }
-
-        It "Verifies Invoke-WebRequest -Credential produces a warning on HTTP requests" {
-            $params = @{
-                Uri = $httpUri
-                Credential = $credential
-                WarningVariable = 'warnings'
-                WarningAction =  'SilentlyContinue'
-            }
-            $Response = Invoke-WebRequest @params
-
-            $warnings.Count | should be 1
-        }
-
-        It "Verifies Invoke-WebRequest -Credential suppresses a warning on HTTP requests with -AllowUnencryptedAuthentication " {
-            $params = @{
-                Uri = $httpUri
-                Credential = $credential
-                WarningVariable = 'warnings'
-                WarningAction =  'SilentlyContinue'
-                AllowUnencryptedAuthentication = $true
-            }
-            $Response = Invoke-WebRequest @params
-
-            $warnings.Count | should be 0
-        }
     }
 
     BeforeEach {
@@ -2334,31 +2309,6 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
             $result = Invoke-RestMethod @params
 
             $result.Headers.Authorization | Should BeExactly "Bearer testpassword"
-        }
-
-        It "Verifies Invoke-RestMethod -Credential produces a warning on HTTP requests" {
-            $params = @{
-                Uri = $httpUri
-                Credential = $credential
-                WarningVariable = 'warnings'
-                WarningAction =  'SilentlyContinue'
-            }
-            $Response = Invoke-RestMethod @params
-
-            $warnings.Count | should be 1
-        }
-
-        It "Verifies Invoke-RestMethod -Credential suppresses a warning on HTTP requests with -AllowUnencryptedAuthentication " {
-            $params = @{
-                Uri = $httpUri
-                Credential = $credential
-                WarningVariable = 'warnings'
-                WarningAction =  'SilentlyContinue'
-                AllowUnencryptedAuthentication = $true
-            }
-            $Response = Invoke-RestMethod @params
-
-            $warnings.Count | should be 0
         }
     }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -1293,6 +1293,10 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
             $credential = [pscredential]::new("testuser",$token)
             $httpUri = Get-WebListenerUrl -Test 'Get'
             $httpsUri = Get-WebListenerUrl -Test 'Get' -Https
+            $testCases = @(
+                @{authorization = "bearer"}
+                @{authorization = "OAuth"}
+            )
         }
 
         It "Verifies Invoke-WebRequest -Authorization Basic" {
@@ -1308,10 +1312,7 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
             $result.Headers.Authorization | Should BeExactly "Basic dGVzdHVzZXI6dGVzdHBhc3N3b3Jk"
         }
 
-        It "Verifies Invoke-WebRequest -Authorization <authorization>" -TestCases @(
-            @{ authorization = "bearer"}
-            @{ authorization = "OAuth"}
-        ) {
+        It "Verifies Invoke-WebRequest -Authorization <authorization>" -TestCases $testCases {
             param($authorization)
             $params = @{
                 Uri = $httpsUri
@@ -1349,10 +1350,7 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
             { Invoke-WebRequest @params } | ShouldBeErrorId "WebCmdletAuthorizationTokenConflictException,Microsoft.PowerShell.Commands.InvokeWebRequestCommand"
         }
 
-        It "Verifies Invoke-WebRequest -Authorization <authorization> requires -Token" -TestCases @(
-            @{ authorization = "bearer"}
-            @{ authorization = "OAuth"}
-        ) {
+        It "Verifies Invoke-WebRequest -Authorization <authorization> requires -Token" -TestCases $testCases {
             param($authorization)
             $params = @{
                 Uri = $httpsUri
@@ -2215,6 +2213,10 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
             $credential = [pscredential]::new("testuser",$token)
             $httpUri = Get-WebListenerUrl -Test 'Get'
             $httpsUri = Get-WebListenerUrl -Test 'Get' -Https
+            $testCases = @(
+                @{authorization = "bearer"}
+                @{authorization = "OAuth"}
+            )
         }
 
         It "Verifies Invoke-RestMethod -Authorization Basic" {
@@ -2229,10 +2231,7 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
             $result.Headers.Authorization | Should BeExactly "Basic dGVzdHVzZXI6dGVzdHBhc3N3b3Jk"
         }
 
-        It "Verifies Invoke-RestMethod -Authorization <authorization>" -TestCases @(
-            @{ authorization = "Bearer"}
-            @{ authorization = "OAuth"}
-        ) {
+        It "Verifies Invoke-RestMethod -Authorization <authorization>" -TestCases $testCases {
             param($authorization)
             $params = @{
                 Uri = $httpsUri
@@ -2269,10 +2268,7 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
             { Invoke-RestMethod @params } | ShouldBeErrorId "WebCmdletAuthorizationTokenConflictException,Microsoft.PowerShell.Commands.InvokeRestMethodCommand"
         }
 
-        It "Verifies Invoke-RestMethod -Authorization <authorization> requires -Token" -TestCases @(
-            @{ authorization = "Bearer"}
-            @{ authorization = "OAuth"}
-        ) {
+        It "Verifies Invoke-RestMethod -Authorization <authorization> requires -Token" -TestCases $testCases {
             param($authorization)
             $params = @{
                 Uri = $httpsUri


### PR DESCRIPTION
Closes #4274

- Adds an `-Authentication` parameter to `Invoke-RestMethod` and `Invoke-WebRequest`
- Adds an `-Token` parameter to `Invoke-RestMethod` and `Invoke-WebRequest`
- Adds an `-AllowUnencryptedAuthentication` parameter to `Invoke-RestMethod` and `Invoke-WebRequest`
- Adds tests for various `-Authorization` uses
-  `-Authentication` Parameter has 3 options: `Basic`, `OAuth`, and `Bearer`
- `Basic` requires `-Credential` and provides RFC-7617 Basic Authorization credentials to the remote server
- `OAuth` and `Bearer` require the `-Token` which is a SecureString containing the bearer token to send to the remote server
- If any authentication is provided for any transport scheme other than HTTPS, the request will result in an error. A user may use the `-AllowUnencryptedAuthentication` switch to bypass this behavior and send their secrets unencrypted at their own risk.
- `-Authentication` does not work with `-UseDefaultCredentials` and will result in an error.

The existing behavior with `-Credential` is left untouched. When *not* supplying `-Authentication`, A user will *not* receive an error when using `-Credential` over unencrypted connections.

Code design choice is meant to accommodate more Authentication types in the future.

# Documentation Needed
The 3 new parameters will need to be added to the `Invoke-RestMethod` and `Invoke-WebRequest` documentation along with examples. Syntax will need to be updated.