### PR TITLE
Add better error message for empty and null -UFormat arg

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetDateCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetDateCommand.cs
@@ -199,6 +199,7 @@ namespace Microsoft.PowerShell.Commands
         /// Unix format string
         /// </summary>
         [Parameter(ParameterSetName = "UFormat")]
+        [ValidateNotNullOrEmpty]
         public string UFormat { get; set; }
 
 
@@ -331,7 +332,6 @@ namespace Microsoft.PowerShell.Commands
             DateTime epoch = DateTime.Parse("January 1, 1970", System.Globalization.CultureInfo.InvariantCulture);
             int offset = 0;
             StringBuilder sb = new StringBuilder();
-
 
             // folks may include the "+" as part of the format string
             if (UFormat[0] == '+')

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Date.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Date.Tests.ps1
@@ -37,6 +37,14 @@ Describe "Get-Date DRT Unit Tests" -Tags "CI" {
         Get-date -Date 1/1/0030 -uformat %S%T%u%U%V%w%W%x%X%y%Y%% | Should be "0000:00:002012001/01/3000:00:00300030%"
     }
 
+    It "Passing '<name>' to -uformat produces a descriptive error" -TestCases @(
+        @{ name = "`$null"      ; value = $null }
+        @{ name = "empty string"; value = "" }
+    ) {
+        param($value)
+        { Get-date -Date 1/1/1970 -uformat $value -ErrorAction Stop } | ShouldBeErrorId "ParameterArgumentValidationError,Microsoft.PowerShell.Commands.GetDateCommand"
+    }
+
     It "Get-date works with pipeline input" {
         $x = new-object System.Management.Automation.PSObject
         $x | add-member NoteProperty Date ([DateTime]::Now)


### PR DESCRIPTION
Previously, when passing an empty format string to -UFormat, a somewhat unhelpful
error message would appear. This commit fixes #5047 by adding a more descriptive error to better
guide the user

<!--

If you are a PowerShell Team member, please make sure you choose the Reviewer(s) and Assignee for your PR.
If you are not from the PowerShell Team, you can leave the fields blank and the Maintainers will choose them for you. If you are familiar with the team, feel free to mention some Reviewers yourself.

For more information about the roles of Reviewer and Assignee, refer to [CONTRIBUTING.md](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md).

-->
