### PR TITLE
Add NoNewLine switch for Out-String cmdlet

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/out-string/out-string.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/out-string/out-string.cs
@@ -13,7 +13,7 @@ namespace Microsoft.PowerShell.Commands
     /// <summary>
     /// implementation for the out-string command
     /// </summary>
-    [Cmdlet(VerbsData.Out, "String", HelpUri = "https://go.microsoft.com/fwlink/?LinkID=113368", RemotingCapability = RemotingCapability.None)]
+    [Cmdlet(VerbsData.Out, "String", DefaultParameterSetName = "NoNewLineFormatting", HelpUri = "https://go.microsoft.com/fwlink/?LinkID=113368", RemotingCapability = RemotingCapability.None)]
     [OutputType(typeof(string))]
     public class OutStringCommand : FrontEndCommandBase
     {
@@ -24,7 +24,7 @@ namespace Microsoft.PowerShell.Commands
         /// FALSE: accumulate all the data, then write a single string
         /// TRUE: write one line at the time
         /// </summary>
-        [Parameter]
+        [Parameter(ParameterSetName="StreamFormatting")]
         public SwitchParameter Stream
         {
             get { return _stream; }
@@ -45,6 +45,19 @@ namespace Microsoft.PowerShell.Commands
         }
 
         private Nullable<int> _width = null;
+
+        /// <summary>
+        /// False to add a newline to the end of the output string, true if not.
+        /// </summary>
+        [Parameter(ParameterSetName="NoNewLineFormatting")]
+        public SwitchParameter NoNewline
+        {
+            get { return _noNewLine; }
+            set { _noNewLine = value;}
+        }
+
+        private bool _noNewLine = false;
+
         #endregion
 
         /// <summary>
@@ -122,9 +135,20 @@ namespace Microsoft.PowerShell.Commands
         private void OnWriteLine(string s)
         {
             if (_stream)
+            {
                 this.WriteObject(s);
+            }
             else
-                _buffer.AppendLine(s);
+            {
+                if (_noNewLine)
+                {
+                    _buffer.Append(s);
+                }
+                else
+                {
+                    _buffer.AppendLine(s);
+                }
+            }
         }
 
         /// <summary>

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Out-String.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Out-String.Tests.ps1
@@ -45,4 +45,19 @@ Describe "Out-String" -Tags "CI" {
 
 	$streamoutputlength | Should BeLessThan $nonstreamoutputlength
     }
+
+    It "Should not print a newline when the nonewline switch is used" {
+        $testArray = "a", "b"
+        $testArray | Out-String -NoNewLine | Should Be "ab"
+    }
+
+    It "Should preserve embedded newline when the nonewline switch is used" {
+        $testArray = "a$nl", "b"
+        $testArray | Out-String -NoNewLine | Should Be "a${nl}b"
+    }
+
+    It "Should throw error when NoNewLine and Stream are used together" {
+        $testArray = "a", "b"
+        { $testArray | Out-String -NoNewLine -Stream }| ShouldBeErrorId  "AmbiguousParameterSet,Microsoft.PowerShell.Commands.OutStringCommand"
+    }
 }


### PR DESCRIPTION
Fix #3684.

First PS pull request {insert nervous emoji}
Mostly adapted from the -NoNewLine changes for Out-File
