### PR TITLE
Replace HttpBin.org/response-headers Tests with WebListener

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -1190,3 +1190,8 @@ tests.zip
 v5.0
 v6.0.
 #endregion
+
+#region test/tools/WebListener/README.md Overrides
+ - test/tools/WebListener/README.md
+ResponseHeaders
+#endregion

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -737,7 +737,8 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
     It "Validate Invoke-WebRequest handles missing Content-Type in response header" {
 
         #Validate that exception is not thrown when response headers are missing Content-Type.
-        $command = "Invoke-WebRequest -Uri 'http://httpbin.org/response-headers?Content-Type='"
+        $uri = Get-WebListenerUrl -Test 'ResponseHeaders' -Query @{'Content-Type' = ''}
+        $command = "Invoke-WebRequest -Uri '$uri'"
         $result = ExecuteWebCommand -command $command
         $result.Error | Should BeNullOrEmpty
     }
@@ -1588,7 +1589,8 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
     It "Validate Invoke-RestMethod handles missing Content-Type in response header" {
 
         #Validate that exception is not thrown when response headers are missing Content-Type.
-        $command = "Invoke-RestMethod -Uri 'http://httpbin.org/response-headers?Content-Type='"
+        $uri = Get-WebListenerUrl -Test 'ResponseHeaders' -Query @{'Content-Type' = ''}
+        $command = "Invoke-RestMethod -Uri '$uri'"
         $result = ExecuteWebCommand -command $command
         $result.Error | Should BeNullOrEmpty
     }

--- a/test/tools/Modules/WebListener/WebListener.psm1
+++ b/test/tools/Modules/WebListener/WebListener.psm1
@@ -121,11 +121,14 @@ function Get-WebListenerUrl {
             'Home',
             'Multipart',
             'Redirect',
+            'ResponseHeaders',
             '/'
         )]
         [String]$Test,
 
-        [String]$TestValue
+        [String]$TestValue,
+
+        [System.Collections.IDictionary]$Query
     )
     process {
         $runningListener = Get-WebListener
@@ -151,6 +154,15 @@ function Get-WebListenerUrl {
         {
             $Uri.Path = $Test
         }
+        $StringBuilder = [System.Text.StringBuilder]::new()
+        foreach ($key in $Query.Keys)
+        {
+            $null = $StringBuilder.Append([System.Net.WebUtility]::UrlEncode($key))
+            $null = $StringBuilder.Append('=')
+            $null = $StringBuilder.Append([System.Net.WebUtility]::UrlEncode($Query[$key].ToString()))
+            $null = $StringBuilder.Append('&')
+        }
+        $Uri.Query = $StringBuilder.ToString()
 
         return [Uri]$Uri.ToString()
     }

--- a/test/tools/WebListener/Controllers/ResponseHeadersController.cs
+++ b/test/tools/WebListener/Controllers/ResponseHeadersController.cs
@@ -40,6 +40,7 @@ namespace mvc.Controllers
             }
             return JsonConvert.SerializeObject(headers);
         }
+        
         public IActionResult Error()
         {
             return View(new ErrorViewModel { RequestId = Activity.Current?.Id ?? HttpContext.TraceIdentifier });

--- a/test/tools/WebListener/Controllers/ResponseHeadersController.cs
+++ b/test/tools/WebListener/Controllers/ResponseHeadersController.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Extensions;
+using Microsoft.Extensions.Primitives;
+using Newtonsoft.Json;
+using mvc.Models;
+
+namespace mvc.Controllers
+{
+    public class ResponseHeadersController : Controller
+    {
+        public string Index()
+        {
+            Hashtable headers = new Hashtable();
+            foreach (var key in Request.Query.Keys)
+            {
+                headers.Add(key, String.Join(Constants.HeaderSeparator, Request.Query[key]));
+
+                if (String.Equals("Content-Type", key, StringComparison.InvariantCultureIgnoreCase))
+                {
+                    // Content-Type must be applied right before it is sent to the client or MVC will overwrite.
+                    string contentType = Request.Query[key];
+                    Response.OnStarting(state =>
+                    {
+                         var httpContext = (HttpContext) state;
+                         httpContext.Response.ContentType = contentType;
+                         return Task.FromResult(0);
+                    }, HttpContext);
+                }
+                else
+                {
+                    Response.Headers.TryAdd(key, Request.Query[key]);
+                }
+            }
+            return JsonConvert.SerializeObject(headers);
+        }
+        public IActionResult Error()
+        {
+            return View(new ErrorViewModel { RequestId = Activity.Current?.Id ?? HttpContext.TraceIdentifier });
+        }
+    }
+}

--- a/test/tools/WebListener/README.md
+++ b/test/tools/WebListener/README.md
@@ -244,3 +244,34 @@ Location: /Get/
 <h1>Redirecting...</h1>
 <p>You should be redirected automatically to target URL: <a href="/Get/">/Get/</a>.  If not click the link.
 ```
+
+## /ResponseHeaders/
+
+Will return the response headers passed in query string. The response body will be the supplied headers as a JSON object.
+
+```powershell
+$uri = Get-WebListenerUrl -Test 'ResponseHeaders' -Query @{'Content-Type' = 'custom'; 'x-header-01' = 'value01'; 'x-header-02' = 'value02'}
+Invoke-RestMethod -Uri $uri 
+```
+
+Response Headers:
+
+```none
+HTTP/1.1 200 OK
+Date: Sun, 08 Oct 2017 18:20:38 GMT
+Transfer-Encoding: chunked
+Server: Kestrel
+x-header-02: value02
+x-header-01: value01
+Content-Type: custom
+```
+
+Body:
+
+```json
+{
+    "Content-Type": "custom",
+    "x-header-02": "value02",
+    "x-header-01": "value01"
+}
+```

--- a/test/tools/WebListener/Views/Home/Index.cshtml
+++ b/test/tools/WebListener/Views/Home/Index.cshtml
@@ -9,4 +9,5 @@
     <li><a href="/Get/">/Get/</a> - Emulates functionality of https://httpbin.org/get by returning GET headers, Arguments, and Request URL</li>
     <li><a href="/Multipart/">/Multipart/</a> - Multipart/form-data submission testing</li>
     <li><a href="/Redirect/">/Redirect/{count}</a> - 302 redirect <i>count</i> times.</li>
+    <li><a href="/ResponseHeaders/?key=val">/ResponseHeaders/?key=val</a> - Returns given response headers.</li>
 </ul>


### PR DESCRIPTION
* Adds `/ResponseHeaders/` Test to WebListener
* Adds `-Query` parameter to `Get-WebListenerUrl` which accepts a dictionary where keys are wuery string fields and values are query string values
* Replaces http://httpbin.org/response-headers tests with WebListener

Reference #2504 

(note: the tests as they were intended before were actually not accurate. http://httpbin.org/response-headers returns an `Content-Type: application/json` in addition to `Content-Type: ` from the supplied header. The implementation in this PR does allow for a blank/missing `Content-Type` to be returned. It is possible this may reveal errors that were not visible before.)