### PR TITLE
Try to locate dotnet before installing it

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -1402,6 +1402,9 @@ function Start-PSBootstrap {
             }
         }
 
+        # Try to locate dotnet-SDK before installing it
+        Find-Dotnet
+
         # Install dotnet-SDK
         $dotNetExists = precheck 'dotnet' $null
         $dotNetVersion = [string]::Empty


### PR DESCRIPTION
When dotnet-SDK already installed but not added to `PATH` environment variable, then `Start-PSBootstrap` do not try to locate it but reinstall it anyway.