### PR TITLE
Update testing-guidelines.md to remind users about submodules

### DIFF
--- a/docs/testing-guidelines/testing-guidelines.md
+++ b/docs/testing-guidelines/testing-guidelines.md
@@ -100,6 +100,12 @@ Two helper functions are part of the build.psm1 module to help with that:
 
 Our CI system runs these as well; there should be no difference between running these on your dev system, versus in CI.
 
+Make sure that the git submodules have been loaded into your project before running `Start-PSPester`, or it will fail to run. If you did not clone the project with the `--recursive` flag, you can load the submodules by running: 
+
+```
+git submodule update --init
+```
+
 When running tests in this way, be sure that you have started PowerShell with `-noprofile` as some tests will fail if the
 environment is not the default or has any customization.
 


### PR DESCRIPTION
The bit about submodules in the README is easy to miss or forget if you're reading deep into the docs. It might be helpful to have a reminder here if someone is having trouble with the Pester module not being found.

<!--

If you are a PowerShell Team member, please make sure you choose the Reviewer(s) and Assignee for your PR.
If you are not from the PowerShell Team, you can leave the fields blank and the Maintainers will choose them for you. If you are familiar with the team, feel free to mention some Reviewers yourself.

For more information about the roles of Reviewer and Assignee, refer to [CONTRIBUTING.md](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md).

-->
