### PR TITLE
Add warning to Start-PSPester if Pester module not found

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -848,6 +848,10 @@ function Start-PSPester {
         [switch]$IncludeFailingTest
     )
 
+    if (-not (Test-Path $Pester)) {
+        Write-Warning "Pester module not found. Make sure that the proper git submodules are installed by running:`r`n`r`ngit submodule init --update`r`n "
+    }
+
     if ($IncludeFailingTest.IsPresent)
     {
         $Path += "$PSScriptRoot/tools/failingTests"


### PR DESCRIPTION
Currently, if a user does not clone with the --recursive flag or run
git submodule update --init, Start-PSPester will fail to run due to
the Pester module missing. While the errorhints at the Pester module not
being found, there is no suggested way of fixing the issue presented to
the user.

<!--

If you are a PowerShell Team member, please make sure you choose the Reviewer(s) and Assignee for your PR.
If you are not from the PowerShell Team, you can leave the fields blank and the Maintainers will choose them for you. If you are familiar with the team, feel free to mention some Reviewers yourself.

For more information about the roles of Reviewer and Assignee, refer to [CONTRIBUTING.md](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md).

-->
