### PR TITLE
Update linux.md

### DIFF
--- a/docs/building/linux.md
+++ b/docs/building/linux.md
@@ -144,9 +144,9 @@ cd src/powershell-unix
 dotnet build --configuration Linux
 ```
 
-The executable will be in `./bin/[configuration]/[framework]/[rid]/[binary name]`,
-where our configuration is `Linux`, framework is `netcoreapp1.1`,
-runtime identifier is `ubuntu.14.04-x64`, and binary name is `powershell`.
+The executable will be in `./bin/[configuration]/[framework]/[rid]/publish/[binary name]`,
+where our configuration is `Linux`, framework is `netcoreapp2.0`,
+runtime identifier is `linux-x64`, and binary name is `powershell`.
 The function `Get-PSOutput` will return the path to the executable;
 thus you can execute the development copy via `& (Get-PSOutput)`.
 


### PR DESCRIPTION
The documentation is out of sync with the current implementation of `Get-PSOutput` which returns `[IO.Path]::Combine($Top, "bin", $Configuration, $Framework, $Runtime, "publish", $Executable)`

Super minor PR, but I'm setting up my system to build PowerShell and I came across that...
<!--

If you are a PowerShell Team member, please make sure you choose the Reviewer(s) and Assignee for your PR.
If you are not from the PowerShell Team, you can leave the fields blank and the Maintainers will choose them for you. If you are familiar with the team, feel free to mention some Reviewers yourself.

For more information about the roles of Reviewer and Assignee, refer to [CONTRIBUTING.md](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md).

-->
