### PR TITLE
Fix the prerequisite check of MSI package

### DIFF
--- a/assets/Product.wxs
+++ b/assets/Product.wxs
@@ -76,11 +76,6 @@
     </Feature>
     <!-- We need to show EULA, and provide option to customize download location -->
     <Property Id="WIXUI_INSTALLDIR" Value="INSTALLFOLDER" />
-    <!-- Get the real major version of the OS. This registry value name only exists on Win10 -->
-    <Property Id="WIN10_MAJOR_VERSION">
-      <RegistrySearch Id="Win10MajorVersion" Root="HKLM" Key="SOFTWARE\Microsoft\Windows NT\CurrentVersion"
-                      Name="CurrentMajorVersionNumber" Type="raw" />
-    </Property>
     <!-- Prerequisite check for Windows Universal C runtime -->
     <Property Id="UNIVERSAL_C_RUNTIME_INSTALLED" Secure="yes">
       <DirectorySearch Id="WindowsDirectory" Path="[WindowsFolder]">
@@ -89,17 +84,17 @@
         </DirectorySearch>
       </DirectorySearch>
     </Property>
-    <Condition Message="$(env.ProductName) requires the Universal C Runtime to be installed. You can find a download link to it here: https://github.com/PowerShell/PowerShell/blob/master/docs/installation/windows.md#prerequisites">
+    <Condition Message="$(env.ProductName) requires the Universal C Runtime to be installed to enable remoting over WinRM. You can find a download link to it here: https://github.com/PowerShell/PowerShell/blob/master/docs/installation/windows.md#prerequisites">
       <![CDATA[Installed OR UNIVERSAL_C_RUNTIME_INSTALLED]]>
     </Condition>
-    <!-- Prerequisite check for Visual Studio 2015 C++ redistributables -->
-    <Property Id="VISUAL_CPP_RUNTIME_INSTALLED" Secure="yes">
+    <!-- Prerequisite check for Windows Management Framework -->
+    <Property Id="PWRSHPLUGIN_VERSION" Secure="yes">
       <DirectorySearchRef Id="System32" Parent="WindowsDirectory" Path="System32">
-        <FileSearch Id="vcruntime140" Name="vcruntime140.dll"/>
+        <FileSearch Id="pwrshplugin" Name="pwrshplugin.dll" MinVersion="6.3.9600.16383"/>
       </DirectorySearchRef>
     </Property>
-    <Condition Message="$(env.ProductName) requires the Visual Studio 2015 C++ redistributables to be installed. You can find a download link to it here: https://github.com/PowerShell/PowerShell/blob/master/docs/installation/windows.md#prerequisites">
-      <![CDATA[Installed OR VISUAL_CPP_RUNTIME_INSTALLED OR WIN10_MAJOR_VERSION ]]>
+    <Condition Message="$(env.ProductName) requires the Windows Management Framework 4.0 or higher to be installed to enable remoting over WinRM. You can find download links here: https://github.com/PowerShell/PowerShell/blob/master/docs/installation/windows.md#prerequisites">
+      <![CDATA[Installed OR PWRSHPLUGIN_VERSION ]]>
     </Condition>
     <Directory Id="TARGETDIR" Name="SourceDir">
       <Directory Id="$(var.ProductProgFilesDir)">

--- a/assets/Product.wxs
+++ b/assets/Product.wxs
@@ -59,7 +59,7 @@
       <Publish Dialog="MyExitDialog" Control="Finish" Order="1" Event="DoAction" Value="LaunchApplication">LAUNCHAPPONEXIT</Publish>
     </UI>
     <!-- Prerequisites -->
-    <Condition Message="Supported only on Win8 and above">
+    <Condition Message="Supported only on Win7 and above">
       <![CDATA[ Installed OR $(var.MinOSVersionSupported) ]]>
     </Condition>
     <!-- Information About When Older Versions Are Trying To Be Installed-->
@@ -74,8 +74,13 @@
       <ComponentRef Id="ProductVersionFolder"/>
       <ComponentRef Id="ApplicationProgramsMenuShortcut"/>
     </Feature>
-    <!--We need to show EULA, and provide option to customize download location-->
+    <!-- We need to show EULA, and provide option to customize download location -->
     <Property Id="WIXUI_INSTALLDIR" Value="INSTALLFOLDER" />
+    <!-- Get the real major version of the OS. This registry value name only exists on Win10 -->
+    <Property Id="WIN10_MAJOR_VERSION">
+      <RegistrySearch Id="Win10MajorVersion" Root="HKLM" Key="SOFTWARE\Microsoft\Windows NT\CurrentVersion"
+                      Name="CurrentMajorVersionNumber" Type="raw" />
+    </Property>
     <!-- Prerequisite check for Windows Universal C runtime -->
     <Property Id="UNIVERSAL_C_RUNTIME_INSTALLED" Secure="yes">
       <DirectorySearch Id="WindowsDirectory" Path="[WindowsFolder]">
@@ -94,7 +99,7 @@
       </DirectorySearchRef>
     </Property>
     <Condition Message="$(env.ProductName) requires the Visual Studio 2015 C++ redistributables to be installed. You can find a download link to it here: https://github.com/PowerShell/PowerShell/blob/master/docs/installation/windows.md#prerequisites">
-      <![CDATA[Installed OR VISUAL_CPP_RUNTIME_INSTALLED]]>
+      <![CDATA[Installed OR VISUAL_CPP_RUNTIME_INSTALLED OR WIN10_MAJOR_VERSION ]]>
     </Condition>
     <Directory Id="TARGETDIR" Name="SourceDir">
       <Directory Id="$(var.ProductProgFilesDir)">

--- a/assets/Product.wxs
+++ b/assets/Product.wxs
@@ -59,7 +59,7 @@
       <Publish Dialog="MyExitDialog" Control="Finish" Order="1" Event="DoAction" Value="LaunchApplication">LAUNCHAPPONEXIT</Publish>
     </UI>
     <!-- Prerequisites -->
-    <Condition Message="Supported only on Win7 and above">
+    <Condition Message="Supported only on Windows 7 and above">
       <![CDATA[ Installed OR $(var.MinOSVersionSupported) ]]>
     </Condition>
     <!-- Information About When Older Versions Are Trying To Be Installed-->

--- a/assets/Product.wxs
+++ b/assets/Product.wxs
@@ -84,7 +84,7 @@
         </DirectorySearch>
       </DirectorySearch>
     </Property>
-    <Condition Message="$(env.ProductName) requires the Universal C Runtime to be installed to enable remoting over WinRM. You can find a download link to it here: https://github.com/PowerShell/PowerShell/blob/master/docs/installation/windows.md#prerequisites">
+    <Condition Message="$(env.ProductName) requires the Universal C Runtime to be installed to enable remoting over WinRM. You can find a download link to it here: http://aka.ms/pscore6-prereq">
       <![CDATA[Installed OR UNIVERSAL_C_RUNTIME_INSTALLED]]>
     </Condition>
     <!-- Prerequisite check for Windows Management Framework -->
@@ -93,7 +93,7 @@
         <FileSearch Id="pwrshplugin" Name="pwrshplugin.dll" MinVersion="6.3.9600.16383"/>
       </DirectorySearchRef>
     </Property>
-    <Condition Message="$(env.ProductName) requires the Windows Management Framework 4.0 or above to be installed to enable remoting over WinRM. You can find download links here: https://github.com/PowerShell/PowerShell/blob/master/docs/installation/windows.md#prerequisites">
+    <Condition Message="$(env.ProductName) requires the Windows Management Framework 4.0 or newer to be installed to enable remoting over WinRM. You can find download links here: http://aka.ms/pscore6-prereq">
       <![CDATA[Installed OR PWRSHPLUGIN_VERSION ]]>
     </Condition>
     <Directory Id="TARGETDIR" Name="SourceDir">

--- a/assets/Product.wxs
+++ b/assets/Product.wxs
@@ -84,7 +84,7 @@
         </DirectorySearch>
       </DirectorySearch>
     </Property>
-    <Condition Message="$(env.ProductName) requires the Universal C Runtime to be installed to enable remoting over WinRM. You can find a download link to it here: http://aka.ms/pscore6-prereq">
+    <Condition Message="$(env.ProductName) requires the Universal C Runtime to be installed to enable remoting over WinRM. You can find a download link to it here: https://aka.ms/pscore6-prereq">
       <![CDATA[Installed OR UNIVERSAL_C_RUNTIME_INSTALLED]]>
     </Condition>
     <!-- Prerequisite check for Windows Management Framework -->
@@ -93,7 +93,7 @@
         <FileSearch Id="pwrshplugin" Name="pwrshplugin.dll" MinVersion="6.3.9600.16383"/>
       </DirectorySearchRef>
     </Property>
-    <Condition Message="$(env.ProductName) requires the Windows Management Framework 4.0 or newer to be installed to enable remoting over WinRM. You can find download links here: http://aka.ms/pscore6-prereq">
+    <Condition Message="$(env.ProductName) requires the Windows Management Framework 4.0 or newer to be installed to enable remoting over WinRM. You can find download links here: https://aka.ms/pscore6-prereq">
       <![CDATA[Installed OR PWRSHPLUGIN_VERSION ]]>
     </Condition>
     <Directory Id="TARGETDIR" Name="SourceDir">

--- a/assets/Product.wxs
+++ b/assets/Product.wxs
@@ -93,7 +93,7 @@
         <FileSearch Id="pwrshplugin" Name="pwrshplugin.dll" MinVersion="6.3.9600.16383"/>
       </DirectorySearchRef>
     </Property>
-    <Condition Message="$(env.ProductName) requires the Windows Management Framework 4.0 or higher to be installed to enable remoting over WinRM. You can find download links here: https://github.com/PowerShell/PowerShell/blob/master/docs/installation/windows.md#prerequisites">
+    <Condition Message="$(env.ProductName) requires the Windows Management Framework 4.0 or above to be installed to enable remoting over WinRM. You can find download links here: https://github.com/PowerShell/PowerShell/blob/master/docs/installation/windows.md#prerequisites">
       <![CDATA[Installed OR PWRSHPLUGIN_VERSION ]]>
     </Condition>
     <Directory Id="TARGETDIR" Name="SourceDir">

--- a/docs/installation/windows.md
+++ b/docs/installation/windows.md
@@ -19,9 +19,9 @@ To enable PowerShell remoting over WinRM, the following prerequisites need to be
 * Install the [Universal C Runtime](https://www.microsoft.com/download/details.aspx?id=50410) on Windows versions prior to Windows 10.
   It is available via direct download or Windows Update.
   Fully patched (including optional packages), supported systems will already have this installed.
-* Install the Windows Management Framework (WMF) [4.0](https://www.microsoft.com/en-us/download/details.aspx?id=40855)
-  or newer ([5.0](https://www.microsoft.com/en-us/download/details.aspx?id=50395),
-  [5.1](https://www.microsoft.com/en-us/download/details.aspx?id=54616)) on Windows 7.
+* Install the Windows Management Framework (WMF) [4.0](https://www.microsoft.com/download/details.aspx?id=40855)
+  or newer ([5.0](https://www.microsoft.com/download/details.aspx?id=50395),
+  [5.1](https://www.microsoft.com/download/details.aspx?id=54616)) on Windows 7.
 
 ## Deploying on Nano Server
 

--- a/docs/installation/windows.md
+++ b/docs/installation/windows.md
@@ -20,7 +20,7 @@ To enable PowerShell remoting over WinRM, the following prerequisites need to be
   It is available via direct download or Windows Update.
   Fully patched (including optional packages), supported systems will already have this installed.
 * Install the Windows Management Framework (WMF) [4.0](https://www.microsoft.com/en-us/download/details.aspx?id=40855)
-  or above ([5.0](https://www.microsoft.com/en-us/download/details.aspx?id=50395),
+  or newer ([5.0](https://www.microsoft.com/en-us/download/details.aspx?id=50395),
   [5.1](https://www.microsoft.com/en-us/download/details.aspx?id=54616)) on Windows 7.
 
 ## Deploying on Nano Server

--- a/docs/installation/windows.md
+++ b/docs/installation/windows.md
@@ -14,10 +14,14 @@ There is a shortcut placed in the Start Menu upon installation.
 
 ### Prerequisites
 
+To enable PowerShell remoting over WinRM, the following prerequisites need to be met:
+
 * Install the [Universal C Runtime](https://www.microsoft.com/download/details.aspx?id=50410) on Windows versions prior to Windows 10.
   It is available via direct download or Windows Update.
   Fully patched (including optional packages), supported systems will already have this installed.
-* Install the [Visual C++ Redistributable](https://www.microsoft.com/download/details.aspx?id=48145) for VS2015.
+* Install the Windows Management Framework (WMF) [4.0](https://www.microsoft.com/en-us/download/details.aspx?id=40855)
+  or above ([5.0](https://www.microsoft.com/en-us/download/details.aspx?id=50395),
+  [5.1](https://www.microsoft.com/en-us/download/details.aspx?id=54616)) on Windows 7.
 
 ## Deploying on Nano Server
 

--- a/test/powershell/Installer/WindowsInstaller.Tests.ps1
+++ b/test/powershell/Installer/WindowsInstaller.Tests.ps1
@@ -1,22 +1,9 @@
-$thisTestFolder = Split-Path $MyInvocation.MyCommand.Path -Parent
-$wixProductFile = Join-Path $thisTestFolder "..\..\..\assets\Product.wxs"
-
 Describe "Windows Installer" -Tags "Scenario" {
 
-    BeforeAll {
-        $originalDefaultParameterValues = $PSDefaultParameterValues.Clone()
-        if ( ! $IsWindows ) {
-            $PSDefaultParameterValues["it:skip"] = $true
-        }
-    }
-
-    AfterAll {
-        $global:PSDefaultParameterValues = $originalDefaultParameterValues
-    }
-
-    $preRequisitesLink =  'https://github.com/PowerShell/PowerShell/blob/master/docs/installation/windows.md#prerequisites'
+    $preRequisitesLink =  'https://aka.ms/pscore6-prereq'
         
     It "WiX (Windows Installer XML) file contains pre-requisites link $preRequisitesLink" {
+        $wixProductFile = Join-Path -Path $PSScriptRoot -ChildPath "..\..\..\assets\Product.wxs"
         (Get-Content $wixProductFile -Raw).Contains($preRequisitesLink) | Should Be $true
     }
 
@@ -24,5 +11,4 @@ Describe "Windows Installer" -Tags "Scenario" {
         # Because an outdated link 'https://www.microsoft.com/download/details.aspx?id=504100000' would still return a 200 reponse (due to a redirection to an error page), it only checks that it returns something
         (Invoke-WebRequest $preRequisitesLink -UseBasicParsing) | Should Not Be $null
     }
-	
 }

--- a/test/powershell/Installer/WindowsInstaller.Tests.ps1
+++ b/test/powershell/Installer/WindowsInstaller.Tests.ps1
@@ -1,14 +1,24 @@
 Describe "Windows Installer" -Tags "Scenario" {
 
-    $preRequisitesLink =  'https://aka.ms/pscore6-prereq'
+    BeforeAll {
+        $preRequisitesLink =  'https://aka.ms/pscore6-prereq'
+        $linkCheckTestCases = @(
+            @{ Name = "Universal C Runtime"; Url = $preRequisitesLink }
+            @{ Name = "WMF 4.0"; Url = "https://www.microsoft.com/download/details.aspx?id=40855" }
+            @{ Name = "WMF 5.0"; Url = "https://www.microsoft.com/download/details.aspx?id=50395" }
+            @{ Name = "WMF 5.1"; Url = "https://www.microsoft.com/download/details.aspx?id=54616" }
+        )
+    }
         
     It "WiX (Windows Installer XML) file contains pre-requisites link $preRequisitesLink" {
         $wixProductFile = Join-Path -Path $PSScriptRoot -ChildPath "..\..\..\assets\Product.wxs"
         (Get-Content $wixProductFile -Raw).Contains($preRequisitesLink) | Should Be $true
     }
 
-    It "Pre-Requisistes link $preRequisitesLink is reachable" -TestCases $downloadLinks -Test {
+    It "Pre-Requisistes link for '<Name>' is reachable" -TestCases $linkCheckTestCases -Test {
+        param ($Url)
+
         # Because an outdated link 'https://www.microsoft.com/download/details.aspx?id=504100000' would still return a 200 reponse (due to a redirection to an error page), it only checks that it returns something
-        (Invoke-WebRequest $preRequisitesLink -UseBasicParsing) | Should Not Be $null
+        (Invoke-WebRequest $Url -UseBasicParsing) | Should Not Be $null
     }
 }


### PR DESCRIPTION
Fix #5029 

The Fix
-------
- Remove the check for `Visual C++ Redistributable`
- Add a precheck for WMF 4.0 on Win7.

`pwrshplugin.dll` has the following dependencies. All the `api-ms-win-crt-*` api sets are part of the `Universal C Runtime`. The plugin DLL doesn't depend on `Visual C++ Redistributable`.
```
    KERNEL32.dll
    ole32.dll
    WsmSvc.DLL
    api-ms-win-crt-string-l1-1-0.dll
    api-ms-win-crt-convert-l1-1-0.dll
    api-ms-win-crt-heap-l1-1-0.dll
    api-ms-win-crt-runtime-l1-1-0.dll
    api-ms-win-crt-stdio-l1-1-0.dll
    api-ms-win-crt-filesystem-l1-1-0.dll
    ADVAPI32.dll
    api-ms-win-crt-locale-l1-1-0.dll
    api-ms-win-crt-multibyte-l1-1-0.dll
```

On Win7, WMF 4.0 or higher version needs to be installed so that the WinRM can support the side-by-side remoting plugin. So I make the WMF 4.0 a prerequisite too. 
The way to check PSv4 or above is to check the file version of `\windows\system32\pwrshplugin.dll`. The file version for in-box PSv4 is `6.3.9600.16384`, for WMF 4.0 is `6.3.9600.16406`, and for PSv5+ is `10.0.xxx`. So we can check the MinVersion of the file `pwrshplugin.dll` to be `6.3.9600.16383` (means the version needs to be at least `6.3.9600.16384`).

**I have verified that on 2012R2, Win8.1 and Win7 once `Universal C Runtime` is installed (it requires a lot of other KB's to be installed) and PSv4 or WMF 4 is available, PowerShell remoting works.**

Screenshot Examples
----------
**On a machine that doesn't have `Universal C Runtime` installed:**
![image](https://user-images.githubusercontent.com/127450/31361654-2aea10ea-ad09-11e7-893b-2fe0fc995548.png)

**On Win7 that has `Universal C Runtime` installed but no WMF 4 or above**
![image](https://user-images.githubusercontent.com/127450/31361689-63d9cc6a-ad09-11e7-82c9-8ed53a669d64.png)
