### PR TITLE
Get-Content -Raw should not neglects to read the last character

### DIFF
--- a/src/System.Management.Automation/namespaces/FileSystemContentStream.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemContentStream.cs
@@ -733,7 +733,7 @@ namespace Microsoft.PowerShell.Commands
                 //    (Trimming it during backward reading would not only be unnecessary, but could interfere with determining the correct start position.)
                 string contentString = content.ToString();
                 blocks.Add(
-                    !readBackward && contentString.EndsWith(actualDelimiter, StringComparison.Ordinal)
+                    !readBackward && contentString.EndsWith(actualDelimiter, StringComparison.Ordinal) && !_isRawStream
                         ? contentString.Substring(0, content.Length - actualDelimiter.Length)
                         : contentString
                 );

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Content.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Content.Tests.ps1
@@ -285,3 +285,28 @@ baz
         }
     }
 }
+
+Describe "Get-Content -Raw test" -Tags "CI" {
+    BeforeAll {
+        $lfTextUnterminated = "a`nb"
+        $lfText = "a`nb`n"
+        $crlfTextUnterminated = "a`r`nb"
+        $crlfText = "a`r`nb`r`n"
+        Set-Content -Encoding Ascii -NoNewline "$TestDrive\lf.txt" -value $lfText
+        Set-Content -Encoding Ascii -NoNewline "$TestDrive\crlf.txt" -value $crlfText
+        Set-Content -Encoding Ascii -NoNewline "$TestDrive\lf-nt.txt" -value $lfTextUnterminated
+        Set-Content -Encoding Ascii -NoNewline "$TestDrive\crlf-nt.txt" -value $crlfTextUnterminated
+    }
+    It "Reads LF-terminated files in full." {
+        Get-Content -Raw "$TestDrive\lf.txt" | Should BeExactly $lfText
+    }
+    It "Reads CRLF-terminated files in full." {
+        Get-Content -Raw "$TestDrive\crlf.txt" | Should BeExactly $crlfText
+    }
+    It "Reads LF-separated files without trailing newline in full." {
+        Get-Content -Raw "$TestDrive\lf-nt.txt" | Should BeExactly $lfTextUnterminated
+    }
+    It "Reads CRLF-separated files without trailing newline in full." {
+        Get-Content -Raw "$TestDrive\crlf-nt.txt" | Should BeExactly $crlfTextUnterminated
+    }
+}

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Content.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Content.Tests.ps1
@@ -287,26 +287,15 @@ baz
 }
 
 Describe "Get-Content -Raw test" -Tags "CI" {
-    BeforeAll {
-        $lfTextUnterminated = "a`nb"
-        $lfText = "a`nb`n"
-        $crlfTextUnterminated = "a`r`nb"
-        $crlfText = "a`r`nb`r`n"
-        Set-Content -Encoding Ascii -NoNewline "$TestDrive\lf.txt" -value $lfText
-        Set-Content -Encoding Ascii -NoNewline "$TestDrive\crlf.txt" -value $crlfText
-        Set-Content -Encoding Ascii -NoNewline "$TestDrive\lf-nt.txt" -value $lfTextUnterminated
-        Set-Content -Encoding Ascii -NoNewline "$TestDrive\crlf-nt.txt" -value $crlfTextUnterminated
-    }
-    It "Reads LF-terminated files in full." {
-        Get-Content -Raw "$TestDrive\lf.txt" | Should BeExactly $lfText
-    }
-    It "Reads CRLF-terminated files in full." {
-        Get-Content -Raw "$TestDrive\crlf.txt" | Should BeExactly $crlfText
-    }
-    It "Reads LF-separated files without trailing newline in full." {
-        Get-Content -Raw "$TestDrive\lf-nt.txt" | Should BeExactly $lfTextUnterminated
-    }
-    It "Reads CRLF-separated files without trailing newline in full." {
-        Get-Content -Raw "$TestDrive\crlf-nt.txt" | Should BeExactly $crlfTextUnterminated
+
+    It "Reads - <testname> in full" -TestCases @( 
+      @{character = "a`nb`n"; testname = "LF-terminated files"; filename = "lf.txt"}
+      @{character = "a`r`nb`r`n"; testname = "CRLF-terminated files"; filename = "crlf.txt"}
+      @{character = "a`nb"; testname = "LF-separated files without trailing newline"; filename = "lf-nt.txt"}
+      @{character = "a`r`nb"; testname = "CRLF-separated files without trailing newline"; filename = "crlf-nt.txt"}        
+    ) {
+        param ($character, $filename)
+        Set-Content -Encoding Ascii -NoNewline "$TestDrive\$filename" -value $character
+        Get-Content -Raw "$TestDrive\$filename" | Should BeExactly $character
     }
 }


### PR DESCRIPTION
resolve #4980

once the -raw parameter is set, we should force the contentString not to substring under any circumstance

Before the fix:
get-content -raw will ignore \n 

After the fix:
get-content -raw will get all the contents include \n
