### PR TITLE
Support creating tarball package for Linux and macOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ dotnet-uninstall-debian-packages.sh
 
 # Ignore packages
 *.deb
+*.tar.gz
 *.zip
 *.rpm
 *.pkg

--- a/tools/releaseBuild/Images/GenericLinuxFiles/PowerShellPackage.ps1
+++ b/tools/releaseBuild/Images/GenericLinuxFiles/PowerShellPackage.ps1
@@ -43,21 +43,10 @@ finally
     Pop-Location
 }
 
-$linuxPackages = Get-ChildItem "$location/powershell*" -Include *.deb,*.rpm
-
+$linuxPackages = Get-ChildItem "$location/powershell*" -Include *.deb,*.rpm,*.AppImage,*.tar.gz
 foreach ($linuxPackage in $linuxPackages)
 {
-    Copy-Item -Path $linuxPackage.FullName -Destination $destination -force
-}
-
-$extraPackages = @()
-switch ($ExtraPackage)
-{
-    "AppImage" { $extraPackages += @(Get-ChildItem -Path $location -Filter '*.AppImage') }
-    "tar"      { $extraPackages += @(Get-ChildItem -Path $location -Filter '*.tar.gz') }
-}
-
-foreach ($extraPkgFile in $extraPackages)
-{
-    Copy-Item -Path $extraPkgFile.FullName -Destination $destination -force
+    $filePath = $linuxPackage.FullName
+    Write-Verbose "Copying $filePath to $destination" -Verbose
+    Copy-Item -Path $filePath -Destination $destination -force
 }

--- a/tools/releaseBuild/Images/GenericLinuxFiles/PowerShellPackage.ps1
+++ b/tools/releaseBuild/Images/GenericLinuxFiles/PowerShellPackage.ps1
@@ -11,11 +11,13 @@ param (
     [ValidatePattern("^v\d+\.\d+\.\d+(-\w+\.\d+)?$")]
     [ValidateNotNullOrEmpty()]
     [string]$ReleaseTag,
-    [switch]$AppImage
+
+    [ValidateSet("AppImage", "tar")]
+    [string[]]$ExtraPackage
 )
 
 $releaseTagParam = @{}
-if($ReleaseTag)
+if ($ReleaseTag)
 {
     $releaseTagParam = @{ 'ReleaseTag' = $ReleaseTag }
 }
@@ -25,14 +27,15 @@ try {
     Set-Location $location
     Import-Module "$location/build.psm1"
     Import-Module "$location/tools/packaging"
-    
+
     Start-PSBootstrap -Package -NoSudo
     Start-PSBuild -Crossgen -PSModuleRestore @releaseTagParam
 
     Start-PSPackage @releaseTagParam
-    if($AppImage.IsPresent)
+    switch ($ExtraPackage)
     {
-        Start-PSPackage -Type AppImage @releaseTagParam
+        "AppImage" { Start-PSPackage -Type AppImage @releaseTagParam }
+        "tar"      { Start-PSPackage -Type tar @releaseTagParam }
     }
 }
 finally
@@ -41,17 +44,20 @@ finally
 }
 
 $linuxPackages = Get-ChildItem "$location/powershell*" -Include *.deb,*.rpm
-    
-foreach($linuxPackage in $linuxPackages) 
-{ 
+
+foreach ($linuxPackage in $linuxPackages)
+{
     Copy-Item -Path $linuxPackage.FullName -Destination $destination -force
 }
 
-if($AppImage.IsPresent)
+$extraPackages = @()
+switch ($ExtraPackage)
 {
-    $appImages = Get-ChildItem -Path $location -Filter '*.AppImage'
-    foreach($appImageFile in $appImages) 
-    { 
-        Copy-Item -Path $appImageFile.FullName -Destination $destination -force
-    }
+    "AppImage" { $extraPackages += @(Get-ChildItem -Path $location -Filter '*.AppImage') }
+    "tar"      { $extraPackages += @(Get-ChildItem -Path $location -Filter '*.tar.gz') }
+}
+
+foreach ($extraPkgFile in $extraPackages)
+{
+    Copy-Item -Path $extraPkgFile.FullName -Destination $destination -force
 }

--- a/tools/releaseBuild/build.json
+++ b/tools/releaseBuild/build.json
@@ -29,7 +29,7 @@
     {
         "Name": "ubuntu.14.04",
         "RepoDestinationPath": "/PowerShell",
-        "BuildCommand": "/PowerShellPackage.ps1 -location _RepoDestinationPath_ -destination _DockerVolume_ -ReleaseTag _ReleaseTag_ -AppImage",
+        "BuildCommand": "/PowerShellPackage.ps1 -location _RepoDestinationPath_ -destination _DockerVolume_ -ReleaseTag _ReleaseTag_ -ExtraPackage AppImage",
         "BuildDockerOptions": [
             "--cap-add",
             "SYS_ADMIN",
@@ -43,7 +43,7 @@
         "AdditionalContextFiles" :[ "./tools/releaseBuild/Images/GenericLinuxFiles/PowerShellPackage.ps1"],
         "DockerImageName": "ps-ubunutu-14-04"
     },
-    {  
+    {
         "Name": "ubuntu.16.04",
         "RepoDestinationPath": "/PowerShell",
         "BuildCommand": "/PowerShellPackage.ps1 -location _RepoDestinationPath_ -destination _DockerVolume_ -ReleaseTag _ReleaseTag_",
@@ -51,10 +51,10 @@
         "DockerFile": "./tools/releaseBuild/Images/microsoft_powershell_ubuntu16.04/Dockerfile",
         "DockerImageName": "ps-ubunutu-16-04"
     },
-    {  
+    {
         "Name": "centos.7",
         "RepoDestinationPath": "/PowerShell",
-        "BuildCommand": "/PowerShellPackage.ps1 -location _RepoDestinationPath_ -destination _DockerVolume_ -ReleaseTag _ReleaseTag_",
+        "BuildCommand": "/PowerShellPackage.ps1 -location _RepoDestinationPath_ -destination _DockerVolume_ -ReleaseTag _ReleaseTag_ -ExtraPackage tar",
         "AdditionalContextFiles" :[ "./tools/releaseBuild/Images/GenericLinuxFiles/PowerShellPackage.ps1"],
         "DockerFile": "./tools/releaseBuild/Images/microsoft_powershell_centos7/Dockerfile",
         "DockerImageName": "ps-centos-7"


### PR DESCRIPTION
Related to #5027

- Create tarball package to allow advanced deployment on Linux and macOS.
- Update `build.json` to build and publish tarball package.
- Disable `deb-arm` type in `Start-PSPackage` for now because the underlying `New-UnixPackage` doesn't support it.

Documentation needs to be added about the dependencies of PowerShell Core, so the tarball package can be useful to users. This task is tracked in #3961