### PR TITLE
Add release builds that produce symbols for compliance scans

### DIFF
--- a/tools/releaseBuild/Images/microsoft_powershell_windowsservercore/PowerShellPackage.ps1
+++ b/tools/releaseBuild/Images/microsoft_powershell_windowsservercore/PowerShellPackage.ps1
@@ -78,7 +78,6 @@ try{
     else 
     {
         $pspackageParams += @{'IncludeSymbols' = $true}
-        
     }
 
     $pspackageParams['Type']='zip'

--- a/tools/releaseBuild/Images/microsoft_powershell_windowsservercore/PowerShellPackage.ps1
+++ b/tools/releaseBuild/Images/microsoft_powershell_windowsservercore/PowerShellPackage.ps1
@@ -10,7 +10,8 @@ param (
     [switch] $Wait,
     [ValidatePattern("^v\d+\.\d+\.\d+(-\w+\.\d+)?$")]
     [ValidateNotNullOrEmpty()]
-    [string]$ReleaseTag
+    [string]$ReleaseTag,
+    [switch] $Symbols
 )
 
 $releaseTagParam = @{}
@@ -55,7 +56,13 @@ try{
     Start-PSBootstrap -Force -Package
 
     Write-Verbose "Starting powershell build for RID: $Runtime and ReleaseTag: $ReleaseTag ..." -verbose
-    Start-PSBuild -Clean -CrossGen -PSModuleRestore -Runtime $Runtime -Configuration Release @releaseTagParam
+    $buildParams = @{}
+    if(!$Symbols.IsPresent)
+    {
+        $buildParams['CrossGen'] = $true
+    }
+
+    Start-PSBuild -Clean -PSModuleRestore -Runtime $Runtime -Configuration Release @releaseTagParam @buildParams
 
     $pspackageParams = @{'Type'='msi'}
     if ($Runtime -ne 'win10-x64')
@@ -63,8 +70,11 @@ try{
         $pspackageParams += @{'WindowsRuntime'=$Runtime}
     }
 
-    Write-Verbose "Starting powershell packaging(msi)..." -verbose
-    Start-PSPackage @pspackageParams @releaseTagParam
+    if(!$Symbols.IsPresent)
+    {
+        Write-Verbose "Starting powershell packaging(msi)..." -verbose
+        Start-PSPackage @pspackageParams @releaseTagParam
+    }
 
     $pspackageParams['Type']='zip'
     Write-Verbose "Starting powershell packaging(zip)..." -verbose

--- a/tools/releaseBuild/Images/microsoft_powershell_windowsservercore/PowerShellPackage.ps1
+++ b/tools/releaseBuild/Images/microsoft_powershell_windowsservercore/PowerShellPackage.ps1
@@ -75,6 +75,11 @@ try{
         Write-Verbose "Starting powershell packaging(msi)..." -verbose
         Start-PSPackage @pspackageParams @releaseTagParam
     }
+    else 
+    {
+        $pspackageParams += @{'IncludeSymbols' = $true}
+        
+    }
 
     $pspackageParams['Type']='zip'
     Write-Verbose "Starting powershell packaging(zip)..." -verbose

--- a/tools/releaseBuild/README.md
+++ b/tools/releaseBuild/README.md
@@ -1,0 +1,31 @@
+# VSTS Release Builds
+
+## Requirements
+
+Docker must be installed to run any of the release builds.
+
+## Running Windows Release Builds
+
+From PowerShell on Windows, run `.\vstsbuild.ps1 -ReleaseTag <tag> -Name <buildName>`.
+
+Windows Build Names:
+ * `win7-x64`
+     * Builds the Universal Windows x64 Package
+ * `win7-x86`
+     * Builds the Universal Windows x86 Package
+ * `win7-x64-symbols`
+     * Builds the Windows x64 Zip with symbols
+ * `win7-x86-symbols`
+     * Builds the Windows x86 Zip with symbols
+
+## Running Linux Release Builds
+
+From PowerShell on Linux or macOS, run `.\vstsbuild.ps1 -ReleaseTag <tag> -Name <buildName>`.
+
+Linux Build Names:
+ * `ubuntu.14.04`
+     * Builds the Ubuntu 14.04 Package and AppImage Package
+ * `ubuntu.16.04`
+     * Builds the Ubuntu 16.04 Package
+ * `centos.7`
+     * Builds the CentOs 7 Package

--- a/tools/releaseBuild/README.md
+++ b/tools/releaseBuild/README.md
@@ -9,6 +9,7 @@ Docker must be installed to run any of the release builds.
 From PowerShell on Windows, run `.\vstsbuild.ps1 -ReleaseTag <tag> -Name <buildName>`.
 
 Windows Build Names:
+
  * `win7-x64`
      * Builds the Universal Windows x64 Package
  * `win7-x86`
@@ -23,9 +24,10 @@ Windows Build Names:
 From PowerShell on Linux or macOS, run `.\vstsbuild.ps1 -ReleaseTag <tag> -Name <buildName>`.
 
 Linux Build Names:
+
  * `ubuntu.14.04`
      * Builds the Ubuntu 14.04 Package and AppImage Package
  * `ubuntu.16.04`
      * Builds the Ubuntu 16.04 Package
  * `centos.7`
-     * Builds the CentOs 7 Package
+     * Builds the CentOS 7 Package

--- a/tools/releaseBuild/build.json
+++ b/tools/releaseBuild/build.json
@@ -23,6 +23,30 @@
         "DockerFile": ".\\tools\\releaseBuild\\Images\\microsoft_powershell_windowsservercore\\DockerFile",
         "AdditionalContextFiles" :[ ".\\tools\\releaseBuild\\Images\\microsoft_powershell_windowsservercore\\PowerShellPackage.ps1"],
         "DockerImageName": "ps-winsrvcore"
+    },
+    {
+        "Name": "win7-x64-symbols",
+        "RepoDestinationPath": "C:\\PowerShell",
+        "BuildCommand": "C:\\PowerShellPackage.ps1 -location _RepoDestinationPath_ -destination _DockerVolume_ -Runtime win7-x64 -ReleaseTag _ReleaseTag_ -Symbols",
+        "BuildDockerOptions": [
+            "-m",
+            "3968m"
+        ],
+        "DockerFile": ".\\tools\\releaseBuild\\Images\\microsoft_powershell_windowsservercore\\DockerFile",
+        "AdditionalContextFiles" :[ ".\\tools\\releaseBuild\\Images\\microsoft_powershell_windowsservercore\\PowerShellPackage.ps1"],
+        "DockerImageName": "ps-winsrvcore"
+    },
+    {
+        "Name": "win7-x86-symbols",
+        "RepoDestinationPath": "C:\\PowerShell",
+        "BuildCommand": "C:\\PowerShellPackage.ps1 -location _RepoDestinationPath_ -destination _DockerVolume_ -Runtime win7-x86 -ReleaseTag _ReleaseTag_ -Symbols",
+        "BuildDockerOptions": [
+            "-m",
+            "3968m"
+        ],
+        "DockerFile": ".\\tools\\releaseBuild\\Images\\microsoft_powershell_windowsservercore\\DockerFile",
+        "AdditionalContextFiles" :[ ".\\tools\\releaseBuild\\Images\\microsoft_powershell_windowsservercore\\PowerShellPackage.ps1"],
+        "DockerImageName": "ps-winsrvcore"
     }
   ],
   "Linux": [

--- a/tools/releaseBuild/build.json
+++ b/tools/releaseBuild/build.json
@@ -10,7 +10,8 @@
         ],
         "DockerFile": ".\\tools\\releaseBuild\\Images\\microsoft_powershell_windowsservercore\\DockerFile",
         "AdditionalContextFiles" :[ ".\\tools\\releaseBuild\\Images\\microsoft_powershell_windowsservercore\\PowerShellPackage.ps1"],
-        "DockerImageName": "ps-winsrvcore"
+        "DockerImageName": "ps-winsrvcore",
+        "BinaryBucket": "release"
     },
     {
         "Name": "win7-x86",
@@ -22,7 +23,8 @@
         ],
         "DockerFile": ".\\tools\\releaseBuild\\Images\\microsoft_powershell_windowsservercore\\DockerFile",
         "AdditionalContextFiles" :[ ".\\tools\\releaseBuild\\Images\\microsoft_powershell_windowsservercore\\PowerShellPackage.ps1"],
-        "DockerImageName": "ps-winsrvcore"
+        "DockerImageName": "ps-winsrvcore",
+        "BinaryBucket": "release"
     },
     {
         "Name": "win7-x64-symbols",
@@ -34,7 +36,8 @@
         ],
         "DockerFile": ".\\tools\\releaseBuild\\Images\\microsoft_powershell_windowsservercore\\DockerFile",
         "AdditionalContextFiles" :[ ".\\tools\\releaseBuild\\Images\\microsoft_powershell_windowsservercore\\PowerShellPackage.ps1"],
-        "DockerImageName": "ps-winsrvcore"
+        "DockerImageName": "ps-winsrvcore",
+        "BinaryBucket": "symbols"
     },
     {
         "Name": "win7-x86-symbols",
@@ -46,7 +49,8 @@
         ],
         "DockerFile": ".\\tools\\releaseBuild\\Images\\microsoft_powershell_windowsservercore\\DockerFile",
         "AdditionalContextFiles" :[ ".\\tools\\releaseBuild\\Images\\microsoft_powershell_windowsservercore\\PowerShellPackage.ps1"],
-        "DockerImageName": "ps-winsrvcore"
+        "DockerImageName": "ps-winsrvcore",
+        "BinaryBucket": "symbols"
     }
   ],
   "Linux": [
@@ -65,7 +69,8 @@
         ],
         "DockerFile": "./tools/releaseBuild/Images/microsoft_powershell_ubuntu14.04/Dockerfile",
         "AdditionalContextFiles" :[ "./tools/releaseBuild/Images/GenericLinuxFiles/PowerShellPackage.ps1"],
-        "DockerImageName": "ps-ubunutu-14-04"
+        "DockerImageName": "ps-ubunutu-14-04",
+        "BinaryBucket": "release"
     },
     {
         "Name": "ubuntu.16.04",
@@ -73,7 +78,8 @@
         "BuildCommand": "/PowerShellPackage.ps1 -location _RepoDestinationPath_ -destination _DockerVolume_ -ReleaseTag _ReleaseTag_",
         "AdditionalContextFiles" :[ "./tools/releaseBuild/Images/GenericLinuxFiles/PowerShellPackage.ps1"],
         "DockerFile": "./tools/releaseBuild/Images/microsoft_powershell_ubuntu16.04/Dockerfile",
-        "DockerImageName": "ps-ubunutu-16-04"
+        "DockerImageName": "ps-ubunutu-16-04",
+        "BinaryBucket": "release"
     },
     {
         "Name": "centos.7",
@@ -81,7 +87,8 @@
         "BuildCommand": "/PowerShellPackage.ps1 -location _RepoDestinationPath_ -destination _DockerVolume_ -ReleaseTag _ReleaseTag_ -ExtraPackage tar",
         "AdditionalContextFiles" :[ "./tools/releaseBuild/Images/GenericLinuxFiles/PowerShellPackage.ps1"],
         "DockerFile": "./tools/releaseBuild/Images/microsoft_powershell_centos7/Dockerfile",
-        "DockerImageName": "ps-centos-7"
+        "DockerImageName": "ps-centos-7",
+        "BinaryBucket": "release"
     }
   ]
 }

--- a/tools/releaseBuild/vstsbuild.ps1
+++ b/tools/releaseBuild/vstsbuild.ps1
@@ -3,12 +3,12 @@ param(
     [ValidatePattern("^v\d+\.\d+\.\d+(-\w+\.\d+)?$")]
     [string]$ReleaseTag,
 
-    [ValidateSet('win7-x86','win7-x64','ubuntu.14.04','ubuntu.16.04','centos.7')]
+    [ValidateSet('win7-x86','win7-x64','win7-x86-symbols','win7-x64-symbols','ubuntu.14.04','ubuntu.16.04','centos.7')]
     [String]
     $Name
 )
-$ErrorActionPreference = 'Stop'
 
+$ErrorActionPreference = 'Stop'
 
 $psReleaseBranch = 'master'
 $psReleaseFork = 'PowerShell'


### PR DESCRIPTION
Add two new named release builds that produce zip files with symbols.
update the infrastructure to support these builds.
Add a readme to describe how to use the release builds.