### PR TITLE
StopJobCommand: Remove Unreachable Code

### DIFF
--- a/src/System.Management.Automation/engine/remoting/commands/StopJob.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/StopJob.cs
@@ -161,17 +161,6 @@ namespace Microsoft.PowerShell.Commands
                     else
                     {
                         job.StopJob();
-                        var parentJob = job as ContainerParentJob;
-                        if (parentJob != null && parentJob.ExecutionError.Count > 0)
-                        {
-                            foreach (
-                                var e in
-                                    parentJob.ExecutionError.Where(
-                                        e => e.FullyQualifiedErrorId == "ContainerParentJobStopError"))
-                            {
-                                WriteError(e);
-                            }
-                        }
                     }
                 }
             }


### PR DESCRIPTION
This code will never get executed, and its logic is
duplicated in the HandleStopJobCompleted() method.

Closes #1696.

<!--

If you are a PowerShell Team member, please make sure you choose the Reviewer(s) and Assignee for your PR.
If you are not from the PowerShell Team, you can leave the fields blank and the Maintainers will choose them for you. If you are familiar with the team, feel free to mention some Reviewers yourself.

For more information about the roles of Reviewer and Assignee, refer to [CONTRIBUTING.md](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md).

-->
