### PR TITLE
Enable import-module to be case insensitive

### DIFF
--- a/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
@@ -309,7 +309,7 @@ namespace Microsoft.PowerShell.Commands
                             {
                                 qualifiedPath = Path.Combine(qualifiedPath, fileBaseName);
                             }
-                            else if (Directory.Exists(qualifiedPath))
+                            else if (Utils.NativeDirectoryExists(qualifiedPath))
                             {
                                 // if it points to a directory, add the basename back onto the path...
                                 qualifiedPath = Path.Combine(qualifiedPath, Path.GetFileName(fileBaseName));

--- a/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
@@ -296,14 +296,12 @@ namespace Microsoft.PowerShell.Commands
 #if UNIX
                 foreach (string folder in Directory.EnumerateDirectories(path))
                 {
-                    string fileName = Path.GetFileName(folder);
-                    if (String.Compare(fileName, name, StringComparison.OrdinalIgnoreCase) == 0)
+                    string moduleName = Path.GetFileName(folder);
+                    if (String.Compare(moduleName, fileBaseName, StringComparison.OrdinalIgnoreCase) == 0)
                     {
-                        string qualifiedPath = folder;
-                        name = fileName;
-#else
-                        string qualifiedPath = Path.Combine(path, fileBaseName);
+                        fileBaseName = moduleName;
 #endif
+                        string qualifiedPath = Path.Combine(path, fileBaseName);
                         module = LoadUsingMultiVersionModuleBase(qualifiedPath, manifestProcessingFlags, options, out found);
                         if (!found)
                         {

--- a/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
@@ -309,11 +309,7 @@ namespace Microsoft.PowerShell.Commands
                         {
                             if (name.IndexOfAny(Utils.Separators.Directory) == -1)
                             {
-#if UNIX
-                                qualifiedPath = Path.Combine(folder, fileName);
-#else
                                 qualifiedPath = Path.Combine(qualifiedPath, fileBaseName);
-#endif
                             }
                             else if (Directory.Exists(qualifiedPath))
                             {

--- a/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
@@ -323,32 +323,23 @@ namespace Microsoft.PowerShell.Commands
                 }
             }
 
+#if UNIX    // case-sensitive filesystems are predominately used only on Unix
             if (!found)
             {
                 // try a case-insensitive search for the module folder
+                // based on PSGet, we can assume the module file casing matches the folder
                 foreach (string path in modulePath)
                 {
                     foreach (string folder in Directory.EnumerateDirectories(path))
                     {
-                        if (String.Compare(Path.GetFileName(folder), name, StringComparison.OrdinalIgnoreCase) == 0)
+                        string fileName = Path.GetFileName(folder);
+                        if (String.Compare(fileName, name, StringComparison.OrdinalIgnoreCase) == 0)
                         {
                             module = LoadUsingMultiVersionModuleBase(folder, manifestProcessingFlags, options, out found);
                             if (!found)
                             {
-                                // try a case-insensitive search for the module file
-                                foreach (string file in Directory.EnumerateFiles(folder))
-                                {
-                                    string fileName = Path.GetFileNameWithoutExtension(file);
-                                    if (String.Compare(fileName, name, StringComparison.OrdinalIgnoreCase) == 0)
-                                    {
-                                        string qualifiedPath = Path.Combine(folder, fileName);
-                                        module = LoadUsingExtensions(parentModule, fileName, qualifiedPath, extension, null, this.BasePrefix, ss, options, manifestProcessingFlags, out found);
-                                    }
-                                    if (found)
-                                    {
-                                        break;
-                                    }
-                                }
+                                string qualifiedPath = Path.Combine(folder, fileName);
+                                module = LoadUsingExtensions(parentModule, fileName, qualifiedPath, extension, null, this.BasePrefix, ss, options, manifestProcessingFlags, out found);
                             }
                         }
                         if (found)
@@ -362,6 +353,7 @@ namespace Microsoft.PowerShell.Commands
                     }
                 }
             }
+#endif
 
             if (found)
             {

--- a/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
@@ -323,6 +323,46 @@ namespace Microsoft.PowerShell.Commands
                 }
             }
 
+            if (!found)
+            {
+                // try a case-insensitive search for the module folder
+                foreach (string path in modulePath)
+                {
+                    foreach (string folder in Directory.EnumerateDirectories(path))
+                    {
+                        if (String.Compare(Path.GetFileName(folder), name, StringComparison.OrdinalIgnoreCase) == 0)
+                        {
+                            module = LoadUsingMultiVersionModuleBase(folder, manifestProcessingFlags, options, out found);
+                            if (!found)
+                            {
+                                // try a case-insensitive search for the module file
+                                foreach (string file in Directory.EnumerateFiles(folder))
+                                {
+                                    string fileName = Path.GetFileNameWithoutExtension(file);
+                                    if (String.Compare(fileName, name, StringComparison.OrdinalIgnoreCase) == 0)
+                                    {
+                                        string qualifiedPath = Path.Combine(folder, fileName);
+                                        module = LoadUsingExtensions(parentModule, fileName, qualifiedPath, extension, null, this.BasePrefix, ss, options, manifestProcessingFlags, out found);
+                                    }
+                                    if (found)
+                                    {
+                                        break;
+                                    }
+                                }
+                            }
+                        }
+                        if (found)
+                        {
+                            break;
+                        }
+                    }
+                    if (found)
+                    {
+                        break;
+                    }
+                }
+            }
+
             if (found)
             {
                 // Cache the module's exported commands after importing it, or if the -Refresh flag is used on

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Import-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Import-Module.Tests.ps1
@@ -103,7 +103,7 @@ using System.Management.Automation;           // Windows PowerShell namespace.
 
 namespace ModuleCmdlets
 {
-  [Cmdlet(VerbsDiagnostic.Test,"BinaryModuleCmdlet1")]   
+  [Cmdlet(VerbsDiagnostic.Test,"BinaryModuleCmdlet1")]
   public class TestBinaryModuleCmdlet1Command : Cmdlet
   {
     protected override void BeginProcessing()
@@ -124,25 +124,26 @@ namespace ModuleCmdlets
     }
  }
 
-Describe "Import-Module should be case insensitive on Linux" -Tags 'CI' {
+Describe "Import-Module should be case insensitive" -Tags 'CI' {
     BeforeAll {
-        $defaultParamValues = $PSDefaultParameterValues.Clone()
         $defaultPSModuleAutoloadingPreference = $PSModuleAutoloadingPreference
         $originalPSModulePath = $env:PSModulePath.Clone()
         $modulesPath = "$TestDrive\Modules"
         $env:PSModulePath += [System.IO.Path]::PathSeparator + $modulesPath
         $PSModuleAutoloadingPreference = "none"
-        $PSDefaultParameterValues["it:skip"] = !$IsLinux
     }
+
     AfterAll {
-        $global:PSDefaultParameterValues = $defaultParamValues
         $global:PSModuleAutoloadingPreference = $defaultPSModuleAutoloadingPreference
         $env:PSModulePath = $originalPSModulePath
     }
 
+    AfterEach {
+        Remove-Item -Recurse -Path $modulesPath -Force -ErrorAction SilentlyContinue
+    }
+
     It "Import-Module can import a module using different casing using '<modulePath>' and manifest:<manifest>" -TestCases @(
         @{modulePath="TESTMODULE/1.1"; manifest=$true},
-        @{modulePath="TESTMODULE/1.1"; manifest=$false},
         @{modulePath="TESTMODULE"    ; manifest=$true},
         @{modulePath="TESTMODULE"    ; manifest=$false}
         ) {
@@ -155,7 +156,7 @@ Describe "Import-Module should be case insensitive on Linux" -Tags 'CI' {
         Import-Module testMODULE
         $m = Get-Module TESTmodule
         $m | Should BeOfType "System.Management.Automation.PSModuleInfo"
-        $m.Name | Should BeExactly "TESTMODULE"
+        $m.Name | Should Be "TESTMODULE"
         mytest | Should BeExactly "hello"
         Remove-Module TestModule
         Get-Module tESTmODULE | Should BeNullOrEmpty

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Import-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Import-Module.Tests.ps1
@@ -160,20 +160,4 @@ Describe "Import-Module should be case insensitive on Linux" -Tags 'CI' {
         Remove-Module TestModule
         Get-Module tESTmODULE | Should BeNullOrEmpty
     }
-
-    It "Import-Module will import exact casing if available" {
-        New-Item -ItemType Directory -Path "$modulesPath\Test" -Force > $null
-        Set-Content -Path "$modulesPath\Test\Test.psm1" -Value "function casetest { 'first' }"
-        New-Item -ItemType Directory -Path "$modulesPath\tEST" -Force > $null
-        Set-Content -Path "$modulesPath\tEST\tEST.psm1" -Value "function casetest { 'second' }"
-        Import-Module Test
-        casetest | Should BeExactly 'first'
-        Remove-Module test
-        Import-Module test
-        casetest | Should BeExactly 'second'
-        Remove-Module test
-        Import-Module tEST
-        casetest | Should BeExactly 'second'
-        Remove-Module test
-    }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Import-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Import-Module.Tests.ps1
@@ -124,7 +124,7 @@ namespace ModuleCmdlets
     }
  }
 
-Describe "Import-Module should be case insensitive on Unix" -Tags 'CI' {
+Describe "Import-Module should be case insensitive on Linux" -Tags 'CI' {
     BeforeAll {
         $defaultParamValues = $PSDefaultParameterValues.Clone()
         $defaultPSModuleAutoloadingPreference = $PSModuleAutoloadingPreference
@@ -147,7 +147,7 @@ Describe "Import-Module should be case insensitive on Unix" -Tags 'CI' {
         @{modulePath="TESTMODULE"    ; manifest=$false}
         ) {
         param ($modulePath, $manifest)
-        New-Item -ItemType Directory -Path "$modulesPath/$modulePath" -Force
+        New-Item -ItemType Directory -Path "$modulesPath/$modulePath" -Force > $null
         if ($manifest) {
             New-ModuleManifest -Path "$modulesPath/$modulePath/TESTMODULE.psd1" -RootModule "TESTMODULE.psm1" -ModuleVersion 1.1
         }
@@ -162,9 +162,9 @@ Describe "Import-Module should be case insensitive on Unix" -Tags 'CI' {
     }
 
     It "Import-Module will import exact casing if available" {
-        New-Item -ItemType Directory -Path "$modulesPath\Test" -Force
+        New-Item -ItemType Directory -Path "$modulesPath\Test" -Force > $null
         Set-Content -Path "$modulesPath\Test\Test.psm1" -Value "function casetest { 'first' }"
-        New-Item -ItemType Directory -Path "$modulesPath\tEST" -Force
+        New-Item -ItemType Directory -Path "$modulesPath\tEST" -Force > $null
         Set-Content -Path "$modulesPath\tEST\tEST.psm1" -Value "function casetest { 'second' }"
         Import-Module Test
         casetest | Should BeExactly 'first'


### PR DESCRIPTION
Apparently macOS is case insensitive

Fix https://github.com/PowerShell/PowerShell/issues/1621
<!--

If you are a PowerShell Team member, please make sure you choose the Reviewer(s) and Assignee for your PR.
If you are not from the PowerShell Team, you can leave the fields blank and the Maintainers will choose them for you. If you are familiar with the team, feel free to mention some Reviewers yourself.

For more information about the roles of Reviewer and Assignee, refer to [CONTRIBUTING.md](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md).

-->
