### PR TITLE
Rename powershell.exe to pwsh.exe

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -147,6 +147,7 @@ psobjects
 psproxyjobs
 PSReadline
 PSSessionConfiguration
+pwsh
 redistributables
 Register-EngineEvent
 Register-PSSessionConfiguration

--- a/assets/Product.wxs
+++ b/assets/Product.wxs
@@ -113,7 +113,7 @@
             </Component>
             <!-- add ourselvs to %PATH% so pwsh.exe can be started from Windows PowerShell or cmd.exe -->
             <Component Id="SetPath" Guid="{9dbb7763-7baf-48e7-b025-3bdedcb0632f}">
-              <Environment Id="PATH" Action="set" Name="PATH" Part="last" Permanent="yes" System="yes" Value="[$(var.ProductVersionWithName)]"/>
+              <Environment Id="PATH" Action="set" Name="PATH" Part="last" Permanent="no" System="yes" Value="[$(var.ProductVersionWithName)]"/>
             </Component>
           </Directory>
         </Directory>

--- a/assets/Product.wxs
+++ b/assets/Product.wxs
@@ -31,7 +31,7 @@
     <WixVariable Id="WixUIInfoIco" Value="assets\WixUIInfoIco.bmp" />
     <Property Id="WIXUI_EXITDIALOGOPTIONALCHECKBOXTEXT" Value="Open $(env.ProductName)" />
     <!-- Default value of Checkbox of starting PowerShell after installation -->
-    <Property Id="WixShellExecTarget" Value="[$(var.ProductVersionWithName)]PowerShell.exe"/>
+    <Property Id="WixShellExecTarget" Value="[$(var.ProductVersionWithName)]pwsh.exe"/>
     <CustomAction Id="LaunchApplication" BinaryKey="WixCA" DllEntry="WixShellExec" Impersonate="yes" />
     <UI>
       <Dialog Id="MyExitDialog" Width="370" Height="270" Title="!(loc.ExitDialog_Title)">
@@ -73,6 +73,8 @@
       <ComponentGroupRef Id="$(var.ProductVersionWithName)"/>
       <ComponentRef Id="ProductVersionFolder"/>
       <ComponentRef Id="ApplicationProgramsMenuShortcut"/>
+      <ComponentRef Id="RegistryEntries"/>
+      <ComponentRef Id="SetPath"/>
     </Feature>
     <!-- We need to show EULA, and provide option to customize download location -->
     <Property Id="WIXUI_INSTALLDIR" Value="INSTALLFOLDER" />
@@ -103,13 +105,23 @@
             <Component Id="ProductVersionFolder" Guid="{e1a7f05e-0cd6-4227-80a8-e4fb311f045c}">
               <CreateFolder/>
             </Component>
+            <!-- register ourselves in application registry so can be started using just Win+R `pwsh.exe` -->
+            <Component Id="RegistryEntries" Guid="{402e52f7-baf8-489d-af21-f756a6ca3530}">
+                <RegistryKey Root="HKCU" Key="Software\Microsoft\Windows\CurrentVersion\App Paths\pwsh.exe" ForceCreateOnInstall="yes" ForceDeleteOnUninstall="yes">
+                    <RegistryValue Type="string" Value="[$(var.ProductVersionWithName)]pwsh.exe"/>
+                </RegistryKey>
+            </Component>
+            <!-- add ourselvs to %PATH% so pwsh.exe can be started from Windows PowerShell or cmd.exe -->
+            <Component Id="SetPath" Guid="{9dbb7763-7baf-48e7-b025-3bdedcb0632f}">
+              <Environment Id="PATH" Action="set" Name="PATH" Part="last" Permanent="yes" System="yes" Value="[$(var.ProductVersionWithName)]"/>
+            </Component>
           </Directory>
         </Directory>
       </Directory>
       <Directory Id="ProgramMenuFolder">
         <Directory Id="ApplicationProgramsFolder" Name="$(var.ProductSemanticVersionWithName)">
           <Component Id="ApplicationProgramsMenuShortcut" Guid="{A77507A7-F970-4618-AC30-20AFE36EE2EB}">
-            <Shortcut Id="PowerShell_ProgramsMenuShortcut" Name="$(var.ProductSemanticVersionWithName)" Description="$(var.ProductSemanticVersionWithName)" Target="[$(var.ProductVersionWithName)]PowerShell.exe" WorkingDirectory="$(var.ProductVersionWithName)"
+            <Shortcut Id="PowerShell_ProgramsMenuShortcut" Name="$(var.ProductSemanticVersionWithName)" Description="$(var.ProductSemanticVersionWithName)" Target="[$(var.ProductVersionWithName)]pwsh.exe" WorkingDirectory="$(var.ProductVersionWithName)"
               Icon = "PowerShellExe.ico" />
             <RemoveFolder Id="ApplicationProgramsFolder" On="uninstall"/>
             <RegistryValue Root="HKCU" Key="Software\Microsoft\$(var.ProductSemanticVersionWithName)\ProgramsMenuShortcut" Name="installed" Type="integer" Value="1" KeyPath="yes"/>

--- a/build.psm1
+++ b/build.psm1
@@ -187,7 +187,7 @@ function Start-BuildNativeWindowsBinaries {
         return
     }
 
-    # cmake is needed to build powershell.exe
+    # cmake is needed to build pwsh.exe
     if (-not (precheck 'cmake' $null)) {
         throw 'cmake not found. Run "Start-PSBootstrap -BuildWindowsNative". You can also install it from https://chocolatey.org/packages/cmake'
     }
@@ -497,7 +497,7 @@ Fix steps:
         Start-TypeGen
     }
 
-    # Get the folder path where powershell.exe is located.
+    # Get the folder path where pwsh.exe is located.
     $publishPath = Split-Path $Options.Output -Parent
     try {
         # Relative paths do not work well if cwd is not changed to project
@@ -507,7 +507,7 @@ Fix steps:
 
         if ($CrossGen) {
             Start-CrossGen -PublishPath $publishPath -Runtime $script:Options.Runtime
-            log "PowerShell.exe with ngen binaries is available at: $($Options.Output)"
+            log "pwsh.exe with ngen binaries is available at: $($Options.Output)"
         } else {
             log "PowerShell output: $($Options.Output)"
         }
@@ -680,9 +680,9 @@ function New-PSOptions {
     }
 
     $Executable = if ($Environment.IsLinux -or $Environment.IsMacOS) {
-        "powershell"
+        "pwsh"
     } elseif ($Environment.IsWindows) {
-        "powershell.exe"
+        "pwsh.exe"
     }
 
     # Build the Output path
@@ -837,7 +837,7 @@ function Start-PSPester {
         [string[]]$Path = @("$PSScriptRoot/test/common","$PSScriptRoot/test/powershell"),
         [switch]$ThrowOnFailure,
         [string]$binDir = (Split-Path (New-PSOptions).Output),
-        [string]$powershell = (Join-Path $binDir 'powershell'),
+        [string]$powershell = (Join-Path $binDir 'pwsh'),
         [string]$Pester = ([IO.Path]::Combine($binDir, "Modules", "Pester")),
         [Parameter(ParameterSetName='Unelevate',Mandatory=$true)]
         [switch]$Unelevate,
@@ -848,7 +848,7 @@ function Start-PSPester {
         [switch]$IncludeFailingTest
     )
 
-    if (-not (Get-Module -ListAvailable -Name $Pester -ErrorAction SilentlyContinue)) 
+    if (-not (Get-Module -ListAvailable -Name $Pester -ErrorAction SilentlyContinue))
     {
         Write-Warning @"
 Pester module not found.

--- a/demos/Raspberry-Pi/README.md
+++ b/demos/Raspberry-Pi/README.md
@@ -72,7 +72,7 @@ cp shared/Microsoft.NetCore.App/2.1.0-preview1-25719-04/* ~/powershell
 ## Start PowerShell
 
 ```bash
-~/powershell/powershell
+~/powershell/pwsh
 ```
 
 Note that until arm32 is [fully supported by CoreCLR](https://github.com/dotnet/coreclr/issues/3977), it's not supported by PowerShell Core.

--- a/demos/SSHRemoting/README.md
+++ b/demos/SSHRemoting/README.md
@@ -46,9 +46,9 @@ In addition you will need to enable password authentication and optionally key b
     ```none
     PasswordAuthentication yes
     ```
-    - Add a PowerShell subsystem entry, replace `c:/program files/powershell/6.0.0/powershell.exe` with the correct path to the version you want to use
+    - Add a PowerShell subsystem entry, replace `c:/program files/powershell/6.0.0/pwsh.exe` with the correct path to the version you want to use
     ```none
-    Subsystem    powershell c:/program files/powershell/6.0.0/powershell.exe -sshs -NoLogo -NoProfile
+    Subsystem    powershell c:/program files/powershell/6.0.0/pwsh.exe -sshs -NoLogo -NoProfile
     ```
     - Optionally enable key authentication
     ```none
@@ -173,7 +173,7 @@ Microsoft Windows [Version 10.0.10586]
 #
 # Windows to Windows
 #
-C:\Users\PSUser\Documents>"C:\Program Files\PowerShell\6.0.0.17\powershell.exe"
+C:\Users\PSUser\Documents>pwsh.exe
 PowerShell
 Copyright (C) Microsoft Corporation. All rights reserved.
 

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
@@ -86,7 +86,7 @@ namespace Microsoft.PowerShell
         /// </param>
         /// <param name = "args">
         ///
-        /// Command line parameters to powershell.exe
+        /// Command line parameters to pwsh.exe
         ///
         /// </param>
         /// <returns>

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostRawUserInterface.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostRawUserInterface.cs
@@ -25,7 +25,7 @@ namespace Microsoft.PowerShell
 {
     /// <summary>
     ///
-    /// implementation of RawConsole for powershell.exe
+    /// implementation of RawConsole for powershell
     ///
     /// </summary>
 

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterface.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterface.cs
@@ -24,7 +24,7 @@ namespace Microsoft.PowerShell
 
     /// <summary>
     ///
-    /// ConsoleHostUserInterface implements console-mode user interface for powershell.exe
+    /// ConsoleHostUserInterface implements console-mode user interface for powershell
     ///
     /// </summary>
     [SuppressMessage("Microsoft.Maintainability", "CA1506:AvoidExcessiveClassCoupling")]

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterfaceSecurity.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterfaceSecurity.cs
@@ -13,7 +13,7 @@ namespace Microsoft.PowerShell
 {
     /// <summary>
     ///
-    /// ConsoleHostUserInterface implements console-mode user interface for powershell.exe
+    /// ConsoleHostUserInterface implements console-mode user interface for powershell
     ///
     /// </summary>
     internal partial

--- a/src/Microsoft.PowerShell.ScheduledJob/ScheduledJobDefinition.cs
+++ b/src/Microsoft.PowerShell.ScheduledJob/ScheduledJobDefinition.cs
@@ -42,7 +42,7 @@ namespace Microsoft.PowerShell.ScheduledJob
         private bool _isDisposed;
 
         // Task Action strings.
-        private const string TaskExecutionPath = @"powershell.exe";
+        private const string TaskExecutionPath = @"pwsh.exe";
         private const string TaskArguments = @"-NoLogo -NonInteractive -WindowStyle Hidden -Command ""Import-Module PSScheduledJob; $jobDef = [Microsoft.PowerShell.ScheduledJob.ScheduledJobDefinition]::LoadFromStore('{0}', '{1}'); $jobDef.Run()""";
         private static object LockObject = new object();
         private static int CurrentId = 0;

--- a/src/System.Management.Automation/CoreCLR/CorePsAssemblyLoadContext.cs
+++ b/src/System.Management.Automation/CoreCLR/CorePsAssemblyLoadContext.cs
@@ -503,7 +503,7 @@ namespace System.Management.Automation
         /// </summary>
         /// <remarks>
         /// This method is to be used by native host whose TPA list doesn't include PS assemblies, such as the
-        /// in-box Nano powershell.exe, the PS remote WinRM plugin, in-box Nano DSC and in-box Nano SCOM agent.
+        /// in-box Nano powershell, the PS remote WinRM plugin, in-box Nano DSC and in-box Nano SCOM agent.
         /// </remarks>
         /// <param name="basePaths">
         /// Base directory paths that are separated by semicolon ';'.

--- a/src/System.Management.Automation/commands/utility/FormatAndOutput/out-console/OutConsole.cs
+++ b/src/System.Management.Automation/commands/utility/FormatAndOutput/out-console/OutConsole.cs
@@ -39,7 +39,7 @@ namespace Microsoft.PowerShell.Commands
     /// <summary>
     /// implementation for the out-default command
     /// this command it implicitly inject by the
-    /// powershell.exe host at the end of the pipeline as the
+    /// powershell host at the end of the pipeline as the
     /// default sink (display to console screen)
     /// </summary>
     [Cmdlet(VerbsData.Out, "Default", HelpUri = "https://go.microsoft.com/fwlink/?LinkID=113362", RemotingCapability = RemotingCapability.None)]

--- a/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
@@ -774,6 +774,9 @@ namespace System.Management.Automation
             const string powershellExeName = "pwsh.exe";
             const string oldPowershellExeName = "powershell.exe";
 #endif
+            const string powershellDepsName = "pwsh.deps.json";
+            const string oldPowerShellDepsName = "powershell.deps.json";
+
             StringBuilder modulePathString = new StringBuilder(currentProcessModulePath.Length);
             char[] invalidPathChars = Path.GetInvalidPathChars();
 
@@ -794,8 +797,9 @@ namespace System.Management.Automation
                     string parentDir = Path.GetDirectoryName(trimedPath);
                     string psExePath = Path.Combine(parentDir, powershellExeName);
                     string oldExePath = Path.Combine(parentDir, oldPowershellExeName);
-                    string psDepsPath = Path.Combine(parentDir, "powershell.deps.json");
-                    if ((File.Exists(psExePath) || File.Exists(oldExePath)) && File.Exists(psDepsPath))
+                    string psDepsPath = Path.Combine(parentDir, powershellDepsName);
+                    string oldDepsPath = Path.Combine(parentDir, oldPowershellDepsName);
+                    if ((File.Exists(psExePath) && File.Exists(psDepsPath)) || (File.Exists(oldDepsPath) && File.Exists(oldDepsPath)))
                     {
                         // Path is a PSHome module path from a different powershell core instance. Ignore it.
                         continue;

--- a/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
@@ -799,7 +799,7 @@ namespace System.Management.Automation
                     string oldExePath = Path.Combine(parentDir, oldPowershellExeName);
                     string psDepsPath = Path.Combine(parentDir, powershellDepsName);
                     string oldDepsPath = Path.Combine(parentDir, oldPowershellDepsName);
-                    if ((File.Exists(psExePath) && File.Exists(psDepsPath)) || (File.Exists(oldDepsPath) && File.Exists(oldDepsPath)))
+                    if ((File.Exists(psExePath) && File.Exists(psDepsPath)) || (File.Exists(oldExePath) && File.Exists(oldDepsPath)))
                     {
                         // Path is a PSHome module path from a different powershell core instance. Ignore it.
                         continue;

--- a/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
@@ -775,7 +775,7 @@ namespace System.Management.Automation
             const string oldPowershellExeName = "powershell.exe";
 #endif
             const string powershellDepsName = "pwsh.deps.json";
-            const string oldPowerShellDepsName = "powershell.deps.json";
+            const string oldPowershellDepsName = "powershell.deps.json";
 
             StringBuilder modulePathString = new StringBuilder(currentProcessModulePath.Length);
             char[] invalidPathChars = Path.GetInvalidPathChars();

--- a/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
@@ -769,8 +769,10 @@ namespace System.Management.Automation
         {
 #if UNIX
             const string powershellExeName = "pwsh";
+            const string oldPowershellExeName = "powershell";
 #else
             const string powershellExeName = "pwsh.exe";
+            const string oldPowershellExeName = "powershell.exe";
 #endif
             StringBuilder modulePathString = new StringBuilder(currentProcessModulePath.Length);
             char[] invalidPathChars = Path.GetInvalidPathChars();
@@ -791,8 +793,9 @@ namespace System.Management.Automation
                 {
                     string parentDir = Path.GetDirectoryName(trimedPath);
                     string psExePath = Path.Combine(parentDir, powershellExeName);
+                    string oldExePath = Path.Combine(parentDir, oldPowershellExeName);
                     string psDepsPath = Path.Combine(parentDir, "powershell.deps.json");
-                    if (File.Exists(psExePath) && File.Exists(psDepsPath))
+                    if ((File.Exists(psExePath) || File.Exists(oldExePath)) && File.Exists(psDepsPath))
                     {
                         // Path is a PSHome module path from a different powershell core instance. Ignore it.
                         continue;

--- a/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
@@ -768,9 +768,9 @@ namespace System.Management.Automation
         private static string RemoveSxSPsHomeModulePath(string currentProcessModulePath, string personalModulePath, string sharedModulePath, string psHomeModulePath)
         {
 #if UNIX
-            const string powershellExeName = "powershell";
+            const string powershellExeName = "pwsh";
 #else
-            const string powershellExeName = "powershell.exe";
+            const string powershellExeName = "pwsh.exe";
 #endif
             StringBuilder modulePathString = new StringBuilder(currentProcessModulePath.Length);
             char[] invalidPathChars = Path.GetInvalidPathChars();

--- a/src/System.Management.Automation/engine/hostifaces/MshHost.cs
+++ b/src/System.Management.Automation/engine/hostifaces/MshHost.cs
@@ -43,7 +43,7 @@ namespace System.Management.Automation.Host
     public abstract class PSHost
     {
         /// <summary>
-        /// The powershell.exe spec states that 128 is the maximum nesting depth.
+        /// The powershell spec states that 128 is the maximum nesting depth.
         /// </summary>
         internal const int MaximumNestedPromptLevel = 128;
         internal static bool IsStdOutputRedirected;

--- a/src/System.Management.Automation/engine/hostifaces/PowerShellProcessInstance.cs
+++ b/src/System.Management.Automation/engine/hostifaces/PowerShellProcessInstance.cs
@@ -38,10 +38,10 @@ namespace System.Management.Automation.Runspaces
         {
 #if UNIX
             s_PSExePath = Path.Combine(Utils.DefaultPowerShellAppBase,
-                            "powershell");
+                            "pwsh");
 #else
             s_PSExePath = Path.Combine(Utils.DefaultPowerShellAppBase,
-                            "powershell.exe");
+                            "pwsh.exe");
 #endif
         }
 
@@ -79,7 +79,7 @@ namespace System.Management.Automation.Runspaces
 #if CORECLR
             string processArguments = " -s -NoLogo -NoProfile";
 #else
-            // Adding Version parameter to powershell.exe
+            // Adding Version parameter to powershell
             // Version parameter needs to go before all other parameters because the native layer looks for Version or
             // PSConsoleFile parameters before parsing other parameters.
             // The other parameters get parsed in the managed layer.

--- a/src/System.Management.Automation/engine/remoting/common/RunspaceConnectionInfo.cs
+++ b/src/System.Management.Automation/engine/remoting/common/RunspaceConnectionInfo.cs
@@ -3164,6 +3164,8 @@ namespace System.Management.Automation.Runspaces
                     //
                     // Hyper-V container (i.e., RuntimeId is not empty) uses Hyper-V socket transport.
                     // Windows Server container (i.e., RuntimeId is empty) uses named pipe transport for now.
+                    // This code executes `powershell.exe` as it exists in the container which currently is
+                    // expected to be Windows PowerShell as it's inbox in the container.
                     //
                     cmd = string.Format(System.Globalization.CultureInfo.InvariantCulture,
                         @"{{""CommandLine"": ""powershell.exe {0} -NoLogo {1}"",""RestrictedToken"": {2}}}",

--- a/src/System.Management.Automation/engine/remoting/common/RunspaceConnectionInfo.cs
+++ b/src/System.Management.Automation/engine/remoting/common/RunspaceConnectionInfo.cs
@@ -2033,11 +2033,11 @@ namespace System.Management.Automation.Runspaces
             }
 #endif
 
-            // Create client ssh process that hosts powershell.exe as a subsystem and is configured
+            // Create client ssh process that hosts powershell as a subsystem and is configured
             // to be in server mode for PSRP over SSHD:
-            //   powershell -Version 5.1 -sshs -NoLogo -NoProfile
+            //   powershell -sshs -NoLogo -NoProfile
             //   See sshd_configuration file, subsystems section and it will have this entry:
-            //     Subsystem       powershell C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -Version 5.1 -sshs -NoLogo -NoProfile
+            //     Subsystem       powershell C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -sshs -NoLogo -NoProfile
             string arguments;
             if (!string.IsNullOrEmpty(this.KeyFilePath))
             {
@@ -3166,7 +3166,7 @@ namespace System.Management.Automation.Runspaces
                     // Windows Server container (i.e., RuntimeId is empty) uses named pipe transport for now.
                     //
                     cmd = string.Format(System.Globalization.CultureInfo.InvariantCulture,
-                        @"{{""CommandLine"": ""powershell.exe {0} -NoLogo {1}"",""RestrictedToken"": {2}}}",
+                        @"{{""CommandLine"": ""pwsh.exe {0} -NoLogo {1}"",""RestrictedToken"": {2}}}",
                         (RuntimeId != Guid.Empty) ? "-so -NoProfile" : "-NamedPipeServerMode",
                         String.IsNullOrEmpty(ConfigurationName) ? String.Empty : String.Concat("-Config ", ConfigurationName),
                         (RunAsAdmin) ? "false" : "true");

--- a/src/System.Management.Automation/engine/remoting/common/RunspaceConnectionInfo.cs
+++ b/src/System.Management.Automation/engine/remoting/common/RunspaceConnectionInfo.cs
@@ -3166,7 +3166,7 @@ namespace System.Management.Automation.Runspaces
                     // Windows Server container (i.e., RuntimeId is empty) uses named pipe transport for now.
                     //
                     cmd = string.Format(System.Globalization.CultureInfo.InvariantCulture,
-                        @"{{""CommandLine"": ""pwsh.exe {0} -NoLogo {1}"",""RestrictedToken"": {2}}}",
+                        @"{{""CommandLine"": ""powershell.exe {0} -NoLogo {1}"",""RestrictedToken"": {2}}}",
                         (RuntimeId != Guid.Empty) ? "-so -NoProfile" : "-NamedPipeServerMode",
                         String.IsNullOrEmpty(ConfigurationName) ? String.Empty : String.Concat("-Config ", ConfigurationName),
                         (RunAsAdmin) ? "false" : "true");

--- a/src/System.Management.Automation/engine/remoting/fanin/OutOfProcTransportManager.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/OutOfProcTransportManager.cs
@@ -948,7 +948,7 @@ namespace System.Management.Automation.Remoting.Client
         #region Overrides
 
         /// <summary>
-        /// Launch a new Process (PowerShell.exe -s) to perform remoting. This is used by *-Job cmdlets
+        /// Launch a new Process (pwsh -s) to perform remoting. This is used by *-Job cmdlets
         /// to support background jobs without depending on WinRM (WinRM has complex requirements like
         /// elevation to support local machine remoting)
         /// </summary>

--- a/src/powershell-native/Install-PowerShellRemoting.ps1
+++ b/src/powershell-native/Install-PowerShellRemoting.ps1
@@ -116,7 +116,7 @@ if (! ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity
 if ($PsCmdlet.ParameterSetName -eq "ByPath")
 {
     $targetPsHome = $PowerShellHome
-    $targetPsVersion = & "$targetPsHome\powershell" -NoProfile -Command '$PSVersionTable.PSVersion.ToString()'
+    $targetPsVersion = & "$targetPsHome\pwsh" -NoProfile -Command '$PSVersionTable.PSVersion.ToString()'
 }
 else
 {

--- a/src/powershell-unix/powershell-unix.csproj
+++ b/src/powershell-unix/powershell-unix.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <Description>PowerShell top-level project with .NET CLI host</Description>
-    <AssemblyName>powershell</AssemblyName>
+    <AssemblyName>pwsh</AssemblyName>
     <OutputType>Exe</OutputType>
     <RuntimeIdentifiers>linux-x64;osx.10.12-x64;</RuntimeIdentifiers>
   </PropertyGroup>

--- a/src/powershell-win-core/powershell-win-core.csproj
+++ b/src/powershell-win-core/powershell-win-core.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\PowerShell.Common.props" />
   <PropertyGroup>
     <Description>PowerShell Core on Windows top-level project</Description>
-    <AssemblyName>powershell</AssemblyName>
+    <AssemblyName>pwsh</AssemblyName>
     <OutputType>Exe</OutputType>
     <RuntimeIdentifiers>win7-x86;win7-x64</RuntimeIdentifiers>
     <RootNamespace>Microsoft.PowerShell</RootNamespace>

--- a/test/docker/networktest/DockerRemoting.Tests.ps1
+++ b/test/docker/networktest/DockerRemoting.Tests.ps1
@@ -20,7 +20,7 @@ Describe "Basic remoting test with docker" -tags @("Scenario","Slow"){
 
         # get fullpath to installed core powershell
         Write-Verbose -verbose "Getting path to PowerShell core"
-        $powershellcorepath = docker exec $server powershell -c "(get-childitem 'c:\program files\powershell\*\powershell.exe').fullname"
+        $powershellcorepath = docker exec $server powershell -c "(get-childitem 'c:\program files\powershell\*\pwsh.exe').fullname"
         if ( ! $powershellcorepath )
         {
             $pending = $true
@@ -40,7 +40,7 @@ Describe "Basic remoting test with docker" -tags @("Scenario","Slow"){
         # capture the versions of full and core PowerShell
         write-verbose -verbose "getting powershell full version"
         $fullVersion = docker exec $client powershell -c "`$psversiontable.psversion.tostring()"
-        if ( ! $fullVersion ) 
+        if ( ! $fullVersion )
         {
             $pending = $true
             write-warning "Cannot determine PowerShell full version, not running tests"
@@ -49,7 +49,7 @@ Describe "Basic remoting test with docker" -tags @("Scenario","Slow"){
 
         write-verbose -verbose "getting powershell core version"
         $coreVersion = docker exec $client "$powershellcorepath" -c "`$psversiontable.psversion.tostring()"
-        if ( ! $coreVersion ) 
+        if ( ! $coreVersion )
         {
             $pending = $true
             write-warning "Cannot determine PowerShell core version, not running tests"

--- a/test/docker/networktest/Dockerfile
+++ b/test/docker/networktest/Dockerfile
@@ -1,7 +1,7 @@
 # escape=`
 FROM microsoft/windowsservercore
 
-SHELL ["powershell.exe","-command"]
+SHELL ["pwsh.exe","-command"]
 
 # the source msi should change on a daily basis
 # the destination should not change
@@ -18,7 +18,7 @@ RUN new-LocalUser -Name testuser -password (ConvertTo-SecureString 11aa!!AA -asp
     set-item WSMan:/localhost/client/AllowUnencrypted $true; `
     Start-Process -FilePath msiexec.exe -ArgumentList '-qn', `
     '-i c:\PSCore.msi','-log c:\PSCore-install.log','-norestart' -wait ; `
-    $psexec = get-item -path ${ENV:ProgramFiles}/powershell/*/powershell.exe; `
+    $psexec = get-item -path ${ENV:ProgramFiles}/powershell/*/pwsh.exe; `
     $corehome = $psexec.directory.fullname; `
     & $psexec Install-PowerShellRemoting.ps1; `
     remove-item -force c:\PSCore.msi

--- a/test/powershell/Host/Base-Directory.Tests.ps1
+++ b/test/powershell/Host/Base-Directory.Tests.ps1
@@ -1,7 +1,7 @@
 Describe "Configuration file locations" -tags "CI","Slow" {
 
     BeforeAll {
-        $powershell = Join-Path -Path $PsHome -ChildPath "powershell"
+        $powershell = Join-Path -Path $PsHome -ChildPath "pwsh"
         $profileName = "Microsoft.PowerShell_profile.ps1"
     }
 

--- a/test/powershell/Host/ConsoleHost.Tests.ps1
+++ b/test/powershell/Host/ConsoleHost.Tests.ps1
@@ -9,7 +9,7 @@ using namespace System.Diagnostics
 Describe 'minishell for native executables' -Tag 'CI' {
 
     BeforeAll {
-        $powershell = Join-Path -Path $PsHome -ChildPath "powershell"
+        $powershell = Join-Path -Path $PsHome -ChildPath "pwsh"
     }
 
     Context 'Streams from minishell' {
@@ -51,7 +51,7 @@ Describe 'minishell for native executables' -Tag 'CI' {
 Describe "ConsoleHost unit tests" -tags "Feature" {
 
     BeforeAll {
-        $powershell = Join-Path -Path $PsHome -ChildPath "powershell"
+        $powershell = Join-Path -Path $PsHome -ChildPath "pwsh"
         $ExitCodeBadCommandLineParameter = 64
 
         function NewProcessStartInfo([string]$CommandLine, [switch]$RedirectStdIn)
@@ -152,7 +152,7 @@ Describe "ConsoleHost unit tests" -tags "Feature" {
         }
         foreach ($x in "--help", "-help", "-h", "-?", "--he", "-hel", "--HELP", "-hEl") {
             It "Accepts '$x' as a parameter for help" {
-                & $powershell -noprofile $x | Where-Object { $_ -match "PowerShell[.exe] -Help | -? | /?" } | Should Not BeNullOrEmpty
+                & $powershell -noprofile $x | Where-Object { $_ -match "pwsh[.exe] -Help | -? | /?" } | Should Not BeNullOrEmpty
             }
         }
 
@@ -170,7 +170,7 @@ Describe "ConsoleHost unit tests" -tags "Feature" {
             @{value = "2"},
             @{value = "-command 1-1"}
         ) {
-            $currentVersion = "powershell " + $PSVersionTable.GitCommitId.ToString()
+            $currentVersion = "PowerShell " + $PSVersionTable.GitCommitId.ToString()
             $observed = & $powershell -version $value 2>&1
             $observed | should be $currentVersion
             $LASTEXITCODE | Should Be 0
@@ -487,8 +487,8 @@ foo
     }
 
     Context "PATH environment variable" {
-        It "`$PSHOME should be in front so that powershell.exe starts current running PowerShell" {
-            powershell -v | Should Match $psversiontable.GitCommitId
+        It "`$PSHOME should be in front so that pwsh.exe starts current running PowerShell" {
+            pwsh -v | Should Match $psversiontable.GitCommitId
         }
 
         It "powershell starts if PATH is not set" -Skip:($IsWindows) {
@@ -568,7 +568,7 @@ public enum ShowWindowCommands : int
             @{WindowStyle="Maximized"}  # hidden doesn't work in CI/Server Core
         ) {
         param ($WindowStyle)
-        $ps = Start-Process powershell -ArgumentList "-WindowStyle $WindowStyle -noexit -interactive" -PassThru
+        $ps = Start-Process pwsh -ArgumentList "-WindowStyle $WindowStyle -noexit -interactive" -PassThru
         $startTime = Get-Date
         $showCmd = "Unknown"
         while (((Get-Date) - $startTime).TotalSeconds -lt 10 -and $showCmd -ne $WindowStyle)
@@ -581,7 +581,7 @@ public enum ShowWindowCommands : int
     }
 
     It "Invalid -WindowStyle returns error" {
-        powershell -WindowStyle invalid
+        pwsh -WindowStyle invalid
         $LASTEXITCODE | Should Be $ExitCodeBadCommandLineParameter
     }
 }

--- a/test/powershell/Host/Read-Host.Tests.ps1
+++ b/test/powershell/Host/Read-Host.Tests.ps1
@@ -1,7 +1,7 @@
 Describe "Read-Host" -Tags "Slow","Feature" {
     Context "[Console]::ReadKey() implementation on non-Windows" {
         BeforeAll {
-            $powershell = Join-Path -Path $PsHome -ChildPath "powershell"
+            $powershell = Join-Path -Path $PsHome -ChildPath "pwsh"
             $assetsDir = Join-Path -Path $PSScriptRoot -ChildPath assets
             if ($IsWindows) {
                 $ItArgs = @{ skip = $true }

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -355,7 +355,7 @@ Describe "TabCompletion" -Tags CI {
                 @{ inputStr = '$host.UI.WriteD'; expected = 'WriteDebugLine('; setup = $null }
                 @{ inputStr = '$MaximumHistoryCount.'; expected = 'CompareTo('; setup = $null }
                 @{ inputStr = '$A=[datetime]::now;$A.'; expected = 'Date'; setup = $null }
-                @{ inputStr = '$x= gps powershell;$x.*pm'; expected = 'NPM'; setup = $null }
+                @{ inputStr = '$x= gps pwsh;$x.*pm'; expected = 'NPM'; setup = $null }
                 @{ inputStr = 'function write-output {param($abcd) $abcd};Write-Output -a'; expected = '-abcd'; setup = $null }
                 @{ inputStr = 'function write-output {param($abcd) $abcd};Microsoft.PowerShell.Utility\Write-Output -'; expected = '-InputObject'; setup = $null }
                 @{ inputStr = '[math]::Co'; expected = 'Cos('; setup = $null }
@@ -418,7 +418,7 @@ Describe "TabCompletion" -Tags CI {
                 @{ inputStr = 'gmo -list PackageM'; expected = 'PackageManagement'; setup = $null }
                 @{ inputStr = 'gcm -Module PackageManagement Find-Pac'; expected = 'Find-Package'; setup = $null }
                 @{ inputStr = 'ipmo PackageM'; expected = 'PackageManagement'; setup = $null }
-                @{ inputStr = 'Get-Process powersh'; expected = 'powershell'; setup = $null }
+                @{ inputStr = 'Get-Process pws'; expected = 'pwsh'; setup = $null }
                 @{ inputStr = "function bar { [OutputType('System.IO.FileInfo')][OutputType('System.Diagnostics.Process')]param() }; bar | ? { `$_.ProcessN"; expected = 'ProcessName'; setup = $null }
                 @{ inputStr = "function bar { [OutputType('System.IO.FileInfo')][OutputType('System.Diagnostics.Process')]param() }; bar | ? { `$_.LastAc"; expected = 'LastAccessTime'; setup = $null }
                 @{ inputStr = "& 'get-comm"; expected = "'Get-Command'"; setup = $null }

--- a/test/powershell/Language/Parser/Conversions.Tests.ps1
+++ b/test/powershell/Language/Parser/Conversions.Tests.ps1
@@ -114,7 +114,7 @@ namespace TestTypeResolution {
         Add-Type $cmdletCode -OutputAssembly $cmdletDllPath
         Add-Type $dupTypeCode -OutputAssembly $dupTypeDllPath
 
-        $powershell = Join-Path $PSHOME "powershell"
+        $powershell = Join-Path $PSHOME "pwsh"
     }
 
     It "validate Type resolution should prefer the assembly loaded by Import-Module" {

--- a/test/powershell/Language/Parser/UsingAssembly.Tests.ps1
+++ b/test/powershell/Language/Parser/UsingAssembly.Tests.ps1
@@ -79,26 +79,26 @@ public class ABC {}
         }
 #>
         It "Assembly loaded at runtime" -pending {
-            $assemblies = powershell -noprofile -command @"
+            $assemblies = pwsh -noprofile -command @"
     using assembly .\UsingAssemblyTest$guid.dll
     [Appdomain]::CurrentDomain.GetAssemblies().GetName().Name
 "@
             $assemblies -contains "UsingAssemblyTest$guid" | Should Be $true
 
-            $assemblies = powershell -noprofile -command @"
+            $assemblies = pwsh -noprofile -command @"
     using assembly $PSScriptRoot\UsingAssemblyTest$guid.dll
     [Appdomain]::CurrentDomain.GetAssemblies().GetName().Name
 "@
             $assemblies -contains "UsingAssemblyTest$guid" | Should Be $true
 
 
-            $assemblies = powershell -noprofile -command @"
+            $assemblies = pwsh -noprofile -command @"
     using assembly System.Drawing
     [Appdomain]::CurrentDomain.GetAssemblies().GetName().Name
 "@
             $assemblies -contains "System.Drawing" | Should Be $true
 
-            $assemblies = powershell -noprofile -command @"
+            $assemblies = pwsh -noprofile -command @"
     using assembly 'System.Drawing, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'
     [Appdomain]::CurrentDomain.GetAssemblies().GetName().Name
 "@

--- a/test/powershell/Language/Scripting/NativeExecution/NativeCommandProcessor.Tests.ps1
+++ b/test/powershell/Language/Scripting/NativeExecution/NativeCommandProcessor.Tests.ps1
@@ -1,7 +1,7 @@
 Describe 'native commands with pipeline' -tags 'Feature' {
 
     BeforeAll {
-        $powershell = Join-Path -Path $PsHome -ChildPath "powershell"
+        $powershell = Join-Path -Path $PsHome -ChildPath "pwsh"
     }
 
     It "native | ps | native doesn't block" {
@@ -30,8 +30,8 @@ Describe 'native commands with pipeline' -tags 'Feature' {
             $result = @(ping.exe | findstr.exe count | findstr.exe ping)
             $result[0] | Should Match "Usage: ping"
         } else {
-            $result = @(ps aux | grep powershell | grep -v grep)
-            $result[0] | Should Match "powershell"
+            $result = @(ps aux | grep pwsh | grep -v grep)
+            $result[0] | Should Match "pwsh"
         }
     }
 }

--- a/test/powershell/Language/Scripting/NativeExecution/NativeStreams.Tests.ps1
+++ b/test/powershell/Language/Scripting/NativeExecution/NativeStreams.Tests.ps1
@@ -1,5 +1,5 @@
 Describe "Native streams behavior with PowerShell" -Tags 'CI' {
-    $powershell = Join-Path -Path $PsHome -ChildPath "powershell"
+    $powershell = Join-Path -Path $PsHome -ChildPath "pwsh"
 
     Context "Error stream" {
         # we are using powershell itself as an example of a native program.

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Import-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Import-Module.Tests.ps1
@@ -103,7 +103,7 @@ using System.Management.Automation;           // Windows PowerShell namespace.
 
 namespace ModuleCmdlets
 {
-  [Cmdlet(VerbsDiagnostic.Test,"BinaryModuleCmdlet1")]   
+  [Cmdlet(VerbsDiagnostic.Test,"BinaryModuleCmdlet1")]
   public class TestBinaryModuleCmdlet1Command : Cmdlet
   {
     protected override void BeginProcessing()
@@ -115,7 +115,7 @@ namespace ModuleCmdlets
 "@
 
     Add-Type -TypeDefinition $src -OutputAssembly $TESTDRIVE\System.dll
-    $results = powershell -noprofile -c "`$module = Import-Module $TESTDRIVE\System.dll -Passthru; `$module.ImplementingAssembly.Location; Test-BinaryModuleCmdlet1"
+    $results = pwsh -noprofile -c "`$module = Import-Module $TESTDRIVE\System.dll -Passthru; `$module.ImplementingAssembly.Location; Test-BinaryModuleCmdlet1"
 
     #Ignore slash format difference under windows/Unix
     $path = (Get-ChildItem $TESTDRIVE\System.dll).FullName

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Out-Default.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Out-Default.Tests.ps1
@@ -3,7 +3,7 @@ Describe "Out-Default Tests" -tag CI {
         # due to https://github.com/PowerShell/PowerShell/issues/3405, `Out-Default -Transcript` emits output to pipeline
         # as running in Pester effectively wraps everything in parenthesis, workaround is to use another powershell
         # to run the test script passed as a string
-        $powershell = "$PSHOME/powershell"
+        $powershell = "$PSHOME/pwsh"
     }
 
     It "'Out-Default -Transcript' shows up in transcript, but not host" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
@@ -240,7 +240,7 @@ Describe "Basic FileSystem Provider Tests" -Tags "CI" {
 
     Context "Validate behavior when access is denied" {
         BeforeAll {
-            $powershell = Join-Path $PSHOME "powershell"
+            $powershell = Join-Path $PSHOME "pwsh"
             if ($IsWindows)
             {
                 $protectedPath = Join-Path ([environment]::GetFolderPath("windows")) "appcompat" "Programs"

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Service.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Service.Tests.ps1
@@ -126,7 +126,7 @@ Describe "Set/New/Remove-Service cmdlet tests" -Tags "Feature", "RequireAdminOnW
             $creds = [pscredential]::new(".\$startUsername", $password)
             $parameters = @{
                 Name           = $servicename;
-                BinaryPathName = "$PSHOME\powershell.exe";
+                BinaryPathName = "$PSHOME\pwsh.exe";
                 StartupType    = "Manual";
                 Credential     = $creds
             }
@@ -156,7 +156,7 @@ Describe "Set/New/Remove-Service cmdlet tests" -Tags "Feature", "RequireAdminOnW
         try {
             $parameters = @{
                 Name           = $name;
-                BinaryPathName = "$PSHOME\powershell.exe";
+                BinaryPathName = "$PSHOME\pwsh.exe";
                 StartupType    = $startupType;
             }
             if ($description) {
@@ -200,7 +200,7 @@ Describe "Set/New/Remove-Service cmdlet tests" -Tags "Feature", "RequireAdminOnW
             $servicename = "testremoveservice"
             $parameters = @{
                 Name           = $servicename;
-                BinaryPathName = "$PSHOME\powershell.exe"
+                BinaryPathName = "$PSHOME\pwsh.exe"
             }
             $service = New-Service @parameters
             $service | Should Not BeNullOrEmpty
@@ -218,7 +218,7 @@ Describe "Set/New/Remove-Service cmdlet tests" -Tags "Feature", "RequireAdminOnW
             $servicename = "testremoveservice"
             $parameters = @{
                 Name           = $servicename;
-                BinaryPathName = "$PSHOME\powershell.exe"
+                BinaryPathName = "$PSHOME\pwsh.exe"
             }
             $service = New-Service @parameters
             $service | Should Not BeNullOrEmpty
@@ -241,7 +241,7 @@ Describe "Set/New/Remove-Service cmdlet tests" -Tags "Feature", "RequireAdminOnW
             $newdisplayname = "newdisplayname"
             $parameters = @{
                 Name           = $servicename;
-                BinaryPathName = "$PSHOME\powershell.exe"
+                BinaryPathName = "$PSHOME\pwsh.exe"
             }
             $service = New-Service @parameters
             $service | Should Not BeNullOrEmpty
@@ -260,7 +260,7 @@ Describe "Set/New/Remove-Service cmdlet tests" -Tags "Feature", "RequireAdminOnW
             $newdisplayname = "newdisplayname"
             $parameters = @{
                 Name           = $servicename;
-                BinaryPathName = "$PSHOME\powershell.exe"
+                BinaryPathName = "$PSHOME\pwsh.exe"
             }
             $service = New-Service @parameters
             $service | Should Not BeNullOrEmpty
@@ -290,7 +290,7 @@ Describe "Set/New/Remove-Service cmdlet tests" -Tags "Feature", "RequireAdminOnW
         param($cmdlet, $name, $parameter, $value, $errorid)
         $parameters = @{$parameter = $value; Name = $name; ErrorAction = "Stop"}
         if ($cmdlet -eq "New-Service") {
-            $parameters += @{Binary = "$PSHOME\powershell.exe"};
+            $parameters += @{Binary = "$PSHOME\pwsh.exe"};
         }
         { & $cmdlet @parameters } | ShouldBeErrorId $errorid
     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Invoke-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Invoke-Item.Tests.ps1
@@ -2,7 +2,7 @@ using namespace System.Diagnostics
 
 Describe "Invoke-Item basic tests" -Tags "Feature" {
     BeforeAll {
-        $powershell = Join-Path $PSHOME -ChildPath powershell
+        $powershell = Join-Path $PSHOME -ChildPath pwsh
 
         $testFile1 = Join-Path -Path $TestDrive -ChildPath "text1.txt"
         New-Item -Path $testFile1 -ItemType File -Force > $null

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Set-PSBreakpoint.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Set-PSBreakpoint.Tests.ps1
@@ -1,4 +1,4 @@
-$ps = Join-Path -Path $PsHome -ChildPath "powershell"
+$ps = Join-Path -Path $PsHome -ChildPath "pwsh"
 
 Describe "Set-PSBreakpoint DRT Unit Tests" -Tags "CI" {
     #Set up

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Host.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Host.Tests.ps1
@@ -1,7 +1,7 @@
 ﻿Describe "Write-Host with default Console Host" -Tags "Slow","Feature" {
 
     BeforeAll {
-        $powershell = Join-Path -Path $PsHome -ChildPath "powershell"
+        $powershell = Join-Path -Path $PsHome -ChildPath "pwsh"
 
         $testData = @(
             @{ Name = '-Separator';       Command = "Write-Host a,b,c -Separator '+'";                 returnCount = 1; returnValue = @("a+b+c") }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/XMLCommand.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/XMLCommand.Tests.ps1
@@ -102,9 +102,9 @@ Describe "XmlCommand DRT basic functionality Tests" -Tags "CI" {
 		$deserialized_one.two.three.num | Should BeNullOrEmpty
 	}
 
-	It "Import-Clixml should work with XML serialization from powershell.exe" {
+	It "Import-Clixml should work with XML serialization from pwsh.exe" {
 		# need to create separate process so that current powershell doesn't interpret clixml output
-		Start-Process -FilePath $pshome\powershell -RedirectStandardOutput $testfile -Args "-noprofile -nologo -outputformat xml -command get-command import-clixml" -Wait
+		Start-Process -FilePath $pshome\pwsh -RedirectStandardOutput $testfile -Args "-noprofile -nologo -outputformat xml -command get-command import-clixml" -Wait
 		$out = Import-Clixml -Path $testfile
 		$out.Name | Should Be "Import-CliXml"
 		$out.CommandType.ToString() | Should Be "Cmdlet"

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/clixml.tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/clixml.tests.ps1
@@ -37,7 +37,7 @@
 
     Context "Export-CliXml" {
         BeforeAll {
-            $gpsList = Get-Process powershell
+            $gpsList = Get-Process pwsh
             $gps = $gpsList | Select-Object -First 1
             $filePath = Join-Path $subFilePath 'gps.xml'
 
@@ -213,7 +213,7 @@ Describe "Deserializing corrupted Cim classes should not instantiate non-Cim typ
     It "Verifies that importing the corrupted Cim class does not launch calc.exe" -skip:$skipNotWindows {
 
         Import-Clixml -Path (Join-Path $PSScriptRoot "assets\CorruptedCim.clixml")
-        
+
         # Wait up to 10 seconds for calc.exe to run
         $calcProc = $null
         $count = 0

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/object.tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/object.tests.ps1
@@ -2,7 +2,7 @@
     Context "Group-Object" {
         It "AsHashtable returns a hashtable" {
             $result = Get-Process | Group-Object -Property ProcessName -AsHashTable
-            $result["powershell"].Count | Should BeGreaterThan 0
+            $result["pwsh"].Count | Should BeGreaterThan 0
         }
 
         It "AsString returns a string" {

--- a/test/powershell/Modules/Microsoft.WSMan.Management/CredSSP.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.WSMan.Management/CredSSP.Tests.ps1
@@ -1,7 +1,7 @@
 Describe "CredSSP cmdlet tests" -Tags 'Feature','RequireAdminOnWindows' {
 
     BeforeAll {
-        $powershell = Join-Path $PSHOME "powershell"
+        $powershell = Join-Path $PSHOME "pwsh"
         $notEnglish = $false
         $IsToBeSkipped = !$IsWindows;
 

--- a/test/powershell/Provider/Pester.AutomountedDrives.Tests.ps1
+++ b/test/powershell/Provider/Pester.AutomountedDrives.Tests.ps1
@@ -1,4 +1,4 @@
-﻿<############################################################################################ 
+﻿<############################################################################################
  # File: Pester.AutomountedDrives.Tests.ps1
  # Pester.AutomountedDrives.Tests suite contains Tests that are
  # used for validating automounted PowerShell drives.
@@ -7,8 +7,8 @@ $script:TestSourceRoot = $PSScriptRoot
 Describe "Test suite for validating automounted PowerShell drives" -Tags @('Feature', 'Slow', 'RequireAdminOnWindows') {
 
     BeforeAll {
-        $powershell = Join-Path -Path $PsHome -ChildPath "powershell"
-        
+        $powershell = Join-Path -Path $PsHome -ChildPath "pwsh"
+
         $AutomountVHDDriveScriptPath = Join-Path $script:TestSourceRoot 'AutomountVHDDrive.ps1'
         $vhdPath = Join-Path $TestDrive 'TestAutomountVHD.vhd'
 
@@ -29,24 +29,24 @@ Describe "Test suite for validating automounted PowerShell drives" -Tags @('Feat
         catch
         { $VHDToolsNotFound = $true }
     }
-    
+
     Context "Validating automounting FileSystem drives" {
-        
+
         It "Test automounting using subst.exe" -Skip:$SubstNotFound {
            & $powershell -noprofile -command "& '$AutomountSubstDriveScriptPath' -FullPath '$substDir'" | Should Be "Drive found"
         }
-     
+
         It "Test automounting using New-VHD/Mount-VHD" -Skip:$VHDToolsNotFound {
             & $powershell -noprofile -command "& '$AutomountVHDDriveScriptPath' -VHDPath '$vhdPath'" | Should Be "Drive found"
         }
     }
 
     Context "Validating automounting FileSystem drives from modules" {
-        
+
         It "Test automounting using subst.exe" -Skip:$SubstNotFound {
            & $powershell -noprofile -command "& '$AutomountSubstDriveScriptPath' -useModule -FullPath '$substDir'" | Should Be "Drive found"
         }
-        
+
         It "Test automounting using New-VHD/Mount-VHD" -Skip:$VHDToolsNotFound {
             $vhdPath = Join-Path $TestDrive 'TestAutomountVHD.vhd'
             & $powershell -noprofile -command "& '$AutomountVHDDriveScriptPath' -useModule -VHDPath '$vhdPath'" | Should Be "Drive found"

--- a/test/powershell/README.md
+++ b/test/powershell/README.md
@@ -23,7 +23,7 @@ one on the path.
 Example:
 
 ```powershell
-    $powershell = Join-Path -Path $PsHome -ChildPath "powershell"
+    $powershell = Join-Path -Path $PsHome -ChildPath "pwsh"
     & $powershell -noprofile -command "ExampleCommand" | Should Be "ExampleOutput"
 ```
 

--- a/test/powershell/SDK/PSDebugging.Tests.ps1
+++ b/test/powershell/SDK/PSDebugging.Tests.ps1
@@ -4,7 +4,7 @@ using namespace System.Management.Automation.Internal
 Describe "PowerShell Command Debugging" -tags "CI" {
 
     BeforeAll {
-        $powershell = Join-Path -Path $PsHome -ChildPath "powershell"
+        $powershell = Join-Path -Path $PsHome -ChildPath "pwsh"
     }
 
     function NewProcessStartInfo([string]$CommandLine, [switch]$RedirectStdIn)

--- a/test/powershell/engine/Job/Jobs.Tests.ps1
+++ b/test/powershell/engine/Job/Jobs.Tests.ps1
@@ -69,7 +69,7 @@ Describe 'Basic Job Tests' -Tags 'CI' {
 
         It "Create job with native command" {
             try {
-                $nativeJob = Start-job { powershell -c 1+1 }
+                $nativeJob = Start-job { pwsh -c 1+1 }
                 $nativeJob | Wait-Job
                 $nativeJob.State | Should BeExactly "Completed"
                 $nativeJob.HasMoreData | Should Be $true

--- a/test/powershell/engine/Module/ModulePath.Tests.ps1
+++ b/test/powershell/engine/Module/ModulePath.Tests.ps1
@@ -25,7 +25,7 @@ Describe "SxS Module Path Basic Tests" -tags "CI" {
         $fakePSHome = Join-Path -Path $TestDrive -ChildPath 'FakePSHome'
         $fakePSHomeModuleDir = Join-Path -Path $fakePSHome -ChildPath 'Modules'
         $fakePowerShell = Join-Path -Path $fakePSHome -ChildPath (Split-Path -Path $powershell -Leaf)
-        $fakePSDepsFile = Join-Path -Path $fakePSHome -ChildPath "powershell.deps.json"
+        $fakePSDepsFile = Join-Path -Path $fakePSHome -ChildPath "pwsh.deps.json"
 
         New-Item -Path $fakePSHome -ItemType Directory > $null
         New-Item -Path $fakePSHomeModuleDir -ItemType Directory > $null
@@ -56,7 +56,7 @@ Describe "SxS Module Path Basic Tests" -tags "CI" {
 
     It "ignore pshome module path derived from a different powershell core instance" -Skip:(!$IsCoreCLR) {
 
-        ## Create 'powershell' and 'powershell.deps.json' in the fake PSHome folder,
+        ## Create 'powershell' and 'pwsh.deps.json' in the fake PSHome folder,
         ## so that the module path calculation logic would believe it's real.
         New-Item -Path $fakePowerShell -ItemType File -Force > $null
         New-Item -Path $fakePSDepsFile -ItemType File -Force > $null
@@ -75,7 +75,7 @@ Describe "SxS Module Path Basic Tests" -tags "CI" {
 
         } finally {
 
-            ## Remove 'powershell' and 'powershell.deps.json' from the fake PSHome folder
+            ## Remove 'powershell' and 'pwsh.deps.json' from the fake PSHome folder
             Remove-Item -Path $fakePowerShell -Force -ErrorAction SilentlyContinue
             Remove-Item -Path $fakePSDepsFile -Force -ErrorAction SilentlyContinue
         }

--- a/test/powershell/engine/Module/ModulePath.Tests.ps1
+++ b/test/powershell/engine/Module/ModulePath.Tests.ps1
@@ -4,7 +4,7 @@ Describe "SxS Module Path Basic Tests" -tags "CI" {
 
         if ($IsWindows)
         {
-            $powershell = "$PSHOME\powershell.exe"
+            $powershell = "$PSHOME\pwsh.exe"
             $ProductName = "WindowsPowerShell"
             if ($IsCoreCLR -and ($PSHOME -notlike "*Windows\System32\WindowsPowerShell\v1.0"))
             {
@@ -15,7 +15,7 @@ Describe "SxS Module Path Basic Tests" -tags "CI" {
         }
         else
         {
-            $powershell = "$PSHOME/powershell"
+            $powershell = "$PSHOME/pwsh"
             $expectedUserPath = [System.Management.Automation.Platform]::SelectProductNameForDirectory("USER_MODULES")
             $expectedSharedPath = [System.Management.Automation.Platform]::SelectProductNameForDirectory("SHARED_MODULES")
         }

--- a/test/powershell/engine/ParameterBinding/ParameterBinding.Tests.ps1
+++ b/test/powershell/engine/ParameterBinding/ParameterBinding.Tests.ps1
@@ -302,7 +302,7 @@
             $test2File = Join-Path -Path $tempDir -ChildPath "test2.ps1"
 
             $expected = "[$tempDir]"
-            $psPath = "$PSHOME\powershell"
+            $psPath = "$PSHOME\pwsh"
 
             $null = New-Item -Path $tempDir -ItemType Directory -Force
             Set-Content -Path $test1File -Value $test1 -Force

--- a/test/tools/CodeCoverageAutomation/Start-CodeCoverageRun.ps1
+++ b/test/tools/CodeCoverageAutomation/Start-CodeCoverageRun.ps1
@@ -238,7 +238,7 @@ try
     }
 
     # grab the commitID, we need this to grab the right sources
-    $gitCommitId = & "$psBinPath\powershell.exe" -noprofile -command { $PSVersiontable.GitCommitId }
+    $gitCommitId = & "$psBinPath\pwsh.exe" -noprofile -command { $PSVersiontable.GitCommitId }
     $commitId = $gitCommitId.substring($gitCommitId.LastIndexOf('-g') + 2)
 
     # download the src directory

--- a/test/tools/OpenCover/OpenCover.psm1
+++ b/test/tools/OpenCover/OpenCover.psm1
@@ -611,7 +611,7 @@ function Install-OpenCover
 .Synopsis
    Invoke-OpenCover runs tests under OpenCover to collect code coverage.
 .Description
-   Invoke-OpenCover runs tests under OpenCover by executing tests on PowerShell.exe located at $PowerShellExeDirectory.
+   Invoke-OpenCover runs tests under OpenCover by executing tests on PowerShell located at $PowerShellExeDirectory.
 .EXAMPLE
    Invoke-OpenCover -TestPath $pwd/test/powershell -PowerShellExeDirectory $pwd/src/powershell-win-core/bin/CodeCoverage/netcoreapp1.0/win7-x64
 #>
@@ -654,8 +654,8 @@ function Invoke-OpenCover
         }
     }
 
-    # check to be sure that powershell.exe is present
-    $target = "${PowerShellExeDirectory}\powershell.exe"
+    # check to be sure that pwsh.exe is present
+    $target = "${PowerShellExeDirectory}\pwsh.exe"
     if ( ! (test-path $target) )
     {
         throw "$target does not exist, use 'Start-PSBuild -configuration CodeCoverage'"
@@ -702,12 +702,12 @@ function Invoke-OpenCover
             # '&' invoke caused issues with cmdline parameters for opencover.console.exe
             $elevatedFile = "$env:temp\elevated.ps1"
             "$OpenCoverBin $cmdlineElevated" | Out-File -FilePath $elevatedFile -force
-            powershell.exe -file $elevatedFile
+            pwsh.exe -file $elevatedFile
 
             # invoke OpenCover unelevated and poll for completion
             $unelevatedFile = "$env:temp\unelevated.ps1"
             "$openCoverBin $cmdlineUnelevated" | Out-File -FilePath $unelevatedFile -Force
-            runas.exe /trustlevel:0x20000 "powershell.exe -file $unelevatedFile"
+            runas.exe /trustlevel:0x20000 "pwsh.exe -file $unelevatedFile"
             # poll for process exit every 60 seconds
             # timeout of 6 hours
             # Runs currently take about 2.5 - 3 hours, we picked 6 hours to be substantially larger.

--- a/tools/appveyor.psm1
+++ b/tools/appveyor.psm1
@@ -323,9 +323,9 @@ function Invoke-AppVeyorTest
     Write-Host -Foreground Green 'Run CoreCLR tests'
     $testResultsNonAdminFile = "$pwd\TestsResultsNonAdmin.xml"
     $testResultsAdminFile = "$pwd\TestsResultsAdmin.xml"
-    if(!(Test-Path "$env:CoreOutput\powershell.exe"))
+    if(!(Test-Path "$env:CoreOutput\pwsh.exe"))
     {
-        throw "CoreCLR PowerShell.exe was not built"
+        throw "CoreCLR pwsh.exe was not built"
     }
 
     if(-not (Test-DailyBuild))

--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -437,7 +437,7 @@ function New-UnixPackage {
         # Setup staging directory so we don't change the original source directory
         $Staging = "$PSScriptRoot/staging"
         if ($pscmdlet.ShouldProcess("Create staging folder")) {
-            New-StagingFolder -StagingPath $Staging -Name $Name
+            New-StagingFolder -StagingPath $Staging
         }
 
         # Follow the Filesystem Hierarchy Standard for Linux and macOS
@@ -456,7 +456,7 @@ function New-UnixPackage {
 
         if($pscmdlet.ShouldProcess("Create package file system"))
         {
-            New-Item -Force -ItemType SymbolicLink -Path "/tmp/$Name" -Target "$Destination/$Name" >$null
+            New-Item -Force -ItemType SymbolicLink -Path "/tmp/pwsh" -Target "$Destination/$Name" >$null
 
             if ($Environment.IsRedHatFamily) {
                 # add two symbolic links to system shared libraries that libmi.so is dependent on to handle
@@ -468,14 +468,14 @@ function New-UnixPackage {
 
                 $AfterInstallScript = [io.path]::GetTempFileName()
                 $AfterRemoveScript = [io.path]::GetTempFileName()
-                $packagingStrings.RedHatAfterInstallScript -f "$Link/$Name" | Out-File -FilePath $AfterInstallScript -Encoding ascii
-                $packagingStrings.RedHatAfterRemoveScript -f "$Link/$Name" | Out-File -FilePath $AfterRemoveScript -Encoding ascii
+                $packagingStrings.RedHatAfterInstallScript -f "$Link/pwsh" | Out-File -FilePath $AfterInstallScript -Encoding ascii
+                $packagingStrings.RedHatAfterRemoveScript -f "$Link/pwsh" | Out-File -FilePath $AfterRemoveScript -Encoding ascii
             }
             elseif ($Environment.IsUbuntu -or $Environment.IsDebian) {
                 $AfterInstallScript = [io.path]::GetTempFileName()
                 $AfterRemoveScript = [io.path]::GetTempFileName()
-                $packagingStrings.UbuntuAfterInstallScript -f "$Link/$Name" | Out-File -FilePath $AfterInstallScript -Encoding ascii
-                $packagingStrings.UbuntuAfterRemoveScript -f "$Link/$Name" | Out-File -FilePath $AfterRemoveScript -Encoding ascii
+                $packagingStrings.UbuntuAfterInstallScript -f "$Link/pwsh" | Out-File -FilePath $AfterInstallScript -Encoding ascii
+                $packagingStrings.UbuntuAfterRemoveScript -f "$Link/pwsh" | Out-File -FilePath $AfterRemoveScript -Encoding ascii
             }
 
 
@@ -584,7 +584,7 @@ function New-UnixPackage {
         $Arguments += @(
             "$Staging/=$Destination/",
             "$GzipFile=$ManFile",
-            "/tmp/$Name=$Link"
+            "/tmp/pwsh=$Link"
         )
         # Build package
         try {
@@ -639,32 +639,11 @@ function New-StagingFolder
     param(
         [Parameter(Mandatory)]
         [string]
-        $StagingPath,
-
-        # Must start with 'powershell' but may have any suffix
-        [Parameter(Mandatory)]
-        [ValidatePattern("^powershell")]
-        [string]
-        $Name
+        $StagingPath
     )
 
     Remove-Item -Recurse -Force -ErrorAction SilentlyContinue $StagingPath
     Copy-Item -Recurse $PackageSourcePath $StagingPath
-
-    # Rename files to given name if not "powershell"
-    if ($Name -ne "powershell") {
-        $Files = @("powershell",
-                "powershell.dll",
-                "powershell.deps.json",
-                "powershell.pdb",
-                "powershell.runtimeconfig.json",
-                "powershell.xml")
-
-        foreach ($File in $Files) {
-            $NewName = $File -replace "^powershell", $Name
-            Move-Item "$StagingPath/$File" "$StagingPath/$NewName"
-        }
-    }
 }
 
 # Function to create a zip file for Nano Server and xcopy deployment
@@ -790,7 +769,7 @@ function New-NugetPackage
     $stagingRoot = New-SubFolder -Path $PSScriptRoot -ChildPath 'nugetStaging' -Clean
     $contentFolder = Join-Path -path $stagingRoot -ChildPath 'content'
     if ($pscmdlet.ShouldProcess("Create staging folder")) {
-        New-StagingFolder -StagingPath $contentFolder -Name $Name
+        New-StagingFolder -StagingPath $contentFolder
     }
 
     $projectFolder = Join-Path $PSScriptRoot -ChildPath 'project'


### PR DESCRIPTION
renamed powershell.exe to pwsh.exe
updated powershell core code dependencies, console host references, and tests
updated vscode json files
updated docker files
updated logic in moduleintrinsics.cs to account for SxS where you are starting pwsh from powershell.exe

Fix https://github.com/PowerShell/PowerShell/issues/4214
<!--

If you are a PowerShell Team member, please make sure you choose the Reviewer(s) and Assignee for your PR.
If you are not from the PowerShell Team, you can leave the fields blank and the Maintainers will choose them for you. If you are familiar with the team, feel free to mention some Reviewers yourself.

For more information about the roles of Reviewer and Assignee, refer to [CONTRIBUTING.md](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md).

-->