### PR TITLE
Use InvariantCulture for implicit argument conversion

### DIFF
--- a/src/System.Management.Automation/engine/ParameterBinderBase.cs
+++ b/src/System.Management.Automation/engine/ParameterBinderBase.cs
@@ -1282,7 +1282,7 @@ namespace System.Management.Automation
                                 _context.LanguageMode = PSLanguageMode.FullLanguage;
                             }
 
-                            result = LanguagePrimitives.ConvertTo(currentValue, toType, CultureInfo.CurrentCulture);
+                            result = LanguagePrimitives.ConvertTo(currentValue, toType, CultureInfo.InvariantCulture);
                         }
                         finally
                         {

--- a/test/powershell/Language/Parser/Conversions.Tests.ps1
+++ b/test/powershell/Language/Parser/Conversions.Tests.ps1
@@ -21,6 +21,19 @@ Describe 'conversion syntax' -Tags "CI" {
         ([System.Management.Automation.ActionPreference]"Stop").ToString() | Should Be "Stop"
     }
 
+    It "language conversion uses 'InvariantCulture' by default" {
+        $dateString = "1/11/1111"
+        $expected = [System.Management.Automation.LanguagePrimitives]::ConvertTo($dateString, [datetime], [cultureinfo]::InvariantCulture)
+        $result = try {
+            $oldCulture = [CultureInfo]::CurrentCulture
+            [CultureInfo]::CurrentCulture = 'ru-RU'
+            [datetime] $dateString
+        } finally {
+            [CultureInfo]::CurrentCulture = $oldCulture
+        }
+        $result | Should Be $expected
+    }
+
     Context "Cast object[] to more narrow generic collection" {
         BeforeAll {
             $testCases1 = @(

--- a/test/powershell/Language/Parser/Conversions.Tests.ps1
+++ b/test/powershell/Language/Parser/Conversions.Tests.ps1
@@ -24,8 +24,8 @@ Describe 'conversion syntax' -Tags "CI" {
     It "language conversion uses 'InvariantCulture' by default" {
         $dateString = "1/11/1111"
         $expected = [System.Management.Automation.LanguagePrimitives]::ConvertTo($dateString, [datetime], [cultureinfo]::InvariantCulture)
+        $oldCulture = [CultureInfo]::CurrentCulture
         $result = try {
-            $oldCulture = [CultureInfo]::CurrentCulture
             [CultureInfo]::CurrentCulture = 'ru-RU'
             [datetime] $dateString
         } finally {

--- a/test/powershell/engine/ParameterBinding/ParameterBinding.Tests.ps1
+++ b/test/powershell/engine/ParameterBinding/ParameterBinding.Tests.ps1
@@ -301,9 +301,9 @@
         $ruCastResult = [System.Management.Automation.LanguagePrimitives]::ConvertTo("1/11/1111", [datetime], $ruCulture)
 
         # Implict parameter argument conversion should also use 'InvariantCulture'
+        $oldCulture = [CultureInfo]::CurrentCulture
         $csharpCmdlet, $scriptFunction, $scriptCmdlet = try {
-            $oldCulture = [CultureInfo]::CurrentCulture
-            [CultureInfo]::CurrentCulture = 'ru-RU'
+            [CultureInfo]::CurrentCulture = $ruCulture
             Get-Date -Date 1/11/1111
             Test-Function  1/11/1111
             Test-ScriptCmdlet 1/11/1111

--- a/test/powershell/engine/ParameterBinding/ParameterBinding.Tests.ps1
+++ b/test/powershell/engine/ParameterBinding/ParameterBinding.Tests.ps1
@@ -293,20 +293,23 @@
             $date
         }
 
-        # Explict type cast use 'InvariantCulture' by default
-        $expected = [datetime] "1/11/1111"
+        # Explict type cast using 'InvariantCulture'
+        $expected = [System.Management.Automation.LanguagePrimitives]::ConvertTo("1/11/1111", [datetime], [cultureinfo]::InvariantCulture)
 
         # Cast result with ru-RU culture
         $ruCulture = [cultureinfo]::GetCultureInfo("ru-RU")
         $ruCastResult = [System.Management.Automation.LanguagePrimitives]::ConvertTo("1/11/1111", [datetime], $ruCulture)
 
         # Implict parameter argument conversion should also use 'InvariantCulture'
-        $csharpCmdlet, $scriptFunction, $scriptCmdlet = @(
+        $csharpCmdlet, $scriptFunction, $scriptCmdlet = try {
+            $oldCulture = [CultureInfo]::CurrentCulture
             [CultureInfo]::CurrentCulture = 'ru-RU'
             Get-Date -Date 1/11/1111
             Test-Function  1/11/1111
             Test-ScriptCmdlet 1/11/1111
-        )
+        } finally {
+            [CultureInfo]::CurrentCulture = $oldCulture
+        }
 
         $expected | Should Not Be $ruCastResult
         $csharpCmdlet | Should Be $expected

--- a/test/powershell/engine/ParameterBinding/ParameterBinding.Tests.ps1
+++ b/test/powershell/engine/ParameterBinding/ParameterBinding.Tests.ps1
@@ -281,6 +281,39 @@
         }
     }
 
+    It "Verify implicit argument conversion uses InvariantCulture" {
+        function Test-Function {
+            param([DateTime] $date)
+            $date
+        }
+
+        function Test-ScriptCmdlet {
+            [CmdletBinding()]
+            param([DateTime] $date)
+            $date
+        }
+
+        # Explict type cast use 'InvariantCulture' by default
+        $expected = [datetime] "1/11/1111"
+
+        # Cast result with ru-RU culture
+        $ruCulture = [cultureinfo]::GetCultureInfo("ru-RU")
+        $ruCastResult = [System.Management.Automation.LanguagePrimitives]::ConvertTo("1/11/1111", [datetime], $ruCulture)
+
+        # Implict parameter argument conversion should also use 'InvariantCulture'
+        $csharpCmdlet, $scriptFunction, $scriptCmdlet = @(
+            [CultureInfo]::CurrentCulture = 'ru-RU'
+            Get-Date -Date 1/11/1111
+            Test-Function  1/11/1111
+            Test-ScriptCmdlet 1/11/1111
+        )
+
+        $expected | Should Not Be $ruCastResult
+        $csharpCmdlet | Should Be $expected
+        $scriptFunction | Should Be $expected
+        $scriptFunction | Should Be $expected
+    }
+
     Context "Use automatic variables as default value for parameters" {
         BeforeAll {
             ## Explicit use of 'CmdletBinding' make it a script cmdlet


### PR DESCRIPTION
Fix #3348

PowerShell uses `InvariantCulture` for explicit type conversion. The implicit argument conversion for the script function/cmdlet also uses `InvariantCulture`. However, the implicit parameter argument type conversion for the C# cmdlet uses `CurrentCulture`. Change it to use 'InvariantCulture' too.