### PR TITLE
More value from remaining arguments fixes

### DIFF
--- a/src/System.Management.Automation/engine/CmdletParameterBinderController.cs
+++ b/src/System.Management.Automation/engine/CmdletParameterBinderController.cs
@@ -1691,7 +1691,7 @@ namespace System.Management.Automation
                         //     Set-ClusterOwnerNode foo bar
                         //     Set-ClusterOwnerNode foo,bar
                         // we unwrap our List, but only if there is a single argument of type object[].
-                        if (valueFromRemainingArguments.Count == 1 && valueFromRemainingArguments[0] is object[])
+                        if (valueFromRemainingArguments.Count == 1 && null != LanguagePrimitives.GetEnumerable(valueFromRemainingArguments[0]))
                         {
                             cpi.SetArgumentValue(UnboundArguments[0].ArgumentExtent, valueFromRemainingArguments[0]);
                         }

--- a/src/System.Management.Automation/engine/CmdletParameterBinderController.cs
+++ b/src/System.Management.Automation/engine/CmdletParameterBinderController.cs
@@ -1691,7 +1691,7 @@ namespace System.Management.Automation
                         //     Set-ClusterOwnerNode foo bar
                         //     Set-ClusterOwnerNode foo,bar
                         // we unwrap our List, but only if there is a single argument which is a collection.
-                        if (valueFromRemainingArguments.Count == 1 && null != LanguagePrimitives.GetEnumerable(valueFromRemainingArguments[0]))
+                        if (valueFromRemainingArguments.Count == 1 && null != valueFromRemainingArguments[0] && LanguagePrimitives.IsTypeEnumerable(valueFromRemainingArguments[0].GetType()))
                         {
                             cpi.SetArgumentValue(UnboundArguments[0].ArgumentExtent, valueFromRemainingArguments[0]);
                         }

--- a/src/System.Management.Automation/engine/CmdletParameterBinderController.cs
+++ b/src/System.Management.Automation/engine/CmdletParameterBinderController.cs
@@ -1691,7 +1691,7 @@ namespace System.Management.Automation
                         //     Set-ClusterOwnerNode foo bar
                         //     Set-ClusterOwnerNode foo,bar
                         // we unwrap our List, but only if there is a single argument which is a collection.
-                        if (valueFromRemainingArguments.Count == 1 && null != valueFromRemainingArguments[0] && LanguagePrimitives.IsTypeEnumerable(valueFromRemainingArguments[0].GetType()))
+                        if (valueFromRemainingArguments.Count == 1 && LanguagePrimitives.IsObjectEnumerable(valueFromRemainingArguments[0]))
                         {
                             cpi.SetArgumentValue(UnboundArguments[0].ArgumentExtent, valueFromRemainingArguments[0]);
                         }

--- a/src/System.Management.Automation/engine/CmdletParameterBinderController.cs
+++ b/src/System.Management.Automation/engine/CmdletParameterBinderController.cs
@@ -1690,7 +1690,7 @@ namespace System.Management.Automation
                         //     Set-ClusterOwnerNode -Owners foo,bar
                         //     Set-ClusterOwnerNode foo bar
                         //     Set-ClusterOwnerNode foo,bar
-                        // we unwrap our List, but only if there is a single argument of type object[].
+                        // we unwrap our List, but only if there is a single argument which is a collection.
                         if (valueFromRemainingArguments.Count == 1 && null != LanguagePrimitives.GetEnumerable(valueFromRemainingArguments[0]))
                         {
                             cpi.SetArgumentValue(UnboundArguments[0].ArgumentExtent, valueFromRemainingArguments[0]);

--- a/src/System.Management.Automation/engine/LanguagePrimitives.cs
+++ b/src/System.Management.Automation/engine/LanguagePrimitives.cs
@@ -445,22 +445,6 @@ namespace System.Management.Automation
             return (getEnumerable != LanguagePrimitives.ReturnNullEnumerable);
         }
 
-        private static object GetBaseObject(object obj)
-        {
-            if (obj == null)
-            {
-                return null;
-            }
-
-            var psobj = obj as PSObject;
-            if (null != psobj)
-            {
-                obj = psobj.BaseObject;
-            }
-
-            return obj;
-        }
-
         /// <summary>
         /// Returns True if the language considers obj to be IEnumerable
         /// </summary>
@@ -470,7 +454,7 @@ namespace System.Management.Automation
         [SuppressMessage("Microsoft.Naming", "CA1720:IdentifiersShouldNotContainTypeNames", MessageId = "obj", Justification = "Since V1 code is already shipped, excluding this message.")]
         public static bool IsObjectEnumerable(object obj)
         {
-            return IsTypeEnumerable(GetBaseObject(obj)?.GetType());
+            return IsTypeEnumerable(PSObject.Base(obj)?.GetType());
         }
 
 
@@ -483,7 +467,7 @@ namespace System.Management.Automation
         [SuppressMessage("Microsoft.Naming", "CA1720:IdentifiersShouldNotContainTypeNames", MessageId = "obj", Justification = "Since V1 code is already shipped, excluding this message.")]
         public static IEnumerable GetEnumerable(object obj)
         {
-            obj = GetBaseObject(obj);
+            obj = PSObject.Base(obj);
             if (obj == null) { return null; }
             GetEnumerableDelegate getEnumerable = GetOrCalculateEnumerable(obj.GetType());
             return getEnumerable(obj);

--- a/src/System.Management.Automation/engine/LanguagePrimitives.cs
+++ b/src/System.Management.Automation/engine/LanguagePrimitives.cs
@@ -440,18 +440,12 @@ namespace System.Management.Automation
 
         internal static bool IsTypeEnumerable(Type type)
         {
+            if (type == null) { return false; }
             GetEnumerableDelegate getEnumerable = GetOrCalculateEnumerable(type);
             return (getEnumerable != LanguagePrimitives.ReturnNullEnumerable);
         }
 
-        /// <summary>
-        /// Retrieves the IEnumerable of obj or null if the language does not consider obj to be IEnumerable
-        /// </summary>
-        /// <param name="obj">
-        /// IEnumerable or IEnumerable-like object
-        /// </param>
-        [SuppressMessage("Microsoft.Naming", "CA1720:IdentifiersShouldNotContainTypeNames", MessageId = "obj", Justification = "Since V1 code is already shipped, excluding this message.")]
-        public static IEnumerable GetEnumerable(object obj)
+        internal static Type GetBaseObjectType(object obj)
         {
             if (obj == null)
             {
@@ -472,6 +466,33 @@ namespace System.Management.Automation
                 objectType = obj.GetType();
             }
 
+            return objectType;
+        }
+
+        /// <summary>
+        /// Returns True if the language considers obj to be IEnumerable
+        /// </summary>
+        /// <param name="obj">
+        /// IEnumerable or IEnumerable-like object
+        /// </param>
+        [SuppressMessage("Microsoft.Naming", "CA1720:IdentifiersShouldNotContainTypeNames", MessageId = "obj", Justification = "Since V1 code is already shipped, excluding this message.")]
+        public static bool IsObjectEnumerable(object obj)
+        {
+            return IsTypeEnumerable(GetBaseObjectType(obj));
+        }
+
+
+        /// <summary>
+        /// Retrieves the IEnumerable of obj or null if the language does not consider obj to be IEnumerable
+        /// </summary>
+        /// <param name="obj">
+        /// IEnumerable or IEnumerable-like object
+        /// </param>
+        [SuppressMessage("Microsoft.Naming", "CA1720:IdentifiersShouldNotContainTypeNames", MessageId = "obj", Justification = "Since V1 code is already shipped, excluding this message.")]
+        public static IEnumerable GetEnumerable(object obj)
+        {
+            Type objectType = GetBaseObjectType(obj);
+            if (objectType == null) { return null; }
             GetEnumerableDelegate getEnumerable = GetOrCalculateEnumerable(objectType);
             return getEnumerable(obj);
         }

--- a/src/System.Management.Automation/engine/LanguagePrimitives.cs
+++ b/src/System.Management.Automation/engine/LanguagePrimitives.cs
@@ -445,28 +445,20 @@ namespace System.Management.Automation
             return (getEnumerable != LanguagePrimitives.ReturnNullEnumerable);
         }
 
-        internal static Type GetBaseObjectType(object obj)
+        private static object GetBaseObject(object obj)
         {
             if (obj == null)
             {
                 return null;
             }
 
-            Type objectType = obj.GetType();
-
-            // if the object passed is an PSObject,
-            // look at the base object. Notice that, if the
-            // object has been serialized, the base object
-            // will be there as an ArrayList if the original
-            // object was IEnumerable
-            if (objectType == typeof(PSObject))
+            var psobj = obj as PSObject;
+            if (null != psobj)
             {
-                PSObject mshObj = (PSObject)obj;
-                obj = mshObj.BaseObject;
-                objectType = obj.GetType();
+                obj = psobj.BaseObject;
             }
 
-            return objectType;
+            return obj;
         }
 
         /// <summary>
@@ -478,7 +470,7 @@ namespace System.Management.Automation
         [SuppressMessage("Microsoft.Naming", "CA1720:IdentifiersShouldNotContainTypeNames", MessageId = "obj", Justification = "Since V1 code is already shipped, excluding this message.")]
         public static bool IsObjectEnumerable(object obj)
         {
-            return IsTypeEnumerable(GetBaseObjectType(obj));
+            return IsTypeEnumerable(GetBaseObject(obj)?.GetType());
         }
 
 
@@ -491,9 +483,9 @@ namespace System.Management.Automation
         [SuppressMessage("Microsoft.Naming", "CA1720:IdentifiersShouldNotContainTypeNames", MessageId = "obj", Justification = "Since V1 code is already shipped, excluding this message.")]
         public static IEnumerable GetEnumerable(object obj)
         {
-            Type objectType = GetBaseObjectType(obj);
-            if (objectType == null) { return null; }
-            GetEnumerableDelegate getEnumerable = GetOrCalculateEnumerable(objectType);
+            obj = GetBaseObject(obj);
+            if (obj == null) { return null; }
+            GetEnumerableDelegate getEnumerable = GetOrCalculateEnumerable(obj.GetType());
             return getEnumerable(obj);
         }
 

--- a/test/powershell/engine/ParameterBinding/ParameterBinding.Tests.ps1
+++ b/test/powershell/engine/ParameterBinding/ParameterBinding.Tests.ps1
@@ -422,5 +422,25 @@
             $result.Value[1] | Should Be 2
             $result.Value[2] | Should Be 3
         }
+
+        It "Binds properly when collections of type other than object[] are used on an advanced function" {
+            $list = [Collections.Generic.List[int]](1..3)
+            $result = Test-BindingFunction $list
+
+            $result.ArgumentCount | Should Be 3
+            $result.Value[0] | Should Be 1
+            $result.Value[1] | Should Be 2
+            $result.Value[2] | Should Be 3
+        }
+
+        It "Binds properly when collections of type other than object[] are used on a cmdlet" {
+            $list = [Collections.Generic.List[int]](1..3)
+            $result = Test-BindingCmdlet $list
+
+            $result.ArgumentCount | Should Be 3
+            $result.Value[0] | Should Be 1
+            $result.Value[1] | Should Be 2
+            $result.Value[2] | Should Be 3
+        }
     }
 }


### PR DESCRIPTION
Expands on a previous PR based on conversation here:  https://github.com/PowerShell/PowerShell/pull/2038#discussion_r144460107

Unwrapping of ValueFromRemainingArguments was being performed only for object[] arrays (which covers the most common PowerShell binding scenarios), but could be skipped if a collection of any other type were passed to the parameter.