### PR TITLE
-Verbose should not override $ErrorActionPreference

### DIFF
--- a/src/System.Management.Automation/engine/MshCommandRuntime.cs
+++ b/src/System.Management.Automation/engine/MshCommandRuntime.cs
@@ -3212,10 +3212,6 @@ namespace System.Management.Automation
                 if (IsErrorActionSet)
                     return _errorAction;
 
-                // Debug takes preference
-                if (Debug)
-                    return ActionPreference.Inquire;
-
                 if (!_isErrorActionPreferenceCached)
                 {
                     bool defaultUsed = false;

--- a/src/System.Management.Automation/engine/MshCommandRuntime.cs
+++ b/src/System.Management.Automation/engine/MshCommandRuntime.cs
@@ -3212,13 +3212,10 @@ namespace System.Management.Automation
                 if (IsErrorActionSet)
                     return _errorAction;
 
-                // Debug takes preference over Verbose
+                // Debug takes preference
                 if (Debug)
                     return ActionPreference.Inquire;
-                if (Verbose)
-                    return ActionPreference.Continue;
 
-                // fall back to $ErrorAction
                 if (!_isErrorActionPreferenceCached)
                 {
                     bool defaultUsed = false;

--- a/test/powershell/Language/Scripting/ActionPreference.Tests.ps1
+++ b/test/powershell/Language/Scripting/ActionPreference.Tests.ps1
@@ -127,11 +127,22 @@
             $num | Should Be 2
         }
 
-        It '-Verbose does not take precedence over $ErrorActionPreference' {
+        It '<switch> does not take precedence over $ErrorActionPreference' -TestCases @(
+            @{switch="-Verbose"},
+            @{switch="-Debug"}
+        ) {
+            param($switch)
             $ErrorActionPreference = "SilentlyContinue"
-            New-Item -ItemType File -Path "$testdrive\test.txt"
-            { New-Item -ItemType File -Path "$testdrive\test.txt" -Verbose } | Should Not Throw
+            $params = @{
+                ItemType = "File";
+                Path = "$testdrive\test.txt";
+                Confirm = $false
+            }
+            New-Item @params
+            $params += @{$switch=$true}
+            { New-Item @params } | Should Not Throw
             $ErrorActionPreference = "Stop"
-            { New-Item -ItemType File -Path "$testdrive\test.txt" -Verbose } | ShouldBeErrorId "NewItemIOError,Microsoft.PowerShell.Commands.NewItemCommand"
+            { New-Item @params } | ShouldBeErrorId "NewItemIOError,Microsoft.PowerShell.Commands.NewItemCommand"
+            Remove-Item "$testdrive\test.txt" -Force
         }
 }

--- a/test/powershell/Language/Scripting/ActionPreference.Tests.ps1
+++ b/test/powershell/Language/Scripting/ActionPreference.Tests.ps1
@@ -138,7 +138,7 @@
                 Path = "$testdrive\test.txt";
                 Confirm = $false
             }
-            New-Item @params
+            New-Item @params > $null
             $params += @{$switch=$true}
             { New-Item @params } | Should Not Throw
             $ErrorActionPreference = "Stop"

--- a/test/powershell/Language/Scripting/ActionPreference.Tests.ps1
+++ b/test/powershell/Language/Scripting/ActionPreference.Tests.ps1
@@ -126,4 +126,12 @@
                     }
             $num | Should Be 2
         }
+
+        It '-Verbose does not take precedence over $ErrorActionPreference' {
+            $ErrorActionPreference = "SilentlyContinue"
+            New-Item -ItemType File -Path "$testdrive\test.txt"
+            { New-Item -ItemType File -Path "$testdrive\test.txt" -Verbose } | Should Not Throw
+            $ErrorActionPreference = "Stop"
+            { New-Item -ItemType File -Path "$testdrive\test.txt" -Verbose } | ShouldBeErrorId "NewItemIOError,Microsoft.PowerShell.Commands.NewItemCommand"
+        }
 }


### PR DESCRIPTION
Fix https://github.com/PowerShell/PowerShell/issues/2247

<!--

If you are a PowerShell Team member, please make sure you choose the Reviewer(s) and Assignee for your PR.
If you are not from the PowerShell Team, you can leave the fields blank and the Maintainers will choose them for you. If you are familiar with the team, feel free to mention some Reviewers yourself.

For more information about the roles of Reviewer and Assignee, refer to [CONTRIBUTING.md](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md).

-->