### PR TITLE
Fetch resource string correctly

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/AddMember.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/AddMember.cs
@@ -514,7 +514,7 @@ namespace Microsoft.PowerShell.Commands
         private ErrorRecord NewError(string errorId, string resourceId, object targetObject, params object[] args)
         {
             ErrorDetails details = new ErrorDetails(this.GetType().GetTypeInfo().Assembly,
-                "AddMember", resourceId, args);
+                "Microsoft.PowerShell.Commands.Utility.resources.AddMember", resourceId, args);
             ErrorRecord errorRecord = new ErrorRecord(
                 new InvalidOperationException(details.Message),
                 errorId,

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/ConvertToJsonCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/ConvertToJsonCommand.cs
@@ -381,10 +381,8 @@ namespace Microsoft.PowerShell.Commands
 
         private ErrorRecord NewError()
         {
-            ErrorDetails details = new ErrorDetails(this.GetType().GetTypeInfo().Assembly,
-                "WebCmdletStrings", "JsonStringInBadFormat");
             ErrorRecord errorRecord = new ErrorRecord(
-                new InvalidOperationException(details.Message),
+                new InvalidOperationException(WebCmdletStrings.JsonStringInBadFormat),
                 "JsonStringInBadFormat",
                 ErrorCategory.InvalidOperation,
                 InputObject);

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Add-Member.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Add-Member.Tests.ps1
@@ -276,6 +276,14 @@
         $results = add-member -InputObject a 16 sp {1+1} -passthru
         $results.sp | Should Be 2
     }
+
+    It "Verify Add-Member error message is not empty" {
+        $object = @(1,2)
+        Add-Member -InputObject $object "ABC" "Value1"
+        Add-Member -InputObject $object "ABC" "Value2" -ErrorVariable errorVar -ErrorAction SilentlyContinue
+        $errorVar.Exception | Should BeOfType "System.InvalidOperationException"
+        $errorVar.Exception.Message | Should Not BeNullOrEmpty
+    }
 }
 
 Describe "Add-Member" -Tags "CI" {


### PR DESCRIPTION
I found `Add-Member` throws error with an empty message. This PR fixes it.

**Before fix**
```
PS:2> Add-Member -InputObject $object "ABC" "Value1"
[C:\arena\pscore]
PS:3> Add-Member -InputObject $object "ABC" "Value1"
Add-Member :
At line:1 char:1
+ Add-Member -InputObject $object "ABC" "Value1"
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (1 2:PSObject) [Add-Member], InvalidOperationException
    + FullyQualifiedErrorId : MemberAlreadyExists,Microsoft.PowerShell.Commands.AddMemberCommand
```

**After fix**
```
PS:8> Add-Member -InputObject $object "ABC" "Value1"
Add-Member : Cannot add a member with the name "ABC" because a member with that name already exists. To overwrite the
member anyway, add the Force parameter to your command.
At line:1 char:1
+ Add-Member -InputObject $object "ABC" "Value1"
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (1 2:PSObject) [Add-Member], InvalidOperationException
    + FullyQualifiedErrorId : MemberAlreadyExists,Microsoft.PowerShell.Commands.AddMemberCommand
```
Also updated a resource string use in `ConvertTo-Json` to directly use the C# property.