### PR TITLE
put command discovery before scripts for Unix

### DIFF
--- a/src/System.Management.Automation/engine/CommandPathSearch.cs
+++ b/src/System.Management.Automation/engine/CommandPathSearch.cs
@@ -65,7 +65,7 @@ namespace System.Management.Automation
                     // Porting note: on non-Windows platforms, we want to always allow just 'commandName'
                     // as an acceptable command name. However, we also want to allow commands to be
                     // called with the .ps1 extension, so that 'script.ps1' can be called by 'script'.
-                    commandPatterns = new[] { commandName + ".ps1", commandName };
+                    commandPatterns = new[] { commandName, commandName + ".ps1" };
                 }
                 _postProcessEnumeratedFiles = CheckAgainstAcceptableCommandNames;
                 _acceptableCommandNames = acceptableCommandNames;

--- a/test/powershell/Language/Scripting/NativeExecution/NativeLinuxCommands.Tests.ps1
+++ b/test/powershell/Language/Scripting/NativeExecution/NativeLinuxCommands.Tests.ps1
@@ -1,38 +1,56 @@
-if ( $IsWindows ) {
-    $PesterSkipOrPending = @{ Skip = $true }
-}
-else {
-    $PesterSkipOrPending = @{}
-}
 Describe "NativeLinuxCommands" -tags "CI" {
+    BeforeAll {
+        $originalDefaultParams = $PSDefaultParameterValues.Clone()
+        $PSDefaultParameterValues["It:Skip"] = $IsWindows
+        $originalPath = $env:PATH
+        $env:PATH += [IO.Path]::PathSeparator + $TestDrive
+    }
+
+    AfterAll {
+        $global:PSDefaultParameterValues = $originalDefaultParams
+        $env:PATH = $originalPath
+    }
+
     It "Should return a type of 'string' for hostname cmdlet" {
         $result = hostname
         $result | Should Not BeNullOrEmpty
         $result | Should BeOfType string
     }
 
-    It "Should find Application grep" @PesterSkipOrPending {
+    It "Should find Application grep" {
         (get-command grep).CommandType | Should Be Application
     }
 
-    It "Should pipe to grep and get result" @PesterSkipOrPending {
+    It "Should pipe to grep and get result" {
         "hello world" | grep hello | Should Be "hello world"
     }
 
-    It "Should find Application touch" @PesterSkipOrPending {
+    It "Should find Application touch" {
         (get-command touch).CommandType | Should Be Application
     }
 
-    It "Should not redirect standard input if native command is the first command in pipeline (1)" @PesterSkipOrPending {
+    It "Should not redirect standard input if native command is the first command in pipeline (1)" {
         df | ForEach-Object -Begin { $out = @() } -Process { $out += $_ }
         $out.Length -gt 0 | Should Be $true
         $out[0] -like "Filesystem*Available*" | Should Be $true
     }
 
-    It "Should not redirect standard input if native command is the first command in pipeline (2)" @PesterSkipOrPending {
+    It "Should not redirect standard input if native command is the first command in pipeline (2)" {
         $out = df
         $out.Length -gt 0 | Should Be $true
         $out[0] -like "Filesystem*Available*" | Should Be $true
+    }
+
+    It "Should find command before script with same name" {
+        Set-Content "$TestDrive\foo" -Value @"
+#!/usr/bin/env bash
+echo 'command'
+"@ -Encoding Ascii
+        chmod +x "$TestDrive/foo"
+        Set-Content "$TestDrive\foo.ps1" -Value @"
+'script'
+"@ -Encoding Ascii
+        foo | Should BeExactly 'command'
     }
 }
 

--- a/test/powershell/Language/Scripting/NativeExecution/NativeLinuxCommands.Tests.ps1
+++ b/test/powershell/Language/Scripting/NativeExecution/NativeLinuxCommands.Tests.ps1
@@ -11,12 +11,6 @@ Describe "NativeLinuxCommands" -tags "CI" {
         $env:PATH = $originalPath
     }
 
-    It "Should return a type of 'string' for hostname cmdlet" {
-        $result = hostname
-        $result | Should Not BeNullOrEmpty
-        $result | Should BeOfType string
-    }
-
     It "Should find Application grep" {
         (get-command grep).CommandType | Should Be Application
     }


### PR DESCRIPTION
Also cleaned up the NativeLinuxCommands.Tests.ps1 script on skipping tests

Fix https://github.com/PowerShell/PowerShell/issues/2095

<!--

If you are a PowerShell Team member, please make sure you choose the Reviewer(s) and Assignee for your PR.
If you are not from the PowerShell Team, you can leave the fields blank and the Maintainers will choose them for you. If you are familiar with the team, feel free to mention some Reviewers yourself.

For more information about the roles of Reviewer and Assignee, refer to [CONTRIBUTING.md](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md).

-->