### PR TITLE
Fix MatchInfoContext Clone implementation

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
@@ -61,12 +61,13 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         public object Clone()
         {
-            MatchInfoContext clone = new MatchInfoContext();
-            clone.PreContext = (clone.PreContext != null) ? (string[])PreContext.Clone() : null;
-            clone.PostContext = (clone.PostContext != null) ? (string[])PostContext.Clone() : null;
-            clone.DisplayPreContext = (clone.DisplayPreContext != null) ? (string[])DisplayPreContext.Clone() : null;
-            clone.DisplayPostContext = (clone.DisplayPostContext != null) ? (string[])DisplayPostContext.Clone() : null;
-            return clone;
+            return new MatchInfoContext()
+            {
+                PreContext = (string[])PreContext?.Clone(),
+                PostContext = (string[])PostContext?.Clone(),
+                DisplayPreContext = (string[])DisplayPreContext?.Clone(),
+                DisplayPostContext = (string[])DisplayPostContext?.Clone()
+            };
         }
     }
 


### PR DESCRIPTION
Fix #3994 

The old implementation always set the new object's properties to null.

The original issue mentioned that the other `Clone` implementation in MatchString.cs had the same bug, but in fact it's correct because of the use of `MemberwiseClone`.

I didn't much unit testing of C# code going on in the project (or maybe I missed it?). Should I add a test and if so, where?

<!--

If you are a PowerShell Team member, please make sure you choose the Reviewer(s) and Assignee for your PR.
If you are not from the PowerShell Team, you can leave the fields blank and the Maintainers will choose them for you. If you are familiar with the team, feel free to mention some Reviewers yourself.

For more information about the roles of Reviewer and Assignee, refer to [CONTRIBUTING.md](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md).

-->
