### PR TITLE
Make testablescript.ps1 binary

### DIFF
--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/assets/.gitattributes
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/assets/.gitattributes
@@ -1,1 +1,3 @@
+# testablescript.ps1 used in Get-FileHash tests.
+# It need to be checked-out without any conversion.
 /testablescript.ps1 binary

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/assets/.gitattributes
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/assets/.gitattributes
@@ -1,0 +1,1 @@
+/testablescript.ps1 binary


### PR DESCRIPTION
As file `testablescript.ps1` used in hash testing, it should be checked-out without any line ending correction.