### PR TITLE
StdErr/ErrorRecord should not be modified on output

### DIFF
--- a/src/System.Management.Automation/commands/utility/FormatAndOutput/common/BaseOutputtingCommand.cs
+++ b/src/System.Management.Automation/commands/utility/FormatAndOutput/common/BaseOutputtingCommand.cs
@@ -565,7 +565,14 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             {
                 ComplexWriter complexWriter = new ComplexWriter();
 
-                complexWriter.Initialize(_lo, _lo.ColumnNumber);
+                if (fed.isErrorRecord)
+                {
+                    complexWriter.Initialize(_lo, int.MaxValue);
+                }
+                else
+                {
+                    complexWriter.Initialize(_lo, _lo.ColumnNumber);
+                }
                 complexWriter.WriteObject(cve.formatValueList);
 
                 return;

--- a/src/System.Management.Automation/commands/utility/FormatAndOutput/common/DefaultFormatters/PowerShellCore_format_ps1xml.cs
+++ b/src/System.Management.Automation/commands/utility/FormatAndOutput/common/DefaultFormatters/PowerShellCore_format_ps1xml.cs
@@ -789,7 +789,6 @@ namespace System.Management.Automation.Runspaces
                                         }
 
                                         $indent = 4
-                                        $width = $host.UI.RawUI.BufferSize.Width - $indent - 2
 
                                         $errorCategoryMsg = & { Set-StrictMode -Version 1; $_.ErrorCategory_Message }
                                         if ($null -ne $errorCategoryMsg)
@@ -800,19 +799,16 @@ namespace System.Management.Automation.Runspaces
                                         {
                                             $indentString = ""+ CategoryInfo          : "" + $_.CategoryInfo
                                         }
-                                        $posmsg += ""`n""
-                                        foreach($line in @($indentString -split ""(.{$width})"")) { if($line) { $posmsg += ("" "" * $indent + $line) } }
+                                        $posmsg += ""`n"" + $indentString
 
                                         $indentString = ""+ FullyQualifiedErrorId : "" + $_.FullyQualifiedErrorId
-                                        $posmsg += ""`n""
-                                        foreach($line in @($indentString -split ""(.{$width})"")) { if($line) { $posmsg += ("" "" * $indent + $line) } }
+                                        $posmsg += ""`n"" + $indentString
 
                                         $originInfo = & { Set-StrictMode -Version 1; $_.OriginInfo }
                                         if (($null -ne $originInfo) -and ($null -ne $originInfo.PSComputerName))
                                         {
                                             $indentString = ""+ PSComputerName        : "" + $originInfo.PSComputerName
-                                            $posmsg += ""`n""
-                                            foreach($line in @($indentString -split ""(.{$width})"")) { if($line) { $posmsg += ("" "" * $indent + $line) } }
+                                            $posmsg += ""`n"" + $indentString
                                         }
 
                                         if ($ErrorView -eq ""CategoryView"") {

--- a/src/System.Management.Automation/commands/utility/FormatAndOutput/common/FormatViewManager.cs
+++ b/src/System.Management.Automation/commands/utility/FormatAndOutput/common/FormatViewManager.cs
@@ -567,6 +567,10 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             }
 
             FormatEntryData fed = outOfBandViewGenerator.GeneratePayload(so, enumerationLimit);
+            if (typeNames.Contains("System.Management.Automation.ErrorRecord"))
+            {
+                fed.isErrorRecord = true;
+            }
             fed.outOfBand = true;
             fed.SetStreamTypeFromPSObject(so);
 

--- a/src/System.Management.Automation/commands/utility/FormatAndOutput/common/FormattingObjects.cs
+++ b/src/System.Management.Automation/commands/utility/FormatAndOutput/common/FormattingObjects.cs
@@ -151,6 +151,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         public bool outOfBand = false;
         public WriteStreamType writeStream = WriteStreamType.None;
         internal bool isHelpObject = false;
+        internal bool isErrorRecord = false;
 
         /// <summary>
         /// Helper method to set the WriteStreamType property

--- a/test/powershell/Language/Scripting/NativeExecution/NativeStreams.Tests.ps1
+++ b/test/powershell/Language/Scripting/NativeExecution/NativeStreams.Tests.ps1
@@ -49,6 +49,17 @@ Describe "Native streams behavior with PowerShell" -Tags 'CI' {
         It 'preserves error stream as is with Out-String' {
             ($out | Out-String).Replace("`r", '') | Should Be "foo`n`nbar`n`nbazmiddlefoo`n`nbar`n`nbaz`n"
         }
+
+        It 'does not get truncated or split when redirected' {
+            $longtext = "0123456789"
+            while ($longtext.Length -lt [console]::WindowWidth) {
+                $longtext += $longtext
+            }
+            testexe -echostderr $longtext 2>&1 > $testdrive\error.txt
+            $e = Get-Content -Path $testdrive\error.txt
+            $e.Count | Should BeExactly 1
+            $e | Should Match $longtext
+        }
     }
 }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Error.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Error.Tests.ps1
@@ -1,4 +1,4 @@
-Describe "Write-Error DRT Unit Tests" -Tags "CI" {
+Describe "Write-Error Tests" -Tags "CI" {
     It "Should be works with command: write-error myerrortext" {
         $e = Write-Error myerrortext 2>&1
         $e | Should BeOfType 'System.Management.Automation.ErrorRecord'
@@ -74,40 +74,49 @@ Describe "Write-Error DRT Unit Tests" -Tags "CI" {
         $e.CategoryInfo.TargetType | Should Be 'fooTargetType'
         $e.CategoryInfo.GetMessage() | Should Be 'NotSpecified: (fooTargetName:fooTargetType) [fooAct], fooReason'
     }
-}
 
-Describe "Write-Error" -Tags "CI" {
     It "Should be able to throw" {
-	Write-Error "test throw" -ErrorAction SilentlyContinue | Should Throw
+    	Write-Error "test throw" -ErrorAction SilentlyContinue | Should Throw
     }
 
     It "Should throw a non-terminating error" {
-	Write-Error "test throw" -ErrorAction SilentlyContinue
+        Write-Error "test throw" -ErrorAction SilentlyContinue
 
-	1 + 1 | Should Be 2
+        1 + 1 | Should Be 2
     }
 
     It "Should trip an exception using the exception switch" {
-	$var = 0
-	try
-	{
-	    Write-Error -Exception -Message "test throw"
-	}
-	catch [System.Exception]
-	{
+        $var = 0
+        try
+        {
+            Write-Error -Exception -Message "test throw"
+        }
+        catch [System.Exception]
+        {
 
-	    $var++
-	}
-	finally
-	{
-	    $var | Should Be 1
-	}
+            $var++
+        }
+        finally
+        {
+            $var | Should Be 1
+        }
     }
 
     It "Should output the error message to the `$error automatic variable" {
-	$theError = "Error: Too many input values."
-	write-error -message $theError -category InvalidArgument -ErrorAction SilentlyContinue
+        $theError = "Error: Too many input values."
+        write-error -message $theError -category InvalidArgument -ErrorAction SilentlyContinue
 
-	$error[0]| Should Be $theError
+        $error[0]| Should Be $theError
+    }
+
+    It "ErrorRecord should not be truncated" {
+        $longtext = "0123456789"
+        while ($longtext.Length -lt [console]::WindowWidth) {
+            $longtext += $longtext
+        }
+        powershell -c Write-Error -Message $longtext 2>&1 > $testdrive\error.txt
+        $e = Get-Content -Path $testdrive\error.txt
+        $e.Count | Should BeExactly 4
+        $e[0] | Should Match $longtext
     }
 }

--- a/test/tools/TestExe/TestExe.cs
+++ b/test/tools/TestExe/TestExe.cs
@@ -15,6 +15,9 @@ namespace TestExe
                     case "-echoargs":
                         EchoArgs(args);
                         break;
+                    case "-echostderr":
+                        EchoStderr(args);
+                        break;
                     case "-createchildprocess":
                         CreateChildProcess(args);
                         break;
@@ -37,6 +40,17 @@ namespace TestExe
             for (int i = 1; i < args.Length; i++)
             {
                 Console.WriteLine("Arg {0} is <{1}>", i-1, args[i]);
+            }
+        }
+
+        // <Summary>
+        // Echos back to stderr the arguments passed in
+        // </Summary>
+        static void EchoStderr(string[] args)
+        {
+            for (int i = 1; i < args.Length; i++)
+            {
+                Console.Error.WriteLine("{0}", args[i]);
             }
         }
 


### PR DESCRIPTION
ErrorRecord output goes through ComplexWriter which splits lines based on console window width

Fix is to add a flag to FormatEntryData to know that it's an ErrorRecord and don't constrain
the output to window width

Existing Write-Error.Tests.ps1 was not formatted correctly, so added some indentation to make it easier to read while modifying the file.

Fix https://github.com/PowerShell/PowerShell/issues/3813

<!--

If you are a PowerShell Team member, please make sure you choose the Reviewer(s) and Assignee for your PR.
If you are not from the PowerShell Team, you can leave the fields blank and the Maintainers will choose them for you. If you are familiar with the team, feel free to mention some Reviewers yourself.

For more information about the roles of Reviewer and Assignee, refer to [CONTRIBUTING.md](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md).

-->