### PR TITLE
allow pscustomobject to have property with empty string name

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/AddMember.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/AddMember.cs
@@ -59,6 +59,7 @@ namespace Microsoft.PowerShell.Commands
         /// The name of the new member
         /// </summary>
         [Parameter(Mandatory = true, Position = 1, ParameterSetName = "MemberSet")]
+        [AllowEmptyString]
         public string Name
         {
             set { _memberName = value; }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetMember.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetMember.cs
@@ -73,7 +73,7 @@ namespace Microsoft.PowerShell.Commands
         /// The member names to be retrieved
         /// </summary>
         [Parameter(Position = 0)]
-        [ValidateNotNullOrEmpty]
+        [ValidateNotNull]
         public string[] Name { set; get; } = new string[] { "*" };
 
 

--- a/src/System.Management.Automation/commands/utility/FormatAndOutput/common/Utilities/Mshexpression.cs
+++ b/src/System.Management.Automation/commands/utility/FormatAndOutput/common/Utilities/Mshexpression.cs
@@ -52,7 +52,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         /// <exception cref="ArgumentNullException"></exception>
         internal MshExpression(string s, bool isResolved)
         {
-            if (string.IsNullOrEmpty(s))
+            if (null == s)
             {
                 throw PSTraceSource.NewArgumentNullException("s");
             }

--- a/src/System.Management.Automation/engine/InternalCommands.cs
+++ b/src/System.Management.Automation/engine/InternalCommands.cs
@@ -130,7 +130,8 @@ namespace Microsoft.PowerShell.Commands
         /// The property or method name
         /// </summary>
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "PropertyAndMethodSet")]
-        [ValidateNotNullOrEmpty]
+        [ValidateNotNull]
+        [AllowEmptyString]
         public string MemberName
         {
             set { _propertyOrMethodName = value; }
@@ -295,12 +296,12 @@ namespace Microsoft.PowerShell.Commands
                                 else
                                 {
                                     // we write null out because:
-                                    // PS C:\> “$null | ForEach-object {$_.aa} | ForEach-Object {$_ + 3}”
+                                    // PS C:\> $null | ForEach-object {$_.aa} | ForEach-Object {$_ + 3}
                                     // 3
                                     // so we also want
-                                    // PS C:\> “$null | ForEach-object aa | ForEach-Object {$_ + 3}”
+                                    // PS C:\> $null | ForEach-object aa | ForEach-Object {$_ + 3}
                                     // 3
-                                    // But if we don’t write anything to the pipeline when _inputObject is null,
+                                    // But if we don't write anything to the pipeline when _inputObject is null,
                                     // the result 3 will not be generated.
                                     WriteObject(null);
                                 }
@@ -473,7 +474,7 @@ namespace Microsoft.PowerShell.Commands
                                 // so we also want
                                 // PS C:\> "string" | ForEach-Object aa | ForEach-Object {$_ + 3}
                                 // 3
-                                // But if we don’t write anything to the pipeline when no member is found,
+                                // But if we don't write anything to the pipeline when no member is found,
                                 // the result 3 will not be generated.
                                 WriteObject(null);
                             }

--- a/src/System.Management.Automation/engine/MshMemberInfo.cs
+++ b/src/System.Management.Automation/engine/MshMemberInfo.cs
@@ -3518,7 +3518,7 @@ namespace System.Management.Automation
                 throw PSTraceSource.NewArgumentNullException("memberList");
             }
 
-            if (String.IsNullOrEmpty(name))
+            if (null == name)
             {
                 throw PSTraceSource.NewArgumentException("name");
             }
@@ -3709,7 +3709,7 @@ namespace System.Management.Automation
         {
             get
             {
-                if (String.IsNullOrEmpty(name))
+                if (null == name)
                 {
                     throw PSTraceSource.NewArgumentException("name");
                 }
@@ -3725,7 +3725,7 @@ namespace System.Management.Automation
         /// <exception cref="ArgumentException">for invalid arguments</exception>
         public ReadOnlyPSMemberInfoCollection<T> Match(string name)
         {
-            if (String.IsNullOrEmpty(name))
+            if (null == name)
             {
                 throw PSTraceSource.NewArgumentException("name");
             }
@@ -3741,7 +3741,7 @@ namespace System.Management.Automation
         /// <exception cref="ArgumentException">for invalid arguments</exception>
         public ReadOnlyPSMemberInfoCollection<T> Match(string name, PSMemberTypes memberTypes)
         {
-            if (String.IsNullOrEmpty(name))
+            if (null == name)
             {
                 throw PSTraceSource.NewArgumentException("name");
             }
@@ -4625,7 +4625,7 @@ namespace System.Management.Automation
         /// <exception cref="ArgumentException">for invalid arguments</exception>
         public override ReadOnlyPSMemberInfoCollection<T> Match(string name)
         {
-            if (String.IsNullOrEmpty(name))
+            if (null == name)
             {
                 throw PSTraceSource.NewArgumentException("name");
             }
@@ -4641,7 +4641,7 @@ namespace System.Management.Automation
         /// <exception cref="ArgumentException">for invalid arguments</exception>
         public override ReadOnlyPSMemberInfoCollection<T> Match(string name, PSMemberTypes memberTypes)
         {
-            if (String.IsNullOrEmpty(name))
+            if (null == name)
             {
                 throw PSTraceSource.NewArgumentException("name");
             }
@@ -4660,7 +4660,7 @@ namespace System.Management.Automation
         {
             using (PSObject.memberResolution.TraceScope("Matching \"{0}\"", name))
             {
-                if (String.IsNullOrEmpty(name))
+                if (null == name)
                 {
                     throw PSTraceSource.NewArgumentException("name");
                 }

--- a/src/System.Management.Automation/engine/MshMemberInfo.cs
+++ b/src/System.Management.Automation/engine/MshMemberInfo.cs
@@ -208,7 +208,7 @@ namespace System.Management.Automation
         /// <param name="name"></param>
         protected void SetMemberName(string name)
         {
-            if (string.IsNullOrEmpty(name))
+            if (null == name)
             {
                 throw PSTraceSource.NewArgumentException("name");
             }
@@ -1248,13 +1248,14 @@ namespace System.Management.Automation
         /// </summary>
         /// <param name="name">name of the property</param>
         /// <param name="value">value of the property</param>
-        /// <exception cref="ArgumentException">for an empty or null name</exception>
+        /// <exception cref="ArgumentException">for null name</exception>
         public PSNoteProperty(string name, object value)
         {
-            if (String.IsNullOrEmpty(name))
+            if (null == name)
             {
                 throw PSTraceSource.NewArgumentException("name");
             }
+            // name can be empty
             this.name = name;
             // value can be null
             this.noteValue = value;
@@ -3913,7 +3914,7 @@ namespace System.Management.Automation
         {
             get
             {
-                if (String.IsNullOrEmpty(name))
+                if (null == name)
                 {
                     throw PSTraceSource.NewArgumentException("name");
                 }
@@ -4467,7 +4468,7 @@ namespace System.Management.Automation
             {
                 using (PSObject.memberResolution.TraceScope("Lookup"))
                 {
-                    if (String.IsNullOrEmpty(name))
+                    if (null == name)
                     {
                         throw PSTraceSource.NewArgumentException("name");
                     }

--- a/test/powershell/Language/Scripting/HashtableToPSCustomObjectConversion.Tests.ps1
+++ b/test/powershell/Language/Scripting/HashtableToPSCustomObjectConversion.Tests.ps1
@@ -137,6 +137,7 @@
 	    $obj.PSTypeNames.Count | Should Be 3
 	    $obj.PSTypeNames[0] | Should Be 'System.Object'
     }
+
     It "new-object should fail to create object for System.Management.Automation.PSCustomObject" {
 
         $errorObj = $null
@@ -152,6 +153,11 @@
         }
         $obj | should be $null
         $errorObj.FullyQualifiedErrorId | should be "CannotFindAppropriateCtor,Microsoft.PowerShell.Commands.NewObjectCommand"
+    }
+
+    It "Empty string is allowed for property name" {
+        $obj = [PSCustomObject] @{"" = "hello"}
+        $obj."" | Should BeExactly "hello"
     }
 }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertFrom-Json.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertFrom-Json.Tests.ps1
@@ -13,4 +13,9 @@ Describe 'ConvertFrom-Json' -tags "CI" {
         $json = @('{"a" :', '"x"}') | ConvertFrom-Json
         $json.a | Should Be 'x'
     }
+
+    It 'can support empty string named property' {
+        $json = '{"" : "hello"}' | ConvertFrom-Json
+        $json."" | Should BeExactly "hello"
+    }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Member.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Member.Tests.ps1
@@ -1,50 +1,59 @@
 Describe "Get-Member" -Tags "CI" {
     It "Should be able to be called on string objects, ints, arrays, etc" {
-	$a = 1 #test numbers
-	$b = 1.3
-	$c = $false #test bools
-	$d = @(1,3) # test arrays
-	$e = "anoeduntodeu" #test strings
-	$f = 'asntoheusth' #test strings
+        $a = 1 #test numbers
+        $b = 1.3
+        $c = $false #test bools
+        $d = @(1,3) # test arrays
+        $e = "anoeduntodeu" #test strings
+        $f = 'asntoheusth' #test strings
 
-	Get-Member -InputObject $a | Should Not BeNullOrEmpty
-	Get-Member -InputObject $b | Should Not BeNullOrEmpty
-	Get-Member -InputObject $c | Should Not BeNullOrEmpty
-	Get-Member -InputObject $d | Should Not BeNullOrEmpty
-	Get-Member -InputObject $e | Should Not BeNullOrEmpty
-	Get-Member -InputObject $f | Should Not BeNullOrEmpty
+        Get-Member -InputObject $a | Should Not BeNullOrEmpty
+        Get-Member -InputObject $b | Should Not BeNullOrEmpty
+        Get-Member -InputObject $c | Should Not BeNullOrEmpty
+        Get-Member -InputObject $d | Should Not BeNullOrEmpty
+        Get-Member -InputObject $e | Should Not BeNullOrEmpty
+        Get-Member -InputObject $f | Should Not BeNullOrEmpty
     }
 
     It "Should be able to extract a field from string objects, ints, arrays, etc" {
-	$a = 1 #test numbers
-	$b = 1.3
-	$c = $false #test bools
-	$d = @(1,3) # test arrays
-	$e = "anoeduntodeu" #test strings
-	$f = 'asntoheusth' #test strings
+        $a = 1 #test numbers
+        $b = 1.3
+        $c = $false #test bools
+        $d = @(1,3) # test arrays
+        $e = "anoeduntodeu" #test strings
+        $f = 'asntoheusth' #test strings
 
-	$a | Should BeOfType 'Int32'
-	$b | Should BeOfType 'Double'
-	$c | Should BeOfType 'Boolean'
-	,$d | Should BeOfType 'Object[]'
-	$e | Should BeOfType 'String'
-	$f | Should BeOfType 'String'
+        $a | Should BeOfType 'Int32'
+        $b | Should BeOfType 'Double'
+        $c | Should BeOfType 'Boolean'
+        ,$d | Should BeOfType 'Object[]'
+        $e | Should BeOfType 'String'
+        $f | Should BeOfType 'String'
+        }
+
+        It "Should be able to be called on a newly created PSObject" {
+        $o = New-Object psobject
+        # this creates a dependency on the Add-Member cmdlet.
+        Add-Member -InputObject $o -MemberType NoteProperty -Name proppy -Value "superVal"
+
+        Get-Member -InputObject $o | Should Not BeNullOrEmpty
     }
 
-    It "Should be able to be called on a newly created PSObject" {
-	$o = New-Object psobject
-	# this creates a dependency on the Add-Member cmdlet.
-	Add-Member -InputObject $o -MemberType NoteProperty -Name proppy -Value "superVal"
-
-	Get-Member -InputObject $o | Should Not BeNullOrEmpty
+    It "Should show members where name is empty string" {
+        $obj = [pscustomobject]@{""="hello"}
+        $member = $obj | Get-Member -Name ""
+        $member.Name | Should BeExactly ""
+        $member.MemberType | Should BeExactly "NoteProperty"
+        $member.Definition | Should BeExactly "string =hello"
     }
 }
 
 Describe "Get-Member DRT Unit Tests" -Tags "CI" {
     Context "Verify Get-Member with Class" {
-		if(-not ([System.Management.Automation.PSTypeName]'Employee').Type)
-		{
-			Add-Type -TypeDefinition @"
+        BeforeAll {
+            if(-not ([System.Management.Automation.PSTypeName]'Employee').Type)
+            {
+                Add-Type -TypeDefinition @"
         public class Employee
         {
             private string firstName;
@@ -97,10 +106,10 @@ Describe "Get-Member DRT Unit Tests" -Tags "CI" {
             }
         }
 "@
-		}
+            }
 
-        $fileToDeleteName = Join-Path $TestDrive -ChildPath "getMemberTest.ps1xml"
-        $XMLFile= @"
+            $fileToDeleteName = Join-Path $TestDrive -ChildPath "getMemberTest.ps1xml"
+            $XMLFile= @"
 <Types>
     <Type>
     <Name>Employee</Name>
@@ -145,8 +154,9 @@ Describe "Get-Member DRT Unit Tests" -Tags "CI" {
 </Types>
 "@
 
-        $XMLFile > $fileToDeleteName
-        Update-TypeData -AppendPath $fileToDeleteName
+            $XMLFile > $fileToDeleteName
+            Update-TypeData -AppendPath $fileToDeleteName
+        }
 
         It "Fail to get member without any input" {
             try

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/object.tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/object.tests.ps1
@@ -19,6 +19,13 @@
             $TeeObjectLiteralPathShouldWorkForSpecialFilename | Should Be (Get-Content -LiteralPath $path)
         }
     }
+
+    Context "ForEach-Object" {
+        It "with member named empty string" {
+            $obj = [pscustomobject]@{""="hello"},[pscustomobject]@{""="world"}
+            $obj | ForEach-Object -MemberName "" | Should Be "hello","world"
+        }
+    }
 }
 
 Describe "Object cmdlets" -Tags "CI" {


### PR DESCRIPTION
Needed to allow convertfrom-json to support json objects that have empty string property names which apparently is used pretty often

Fix https://github.com/PowerShell/PowerShell/issues/1755
<!--

If you are a PowerShell Team member, please make sure you choose the Reviewer(s) and Assignee for your PR.
If you are not from the PowerShell Team, you can leave the fields blank and the Maintainers will choose them for you. If you are familiar with the team, feel free to mention some Reviewers yourself.

For more information about the roles of Reviewer and Assignee, refer to [CONTRIBUTING.md](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md).

-->