### PR TITLE
Add Jobject serialization support to ConvertTo-Json

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/ConvertToJsonCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/ConvertToJsonCommand.cs
@@ -428,6 +428,10 @@ namespace Microsoft.PowerShell.Commands
             {
                 rv = obj;
             }
+            else if (obj is Newtonsoft.Json.Linq.JProperty)
+            {
+                rv = obj.ToString();
+            }
             else
             {
                 TypeInfo t = obj.GetType().GetTypeInfo();

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/ConvertToJsonCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/ConvertToJsonCommand.cs
@@ -428,9 +428,9 @@ namespace Microsoft.PowerShell.Commands
             {
                 rv = obj;
             }
-            else if (obj is Newtonsoft.Json.Linq.JProperty)
+            else if (obj is Newtonsoft.Json.Linq.JObject jObject)
             {
-                rv = obj.ToString();
+                rv = jObject.ToObject<Dictionary<object,object>>();
             }
             else
             {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Json.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Json.Tests.ps1
@@ -1,0 +1,20 @@
+Describe 'ConvertTo-Json' -tags "CI" {
+    It 'Newtonsoft.Json.Linq.Jproperty should be converted to Json properly' {
+        $EgJObject = New-Object -TypeName Newtonsoft.Json.Linq.JObject
+        $EgJObject.Add("TestValue1", "123456")
+        $EgJObject.Add("TestValue2", "78910")
+        $EgJObject.Add("TestValue3", "99999")
+        $dict = @{}
+        $dict.Add('JObject', $EgJObject)
+        $dict.Add('StrObject', 'This is a string Object')
+        $properties = @{'DictObject' = $dict; 'RandomString' = 'A quick brown fox jumped over the lazy dog'}
+        $object = New-Object -TypeName psobject -Property $properties
+        $jsonFormat = ConvertTo-Json -InputObject $object
+        $jsonFormat.contains("TestValue1") | Should Be True 
+        $jsonFormat.contains("123456") | Should Be True
+        $jsonFormat.contains("TestValue2") | Should Be True
+        $jsonFormat.contains("78910") | Should Be True
+        $jsonFormat.contains("TestValue3") | Should Be True
+        $jsonFormat.contains("99999") | Should Be True
+    }
+}

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Json.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Json.Tests.ps1
@@ -10,11 +10,8 @@ Describe 'ConvertTo-Json' -tags "CI" {
         $properties = @{'DictObject' = $dict; 'RandomString' = 'A quick brown fox jumped over the lazy dog'}
         $object = New-Object -TypeName psobject -Property $properties
         $jsonFormat = ConvertTo-Json -InputObject $object
-        $jsonFormat.contains("TestValue1") | Should Be True 
-        $jsonFormat.contains("123456") | Should Be True
-        $jsonFormat.contains("TestValue2") | Should Be True
-        $jsonFormat.contains("78910") | Should Be True
-        $jsonFormat.contains("TestValue3") | Should Be True
-        $jsonFormat.contains("99999") | Should Be True
+        $jsonFormat | Should Match '"TestValue1": 123456'
+        $jsonFormat | Should Match '"TestValue2": 78910'
+        $jsonFormat | Should Match '"TestValue3": 99999'
     }
 }


### PR DESCRIPTION
This is to resolve #4996
Newtonsoft.Json.Linq.Jproperty is not properly handled.

Adding handling for Newtonsoft.Json.Linq.Jproperty

Repro:
$EgJObject = New-Object -TypeName Newtonsoft.Json.Linq.JObject
$EgJObject.Add("TestValue1", "123456")
$EgJObject.Add("TestValue2", "78910")
$EgJObject.Add("TestValue3", "99999")
$dict = @{}
$dict.Add('JObject', $EgJObject)
$dict.Add('StrObject', 'This is a string Object')
$properties = @{'DictObject' = $dict; 'RandomString' = 'A quick brown fox jumped over the lazy dog'}
$object = New-Object -TypeName psobject -Property $properties
$object | ConvertTo-Json

Before fix:

{
    "RandomString":  "A quick brown fox jumped over the lazy dog",
    "DictObject":  {
                       "JObject":  [
                                       "123456",
                                       "78910",
                                       "99999"
                                   ],
                       "StrObject":  "This is a string Object"
                   }
}

After fix:

{
  "DictObject": {
    "JObject": [
      "\"TestValue1\": 123456",
      "\"TestValue2\": 78910",
      "\"TestValue3\": 99999"
    ],
    "StrObject": "This is a string Object"
  },
  "RandomString": "A quick brown fox jumped over the lazy dog"
}