### PR TITLE
Add exports for syslog api.

### DIFF
--- a/src/libpsl-native/src/CMakeLists.txt
+++ b/src/libpsl-native/src/CMakeLists.txt
@@ -21,6 +21,7 @@ add_library(psl-native SHARED
   createhardlink.cpp
   createsymlink.cpp
   followsymlink.cpp
-  createprocess.cpp)
+  createprocess.cpp
+  nativesyslog.cpp)
 
 target_include_directories(psl-native PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/libpsl-native/src/nativesyslog.cpp
+++ b/src/libpsl-native/src/nativesyslog.cpp
@@ -1,0 +1,17 @@
+#include <syslog.h>
+#include <nativesyslog.h>
+
+extern "C" void Native_SysLog(int32_t priority, const char* message)
+{
+    syslog(priority, "%s", message);
+}
+
+extern "C" void Native_OpenLog(const char* ident, int facility)
+{
+    openlog(ident, LOG_NDELAY | LOG_PID, facility);
+}
+
+extern "C" void Native_CloseLog()
+{
+    closelog();
+}

--- a/src/libpsl-native/src/nativesyslog.cpp
+++ b/src/libpsl-native/src/nativesyslog.cpp
@@ -1,16 +1,34 @@
+//! @file nativesyslog.cpp
+//! @brief Provides wrappers around the syslog apis to support exporting
+//! for PInvoke calls by powershell.
+//! These functions are intended only for PowerShell internal use.
 #include <syslog.h>
 #include <nativesyslog.h>
 
+//! @brief Native_SysLog is a wrapper around the syslog api.
+//! It explicitly passes the message as a parameter to a %s format
+//! string since the message may have arbitray characters that can
+//! be misinterpreted as format specifiers.
+//!
+//! @retval none.
 extern "C" void Native_SysLog(int32_t priority, const char* message)
 {
     syslog(priority, "%s", message);
 }
 
+//! @brief Native_OpenLog is a wrapper around the openlog, syslog api.
+//! it allows passing an ident and facility but uses an explicit
+//! option value for consistent logging across powershell instances.
+//!
+//! @retval none.
 extern "C" void Native_OpenLog(const char* ident, int facility)
 {
     openlog(ident, LOG_NDELAY | LOG_PID, facility);
 }
 
+//! @brief Native_OpenLog is a wrapper around the closelog, syslog api.
+//!
+//! @retval none.
 extern "C" void Native_CloseLog()
 {
     closelog();

--- a/src/libpsl-native/src/nativesyslog.h
+++ b/src/libpsl-native/src/nativesyslog.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "pal.h"
+
+PAL_BEGIN_EXTERNC
+
+void Native_OpenLog(const char* ident, int facility);
+void Native_SysLog(int32_t priority, const char* message);
+void Native_CloseLog();
+
+PAL_END_EXTERNC


### PR DESCRIPTION
This change enables calling the syslog apis to support issue https://github.com/PowerShell/PowerShell/issues/3766

https://github.com/PowerShell/PowerShell/pull/5144 is dependent on this change and also requires the libpsl-native nuget package to be republished.


