### PR TITLE
Update PS should try to load the assembly from file path first before…

### DIFF
--- a/src/System.Management.Automation/engine/ExecutionContext.cs
+++ b/src/System.Management.Automation/engine/ExecutionContext.cs
@@ -1255,18 +1255,14 @@ namespace System.Management.Automation
                 catch (FileLoadException fileLoadException)
                 {
                     error = fileLoadException;
-                    // this is a legitimate error on CoreCLR for a newly emited with Add-Type assemblies
-                    // they cannot be loaded by name, but we are only interested in importing them by path
                 }
                 catch (BadImageFormatException badImage)
                 {
                     error = badImage;
-                    return null;
                 }
                 catch (SecurityException securityException)
                 {
                     error = securityException;
-                    return null;
                 }
             }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Import-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Import-Module.Tests.ps1
@@ -123,13 +123,28 @@ namespace ModuleCmdlets
     $results[1] | Should BeExactly "BinaryModuleCmdlet1 exported by the ModuleCmdlets module."
     }
 
-    It "PS should try to load the assembly from assembly name if file path doesn't exist" -skip:(!$IsWindows) {
+    It "PS should try to load the assembly from assembly name if file path doesn't exist" {
 
-        New-ModuleManifest -Path $TESTDRIVE\test.psd1 -NestedModules \NOExistedPath\System.Management.Automation.dll
-        $module = Import-Module $TESTDRIVE\test.psd1 -PassThru
-        $module.NestedModules | Should Not BeNullOrEmpty
-        $assemblyLocation = [psobject].Assembly.location
-        $module.NestedModules.ImplementingAssembly.Location | Should Be $assemblyLocation
+        if ($IsWindows)
+        {
+            New-ModuleManifest -Path $TESTDRIVE\test.psd1 -NestedModules \NOExistedPath\System.Management.Automation.dll
+        }
+        else
+        {
+            New-ModuleManifest -Path $TESTDRIVE/test.psd1 -NestedModules /NOExistedPath/System.Management.Automation.dll
+        }
+        try
+        {
+            $module = Import-Module $TESTDRIVE\test.psd1 -PassThru
+            $module.NestedModules | Should Not BeNullOrEmpty
+            $assemblyLocation = [psobject].Assembly.location
+            $module.NestedModules.ImplementingAssembly.Location | Should Be $assemblyLocation
+        }
+        finally
+        {
+            Remove-Module  $TESTDRIVE\test.psd1 -ErrorAction SilentlyContinue
+        }
+        
     }
  }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Import-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Import-Module.Tests.ps1
@@ -125,24 +125,19 @@ namespace ModuleCmdlets
 
     It "PS should try to load the assembly from assembly name if file path doesn't exist" {
 
-        if ($IsWindows)
-        {
-            New-ModuleManifest -Path $TESTDRIVE\test.psd1 -NestedModules \NOExistedPath\System.Management.Automation.dll
-        }
-        else
-        {
-            New-ModuleManifest -Path $TESTDRIVE/test.psd1 -NestedModules /NOExistedPath/System.Management.Automation.dll
-        }
+        $psdFile = Join-Path $TESTDRIVE test.psd1
+        $nestedModule = Join-Path NOExistedPath Microsoft.PowerShell.Commands.Utility.dll
+        New-ModuleManifest -Path $psdFile -NestedModules $nestedModule 
         try
         {
-            $module = Import-Module $TESTDRIVE\test.psd1 -PassThru
+            $module = Import-Module $psdFile -PassThru
             $module.NestedModules | Should Not BeNullOrEmpty
-            $assemblyLocation = [psobject].Assembly.location
+            $assemblyLocation = [Microsoft.PowerShell.Commands.AddTypeCommand].Assembly.Location
             $module.NestedModules.ImplementingAssembly.Location | Should Be $assemblyLocation
         }
         finally
         {
-            Remove-Module  $TESTDRIVE\test.psd1 -ErrorAction SilentlyContinue
+            Remove-Module $module -ErrorAction SilentlyContinue
         }
         
     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Import-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Import-Module.Tests.ps1
@@ -122,5 +122,14 @@ namespace ModuleCmdlets
     $results[0] | Should Be $path
     $results[1] | Should BeExactly "BinaryModuleCmdlet1 exported by the ModuleCmdlets module."
     }
+
+    It "PS should try to load the assembly from assembly name if file path doesn't exist" -skip:(!$IsWindows) {
+
+        New-ModuleManifest -Path $TESTDRIVE\test.psd1 -NestedModules \NOExistedPath\System.Management.Automation.dll
+        $module = Import-Module $TESTDRIVE\test.psd1 -PassThru
+        $module.NestedModules | Should Not BeNullOrEmpty
+        $assemblyLocation = [psobject].Assembly.location
+        $module.NestedModules.ImplementingAssembly.Location | Should Be $assemblyLocation
+    }
  }
 


### PR DESCRIPTION
 fix issue #3325

After we merge #4196, the fix will break some our partner's working code. Although the working code often works with an invalid assembly path.

This fix is to follow the old logic to minimize the breaking change.

1. we first try to load the assembly from the file path
2. if it fails, we try to load the assembly from the assembly name
3. if 2 passes, we ignore the exception and return the assembly. otherwise we throw the exception.