### PR TITLE
Make -NoTypeInformation Default on Export-Csv and ConvertTo-Csv

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CSVCommands.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CSVCommands.cs
@@ -96,7 +96,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         protected override void BeginProcessing()
         {
-            if (this.MyInvocation.BoundParameters.ContainsKey("IncludeTypeInformation") && this.MyInvocation.BoundParameters.ContainsKey("NoTypeInformation"))
+            if (this.MyInvocation.BoundParameters.ContainsKey(nameof(IncludeTypeInformation)) && this.MyInvocation.BoundParameters.ContainsKey(nameof(NoTypeInformation)))
             {
                 InvalidOperationException exception = new InvalidOperationException(CsvCommandStrings.CannotSpecifyIncludeTypeInformationAndNoTypeInformation);
                 ErrorRecord errorRecord = new ErrorRecord(exception, "CannotSpecifyIncludeTypeInformationAndNoTypeInformation", ErrorCategory.InvalidData, null);

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CSVCommands.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CSVCommands.cs
@@ -67,9 +67,29 @@ namespace Microsoft.PowerShell.Commands
         }
 
         /// <summary>
-        /// NoTypeInformation : should the #TYPE line be generated
+        /// IncludeTypeInformation : The #TYPE line should be generated. Default is false. Cannot specify with NoTypeInformation.
         /// </summary>
         [Parameter]
+        [Alias("ITI")]
+        public SwitchParameter IncludeTypeInformation
+        {
+            get
+            {
+                return _includeTypeInformation;
+            }
+            set
+            {
+                _includeTypeInformation = value;
+                _includeTypeInformationIsSet = true;
+            }
+        }
+        private bool _includeTypeInformation;
+        private bool _includeTypeInformationIsSet;
+
+        /// <summary>
+        /// NoTypeInformation : The #TYPE line should not be generated. Default is true. Cannot specify with IncludeTypeInformation.
+        /// </summary>
+        [Parameter(DontShow = true)]
         [Alias("NTI")]
         public SwitchParameter NoTypeInformation
         {
@@ -80,9 +100,11 @@ namespace Microsoft.PowerShell.Commands
             set
             {
                 _noTypeInformation = value;
+                _noTypeInformationIsSet = true;
             }
         }
-        private bool _noTypeInformation;
+        private bool _noTypeInformation = true;
+        private bool _noTypeInformationIsSet;
 
         #endregion Command Line Parameters
 
@@ -100,6 +122,16 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         protected override void BeginProcessing()
         {
+            if (_noTypeInformationIsSet && _includeTypeInformationIsSet)
+            {
+                InvalidOperationException exception = new InvalidOperationException(CsvCommandStrings.CannotSpecifyIncludeTypeInformationAndNoTypeInformation);
+                ErrorRecord errorRecord = new ErrorRecord(exception, "CannotSpecifyIncludeTypeInformationAndNoTypeInformation", ErrorCategory.InvalidData, null);
+                this.ThrowTerminatingError(errorRecord);
+            }
+            if (_includeTypeInformationIsSet)
+            {
+                _noTypeInformation = !_includeTypeInformation;
+            }
             _delimiter = ImportExportCSVHelper.SetDelimiter(this, ParameterSetName, _delimiter, UseCulture);
         }
     }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CSVCommands.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CSVCommands.cs
@@ -71,40 +71,14 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         [Parameter]
         [Alias("ITI")]
-        public SwitchParameter IncludeTypeInformation
-        {
-            get
-            {
-                return _includeTypeInformation;
-            }
-            set
-            {
-                _includeTypeInformation = value;
-                _includeTypeInformationIsSet = true;
-            }
-        }
-        private bool _includeTypeInformation;
-        private bool _includeTypeInformationIsSet;
+        public SwitchParameter IncludeTypeInformation { get; set; }
 
         /// <summary>
         /// NoTypeInformation : The #TYPE line should not be generated. Default is true. Cannot specify with IncludeTypeInformation.
         /// </summary>
         [Parameter(DontShow = true)]
         [Alias("NTI")]
-        public SwitchParameter NoTypeInformation
-        {
-            get
-            {
-                return _noTypeInformation;
-            }
-            set
-            {
-                _noTypeInformation = value;
-                _noTypeInformationIsSet = true;
-            }
-        }
-        private bool _noTypeInformation = true;
-        private bool _noTypeInformationIsSet;
+        public SwitchParameter NoTypeInformation { get; set; } = true;
 
         #endregion Command Line Parameters
 
@@ -122,15 +96,15 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         protected override void BeginProcessing()
         {
-            if (_noTypeInformationIsSet && _includeTypeInformationIsSet)
+            if (this.MyInvocation.BoundParameters.ContainsKey("IncludeTypeInformation") && this.MyInvocation.BoundParameters.ContainsKey("NoTypeInformation"))
             {
                 InvalidOperationException exception = new InvalidOperationException(CsvCommandStrings.CannotSpecifyIncludeTypeInformationAndNoTypeInformation);
                 ErrorRecord errorRecord = new ErrorRecord(exception, "CannotSpecifyIncludeTypeInformationAndNoTypeInformation", ErrorCategory.InvalidData, null);
                 this.ThrowTerminatingError(errorRecord);
             }
-            if (_includeTypeInformationIsSet)
+            if (this.MyInvocation.BoundParameters.ContainsKey("IncludeTypeInformation"))
             {
-                _noTypeInformation = !_includeTypeInformation;
+                NoTypeInformation = !IncludeTypeInformation;
             }
             _delimiter = ImportExportCSVHelper.SetDelimiter(this, ParameterSetName, _delimiter, UseCulture);
         }

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/CsvCommandStrings.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/CsvCommandStrings.resx
@@ -127,6 +127,9 @@
         Reviewed by TArcher on 2010-06-29.
     </comment>
   </data>
+  <data name="CannotSpecifyIncludeTypeInformationAndNoTypeInformation" xml:space="preserve">
+    <value>You must specify either the -IncludeTypeInformation or -NoTypeInformation parameters, but not both.</value>
+  </data>
   <data name="CannotSpecifyPathAndLiteralPath" xml:space="preserve">
     <value>You must specify either the -Path or -LiteralPath parameters, but not both.</value>
   </data>

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Csv.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Csv.Tests.ps1
@@ -2,7 +2,7 @@ Describe "ConvertTo-Csv DRT Unit Tests" -Tags "CI" {
     $inputObject = [pscustomobject]@{ First = 1; Second = 2 }
 
     It "Test convertto-csv with psobject pipelined" {
-        $returnObject = $inputObject | ConvertTo-Csv
+        $returnObject = $inputObject | ConvertTo-Csv -IncludeTypeInformation
         $returnObject.Count | Should Be 3
         $returnObject[0] | Should Be "#TYPE System.Management.Automation.PSCustomObject"
         $returnObject[1] | Should Be "`"First`",`"Second`""
@@ -18,7 +18,7 @@ Describe "ConvertTo-Csv DRT Unit Tests" -Tags "CI" {
 
     It "Test convertto-csv with a useculture flag" {
         #The default value is ','
-        $returnObject = $inputObject | ConvertTo-Csv -UseCulture
+        $returnObject = $inputObject | ConvertTo-Csv -UseCulture -IncludeTypeInformation
         $returnObject.Count | Should Be 3
         $returnObject[0] | Should Be "#TYPE System.Management.Automation.PSCustomObject"
         $returnObject[1] | Should Be "`"First`",`"Second`""
@@ -27,7 +27,7 @@ Describe "ConvertTo-Csv DRT Unit Tests" -Tags "CI" {
 
     It "Test convertto-csv with Delimiter" {
         #The default value is ','
-        $returnObject = $inputObject | ConvertTo-Csv -Delimiter ";"
+        $returnObject = $inputObject | ConvertTo-Csv -Delimiter ";" -IncludeTypeInformation
         $returnObject.Count | Should Be 3
         $returnObject[0] | Should Be "#TYPE System.Management.Automation.PSCustomObject"
         $returnObject[1] | Should Be "`"First`";`"Second`""
@@ -45,27 +45,44 @@ Describe "ConvertTo-Csv" -Tags "CI" {
     }
 
     It "Should output an array of objects" {
-        $result = $testObject | ConvertTo-Csv
+        $result = $testObject | ConvertTo-Csv -IncludeTypeInformation
         ,$result | Should BeOfType "System.Array"
     }
 
     It "Should return the type of data in the first element of the output array" {
-	$result = $testObject | ConvertTo-Csv
+	$result = $testObject | ConvertTo-Csv -IncludeTypeInformation
 
 	$result[0] | Should Be "#TYPE System.Management.Automation.PSCustomObject"
     }
 
     It "Should return the column info in the second element of the output array" {
-	$result = $testObject | ConvertTo-Csv
+	$result = $testObject | ConvertTo-Csv -IncludeTypeInformation
 
 	$result[1] | Should Match "`"FirstColumn`""
 	$result[1] | Should Match "`"SecondColumn`""
     }
 
     It "Should return the data as a comma-separated list in the third element of the output array" {
-	$result = $testObject | ConvertTo-Csv
+	$result = $testObject | ConvertTo-Csv -IncludeTypeInformation
 	$result[2] | Should Match "`"Hello`""
 	$result[2] | Should Match "`"World`""
+    }
+
+    It "Includes type information when -IncludeTypeInformation is supplied" {
+        $result = $testObject | ConvertTo-Csv -IncludeTypeInformation
+
+        ($result -split ([Environment]::NewLine))[0] | Should BeExactly "#TYPE System.Management.Automation.PSCustomObject"
+    }
+
+    It "Does not include type information by default" {
+        $result = $testObject | ConvertTo-Csv 
+
+        $result | Should Not Match 'System\.Management\.Automation\.PSCustomObject'
+    }
+
+    It "Does not support -IncludeTypeInformation and -NoTypeInformation at the same time" {
+        { $testObject | ConvertTo-Csv -IncludeTypeInformation -NoTypeInformation } | 
+            ShouldBeErrorId "CannotSpecifyIncludeTypeInformationAndNoTypeInformation,Microsoft.PowerShell.Commands.ConvertToCsvCommand"
     }
 
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Csv.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Csv.Tests.ps1
@@ -45,7 +45,7 @@ Describe "ConvertTo-Csv" -Tags "CI" {
     }
 
     It "Should output an array of objects" {
-        $result = $testObject | ConvertTo-Csv -IncludeTypeInformation
+        $result = $testObject | ConvertTo-Csv
         ,$result | Should BeOfType "System.Array"
     }
 
@@ -77,7 +77,15 @@ Describe "ConvertTo-Csv" -Tags "CI" {
     It "Does not include type information by default" {
         $result = $testObject | ConvertTo-Csv 
 
-        $result | Should Not Match 'System\.Management\.Automation\.PSCustomObject'
+        $result | Should Not Match ([regex]::Escape('System.Management.Automation.PSCustomObject'))
+        $result | Should Not Match ([regex]::Escape('#TYPE'))
+    }
+
+    It "Does not include type information with -NoTypeInformation" {
+        $result = $testObject | ConvertTo-Csv -NoTypeInformation
+
+        $result | Should Not Match ([regex]::Escape('System.Management.Automation.PSCustomObject'))
+        $result | Should Not Match ([regex]::Escape('#TYPE'))
     }
 
     It "Does not support -IncludeTypeInformation and -NoTypeInformation at the same time" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Export-Csv.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Export-Csv.Tests.ps1
@@ -67,7 +67,15 @@ Describe "Export-Csv" -Tags "CI" {
     It "Does not include type information by default" {
         $testObject | Export-Csv -Path $testCsv
 
-        $(Get-Content $testCsv)[0] | Should Not Match 'System\.String'
+        $(Get-Content $testCsv)[0] | Should Not Match ([regex]::Escape("System.String"))
+        $(Get-Content $testCsv)[0] | Should Not Match ([regex]::Escape("#TYPE"))
+    }
+
+    It "Does not include type information with -NoTypeInformation" {
+        $testObject | Export-Csv -Path $testCsv -NoTypeInformation
+
+        $(Get-Content $testCsv)[0] | Should Not Match ([regex]::Escape("System.String"))
+        $(Get-Content $testCsv)[0] | Should Not Match ([regex]::Escape("#TYPE"))
     }
 
     It "Includes type information when -IncludeTypeInformation is supplied" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Export-Csv.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Export-Csv.Tests.ps1
@@ -15,7 +15,7 @@ Describe "Export-Csv" -Tags "CI" {
     }
 
     It "Should be a string when exporting via pipe" {
-	$testObject | Export-Csv $testCsv
+	$testObject | Export-Csv $testCsv -IncludeTypeInformation
 
 	$piped = Get-Content $testCsv
 
@@ -23,15 +23,15 @@ Describe "Export-Csv" -Tags "CI" {
     }
 
     It "Should be an object when exporting via the inputObject switch" {
-	Export-Csv -InputObject $testObject -Path $testCsv
+	Export-Csv -InputObject $testObject -Path $testCsv -IncludeTypeInformation
 
-	$switch = Get-Content $testCsv
+	$switch = Get-Content $testCsv 
 
 	$switch[0] | Should Match ".Object"
     }
 
     It "Should output a csv file containing a string of all the lengths of each element when piped input is used" {
-	$testObject | Export-Csv -Path $testCsv
+	$testObject | Export-Csv -Path $testCsv -IncludeTypeInformation
 
 	$first    = "`"" + $testObject[0].Length.ToString() + "`""
 	$second   = "`"" + $testObject[1].Length.ToString() + "`""
@@ -62,6 +62,23 @@ Describe "Export-Csv" -Tags "CI" {
 
 	# Clean up after yourself
 	Remove-Item $aliasObject -Force
+    }
+
+    It "Does not include type information by default" {
+        $testObject | Export-Csv -Path $testCsv
+
+        $(Get-Content $testCsv)[0] | Should Not Match 'System\.String'
+    }
+
+    It "Includes type information when -IncludeTypeInformation is supplied" {
+        $testObject | Export-Csv -Path $testCsv -IncludeTypeInformation
+
+        $(Get-Content $testCsv)[0] | Should BeExactly "#TYPE System.String"
+    }
+
+    It "Does not support -IncludeTypeInformation and -NoTypeInformation at the same time" {
+        { $testObject | Export-Csv -Path $testCsv -IncludeTypeInformation -NoTypeInformation } | 
+            ShouldBeErrorId "CannotSpecifyIncludeTypeInformationAndNoTypeInformation,Microsoft.PowerShell.Commands.ExportCsvCommand"
     }
 }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Import-Csv.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Import-Csv.Tests.ps1
@@ -79,7 +79,7 @@ Describe "Import-Csv #Type Tests" -Tags "CI" {
         $testfile = Join-Path $TestDrive -ChildPath "testfile.csv"
         Remove-Item -Path $testfile -Force -ErrorAction SilentlyContinue
         $processlist = (Get-Process)[0..1]
-        $processlist | Export-Csv -Path $testfile -Force
+        $processlist | Export-Csv -Path $testfile -Force -IncludeTypeInformation
         # Import-Csv add "CSV:" before actual type
         $expectedProcessType = "CSV:System.Diagnostics.Process"
     }


### PR DESCRIPTION
closes #5131

* Sets `-NoTypeInformation` as the default behavior for `Export-Csv` and `ConvertTo-Csv`
* Hides the `-NoTypeInformation` parameter switch
* Adds `-IncludeTypeInformation` switch to `Export-Csv` and `ConvertTo-Csv` to enable legacy behavior
* Provides a terminating error when both `-NoTypeInformation` and `-IncludeTypeInformation` are supplied
* adds tests for the new behavior
* fixes existing tests to align with new behavior


Breaking change was approved by committee in #5131 

The new behavior will need to be documented.