### PR TITLE
use rcedit to embed icon and version information into pwsh.exe

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -1862,6 +1862,18 @@ function New-MSIPackage
         [Switch] $Force
     )
 
+    ## need RCEdit to modify the binaries embedded resources
+    if (-not (Test-Path "~/.rcedit/rcedit-x64.exe"))
+    {
+        $rceditUrl = "https://github.com/electron/rcedit/releases/download/v1.0.0/rcedit-x64.exe"
+        New-Item -Path "~/.rcedit" -Type Directory -Force > $null
+        Invoke-WebRequest -OutFile "~/.rcedit/rcedit-x64.exe" -Uri $rceditUrl
+    }
+
+    Start-NativeExecution { & "~/.rcedit/rcedit-x64.exe" (Get-PSOutput) --set-icon "$AssetsPath\Powershell_black.ico" `
+        --set-file-version $ProductVersion --set-product-version $ProductVersion --set-version-string "ProductName" "PowerShell Core 6" `
+        --set-version-string "LegalCopyright" "(C) Microsoft Corporation.  All Rights Reserved." } | Write-Verbose
+
     ## AppVeyor base image might update the version for Wix. Hence, we should
     ## not hard code version numbers.
     $wixToolsetBinPath = "${env:ProgramFiles(x86)}\WiX Toolset *\bin"

--- a/build.psm1
+++ b/build.psm1
@@ -1442,6 +1442,15 @@ function Start-PSBootstrap {
 
         # Install Windows dependencies if `-Package` or `-BuildWindowsNative` is specified
         if ($Environment.IsWindows) {
+            ## need RCEdit to modify the binaries embedded resources
+            if (-not (Test-Path "~/.rcedit/rcedit-x64.exe"))
+            {
+                log "Install RCEdit for modifying exe resources"
+                $rceditUrl = "https://github.com/electron/rcedit/releases/download/v1.0.0/rcedit-x64.exe"
+                New-Item -Path "~/.rcedit" -Type Directory -Force > $null
+                Invoke-WebRequest -OutFile "~/.rcedit/rcedit-x64.exe" -Uri $rceditUrl
+            }
+
             if ($BuildWindowsNative) {
                 log "Install Windows dependencies for building PSRP plugin"
 
@@ -1865,9 +1874,7 @@ function New-MSIPackage
     ## need RCEdit to modify the binaries embedded resources
     if (-not (Test-Path "~/.rcedit/rcedit-x64.exe"))
     {
-        $rceditUrl = "https://github.com/electron/rcedit/releases/download/v1.0.0/rcedit-x64.exe"
-        New-Item -Path "~/.rcedit" -Type Directory -Force > $null
-        Invoke-WebRequest -OutFile "~/.rcedit/rcedit-x64.exe" -Uri $rceditUrl
+        throw "RCEdit is required to modify pwsh.exe resources, please run 'Start-PSBootStrap' to install"
     }
 
     Start-NativeExecution { & "~/.rcedit/rcedit-x64.exe" (Get-PSOutput) --set-icon "$AssetsPath\Powershell_black.ico" `


### PR DESCRIPTION
pwsh.exe today doesn't contain file version information and the icon is only associated with the shortcut file and not the exe

Fix is to use rcedit to embed:
- icon
- product version
- file version
- product name
- copyright

Fix https://github.com/PowerShell/PowerShell/issues/2883
Fix https://github.com/PowerShell/PowerShell/issues/5166
Fix https://github.com/PowerShell/PowerShell/issues/5034

<!--

If you are a PowerShell Team member, please make sure you choose the Reviewer(s) and Assignee for your PR.
If you are not from the PowerShell Team, you can leave the fields blank and the Maintainers will choose them for you. If you are familiar with the team, feel free to mention some Reviewers yourself.

For more information about the roles of Reviewer and Assignee, refer to [CONTRIBUTING.md](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md).

-->
