### PR TITLE
Stop globbing of quoted arguments to native commands

### DIFF
--- a/src/System.Management.Automation/commands/utility/FormatAndOutput/common/BaseCommand.cs
+++ b/src/System.Management.Automation/commands/utility/FormatAndOutput/common/BaseCommand.cs
@@ -62,8 +62,8 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         {
             _commandParameterList.Add(
                 CommandParameterInternal.CreateParameterWithArgument(
-                    PositionUtilities.EmptyExtent, parameterName, null,
-                    PositionUtilities.EmptyExtent, parameterValue,
+                    /*parameterAst*/null, parameterName, null,
+                    /*argumentAst*/null, parameterValue,
                     false));
         }
 

--- a/src/System.Management.Automation/engine/CmdletParameterBinderController.cs
+++ b/src/System.Management.Automation/engine/CmdletParameterBinderController.cs
@@ -450,8 +450,8 @@ namespace System.Management.Automation
 
                     CommandParameterInternal bindableArgument =
                         CommandParameterInternal.CreateParameterWithArgument(
-                           PositionUtilities.EmptyExtent, parameterName, "-" + parameterName + ":",
-                           PositionUtilities.EmptyExtent, argumentValue, false);
+                           /*parameterAst*/null, parameterName, "-" + parameterName + ":",
+                           /*argumentAst*/null, argumentValue, false);
 
                     bool bindResult =
                             BindParameter(
@@ -1678,12 +1678,10 @@ namespace System.Management.Automation
 
                         // If there are multiple arguments, it's not clear how best to represent the extent as the extent
                         // may be disjoint, as in 'echo a -verbose b', we have 'a' and 'b' in UnboundArguments.
-                        IScriptExtent argumentExtent = UnboundArguments.Count == 1
-                                                           ? UnboundArguments[0].ArgumentExtent
-                                                           : PositionUtilities.EmptyExtent;
+                        var argumentAst = UnboundArguments.Count == 1 ? UnboundArguments[0].ArgumentAst : null;
                         var cpi = CommandParameterInternal.CreateParameterWithArgument(
-                            PositionUtilities.EmptyExtent, varargsParameter.Parameter.Name, "-" + varargsParameter.Parameter.Name + ":",
-                            argumentExtent, valueFromRemainingArguments, false);
+                            /*parameterAst*/null, varargsParameter.Parameter.Name, "-" + varargsParameter.Parameter.Name + ":",
+                            argumentAst, valueFromRemainingArguments, false);
 
                         // To make all of the following work similarly (the first is handled elsewhere, but second and third are
                         // handled here):
@@ -1693,7 +1691,7 @@ namespace System.Management.Automation
                         // we unwrap our List, but only if there is a single argument which is a collection.
                         if (valueFromRemainingArguments.Count == 1 && LanguagePrimitives.IsObjectEnumerable(valueFromRemainingArguments[0]))
                         {
-                            cpi.SetArgumentValue(UnboundArguments[0].ArgumentExtent, valueFromRemainingArguments[0]);
+                            cpi.SetArgumentValue(UnboundArguments[0].ArgumentAst, valueFromRemainingArguments[0]);
                         }
 
                         try
@@ -3036,8 +3034,8 @@ namespace System.Management.Automation
                         {
                             var argument =
                                 CommandParameterInternal.CreateParameterWithArgument(
-                                PositionUtilities.EmptyExtent, entry.Key, "-" + entry.Key + ":",
-                                PositionUtilities.EmptyExtent, entry.Value,
+                                /*parameterAst*/null, entry.Key, "-" + entry.Key + ":",
+                                /*argumentAst*/null, entry.Value,
                                 false);
 
                             // Ignore the result since any failure should cause an exception
@@ -3920,8 +3918,8 @@ namespace System.Management.Automation
 
                 // Create a new CommandParameterInternal for the output of the script block.
                 var newArgument = CommandParameterInternal.CreateParameterWithArgument(
-                    argument.ParameterExtent, argument.ParameterName, "-" + argument.ParameterName + ":",
-                    argument.ArgumentExtent, newValue,
+                    argument.ParameterAst, argument.ParameterName, "-" + argument.ParameterName + ":",
+                    argument.ArgumentAst, newValue,
                     false);
 
                 if (!BindParameter(newArgument, parameter, ParameterBindingFlags.ShouldCoerceType))
@@ -4284,8 +4282,8 @@ namespace System.Management.Automation
 
                 // Now bind the new value
                 CommandParameterInternal param = CommandParameterInternal.CreateParameterWithArgument(
-                    PositionUtilities.EmptyExtent, parameter.Parameter.Name, "-" + parameter.Parameter.Name + ":",
-                    PositionUtilities.EmptyExtent, parameterValue,
+                    /*parameterAst*/null, parameter.Parameter.Name, "-" + parameter.Parameter.Name + ":",
+                    /*argumentAst*/null, parameterValue,
                     false);
 
                 flags = flags & ~ParameterBindingFlags.DelayBindScriptBlock;
@@ -4306,8 +4304,8 @@ namespace System.Management.Automation
         {
             _defaultParameterValues.Add(name,
                 CommandParameterInternal.CreateParameterWithArgument(
-                    PositionUtilities.EmptyExtent, name, "-" + name + ":",
-                    PositionUtilities.EmptyExtent, value,
+                    /*parameterAst*/null, name, "-" + name + ":",
+                    /*argumentAst*/null, value,
                     false));
         }
 
@@ -4331,8 +4329,8 @@ namespace System.Management.Automation
                 _defaultParameterValues.Add(
                     parameter.Parameter.Name,
                     CommandParameterInternal.CreateParameterWithArgument(
-                        PositionUtilities.EmptyExtent, parameter.Parameter.Name, "-" + parameter.Parameter.Name + ":",
-                        PositionUtilities.EmptyExtent, defaultParameterValue,
+                        /*parameterAst*/null, parameter.Parameter.Name, "-" + parameter.Parameter.Name + ":",
+                        /*argumentAst*/null, defaultParameterValue,
                         false));
             }
         }

--- a/src/System.Management.Automation/engine/CommandParameter.cs
+++ b/src/System.Management.Automation/engine/CommandParameter.cs
@@ -15,13 +15,13 @@ namespace System.Management.Automation
     {
         private class Parameter
         {
-            internal IScriptExtent extent;
+            internal Ast ast;
             internal string parameterName;
             internal string parameterText;
         }
         private class Argument
         {
-            internal IScriptExtent extent;
+            internal Ast ast;
             internal object value;
             internal bool splatted;
             internal bool arrayIsSingleArgumentForNativeCommand;
@@ -66,11 +66,27 @@ namespace System.Management.Automation
         }
 
         /// <summary>
+        /// The ast of the parameter, if one was specified.
+        /// </summary>
+        internal Ast ParameterAst
+        {
+            get => _parameter?.ast;
+        }
+
+        /// <summary>
         /// The extent of the parameter, if one was specified.
         /// </summary>
         internal IScriptExtent ParameterExtent
         {
-            get { return _parameter != null ? _parameter.extent : PositionUtilities.EmptyExtent; }
+            get => ParameterAst?.Extent ?? PositionUtilities.EmptyExtent;
+        }
+
+        /// <summary>
+        /// The ast of the optional argument, if one was specified.
+        /// </summary>
+        internal Ast ArgumentAst
+        {
+            get => _argument?.ast;
         }
 
         /// <summary>
@@ -78,7 +94,7 @@ namespace System.Management.Automation
         /// </summary>
         internal IScriptExtent ArgumentExtent
         {
-            get { return _argument != null ? _argument.extent : PositionUtilities.EmptyExtent; }
+            get => ArgumentAst?.Extent ?? PositionUtilities.EmptyExtent;
         }
 
         /// <summary>
@@ -108,18 +124,16 @@ namespace System.Management.Automation
         }
 
         /// <summary>
-        /// Set the argument value and extent.
+        /// Set the argument value and ast.
         /// </summary>
-        internal void SetArgumentValue(IScriptExtent extent, object value)
+        internal void SetArgumentValue(Ast ast, object value)
         {
-            Diagnostics.Assert(extent != null, "Caller to verify extent argument");
-
             if (_argument == null)
             {
                 _argument = new Argument();
             }
             _argument.value = value;
-            _argument.extent = extent;
+            _argument.ast = ast;
         }
 
         /// <summary>
@@ -130,9 +144,8 @@ namespace System.Management.Automation
         {
             get
             {
-                return _argument != null && _argument.extent != PositionUtilities.EmptyExtent
-                           ? _argument.extent
-                           : _parameter != null ? _parameter.extent : PositionUtilities.EmptyExtent;
+                var argExtent = ArgumentExtent;
+                return argExtent != PositionUtilities.EmptyExtent ? argExtent : ParameterExtent;
             }
         }
 
@@ -141,42 +154,40 @@ namespace System.Management.Automation
         /// <summary>
         /// Create a parameter when no argument has been specified.
         /// </summary>
-        /// <param name="extent">The extent in script of the parameter.</param>
+        /// <param name="ast">The ast in script of the parameter.</param>
         /// <param name="parameterName">The parameter name (with no leading dash).</param>
         /// <param name="parameterText">The text of the parameter, as it did, or would, appear in script.</param>
         internal static CommandParameterInternal CreateParameter(
-            IScriptExtent extent,
             string parameterName,
-            string parameterText)
+            string parameterText,
+            Ast ast = null)
         {
-            Diagnostics.Assert(extent != null, "Caller to verify extent argument");
             return new CommandParameterInternal
             {
                 _parameter =
-                           new Parameter { extent = extent, parameterName = parameterName, parameterText = parameterText }
+                           new Parameter { ast = ast, parameterName = parameterName, parameterText = parameterText }
             };
         }
 
         /// <summary>
         /// Create a positional argument to a command.
         /// </summary>
-        /// <param name="extent">The extent of the argument value in the script.</param>
         /// <param name="value">The argument value.</param>
+        /// <param name="ast">The ast of the argument value in the script.</param>
         /// <param name="splatted">True if the argument value is to be splatted, false otherwise.</param>
         /// <param name="arrayIsSingleArgumentForNativeCommand">If the command is native, pass the string with commas instead of multiple arguments</param>
         internal static CommandParameterInternal CreateArgument(
-            IScriptExtent extent,
             object value,
+            Ast ast = null,
             bool splatted = false,
             bool arrayIsSingleArgumentForNativeCommand = false)
         {
-            Diagnostics.Assert(extent != null, "Caller to verify extent argument");
             return new CommandParameterInternal
             {
                 _argument = new Argument
                 {
-                    extent = extent,
                     value = value,
+                    ast = ast,
                     splatted = splatted,
                     arrayIsSingleArgumentForNativeCommand = arrayIsSingleArgumentForNativeCommand
                 }
@@ -193,28 +204,26 @@ namespace System.Management.Automation
         ///     * In the parameter binder when it resolves a positional argument
         ///     * Other random places that manually construct command processors and know their arguments.
         /// </summary>
-        /// <param name="parameterExtent">The extent in script of the parameter.</param>
+        /// <param name="parameterAst">The ast in script of the parameter.</param>
         /// <param name="parameterName">The parameter name (with no leading dash).</param>
         /// <param name="parameterText">The text of the parameter, as it did, or would, appear in script.</param>
-        /// <param name="argumentExtent">The extent of the argument value in the script.</param>
+        /// <param name="argumentAst">The ast of the argument value in the script.</param>
         /// <param name="value">The argument value.</param>
         /// <param name="spaceAfterParameter">Used in native commands to correctly handle -foo:bar vs. -foo: bar</param>
         /// <param name="arrayIsSingleArgumentForNativeCommand">If the command is native, pass the string with commas instead of multiple arguments</param>
         internal static CommandParameterInternal CreateParameterWithArgument(
-            IScriptExtent parameterExtent,
+            Ast parameterAst,
             string parameterName,
             string parameterText,
-            IScriptExtent argumentExtent,
+            Ast argumentAst,
             object value,
             bool spaceAfterParameter,
             bool arrayIsSingleArgumentForNativeCommand = false)
         {
-            Diagnostics.Assert(parameterExtent != null, "Caller to verify parameterExtent argument");
-            Diagnostics.Assert(argumentExtent != null, "Caller to verify argumentExtent argument");
             return new CommandParameterInternal
             {
-                _parameter = new Parameter { extent = parameterExtent, parameterName = parameterName, parameterText = parameterText },
-                _argument = new Argument { extent = argumentExtent, value = value, arrayIsSingleArgumentForNativeCommand = arrayIsSingleArgumentForNativeCommand },
+                _parameter = new Parameter { ast = parameterAst, parameterName = parameterName, parameterText = parameterText },
+                _argument = new Argument { ast = argumentAst, value = value, arrayIsSingleArgumentForNativeCommand = arrayIsSingleArgumentForNativeCommand },
                 _spaceAfterParameter = spaceAfterParameter
             };
         }

--- a/src/System.Management.Automation/engine/CommandProcessorBase.cs
+++ b/src/System.Management.Automation/engine/CommandProcessorBase.cs
@@ -265,13 +265,13 @@ namespace System.Management.Automation
 
             CommandProcessorBase helpCommandProcessor = context.CreateCommand("get-help", false);
             var cpi = CommandParameterInternal.CreateParameterWithArgument(
-                PositionUtilities.EmptyExtent, "Name", "-Name:",
-                PositionUtilities.EmptyExtent, helpTarget,
+                /*parameterAst*/null, "Name", "-Name:",
+                /*argumentAst*/null, helpTarget,
                 false);
             helpCommandProcessor.AddParameter(cpi);
             cpi = CommandParameterInternal.CreateParameterWithArgument(
-                PositionUtilities.EmptyExtent, "Category", "-Category:",
-                PositionUtilities.EmptyExtent, helpCategory.ToString(),
+                /*parameterAst*/null, "Category", "-Category:",
+                /*argumentAst*/null, helpCategory.ToString(),
                 false);
             helpCommandProcessor.AddParameter(cpi);
             return helpCommandProcessor;

--- a/src/System.Management.Automation/engine/MinishellParameterBinderController.cs
+++ b/src/System.Management.Automation/engine/MinishellParameterBinderController.cs
@@ -136,9 +136,9 @@ namespace System.Management.Automation
                         }
 
                         // Replace the parameters with -EncodedCommand <base64 encoded scriptblock>
-                        parameters[i - 1] = CommandParameterInternal.CreateParameter(parameter.ParameterExtent, EncodedCommandParameter, "-" + EncodedCommandParameter);
+                        parameters[i - 1] = CommandParameterInternal.CreateParameter(EncodedCommandParameter, "-" + EncodedCommandParameter, parameter.ParameterAst);
                         string encodedScript = StringToBase64Converter.StringToBase64String(argumentValue.ToString());
-                        parameters[i] = CommandParameterInternal.CreateArgument(scriptBlockArgument.ArgumentExtent, encodedScript);
+                        parameters[i] = CommandParameterInternal.CreateArgument(encodedScript, scriptBlockArgument.ArgumentAst);
                     }
                     else if (InputFormatParameter.StartsWith(parameterName, StringComparison.OrdinalIgnoreCase))
                     {
@@ -157,8 +157,8 @@ namespace System.Management.Automation
                         i += 1;
                         var inputFormatArg = parameters[i];
                         inputFormat = ProcessFormatParameterValue(InputFormatParameter, inputFormatArg.ArgumentValue);
-                        parameters[i - 1] = CommandParameterInternal.CreateParameter(parameter.ParameterExtent, InputFormatParameter, "-" + InputFormatParameter);
-                        parameters[i] = CommandParameterInternal.CreateArgument(inputFormatArg.ArgumentExtent, inputFormat);
+                        parameters[i - 1] = CommandParameterInternal.CreateParameter(InputFormatParameter, "-" + InputFormatParameter, parameter.ParameterAst);
+                        parameters[i] = CommandParameterInternal.CreateArgument(inputFormat, inputFormatArg.ArgumentAst);
                     }
                     else if (OutputFormatParameter.StartsWith(parameterName, StringComparison.OrdinalIgnoreCase))
                     {
@@ -177,8 +177,8 @@ namespace System.Management.Automation
                         i += 1;
                         var outputFormatArg = parameters[i];
                         outputFormat = ProcessFormatParameterValue(OutputFormatParameter, outputFormatArg.ArgumentValue);
-                        parameters[i - 1] = CommandParameterInternal.CreateParameter(parameter.ParameterExtent, OutputFormatParameter, "-" + OutputFormatParameter);
-                        parameters[i] = CommandParameterInternal.CreateArgument(outputFormatArg.ArgumentExtent, outputFormat);
+                        parameters[i - 1] = CommandParameterInternal.CreateParameter(OutputFormatParameter, "-" + OutputFormatParameter, parameter.ParameterAst);
+                        parameters[i] = CommandParameterInternal.CreateArgument(outputFormat, outputFormatArg.ArgumentAst);
                     }
                     else if (ArgsParameter.StartsWith(parameterName, StringComparison.OrdinalIgnoreCase))
                     {
@@ -196,8 +196,8 @@ namespace System.Management.Automation
                         i += 1;
                         var argsArg = parameters[i];
                         var encodedArgs = ConvertArgsValueToEncodedString(argsArg.ArgumentValue);
-                        parameters[i - 1] = CommandParameterInternal.CreateParameter(parameter.ParameterExtent, EncodedArgsParameter, "-" + EncodedArgsParameter);
-                        parameters[i] = CommandParameterInternal.CreateArgument(argsArg.ArgumentExtent, encodedArgs);
+                        parameters[i - 1] = CommandParameterInternal.CreateParameter(EncodedArgsParameter, "-" + EncodedArgsParameter, parameter.ParameterAst);
+                        parameters[i] = CommandParameterInternal.CreateArgument(encodedArgs, argsArg.ArgumentAst);
                     }
                 }
                 else
@@ -212,8 +212,8 @@ namespace System.Management.Automation
                         // Replace the argument with -EncodedCommand <base64 encoded scriptblock>
                         string encodedScript = StringToBase64Converter.StringToBase64String(argumentValue.ToString());
                         parameters[i] = CommandParameterInternal.CreateParameterWithArgument(
-                            parameter.ArgumentExtent, EncodedCommandParameter, "-" + EncodedCommandParameter,
-                            parameter.ArgumentExtent, encodedScript,
+                            parameter.ArgumentAst, EncodedCommandParameter, "-" + EncodedCommandParameter,
+                            parameter.ArgumentAst, encodedScript,
                             spaceAfterParameter: true, arrayIsSingleArgumentForNativeCommand: false);
                     }
                 }
@@ -223,8 +223,8 @@ namespace System.Management.Automation
             if (inputFormat == null)
             {
                 // For minishell default input format is xml
-                parameters.Add(CommandParameterInternal.CreateParameter(PositionUtilities.EmptyExtent, InputFormatParameter, "-" + InputFormatParameter));
-                parameters.Add(CommandParameterInternal.CreateArgument(PositionUtilities.EmptyExtent, XmlFormatValue));
+                parameters.Add(CommandParameterInternal.CreateParameter(InputFormatParameter, "-" + InputFormatParameter));
+                parameters.Add(CommandParameterInternal.CreateArgument(XmlFormatValue));
                 inputFormat = XmlFormatValue;
             }
 
@@ -232,8 +232,8 @@ namespace System.Management.Automation
             {
                 // If output is redirected, output format should be xml
                 outputFormat = outputRedirected ? XmlFormatValue : TextFormatValue;
-                parameters.Add(CommandParameterInternal.CreateParameter(PositionUtilities.EmptyExtent, OutputFormatParameter, "-" + OutputFormatParameter));
-                parameters.Add(CommandParameterInternal.CreateArgument(PositionUtilities.EmptyExtent, outputFormat));
+                parameters.Add(CommandParameterInternal.CreateParameter(OutputFormatParameter, "-" + OutputFormatParameter));
+                parameters.Add(CommandParameterInternal.CreateArgument(outputFormat));
             }
 
             // Set the output and input format class variable
@@ -251,7 +251,7 @@ namespace System.Management.Automation
             if (string.IsNullOrEmpty(hostName) || !hostName.Equals("ConsoleHost", StringComparison.OrdinalIgnoreCase))
             {
                 NonInteractive = true;
-                parameters.Insert(0, CommandParameterInternal.CreateParameter(PositionUtilities.EmptyExtent, NonInteractiveParameter, "-" + NonInteractiveParameter));
+                parameters.Insert(0, CommandParameterInternal.CreateParameter(NonInteractiveParameter, "-" + NonInteractiveParameter));
             }
 
             ((NativeCommandParameterBinder)DefaultParameterBinder).BindParameters(parameters);

--- a/src/System.Management.Automation/engine/ParameterBinderController.cs
+++ b/src/System.Management.Automation/engine/ParameterBinderController.cs
@@ -232,7 +232,7 @@ namespace System.Management.Automation
                         }
                         ++index;
                         argument.ParameterName = matchingParameter.Parameter.Name;
-                        argument.SetArgumentValue(nextArgument.ArgumentExtent, nextArgument.ParameterText);
+                        argument.SetArgumentValue(nextArgument.ArgumentAst, nextArgument.ParameterText);
                         result.Add(argument);
                         continue;
                     }
@@ -242,7 +242,7 @@ namespace System.Management.Automation
 
                     ++index;
                     argument.ParameterName = matchingParameter.Parameter.Name;
-                    argument.SetArgumentValue(nextArgument.ArgumentExtent, nextArgument.ArgumentValue);
+                    argument.SetArgumentValue(nextArgument.ArgumentAst, nextArgument.ArgumentValue);
                     result.Add(argument);
                 }
                 else
@@ -278,7 +278,7 @@ namespace System.Management.Automation
             if (matchingParameter.Type == typeof(SwitchParameter))
             {
                 argument.ParameterName = argumentName;
-                argument.SetArgumentValue(PositionUtilities.EmptyExtent, SwitchParameter.Present);
+                argument.SetArgumentValue(null, SwitchParameter.Present);
                 result = true;
             }
 
@@ -336,8 +336,8 @@ namespace System.Management.Automation
                     foreach (KeyValuePair<string, object> boundParameter in boundParameters)
                     {
                         CommandParameterInternal param = CommandParameterInternal.CreateParameterWithArgument(
-                            PositionUtilities.EmptyExtent, boundParameter.Key, boundParameter.Key,
-                            PositionUtilities.EmptyExtent, boundParameter.Value, false);
+                            /*parameterAst*/null, boundParameter.Key, boundParameter.Key,
+                            /*argumentAst*/null, boundParameter.Value, false);
                         commandProcessor.AddParameter(param);
                     }
                 }
@@ -358,28 +358,27 @@ namespace System.Management.Automation
                             if (colonIndex != -1 && colonIndex != paramText.Length - 1)
                             {
                                 param = CommandParameterInternal.CreateParameterWithArgument(
-                                    PositionUtilities.EmptyExtent, paramText.Substring(1, colonIndex - 1), paramText,
-                                    PositionUtilities.EmptyExtent, paramText.Substring(colonIndex + 1).Trim(),
+                                    /*parameterAst*/null, paramText.Substring(1, colonIndex - 1), paramText,
+                                    /*argumentAst*/null, paramText.Substring(colonIndex + 1).Trim(),
                                     false);
                             }
                             else if (argIndex == arguments.Length - 1 || paramText[paramText.Length - 1] != ':')
                             {
                                 param = CommandParameterInternal.CreateParameter(
-                                    PositionUtilities.EmptyExtent, paramText.Substring(1), paramText);
+                                    paramText.Substring(1), paramText);
                             }
                             else
                             {
                                 param = CommandParameterInternal.CreateParameterWithArgument(
-                                    PositionUtilities.EmptyExtent, paramText.Substring(1, paramText.Length - 2), paramText,
-                                    PositionUtilities.EmptyExtent, arguments[argIndex + 1],
+                                    /*parameterAst*/null, paramText.Substring(1, paramText.Length - 2), paramText,
+                                    /*argumentAst*/null, arguments[argIndex + 1],
                                     false);
                                 argIndex++;
                             }
                         }
                         else
                         {
-                            param = CommandParameterInternal.CreateArgument(
-                                PositionUtilities.EmptyExtent, arguments[argIndex]);
+                            param = CommandParameterInternal.CreateArgument(arguments[argIndex]);
                         }
                         commandProcessor.AddParameter(param);
                     }
@@ -841,8 +840,8 @@ namespace System.Management.Automation
                     {
                         CommandParameterInternal bindableArgument =
                             CommandParameterInternal.CreateParameterWithArgument(
-                                PositionUtilities.EmptyExtent, parameterName, "-" + parameterName + ":",
-                                argument.ArgumentExtent, argument.ArgumentValue,
+                                /*parameterAst*/null, parameterName, "-" + parameterName + ":",
+                                argument.ArgumentAst, argument.ArgumentValue,
                                 false);
 
                         bindResult =
@@ -1173,8 +1172,8 @@ namespace System.Management.Automation
                     object result = spb.GetDefaultScriptParameterValue(runtimeDefinedParameter, implicitUsingParameters);
                     SaveDefaultScriptParameterValue(parameter.Parameter.Name, result);
                     CommandParameterInternal argument = CommandParameterInternal.CreateParameterWithArgument(
-                        PositionUtilities.EmptyExtent, parameter.Parameter.Name, "-" + parameter.Parameter.Name + ":",
-                        PositionUtilities.EmptyExtent, result,
+                        /*parameterAst*/null, parameter.Parameter.Name, "-" + parameter.Parameter.Name + ":",
+                        /*argumentAst*/null, result,
                         false);
                     ParameterBindingFlags flags = ParameterBindingFlags.IsDefaultValue;
                     // Only coerce explicit values.  We default to null, which isn't always convertible.

--- a/src/System.Management.Automation/engine/hostifaces/Parameter.cs
+++ b/src/System.Management.Automation/engine/hostifaces/Parameter.cs
@@ -134,7 +134,7 @@ namespace System.Management.Automation.Runspaces
 
             if (name == null)
             {
-                return CommandParameterInternal.CreateArgument(PositionUtilities.EmptyExtent, value);
+                return CommandParameterInternal.CreateArgument(value);
             }
 
             string parameterText;
@@ -142,8 +142,8 @@ namespace System.Management.Automation.Runspaces
             {
                 parameterText = forNativeCommand ? name : "-" + name;
                 return CommandParameterInternal.CreateParameterWithArgument(
-                    PositionUtilities.EmptyExtent, name, parameterText,
-                    PositionUtilities.EmptyExtent, value,
+                    /*parameterAst*/null, name, parameterText,
+                    /*argumentAst*/null, value,
                     true);
             }
 
@@ -177,14 +177,13 @@ namespace System.Management.Automation.Runspaces
             if (!hasColon && value == null)
             {
                 // just a name
-                return CommandParameterInternal.CreateParameter(
-                    PositionUtilities.EmptyExtent, parameterName, parameterText);
+                return CommandParameterInternal.CreateParameter(parameterName, parameterText);
             }
 
             // name+value pair
             return CommandParameterInternal.CreateParameterWithArgument(
-                PositionUtilities.EmptyExtent, parameterName, parameterText,
-                PositionUtilities.EmptyExtent, value,
+                /*parameterAst*/null, parameterName, parameterText,
+                /*argumentAst*/null, value,
                 spaceAfterParameter);
         }
 

--- a/src/System.Management.Automation/engine/parser/Compiler.cs
+++ b/src/System.Management.Automation/engine/parser/Compiler.cs
@@ -3446,8 +3446,8 @@ namespace System.Management.Automation.Language
                     bool arrayIsSingleArgumentForNativeCommand = ArgumentIsNotReallyArrayIfCommandIsNative(element);
                     elementExprs[i] =
                         Expression.Call(CachedReflectionInfo.CommandParameterInternal_CreateArgument,
-                                        Expression.Constant(element.Extent),
                                         Expression.Convert(GetCommandArgumentExpression(element), typeof(object)),
+                                        Expression.Constant(element),
                                         ExpressionCache.Constant(splatted),
                                         ExpressionCache.Constant(arrayIsSingleArgumentForNativeCommand));
                 }
@@ -3554,19 +3554,19 @@ namespace System.Management.Automation.Language
                                             errorPos.EndColumnNumber != arg.Extent.StartColumnNumber);
                 bool arrayIsSingleArgumentForNativeCommand = ArgumentIsNotReallyArrayIfCommandIsNative(arg);
                 return Expression.Call(CachedReflectionInfo.CommandParameterInternal_CreateParameterWithArgument,
-                                       Expression.Constant(errorPos),
+                                       Expression.Constant(commandParameterAst),
                                        Expression.Constant(commandParameterAst.ParameterName),
                                        Expression.Constant(errorPos.Text),
-                                       Expression.Constant(arg.Extent),
+                                       Expression.Constant(arg),
                                        Expression.Convert(GetCommandArgumentExpression(arg), typeof(object)),
                                        ExpressionCache.Constant(spaceAfterParameter),
                                        ExpressionCache.Constant(arrayIsSingleArgumentForNativeCommand));
             }
 
             return Expression.Call(CachedReflectionInfo.CommandParameterInternal_CreateParameter,
-                                   Expression.Constant(errorPos),
                                    Expression.Constant(commandParameterAst.ParameterName),
-                                   Expression.Constant(errorPos.Text));
+                                   Expression.Constant(errorPos.Text),
+                                   Expression.Constant(commandParameterAst));
         }
 
         internal static Expression ThrowRuntimeError(string errorID, string resourceString, params Expression[] exceptionArgs)

--- a/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
+++ b/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
@@ -162,7 +162,7 @@ namespace System.Management.Automation
 
                 if (cpi.ArgumentSplatted)
                 {
-                    foreach (var splattedCpi in Splat(cpi.ArgumentValue, cpi.ArgumentExtent))
+                    foreach (var splattedCpi in Splat(cpi.ArgumentValue, cpi.ArgumentAst))
                     {
                         commandProcessor.AddParameter(splattedCpi);
                     }
@@ -293,7 +293,7 @@ namespace System.Management.Automation
             return commandProcessor;
         }
 
-        internal static IEnumerable<CommandParameterInternal> Splat(object splattedValue, IScriptExtent splatExtent)
+        internal static IEnumerable<CommandParameterInternal> Splat(object splattedValue, Ast splatAst)
         {
             splattedValue = PSObject.Base(splattedValue);
             IDictionary splattedTable = splattedValue as IDictionary;
@@ -306,8 +306,8 @@ namespace System.Management.Automation
                     string parameterText = GetParameterText(parameterName);
 
                     yield return CommandParameterInternal.CreateParameterWithArgument(
-                        splatExtent, parameterName, parameterText,
-                        splatExtent, parameterValue, false);
+                        splatAst, parameterName, parameterText,
+                        splatAst, parameterValue, false);
                 }
             }
             else
@@ -317,17 +317,17 @@ namespace System.Management.Automation
                 {
                     foreach (object obj in enumerableValue)
                     {
-                        yield return SplatEnumerableElement(obj, splatExtent);
+                        yield return SplatEnumerableElement(obj, splatAst);
                     }
                 }
                 else
                 {
-                    yield return SplatEnumerableElement(splattedValue, splatExtent);
+                    yield return SplatEnumerableElement(splattedValue, splatAst);
                 }
             }
         }
 
-        private static CommandParameterInternal SplatEnumerableElement(object splattedArgument, IScriptExtent splatExtent)
+        private static CommandParameterInternal SplatEnumerableElement(object splattedArgument, Ast splatAst)
         {
             var psObject = splattedArgument as PSObject;
             if (psObject != null)
@@ -336,11 +336,11 @@ namespace System.Management.Automation
                 var baseObj = psObject.BaseObject;
                 if (prop != null && prop.Value is string && baseObj is string)
                 {
-                    return CommandParameterInternal.CreateParameter(splatExtent, (string)prop.Value, (string)baseObj);
+                    return CommandParameterInternal.CreateParameter((string)prop.Value, (string)baseObj, splatAst);
                 }
             }
 
-            return CommandParameterInternal.CreateArgument(splatExtent, splattedArgument);
+            return CommandParameterInternal.CreateArgument(splattedArgument, splatAst);
         }
 
         private static string GetParameterText(string parameterName)
@@ -519,8 +519,8 @@ namespace System.Management.Automation
                 commandProcessor = context.CommandDiscovery.LookupCommandProcessor(
                     commandInfo, CommandOrigin.Internal, false, context.EngineSessionState);
                 var parameter = CommandParameterInternal.CreateParameterWithArgument(
-                    pipelineAst.Extent, "ScriptBlock", null,
-                    pipelineAst.Extent, sb,
+                    /*parameterAst*/pipelineAst, "ScriptBlock", null,
+                    /*argumentAst*/pipelineAst, sb,
                     false);
                 commandProcessor.AddParameter(parameter);
                 pipelineProcessor.Add(commandProcessor);
@@ -646,7 +646,7 @@ namespace System.Management.Automation
                         var exprAst = (ExpressionAst)commandElement;
                         var argument = Compiler.GetExpressionValue(exprAst, isTrusted, context);
                         var splatting = (exprAst is VariableExpressionAst && ((VariableExpressionAst)exprAst).Splatted);
-                        commandParameters.Add(CommandParameterInternal.CreateArgument(exprAst.Extent, argument, splatting));
+                        commandParameters.Add(CommandParameterInternal.CreateArgument(argument, exprAst, splatting));
                     }
 
                     var redirections = new List<CommandRedirection>();
@@ -709,14 +709,14 @@ namespace System.Management.Automation
 
             if (argumentAst == null)
             {
-                return CommandParameterInternal.CreateParameter(errorPos, commandParameterAst.ParameterName, errorPos.Text);
+                return CommandParameterInternal.CreateParameter(commandParameterAst.ParameterName, errorPos.Text, commandParameterAst);
             }
 
             object argumentValue = Compiler.GetExpressionValue(argumentAst, isTrusted, context);
             bool spaceAfterParameter = (errorPos.EndLineNumber != argumentAst.Extent.StartLineNumber ||
                                         errorPos.EndColumnNumber != argumentAst.Extent.StartColumnNumber);
-            return CommandParameterInternal.CreateParameterWithArgument(errorPos, commandParameterAst.ParameterName,
-                                                                        errorPos.Text, argumentAst.Extent, argumentValue,
+            return CommandParameterInternal.CreateParameterWithArgument(commandParameterAst, commandParameterAst.ParameterName,
+                                                                        errorPos.Text, argumentAst, argumentValue,
                                                                         spaceAfterParameter);
         }
 
@@ -1115,16 +1115,16 @@ namespace System.Management.Automation
             // Unicode is still the default, but now may be overridden
 
             var cpi = CommandParameterInternal.CreateParameterWithArgument(
-                PositionUtilities.EmptyExtent, "Filepath", "-Filepath:",
-                PositionUtilities.EmptyExtent, File,
+                /*parameterAst*/null, "Filepath", "-Filepath:",
+                /*argumentAst*/null, File,
                 false);
             commandProcessor.AddParameter(cpi);
 
             if (this.Appending)
             {
                 cpi = CommandParameterInternal.CreateParameterWithArgument(
-                    PositionUtilities.EmptyExtent, "Append", "-Append:",
-                    PositionUtilities.EmptyExtent, true,
+                    /*parameterAst*/null, "Append", "-Append:",
+                    /*argumentAst*/null, true,
                     false);
                 commandProcessor.AddParameter(cpi);
             }

--- a/src/System.Management.Automation/engine/runtime/ScriptBlockToPowerShell.cs
+++ b/src/System.Management.Automation/engine/runtime/ScriptBlockToPowerShell.cs
@@ -742,7 +742,7 @@ namespace System.Management.Automation
             // If it's an enumerable, then distribute the values as $args and finally
             // if it's a scalar, then the effect is equivalent to $var
             object splattedValue = _context.GetVariableValue(variableAst.VariablePath);
-            foreach (var splattedParameter in PipelineOps.Splat(splattedValue, variableAst.Extent))
+            foreach (var splattedParameter in PipelineOps.Splat(splattedValue, variableAst))
             {
                 CommandParameter publicParameter = CommandParameter.FromCommandParameterInternal(splattedParameter);
                 _powershell.AddParameter(publicParameter.Name, publicParameter.Value);


### PR DESCRIPTION
Fix globbing so that quoted args are not expanded.

Also Fix some minor issues with exceptions being raised when resolving
the path - falling back to no glob.

The bulk of the change is in the first commit, which passes the `Ast` or `null` instead of the `IScriptExtent` when constructing the parameters and arguments that are used by the parameter binder.

Fix #3931,#4971

<!--

If you are a PowerShell Team member, please make sure you choose the Reviewer(s) and Assignee for your PR.
If you are not from the PowerShell Team, you can leave the fields blank and the Maintainers will choose them for you. If you are familiar with the team, feel free to mention some Reviewers yourself.

For more information about the roles of Reviewer and Assignee, refer to [CONTRIBUTING.md](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md).

-->
