### PR TITLE
Don't wrap stderr as ErrorRecord

### DIFF
--- a/src/System.Management.Automation/engine/MshCommandRuntime.cs
+++ b/src/System.Management.Automation/engine/MshCommandRuntime.cs
@@ -2579,6 +2579,13 @@ namespace System.Management.Automation
             this.OutputPipe.Add(sendToPipeline);
         }
 
+        // Use this variant to write stderr as string and skip the ThrowIfWriteNotPermitted check
+        /// <exception cref="System.Management.Automation.PipelineStoppedException">
+        /// The pipeline has already been terminated, or was terminated
+        /// during the execution of this method.
+        /// The Cmdlet should generally just allow PipelineStoppedException
+        /// to percolate up to the caller of ProcessRecord etc.
+        /// </exception>
         internal void _WriteErrorSkipAllowCheck(object sendToPipeline)
         {
             ThrowIfStopping();

--- a/src/System.Management.Automation/engine/MshCommandRuntime.cs
+++ b/src/System.Management.Automation/engine/MshCommandRuntime.cs
@@ -2579,6 +2579,25 @@ namespace System.Management.Automation
             this.OutputPipe.Add(sendToPipeline);
         }
 
+        internal void _WriteErrorSkipAllowCheck(object sendToPipeline)
+        {
+            ThrowIfStopping();
+
+            if (AutomationNull.Value == sendToPipeline)
+                return;
+
+            sendToPipeline = LanguagePrimitives.AsPSObjectOrNull(sendToPipeline);
+
+            if (ErrorMergeTo != MergeDataStream.None)
+            {
+                Dbg.Assert(ErrorMergeTo == MergeDataStream.Output, "Only merging to success output is supported.");
+                this.OutputPipe.Add(sendToPipeline);
+            }
+            else
+            {
+                this.ErrorOutputPipe.Add(sendToPipeline);
+            }
+        }
 
         // NOTICE-2004/06/08-JonN 959638
         // Use this variant to skip the ThrowIfWriteNotPermitted check

--- a/src/System.Management.Automation/engine/NativeCommandProcessor.cs
+++ b/src/System.Management.Automation/engine/NativeCommandProcessor.cs
@@ -1032,6 +1032,7 @@ namespace System.Management.Automation
 
             if (outputValue.Stream == MinishellStream.Error)
             {
+                // write stderr as string instead of as ErrorRecord
                 this.commandRuntime._WriteErrorSkipAllowCheck(outputValue.Data);
             }
             else if (outputValue.Stream == MinishellStream.Output)

--- a/src/System.Management.Automation/engine/NativeCommandProcessor.cs
+++ b/src/System.Management.Automation/engine/NativeCommandProcessor.cs
@@ -1032,10 +1032,7 @@ namespace System.Management.Automation
 
             if (outputValue.Stream == MinishellStream.Error)
             {
-                ErrorRecord record = outputValue.Data as ErrorRecord;
-                Dbg.Assert(record != null, "ProcessReader should ensure that data is ErrorRecord");
-                record.SetInvocationInfo(this.Command.MyInvocation);
-                this.commandRuntime._WriteErrorSkipAllowCheck(record, isNativeError: true);
+                this.commandRuntime._WriteErrorSkipAllowCheck(outputValue.Data);
             }
             else if (outputValue.Stream == MinishellStream.Output)
             {

--- a/test/powershell/Host/ConsoleHost.Tests.ps1
+++ b/test/powershell/Host/ConsoleHost.Tests.ps1
@@ -102,24 +102,13 @@ Describe "ConsoleHost unit tests" -tags "Feature" {
             }
         }
 
-        It "Verify Validate Dollar Error Populated should throw exception" {
-            $origEA = $ErrorActionPreference
-            $ErrorActionPreference = "Stop"
-            try
-            {
-                $a = 1,2,3
-                $a | & $powershell -noprofile -command { wgwg-wrwrhqwrhrh35h3h3}
-                Throw "Test execution should not reach here!"
-            }
-            catch
-            {
-                $_.ToString() | Should Match "wgwg-wrwrhqwrhrh35h3h3"
-                $_.FullyQualifiedErrorId | Should Be "CommandNotFoundException"
-            }
-            finally
-            {
-                $ErrorActionPreference = $origEA
-            }
+        It "Verify Validate Dollar Error Populated should be in stderr" {
+            $stderrFile = "$testdrive\stderr.txt"
+            & $powershell -noprofile -command { wgwg-wrwrhqwrhrh35h3h3} 2> $stderrFile
+            $stderrFile | Should Exist
+            $stderr = Get-Content $stderrFile -Raw
+            $stderr | Should Match "wgwg-wrwrhqwrhrh35h3h3"
+            $stderr | Should Match "CommandNotFoundException"
         }
 
         It "Verify Validate Output Format As Text Explicitly Child Single Shell should works" {

--- a/test/powershell/Host/ConsoleHost.Tests.ps1
+++ b/test/powershell/Host/ConsoleHost.Tests.ps1
@@ -104,11 +104,17 @@ Describe "ConsoleHost unit tests" -tags "Feature" {
 
         It "Verify Validate Dollar Error Populated should be in stderr" {
             $stderrFile = "$testdrive\stderr.txt"
-            & $powershell -noprofile -command { wgwg-wrwrhqwrhrh35h3h3} 2> $stderrFile
+            & $powershell -noprofile -command { wgwg-wrwrhqwrhrh35h3h3 } 2> $stderrFile
             $stderrFile | Should Exist
             $stderr = Get-Content $stderrFile -Raw
             $stderr | Should Match "wgwg-wrwrhqwrhrh35h3h3"
             $stderr | Should Match "CommandNotFoundException"
+        }
+
+        It "Verify Validate Dollar Error Populated should be in stderr redirected to stdout" {
+            $err = & $powershell -noprofile -command { wgwg-wrwrhqwrhrh35h3h3 } 2>&1
+            $err.Exception.Message | Should Match "wgwg-wrwrhqwrhrh35h3h3"
+            $err.FullyQualifiedErrorId | Should BeExactly "CommandNotFoundException"
         }
 
         It "Verify Validate Output Format As Text Explicitly Child Single Shell should works" {

--- a/test/powershell/Language/Scripting/NativeExecution/NativeStreams.Tests.ps1
+++ b/test/powershell/Language/Scripting/NativeExecution/NativeStreams.Tests.ps1
@@ -18,7 +18,7 @@ Describe "Native streams behavior with PowerShell" -Tags 'CI' {
         # this check should be the first one, because $error is a global shared variable
         It 'should not add records to $error variable' {
             # we are keeping existing Windows PS v5.1 behavior for $error variable
-            $error.Count | Should Be 9
+            $error.Count | Should Be 0
         }
 
         It 'uses ErrorRecord object to return stderr output' {

--- a/test/tools/TestExe/TestExe.cs
+++ b/test/tools/TestExe/TestExe.cs
@@ -18,6 +18,9 @@ namespace TestExe
                     case "-createchildprocess":
                         CreateChildProcess(args);
                         break;
+                    case "-echostderr":
+                        EchoStderr(args);
+                        break;
                     default:
                         Console.WriteLine("Unknown test {0}", args[0]);
                         break;
@@ -38,6 +41,17 @@ namespace TestExe
             {
                 Console.WriteLine("Arg {0} is <{1}>", i-1, args[i]);
             }
+        }
+
+        // <Summary>
+        // Echos back to stderr the arguments passed in
+        // </Summary>
+        static void EchoStderr(string[] args)
+        {
+             for (int i = 1; i < args.Length; i++)
+             {
+                 Console.Error.WriteLine("{0}", args[i]);
+             }
         }
 
         // <Summary>


### PR DESCRIPTION
Keep stderr as string and don't wrap as ErrorRecord.
This also means that errors from running pwsh.exe within pwsh are now just stderr strings even though they visually look like ErrorRecords so tests had to be changed.
Most customers are likely not running powershell within powershell and expecting errors, but it does mean that try{}catch{} won't work (until we add the enhancement to throw on any stderr).

Fix https://github.com/PowerShell/PowerShell/issues/3813

<!--

If you are a PowerShell Team member, please make sure you choose the Reviewer(s) and Assignee for your PR.
If you are not from the PowerShell Team, you can leave the fields blank and the Maintainers will choose them for you. If you are familiar with the team, feel free to mention some Reviewers yourself.

For more information about the roles of Reviewer and Assignee, refer to [CONTRIBUTING.md](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md).

-->
