### PR TITLE
don't insert linebreaks to output (except for tables)

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/out-file/Out-File.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/out-file/Out-File.cs
@@ -211,31 +211,12 @@ namespace Microsoft.PowerShell.Commands
                 return null;
 
             // compute the # of columns available
-            int computedWidth = 120;
+            int computedWidth = int.MaxValue;
 
             if (_width != null)
             {
                 // use the value from the command line
                 computedWidth = _width.Value;
-            }
-            else
-            {
-                // use the value we get from the console
-                try
-                {
-                    // NOTE: we subtract 1 because we want to properly handle
-                    // the following scenario:
-                    // MSH>get-foo|out-file foo.txt
-                    // MSH>get-content foo.txt
-                    // in this case, if the computed width is (say) 80, get-content
-                    // would cause a wrapping of the 80 column long raw strings.
-                    // Hence we set the width to 79.
-                    computedWidth = this.Host.UI.RawUI.BufferSize.Width - 1;
-                }
-                catch (HostException)
-                {
-                    // non interactive host
-                }
             }
 
             // use the stream writer to create and initialize the Line Output writer

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/out-string/out-string.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/out-string/out-string.cs
@@ -94,30 +94,12 @@ namespace Microsoft.PowerShell.Commands
             _writer = new StreamingTextWriter(callback, Host.CurrentCulture);
 
             // compute the # of columns available
-            int computedWidth = 120;
+            int computedWidth = int.MaxValue;
 
             if (_width != null)
             {
                 // use the value from the command line
                 computedWidth = _width.Value;
-            }
-            else
-            {
-                // use the value we get from the console
-                try
-                {
-                    // NOTE: we subtract 1 because we want to properly handle
-                    // the following scenario:
-                    // MSH>get-foo|format-table|out-string
-                    // in this case, if the computed width is (say) 80, get-content
-                    // would cause a wrapping of the 80 column long raw strings.
-                    // Hence we set the width to 79.
-                    computedWidth = this.Host.UI.RawUI.BufferSize.Width - 1;
-                }
-                catch (HostException)
-                {
-                    // non interactive host
-                }
             }
 
             // use it to create and initialize the Line Output writer

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
@@ -2222,7 +2222,7 @@ namespace Microsoft.PowerShell
         /// </summary>
         private void WriteDebuggerMessage(string line)
         {
-            this.ui.WriteWrappedLine(this.ui.DebugForegroundColor, this.ui.DebugBackgroundColor, line);
+            this.ui.WriteLine(this.ui.DebugForegroundColor, this.ui.DebugBackgroundColor, line);
         }
 
         #endregion debugger

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterface.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterface.cs
@@ -1148,44 +1148,6 @@ namespace Microsoft.PowerShell
             }
         }
 
-        /// <summary>
-        ///
-        /// Writes text, wrapping a "word" boundaries when needed.
-        ///
-        /// </summary>
-        /// <param name="fg">
-        ///
-        /// Foreground color to output the text.
-        ///
-        /// </param>
-        /// <param name="bg">
-        ///
-        /// Background color to output the text.
-        ///
-        /// </param>
-        /// <param name="text">
-        ///
-        /// Text to be emitted.
-        ///
-        /// </param>
-
-        internal void WriteWrappedLine(ConsoleColor fg, ConsoleColor bg, string text)
-        {
-            WriteLine(fg, bg, WrapToCurrentWindowWidth(text));
-        }
-
-
-
-        // unused for now.
-        //internal
-        //void
-        //WriteWrappedLine(string text)
-        //{
-        //    WriteWrappedLine(RawUI.ForegroundColor, RawUI.BackgroundColor, text);
-        //}
-
-
-
         internal string WrapToCurrentWindowWidth(string text)
         {
             StringBuilder sb = new StringBuilder();
@@ -1207,11 +1169,7 @@ namespace Microsoft.PowerShell
             return sb.ToString();
         }
 
-
-
-        #endregion Word Wrapping
-
-
+#endregion Word Wrapping
 
         /// <summary>
         ///
@@ -1248,7 +1206,7 @@ namespace Microsoft.PowerShell
             else
             {
                 // NTRAID#Windows OS Bugs-1061752-2004/12/15-sburns should read a skin setting here...
-                WriteWrappedLine(
+                WriteLine(
                     DebugForegroundColor,
                     DebugBackgroundColor,
                     StringUtil.Format(ConsoleHostUserInterfaceStrings.DebugFormatString, message));
@@ -1309,7 +1267,7 @@ namespace Microsoft.PowerShell
             }
             else
             {
-                WriteWrappedLine(
+                WriteLine(
                     VerboseForegroundColor,
                     VerboseBackgroundColor,
                     StringUtil.Format(ConsoleHostUserInterfaceStrings.VerboseFormatString, message));
@@ -1352,7 +1310,7 @@ namespace Microsoft.PowerShell
             }
             else
             {
-                WriteWrappedLine(
+                WriteLine(
                     WarningForegroundColor,
                     WarningBackgroundColor,
                     StringUtil.Format(ConsoleHostUserInterfaceStrings.WarningFormatString, message));

--- a/src/System.Management.Automation/commands/utility/FormatAndOutput/common/BaseOutputtingCommand.cs
+++ b/src/System.Management.Automation/commands/utility/FormatAndOutput/common/BaseOutputtingCommand.cs
@@ -921,7 +921,11 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 }
 
                 int columnsOnTheScreen = this.InnerCommand._lo.ColumnNumber;
-                // for tables, we want to make sure we don't end up adding padding to int.MaxValue and default to 120 columns instead
+                // Tables need to use spaces for padding to maintain table look even if console window is resized.
+                // For all other output, we use int.MaxValue if the user didn't explicitly specify a width.
+                // If we detect that int.MaxValue is used, first we try to get the current console window width.
+                // However, if we can't read that (for example, implicit remoting has no console window), we default
+                // to something reasonable: 120 columns.
                 if (columnsOnTheScreen == int.MaxValue)
                 {
                     try

--- a/src/System.Management.Automation/commands/utility/FormatAndOutput/common/BaseOutputtingCommand.cs
+++ b/src/System.Management.Automation/commands/utility/FormatAndOutput/common/BaseOutputtingCommand.cs
@@ -921,6 +921,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 }
 
                 int columnsOnTheScreen = this.InnerCommand._lo.ColumnNumber;
+                // for tables, we want to make sure we don't end up adding padding to int.MaxValue and default to 120 columns instead
                 if (columnsOnTheScreen == int.MaxValue)
                 {
                     try

--- a/src/System.Management.Automation/commands/utility/FormatAndOutput/common/BaseOutputtingCommand.cs
+++ b/src/System.Management.Automation/commands/utility/FormatAndOutput/common/BaseOutputtingCommand.cs
@@ -565,7 +565,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             {
                 ComplexWriter complexWriter = new ComplexWriter();
 
-                complexWriter.Initialize(_lo, _lo.ColumnNumber);
+                complexWriter.Initialize(_lo, int.MaxValue);
                 complexWriter.WriteObject(cve.formatValueList);
 
                 return;
@@ -921,6 +921,10 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 }
 
                 int columnsOnTheScreen = this.InnerCommand._lo.ColumnNumber;
+                if (columnsOnTheScreen == int.MaxValue)
+                {
+                    columnsOnTheScreen = Console.WindowWidth;
+                }
 
                 int columns = this.CurrentTableHeaderInfo.tableColumnInfoList.Count;
                 if (columns == 0)

--- a/src/System.Management.Automation/commands/utility/FormatAndOutput/common/BaseOutputtingCommand.cs
+++ b/src/System.Management.Automation/commands/utility/FormatAndOutput/common/BaseOutputtingCommand.cs
@@ -923,7 +923,14 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 int columnsOnTheScreen = this.InnerCommand._lo.ColumnNumber;
                 if (columnsOnTheScreen == int.MaxValue)
                 {
-                    columnsOnTheScreen = Console.WindowWidth;
+                    try
+                    {
+                        columnsOnTheScreen = Console.WindowWidth;
+                    }
+                    catch
+                    {
+                        columnsOnTheScreen = 120;
+                    }
                 }
 
                 int columns = this.CurrentTableHeaderInfo.tableColumnInfoList.Count;

--- a/src/System.Management.Automation/commands/utility/FormatAndOutput/common/DefaultFormatters/PowerShellCore_format_ps1xml.cs
+++ b/src/System.Management.Automation/commands/utility/FormatAndOutput/common/DefaultFormatters/PowerShellCore_format_ps1xml.cs
@@ -789,7 +789,6 @@ namespace System.Management.Automation.Runspaces
                                         }
 
                                         $indent = 4
-                                        $width = $host.UI.RawUI.BufferSize.Width - $indent - 2
 
                                         $errorCategoryMsg = & { Set-StrictMode -Version 1; $_.ErrorCategory_Message }
                                         if ($null -ne $errorCategoryMsg)
@@ -800,19 +799,16 @@ namespace System.Management.Automation.Runspaces
                                         {
                                             $indentString = ""+ CategoryInfo          : "" + $_.CategoryInfo
                                         }
-                                        $posmsg += ""`n""
-                                        foreach($line in @($indentString -split ""(.{$width})"")) { if($line) { $posmsg += ("" "" * $indent + $line) } }
+                                        $posmsg += ""`n"" + $indentString
 
                                         $indentString = ""+ FullyQualifiedErrorId : "" + $_.FullyQualifiedErrorId
-                                        $posmsg += ""`n""
-                                        foreach($line in @($indentString -split ""(.{$width})"")) { if($line) { $posmsg += ("" "" * $indent + $line) } }
+                                        $posmsg += ""`n"" + $indentString
 
                                         $originInfo = & { Set-StrictMode -Version 1; $_.OriginInfo }
                                         if (($null -ne $originInfo) -and ($null -ne $originInfo.PSComputerName))
                                         {
                                             $indentString = ""+ PSComputerName        : "" + $originInfo.PSComputerName
-                                            $posmsg += ""`n""
-                                            foreach($line in @($indentString -split ""(.{$width})"")) { if($line) { $posmsg += ("" "" * $indent + $line) } }
+                                            $posmsg += ""`n"" + $indentString
                                         }
 
                                         if ($ErrorView -eq ""CategoryView"") {

--- a/src/System.Management.Automation/commands/utility/FormatAndOutput/common/TableWriter.cs
+++ b/src/System.Management.Automation/commands/utility/FormatAndOutput/common/TableWriter.cs
@@ -84,7 +84,14 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
 
             if (screenColumns == int.MaxValue)
             {
-                screenColumns = System.Console.WindowWidth;
+                try
+                {
+                    screenColumns = System.Console.WindowWidth;
+                }
+                catch
+                {
+                    screenColumns = 120;
+                }
             }
 
             if (leftMarginIndent < 0)

--- a/src/System.Management.Automation/commands/utility/FormatAndOutput/common/TableWriter.cs
+++ b/src/System.Management.Automation/commands/utility/FormatAndOutput/common/TableWriter.cs
@@ -82,6 +82,11 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             //Console.WriteLine("         1         2         3         4         5         6         7");
             //Console.WriteLine("01234567890123456789012345678901234567890123456789012345678901234567890123456789");
 
+            if (screenColumns == int.MaxValue)
+            {
+                screenColumns = System.Console.WindowWidth;
+            }
+
             if (leftMarginIndent < 0)
             {
                 leftMarginIndent = 0;

--- a/test/powershell/Language/Scripting/NativeExecution/NativeStreams.Tests.ps1
+++ b/test/powershell/Language/Scripting/NativeExecution/NativeStreams.Tests.ps1
@@ -49,6 +49,17 @@ Describe "Native streams behavior with PowerShell" -Tags 'CI' {
         It 'preserves error stream as is with Out-String' {
             ($out | Out-String).Replace("`r", '') | Should Be "foo`n`nbar`n`nbazmiddlefoo`n`nbar`n`nbaz`n"
         }
+
+        It 'does not get truncated or split when redirected' {
+            $longtext = "0123456789"
+            while ($longtext.Length -lt [console]::WindowWidth) {
+                $longtext += $longtext
+            }
+            pwsh -c "& { [Console]::Error.WriteLine('$longtext') }" 2>&1 > $testdrive\error.txt
+            $e = Get-Content -Path $testdrive\error.txt
+            $e.Count | Should BeExactly 1
+            $e | Should Match $longtext
+        }
     }
 }
 
@@ -56,7 +67,7 @@ Describe 'piping powershell objects to finished native executable' -Tags 'CI' {
     It 'doesn''t throw any exceptions, when we are piping to the closed executable' {
         1..3 | ForEach-Object {
             Start-Sleep -Milliseconds 100
-            # yeild some multi-line formatted object
+            # yield some multi-line formatted object
             @{'a' = 'b'}
         } | testexe -echoargs | Should Be $null
     }

--- a/test/powershell/Language/Scripting/NativeExecution/NativeStreams.Tests.ps1
+++ b/test/powershell/Language/Scripting/NativeExecution/NativeStreams.Tests.ps1
@@ -58,7 +58,7 @@ Describe "Native streams behavior with PowerShell" -Tags 'CI' {
             pwsh -c "& { [Console]::Error.WriteLine('$longtext') }" 2>&1 > $testdrive\error.txt
             $e = Get-Content -Path $testdrive\error.txt
             $e.Count | Should BeExactly 1
-            $e | Should Match $longtext
+            $e | Should BeExactly $longtext
         }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Debug.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Debug.Tests.ps1
@@ -1,0 +1,17 @@
+Describe "Write-Debug tests" -Tags "CI" {
+    It "Should not have added line breaks" {
+        $text = "0123456789"
+        while ($text.Length -lt [Console]::WindowWidth) {
+            $text += $text
+        }
+        $origDebugPref = $DebugPreference
+        $DebugPreference = "Continue"
+        try {
+            $out = Write-Debug $text *>&1
+            $out | Should Match $text
+        }
+        finally {
+            $DebugPreference = $origDebugPref
+        }
+    }
+}

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Debug.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Debug.Tests.ps1
@@ -7,8 +7,8 @@ Describe "Write-Debug tests" -Tags "CI" {
         $origDebugPref = $DebugPreference
         $DebugPreference = "Continue"
         try {
-            $out = Write-Debug $text *>&1
-            $out | Should Match $text
+            $out = Write-Debug $text 5>&1
+            $out | Should BeExactly $text
         }
         finally {
             $DebugPreference = $origDebugPref

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Error.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Error.Tests.ps1
@@ -1,4 +1,4 @@
-Describe "Write-Error DRT Unit Tests" -Tags "CI" {
+Describe "Write-Error Tests" -Tags "CI" {
     It "Should be works with command: write-error myerrortext" {
         $e = Write-Error myerrortext 2>&1
         $e | Should BeOfType 'System.Management.Automation.ErrorRecord'
@@ -74,40 +74,49 @@ Describe "Write-Error DRT Unit Tests" -Tags "CI" {
         $e.CategoryInfo.TargetType | Should Be 'fooTargetType'
         $e.CategoryInfo.GetMessage() | Should Be 'NotSpecified: (fooTargetName:fooTargetType) [fooAct], fooReason'
     }
-}
 
-Describe "Write-Error" -Tags "CI" {
     It "Should be able to throw" {
-	Write-Error "test throw" -ErrorAction SilentlyContinue | Should Throw
+    	Write-Error "test throw" -ErrorAction SilentlyContinue | Should Throw
     }
 
     It "Should throw a non-terminating error" {
-	Write-Error "test throw" -ErrorAction SilentlyContinue
+        Write-Error "test throw" -ErrorAction SilentlyContinue
 
-	1 + 1 | Should Be 2
+        1 + 1 | Should Be 2
     }
 
     It "Should trip an exception using the exception switch" {
-	$var = 0
-	try
-	{
-	    Write-Error -Exception -Message "test throw"
-	}
-	catch [System.Exception]
-	{
+        $var = 0
+        try
+        {
+            Write-Error -Exception -Message "test throw"
+        }
+        catch [System.Exception]
+        {
 
-	    $var++
-	}
-	finally
-	{
-	    $var | Should Be 1
-	}
+            $var++
+        }
+        finally
+        {
+            $var | Should Be 1
+        }
     }
 
     It "Should output the error message to the `$error automatic variable" {
-	$theError = "Error: Too many input values."
-	write-error -message $theError -category InvalidArgument -ErrorAction SilentlyContinue
+        $theError = "Error: Too many input values."
+        write-error -message $theError -category InvalidArgument -ErrorAction SilentlyContinue
 
-	$error[0]| Should Be $theError
+        $error[0]| Should Be $theError
+    }
+
+    It "ErrorRecord should not be truncated" {
+        $longtext = "0123456789"
+        while ($longtext.Length -lt [console]::WindowWidth) {
+            $longtext += $longtext
+        }
+        pwsh -c Write-Error -Message $longtext 2>&1 > $testdrive\error.txt
+        $e = Get-Content -Path $testdrive\error.txt
+        $e.Count | Should BeExactly 4
+        $e[0] | Should Match $longtext
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Verbose.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Verbose.Tests.ps1
@@ -35,8 +35,8 @@ Describe "Write-Verbose" -Tags "CI" {
         $origVerbosePref = $VerbosePreference
         $VerbosePreference = "continue"
         try {
-            $out = Write-Verbose $text *>&1
-            $out | Should Match $text
+            $out = Write-Verbose $text 4>&1
+            $out | Should BeExactly $text
         }
         finally {
             $VerbosePreference = $origVerbosePref

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Verbose.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Verbose.Tests.ps1
@@ -26,4 +26,20 @@ Describe "Write-Verbose" -Tags "CI" {
 
 	$(Write-Verbose -Message "test" -Verbose:$true) 4>&1 | Should Be "test"
     }
+
+    It "Should not have added line breaks" {
+        $text = "0123456789"
+        while ($text.Length -lt [Console]::WindowWidth) {
+            $text += $text
+        }
+        $origVerbosePref = $VerbosePreference
+        $VerbosePreference = "continue"
+        try {
+            $out = Write-Verbose $text *>&1
+            $out | Should Match $text
+        }
+        finally {
+            $VerbosePreference = $origVerbosePref
+        }
+    }
 }


### PR DESCRIPTION
don't use current console window width to add linebreaks to output (including debug, error, and verbose)
explicitly change errorrecord formatter to not add linebreaks
set width to int.maxvalue if not specified, in some special cases if width is int.maxvalue, set to console.windowwidth
so that you don't get int.maxvalue padding (like tables)

Related: https://github.com/PowerShell/PowerShell/issues/3813

<!--

If you are a PowerShell Team member, please make sure you choose the Reviewer(s) and Assignee for your PR.
If you are not from the PowerShell Team, you can leave the fields blank and the Maintainers will choose them for you. If you are familiar with the team, feel free to mention some Reviewers yourself.

For more information about the roles of Reviewer and Assignee, refer to [CONTRIBUTING.md](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md).

-->
