### PR TITLE
fix get-item -literalpath a*b if `a*b` doesn't actually exist to return error

### DIFF
--- a/src/System.Management.Automation/namespaces/LocationGlobber.cs
+++ b/src/System.Management.Automation/namespaces/LocationGlobber.cs
@@ -252,7 +252,7 @@ namespace System.Management.Automation
 
                 if (!allowNonexistingPaths &&
                     result.Count < 1 &&
-                    !WildcardPattern.ContainsWildcardCharacters(path) &&
+                    (!WildcardPattern.ContainsWildcardCharacters(path) || context.SuppressWildcardExpansion) &&
                     (context.Include == null || context.Include.Count == 0) &&
                     (context.Exclude == null || context.Exclude.Count == 0))
                 {


### PR DESCRIPTION
Previously, -literalpath given a wildcard will treat it the same as -path and if the wildcard found no files, it would silently exit.  Correct behavior should be that -literalpath is literal so if the file doesn't exist, it should error.  Fix is to also see if wildcard is being suppressed.

Also re-enabled and fixed some tests that were skipped incorrectly (should have been pending) since the issue was addressed.

Fix https://github.com/PowerShell/PowerShell/issues/5057

<!--

If you are a PowerShell Team member, please make sure you choose the Reviewer(s) and Assignee for your PR.
If you are not from the PowerShell Team, you can leave the fields blank and the Maintainers will choose them for you. If you are familiar with the team, feel free to mention some Reviewers yourself.

For more information about the roles of Reviewer and Assignee, refer to [CONTRIBUTING.md](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md).

-->
