### PR TITLE
Fix AppImage package name to be lower case 'powershell-..'

### DIFF
--- a/docs/installation/linux.md
+++ b/docs/installation/linux.md
@@ -553,14 +553,14 @@ For more information on installing packages from the AUR, see the [Arch Linux wi
 ## Linux AppImage
 
 Using a recent Linux distribution,
-download the AppImage `PowerShell-6.0.0-beta.8-x86_64.AppImage`
+download the AppImage `powershell-6.0.0-beta.8-x86_64.AppImage`
 from the [releases][] page onto the Linux machine.
 
 Then execute the following in the terminal:
 
 ```bash
-chmod a+x PowerShell-6.0.0-beta.8-x86_64.AppImage
-./PowerShell-6.0.0-beta.8-x86_64.AppImage
+chmod a+x powershell-6.0.0-beta.8-x86_64.AppImage
+./powershell-6.0.0-beta.8-x86_64.AppImage
 ```
 
 The [AppImage][] lets you run PowerShell without installing it.
@@ -705,13 +705,13 @@ powershell
 
 ```sh
 # Grab the latest App Image
-wget https://github.com/PowerShell/PowerShell/releases/download/v6.0.0-beta.8/PowerShell-6.0.0-beta.8-x86_64.AppImage
+wget https://github.com/PowerShell/PowerShell/releases/download/v6.0.0-beta.8/powershell-6.0.0-beta.8-x86_64.AppImage
 
 # Make executable
-chmod a+x PowerShell-6.0.0-beta.8-x86_64.AppImage
+chmod a+x powershell-6.0.0-beta.8-x86_64.AppImage
 
 # Start PowerShell
-./PowerShell-6.0.0-beta.8-x86_64.AppImage
+./powershell-6.0.0-beta.8-x86_64.AppImage
 ```
 
 ### Uninstallation - Kali

--- a/tools/appimage.sh
+++ b/tools/appimage.sh
@@ -427,7 +427,7 @@ mv opt/microsoft/powershell/*/* usr/bin/
 
 cat > $APP.desktop <<\EOF
 [Desktop Entry]
-Name=PowerShell
+Name=powershell
 Comment=Microsoft PowerShell
 Exec=pwsh
 Keywords=shell;prompt;command;commandline;cmd;
@@ -472,6 +472,6 @@ cd ..
 wget -c https://psgithub.blob.core.windows.net/files/appimagetool-x86_64.AppImage
 chmod a+x appimagetool-x86_64.AppImage
 ./appimagetool-x86_64.AppImage ./powershell.AppDir
-cp ./PowerShell*AppImage ..
+cp ./powershell*AppImage ..
 
 cd ..

--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -140,7 +140,7 @@ function Start-PSPackage {
         # If building a symbols package, don't include the publish build.
         if ($IncludeSymbols.IsPresent)
         {
-            $buildSource = Split-Path -Path $Source -Parent           
+            $buildSource = Split-Path -Path $Source -Parent
             $Source = New-TempFolder
             Get-ChildItem -Path $buildSource | Where-Object {$_.Name -ine 'Publish'} | Copy-Item -Destination $Source -Recurse
         }
@@ -217,7 +217,7 @@ function Start-PSPackage {
 
                 if ($Environment.IsUbuntu14) {
                     $null = Start-NativeExecution { bash -iex "$PSScriptRoot/../appimage.sh" }
-                    $appImage = Get-Item PowerShell-*.AppImage
+                    $appImage = Get-Item powershell-*.AppImage
                     if ($appImage.Count -gt 1) {
                         throw "Found more than one AppImage package, remove all *.AppImage files and try to create the package again"
                     }


### PR DESCRIPTION
Fix AppImage package name to be lower case 'powershell-..'
This makes the package name consistent with all the other Linux package names.