### PR TITLE
Add Duration property to HistoryInfo

### DIFF
--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
@@ -343,7 +343,7 @@ namespace System.Management.Automation.Runspaces
             yield return new FormatViewDefinition("time",
                 TableControl.Create()
                     .AddHeader(Alignment.Right, width: 4)
-                    .AddHeader(Alignment.Right, width: 13, label: "ExecutionTime")
+                    .AddHeader(Alignment.Right, width: 13, label: "Duration")
                     .AddHeader()
                     .StartRowDefinition()
                         .AddPropertyColumn("Id")

--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
@@ -340,6 +340,18 @@ namespace System.Management.Automation.Runspaces
                     .EndRowDefinition()
                 .EndTable());
 
+            yield return new FormatViewDefinition("time",
+                TableControl.Create()
+                    .AddHeader(Alignment.Right, width: 4)
+                    .AddHeader(Alignment.Right, width: 13, label: "ExecutionTime")
+                    .AddHeader()
+                    .StartRowDefinition()
+                        .AddPropertyColumn("Id")
+                        .AddScriptBlockColumn("$_.GetExecutionTimeString()")
+                        .AddPropertyColumn("CommandLine")
+                    .EndRowDefinition()
+                    .EndTable());
+
             yield return new FormatViewDefinition("history",
                 WideControl.Create()
                     .AddPropertyEntry("CommandLine")

--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
@@ -340,18 +340,6 @@ namespace System.Management.Automation.Runspaces
                     .EndRowDefinition()
                 .EndTable());
 
-            yield return new FormatViewDefinition("time",
-                TableControl.Create()
-                    .AddHeader(Alignment.Right, width: 4)
-                    .AddHeader(Alignment.Right, width: 13)
-                    .AddHeader()
-                    .StartRowDefinition()
-                        .AddPropertyColumn("Id")
-                        .AddPropertyColumn("Duration")
-                        .AddPropertyColumn("CommandLine")
-                    .EndRowDefinition()
-                    .EndTable());
-
             yield return new FormatViewDefinition("history",
                 WideControl.Create()
                     .AddPropertyEntry("CommandLine")

--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
@@ -343,11 +343,11 @@ namespace System.Management.Automation.Runspaces
             yield return new FormatViewDefinition("time",
                 TableControl.Create()
                     .AddHeader(Alignment.Right, width: 4)
-                    .AddHeader(Alignment.Right, width: 13, label: "Duration")
+                    .AddHeader(Alignment.Right, width: 13)
                     .AddHeader()
                     .StartRowDefinition()
                         .AddPropertyColumn("Id")
-                        .AddScriptBlockColumn("$_.GetExecutionTimeString()")
+                        .AddPropertyColumn("Duration")
                         .AddPropertyColumn("CommandLine")
                     .EndRowDefinition()
                     .EndTable());

--- a/src/System.Management.Automation/engine/hostifaces/History.cs
+++ b/src/System.Management.Automation/engine/hostifaces/History.cs
@@ -87,7 +87,7 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// The time it took to execute the associeated pipeline
         /// </summary>
-        public TimeSpan ExecutionTime => EndExecutionTime - StartExecutionTime;
+        public TimeSpan Duration => EndExecutionTime - StartExecutionTime;
 
         /// <summary>
         /// Override for ToString() method
@@ -158,16 +158,16 @@ namespace Microsoft.PowerShell.Commands
         /// <returns></returns>
         public string GetExecutionTimeString()
         {
-            var executionTime = ExecutionTime;
-            if (executionTime.Days > 0)
+            var duration = Duration;
+            if (duration.Days > 0)
             {
-                return $@"{executionTime:d\.hh\:mm\:ss}";
+                return $@"{duration:d\.hh\:mm\:ss}";
             }
-            if (executionTime.Hours > 1)
+            if (duration.Hours > 1)
             { 
-                return $@"{executionTime:hh\:mm\:ss}";
+                return $@"{duration:hh\:mm\:ss}";
             }
-            return $@"{executionTime:mm\:ss\.fff}";
+            return $@"{duration:mm\:ss\.fff}";
         }
 
         /// <summary>

--- a/src/System.Management.Automation/engine/hostifaces/History.cs
+++ b/src/System.Management.Automation/engine/hostifaces/History.cs
@@ -85,6 +85,11 @@ namespace Microsoft.PowerShell.Commands
         public DateTime EndExecutionTime { get; private set; }
 
         /// <summary>
+        /// The time it took to execute the associeated pipeline
+        /// </summary>
+        public TimeSpan ExecutionTime => EndExecutionTime - StartExecutionTime;
+
+        /// <summary>
         /// Override for ToString() method
         /// </summary>
         /// <returns></returns>

--- a/src/System.Management.Automation/engine/hostifaces/History.cs
+++ b/src/System.Management.Automation/engine/hostifaces/History.cs
@@ -19,8 +19,6 @@ namespace Microsoft.PowerShell.Commands
     /// </summary>
     public class HistoryInfo
     {
-        #region constuctor
-
         /// <summary>
         /// Constructor
         /// </summary>
@@ -56,9 +54,6 @@ namespace Microsoft.PowerShell.Commands
             _cleared = history._cleared;
         }
 
-        #endregion constructor
-
-        #region public
         /// <summary>
         /// Id of this history entry.
         /// </summary>
@@ -135,10 +130,6 @@ namespace Microsoft.PowerShell.Commands
             }
         }
 
-        #endregion public
-
-        #region internal
-
         /// <summary>
         /// Cleared status of an entry
         /// </summary>
@@ -191,10 +182,6 @@ namespace Microsoft.PowerShell.Commands
             _cmdline = command;
         }
 
-        #endregion internal
-
-        #region private
-
         /// <summary>
         /// Id of the pipeline corresponding to this history entry
         /// </summary>
@@ -231,10 +218,6 @@ namespace Microsoft.PowerShell.Commands
 
         private bool _cleared = false;
 
-        #endregion private
-
-        #region ICloneable Members
-
         /// <summary>
         /// Returns a clone of this object
         /// </summary>
@@ -243,8 +226,6 @@ namespace Microsoft.PowerShell.Commands
         {
             return new HistoryInfo(this);
         }
-
-        #endregion
     }
 
     /// <summary>

--- a/src/System.Management.Automation/engine/hostifaces/History.cs
+++ b/src/System.Management.Automation/engine/hostifaces/History.cs
@@ -115,37 +115,25 @@ namespace Microsoft.PowerShell.Commands
         /// Sets Id
         /// </summary>
         /// <param name="id"></param>
-        internal void SetId(long id)
-        {
-            Id = id;
-        }
+        internal void SetId(long id) => Id = id;
 
         /// <summary>
         /// Set status
         /// </summary>
         /// <param name="status"></param>
-        internal void SetStatus(PipelineState status)
-        {
-            ExecutionStatus = status;
-        }
+        internal void SetStatus(PipelineState status) => ExecutionStatus = status;
 
         /// <summary>
         /// Set endtime
         /// </summary>
         /// <param name="endTime"></param>
-        internal void SetEndTime(DateTime endTime)
-        {
-            EndExecutionTime = endTime;
-        }
+        internal void SetEndTime(DateTime endTime) => EndExecutionTime = endTime;
 
         /// <summary>
         /// Sets command
         /// </summary>
         /// <param name="command"></param>
-        internal void SetCommand(string command)
-        {
-            CommandLine = command;
-        }
+        internal void SetCommand(string command) => CommandLine = command;
 
         /// <summary>
         /// Id of the pipeline corresponding to this history entry

--- a/src/System.Management.Automation/engine/hostifaces/History.cs
+++ b/src/System.Management.Automation/engine/hostifaces/History.cs
@@ -152,23 +152,6 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         private long _pipelineId;
 
-        /// <summary>
-        /// Gets a string representation of the execution time
-        /// </summary>
-        /// <returns></returns>
-        public string GetExecutionTimeString()
-        {
-            var duration = Duration;
-            if (duration.Days > 0)
-            {
-                return $@"{duration:d\.hh\:mm\:ss}";
-            }
-            if (duration.Hours > 1)
-            { 
-                return $@"{duration:hh\:mm\:ss}";
-            }
-            return $@"{duration:mm\:ss\.fff}";
-        }
 
         /// <summary>
         /// Returns a clone of this object

--- a/src/System.Management.Automation/engine/hostifaces/History.cs
+++ b/src/System.Management.Automation/engine/hostifaces/History.cs
@@ -152,6 +152,23 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         private long _pipelineId;
 
+        /// <summary>
+        /// Gets a string representation of the execution time
+        /// </summary>
+        /// <returns></returns>
+        public string GetExecutionTimeString()
+        {
+            var executionTime = ExecutionTime;
+            if (executionTime.Days > 0)
+            {
+                return $@"{executionTime:d\.hh\:mm\:ss}";
+            }
+            if (executionTime.Hours > 1)
+            { 
+                return $@"{executionTime:hh\:mm\:ss}";
+            }
+            return $@"{executionTime:mm\:ss\.fff}";
+        }
 
         /// <summary>
         /// Returns a clone of this object

--- a/src/System.Management.Automation/engine/hostifaces/History.cs
+++ b/src/System.Management.Automation/engine/hostifaces/History.cs
@@ -32,11 +32,11 @@ namespace Microsoft.PowerShell.Commands
         {
             Dbg.Assert(cmdline != null, "caller should validate the parameter");
             _pipelineId = pipelineId;
-            _cmdline = cmdline;
-            _status = status;
-            _startTime = startTime;
-            _endTime = endTime;
-            _cleared = false;
+            CommandLine = cmdline;
+            ExecutionStatus = status;
+            StartExecutionTime = startTime;
+            EndExecutionTime = endTime;
+            Cleared = false;
         }
 
         /// <summary>
@@ -45,74 +45,44 @@ namespace Microsoft.PowerShell.Commands
         /// <param name="history"></param>
         private HistoryInfo(HistoryInfo history)
         {
-            _id = history._id;
+            Id = history.Id;
             _pipelineId = history._pipelineId;
-            _cmdline = history._cmdline;
-            _status = history._status;
-            _startTime = history._startTime;
-            _endTime = history._endTime;
-            _cleared = history._cleared;
+            CommandLine = history.CommandLine;
+            ExecutionStatus = history.ExecutionStatus;
+            StartExecutionTime = history.StartExecutionTime;
+            EndExecutionTime = history.EndExecutionTime;
+            Cleared = history.Cleared;
         }
 
         /// <summary>
         /// Id of this history entry.
         /// </summary>
         /// <value></value>
-        public long Id
-        {
-            get
-            {
-                return _id;
-            }
-        }
+        public long Id { get; private set; }
 
         /// <summary>
         /// CommandLine string
         /// </summary>
         /// <value></value>
-        public string CommandLine
-        {
-            get
-            {
-                return _cmdline;
-            }
-        }
+        public string CommandLine { get; private set; }
 
         /// <summary>
         /// Execution status of associated pipeline
         /// </summary>
         /// <value></value>
-        public PipelineState ExecutionStatus
-        {
-            get
-            {
-                return _status;
-            }
-        }
+        public PipelineState ExecutionStatus { get; private set; }
 
         /// <summary>
         /// Start time of execution of associated pipeline
         /// </summary>
         /// <value></value>
-        public DateTime StartExecutionTime
-        {
-            get
-            {
-                return _startTime;
-            }
-        }
+        public DateTime StartExecutionTime { get; }
 
         /// <summary>
         /// End time of execution of associated pipeline
         /// </summary>
         /// <value></value>
-        public DateTime EndExecutionTime
-        {
-            get
-            {
-                return _endTime;
-            }
-        }
+        public DateTime EndExecutionTime { get; private set; }
 
         /// <summary>
         /// Override for ToString() method
@@ -120,13 +90,13 @@ namespace Microsoft.PowerShell.Commands
         /// <returns></returns>
         public override string ToString()
         {
-            if (string.IsNullOrEmpty(_cmdline))
+            if (string.IsNullOrEmpty(CommandLine))
             {
                 return base.ToString();
             }
             else
             {
-                return _cmdline;
+                return CommandLine;
             }
         }
 
@@ -134,17 +104,7 @@ namespace Microsoft.PowerShell.Commands
         /// Cleared status of an entry
         /// </summary>
 
-        internal bool Cleared
-        {
-            get
-            {
-                return _cleared;
-            }
-            set
-            {
-                _cleared = value;
-            }
-        }
+        internal bool Cleared { get; set; } = false;
 
         /// <summary>
         /// Sets Id
@@ -152,7 +112,7 @@ namespace Microsoft.PowerShell.Commands
         /// <param name="id"></param>
         internal void SetId(long id)
         {
-            _id = id;
+            Id = id;
         }
 
         /// <summary>
@@ -161,7 +121,7 @@ namespace Microsoft.PowerShell.Commands
         /// <param name="status"></param>
         internal void SetStatus(PipelineState status)
         {
-            _status = status;
+            ExecutionStatus = status;
         }
 
         /// <summary>
@@ -170,7 +130,7 @@ namespace Microsoft.PowerShell.Commands
         /// <param name="endTime"></param>
         internal void SetEndTime(DateTime endTime)
         {
-            _endTime = endTime;
+            EndExecutionTime = endTime;
         }
 
         /// <summary>
@@ -179,7 +139,7 @@ namespace Microsoft.PowerShell.Commands
         /// <param name="command"></param>
         internal void SetCommand(string command)
         {
-            _cmdline = command;
+            CommandLine = command;
         }
 
         /// <summary>
@@ -187,36 +147,6 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         private long _pipelineId;
 
-        /// <summary>
-        /// Id of the history entry
-        /// </summary>
-        private long _id;
-
-        /// <summary>
-        /// CommandLine string
-        /// </summary>
-        private string _cmdline;
-
-        /// <summary>
-        /// ExecutionStatus of execution
-        /// </summary>
-        private PipelineState _status;
-
-        /// <summary>
-        /// Start time of execution
-        /// </summary>
-        private DateTime _startTime;
-
-        ///
-        ///End time of execution
-        ///
-        private DateTime _endTime;
-
-        /// <summary>
-        /// Flag indicating an entry is present/cleared
-        /// </summary>
-
-        private bool _cleared = false;
 
         /// <summary>
         /// Returns a clone of this object

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/History.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/History.Tests.ps1
@@ -110,4 +110,10 @@ Describe "History cmdlet test cases" -Tags "CI" {
 
         $errorResult | Should -BeExactly 'CommandNotFoundException'
     }
+
+    It "Has time view in table format" {
+        $null = Get-ChildItem
+        Get-History | Format-Table -View time -ErrorVariable ftError | Out-Null
+        $ftError.Count | Should Be 0
+    }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/History.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/History.Tests.ps1
@@ -116,4 +116,13 @@ Describe "History cmdlet test cases" -Tags "CI" {
         Get-History | Format-Table -View time -ErrorVariable ftError | Out-Null
         $ftError.Count | Should Be 0
     }
+
+    It "HistoryInfo calculates Duration" {
+        $ctor = [Microsoft.PowerShell.Commands.HistoryInfo].GetConstructors([Reflection.BindingFlags]::NonPublic -bor [Reflection.BindingFlags]::Instance).Where{$_.GetParameters().Length -eq 5}
+        $start = [datetime]::new(2001, 01, 01, 10, 01, 01)
+        $duration = [timespan] "1:2:21"
+        $end = $start + $duration
+        $hi = $ctor.Invoke((1, "command", [Management.Automation.Runspaces.PipelineState]::Completed, $start, $end))
+        $hi.Duration | Should Be $duration
+    }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/History.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/History.Tests.ps1
@@ -112,11 +112,17 @@ Describe "History cmdlet test cases" -Tags "CI" {
     }
 
     It "HistoryInfo calculates Duration" {
-        $ctor = [Microsoft.PowerShell.Commands.HistoryInfo].GetConstructors([Reflection.BindingFlags]::NonPublic -bor [Reflection.BindingFlags]::Instance).Where{$_.GetParameters().Length -eq 5}
         $start = [datetime]::new(2001, 01, 01, 10, 01, 01)
         $duration = [timespan] "1:2:21"
         $end = $start + $duration
-        $hi = $ctor.Invoke((1, "command", [Management.Automation.Runspaces.PipelineState]::Completed, $start, $end))
-        $hi.Duration | Should Be $duration
+        $history = [PSCustomObject] @{
+                CommandLine="command"
+                ExecutionStatus=[Management.Automation.Runspaces.PipelineState]::Completed
+                StartExecutionTime=$start
+                EndExecutionTime=$end
+        }
+        $history | Add-History
+        $h = Get-History -count 1
+        $h.Duration | Should Be $duration
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/History.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/History.Tests.ps1
@@ -8,11 +8,11 @@ Describe "History cmdlet test cases" -Tags "CI" {
             $ps = [PowerShell]::Create("NewRunspace")
             # we need to be sure that history is added, so use the proper
             # Invoke variant
-            $null = $ps.addcommand("Get-Date").Invoke($null,$setting)
+            $null = $ps.addcommand("Get-Date").Invoke($null, $setting)
             $ps.commands.clear()
-            $null = $ps.addscript("1+1").Invoke($null,$setting)
+            $null = $ps.addscript("1+1").Invoke($null, $setting)
             $ps.commands.clear()
-            $null = $ps.addcommand("Get-Location").Invoke($null,$setting)
+            $null = $ps.addcommand("Get-Location").Invoke($null, $setting)
             $ps.commands.clear()
         }
         AfterEach {
@@ -38,18 +38,18 @@ Describe "History cmdlet test cases" -Tags "CI" {
         }
         It "Add-History actually adds to history" {
             # add this invocation to history
-            $ps.AddScript("Get-History|Add-History").Invoke($null,$setting)
+            $ps.AddScript("Get-History|Add-History").Invoke($null, $setting)
             # that's 4 history lines * 2
             $ps.Commands.Clear()
             $result = $ps.AddCommand("Get-History").Invoke()
             $result.Count | Should -Be 8
-            for($i = 0; $i -lt 4; $i++) {
-                $result[$i+4].CommandLine | Should -BeExactly $result[$i].CommandLine
+            for ($i = 0; $i -lt 4; $i++) {
+                $result[$i + 4].CommandLine | Should -BeExactly $result[$i].CommandLine
             }
         }
     }
 
-	It "Tests Invoke-History on a cmdlet that generates output on all streams" {
+    It "Tests Invoke-History on a cmdlet that generates output on all streams" {
         $streamSpammer = '
         function StreamSpammer
         {
@@ -93,7 +93,7 @@ Describe "History cmdlet test cases" -Tags "CI" {
         $outputCount | Should -Be 12
     }
 
-	It "Tests Invoke-History on a private command" {
+    It "Tests Invoke-History on a private command" {
 
         $invocationSettings = New-Object System.Management.Automation.PSInvocationSettings
         $invocationSettings.AddToHistory = $true
@@ -109,12 +109,6 @@ Describe "History cmdlet test cases" -Tags "CI" {
         $ps.Dispose()
 
         $errorResult | Should -BeExactly 'CommandNotFoundException'
-    }
-
-    It "Has time view in table format" {
-        $null = Get-ChildItem
-        Get-History | Format-Table -View time -ErrorVariable ftError | Out-Null
-        $ftError.Count | Should Be 0
     }
 
     It "HistoryInfo calculates Duration" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/History.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/History.Tests.ps1
@@ -116,13 +116,13 @@ Describe "History cmdlet test cases" -Tags "CI" {
         $duration = [timespan] "1:2:21"
         $end = $start + $duration
         $history = [PSCustomObject] @{
-                CommandLine="command"
-                ExecutionStatus=[Management.Automation.Runspaces.PipelineState]::Completed
-                StartExecutionTime=$start
-                EndExecutionTime=$end
+            CommandLine        = "command"
+            ExecutionStatus    = [Management.Automation.Runspaces.PipelineState]::Completed
+            StartExecutionTime = $start
+            EndExecutionTime   = $end
         }
         $history | Add-History
         $h = Get-History -count 1
-        $h.Duration | Should Be $duration
+        $h.Duration | Should -Be $duration
     }
 }


### PR DESCRIPTION
Fixes #4181 
Adding a property Duration to HistoryInfo to end the  `{$_.EndExecutionTime - $_.StartExecutionTime}` madness :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/powershell/5208)
<!-- Reviewable:end -->
