### PR TITLE
Update install/build scripts and dockerfiles due to the executable name change

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,10 +35,10 @@ install:
       npm install -g markdown-spellcheck@0.11.0;
     fi
   - ulimit -n 4096
-  - powershell -File tools/travis.ps1 -Bootstrap
+  - pwsh -File tools/travis.ps1 -Bootstrap
 
 script:
-  - powershell -File tools/travis.ps1
+  - pwsh -File tools/travis.ps1
   # spellcheck
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
       mdspell '**/*.md' '!powershell/**/*.md' --ignore-numbers --ignore-acronyms --report;

--- a/tools/debug.sh
+++ b/tools/debug.sh
@@ -18,5 +18,5 @@ Most useful commands are 'clrstack', 'clrthreads', and 'pe'.
 EOF
 
 pushd debug
-lldb-3.6 -o "plugin load libsosplugin.so" -- ./powershell $@
+lldb-3.6 -o "plugin load libsosplugin.so" -- ./pwsh $@
 popd

--- a/tools/installpsh-debian.sh
+++ b/tools/installpsh-debian.sh
@@ -132,7 +132,7 @@ $SUDO apt-get update
 # Install PowerShell
 $SUDO apt-get install -y powershell
 
-powershell -noprofile -c '"Congratulations! PowerShell is installed at $PSHOME"'
+pwsh -noprofile -c '"Congratulations! PowerShell is installed at $PSHOME"'
 success=$?
 
 if [[ "$success" != 0 ]]; then

--- a/tools/installpsh-osx.sh
+++ b/tools/installpsh-osx.sh
@@ -141,7 +141,7 @@ if [[ ! -d $(brew --prefix cask) ]]; then
     fi
 fi
 
-if ! hash powershell 2>/dev/null; then
+if ! hash pwsh 2>/dev/null; then
     echo "Installing PowerShell..."
     if ! brew cask install powershell; then
         echo "ERROR: PowerShell failed to install! Cannot install powershell..." >&2
@@ -165,7 +165,7 @@ if [[ "'$*'" =~ includeide ]] ; then
     code --install-extension ms-vscode.PowerShell
 fi
 
-powershell -noprofile -c '"Congratulations! PowerShell is installed at $PSHOME"'
+pwsh -noprofile -c '"Congratulations! PowerShell is installed at $PSHOME"'
 success=$?
 
 if [[ "$success" != 0 ]]; then

--- a/tools/installpsh-redhat.sh
+++ b/tools/installpsh-redhat.sh
@@ -129,7 +129,7 @@ echo "*** Setting up PowerShell Core repo..."
 $SUDO curl https://packages.microsoft.com/config/rhel/7/prod.repo > /etc/yum.repos.d/microsoft.repo
 $SUDO yum install -y powershell
 
-powershell -noprofile -c '"Congratulations! PowerShell is installed at $PSHOME"'
+pwsh -noprofile -c '"Congratulations! PowerShell is installed at $PSHOME"'
 success=$?
 
 if [[ "$success" != 0 ]]; then

--- a/tools/releaseBuild/Images/microsoft_powershell_centos7/Dockerfile
+++ b/tools/releaseBuild/Images/microsoft_powershell_centos7/Dockerfile
@@ -24,4 +24,4 @@ RUN yum install -y \
 COPY PowerShellPackage.ps1 /
 
 # Use PowerShell as the default shell
-ENTRYPOINT [ "powershell" ]
+ENTRYPOINT [ "pwsh" ]

--- a/tools/releaseBuild/Images/microsoft_powershell_ubuntu14.04/Dockerfile
+++ b/tools/releaseBuild/Images/microsoft_powershell_ubuntu14.04/Dockerfile
@@ -33,4 +33,4 @@ RUN apt-get update \
 COPY PowerShellPackage.ps1 /
 
 # Use PowerShell as the default shell
-ENTRYPOINT [ "powershell" ]
+ENTRYPOINT [ "pwsh" ]

--- a/tools/releaseBuild/Images/microsoft_powershell_ubuntu16.04/Dockerfile
+++ b/tools/releaseBuild/Images/microsoft_powershell_ubuntu16.04/Dockerfile
@@ -31,4 +31,4 @@ RUN apt-get update \
 COPY PowerShellPackage.ps1 /
 
 # Use PowerShell as the default shell
-ENTRYPOINT [ "powershell" ]
+ENTRYPOINT [ "pwsh" ]

--- a/tools/releaseBuild/vstsbuild.sh
+++ b/tools/releaseBuild/vstsbuild.sh
@@ -1,1 +1,1 @@
-powershell -command ".\vstsbuild.ps1 $*"
+pwsh -command ".\vstsbuild.ps1 $*"


### PR DESCRIPTION
Need to update install script, otherwise, Travis-CI will fail.

**Note that:** the `installpsh-osx.sh` depends on homebrew to install macOS package, so this script will fail until the new macOS package is uploaded to homebrew, which depends on the package being available on Github release page.