### PR TITLE
Remove @vors from engine area owners. Add a regex for Language area.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -41,7 +41,7 @@ demos/                                             @joeyaiello @SteveL-MSFT @Hem
 src/System.Management.Automation/DscSupport        @TravisEz13 @dantraMSFT
 
 # Area: engine
-src/System.Management.Automation/engine            @daxian-dbw @vors @lzybkr @BrucePay
+src/System.Management.Automation/engine            @daxian-dbw @lzybkr @BrucePay
 
 # Area: Debugging
 # Must be below engine to override
@@ -54,6 +54,7 @@ src/System.Management.Automation/help              @Francisco-Gamino @adityapatw
 # @daxian-dbw @lzybkr @charub
 
 # Area: Language
+src/System.Management.Automation/engine/parser
 # @daxian-dbw @vors @lzybkr @BrucePay
 
 # Area: Providers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -54,8 +54,7 @@ src/System.Management.Automation/help              @Francisco-Gamino @adityapatw
 # @daxian-dbw @lzybkr @charub
 
 # Area: Language
-src/System.Management.Automation/engine/parser
-# @daxian-dbw @vors @lzybkr @BrucePay
+src/System.Management.Automation/engine/parser     @daxian-dbw @vors @lzybkr @BrucePay
 
 # Area: Providers
 src/System.Management.Automation/namespaces        @BrucePay @anmenaga


### PR DESCRIPTION
I'm getting too many PR notifications that I don't have a chance to look at. Hence removing myself from the owners.
`src/System.Management.Automation/engine/parser` is not a very accurate prefix for Language, but it's a fine-ish first approximation imo. 