### PR TITLE
Documentation fix about rename to pwsh

### DIFF
--- a/demos/SSHRemoting/README.md
+++ b/demos/SSHRemoting/README.md
@@ -77,7 +77,7 @@ In addition you will need to enable password authentication and optionally key b
     ```
     - Add a PowerShell subsystem entry
     ```none
-    Subsystem powershell /usr/bin/powershell -sshs -NoLogo -NoProfile
+    Subsystem powershell /usr/bin/pwsh -sshs -NoLogo -NoProfile
     ```
     - Optionally enable key authentication
     ```none


### PR DESCRIPTION
Fix SSH remoting documentation which only got partially updated with respect to the rename of the PowerShell binary to pwsh.
Because I was setting up remoting again and it was not working at first, I could actually repro that changing the line as proposed in this PR made it work again.