### PR TITLE
import-module incorrectly reporting a loaded module was not found

### DIFF
--- a/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
@@ -317,11 +317,11 @@ namespace Microsoft.PowerShell.Commands
 
                             module = LoadUsingExtensions(parentModule, name, qualifiedPath, extension, null, this.BasePrefix, ss, options, manifestProcessingFlags, out found);
                         }
+                        if (found)
+                        {
+                            break;
+                        }
 #if UNIX
-                    }
-                    if (found)
-                    {
-                        break;
                     }
                 }
                 if (found)

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Import-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Import-Module.Tests.ps1
@@ -36,7 +36,7 @@
 
     It "should be able to load an already loaded module" {
         Import-Module $moduleName
-        { $script:module = Import-Module $moduleName -PassThru } | Should Not Throw
+        { $script:module = Import-Module $moduleName -PassThru -ErrorAction Stop } | Should Not Throw
         Get-Module -Name $moduleName | Should Be $script:module
     }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Import-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Import-Module.Tests.ps1
@@ -1,5 +1,17 @@
 ﻿Describe "Import-Module" -Tags "CI" {
     $moduleName = "Microsoft.PowerShell.Security"
+    BeforeAll {
+        $originalPSModulePath = $env:PSModulePath
+        New-Item -ItemType Directory -Path "$testdrive\Modules\TestModule\1.1" -Force > $null
+        New-Item -ItemType Directory -Path "$testdrive\Modules\TestModule\2.0" -Force > $null
+        $env:PSModulePath += [System.IO.Path]::PathSeparator + "$testdrive\Modules"
+        New-ModuleManifest -Path "$testdrive\Modules\TestModule\1.1\TestModule.psd1" -ModuleVersion 1.1
+        New-ModuleManifest -Path "$testdrive\Modules\TestModule\2.0\TestModule.psd1" -ModuleVersion 2.0
+    }
+
+    AfterAll {
+        $env:PSModulePath = $originalPSModulePath
+    }
 
     BeforeEach {
         Remove-Module -Name $moduleName -Force
@@ -26,6 +38,11 @@
         Import-Module $moduleName
         { $script:module = Import-Module $moduleName -PassThru } | Should Not Throw
         Get-Module -Name $moduleName | Should Be $script:module
+    }
+
+    It "should only load the specified version" {
+        Import-Module TestModule -RequiredVersion 1.1
+        (Get-Module TestModule).Version | Should Be "1.1"
     }
 }
 


### PR DESCRIPTION
missing break after module was loaded successfully so loop continues
but module isn't "found" and thus reports error even though loaded

Fix https://github.com/PowerShell/PowerShell/issues/5232

<!--

If you are a PowerShell Team member, please make sure you choose the Reviewer(s) and Assignee for your PR.
If you are not from the PowerShell Team, you can leave the fields blank and the Maintainers will choose them for you. If you are familiar with the team, feel free to mention some Reviewers yourself.

For more information about the roles of Reviewer and Assignee, refer to [CONTRIBUTING.md](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md).

-->
