### PR TITLE
Fix performance issues in Add-Type

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/AddType.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/AddType.cs
@@ -913,15 +913,44 @@ namespace Microsoft.PowerShell.Commands
                     String.Equals(ParameterSetName, "FromLiteralPath", StringComparison.OrdinalIgnoreCase)
                    )
                 {
-                    StringBuilder sb = new StringBuilder(paths.Length);
-
-                    foreach (string file in paths)
+                    if (paths.Length == 1)
                     {
-                        sb.Append(System.IO.File.ReadAllText(file));
-                        sb.Append("\n");
+                        sourceCode = File.ReadAllText(paths[0]);
                     }
+                    else
+                    {
 
-                    sourceCode = sb.ToString();
+                        long initLength = 0;
+
+                        foreach (string file in paths)
+                        {
+                            FileInfo f = new FileInfo(file);
+                            initLength = f.Length;
+                        }
+
+                        if (initLength < int.MaxValue)
+                        {
+                            StringBuilder sb = new StringBuilder((int)initLength);
+
+                            foreach (string file in paths)
+                            {
+                                foreach (string line in File.ReadAllLines(file))
+                                {
+                                    sb.AppendLine(line);
+                                }
+                            }
+
+                            sourceCode = sb.ToString();
+                        }
+                        else
+                        {
+                            sourceCode = "";
+                            foreach (string file in paths)
+                            {
+                                sourceCode += System.IO.File.ReadAllText(file) + "\n";
+                            }
+                        }
+                    }
                 }
                 else if (String.Equals(ParameterSetName, "FromMember", StringComparison.OrdinalIgnoreCase))
                 {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/AddType.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/AddType.cs
@@ -914,7 +914,6 @@ namespace Microsoft.PowerShell.Commands
                    )
                 {
                     StringBuilder sb = new StringBuilder(paths.Length);
-                    sourceCode = "";
 
                     foreach (string file in paths)
                     {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/AddType.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/AddType.cs
@@ -920,17 +920,10 @@ namespace Microsoft.PowerShell.Commands
                     else
                     {
 
-                        long initLength = 0;
-
                         // We replace 'ReadAllText' with 'StringBuilder' and 'ReadAllLines'
                         // to avoide temporary LOH allocations.
-                        foreach (string file in paths)
-                        {
-                            FileInfo f = new FileInfo(file);
-                            initLength += f.Length;
-                        }
 
-                        StringBuilder sb = new StringBuilder((int)initLength);
+                        StringBuilder sb = new StringBuilder(8192);
 
                         foreach (string file in paths)
                         {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/AddType.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/AddType.cs
@@ -853,12 +853,12 @@ namespace Microsoft.PowerShell.Commands
             {
                 if (!String.IsNullOrEmpty(error.FileName))
                 {
-                    actualSource = System.IO.File.ReadAllText(error.FileName).Split(Utils.Separators.Newline);
+                    actualSource = System.IO.File.ReadAllLines(error.FileName);
                 }
             }
 
             string errorText = StringUtil.Format(AddTypeStrings.CompilationErrorFormat,
-                        error.FileName, error.Line, error.ErrorText) + "\n";
+                        error.FileName, error.Line, error.ErrorText) + Environment.NewLine;
 
             for (int lineNumber = error.Line - 1; lineNumber < error.Line + 2; lineNumber++)
             {
@@ -876,8 +876,8 @@ namespace Microsoft.PowerShell.Commands
 
                     lineText += actualSource[lineNumber - 1];
 
-                    errorText += "\n" + StringUtil.Format(AddTypeStrings.CompilationErrorFormat,
-                        error.FileName, lineNumber, lineText) + "\n";
+                    errorText += Environment.NewLine + StringUtil.Format(AddTypeStrings.CompilationErrorFormat,
+                        error.FileName, lineNumber, lineText) + Environment.NewLine;
                 }
             }
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/AddType.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/AddType.cs
@@ -922,34 +922,25 @@ namespace Microsoft.PowerShell.Commands
 
                         long initLength = 0;
 
+                        // We replace 'ReadAllText' with 'StringBuilder' and 'ReadAllLines'
+                        // to avoide temporary LOH allocations.
                         foreach (string file in paths)
                         {
                             FileInfo f = new FileInfo(file);
-                            initLength = f.Length;
+                            initLength += f.Length;
                         }
 
-                        if (initLength < int.MaxValue)
-                        {
-                            StringBuilder sb = new StringBuilder((int)initLength);
+                        StringBuilder sb = new StringBuilder((int)initLength);
 
-                            foreach (string file in paths)
-                            {
-                                foreach (string line in File.ReadAllLines(file))
-                                {
-                                    sb.AppendLine(line);
-                                }
-                            }
-
-                            sourceCode = sb.ToString();
-                        }
-                        else
+                        foreach (string file in paths)
                         {
-                            sourceCode = "";
-                            foreach (string file in paths)
+                            foreach (string line in File.ReadAllLines(file))
                             {
-                                sourceCode += System.IO.File.ReadAllText(file) + "\n";
+                                sb.AppendLine(line);
                             }
                         }
+
+                        sourceCode = sb.ToString();
                     }
                 }
                 else if (String.Equals(ParameterSetName, "FromMember", StringComparison.OrdinalIgnoreCase))

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Add-Type.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Add-Type.Tests.ps1
@@ -1,6 +1,38 @@
-$guid = [Guid]::NewGuid().ToString().Replace("-","")
-
 Describe "Add-Type" -Tags "CI" {
+    BeforeAll {
+        $guid = [Guid]::NewGuid().ToString().Replace("-","")
+
+        $code1 = @"
+        namespace Test.AddType
+        {
+            public class BasicTest1
+            {
+                public static int Add1(int a, int b)
+                {
+                    return (a + b);
+                }
+            }
+        }
+"@
+        $code2 = @"
+        namespace Test.AddType
+        {
+            public class BasicTest2
+            {
+                public static int Add2(int a, int b)
+                {
+                    return (a + b);
+                }
+            }
+        }
+"@
+        $codeFile1 = Join-Path -Path $TestDrive -ChildPath "codeFile1.cs"
+        $codeFile2 = Join-Path -Path $TestDrive -ChildPath "codeFile2.cs"
+
+        Set-Content -Path $codeFile1 -Value $code1 -Force
+        Set-Content -Path $codeFile2 -Value $code2 -Force
+    }
+
     It "Public 'Language' enumeration contains all members" {
         [Enum]::GetNames("Microsoft.PowerShell.Commands.Language") -join "," | Should Be "CSharp,CSharpVersion7,CSharpVersion6,CSharpVersion5,CSharpVersion4,CSharpVersion3,CSharpVersion2,CSharpVersion1,VisualBasic,JScript"
     }
@@ -19,5 +51,16 @@ public class AttributeTest$guid {}
 
     It "Can load TPA assembly System.Runtime.Serialization.Primitives.dll" {
         Add-Type -AssemblyName 'System.Runtime.Serialization.Primitives' -PassThru | Should Not Be $null
+    }
+
+    It "Can compile C# files" {
+
+        { [Test.AddType.BasicTest1]::Add1(1, 2) } | Should Throw
+        { [Test.AddType.BasicTest2]::Add2(3, 4) } | Should Throw
+
+        Add-Type -Path $codeFile1,$codeFile2
+
+        { [Test.AddType.BasicTest1]::Add1(1, 2) } | Should Not Throw
+        { [Test.AddType.BasicTest2]::Add2(3, 4) } | Should Not Throw
     }
 }


### PR DESCRIPTION
Related #5158.

### Fix description

Commit 1. Minor optimizations in `OutputError()`.

Commit 2. Before the fix we read sources files twice in base.EndProcessing() and in this.EndProcessing() - it is excluded. Also now we read source files in StringBuilder to exclude large reallocations. Added one test.

### Additional considerations
I expect the fix remove performance issues reported in #5158. So we can close the Issue by the PR and open new Issue to discuss refactoring the code to use ` CompileAssemblyFromFile()`. Using Roslyn can open paths to enhance the Add-Type cmdlet's capabilities but requires a lot of work.