### PR TITLE
Make sure web hook gets called

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ install:
       npm install -g markdown-spellcheck@0.11.0;
     fi
   - ulimit -n 4096
-  - pwsh -File tools/travis.ps1 -Bootstrap
+  - pwsh -File tools/travis.ps1 -Stage Bootstrap
 
 script:
   - pwsh -File tools/travis.ps1
@@ -43,3 +43,9 @@ script:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
       mdspell '**/*.md' '!powershell/**/*.md' --ignore-numbers --ignore-acronyms --report;
     fi
+
+after_failure:
+  - pwsh -File tools/travis.ps1 -Stage Failure
+
+after_success:
+  - pwsh -File tools/travis.ps1 -Stage Success

--- a/tools/travis.ps1
+++ b/tools/travis.ps1
@@ -271,6 +271,7 @@ elseif($Stage -eq 'Build')
                 Start-NativeExecution -sb {dotnet nuget push $package --api-key $env:NUGET_KEY --source "$env:NUGET_URL/api/v2/package"} -IgnoreExitcode
             }            
         }
+    }
 
     # if the tests did not pass, throw the reason why
     if ( $result -eq "FAIL" ) {

--- a/tools/travis.ps1
+++ b/tools/travis.ps1
@@ -285,7 +285,7 @@ elseif($Stage -in 'Failure', 'Success')
         $result = 'FAIL'
     }
 
-    if ((-not $isPr) -and $cronBuild) {
+    if ($cronBuild) {
         # update the badge if you've done a cron build, these are not fatal issues
         try {
             $svgData = Get-DailyBadge -result $result


### PR DESCRIPTION
if something goes wrong during the build, we might exit and not update the badge or fire the webhook.

Enable the `after_success` and `after_failure` stages of the travis-ci build so we can have a better chance of getting these done.