### PR TITLE
change VSCode build task to use pwsh

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,6 +1,6 @@
 {
     "version": "0.1.0",
-    "command": "powershell",
+    "command": "pwsh",
     "isShellCommand": true,
     "showOutput": "always",
     "suppressTaskName": true,


### PR DESCRIPTION
Now that beta.9 is out, we need to update VSCode tasks.json so that it uses pwsh to do the build

<!--

If you are a PowerShell Team member, please make sure you choose the Reviewer(s) and Assignee for your PR.
If you are not from the PowerShell Team, you can leave the fields blank and the Maintainers will choose them for you. If you are familiar with the team, feel free to mention some Reviewers yourself.

For more information about the roles of Reviewer and Assignee, refer to [CONTRIBUTING.md](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md).

-->
