### PR TITLE
Fix PSUserAgent Generation Exception on Windows 7

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/PSUserAgent.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/PSUserAgent.cs
@@ -6,6 +6,7 @@ using System;
 using System.Management.Automation;
 using System.Runtime.InteropServices;
 using System.Globalization;
+using System.Text.RegularExpressions;
 
 namespace Microsoft.PowerShell.Commands
 {
@@ -131,7 +132,8 @@ namespace Microsoft.PowerShell.Commands
                     // only generate the windows user agent once
                     if(s_windowsUserAgent == null){
                         // find the version in the windows operating system description
-                        string versionText = OS.Substring(OS.LastIndexOf(" ") +1);
+                        Regex pattern = new Regex(@"\d+(\.\d+)+");
+                        string versionText = pattern.Match(OS).Value;
                         Version windowsPlatformversion = new Version(versionText);
                         s_windowsUserAgent = $"Windows NT {windowsPlatformversion.Major}.{windowsPlatformversion.Minor}";
                     }


### PR DESCRIPTION
fixes #5242 

On Windows 7 `RuntimeInformation.OSDescription` produces `Microsoft Windows 6.1.7601 S`. This resulted in `S` attempting to be evaluated as a `Version` and a `System.ArgumentException: Version string portion was too short or too long.` exception.

This PR switches to a regex capture of the version from the `OSDescription` String.

I have verfied this is working on windows 10 and Windows 7

```none
Name                           Value
----                           -----
PSVersion                      6.0.0-beta.9
PSEdition                      Core
GitCommitId                    v6.0.0-beta.9-12-gb78af9477186032e675b990df629dbc2f15d0a13
OS                             Microsoft Windows 6.1.7601 S
Platform                       Win32NT
PSCompatibleVersions           {1.0, 2.0, 3.0, 4.0...}
PSRemotingProtocolVersion      2.3
SerializationVersion           1.1.0.1
WSManStackVersion              3.0
```

```none
Name                           Value
----                           -----
PSVersion                      6.0.0-beta.9
PSEdition                      Core
GitCommitId                    v6.0.0-beta.9-12-gb78af9477186032e675b990df629dbc2f15d0a13
OS                             Microsoft Windows 10.0.15063
Platform                       Win32NT
PSCompatibleVersions           {1.0, 2.0, 3.0, 4.0...}
PSRemotingProtocolVersion      2.3
SerializationVersion           1.1.0.1
WSManStackVersion              3.0
```