### PR TITLE
Porting random hang fixes

### DIFF
--- a/src/System.Management.Automation/engine/remoting/client/Job.cs
+++ b/src/System.Management.Automation/engine/remoting/client/Job.cs
@@ -1542,14 +1542,25 @@ namespace System.Management.Automation
         /// </summary>
         internal void CloseAllStreams()
         {
-            if (_resultsOwner) _results.Complete();
-            if (_outputOwner) _output.Complete();
-            if (_errorOwner) _error.Complete();
-            if (_progressOwner) _progress.Complete();
-            if (_verboseOwner) _verbose.Complete();
-            if (_warningOwner) _warning.Complete();
-            if (_debugOwner) _debug.Complete();
-            if (_informationOwner) _information.Complete();
+            // The Complete() method includes raising public notification events that third parties can
+            // handle and potentially throw exceptions on the notification thread.  We don't want to 
+            // propagate those exceptions because it prevents this thread from completing its processing.
+            if (_resultsOwner) { try { _results.Complete(); } catch (Exception e) { TraceException(e); } }
+            if (_outputOwner) { try { _output.Complete(); } catch (Exception e) { TraceException(e); } }
+            if (_errorOwner) { try { _error.Complete(); } catch (Exception e) { TraceException(e); } }
+            if (_progressOwner) { try { _progress.Complete(); } catch (Exception e) { TraceException(e); } }
+            if (_verboseOwner) { try { _verbose.Complete(); } catch (Exception e) { TraceException(e); } }
+            if (_warningOwner) { try { _warning.Complete(); } catch (Exception e) { TraceException(e); } }
+            if (_debugOwner) { try { _debug.Complete(); } catch (Exception e) { TraceException(e); } }
+            if (_informationOwner) { try { _information.Complete(); } catch (Exception e) { TraceException(e); } }
+        }
+
+        private static void TraceException(Exception e)
+        {
+            using (PowerShellTraceSource tracer = PowerShellTraceSourceFactory.GetTraceSource())
+            {
+                tracer.TraceException(e);
+            }
         }
 
         /// <summary>

--- a/src/System.Management.Automation/engine/remoting/commands/InvokeCommandCommand.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/InvokeCommandCommand.cs
@@ -1624,7 +1624,12 @@ namespace Microsoft.PowerShell.Commands
         /// <param name="nonblocking">Write in a non-blocking manner</param>
         private void WriteJobResults(bool nonblocking)
         {
-            if (_job != null)
+            if (_job == null)
+            {
+                return;
+            }
+
+            try
             {
                 PipelineStoppedException caughtPipelineStoppedException = null;
                 _job.PropagateThrows = _propagateErrors;
@@ -1756,7 +1761,12 @@ namespace Microsoft.PowerShell.Commands
                                     session.Name, session.InstanceId));
                         }
                     }
-
+                }
+            }
+            finally
+            {
+                if (_job.JobStateInfo.State == JobState.Disconnected)
+                {
                     // Allow Invoke-Command to end even though not all remote pipelines
                     // finished.
                     HandleThrottleComplete(null, null);


### PR DESCRIPTION
These are two fixes for random hangs found internally.

The first fix (job.cs) is for data stream Close calls on PSDataCollection objects because the method also raises public events.  If an exception is thrown on the event handler then the thread never completes job clean up causing a hang.  Fix is to catch all thrown exceptions and report.

The second (invokecommandcommand.cs) fixes a hang scenario where a remote job goes into disconnected state while simultaneously handling an exception.  Fix is to use try/finally pattern to ensure Invoke-Command can always complete with jobs in the disconnected state.