### PR TITLE
fix sparse-checkout list

### DIFF
--- a/test/tools/CodeCoverageAutomation/Start-CodeCoverageRun.ps1
+++ b/test/tools/CodeCoverageAutomation/Start-CodeCoverageRun.ps1
@@ -251,19 +251,19 @@ try
         # operations relative to where the test location is.
         # some tests rely on source files being available in $outputBaseFolder/test
         Push-Location $outputBaseFolder
+
         # clean up partial repo clone before starting
-        if ( Test-Path "$outputBaseFolder/.git" )
+        $cleanupDirectories = "${outputBaseFolder}/.git",
+            "${outputBaseFolder}/src",
+            "${outputBaseFolder}/assets"
+        foreach($directory in $cleanupDirectories)
         {
-            Remove-Item -Force -Recurse "${outputBaseFolder}/.git"
+            if ( Test-Path "$directory" )
+            {
+                Remove-Item -Force -Recurse "$directory"
+            }
         }
-        if ( Test-Path "$outputBaseFolder/src" )
-        {
-            Remove-Item -Force -Recurse "${outputBaseFolder}/src"
-        }
-        if ( Test-Path "$outputBaseFolder/assests" )
-        {
-            Remove-Item -Force -Recurse "${outputBaseFolder}/assets"
-        }
+
         Write-LogPassThru -Message "initializing repo in $outputBaseFolder"
         & $gitexe init
         Write-LogPassThru -Message "git operation 'init' returned $LASTEXITCODE"
@@ -277,7 +277,7 @@ try
         Write-LogPassThru -Message "git operation 'set sparse-checkout' returned $LASTEXITCODE"
 
         Write-LogPassThru -Message "pulling sparse repo"
-        "src" | Out-File -Encoding ascii .git\info\sparse-checkout -Force
+        "/src" | Out-File -Encoding ascii .git\info\sparse-checkout -Force
         "/assets" | Out-File -Encoding ascii .git\info\sparse-checkout -Append
         & $gitexe pull origin master
         Write-LogPassThru -Message "git operation 'pull' returned $LASTEXITCODE"

--- a/test/tools/OpenCover/OpenCover.psm1
+++ b/test/tools/OpenCover/OpenCover.psm1
@@ -702,12 +702,12 @@ function Invoke-OpenCover
             # '&' invoke caused issues with cmdline parameters for opencover.console.exe
             $elevatedFile = "$env:temp\elevated.ps1"
             "$OpenCoverBin $cmdlineElevated" | Out-File -FilePath $elevatedFile -force
-            pwsh.exe -file $elevatedFile
+            powershell.exe -file $elevatedFile
 
             # invoke OpenCover unelevated and poll for completion
             $unelevatedFile = "$env:temp\unelevated.ps1"
             "$openCoverBin $cmdlineUnelevated" | Out-File -FilePath $unelevatedFile -Force
-            runas.exe /trustlevel:0x20000 "pwsh.exe -file $unelevatedFile"
+            runas.exe /trustlevel:0x20000 "powershell.exe -file $unelevatedFile"
             # poll for process exit every 60 seconds
             # timeout of 6 hours
             # Runs currently take about 2.5 - 3 hours, we picked 6 hours to be substantially larger.


### PR DESCRIPTION
Run powershell.exe in OpenCover since it will be in the path.
If there's an error in Start-CodeCoverageRun be sure to log as much as possible

