### PR TITLE
[Feature] Add Multiple Link Header Support

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebRequestPSCmdlet.CoreClr.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebRequestPSCmdlet.CoreClr.cs
@@ -847,17 +847,20 @@ namespace Microsoft.PowerShell.Commands
             IEnumerable<string> links;
             if (response.Headers.TryGetValues("Link", out links))
             {
-                foreach(string link in links.FirstOrDefault().Split(","))
+                foreach (string linkHeader in links)
                 {
-                    Match match = Regex.Match(link, pattern);
-                    if (match.Success)
+                    foreach (string link in linkHeader.Split(","))
                     {
-                        string url = match.Groups["url"].Value;
-                        string rel = match.Groups["rel"].Value;
-                        if (url != String.Empty && rel != String.Empty && !_relationLink.ContainsKey(rel))
+                        Match match = Regex.Match(link, pattern);
+                        if (match.Success)
                         {
-                            Uri absoluteUri = new Uri(requestUri, url);
-                            _relationLink.Add(rel, absoluteUri.AbsoluteUri.ToString());
+                            string url = match.Groups["url"].Value;
+                            string rel = match.Groups["rel"].Value;
+                            if (url != String.Empty && rel != String.Empty && !_relationLink.ContainsKey(rel))
+                            {
+                                Uri absoluteUri = new Uri(requestUri, url);
+                                _relationLink.Add(rel, absoluteUri.AbsoluteUri.ToString());
+                            }
                         }
                     }
                 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -803,7 +803,7 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
         $result.Output.RelationLink["last"] | Should BeExactly "http://localhost:8080/PowerShell?test=linkheader&maxlinks=5&linknumber=5"
     }
 
-    # Test pending support for multiple header capable server on Linux/macOS ses issue #4639
+    # Test pending support for multiple header capable server on Linux/macOS see issue #4639
     It "Validate Invoke-WebRequest returns valid RelationLink property with absolute uris if Multiple Link Headers are present" -Pending:$(!$IsWindows){
         $headers = @{
             Link =


### PR DESCRIPTION
fixes #5257 

Adds support for the following response Header scenario:

```none
Link: <https://MYDEVORG.okta.com/api/v1/users?limit=200&filter=status+eq+%22STAGED%22>; rel="self"
Link: <https://MYDEVORG.okta.com/api/v1/users?after=OKTAID&limit=200&filter=status+eq+%22STAGED%22>; rel="next"
```

CoreFX treats multiple header responses as separate array elements. Unless each array element is parsed, only the first one would be accepted. The current implimentation not only returns an incomplete `RelationLink` dictionary, but also breaks `-FollowRelLink` when a sever responds with multiple  Link headers. This PR corrects both the pagination and dictionary.

The test can currently only be done on Windows as we currently lack a native server that supports returning multiple headers with the same name (see #4639). The test would only result in a false pass on Linux and macOS.