### PR TITLE
Enable macOS launcher

### DIFF
--- a/tools/packaging/macos/launcher/ROOT/Applications/PowerShell.app/Contents/Info.plist
+++ b/tools/packaging/macos/launcher/ROOT/Applications/PowerShell.app/Contents/Info.plist
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleExecutable</key>
+	<string>PowerShell.sh</string>
+	<key>CFBundleGetInfoString</key>
+	<string></string>
+	<key>CFBundleIconFile</key>
+	<string></string>
+	<key>CFBundleIdentifier</key>
+	<string></string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>PowerShell</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string></string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
+	<key>CFBundleVersion</key>
+	<string></string>
+</dict>
+</plist>

--- a/tools/packaging/macos/launcher/ROOT/Applications/PowerShell.app/Contents/MacOS/PowerShell.sh
+++ b/tools/packaging/macos/launcher/ROOT/Applications/PowerShell.app/Contents/MacOS/PowerShell.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+open /usr/local/bin/pwsh

--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -648,7 +648,7 @@ function New-UnixPackage {
                 # Set values in plist.
                 $plist = "$macosapp/Contents/Info.plist"
                 Start-NativeExecution {
-                    defaults write $plist CFBundleIdentifier $Name
+                    defaults write $plist CFBundleIdentifier com.microsoft.powershell
                     defaults write $plist CFBundleVersion $Version
                     defaults write $plist CFBundleShortVersionString $Version
                     defaults write $plist CFBundleGetInfoString $Version

--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -712,7 +712,7 @@ function New-UnixPackage {
             {
                 # This is needed to prevent installer from picking up
                 # the launcher app in the build structure and updating
-                # it which locks out subsequnent package build due to
+                # it which locks out subsequent package builds due to
                 # increase permissions.
                 $plist = "$PSScriptRoot/macos/launcher/ROOT/Applications/Powershell.app/Contents/Info.plist"
                 $tempguid = (New-Guid).Guid

--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -629,6 +629,49 @@ function New-UnixPackage {
             "$GzipFile=$ManFile",
             "/tmp/pwsh=$Link"
         )
+
+        # Add macOS powershell launcher
+        if($Type -eq "osxpkg")
+        {
+            if($pscmdlet.ShouldProcess("Add macOS launch application")) {
+                # Define folder for launch application.
+                $macosapp = "$PSScriptRoot/macos/launcher/ROOT/Applications/Powershell.app"
+
+                # Update icns file.
+                $iconfile = "$PSScriptRoot/../../assets/Powershell.icns"
+                $iconfilebase = (Get-Item -Path $iconfile).BaseName
+                # Create Resources folder, ignore error if exists.
+                New-Item -Force -ItemType Directory -Path "$macosapp/Contents/Resources" | Out-Null
+                Copy-Item -Force -Path $iconfile -Destination "$macosapp/Contents/Resources"
+
+                # Set values in plist.
+                $plist = "$macosapp/Contents/Info.plist"
+                Start-NativeExecution {
+                    defaults write $plist CFBundleIdentifier $Name
+                    defaults write $plist CFBundleVersion $Version
+                    defaults write $plist CFBundleShortVersionString $Version
+                    defaults write $plist CFBundleGetInfoString $Version
+                    defaults write $plist CFBundleIconFile $iconfilebase
+                }
+
+                # Convert to XML plist, needed because defaults native
+                # app auto converts it to binary format when it modify
+                # the plist file.
+                Start-NativeExecution {
+                    plutil -convert xml1 $plist
+                }
+
+                # Set permissions.
+                Start-NativeExecution {
+                    find $macosapp | xargs chmod 755
+                }
+
+                # Add app folder to fpm paths.
+                $appsfolder = (Resolve-Path -Path "$macosapp/..").Path
+                $Arguments += "$appsfolder=/"
+            }
+        }
+
         # Build package
         try {
             if($pscmdlet.ShouldProcess("Create $type package")) {
@@ -664,6 +707,20 @@ function New-UnixPackage {
                 $newPackageName = "{0}-{1}{2}" -f $packageNameWithoutExt, $script:Options.Runtime, $packageExt
                 $newPackagePath = Join-Path $createdPackage.DirectoryName $newPackageName
                 $createdPackage = Rename-Item $createdPackage.FullName $newPackagePath -PassThru -Force:$Force
+            }
+            if($pscmdlet.ShouldProcess("Change macOS launcher identifier"))
+            {
+                # This is needed to prevent installer from picking up
+                # the launcher app in the build structure and updating
+                # it which locks out subsequnent package build due to
+                # increase permissions.
+                $plist = "$PSScriptRoot/macos/launcher/ROOT/Applications/Powershell.app/Contents/Info.plist"
+                $tempguid = (New-Guid).Guid
+                Start-NativeExecution {
+                    defaults write $plist CFBundleIdentifier $tempguid
+                    # This magic forces macOS to recognized the change.
+                    touch $plist
+                }
             }
         }
 

--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -718,6 +718,7 @@ function New-UnixPackage {
                 $tempguid = (New-Guid).Guid
                 Start-NativeExecution {
                     defaults write $plist CFBundleIdentifier $tempguid
+                    plutil -convert xml1 $plist
                     # This magic forces macOS to recognized the change.
                     touch $plist
                 }

--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -719,8 +719,6 @@ function New-UnixPackage {
                 Start-NativeExecution {
                     defaults write $plist CFBundleIdentifier $tempguid
                     plutil -convert xml1 $plist
-                    # This magic forces macOS to recognized the change.
-                    touch $plist
                 }
             }
         }


### PR DESCRIPTION
Notable change this time around.

* Values set by script are "unset" in `Info.plist` by default to prevent conflicts if a fresh clone.
* After packaging `CFBundleIdentifier` is set to random value to prevent it from being picked up by installer. An empty value could not be used because native defaults doesn't allow it.
* The magic here is getting macOS to recognize the change in the plist file. `plutil` is enough to make this happen.

Fixes #5262