### PR TITLE
Refactor for signing

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -438,6 +438,7 @@ Fix steps:
         Configuration=$Configuration
         Verbose=$true
         SMAOnly=[bool]$SMAOnly
+        PSModuleRestore=$PSModuleRestore
     }
     $script:Options = New-PSOptions @OptionsArguments
 
@@ -602,7 +603,9 @@ function New-PSOptions {
 
         [string]$Output,
 
-        [switch]$SMAOnly
+        [switch]$SMAOnly,
+        
+        [switch]$PSModuleRestore
     )
 
     # Add .NET CLI tools to PATH
@@ -716,7 +719,8 @@ function New-PSOptions {
               Framework = $Framework;
               Runtime = $Runtime;
               Output = $Output;
-              CrossGen = $CrossGen }
+              CrossGen = $CrossGen
+              PSModuleRestore = $PSModuleRestore }
 }
 
 # Get the Options of the last build

--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -88,6 +88,9 @@ function Start-PSPackage {
         }
 
         $PSModuleRestoreCorrect = $false
+        
+        # Require PSModuleRestore for packaging without symbols
+        # But Disallow it when packaging with symbols
         if (!$IncludeSymbols.IsPresent -and $Script:Options.PSModuleRestore) {
             $PSModuleRestoreCorrect = $true
         }

--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -83,11 +83,16 @@ function Start-PSPackage {
             # crossgen doesn't support arm32 yet
             $crossGenCorrect = $true
         }
-        elseif(-not $IncludeSymbols.IsPresent -and $Script:Options.CrossGen) {
+        elseif($Script:Options.CrossGen) {
             $crossGenCorrect = $true
         }
-        elseif ($IncludeSymbols.IsPresent) {
-            $crossGenCorrect = $true
+
+        $PSModuleRestoreCorrect = $false
+        if (!$IncludeSymbols.IsPresent -and $Script:Options.PSModuleRestore) {
+            $PSModuleRestoreCorrect = $true
+        }
+        elseif ($IncludeSymbols.IsPresent -and !$Script:Options.PSModuleRestore) {
+            $PSModuleRestoreCorrect = $true
         }
 
         # Make sure the most recent build satisfies the package requirement
@@ -108,10 +113,11 @@ function Start-PSPackage {
             # also ensure `Start-PSPackage` does what the user asks/expects, because once packages
             # are generated, it'll be hard to verify if they were built from the correct content.
             $params = @('-Clean')
-            if(-not $IncludeSymbols.IsPresent)
-            {
-                $params += '-CrossGen'
+            $params += '-CrossGen'
+            if (!$IncludeSymbols.IsPresent) {
+                $params += '-PSModuleRestore'
             }
+
             $params += '-Runtime', $Runtime
             $params += '-Configuration', $Configuration
 
@@ -140,9 +146,31 @@ function Start-PSPackage {
         # If building a symbols package, don't include the publish build.
         if ($IncludeSymbols.IsPresent)
         {
+            $publishSource = $Source
             $buildSource = Split-Path -Path $Source -Parent
             $Source = New-TempFolder
-            Get-ChildItem -Path $buildSource | Where-Object {$_.Name -ine 'Publish'} | Copy-Item -Destination $Source -Recurse
+            $toExclude = @(
+                'hostfxr.dll'
+                'hostpolicy.dll'                
+                'libhostfxr.so'
+                'libhostpolicy.so'                
+                'libhostfxr.dylib'
+                'libhostpolicy.dylib'
+                'Publish'
+                )
+            Get-ChildItem -Path $buildSource | Where-Object {$toExclude -inotcontains $_.Name} | Copy-Item -Destination $Source -Recurse
+            Get-ChildItem -Recurse $Source | ForEach-Object {
+                $relativePath = $_.FullName -replace $Source, ''
+                $publishPath = Join-Path $publishSource -ChildPath $relativePath
+                if (Test-Path -Path $publishPath)
+                {
+                    Copy-Item -Path $publishPath -Destination $_.FullName -Force
+                }
+            }
+
+            $zipSource = Join-Path $publishSource -ChildPath '*' 
+            $zipPath = Join-Path -Path $Source -ChildPath 'publish.zip'
+            Compress-Archive -Path $zipSource -DestinationPath $zipPath
         }
 
         log "Packaging Source: '$Source'"

--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -88,7 +88,7 @@ function Start-PSPackage {
         }
 
         $PSModuleRestoreCorrect = $false
-        
+
         # Require PSModuleRestore for packaging without symbols
         # But Disallow it when packaging with symbols
         if (!$IncludeSymbols.IsPresent -and $Script:Options.PSModuleRestore) {
@@ -152,13 +152,13 @@ function Start-PSPackage {
             $publishSource = $Source
             $buildSource = Split-Path -Path $Source -Parent
             $Source = New-TempFolder
-            
+
             # files not to include as individual files.  These files will be included in publish.zip
             $toExclude = @(
                 'hostfxr.dll'
-                'hostpolicy.dll'                
+                'hostpolicy.dll'
                 'libhostfxr.so'
-                'libhostpolicy.so'                
+                'libhostpolicy.so'
                 'libhostfxr.dylib'
                 'libhostpolicy.dylib'
                 'Publish'
@@ -175,7 +175,7 @@ function Start-PSPackage {
                 }
             }
 
-            $zipSource = Join-Path $publishSource -ChildPath '*' 
+            $zipSource = Join-Path $publishSource -ChildPath '*'
             $zipPath = Join-Path -Path $Source -ChildPath 'publish.zip'
             Compress-Archive -Path $zipSource -DestinationPath $zipPath
         }

--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -149,6 +149,8 @@ function Start-PSPackage {
             $publishSource = $Source
             $buildSource = Split-Path -Path $Source -Parent
             $Source = New-TempFolder
+            
+            # files not to include as individual files.  These files will be included in publish.zip
             $toExclude = @(
                 'hostfxr.dll'
                 'hostpolicy.dll'                
@@ -159,6 +161,8 @@ function Start-PSPackage {
                 'Publish'
                 )
             Get-ChildItem -Path $buildSource | Where-Object {$toExclude -inotcontains $_.Name} | Copy-Item -Destination $Source -Recurse
+
+            # Replace binaries with crossgen'ed binaires from publish folder.
             Get-ChildItem -Recurse $Source | ForEach-Object {
                 $relativePath = $_.FullName -replace $Source, ''
                 $publishPath = Join-Path $publishSource -ChildPath $relativePath

--- a/tools/releaseBuild/Images/microsoft_powershell_windowsservercore/PowerShellPackage.ps1
+++ b/tools/releaseBuild/Images/microsoft_powershell_windowsservercore/PowerShellPackage.ps1
@@ -61,12 +61,13 @@ try{
 
     Write-Verbose "Starting powershell build for RID: $Runtime and ReleaseTag: $ReleaseTag ..." -verbose
     $buildParams = @{}
+    $buildParams['CrossGen'] = $true
     if(!$Symbols.IsPresent)
     {
-        $buildParams['CrossGen'] = $true
+        $buildParams['PSModuleRestore'] = $true
     }
 
-    Start-PSBuild -Clean -PSModuleRestore -Runtime $Runtime -Configuration Release @releaseTagParam @buildParams
+    Start-PSBuild -Clean -Runtime $Runtime -Configuration Release @releaseTagParam @buildParams
 
     $pspackageParams = @{'Type'='msi'}
     if ($Runtime -ne 'win10-x64')


### PR DESCRIPTION
1. make symbols zip include the crossgen'ed files
1. make symbols zip include a zip for the publish folder.
1. make symbols zip not allow PSModuleRestore
