### PR TITLE
Rework passing array literal to native commands

### DIFF
--- a/src/System.Management.Automation/engine/CommandParameter.cs
+++ b/src/System.Management.Automation/engine/CommandParameter.cs
@@ -24,7 +24,6 @@ namespace System.Management.Automation
             internal Ast ast;
             internal object value;
             internal bool splatted;
-            internal bool arrayIsSingleArgumentForNativeCommand;
         }
 
         private Parameter _parameter;
@@ -114,16 +113,6 @@ namespace System.Management.Automation
         }
 
         /// <summary>
-        /// If an argument was specified and it was an array literal with no spaces around the
-        /// commas, the value should be passed a single argument with it's commas if the command is
-        /// a native command.
-        /// </summary>
-        internal bool ArrayIsSingleArgumentForNativeCommand
-        {
-            get { return _argument != null ? _argument.arrayIsSingleArgumentForNativeCommand : false; }
-        }
-
-        /// <summary>
         /// Set the argument value and ast.
         /// </summary>
         internal void SetArgumentValue(Ast ast, object value)
@@ -175,12 +164,10 @@ namespace System.Management.Automation
         /// <param name="value">The argument value.</param>
         /// <param name="ast">The ast of the argument value in the script.</param>
         /// <param name="splatted">True if the argument value is to be splatted, false otherwise.</param>
-        /// <param name="arrayIsSingleArgumentForNativeCommand">If the command is native, pass the string with commas instead of multiple arguments</param>
         internal static CommandParameterInternal CreateArgument(
             object value,
             Ast ast = null,
-            bool splatted = false,
-            bool arrayIsSingleArgumentForNativeCommand = false)
+            bool splatted = false)
         {
             return new CommandParameterInternal
             {
@@ -189,7 +176,6 @@ namespace System.Management.Automation
                     value = value,
                     ast = ast,
                     splatted = splatted,
-                    arrayIsSingleArgumentForNativeCommand = arrayIsSingleArgumentForNativeCommand
                 }
             };
         }
@@ -210,20 +196,18 @@ namespace System.Management.Automation
         /// <param name="argumentAst">The ast of the argument value in the script.</param>
         /// <param name="value">The argument value.</param>
         /// <param name="spaceAfterParameter">Used in native commands to correctly handle -foo:bar vs. -foo: bar</param>
-        /// <param name="arrayIsSingleArgumentForNativeCommand">If the command is native, pass the string with commas instead of multiple arguments</param>
         internal static CommandParameterInternal CreateParameterWithArgument(
             Ast parameterAst,
             string parameterName,
             string parameterText,
             Ast argumentAst,
             object value,
-            bool spaceAfterParameter,
-            bool arrayIsSingleArgumentForNativeCommand = false)
+            bool spaceAfterParameter)
         {
             return new CommandParameterInternal
             {
                 _parameter = new Parameter { ast = parameterAst, parameterName = parameterName, parameterText = parameterText },
-                _argument = new Argument { ast = argumentAst, value = value, arrayIsSingleArgumentForNativeCommand = arrayIsSingleArgumentForNativeCommand },
+                _argument = new Argument { ast = argumentAst, value = value },
                 _spaceAfterParameter = spaceAfterParameter
             };
         }

--- a/src/System.Management.Automation/engine/MinishellParameterBinderController.cs
+++ b/src/System.Management.Automation/engine/MinishellParameterBinderController.cs
@@ -214,7 +214,7 @@ namespace System.Management.Automation
                         parameters[i] = CommandParameterInternal.CreateParameterWithArgument(
                             parameter.ArgumentAst, EncodedCommandParameter, "-" + EncodedCommandParameter,
                             parameter.ArgumentAst, encodedScript,
-                            spaceAfterParameter: true, arrayIsSingleArgumentForNativeCommand: false);
+                            spaceAfterParameter: true);
                     }
                 }
             }

--- a/src/System.Management.Automation/engine/NativeCommandParameterBinder.cs
+++ b/src/System.Management.Automation/engine/NativeCommandParameterBinder.cs
@@ -366,19 +366,14 @@ namespace System.Management.Automation
             var afterPrev = prev.Extent.EndOffset;
             var beforeNext = next.Extent.StartOffset - 1;
 
-            if (afterPrev == beforeNext)
-                return ",";
+            if (afterPrev == beforeNext) return ",";
 
             var arrayText = arrayExtent.Text;
             afterPrev -= arrayExtent.StartOffset;
             beforeNext -= arrayExtent.StartOffset;
 
-            if (arrayText[afterPrev] == ',')
-                return ", ";
-
-            if (arrayText[beforeNext] == ',')
-                return " ,";
-
+            if (arrayText[afterPrev] == ',') return ", ";
+            if (arrayText[beforeNext] == ',') return " ,";
             return " , ";
         }
 

--- a/src/System.Management.Automation/engine/NativeCommandParameterBinder.cs
+++ b/src/System.Management.Automation/engine/NativeCommandParameterBinder.cs
@@ -105,28 +105,27 @@ namespace System.Management.Automation
 
                     if (argValue != AutomationNull.Value && argValue != UnboundParameter.Value)
                     {
-                        // ArrayIsSingleArgumentForNativeCommand is true when a comma is used in the
-                        // command line, e.g.
+                        // ArrayLiteralAst is used to reconstruct the correct argument, e.g.
                         //    windbg  -k com:port=\\devbox\pipe\debug,pipe,resets=0,reconnect
                         // The parser produced an array of strings but marked the parameter so we
                         // can properly reconstruct the correct command line.
                         bool usedQuotes = false;
-                        var pAst = parameter.ArgumentAst;
-                        if (pAst != null)
+                        ArrayLiteralAst arrayLiteralAst = null;
+                        switch (parameter?.ArgumentAst)
                         {
-                            if (pAst is StringConstantExpressionAst sce)
-                            {
-                                usedQuotes = sce.StringConstantType != StringConstantType.BareWord;
-                            }
-                            else if (pAst is ExpandableStringExpressionAst ese)
-                            {
-                                usedQuotes = ese.StringConstantType != StringConstantType.BareWord;
-                            }
+                        case StringConstantExpressionAst sce:
+                            usedQuotes = sce.StringConstantType != StringConstantType.BareWord;
+                            break;
+                        case ExpandableStringExpressionAst ese:
+                            usedQuotes = ese.StringConstantType != StringConstantType.BareWord;
+                            break;
+                        case ArrayLiteralAst ala:
+                            arrayLiteralAst = ala;
+                            break;
                         }
+
                         appendOneNativeArgument(Context, argValue,
-                            parameter.ArrayIsSingleArgumentForNativeCommand ? ',' : ' ',
-                            sawVerbatimArgumentMarker,
-                            usedQuotes);
+                            arrayLiteralAst, sawVerbatimArgumentMarker, usedQuotes);
                     }
                 }
             }
@@ -158,14 +157,19 @@ namespace System.Management.Automation
         /// </summary>
         /// <param name="context">Execution context instance</param>
         /// <param name="obj">The object to append</param>
-        /// <param name="separator">A space or comma used when obj is enumerable</param>
+        /// <param name="argArrayAst">If the argument was an array literal, the Ast, otherwise null</param>
         /// <param name="sawVerbatimArgumentMarker">true if the argument occurs after --%</param>
         /// <param name="usedQuotes">True if the argument was a quoted string (single or double)</param>
-        private void appendOneNativeArgument(ExecutionContext context, object obj, char separator, bool sawVerbatimArgumentMarker, bool usedQuotes)
+        private void appendOneNativeArgument(ExecutionContext context, object obj, ArrayLiteralAst argArrayAst, bool sawVerbatimArgumentMarker, bool usedQuotes)
         {
             IEnumerator list = LanguagePrimitives.GetEnumerator(obj);
-            bool needSeparator = false;
 
+            Diagnostics.Assert(argArrayAst == null
+                || obj is object[] && ((object[])obj).Length == argArrayAst.Elements.Count,
+                "array argument and ArrayLiteralAst differ in number of elements");
+
+            int currentElement = -1;
+            string separator = "";
             do
             {
                 string arg;
@@ -180,18 +184,17 @@ namespace System.Management.Automation
                         break;
                     }
                     arg = PSObject.ToStringParser(context, ParserOps.Current(null, list));
+
+                    currentElement += 1;
+                    if (currentElement != 0)
+                    {
+                        separator = GetEnumerableArgSeparator(argArrayAst, currentElement);
+                    }
                 }
 
                 if (!String.IsNullOrEmpty(arg))
                 {
-                    if (needSeparator)
-                    {
-                        _arguments.Append(separator);
-                    }
-                    else
-                    {
-                        needSeparator = true;
-                    }
+                    _arguments.Append(separator);
 
                     if (sawVerbatimArgumentMarker)
                     {
@@ -349,6 +352,35 @@ namespace System.Management.Automation
             return needQuotes;
         }
 
+        static private string GetEnumerableArgSeparator(ArrayLiteralAst arrayLiteralAst, int index)
+        {
+            if (arrayLiteralAst == null) return " ";
+
+            // index points to the *next* element, so we're looking for space between
+            // it and the previous element.
+
+            var next = arrayLiteralAst.Elements[index];
+            var prev = arrayLiteralAst.Elements[index - 1];
+
+            var arrayExtent = arrayLiteralAst.Extent;
+            var afterPrev = prev.Extent.EndOffset;
+            var beforeNext = next.Extent.StartOffset - 1;
+
+            if (afterPrev == beforeNext)
+                return ",";
+
+            var arrayText = arrayExtent.Text;
+            afterPrev -= arrayExtent.StartOffset;
+            beforeNext -= arrayExtent.StartOffset;
+
+            if (arrayText[afterPrev] == ',')
+                return ", ";
+
+            if (arrayText[beforeNext] == ',')
+                return " ,";
+
+            return " , ";
+        }
 
         /// <summary>
         /// The native command to bind to

--- a/test/powershell/Language/Scripting/NativeExecution/NativeCommandArguments.Tests.ps1
+++ b/test/powershell/Language/Scripting/NativeExecution/NativeCommandArguments.Tests.ps1
@@ -45,7 +45,8 @@ Describe "Native Command Arguments" -tags "CI" {
     }
 
     It "Should handle PowerShell arrays with or without spaces correctly: <arguments>" -TestCases @(
-        @{arguments = "a 1,2"; expected = "a", "1,2"}
+        @{arguments = "1,2"; expected = @("1,2")}
+        @{arguments = "1,2,3"; expected = @("1,2,3")}
         @{arguments = "1, 2"; expected = "1,", "2"}
         @{arguments = "1 ,2"; expected = "1", ",2"}
         @{arguments = "1 , 2"; expected = "1", ",", "2"}
@@ -54,9 +55,9 @@ Describe "Native Command Arguments" -tags "CI" {
         @{arguments = "1 , 2,3"; expected = "1", ",", "2,3"}
     ) {
         param($arguments, $expected)
-        $lines = Invoke-Expression "testexe -echoargs $arguments"
+        $lines = @(Invoke-Expression "testexe -echoargs $arguments")
         $lines.Count | Should Be $expected.Count
-        for ($i = 0; $i -lt $lines.Count; $i++) {
+        for ($i = 0; $i -lt $expected.Count; $i++) {
             $lines[$i] | Should Be "Arg $i is <$($expected[$i])>"
         }
     }

--- a/test/powershell/Language/Scripting/NativeExecution/NativeCommandArguments.Tests.ps1
+++ b/test/powershell/Language/Scripting/NativeExecution/NativeCommandArguments.Tests.ps1
@@ -43,4 +43,21 @@ Describe "Native Command Arguments" -tags "CI" {
             $lines[$i] | Should Be "Arg $i is <$($expected[$i])>"
         }
     }
+
+    It "Should handle PowerShell arrays with or without spaces correctly: <arguments>" -TestCases @(
+        @{arguments = "a 1,2"; expected = "a", "1,2"}
+        @{arguments = "1, 2"; expected = "1,", "2"}
+        @{arguments = "1 ,2"; expected = "1", ",2"}
+        @{arguments = "1 , 2"; expected = "1", ",", "2"}
+        @{arguments = "1, 2,3"; expected = "1,", "2,3"}
+        @{arguments = "1 ,2,3"; expected = "1", ",2,3"}
+        @{arguments = "1 , 2,3"; expected = "1", ",", "2,3"}
+    ) {
+        param($arguments, $expected)
+        $lines = Invoke-Expression "testexe -echoargs $arguments"
+        $lines.Count | Should Be $expected.Count
+        for ($i = 0; $i -lt $lines.Count; $i++) {
+            $lines[$i] | Should Be "Arg $i is <$($expected[$i])>"
+        }
+    }
 }


### PR DESCRIPTION
Now that the Ast is passed through to the NativeCommandParameterBinder, there is a cleaner fix to ensuring we pass the correct text to a command that uses PowerShell array syntax.
<!--

If you are a PowerShell Team member, please make sure you choose the Reviewer(s) and Assignee for your PR.
If you are not from the PowerShell Team, you can leave the fields blank and the Maintainers will choose them for you. If you are familiar with the team, feel free to mention some Reviewers yourself.

For more information about the roles of Reviewer and Assignee, refer to [CONTRIBUTING.md](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md).

-->
