### PR TITLE
Speed up check for suspicious content

### DIFF
--- a/src/System.Management.Automation/engine/runtime/CompiledScriptBlock.cs
+++ b/src/System.Management.Automation/engine/runtime/CompiledScriptBlock.cs
@@ -1743,11 +1743,10 @@ namespace System.Management.Automation
                     {
                         h = h | 0x20; // ToLower
                     }
-
-                    // If the character isn't in any of our patterns,
-                    // don't bother hashing and reset the running length.
-                    if (!((h >= 'a' && h <= 'z') || h == '-'))
+                    else if (!((h >= 'a' && h <= 'z') || h == '-'))
                     {
+                        // If the character isn't in any of our patterns,
+                        // don't bother hashing and reset the running length.
                         longestPossiblePattern = 0;
                         continue;
                     }

--- a/src/System.Management.Automation/engine/runtime/CompiledScriptBlock.cs
+++ b/src/System.Management.Automation/engine/runtime/CompiledScriptBlock.cs
@@ -1791,6 +1791,11 @@ namespace System.Management.Automation
                     return c;
                 }
 
+                if (pattern.Length > 29) {
+                    throw new Exception("Update runningHash in match for new longest string.\n" +
+                        "Also a longer maximum length could greatly affect the performance of this algorithm, so only increase with care.");
+                }
+
                 uint h = 0;
                 foreach (var c in pattern)
                 {

--- a/src/System.Management.Automation/engine/runtime/CompiledScriptBlock.cs
+++ b/src/System.Management.Automation/engine/runtime/CompiledScriptBlock.cs
@@ -1753,16 +1753,17 @@ namespace System.Management.Automation
 
                     for (int j = Math.Min(i, runningHash.Length) - 1; j > 0; j--)
                     {
-                        // Say our input is: `$Emit+1` and i is 4 (points to 't')
-                        // Our shortest pattern is 4 ('Emit'), and we're about to
-                        // finish computing the hash for Emit. The previous iteration
-                        // will hold the hash for `Emi` in runningHash[3], or j-1,
-                        // so we simply add the hash for t.
+                        // Say our input is: `Emit` (our shortest pattern, len 4).
+                        // Towards the end just before matching, we will:
+                        //
+                        // iter n: compute hash on `Emi` (len 3)
+                        // iter n+1: compute hash on `Emit` (len 4) using hash from previous iteration (j-1)
+                        // iter n+1: compute hash on `mit` (len 3)
+                        //    This overwrites the previous iteration, hence we go from longest to shortest.
                         //
                         // LCG comes from a trivial (bad) random number generator,
                         // but it's sufficient for us - the hashes for our patterns
-                        // is unique, and processing of 2200 files found no false
-                        // matches.
+                        // are unique, and processing of 2200 files found no false matches.
                         runningHash[j] = LCG * runningHash[j - 1] + h;
                     }
 


### PR DESCRIPTION
This replaces the code that scanned a script block for suspicious strings.
The previous implementation:
* Tokenized input (generating many strings for garbage collection)
* Use multiple threads

This approach is based on Rubin-Karp and does not allocate any memory
other than a small array to hold the running hash values.

I tested the new and old approaches on 2200 files in the PowerShell repo.
The old code ran in about 1.8-2.1s (ignoring time spent reading files)
The new code runs in about 0.6s and is more stable due to no garbage.

<!--

If you are a PowerShell Team member, please make sure you choose the Reviewer(s) and Assignee for your PR.
If you are not from the PowerShell Team, you can leave the fields blank and the Maintainers will choose them for you. If you are familiar with the team, feel free to mention some Reviewers yourself.

For more information about the roles of Reviewer and Assignee, refer to [CONTRIBUTING.md](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md).

-->
