### PR TITLE
Always run test with crossgen'ed assemblies in CI

### DIFF
--- a/test/powershell/Language/Classes/Scripting.Classes.BasicParsing.Tests.ps1
+++ b/test/powershell/Language/Classes/Scripting.Classes.BasicParsing.Tests.ps1
@@ -2,24 +2,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 #
 
-try {
-#
-# CrossGen'ed assemblies cause a hang to happen intermittently when running this test suite in Linux and macOS.
-# The issue has been reported to CoreCLR team. We need to work around it for now with the following approach:
-#  1. For pull request and push commit, build without '-CrossGen' and run the parsing tests
-#  2. For daily build, build with '-CrossGen' but don't run the parsing tests
-# In this way, we will continue to exercise these parsing tests for each CI build, and skip them for daily
-# build to avoid a hang.
-# Note: this change should be reverted once the 'CrossGen' issue is fixed by CoreCLR. The issue is tracked by
-#       https://github.com/dotnet/coreclr/issues/9745
-#
-$isDailyBuild = $env:TRAVIS_EVENT_TYPE -eq 'cron' -or $env:TRAVIS_EVENT_TYPE -eq 'api'
-$defaultParamValues = $PSdefaultParameterValues.Clone()
-$IsSkipped = (!$IsWindows -and $isDailyBuild)
-$PSDefaultParameterValues["it:skip"] = $IsSkipped
-$PSDefaultParameterValues["ShouldBeParseError:SkipInTravisFullBuild"] = $IsSkipped
-
-
 Describe 'Positive Parse Properties Tests' -Tags "CI" {
     It 'PositiveParsePropertiesTest' {
         # Just a bunch of random basic things here
@@ -858,8 +840,4 @@ Describe 'variable analysis' -Tags "CI" {
 
         [B]::getA().getFoo() | Should Be 'foo'
     }
-}
-
-} finally {
-    $global:PSdefaultParameterValues = $defaultParamValues
 }

--- a/test/powershell/Language/Classes/scripting.Classes.inheritance.tests.ps1
+++ b/test/powershell/Language/Classes/scripting.Classes.inheritance.tests.ps1
@@ -2,24 +2,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 #
 
-try {
-#
-# CrossGen'ed assemblies cause a hang to happen intermittently when running this test suite in Linux and macOS.
-# The issue has been reported to CoreCLR team. We need to work around it for now with the following approach:
-#  1. For pull request and push commit, build without '-CrossGen' and run the parsing tests
-#  2. For daily build, build with '-CrossGen' but don't run the parsing tests
-# In this way, we will continue to exercise these parsing tests for each CI build, and skip them for daily
-# build to avoid a hang.
-# Note: this change should be reverted once the 'CrossGen' issue is fixed by CoreCLR. The issue is tracked by
-#       https://github.com/dotnet/coreclr/issues/9745
-#
-$isDailyBuild = $env:TRAVIS_EVENT_TYPE -eq 'cron' -or $env:TRAVIS_EVENT_TYPE -eq 'api'
-$defaultParamValues = $PSdefaultParameterValues.Clone()
-$IsSkipped = (!$IsWindows -and $isDailyBuild)
-$PSDefaultParameterValues["it:skip"] = $IsSkipped
-$PSDefaultParameterValues["ShouldBeParseError:SkipInTravisFullBuild"] = $IsSkipped
-
-
 Describe 'Classes inheritance syntax' -Tags "CI" {
 
     It 'Base types' {
@@ -538,8 +520,4 @@ class Derived : Base
         $sb.Invoke() | Should Be 200
         $sb.Invoke() | Should Be 200
     }
-}
-
-} finally {
-    $global:PSdefaultParameterValues = $defaultParamValues
 }

--- a/test/tools/Modules/HelpersLanguage/HelpersLanguage.psm1
+++ b/test/tools/Modules/HelpersLanguage/HelpersLanguage.psm1
@@ -65,39 +65,8 @@ function ShouldBeParseError
         # This is a temporary solution after moving type creation from parse time to runtime
         [switch]$SkipAndCheckRuntimeError,
         # for test coverarage purpose, tests validate columnNumber or offset
-        [switch]$CheckColumnNumber,
-        # Skip this test in Travis CI nightly build
-        [switch]$SkipInTravisFullBuild
+        [switch]$CheckColumnNumber
     )
-
-    #
-    # CrossGen'ed assemblies cause a hang to happen when running tests with this helper function in Linux and macOS.
-    # The issue has been reported to CoreCLR team. We need to work around it for now with the following approach:
-    #  1. For pull request and push commit, build without '-CrossGen' and run the parsing tests
-    #  2. For nightly build, build with '-CrossGen' but don't run the parsing tests
-    # In this way, we will continue to exercise these parsing tests for each CI build, and skip them for nightly
-    # build to avoid a hang.
-    # Note: this change should be reverted once the 'CrossGen' issue is fixed by CoreCLR. The issue is tracked by
-    #       https://github.com/dotnet/coreclr/issues/9745
-    #
-    if ($SkipInTravisFullBuild) {
-        ## Report that we skipped the tests and return
-        ## be sure to report the same number of tests
-        ## it should have the same appearance as if the tests were run
-        Context "Parse error expected: <<$src>>" {
-            if ($SkipAndCheckRuntimeError)
-            {
-                It "error should happen at parse time, not at runtime" -Skip {}
-            }
-            It "Error count" -Skip { }
-            foreach($expectedError in $expectedErrors)
-            {
-                It "Error Id" -Skip { }
-                It "Error position" -Skip { }
-            }
-        }
-        return
-    }
 
     Context "Parse error expected: <<$src>>" {
         # Test case error if this fails


### PR DESCRIPTION
The crossgen issue dotnet/coreclr#9745 that causes parser test to hang has been fixed in 2.0.4-servicing preview packages, and we have updated powershell project files to build against that runtime (see PR #5295). So now we need to revert the previous workaround in our CI/test scripts, so that we always run crossgen in our CI build and run tests with the crossgen'ed assemblies.
