### PR TITLE
Release build fixes

### DIFF
--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -167,7 +167,7 @@ function Start-PSPackage {
 
             # Replace binaries with crossgen'ed binaires from publish folder.
             Get-ChildItem -Recurse $Source | ForEach-Object {
-                $relativePath = $_.FullName -replace $Source, ''
+                $relativePath = $_.FullName.Replace($Source, '')
                 $publishPath = Join-Path $publishSource -ChildPath $relativePath
                 if (Test-Path -Path $publishPath)
                 {

--- a/tools/releaseBuild/Images/microsoft_powershell_windowsservercore/PowerShellPackage.ps1
+++ b/tools/releaseBuild/Images/microsoft_powershell_windowsservercore/PowerShellPackage.ps1
@@ -54,7 +54,7 @@ try{
     $env:platform = $null
 
     Write-Verbose "Sync'ing Tags..." -verbose
-    Sync-PSTags
+    Sync-PSTags -AddRemoteIfMissing
 
     Write-Verbose "Bootstrapping powershell build..." -verbose
     Start-PSBootstrap -Force -Package


### PR DESCRIPTION
small fixes found while doing current work item

- -replace expects a regex when I wanted to do a literal replace.
- Have `Sync-PSTags` fix any issues it find
