### PR TITLE
Remove $IsCoreClr

### DIFF
--- a/src/System.Management.Automation/CoreCLR/CorePsPlatform.cs
+++ b/src/System.Management.Automation/CoreCLR/CorePsPlatform.cs
@@ -52,17 +52,6 @@ namespace System.Management.Automation
         }
 
         /// <summary>
-        /// True if PowerShell was built targeting .NET Core.
-        /// </summary>
-        public static bool IsCoreCLR
-        {
-            get
-            {
-                return true;
-            }
-        }
-
-        /// <summary>
         /// True if the underlying system is NanoServer.
         /// </summary>
         public static bool IsNanoServer

--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -4534,12 +4534,6 @@ end
                 Platform.IsWindows,
                 String.Empty,
                 ScopedItemOptions.ReadOnly | ScopedItemOptions.AllScope),
-
-            new SessionStateVariableEntry(
-                SpecialVariables.IsCoreCLR,
-                Platform.IsCoreCLR,
-                String.Empty,
-                ScopedItemOptions.ReadOnly | ScopedItemOptions.AllScope),
             #endregion
         };
 

--- a/src/System.Management.Automation/engine/SpecialVariables.cs
+++ b/src/System.Management.Automation/engine/SpecialVariables.cs
@@ -166,9 +166,6 @@ namespace System.Management.Automation
         internal const string IsWindows = "IsWindows";
         internal static VariablePath IsWindowsPath = new VariablePath("IsWindows");
 
-        internal const string IsCoreCLR = "IsCoreCLR";
-        internal static VariablePath IsCoreCLRPath = new VariablePath("IsCoreCLR");
-
         #endregion
         #region Preference Variables
 

--- a/test/csharp/test_CorePsPlatform.cs
+++ b/test/csharp/test_CorePsPlatform.cs
@@ -10,12 +10,6 @@ namespace PSTests
     public static class PlatformTests
     {
         [Fact]
-        public static void TestIsCoreCLR()
-        {
-            Assert.True(Platform.IsCoreCLR);
-        }
-
-        [Fact]
         public static void TestGetUserName()
         {
             var startInfo = new ProcessStartInfo

--- a/test/powershell/Host/Base-Directory.Tests.ps1
+++ b/test/powershell/Host/Base-Directory.Tests.ps1
@@ -1,6 +1,7 @@
 Describe "Configuration file locations" -tags "CI","Slow" {
 
     BeforeAll {
+        $isCoreCLR = $true
         $powershell = Join-Path -Path $PsHome -ChildPath "pwsh"
         $profileName = "Microsoft.PowerShell_profile.ps1"
     }

--- a/test/powershell/Host/PSVersionTable.Tests.ps1
+++ b/test/powershell/Host/PSVersionTable.Tests.ps1
@@ -1,6 +1,7 @@
 Describe "PSVersionTable" -Tags "CI" {
 
     BeforeAll {
+        $isCoreCLR = $true
         $sma = Get-Item (Join-Path $PSHome "System.Management.Automation.dll")
         $formattedVersion = $sma.VersionInfo.ProductVersion
 

--- a/test/powershell/Language/Classes/Scripting.Classes.BasicParsing.Tests.ps1
+++ b/test/powershell/Language/Classes/Scripting.Classes.BasicParsing.Tests.ps1
@@ -471,6 +471,7 @@ Describe 'PositiveReturnSelfClassTypeFromMemberFunction Test' -Tags "CI" {
 }
 
 Describe 'TestMultipleArguments Test' -Tags "CI" {
+        $isCoreCLR = $true
         if ( $IsCoreCLR ) { $maxCount = 14 } else { $maxCount = 16 }
         for ($i = 0; $i -lt $maxCount; $i++)
         {

--- a/test/powershell/Language/Parser/MethodInvocation.Tests.ps1
+++ b/test/powershell/Language/Parser/MethodInvocation.Tests.ps1
@@ -1,3 +1,5 @@
+$isCoreCLR = $true
+
 if ( $IsCoreCLR ) {
     return
 }

--- a/test/powershell/Language/Parser/TypeAccelerator.Tests.ps1
+++ b/test/powershell/Language/Parser/TypeAccelerator.Tests.ps1
@@ -1,6 +1,7 @@
 
 Describe "Type accelerators" -Tags "CI" {
     BeforeAll {
+        $isCoreCLR = $true
         $TypeAcceleratorsType = [psobject].Assembly.GetType("System.Management.Automation.TypeAccelerators")
         $TypeAccelerators = $TypeAcceleratorsType::Get
     }

--- a/test/powershell/Language/Scripting/ActionPreference.Tests.ps1
+++ b/test/powershell/Language/Scripting/ActionPreference.Tests.ps1
@@ -1,5 +1,6 @@
 ﻿Describe "Tests for (error, warning, etc) action preference" -Tags "CI" {
         BeforeAll {
+            $isCoreCLR = $true
             $orgin = $GLOBAL:errorActionPreference
         }
 

--- a/test/powershell/Language/Scripting/ConstrainedLanguageMode.Tests.ps1
+++ b/test/powershell/Language/Scripting/ConstrainedLanguageMode.Tests.ps1
@@ -1,6 +1,7 @@
 
 Describe "Test constrained language mode" -Tags "CI" {
     It "dynamic invocation on non-PowerShell thread should work" {
+        $isCoreCLR = $true
         $refAssemblies = @()
         if (!$IsCoreCLR) {
             $refAssemblies += "Microsoft.CSharp"

--- a/test/powershell/Language/Scripting/Debugging/DebuggerScriptTests.Tests.ps1
+++ b/test/powershell/Language/Scripting/Debugging/DebuggerScriptTests.Tests.ps1
@@ -215,6 +215,7 @@ Describe "Line breakpoints on commands in multi-line pipelines" -Tags "CI" {
     Context "COM TESTS" {
         # DRT for 133807 SetBreakpointWithShortPath
         BeforeAll {
+            $isCoreCLR = $true
             if ( $IsCoreCLR ) { return } # no COM on core
             $scriptPath1 = Join-Path $TestDrive SBPShortPathBug133807.DRT.tmp.ps1
             $scriptPath1 = setup -f SBPShortPathBug133807.DRT.tmp.ps1 -content '

--- a/test/powershell/Language/Scripting/ForeachParallel.Tests.ps1
+++ b/test/powershell/Language/Scripting/ForeachParallel.Tests.ps1
@@ -1,3 +1,5 @@
+$isCoreCLR = $true
+
 Describe "Parallel foreach syntax" -Tags "CI" {
 
    Context 'Should be able to retrieve AST of parallel foreach, error in regular case' {

--- a/test/powershell/Language/Scripting/Generics.Tests.ps1
+++ b/test/powershell/Language/Scripting/Generics.Tests.ps1
@@ -1,5 +1,8 @@
 ﻿using namespace system.collections.generic
 using namespace System.Management.Automation
+
+$isCoreCLR = $true
+
 Describe "Generics support" -Tags "CI" {
     # list and stack are in different assemblies, and dictionary
     # takes more than one type parameter.

--- a/test/powershell/Language/Scripting/Indexer.Tests.ps1
+++ b/test/powershell/Language/Scripting/Indexer.Tests.ps1
@@ -1,3 +1,5 @@
+$isCoreCLR = $true
+
 Describe 'Tests for indexers' -Tags "CI" {
     It 'Indexer in dictionary' {
 

--- a/test/powershell/Language/Scripting/OrderedAttributeForHashTables.Tests.ps1
+++ b/test/powershell/Language/Scripting/OrderedAttributeForHashTables.Tests.ps1
@@ -1,5 +1,6 @@
 ﻿Describe 'Test for cmdlet to support Ordered Attribute on hash literal nodes' -Tags "CI" {
     BeforeAll {
+        $isCoreCLR = $true
         If (-not $IsCoreCLR) {
             Get-WmiObject -Query "select * from win32_environment where name='TestWmiInstance'"  | Remove-WmiObject
         }

--- a/test/powershell/Language/Scripting/ParameterBinding.Tests.ps1
+++ b/test/powershell/Language/Scripting/ParameterBinding.Tests.ps1
@@ -1,4 +1,6 @@
-﻿Describe "Tests for parameter binding" -Tags "CI" {
+﻿$isCoreCLR = $true
+
+Describe "Tests for parameter binding" -Tags "CI" {
     Context 'Test of Mandatory parameters' {
         BeforeAll {
             $f = "function get-foo { param([Parameter(mandatory=`$true)] `$a) `$a };"

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/PSSessionConfiguration.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/PSSessionConfiguration.Tests.ps1
@@ -4,6 +4,7 @@ try
     $originalDefaultParameterValues = $PSDefaultParameterValues.Clone()
     $originalWarningPreference = $WarningPreference
     $WarningPreference = "SilentlyContinue"
+    $isCoreCLR = $true
     $IsNotSkipped = ($IsWindows -and $IsCoreCLR -and (Test-IsElevated))
     $PSDefaultParameterValues["it:skip"] = !$IsNotSkipped
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Clear-EventLog.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Clear-EventLog.Tests.ps1
@@ -1,6 +1,7 @@
 Describe "Clear-EventLog cmdlet tests" -Tags @('CI', 'RequireAdminOnWindows') {
 
     BeforeAll {
+        $isCoreCLR = $true
         $defaultParamValues = $PSdefaultParameterValues.Clone()
         $PSDefaultParameterValues["it:skip"] = !$IsWindows -or $IsCoreCLR
     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Copy.Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Copy.Item.Tests.ps1
@@ -7,6 +7,7 @@
 # If PS Remoting is not available, do not run the suite.
 function ShouldRun
 {
+    $isCoreCLR = $true
     if ( $IsCoreCLR ) { return $false }
     $result = Invoke-Command -ComputerName . -ScriptBlock {1} -ErrorAction SilentlyContinue
     return ($result -eq 1)

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-EventLog.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-EventLog.Tests.ps1
@@ -1,6 +1,7 @@
 ﻿Describe "Get-EventLog cmdlet tests" -Tags @('CI', 'RequireAdminOnWindows') {
 
     BeforeAll {
+        $isCoreCLR = $true
         $defaultParamValues = $PSdefaultParameterValues.Clone()
         $PSDefaultParameterValues["it:skip"] = !$IsWindows -or $IsCoreCLR
     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/New-EventLog.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/New-EventLog.Tests.ps1
@@ -1,6 +1,7 @@
 ﻿Describe "New-EventLog cmdlet tests" -Tags @('CI', 'RequireAdminOnWindows') {
 
     BeforeAll {
+        $isCoreCLR = $true
         $defaultParamValues = $PSdefaultParameterValues.Clone()
         $IsNotSkipped = ($IsWindows -and !$IsCoreCLR)
         $PSDefaultParameterValues["it:skip"] = !$IsNotSkipped

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Remove-EventLog.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Remove-EventLog.Tests.ps1
@@ -1,6 +1,7 @@
 ﻿Describe "New-EventLog cmdlet tests" -Tags @('CI', 'RequireAdminOnWindows') {
 
     BeforeAll {
+        $isCoreCLR = $true
         $defaultParamValues = $PSdefaultParameterValues.Clone()
         $IsNotSkipped = ($IsWindows -and !$IsCoreCLR)
         $PSDefaultParameterValues["it:skip"] = !$IsNotSkipped

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/certificateCommon.psm1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/certificateCommon.psm1
@@ -101,6 +101,7 @@ function Install-TestCertificates
     $script:badCertLocation = New-BadCertificate
     $script:badCertLocation | Should Not BeNullOrEmpty | Out-Null
 
+    $isCoreCLR = $true
     if ($IsCoreCLR -and $IsWindows)
     {
         # PKI module is not available for PowerShell Core, so we need to use Windows PowerShell to import the cert

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Implicit.Remoting.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Implicit.Remoting.Tests.ps1
@@ -4,6 +4,7 @@
 $originalDefaultParameterValues = $PSDefaultParameterValues.Clone()
 $originalWarningPreference = $WarningPreference
 $WarningPreference = "SilentlyContinue"
+$isCoreCLR = $true
 $skipTest = ! ($IsWindows -and $IsCoreCLR -and (Test-IsElevated))
 $PSDefaultParameterValues["it:skip"] = $skipTest
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/ImportExportCSV.Delimiter.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/ImportExportCSV.Delimiter.Tests.ps1
@@ -1,5 +1,6 @@
 ﻿Describe "Using delimiters with Export-CSV and Import-CSV behave correctly" -tags "Feature" {
     BeforeAll {
+        $isCoreCLR = $true
         # note, we will not use "," as that's the default for CSV
         $delimiters = "/", " ", "@", "#", "$", "\", "&", "(", ")",
               "{", "}", "|", "<", ">", ";", "'",

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Pester.Commands.Cmdlets.Json.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Pester.Commands.Cmdlets.Json.Tests.ps1
@@ -8,10 +8,11 @@
 # This 'Describe' is for tests that were converted from utscripts (SDXROOT/admin/monad/tests/monad/DRT/utscripts)
 # and C# tests (SDXROOT/admin/monad/tests/monad/DRT/commands/utility/UnitTests) to Pester.
 #
+$isCoreCLR = $true
+
 Describe "Json Tests" -Tags "Feature" {
 
     BeforeAll {
-
         function ValidateSampleObject
         {
             param ($result, [switch]$hasEmbeddedSampleObject )

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Trace-Command.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Trace-Command.Tests.ps1
@@ -1,4 +1,5 @@
-# This came from monad/tests/ci/PowerShell/tests/Commands/Cmdlets/pester.utility.command.tests.ps1
+$isCoreCLR = $true
+
 Describe "Trace-Command" -tags "CI" {
 
     Context "Listener options" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/command.tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/command.tests.ps1
@@ -1,4 +1,6 @@
-﻿Describe "Trace-Command" -tags "Feature" {
+﻿$isCoreCLR = $true
+
+Describe "Trace-Command" -tags "Feature" {
 
     Context "Listener options" {
         BeforeAll {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/xml.tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/xml.tests.ps1
@@ -1,4 +1,6 @@
-﻿Describe "XML cmdlets" -Tags "Feature" {
+﻿$isCoreCLR = $true
+
+Describe "XML cmdlets" -Tags "Feature" {
     Context "Select-XML" {
         BeforeAll {
             $fileName = New-Item -Path 'TestDrive:\testSelectXml.xml'

--- a/test/powershell/Modules/PowerShellGet/PowerShellGet.Tests.ps1
+++ b/test/powershell/Modules/PowerShellGet/PowerShellGet.Tests.ps1
@@ -13,7 +13,6 @@ $Initialized = $false
 
 function IsInbox { $PSHOME.EndsWith('\WindowsPowerShell\v1.0', [System.StringComparison]::OrdinalIgnoreCase) }
 function IsWindows { $PSVariable = Get-Variable -Name IsWindows -ErrorAction Ignore; return (-not $PSVariable -or $PSVariable.Value) }
-function IsCoreCLR { $PSVariable = Get-Variable -Name IsCoreCLR -ErrorAction Ignore; return ($PSVariable -and $PSVariable.Value) }
 
 #endregion
 

--- a/test/powershell/engine/Basic/DefaultCommands.Tests.ps1
+++ b/test/powershell/engine/Basic/DefaultCommands.Tests.ps1
@@ -1,5 +1,6 @@
 Describe "Verify approved aliases list" -Tags "CI" {
     BeforeAll {
+        $isCoreCLR = $true
         $FullCLR = !$isCoreCLR
         $CoreWindows = $isCoreCLR -and $IsWindows
         $CoreUnix = $isCoreCLR -and !$IsWindows

--- a/test/powershell/engine/Module/ModulePath.Tests.ps1
+++ b/test/powershell/engine/Module/ModulePath.Tests.ps1
@@ -2,6 +2,7 @@ Describe "SxS Module Path Basic Tests" -tags "CI" {
 
     BeforeAll {
 
+        $isCoreCLR = $true
         if ($IsWindows)
         {
             $powershell = "$PSHOME\pwsh.exe"

--- a/test/tools/Modules/HelpersHostCS/HelpersHostCS.psm1
+++ b/test/tools/Modules/HelpersHostCS/HelpersHostCS.psm1
@@ -298,6 +298,7 @@ namespace TestHost
 ## '
 function New-TestHost
 {
+    $isCoreCLR = $true
     If ($IsCoreCLR)
     {
         $references = @()


### PR DESCRIPTION
Fix #4904.

### Fix description
1. `$isCoreCLR` is removed from C# code.
2. `$isCoreCLR = $true` is added in tests because these tests are very different and each one requires a separate conclusion.

