### PR TITLE
Replace pwsh with powershell in VS Code tasks.json for Windows

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -5,6 +5,9 @@
     "showOutput": "always",
     "suppressTaskName": true,
     "args": [ "-command" ],
+    "windows": {
+        "command": "powershell"
+    },
 
     "tasks": [
         {


### PR DESCRIPTION
### Problem
It is impossible to build and debug from VS Code on Windows - VS Code cannot find pwsh.exe.
### Fix
Use powershell.exe on Windows to build.


