### PR TITLE
Add SslProtocol Support to WebCmdlets

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -11,6 +11,7 @@ using System.Text;
 using System.Collections;
 using System.Globalization;
 using System.Security;
+using System.Security.Authentication;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 #if !CORECLR
@@ -44,6 +45,33 @@ namespace Microsoft.PowerShell.Commands
         /// RFC-6750 OAuth 2.0 Bearer Authentication. Requires -Token
         /// </summary>
         OAuth,
+    }
+
+    /// <summary>
+    /// The valid values for the -SslProtocol parameter for Invoke-RestMethod and Invoke-WebRequest
+    /// </summary>
+    [Flags]
+    public enum WebSslProtocol
+    {
+        /// <summary>
+        ///  No SSL protocol will be set and the system defaults will be used.
+        /// </summary>
+        Default = 0,
+
+        /// <summary>
+        /// Specifies the TLS 1.0 security protocol. The TLS protocol is defined in IETF RFC 2246.
+        /// </summary>
+        Tls = SslProtocols.Tls,
+
+        /// <summary>
+        ///  Specifies the TLS 1.1 security protocol. The TLS protocol is defined in IETF RFC 4346.
+        /// </summary>
+        Tls11 = SslProtocols.Tls11,
+
+        /// <summary>
+        /// Specifies the TLS 1.2 security protocol. The TLS protocol is defined in IETF RFC 5246
+        /// </summary>
+        Tls12 = SslProtocols.Tls12
     }
 
     /// <summary>
@@ -136,6 +164,12 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         [Parameter]
         public virtual SwitchParameter SkipCertificateCheck { get; set; }
+
+        /// <summary>
+        /// Gets or sets the TLS/SSL protocol used by the Web Cmdlet
+        /// </summary>
+        [Parameter]
+        public virtual WebSslProtocol SslProtocol { get; set; } = WebSslProtocol.Default;
 
         /// <summary>
         /// Gets or sets the Token property. Token is required by Authentication OAuth and Bearer.

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -47,6 +47,8 @@ namespace Microsoft.PowerShell.Commands
         OAuth,
     }
 
+    // WebSslProtocol is used because not all SslProtocols are supported by HttpClientHandler.
+    // Also SslProtocols.Default is not the "default" for HttpClientHandler as SslProtocols.Ssl3 is not supported.
     /// <summary>
     /// The valid values for the -SslProtocol parameter for Invoke-RestMethod and Invoke-WebRequest
     /// </summary>

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebRequestPSCmdlet.CoreClr.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebRequestPSCmdlet.CoreClr.cs
@@ -193,7 +193,6 @@ namespace Microsoft.PowerShell.Commands
                 }
             }
 
-            // Set The SslProtocol.
             handler.SslProtocols = (SslProtocols)SslProtocol;
 
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebRequestPSCmdlet.CoreClr.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebRequestPSCmdlet.CoreClr.cs
@@ -193,8 +193,7 @@ namespace Microsoft.PowerShell.Commands
                 }
             }
 
-            // Set The SslProtocol. WebSslProtocol is used because not all SslProtocols are supported by HttpClientHandler.
-            // Also SslProtocols.Default is not the "default" for HttpClientHandler as SslProtocols.Ssl3 is not supported.
+            // Set The SslProtocol.
             handler.SslProtocols = (SslProtocols)SslProtocol;
 
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebRequestPSCmdlet.CoreClr.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/CoreCLR/WebRequestPSCmdlet.CoreClr.cs
@@ -13,6 +13,7 @@ using System.IO;
 using System.Text;
 using System.Collections;
 using System.Globalization;
+using System.Security.Authentication;
 using System.Security.Cryptography;
 using System.Threading;
 using System.Xml;
@@ -191,6 +192,11 @@ namespace Microsoft.PowerShell.Commands
                     handler.MaxAutomaticRedirections = WebSession.MaximumRedirection;
                 }
             }
+
+            // Set The SslProtocol. WebSslProtocol is used because not all SslProtocols are supported by HttpClientHandler.
+            // Also SslProtocols.Default is not the "default" for HttpClientHandler as SslProtocols.Ssl3 is not supported.
+            handler.SslProtocols = (SslProtocols)SslProtocol;
+
 
             HttpClient httpClient = new HttpClient(handler);
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -1425,17 +1425,18 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
             {
                 @{SslProtocol = 'Tls, Tls11, Tls12'; ActualProtocol = 'Tls12'}
                 @{SslProtocol = 'Tls11, Tls12'; ActualProtocol = 'Tls12'}
-                @{SslProtocol = 'Tls, Tls12'; ActualProtocol = 'Tls12'}
                 @{SslProtocol = 'Tls, Tls11, Tls12'; ActualProtocol = 'Tls11'}
                 @{SslProtocol = 'Tls11, Tls12'; ActualProtocol = 'Tls11'}
                 @{SslProtocol = 'Tls, Tls11'; ActualProtocol = 'Tls11'}
                 @{SslProtocol = 'Tls, Tls11, Tls12'; ActualProtocol = 'Tls'}
                 @{SslProtocol = 'Tls, Tls11'; ActualProtocol = 'Tls'}
+                @{SslProtocol = 'Tls, Tls12'; ActualProtocol = 'Tls'}
             }
             # macOS does not support multiple SslProtocols and possible CoreFX for this combo on Linux
             if($IsWindows)
             {
-                @{SslProtocol = 'Tls, Tls12'; ActualProtocol = 'Tls'}
+                
+                @{SslProtocol = 'Tls, Tls12'; ActualProtocol = 'Tls12'}
             }
         ) {
             param($SslProtocol, $ActualProtocol)
@@ -2406,17 +2407,17 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
             {
                 @{SslProtocol = 'Tls, Tls11, Tls12'; ActualProtocol = 'Tls12'}
                 @{SslProtocol = 'Tls11, Tls12'; ActualProtocol = 'Tls12'}
-                @{SslProtocol = 'Tls, Tls12'; ActualProtocol = 'Tls12'}
                 @{SslProtocol = 'Tls, Tls11, Tls12'; ActualProtocol = 'Tls11'}
                 @{SslProtocol = 'Tls11, Tls12'; ActualProtocol = 'Tls11'}
                 @{SslProtocol = 'Tls, Tls11'; ActualProtocol = 'Tls11'}
                 @{SslProtocol = 'Tls, Tls11, Tls12'; ActualProtocol = 'Tls'}
                 @{SslProtocol = 'Tls, Tls11'; ActualProtocol = 'Tls'}
+                @{SslProtocol = 'Tls, Tls12'; ActualProtocol = 'Tls'}
             }
             # macOS does not support multiple SslProtocols and possible CoreFX for this combo on Linux
             if($IsWindows)
             {
-                @{SslProtocol = 'Tls, Tls12'; ActualProtocol = 'Tls'}
+                @{SslProtocol = 'Tls, Tls12'; ActualProtocol = 'Tls12'}
             }
         ) {
             param($SslProtocol, $ActualProtocol)

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -1415,15 +1415,25 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
     }
 
     Context "Invoke-WebRequest -SslProtocol Test" {
-        It "Verifies Invoke-WebRequest -SslProtocol <SslProtocol>" -TestCases @(
-            @{SslProtocol = 'Default'}
-            @{SslProtocol = 'Tls'}
-            @{SslProtocol = 'Tls11'}
-            @{SslProtocol = 'Tls12'}
+        It "Verifies Invoke-WebRequest -SslProtocol <SslProtocol> works on <ActualProtocol>" -TestCases @(
+            @{SslProtocol = 'Default'; ActualProtocol = 'Default'}
+            @{SslProtocol = 'Tls'; ActualProtocol = 'Tls'}
+            @{SslProtocol = 'Tls11'; ActualProtocol = 'Tls11'}
+            @{SslProtocol = 'Tls12'; ActualProtocol = 'Tls12'}
+            @{SslProtocol = 'Tls, Tls11, Tls12'; ActualProtocol = 'Tls12'}
+            @{SslProtocol = 'Tls11, Tls12'; ActualProtocol = 'Tls12'}
+            @{SslProtocol = 'Tls, Tls12'; ActualProtocol = 'Tls12'}
+            @{SslProtocol = 'Tls, Tls11, Tls12'; ActualProtocol = 'Tls11'}
+            @{SslProtocol = 'Tls11, Tls12'; ActualProtocol = 'Tls11'}
+            @{SslProtocol = 'Tls, Tls11'; ActualProtocol = 'Tls11'}
+            @{SslProtocol = 'Tls, Tls11, Tls12'; ActualProtocol = 'Tls'}
+            @{SslProtocol = 'Tls, Tls12'; ActualProtocol = 'Tls'}
+            @{SslProtocol = 'Tls, Tls11'; ActualProtocol = 'Tls'}
+
         ) {
-            param($SslProtocol)
+            param($SslProtocol, $ActualProtocol)
             $params = @{
-                Uri = Get-WebListenerUrl -Test 'Get' -Https -SslProtocol $SslProtocol
+                Uri = Get-WebListenerUrl -Test 'Get' -Https -SslProtocol $ActualProtocol
                 SslProtocol = $SslProtocol
                 SkipCertificateCheck = $true
             }
@@ -1440,6 +1450,9 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
             @{IntendedProtocol = 'Tls11'; ActualProtocol = 'Tls'}
             @{IntendedProtocol = 'Tls12'; ActualProtocol = 'Tls'}
             @{IntendedProtocol = 'Tls12'; ActualProtocol = 'Tls11'}
+            @{IntendedProtocol = 'Tls11, Tls12';   ActualProtocol = 'Tls'}
+            @{IntendedProtocol = 'Tls, Tls12';   ActualProtocol = 'Tls11'}
+            @{IntendedProtocol = 'Tls, Tls11';   ActualProtocol = 'Tls12'}
         ) {
             param( $IntendedProtocol, $ActualProtocol)
             $params = @{
@@ -1450,6 +1463,7 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
             }
             { Invoke-WebRequest @params } | ShouldBeErrorId 'WebCmdletWebResponseException,Microsoft.PowerShell.Commands.InvokeWebRequestCommand'
         }
+
     }
 
     BeforeEach {
@@ -2371,15 +2385,25 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
     }
 
     Context "Invoke-RestMethod -SslProtocol Test" {
-        It "Verifies Invoke-RestMethod -SslProtocol <SslProtocol>" -TestCases @(
-            @{SslProtocol = 'Default'}
-            @{SslProtocol = 'Tls'}
-            @{SslProtocol = 'Tls11'}
-            @{SslProtocol = 'Tls12'}
+        It "Verifies Invoke-RestMethod -SslProtocol <SslProtocol> works on <ActualProtocol>" -TestCases @(
+            @{SslProtocol = 'Default'; ActualProtocol = 'Default'}
+            @{SslProtocol = 'Tls'; ActualProtocol = 'Tls'}
+            @{SslProtocol = 'Tls11'; ActualProtocol = 'Tls11'}
+            @{SslProtocol = 'Tls12'; ActualProtocol = 'Tls12'}
+            @{SslProtocol = 'Tls, Tls11, Tls12'; ActualProtocol = 'Tls12'}
+            @{SslProtocol = 'Tls11, Tls12'; ActualProtocol = 'Tls12'}
+            @{SslProtocol = 'Tls, Tls12'; ActualProtocol = 'Tls12'}
+            @{SslProtocol = 'Tls, Tls11, Tls12'; ActualProtocol = 'Tls11'}
+            @{SslProtocol = 'Tls11, Tls12'; ActualProtocol = 'Tls11'}
+            @{SslProtocol = 'Tls, Tls11'; ActualProtocol = 'Tls11'}
+            @{SslProtocol = 'Tls, Tls11, Tls12'; ActualProtocol = 'Tls'}
+            @{SslProtocol = 'Tls, Tls12'; ActualProtocol = 'Tls'}
+            @{SslProtocol = 'Tls, Tls11'; ActualProtocol = 'Tls'}
+
         ) {
-            param($SslProtocol)
+            param($SslProtocol, $ActualProtocol)
             $params = @{
-                Uri = Get-WebListenerUrl -Test 'Get' -Https -SslProtocol $SslProtocol
+                Uri = Get-WebListenerUrl -Test 'Get' -Https -SslProtocol $ActualProtocol
                 SslProtocol = $SslProtocol
                 SkipCertificateCheck = $true
             }
@@ -2394,7 +2418,10 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
             @{IntendedProtocol = 'Tls11'; ActualProtocol = 'Tls12'}
             @{IntendedProtocol = 'Tls11'; ActualProtocol = 'Tls'}
             @{IntendedProtocol = 'Tls12'; ActualProtocol = 'Tls'}
-            @{IntendedProtocol = 'Tls12'; ActualProtocol = 'Tls11'}
+            @{IntendedProtocol = 'Tls12'; ActualProtocol = 'Tls11'}            
+            @{IntendedProtocol = 'Tls11, Tls12';   ActualProtocol = 'Tls'}
+            @{IntendedProtocol = 'Tls, Tls12';   ActualProtocol = 'Tls11'}
+            @{IntendedProtocol = 'Tls, Tls11';   ActualProtocol = 'Tls12'}
         ) {
             param( $IntendedProtocol, $ActualProtocol)
             $params = @{
@@ -2405,6 +2432,8 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
             }
             { Invoke-RestMethod @params } | ShouldBeErrorId 'WebCmdletWebResponseException,Microsoft.PowerShell.Commands.InvokeRestMethodCommand'
         }
+
+
     }
 
     BeforeEach {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -1430,8 +1430,12 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
                 @{SslProtocol = 'Tls11, Tls12'; ActualProtocol = 'Tls11'}
                 @{SslProtocol = 'Tls, Tls11'; ActualProtocol = 'Tls11'}
                 @{SslProtocol = 'Tls, Tls11, Tls12'; ActualProtocol = 'Tls'}
-                @{SslProtocol = 'Tls, Tls12'; ActualProtocol = 'Tls'}
                 @{SslProtocol = 'Tls, Tls11'; ActualProtocol = 'Tls'}
+            }
+            # macOS does not support multiple SslProtocols and possible CoreFX for this combo on Linux
+            if($IsWindows)
+            {
+                @{SslProtocol = 'Tls, Tls12'; ActualProtocol = 'Tls'}
             }
         ) {
             param($SslProtocol, $ActualProtocol)
@@ -2407,8 +2411,12 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
                 @{SslProtocol = 'Tls11, Tls12'; ActualProtocol = 'Tls11'}
                 @{SslProtocol = 'Tls, Tls11'; ActualProtocol = 'Tls11'}
                 @{SslProtocol = 'Tls, Tls11, Tls12'; ActualProtocol = 'Tls'}
-                @{SslProtocol = 'Tls, Tls12'; ActualProtocol = 'Tls'}
                 @{SslProtocol = 'Tls, Tls11'; ActualProtocol = 'Tls'}
+            }
+            # macOS does not support multiple SslProtocols and possible CoreFX for this combo on Linux
+            if($IsWindows)
+            {
+                @{SslProtocol = 'Tls, Tls12'; ActualProtocol = 'Tls'}
             }
         ) {
             param($SslProtocol, $ActualProtocol)

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -1420,16 +1420,19 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
             @{SslProtocol = 'Tls'; ActualProtocol = 'Tls'}
             @{SslProtocol = 'Tls11'; ActualProtocol = 'Tls11'}
             @{SslProtocol = 'Tls12'; ActualProtocol = 'Tls12'}
-            @{SslProtocol = 'Tls, Tls11, Tls12'; ActualProtocol = 'Tls12'}
-            @{SslProtocol = 'Tls11, Tls12'; ActualProtocol = 'Tls12'}
-            @{SslProtocol = 'Tls, Tls12'; ActualProtocol = 'Tls12'}
-            @{SslProtocol = 'Tls, Tls11, Tls12'; ActualProtocol = 'Tls11'}
-            @{SslProtocol = 'Tls11, Tls12'; ActualProtocol = 'Tls11'}
-            @{SslProtocol = 'Tls, Tls11'; ActualProtocol = 'Tls11'}
-            @{SslProtocol = 'Tls, Tls11, Tls12'; ActualProtocol = 'Tls'}
-            @{SslProtocol = 'Tls, Tls12'; ActualProtocol = 'Tls'}
-            @{SslProtocol = 'Tls, Tls11'; ActualProtocol = 'Tls'}
-
+            # macOS does not support multiple SslProtocols
+            if (-not $IsMacOS) 
+            {
+                @{SslProtocol = 'Tls, Tls11, Tls12'; ActualProtocol = 'Tls12'}
+                @{SslProtocol = 'Tls11, Tls12'; ActualProtocol = 'Tls12'}
+                @{SslProtocol = 'Tls, Tls12'; ActualProtocol = 'Tls12'}
+                @{SslProtocol = 'Tls, Tls11, Tls12'; ActualProtocol = 'Tls11'}
+                @{SslProtocol = 'Tls11, Tls12'; ActualProtocol = 'Tls11'}
+                @{SslProtocol = 'Tls, Tls11'; ActualProtocol = 'Tls11'}
+                @{SslProtocol = 'Tls, Tls11, Tls12'; ActualProtocol = 'Tls'}
+                @{SslProtocol = 'Tls, Tls12'; ActualProtocol = 'Tls'}
+                @{SslProtocol = 'Tls, Tls11'; ActualProtocol = 'Tls'}
+            }
         ) {
             param($SslProtocol, $ActualProtocol)
             $params = @{
@@ -1450,9 +1453,13 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
             @{IntendedProtocol = 'Tls11'; ActualProtocol = 'Tls'}
             @{IntendedProtocol = 'Tls12'; ActualProtocol = 'Tls'}
             @{IntendedProtocol = 'Tls12'; ActualProtocol = 'Tls11'}
-            @{IntendedProtocol = 'Tls11, Tls12';   ActualProtocol = 'Tls'}
-            @{IntendedProtocol = 'Tls, Tls12';   ActualProtocol = 'Tls11'}
-            @{IntendedProtocol = 'Tls, Tls11';   ActualProtocol = 'Tls12'}
+            # macOS does not support multiple SslProtocols
+            if (-not $IsMacOS) 
+            {
+                @{IntendedProtocol = 'Tls11, Tls12';   ActualProtocol = 'Tls'}
+                @{IntendedProtocol = 'Tls, Tls12';   ActualProtocol = 'Tls11'}
+                @{IntendedProtocol = 'Tls, Tls11';   ActualProtocol = 'Tls12'}
+            }
         ) {
             param( $IntendedProtocol, $ActualProtocol)
             $params = @{
@@ -2390,16 +2397,19 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
             @{SslProtocol = 'Tls'; ActualProtocol = 'Tls'}
             @{SslProtocol = 'Tls11'; ActualProtocol = 'Tls11'}
             @{SslProtocol = 'Tls12'; ActualProtocol = 'Tls12'}
-            @{SslProtocol = 'Tls, Tls11, Tls12'; ActualProtocol = 'Tls12'}
-            @{SslProtocol = 'Tls11, Tls12'; ActualProtocol = 'Tls12'}
-            @{SslProtocol = 'Tls, Tls12'; ActualProtocol = 'Tls12'}
-            @{SslProtocol = 'Tls, Tls11, Tls12'; ActualProtocol = 'Tls11'}
-            @{SslProtocol = 'Tls11, Tls12'; ActualProtocol = 'Tls11'}
-            @{SslProtocol = 'Tls, Tls11'; ActualProtocol = 'Tls11'}
-            @{SslProtocol = 'Tls, Tls11, Tls12'; ActualProtocol = 'Tls'}
-            @{SslProtocol = 'Tls, Tls12'; ActualProtocol = 'Tls'}
-            @{SslProtocol = 'Tls, Tls11'; ActualProtocol = 'Tls'}
-
+            # macOS does not support multiple SslProtocols
+            if (-not $IsMacOS) 
+            {
+                @{SslProtocol = 'Tls, Tls11, Tls12'; ActualProtocol = 'Tls12'}
+                @{SslProtocol = 'Tls11, Tls12'; ActualProtocol = 'Tls12'}
+                @{SslProtocol = 'Tls, Tls12'; ActualProtocol = 'Tls12'}
+                @{SslProtocol = 'Tls, Tls11, Tls12'; ActualProtocol = 'Tls11'}
+                @{SslProtocol = 'Tls11, Tls12'; ActualProtocol = 'Tls11'}
+                @{SslProtocol = 'Tls, Tls11'; ActualProtocol = 'Tls11'}
+                @{SslProtocol = 'Tls, Tls11, Tls12'; ActualProtocol = 'Tls'}
+                @{SslProtocol = 'Tls, Tls12'; ActualProtocol = 'Tls'}
+                @{SslProtocol = 'Tls, Tls11'; ActualProtocol = 'Tls'}
+            }
         ) {
             param($SslProtocol, $ActualProtocol)
             $params = @{
@@ -2418,10 +2428,14 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
             @{IntendedProtocol = 'Tls11'; ActualProtocol = 'Tls12'}
             @{IntendedProtocol = 'Tls11'; ActualProtocol = 'Tls'}
             @{IntendedProtocol = 'Tls12'; ActualProtocol = 'Tls'}
-            @{IntendedProtocol = 'Tls12'; ActualProtocol = 'Tls11'}            
-            @{IntendedProtocol = 'Tls11, Tls12';   ActualProtocol = 'Tls'}
-            @{IntendedProtocol = 'Tls, Tls12';   ActualProtocol = 'Tls11'}
-            @{IntendedProtocol = 'Tls, Tls11';   ActualProtocol = 'Tls12'}
+            @{IntendedProtocol = 'Tls12'; ActualProtocol = 'Tls11'}
+            # macOS does not support multiple SslProtocols
+            if (-not $IsMacOS) 
+            {
+                @{IntendedProtocol = 'Tls11, Tls12';   ActualProtocol = 'Tls'}
+                @{IntendedProtocol = 'Tls, Tls12';   ActualProtocol = 'Tls11'}
+                @{IntendedProtocol = 'Tls, Tls11';   ActualProtocol = 'Tls12'}
+            }
         ) {
             param( $IntendedProtocol, $ActualProtocol)
             $params = @{

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -1414,6 +1414,44 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
         }
     }
 
+    Context "Invoke-WebRequest -SslProtocol Test" {
+        It "Verifies Invoke-WebRequest -SslProtocol <SslProtocol>" -TestCases @(
+            @{SslProtocol = 'Default'}
+            @{SslProtocol = 'Tls'}
+            @{SslProtocol = 'Tls11'}
+            @{SslProtocol = 'Tls12'}
+        ) {
+            param($SslProtocol)
+            $params = @{
+                Uri = Get-WebListenerUrl -Test 'Get' -Https -SslProtocol $SslProtocol
+                SslProtocol = $SslProtocol
+                SkipCertificateCheck = $true
+            }
+            $response = Invoke-WebRequest @params
+            $result = $Response.Content | ConvertFrom-Json
+
+            $result.headers.Host | Should Be $params.Uri.Authority
+        }
+
+        It "Verifies Invoke-WebRequest -SslProtocol -SslProtocol <IntendedProtocol> fails on a <ActualProtocol> only connection" -TestCases @(
+            @{IntendedProtocol = 'Tls';   ActualProtocol = 'Tls12'}
+            @{IntendedProtocol = 'Tls';   ActualProtocol = 'Tls11'}
+            @{IntendedProtocol = 'Tls11'; ActualProtocol = 'Tls12'}
+            @{IntendedProtocol = 'Tls11'; ActualProtocol = 'Tls'}
+            @{IntendedProtocol = 'Tls12'; ActualProtocol = 'Tls'}
+            @{IntendedProtocol = 'Tls12'; ActualProtocol = 'Tls11'}
+        ) {
+            param( $IntendedProtocol, $ActualProtocol)
+            $params = @{
+                Uri = Get-WebListenerUrl -Test 'Get' -Https -SslProtocol $ActualProtocol
+                SslProtocol = $IntendedProtocol
+                SkipCertificateCheck = $true
+                ErrorAction = 'Stop'
+            }
+            { Invoke-WebRequest @params } | ShouldBeErrorId 'WebCmdletWebResponseException,Microsoft.PowerShell.Commands.InvokeWebRequestCommand'
+        }
+    }
+
     BeforeEach {
         if ($env:http_proxy) {
             $savedHttpProxy = $env:http_proxy
@@ -2329,6 +2367,43 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
             $result = Invoke-RestMethod @params
 
             $result.Headers.Authorization | Should BeExactly "Bearer testpassword"
+        }
+    }
+
+    Context "Invoke-RestMethod -SslProtocol Test" {
+        It "Verifies Invoke-RestMethod -SslProtocol <SslProtocol>" -TestCases @(
+            @{SslProtocol = 'Default'}
+            @{SslProtocol = 'Tls'}
+            @{SslProtocol = 'Tls11'}
+            @{SslProtocol = 'Tls12'}
+        ) {
+            param($SslProtocol)
+            $params = @{
+                Uri = Get-WebListenerUrl -Test 'Get' -Https -SslProtocol $SslProtocol
+                SslProtocol = $SslProtocol
+                SkipCertificateCheck = $true
+            }
+            $result = Invoke-RestMethod @params
+
+            $result.headers.Host | Should Be $params.Uri.Authority
+        }
+
+        It "Verifies Invoke-RestMethod -SslProtocol <IntendedProtocol> fails on a <ActualProtocol> only connection" -TestCases @(
+            @{IntendedProtocol = 'Tls';   ActualProtocol = 'Tls12'}
+            @{IntendedProtocol = 'Tls';   ActualProtocol = 'Tls11'}
+            @{IntendedProtocol = 'Tls11'; ActualProtocol = 'Tls12'}
+            @{IntendedProtocol = 'Tls11'; ActualProtocol = 'Tls'}
+            @{IntendedProtocol = 'Tls12'; ActualProtocol = 'Tls'}
+            @{IntendedProtocol = 'Tls12'; ActualProtocol = 'Tls11'}
+        ) {
+            param( $IntendedProtocol, $ActualProtocol)
+            $params = @{
+                Uri = Get-WebListenerUrl -Test 'Get' -Https -SslProtocol $ActualProtocol
+                SslProtocol = $IntendedProtocol
+                SkipCertificateCheck = $true
+                ErrorAction = 'Stop'
+            }
+            { Invoke-RestMethod @params } | ShouldBeErrorId 'WebCmdletWebResponseException,Microsoft.PowerShell.Commands.InvokeRestMethodCommand'
         }
     }
 

--- a/test/tools/Modules/WebListener/README.md
+++ b/test/tools/Modules/WebListener/README.md
@@ -1,6 +1,6 @@
 # WebListener Module
 
-A PowerShell module for managing the WebListener App. The included SelF-Signed Certificate `ServerCert.pfx` has the password set to `password` and is issued for the Client and Server Authentication key usages. This certificate is used by the WebListener App for SSL/TLS. The included SelF-Signed Certificate `ClientCert.pfx` has the password set to `password` and has not been issued for any specific key usage. This Certificate is used for Client Certificate Authentication with the WebListener App.
+A PowerShell module for managing the WebListener App. The included SelF-Signed Certificate `ServerCert.pfx` has the password set to `password` and is issued for the Client and Server Authentication key usages. This certificate is used by the WebListener App for SSL/TLS. The included SelF-Signed Certificate `ClientCert.pfx` has the password set to `password` and has not been issued for any specific key usage. This Certificate is used for Client Certificate Authentication with the WebListener App. The port used for `-HttpsPort` will use TLS 2.0.
 
 # Running WebListener
 

--- a/test/tools/Modules/WebListener/README.md
+++ b/test/tools/Modules/WebListener/README.md
@@ -1,6 +1,6 @@
 # WebListener Module
 
-A PowerShell module for managing the WebListener App. The included SelF-Signed Certificate `ServerCert.pfx` has the password set to `password` and is issued for the Client and Server Authentication key usages. This certificate is used by the WebListener App for SSL/TLS. The included SelF-Signed Certificate `ClientCert.pfx` has the password set to `password` and has not been issued for any specific key usage. This Certificate is used for Client Certificate Authentication with the WebListener App. The port used for `-HttpsPort` will use TLS 2.0.
+A PowerShell module for managing the WebListener App. The included SelF-Signed Certificate `ServerCert.pfx` has the password set to `password` and is issued for the Client and Server Authentication key usages. This certificate is used by the WebListener App for SSL/TLS. The included SelF-Signed Certificate `ClientCert.pfx` has the password set to `password` and has not been issued for any specific key usage. This Certificate is used for Client Certificate Authentication with the WebListener App. The port used for `-HttpsPort` will use TLS 1.2.
 
 # Running WebListener
 

--- a/test/tools/Modules/WebListener/README.md
+++ b/test/tools/Modules/WebListener/README.md
@@ -7,7 +7,7 @@ A PowerShell module for managing the WebListener App. The included SelF-Signed C
 ```powershell
 Import-Module .\build.psm1
 Publish-PSTestTools
-$Listener = Start-WebListener -HttpPort 8083 -HttpsPort 8084
+$Listener = Start-WebListener -HttpPort 8083 -HttpsPort 8084 -Tls11Port 8085 -TlsPort 8086
 ```
 
 # Stopping WebListener

--- a/test/tools/Modules/WebListener/WebListener.psm1
+++ b/test/tools/Modules/WebListener/WebListener.psm1
@@ -2,6 +2,8 @@ Class WebListener
 {
     [int]$HttpPort
     [int]$HttpsPort
+    [int]$Tls11Port
+    [int]$TlsPort
     [System.Management.Automation.Job]$Job
 
     WebListener () { }
@@ -36,7 +38,13 @@ function Start-WebListener
         [int]$HttpPort = 8083,
 
         [ValidateRange(1,65535)]
-        [int]$HttpsPort = 8084
+        [int]$HttpsPort = 8084,
+
+        [ValidateRange(1,65535)]
+        [int]$Tls11Port = 8085,
+
+        [ValidateRange(1,65535)]
+        [int]$TlsPort = 8086
     )
     
     process 
@@ -58,11 +66,13 @@ function Start-WebListener
         $Job = Start-Job {
             $path = Split-Path -parent (get-command WebListener).Path
             Push-Location $path
-            dotnet $using:appDll $using:serverPfxPath $using:serverPfxPassword $using:HttpPort $using:HttpsPort
+            dotnet $using:appDll $using:serverPfxPath $using:serverPfxPassword $using:HttpPort $using:HttpsPort $using:Tls11Port $using:TlsPort
         }
         $Script:WebListener = [WebListener]@{
             HttpPort  = $HttpPort 
             HttpsPort = $HttpsPort
+            Tls11Port = $Tls11Port
+            TlsPort   = $TlsPort
             Job       = $Job
         }
         # Wait until the app is running or until the initTimeoutSeconds have been reached
@@ -112,6 +122,10 @@ function Get-WebListenerUrl {
     [OutputType([Uri])]
     param (
         [switch]$Https,
+
+        [ValidateSet('Default', 'Tls12', 'Tls11', 'Tls')]
+        [string]$SslProtocol = 'Default',
+
         [ValidateSet(
             'Cert',
             'Compression',
@@ -140,9 +154,15 @@ function Get-WebListenerUrl {
         $Uri.Host = 'localhost'
         $Uri.Port = $runningListener.HttpPort
         $Uri.Scheme = 'Http'
+
         if ($Https.IsPresent)
         {
-            $Uri.Port = $runningListener.HttpsPort
+            switch ($SslProtocol)
+            {
+                'Tls11' { $Uri.Port = $runningListener.Tls11Port }
+                'Tls'   { $Uri.Port = $runningListener.TlsPort }
+                default { $Uri.Port = $runningListener.HttpsPort }
+            }
             $Uri.Scheme = 'Https'
         }
 

--- a/test/tools/Modules/WebListener/WebListener.psm1
+++ b/test/tools/Modules/WebListener/WebListener.psm1
@@ -161,7 +161,7 @@ function Get-WebListenerUrl {
             {
                 'Tls11' { $Uri.Port = $runningListener.Tls11Port }
                 'Tls'   { $Uri.Port = $runningListener.TlsPort }
-                # The base HTTPs port is configured for Tls2 only
+                # The base HTTPs port is configured for Tls12 only
                 default { $Uri.Port = $runningListener.HttpsPort }
             }
             $Uri.Scheme = 'Https'

--- a/test/tools/Modules/WebListener/WebListener.psm1
+++ b/test/tools/Modules/WebListener/WebListener.psm1
@@ -161,6 +161,7 @@ function Get-WebListenerUrl {
             {
                 'Tls11' { $Uri.Port = $runningListener.Tls11Port }
                 'Tls'   { $Uri.Port = $runningListener.TlsPort }
+                # The base HTTPs port is configured for Tls2 only
                 default { $Uri.Port = $runningListener.HttpsPort }
             }
             $Uri.Scheme = 'Https'

--- a/test/tools/WebListener/Program.cs
+++ b/test/tools/WebListener/Program.cs
@@ -20,9 +20,9 @@ namespace mvc
     {
         public static void Main(string[] args)
         {
-            if (args.Count() != 4)
+            if (args.Count() != 6)
             {
-                System.Console.WriteLine("Required: <CertificatePath> <CertificatePassword> <HTTPPortNumber> <HTTPSPortNumber>");  
+                System.Console.WriteLine("Required: <CertificatePath> <CertificatePassword> <HTTPPortNumber> <HTTPSPortNumberTls2> <HTTPSPortNumberTls11> <HTTPSPortNumberTls>");
                 Environment.Exit(1); 
             }
             BuildWebHost(args).Run();
@@ -38,6 +38,28 @@ namespace mvc
                        var certificate = new X509Certificate2(args[0], args[1]);
                        HttpsConnectionAdapterOptions httpsOption = new HttpsConnectionAdapterOptions();
                        httpsOption.SslProtocols = SslProtocols.Tls12;
+                       httpsOption.ClientCertificateMode = ClientCertificateMode.AllowCertificate;
+                       httpsOption.ClientCertificateValidation = (inCertificate, inChain, inPolicy) => {return true;};
+                       httpsOption.CheckCertificateRevocation = false;
+                       httpsOption.ServerCertificate = certificate;
+                       listenOptions.UseHttps(httpsOption);
+                   });
+                   options.Listen(IPAddress.Loopback, int.Parse(args[4]), listenOptions =>
+                   {
+                       var certificate = new X509Certificate2(args[0], args[1]);
+                       HttpsConnectionAdapterOptions httpsOption = new HttpsConnectionAdapterOptions();
+                       httpsOption.SslProtocols = SslProtocols.Tls11;
+                       httpsOption.ClientCertificateMode = ClientCertificateMode.AllowCertificate;
+                       httpsOption.ClientCertificateValidation = (inCertificate, inChain, inPolicy) => {return true;};
+                       httpsOption.CheckCertificateRevocation = false;
+                       httpsOption.ServerCertificate = certificate;
+                       listenOptions.UseHttps(httpsOption);
+                   });
+                   options.Listen(IPAddress.Loopback, int.Parse(args[5]), listenOptions =>
+                   {
+                       var certificate = new X509Certificate2(args[0], args[1]);
+                       HttpsConnectionAdapterOptions httpsOption = new HttpsConnectionAdapterOptions();
+                       httpsOption.SslProtocols = SslProtocols.Tls;
                        httpsOption.ClientCertificateMode = ClientCertificateMode.AllowCertificate;
                        httpsOption.ClientCertificateValidation = (inCertificate, inChain, inPolicy) => {return true;};
                        httpsOption.CheckCertificateRevocation = false;

--- a/test/tools/WebListener/README.md
+++ b/test/tools/WebListener/README.md
@@ -18,7 +18,7 @@ The `WebListener.dll` takes 6 arguments:
 * The path to the Server Certificate
 * The Server Certificate Password
 * The TCP Port to bind on for HTTP
-* The TCP Port to bind on for HTTPS using TLS 2.0
+* The TCP Port to bind on for HTTPS using TLS 1.2
 * The TCP Port to bind on for HTTPS using TLS 1.1
 * The TCP Port to bind on for HTTPS using TLS 1.0
 

--- a/test/tools/WebListener/README.md
+++ b/test/tools/WebListener/README.md
@@ -8,10 +8,10 @@ ASP.NET Core 2.0 app for testing HTTP and HTTPS Requests.
 dotnet restore
 dotnet publish --output bin --configuration Release
 cd bin
-dotnet WebListener.dll ServerCert.pfx password 8083 8084
+dotnet WebListener.dll ServerCert.pfx password 8083 8084 8085 8086
 ```
 
-The test site can then be accessed via `http://localhost:8083/` or `https://localhost:8084/`.  
+The test site can then be accessed via `http://localhost:8083/`, `https://localhost:8084/`, `https://localhost:8085/`, or `https://localhost:8086/`.
 
 The `WebListener.dll` takes 4 arguments: 
 
@@ -25,7 +25,7 @@ The `WebListener.dll` takes 4 arguments:
 ```powershell
 Import-Module .\build.psm1
 Publish-PSTestTools
-$Listener = Start-WebListener -HttpPort 8083 -HttpsPort 8084
+$Listener = Start-WebListener -HttpPort 8083 -HttpsPort 8084 -Tls11Port 8085 -TlsPort = 8086
 ```
 
 # Tests

--- a/test/tools/WebListener/README.md
+++ b/test/tools/WebListener/README.md
@@ -13,12 +13,14 @@ dotnet WebListener.dll ServerCert.pfx password 8083 8084 8085 8086
 
 The test site can then be accessed via `http://localhost:8083/`, `https://localhost:8084/`, `https://localhost:8085/`, or `https://localhost:8086/`.
 
-The `WebListener.dll` takes 4 arguments: 
+The `WebListener.dll` takes 6 arguments: 
 
 * The path to the Server Certificate
 * The Server Certificate Password
 * The TCP Port to bind on for HTTP
-* The TCP Port to bind on for HTTPS
+* The TCP Port to bind on for HTTPS using TLS 2.0
+* The TCP Port to bind on for HTTPS using TLS 1.1
+* The TCP Port to bind on for HTTPS using TLS 1.0
 
 # Run With WebListener Module
 


### PR DESCRIPTION
closes #2662 

This feature adds the ability to restrict the SSL/TLS protocol used when making the web request. In 5.1 the user could make use of .NET API's to enforce this on the Web Cmdlets. With the move to `HttpClient` in PowerShell Core, those APIs have no impact. The user still has requirements to ensure specific protocols are used.

The public enum `WebSslProtocol` is added as a wrapper to the underlying `SslProtocols` enum. Neither it nor ` SecurityProtocolType` can be used because `Ssl3` and `Ssl2` are not supported by `HttpClientHandler.SslProtocols`. While it may not be intuitive to a PowerShell user to use `-bor` or `"Tls, Tls11"` to set multiple options, the general use case for this will be a single protocol.

* Adds `-SslProtocol` parameter to Web Cmdlets
* Adds `WebSslProtocol` Enum to support limited subset of SslProtocol enum supported by `HttpClientHandler`
* Adds TLS 1.1 and TLS 1.0 listening ports to WebListener
* Adds 100% test coverage for new feature

I spoke with @SteveL-MSFT about getting this approved before RC release.