### PR TITLE
Separate Install-PowerShellRemoting.ps1 from psrp.windows nuget package

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -257,10 +257,6 @@ cmd.exe /C cd /d "$location" "&" "$($vcPath)\vcvarsall.bat" "$Arch" "&" cmake "$
             log "  Copying $srcPath to $dstPath"
             Copy-Item $srcPath $dstPath
         }
-
-        # Place the remoting configuration script in the same directory
-        # as the binary so it will get published.
-        Copy-Item .\Install-PowerShellRemoting.ps1 $dstPath
     } finally {
         Pop-Location
     }

--- a/docs/building/internals.md
+++ b/docs/building/internals.md
@@ -124,8 +124,6 @@ Start-BuildNativeWindowsBinaries -Configuration Release -Arch x64
 ```
 
 After that, the binary `pwrshplugin.dll` and its PDB file will be placed under 'src/powershell-win-core'.
-The script file `Install-PowerShellRemoting.ps1` will also be placed in the same folder,
-which is supposed to be used to set up remoting configurations for PowerShell Core.
 
 To create a new NuGet package for `pwrshplugin.dll`, first you need to get the `psrp.windows.nuspec` from an existing `psrp.windows` package.
 You can find it at `~/.nuget/packages/psrp.windows` on your windows machine if you have recently built PowerShell on it.
@@ -138,11 +136,6 @@ and create the same layout of files as in the existing package.
 The layout of files should look like this:
 
 ```none
-+---contentFiles
-|   \---any
-|       \---any
-|               Install-PowerShellRemoting.ps1
-|
 \---runtimes
     +---win-x64
     |   \---native

--- a/src/powershell-win-core/.gitignore
+++ b/src/powershell-win-core/.gitignore
@@ -1,1 +1,0 @@
-Install-PowerShellRemoting.ps1

--- a/src/powershell-win-core/powershell-win-core.csproj
+++ b/src/powershell-win-core/powershell-win-core.csproj
@@ -19,7 +19,7 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
     </Content>
-    <Content Include="..\..\license_thirdparty_proprietary.txt;..\..\DELETE_ME_TO_DISABLE_CONSOLEHOST_TELEMETRY">
+    <Content Include="..\..\license_thirdparty_proprietary.txt;..\..\DELETE_ME_TO_DISABLE_CONSOLEHOST_TELEMETRY;..\powershell-native\Install-PowerShellRemoting.ps1">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
     </Content>


### PR DESCRIPTION
Fix #5307
Separate Install-PowerShellRemoting.ps1 from psrp.windows nuget package.
A new psrp.windows nuget package (beta.4) has been published to powershell-core feed. It doesn't contain the `Install-PowerShellRemoting.ps1` script.