### PR TITLE
Fix Single Value JSON null in Invoke-RestMethod

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/InvokeRestMethodCommand.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/InvokeRestMethodCommand.Common.cs
@@ -5,6 +5,7 @@ Copyright (c) Microsoft Corporation. All rights reserved.
 using System;
 using System.Management.Automation;
 using System.IO;
+using System.Text.RegularExpressions;
 using System.Xml;
 
 namespace Microsoft.PowerShell.Commands
@@ -168,28 +169,39 @@ namespace Microsoft.PowerShell.Commands
 
         private bool TryConvertToJson(string json, out object obj, ref Exception exRef)
         {
+            bool converted;
             try
             {
                 ErrorRecord error;
                 obj = JsonObject.ConvertFromJson(json, out error);
+                converted = true;
+
+                if (null == obj)
+                {
+                    string pattern = @"^\s*null\s*$";
+                    Match matches = Regex.Match(json, pattern);
+                    converted = matches.Success;
+                }
 
                 if (error != null)
                 {
                     exRef = error.Exception;
-                    obj = null;
+                    converted = false;
                 }
             }
             catch (ArgumentException ex)
             {
                 exRef = ex;
+                converted = false;
                 obj = null;
             }
             catch (InvalidOperationException ex)
             {
                 exRef = ex;
+                converted = false;
                 obj = null;
             }
-            return (null != obj);
+            return converted;
         }
 
         #endregion

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -2624,9 +2624,7 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
         It "Invoke-RestMethod Supports a Single Value JSON null and ignores whitespace" {
             $url = '{0}{1}' -f $baseUrl, "            null         "
             Invoke-RestMethod -Uri $url | Should Be $null
-            $url = '{0}{1}' -f $baseUrl, "            
-                                            null         
-                                         "
+            $url = '{0}{1}' -f $baseUrl, "           null         `n"
             Invoke-RestMethod -Uri $url | Should Be $null
         }
     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -2613,6 +2613,24 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
 
     }
 
+    Context "Invoke-RestMethod Single Value JSON null support" {
+        BeforeAll {
+            $baseUrl = 'http://localhost:8081/PowerShell?test=response&contenttype=application/json&output='
+        }
+        It "Invoke-RestMethod Supports a Single Value JSON null" {
+            $url = '{0}{1}' -f $baseUrl, 'null'
+            Invoke-RestMethod -Uri $url | Should Be $null
+        }
+        It "Invoke-RestMethod Supports a Single Value JSON null and ignores whitespace" {
+            $url = '{0}{1}' -f $baseUrl, "            null         "
+            Invoke-RestMethod -Uri $url | Should Be $null
+            $url = '{0}{1}' -f $baseUrl, "            
+                                            null         
+                                         "
+            Invoke-RestMethod -Uri $url | Should Be $null
+        }
+    }
+
     BeforeEach {
         if ($env:http_proxy) {
             $savedHttpProxy = $env:http_proxy


### PR DESCRIPTION
closes #5320 

When an API returns just `null`, `Invoke-RestMethod` was serializing this as the string `"null"` instead of `$null`. Singe value literals are valid JSON according to [rfc7159](https://tools.ietf.org/html/rfc7159) section 2:

```none
   A JSON text is a serialized value.  Note that certain previous
   specifications of JSON constrained a JSON text to be an object or an
   array.  Implementations that generate only objects or arrays where a
   JSON text is called for will be interoperable in the sense that all
   implementations will accept these as conforming JSON texts.
```

Invoke-RestMethod is already properly managing `false`, `true`, numbers, string, arrays, and objects.

This PR fixes the logic in `Invoke-RestMethod` to properly serialize a valid single value JSON `null` literal as `$null`.

This is a breaking change in the sense that users who are using `Invoke-RestMethod` against endpoints that returned single value `null` likely have logic in place to work around the current broken behavior.This change will break that logic.