### PR TITLE
Update Wix toolset download link in error message to newer version 3.11 (same as CI)

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -1888,7 +1888,7 @@ function New-MSIPackage
     Write-Verbose "Ensure Wix Toolset is present on the machine @ $wixToolsetBinPath"
     if (-not (Test-Path $wixToolsetBinPath))
     {
-        throw "Wix Toolset is required to create MSI package. Please install Wix from https://wix.codeplex.com/downloads/get/1540240"
+        throw "Wix Toolset is required to create MSI package. Please install it from https://github.com/wixtoolset/wix3/releases/download/wix311rtm/wix311.exe"
     }
 
     ## Get the latest if multiple versions exist.


### PR DESCRIPTION
This makes it also future proof because:
- Codeplexx is going to get deprecated and the new link links directly to the GitHub repository.
- Only version 3.11 enabled support for Visual Studio 2017.

I have tested locally (on a machine that does not have the old WiX v 3.10 but only the new version 3.11) that building the installer still works.