### PR TITLE
Update Find-Dotnet to find dotnet with compat SDK

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -3,7 +3,7 @@
 $script:TestModulePathSeparator = [System.IO.Path]::PathSeparator
 
 $dotnetCLIChannel = "release"
-$dotnetCLIRequiredVersion = "2.0.2"
+$dotnetCLIRequiredVersion = $(Get-Content $PSScriptRoot/global.json | ConvertFrom-Json).Sdk.Version
 
 # Track if tags have been sync'ed
 $tagsUpToDate = $false
@@ -600,7 +600,7 @@ function New-PSOptions {
         [string]$Output,
 
         [switch]$SMAOnly,
-        
+
         [switch]$PSModuleRestore
     )
 
@@ -1685,13 +1685,23 @@ function Start-ResGen
 
 function Find-Dotnet() {
     $originalPath = $env:PATH
-    $dotnetPath = if ($Environment.IsWindows) {
-        "$env:LocalAppData\Microsoft\dotnet"
-    } else {
-        "$env:HOME/.dotnet"
-    }
+    $dotnetPath = if ($Environment.IsWindows) { "$env:LocalAppData\Microsoft\dotnet" } else { "$env:HOME/.dotnet" }
 
-    if (-not (precheck 'dotnet' "Could not find 'dotnet', appending $dotnetPath to PATH.")) {
+    # If there dotnet is already in the PATH, check to see if that version of dotnet can find the required SDK
+    # This is "typically" the globally installed dotnet
+    if (precheck dotnet) {
+        # Must run from within repo to ensure global.json can specify the required SDK version
+        Push-Location $PSScriptRoot
+        $dotnetCLIInstalledVersion = (dotnet --version)
+        Pop-Location
+        if ($dotnetCLIInstalledVersion -ne $dotnetCLIRequiredVersion) {
+            Write-Warning "The 'dotnet' in the current path can't find SDK version ${dotnetCLIRequiredVersion}, prepending $dotnetPath to PATH."
+            # Globally installed dotnet doesn't have the required SDK version, prepend the user local dotnet location
+            $env:PATH = $dotnetPath + [IO.Path]::PathSeparator + $env:PATH
+        }
+    }
+    else {
+        Write-Warning "Could not find 'dotnet', appending $dotnetPath to PATH."
         $env:PATH += [IO.Path]::PathSeparator + $dotnetPath
     }
 


### PR DESCRIPTION
Fix #5260 - with this fix, folks shouldn't run afoul of the SDK version mismatch check.

Note: the branch name turns out to be a little misleading.  Read further.

The approach is to see if the dotnet in the current PATH has a compatible SDK.  Folks will have a globally installed dotnet if they've installed VS or have installed the .NET Core SDK themselves.  The global dotnet may not have access to the SDK required by PSCore.  That is, the global dotnet cannot see user local dotnet SDK installs.  So if the global dotnet doesn't have the right SDK, we prepend the path to the user's local dotnet dir.

Also, update $dotnetCLIRequiredVersion to read its value from global.json so there is one less source of the truth (for the SDK version).

<!--

If you are a PowerShell Team member, please make sure you choose the Reviewer(s) and Assignee for your PR.
If you are not from the PowerShell Team, you can leave the fields blank and the Maintainers will choose them for you. If you are familiar with the team, feel free to mention some Reviewers yourself.

For more information about the roles of Reviewer and Assignee, refer to [CONTRIBUTING.md](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md).

-->
