### PR TITLE
Fix Start-PSBuild on WSL if repository was already built on Windows

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -492,8 +492,8 @@ Fix steps:
     $incFileName = 'powershell.inc'
     if (-not [string]::IsNullOrEmpty($Runtime)) {
         # File name must be different for Windows and Linux to allow build on Windows and WSL.
-        # Append the first 3 characters fo the Runtime only because otherwise dotnet will crash due to the separation characters. The underscore is only for better readability.
-        $incFileName = "$($incFileName)_$($Runtime.Substring(0,3)).inc"
+        # Append the first 3 characters for the Runtime only because otherwise dotnet will crash due to the separation characters. The underscore is only for better readability.
+        $incFileName = "$($incFileName)_$($Runtime).inc"
     }
     if ($TypeGen -or -not (Test-Path "$PSScriptRoot/TypeCatalogGen/$($incFileName)")) {
         log "Run TypeGen (generating CorePsTypeCatalog.cs)"

--- a/build.psm1
+++ b/build.psm1
@@ -489,13 +489,13 @@ Fix steps:
     }
 
     # handle TypeGen
-    $incFileName = 'powershell'
+    $incFileName = 'powershell.inc'
     if (-not [string]::IsNullOrEmpty($Runtime)) {
         # File name must be different for Windows and Linux to allow build on Windows and WSL.
         # Append the first 3 characters fo the Runtime only because otherwise dotnet will crash due to the separation characters. The underscore is only for better readability.
-        $incFileName = "$($incFileName)_$($Runtime.Substring(0,3))"
+        $incFileName = "$($incFileName)_$($Runtime.Substring(0,3)).inc"
     }
-    if ($TypeGen -or -not (Test-Path "$PSScriptRoot/TypeCatalogGen/$($incFileName).inc")) {
+    if ($TypeGen -or -not (Test-Path "$PSScriptRoot/TypeCatalogGen/$($incFileName)")) {
         log "Run TypeGen (generating CorePsTypeCatalog.cs)"
         Start-TypeGen -IncFileName $incFileName
     }
@@ -521,7 +521,7 @@ Fix steps:
     # publish netcoreapp2.0 reference assemblies
     try {
         Push-Location "$PSScriptRoot/src/TypeCatalogGen"
-        $refAssemblies = Get-Content -Path "$($incFileName).inc" | Where-Object { $_ -like "*microsoft.netcore.app*" } | ForEach-Object { $_.TrimEnd(';') }
+        $refAssemblies = Get-Content -Path $incFileName | Where-Object { $_ -like "*microsoft.netcore.app*" } | ForEach-Object { $_.TrimEnd(';') }
         $refDestFolder = Join-Path -Path $publishPath -ChildPath "ref"
 
         if (Test-Path $refDestFolder -PathType Container) {
@@ -1663,7 +1663,7 @@ function Start-TypeGen
 
     Push-Location "$PSScriptRoot/src/Microsoft.PowerShell.SDK"
     try {
-        $ps_inc_file = "$PSScriptRoot/src/TypeCatalogGen/$($incFileName).inc"
+        $ps_inc_file = "$PSScriptRoot/src/TypeCatalogGen/$($incFileName)"
         dotnet msbuild .\Microsoft.PowerShell.SDK.csproj /t:_GetDependencies "/property:DesignTimeBuild=true;_DependencyFile=$ps_inc_file" /nologo
     } finally {
         Pop-Location
@@ -1671,7 +1671,7 @@ function Start-TypeGen
 
     Push-Location "$PSScriptRoot/src/TypeCatalogGen"
     try {
-        dotnet run ../System.Management.Automation/CoreCLR/CorePsTypeCatalog.cs "$($incFileName).inc"
+        dotnet run ../System.Management.Automation/CoreCLR/CorePsTypeCatalog.cs $incFileName
     } finally {
         Pop-Location
     }

--- a/build.psm1
+++ b/build.psm1
@@ -488,13 +488,9 @@ Fix steps:
         Start-ResGen
     }
 
-    # handle TypeGen
-    $incFileName = 'powershell.inc'
-    if (-not [string]::IsNullOrEmpty($Runtime)) {
-        # File name must be different for Windows and Linux to allow build on Windows and WSL.
-        # Append the first 3 characters for the Runtime only because otherwise dotnet will crash due to the separation characters. The underscore is only for better readability.
-        $incFileName = "$($incFileName)_$($Runtime).inc"
-    }
+    # Handle TypeGen
+    # .inc file name must be different for Windows and Linux to allow build on Windows and WSL.
+    $incFileName = "powershell_$($Options.Runtime).inc"
     if ($TypeGen -or -not (Test-Path "$PSScriptRoot/TypeCatalogGen/$($incFileName)")) {
         log "Run TypeGen (generating CorePsTypeCatalog.cs)"
         Start-TypeGen -IncFileName $incFileName

--- a/build.psm1
+++ b/build.psm1
@@ -491,7 +491,9 @@ Fix steps:
     # handle TypeGen
     $incFileName = 'powershell'
     if (-not [string]::IsNullOrEmpty($Runtime)) {
-        $incFileName = "$($incFileName)_$($Runtime.Substring(0,3))" # use the first 3 characters only because otherwise dotnet will crash due to the separation characters
+        # File name must be different for Windows and Linux to allow build on Windows and WSL.
+        # Append the first 3 characters fo the Runtime only because otherwise dotnet will crash due to the separation characters. The underscore is only for better readability.
+        $incFileName = "$($incFileName)_$($Runtime.Substring(0,3))"
     }
     if ($TypeGen -or -not (Test-Path "$PSScriptRoot/TypeCatalogGen/$($incFileName).inc")) {
         log "Run TypeGen (generating CorePsTypeCatalog.cs)"

--- a/build.psm1
+++ b/build.psm1
@@ -346,6 +346,7 @@ function Start-PSBuild {
 
         # These runtimes must match those in project.json
         # We do not use ValidateScript since we want tab completion
+        # If this parameter is not provided it will get determined automatically.
         [ValidateSet("win7-x64",
                      "win7-x86",
                      "osx.10.12-x64",
@@ -491,7 +492,7 @@ Fix steps:
     # Handle TypeGen
     # .inc file name must be different for Windows and Linux to allow build on Windows and WSL.
     $incFileName = "powershell_$($Options.Runtime).inc"
-    if ($TypeGen -or -not (Test-Path "$PSScriptRoot/TypeCatalogGen/$($incFileName)")) {
+    if ($TypeGen -or -not (Test-Path "$PSScriptRoot/TypeCatalogGen/$incFileName")) {
         log "Run TypeGen (generating CorePsTypeCatalog.cs)"
         Start-TypeGen -IncFileName $incFileName
     }
@@ -1635,9 +1636,8 @@ function Start-TypeGen
     [CmdletBinding()]
     param
     (
-        [Parameter(Mandatory=$true)]
         [ValidateNotNullOrEmpty()]
-        $IncFileName
+        $IncFileName = 'powershell.inc'
     )
 
     # Add .NET CLI tools to PATH
@@ -1659,7 +1659,7 @@ function Start-TypeGen
 
     Push-Location "$PSScriptRoot/src/Microsoft.PowerShell.SDK"
     try {
-        $ps_inc_file = "$PSScriptRoot/src/TypeCatalogGen/$($incFileName)"
+        $ps_inc_file = "$PSScriptRoot/src/TypeCatalogGen/$IncFileName"
         dotnet msbuild .\Microsoft.PowerShell.SDK.csproj /t:_GetDependencies "/property:DesignTimeBuild=true;_DependencyFile=$ps_inc_file" /nologo
     } finally {
         Pop-Location
@@ -1667,7 +1667,7 @@ function Start-TypeGen
 
     Push-Location "$PSScriptRoot/src/TypeCatalogGen"
     try {
-        dotnet run ../System.Management.Automation/CoreCLR/CorePsTypeCatalog.cs $incFileName
+        dotnet run ../System.Management.Automation/CoreCLR/CorePsTypeCatalog.cs $IncFileName
     } finally {
         Pop-Location
     }

--- a/src/TypeCatalogGen/.gitignore
+++ b/src/TypeCatalogGen/.gitignore
@@ -1,1 +1,1 @@
-powershell.inc
+powershell**.inc


### PR DESCRIPTION
To fix #5194: Use the first 3 characters of the passed `-Runtime` parameter for the .inc file (the full runtime name could not be used since the separation characters ike e.g. the the hyphen would make dotnet crash when building).

A separate issue is that the runtime does not get determined if is not being passed (which is OK since dotnet takes then care of choosing the right one) but maybe given this scenario would it make sense to determine and set it as a convenience?
