### PR TITLE
Change $OutputEncoding to use iso-8859-1 encoding rather than ASCII

### DIFF
--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -4410,7 +4410,7 @@ end
             // Variable which controls the encoding for piping data to a NativeCommand
             new SessionStateVariableEntry(
                 SpecialVariables.OutputEncoding,
-                System.Text.Encoding.ASCII,
+                Utils.iso8859,
                 RunspaceInit.OutputEncodingDescription,
                 ScopedItemOptions.None,
                 new ArgumentTypeConverterAttribute(typeof(System.Text.Encoding))

--- a/src/System.Management.Automation/engine/NativeCommandProcessor.cs
+++ b/src/System.Management.Automation/engine/NativeCommandProcessor.cs
@@ -1797,8 +1797,7 @@ namespace System.Management.Automation
             //Get the encoding for writing to native command. Note we get the Encoding
             //from the current scope so a script or function can use a different encoding
             //than global value.
-            Encoding pipeEncoding = _command.Context.GetVariableValue(SpecialVariables.OutputEncodingVarPath) as System.Text.Encoding ??
-                                    Encoding.ASCII;
+            Encoding pipeEncoding = _command.Context.GetVariableValue(SpecialVariables.OutputEncodingVarPath) as System.Text.Encoding ??  Utils.iso8859;
 
             _streamWriter = new StreamWriter(process.StandardInput.BaseStream, pipeEncoding);
             _streamWriter.AutoFlush = true;

--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -1239,8 +1239,9 @@ namespace System.Management.Automation
             (char) 21, (char) 22, (char) 23, (char) 24, (char) 25, (char) 26, (char) 28, (char) 29, (char) 30,
             (char) 31, (char) 127, (char) 129, (char) 141, (char) 143, (char) 144, (char) 157 };
 
-        internal static readonly UTF8Encoding utf8NoBom =
-            new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+        internal static readonly UTF8Encoding utf8NoBom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+        // encoding which is essentially a passthru
+        internal static readonly Encoding iso8859 = Encoding.GetEncoding(28591);
 
 #if !CORECLR // TODO:CORECLR - WindowsIdentity.Impersonate() is not available. Use WindowsIdentity.RunImpersonated to replace it.
         /// <summary>

--- a/src/System.Management.Automation/engine/remoting/common/RunspaceConnectionInfo.cs
+++ b/src/System.Management.Automation/engine/remoting/common/RunspaceConnectionInfo.cs
@@ -2179,14 +2179,14 @@ namespace System.Management.Automation.Runspaces
             {
                 Debug.Assert(stdinFd >= 0, "Invalid Fd");
                 standardInput = new StreamWriter(OpenStream(stdinFd, FileAccess.Write),
-                    Utils.utf8NoBom, StreamBufferSize)
+                    Utils.iso8859, StreamBufferSize)
                 { AutoFlush = true };
             }
             if (startInfo.RedirectStandardOutput)
             {
                 Debug.Assert(stdoutFd >= 0, "Invalid Fd");
                 standardOutput = new StreamReader(OpenStream(stdoutFd, FileAccess.Read),
-                    startInfo.StandardOutputEncoding ?? Utils.utf8NoBom, true, StreamBufferSize);
+                    startInfo.StandardOutputEncoding ?? Utils.iso8859, true, StreamBufferSize);
             }
             if (startInfo.RedirectStandardError)
             {

--- a/src/System.Management.Automation/utils/EncodingUtils.cs
+++ b/src/System.Management.Automation/utils/EncodingUtils.cs
@@ -19,6 +19,7 @@ namespace System.Management.Automation
         internal const string Unicode = "unicode";
         internal const string BigEndianUnicode = "bigendianunicode";
         internal const string Ascii = "ascii";
+        internal const string Iso8859 = "iso8859";
         internal const string Utf8 = "utf8";
         internal const string Utf8NoBom = "utf8NoBOM";
         internal const string Utf8Bom = "utf8BOM";
@@ -27,7 +28,7 @@ namespace System.Management.Automation
         internal const string Default = "default";
         internal const string OEM = "oem";
         internal static readonly string[] TabCompletionResults = {
-                Ascii, BigEndianUnicode, OEM, Unicode, Utf7, Utf8, Utf8Bom, Utf8NoBom, Utf32
+                Ascii, BigEndianUnicode, Iso8859, OEM, Unicode, Utf7, Utf8, Utf8Bom, Utf8NoBom, Utf32
             };
 
         internal static Dictionary<string, Encoding> encodingMap = new Dictionary<string,Encoding>(StringComparer.OrdinalIgnoreCase)
@@ -37,6 +38,7 @@ namespace System.Management.Automation
             { Default, ClrFacade.GetDefaultEncoding() },
             { OEM, ClrFacade.GetOEMEncoding() },
             { Unicode, System.Text.Encoding.Unicode },
+            { Iso8859, Utils.iso8859 },
             { Utf7, System.Text.Encoding.UTF7 },
             { Utf8, ClrFacade.GetDefaultEncoding() },
             { Utf8Bom, System.Text.Encoding.UTF8 },

--- a/test/tools/TestExe/TestExe.cs
+++ b/test/tools/TestExe/TestExe.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Text;
 using System.Threading;
 using System.Diagnostics;
 
@@ -17,6 +18,12 @@ namespace TestExe
                         break;
                     case "-createchildprocess":
                         CreateChildProcess(args);
+                        break;
+                    case "-writeoutput":
+                        WriteStandardOutput();
+                        break;
+                    case "-readinput":
+                        ReadStandardInput(args);
                         break;
                     default:
                         Console.WriteLine("Unknown test {0}", args[0]);
@@ -37,6 +44,48 @@ namespace TestExe
             for (int i = 1; i < args.Length; i++)
             {
                 Console.WriteLine("Arg {0} is <{1}>", i-1, args[i]);
+            }
+        }
+
+        static void WriteStandardOutput()
+        {
+            // write a string of characters (bytes), this closest resembles a binary
+            // write the string "test" with an accent over the e
+            byte[] testbytes = new byte[] { 116, 233, 115, 116 };
+            foreach(byte b in testbytes)
+            {
+                Console.Write((char)b);
+            }
+        }
+
+        static void ReadStandardInput(string[] args)
+        {
+            Encoding encodingToUse = null;
+            if (args.Length > 1)
+            {
+                // the encoding page to get could be provided as an argument;
+                int result;
+                if ( int.TryParse(args[1], out result))
+                {
+                    try
+                    {
+                        encodingToUse = Encoding.GetEncoding(result);
+                    }
+                    catch
+                    {
+                        ;
+                    }
+                }
+            }
+            if ( encodingToUse == null )
+            {
+                encodingToUse = Encoding.GetEncoding(28591);
+            }
+            Console.InputEncoding = encodingToUse;
+            string pipedText = Console.In.ReadToEnd();
+            foreach(char c in pipedText.ToCharArray())
+            {
+                Console.WriteLine((byte)c);
             }
         }
 


### PR DESCRIPTION
This enables a number of useful scenarios.
With this change it is now possible to do the following:

```powershell
get-content -raw -encoding iso8859 /tmp/archive.tgz | gunzip | tar xvf -
```
and expand a compressed tar archive.
It also ensures that the bytes/characters passed to a native executable are not changed by the pipeline.
What is passed into the pipeline is passed to the next native application

This does _not_ address https://github.com/PowerShell/PowerShell/issues/1908, as that requires a larger re-architecture of the pipeline. This PR continues to have a `[environment]::newline` which is added to the native output which should be addressed when 1908 is fixed.

This is marked as a breaking change because the output of the pipeline is not altered as it was previously, anyone relying on ascii encoding (especially for extended ascii sequences) will no longer have that behavior (broken though it was).