### PR TITLE
Add support LF newlines in Import-Csv

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CSVCommands.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CSVCommands.cs
@@ -1485,22 +1485,19 @@ namespace Microsoft.PowerShell.Commands
                 }
                 else if (IsNewLine(ch))
                 {
-                    if (ch == '\r')
-                    {
-                        ReadChar();
-                    }
-
                     if (seenBeginQuote)
                     {
                         //newline inside quote are valid
                         current.Append(ch);
-                        if (ch == '\r')
+                        if (ch == '\r' && PeekNextChar('\n'))
                         {
+                            ReadChar();
                             current.Append('\n');
                         }
                     }
                     else
                     {
+                        SkipNewLine();
                         result.Add(current.ToString());
                         current.Remove(0, current.Length);
                         //New line outside quote is end of word and end of record
@@ -1524,19 +1521,17 @@ namespace Microsoft.PowerShell.Commands
         bool
         IsNewLine(char ch)
         {
-            bool newLine = false;
-            if (ch == '\n')
+            return ch == '\r' || ch == '\n';
+        }
+
+        private
+        void
+        SkipNewLine()
+        {
+            if (PeekNextChar('\n'))
             {
-                newLine = true;
+                ReadChar();
             }
-            else if (ch == '\r')
-            {
-                if (PeekNextChar('\n'))
-                {
-                    newLine = true;
-                }
-            }
-            return newLine;
         }
 
         /// <summary>
@@ -1577,10 +1572,7 @@ namespace Microsoft.PowerShell.Commands
                 else if (IsNewLine(ch))
                 {
                     endOfRecord = true;
-                    if (ch == '\r')
-                    {
-                        ReadChar();
-                    }
+                    SkipNewLine();
                     break;
                 }
                 else

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CSVCommands.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CSVCommands.cs
@@ -1488,7 +1488,6 @@ namespace Microsoft.PowerShell.Commands
                     if (seenBeginQuote)
                     {
                         //newline inside quote are valid
-                        current.Append(ch);
                         current.Append(newLine);
                     }
                     else

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Import-Csv.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Import-Csv.Tests.ps1
@@ -92,3 +92,24 @@ Describe "Import-Csv #Type Tests" -Tags "CI" {
         $importType | Should Be $expectedProcessType
     }
 }
+
+Describe "Import-Csv with different newlines" -Tags "CI" {
+    It "Test import-csv with '<name>' newline" -TestCases @(
+        @{ name = "CR"; newline = "`r" }
+        @{ name = "LF"; newline = "`n" }
+        @{ name = "CRLF"; newline = "`r`n" }
+        ) {
+        param($newline)
+        $csvFile = Join-Path $TestDrive -ChildPath $((New-Guid).Guid)
+        $delimiter = ','
+        "h1,h2,h3$($newline)11,12,13$($newline)21,22,23$($newline)" | Out-File -FilePath $csvFile
+        $returnObject = Import-Csv -Path $csvFile -Delimiter $delimiter
+        $returnObject.Count | Should Be 2
+        $returnObject[0].h1 | Should Be 11
+        $returnObject[0].h2 | Should Be 12
+        $returnObject[0].h3 | Should Be 13
+        $returnObject[1].h1 | Should Be 21
+        $returnObject[1].h2 | Should Be 22
+        $returnObject[1].h3 | Should Be 23
+    }
+}


### PR DESCRIPTION
Fix #3692.

## Fix description
After the fix Import-Csv support CR (\r), LF (\n), CRLF (\r\n) as line delimiters.