### PR TITLE
update instructions to build on VSCode based on pwsh

### DIFF
--- a/docs/building/windows-core.md
+++ b/docs/building/windows-core.md
@@ -24,7 +24,7 @@ The free Community edition of Visual Studio 2015 can be downloaded [here](https:
 ### Visual Studio Code
 
 Building PowerShell using [Visual Studio Code](https://code.visualstudio.com/) depends on the PowerShell executable to be called `pwsh` which means
-that you must have PowerShell Core 6 beta.9 (or newer) installed to successfully build this project (typically for the purpose of debugging).
+that you must have PowerShell Core 6 Beta.9 (or newer) installed to successfully build this project (typically for the purpose of debugging).
 
 ### .NET CLI
 

--- a/docs/building/windows-core.md
+++ b/docs/building/windows-core.md
@@ -21,6 +21,11 @@ This guide assumes that you have recursively cloned the PowerShell repository an
 You will need to install an edition of Visual Studio 2015 (Community, Enterprise, or Professional) with the optional feature 'Common Tools for Visual C++' installed.
 The free Community edition of Visual Studio 2015 can be downloaded [here](https://www.visualstudio.com/visual-studio-community-vs/).
 
+### Visual Studio Code
+
+Building PowerShell using [Visual Studio Code](https://code.visualstudio.com/) depends on the PowerShell executable to be called `pwsh` which means
+that you must have PowerShell Core 6 beta.9 (or newer) installed to successfully build this project (typically for the purpose of debugging).
+
 ### .NET CLI
 
 We use the [.NET Command Line Interface][dotnet-cli] (`dotnet`) to build PowerShell.


### PR DESCRIPTION
Our vscode .json configuration files expect PowerShell exe to be called pwsh. 
<!--

If you are a PowerShell Team member, please make sure you choose the Reviewer(s) and Assignee for your PR.
If you are not from the PowerShell Team, you can leave the fields blank and the Maintainers will choose them for you. If you are familiar with the team, feel free to mention some Reviewers yourself.

For more information about the roles of Reviewer and Assignee, refer to [CONTRIBUTING.md](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md).

-->
