### PR TITLE
Exclude EventResource.resx from SMAResources.Tests.ps1

### DIFF
--- a/test/powershell/engine/ResourceValidation/SMAResources.Tests.ps1
+++ b/test/powershell/engine/ResourceValidation/SMAResources.Tests.ps1
@@ -4,6 +4,7 @@ $AssemblyName = "System.Management.Automation"
 # excluded resources, taken from the 'EmbeddedResource Remove'
 # entries in the csproj for the assembly
 $excludeList = "CoreMshSnapinResources.resx",
-    "ErrorPackageRemoting.resx"
+    "ErrorPackageRemoting.resx",
+    "EventResource.resx"
 # run the tests
 Test-ResourceStrings -AssemblyName $AssemblyName -ExcludeList $excludeList


### PR DESCRIPTION
[Feature]
Fix https://github.com/PowerShell/PowerShell/issues/5378
EventResource.resx does not have a generated C# class.
