### PR TITLE
Fedora documation correction

### DIFF
--- a/docs/installation/linux.md
+++ b/docs/installation/linux.md
@@ -455,7 +455,7 @@ pwsh
 
 Download the RPM package
 `powershell-6.0.0_beta.9-1.rhel.7.x86_64.rpm`
-from the [releases][] page onto the Red Hat Enterprise Linux machine.
+from the [releases][] page onto the Fedora machine.
 
 Then execute the following in the terminal:
 
@@ -505,7 +505,7 @@ pwsh
 
 Download the RPM package
 `powershell-6.0.0_beta.9-1.rhel.7.x86_64.rpm`
-from the [releases][] page onto the Red Hat Enterprise Linux machine.
+from the [releases][] page onto the Fedora machine.
 
 Then execute the following in the terminal:
 


### PR DESCRIPTION
Correction to the Fedora documentation: "Fedora machine" instead of "Red Hat Enterprise Linux machine"

<!--

If you are a PowerShell Team member, please make sure you choose the Reviewer(s) and Assignee for your PR.
If you are not from the PowerShell Team, you can leave the fields blank and the Maintainers will choose them for you. If you are familiar with the team, feel free to mention some Reviewers yourself.

For more information about the roles of Reviewer and Assignee, refer to [CONTRIBUTING.md](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md).

-->
