### PR TITLE
Revive 'download.sh' and make it redirect to 'install-powershell.sh'

### DIFF
--- a/tools/download.sh
+++ b/tools/download.sh
@@ -1,0 +1,2 @@
+bash <(curl -s https://raw.githubusercontent.com/PowerShell/PowerShell/master/tools/install-powershell.sh)
+

--- a/tools/download.sh
+++ b/tools/download.sh
@@ -1,2 +1,1 @@
 bash <(curl -s https://raw.githubusercontent.com/PowerShell/PowerShell/master/tools/install-powershell.sh)
-


### PR DESCRIPTION
Per the discussion at https://github.com/PowerShell/PowerShell/pull/5309#issuecomment-342575567, I add the `download.sh` back and make it redirect to `install-powershell.sh`.

/cc @DarwinJS 