### PR TITLE
add ability to produce tar.gz pkg for Raspbian

### DIFF
--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -33,10 +33,6 @@ function Start-PSPackage {
         [Switch] $SkipReleaseChecks
     )
 
-    # The package type 'deb-arm' is current disabled for '-Type' parameter because 'New-UnixPackage' doesn't support
-    # creating package for 'deb-arm'. It should be added back to the ValidateSet of '-Type' once the implementation
-    # of creating 'deb-arm' package is done.
-
     DynamicParam {
         if ($Type -eq "zip") {
             # Add a dynamic parameter '-IncludeSymbols' when the specified package type is 'zip'.
@@ -154,7 +150,7 @@ function Start-PSPackage {
             $Source = New-TempFolder
             $symbolsSource = New-TempFolder
 
-            try 
+            try
             {
                 # Copy files which go into the root package
                 Get-ChildItem -Path $publishSource | Copy-Item -Destination $Source -Recurse


### PR DESCRIPTION
Although Raspbian supports .deb pkgs, the creation of a deb pkg needs to happen on an actual R-Pi device.  Next best thing for now is to produce a .tar.gz pkg making it easier to deploy PowerShell on R-Pi.

Not sure if any other files need to be updated so we have a `preview` release of R-Pi support with 6.0.0-RC.
<!--

If you are a PowerShell Team member, please make sure you choose the Reviewer(s) and Assignee for your PR.
If you are not from the PowerShell Team, you can leave the fields blank and the Maintainers will choose them for you. If you are familiar with the team, feel free to mention some Reviewers yourself.

For more information about the roles of Reviewer and Assignee, refer to [CONTRIBUTING.md](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md).

-->
