### PR TITLE
Add PSTypeName Support for Import-Csv and ConvertFrom-Csv

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CSVCommands.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CSVCommands.cs
@@ -1336,10 +1336,6 @@ namespace Microsoft.PowerShell.Commands
                     {
                         type = null;
                     }
-                    else
-                    {
-                        type = ImportExportCSVHelper.CSVTypePrefix + type;
-                    }
                 }
             }
             return type;
@@ -1606,11 +1602,6 @@ namespace Microsoft.PowerShell.Commands
             PSObject result = new PSObject();
             char delimiterlocal = delimiter;
             int unspecifiedNameIndex = 1;
-            if (type != null && type.Length > 0)
-            {
-                result.TypeNames.Clear();
-                result.TypeNames.Add(type);
-            }
             for (int i = 0; i <= names.Count - 1; i++)
             {
                 string name = names[i];
@@ -1636,6 +1627,13 @@ namespace Microsoft.PowerShell.Commands
             {
                 _cmdlet.WriteWarning(CsvCommandStrings.UseDefaultNameForUnspecifiedHeader);
                 _alreadyWarnedUnspecifiedName = true;
+            }
+
+            if (type != null && type.Length > 0)
+            {
+                result.TypeNames.Clear();
+                result.TypeNames.Add(type);
+                result.TypeNames.Add(ImportExportCSVHelper.CSVTypePrefix + type);
             }
 
             return result;

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertFrom-Csv.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertFrom-Csv.Tests.ps1
@@ -10,6 +10,11 @@ Describe "ConvertFrom-Csv" -Tags "CI" {
 a,b,c
 1,2,3
 "@
+        $testTypeData = @"
+#TYPE My.Custom.Object
+a,b,c
+1,2,3
+"@
     }
 
     It "Should be able to be called" {
@@ -52,6 +57,12 @@ a,b,c
         $actualLength = $($( $actualData | gm) | Where-Object {$_.MemberType -eq "NoteProperty" }).Length
 
         $actualLength | Should Be 3
+    }
+
+    It "Should Contain the Imported Type data" {
+        $actualData = $testTypeData | ConvertFrom-Csv
+        $actualData.PSObject.TypeNames[0] | Should Be "My.Custom.Object"
+        $actualData.PSObject.TypeNames[1] | Should Be "CSV:My.Custom.Object"
     }
 }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertFrom-Csv.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertFrom-Csv.Tests.ps1
@@ -61,6 +61,7 @@ a,b,c
 
     It "Should Contain the Imported Type data" {
         $actualData = $testTypeData | ConvertFrom-Csv
+        $actualData.PSObject.TypeNames.Count | Should Be 2
         $actualData.PSObject.TypeNames[0] | Should Be "My.Custom.Object"
         $actualData.PSObject.TypeNames[1] | Should Be "CSV:My.Custom.Object"
     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Import-Csv.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Import-Csv.Tests.ps1
@@ -90,6 +90,7 @@ Describe "Import-Csv #Type Tests" -Tags "CI" {
         $importTypes = $importObjectList[0].psobject.TypeNames
         $importTypes[0] | Should Be $expectedProcessTypes[0]
         $importTypes[1] | Should Be $expectedProcessTypes[1]
+        $importTypes.Count | Should Be $expectedProcessTypes.Count
     }
 }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Import-Csv.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Import-Csv.Tests.ps1
@@ -88,9 +88,9 @@ Describe "Import-Csv #Type Tests" -Tags "CI" {
         $processlist.Count | Should Be $importObjectList.Count
 
         $importTypes = $importObjectList[0].psobject.TypeNames
+        $importTypes.Count | Should Be $expectedProcessTypes.Count
         $importTypes[0] | Should Be $expectedProcessTypes[0]
         $importTypes[1] | Should Be $expectedProcessTypes[1]
-        $importTypes.Count | Should Be $expectedProcessTypes.Count
     }
 }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Import-Csv.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Import-Csv.Tests.ps1
@@ -80,16 +80,16 @@ Describe "Import-Csv #Type Tests" -Tags "CI" {
         Remove-Item -Path $testfile -Force -ErrorAction SilentlyContinue
         $processlist = (Get-Process)[0..1]
         $processlist | Export-Csv -Path $testfile -Force -IncludeTypeInformation
-        # Import-Csv add "CSV:" before actual type
-        $expectedProcessType = "CSV:System.Diagnostics.Process"
+        $expectedProcessTypes = "System.Diagnostics.Process","CSV:System.Diagnostics.Process"
     }
 
     It "Test import-csv import Object" {
         $importObjectList = Import-Csv -Path $testfile
         $processlist.Count | Should Be $importObjectList.Count
 
-        $importType = $importObjectList[0].psobject.TypeNames[0]
-        $importType | Should Be $expectedProcessType
+        $importTypes = $importObjectList[0].psobject.TypeNames
+        $importTypes[0] | Should Be $expectedProcessTypes[0]
+        $importTypes[1] | Should Be $expectedProcessTypes[1]
     }
 }
 


### PR DESCRIPTION
closes #5134

* Adds PSTypeName preservation on `Import-Csv` and `ConvertFrom-Csv`

A note for reviewers: the logic for adding the type name was moved to after the object's properties are populated to prevent `Cannot add a member with the name "<PorpertyName>" because a member with that name already exists` errors during object serialization. 