### PR TITLE
fix `help` function to not pipe to more if objects are returned

### DIFF
--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -4258,10 +4258,20 @@ param(
         $PSBoundParameters['Full'] = $true
     }
 
-    #Set the outputencoding to Console::OutputEncoding. More.com doesn't work well with Unicode.
+    # Set the outputencoding to Console::OutputEncoding. More.com doesn't work well with Unicode.
     $outputEncoding=[System.Console]::OutputEncoding
 
-    Get-Help @PSBoundParameters | more
+    $help = Get-Help @PSBoundParameters
+
+    # If a list of help is returned, don't pipe to more
+    if (($help | Select-Object -First 1).PSTypeNames -Contains 'HelpInfoShort')
+    {
+        $help
+    }
+    else
+    {
+        $help | more
+    }
 ";
         }
 


### PR DESCRIPTION
`help` function was piping all output to `more` which messes up the screen if the output is objects when Get-Help doesn't return a single help document.

Fix https://github.com/PowerShell/PowerShell/issues/5380
<!--

If you are a PowerShell Team member, please make sure you choose the Reviewer(s) and Assignee for your PR.
If you are not from the PowerShell Team, you can leave the fields blank and the Maintainers will choose them for you. If you are familiar with the team, feel free to mention some Reviewers yourself.

For more information about the roles of Reviewer and Assignee, refer to [CONTRIBUTING.md](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md).

-->
