### PR TITLE
Add dependency nuget instructions for PowerShell.Core.Instrumentation resource binary

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -25,6 +25,7 @@ artifact
 artifacts
 ASP.NET
 AssemblyLoadContext
+authenticode
 authenticodesignature
 behavior
 behaviors
@@ -135,6 +136,7 @@ parameterized
 patwardhan
 powershell
 PowerShell
+PowerShell.Core.Instrumentation
 powershell.exe
 PowerShellGet
 program.cs

--- a/docs/building/internals.md
+++ b/docs/building/internals.md
@@ -199,6 +199,7 @@ The layout of files should look like this:
 Lastly, run `nuget pack .` from within the folder. Note that you may need the latest `nuget.exe`.
 
 ### PowerShell.Core.Instrumentation
+
 To successfully decode PowerShell Core ETW events, The manifest and resource binary need to be registered on the system.
 
 To create a new NuGet package for `PowerShell.Core.Instrumentation.dll`, you will need the PowerShell.Core.Instrumentation.nuspec found in the repo under src\PowerShell.Core.Instrumentation.

--- a/docs/building/internals.md
+++ b/docs/building/internals.md
@@ -255,7 +255,7 @@ The layout of files looks like this:
 
 NOTE: Since these are native binaries used on Windows, they need to be Authenticode Dual signed before creating the nuget package.
 
-Lastly, run the following command from the root of the repo to create the nuget package. The nuget package is placed `.\src\powershell-win-core`.  Note that you may need the latest `nuget.exe`.
+Lastly, run the following command from the root of the repo to create the nuget package. The nuget package is placed at `.\src\powershell-win-core`.  Note that you may need the latest `nuget.exe`.
 
 ```powershell
 nuget pack .\src\PowerShell.Core.Instrumentation\PowerShell.Core.Instrumentation.nuspec -BasePath c:\mypackage -OutputDirectory .\src\powershell-win-core

--- a/docs/building/internals.md
+++ b/docs/building/internals.md
@@ -200,9 +200,9 @@ Lastly, run `nuget pack .` from within the folder. Note that you may need the la
 
 ### PowerShell.Core.Instrumentation
 
-To successfully decode PowerShell Core ETW events, The manifest and resource binary need to be registered on the system.
+To successfully decode PowerShell Core ETW events, the manifest and resource binary need to be registered on the system.
 
-To create a new NuGet package for `PowerShell.Core.Instrumentation.dll`, you will need the PowerShell.Core.Instrumentation.nuspec found in the repo under src\PowerShell.Core.Instrumentation.
+To create a new NuGet package for `PowerShell.Core.Instrumentation.dll`, you will need the `PowerShell.Core.Instrumentation.nuspec` found in the repo under src\PowerShell.Core.Instrumentation.
 
 Update the version information for the package.
 
@@ -210,7 +210,7 @@ Update the version information for the package.
 <version>6.0.0-RC</version>
 ```
 
-Next,  create the directory structure needed for the contents of the nuget packagestructure. The final directory and file layout is listed below.
+Next, create the directory structure needed for the contents of the nuget package structure. The final directory and file layout is listed below.
 
 ```powershell
 if (Test-Path -Path c:\mypackage)
@@ -253,11 +253,10 @@ The layout of files looks like this:
     │       └── PowerShell.Core.Instrumentation.dll
 ```
 
-NOTE: Since these are native binaries used on Windows, they need to be AuthenticodeDual signed, certificate code: 402 before creating the nuget package.
+NOTE: Since these are native binaries used on Windows, they need to be Authenticode Dual signed before creating the nuget package.
 
-Lastly, run `nuget pack` from teh root of the repo. The following command creates the nuget package from the c:\mypackage directory and places the nuget package in .\src\powershell-win-core.  Note that you may need the latest `nuget.exe`.
+Lastly, run the following command from the root of the repo to create the nuget package. The nuget package is placed `.\src\powershell-win-core`.  Note that you may need the latest `nuget.exe`.
 
 ```powershell
-nuget pack .\src\PowerShell.Core.Instrumentation\PowerShell.Core.Instrumentation.nuspec -BasePath c:\mypackage -OutputDirectory .\src\powershell-win-
-core
+nuget pack .\src\PowerShell.Core.Instrumentation\PowerShell.Core.Instrumentation.nuspec -BasePath c:\mypackage -OutputDirectory .\src\powershell-win-core
 ```

--- a/docs/building/internals.md
+++ b/docs/building/internals.md
@@ -219,6 +219,7 @@ if (Test-Path -Path c:\mypackage)
 $null = New-Item -Path c:\mypackage\runtimes\win-x64\native -ItemType Directory
 $null = New-Item -Path c:\mypackage\runtimes\win-x86\native -ItemType Directory
 ```
+
 You will need to build `PowerShell.Core.Instrumentation.dll` targeting both `win-x64` and `win-x86` on Windows 10.
 The output files will be placed under src\powershell-win-core.
 
@@ -229,6 +230,7 @@ Build the `win-x64` platform and copy the `PowerShell.Core.Instrumentation.dll` 
 Start-BuildNativeWindowsBinaries -Configuration Release -Arch x64
 Copy-Item -Path .\src\powershell-win-core\PowerShell.Core.Instrumentation.dll -Destination c:\mypackage\runtimes\win-x64\native
 ```
+
 Next, build the `win-x86` platform and copy `PowerShell.Core.Instrumentation.dll` to the win-x86 portion of the tree.
 
 ```powershell
@@ -238,6 +240,7 @@ Copy-Item -Path .\src\powershell-win-core\PowerShell.Core.Instrumentation.dll -D
 ```
 
 The layout of files looks like this:
+
 ```none
 └── runtimes
     ├── win-x64
@@ -248,6 +251,7 @@ The layout of files looks like this:
     │   └── native
     │       └── PowerShell.Core.Instrumentation.dll
 ```
+
 Lastly, run `nuget pack` from teh root of the repo. The following command creates the nuget package from the c:\mypackage directory and places the nuget package in .\src\powershell-win-core.  Note that you may need the latest `nuget.exe`.
 
 ```powershell

--- a/docs/building/internals.md
+++ b/docs/building/internals.md
@@ -197,3 +197,60 @@ The layout of files should look like this:
 ```
 
 Lastly, run `nuget pack .` from within the folder. Note that you may need the latest `nuget.exe`.
+
+### PowerShell.Core.Instrumentation
+To successfully decode PowerShell Core ETW events, The manifest and resource binary need to be registered on the system.
+
+To create a new NuGet package for `PowerShell.Core.Instrumentation.dll`, you will need the PowerShell.Core.Instrumentation.nuspec found in the repo under src\PowerShell.Core.Instrumentation.
+
+Update the version information for the package.
+
+```none
+<version>6.0.0-RC</version>
+```
+
+Next,  create the directory structure needed for the contents of the nuget packagestructure. The final directory and file layout is listed below.
+
+```powershell
+if (Test-Path -Path c:\mypackage)
+{
+  Remove-Item -Recurse -Force -Path c:\mypackage
+}
+$null = New-Item -Path c:\mypackage\runtimes\win-x64\native -ItemType Directory
+$null = New-Item -Path c:\mypackage\runtimes\win-x86\native -ItemType Directory
+```
+You will need to build `PowerShell.Core.Instrumentation.dll` targeting both `win-x64` and `win-x86` on Windows 10.
+The output files will be placed under src\powershell-win-core.
+
+Build the `win-x64` platform and copy the `PowerShell.Core.Instrumentation.dll` to the win-x86 portion of the tree.
+
+```powershell
+## Build targeting win-x64
+Start-BuildNativeWindowsBinaries -Configuration Release -Arch x64
+Copy-Item -Path .\src\powershell-win-core\PowerShell.Core.Instrumentation.dll -Destination c:\mypackage\runtimes\win-x64\native
+```
+Next, build the `win-x86` platform and copy `PowerShell.Core.Instrumentation.dll` to the win-x86 portion of the tree.
+
+```powershell
+## Build targeting win-x86
+Start-BuildNativeWindowsBinaries -Configuration Release -Arch x86
+Copy-Item -Path .\src\powershell-win-core\PowerShell.Core.Instrumentation.dll -Destination c:\mypackage\runtimes\win-x86\native
+```
+
+The layout of files looks like this:
+```none
+└── runtimes
+    ├── win-x64
+    │   └── native
+    │       └── PowerShell.Core.Instrumentation.dll
+    │
+    ├── win-x86
+    │   └── native
+    │       └── PowerShell.Core.Instrumentation.dll
+```
+Lastly, run `nuget pack` from teh root of the repo. The following command creates the nuget package from the c:\mypackage directory and places the nuget package in .\src\powershell-win-core.  Note that you may need the latest `nuget.exe`.
+
+```powershell
+nuget pack .\src\PowerShell.Core.Instrumentation\PowerShell.Core.Instrumentation.nuspec -BasePath c:\mypackage -OutputDirectory .\src\powershell-win-
+core
+```

--- a/docs/building/internals.md
+++ b/docs/building/internals.md
@@ -253,6 +253,8 @@ The layout of files looks like this:
     │       └── PowerShell.Core.Instrumentation.dll
 ```
 
+NOTE: Since these are native binaries used on Windows, they need to be AuthenticodeDual signed, certificate code: 402 before creating the nuget package.
+
 Lastly, run `nuget pack` from teh root of the repo. The following command creates the nuget package from the c:\mypackage directory and places the nuget package in .\src\powershell-win-core.  Note that you may need the latest `nuget.exe`.
 
 ```powershell

--- a/docs/building/internals.md
+++ b/docs/building/internals.md
@@ -202,7 +202,7 @@ Lastly, run `nuget pack .` from within the folder. Note that you may need the la
 
 To successfully decode PowerShell Core ETW events, the manifest and resource binary need to be registered on the system.
 
-To create a new NuGet package for `PowerShell.Core.Instrumentation.dll`, you will need the `PowerShell.Core.Instrumentation.nuspec` found in the repo under src\PowerShell.Core.Instrumentation.
+To create a new NuGet package for `PowerShell.Core.Instrumentation.dll`, you will need the `PowerShell.Core.Instrumentation.nuspec` found in the repo under `src\PowerShell.Core.Instrumentation`.
 
 Update the version information for the package.
 
@@ -253,7 +253,7 @@ The layout of files looks like this:
     │       └── PowerShell.Core.Instrumentation.dll
 ```
 
-NOTE: Since these are native binaries used on Windows, they need to be Authenticode Dual signed before creating the nuget package.
+NOTE: Since these are native binaries used on Windows, they need to be `authenticode dual signed` before creating the nuget package.
 
 Lastly, run the following command from the root of the repo to create the nuget package. The nuget package is placed at `.\src\powershell-win-core`.  Note that you may need the latest `nuget.exe`.
 

--- a/src/PowerShell.Core.Instrumentation/PowerShell.Core.Instrumentation.nuspec
+++ b/src/PowerShell.Core.Instrumentation/PowerShell.Core.Instrumentation.nuspec
@@ -7,6 +7,6 @@
     <owners>Microsoft</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>PowerShell Core ETW resource binary</description>
-    <copyright>Copyright 2017 Microsoft</copyright>
+    <copyright>(c) Microsoft Corporation. All rights reserved.</copyright>
   </metadata>
 </package>

--- a/src/PowerShell.Core.Instrumentation/PowerShell.Core.Instrumentation.nuspec
+++ b/src/PowerShell.Core.Instrumentation/PowerShell.Core.Instrumentation.nuspec
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+  <metadata>
+    <id>PowerShell.Core.Instrumentation</id>
+    <version>6.0.0-beta.9</version>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>PowerShell Core ETW resource binary</description>
+    <copyright>Copyright 2017 Microsoft</copyright>
+  </metadata>
+</package>

--- a/src/PowerShell.Core.Instrumentation/PowerShell.Core.Instrumentation.nuspec
+++ b/src/PowerShell.Core.Instrumentation/PowerShell.Core.Instrumentation.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata>
     <id>PowerShell.Core.Instrumentation</id>
-    <version>6.0.0-beta.9</version>
+    <version>6.0.0-beta.10</version>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/src/System.Management.Automation/System.Management.Automation.csproj
+++ b/src/System.Management.Automation/System.Management.Automation.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="System.Security.Permissions" Version="4.4.0" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="4.4.0" />
     <PackageReference Include="Microsoft.Management.Infrastructure" Version="1.0.0-alpha*" />
+    <PackageReference Include="PowerShell.Core.Instrumentation" Version="6.0.0-beta*" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Fix: https://github.com/PowerShell/PowerShell/issues/4939

This PR adds a dependency on PowerShell.Core.Instrumentation.dll to System.Management.Automation.csproj.

This is a native, resource-only binary containing ETW resource manifest and associated strings.

internals.md documents the steps for creating the nuget package and PowerShell.Core.Instrumentation.nuspec contains the template nuget spec.
