### PR TITLE
Try fixing the 'brew update' issue in bootstrap script

### DIFF
--- a/tools/installpsh-osx.sh
+++ b/tools/installpsh-osx.sh
@@ -138,6 +138,7 @@ for count in {1..2}; do
     fi
 
     # The update failed for the first try. An error we see a lot in our CI is "RPC failed; curl 56 SSLRead() return error -36".
+    # What 'brew update' does is to fetch the newest version of Homebrew from GitHub using git, and the error comes from git.
     # A potential solution is to increase the Git buffer size to a larger number, say 150 mb. The default buffer size is 1 mb.
     echo "First attempt of update failed. Increase Git buffer size and try again ..."
     git config --global http.postBuffer 157286400

--- a/tools/installpsh-osx.sh
+++ b/tools/installpsh-osx.sh
@@ -139,6 +139,7 @@ for count in {1..2}; do
 
     # The update failed for the first try. An error we see a lot in our CI is "RPC failed; curl 56 SSLRead() return error -36".
     # A potential solution is to increase the Git buffer size to a larger number, say 150 mb. The default buffer size is 1 mb.
+    echo "First attempt of update failed. Increase Git buffer size and try again ..."
     git config --global http.postBuffer 157286400
     sleep 5
 done

--- a/tools/installpsh-osx.sh
+++ b/tools/installpsh-osx.sh
@@ -127,10 +127,21 @@ fi
 
 # Suppress output, it's very noisy on travis-ci
 echo "Refreshing Homebrew cache..."
-if ! brew update > /dev/null; then
-    echo "ERROR: Refreshing Homebrew cache failed..." >&2
-    exit 2
-fi
+for count in {1..2}; do
+    # Try the update twice if the first time fails
+    brew update > /dev/null && break
+
+    # If the update fails again after increasing the Git buffer size, exit with error.
+    if [[ $count == 2 ]]; then
+        echo "ERROR: Refreshing Homebrew cache failed..." >&2
+        exit 2
+    fi
+
+    # The update failed for the first try. An error we see a lot in our CI is "RPC failed; curl 56 SSLRead() return error -36".
+    # A potential solution is to increase the Git buffer size to a larger number, say 150 mb. The default buffer size is 1 mb.
+    git config --global http.postBuffer 157286400
+    sleep 5
+done
 
 # Suppress output, it's very noisy on travis-ci
 if [[ ! -d $(brew --prefix cask) ]]; then


### PR DESCRIPTION
This is an attempt to fix the 'brew update' failure that happens a lot in your macOS CI runs: `RPC failed; curl 56 SSLRead() return error -36`.

With this change, we will try run `brew update` twice. The first run is the same as before, but if it fails, then we increase the Git buffer size before the second attempt.