### PR TITLE
Add error on Legacy Credential over non-HTTPS for Web Cmdlets

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -1239,5 +1239,6 @@ v6.0.
 
 #region test/tools/WebListener/README.md Overrides
  - test/tools/WebListener/README.md
+NTLM
 ResponseHeaders
 #endregion

--- a/.spelling
+++ b/.spelling
@@ -1239,6 +1239,7 @@ v6.0.
 
 #region test/tools/WebListener/README.md Overrides
  - test/tools/WebListener/README.md
+Auth
 NTLM
 ResponseHeaders
 #endregion

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -354,6 +354,12 @@ namespace Microsoft.PowerShell.Commands
                                                        "WebCmdletAllowUnencryptedAuthenticationRequiredException");
                 ThrowTerminatingError(error);
             }
+            if (!AllowUnencryptedAuthentication && (null != Credential || UseDefaultCredentials) && (Uri.Scheme != "https"))
+            {
+                ErrorRecord error = GetValidationError(WebCmdletStrings.AllowUnencryptedAuthenticationRequired,
+                                                       "WebCmdletAllowUnencryptedAuthenticationRequiredException");
+                ThrowTerminatingError(error);
+            }
 
             // credentials
             if (UseDefaultCredentials && (null != Credential))

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -1314,8 +1314,6 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
             $httpsUri = Get-WebListenerUrl -Test 'Get' -Https
             $httpBasicUri = Get-WebListenerUrl -Test 'Auth' -TestValue 'Basic'
             $httpsBasicUri = Get-WebListenerUrl -Test 'Auth' -TestValue 'Basic' -Https
-            $httpNegotiateUri = Get-WebListenerUrl -Test 'Auth' -TestValue 'Negotiate'
-            $httpsNegotiateUri = Get-WebListenerUrl -Test 'Auth' -TestValue 'Negotiate' -Https
             $testCases = @(
                 @{Authentication = "bearer"}
                 @{Authentication = "OAuth"}
@@ -1451,22 +1449,26 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
         }
 
         # UseDefaultCredentials is only reliably testable on Windows
-        It "Verifies Invoke-WebRequest Negotiated -UseDefaultCredentials over HTTPS" -Skip:$(!$IsWindows) {
+        It "Verifies Invoke-WebRequest Negotiated -UseDefaultCredentials with '<AuthType>' over HTTPS" -Skip:$(!$IsWindows) -TestCases @(
+            @{AuthType = 'NTLM'}
+            @{AuthType = 'Negotiate'}
+        ) {
+            param($AuthType)
             $params = @{
-                Uri = $httpsNegotiateUri
-                Credential = $credential
+                Uri = Get-WebListenerUrl -Test 'Auth' -TestValue $AuthType -Https
+                UseDefaultCredentials = $true
                 SkipCertificateCheck = $true
             }
             $Response = Invoke-WebRequest @params
             $result = $response.Content | ConvertFrom-Json
 
-            $result.Headers.Authorization | Should Match '^Negotiate '
+            $result.Headers.Authorization | Should Match "^$AuthType "
         }
 
         # The error condition can at least be tested on all platforms.
         It "Verifies Invoke-WebRequest Negotiated -UseDefaultCredentials Requires HTTPS" {
             $params = @{
-                Uri = $httpNegotiateUri
+                Uri = $httpUri
                 UseDefaultCredentials = $true
                 ErrorAction = 'Stop'
             }
@@ -1474,16 +1476,20 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
         }
 
         # UseDefaultCredentials is only reliably testable on Windows
-        It "Verifies Invoke-WebRequest Negotiated -UseDefaultCredentials Can use HTTP with -AllowUnencryptedAuthentication" -Skip:$(!$IsWindows) {
+        It "Verifies Invoke-WebRequest Negotiated -UseDefaultCredentials with '<AuthType>' Can use HTTP with -AllowUnencryptedAuthentication" -Skip:$(!$IsWindows) -TestCases @(
+            @{AuthType = 'NTLM'}
+            @{AuthType = 'Negotiate'}
+        ) {
+            param($AuthType)
             $params = @{
-                Uri = $httpNegotiateUri
+                Uri = Get-WebListenerUrl -Test 'Auth' -TestValue $AuthType
                 UseDefaultCredentials = $true
                 AllowUnencryptedAuthentication = $true
             }
             $Response = Invoke-WebRequest @params
             $result = $response.Content | ConvertFrom-Json
 
-            $result.Headers.Authorization | Should Match '^Negotiate '
+            $result.Headers.Authorization | Should Match "^$AuthType "
         }
     }
 
@@ -2308,8 +2314,6 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
             $httpsUri = Get-WebListenerUrl -Test 'Get' -Https
             $httpBasicUri = Get-WebListenerUrl -Test 'Auth' -TestValue 'Basic'
             $httpsBasicUri = Get-WebListenerUrl -Test 'Auth' -TestValue 'Basic' -Https
-            $httpNegotiateUri = Get-WebListenerUrl -Test 'Auth' -TestValue 'Negotiate'
-            $httpsNegotiateUri = Get-WebListenerUrl -Test 'Auth' -TestValue 'Negotiate' -Https
             $testCases = @(
                 @{Authentication = "bearer"}
                 @{Authentication = "OAuth"}
@@ -2440,21 +2444,25 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
         }
 
         # UseDefaultCredentials is only reliably testable on Windows
-        It "Verifies Invoke-RestMethod Negotiated -UseDefaultCredentials over HTTPS" -Skip:$(!$IsWindows) {
+        It "Verifies Invoke-RestMethod Negotiated -UseDefaultCredentials with '<AuthType>' over HTTPS" -Skip:$(!$IsWindows) -TestCases @(
+            @{AuthType = 'NTLM'}
+            @{AuthType = 'Negotiate'}
+        ) {
+            param($AuthType)
             $params = @{
-                Uri = $httpsNegotiateUri
-                Credential = $credential
+                Uri = Get-WebListenerUrl -Test 'Auth' -TestValue $AuthType -Https
+                UseDefaultCredentials = $true
                 SkipCertificateCheck = $true
             }
             $result = Invoke-RestMethod @params
 
-            $result.Headers.Authorization | Should Match '^Negotiate '
+            $result.Headers.Authorization | Should Match "^$AuthType "
         }
 
         # The error condition can at least be tested on all platforms.
         It "Verifies Invoke-RestMethod Negotiated -UseDefaultCredentials Requires HTTPS" {
             $params = @{
-                Uri = $httpNegotiateUri
+                Uri = $httpUri
                 UseDefaultCredentials = $true
                 ErrorAction = 'Stop'
             }
@@ -2462,15 +2470,19 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
         }
 
         # UseDefaultCredentials is only reliably testable on Windows
-        It "Verifies Invoke-RestMethod Negotiated -UseDefaultCredentials Can use HTTP with -AllowUnencryptedAuthentication" -Skip:$(!$IsWindows) {
+        It "Verifies Invoke-RestMethod Negotiated -UseDefaultCredentials with '<AuthType>' Can use HTTP with -AllowUnencryptedAuthentication" -Skip:$(!$IsWindows) -TestCases @(
+            @{AuthType = 'NTLM'}
+            @{AuthType = 'Negotiate'}
+        ) {
+            param($AuthType)
             $params = @{
-                Uri = $httpNegotiateUri
+                Uri = Get-WebListenerUrl -Test 'Auth' -TestValue $AuthType
                 UseDefaultCredentials = $true
                 AllowUnencryptedAuthentication = $true
             }
             $result = Invoke-RestMethod @params
 
-            $result.Headers.Authorization | Should Match '^Negotiate '
+            $result.Headers.Authorization | Should Match "^$AuthType "
         }
     }
 

--- a/test/tools/Modules/WebListener/WebListener.psm1
+++ b/test/tools/Modules/WebListener/WebListener.psm1
@@ -113,6 +113,7 @@ function Get-WebListenerUrl {
     param (
         [switch]$Https,
         [ValidateSet(
+            'Auth',
             'Cert',
             'Compression',
             'Delay',

--- a/test/tools/WebListener/Controllers/AuthController.cs
+++ b/test/tools/WebListener/Controllers/AuthController.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Http.Extensions;
+using Microsoft.Extensions.Primitives;
+using mvc.Models;
+
+namespace mvc.Controllers
+{
+    public class AuthController : Controller
+    {
+        public JsonResult Basic()
+        {
+            StringValues authorization;
+            if (Request.Headers.TryGetValue("Authorization", out authorization))
+            {
+                var getController = new GetController();
+                getController.ControllerContext = this.ControllerContext;
+                return getController.Index();
+            }
+            else
+            {
+                Response.Headers.Add("WWW-Authenticate","Basic realm=\"WebListener\"");
+                Response.StatusCode = 401;
+                return Json("401 Unauthorized");
+            }
+        }
+
+        public JsonResult Negotiate()
+        {
+            StringValues authorization;
+            if (Request.Headers.TryGetValue("Authorization", out authorization))
+            {
+                var getController = new GetController();
+                getController.ControllerContext = this.ControllerContext;
+                return getController.Index();
+            }
+            else
+            {
+                Response.Headers.Add("WWW-Authenticate","Negotiate");
+                Response.StatusCode = 401;
+                return Json("401 Unauthorized");
+            }
+        }
+
+        public JsonResult Ntlm()
+        {
+            StringValues authorization;
+            if (Request.Headers.TryGetValue("Authorization", out authorization))
+            {
+                var getController = new GetController();
+                getController.ControllerContext = this.ControllerContext;
+                return getController.Index();
+            }
+            else
+            {
+                Response.Headers.Add("WWW-Authenticate","NTLM");
+                Response.StatusCode = 401;
+                return Json("401 Unauthorized");
+            }
+        }
+
+        public IActionResult Error()
+        {
+            return View(new ErrorViewModel { RequestId = Activity.Current?.Id ?? HttpContext.TraceIdentifier });
+        }
+    }
+}

--- a/test/tools/WebListener/README.md
+++ b/test/tools/WebListener/README.md
@@ -34,6 +34,76 @@ $Listener = Start-WebListener -HttpPort 8083 -HttpsPort 8084
 
 Returns a static HTML page containing links and descriptions of the available tests in WebListener. This can be used as a default or general test where no specific test functionality or return data is required.
 
+## /Auth/Basic/
+
+Provides a mock Basic authentication challenge. If a basic authorization header is sent, then the same results as /Get/ are returned.
+
+```powershell
+$credential = Get-Credential
+$uri = Get-WebListenerUrl -Test 'Auth' -TestValue 'Basic' -Https
+Invoke-RestMethod -Uri $uri -Credential $credential -SkipCertificateCheck
+```
+
+```json
+{
+    "headers":{
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Microsoft Windows 10.0.15063; en-US) PowerShell/6.0.0",
+        "Connection": "Keep-Alive",
+        "Authorization": "Basic dGVzdHVzZXI6dGVzdHBhc3N3b3Jk", 
+        "Host": "localhost:8084"
+    },
+    "origin": "127.0.0.1",
+    "args": {},
+    "url": "https://localhost:8084/Auth/Basic"
+}
+```
+
+## /Auth/Negotiate/
+
+Provides a mock Negotiate authentication challenge. If a basic authorization header is sent, then the same results as /Get/ are returned.
+
+```powershell
+$uri = Get-WebListenerUrl -Test 'Auth' -TestValue 'Negotiate' -Https
+Invoke-RestMethod -Uri $uri -UseDefaultCredential -SkipCertificateCheck
+```
+
+```json
+{
+    "headers":{
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Microsoft Windows 10.0.15063; en-US) PowerShell/6.0.0",
+        "Connection": "Keep-Alive",
+        "Authorization": "Negotiate jjaguasgtisi7tiqkagasjjajvs", 
+        "Host": "localhost:8084"
+    },
+    "origin": "127.0.0.1",
+    "args": {},
+    "url": "https://localhost:8084/Auth/Negotiate"
+}
+```
+
+## /Auth/NTLM/
+
+Provides a mock NTLM authentication challenge. If a basic authorization header is sent, then the same results as /Get/ are returned.
+
+```powershell
+$uri = Get-WebListenerUrl -Test 'Auth' -TestValue 'NTLM' -Https
+Invoke-RestMethod -Uri $uri -UseDefaultCredential -SkipCertificateCheck
+```
+
+```json
+{
+    "headers":{
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Microsoft Windows 10.0.15063; en-US) PowerShell/6.0.0",
+        "Connection": "Keep-Alive",
+        "Authorization": "NTLM jjaguasgtisi7tiqkagasjjajvs", 
+        "Host": "localhost:8084"
+    },
+    "origin": "127.0.0.1",
+    "args": {},
+    "url": "https://localhost:8084/Auth/NTLM"
+}
+```
+
 ## /Cert/
 
 Returns a JSON object containing the details of the Client Certificate if one is provided in the request.

--- a/test/tools/WebListener/Views/Home/Index.cshtml
+++ b/test/tools/WebListener/Views/Home/Index.cshtml
@@ -1,6 +1,9 @@
 ﻿<h1>Available Tests</h1>
 <ul>
     <li><a href="/">/</a> - This page</li>
+    <li><a href="/Auth/Basic/">/Auth/Basic/</a> - Basic Authentication</li>
+    <li><a href="/Auth/Negotiate/">/Auth/Negotiate/</a> - Negotiate Authentication</li>
+    <li><a href="/Auth/NTLM/">/Auth/NTLM/</a> - NTLM Authentication</li>
     <li><a href="/Cert/">/Cert/</a> - Client Certificate Details</li>
     <li><a href="/Compression/Deflate/">/Compression/Deflate/</a> - Returns deflate compressed response</li>
     <li><a href="/Compression/GZip/">/Compression/Gzip/</a> - Returns gzip compressed response</li>


### PR DESCRIPTION
closes #5112

* Adds an error when a user tries to use `-Credential` (legacy usage without `-Authentication`) or `-UseDefaultCredentials` over a non-HTTPS URI
* User can Bypass error with `-AllowUnencryptedAuthentication`
* `-UseDefaultCredentials` can only be reliably tested on Windows as support on other platforms depends on a kerberos infrastructure. 
* Adds `/Auth/` tests to WebListener for challenge authentication Basic, Negotiate, and NTLM

Incidentally, this increases test coverage for the web cmdlets as `-Credential` and `-UseDefaultCredentials` were not being tested.