### PR TITLE
Support '[package]' tag in PR CI and fix nightly build on macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
 addons:
   artifacts:
     paths:
-      - $(ls powershell*{deb,pkg,AppImage} | tr "\n" ":")
+      - $(ls powershell*{deb,pkg,AppImage,tar.gz} | tr "\n" ":")
       - pester-tests.xml
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
 addons:
   artifacts:
     paths:
-      - $(ls powershell*{deb,pkg,AppImage,tar.gz} | tr "\n" ":")
+      - $(ls powershell*{deb,pkg,AppImage,gz} | tr "\n" ":")
       - pester-tests.xml
 
 install:

--- a/docs/testing-guidelines/testing-guidelines.md
+++ b/docs/testing-guidelines/testing-guidelines.md
@@ -78,12 +78,24 @@ Additionally, the tag:
 
 #### Requesting additional tests for a PR
 
-In our CI systems, we normally run only run tests tagged with `CI`.  If in the first line of the last (most recent) commit description you add `[Feature]`,
-we will ensure that we will also run the tests tagged with `Feature`.  When you would want to do this:
+In our CI systems, we normally run only run tests tagged with `CI`.
+If in the first line of the last (most recent) commit description you add `[Feature]`,
+we will ensure that we will also run the tests tagged with `Feature`.
+When you would want to do this:
 
 - You have added or changed a `Feature` test.
 - A maintainer asks you to run the `Feature` tests.
 - Based on experience, you are confident that a maintainer will ask you to run the `Feature` tests.
+
+#### Validating packaging changes for a PR
+
+By default, our CI system does a build and run tests for a PR and does not exercise code to create a package.
+If your PR includes changes to packaging, you can have the CI system exercise the packaging code by
+using `[Package]` as the first line in the commit message.
+When you would want to do this:
+
+- You made change to PowerShell Core packaging
+- A maintainer asks you to run as `[Package]`
 
 ### xUnit
 
@@ -100,7 +112,8 @@ Two helper functions are part of the build.psm1 module to help with that:
 
 Our CI system runs these as well; there should be no difference between running these on your dev system, versus in CI.
 
-Make sure that the git submodules have been loaded into your project before running `Start-PSPester`, or it will fail to run. If you did not clone the project with the `--recursive` flag, you can load the submodules by running: 
+Make sure that the git submodules have been loaded into your project before running `Start-PSPester`, or it will fail to run.
+If you did not clone the project with the `--recursive` flag, you can load the submodules by running: 
 
 ```
 git submodule update --init

--- a/tools/appveyor.psm1
+++ b/tools/appveyor.psm1
@@ -95,9 +95,9 @@ Function Test-DailyBuild
         return $true
     }
 
-    # if [Feature] or [Package] is in the commit message,
+    # if [Feature] is in the commit message,
     # Run Daily tests
-    if($env:APPVEYOR_REPO_COMMIT_MESSAGE -match '(\[feature\])|(\[package\])')
+    if($env:APPVEYOR_REPO_COMMIT_MESSAGE -match '\[feature\]')
     {
         Set-AppveyorBuildVariable -Name PS_DAILY_BUILD -Value $trueString
         return $true

--- a/tools/appveyor.psm1
+++ b/tools/appveyor.psm1
@@ -95,9 +95,9 @@ Function Test-DailyBuild
         return $true
     }
 
-    # if [Feature] is in the commit message,
+    # if [Feature] or [Package] is in the commit message,
     # Run Daily tests
-    if($env:APPVEYOR_REPO_COMMIT_MESSAGE -match '\[feature\]')
+    if($env:APPVEYOR_REPO_COMMIT_MESSAGE -match '(\[feature\])|(\[package\])')
     {
         Set-AppveyorBuildVariable -Name PS_DAILY_BUILD -Value $trueString
         return $true

--- a/tools/travis.ps1
+++ b/tools/travis.ps1
@@ -155,7 +155,7 @@ else
 # Run a full build if the build was trigger via cron, api or the commit message contains `[Feature]`
 $hasFeatureTag = $commitMessage -match '\[feature\]'
 $hasRunFailingTestTag = $commitMessage -match '\[includeFailingTest\]'
-$isDailyBuild = $env:TRAVIS_EVENT_TYPE -eq 'cron' -or $env:TRAVIS_EVENT_TYPE -eq 'api'
+$isDailyBuild = $env:TRAVIS_EVENT_TYPE -eq 'cron' -or $env:TRAVIS_EVENT_TYPE -eq 'api' -or $commitMessage -match '\[daily\]'
 # only update the build badge for the cron job
 $cronBuild = $env:TRAVIS_EVENT_TYPE -eq 'cron'
 $isFullBuild = $isDailyBuild -or $hasFeatureTag

--- a/tools/travis.ps1
+++ b/tools/travis.ps1
@@ -155,6 +155,7 @@ else
 # Run a full build if the build was trigger via cron, api or the commit message contains `[Feature]`
 $hasFeatureTag = $commitMessage -match '\[feature\]'
 $hasPackageTag = $commitMessage -match '\[package\]'
+$createPackages = -not $isPr -or $hasPackageTag
 $hasRunFailingTestTag = $commitMessage -match '\[includeFailingTest\]'
 $isDailyBuild = $env:TRAVIS_EVENT_TYPE -eq 'cron' -or $env:TRAVIS_EVENT_TYPE -eq 'api'
 # only update the build badge for the cron job
@@ -166,7 +167,7 @@ if($Stage -eq 'Bootstrap')
     Write-Host -Foreground Green "Executing travis.ps1 -BootStrap `$isPR='$isPr' - $commitMessage"
     # Make sure we have all the tags
     Sync-PSTags -AddRemoteIfMissing
-    Start-PSBootstrap -Package:(-not $isPr)
+    Start-PSBootstrap -Package:$createPackages
 }
 elseif($Stage -eq 'Build')
 {
@@ -233,7 +234,7 @@ elseif($Stage -eq 'Build')
         }
     }
 
-    if (-not $isPr -or $hasPackageTag) {
+    if ($createPackages) {
         $packageParams = @{}
         if($env:TRAVIS_BUILD_NUMBER)
         {

--- a/tools/travis.ps1
+++ b/tools/travis.ps1
@@ -154,8 +154,9 @@ else
 
 # Run a full build if the build was trigger via cron, api or the commit message contains `[Feature]`
 $hasFeatureTag = $commitMessage -match '\[feature\]'
+$hasPackageTag = $commitMessage -match '\[package\]'
 $hasRunFailingTestTag = $commitMessage -match '\[includeFailingTest\]'
-$isDailyBuild = $env:TRAVIS_EVENT_TYPE -eq 'cron' -or $env:TRAVIS_EVENT_TYPE -eq 'api' -or $commitMessage -match '\[daily\]'
+$isDailyBuild = $env:TRAVIS_EVENT_TYPE -eq 'cron' -or $env:TRAVIS_EVENT_TYPE -eq 'api'
 # only update the build badge for the cron job
 $cronBuild = $env:TRAVIS_EVENT_TYPE -eq 'cron'
 $isFullBuild = $isDailyBuild -or $hasFeatureTag
@@ -232,7 +233,7 @@ elseif($Stage -eq 'Build')
         }
     }
 
-    if (-not $isPr) {
+    if (-not $isPr -or $hasPackageTag) {
         $packageParams = @{}
         if($env:TRAVIS_BUILD_NUMBER)
         {

--- a/tools/travis.ps1
+++ b/tools/travis.ps1
@@ -255,9 +255,12 @@ elseif($Stage -eq 'Build')
                 Start-NativeExecution -sb {dotnet nuget push $package --api-key $env:NUGET_KEY --source "$env:NUGET_URL/api/v2/package"} -IgnoreExitcode
             }
         }
-        # Create and package Raspbian .tgz
-        Start-PSBuild -Clean -Runtime linux-arm
-        Start-PSPackage @packageParams -Type tar-arm -SkipReleaseChecks
+        if ($IsLinux)
+        {
+            # Create and package Raspbian .tgz
+            Start-PSBuild -Clean -Runtime linux-arm
+            Start-PSPackage @packageParams -Type tar-arm -SkipReleaseChecks
+        }
     }
 
     # if the tests did not pass, throw the reason why


### PR DESCRIPTION
- Support '[package]' tag in PR CI to validate packaging changes in PR CI runs.
  When using '[package]' tag, regular CI tests will run and packaging steps will also run.
- Fix nightly build on macOS.
