### PR TITLE
Make name a dynamic parameter in vstsbuild.ps1

### DIFF
--- a/tools/releaseBuild/vstsbuild.ps1
+++ b/tools/releaseBuild/vstsbuild.ps1
@@ -1,59 +1,87 @@
 param(
     [Parameter(ParameterSetName='Build')]
     [ValidatePattern("^v\d+\.\d+\.\d+(-\w+\.\d+)?$")]
-    [string]$ReleaseTag,
-
-    [ValidateSet('win7-x86','win7-x64','win7-x86-symbols','win7-x64-symbols','ubuntu.14.04','ubuntu.16.04','centos.7')]
-    [String]
-    $Name
+    [string]$ReleaseTag
 )
 
-$ErrorActionPreference = 'Stop'
+DynamicParam {
+    # Add a dynamic parameter '-Name' which specifies the name of the build to run
 
-$psReleaseBranch = 'master'
-$psReleaseFork = 'PowerShell'
-$location = Join-Path -Path $PSScriptRoot -ChildPath 'PSRelease'
-if(Test-Path $location)
-{
-    Remove-Item -Path $location -Recurse -Force
+    # Get the names of the builds.
+    $buildJsonPath = (Join-Path -path $PSScriptRoot -ChildPath 'build.json')
+    $build = Get-Content -Path $buildJsonPath | ConvertFrom-Json
+    $names = @($build.Windows.Name)
+    foreach($name in $build.Linux.Name)
+    {
+        $names += $name
+    }
+
+    # Create the parameter attributs
+    $ParameterAttr = New-Object "System.Management.Automation.ParameterAttribute"
+    $ValidateSetAttr = New-Object "System.Management.Automation.ValidateSetAttribute" -ArgumentList $names
+    $Attributes = New-Object "System.Collections.ObjectModel.Collection``1[System.Attribute]"
+    $Attributes.Add($ParameterAttr) > $null
+    $Attributes.Add($ValidateSetAttr) > $null
+    
+    # Create the parameter
+    $Parameter = New-Object "System.Management.Automation.RuntimeDefinedParameter" -ArgumentList ("Name", [string], $Attributes)
+    $Dict = New-Object "System.Management.Automation.RuntimeDefinedParameterDictionary"
+    $Dict.Add("Name", $Parameter) > $null
+    return $Dict
 }
 
-$gitBinFullPath = (Get-Command -Name git).Source
-if (-not $gitBinFullPath)
-{
-    throw "Git is required to proceed. Install from 'https://git-scm.com/download/win'"
+Begin {
+    $Name = $PSBoundParameters['Name']
 }
 
-Write-Verbose "cloning -b $psReleaseBranch --quiet https://github.com/$psReleaseFork/PSRelease.git" -verbose
-& $gitBinFullPath clone -b $psReleaseBranch --quiet https://github.com/$psReleaseFork/PSRelease.git $location
+End {
+    $ErrorActionPreference = 'Stop'
 
-Push-Location -Path $PWD.Path
-try{
-    Set-Location $location
-    & $gitBinFullPath  submodule update --init --recursive --quiet
-}
-finally
-{
-    Pop-Location
-}
+    $psReleaseBranch = 'master'
+    $psReleaseFork = 'PowerShell'
+    $location = Join-Path -Path $PSScriptRoot -ChildPath 'PSRelease'
+    if(Test-Path $location)
+    {
+        Remove-Item -Path $location -Recurse -Force
+    }
 
-$unresolvedRepoRoot = Join-Path -Path $PSScriptRoot '../..'
-$resolvedRepoRoot = (Resolve-Path -Path $unresolvedRepoRoot).ProviderPath
+    $gitBinFullPath = (Get-Command -Name git).Source
+    if (-not $gitBinFullPath)
+    {
+        throw "Git is required to proceed. Install from 'https://git-scm.com/download/win'"
+    }
 
-try 
-{
-    Write-Verbose "Starting build at $resolvedRepoRoot  ..." -Verbose
-    Import-Module "$location/vstsBuild" -Force
-    Import-Module "$location/dockerBasedBuild" -Force
-    Clear-VstsTaskState
+    Write-Verbose "cloning -b $psReleaseBranch --quiet https://github.com/$psReleaseFork/PSRelease.git" -verbose
+    & $gitBinFullPath clone -b $psReleaseBranch --quiet https://github.com/$psReleaseFork/PSRelease.git $location
 
-    Invoke-Build -RepoPath $resolvedRepoRoot  -BuildJsonPath './tools/releaseBuild/build.json' -Name $Name -Parameters $PSBoundParameters 
-}
-catch
-{
-    Write-VstsError -Error $_
-}
-finally{
-    Write-VstsTaskState
-    exit 0
+    Push-Location -Path $PWD.Path
+    try{
+        Set-Location $location
+        & $gitBinFullPath  submodule update --init --recursive --quiet
+    }
+    finally
+    {
+        Pop-Location
+    }
+
+    $unresolvedRepoRoot = Join-Path -Path $PSScriptRoot '../..'
+    $resolvedRepoRoot = (Resolve-Path -Path $unresolvedRepoRoot).ProviderPath
+
+    try 
+    {
+        Write-Verbose "Starting build at $resolvedRepoRoot  ..." -Verbose
+        Import-Module "$location/vstsBuild" -Force
+        Import-Module "$location/dockerBasedBuild" -Force
+        Clear-VstsTaskState
+
+        Invoke-Build -RepoPath $resolvedRepoRoot  -BuildJsonPath './tools/releaseBuild/build.json' -Name $Name -Parameters $PSBoundParameters
+    }
+    catch
+    {
+        Write-VstsError -Error $_
+    }
+    finally{
+        Write-VstsTaskState
+        exit 0
+    }
 }


### PR DESCRIPTION
1. it eliminates keeping the build names in two places
2. due to all the whitespace change it's easier to review seperately