### PR TITLE
get-childitem <PATH>/* -file should include <Path> as search directory

### DIFF
--- a/src/System.Management.Automation/engine/SessionStateContainer.cs
+++ b/src/System.Management.Automation/engine/SessionStateContainer.cs
@@ -1502,8 +1502,13 @@ namespace System.Management.Automation
                         string childName = GetChildName(path, context);
                             
                         // If -File or -Directory is specified and path is ended with '*', we should include the parent path as search path
-                        bool isFileOrDirectoryPresent = (((Microsoft.PowerShell.Commands.GetChildDynamicParameters)context.DynamicParameters).File.IsPresent) ||
-                                                 (((Microsoft.PowerShell.Commands.GetChildDynamicParameters)context.DynamicParameters).Directory.IsPresent);
+
+                        bool isFileOrDirectoryPresent = false;
+
+                        if(context.DynamicParameters is Microsoft.PowerShell.Commands.GetChildDynamicParameters dynParam)
+                        {
+                            isFileOrDirectoryPresent = dynParam.File.IsPresent || dynParam.Directory.IsPresent;
+                        }
 
                         if (String.Equals(childName, "*", StringComparison.OrdinalIgnoreCase) && isFileOrDirectoryPresent)
                         {

--- a/src/System.Management.Automation/engine/SessionStateContainer.cs
+++ b/src/System.Management.Automation/engine/SessionStateContainer.cs
@@ -1499,6 +1499,14 @@ namespace System.Management.Automation
                     // expectations:
                     if (recurse)
                     {
+                        string childName = GetChildName(path, context);
+                            
+                        // If -File is specified and path is ended with '*', we should include the parent path as search path
+                        if (String.Equals(childName, "*", StringComparison.OrdinalIgnoreCase) && ((Microsoft.PowerShell.Commands.GetChildDynamicParameters)context.DynamicParameters).File.IsPresent)
+                        {
+                            string parentName = path.Substring(0, path.Length - childName.Length);
+                            path = parentName;
+                        }
                         // dir c:\tem* -include *.ps1 -rec => No change
                         if ((context.Include == null) || (context.Include.Count == 0))
                         {
@@ -1509,9 +1517,9 @@ namespace System.Management.Automation
                             // Should glob paths and files that match tem*, but then
                             // recurse into all subdirectories and do the same for
                             // those directories.
-                            if ((!String.IsNullOrEmpty(path)) && (!IsItemContainer(path)))
+
+                            if ((!String.IsNullOrEmpty(path)) && ((!IsItemContainer(path))))
                             {
-                                string childName = GetChildName(path, context);
                                 if (!String.Equals(childName, "*", StringComparison.OrdinalIgnoreCase))
                                 {
                                     if (context.Include != null)
@@ -1524,6 +1532,7 @@ namespace System.Management.Automation
                                 string parentName = path.Substring(0, path.Length - childName.Length);
                                 path = parentName;
                             }
+
                         }
                     }
 

--- a/src/System.Management.Automation/engine/SessionStateContainer.cs
+++ b/src/System.Management.Automation/engine/SessionStateContainer.cs
@@ -1501,8 +1501,11 @@ namespace System.Management.Automation
                     {
                         string childName = GetChildName(path, context);
                             
-                        // If -File is specified and path is ended with '*', we should include the parent path as search path
-                        if (String.Equals(childName, "*", StringComparison.OrdinalIgnoreCase) && ((Microsoft.PowerShell.Commands.GetChildDynamicParameters)context.DynamicParameters).File.IsPresent)
+                        // If -File or -Directory is specified and path is ended with '*', we should include the parent path as search path
+                        bool isFileOrDirectoryPresent = (((Microsoft.PowerShell.Commands.GetChildDynamicParameters)context.DynamicParameters).File.IsPresent) ||
+                                                 (((Microsoft.PowerShell.Commands.GetChildDynamicParameters)context.DynamicParameters).Directory.IsPresent);
+
+                        if (String.Equals(childName, "*", StringComparison.OrdinalIgnoreCase) && isFileOrDirectoryPresent)
                         {
                             string parentName = path.Substring(0, path.Length - childName.Length);
                             path = parentName;

--- a/src/System.Management.Automation/engine/SessionStateContainer.cs
+++ b/src/System.Management.Automation/engine/SessionStateContainer.cs
@@ -1525,7 +1525,7 @@ namespace System.Management.Automation
                             // Should glob paths and files that match tem*, but then
                             // recurse into all subdirectories and do the same for
                             // those directories.
-                            if ((!String.IsNullOrEmpty(path)) && ((!IsItemContainer(path))))
+                            if (!String.IsNullOrEmpty(path) && !IsItemContainer(path))
                             {
                                 if (!String.Equals(childName, "*", StringComparison.OrdinalIgnoreCase))
                                 {

--- a/src/System.Management.Automation/engine/SessionStateContainer.cs
+++ b/src/System.Management.Automation/engine/SessionStateContainer.cs
@@ -1517,7 +1517,6 @@ namespace System.Management.Automation
                             // Should glob paths and files that match tem*, but then
                             // recurse into all subdirectories and do the same for
                             // those directories.
-
                             if ((!String.IsNullOrEmpty(path)) && ((!IsItemContainer(path))))
                             {
                                 if (!String.Equals(childName, "*", StringComparison.OrdinalIgnoreCase))
@@ -1532,7 +1531,6 @@ namespace System.Management.Automation
                                 string parentName = path.Substring(0, path.Length - childName.Length);
                                 path = parentName;
                             }
-
                         }
                     }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ChildItem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ChildItem.Tests.ps1
@@ -10,7 +10,7 @@ Describe "Get-ChildItem" -Tags "CI" {
             $item_D = "D39B4FD9-3E1D-4DD5-8718-22FE2C934CE3"
             $item_E = "EE150FEB-0F21-4AFF-8066-AF59E925810C"
             $item_F = ".F81D8514-8862-4227-B041-0529B1656A43"
-            $item_G = "5560A62F-74F1-4FAE-9A23-F4EBD90D2676" 
+            $item_G = "5560A62F-74F1-4FAE-9A23-F4EBD90D2676"
             $null = New-Item -Path $TestDrive -Name $item_a -ItemType "File" -Force
             $null = New-Item -Path $TestDrive -Name $item_B -ItemType "File" -Force
             $null = New-Item -Path $TestDrive -Name $item_c -ItemType "File" -Force
@@ -76,16 +76,14 @@ Describe "Get-ChildItem" -Tags "CI" {
         }
 
         It "Should return items recursively when using 'Include' or 'Exclude' parameters" {
-            (Get-ChildItem -Path $TestDrive -Depth 1).Count | Should Be 6 
+            (Get-ChildItem -Path $TestDrive -Depth 1).Count | Should Be 6
             (Get-ChildItem -Path $TestDrive -Depth 1 -Include $item_G).Count | Should Be 1
             (Get-ChildItem -Path $TestDrive -Depth 1 -Exclude $item_a).Count | Should Be 5
         }
-        
+
         It "get-childitem <PATH>/* -file should include <Path> as search directory" {
-            $rootPath = Join-Path $TestDrive "TestPS"
-            $subPath = Join-Path $rootPath "D1"
-            $filePath = Join-Path $subPath "File1.txt"
-            New-Item $filePath -type file -Force
+            $rootPath = Join-Path $TestDrive -ChildPath "TestPS" -AdditionalChildPath "D1","File1.txt"
+            New-Item $filePath -type file -Force > $null
             (Get-ChildItem -Path $rootPath/* -File -Recurse).Name | Should Be "File1.txt"
         }
     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ChildItem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ChildItem.Tests.ps1
@@ -76,9 +76,17 @@ Describe "Get-ChildItem" -Tags "CI" {
         }
 
         It "Should return items recursively when using 'Include' or 'Exclude' parameters" {
-            (Get-ChildItem -Path $TestDrive -Depth 1).Count | Should Be 6
+            (Get-ChildItem -Path $TestDrive -Depth 1).Count | Should Be 6 
             (Get-ChildItem -Path $TestDrive -Depth 1 -Include $item_G).Count | Should Be 1
             (Get-ChildItem -Path $TestDrive -Depth 1 -Exclude $item_a).Count | Should Be 5
+        }
+        
+        It "get-childitem <PATH>/* -file should include <Path> as search directory" {
+            $rootPath = Join-Path $TestDrive "TestPS"
+            $subPath = Join-Path $rootPath "D1"
+            $filePath = Join-Path $subPath "File1.txt"
+            New-Item $filePath -type file -Force
+            (Get-ChildItem -Path $rootPath/* -File -Recurse).Name | Should Be "File1.txt"
         }
     }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ChildItem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ChildItem.Tests.ps1
@@ -18,6 +18,18 @@ Describe "Get-ChildItem" -Tags "CI" {
             $null = New-Item -Path $TestDrive -Name $item_E -ItemType "Directory" -Force
             $null = New-Item -Path $TestDrive -Name $item_F -ItemType "File" -Force | ForEach-Object {$_.Attributes = "hidden"}
             $null = New-Item -Path (Join-Path -Path $TestDrive -ChildPath $item_E) -Name $item_G -ItemType "File" -Force
+
+            $searchRoot = Join-Path $TestDrive -ChildPath "TestPS"
+            $file1 = Join-Path $searchRoot -ChildPath "D1" -AdditionalChildPath "File1.txt"
+            $file2 = Join-Path $searchRoot -ChildPath "File1.txt"
+
+            $PathWildCardTestCases = @(
+                @{Parameters = @{Path = $searchRoot; Recurse = $true; Directory = $true }; ExpectedCount = 1; Title = "directory without wildcard"},
+                @{Parameters = @{Path = (Join-Path $searchRoot '*'); Recurse = $true; Directory = $true }; ExpectedCount = 1; Title = "directory with wildcard"},
+                @{Parameters = @{Path = $searchRoot; Recurse = $true; File = $true }; ExpectedCount = 1; Title = "file without wildcard"},
+                @{Parameters = @{Path = (Join-Path $searchRoot '*'); Recurse = $true; File = $true }; ExpectedCount = 1; Title = "file with wildcard"},
+                @{Parameters = @{Path = (Join-Path $searchRoot 'F*.txt'); Recurse = $true; File = $true }; ExpectedCount = 1; Title = "file with wildcard filename"}
+            )
         }
 
         It "Should list the contents of the current folder" {
@@ -81,10 +93,23 @@ Describe "Get-ChildItem" -Tags "CI" {
             (Get-ChildItem -Path $TestDrive -Depth 1 -Exclude $item_a).Count | Should Be 5
         }
 
-        It "get-childitem <PATH>/* -file should include <Path> as search directory" {
-            $rootPath = Join-Path $TestDrive -ChildPath "TestPS" -AdditionalChildPath "D1","File1.txt"
-            New-Item $rootPath -type file -Force > $null
-            (Get-ChildItem -Path $rootPath/* -File -Recurse).Name | Should Be "File1.txt"
+        It "get-childitem path wildcard - <title>" -TestCases $PathWildCardTestCases {
+            param($Parameters, $ExpectedCount)
+
+            $null = New-Item $file1 -Force -ItemType File
+
+            (Get-ChildItem @Parameters).Count | Should Be $ExpectedCount
+        }
+
+        It "get-childitem with and without file in search root" {
+            $null = New-Item $file2 -Force -ItemType File
+
+            (Get-ChildItem -Path $searchRoot -File -Recurse).Count | Should be 2
+            (Get-ChildItem -Path $searchRoot -Directory -Recurse).Count | Should be 1
+
+            Remove-Item $file2 -ErrorAction SilentlyContinue -Force
+            (Get-ChildItem -Path $searchRoot -File -Recurse).Count | Should be 1
+            (Get-ChildItem -Path $searchRoot -Directory -Recurse).Count | Should be 1
         }
     }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ChildItem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ChildItem.Tests.ps1
@@ -83,7 +83,7 @@ Describe "Get-ChildItem" -Tags "CI" {
 
         It "get-childitem <PATH>/* -file should include <Path> as search directory" {
             $rootPath = Join-Path $TestDrive -ChildPath "TestPS" -AdditionalChildPath "D1","File1.txt"
-            New-Item $filePath -type file -Force > $null
+            New-Item $rootPath -type file -Force > $null
             (Get-ChildItem -Path $rootPath/* -File -Recurse).Name | Should Be "File1.txt"
         }
     }


### PR DESCRIPTION
This is to resolve #5269

When get-childitem is ended with * and -recurse, we only include the parent path as search path if the given path is a itemcontainer. We will return null if the parent directory only contains 1 sub folder with no sub folder under that folder. As if the parent folder only contains 1 subfolder, "*" will be mapped to that subfolder, and since it doesn't contain any subfolder, return is null.

However, the following scenario should also be included:
Given path is not a itemcontainer but -file parameter is specified 

$Path='C:\temp'
md "$Path\TestPS"
md "$Path\TestPS\D1"

"Test" > "$Path\TestPS\D1\File1.txt"
get-childitem -path "$Path\TestPS" -File -Recurse 

Before fix:
returns nothing

After fix:
File1.txt will be returned.
