### PR TITLE
Skip null-element check for collections with a value-type element type

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -568,7 +568,7 @@ Fix steps:
         if ($ReleaseTagToUse) {
             $ReleaseVersion = $ReleaseTagToUse
         } else {
-            $ReleaseVersion = (Get-PSCommitId -WarningAction SilentlyContinue) -replace '^v'
+            $ReleaseVersion = (Get-PSCommitId) -replace '^v'
         }
 
         Start-NativeExecution { & "~/.rcedit/rcedit-x64.exe" "$($Options.Output)" --set-icon "$PSScriptRoot\assets\Powershell_black.ico" `

--- a/build.psm1
+++ b/build.psm1
@@ -568,7 +568,7 @@ Fix steps:
         if ($ReleaseTagToUse) {
             $ReleaseVersion = $ReleaseTagToUse
         } else {
-            $ReleaseVersion = (Get-PSCommitId) -replace '^v'
+            $ReleaseVersion = (Get-PSCommitId -WarningAction SilentlyContinue) -replace '^v'
         }
 
         Start-NativeExecution { & "~/.rcedit/rcedit-x64.exe" "$($Options.Output)" --set-icon "$PSScriptRoot\assets\Powershell_black.ico" `

--- a/src/System.Management.Automation/engine/Attributes.cs
+++ b/src/System.Management.Automation/engine/Attributes.cs
@@ -1994,32 +1994,33 @@ namespace System.Management.Automation
             {
                 bool isEmpty = true;
                 IEnumerator ienum = LanguagePrimitives.GetEnumerator(arguments);
-                while (ienum.MoveNext())
+                if (ienum.MoveNext()) { isEmpty = false; }
+
+                // If the element of the collection is of value type, then no need to check for null
+                // because a value-type value cannot be null.
+                if (!isEmpty && !isElementValueType)
                 {
-                    isEmpty = false;
-                    // If the element of the collection is of value type, then no need to check for null
-                    // because a value-type value cannot be null.
-                    if (isElementValueType) { break; }
-
-                    object element = ienum.Current;
-                    if (element == null || element == AutomationNull.Value)
-                    {
-                        throw new ValidationMetadataException(
-                            "ArgumentIsNull",
-                            null,
-                            Metadata.ValidateNotNullOrEmptyCollectionFailure);
-                    }
-
-                    if (element is string elementAsString)
-                    {
-                        if (String.IsNullOrEmpty(elementAsString))
+                    do {
+                        object element = ienum.Current;
+                        if (element == null || element == AutomationNull.Value)
                         {
                             throw new ValidationMetadataException(
-                                "ArgumentCollectionContainsEmpty",
+                                "ArgumentIsNull",
                                 null,
                                 Metadata.ValidateNotNullOrEmptyCollectionFailure);
                         }
-                    }
+
+                        if (element is string elementAsString)
+                        {
+                            if (String.IsNullOrEmpty(elementAsString))
+                            {
+                                throw new ValidationMetadataException(
+                                    "ArgumentCollectionContainsEmpty",
+                                    null,
+                                    Metadata.ValidateNotNullOrEmptyCollectionFailure);
+                            }
+                        }
+                    } while (ienum.MoveNext());
                 }
 
                 if (isEmpty)

--- a/src/System.Management.Automation/engine/Attributes.cs
+++ b/src/System.Management.Automation/engine/Attributes.cs
@@ -1867,7 +1867,7 @@ namespace System.Management.Automation
     #region NULL validation attributes
 
     /// <summary>
-    /// Base type of Null Validation attributes
+    /// Base type of Null Validation attributes.
     /// </summary>
     public abstract class NullValidationAttributeBase : ValidateArgumentsAttribute
     {

--- a/src/System.Management.Automation/engine/CompiledCommandParameter.cs
+++ b/src/System.Management.Automation/engine/CompiledCommandParameter.cs
@@ -698,7 +698,7 @@ namespace System.Management.Automation
         /// <summary>
         /// The type of the elements in the collection
         /// </summary>
-        internal Type ElementType { get; set; }
+        internal Type ElementType { get; private set; }
     }
 }
 

--- a/src/System.Management.Automation/engine/ParameterBinderBase.cs
+++ b/src/System.Management.Automation/engine/ParameterBinderBase.cs
@@ -787,12 +787,18 @@ namespace System.Management.Automation
 
             // Ensure that each element abides by the metadata
             bool isEmpty = true;
+            Type elementType = parameterMetadata.CollectionTypeInformation.ElementType;
+            bool isElementValueType = elementType != null && elementType.IsValueType;
             // Note - we explicitly don't pass the context here because we don't want
             // the overhead of the calls that check for stopping.
             while (ParserOps.MoveNext(null, null, ienum))
             {
-                object element = ParserOps.Current(null, ienum);
                 isEmpty = false;
+                // If the element of the collection is of value type, then no need to check for null
+                // because a value-type value cannot be null.
+                if (isElementValueType) { break; }
+
+                object element = ParserOps.Current(null, ienum);
                 ValidateNullOrEmptyArgument(
                     parameter,
                     parameterMetadata,

--- a/src/System.Management.Automation/engine/ParameterBinderBase.cs
+++ b/src/System.Management.Automation/engine/ParameterBinderBase.cs
@@ -789,22 +789,24 @@ namespace System.Management.Automation
             bool isEmpty = true;
             Type elementType = parameterMetadata.CollectionTypeInformation.ElementType;
             bool isElementValueType = elementType != null && elementType.IsValueType;
+
             // Note - we explicitly don't pass the context here because we don't want
             // the overhead of the calls that check for stopping.
-            while (ParserOps.MoveNext(null, null, ienum))
-            {
-                isEmpty = false;
-                // If the element of the collection is of value type, then no need to check for null
-                // because a value-type value cannot be null.
-                if (isElementValueType) { break; }
+            if (ParserOps.MoveNext(null, null, ienum)) { isEmpty = false; }
 
-                object element = ParserOps.Current(null, ienum);
-                ValidateNullOrEmptyArgument(
-                    parameter,
-                    parameterMetadata,
-                    parameterMetadata.CollectionTypeInformation.ElementType,
-                    element,
-                    false);
+            // If the element of the collection is of value type, then no need to check for null
+            // because a value-type value cannot be null.
+            if (!isEmpty && !isElementValueType)
+            {
+                do {
+                    object element = ParserOps.Current(null, ienum);
+                    ValidateNullOrEmptyArgument(
+                        parameter,
+                        parameterMetadata,
+                        parameterMetadata.CollectionTypeInformation.ElementType,
+                        element,
+                        false);
+                } while (ParserOps.MoveNext(null, null, ienum))
             }
 
             if (isEmpty && !parameterMetadata.AllowsEmptyCollectionArgument)

--- a/src/System.Management.Automation/engine/ParameterBinderBase.cs
+++ b/src/System.Management.Automation/engine/ParameterBinderBase.cs
@@ -806,7 +806,7 @@ namespace System.Management.Automation
                         parameterMetadata.CollectionTypeInformation.ElementType,
                         element,
                         false);
-                } while (ParserOps.MoveNext(null, null, ienum))
+                } while (ParserOps.MoveNext(null, null, ienum));
             }
 
             if (isEmpty && !parameterMetadata.AllowsEmptyCollectionArgument)

--- a/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
+++ b/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
@@ -594,7 +594,6 @@ namespace System.Management.Automation.Language
                 return (errorSuggestion ?? NullResult(target)).WriteToDebugLog(this);
             }
 
-            // In CORECLR System.Data.DataTable does not have the DataRowCollection IEnumerable, so disabling code.
             if (targetValue is DataTable)
             {
                 // Generate:

--- a/test/powershell/engine/Basic/ValidateAttributes.Tests.ps1
+++ b/test/powershell/engine/Basic/ValidateAttributes.Tests.ps1
@@ -264,7 +264,7 @@ Describe 'Validate Attributes Tests' -Tags 'CI' {
     Context "ValidateNotNull, ValidateNotNullOrEmpty and Not-Null-Or-Empty check for Mandatory parameter" {
 
         BeforeAll {
-            function MandType {
+            function MandatoryFunc {
                 param(
                     [Parameter(Mandatory, ParameterSetName = "ByteArray")]
                     [byte[]] $ByteArray,
@@ -316,8 +316,8 @@ Describe 'Validate Attributes Tests' -Tags 'CI' {
             $byteArray = [System.IO.File]::ReadAllBytes($filePath)
             $byteList  = [System.Collections.Generic.List[byte]] $byteArray
             $byteCollection = [System.Collections.ObjectModel.Collection[byte]] $byteArray
-            ## Use the running time of 'MandType -Value $byteArray' as the baseline time
-            $baseline = (Measure-Command { MandType -Value $byteArray }).Milliseconds
+            ## Use the running time of 'MandatoryFunc -Value $byteArray' as the baseline time
+            $baseline = (Measure-Command { MandatoryFunc -Value $byteArray }).Milliseconds
             ## Running time should be less than 'expected'
             $expected = $baseline + 20
 
@@ -326,9 +326,9 @@ Describe 'Validate Attributes Tests' -Tags 'CI' {
             }
 
             $testCases = @(
-                @{ ScriptBlock = { MandType -ByteArray $byteArray } }
-                @{ ScriptBlock = { MandType -ByteList $byteList } }
-                @{ ScriptBlock = { MandType -ByteCollection $byteCollection } }
+                @{ ScriptBlock = { MandatoryFunc -ByteArray $byteArray } }
+                @{ ScriptBlock = { MandatoryFunc -ByteList $byteList } }
+                @{ ScriptBlock = { MandatoryFunc -ByteCollection $byteCollection } }
                 @{ ScriptBlock = { NotNullFunc -Value $byteArray } }
                 @{ ScriptBlock = { NotNullFunc -Value $byteList } }
                 @{ ScriptBlock = { NotNullFunc -Value $byteCollection } }
@@ -375,9 +375,9 @@ Describe 'Validate Attributes Tests' -Tags 'CI' {
         }
 
         It "Mandatory parameter should throw on empty collection" {
-            { MandType -ByteArray ([byte[]]@()) } | Should Throw
-            { MandType -ByteList ([System.Collections.Generic.List[byte]]@()) } | Should Throw
-            { MandType -ByteList ([System.Collections.ObjectModel.Collection[byte]]@()) } | Should Throw
+            { MandatoryFunc -ByteArray ([byte[]]@()) } | Should Throw
+            { MandatoryFunc -ByteList ([System.Collections.Generic.List[byte]]@()) } | Should Throw
+            { MandatoryFunc -ByteList ([System.Collections.ObjectModel.Collection[byte]]@()) } | Should Throw
         }
     }
 }

--- a/test/powershell/engine/Basic/ValidateAttributes.Tests.ps1
+++ b/test/powershell/engine/Basic/ValidateAttributes.Tests.ps1
@@ -322,7 +322,7 @@ Describe 'Validate Attributes Tests' -Tags 'CI' {
             $expected = $baseline + 20
 
             if ($IsWindows) {
-                $null = New-Item -Path $TESTDRIVE/file1 -ItemType File
+                $null = New-Item -Path $TESTDRIVE/file1
             }
 
             $testCases = @(

--- a/test/powershell/engine/Basic/ValidateAttributes.Tests.ps1
+++ b/test/powershell/engine/Basic/ValidateAttributes.Tests.ps1
@@ -260,4 +260,123 @@ Describe 'Validate Attributes Tests' -Tags 'CI' {
                 $ScriptBlock | Should Not Throw
         }
     }
+
+    Context "ValidateNotNull, ValidateNotNullOrEmpty and Not-Null-Or-Empty check for Mandatory parameter" {
+
+        BeforeAll {
+            function MandType {
+                param(
+                    [Parameter(Mandatory, ParameterSetName = "ByteArray")]
+                    [byte[]] $ByteArray,
+
+                    [Parameter(Mandatory, ParameterSetName = "ByteList")]
+                    [System.Collections.Generic.List[byte]] $ByteList,
+
+                    [Parameter(Mandatory, ParameterSetName = "ByteCollection")]
+                    [System.Collections.ObjectModel.Collection[byte]] $ByteCollection,
+
+                    [Parameter(ParameterSetName = "Default")]
+                    $Value
+                )
+            }
+
+            function NotNullFunc {
+                param(
+                    [ValidateNotNull()]
+                    $Value,
+                    [string] $TestType
+                )
+
+                switch ($TestType) {
+                    "COM-Enumerable" { $Value | ForEach-Object Name }
+                    "Enumerator"     {
+                        $items = foreach ($i in $Value) { $i }
+                        $items -join ","
+                    }
+                }
+            }
+
+            function NotNullOrEmptyFunc {
+                param(
+                    [ValidateNotNullOrEmpty()]
+                    $Value,
+                    [string] $TestType
+                )
+
+                switch ($TestType) {
+                    "COM-Enumerable" { $Value | ForEach-Object Name }
+                    "Enumerator"     {
+                        $items = foreach ($i in $Value) { $i }
+                        $items -join ","
+                    }
+                }
+            }
+
+            $byteArray = [System.IO.File]::ReadAllBytes("$PSHOME\System.Management.Automation.dll")
+            $byteList  = [System.Collections.Generic.List[byte]] $byteArray
+            $byteCollection = [System.Collections.ObjectModel.Collection[byte]] $byteArray
+            ## Use the running time of 'MandType -Value $byteArray' as the baseline time
+            $baseline = (Measure-Command { MandType -Value $byteArray }).Milliseconds
+            ## Running time should be less than 'expected'
+            $expected = $baseline + 20
+
+            if ($IsWindows) {
+                $null = New-Item -Path $TESTDRIVE/file1 -ItemType File
+            }
+
+            $testCases = @(
+                @{ ScriptBlock = { MandType -ByteArray $byteArray } }
+                @{ ScriptBlock = { MandType -ByteList $byteList } }
+                @{ ScriptBlock = { MandType -ByteCollection $byteCollection } }
+                @{ ScriptBlock = { NotNullFunc -Value $byteArray } }
+                @{ ScriptBlock = { NotNullFunc -Value $byteList } }
+                @{ ScriptBlock = { NotNullFunc -Value $byteCollection } }
+                @{ ScriptBlock = { NotNullOrEmptyFunc -Value $byteArray } }
+                @{ ScriptBlock = { NotNullOrEmptyFunc -Value $byteList } }
+                @{ ScriptBlock = { NotNullOrEmptyFunc -Value $byteCollection } }
+            )
+        }
+
+        It "Validate running time '<ScriptBlock>'" -TestCases $testCases {
+            param ($ScriptBlock)
+            (Measure-Command $ScriptBlock).Milliseconds | Should BeLessThan $expected
+        }
+
+        It "COM enumerable argument should work with 'ValidateNotNull' and 'ValidateNotNullOrEmpty'" -Skip:(!$IsWindows) {
+            $shell = New-Object -ComObject "Shell.Application"
+            $folder = $shell.Namespace("$TESTDRIVE")
+            $items = $folder.Items()
+
+            NotNullFunc -Value $items -TestType "COM-Enumerable" | Should Be "file1"
+            NotNullOrEmptyFunc -Value $items -TestType "COM-Enumerable" | Should Be "file1"
+        }
+
+        It "Enumerator argument should work with 'ValidateNotNull' and 'ValidateNotNullOrEmpty'" {
+            $data = @(1,2,3)
+            NotNullFunc -Value $data.GetEnumerator() -TestType "Enumerator" | Should Be "1,2,3"
+            NotNullOrEmptyFunc -Value $data.GetEnumerator() -TestType "Enumerator" | Should Be "1,2,3"
+        }
+
+        It "'ValidateNotNull' should throw on null element of a collection argument" {
+            ## Should throw on null element
+            { NotNullFunc -Value @("string", $null, 2) } | Should Throw
+            ## Should not throw on empty string element
+            { NotNullFunc -Value @("string", "", 2) } | Should Not Throw
+            ## Should not throw on an empty collection
+            { NotNullFunc -Value @() } | Should Not Throw
+        }
+
+        It "'ValidateNotNullOrEmpty' should throw on null element of a collection argument or empty collection/dictionary" {
+            { NotNullOrEmptyFunc -Value @("string", $null, 2) } | Should Throw
+            { NotNullOrEmptyFunc -Value @("string", "", 2) } | Should Throw
+            { NotNullOrEmptyFunc -Value @() } | Should Throw
+            { NotNullOrEmptyFunc -Value @{} } | Should Throw
+        }
+
+        It "Mandatory parameter should throw on empty collection" {
+            { MandType -ByteArray ([byte[]]@()) } | Should Throw
+            { MandType -ByteList ([System.Collections.Generic.List[byte]]@()) } | Should Throw
+            { MandType -ByteList ([System.Collections.ObjectModel.Collection[byte]]@()) } | Should Throw
+        }
+    }
 }

--- a/test/powershell/engine/Basic/ValidateAttributes.Tests.ps1
+++ b/test/powershell/engine/Basic/ValidateAttributes.Tests.ps1
@@ -381,4 +381,3 @@ Describe 'Validate Attributes Tests' -Tags 'CI' {
         }
     }
 }
-

--- a/test/powershell/engine/Basic/ValidateAttributes.Tests.ps1
+++ b/test/powershell/engine/Basic/ValidateAttributes.Tests.ps1
@@ -312,7 +312,8 @@ Describe 'Validate Attributes Tests' -Tags 'CI' {
                 }
             }
 
-            $byteArray = [System.IO.File]::ReadAllBytes("$PSHOME\System.Management.Automation.dll")
+            $filePath  = Join-Path -Path $PSHOME -ChildPath System.Management.Automation.dll
+            $byteArray = [System.IO.File]::ReadAllBytes($filePath)
             $byteList  = [System.Collections.Generic.List[byte]] $byteArray
             $byteCollection = [System.Collections.ObjectModel.Collection[byte]] $byteArray
             ## Use the running time of 'MandType -Value $byteArray' as the baseline time
@@ -380,3 +381,4 @@ Describe 'Validate Attributes Tests' -Tags 'CI' {
         }
     }
 }
+


### PR DESCRIPTION
Fix #5417

- For `Mandatory` parameter, `ValidateNotNull` and `ValidateNotNullOrEmpty` attributes, skip null-element check if the collection's element type is value type.
- For `ValidateNotNull` and `ValidateNotNullOrEmpty`, they are changed to do null/empty check only on collections (as defined in `ParameterCollectionTypeInformation`) and hashtable. They currently enumerate elements of any object that implements `IEnumerable` and also enumerate elements if the argument is an enumerator. I think this behavior is not right for the following reasons:
    - The argument may be an object that talks to Azure to retrieve elements back. It doesn't seem right to have the `ValidateNotNull/ValidateNotNullOrEmpty` attributes wait on that.
    - On Windows, COM object may be enumerable, but the `GetEnumerator()` method is not supported in .NET Core on COM object. (See the COM example below)
    - When the argument is an enumerator, the enumerator may not be useful after the validate attribute walks through all its elements. (See the enumerator example below)


COM Example
```
function bar {
   param ([ValidateNotNull()] $object)
}
> $shell = New-Object -ComObject Shell.Application
> $folder = $shell.NameSpace("F:\tmp\dd\")
> bar -object ($folder.Items())
bar : Cannot validate argument on parameter 'object'. Could not load type 'System.Runtime.InteropServices.ComTypes.IEnumerable' from assembly 'System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e'.
At line:1 char:13
+ bar -object ($folder.Items())
+             ~~~~~~~~~~~~~~~~~
+ CategoryInfo          : InvalidData: (:) [bar], ParameterBindingValidationException
+ FullyQualifiedErrorId : ParameterArgumentValidationError,bar
```

Enumerator Example
```
function bar {
   param ([ValidateNotNull()] $object)
   "MoveNext:  $($object.MoveNext())"
}

> bar -object @(1,2,3).GetEnumerator()
MoveNext:  False
```