### PR TITLE
fix build in vscode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,7 @@
             "justMyCode": false,
             "stopAtEntry": true,
             "program": "${workspaceRoot}/debug/pwsh",
-            "preLaunchTask": "build",
+            "preLaunchTask": "Build",
             "externalConsole": true,
             "cwd": "${workspaceRoot}"
         },

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,17 +1,74 @@
 {
-    "version": "0.1.0",
-    "command": "pwsh",
-    "isShellCommand": true,
-    "showOutput": "always",
-    "suppressTaskName": true,
-    "args": [ "-command" ],
+    "version": "2.0.0",
+
+    "windows": {
+        "options": {
+            "shell": {
+                "executable": "pwsh.exe",
+                "args": [
+                    "-NoProfile",
+                    "-ExecutionPolicy",
+                    "Bypass",
+                    "-Command"
+                ]
+            }
+        }
+    },
+    "linux": {
+        "options": {
+            "shell": {
+                "executable": "/usr/bin/pwsh",
+                "args": [
+                    "-NoProfile",
+                    "-Command"
+                ]
+            }
+        }
+    },
+    "osx": {
+        "options": {
+            "shell": {
+                "executable": "/usr/local/bin/pwsh",
+                "args": [
+                    "-NoProfile",
+                    "-Command"
+                ]
+            }
+        }
+    },
 
     "tasks": [
         {
-            "taskName": "build",
-            "args": [ "Import-Module ${workspaceRoot}/build.psm1; Start-PSBuild -Output ${workspaceRoot}/debug" ],
-            "isBuildCommand": true,
+            "label": "Bootstrap",
+            "type": "shell",
+            "command": "Import-Module ${workspaceFolder}/build.psm1; Start-PSBootstrap",
+            "problemMatcher": []
+        },
+        {
+            "label": "Clean Build",
+            "type": "shell",
+            "command": "Import-Module ${workspaceFolder}/build.psm1; Start-PSBuild -Clean",
+            "problemMatcher": []
+        },
+        {
+            "label": "Build",
+            "type": "shell",
+            "command": "Import-Module ${workspaceFolder}/build.psm1; Start-PSBuild -Output (Join-Path ${workspaceFolder} debug)",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
             "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "Test",
+            "type": "shell",
+            "command": "Import-Module ${workspaceFolder}/build.psm1; Start-PSPester -Path ${workspaceFolder}/test",
+            "group": {
+                "kind": "test",
+                "isDefault": true
+            },
+            "problemMatcher": "$pester"
         }
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -47,7 +47,7 @@
         {
             "label": "Clean Build",
             "type": "shell",
-            "command": "Import-Module ${workspaceFolder}/build.psm1; Start-PSBuild -Clean",
+            "command": "Import-Module ${workspaceFolder}/build.psm1; Start-PSBuild -Clean -Output (Join-Path ${workspaceFolder} debug)",
             "problemMatcher": "$msCompile"
         },
         {

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -48,7 +48,7 @@
             "label": "Clean Build",
             "type": "shell",
             "command": "Import-Module ${workspaceFolder}/build.psm1; Start-PSBuild -Clean",
-            "problemMatcher": []
+            "problemMatcher": "$msCompile"
         },
         {
             "label": "Build",
@@ -59,16 +59,6 @@
                 "isDefault": true
             },
             "problemMatcher": "$msCompile"
-        },
-        {
-            "label": "Test",
-            "type": "shell",
-            "command": "Import-Module ${workspaceFolder}/build.psm1; Start-PSPester -Path ${workspaceFolder}/test",
-            "group": {
-                "kind": "test",
-                "isDefault": true
-            },
-            "problemMatcher": "$pester"
         }
     ]
 }

--- a/build.psm1
+++ b/build.psm1
@@ -569,10 +569,28 @@ Fix steps:
             $ReleaseVersion = $ReleaseTagToUse
         } else {
             $ReleaseVersion = (Get-PSCommitId) -replace '^v'
+            $fileVersion = $ReleaseVersion.Split("-")[0]
+        }
+        if (!$ReleaseVersion) {
+            $ReleaseVersion = "6.0.0"
+            $fileVersion = "6.0.0"
         }
 
-        Start-NativeExecution { & "~/.rcedit/rcedit-x64.exe" "$($Options.Output)" --set-icon "$PSScriptRoot\assets\Powershell_black.ico" `
-            --set-file-version $ReleaseVersion --set-product-version $ReleaseVersion --set-version-string "ProductName" "PowerShell Core 6" `
+        Write-Verbose "Release version: $ReleaseVersion" -Verbose
+
+        $pwshPath = $Options.Output
+        if ($Environment.IsWindows) {
+            if (!$pwshPath.EndsWith("pwsh.exe")) {
+                $pwshPath = Join-Path $Options.Output "pwsh.exe"
+            }
+        } else {
+            if (!$pwshPath.EndsWith("pwsh")) {
+                $pwshPath = Join-Path $Options.Output "pwsh"
+            }
+        }
+
+        Start-NativeExecution { & "~/.rcedit/rcedit-x64.exe" $pwshPath --set-icon "$PSScriptRoot\assets\Powershell_black.ico" `
+            --set-file-version $fileVersion --set-product-version $ReleaseVersion --set-version-string "ProductName" "PowerShell Core 6" `
             --set-requested-execution-level "asInvoker" --set-version-string "LegalCopyright" "(C) Microsoft Corporation.  All Rights Reserved." } | Write-Verbose
     }
 

--- a/build.psm1
+++ b/build.psm1
@@ -569,24 +569,19 @@ Fix steps:
             $ReleaseVersion = $ReleaseTagToUse
         } else {
             $ReleaseVersion = (Get-PSCommitId) -replace '^v'
-            $fileVersion = $ReleaseVersion.Split("-")[0]
         }
+        # in VSCode, depending on where you started it from, the git commit id may be empty so provide a default value 
         if (!$ReleaseVersion) {
             $ReleaseVersion = "6.0.0"
             $fileVersion = "6.0.0"
+        } else {
+            $fileVersion = $ReleaseVersion.Split("-")[0]
         }
 
-        Write-Verbose "Release version: $ReleaseVersion" -Verbose
-
+        # in VSCode, the build output folder doesn't include the name of the exe so we have to add it for rcedit
         $pwshPath = $Options.Output
-        if ($Environment.IsWindows) {
-            if (!$pwshPath.EndsWith("pwsh.exe")) {
-                $pwshPath = Join-Path $Options.Output "pwsh.exe"
-            }
-        } else {
-            if (!$pwshPath.EndsWith("pwsh")) {
-                $pwshPath = Join-Path $Options.Output "pwsh"
-            }
+        if (!$pwshPath.EndsWith("pwsh.exe")) {
+            $pwshPath = Join-Path $Options.Output "pwsh.exe"
         }
 
         Start-NativeExecution { & "~/.rcedit/rcedit-x64.exe" $pwshPath --set-icon "$PSScriptRoot\assets\Powershell_black.ico" `

--- a/build.psm1
+++ b/build.psm1
@@ -461,7 +461,7 @@ Fix steps:
     }
 
     # setup arguments
-    $Arguments = @("publish")
+    $Arguments = @("publish","/property:GenerateFullPaths=true")
     if ($Output) {
         $Arguments += "--output", $Output
     }
@@ -570,7 +570,7 @@ Fix steps:
         } else {
             $ReleaseVersion = (Get-PSCommitId) -replace '^v'
         }
-        # in VSCode, depending on where you started it from, the git commit id may be empty so provide a default value 
+        # in VSCode, depending on where you started it from, the git commit id may be empty so provide a default value
         if (!$ReleaseVersion) {
             $ReleaseVersion = "6.0.0"
             $fileVersion = "6.0.0"


### PR DESCRIPTION
There were several issues:

In vscode, depending on where you started it from, it may not get the git commit id so it ends up empty.  Add a default value to use.

From the console, the commit id was typically in a form that is not parse-able as a fileversion.  Fix is to chop off everything right of the dash.

It also seems that building from the console and building from vscode, the output path may or may not include `pwsh`, however, rcedit needs the actual executable in the path.  

Fix https://github.com/PowerShell/PowerShell/issues/5440

<!--

If you are a PowerShell Team member, please make sure you choose the Reviewer(s) and Assignee for your PR.
If you are not from the PowerShell Team, you can leave the fields blank and the Maintainers will choose them for you. If you are familiar with the team, feel free to mention some Reviewers yourself.

For more information about the roles of Reviewer and Assignee, refer to [CONTRIBUTING.md](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md).

-->
