### PR TITLE
Updated csproj to use the latest help package

### DIFF
--- a/src/powershell-unix/powershell-unix.csproj
+++ b/src/powershell-unix/powershell-unix.csproj
@@ -31,7 +31,7 @@
     <PackageReference Include="libpsl" Version="6.0.0-*" />
     <PackageReference Include="psrp" Version="1.1.0-*" />
     <PackageReference Include="PSDesiredStateConfiguration" Version="6.0.0-beta.8" />
-    <PackageReference Include="PowerShellHelpFiles" Version="1.0.0-alpha01" />
+    <PackageReference Include="PowerShellHelpFiles" Version="1.0.0-*" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/powershell-win-core/powershell-win-core.csproj
+++ b/src/powershell-win-core/powershell-win-core.csproj
@@ -35,7 +35,7 @@
 
   <ItemGroup>
     <PackageReference Include="PSDesiredStateConfiguration" Version="6.0.0-beta.8" />
-    <PackageReference Include="PowerShellHelpFiles" Version="1.0.0-alpha01" />
+    <PackageReference Include="PowerShellHelpFiles" Version="1.0.0-*" />
     <PackageReference Include="psrp.windows" Version="6.0.0-*" />
   </ItemGroup>
 

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -119,21 +119,6 @@ Describe "TabCompletion" -Tags CI {
         $res.CompletionMatches[0].CompletionText | Should Be 'namespace'
     }
 
-    It 'Should complete about help topic' {
-
-        $aboutHelpPath = Join-Path $PSHOME (Get-Culture).Name
-
-        ## If help content does not exist, tab completion will not work. So update it first.
-        if(-not (Test-Path (Join-Path $aboutHelpPath "about_Splatting.help.txt")))
-        {
-            Update-Help -Force -ErrorAction SilentlyContinue
-        }
-
-        $res = TabExpansion2 -inputScript 'get-help about_spla' -cursorColumn 'get-help about_spla'.Length
-        $res.CompletionMatches.Count | Should Be 1
-        $res.CompletionMatches[0].CompletionText | Should BeExactly 'about_Splatting'
-    }
-
     Context NativeCommand {
         BeforeAll {
             $nativeCommand = (Get-Command -CommandType Application -TotalCount 1).Name
@@ -950,6 +935,23 @@ dir -Recurse `
             }
             $completionOptions | Should Be ([string]::Join("", $expected))
         }
+    }
+}
+
+Describe "Tab completion help test" -Tags @('RequireAdminOnWindows', 'CI') {
+    It 'Should complete about help topic' {
+
+        $aboutHelpPath = Join-Path $PSHOME (Get-Culture).Name
+
+        ## If help content does not exist, tab completion will not work. So update it first.
+        if (-not (Test-Path (Join-Path $aboutHelpPath "about_Splatting.help.txt")))
+        {
+            Update-Help -Force -ErrorAction SilentlyContinue
+        }
+
+        $res = TabExpansion2 -inputScript 'get-help about_spla' -cursorColumn 'get-help about_spla'.Length
+        $res.CompletionMatches.Count | Should Be 1
+        $res.CompletionMatches[0].CompletionText | Should BeExactly 'about_Splatting'
     }
 }
 


### PR DESCRIPTION
Fixes #5181 

The help package is updated to only have default help. All the other help content can be downloaded using `Update-Help`
