### PR TITLE
Add standard set of vscode workspace setting files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,9 +57,6 @@ gen
 # Per repo profile
 .profile.ps1
 
-#VS Code files
-.vscode
-
 # macOS
 .DS_Store
 
@@ -68,4 +65,3 @@ TestsResults*.xml
 
 # Resharper settings
 PowerShell.sln.DotSettings.user
-

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,11 @@
+{
+  // See http://go.microsoft.com/fwlink/?LinkId=827846
+  // for the documentation about the extensions.json format
+  "recommendations": [
+    "ms-vscode.cpptools",
+    "ms-vscode.csharp",
+    "ms-vscode.PowerShell",
+    "twxs.cmake",
+    "DavidAnson.vscode-markdownlint"
+  ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -18,6 +18,24 @@
             "request": "attach",
             "justMyCode": false,
             "processId": "${command:pickProcess}"
+        },
+        {
+            "type": "PowerShell",
+            "request": "launch",
+            "name": "PowerShell Launch Current File",
+            "script": "${file}",
+            "args": [],
+            "cwd": "${file}"
+        },
+        {
+            "type": "PowerShell",
+            "request": "launch",
+            "name": "PowerShell Launch Current File w/Args Prompt",
+            "script": "${file}",
+            "args": [
+                "${command:SpecifyScriptArgs}"
+            ],
+            "cwd": "${file}"
         }
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,16 @@
+// Place your settings in this file to overwrite default and user settings.
+{
+  "editor.tabSize": 4,
+  "editor.insertSpaces": true,
+  "markdownlint.config": {
+    "MD004": false,
+    "MD024": false,
+    "MD033": false,
+    "MD034": false,
+    "MD038": false,
+    "MD042": false
+  },
+  "[powershell]": {
+    "files.trimTrailingWhitespace": true
+  }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,8 @@
   "editor.tabSize": 4,
   "editor.insertSpaces": true,
 
+  "files.insertFinalNewline": true,
+
   // Based on current .markdownlist.json settings:
   // https://github.com/PowerShell/PowerShell/blob/master/.markdownlint.json
   "markdownlint.config": {

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,9 @@
 {
   "editor.tabSize": 4,
   "editor.insertSpaces": true,
+
+  // Based on current .markdownlist.json settings:
+  // https://github.com/PowerShell/PowerShell/blob/master/.markdownlint.json
   "markdownlint.config": {
     "MD004": false,
     "MD024": false,
@@ -10,6 +13,7 @@
     "MD038": false,
     "MD042": false
   },
+
   "[powershell]": {
     "files.trimTrailingWhitespace": true
   }


### PR DESCRIPTION
Add an extensions.json file that will prompt folks to install extensions that are recommended for this workspace (c++, c#, powershell, cmake (editing syntax) and markdown linter.

Add settings.json to start to configure C# syntax, PoweShell trim trailing whitespace and configure the markdown lint extension.

Update launch.json to provide ability to debug PowerShell scripts.

BTW I'm hoping as more people on the team use the VSCode extension , it will help get more attention to fixing some lingering issues in the PS extension.  Dogfooding FTW!!

<!--

If you are a PowerShell Team member, please make sure you choose the Reviewer(s) and Assignee for your PR.
If you are not from the PowerShell Team, you can leave the fields blank and the Maintainers will choose them for you. If you are familiar with the team, feel free to mention some Reviewers yourself.

For more information about the roles of Reviewer and Assignee, refer to [CONTRIBUTING.md](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md).

-->
