### PR TITLE
Disambiguate icon for daily builds on Windows

### DIFF
--- a/tools/install-powershell.ps1
+++ b/tools/install-powershell.ps1
@@ -209,13 +209,13 @@ try {
     # Edit icon to disambiguate daily builds.
     if ($IsWinEnv -and $Daily.IsPresent) {
         if (-not (Test-Path "~/.rcedit/rcedit-x64.exe")) {
-            Write-Verbose "Install RCEdit for modifying exe resources"
+            Write-Verbose "Install RCEdit for modifying exe resources" -Verbose
             $rceditUrl = "https://github.com/electron/rcedit/releases/download/v1.0.0/rcedit-x64.exe"
             New-Item -Path "~/.rcedit" -Type Directory -Force > $null
             Invoke-WebRequest -OutFile "~/.rcedit/rcedit-x64.exe" -Uri $rceditUrl
         }
 
-        Write-Verbose "Change icon to disambiguate it from a released installation"
+        Write-Verbose "Change icon to disambiguate it from a released installation" -Verbose
         & "~/.rcedit/rcedit-x64.exe" "$Destination\pwsh.exe" --set-icon "$Destination\assets\Powershell_av_colors.ico"
     }
 

--- a/tools/install-powershell.ps1
+++ b/tools/install-powershell.ps1
@@ -206,6 +206,21 @@ try {
         }
     }
 
+    # Edit icon to disambiguate daily builds.
+    if ($IsWinEnv -and $Daily.IsPresent)
+    {
+        if (-not (Test-Path "~/.rcedit/rcedit-x64.exe"))
+        {
+            Write-Verbose "Install RCEdit for modifying exe resources"
+            $rceditUrl = "https://github.com/electron/rcedit/releases/download/v1.0.0/rcedit-x64.exe"
+            New-Item -Path "~/.rcedit" -Type Directory -Force > $null
+            Invoke-WebRequest -OutFile "~/.rcedit/rcedit-x64.exe" -Uri $rceditUrl
+        }
+
+        Write-Verbose "Change icon to disambiguate it from a released installation"
+        & "~/.rcedit/rcedit-x64.exe" "$Destination\pwsh.exe" --set-icon "$Destination\assets\Powershell_av_colors.ico"
+    }
+
     Write-Host "PowerShell Core has been installed at $Destination" -ForegroundColor Green
     if ($Destination -eq $PSHome) {
         Write-Host "Please restart pwsh" -ForegroundColor Magenta

--- a/tools/install-powershell.ps1
+++ b/tools/install-powershell.ps1
@@ -207,10 +207,8 @@ try {
     }
 
     # Edit icon to disambiguate daily builds.
-    if ($IsWinEnv -and $Daily.IsPresent)
-    {
-        if (-not (Test-Path "~/.rcedit/rcedit-x64.exe"))
-        {
+    if ($IsWinEnv -and $Daily.IsPresent) {
+        if (-not (Test-Path "~/.rcedit/rcedit-x64.exe")) {
             Write-Verbose "Install RCEdit for modifying exe resources"
             $rceditUrl = "https://github.com/electron/rcedit/releases/download/v1.0.0/rcedit-x64.exe"
             New-Item -Path "~/.rcedit" -Type Directory -Force > $null

--- a/tools/install-powershell.ps1
+++ b/tools/install-powershell.ps1
@@ -156,6 +156,19 @@ try {
         Move-Item -Path $contentPath -Destination $Destination
     }
 
+    # Edit icon to disambiguate daily builds.
+    if ($IsWinEnv -and $Daily.IsPresent) {
+        if (-not (Test-Path "~/.rcedit/rcedit-x64.exe")) {
+            Write-Verbose "Install RCEdit for modifying exe resources" -Verbose
+            $rceditUrl = "https://github.com/electron/rcedit/releases/download/v1.0.0/rcedit-x64.exe"
+            New-Item -Path "~/.rcedit" -Type Directory -Force > $null
+            Invoke-WebRequest -OutFile "~/.rcedit/rcedit-x64.exe" -Uri $rceditUrl
+        }
+
+        Write-Verbose "Change icon to disambiguate it from a released installation" -Verbose
+        & "~/.rcedit/rcedit-x64.exe" "$Destination\pwsh.exe" --set-icon "$Destination\assets\Powershell_av_colors.ico"
+    }
+
     ## Change the mode of 'pwsh' to 'rwxr-xr-x' to allow execution
     if (-not $IsWinEnv) { chmod 755 $Destination/pwsh }
 
@@ -204,19 +217,6 @@ try {
         if ($runningProcessName -ne 'pwsh') {
             $env:Path = $Destination + [System.IO.Path]::PathSeparator + $env:Path
         }
-    }
-
-    # Edit icon to disambiguate daily builds.
-    if ($IsWinEnv -and $Daily.IsPresent) {
-        if (-not (Test-Path "~/.rcedit/rcedit-x64.exe")) {
-            Write-Verbose "Install RCEdit for modifying exe resources" -Verbose
-            $rceditUrl = "https://github.com/electron/rcedit/releases/download/v1.0.0/rcedit-x64.exe"
-            New-Item -Path "~/.rcedit" -Type Directory -Force > $null
-            Invoke-WebRequest -OutFile "~/.rcedit/rcedit-x64.exe" -Uri $rceditUrl
-        }
-
-        Write-Verbose "Change icon to disambiguate it from a released installation" -Verbose
-        & "~/.rcedit/rcedit-x64.exe" "$Destination\pwsh.exe" --set-icon "$Destination\assets\Powershell_av_colors.ico"
     }
 
     Write-Host "PowerShell Core has been installed at $Destination" -ForegroundColor Green


### PR DESCRIPTION
Change icon of `pwsh.exe` for daily builds on Windows to [this](https://raw.githubusercontent.com/PowerShell/PowerShell/master/assets/Powershell_av_colors.ico) icon.
Some code had to be borrowed from build.psm1 because this script has to be self contained in case it gets executed by only downloading this file via the published download link [here](https://twitter.com/Steve_MSFT/status/930585082451992576).
Tested on Windows 10.0.16299 (Fall Creators Update) with WMF 5.1

<!--

If you are a PowerShell Team member, please make sure you choose the Reviewer(s) and Assignee for your PR.
If you are not from the PowerShell Team, you can leave the fields blank and the Maintainers will choose them for you. If you are familiar with the team, feel free to mention some Reviewers yourself.

For more information about the roles of Reviewer and Assignee, refer to [CONTRIBUTING.md](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md).

-->
