### PR TITLE
 Change 'Install-PowerShell.ps1' to query for metadata from our file

### DIFF
--- a/tools/install-powershell.ps1
+++ b/tools/install-powershell.ps1
@@ -119,8 +119,8 @@ try {
         Install-Package -InputObject $package -Destination $tempDir -ExcludeVersion > $null
         $contentPath = [System.IO.Path]::Combine($tempDir, $packageName, "content")
     } else {
-        $metadata = Invoke-RestMethod https://api.github.com/repos/powershell/powershell/releases/latest
-        $release = $metadata.tag_name -replace '^v'
+        $metadata = Invoke-RestMethod https://raw.githubusercontent.com/PowerShell/PowerShell/master/tools/metadata.json
+        $release = $metadata.ReleaseTag -replace '^v'
 
         $packageName = if ($IsWinEnv) {
             "PowerShell-${release}-win-${architecture}.zip"

--- a/tools/metadata.json
+++ b/tools/metadata.json
@@ -1,0 +1,3 @@
+{
+    "ReleaseTag": "v6.0.0-beta.9"
+}


### PR DESCRIPTION
Fix #5456 

- Add a `metadata.json` file.
- Change 'Install-PowerShell.ps1' to query for metadata from `metadata.json`