### PR TITLE
Start-Process: add parameter -ExitTimeout

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/resources/ProcessResources.resx
+++ b/src/Microsoft.PowerShell.Commands.Management/resources/ProcessResources.resx
@@ -177,8 +177,8 @@
   <data name="ProcessNotTerminated" xml:space="preserve">
     <value>This command stopped operation because process "{0} ({1})" is not stopped in the specified time-out.</value>
   </data>
-  <data name="StartProcessTimeoutExceeded" xml:space="preserve">
-    <value>This command stopped operation because process "{0}" did not complete within the specified time-out.</value>
+  <data name="StartProcessExitTimeoutExceeded" xml:space="preserve">
+    <value>This command stopped operation because process "{0}" did not exit within the specified time-out.</value>
   </data>
   <data name="InvalidStartProcess" xml:space="preserve">
     <value>This command cannot be run due to the error: {0}.</value>

--- a/src/Microsoft.PowerShell.Commands.Management/resources/ProcessResources.resx
+++ b/src/Microsoft.PowerShell.Commands.Management/resources/ProcessResources.resx
@@ -129,6 +129,12 @@
   <data name="CouldNotStopProcess" xml:space="preserve">
     <value>Cannot stop process "{0} ({1})" because of the following error: {2}</value>
   </data>
+  <data name="CouldNotResolveProcessTree" xml:space="preserve">
+    <value>The process tree cannot be resolved for "{0}".</value>
+  </data>
+  <data name="DescendantProcessesPossiblyRunning" xml:space="preserve">
+    <value>Descendant processes may still be running.</value>
+  </data>
   <data name="ProcessNameForConfirmation" xml:space="preserve">
     <value>{0} ({1})</value>
   </data>
@@ -170,6 +176,9 @@
   </data>
   <data name="ProcessNotTerminated" xml:space="preserve">
     <value>This command stopped operation because process "{0} ({1})" is not stopped in the specified time-out.</value>
+  </data>
+  <data name="StartProcessTimeoutExceeded" xml:space="preserve">
+    <value>This command stopped operation because process "{0}" did not complete within the specified time-out.</value>
   </data>
   <data name="InvalidStartProcess" xml:space="preserve">
     <value>This command cannot be run due to the error: {0}.</value>

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Start-Process.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Start-Process.Tests.ps1
@@ -125,33 +125,26 @@ Describe "Start-Process -Timeout" -Tags "Feature","Slow" {
         elseif ($IsLinux -Or $IsMacOS) {
             $pingParam = "-c 30 localhost"
         }
-
-        # Find where test/powershell is so we can find the testexe command relative to it
-        $powershellTestDir = $PSScriptRoot
-        while ($powershellTestDir -notmatch 'test[\\/]powershell$') {
-            $powershellTestDir = Split-Path $powershellTestDir
-        }
-        $testexe = Join-Path (Split-Path $powershellTestDir) tools/TestExe/bin/testexe
     }
 
-    It "Should work correctly if process completes before specified time-out" {
-        Start-Process ping -ArgumentList $pingParam -Timeout 40 -RedirectStandardOutput "$TESTDRIVE/output" | Should Be $null
+    It "Should work correctly if process completes before specified exit time-out" {
+        Start-Process ping -ArgumentList $pingParam -ExitTimeout 40000 -RedirectStandardOutput "$TESTDRIVE/output" | Should Be $null
     }
 
-    It "Should give an error when the specified time-out is exceeded" {
-        { Start-Process ping -ArgumentList $pingParam -Timeout 20 -RedirectStandardOutput "$TESTDRIVE/output" } | ShouldBeErrorId "StartProcessTimeoutExceeded,Microsoft.PowerShell.Commands.StartProcessCommand"
+    It "Should give an error when the specified exit time-out is exceeded" {
+        { Start-Process ping -ArgumentList $pingParam -ExitTimeout 20000 -RedirectStandardOutput "$TESTDRIVE/output" } | ShouldBeErrorId "StartProcessExitTimeoutExceeded,Microsoft.PowerShell.Commands.StartProcessCommand"
     }
 
-    It "Should use time-out value when both -Timeout and -Wait are passed" {
-        { Start-Process ping -ArgumentList $pingParam -Timeout 20 -Wait -RedirectStandardOutput "$TESTDRIVE/output" } | ShouldBeErrorId "StartProcessTimeoutExceeded,Microsoft.PowerShell.Commands.StartProcessCommand"
+    It "Should use exit time-out value when both -ExitTimeout and -Wait are passed" {
+        { Start-Process ping -ArgumentList $pingParam -ExitTimeout 20000 -Wait -RedirectStandardOutput "$TESTDRIVE/output" } | ShouldBeErrorId "StartProcessExitTimeoutExceeded,Microsoft.PowerShell.Commands.StartProcessCommand"
     }
 
     # This is based on the test "Should kill native process tree" in
     # test\powershell\Language\Scripting\NativeExecution\NativeCommandProcessor.Tests.ps1
-    It "Should stop any descendant processes when the specified time-out is exceeded" {
+    It "Should stop any descendant processes when the specified exit time-out is exceeded" {
         Get-Process testexe -ErrorAction SilentlyContinue | Stop-Process
 
-        { Start-Process $testexe -ArgumentList "-createchildprocess 6" -Timeout 10 -RedirectStandardOutput "$TESTDRIVE/output" } | ShouldBeErrorId "StartProcessTimeoutExceeded,Microsoft.PowerShell.Commands.StartProcessCommand"
+        { Start-Process testexe -ArgumentList "-createchildprocess 6" -ExitTimeout 10000 -RedirectStandardOutput "$TESTDRIVE/output" } | ShouldBeErrorId "StartProcessExitTimeoutExceeded,Microsoft.PowerShell.Commands.StartProcessCommand"
 
         # Waiting for a second, as the $testexe processes may still be exiting
         # and the Get-Process cmdlet will count them accidentally


### PR DESCRIPTION
This is to resolve #5185 by adding a `Timeout` parameter to `Start-Process`.

If the timeout is reached and the process hasn't finished, the process is stopped.

To perform the stopping of processes, the `Stop-Process` cmdlet is invoked. This is done to prevent repeating any checks needed when killing a process.

Before the process is stopped, a "search" is attempted to find all descendant processes to hopefully avoid any orphaned processes remaining active. This uses WMI on Windows and the `ps` command on UNIX-like systems, as this provided the most reliable way for cross-platform support.

As mentioned in the contributing guidelines, this change may warrant a note in the changelog (I am unsure where to put it).