### PR TITLE
Remove PerformWSManPluginReportCompletion from pwrshplugin.dll

### DIFF
--- a/src/powershell-native/nativemsh/pwrshplugin/pwrshplugin.def
+++ b/src/powershell-native/nativemsh/pwrshplugin/pwrshplugin.def
@@ -15,4 +15,3 @@ WSManPluginSend
 WSManPluginSignal
 WSManPluginReceive
 WSManPluginConnect
-PerformWSManPluginReportCompletion

--- a/src/powershell-native/nativemsh/pwrshplugin/pwrshplugin.h
+++ b/src/powershell-native/nativemsh/pwrshplugin/pwrshplugin.h
@@ -1090,13 +1090,3 @@ public:
         return version;
     }
 };
-
-extern "C"
-void WINAPI PerformWSManPluginReportCompletion()
-{
-    // Now report the plugin completion, to indicate that plugin is ready to shutdown.
-    // This API is used by plugins to report completion
-    // - pluginContext MUST be the same context that plugin provided to the WSManPluginStartup method
-    // - flags are reserved, so 0
-    WSManPluginReportCompletion(g_pPluginContext, 0);
-}

--- a/src/powershell-native/nativemsh/pwrshplugin/pwrshplugin.h
+++ b/src/powershell-native/nativemsh/pwrshplugin/pwrshplugin.h
@@ -26,10 +26,6 @@ using namespace NativeMsh;
 // Forward declaration of class PwrshPlugIn
 class PwrshPlugIn;
 
-// To report the plugin completion using WSManPluginReportCompletion API
-// g_pPluginContext MUST be the same context that plugin provided to the WSManPluginStartup method
-PwrshPlugIn* g_pPluginContext;
-
 class PwrshPlugIn
 {
 private:
@@ -230,7 +226,6 @@ public:
         // storing the extra info for plugin use later.
         VerifyAndStoreExtraInfo(extraInfo, &initParameters);
         PwrshPlugIn* result = new PwrshPlugIn(applicationIdentification, initParameters);
-        g_pPluginContext = result;
         return result;
     }
 


### PR DESCRIPTION
This resolves issue #5391, which is tagged with `6.0.0-GA`, therefore this should help with getting pwsh out of the door in January.

It removes `PerformWSManPluginReportCompletion` as stated in the issue and its associated class member `g_pPluginContext `, which is now unused as well.

The best reviewer is probably @mirichmo , who raised the initial issue with very helpful descriptions or @dantraMSFT who is currently assigned to the issue.