### PR TITLE
Fix Import-CliXml Test

### DIFF
--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/clixml.tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/clixml.tests.ps1
@@ -125,7 +125,7 @@
 
     Context "Import-CliXML" {
         BeforeAll {
-            $gpsList = Get-Process powershell
+            $gpsList = Get-Process pwsh
             $gps = $gpsList | Select-Object -First 1
             $filePath = Join-Path $subFilePath 'gps.xml'
 
@@ -161,7 +161,9 @@
             $fileContent | Should Not Be $null
 
             $importedProcess = Import-Clixml $filePath
+            $importedProcess.ProcessName | Should Not BeNullOrEmpty
             $gps.ProcessName | Should Be $importedProcess.ProcessName
+            $importedProcess.Id | Should Not BeNullOrEmpty
             $gps.Id | Should Be $importedProcess.Id
         }
 
@@ -173,7 +175,9 @@
             $fileContent | Should Not Be $null
 
             $importedProcess = Import-Clixml $filePath
+            $importedProcess.ProcessName | Should Not BeNullOrEmpty
             $gps.ProcessName | Should Be $importedProcess.ProcessName
+            $importedProcess.Id | Should Not BeNullOrEmpty
             $gps.Id | Should Be $importedProcess.Id
         }
 


### PR DESCRIPTION
I noticed that there was an error in the Import-CliXml context but no failed tests. It turns out this was working because it was exporting null and then checking if null is null.. 🙁 

This fixes the error generated by get-process and ensure the imported values are not null or empty.
