### PR TITLE
remove `signed` folder in zip after copying signed binaries for packaging

### DIFF
--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -448,6 +448,12 @@ function New-PSSignedBuildZip
         Copy-Item -Path $_ -Destination $destination -force
     }
 
+    # Remove `signed` folder in buildpath now that signed binaries are copied
+    if (Test-Path $BuildPath\signed)
+    {
+        Remove-Item -Recurse -Force -Path $BuildPath\signed
+    }
+
     $name = split-path -Path $BuildPath -Leaf
     $zipLocationPath = Join-Path -Path $DestinationFolder -ChildPath "$name-signed.zip"
     Compress-Archive -Path $BuildPath\* -DestinationPath $zipLocationPath


### PR DESCRIPTION
It appears that signing puts the signed binaries in a folder called [signed](https://github.com/PowerShell/PowerShell/blob/400747040300bb6a1a2dfcaec846a8fca092aadc/tools/releaseBuild/packagesigning.xml).  The current packaging copies the signed binaries over the unsigned binaries, but the signed folder is a child folder of the unsigned binaries so it gets added to the zip resulting in duplicate files that aren't used.  Fix is to remove the `signed` folder after copying the signed binaries.

Fix https://github.com/PowerShell/PowerShell/issues/5506
