### PR TITLE
Add PowerShell VSCode style settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,5 +19,19 @@
   "[powershell]": {
     "files.trimTrailingWhitespace": true
   },
-  "powershell.codeFormatting.preset": "Stroustrup"
+
+  // Sets the codeformatting options to follow the given indent style in a way that is compatible with PowerShell syntax. For more information about the brace styles please refer to https://github.com/PoshCode/PowerShellPracticeAndStyle/issues/81.
+  "powershell.codeFormatting.preset": "OTBS",
+  
+  // Adds a space between a keyword and its associated scriptblock expression.
+  "powershell.codeFormatting.whitespaceBeforeOpenBrace": true,
+  
+  // Adds a space between a keyword (if, elseif, while, switch, etc) and its associated conditional expression.
+  "powershell.codeFormatting.whitespaceBeforeOpenParen": true,
+  
+  // Adds spaces before and after an operator ('=', '+', '-', etc.).
+  "powershell.codeFormatting.whitespaceAroundOperator": true,
+  
+  // Adds a space after a separator (',' and ';').
+  "powershell.codeFormatting.whitespaceAfterSeparator": true
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,5 +18,6 @@
 
   "[powershell]": {
     "files.trimTrailingWhitespace": true
-  }
+  },
+  "powershell.codeFormatting.preset": "Stroustrup"
 }


### PR DESCRIPTION
Add the following VS Code settings to have a more consistent `PowerShell` style already at the PR stage. It is mainly based on the [K&R/OTBS](https://github.com/PoshCode/PowerShellPracticeAndStyle/issues/81#issuecomment-285835313) style, which basically means braces are on the same line and that else, catch, and other keywords are "cuddled" (e.g. `} else {`)
Personally I'd prefer rather the [Stroustrup](https://github.com/PoshCode/PowerShellPracticeAndStyle/issues/81#issuecomment-285835361) style where there is no "cuddling" but I have seen that the `K&R/OTBS` is used more often in the codebase.

````
  // Sets the codeformatting options to follow the given indent style in a way that is compatible with PowerShell syntax. For more information about the brace styles please refer to https://github.com/PoshCode/PowerShellPracticeAndStyle/issues/81.
  "powershell.codeFormatting.preset": "OTBS",
  
  // Adds a space between a keyword and its associated scriptblock expression.
  "powershell.codeFormatting.whitespaceBeforeOpenBrace": true,
  
  // Adds a space between a keyword (if, elseif, while, switch, etc) and its associated conditional expression.
  "powershell.codeFormatting.whitespaceBeforeOpenParen": true,
  
  // Adds spaces before and after an operator ('=', '+', '-', etc.).
  "powershell.codeFormatting.whitespaceAroundOperator": true,
  
  // Adds a space after a separator (',' and ';').
  "powershell.codeFormatting.whitespaceAfterSeparator": true
````