### PR TITLE
Stop running TypeGen every time

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -510,7 +510,7 @@ Fix steps:
     # Handle TypeGen
     # .inc file name must be different for Windows and Linux to allow build on Windows and WSL.
     $incFileName = "powershell_$($Options.Runtime).inc"
-    if ($TypeGen -or -not (Test-Path "$PSScriptRoot/TypeCatalogGen/$incFileName")) {
+    if ($TypeGen -or -not (Test-Path "$PSScriptRoot/src/TypeCatalogGen/$incFileName")) {
         log "Run TypeGen (generating CorePsTypeCatalog.cs)"
         Start-TypeGen -IncFileName $incFileName
     }


### PR DESCRIPTION
Because of an error in the path, `Start-Build` cannot find the `powershell_xxx.inc` file and generates it every time. This causes the _entire_ project to be recompiled.