### PR TITLE
Fix accidental wrapping of scalar Write-Output input

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Write-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Write-Object.cs
@@ -3,6 +3,7 @@ Copyright (c) Microsoft Corporation. All rights reserved.
 --********************************************************************/
 
 using System.Management.Automation;
+using System.Collections.Generic;
 
 namespace Microsoft.PowerShell.Commands
 {
@@ -14,7 +15,7 @@ namespace Microsoft.PowerShell.Commands
     [Cmdlet(VerbsCommunications.Write, "Output", HelpUri = "https://go.microsoft.com/fwlink/?LinkID=113427", RemotingCapability = RemotingCapability.None)]
     public sealed class WriteOutputCommand : PSCmdlet
     {
-        private PSObject[] _inputObjects = null;
+        private object _inputObjects = null;
 
         /// <summary>
         /// Holds the list of objects to be Written
@@ -22,7 +23,7 @@ namespace Microsoft.PowerShell.Commands
         [Parameter(Position = 0, Mandatory = true, ValueFromPipeline = true, ValueFromRemainingArguments = true)]
         [AllowNull]
         [AllowEmptyCollection]
-        public PSObject[] InputObject
+        public object InputObject
         {
             get { return _inputObjects; }
             set { _inputObjects = value; }
@@ -37,6 +38,25 @@ namespace Microsoft.PowerShell.Commands
         {
             get;
             set;
+        }
+
+        /// <summary>
+        /// This method implements the BeginProcessing method for Write-output command
+        /// </summary>
+        protected override void BeginProcessing() {
+            // If the input is a List<object> instance with a single element,
+            // assume that it is a single argument bound via ValueFromRemainingArguments and unwrap it.
+            // Note: 
+            //  * This case is indistinguishable from something like the following:
+            //      Write-Output -NoEnumerate -InputObject ([System.Collections.Generic.List[object]]::new((, 1)))
+            //    However, this seems like an acceptable price to pay in order to prevent unexpected wrapping of
+            //    a scalar in a collection when using -NoEnumerate.
+            //  * Is the case of *multiple* ValueFromRemainingArguments values, the List<object> instance
+            //    is passed through when -NoEnumerate is specified.
+            List<object> lst;
+            if (_inputObjects is List<object> && (lst = (List<object>)_inputObjects).Count == 1) {
+                _inputObjects = lst[0];
+            }            
         }
 
         /// <summary>

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Output.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Output.Tests.ps1
@@ -71,4 +71,12 @@ Describe "Write-Output" -Tags "CI" {
 	    $singleCollection | Should Be 1
 	}
     }
+
+    Context "Scalar input" {
+        It "Write-Object -NoEnumerate should not wrap a scalar" {
+            Write-Output -NoEnumerate 1              | Should BeOfType [int]
+            Write-Output -NoEnumerate -InputObject 1 | Should BeOfType [int]
+            1 | Write-Output -NoEnumerate            | Should BeOfType [int]
+        }
+    }
 }


### PR DESCRIPTION
when `-NoEnumerate` is used. Fixes #5122.

Note: This PR is a _compromise_ that attempts to reconcile @PetSerAl's conceptually cleaner, but abandoned #5123 with the conflicting changes in #2038.

#2038 [should never have happened](https://github.com/PowerShell/PowerShell/issues/2035#issuecomment-323641345) and continues to cause problems.

Specifically, the implications of this PR are:

* a single scalar input object is now also passed through when `-NoEnumerate` is specified, as is desirable
   * the price to pay is that `Write-Output -NoEnumerate 1` is now indistinguishable from `Write-Output -NoEnumerate -InputObject ([System.Collections.Generic.List[object]]::new((, 1)))`

* by changing the `-InputObject` parameter type from `[psobject[]` to `[object]`, _multi_-argument inputs passed without explicit use of `-InputObject`  are now passed through as a `[List[object]]` instance when using `-NoEnumerate`, which is an unfortunate side effect of how `ValueFromRemainingArguments` arguments are reported - see #4625.






