### PR TITLE
Fix PSVersion in PSSessionConfiguration tests

### DIFF
--- a/test/powershell/Modules/Microsoft.PowerShell.Core/PSSessionConfiguration.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/PSSessionConfiguration.Tests.ps1
@@ -581,7 +581,7 @@ namespace PowershellTestConfigNamespace
 
                 It "Validate Set-PSSessionConfiguration -PSVersion" {
 
-                    Set-PSSessionConfiguration -Name $TestSessionConfigName -PSVerion 5.1
+                    Set-PSSessionConfiguration -Name $TestSessionConfigName -PSVersion 5.1
                     $Session = (Get-PSSessionConfiguration -Name $TestSessionConfigName)
 
                     $Session.Name | Should be $TestSessionConfigName

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/PSSessionConfiguration.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/PSSessionConfiguration.Tests.ps1
@@ -115,6 +115,8 @@ try
                     }
 
                     $LocalConfigFilePath = CreateTestConfigFile
+
+                    $expectedPSVersion = "$($PSVersionTable.PSVersion.Major)`.$($PSVersionTable.PSVersion.Minor)"
                 }
             }
 
@@ -125,7 +127,7 @@ try
                     $Result = Get-PSSessionConfiguration
 
                     $Result.Name -contains $endpointName | Should Be $true
-                    $Result.PSVersion -ge 5.1 | Should be $true
+                    $Result.PSVersion | Should BeExactly $expectedPSVersion
                 }
 
                 It "Get-PSSessionConfiguration with Name parameter" {
@@ -133,7 +135,7 @@ try
                     $Result = Get-PSSessionConfiguration -Name $endpointName
 
                     $Result.Name | Should Be $endpointName
-                    $Result.PSVersion -ge 5.1 | Should be $true
+                    $Result.PSVersion | Should BeExactly $expectedPSVersion
                 }
 
                 It "Get-PSSessionConfiguration -Name with wildcard character" {
@@ -143,7 +145,7 @@ try
                     $Result = Get-PSSessionConfiguration -Name $endpointWildcard
 
                     $Result.Name -contains $endpointName | Should Be $true
-                    $Result.PSVersion -ge 5.1 | Should be $true
+                    $Result.PSVersion | Should BeExactly $expectedPSVersion
                 }
 
                 It "Get-PSSessionConfiguration -Name with Non-Existent session configuration" {
@@ -470,6 +472,8 @@ namespace PowershellTestConfigNamespace
                         $TestSessionConfigName = "TestRegisterPSSesionConfig"
                         Unregister-PSSessionConfiguration -Name $TestSessionConfigName -Force -NoServiceRestart -ErrorAction SilentlyContinue
                     }
+
+                    $expectedPSVersion = "$($PSVersionTable.PSVersion.Major)`.$($PSVersionTable.PSVersion.Minor)"
                 }
 
                 AfterEach {
@@ -488,7 +492,7 @@ namespace PowershellTestConfigNamespace
 
                     $Result.Session.Name | Should be $TestSessionConfigName
                     $Result.Session.SessionType | Should be "Default"
-                    $Result.Session.PSVersion | Should be 6.0
+                    $Result.Session.PSVersion | Should BeExactly $expectedPSVersion
                     $Result.Session.Enabled | Should be $true
                     $Result.Session.lang | Should be $Result.Culture
                     $Result.Session.pssessionthreadoptions | Should be $pssessionthreadoptions
@@ -496,6 +500,15 @@ namespace PowershellTestConfigNamespace
                     $Result.Session.psmaximumreceiveddatasizepercommandmb | Should be $psmaximumreceiveddatasizepercommandmb
                     $Result.Session.UseSharedProcess | Should be $UseSharedProcess
                 }
+
+                It "Validate Register-PSSessionConfiguration -PSVersion" {
+
+                Register-PSSessionConfiguration -Name $TestSessionConfigName -PSVersion 5.1
+                $Session = Get-PSSessionConfiguration -Name $TestSessionConfigName
+
+                $Session.Name | Should be $TestSessionConfigName
+                $Session.PSVersion | Should Be 5.1
+            }
 
                 It "Validate Register-PSSessionConfiguration -startupscript parameter" -Pending {
 
@@ -557,13 +570,22 @@ namespace PowershellTestConfigNamespace
                     $Result = [PSObject]@{Session = (Get-PSSessionConfiguration -Name $TestSessionConfigName) ; Culture = (Get-Item WSMan:\localhost\Plugin\microsoft.powershell\lang -ea SilentlyContinue).value}
 
                     $Result.Session.Name | Should be $TestSessionConfigName
-                    $Result.Session.PSVersion | Should be 6.0
+                    $Result.Session.PSVersion | Should BeExactly $expectedPSVersion
                     $Result.Session.Enabled | Should be $true
                     $Result.Session.lang | Should be $result.Culture
                     $Result.Session.pssessionthreadoptions | Should be $pssessionthreadoptions
                     $Result.Session.psmaximumreceivedobjectsizemb | Should be $psmaximumreceivedobjectsizemb
                     $Result.Session.psmaximumreceiveddatasizepercommandmb | Should be $psmaximumreceiveddatasizepercommandmb
                     $Result.Session.UseSharedProcess | Should be $UseSharedProcess
+                }
+
+                It "Validate Set-PSSessionConfiguration -PSVersion" {
+
+                    Set-PSSessionConfiguration -Name $TestSessionConfigName -PSVerion 5.1
+                    $Session = (Get-PSSessionConfiguration -Name $TestSessionConfigName)
+
+                    $Session.Name | Should be $TestSessionConfigName
+                    $Session.PSVersion | Should Be 5.1
                 }
 
                 It "Validate Set-PSSessionConfiguration -startupscript parameter" -Pending {

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/PSSessionConfiguration.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/PSSessionConfiguration.Tests.ps1
@@ -116,7 +116,7 @@ try
 
                     $LocalConfigFilePath = CreateTestConfigFile
 
-                    $expectedPSVersion = "$($PSVersionTable.PSVersion.Major)`.$($PSVersionTable.PSVersion.Minor)"
+                    $expectedPSVersion = "$($PSVersionTable.PSVersion.Major).$($PSVersionTable.PSVersion.Minor)"
                 }
             }
 
@@ -326,6 +326,8 @@ try
             BeforeAll {
                 if ($IsNotSkipped)
                 {
+                    $expectedPSVersion = "$($PSVersionTable.PSVersion.Major).$($PSVersionTable.PSVersion.Minor)"
+
                     function ValidateRemoteEndpoint {
                         param ($TestSessionConfigName, $ScriptToExecute, $ExpectedOutput)
 
@@ -472,8 +474,6 @@ namespace PowershellTestConfigNamespace
                         $TestSessionConfigName = "TestRegisterPSSesionConfig"
                         Unregister-PSSessionConfiguration -Name $TestSessionConfigName -Force -NoServiceRestart -ErrorAction SilentlyContinue
                     }
-
-                    $expectedPSVersion = "$($PSVersionTable.PSVersion.Major)`.$($PSVersionTable.PSVersion.Minor)"
                 }
 
                 AfterEach {
@@ -503,12 +503,12 @@ namespace PowershellTestConfigNamespace
 
                 It "Validate Register-PSSessionConfiguration -PSVersion" {
 
-                Register-PSSessionConfiguration -Name $TestSessionConfigName -PSVersion 5.1
-                $Session = Get-PSSessionConfiguration -Name $TestSessionConfigName
+                    Register-PSSessionConfiguration -Name $TestSessionConfigName -PSVersion 5.1
+                    $Session = Get-PSSessionConfiguration -Name $TestSessionConfigName
 
-                $Session.Name | Should be $TestSessionConfigName
-                $Session.PSVersion | Should Be 5.1
-            }
+                    $Session.Name | Should be $TestSessionConfigName
+                    $Session.PSVersion | Should BeExactly 5.1
+                }
 
                 It "Validate Register-PSSessionConfiguration -startupscript parameter" -Pending {
 
@@ -585,7 +585,7 @@ namespace PowershellTestConfigNamespace
                     $Session = (Get-PSSessionConfiguration -Name $TestSessionConfigName)
 
                     $Session.Name | Should be $TestSessionConfigName
-                    $Session.PSVersion | Should Be 5.1
+                    $Session.PSVersion | Should BeExactly 5.1
                 }
 
                 It "Validate Set-PSSessionConfiguration -startupscript parameter" -Pending {


### PR DESCRIPTION
Check that we can register and change (Set-) remote endpoint
configurations with given PSVersion.
