### PR TITLE
Remove hard coded expected version string

### DIFF
--- a/test/powershell/Modules/Microsoft.PowerShell.Core/PSSessionConfiguration.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/PSSessionConfiguration.Tests.ps1
@@ -452,6 +452,7 @@ namespace PowershellTestConfigNamespace
                     $LocalTestModulePath = CreateTestModule
                     $LocalTestAssemblyName = CreateTestAssembly
                     $LocalTestDir = $script:TestDir
+                    $ExpectedPSVersion = ("{0}.{1}" -f $PSVersionTable.PSVersion.Major, $PSVersionTable.PSVersion.Minor)
                 }
             }
 
@@ -488,7 +489,7 @@ namespace PowershellTestConfigNamespace
 
                     $Result.Session.Name | Should be $TestSessionConfigName
                     $Result.Session.SessionType | Should be "Default"
-                    $Result.Session.PSVersion | Should be 6.0
+                    $Result.Session.PSVersion | Should be $ExpectedPSVersion
                     $Result.Session.Enabled | Should be $true
                     $Result.Session.lang | Should be $Result.Culture
                     $Result.Session.pssessionthreadoptions | Should be $pssessionthreadoptions
@@ -557,7 +558,7 @@ namespace PowershellTestConfigNamespace
                     $Result = [PSObject]@{Session = (Get-PSSessionConfiguration -Name $TestSessionConfigName) ; Culture = (Get-Item WSMan:\localhost\Plugin\microsoft.powershell\lang -ea SilentlyContinue).value}
 
                     $Result.Session.Name | Should be $TestSessionConfigName
-                    $Result.Session.PSVersion | Should be 6.0
+                    $Result.Session.PSVersion | Should be $ExpectedPSVersion
                     $Result.Session.Enabled | Should be $true
                     $Result.Session.lang | Should be $result.Culture
                     $Result.Session.pssessionthreadoptions | Should be $pssessionthreadoptions


### PR DESCRIPTION
PSSessionConfiguration.Tests.ps1 contains tests that compare Session.PSVersion to a  hard coded version string. These tests break when the next release version doesn't match the string.

Update the test to rely on PSVersionTable.PSVersion instead of the hard code value.