### PR TITLE
Update test to construct the version from $PSVersionTable.PSVersion

### DIFF
--- a/test/powershell/Modules/Microsoft.PowerShell.Core/PSSessionConfiguration.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/PSSessionConfiguration.Tests.ps1
@@ -452,6 +452,7 @@ namespace PowershellTestConfigNamespace
                     $LocalTestModulePath = CreateTestModule
                     $LocalTestAssemblyName = CreateTestAssembly
                     $LocalTestDir = $script:TestDir
+                    $ExpectedVersion = "{0}.{1}" -f $PSVersionTable.PSVersion.Major, $PSVersionTable.PSVersion.Minor
                 }
             }
 
@@ -488,7 +489,7 @@ namespace PowershellTestConfigNamespace
 
                     $Result.Session.Name | Should be $TestSessionConfigName
                     $Result.Session.SessionType | Should be "Default"
-                    $Result.Session.PSVersion | Should be 6.0
+                    $Result.Session.PSVersion | Should be $ExpectedVersion
                     $Result.Session.Enabled | Should be $true
                     $Result.Session.lang | Should be $Result.Culture
                     $Result.Session.pssessionthreadoptions | Should be $pssessionthreadoptions
@@ -557,7 +558,7 @@ namespace PowershellTestConfigNamespace
                     $Result = [PSObject]@{Session = (Get-PSSessionConfiguration -Name $TestSessionConfigName) ; Culture = (Get-Item WSMan:\localhost\Plugin\microsoft.powershell\lang -ea SilentlyContinue).value}
 
                     $Result.Session.Name | Should be $TestSessionConfigName
-                    $Result.Session.PSVersion | Should be 6.0
+                    $Result.Session.PSVersion | Should be $ExpectedVersion
                     $Result.Session.Enabled | Should be $true
                     $Result.Session.lang | Should be $result.Culture
                     $Result.Session.pssessionthreadoptions | Should be $pssessionthreadoptions


### PR DESCRIPTION
Two tests related to `*-PSSessionConfiguration` failed (see the failure below). The tests failed because the powershell built from the master branch is now with the version `v6.1.0-preview.1`, but we hardcoded the expected version to be `6.0`. The fix is to generate the expected version from `$PSVersionTable.PSVersion`.

```none
Describing Validate Register-PSSessionConfiguration, Set-PSSessionConfiguration cmdlets
   Context Validate Register-PSSessionConfiguration
    [-] Validate Register-PSSessionConfiguration -name -path 14.51s
      Expected: {6}
      But was:  {6.1}
      at line: 491 in C:\projects\powershell-f975h\test\powershell\Modules\Microsoft.PowerShell.Core\PSSessionConfiguration.Tests.ps1
      491:                     $Result.Session.PSVersion | Should be 6.0
   Context Validate Set-PSSessionConfiguration
    [-] Validate Set-PSSessionConfiguration -name -path -MaximumReceivedObjectSizeMB -MaximumReceivedDataSizePerCommandMB -UseSharedProcess -ThreadOptions parameters 27.69s
      Expected: {6}
      But was:  {6.1}
      at line: 560 in C:\projects\powershell-f975h\test\powershell\Modules\Microsoft.PowerShell.Core\PSSessionConfiguration.Tests.ps1
      560:                     $Result.Session.PSVersion | Should be 6.0
```