### PR TITLE
Don't add trailing spaces to last column when using Format-Table

### DIFF
--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-Table.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-Table.Tests.ps1
@@ -139,42 +139,32 @@ Describe "Format-Table DRT Unit Tests" -Tags "CI" {
 
 		It "Format-Table with No Objects for End-To-End should work"{
 				$p = @{}
-				$result = $p|Format-Table -Property "foo","bar"|Out-String
+				$result = $p | Format-Table -Property "foo","bar" | Out-String
 				$result | Should BeNullOrEmpty
 		}
 
 		It "Format-Table with Null Objects for End-To-End should work"{
 				$p = $null
-				$result = $p|Format-Table -Property "foo","bar"|Out-String
+				$result = $p | Format-Table -Property "foo","bar" | Out-String
 				$result | Should BeNullOrEmpty
 		}
 
-		#pending on issue#900
-		It "Format-Table with single line string for End-To-End should work" -pending{
+		It "Format-Table with single line string for End-To-End should work" {
 				$p = "single line string"
-				$result = $p|Format-Table -Property "foo","bar"|Out-String
-				$result | Should BeNullOrEmpty
+				$result = $p | Format-Table -Property "foo","bar" -Force | Out-String
+				$result.Replace(" ","").Replace([Environment]::NewLine,"") | Should BeExactly "foobar------"
 		}
 
-		#pending on issue#900
-		It "Format-Table with multiple line string for End-To-End should work" -pending{
+		It "Format-Table with multiple line string for End-To-End should work" {
 				$p = "Line1\nLine2"
-				$result = $p|Format-Table -Property "foo","bar"|Out-String
-				$result | Should BeNullOrEmpty
+				$result = $p | Format-Table -Property "foo","bar" -Force | Out-String
+				$result.Replace(" ","").Replace([Environment]::NewLine,"") | Should BeExactly "foobar------"
 		}
 
-		#pending on issue#900
-		It "Format-Table with string sequence for End-To-End should work" -pending{
+		It "Format-Table with string sequence for End-To-End should work" {
 				$p = "Line1","Line2"
-				$result = $p|Format-Table -Property "foo","bar"|Out-String
-				$result | Should BeNullOrEmpty
-		}
-
-		#pending on issue#900
-		It "Format-Table with string sequence for End-To-End should work" -pending{
-				$p = "Line1","Line2"
-				$result = $p|Format-Table -Property "foo","bar"|Out-String
-				$result | Should BeNullOrEmpty
+				$result = $p | Format-Table -Property "foo","bar" -Force | Out-String
+				$result.Replace(" ","").Replace([Environment]::NewLine,"") | Should BeExactly "foobar------"
 		}
 
 		It "Format-Table with complex object for End-To-End should work" {
@@ -210,5 +200,15 @@ Describe "Format-Table DRT Unit Tests" -Tags "CI" {
 				$result3 = $mo|Format-Table -Expand Both|Out-String
 				$result3 | Should Match "name\s+sub"
 				$result3 | Should Match "this is name\s+{x 0 y 0, x 1 y 1}"
+		}
+
+		It "Format-Table should not add trailing whitespace to the header" {
+			$out = "hello" | Format-Table -Property foo -Force | Out-String
+			$out.Replace([System.Environment]::NewLine, "") | Should BeExactly "foo---"
+		}
+
+		It "Format-Table should not add trailing whitespace to rows" {
+			$out = [pscustomobject]@{a=1;b=2} | Format-Table -HideTableHeaders | Out-String
+			$out.Replace([System.Environment]::NewLine, "") | Should BeExactly "1 2"
 		}
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-Table.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-Table.Tests.ps1
@@ -156,7 +156,7 @@ Describe "Format-Table DRT Unit Tests" -Tags "CI" {
 		}
 
 		It "Format-Table with multiple line string for End-To-End should work" {
-				$p = "Line1\nLine2"
+				$p = "Line1`nLine2"
 				$result = $p | Format-Table -Property "foo","bar" -Force | Out-String
 				$result.Replace(" ","").Replace([Environment]::NewLine,"") | Should BeExactly "foobar------"
 		}

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-Table.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-Table.Tests.ps1
@@ -137,34 +137,23 @@ Describe "Format-Table DRT Unit Tests" -Tags "CI" {
 				$result | Should Match "Jim\s+5678\s+False"
 		}
 
-		It "Format-Table with No Objects for End-To-End should work"{
-				$p = @{}
-				$result = $p | Format-Table -Property "foo","bar" | Out-String
+		It "Format-Table with '<testName>' should return `$null" -TestCases @(
+			@{ testName = "empty array"; testObject = @{}   },
+			@{ testName = "null"       ; testObject = $null }
+		) {
+			param ($testObject)
+				$result = $testObject | Format-Table -Property "foo","bar" | Out-String
 				$result | Should BeNullOrEmpty
 		}
 
-		It "Format-Table with Null Objects for End-To-End should work"{
-				$p = $null
-				$result = $p | Format-Table -Property "foo","bar" | Out-String
-				$result | Should BeNullOrEmpty
-		}
-
-		It "Format-Table with single line string for End-To-End should work" {
-				$p = "single line string"
-				$result = $p | Format-Table -Property "foo","bar" -Force | Out-String
-				$result.Replace(" ","").Replace([Environment]::NewLine,"") | Should BeExactly "foobar------"
-		}
-
-		It "Format-Table with multiple line string for End-To-End should work" {
-				$p = "Line1`nLine2"
-				$result = $p | Format-Table -Property "foo","bar" -Force | Out-String
-				$result.Replace(" ","").Replace([Environment]::NewLine,"") | Should BeExactly "foobar------"
-		}
-
-		It "Format-Table with string sequence for End-To-End should work" {
-				$p = "Line1","Line2"
-				$result = $p | Format-Table -Property "foo","bar" -Force | Out-String
-				$result.Replace(" ","").Replace([Environment]::NewLine,"") | Should BeExactly "foobar------"
+		It "Format-Table with '<testName>' string and -Force should output table with requested properties" -TestCases @(
+			@{ testName = "single line"; testString = "single line string" },
+			@{ testName = "multi line" ; testString = "line1`nline2"       },
+			@{ testName = "array"      ; testString = "line1","line2"      }
+		) {
+			param ($testString)
+			$result = $testString | Format-Table -Property "foo","bar" -Force | Out-String
+			$result.Replace(" ","").Replace([Environment]::NewLine,"") | Should BeExactly "foobar------"
 		}
 
 		It "Format-Table with complex object for End-To-End should work" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Out-File.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Out-File.Tests.ps1
@@ -98,8 +98,8 @@ Describe "Out-File" -Tags "CI" {
         $actual = Get-Content $testfile
 
         $actual[0] | Should Be ""
-        $actual[1] | Should Be "text      "
-        $actual[2] | Should Be "----      "
+        $actual[1] | Should Be "text"
+        $actual[2] | Should Be "----"
         $actual[3] | Should Be "some te..."
     }
 
@@ -129,7 +129,7 @@ Describe "Out-File" -Tags "CI" {
         # reset to not read only so it can be deleted
         Set-ItemProperty -Path $testfile -Name IsReadOnly -Value $false
     }
-    
+
     It "Should be able to use the 'Path' alias for the 'FilePath' parameter" {
         { Out-File -Path $testfile } | Should Not Throw
     }


### PR DESCRIPTION
Separate fixes for the header and the data rows.  If it's the last column, don't add trailing padding.

Also fixed some Format-Table tests that were `Pending` but the issue was closed.

One side-effect is that using `out-file -width` you don't get the padding on the right most column which seems fine as the parameter is for limiting the width rather than ensuring the width.  But it is a breaking change.

Fixes https://github.com/PowerShell/PowerShell/issues/5532

<!--

If you are a PowerShell Team member, please make sure you choose the Reviewer(s) and Assignee for your PR.
If you are not from the PowerShell Team, you can leave the fields blank and the Maintainers will choose them for you. If you are familiar with the team, feel free to mention some Reviewers yourself.

For more information about the roles of Reviewer and Assignee, refer to [CONTRIBUTING.md](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md).

-->
