### PR TITLE
References to RunspaceConfiguration still present

### DIFF
--- a/src/System.Management.Automation/engine/hostifaces/RunspacePoolInternal.cs
+++ b/src/System.Management.Automation/engine/hostifaces/RunspacePoolInternal.cs
@@ -63,7 +63,6 @@ namespace System.Management.Automation.Runspaces.Internal
         /// The explicit PSHost implementation.
         /// </param>
         /// <exception cref="ArgumentNullException">
-        /// RunspaceConfiguration is null.
         /// Host is null.
         /// </exception>
         /// <exception cref="ArgumentException">

--- a/test/csharp/test_FileSystemProvider.cs
+++ b/test/csharp/test_FileSystemProvider.cs
@@ -37,9 +37,8 @@ namespace PSTests
         {
             CultureInfo currentCulture = CultureInfo.CurrentCulture;
             PSHost hostInterface =  new DefaultHost(currentCulture,currentCulture);
-            RunspaceConfiguration runspaceConfiguration =  RunspaceConfiguration.Create();
             InitialSessionState iss = InitialSessionState.CreateDefault2();
-            AutomationEngine engine = new AutomationEngine(hostInterface, runspaceConfiguration, iss);
+            AutomationEngine engine = new AutomationEngine(hostInterface, iss);
             ExecutionContext executionContext = new ExecutionContext(engine, hostInterface, iss);
             return executionContext;
         }

--- a/test/csharp/test_SessionState.cs
+++ b/test/csharp/test_SessionState.cs
@@ -20,9 +20,8 @@ namespace PSTests
         {
             CultureInfo currentCulture = CultureInfo.CurrentCulture;
             PSHost hostInterface =  new DefaultHost(currentCulture,currentCulture);
-            RunspaceConfiguration runspaceConfiguration =  RunspaceConfiguration.Create();
             InitialSessionState iss = InitialSessionState.CreateDefault2();
-            AutomationEngine engine = new AutomationEngine(hostInterface, runspaceConfiguration, iss);
+            AutomationEngine engine = new AutomationEngine(hostInterface, iss);
             ExecutionContext executionContext = new ExecutionContext(engine, hostInterface, iss);
             SessionStateInternal sessionState = new SessionStateInternal(executionContext);
             Collection<PSDriveInfo> drives = sessionState.Drives(null);


### PR DESCRIPTION
RunspaceConfiguration still mentionned in RunspacePoolInternal ctor API documentation
Removed 2 obsolete test files

Those 2 files should even not compile.

 #4942
