### PR TITLE
Suppress the expected errors from Select-Xml tests

### DIFF
--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/xml.tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/xml.tests.ps1
@@ -2,15 +2,15 @@
     Context "Select-XML" {
         BeforeAll {
             $fileName = New-Item -Path 'TestDrive:\testSelectXml.xml'
-	        Push-Location "$fileName\.."
-	        "<Root>" | out-file -LiteralPath $fileName
-	        "   <Node Attribute='blah' />" | out-file -LiteralPath $fileName -Append
-	        "</Root>" | out-file -LiteralPath $fileName -Append
+            Push-Location "$fileName\.."
+            "<Root>" | out-file -LiteralPath $fileName
+            "   <Node Attribute='blah' />" | out-file -LiteralPath $fileName -Append
+            "</Root>" | out-file -LiteralPath $fileName -Append
 
             $fileNameWithDots = $fileName.FullName.Replace("\", "\.\")
 
             $driveLetter = [string]($fileName.FullName)[0]
-	        $fileNameAsNetworkPath = "\\localhost\$driveLetter`$" + $fileName.FullName.SubString(2)
+            $fileNameAsNetworkPath = "\\localhost\$driveLetter`$" + $fileName.FullName.SubString(2)
 
             class TestData
             {
@@ -65,7 +65,7 @@
                 $file = 'env:xmltestfile'
                 $params = @{$parameter=$file}
                 $err = $null
-                Select-XML @params "Root" -ErrorVariable err
+                Select-XML @params "Root" -ErrorVariable err -ErrorAction SilentlyContinue
                 $err.FullyQualifiedErrorId | Should Be $expectedError
             }
             finally
@@ -78,7 +78,7 @@
             $testfile = "$testdrive/test.xml"
             Set-Content -Path $testfile -Value "<a><b>"
             $err = $null
-            Select-Xml -Path $testfile -XPath foo -ErrorVariable err
+            Select-Xml -Path $testfile -XPath foo -ErrorVariable err -ErrorAction SilentlyContinue
             $err.FullyQualifiedErrorId | Should Be 'ProcessingFile,Microsoft.PowerShell.Commands.SelectXmlCommand'
         }
 
@@ -93,13 +93,13 @@
         It "Returns error for invalid xmlnamespace" {
             $err = $null
             [xml]$xml = "<a xmlns='bar'><b xmlns:b='foo'>hello</b><c>world</c></a>"
-            Select-Xml -Xml $xml -XPath foo -Namespace @{c=$null} -ErrorVariable err
+            Select-Xml -Xml $xml -XPath foo -Namespace @{c=$null} -ErrorVariable err -ErrorAction SilentlyContinue
             $err.FullyQualifiedErrorId | Should Be 'PrefixError,Microsoft.PowerShell.Commands.SelectXmlCommand'
         }
 
         It "Returns error for invalid content" {
             $err = $null
-            Select-Xml -Content "hello" -XPath foo -ErrorVariable err
+            Select-Xml -Content "hello" -XPath foo -ErrorVariable err -ErrorAction SilentlyContinue
             $err.FullyQualifiedErrorId | Should Be 'InvalidCastToXmlDocument,Microsoft.PowerShell.Commands.SelectXmlCommand'
         }
 


### PR DESCRIPTION
Suppress expected errors from `Select-Xml` tests to reduce noises:
```
Describing XML cmdlets
   Context Select-XML
++++++
Select-XML : The file 'xmltestfile' cannot be read: Could not find file 'C:\projects\powershell-f975h\xmltestfile'.
At C:\projects\powershell-f975h\test\powershell\Modules\Microsoft.PowerShell.Utility\xml.tests.ps1:68 char:17
+                 Select-XML @params "Root" -ErrorVariable err
+                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ CategoryInfo          : InvalidArgument: (xmltestfile:String) [Select-Xml], ArgumentException
+ FullyQualifiedErrorId : ProcessingFile,Microsoft.PowerShell.Commands.SelectXmlCommand
 
+
Select-XML : Cannot open the file because the current provider (Microsoft.PowerShell.Core\Environment) cannot open files.
At C:\projects\powershell-f975h\test\powershell\Modules\Microsoft.PowerShell.Utility\xml.tests.ps1:68 char:17
+                 Select-XML @params "Root" -ErrorVariable err
+                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ CategoryInfo          : InvalidOperation: (env:xmltestfile:String) [Select-Xml], InvalidOperationException
+ FullyQualifiedErrorId : ProcessingFile,Microsoft.PowerShell.Commands.SelectXmlCommand
 
...
```
After the fix:
```
Describing XML cmdlets
   Context Select-XML
    [+] literalpath with relative paths 591ms
    [+] literalpath with absolute paths 82ms
    [+] literalpath with path with dots 11ms
    [+] path with relative paths 11ms
    [+] path with absolute paths 11ms
    [+] path with path with dots 13ms
    [+] Verifies a non filesystem path using literalPath should fail 46ms
    [+] Verifies a non filesystem path using path should fail 9ms
    [+] Invalid xml file 72ms
    [+] -xml works with inputstream 46ms
    [+] Returns error for invalid xmlnamespace 16ms
    [+] Returns error for invalid content 18ms
    [+] ToString() works correctly on nested node 15ms
    [+] ToString() works correctly with file 64ms
Tests completed in 1.01s
Passed: 14 Failed: 0 Skipped: 0 Pending: 0
```