### PR TITLE
Fix Get-EnvironmentInformation IsCoreCLR logic

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -97,19 +97,12 @@ function Get-PSCommitId
 function Get-EnvironmentInformation
 {
     $environment = @{}
-    # Use the .NET Core APIs to determine the current platform.
-    # If a runtime exception is thrown, we are on Windows PowerShell, not PowerShell Core,
-    # because System.Runtime.InteropServices.RuntimeInformation
-    # and System.Runtime.InteropServices.OSPlatform do not exist in .NET versions older than 4.7.1.
-    try {
-        $Runtime = [System.Runtime.InteropServices.RuntimeInformation]
-        $OSPlatform = [System.Runtime.InteropServices.OSPlatform]
-
-        $environment += @{'IsCoreCLR' = 'Core' -eq $PSVersionTable.PSEdition}
-        $environment += @{'IsLinux' = $Runtime::IsOSPlatform($OSPlatform::Linux)}
-        $environment += @{'IsMacOS' = $Runtime::IsOSPlatform($OSPlatform::OSX)}
-        $environment += @{'IsWindows' = $Runtime::IsOSPlatform($OSPlatform::Windows)}
-    } catch {
+    if ($PSVersionTable.ContainsKey("PSEdition") -and "Core" -eq $PSVersionTable.PSEdition) {
+        $environment += @{'IsCoreCLR' = $true}
+        $environment += @{'IsLinux' = $IsLinux}
+        $environment += @{'IsMacOS' = $IsMacOS}
+        $environment += @{'IsWindows' = $IsWindows}
+    } else {
         $environment += @{'IsCoreCLR' = $false}
         $environment += @{'IsLinux' = $false}
         $environment += @{'IsMacOS' = $false}

--- a/build.psm1
+++ b/build.psm1
@@ -97,6 +97,7 @@ function Get-PSCommitId
 function Get-EnvironmentInformation
 {
     $environment = @{}
+    # PowerShell Core will likely not be built on pre-1709 nanoserver
     if ($PSVersionTable.ContainsKey("PSEdition") -and "Core" -eq $PSVersionTable.PSEdition) {
         $environment += @{'IsCoreCLR' = $true}
         $environment += @{'IsLinux' = $IsLinux}

--- a/build.psm1
+++ b/build.psm1
@@ -100,12 +100,12 @@ function Get-EnvironmentInformation
     # Use the .NET Core APIs to determine the current platform.
     # If a runtime exception is thrown, we are on Windows PowerShell, not PowerShell Core,
     # because System.Runtime.InteropServices.RuntimeInformation
-    # and System.Runtime.InteropServices.OSPlatform do not exist in Windows PowerShell.
+    # and System.Runtime.InteropServices.OSPlatform do not exist in .NET versions older than 4.7.1.
     try {
         $Runtime = [System.Runtime.InteropServices.RuntimeInformation]
         $OSPlatform = [System.Runtime.InteropServices.OSPlatform]
 
-        $environment += @{'IsCoreCLR' = $true}
+        $environment += @{'IsCoreCLR' = 'Core' -eq $PSVersionTable.PSEdition}
         $environment += @{'IsLinux' = $Runtime::IsOSPlatform($OSPlatform::Linux)}
         $environment += @{'IsMacOS' = $Runtime::IsOSPlatform($OSPlatform::OSX)}
         $environment += @{'IsWindows' = $Runtime::IsOSPlatform($OSPlatform::Windows)}


### PR DESCRIPTION
closes #5581 

.NET 4.7.1 adds the APIs `Get-EnvironmentInformation` was using to determine if it is on CoreCLR or not. This is not `$IsCoreCLR`, but a part of the environment gathering used in the build and packaging. 
