### PR TITLE
Fix FileCatalog cmdlets to work if -Path is not specified

### DIFF
--- a/src/Microsoft.PowerShell.Security/security/CatalogCommands.cs
+++ b/src/Microsoft.PowerShell.Security/security/CatalogCommands.cs
@@ -95,7 +95,7 @@ namespace Microsoft.PowerShell.Commands
                 {
                     foreach (PathInfo tempPath in SessionState.Path.GetResolvedPSPathFromPSPath(p))
                     {
-                        if (ShouldProcess(tempPath.ProviderPath))
+                        if (ShouldProcess("Including path " + tempPath.ProviderPath, "", ""))
                         {
                             paths.Add(tempPath.ProviderPath);
                         }
@@ -103,17 +103,16 @@ namespace Microsoft.PowerShell.Commands
                 }
             }
 
-            // We add 'paths.Count > 0' to support 'ShouldProcess()'
-            if (paths.Count > 0 )
+            string drive = null;
+
+            // resolve catalog destination Path
+            if (!SessionState.Path.IsPSAbsolute(catalogFilePath, out drive) && !System.IO.Path.IsPathRooted(catalogFilePath))
             {
-                string drive = null;
+                catalogFilePath = SessionState.Path.GetUnresolvedProviderPathFromPSPath(catalogFilePath);
+            }
 
-                // resolve catalog destination Path
-                if (!SessionState.Path.IsPSAbsolute(catalogFilePath, out drive) && !System.IO.Path.IsPathRooted(catalogFilePath))
-                {
-                    catalogFilePath = SessionState.Path.GetUnresolvedProviderPathFromPSPath(catalogFilePath);
-                }
-
+            if (ShouldProcess(catalogFilePath))
+            {
                 PerformAction(paths, catalogFilePath);
             }
         }

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/FileCatalog.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/FileCatalog.Tests.ps1
@@ -233,11 +233,14 @@ Describe "Test suite for NewFileCatalogAndTestFileCatalogCmdlets" -Tags "CI" {
             try
             {
                 copy-item "$testDataPath\UserConfigProv" $env:temp -Recurse -ErrorAction SilentlyContinue
-                $null = New-FileCatalog -Path $env:temp\UserConfigProv\ -CatalogFilePath $catalogPath -CatalogVersion 1.0
-                $result = Test-FileCatalog -Path $env:temp\UserConfigProv\ -CatalogFilePath $catalogPath
+                Push-Location "$env:TEMP\UserConfigProv"
+                # When -Path is not specified, it should use current directory
+                $null = New-FileCatalog -CatalogFilePath $catalogPath -CatalogVersion 1.0
+                $result = Test-FileCatalog -CatalogFilePath $catalogPath
             }
             finally
             {
+                Pop-Location
                 Remove-Item "$catalogPath" -Force -ErrorAction SilentlyContinue
                 Remove-Item "$env:temp\UserConfigProv\" -Force -ErrorAction SilentlyContinue -Recurse
             }


### PR DESCRIPTION
Remove unnecessary check for Paths.count > 0 as there is code later to use the current working directory since -Path is not a mandatory parameter.
Updated ShouldProcess to output the internal action on adding paths rather than the user action (which is the cmdlet name).

Updated tests to not specify -Path

Fix https://github.com/PowerShell/PowerShell/issues/5594

<!--

If you are a PowerShell Team member, please make sure you choose the Reviewer(s) and Assignee for your PR.
If you are not from the PowerShell Team, you can leave the fields blank and the Maintainers will choose them for you. If you are familiar with the team, feel free to mention some Reviewers yourself.

For more information about the roles of Reviewer and Assignee, refer to [CONTRIBUTING.md](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md).

-->
