### PR TITLE
Add retry logic to prerequisite URL tests

### DIFF
--- a/test/powershell/Installer/WindowsInstaller.Tests.ps1
+++ b/test/powershell/Installer/WindowsInstaller.Tests.ps1
@@ -18,8 +18,18 @@ Describe "Windows Installer" -Tags "Scenario" {
     ## Running 'Invoke-WebRequest' with WMF download URLs has been failing intermittently,
     ## because sometimes the URLs lead to a 'this download is no longer available' page.
     ## Therefore, this test is disabled for now.
-    It "Pre-Requisistes link for '<Name>' is reachable: <url>" -TestCases $linkCheckTestCases -Skip {
+    It "Pre-Requisistes link for '<Name>' is reachable: <url>" -TestCases $linkCheckTestCases {
         param ($Url)
-        (Invoke-WebRequest $Url -UseBasicParsing) | Should Not Be $null
+
+        foreach ($i in 1..5) {
+            try {
+                $result = Invoke-WebRequest $Url -UseBasicParsing
+                break;
+            } catch {
+                Start-Sleep -Seconds 1
+            }
+        }
+
+        $result | Should Not Be $null
     }
 }

--- a/test/powershell/Installer/WindowsInstaller.Tests.ps1
+++ b/test/powershell/Installer/WindowsInstaller.Tests.ps1
@@ -15,10 +15,11 @@ Describe "Windows Installer" -Tags "Scenario" {
         (Get-Content $wixProductFile -Raw).Contains($preRequisitesLink) | Should Be $true
     }
 
-    It "Pre-Requisistes link for '<Name>' is reachable: <url>" -TestCases $linkCheckTestCases -Test {
+    ## Running 'Invoke-WebRequest' with WMF download URLs has been failing intermittently,
+    ## because sometimes the URLs lead to a 'this download is no longer available' page.
+    ## Therefore, this test is disabled for now.
+    It "Pre-Requisistes link for '<Name>' is reachable: <url>" -TestCases $linkCheckTestCases -Skip {
         param ($Url)
-
-        # Because an outdated link 'https://www.microsoft.com/download/details.aspx?id=504100000' would still return a 200 reponse (due to a redirection to an error page), it only checks that it returns something
         (Invoke-WebRequest $Url -UseBasicParsing) | Should Not Be $null
     }
 }

--- a/test/powershell/Installer/WindowsInstaller.Tests.ps1
+++ b/test/powershell/Installer/WindowsInstaller.Tests.ps1
@@ -17,7 +17,7 @@ Describe "Windows Installer" -Tags "Scenario" {
 
     ## Running 'Invoke-WebRequest' with WMF download URLs has been failing intermittently,
     ## because sometimes the URLs lead to a 'this download is no longer available' page.
-    ## Therefore, this test is disabled for now.
+    ## We use a retry logic here. Retry for 5 times with 1 second interval.
     It "Pre-Requisistes link for '<Name>' is reachable: <url>" -TestCases $linkCheckTestCases {
         param ($Url)
 


### PR DESCRIPTION
The package prerequisite URL tests have been failing intermittently recently, because sometimes the WMF download URLs lead to a "we're sorry, this download is no longer available" page, even though the URLs actually work in the web browser. I'm disabling those tests for now.

Close #5567