### PR TITLE
SAL annotation updates & fix warnings

### DIFF
--- a/src/powershell-native/nativemsh/pwrshcommon/NativeMsh.h
+++ b/src/powershell-native/nativemsh/pwrshcommon/NativeMsh.h
@@ -78,25 +78,27 @@ namespace NativeMsh
         // Note: During successful calls the following values must be freed by the caller:
         //      pwszMonadVersion
         //      pwszRuntimeVersion
-        //      pwzsRegKeyValue
+        //      pwszRegKeyValue
         //
         // The caller must take care to check to see if they must be freed during error scenarios
         // because the function may fail after allocating one or more strings.
         //
+        _Success_(return == 0)
         unsigned int GetRegistryInfo(
-            __deref_out_opt PWSTR * pwszMonadVersion,
+            __out PWSTR * pwszMonadVersion,
             __inout_ecount(1) int * lpMonadMajorVersion,
             int monadMinorVersion,
-            __deref_out_opt PWSTR * pwszRuntimeVersion,
+            __out PWSTR * pwszRuntimeVersion,
             LPCWSTR lpszRegKeyNameToRead,
-            __deref_out_opt PWSTR * pwzsRegKeyValue);
+            __out PWSTR * pwszRegKeyValue);
 
+        _Success_(return == 0)
         unsigned int GetRegistryInfo(
-            __deref_out_opt PWSTR * pwszMonadVersion,
+            __out PWSTR * pwszMonadVersion,
             __inout_ecount(1) int * lpMonadMajorVersion,
             int monadMinorVersion,
-            __deref_out_opt PWSTR * pwszRuntimeVersion,
-            __deref_out_opt PWSTR * pwszConsoleHostAssemblyName);
+            __out PWSTR * pwszRuntimeVersion,
+            __out PWSTR * pwszConsoleHostAssemblyName);
 
         unsigned int LaunchCoreCLR(
             ClrHostWrapper* hostWrapper,

--- a/src/powershell-native/nativemsh/pwrshcommon/pwrshcommon.cpp
+++ b/src/powershell-native/nativemsh/pwrshcommon/pwrshcommon.cpp
@@ -1238,18 +1238,19 @@ namespace NativeMsh
     // Note: During successful calls the following values must be freed by the caller:
     //      pwszMonadVersion
     //      pwszRuntimeVersion
-    //      pwzsRegKeyValue
+    //      pwszRegKeyValue
     //
     // The caller must take care to check to see if they must be freed during error scenarios
     // because the function may fail after allocating one or more strings.
     //
+    _Success_(return == 0)
     unsigned int PwrshCommon::GetRegistryInfo(
-        __deref_out_opt PWSTR * pwszMonadVersion,
+        __out PWSTR * pwszMonadVersion,
         __inout_ecount(1) int * lpMonadMajorVersion,
         int monadMinorVersion,
-        __deref_out_opt PWSTR * pwszRuntimeVersion,
+        __out PWSTR * pwszRuntimeVersion,
         LPCWSTR lpszRegKeyNameToRead,
-        __deref_out_opt PWSTR * pwzsRegKeyValue)
+        __out PWSTR * pwszRegKeyValue)
     {
         HKEY hEngineKey = NULL;
         bool bEngineKeyOpened = true;
@@ -1257,12 +1258,27 @@ namespace NativeMsh
         wchar_t * wszMshEngineRegKeyPath = NULL;
         LPWSTR wszFullMonadVersion = NULL;
 
+        if (NULL != pwszRegKeyValue)
+        {
+            *pwszRegKeyValue = NULL;
+        }
+
+        if (NULL != pwszRuntimeVersion)
+        {
+            *pwszRuntimeVersion = NULL;
+        }
+
+        if (NULL != pwszMonadVersion)
+        {
+            pwszMonadVersion = NULL;
+        }
+
         do
         {
             if (NULL == pwszMonadVersion ||
                 NULL == lpMonadMajorVersion ||
                 NULL == pwszRuntimeVersion ||
-                NULL == pwzsRegKeyValue)
+                NULL == pwszRegKeyValue)
             {
                 exitCode = EXIT_CODE_READ_REGISTRY_FAILURE;
                 break;
@@ -1315,7 +1331,7 @@ namespace NativeMsh
             {
                 LPCWSTR wszRequestedRegValueName = lpszRegKeyNameToRead;
                 if (!this->RegQueryREG_SZValue(hEngineKey, wszRequestedRegValueName,
-                    wszMshEngineRegKeyPath, pwzsRegKeyValue))
+                    wszMshEngineRegKeyPath, pwszRegKeyValue))
                 {
                     exitCode = EXIT_CODE_READ_REGISTRY_FAILURE;
                     break;
@@ -1361,12 +1377,13 @@ namespace NativeMsh
         return exitCode;
     }
 
+    _Success_(return == 0)
     unsigned int PwrshCommon::GetRegistryInfo(
-        __deref_out_opt PWSTR * pwszMonadVersion,
+        __out PWSTR * pwszMonadVersion,
         __inout_ecount(1) int * lpMonadMajorVersion,
         int monadMinorVersion,
-        __deref_out_opt PWSTR * pwszRuntimeVersion,
-        __deref_out_opt PWSTR * pwszConsoleHostAssemblyName)
+        __out PWSTR * pwszRuntimeVersion,
+        __out PWSTR * pwszConsoleHostAssemblyName)
     {
         return GetRegistryInfo(pwszMonadVersion,
             lpMonadMajorVersion,

--- a/src/powershell-native/nativemsh/pwrshcommon/pwrshcommon.cpp
+++ b/src/powershell-native/nativemsh/pwrshcommon/pwrshcommon.cpp
@@ -1270,7 +1270,7 @@ namespace NativeMsh
 
         if (NULL != pwszMonadVersion)
         {
-            pwszMonadVersion = NULL;
+            *pwszMonadVersion = NULL;
         }
 
         do

--- a/src/powershell-native/nativemsh/pwrshexe/CssMainEntry.cpp
+++ b/src/powershell-native/nativemsh/pwrshexe/CssMainEntry.cpp
@@ -217,7 +217,7 @@ int __cdecl wmain(const int argc, const wchar_t* argv[])
     if (debug)
     {
         ::wprintf(L"  Attach the debugger to powershell.exe and press any key to continue\n");
-        ::getchar();
+        (void) ::getchar();
     }
 
     if (helpRequested)

--- a/src/powershell-native/nativemsh/pwrshplugin/entrypoints.cpp
+++ b/src/powershell-native/nativemsh/pwrshplugin/entrypoints.cpp
@@ -31,7 +31,7 @@ LPCWSTR g_MAIN_BINARY_NAME = L"pwrshplugin.dll";
 // the caller should free pwszErrorMessage using LocalFree().
 // returns: If the function succeeds the return value is the number of CHARs stored int the output
 // buffer, excluding the terminating null character. If the function fails the return value is zero.
-_Success_(return >= 0)
+_Success_(return > 0)
 DWORD GetFormattedErrorMessage(__out PWSTR * pwszErrorMessage, DWORD dwMessageId, va_list* arguments)
 {
     DWORD dwLength = 0;
@@ -313,6 +313,7 @@ DWORD ReportOperationComplete(WSMAN_PLUGIN_REQUEST *requestDetails, DWORD errorC
     if (GetFormattedErrorMessage(&pwszErrorMessage, errorCode) == 0)
     {
         swprintf_s(szMessage,_countof(szMessage), L"ReportOperationComplete: %d", errorCode);
+        pwszErrorMessage = szMessage;
     }
 
     result = WSManPluginOperationComplete(requestDetails, 0, errorCode, pwszErrorMessage);

--- a/src/powershell-native/nativemsh/pwrshplugin/entrypoints.h
+++ b/src/powershell-native/nativemsh/pwrshplugin/entrypoints.h
@@ -13,6 +13,6 @@
 
 const int EXIT_CODE_BAD_INPUT = 100;
 
-extern DWORD GetFormattedErrorMessage(__deref_out PWSTR * pwszErrorMessage, DWORD dwMessageId, ...);
+extern DWORD GetFormattedErrorMessage(__out PWSTR * pwszErrorMessage, DWORD dwMessageId, ...);
 extern unsigned int ConstructPowerShellVersion(int iPSMajorVersion, int iPSMinorVersion, __deref_out_opt PWSTR *pwszMonadVersion);
 

--- a/src/powershell-native/nativemsh/pwrshplugin/pwrshclrhost.cpp
+++ b/src/powershell-native/nativemsh/pwrshplugin/pwrshclrhost.cpp
@@ -270,7 +270,7 @@ unsigned int PowerShellClrWorker::LoadWorkerCallbackPtrs(
     {
         PWSTR msg = NULL;
         exitCode = g_MANAGED_METHOD_RESOLUTION_FAILED;
-        /* NOTE: dont' use a string literal for a fallback; PlugInException expects msg to allocated
+        /* NOTE: don't use a string literal for a fallback; PlugInException expects msg to allocated
            and will free it but also supports NULL.
         */
         (void) GetFormattedErrorMessage(&msg, exitCode);

--- a/src/powershell-native/nativemsh/pwrshplugin/pwrshclrhost.cpp
+++ b/src/powershell-native/nativemsh/pwrshplugin/pwrshclrhost.cpp
@@ -270,7 +270,10 @@ unsigned int PowerShellClrWorker::LoadWorkerCallbackPtrs(
     {
         PWSTR msg = NULL;
         exitCode = g_MANAGED_METHOD_RESOLUTION_FAILED;
-        GetFormattedErrorMessage(&msg, exitCode);
+        /* NOTE: dont' use a string literal for a fallback; PlugInException expects msg to allocated
+           and will free it but also supports NULL.
+        */
+        (void) GetFormattedErrorMessage(&msg, exitCode);
         *pPluginException = new PlugInException(exitCode, msg);
         return exitCode;
     }

--- a/src/powershell-native/nativemsh/pwrshplugin/pwrshplugin.h
+++ b/src/powershell-native/nativemsh/pwrshplugin/pwrshplugin.h
@@ -490,6 +490,11 @@ private:
         {
             iMajorVersion = iVPSMajorVersion;
 
+            if (NULL != wszMgdPlugInFileName)
+            {
+                *wszMgdPlugInFileName = NULL;
+            }
+
             exitCode = ConstructPowerShellVersion(iVPSMajorVersion, iVPSMinorVersion, &wszMonadVersion);
             if (EXIT_CODE_SUCCESS != exitCode)
             {
@@ -561,9 +566,18 @@ private:
         _In_ PWSTR wszMgdPlugInFileName,
         _In_ PWSTR wszVCLRVersion,  // Conditionally set to wszCLRVersion on success
         _In_ PWSTR wszVAppBase,     // Conditionally set to wszAppBase on success
-        __out_opt PlugInException** pPluginException )
+        __out PlugInException** pPluginException )
     {
         unsigned int exitCode = EXIT_CODE_SUCCESS;
+
+        if (NULL != pPluginException)
+        {
+            *pPluginException = NULL;
+        }
+        else
+        {
+             return g_INVALID_INPUT;
+        }
 
         if (bIsPluginLoaded)
         {
@@ -577,8 +591,6 @@ private:
 
         do
         {
-            *pPluginException = NULL;
-
             // Setting global AppBase and CLR Version
             wszCLRVersion = wszVCLRVersion;
             wszAppBase = wszVAppBase;
@@ -768,7 +780,9 @@ private:
             else
             {
                 PWSTR msg = NULL;
-                GetFormattedErrorMessage(&msg, g_OPTION_SET_NOT_COMPLY, g_BUILD_VERSION);
+                (void) GetFormattedErrorMessage(&msg, g_OPTION_SET_NOT_COMPLY, g_BUILD_VERSION);
+                /* NOTE: Passing possible NULL msg. PlugInExpecption requires allocated
+                   or NULL. Literal strings are not supported. */
                 throw new PlugInException(exitCode, msg);
             }
         }

--- a/src/powershell-native/nativemsh/pwrshplugin/pwrshplugindefs.h
+++ b/src/powershell-native/nativemsh/pwrshplugin/pwrshplugindefs.h
@@ -140,7 +140,7 @@ public:
     // the memory.
     PWSTR extendedErrorInformation;
 
-    PlugInException(DWORD msgId, __in PWSTR msg)
+    PlugInException(DWORD msgId, __in_opt PWSTR msg)
     {
         dwMessageId = msgId;
         extendedErrorInformation = msg;


### PR DESCRIPTION
Various SAL annotations were either incorrect or not backed up by code. This PR address these issues.

NOTE: By default, Start-BuildNativeWindowsBinaries does not enable code analysis and issues detected by SAL annotations are not reported.  To identify these issues, run Start-BuildNativeWindowsBinaries to generate the solution and vcxproj files.  Launch a Visual Studio developer prompt,  cd to src\powershell-native and run msbuild manually. 

```
msbuild PowerShellNative.sln /p:RunCodeAnalysis=true /p:Configuration=RelWithDebInfo /p:Platform=x64
```

The following changes address all code analysis warnings:
* GetRegistryInfo in NativeMsh had incorrect out annotations, remove __opt
* Fix handling of various out parameters - check for non-null and initialize
* Update and Align  SAL annotations for GetFormattedErrorMessage overloads
* Allow PluginException to accept NULL message.