### PR TITLE
remoting: Handle DLLImport failure of libpsrpclient

### DIFF
--- a/src/System.Management.Automation/engine/remoting/fanin/PriorityCollection.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/PriorityCollection.cs
@@ -170,7 +170,6 @@ namespace System.Management.Automation.Remoting
                     {
                         _dataToBeSent[(int)DataPriorityType.PromptResponse].Dispose();
                     }
-                    _dataToBeSent = null;
 
                     lock (_syncObjects[(int)DataPriorityType.Default])
                     {

--- a/src/System.Management.Automation/engine/remoting/fanin/WSManTransportManager.cs
+++ b/src/System.Management.Automation/engine/remoting/fanin/WSManTransportManager.cs
@@ -2602,9 +2602,19 @@ namespace System.Management.Automation.Remoting.Client
                 {
                     ErrorCode = WSManNativeApi.WSManInitialize(WSManNativeApi.WSMAN_FLAG_REQUESTED_API_VERSION_1_1, ref _handle);
                 }
-                catch (DllNotFoundException)
+                catch (DllNotFoundException ex)
                 {
-                    throw new PSRemotingTransportException(RemotingErrorIdStrings.WSManClientDllNotAvailable);
+                    PSEtwLog.LogOperationalError(
+                        PSEventId.TransportError,
+                        PSOpcode.Open,
+                        PSTask.None,
+                        PSKeyword.UseAlwaysOperational,
+                        "WSManAPIDataCommon.ctor",
+                        "WSManInitialize",
+                        ex.HResult.ToString(CultureInfo.InvariantCulture),
+                        ex.Message,
+                        ex.StackTrace);
+                    throw new PSRemotingTransportException(RemotingErrorIdStrings.WSManClientDllNotAvailable, ex);
                 }
 
                 // input / output streams common to all connections


### PR DESCRIPTION
Issue https://github.com/PowerShell/PowerShell/issues/4029 exposed two problems when failing to load libpsrpclient. 
* WSManAPIDataCommon.ctor was not identifying the binary that failed DLLImport; hindering diagnosability 
* PrioritySendDataCollection.Clear() would throw a NullReferenceException when called from the finalizer after an error path.

This change addresses both of the above:

* Guard against null arrays in PrioritySendDataCollection.Clear() - called from finalizer in error paths.

* Diagnosability: Log the DllNotFoundException in WSManAPIDataCommon ctor and also include it as the internal exception when throwing PSRemotingTransportException.
