### PR TITLE
Make Travis CI use libcurl+openssl+gssapi for macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,10 @@ install:
       rvm install ruby-2.3.3;
       rvm --default use 2.3.3;
     fi
+  # Ensure that libcurl+openssl is used on macOS for greater feature support.
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+      export DYLD_LIBRARY_PATH=/usr/local/opt/curl/lib:/usr/local/opt/openssl/lib:${DYLD_LIBRARY_PATH};
+    fi
   - pushd tools
   - ./install-powershell.sh
   - popd

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@
 - Update the contribution guideline to note that updating the changelog is required. (#5586)
 - Remove Pester as a module include with the PowerShell Packages.
   In the future, you should be able to add it by running `Install-Module Pester`. (#5623, #5631)
-- Make Travis CI use `libcurl+openssl` (#5629, @markekraus)
 - Make Travis CI use `libcurl+openssl+gssapi` (#5629, @markekraus)
 
 ## v6.0.0-rc - 2017-11-16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Update the contribution guideline to note that updating the changelog is required. (#5586)
 - Remove Pester as a module include with the PowerShell Packages.
   In the future, you should be able to add it by running `Install-Module Pester`. (#5623, #5631)
+- Make Travis CI use `libcurl+openssl` (#5629, @markekraus)
 
 ## v6.0.0-rc - 2017-11-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Remove Pester as a module include with the PowerShell Packages.
   In the future, you should be able to add it by running `Install-Module Pester`. (#5623, #5631)
 - Make Travis CI use `libcurl+openssl` (#5629, @markekraus)
+- Make Travis CI use `libcurl+openssl+gssapi` (#5629, @markekraus)
 
 ## v6.0.0-rc - 2017-11-16
 

--- a/build.psm1
+++ b/build.psm1
@@ -1533,7 +1533,7 @@ function Start-PSBootstrap {
                 Start-NativeExecution { brew install $Deps } -IgnoreExitcode
 
                 # Install patched version of curl
-                Start-NativeExecution { brew install curl --with-openssl } -IgnoreExitcode
+                Start-NativeExecution { brew install curl --with-openssl --with-gssapi } -IgnoreExitcode
             }
 
             # Install [fpm](https://github.com/jordansissel/fpm) and [ronn](https://github.com/rtomayko/ronn)

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -1412,9 +1412,8 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
             $testCases1 = @(
                 @{ Test = @{SslProtocol = 'Default'; ActualProtocol = 'Default'}; Pending = $false }
                 @{ Test = @{SslProtocol = 'Tls'; ActualProtocol = 'Tls'}; Pending = $false }
-                # these two currently fail on Travis CI macOS build
-                @{ Test = @{SslProtocol = 'Tls11'; ActualProtocol = 'Tls11'}; Pending = $IsMacOS }
-                @{ Test = @{SslProtocol = 'Tls12'; ActualProtocol = 'Tls12'}; Pending = $IsMacOS }
+                @{ Test = @{SslProtocol = 'Tls11'; ActualProtocol = 'Tls11'}; Pending = $false }
+                @{ Test = @{SslProtocol = 'Tls12'; ActualProtocol = 'Tls12'}; Pending = $false }
                 # macOS does not support multiple SslProtocols
                 @{ Test = @{SslProtocol = 'Tls, Tls11, Tls12'; ActualProtocol = 'Tls12'}; Pending = $IsMacOS }
                 @{ Test = @{SslProtocol = 'Tls11, Tls12'; ActualProtocol = 'Tls12'}; Pending = $IsMacOS }
@@ -1433,9 +1432,8 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
                 @{ Test = @{IntendedProtocol = 'Tls';   ActualProtocol = 'Tls11'}; Pending = $false }
                 @{ Test = @{IntendedProtocol = 'Tls11'; ActualProtocol = 'Tls12'}; Pending = $false }
                 @{ Test = @{IntendedProtocol = 'Tls12'; ActualProtocol = 'Tls11'}; Pending = $false }
-                # these two currently fail on Travis CI macOS build
-                @{ Test = @{IntendedProtocol = 'Tls11'; ActualProtocol = 'Tls'}; Pending = $IsMacOS }
-                @{ Test = @{IntendedProtocol = 'Tls12'; ActualProtocol = 'Tls'}; Pending = $IsMacOS }
+                @{ Test = @{IntendedProtocol = 'Tls11'; ActualProtocol = 'Tls'}; Pending = $false }
+                @{ Test = @{IntendedProtocol = 'Tls12'; ActualProtocol = 'Tls'}; Pending = $false }
                 # macOS does not support multiple SslProtocols
                 @{ Test = @{IntendedProtocol = 'Tls11, Tls12';   ActualProtocol = 'Tls'}; Pending = $IsMacOS }
                 @{ Test = @{IntendedProtocol = 'Tls, Tls12';   ActualProtocol = 'Tls11'}; Pending = $IsMacOS }
@@ -2382,9 +2380,8 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
             $testCases1 = @(
                 @{ Test = @{SslProtocol = 'Default'; ActualProtocol = 'Default'}; Pending = $false }
                 @{ Test = @{SslProtocol = 'Tls'; ActualProtocol = 'Tls'}; Pending = $false }
-                # these two currently fail on Travis CI macOS build
-                @{ Test = @{SslProtocol = 'Tls11'; ActualProtocol = 'Tls11'}; Pending = $IsMacOS }
-                @{ Test = @{SslProtocol = 'Tls12'; ActualProtocol = 'Tls12'}; Pending = $IsMacOS }
+                @{ Test = @{SslProtocol = 'Tls11'; ActualProtocol = 'Tls11'}; Pending = $false }
+                @{ Test = @{SslProtocol = 'Tls12'; ActualProtocol = 'Tls12'}; Pending = $false }
                 # macOS does not support multiple SslProtocols
                 @{ Test = @{SslProtocol = 'Tls, Tls11, Tls12'; ActualProtocol = 'Tls12'}; Pending = $IsMacOS }
                 @{ Test = @{SslProtocol = 'Tls11, Tls12'; ActualProtocol = 'Tls12'}; Pending = $IsMacOS }
@@ -2403,9 +2400,8 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
                 @{ Test = @{IntendedProtocol = 'Tls';   ActualProtocol = 'Tls11'}; Pending = $false }
                 @{ Test = @{IntendedProtocol = 'Tls11'; ActualProtocol = 'Tls12'}; Pending = $false }
                 @{ Test = @{IntendedProtocol = 'Tls12'; ActualProtocol = 'Tls11'}; Pending = $false }
-                # these two currently fail on Travis CI macOS build
-                @{ Test = @{IntendedProtocol = 'Tls11'; ActualProtocol = 'Tls'}; Pending = $IsMacOS }
-                @{ Test = @{IntendedProtocol = 'Tls12'; ActualProtocol = 'Tls'}; Pending = $IsMacOS }
+                @{ Test = @{IntendedProtocol = 'Tls11'; ActualProtocol = 'Tls'}; Pending = $false }
+                @{ Test = @{IntendedProtocol = 'Tls12'; ActualProtocol = 'Tls'}; Pending = $false }
                 # macOS does not support multiple SslProtocols
                 @{ Test = @{IntendedProtocol = 'Tls11, Tls12';   ActualProtocol = 'Tls'}; Pending = $IsMacOS }
                 @{ Test = @{IntendedProtocol = 'Tls, Tls12';   ActualProtocol = 'Tls11'}; Pending = $IsMacOS }


### PR DESCRIPTION
Closes #5590

* makes Travis CI use the `brew` installed `libcurl` that uses OpenSSL for the crypto provider and include the gssapi option. The native libcurl provides inconsistent feature support across OS versions.
* re-enable tests marked pending in #5605 
* GSSAPI is required for `PowerShellGet` in order to support `HttpClientHandler.UseDefaultCredentials` which it sets as true (unless you supply credentials).

## PR Checklist

Note: Please mark anything not applicable to this PR `NA`.
- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [X] Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Update the changelog](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---changelog)
- [X] User facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [X] Issue filed - Issue link: PowerShell/PowerShell-Docs#1926
- [X] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [NA] [Make sure you've added a new test, if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
    - [X] [Add `[feature]` if the change is significant or affectes feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)

## PR Summary
