### PR TITLE
Update a flaky test that fails intermittently in CI

### DIFF
--- a/test/powershell/engine/Basic/ValidateAttributes.Tests.ps1
+++ b/test/powershell/engine/Basic/ValidateAttributes.Tests.ps1
@@ -273,7 +273,10 @@ Describe 'Validate Attributes Tests' -Tags 'CI' {
                     [System.Collections.Generic.List[byte]] $ByteList,
 
                     [Parameter(Mandatory, ParameterSetName = "ByteCollection")]
-                    [System.Collections.ObjectModel.Collection[byte]] $ByteCollection
+                    [System.Collections.ObjectModel.Collection[byte]] $ByteCollection,
+
+                    [Parameter(ParameterSetName = "Default")]
+                    $Value
                 )
             }
 
@@ -313,13 +316,16 @@ Describe 'Validate Attributes Tests' -Tags 'CI' {
             $byteArray = [System.IO.File]::ReadAllBytes($filePath)
             $byteList  = [System.Collections.Generic.List[byte]] $byteArray
             $byteCollection = [System.Collections.ObjectModel.Collection[byte]] $byteArray
+            ## Use the running time of 'MandatoryFunc -Value $byteArray' as the baseline time
+            ## because it does no check on the argument.
+            $baseline = (Measure-Command { MandatoryFunc -Value $byteArray }).Milliseconds
             ## Running time should be less than 'UpperBoundTime'
             ## This is not really a performance test (perf test cannot run reliably in our CI), but a test
             ## to make sure we don't check the elements of a value-type collection.
-            ## The crossgen'ed 'S.M.A.dll' is about 28mb in size, and it would take over 2000ms if we check
-            ## each byte of the array, list or collection. We use 200ms as the upper bound value in tests to
-            ## prove that we don't check each byte.
-            $UpperBoundTime = 200
+            ## The crossgen'ed 'S.M.A.dll' is about 28mb in size, and it would take more than 2000ms if we
+            ## check each byte of the array, list or collection. We use ($baseline + 200)ms as the upper
+            ## bound value in tests to prove that we don't check each byte.
+            $UpperBoundTime = $baseline + 200
 
             if ($IsWindows) {
                 $null = New-Item -Path $TESTDRIVE/file1

--- a/test/powershell/engine/Basic/ValidateAttributes.Tests.ps1
+++ b/test/powershell/engine/Basic/ValidateAttributes.Tests.ps1
@@ -273,10 +273,7 @@ Describe 'Validate Attributes Tests' -Tags 'CI' {
                     [System.Collections.Generic.List[byte]] $ByteList,
 
                     [Parameter(Mandatory, ParameterSetName = "ByteCollection")]
-                    [System.Collections.ObjectModel.Collection[byte]] $ByteCollection,
-
-                    [Parameter(ParameterSetName = "Default")]
-                    $Value
+                    [System.Collections.ObjectModel.Collection[byte]] $ByteCollection
                 )
             }
 
@@ -316,10 +313,13 @@ Describe 'Validate Attributes Tests' -Tags 'CI' {
             $byteArray = [System.IO.File]::ReadAllBytes($filePath)
             $byteList  = [System.Collections.Generic.List[byte]] $byteArray
             $byteCollection = [System.Collections.ObjectModel.Collection[byte]] $byteArray
-            ## Use the running time of 'MandatoryFunc -Value $byteArray' as the baseline time
-            $baseline = (Measure-Command { MandatoryFunc -Value $byteArray }).Milliseconds
-            ## Running time should be less than 'expected'
-            $expected = $baseline + 20
+            ## Running time should be less than 'UpperBoundTime'
+            ## This is not really a performance test (perf test cannot run reliably in our CI), but a test
+            ## to make sure we don't check the elements of a value-type collection.
+            ## The crossgen'ed 'S.M.A.dll' is about 28mb in size, and it would take over 2000ms if we check
+            ## each byte of the array, list or collection. We use 200ms as the upper bound value in tests to
+            ## prove that we don't check each byte.
+            $UpperBoundTime = 200
 
             if ($IsWindows) {
                 $null = New-Item -Path $TESTDRIVE/file1
@@ -340,7 +340,7 @@ Describe 'Validate Attributes Tests' -Tags 'CI' {
 
         It "Validate running time '<ScriptBlock>'" -TestCases $testCases {
             param ($ScriptBlock)
-            (Measure-Command $ScriptBlock).Milliseconds | Should BeLessThan $expected
+            (Measure-Command $ScriptBlock).Milliseconds | Should BeLessThan $UpperBoundTime
         }
 
         It "COM enumerable argument should work with 'ValidateNotNull' and 'ValidateNotNullOrEmpty'" -Skip:(!$IsWindows) {


### PR DESCRIPTION
## PR Summary
Close #5627
Update a flaky test that fails intermittently in our CI builds:
```
[-] Validate running time ' NotNullFunc -Value $byteArray ' 88ms
   Expected {35} to be less than {22}
   at line: 343 in /Users/travis/build/PowerShell/PowerShell/test/powershell/engine/Basic/ValidateAttributes.Tests.ps1
   343:             (Measure-Command $ScriptBlock).Milliseconds | Should BeLessThan $expected
```
The tests were added along with the fix for the issue #5417. The tests are to validate that we don't check each element of a value-type collection argument.
This fix is to increase the upper bound of the expected time to 200ms, which is still way less than the time it would take before the fix -- more than 2000ms for a byte collection of 28mb in size.

## PR Checklist

Note: Please mark anything not applicable to this PR `NA`.
- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [x] Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [NA] [Update the changelog](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---changelog)
- [NA] User facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [NA] Issue filed - Issue link:
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [NA] [Make sure you've added a new test, if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
    - [NA] [Add `[feature]` if the change is significant or affectes feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
