### PR TITLE
contribution guidelines: Remove requirement for updating changelog update in pr

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -130,20 +130,6 @@ Additional references:
   please reference the issue in PR description (e.g. ```Fix #11```).
   See [this][closing-via-message] for more details.
 
-#### Pull request - Change log
-
-* All PRs must update the [changelog](../CHANGELOG.MD) in your pull request.
-  New changes always go into the **Unreleased** section at the top of the changelog.
-  Keeping the changelog up-to-date simplifies the release process for Maintainers.
-  An example (with an associated PR #):
-
-  ```markdown
-  ## Unreleased
-
-  * `Update-Item` now supports `-FriendlyName` (#1234, @ExampleUser).
-  ```
-  Note:  Please add `**Breaking Change**` to the front of the entry in the changelog if the change is [breaking.](#making-breaking-changes)
-
 * Please use the present tense and imperative mood when describing your changes:
     * Instead of "Adding support for Windows Server 2012 R2", write "Add support for Windows Server 2012 R2".
     * Instead of "Fixed for server connection issue", write "Fix server connection issue".

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,5 +11,5 @@ Note: Please mark anything not applicable to this PR `NA`.
 - [ ] User facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
     - [ ] Issue filed - Issue link:
 - [ ] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
-- [ ] [Make sure you've added a new test, if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
+- [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
     - [ ] [Add `[feature]` if the change is significant or affectes feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,14 +1,15 @@
+## PR Summary
+<!-- summarize your PR between here and the checklist -->
+
 ## PR Checklist
 
 Note: Please mark anything not applicable to this PR `NA`.
+
 - [ ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
     - [ ] Use the present tense and imperative mood when describing your changes
 - [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
-- [ ] [Update the changelog](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---changelog)
 - [ ] User facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
     - [ ] Issue filed - Issue link:
 - [ ] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
 - [ ] [Make sure you've added a new test, if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
     - [ ] [Add `[feature]` if the change is significant or affectes feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
-
-## PR Summary


### PR DESCRIPTION
## PR Summary

Remove requirement for updating changelog update in pr
It was causing GitHub to flag changes as merge conflicts despite a gitattribute which was supposed to prevent this.

## PR Checklist

Note: Please mark anything not applicable to this PR `NA`.
- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [x] Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [NA] User facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [NA] Issue filed - Issue link:
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [NA] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
    - [NA] [Add `[feature]` if the change is significant or affectes feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
