### PR TITLE
code coverage: Get GitCommitId using the ProductVersion from Assembly

### DIFF
--- a/test/tools/CodeCoverageAutomation/Start-CodeCoverageRun.ps1
+++ b/test/tools/CodeCoverageAutomation/Start-CodeCoverageRun.ps1
@@ -241,8 +241,11 @@ try
     }
 
     # grab the commitID, we need this to grab the right sources
-    $gitCommitId = & "$psBinPath\pwsh.exe" -noprofile -command { $PSVersiontable.GitCommitId }
-    $commitId = $gitCommitId.substring($gitCommitId.LastIndexOf('-g') + 2)
+    $assemblyLocation = & "$psBinPath\pwsh.exe" -noprofile -command { Get-Item ([psobject].Assembly.Location) }
+    $productVersion = $assemblyLocation.VersionInfo.productVersion
+    $commitId = $productVersion.split(" ")[-1]
+
+    Write-LogPassThru -Message "Using GitCommitId: $commitId"
 
     # download the src directory
     try


### PR DESCRIPTION
## PR Summary
We can no longer rely on `PSVersionTable` for the real Git commit Id. We can get it using the VersionInfo from System.Management.Automation.dll. 

## PR Checklist

Note: Please mark anything not applicable to this PR `NA`.

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [X] Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [NA] User facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [ ] Issue filed - Issue link:
- [ ][NA] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [ ][NA] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
    - [ ][NA] [Add `[feature]` if the change is significant or affectes feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
