### PR TITLE
Fix the Linux release build

### DIFF
--- a/tools/releaseBuild/Images/GenericLinuxFiles/PowerShellPackage.ps1
+++ b/tools/releaseBuild/Images/GenericLinuxFiles/PowerShellPackage.ps1
@@ -12,8 +12,9 @@ param (
     [ValidateNotNullOrEmpty()]
     [string]$ReleaseTag,
 
-    [ValidateSet("AppImage", "tar", "tar-arm")]
-    [string[]]$ExtraPackage
+    [switch]$AppImage,
+    [switch]$Tar,
+    [switch]$TarArm
 )
 
 $releaseTagParam = @{}
@@ -32,13 +33,10 @@ try {
     Start-PSBuild -Crossgen -PSModuleRestore @releaseTagParam
 
     Start-PSPackage @releaseTagParam
-    switch ($ExtraPackage)
-    {
-        "AppImage" { Start-PSPackage -Type AppImage @releaseTagParam }
-        "tar"      { Start-PSPackage -Type tar @releaseTagParam }
-    }
+    if ($AppImage) { Start-PSPackage -Type AppImage @releaseTagParam }
+    if ($Tar) { Start-PSPackage -Type tar @releaseTagParam }
 
-    if ($ExtraPackage -contains "tar-arm") {
+    if ($TarArm) {
         ## Build 'linux-arm' and create 'tar.gz' package for it.
         ## Note that 'linux-arm' can only be built on Ubuntu environment.
         Start-PSBuild -Runtime linux-arm -PSModuleRestore @releaseTagParam

--- a/tools/releaseBuild/Images/GenericLinuxFiles/PowerShellPackage.ps1
+++ b/tools/releaseBuild/Images/GenericLinuxFiles/PowerShellPackage.ps1
@@ -13,7 +13,7 @@ param (
     [string]$ReleaseTag,
 
     [switch]$AppImage,
-    [switch]$Tar,
+    [switch]$TarX64,
     [switch]$TarArm
 )
 
@@ -34,7 +34,7 @@ try {
 
     Start-PSPackage @releaseTagParam
     if ($AppImage) { Start-PSPackage -Type AppImage @releaseTagParam }
-    if ($Tar) { Start-PSPackage -Type tar @releaseTagParam }
+    if ($TarX64) { Start-PSPackage -Type tar @releaseTagParam }
 
     if ($TarArm) {
         ## Build 'linux-arm' and create 'tar.gz' package for it.

--- a/tools/releaseBuild/build.json
+++ b/tools/releaseBuild/build.json
@@ -113,7 +113,7 @@
     {
         "Name": "ubuntu.14.04",
         "RepoDestinationPath": "/PowerShell",
-        "BuildCommand": "/PowerShellPackage.ps1 -location _RepoDestinationPath_ -destination _DockerVolume_ -ReleaseTag _ReleaseTag_ -AppImage -Tar -TarArm",
+        "BuildCommand": "/PowerShellPackage.ps1 -location _RepoDestinationPath_ -destination _DockerVolume_ -ReleaseTag _ReleaseTag_ -AppImage -TarX64 -TarArm",
         "BuildDockerOptions": [
             "--cap-add",
             "SYS_ADMIN",

--- a/tools/releaseBuild/build.json
+++ b/tools/releaseBuild/build.json
@@ -9,7 +9,7 @@
             "3968m"
         ],
         "DockerFile": ".\\tools\\releaseBuild\\Images\\microsoft_powershell_windowsservercore\\DockerFile",
-        "AdditionalContextFiles" :[ 
+        "AdditionalContextFiles" :[
             ".\\tools\\releaseBuild\\Images\\microsoft_powershell_windowsservercore\\PowerShellPackage.ps1",
             ".\\tools\\releaseBuild\\Images\\microsoft_powershell_windowsservercore\\wix.psm1",
             ".\\tools\\releaseBuild\\Images\\microsoft_powershell_windowsservercore\\dockerInstall.psm1"
@@ -26,7 +26,7 @@
             "3968m"
         ],
         "DockerFile": ".\\tools\\releaseBuild\\Images\\microsoft_powershell_windowsservercore\\DockerFile",
-        "AdditionalContextFiles" :[ 
+        "AdditionalContextFiles" :[
             ".\\tools\\releaseBuild\\Images\\microsoft_powershell_windowsservercore\\PowerShellPackage.ps1",
             ".\\tools\\releaseBuild\\Images\\microsoft_powershell_windowsservercore\\wix.psm1",
             ".\\tools\\releaseBuild\\Images\\microsoft_powershell_windowsservercore\\dockerInstall.psm1"
@@ -43,7 +43,7 @@
             "3968m"
         ],
         "DockerFile": ".\\tools\\releaseBuild\\Images\\microsoft_powershell_windowsservercore\\DockerFile",
-        "AdditionalContextFiles" :[ 
+        "AdditionalContextFiles" :[
             ".\\tools\\releaseBuild\\Images\\microsoft_powershell_windowsservercore\\PowerShellPackage.ps1",
             ".\\tools\\releaseBuild\\Images\\microsoft_powershell_windowsservercore\\wix.psm1",
             ".\\tools\\releaseBuild\\Images\\microsoft_powershell_windowsservercore\\dockerInstall.psm1"
@@ -62,7 +62,7 @@
             "3968m"
         ],
         "DockerFile": ".\\tools\\releaseBuild\\Images\\microsoft_powershell_windowsservercore\\DockerFile",
-        "AdditionalContextFiles" :[ 
+        "AdditionalContextFiles" :[
             ".\\tools\\releaseBuild\\Images\\microsoft_powershell_windowsservercore\\PowerShellPackage.ps1",
             ".\\tools\\releaseBuild\\Images\\microsoft_powershell_windowsservercore\\wix.psm1",
             ".\\tools\\releaseBuild\\Images\\microsoft_powershell_windowsservercore\\dockerInstall.psm1"
@@ -81,7 +81,7 @@
             "3968m"
         ],
         "DockerFile": ".\\tools\\releaseBuild\\Images\\microsoft_powershell_windowsservercore\\DockerFile",
-        "AdditionalContextFiles" :[ 
+        "AdditionalContextFiles" :[
             ".\\tools\\releaseBuild\\Images\\microsoft_powershell_windowsservercore\\PowerShellPackage.ps1",
             ".\\tools\\releaseBuild\\Images\\microsoft_powershell_windowsservercore\\wix.psm1",
             ".\\tools\\releaseBuild\\Images\\microsoft_powershell_windowsservercore\\dockerInstall.psm1"
@@ -99,7 +99,7 @@
             "3968m"
         ],
         "DockerFile": ".\\tools\\releaseBuild\\Images\\microsoft_powershell_windowsservercore\\DockerFile",
-        "AdditionalContextFiles" :[ 
+        "AdditionalContextFiles" :[
             ".\\tools\\releaseBuild\\Images\\microsoft_powershell_windowsservercore\\PowerShellPackage.ps1",
             ".\\tools\\releaseBuild\\Images\\microsoft_powershell_windowsservercore\\wix.psm1",
             ".\\tools\\releaseBuild\\Images\\microsoft_powershell_windowsservercore\\dockerInstall.psm1"
@@ -113,7 +113,7 @@
     {
         "Name": "ubuntu.14.04",
         "RepoDestinationPath": "/PowerShell",
-        "BuildCommand": "/PowerShellPackage.ps1 -location _RepoDestinationPath_ -destination _DockerVolume_ -ReleaseTag _ReleaseTag_ -ExtraPackage AppImage,tar,tar-arm",
+        "BuildCommand": "/PowerShellPackage.ps1 -location _RepoDestinationPath_ -destination _DockerVolume_ -ReleaseTag _ReleaseTag_ -AppImage -Tar -TarArm",
         "BuildDockerOptions": [
             "--cap-add",
             "SYS_ADMIN",


### PR DESCRIPTION
## PR Summary

The Linux release build was broken because `AppImage,tar,tar-arm` in `build.json` is turned into a string of `"AppImage,tar,tar-arm"` by `docker run`. Now it's changed to use switch parameters.

## PR Checklist

Note: Please mark anything not applicable to this PR `NA`.

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [X] Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [NA] User facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [NA] Issue filed - Issue link:
- [X] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [NA] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
    - [NA] [Add `[feature]` if the change is significant or affectes feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
