### PR TITLE
Minor docker release tests updates

### DIFF
--- a/docker/tests/Templates/centos7/Dockerfile
+++ b/docker/tests/Templates/centos7/Dockerfile
@@ -19,4 +19,4 @@ RUN localedef --charmap=UTF-8 --inputfile=en_US $LANG
 RUN curl -L -o powershell-$PSVERSIONSTUBRPM-1.rhel.7.x86_64.rpm $PACKAGELOCATIONSTUB/powershell-$PSVERSIONSTUBRPM-1.rhel.7.x86_64.rpm
 RUN yum install -y powershell-$PSVERSIONSTUBRPM-1.rhel.7.x86_64.rpm
 RUN git clone --recursive https://github.com/PowerShell/PowerShell.git
-RUN pwsh -c "Import-Module /PowerShell/build.psm1;exit (Invoke-Pester $TESTLISTSTUB -PassThru).FailedCount"
+RUN pwsh -c "Import-Module /PowerShell/build.psm1;Restore-PSPester -Destination /usr/local/share/powershell/Modules;exit (Invoke-Pester $TESTLISTSTUB -PassThru).FailedCount"

--- a/docker/tests/Templates/debian.8/Dockerfile
+++ b/docker/tests/Templates/debian.8/Dockerfile
@@ -24,4 +24,4 @@ RUN curl -L -o powershell_$PSVERSIONSTUB-1.debian.8_amd64.deb $PACKAGELOCATIONST
 RUN dpkg -i powershell_$PSVERSIONSTUB-1.debian.8_amd64.deb || :
 RUN apt-get install -y -f
 RUN git clone --recursive https://github.com/PowerShell/PowerShell.git
-RUN pwsh -c "Import-Module /PowerShell/build.psm1;exit (Invoke-Pester $TESTLISTSTUB -PassThru).FailedCount"
+RUN pwsh -c "Import-Module /PowerShell/build.psm1;Restore-PSPester -Destination /usr/local/share/powershell/Modules;exit (Invoke-Pester $TESTLISTSTUB -PassThru).FailedCount"

--- a/docker/tests/Templates/debian.9/Dockerfile
+++ b/docker/tests/Templates/debian.9/Dockerfile
@@ -24,4 +24,4 @@ RUN curl -L -o powershell_$PSVERSIONSTUB-1.debian.9_amd64.deb $PACKAGELOCATIONST
 RUN dpkg -i powershell_$PSVERSIONSTUB-1.debian.9_amd64.deb || :
 RUN apt-get install -y -f
 RUN git clone --recursive https://github.com/PowerShell/PowerShell.git
-RUN pwsh -c "Import-Module /PowerShell/build.psm1;exit (Invoke-Pester $TESTLISTSTUB -PassThru).FailedCount"
+RUN pwsh -c "Import-Module /PowerShell/build.psm1;Restore-PSPester -Destination /usr/local/share/powershell/Modules;exit (Invoke-Pester $TESTLISTSTUB -PassThru).FailedCount"

--- a/docker/tests/Templates/fedora25/Dockerfile
+++ b/docker/tests/Templates/fedora25/Dockerfile
@@ -19,4 +19,4 @@ RUN localedef --charmap=UTF-8 --inputfile=en_US $LANG
 RUN curl -L -o powershell-$PSVERSIONSTUBRPM-1.rhel.7.x86_64.rpm $PACKAGELOCATIONSTUB/powershell-$PSVERSIONSTUBRPM-1.rhel.7.x86_64.rpm
 RUN dnf install -y powershell-$PSVERSIONSTUBRPM-1.rhel.7.x86_64.rpm
 RUN git clone --recursive https://github.com/PowerShell/PowerShell.git
-RUN pwsh -c "Import-Module /PowerShell/build.psm1;exit (Invoke-Pester $TESTLISTSTUB -PassThru).FailedCount"
+RUN pwsh -c "Import-Module /PowerShell/build.psm1;Restore-PSPester -Destination /usr/local/share/powershell/Modules;exit (Invoke-Pester $TESTLISTSTUB -PassThru).FailedCount"

--- a/docker/tests/Templates/fedora26/Dockerfile
+++ b/docker/tests/Templates/fedora26/Dockerfile
@@ -20,4 +20,4 @@ RUN localedef --charmap=UTF-8 --inputfile=en_US $LANG
 RUN curl -L -o powershell-$PSVERSIONSTUBRPM-1.rhel.7.x86_64.rpm $PACKAGELOCATIONSTUB/powershell-$PSVERSIONSTUBRPM-1.rhel.7.x86_64.rpm
 RUN dnf install -y powershell-$PSVERSIONSTUBRPM-1.rhel.7.x86_64.rpm
 RUN git clone --recursive https://github.com/PowerShell/PowerShell.git
-RUN pwsh -c "Import-Module /PowerShell/build.psm1;exit (Invoke-Pester $TESTLISTSTUB -PassThru).FailedCount"
+RUN pwsh -c "Import-Module /PowerShell/build.psm1;Restore-PSPester -Destination /usr/local/share/powershell/Modules;exit (Invoke-Pester $TESTLISTSTUB -PassThru).FailedCount"

--- a/docker/tests/Templates/kalilinux/Dockerfile
+++ b/docker/tests/Templates/kalilinux/Dockerfile
@@ -26,4 +26,4 @@ RUN dpkg -i libssl1.0.0_1.0.1t-1+deb8u7_amd64.deb || :
 RUN dpkg -i powershell_$PSVERSIONSTUB-1.ubuntu.16.04_amd64.deb || :
 RUN apt-get install -y -f
 RUN git clone --recursive https://github.com/PowerShell/PowerShell.git
-RUN pwsh -c "Import-Module /PowerShell/build.psm1;exit (Invoke-Pester $TESTLISTSTUB -PassThru).FailedCount"
+RUN pwsh -c "Import-Module /PowerShell/build.psm1;Restore-PSPester -Destination /usr/local/share/powershell/Modules;exit (Invoke-Pester $TESTLISTSTUB -PassThru).FailedCount"

--- a/docker/tests/Templates/opensuse42.2/Dockerfile
+++ b/docker/tests/Templates/opensuse42.2/Dockerfile
@@ -35,4 +35,4 @@ RUN tar zxf powershell-$PSVERSIONSTUB-linux-x64.tar.gz -C /opt/microsoft/powersh
 RUN ln -s /opt/microsoft/powershell/$PSVERSIONSTUB/pwsh $POWERSHELL_LINKFILE
 
 RUN git clone --recursive https://github.com/PowerShell/PowerShell.git
-RUN pwsh -c "Import-Module /PowerShell/build.psm1;exit (Invoke-Pester $TESTLISTSTUB -PassThru).FailedCount"
+RUN pwsh -c "Import-Module /PowerShell/build.psm1;Restore-PSPester -Destination /usr/local/share/powershell/Modules;exit (Invoke-Pester $TESTLISTSTUB -PassThru).FailedCount"

--- a/docker/tests/Templates/ubuntu14.04/Dockerfile
+++ b/docker/tests/Templates/ubuntu14.04/Dockerfile
@@ -24,4 +24,4 @@ RUN curl -L -o powershell_$PSVERSIONSTUB-1.ubuntu.14.04_amd64.deb $PACKAGELOCATI
 RUN dpkg -i powershell_$PSVERSIONSTUB-1.ubuntu.14.04_amd64.deb || :
 RUN apt-get install -y -f
 RUN git clone --recursive https://github.com/PowerShell/PowerShell.git
-RUN pwsh -c "Import-Module /PowerShell/build.psm1;exit (Invoke-Pester $TESTLISTSTUB -PassThru).FailedCount"
+RUN pwsh -c "Import-Module /PowerShell/build.psm1;Restore-PSPester -Destination /usr/local/share/powershell/Modules;exit (Invoke-Pester $TESTLISTSTUB -PassThru).FailedCount"

--- a/docker/tests/Templates/ubuntu16.04/Dockerfile
+++ b/docker/tests/Templates/ubuntu16.04/Dockerfile
@@ -24,4 +24,4 @@ RUN curl -L -o powershell_$PSVERSIONSTUB-1.ubuntu.16.04_amd64.deb $PACKAGELOCATI
 RUN dpkg -i powershell_$PSVERSIONSTUB-1.ubuntu.16.04_amd64.deb || :
 RUN apt-get install -y -f
 RUN git clone --recursive https://github.com/PowerShell/PowerShell.git
-RUN pwsh -c "Import-Module /PowerShell/build.psm1;exit (Invoke-Pester $TESTLISTSTUB -PassThru).FailedCount"
+RUN pwsh -c "Import-Module /PowerShell/build.psm1;Restore-PSPester -Destination /usr/local/share/powershell/Modules;exit (Invoke-Pester $TESTLISTSTUB -PassThru).FailedCount"

--- a/docker/tests/Templates/ubuntu17.04/Dockerfile
+++ b/docker/tests/Templates/ubuntu17.04/Dockerfile
@@ -24,4 +24,4 @@ RUN curl -L -o powershell_$PSVERSIONSTUB-1.ubuntu.17.04_amd64.deb $PACKAGELOCATI
 RUN dpkg -i powershell_$PSVERSIONSTUB-1.ubuntu.17.04_amd64.deb || :
 RUN apt-get install -y -f
 RUN git clone --recursive https://github.com/PowerShell/PowerShell.git
-RUN pwsh -c "Import-Module /PowerShell/build.psm1;exit (Invoke-Pester $TESTLISTSTUB -PassThru).FailedCount"
+RUN pwsh -c "Import-Module /PowerShell/build.psm1;Restore-PSPester -Destination /usr/local/share/powershell/Modules;exit (Invoke-Pester $TESTLISTSTUB -PassThru).FailedCount"

--- a/docker/tests/containerTestCommon.psm1
+++ b/docker/tests/containerTestCommon.psm1
@@ -243,6 +243,7 @@ function Test-PSPackage
         $buildArgs += "--build-arg","$versionStubName=$versionStubValue"
         $buildArgs += "--build-arg","$testlistStubName=$testlistStubValue"
         $buildArgs += "--build-arg","$packageLocationStubName=$packageLocationStubValue"
+        $buildArgs += "--no-cache"
         $buildArgs += $dir.FullName
 
         $dockerResult = Invoke-Docker -Command 'build' -Params $buildArgs -FailureAction warning


### PR DESCRIPTION
## PR Summary
This PR has 2 updates to release docker tests:
1) Pester module was recently removed from PS packages - this broke Docker release tests; this change adds a call to Restore-PSPester so that tests could run as expected.
2) Removing caching during docker builds as it was causing random failures during test passes.

## PR Checklist

Note: Please mark anything not applicable to this PR `NA`.

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [x] Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] User facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [ ] Issue filed - Issue link:
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [N/A] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
    - [ ] [Add `[feature]` if the change is significant or affectes feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
