### PR TITLE
tools: fix install-powershell for running during window setup

### DIFF
--- a/tools/install-powershell.ps1
+++ b/tools/install-powershell.ps1
@@ -153,7 +153,7 @@ try {
             Copy-Item $_.fullname -Destination $DestinationFilePath
         }
     } else {
-        $null = New-Item -Path (Split-Path -Path $Destination -Parent -ErrorAction SilentlyContinue) -ItemType Directory -ErrorAction SilentlyContinue
+        $null = New-Item -Path (Split-Path -Path $Destination -Parent) -ItemType Directory -ErrorAction SilentlyContinue
         Move-Item -Path $contentPath -Destination $Destination
     }
 

--- a/tools/install-powershell.ps1
+++ b/tools/install-powershell.ps1
@@ -173,11 +173,11 @@ try {
     if (-not $IsWinEnv) { chmod 755 $Destination/pwsh }
 
     if ($AddToPath) {
-        if ($IsWinEnv -and (-not $env:Path.Contains($Destination))) {
-            ## Add to the User scope 'Path' environment variable
-            $userPath = [System.Environment]::GetEnvironmentVariable("Path", "User")
-            $userPath = $Destination + [System.IO.Path]::PathSeparator + $userPath
-            [System.Environment]::SetEnvironmentVariable("Path", $userPath, "User")
+        if ($IsWinEnv -and (-not [System.Environment]::GetEnvironmentVariable("Path", "Machine").Contains($Destination))) {
+            ## Add to the Machine scope 'Path' environment variable
+            $machinePath = [System.Environment]::GetEnvironmentVariable("Path", "Machine")
+            $machinePath = $Destination + [System.IO.Path]::PathSeparator + $machinePath
+            [System.Environment]::SetEnvironmentVariable("Path", $machinePath, "Machine")
             Write-Verbose "'$Destination' is added to the Path" -Verbose
         }
 

--- a/tools/install-powershell.ps1
+++ b/tools/install-powershell.ps1
@@ -153,6 +153,7 @@ try {
             Copy-Item $_.fullname -Destination $DestinationFilePath
         }
     } else {
+        $null = New-Item -Path (Split-Path -Path $Destination -Parent -ErrorAction SilentlyContinue) -ItemType Directory -ErrorAction SilentlyContinue
         Move-Item -Path $contentPath -Destination $Destination
     }
 


### PR DESCRIPTION
## PR Summary

1.  Set the system path instead of the user path so that all users can use the installation
2.  If the required destination folder doesn't exist, create it

## PR Checklist

Note: Please mark anything not applicable to this PR `NA`.

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [x] Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [NA] User facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [NA] Issue filed - Issue link:
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [NA] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
    - [NA] [Add `[feature]` if the change is significant or affectes feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
