### PR TITLE
Fix range operator

### DIFF
--- a/src/System.Management.Automation/engine/lang/parserutils.cs
+++ b/src/System.Management.Automation/engine/lang/parserutils.cs
@@ -1478,7 +1478,13 @@ namespace System.Management.Automation
         }
 
         private int _current;
-        public object Current
+
+        Object IEnumerator.Current
+        {
+            get { return Current; }
+        }
+
+        public virtual int Current
         {
             get { return _current; }
         }
@@ -1521,6 +1527,81 @@ namespace System.Management.Automation
             return true;
         }
     }
+
+    /// <summary>
+    /// The simple enumerator class is used for the range operator '..'
+    /// in expressions like 'A'..'B' | ForEach-Object { $_ }
+    /// </summary>
+    internal class CharRangeEnumerator : IEnumerator
+    {
+        private int _lowerBound;
+
+        internal int LowerBound
+        {
+            get { return _lowerBound; }
+        }
+
+        private int _upperBound;
+
+        internal int UpperBound
+        {
+            get { return _upperBound; }
+        }
+
+        private int _current;
+
+        Object IEnumerator.Current
+        {
+            get { return Current; }
+        }
+
+        public string Current
+        {
+            get { return new String((char)_current, 1); }
+        }
+
+        internal int CurrentValue
+        {
+            get { return _current; }
+        }
+
+        private int _increment = 1;
+
+        private bool _firstElement = true;
+
+        public CharRangeEnumerator(char lowerBound, char upperBound)
+        {
+            _lowerBound = lowerBound;
+            _current = _lowerBound;
+            _upperBound = upperBound;
+            if (lowerBound > upperBound)
+                _increment = -1;
+        }
+
+        public void Reset()
+        {
+            _current = _lowerBound;
+            _firstElement = true;
+        }
+
+        public bool MoveNext()
+        {
+            if (_firstElement)
+            {
+                _firstElement = false;
+                return true;
+            }
+
+            if (_current == _upperBound)
+            {
+                return false;
+            }
+
+            _current += _increment;
+            return true;
+        }
+    }
+
     #endregion RangeEnumerator
 
     #region InterpreterError

--- a/src/System.Management.Automation/engine/lang/parserutils.cs
+++ b/src/System.Management.Automation/engine/lang/parserutils.cs
@@ -863,7 +863,6 @@ namespace System.Management.Automation
         // and so on.
         //
         // In special case:
-        //     [char]'0'..[char]'9'
         //     "0".."9"
         // return objects of [int] type.
         private static object AsChar(object obj)

--- a/src/System.Management.Automation/engine/lang/parserutils.cs
+++ b/src/System.Management.Automation/engine/lang/parserutils.cs
@@ -786,6 +786,35 @@ namespace System.Management.Automation
         }
 
         /// <summary>
+        /// The implementation of the PowerShell range operator.
+        /// </summary>
+        /// <param name="context">The execution context in which to evaluate the expression</param>
+        /// <param name="errorPosition">The position to use for error reporting.</param>
+        /// <param name="lval">The object on which to replace the values</param>
+        /// <param name="rval">The replacement description.</param>
+        /// <returns>The result of the operator</returns>
+        internal static object RangeOperator(ExecutionContext context, IScriptExtent errorPosition, object lval, object rval)
+        {
+            var lbase = PSObject.Base(lval);
+            var rbase = PSObject.Base(rval);
+
+            try
+            {
+                var l = Convert.ToChar(lbase);
+                var r = Convert.ToChar(rbase);
+
+                return CharOps.Range(l, r);
+            }
+            catch
+            {
+                var l = Convert.ToInt32(lbase);
+                var r = Convert.ToInt32(rbase);
+
+                return IntOps.Range(l, r);
+            }
+        }
+
+        /// <summary>
         /// The implementation of the PowerShell -replace operator....
         /// </summary>
         /// <param name="context">The execution context in which to evaluate the expression</param>

--- a/src/System.Management.Automation/engine/lang/parserutils.cs
+++ b/src/System.Management.Automation/engine/lang/parserutils.cs
@@ -788,12 +788,10 @@ namespace System.Management.Automation
         /// <summary>
         /// The implementation of the PowerShell range operator.
         /// </summary>
-        /// <param name="context">The execution context in which to evaluate the expression.</param>
-        /// <param name="errorPosition">The position to use for error reporting.</param>
         /// <param name="lval">The object on which to start.</param>
         /// <param name="rval">The object on which to stop.</param>
         /// <returns>The array of objects.</returns>
-        internal static object RangeOperator(ExecutionContext context, IScriptExtent errorPosition, object lval, object rval)
+        internal static object RangeOperator(object lval, object rval)
         {
             var lbase = PSObject.Base(lval);
             var rbase = PSObject.Base(rval);

--- a/src/System.Management.Automation/engine/lang/parserutils.cs
+++ b/src/System.Management.Automation/engine/lang/parserutils.cs
@@ -1630,15 +1630,10 @@ namespace System.Management.Automation
         public CharRangeEnumerator(char lowerBound, char upperBound)
         {
             LowerBound = lowerBound;
-            CurrentValue = LowerBound;
+            Current = lowerBound;
             UpperBound = upperBound;
             if (lowerBound > upperBound)
                 _increment = -1;
-        }
-
-        public string Current
-        {
-            get { return new String((char)CurrentValue, 1); }
         }
 
         Object IEnumerator.Current
@@ -1646,17 +1641,17 @@ namespace System.Management.Automation
             get { return Current; }
         }
 
-        internal int LowerBound
+        internal char LowerBound
         {
             get; private set;
         }
 
-        internal int UpperBound
+        internal char UpperBound
         {
             get; private set;
         }
 
-        internal int CurrentValue
+        public char Current
         {
             get; private set;
         }
@@ -1669,18 +1664,18 @@ namespace System.Management.Automation
                 return true;
             }
 
-            if (CurrentValue == UpperBound)
+            if (Current == UpperBound)
             {
                 return false;
             }
 
-            CurrentValue += _increment;
+            Current = (char)(Current + _increment);
             return true;
         }
 
         public void Reset()
         {
-            CurrentValue = LowerBound;
+            Current = LowerBound;
             _firstElement = true;
         }
     }

--- a/src/System.Management.Automation/engine/lang/parserutils.cs
+++ b/src/System.Management.Automation/engine/lang/parserutils.cs
@@ -1629,16 +1629,16 @@ namespace System.Management.Automation
 
         public CharRangeEnumerator(char lowerBound, char upperBound)
         {
-            _lowerBound = lowerBound;
-            _current = _lowerBound;
-            _upperBound = upperBound;
+            LowerBound = lowerBound;
+            CurrentValue = LowerBound;
+            UpperBound = upperBound;
             if (lowerBound > upperBound)
                 _increment = -1;
         }
 
         public string Current
         {
-            get { return new String((char)_current, 1); }
+            get { return new String((char)CurrentValue, 1); }
         }
 
         Object IEnumerator.Current
@@ -1648,24 +1648,18 @@ namespace System.Management.Automation
 
         internal int LowerBound
         {
-            get { return _lowerBound; }
+            get; private set;
         }
-
-        private int _lowerBound;
 
         internal int UpperBound
         {
-            get { return _upperBound; }
+            get; private set;
         }
-
-        private int _upperBound;
 
         internal int CurrentValue
         {
-            get { return _current; }
+            get; private set;
         }
-
-        private int _current;
 
         public bool MoveNext()
         {
@@ -1675,18 +1669,18 @@ namespace System.Management.Automation
                 return true;
             }
 
-            if (_current == _upperBound)
+            if (CurrentValue == UpperBound)
             {
                 return false;
             }
 
-            _current += _increment;
+            CurrentValue += _increment;
             return true;
         }
 
         public void Reset()
         {
-            _current = _lowerBound;
+            CurrentValue = LowerBound;
             _firstElement = true;
         }
     }

--- a/src/System.Management.Automation/engine/lang/parserutils.cs
+++ b/src/System.Management.Automation/engine/lang/parserutils.cs
@@ -1563,37 +1563,6 @@ namespace System.Management.Automation
     /// </summary>
     internal class CharRangeEnumerator : IEnumerator
     {
-        private int _lowerBound;
-
-        internal int LowerBound
-        {
-            get { return _lowerBound; }
-        }
-
-        private int _upperBound;
-
-        internal int UpperBound
-        {
-            get { return _upperBound; }
-        }
-
-        private int _current;
-
-        Object IEnumerator.Current
-        {
-            get { return Current; }
-        }
-
-        public string Current
-        {
-            get { return new String((char)_current, 1); }
-        }
-
-        internal int CurrentValue
-        {
-            get { return _current; }
-        }
-
         private int _increment = 1;
 
         private bool _firstElement = true;
@@ -1607,11 +1576,36 @@ namespace System.Management.Automation
                 _increment = -1;
         }
 
-        public void Reset()
+        public string Current
         {
-            _current = _lowerBound;
-            _firstElement = true;
+            get { return new String((char)_current, 1); }
         }
+
+        Object IEnumerator.Current
+        {
+            get { return Current; }
+        }
+
+        internal int LowerBound
+        {
+            get { return _lowerBound; }
+        }
+
+        private int _lowerBound;
+
+        internal int UpperBound
+        {
+            get { return _upperBound; }
+        }
+
+        private int _upperBound;
+
+        internal int CurrentValue
+        {
+            get { return _current; }
+        }
+
+        private int _current;
 
         public bool MoveNext()
         {
@@ -1628,6 +1622,12 @@ namespace System.Management.Automation
 
             _current += _increment;
             return true;
+        }
+
+        public void Reset()
+        {
+            _current = _lowerBound;
+            _firstElement = true;
         }
     }
 

--- a/src/System.Management.Automation/engine/parser/Compiler.cs
+++ b/src/System.Management.Automation/engine/parser/Compiler.cs
@@ -4869,7 +4869,15 @@ namespace System.Management.Automation.Language
                     return Expression.Call(CachedReflectionInfo.TypeOps_AsOperator, lhs.Cast(typeof(object)), rhs.Convert(typeof(Type)));
 
                 case TokenKind.DotDot:
-                    // TODO: replace this with faster code
+                    // TODO: replace this with faster code.
+                    //
+                    // The idea behind "faster" is to avoid extra runtime type checks.
+                    // The code below generate code like:
+                    //    IntOps.Range((object)lhs, (object)rhs)
+                    // This forces us to perform a type check and casts at both generate time here and at run time in IntOps.Range.
+                    // We can be faster if we generate the code like:
+                    //    IntOps.Range((int)lhs, (int)rhs)
+                    // In the case there are no extra type checks and casts at run time.
                     return Expression.Call(
                         CachedReflectionInfo.ParserOps_RangeOperator,
                         _executionContextParameter, Expression.Constant(binaryExpressionAst.ErrorPosition), lhs.Cast(typeof(object)), rhs.Cast(typeof(object)));

--- a/src/System.Management.Automation/engine/parser/Compiler.cs
+++ b/src/System.Management.Automation/engine/parser/Compiler.cs
@@ -4869,15 +4869,10 @@ namespace System.Management.Automation.Language
                     return Expression.Call(CachedReflectionInfo.TypeOps_AsOperator, lhs.Cast(typeof(object)), rhs.Convert(typeof(Type)));
 
                 case TokenKind.DotDot:
-                    // TODO: replace this with faster code.
-                    //
-                    // The idea behind "faster" is to avoid extra runtime type checks.
-                    // The code below generate code like:
-                    //    IntOps.Range((object)lhs, (object)rhs)
-                    // This forces us to perform a type check and casts at both generate time here and at run time in IntOps.Range.
-                    // We can be faster if we generate the code like:
-                    //    IntOps.Range((int)lhs, (int)rhs)
-                    // In the case there are no extra type checks and casts at run time.
+                    // We could generate faster code using Expression.Dynamic with a binder.
+                    // Currently, type checks are done in ParserOps.RangeOperator at runtime every time
+                    // a range operator is used. By replacing with Expression.Dynamic and a binder, the
+                    // type check is done only once when you repeatedly execute the same line in script.
                     return Expression.Call(
                         CachedReflectionInfo.ParserOps_RangeOperator, lhs.Cast(typeof(object)), rhs.Cast(typeof(object)));
 

--- a/src/System.Management.Automation/engine/parser/Compiler.cs
+++ b/src/System.Management.Automation/engine/parser/Compiler.cs
@@ -4288,8 +4288,6 @@ namespace System.Management.Automation.Language
                 {
                     Expression lhs = Compile(binaryExpr.Left);
                     Expression rhs = Compile(binaryExpr.Right);
-                    var l = lhs.Cast(typeof(object));
-                    var r = rhs.Cast(typeof(object));
 
                     return Expression.Call(CachedReflectionInfo.ParserOps_GetRangeEnumerator,
                                            lhs.Cast(typeof(object)),

--- a/src/System.Management.Automation/engine/parser/Compiler.cs
+++ b/src/System.Management.Automation/engine/parser/Compiler.cs
@@ -65,9 +65,6 @@ namespace System.Management.Automation.Language
             typeof(CharOps).GetMethod(nameof(CharOps.CompareStringIeq), staticFlags);
         internal static readonly MethodInfo CharOps_CompareStringIne =
             typeof(CharOps).GetMethod(nameof(CharOps.CompareStringIne), staticFlags);
-        internal static readonly MethodInfo CharOps_Range =
-            typeof(CharOps).GetMethod(nameof(CharOps.Range), staticFlags);
-
         internal static readonly MethodInfo CommandParameterInternal_CreateArgument =
             typeof(CommandParameterInternal).GetMethod(nameof(CommandParameterInternal.CreateArgument), staticFlags);
         internal static readonly MethodInfo CommandParameterInternal_CreateParameter =
@@ -248,9 +245,6 @@ namespace System.Management.Automation.Language
         internal static readonly MethodInfo InterpreterError_NewInterpreterExceptionWithInnerException =
             typeof(InterpreterError).GetMethod(nameof(InterpreterError.NewInterpreterExceptionWithInnerException), staticFlags);
 
-        internal static readonly MethodInfo IntOps_Range =
-            typeof(IntOps).GetMethod(nameof(IntOps.Range), staticFlags);
-
         internal static readonly MethodInfo LanguagePrimitives_GetInvalidCastMessages =
             typeof(LanguagePrimitives).GetMethod(nameof(LanguagePrimitives.GetInvalidCastMessages), staticFlags);
         internal static readonly MethodInfo LanguagePrimitives_ThrowInvalidCastException =
@@ -294,6 +288,8 @@ namespace System.Management.Automation.Language
             typeof(ParserOps).GetMethod(nameof(ParserOps.MatchOperator), staticFlags);
         internal static readonly MethodInfo ParserOps_RangeOperator =
             typeof(ParserOps).GetMethod(nameof(ParserOps.RangeOperator), staticFlags);
+        internal static readonly MethodInfo ParserOps_RangeEnumerator =
+            typeof(ParserOps).GetMethod(nameof(ParserOps.GetRangeEnumerator), staticFlags);
         internal static readonly MethodInfo ParserOps_ReplaceOperator =
             typeof(ParserOps).GetMethod(nameof(ParserOps.ReplaceOperator), staticFlags);
         internal static readonly MethodInfo ParserOps_SplitOperator =
@@ -398,12 +394,6 @@ namespace System.Management.Automation.Language
             typeof(PSCreateInstanceBinder).GetMethod(nameof(PSCreateInstanceBinder.IsTargetTypeNonPublic), staticFlags);
         internal static readonly MethodInfo PSCreateInstanceBinder_GetTargetTypeName =
             typeof(PSCreateInstanceBinder).GetMethod(nameof(PSCreateInstanceBinder.GetTargetTypeName), staticFlags);
-
-        internal static readonly ConstructorInfo RangeEnumerator_ctor =
-            typeof(RangeEnumerator).GetConstructor(new Type[] { typeof(int), typeof(int) });
-
-        internal static readonly ConstructorInfo CharRangeEnumerator_ctor =
-            typeof(CharRangeEnumerator).GetConstructor(new Type[] { typeof(char), typeof(char) });
 
         internal static readonly MethodInfo ReservedNameMembers_GeneratePSAdaptedMemberSet =
             typeof(ReservedNameMembers).GetMethod(nameof(ReservedNameMembers.GeneratePSAdaptedMemberSet), staticFlags);
@@ -4298,21 +4288,12 @@ namespace System.Management.Automation.Language
                 {
                     Expression lhs = Compile(binaryExpr.Left);
                     Expression rhs = Compile(binaryExpr.Right);
+                    var l = lhs.Cast(typeof(object));
+                    var r = rhs.Cast(typeof(object));
 
-                    if ((lhs.Type == typeof(string) || lhs.Type == typeof(char))
-                        && (rhs.Type == typeof(string) || rhs.Type == typeof(char)))
-                    {
-                        return Expression.New(CachedReflectionInfo.CharRangeEnumerator_ctor,
-                                                lhs.Convert(typeof(char)),
-                                                rhs.Convert(typeof(char)));
-                    }
-
-                    if (lhs.Type == typeof(int) || lhs.Type == typeof(int))
-                    {
-                        return Expression.New(CachedReflectionInfo.RangeEnumerator_ctor,
-                                                lhs.Convert(typeof(int)),
-                                                rhs.Convert(typeof(int)));
-                    }
+                    return Expression.Call(CachedReflectionInfo.ParserOps_RangeEnumerator,
+                                           lhs.Cast(typeof(object)),
+                                           rhs.Cast(typeof(object)));
                 }
             }
 
@@ -4890,19 +4871,6 @@ namespace System.Management.Automation.Language
                     return Expression.Call(CachedReflectionInfo.TypeOps_AsOperator, lhs.Cast(typeof(object)), rhs.Convert(typeof(Type)));
 
                 case TokenKind.DotDot:
-                    if ((lhs.Type == typeof(string) || lhs.Type == typeof(char))
-                        && (rhs.Type == typeof(string) || rhs.Type == typeof(char)))
-                    {
-                        return Expression.Call(CachedReflectionInfo.CharOps_Range,
-                                               lhs.Convert(typeof(char)),
-                                               rhs.Convert(typeof(char)));
-                    }
-                    if (lhs.Type == typeof(int) && rhs.Type == typeof(int))
-                    {
-                        return Expression.Call(CachedReflectionInfo.IntOps_Range,
-                                            lhs.Convert(typeof(int)),
-                                            rhs.Convert(typeof(int)));
-                    }
                     // TODO: replace this with faster code
                     return Expression.Call(
                         CachedReflectionInfo.ParserOps_RangeOperator,

--- a/src/System.Management.Automation/engine/parser/Compiler.cs
+++ b/src/System.Management.Automation/engine/parser/Compiler.cs
@@ -288,7 +288,7 @@ namespace System.Management.Automation.Language
             typeof(ParserOps).GetMethod(nameof(ParserOps.MatchOperator), staticFlags);
         internal static readonly MethodInfo ParserOps_RangeOperator =
             typeof(ParserOps).GetMethod(nameof(ParserOps.RangeOperator), staticFlags);
-        internal static readonly MethodInfo ParserOps_RangeEnumerator =
+        internal static readonly MethodInfo ParserOps_GetRangeEnumerator =
             typeof(ParserOps).GetMethod(nameof(ParserOps.GetRangeEnumerator), staticFlags);
         internal static readonly MethodInfo ParserOps_ReplaceOperator =
             typeof(ParserOps).GetMethod(nameof(ParserOps.ReplaceOperator), staticFlags);
@@ -4291,7 +4291,7 @@ namespace System.Management.Automation.Language
                     var l = lhs.Cast(typeof(object));
                     var r = rhs.Cast(typeof(object));
 
-                    return Expression.Call(CachedReflectionInfo.ParserOps_RangeEnumerator,
+                    return Expression.Call(CachedReflectionInfo.ParserOps_GetRangeEnumerator,
                                            lhs.Cast(typeof(object)),
                                            rhs.Cast(typeof(object)));
                 }

--- a/src/System.Management.Automation/engine/parser/Compiler.cs
+++ b/src/System.Management.Automation/engine/parser/Compiler.cs
@@ -4879,8 +4879,7 @@ namespace System.Management.Automation.Language
                     //    IntOps.Range((int)lhs, (int)rhs)
                     // In the case there are no extra type checks and casts at run time.
                     return Expression.Call(
-                        CachedReflectionInfo.ParserOps_RangeOperator,
-                        _executionContextParameter, Expression.Constant(binaryExpressionAst.ErrorPosition), lhs.Cast(typeof(object)), rhs.Cast(typeof(object)));
+                        CachedReflectionInfo.ParserOps_RangeOperator, lhs.Cast(typeof(object)), rhs.Cast(typeof(object)));
 
                 case TokenKind.Multiply:
                     if (lhs.Type == typeof(double) && rhs.Type == typeof(double))

--- a/src/System.Management.Automation/engine/parser/Compiler.cs
+++ b/src/System.Management.Automation/engine/parser/Compiler.cs
@@ -400,6 +400,9 @@ namespace System.Management.Automation.Language
         internal static readonly ConstructorInfo RangeEnumerator_ctor =
             typeof(RangeEnumerator).GetConstructor(new Type[] { typeof(int), typeof(int) });
 
+        internal static readonly ConstructorInfo CharRangeEnumerator_ctor =
+            typeof(CharRangeEnumerator).GetConstructor(new Type[] { typeof(char), typeof(char) });
+
         internal static readonly MethodInfo ReservedNameMembers_GeneratePSAdaptedMemberSet =
             typeof(ReservedNameMembers).GetMethod(nameof(ReservedNameMembers.GeneratePSAdaptedMemberSet), staticFlags);
         internal static readonly MethodInfo ReservedNameMembers_GeneratePSBaseMemberSet =
@@ -4295,9 +4298,18 @@ namespace System.Management.Automation.Language
                     Expression lhs = Compile(binaryExpr.Left);
                     Expression rhs = Compile(binaryExpr.Right);
 
-                    result = Expression.New(CachedReflectionInfo.RangeEnumerator_ctor,
-                                            lhs.Convert(typeof(int)),
-                                            rhs.Convert(typeof(int)));
+                    if (lhs.Type == typeof(string) || lhs.Type == typeof(Char))
+                    {
+                        result = Expression.New(CachedReflectionInfo.CharRangeEnumerator_ctor,
+                                                lhs.Convert(typeof(char)),
+                                                rhs.Convert(typeof(char)));
+                    }
+                    else
+                    {
+                        result = Expression.New(CachedReflectionInfo.RangeEnumerator_ctor,
+                                                lhs.Convert(typeof(int)),
+                                                rhs.Convert(typeof(int)));
+                    }
                 }
             }
             return result;
@@ -4874,7 +4886,8 @@ namespace System.Management.Automation.Language
                     return Expression.Call(CachedReflectionInfo.TypeOps_AsOperator, lhs.Cast(typeof(object)), rhs.Convert(typeof(Type)));
 
                 case TokenKind.DotDot:
-                    if(lhs.Type == typeof(string)){
+                    if (lhs.Type == typeof(string) || lhs.Type == typeof(char))
+                    {
                         return Expression.Call(CachedReflectionInfo.CharOps_Range,
                                                lhs.Convert(typeof(char)),
                                                rhs.Convert(typeof(char)));

--- a/test/powershell/Language/Operators/RangeOperator.Tests.ps1
+++ b/test/powershell/Language/Operators/RangeOperator.Tests.ps1
@@ -46,10 +46,20 @@ Describe "Range Operator" -Tags CI {
             $Range[3] | Should Be 1
             $Range[4] | Should Be 2
         }
+
+        It "Range operator enumerator works" {
+            $Range = -2..2 | ForEach-Object { $_ }
+            $Range.count | Should Be 5
+            $Range[0] | Should Be -2
+            $Range[1] | Should Be -1
+            $Range[2] | Should Be 0
+            $Range[3] | Should Be 1
+            $Range[4] | Should Be 2
+        }
     }
 
     Context "Character expansion" {
-        It "Range operator generates an array of [char] from single-character string operands" {
+        It "Range operator generates an array of [char] from single-character operands" {
             $CharRange = 'A'..'E'
             $CharRange.count | Should Be 5
             $CharRange[0] | Should BeOfType [char]
@@ -59,16 +69,62 @@ Describe "Range Operator" -Tags CI {
             $CharRange[4] | Should BeOfType [char]
         }
 
+        It "Range operator enumerator generates an array of [string] from single-character operands" {
+            $CharRange = 'A'..'E' | ForEach-Object { $_ }
+            $CharRange.count | Should Be 5
+            $CharRange[0] | Should BeOfType [string]
+            $CharRange[1] | Should BeOfType [string]
+            $CharRange[2] | Should BeOfType [string]
+            $CharRange[3] | Should BeOfType [string]
+            $CharRange[4] | Should BeOfType [string]
+        }
+
         It "Range operator works in ascending and descending order" {
             $CharRange = 'a'..'b'
             $CharRange.count | Should Be 2
-            $CharRange[0] | Should Be ([char]'a')
-            $CharRange[1] | Should Be ([char]'b')
+            $CharRange[0] | Should BeExactly ([char]'a')
+            $CharRange[1] | Should BeExactly ([char]'b')
 
-            $CharRange = 'b'..'a'
+            $CharRange = 'B'..'A'
             $CharRange.count | Should Be 2
-            $CharRange[0] | Should Be ([char]'b')
-            $CharRange[1] | Should Be ([char]'a')
+            $CharRange[0] | Should BeExactly ([char]'B')
+            $CharRange[1] | Should BeExactly ([char]'A')
+        }
+
+        It "Range operator works in ascending and descending order with [char] cast" {
+            $CharRange = [char]'a'..[char]'b'
+            $CharRange.count | Should Be 2
+            $CharRange[0] | Should BeExactly ([char]'a')
+            $CharRange[1] | Should BeExactly ([char]'b')
+
+            $CharRange = [char]'B'..[char]'A'
+            $CharRange.count | Should Be 2
+            $CharRange[0] | Should BeExactly ([char]'B')
+            $CharRange[1] | Should BeExactly ([char]'A')
+        }
+
+        It "Range operator enumerator works in ascending and descending order" {
+            $CharRange = 'a'..'b' | ForEach-Object { $_ }
+            $CharRange.count | Should Be 2
+            $CharRange[0] | Should BeExactly "a"
+            $CharRange[1] | Should BeExactly "b"
+
+            $CharRange = 'B'..'A' | ForEach-Object { $_ }
+            $CharRange.count | Should Be 2
+            $CharRange[0] | Should BeExactly "B"
+            $CharRange[1] | Should BeExactly "A"
+        }
+
+        It "Range operator enumerator works in ascending and descending order with [char] cast" {
+            $CharRange = [char]'a'..[char]'b' | ForEach-Object { $_ }
+            $CharRange.count | Should Be 2
+            $CharRange[0] | Should BeExactly "a"
+            $CharRange[1] | Should BeExactly "b"
+
+            $CharRange = [char]'B'..[char]'A' | ForEach-Object { $_ }
+            $CharRange.count | Should Be 2
+            $CharRange[0] | Should BeExactly "B"
+            $CharRange[1] | Should BeExactly "A"
         }
 
         It "Range operator works with 16-bit unicode characters" {

--- a/test/powershell/Language/Operators/RangeOperator.Tests.ps1
+++ b/test/powershell/Language/Operators/RangeOperator.Tests.ps1
@@ -189,6 +189,20 @@ Describe "Range Operator" -Tags CI {
             $UnicodeRange[4] | Should Be "`u{0114}"[0]
             $UnicodeRange.Where({$_ -is [char]}).count | Should Be 5
         }
+
+        It "Range operator with special ranges" {
+            $SpecRange = "0".."9"
+            $SpecRange.count | Should Be 10
+            $SpecRange.Where({$_ -is [int]}).count | Should Be 10
+
+            $SpecRange = '0'..'9'
+            $SpecRange.count | Should Be 10
+            $SpecRange.Where({$_ -is [int]}).count | Should Be 10
+
+            $SpecRange = [char]'0'..[char]'9'
+            $SpecRange.count | Should Be 10
+            $SpecRange.Where({$_ -is [char]}).count | Should Be 10
+        }
     }
 
     Context "Range operator operand types" {

--- a/test/powershell/Language/Operators/RangeOperator.Tests.ps1
+++ b/test/powershell/Language/Operators/RangeOperator.Tests.ps1
@@ -128,7 +128,32 @@ Describe "Range Operator" -Tags CI {
             $CharRange[1] | Should BeExactly ([char]'b')
             $CharRange[2] | Should BeExactly ([char]'c')
 
+            $CharRange = [char]"a".."c"
+            $CharRange.count | Should Be 3
+            $CharRange[0] | Should BeExactly ([char]'a')
+            $CharRange[1] | Should BeExactly ([char]'b')
+            $CharRange[2] | Should BeExactly ([char]'c')
+
+            $CharRange = "a"..[char]"c"
+            $CharRange.count | Should Be 3
+            $CharRange[0] | Should BeExactly ([char]'a')
+            $CharRange[1] | Should BeExactly ([char]'b')
+            $CharRange[2] | Should BeExactly ([char]'c')
+
+            # The same works in reverse order.
             $CharRange = [char]'C'..[char]'A'
+            $CharRange.count | Should Be 3
+            $CharRange[0] | Should BeExactly ([char]'C')
+            $CharRange[1] | Should BeExactly ([char]'B')
+            $CharRange[2] | Should BeExactly ([char]'A')
+
+            $CharRange = [char]"C".."A"
+            $CharRange.count | Should Be 3
+            $CharRange[0] | Should BeExactly ([char]'C')
+            $CharRange[1] | Should BeExactly ([char]'B')
+            $CharRange[2] | Should BeExactly ([char]'A')
+
+            $CharRange = "C"..[char]"A"
             $CharRange.count | Should Be 3
             $CharRange[0] | Should BeExactly ([char]'C')
             $CharRange[1] | Should BeExactly ([char]'B')

--- a/test/powershell/Language/Operators/RangeOperator.Tests.ps1
+++ b/test/powershell/Language/Operators/RangeOperator.Tests.ps1
@@ -56,6 +56,34 @@ Describe "Range Operator" -Tags CI {
             $Range[3] | Should Be 1
             $Range[4] | Should Be 2
         }
+
+        It "Range operator works with variables" {
+            $var1 = -1
+            $var2 = 1
+            $Range = $var1..$var2
+            $Range.count | Should Be 3
+            $Range[0] | Should Be -1
+            $Range[1] | Should Be 0
+            $Range[2] | Should Be 1
+
+            $Range = [int]$var2..[int]$var1
+            $Range.count | Should Be 3
+            $Range[0] | Should Be 1
+            $Range[1] | Should Be 0
+            $Range[2] | Should Be -1
+
+            $Range = $var1..$var2 | ForEach-Object { $_ }
+            $Range.count | Should Be 3
+            $Range[0] | Should Be -1
+            $Range[1] | Should Be 0
+            $Range[2] | Should Be 1
+
+            $Range = [int]$var2..[int]$var1 | ForEach-Object { $_ }
+            $Range.count | Should Be 3
+            $Range[0] | Should Be 1
+            $Range[1] | Should Be 0
+            $Range[2] | Should Be -1
+        }
     }
 
     Context "Character expansion" {
@@ -125,6 +153,30 @@ Describe "Range Operator" -Tags CI {
             $CharRange.count | Should Be 2
             $CharRange[0] | Should BeExactly "B"
             $CharRange[1] | Should BeExactly "A"
+        }
+
+        It "Range operator works with variables" {
+            $var1 = 'a'
+            $var2 = 'b'
+            $CharRange = $var1..$var2
+            $CharRange.count | Should Be 2
+            $CharRange[0] | Should BeExactly "a"
+            $CharRange[1] | Should BeExactly "b"
+
+            $CharRange = [char]$var2..[char]$var1
+            $CharRange.count | Should Be 2
+            $CharRange[0] | Should BeExactly "b"
+            $CharRange[1] | Should BeExactly "a"
+
+            $CharRange = $var1..$var2 | ForEach-Object { $_ }
+            $CharRange.count | Should Be 2
+            $CharRange[0] | Should BeExactly "a"
+            $CharRange[1] | Should BeExactly "b"
+
+            $CharRange = [char]$var2..[char]$var1 | ForEach-Object { $_ }
+            $CharRange.count | Should Be 2
+            $CharRange[0] | Should BeExactly "b"
+            $CharRange[1] | Should BeExactly "a"
         }
 
         It "Range operator works with 16-bit unicode characters" {

--- a/test/powershell/Language/Operators/RangeOperator.Tests.ps1
+++ b/test/powershell/Language/Operators/RangeOperator.Tests.ps1
@@ -108,75 +108,87 @@ Describe "Range Operator" -Tags CI {
         }
 
         It "Range operator works in ascending and descending order" {
-            $CharRange = 'a'..'b'
-            $CharRange.count | Should Be 2
+            $CharRange = 'a'..'c'
+            $CharRange.count | Should Be 3
             $CharRange[0] | Should BeExactly ([char]'a')
             $CharRange[1] | Should BeExactly ([char]'b')
+            $CharRange[2] | Should BeExactly ([char]'c')
 
-            $CharRange = 'B'..'A'
-            $CharRange.count | Should Be 2
-            $CharRange[0] | Should BeExactly ([char]'B')
-            $CharRange[1] | Should BeExactly ([char]'A')
+            $CharRange = 'C'..'A'
+            $CharRange.count | Should Be 3
+            $CharRange[0] | Should BeExactly ([char]'C')
+            $CharRange[1] | Should BeExactly ([char]'B')
+            $CharRange[2] | Should BeExactly ([char]'A')
         }
 
         It "Range operator works in ascending and descending order with [char] cast" {
-            $CharRange = [char]'a'..[char]'b'
-            $CharRange.count | Should Be 2
+            $CharRange = [char]'a'..[char]'c'
+            $CharRange.count | Should Be 3
             $CharRange[0] | Should BeExactly ([char]'a')
             $CharRange[1] | Should BeExactly ([char]'b')
+            $CharRange[2] | Should BeExactly ([char]'c')
 
-            $CharRange = [char]'B'..[char]'A'
-            $CharRange.count | Should Be 2
-            $CharRange[0] | Should BeExactly ([char]'B')
-            $CharRange[1] | Should BeExactly ([char]'A')
+            $CharRange = [char]'C'..[char]'A'
+            $CharRange.count | Should Be 3
+            $CharRange[0] | Should BeExactly ([char]'C')
+            $CharRange[1] | Should BeExactly ([char]'B')
+            $CharRange[2] | Should BeExactly ([char]'A')
         }
 
         It "Range operator enumerator works in ascending and descending order" {
-            $CharRange = 'a'..'b' | ForEach-Object { $_ }
-            $CharRange.count | Should Be 2
+            $CharRange = 'a'..'c' | ForEach-Object { $_ }
+            $CharRange.count | Should Be 3
             $CharRange[0] | Should BeExactly "a"
             $CharRange[1] | Should BeExactly "b"
+            $CharRange[2] | Should BeExactly "c"
 
-            $CharRange = 'B'..'A' | ForEach-Object { $_ }
-            $CharRange.count | Should Be 2
-            $CharRange[0] | Should BeExactly "B"
-            $CharRange[1] | Should BeExactly "A"
+            $CharRange = 'C'..'A' | ForEach-Object { $_ }
+            $CharRange.count | Should Be 3
+            $CharRange[0] | Should BeExactly "C"
+            $CharRange[1] | Should BeExactly "B"
+            $CharRange[2] | Should BeExactly "A"
         }
 
         It "Range operator enumerator works in ascending and descending order with [char] cast" {
-            $CharRange = [char]'a'..[char]'b' | ForEach-Object { $_ }
-            $CharRange.count | Should Be 2
+            $CharRange = [char]'a'..[char]'c' | ForEach-Object { $_ }
+            $CharRange.count | Should Be 3
             $CharRange[0] | Should BeExactly "a"
             $CharRange[1] | Should BeExactly "b"
+            $CharRange[2] | Should BeExactly "c"
 
-            $CharRange = [char]'B'..[char]'A' | ForEach-Object { $_ }
-            $CharRange.count | Should Be 2
-            $CharRange[0] | Should BeExactly "B"
-            $CharRange[1] | Should BeExactly "A"
+            $CharRange = [char]'C'..[char]'A' | ForEach-Object { $_ }
+            $CharRange.count | Should Be 3
+            $CharRange[0] | Should BeExactly "C"
+            $CharRange[1] | Should BeExactly "B"
+            $CharRange[2] | Should BeExactly "A"
         }
 
         It "Range operator works with variables" {
             $var1 = 'a'
-            $var2 = 'b'
+            $var2 = 'c'
             $CharRange = $var1..$var2
-            $CharRange.count | Should Be 2
+            $CharRange.count | Should Be 3
             $CharRange[0] | Should BeExactly "a"
             $CharRange[1] | Should BeExactly "b"
+            $CharRange[2] | Should BeExactly "c"
 
             $CharRange = [char]$var2..[char]$var1
-            $CharRange.count | Should Be 2
-            $CharRange[0] | Should BeExactly "b"
-            $CharRange[1] | Should BeExactly "a"
+            $CharRange.count | Should Be 3
+            $CharRange[0] | Should BeExactly "c"
+            $CharRange[1] | Should BeExactly "b"
+            $CharRange[2] | Should BeExactly "a"
 
             $CharRange = $var1..$var2 | ForEach-Object { $_ }
-            $CharRange.count | Should Be 2
+            $CharRange.count | Should Be 3
             $CharRange[0] | Should BeExactly "a"
             $CharRange[1] | Should BeExactly "b"
+            $CharRange[2] | Should BeExactly "c"
 
             $CharRange = [char]$var2..[char]$var1 | ForEach-Object { $_ }
-            $CharRange.count | Should Be 2
-            $CharRange[0] | Should BeExactly "b"
-            $CharRange[1] | Should BeExactly "a"
+            $CharRange.count | Should Be 3
+            $CharRange[0] | Should BeExactly "c"
+            $CharRange[1] | Should BeExactly "b"
+            $CharRange[2] | Should BeExactly "a"
         }
 
         It "Range operator works with 16-bit unicode characters" {

--- a/test/powershell/Language/Operators/RangeOperator.Tests.ps1
+++ b/test/powershell/Language/Operators/RangeOperator.Tests.ps1
@@ -100,11 +100,11 @@ Describe "Range Operator" -Tags CI {
         It "Range operator enumerator generates an array of [string] from single-character operands" {
             $CharRange = 'A'..'E' | ForEach-Object { $_ }
             $CharRange.count | Should Be 5
-            $CharRange[0] | Should BeOfType [string]
-            $CharRange[1] | Should BeOfType [string]
-            $CharRange[2] | Should BeOfType [string]
-            $CharRange[3] | Should BeOfType [string]
-            $CharRange[4] | Should BeOfType [string]
+            $CharRange[0] | Should BeOfType [char]
+            $CharRange[1] | Should BeOfType [char]
+            $CharRange[2] | Should BeOfType [char]
+            $CharRange[3] | Should BeOfType [char]
+            $CharRange[4] | Should BeOfType [char]
         }
 
         It "Range operator works in ascending and descending order" {


### PR DESCRIPTION
## PR Summary
Fix range operator enumerator. Close #5519
Fix [char] cast in range operator. Close #5731

Breaking-change:  "0".."9" returns [char] previously in PSCore, now it returns [int]. After the change, the behavior is the same as in Windows PowerShell.

## PR Checklist

Note: Please mark anything not applicable to this PR `NA`.

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [x] Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] User facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [NA] Issue filed - Issue link:
- [ ] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
    - [NA] [Add `[feature]` if the change is significant or affectes feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
