### PR TITLE
Minor syntax fix

### DIFF
--- a/src/Microsoft.PowerShell.PSReadLine/Completion.cs
+++ b/src/Microsoft.PowerShell.PSReadLine/Completion.cs
@@ -247,7 +247,7 @@ namespace Microsoft.PowerShell
             {
                 completions.CurrentMatchIndex = completions.CompletionMatches.Count - 1;
             }
-            else if (completions.CurrentMatchIndex >= completions.CompletionMatches.Count)
+            else if (completions.CurrentMatchIndex == completions.CompletionMatches.Count)
             {
                 completions.CurrentMatchIndex = 0;
             }
@@ -278,7 +278,7 @@ namespace Microsoft.PowerShell
         {
             if (!replacementText.EndsWith(DirectorySeparatorString , StringComparison.Ordinal))
             {
-                if (replacementText.EndsWith(String.Format("{0}'", DirectorySeparatorString), StringComparison.Ordinal) ||
+                if (replacementText.EndsWith(String.Format("{0}\'", DirectorySeparatorString), StringComparison.Ordinal) ||
                     replacementText.EndsWith(String.Format("{0}\"", DirectorySeparatorString), StringComparison.Ordinal))
                 {
                     cursorAdjustment = -1;
@@ -287,12 +287,12 @@ namespace Microsoft.PowerShell
                          replacementText.EndsWith("\"", StringComparison.Ordinal))
                 {
                     var len = replacementText.Length;
-                    replacementText = replacementText.Substring(0, len - 1) + DirectorySeparatorString + replacementText[len - 1];
+                    replacementText = replacementText.Substring(0, len - 1) + System.IO.Path.DirectorySeparatorChar + replacementText[len - 1];
                     cursorAdjustment = -1;
                 }
                 else
                 {
-                    replacementText = replacementText + DirectorySeparatorString;
+                    replacementText = replacementText + System.IO.Path.DirectorySeparatorChar;
                 }
             }
             return replacementText;

--- a/src/Microsoft.PowerShell.PSReadLine/Completion.cs
+++ b/src/Microsoft.PowerShell.PSReadLine/Completion.cs
@@ -247,7 +247,7 @@ namespace Microsoft.PowerShell
             {
                 completions.CurrentMatchIndex = completions.CompletionMatches.Count - 1;
             }
-            else if (completions.CurrentMatchIndex == completions.CompletionMatches.Count)
+            else if (completions.CurrentMatchIndex >= completions.CompletionMatches.Count)
             {
                 completions.CurrentMatchIndex = 0;
             }
@@ -278,7 +278,7 @@ namespace Microsoft.PowerShell
         {
             if (!replacementText.EndsWith(DirectorySeparatorString , StringComparison.Ordinal))
             {
-                if (replacementText.EndsWith(String.Format("{0}\'", DirectorySeparatorString), StringComparison.Ordinal) ||
+                if (replacementText.EndsWith(String.Format("{0}'", DirectorySeparatorString), StringComparison.Ordinal) ||
                     replacementText.EndsWith(String.Format("{0}\"", DirectorySeparatorString), StringComparison.Ordinal))
                 {
                     cursorAdjustment = -1;
@@ -287,12 +287,12 @@ namespace Microsoft.PowerShell
                          replacementText.EndsWith("\"", StringComparison.Ordinal))
                 {
                     var len = replacementText.Length;
-                    replacementText = replacementText.Substring(0, len - 1) + System.IO.Path.DirectorySeparatorChar + replacementText[len - 1];
+                    replacementText = replacementText.Substring(0, len - 1) + DirectorySeparatorString + replacementText[len - 1];
                     cursorAdjustment = -1;
                 }
                 else
                 {
-                    replacementText = replacementText + System.IO.Path.DirectorySeparatorChar;
+                    replacementText = replacementText + DirectorySeparatorString;
                 }
             }
             return replacementText;

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -4262,7 +4262,7 @@ namespace System.Management.Automation
                             {
                                 var sessionStateInternal = executionContext.EngineSessionState;
                                 completionText = sessionStateInternal.NormalizeRelativePath(path, sessionStateInternal.CurrentLocation.ProviderPath);
-                                string parentDirectory = ".." + Path.DirectorySeparatorChar;
+                                string parentDirectory = ".." + StringLiterals.DefaultPathSeparator;
                                 if (!completionText.StartsWith(parentDirectory, StringComparison.Ordinal))
                                     completionText = Path.Combine(".", completionText);
                             }
@@ -4477,13 +4477,9 @@ namespace System.Management.Automation
             var wordToComplete = context.WordToComplete;
             var colon = wordToComplete.IndexOf(':');
 
-            var prefix = "$";
             var lastAst = context.RelatedAsts.Last();
             var variableAst = lastAst as VariableExpressionAst;
-            if (variableAst != null && variableAst.Splatted)
-            {
-                prefix = "@";
-            }
+            var prefix = variableAst != null && variableAst.Splatted ? "@" : "$";
 
             // Look for variables in the input (e.g. parameters, etc.) before checking session state - these
             // variables might not exist in session state yet.
@@ -5929,7 +5925,7 @@ namespace System.Management.Automation
         internal static List<CompletionResult> CompleteHelpTopics(CompletionContext context)
         {
             var results = new List<CompletionResult>();
-            var dirPath = Utils.GetApplicationBase(Utils.DefaultPowerShellShellID) + Path.DirectorySeparatorChar + CultureInfo.CurrentCulture.Name;
+            var dirPath = Utils.GetApplicationBase(Utils.DefaultPowerShellShellID) + StringLiterals.DefaultPathSeparator + CultureInfo.CurrentCulture.Name;
             var wordToComplete = context.WordToComplete + "*";
             var topicPattern = WildcardPattern.Get("about_*.help.txt", WildcardOptions.IgnoreCase);
             List<string> files = new List<string>();

--- a/src/System.Management.Automation/engine/parser/TypeInferenceVisitor.cs
+++ b/src/System.Management.Automation/engine/parser/TypeInferenceVisitor.cs
@@ -422,7 +422,7 @@ namespace System.Management.Automation
     {
         private readonly TypeInferenceContext _context;
 
-		private static readonly PSTypeName StringPSTypeName = new PSTypeName(typeof(string));
+        private static readonly PSTypeName StringPSTypeName = new PSTypeName(typeof(string));
 
         public TypeInferenceVisitor(TypeInferenceContext context)
         {

--- a/src/System.Management.Automation/help/HelpCommentsParser.cs
+++ b/src/System.Management.Automation/help/HelpCommentsParser.cs
@@ -354,7 +354,7 @@ namespace System.Management.Automation
                     // The title is automatically generated
                     XmlElement title = _doc.CreateElement("maml:title", mamlURI);
                     string titleStr = string.Format(CultureInfo.InvariantCulture,
-                        "				-------------------------- {0} {1} --------------------------",
+                        "\t\t\t\t-------------------------- {0} {1} --------------------------",
                         HelpDisplayStrings.ExampleUpperCase, count++);
                     XmlText title_text = _doc.CreateTextNode(titleStr);
                     example_node.AppendChild(title).AppendChild(title_text);

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -4996,13 +4996,13 @@ namespace Microsoft.PowerShell.Commands
                 try
                 {
                     string originalPathComparison = path;
-                    if (!originalPathComparison.EndsWith("" + StringLiterals.DefaultPathSeparator, StringComparison.OrdinalIgnoreCase))
+                    if (!originalPathComparison.EndsWith(StringLiterals.DefaultPathSeparatorString, StringComparison.OrdinalIgnoreCase))
                     {
                         originalPathComparison += StringLiterals.DefaultPathSeparator;
                     }
 
                     string basePathComparison = basePath;
-                    if (!basePathComparison.EndsWith("" + StringLiterals.DefaultPathSeparator, StringComparison.OrdinalIgnoreCase))
+                    if (!basePathComparison.EndsWith(StringLiterals.DefaultPathSeparatorString, StringComparison.OrdinalIgnoreCase))
                     {
                         basePathComparison += StringLiterals.DefaultPathSeparator;
                     }
@@ -5205,7 +5205,7 @@ namespace Microsoft.PowerShell.Commands
                 // See if the base and the path are already the same. We resolve this to
                 // ..\Leaf, since resolving "." to "." doesn't offer much information.
                 if (String.Equals(path, basePath, StringComparison.OrdinalIgnoreCase) &&
-                    (!originalPath.EndsWith("" + StringLiterals.DefaultPathSeparator, StringComparison.OrdinalIgnoreCase)))
+                    (!originalPath.EndsWith(StringLiterals.DefaultPathSeparatorString, StringComparison.OrdinalIgnoreCase)))
                 {
                     string childName = GetChildName(path);
                     result = MakePath("..", childName);
@@ -5252,7 +5252,7 @@ namespace Microsoft.PowerShell.Commands
                     if (!String.IsNullOrEmpty(commonBase))
                     {
                         if (String.Equals(path, commonBase, StringComparison.OrdinalIgnoreCase) &&
-                            (!path.EndsWith("" + StringLiterals.DefaultPathSeparator, StringComparison.OrdinalIgnoreCase)))
+                            (!path.EndsWith(StringLiterals.DefaultPathSeparatorString, StringComparison.OrdinalIgnoreCase)))
                         {
                             string childName = GetChildName(path);
                             result = MakePath("..", result);

--- a/src/System.Management.Automation/namespaces/NavigationProviderBase.cs
+++ b/src/System.Management.Automation/namespaces/NavigationProviderBase.cs
@@ -665,7 +665,7 @@ namespace System.Management.Automation.Provider
                 // See if the base and the path are already the same. We resolve this to
                 // ..\Leaf, since resolving "." to "." doesn't offer much information.
                 if (String.Equals(normalizedPath, normalizedBasePath, StringComparison.OrdinalIgnoreCase) &&
-                    (!originalPath.EndsWith("" + StringLiterals.DefaultPathSeparator, StringComparison.OrdinalIgnoreCase)))
+                    (!originalPath.EndsWith(StringLiterals.DefaultPathSeparatorString, StringComparison.OrdinalIgnoreCase)))
                 {
                     string childName = GetChildName(path);
                     result = MakePath("..", childName);
@@ -705,7 +705,7 @@ namespace System.Management.Automation.Provider
                     if (!String.IsNullOrEmpty(commonBase))
                     {
                         if (String.Equals(normalizedPath, commonBase, StringComparison.OrdinalIgnoreCase) &&
-                            (!normalizedPath.EndsWith("" + StringLiterals.DefaultPathSeparator, StringComparison.OrdinalIgnoreCase)))
+                            (!normalizedPath.EndsWith(StringLiterals.DefaultPathSeparatorString, StringComparison.OrdinalIgnoreCase)))
                         {
                             string childName = GetChildName(path);
                             result = MakePath("..", result);


### PR DESCRIPTION
## PR Summary

*Automation/engine/CommandCompletion/CompletionCompleters:
  Use StringLiterals
  Compact the prefix = "@" or "$" to 1 line
*Automation/engine/parser/TypeInferenceVisitor:
  Replace tab with space on 1 line
*Automation/help/HelpCommentsParser:
  Use \t instead of literal tab
*Automation/namespaces/{FileSystemProvider,NavigationProviderBase}:
  Use static string variable

## PR Checklist

Note: Please mark anything not applicable to this PR `NA`.

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [x] Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] `NA` User facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [x] `NA` Issue filed - Issue link:
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] `NA` [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
    - [x] `NA` [Add `[feature]` if the change is significant or affectes feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.

  
  