### PR TITLE
Some correction around PseudoParameterBinder

### DIFF
--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -6190,6 +6190,11 @@ namespace System.Management.Automation
             if (commandAst != null)
             {
                 var binding = new PseudoParameterBinder().DoPseudoParameterBinding(commandAst, null, null, bindingType: PseudoParameterBinder.BindingType.ArgumentCompletion);
+                if (binding == null)
+                {
+                    return null;
+                }
+
                 string parameterName = null;
                 foreach (var boundArg in binding.BoundArguments)
                 {

--- a/src/System.Management.Automation/engine/CommandCompletion/PseudoParameterBinder.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/PseudoParameterBinder.cs
@@ -1075,15 +1075,15 @@ namespace System.Management.Automation.Language
         /// <param name="executionContext">ExecutionContext</param>
         private void SetTemporaryDefaultHost(ExecutionContext executionContext)
         {
-            if (executionContext.EngineHostInterface.IsHostRefSet)
+            if (_restoreHost == null && executionContext.EngineHostInterface.IsHostRefSet)
             {
                 // A temporary host is already set so we need to track and restore here, because
                 // setting the host again will overwrite the current one.
                 _restoreHost = executionContext.EngineHostInterface.ExternalHost;
-
-                // Revert host back to its original state.
-                executionContext.EngineHostInterface.RevertHostRef();
             }
+
+            // Revert host back to its original state.
+            executionContext.EngineHostInterface.RevertHostRef();
 
             // Temporarily set host to default.
             executionContext.EngineHostInterface.SetHostRef(new Microsoft.PowerShell.DefaultHost(

--- a/src/System.Management.Automation/engine/CommandCompletion/PseudoParameterBinder.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/PseudoParameterBinder.cs
@@ -1075,15 +1075,15 @@ namespace System.Management.Automation.Language
         /// <param name="executionContext">ExecutionContext</param>
         private void SetTemporaryDefaultHost(ExecutionContext executionContext)
         {
-            if (_restoreHost == null && executionContext.EngineHostInterface.IsHostRefSet)
+            if (executionContext.EngineHostInterface.IsHostRefSet)
             {
                 // A temporary host is already set so we need to track and restore here, because
                 // setting the host again will overwrite the current one.
                 _restoreHost = executionContext.EngineHostInterface.ExternalHost;
-            }
 
-            // Revert host back to its original state.
-            executionContext.EngineHostInterface.RevertHostRef();
+                // Revert host back to its original state.
+                executionContext.EngineHostInterface.RevertHostRef();
+            }
 
             // Temporarily set host to default.
             executionContext.EngineHostInterface.SetHostRef(new Microsoft.PowerShell.DefaultHost(

--- a/src/System.Management.Automation/engine/CommandDiscovery.cs
+++ b/src/System.Management.Automation/engine/CommandDiscovery.cs
@@ -301,11 +301,15 @@ namespace System.Management.Automation
         internal CommandProcessorBase LookupCommandProcessor(string commandName,
             CommandOrigin commandOrigin, bool? useLocalScope)
         {
+            CommandProcessorBase processor = null;
             CommandInfo commandInfo = LookupCommandInfo(commandName, commandOrigin);
-            CommandProcessorBase processor = LookupCommandProcessor(commandInfo, commandOrigin, useLocalScope, null);
 
-            // commandInfo.Name might be different than commandName - restore the original invocation name
-            processor.Command.MyInvocation.InvocationName = commandName;
+            if (commandInfo != null)
+            {
+                processor = LookupCommandProcessor(commandInfo, commandOrigin, useLocalScope, null);
+                // commandInfo.Name might be different than commandName - restore the original invocation name
+                processor.Command.MyInvocation.InvocationName = commandName;
+            }
 
             return processor;
         }

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -423,6 +423,7 @@ Describe "TabCompletion" -Tags CI {
                 @{ inputStr = 'cd "$pshome\Modu"'; expected = "`"$(Join-Path $PSHOME 'Modules')`""; setup = $null }
                 @{ inputStr = '$PSHOME\System.Management.Au'; expected = Join-Path $PSHOME 'System.Management.Automation.dll'; setup = $null }
                 @{ inputStr = '"$PSHOME\System.Management.Au"'; expected = "`"$(Join-Path $PSHOME 'System.Management.Automation.dll')`""; setup = $null }
+                @{ inputStr = '& "$PSHOME\System.Management.Au"'; expected = "`"$(Join-Path $PSHOME 'System.Management.Automation.dll')`""; setup = $null }
                 ## tab completion AST-based tests
                 @{ inputStr = 'get-date | ForEach-Object { $PSItem.h'; expected = 'Hour'; setup = $null }
                 @{ inputStr = '$a=gps;$a[0].h'; expected = 'Handle'; setup = $null }


### PR DESCRIPTION
## PR Summary

_*Automation/engine/CommandCompletion/CompletionCompleters:_
Add a missing null checking

_*Automation/engine/CommandDiscovery:_
LookupCommandInfo would return null, also checks for it

Command like `& "$XXX_HOME\` should now be tab completable

## PR Checklist

Note: Please mark anything not applicable to this PR `NA`.

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [x] Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] `NA` User facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [x] `NA` Issue filed - Issue link:
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] `NA` [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
    - [x] `NA` [Add `[feature]` if the change is significant or affectes feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.

  