### PR TITLE
Make Resolve-Path -Relative return useful path when $PWD and -Path is on different drive

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/ResolvePathCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/ResolvePathCommand.cs
@@ -110,7 +110,9 @@ namespace Microsoft.PowerShell.Commands
                             // When result path and base path is on different PSDrive
                             // (../)*path should not go beyond the root of base path
                             if (currentPath.Drive != SessionState.Path.CurrentLocation.Drive &&
-                                !currentPath.ProviderPath.StartsWith(SessionState.Path.CurrentLocation.Drive.Root))
+                                SessionState.Path.CurrentLocation.Drive != null &&
+                                !currentPath.ProviderPath.StartsWith(
+                                    SessionState.Path.CurrentLocation.Drive.Root, StringComparison.OrdinalIgnoreCase))
                             {
                                 WriteObject(currentPath.Path, enumerateCollection: false);
                                 continue;
@@ -118,7 +120,8 @@ namespace Microsoft.PowerShell.Commands
                             string adjustedPath = SessionState.Path.NormalizeRelativePath(currentPath.Path,
                                 SessionState.Path.CurrentLocation.ProviderPath);
                             // Do not insert './' if result path is not relative
-                            if (!adjustedPath.StartsWith(currentPath.Drive.Root, StringComparison.OrdinalIgnoreCase) &&
+                            if (!adjustedPath.StartsWith(
+                                    currentPath.Drive?.Root ?? currentPath.Path, StringComparison.OrdinalIgnoreCase) &&
                                 !adjustedPath.StartsWith(".", StringComparison.OrdinalIgnoreCase))
                             {
                                 adjustedPath = SessionState.Path.Combine(".", adjustedPath);

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/ResolvePathCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/ResolvePathCommand.cs
@@ -112,7 +112,7 @@ namespace Microsoft.PowerShell.Commands
                             if (currentPath.Drive != SessionState.Path.CurrentLocation.Drive &&
                                 !currentPath.ProviderPath.StartsWith(SessionState.Path.CurrentLocation.Drive.Root))
                             {
-                                WriteObject(sendToPipeline: currentPath.Path, enumerateCollection: false);
+                                WriteObject(currentPath.Path, enumerateCollection: false);
                                 continue;
                             }
                             string adjustedPath = SessionState.Path.NormalizeRelativePath(currentPath.Path,
@@ -123,7 +123,7 @@ namespace Microsoft.PowerShell.Commands
                             {
                                 adjustedPath = SessionState.Path.Combine(".", adjustedPath);
                             }
-                            WriteObject(sendToPipeline: adjustedPath, enumerateCollection: false);
+                            WriteObject(adjustedPath, enumerateCollection: false);
                         }
                     }
                 }
@@ -162,7 +162,7 @@ namespace Microsoft.PowerShell.Commands
 
                 if (!_relative)
                 {
-                    WriteObject(sendToPipeline: result, enumerateCollection: true);
+                    WriteObject(result, enumerateCollection: true);
                 }
             }
         } // ProcessRecord

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/ResolvePathCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/ResolvePathCommand.cs
@@ -109,7 +109,8 @@ namespace Microsoft.PowerShell.Commands
                         {
                             string adjustedPath = SessionState.Path.NormalizeRelativePath(currentPath.Path,
                                 SessionState.Path.CurrentLocation.ProviderPath);
-                            if (!adjustedPath.StartsWith(".", StringComparison.OrdinalIgnoreCase))
+                            if (currentPath.Drive == SessionState.Path.CurrentLocation.Drive &&
+                                !adjustedPath.StartsWith(".", StringComparison.OrdinalIgnoreCase))
                             {
                                 adjustedPath = SessionState.Path.Combine(".", adjustedPath);
                             }

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/ResolvePathCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/ResolvePathCommand.cs
@@ -107,9 +107,18 @@ namespace Microsoft.PowerShell.Commands
                     {
                         foreach (PathInfo currentPath in result)
                         {
+                            // When result path and base path is on different PSDrive
+                            // (../)*path should not go beyond the root of base path
+                            if (currentPath.Drive != SessionState.Path.CurrentLocation.Drive &&
+                                !currentPath.ProviderPath.StartsWith(SessionState.Path.CurrentLocation.Drive.Root))
+                            {
+                                WriteObject(currentPath.Path, false);
+                                continue;
+                            }
                             string adjustedPath = SessionState.Path.NormalizeRelativePath(currentPath.Path,
                                 SessionState.Path.CurrentLocation.ProviderPath);
-                            if (currentPath.Drive == SessionState.Path.CurrentLocation.Drive &&
+                            // Do not insert './' if result path is not relative
+                            if (!adjustedPath.StartsWith(currentPath.Drive.Root, StringComparison.OrdinalIgnoreCase) &&
                                 !adjustedPath.StartsWith(".", StringComparison.OrdinalIgnoreCase))
                             {
                                 adjustedPath = SessionState.Path.Combine(".", adjustedPath);

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/ResolvePathCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/ResolvePathCommand.cs
@@ -112,7 +112,7 @@ namespace Microsoft.PowerShell.Commands
                             if (currentPath.Drive != SessionState.Path.CurrentLocation.Drive &&
                                 !currentPath.ProviderPath.StartsWith(SessionState.Path.CurrentLocation.Drive.Root))
                             {
-                                WriteObject(currentPath.Path, false);
+                                WriteObject(sendToPipeline: currentPath.Path, enumerateCollection: false);
                                 continue;
                             }
                             string adjustedPath = SessionState.Path.NormalizeRelativePath(currentPath.Path,
@@ -123,7 +123,7 @@ namespace Microsoft.PowerShell.Commands
                             {
                                 adjustedPath = SessionState.Path.Combine(".", adjustedPath);
                             }
-                            WriteObject(adjustedPath, false);
+                            WriteObject(sendToPipeline: adjustedPath, enumerateCollection: false);
                         }
                     }
                 }
@@ -162,7 +162,7 @@ namespace Microsoft.PowerShell.Commands
 
                 if (!_relative)
                 {
-                    WriteObject(result, true);
+                    WriteObject(sendToPipeline: result, enumerateCollection: true);
                 }
             }
         } // ProcessRecord

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Resolve-Path.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Resolve-Path.Tests.ps1
@@ -16,7 +16,7 @@ Describe "Resolve-Path returns proper path" -Tag "CI" {
         )
     }
     AfterAll {
-        Remove-PSDrive -Name $driveName
+        Remove-PSDrive -Name $driveName -Force
     }
     It "Resolve-Path returns resolved paths" {
         Resolve-Path $TESTDRIVE | Should be "$TESTDRIVE"
@@ -46,7 +46,7 @@ Describe "Resolve-Path returns proper path" -Tag "CI" {
         param($wd, $target, $expected)
         try {
             Push-Location -Path $wd
-            Resolve-Path -Path $target -Relative | Should BeExactly $expected
+            Resolve-Path -Path $target -Relative | Should -BeExactly $expected
         }
         finally {
             Pop-Location

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Resolve-Path.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Resolve-Path.Tests.ps1
@@ -24,9 +24,10 @@ Describe "Resolve-Path returns proper path" -Tag "CI" {
         ($result.Path.TrimEnd('/\')) | Should Be "TestDrive:"
     }
     It "Resolve-Path -Relative should return correct path on different drive" {
-        $base = Join-Path "TestDrive:" "ResolvePath.relative"
+        $base = Join-Path $TestDrive "ResolvePath.relative"
         $root = Join-Path $base "fakeroot"
         $file = Join-Path $root "file.txt"
+        $expectedFilePath = Join-Path "." "fakeroot" "file.txt"
         $driveName = "RvpaTest"
         $null = New-Item -Path $base -ItemType Directory -Force
         $null = New-Item -Path $root -ItemType Directory -Force
@@ -36,14 +37,14 @@ Describe "Resolve-Path returns proper path" -Tag "CI" {
         $driveFile = Join-Path "$driveName`:" "file.txt"
         try {
             Push-Location -Path $driveRoot
-            Resolve-Path -Path $base -Relative | Should Be $base
+            Resolve-Path -Path $base -Relative | Should BeExactly $base
         }
         finally {
             Pop-Location
         }
         try {
             Push-Location -Path $base
-            Resolve-Path -Path $driveFile -Relative | Should Be $(Resolve-Path -Path $file -Relative)
+            Resolve-Path -Path $driveFile -Relative | Should BeExactly $expectedFilePath
         }
         finally {
             Pop-Location

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Resolve-Path.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Resolve-Path.Tests.ps1
@@ -23,7 +23,9 @@ Describe "Resolve-Path returns proper path" -Tag "CI" {
         $result = Resolve-Path -LiteralPath "TestDrive:\\\\\"
         ($result.Path.TrimEnd('/\')) | Should Be "TestDrive:"
     }
-    It "Resolve-Path -Relative should return correct path on different drive" -Skip:(!$IsWindows) {
-        Resolve-Path -Path "HKCU:\Software" -Relative | Should Be "HKCU:\Software"
+    It "Resolve-Path -Relative should return correct path on different drive" {
+        $item = Join-Path "TestDrive:" "ResolvePath.relative"
+        $null = New-Item -Path $item -ItemType File -Force
+        Resolve-Path -Path $item -Relative | Should Be $item
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Resolve-Path.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Resolve-Path.Tests.ps1
@@ -16,7 +16,7 @@ Describe "Resolve-Path returns proper path" -Tag "CI" {
         )
     }
     AfterAll {
-        Remove-PSDrive -Name $driveName -PSProvider FileSystem
+        Remove-PSDrive -Name $driveName
     }
     It "Resolve-Path returns resolved paths" {
         Resolve-Path $TESTDRIVE | Should be "$TESTDRIVE"
@@ -42,7 +42,7 @@ Describe "Resolve-Path returns proper path" -Tag "CI" {
         $result = Resolve-Path -LiteralPath "TestDrive:\\\\\"
         ($result.Path.TrimEnd('/\')) | Should Be "TestDrive:"
     }
-    It "Resolve-Path -Relative should return correct path on different drive" -TestCases $relCases {
+    It "Resolve-Path -Relative '<target>' should return correct path on '<wd>'" -TestCases $relCases {
         param($wd, $target, $expected)
         try {
             Push-Location -Path $wd

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Resolve-Path.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Resolve-Path.Tests.ps1
@@ -23,4 +23,7 @@ Describe "Resolve-Path returns proper path" -Tag "CI" {
         $result = Resolve-Path -LiteralPath "TestDrive:\\\\\"
         ($result.Path.TrimEnd('/\')) | Should Be "TestDrive:"
     }
+    It "Resolve-Path -Relative should return correct path on different drive" -Skip:(!$IsWindows) {
+        Resolve-Path -Path "HKCU:\Software" -Relative | Should Be "HKCU:\Software"
+    }
 }


### PR DESCRIPTION
## PR Summary

Check to make sure the result path is relative before inserting `"./"`
Do not return `"(../)*path"` that would go outside of current root directory

## PR Checklist

Note: Please mark anything not applicable to this PR `NA`.

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [x] Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] User facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [x] `NA` Issue filed - Issue link:
- [ ] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
    - [x] [Add `[feature]` if the change is significant or affectes feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.

  