### PR TITLE
Add Count and Length properties to [PSCustomobject]

### DIFF
--- a/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
+++ b/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
@@ -5690,6 +5690,11 @@ namespace System.Management.Automation.Language
                 return memberInfo.Value;
             }
 
+            if (string.Equals(member, "Length", StringComparison.OrdinalIgnoreCase) || string.Equals(member, "Count", StringComparison.OrdinalIgnoreCase))
+            {
+                return 1;
+            }
+
             if (context != null && context.IsStrictVersion(2))
             {
                 // If the member is undefined and we're in strict mode, throw an exception...

--- a/test/powershell/engine/ETS/Adapter.Tests.ps1
+++ b/test/powershell/engine/ETS/Adapter.Tests.ps1
@@ -112,6 +112,27 @@ Describe "Adapter Tests" -tags "CI" {
             Remove-TypeData TestCodeMethodInvokationWithVoidReturn
         }
     }
+
+    It "Count and length property works for singletons" {
+        $x = 5
+        $x.Count | Should Be 1
+        $x.Length | Should Be 1
+
+        $null.Count | Should Be 0
+        $null.Length | Should Be 0
+
+        (10).Count | Should Be 1
+        (10).Length | Should Be 1
+
+        ("a").Count | Should Be 1
+        ("a").Length | Should Be 1
+
+        ([psobject] @{ foo = 'bar' }).Count | Should Be 1
+        ([psobject] @{ foo = 'bar' }).Length | Should Be 1
+
+        ([pscustomobject] @{ foo = 'bar' }).Count | Should Be 1
+        ([pscustomobject] @{ foo = 'bar' }).Length | Should Be 1
+    }
 }
 
 Describe "Adapter XML Tests" -tags "CI" {

--- a/test/powershell/engine/ETS/Adapter.Tests.ps1
+++ b/test/powershell/engine/ETS/Adapter.Tests.ps1
@@ -114,6 +114,7 @@ Describe "Adapter Tests" -tags "CI" {
     }
 
     It "Count and length property works for singletons" {
+        # Return magic Count and Length property if it absent.
         $x = 5
         $x.Count | Should Be 1
         $x.Length | Should Be 1
@@ -125,13 +126,18 @@ Describe "Adapter Tests" -tags "CI" {
         (10).Length | Should Be 1
 
         ("a").Count | Should Be 1
-        ("a").Length | Should Be 1
+        # The Length property exists for strings, so we skip the test in the context.
+        # ("a").Length | Should Be 1
 
         ([psobject] @{ foo = 'bar' }).Count | Should Be 1
         ([psobject] @{ foo = 'bar' }).Length | Should Be 1
 
         ([pscustomobject] @{ foo = 'bar' }).Count | Should Be 1
         ([pscustomobject] @{ foo = 'bar' }).Length | Should Be 1
+
+        # Return real Count and Length property if it present.
+        ([pscustomobject] @{ foo = 'bar'; count = 5 }).Count | Should Be 5
+        ([pscustomobject] @{ foo = 'bar'; length = 5 }).Length | Should Be 5
     }
 }
 


### PR DESCRIPTION
## PR Summary
Related #3671 

- Add Count and Length properties to [PSCustomobject].
Now following works with singletons and returns 1:
    ([pscustomobject] @{ foo = 'bar' }).Count
    ([pscustomobject] @{ foo = 'bar' }).Length
- Add tests

## PR Checklist

Note: Please mark anything not applicable to this PR `NA`.

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [x] Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [NA] User facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [NA] Issue filed - Issue link:
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
    - [NA] [Add `[feature]` if the change is significant or affectes feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
