### PR TITLE
Fail AppVeyor Build if MSI does not build

### DIFF
--- a/assets/Product.wxs
+++ b/assets/Product.wxs
@@ -124,7 +124,7 @@
             <Shortcut Id="PowerShell_ProgramsMenuShortcut" Name="$(var.ProductSemanticVersionWithName)" Description="$(var.ProductSemanticVersionWithName)" Target="[$(var.ProductVersionWithName)]pwsh.exe" WorkingDirectory="$(var.ProductVersionWithName)"
               Icon = "PowerShellExe.ico" />
             <RemoveFolder Id="ApplicationProgramsFolder" On="uninstall"/>
-            <RegistryValue Root="HKCU" Key="Software\Microsoft\$(var.ProductSemanticVersionWithName)\ProgramsMenuShortcut" Name="installed" Type="integer" Value="1" KeyPath="yes"//>
+            <RegistryValue Root="HKCU" Key="Software\Microsoft\$(var.ProductSemanticVersionWithName)\ProgramsMenuShortcut" Name="installed" Type="integer" Value="1" KeyPath="yes"/>
           </Component>
         </Directory>
       </Directory>

--- a/assets/Product.wxs
+++ b/assets/Product.wxs
@@ -123,7 +123,7 @@
           <Component Id="ApplicationProgramsMenuShortcut" Guid="{A77507A7-F970-4618-AC30-20AFE36EE2EB}">
             <Shortcut Id="PowerShell_ProgramsMenuShortcut" Name="$(var.ProductSemanticVersionWithName)" Description="$(var.ProductSemanticVersionWithName)" Target="[$(var.ProductVersionWithName)]pwsh.exe" WorkingDirectory="$(var.ProductVersionWithName)"
               Icon = "PowerShellExe.ico" />
-            <RemoveFolder Id="ApplicationProgramsFolder" On="uninstall"//>
+            <RemoveFolder Id="ApplicationProgramsFolder" On="uninstall"/>
             <RegistryValue Root="HKCU" Key="Software\Microsoft\$(var.ProductSemanticVersionWithName)\ProgramsMenuShortcut" Name="installed" Type="integer" Value="1" KeyPath="yes"/>
           </Component>
         </Directory>

--- a/assets/Product.wxs
+++ b/assets/Product.wxs
@@ -123,7 +123,7 @@
           <Component Id="ApplicationProgramsMenuShortcut" Guid="{A77507A7-F970-4618-AC30-20AFE36EE2EB}">
             <Shortcut Id="PowerShell_ProgramsMenuShortcut" Name="$(var.ProductSemanticVersionWithName)" Description="$(var.ProductSemanticVersionWithName)" Target="[$(var.ProductVersionWithName)]pwsh.exe" WorkingDirectory="$(var.ProductVersionWithName)"
               Icon = "PowerShellExe.ico" />
-            <RemoveFolder Id="ApplicationProgramsFolder" On="uninstall"/>
+            <RemoveFolder Id="ApplicationProgramsFolder" On="uninstall"//>
             <RegistryValue Root="HKCU" Key="Software\Microsoft\$(var.ProductSemanticVersionWithName)\ProgramsMenuShortcut" Name="installed" Type="integer" Value="1" KeyPath="yes"/>
           </Component>
         </Directory>

--- a/assets/Product.wxs
+++ b/assets/Product.wxs
@@ -124,7 +124,7 @@
             <Shortcut Id="PowerShell_ProgramsMenuShortcut" Name="$(var.ProductSemanticVersionWithName)" Description="$(var.ProductSemanticVersionWithName)" Target="[$(var.ProductVersionWithName)]pwsh.exe" WorkingDirectory="$(var.ProductVersionWithName)"
               Icon = "PowerShellExe.ico" />
             <RemoveFolder Id="ApplicationProgramsFolder" On="uninstall"/>
-            <RegistryValue Root="HKCU" Key="Software\Microsoft\$(var.ProductSemanticVersionWithName)\ProgramsMenuShortcut" Name="installed" Type="integer" Value="1" KeyPath="yes"/>
+            <RegistryValue Root="HKCU" Key="Software\Microsoft\$(var.ProductSemanticVersionWithName)\ProgramsMenuShortcut" Name="installed" Type="integer" Value="1" KeyPath="yes"//>
           </Component>
         </Directory>
       </Directory>

--- a/build.psm1
+++ b/build.psm1
@@ -2179,6 +2179,7 @@ function New-MSIPackage
         $WiXHeatLog   | Out-String | Write-Verbose -Verbose
         $WiXCandleLog | Out-String | Write-Verbose -Verbose
         $WiXLightLog  | Out-String | Write-Verbose -Verbose
+        $host.SetShouldExit(-1)
         throw "Failed to create $msiLocationPath"
     }
 }

--- a/build.psm1
+++ b/build.psm1
@@ -2179,11 +2179,12 @@ function New-MSIPackage
         $WiXHeatLog   | Out-String | Write-Verbose -Verbose
         $WiXCandleLog | Out-String | Write-Verbose -Verbose
         $WiXLightLog  | Out-String | Write-Verbose -Verbose
+        $errorMessage = "Failed to create $msiLocationPath"
         if ($null -ne $env:CI)
         {
-           $host.SetShouldExit(-1)
+           Add-AppveyorCompilationMessage $errorMessage -Category Error -FileName $MyInvocation.ScriptName -Line $MyInvocation.ScriptLineNumber
         }
-        throw "Failed to create $msiLocationPath"
+        throw $errorMessage
     }
 }
 

--- a/build.psm1
+++ b/build.psm1
@@ -2179,7 +2179,10 @@ function New-MSIPackage
         $WiXHeatLog   | Out-String | Write-Verbose -Verbose
         $WiXCandleLog | Out-String | Write-Verbose -Verbose
         $WiXLightLog  | Out-String | Write-Verbose -Verbose
-        $host.SetShouldExit(-1)
+        if ($null -ne $env:CI)
+        {
+           $host.SetShouldExit(-1)
+        }
         throw "Failed to create $msiLocationPath"
     }
 }


### PR DESCRIPTION
## PR Summary

Before this PR, when a `WiX` compilation error occurs then an error is thrown, which appears in the log with details but the AppVeyor build itself is still marked as green.
This PR makes the console host also return an exit code of -1 when being run on `AppVeyor` so that it can then interpret it as a build failure and mark the build as red. It uses the fact that AppVeyor defines an environment variable named CI. Exiting is OK since the MSI build is the last step in CI and nothing happens after that.
The git history shows a test build that proves that this works if the installer was broken.

## PR Checklist

Note: Please mark anything not applicable to this PR `NA`.

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [x] Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [NA] User facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [NA] Issue filed - Issue link:
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [NA] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
    - [ NA] [Add `[feature]` if the change is significant or affectes feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
- [] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
