### PR TITLE
Cleanup temporarily created WiX files after compilation to be able to have a clean re-build

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -2148,9 +2148,9 @@ function New-MSIPackage
     }
     [Environment]::SetEnvironmentVariable("ProductProgFilesDir", $ProductProgFilesDir, "Process")
 
-    $wixFragmentPath = Join-path $env:Temp "Fragment.wxs"
-    $wixObjProductPath = Join-path $env:Temp "Product.wixobj"
-    $wixObjFragmentPath = Join-path $env:Temp "Fragment.wixobj"
+    $wixFragmentPath = Join-Path $env:Temp "Fragment.wxs"
+    $wixObjProductPath = Join-Path $env:Temp "Product.wixobj"
+    $wixObjFragmentPath = Join-Path $env:Temp "Fragment.wixobj"
 
     $packageName = $productSemanticVersionWithName
     if ($ProductNameSuffix) {

--- a/build.psm1
+++ b/build.psm1
@@ -2148,9 +2148,9 @@ function New-MSIPackage
     }
     [Environment]::SetEnvironmentVariable("ProductProgFilesDir", $ProductProgFilesDir, "Process")
 
-    $wixFragmentPath = (Join-path $env:Temp "Fragment.wxs")
-    $wixObjProductPath = (Join-path $env:Temp "Product.wixobj")
-    $wixObjFragmentPath = (Join-path $env:Temp "Fragment.wixobj")
+    $wixFragmentPath = Join-path $env:Temp "Fragment.wxs"
+    $wixObjProductPath = Join-path $env:Temp "Product.wixobj"
+    $wixObjFragmentPath = Join-path $env:Temp "Fragment.wixobj"
 
     $packageName = $productSemanticVersionWithName
     if ($ProductNameSuffix) {
@@ -2168,6 +2168,9 @@ function New-MSIPackage
     $WiXLightLog = & $wixLightExePath -out $msiLocationPath $wixObjProductPath $wixObjFragmentPath -ext WixUIExtension -ext WixUtilExtension -dWixUILicenseRtf="$LicenseFilePath" -v
 
     Remove-Item -ErrorAction SilentlyContinue *.wixpdb -Force
+    Remove-Item -ErrorAction SilentlyContinue $wixFragmentPath -Force
+    Remove-Item -ErrorAction SilentlyContinue $wixObjProductPath -Force
+    Remove-Item -ErrorAction SilentlyContinue $wixObjFragmentPath -Force
 
     if (Test-Path $msiLocationPath)
     {


### PR DESCRIPTION
## PR Summary

When changing the WiX installer locally and rebuilding the MSI one can get into the terrible situation whereby a code change does not get compiled into the new MSI.
This PR fixes the root cause of it, which is due to temporary WiX files that are created but not deleted after compilation and WiX then somehow decides to not recompile properly.

I also removed redundant parenthesis of surrounding code.

## PR Checklist

Note: Please mark anything not applicable to this PR `NA`.

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [x] Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [NA] User facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [NA] Issue filed - Issue link:
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [NA] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
    - [NA] [Add `[feature]` if the change is significant or affectes feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
