### PR TITLE
Build.psm1 - Update Restore-PSPester to include the fix for nested describe errors

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -673,7 +673,7 @@ function Restore-PSPester
         $Destination = ([IO.Path]::Combine((Split-Path (Get-PSOptions -DefaultToNew).Output), "Modules"))
     )
 
-    Restore-GitModule -Destination $Destination -Uri 'https://github.com/PowerShell/psl-pester' -Name Pester -CommitSha 'aa243108e7da50a8cf82513b6dd649b653c70b0e'
+    Restore-GitModule -Destination $Destination -Uri 'https://github.com/PowerShell/psl-pester' -Name Pester -CommitSha '87f531db89a91db86736ac11b4e565ad10c3e334'
 }
 function Compress-TestContent {
     [CmdletBinding()]

--- a/build.psm1
+++ b/build.psm1
@@ -673,7 +673,7 @@ function Restore-PSPester
         $Destination = ([IO.Path]::Combine((Split-Path (Get-PSOptions -DefaultToNew).Output), "Modules"))
     )
 
-    Restore-GitModule -Destination $Destination -Uri 'https://github.com/PowerShell/psl-pester' -Name Pester -CommitSha '87f531db89a91db86736ac11b4e565ad10c3e334'
+    Restore-GitModule -Destination $Destination -Uri 'https://github.com/PowerShell/psl-pester' -Name Pester -CommitSha '1f546b6aaa0893e215e940a14f57c96f56f7eff1'
 }
 function Compress-TestContent {
     [CmdletBinding()]


### PR DESCRIPTION
## PR Summary
Update Restore-PSPester to include PR https://github.com/PowerShell/psl-pester/pull/12 that fixes https://github.com/PowerShell/psl-pester/issues/11 - unhandled exceptions in before/after bypasses Pester's enddescribe logic.

## PR Checklist

Note: Please mark anything not applicable to this PR `NA`.

- [X] [PR has a meaningful title]
    - [X] Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes]
- [ NA] User facing [Documentation needed]
- [X] Issue filed - Issue link: https://github.com/PowerShell/psl-pester/issues/11
- [X] [Change is not breaking]
- [NA ] [Make sure you've added a new test if existing tests do not effectively test the code changed]
    - [NA ] [Add `[feature]` if the change is significant or affectes feature tests]
- [X] This PR is ready to merge and is not [Work in Progress]

  