### PR TITLE
Developer documentation update for git submodules

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -104,7 +104,7 @@ that new packages' binaries get stomped on by old packages' binaries.
 
 ## Why is my submodule empty?
 
-If a submodule (such as `src/Modules/Pester`) is empty, that means it is
+If a submodule (such as `src/libpsl-native/test/googletest`) is empty, that means it is
 uninitialized.
 If you've already cloned, you can do this with:
 
@@ -122,14 +122,12 @@ git submodule status
 If they're initialized, it will look like this:
 
 ```output
-f23641488f8d7bf8630ca3496e61562aa3a64009 src/Modules/Pester (f23641488)
 c99458533a9b4c743ed51537e25989ea55944908 src/libpsl-native/test/googletest (release-1.7.0)
 ```
 
 If they're not, there will be minuses in front (and the folders will be empty):
 
 ```output
--f23641488f8d7bf8630ca3496e61562aa3a64009 src/Modules/Pester (f23641488)
 -c99458533a9b4c743ed51537e25989ea55944908 src/libpsl-native/test/googletest (release-1.7.0)
 ```
 


### PR DESCRIPTION
## PR Summary
 Since Pester is not a submodule any more, replace submodule example in git submodule docs/FAQ.md with the only left over submodule src/libpsl-native/test/googletest

## PR Checklist

Note: Please mark anything not applicable to this PR `NA`.

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [x] Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] NA User facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [ ] NA Issue filed - Issue link:
- [x] NA [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [ ] NA [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
    - [ ] NA [Add `[feature]` if the change is significant or affectes feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
