### PR TITLE
Remove sc alias which conflicts with sc.exe

### DIFF
--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -4687,13 +4687,14 @@ end
                     new SessionStateAliasEntry("type", "Get-Content"),
                     // Native commands we keep because the functions act correctly on Linux
                     new SessionStateAliasEntry("clear", "Clear-Host"),
-//#if !CORECLR is used to disable aliases for cmdlets which are not available on OneCore
+//#if !CORECLR is used to disable aliases for cmdlets which are not available on OneCore or not appropriate for PSCore6 due to conflicts
 #if !CORECLR
                     new SessionStateAliasEntry("gwmi", "Get-WmiObject", "", ReadOnly),
                     new SessionStateAliasEntry("iwmi", "Invoke-WMIMethod", "", ReadOnly),
                     new SessionStateAliasEntry("ogv", "Out-GridView", "", ReadOnly),
                     new SessionStateAliasEntry("ise", "powershell_ise.exe", "", ReadOnly),
                     new SessionStateAliasEntry("rwmi", "Remove-WMIObject", "", ReadOnly),
+                    new SessionStateAliasEntry("sc", "Set-Content", "", ReadOnly),
                     new SessionStateAliasEntry("swmi", "Set-WMIInstance", "", ReadOnly),
                     new SessionStateAliasEntry("shcm", "Show-Command", "", ReadOnly),
                     new SessionStateAliasEntry("trcm", "Trace-Command", "", ReadOnly),

--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -4639,7 +4639,6 @@ end
                     new SessionStateAliasEntry("rvpa", "Resolve-Path", "", ReadOnly),
                     new SessionStateAliasEntry("sal", "Set-Alias", "", ReadOnly),
                     new SessionStateAliasEntry("sbp", "Set-PSBreakpoint", "", ReadOnly),
-                    new SessionStateAliasEntry("sc", "Set-Content", "", ReadOnly),
                     new SessionStateAliasEntry("select", "Select-Object", "", ReadOnly_AllScope),
                     new SessionStateAliasEntry("si", "Set-Item", "", ReadOnly),
                     new SessionStateAliasEntry("sl", "Set-Location", "", ReadOnly),

--- a/test/powershell/engine/Basic/DefaultCommands.Tests.ps1
+++ b/test/powershell/engine/Basic/DefaultCommands.Tests.ps1
@@ -143,7 +143,7 @@ Describe "Verify approved aliases list" -Tags "CI" {
 "Alias",  "saps",                               "Start-Process",                      $($FullCLR -or $CoreWindows -or $CoreUnix),   "ReadOnly",         ""
 "Alias",  "sasv",                               "Start-Service",                      $($FullCLR -or $CoreWindows              ),   "ReadOnly",         ""
 "Alias",  "sbp",                                "Set-PSBreakpoint",                   $($FullCLR -or $CoreWindows -or $CoreUnix),   "ReadOnly",         ""
-"Alias",  "sc",                                 "Set-Content",                        $($FullCLR -or $CoreWindows -or $CoreUnix),   "ReadOnly",         ""
+"Alias",  "sc",                                 "Set-Content",                        $($FullCLR                               ),   "ReadOnly",         ""
 "Alias",  "scb",                                "Set-Clipboard",                      $($FullCLR                               ),   "ReadOnly",         ""
 "Alias",  "select",                             "Select-Object",                      $($FullCLR -or $CoreWindows -or $CoreUnix),   "ReadOnly",         "AllScope"
 "Alias",  "set",                                "Set-Variable",                       $($FullCLR -or $CoreWindows -or $CoreUnix),   "",                 ""


### PR DESCRIPTION
## PR Summary

SC is a default alias for Set-Content, however on Windows there is a sc.exe command for managing NT Services.
If a user executes `sc start service1` in a PowerShell script, what happens is that a file called `start` is created containing `service1` as the content with no error so the user/script may think the service got started.
In addition, there is also a `sc` command on Linux, although it's not installed by default.
If the customer feedback is that we should not have removed this, it'll be easier to add it back in 6.1.0 than to ever try to remove it after 6.0.0.

Fix is to remove `sc` alias from InitialSessionState and corresponding test case.
This was discussed with some members of @PowerShell/powershell-committee whom agreed to the removal.

Doc change https://github.com/PowerShell/PowerShell-Docs/pull/2021

Fix https://github.com/PowerShell/PowerShell/issues/3980

## PR Checklist

Note: Please mark anything not applicable to this PR `NA`.

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [X] Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] User facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [NA] Issue filed - Issue link:
- [ ] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
    - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.

  
  