### PR TITLE
Cleanup Add-Type

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/AddType.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/AddType.cs
@@ -602,7 +602,7 @@ namespace Microsoft.PowerShell.Commands
                     }
                     break;
                 default:
-                        Diagnostics.Assert(false, "GetUsingSet: Unsupported language family.");
+                    Diagnostics.Assert(false, "GetUsingSet: Unsupported language family.");
                     break;
             }
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/AddType.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/AddType.cs
@@ -602,9 +602,7 @@ namespace Microsoft.PowerShell.Commands
                     }
                     break;
                 default:
-                    {
                         Diagnostics.Assert(false, "GetUsingSet: Unsupported language family.");
-                    }
                     break;
             }
 
@@ -1025,15 +1023,7 @@ namespace Microsoft.PowerShell.Commands
             CSharpParseOptions parseOptions;
             if (Language == Language.CSharp)
             {
-                switch (Language)
-                {
-                    case Language.CSharp:
-                        parseOptions = new CSharpParseOptions();
-                        break;
-                    default:
-                        parseOptions = null;
-                        break;
-                }
+                parseOptions = new CSharpParseOptions();
             }
             else
             {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/AddType.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/AddType.cs
@@ -483,6 +483,12 @@ namespace Microsoft.PowerShell.Commands
         [Parameter()]
         public SwitchParameter PassThru { get; set; }
 
+        /// <summary>
+        /// Flag to ignore warnings during compilation.
+        /// </summary>
+        [Parameter()]
+        public SwitchParameter IgnoreWarnings { get; set; }
+
         #endregion Parameters
 
         #region GererateSource

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/AddType.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/AddType.cs
@@ -33,73 +33,33 @@ namespace Microsoft.PowerShell.Commands
     public enum Language
     {
         /// <summary>
-        /// The C# programming language: latest version.
+        /// The C# programming language.
         /// </summary>
         CSharp,
 
         /// <summary>
-        /// The C# programming language v7
+        /// The Visual Basic programming language.
         /// </summary>
-        CSharpVersion7,
-
-        /// <summary>
-        /// The C# programming language v6
-        /// </summary>
-        CSharpVersion6,
-
-        /// <summary>
-        /// The C# programming language v5
-        /// </summary>
-        CSharpVersion5,
-
-        /// <summary>
-        /// The C# programming language v4
-        /// </summary>
-        CSharpVersion4,
-
-        /// <summary>
-        /// The C# programming language v3 (for Linq, etc)
-        /// </summary>
-        CSharpVersion3,
-
-        /// <summary>
-        /// The C# programming language v2
-        /// </summary>
-        CSharpVersion2,
-
-        /// <summary>
-        /// The C# programming language v1
-        /// </summary>
-        CSharpVersion1,
-
-        /// <summary>
-        /// The Visual Basic programming language
-        /// </summary>
-        VisualBasic,
-
-        /// <summary>
-        /// The Managed JScript programming language
-        /// </summary>
-        JScript,
+        VisualBasic
     }
 
     /// <summary>
-    /// Types supported for the OutputAssembly parameter
+    /// Types supported for the OutputAssembly parameter.
     /// </summary>
     public enum OutputAssemblyType
     {
         /// <summary>
-        /// A Dynamically linked library (DLL)
+        /// A Dynamically linked library (DLL).
         /// </summary>
         Library,
 
         /// <summary>
-        /// An executable application that targets the console subsystem
+        /// An executable application that targets the console subsystem.
         /// </summary>
         ConsoleApplication,
 
         /// <summary>
-        /// An executable application that targets the graphical subsystem
+        /// An executable application that targets the graphical subsystem.
         /// </summary>
         WindowsApplication
     }
@@ -148,6 +108,8 @@ namespace Microsoft.PowerShell.Commands
     [OutputType(typeof(Type))]
     public sealed class AddTypeCommand : PSCmdlet
     {
+        #region Parameters
+
         /// <summary>
         /// The source code of this type.
         /// </summary>
@@ -320,10 +282,6 @@ namespace Microsoft.PowerShell.Commands
 
                     case ".VB":
                         Language = Language.VisualBasic;
-                        break;
-
-                    case ".JS":
-                        Language = Language.JScript;
                         break;
 
                     case ".DLL":
@@ -525,11 +483,9 @@ namespace Microsoft.PowerShell.Commands
         [Parameter()]
         public SwitchParameter PassThru { get; set; }
 
-        /// <summary>
-        /// Flag to ignore warnings during compilation.
-        /// </summary>
-        [Parameter()]
-        public SwitchParameter IgnoreWarnings { get; set; }
+        #endregion Parameters
+
+        #region GererateSource
 
         internal string GenerateTypeSource(string typeNamespace, string name, string sourceCode, Language language)
         {
@@ -553,38 +509,17 @@ namespace Microsoft.PowerShell.Commands
             }
         }
 
-        internal bool IsCSharp(Language language)
+        // Get the -FromMember template for a given language
+        private string GetMethodTemplate(Language language)
         {
             switch (language)
             {
                 case Language.CSharp:
-                case Language.CSharpVersion2:
-                case Language.CSharpVersion3:
-                case Language.CSharpVersion1:
-                case Language.CSharpVersion4:
-                case Language.CSharpVersion5:
-                case Language.CSharpVersion6:
-                case Language.CSharpVersion7:
-                    return true;
-                default:
-                    return false;
-            }
-        }
-
-        // Get the -FromMember template for a given language
-        internal string GetMethodTemplate(Language language)
-        {
-            if (IsCSharp(language))
-            {
-                return
-                    "    public class {0}\n" +
-                    "    {{\n" +
-                    "    {1}\n" +
-                    "    }}\n";
-            }
-
-            switch (language)
-            {
+                    return
+                        "    public class {0}\n" +
+                        "    {{\n" +
+                        "    {1}\n" +
+                        "    }}\n";
                 case Language.VisualBasic:
                     return
                         "    public Class {0}\n" +
@@ -592,109 +527,91 @@ namespace Microsoft.PowerShell.Commands
                         "    {1}\n" +
                         "    \n" +
                         "    End Class\n";
-                case Language.JScript:
-                    return
-                        "    public class {0}\n" +
-                        "    {{\n" +
-                        "    {1}\n" +
-                        "    }}\n";
             }
+
+            Diagnostics.Assert(false, "GetMethodTemplate: Unsupported language family.");
+
             return null;
         }
 
         // Get the -FromMember namespace template for a given language
-        internal string GetNamespaceTemplate(Language language)
+        private string GetNamespaceTemplate(Language language)
         {
-            if (IsCSharp(language))
-            {
-                return
-                    "namespace {0}\n" +
-                    "{{\n" +
-                    "{1}\n" +
-                    "}}\n";
-            }
-
             switch (language)
             {
+                case Language.CSharp:
+                    return
+                        "namespace {0}\n" +
+                        "{{\n" +
+                        "{1}\n" +
+                        "}}\n";
                 case Language.VisualBasic:
                     return
                         "Namespace {0}\n" +
                         "\n" +
                         "{1}\n" +
                         "End Namespace\n";
-                case Language.JScript:
-                    return
-                        "package {0}\n" +
-                        "{{\n" +
-                        "{1}\n" +
-                        "}}\n";
             }
+
+            Diagnostics.Assert(false, "GetNamespaceTemplate: Unsupported language family.");
+
             return null;
         }
 
         // Get the -FromMember namespace template for a given language
-        internal string GetUsingTemplate(Language language)
+        private string GetUsingTemplate(Language language)
         {
-            if (IsCSharp(language))
-            {
-                return
-                    "using System;\n" +
-                    "using System.Runtime.InteropServices;\n" +
-                    "{0}" +
-                    "\n";
-            }
-
             switch (language)
             {
+                case Language.CSharp:
+                    return
+                        "using System;\n" +
+                        "using System.Runtime.InteropServices;\n" +
+                        "{0}" +
+                        "\n";
                 case Language.VisualBasic:
                     return
                         "Imports System\n" +
                         "Imports System.Runtime.InteropServices\n" +
                         "{0}" +
                         "\n";
-                case Language.JScript:
-                    return
-                        "import System;\n" +
-                        "import System.Runtime.InteropServices;\n" +
-                        "{0}" +
-                        "\n";
             }
+
+            Diagnostics.Assert(false, "GetUsingTemplate: Unsupported language family.");
+
             return null;
         }
 
         // Generate the code for the using statements
-        internal string GetUsingSet(Language language)
+        private string GetUsingSet(Language language)
         {
             StringBuilder usingNamespaceSet = new StringBuilder();
-            if (IsCSharp(language))
-            {
-                foreach (string namespaceValue in UsingNamespace)
-                {
-                    usingNamespaceSet.Append("using " + namespaceValue + ";\n");
-                }
-            }
-            else
-            {
-                switch (language)
-                {
-                    case Language.VisualBasic:
-                        foreach (string namespaceValue in UsingNamespace)
-                        {
-                            usingNamespaceSet.Append("Imports " + namespaceValue + "\n");
-                        }
-                        break;
 
-                    case Language.JScript:
-                        foreach (string namespaceValue in UsingNamespace)
-                        {
-                            usingNamespaceSet.Append("import " + namespaceValue + ";\n");
-                        }
-                        break;
-                }
+            switch (language)
+            {
+                case Language.CSharp:
+                    foreach (string namespaceValue in UsingNamespace)
+                    {
+                        usingNamespaceSet.Append("using " + namespaceValue + ";\n");
+                    }
+                    break;
+                case Language.VisualBasic:
+                    foreach (string namespaceValue in UsingNamespace)
+                    {
+                        usingNamespaceSet.Append("Imports " + namespaceValue + "\n");
+                    }
+                    break;
+                default:
+                    {
+                        Diagnostics.Assert(false, "GetUsingSet: Unsupported language family.");
+                    }
+                    break;
             }
 
             return usingNamespaceSet.ToString();
         }
+
+        #endregion GererateSource
 
         internal void HandleCompilerErrors(AddTypeCompilerError[] compilerErrors)
         {
@@ -960,7 +877,7 @@ namespace Microsoft.PowerShell.Commands
 
         /// <summary>
         /// Initialize the set of assembly names that should be ignored when they are specified in '-ReferencedAssemblies'.
-        ///   - System.Private.CoreLib.ni.dll - the runtim dll that contains most core/primitive types
+        ///   - System.Private.CoreLib.ni.dll - the runtime dll that contains most core/primitive types
         ///   - System.Private.Uri.dll - the runtime dll that contains 'System.Uri' and related types
         /// Referencing these runtime dlls may cause ambiguous type identity or other issues.
         ///   - System.Runtime.dll - the corresponding reference dll will be automatically included
@@ -1016,7 +933,7 @@ namespace Microsoft.PowerShell.Commands
             if (!assembly.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
             {
                 // It could be a short assembly name or a full assembly name, but we
-                // alwasy want the short name to find the corresponding assembly file.
+                // always want the short name to find the corresponding assembly file.
                 var assemblyName = new AssemblyName(assembly);
                 refAssemblyDll = assemblyName.Name + ".dll";
             }
@@ -1106,31 +1023,10 @@ namespace Microsoft.PowerShell.Commands
         private void CompileSourceToAssembly(string source)
         {
             CSharpParseOptions parseOptions;
-            if (IsCSharp(Language))
+            if (Language == Language.CSharp)
             {
                 switch (Language)
                 {
-                    case Language.CSharpVersion1:
-                        parseOptions = new CSharpParseOptions(LanguageVersion.CSharp1);
-                        break;
-                    case Language.CSharpVersion2:
-                        parseOptions = new CSharpParseOptions(LanguageVersion.CSharp2);
-                        break;
-                    case Language.CSharpVersion3:
-                        parseOptions = new CSharpParseOptions(LanguageVersion.CSharp3);
-                        break;
-                    case Language.CSharpVersion4:
-                        parseOptions = new CSharpParseOptions(LanguageVersion.CSharp4);
-                        break;
-                    case Language.CSharpVersion5:
-                        parseOptions = new CSharpParseOptions(LanguageVersion.CSharp5);
-                        break;
-                    case Language.CSharpVersion6:
-                        parseOptions = new CSharpParseOptions(LanguageVersion.CSharp6);
-                        break;
-                    case Language.CSharpVersion7:
-                        parseOptions = new CSharpParseOptions(LanguageVersion.CSharp7);
-                        break;
                     case Language.CSharp:
                         parseOptions = new CSharpParseOptions();
                         break;

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Add-Type.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Add-Type.Tests.ps1
@@ -34,7 +34,7 @@ Describe "Add-Type" -Tags "CI" {
     }
 
     It "Public 'Language' enumeration contains all members" {
-        [Enum]::GetNames("Microsoft.PowerShell.Commands.Language") -join "," | Should Be "CSharp,CSharpVersion7,CSharpVersion6,CSharpVersion5,CSharpVersion4,CSharpVersion3,CSharpVersion2,CSharpVersion1,VisualBasic,JScript"
+        [Enum]::GetNames("Microsoft.PowerShell.Commands.Language") -join "," | Should Be "CSharp,VisualBasic"
     }
 
     It "Should not throw given a simple class definition" {


### PR DESCRIPTION
## PR Summary
Related #5725.

It's part of the big PR I'm trying to break into smaller pieces.
Subsequent PRs will focus on enhancements.

- Remove CSharp language versions and JScript from Language enum. Later we can use Roslyn parse option if we need set a language version. JScript is not in Roslyn. It is a breaking change (Approved by @SteveL-MSFT in #5725).
- Correct comments.
- Remove IgnoreWarnings parameter.  It is not implemented and no plans do that. We could use the standard parameter `WarningAction` if we'll need.

## PR Checklist

Note: Please mark anything not applicable to this PR `NA`.

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [x] Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [NA] User facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [NA] Issue filed - Issue link:
- [ ] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
    - [NA] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
