### PR TITLE
NativeCommandParameterBinder.appendOneNativeArgument: Remove overly restrictive Diagnostics.Assert - cannot handle -encodedarguments

### DIFF
--- a/src/System.Management.Automation/engine/MinishellParameterBinderController.cs
+++ b/src/System.Management.Automation/engine/MinishellParameterBinderController.cs
@@ -197,7 +197,9 @@ namespace System.Management.Automation
                         var argsArg = parameters[i];
                         var encodedArgs = ConvertArgsValueToEncodedString(argsArg.ArgumentValue);
                         parameters[i - 1] = CommandParameterInternal.CreateParameter(EncodedArgsParameter, "-" + EncodedArgsParameter, parameter.ParameterAst);
-                        parameters[i] = CommandParameterInternal.CreateArgument(encodedArgs, argsArg.ArgumentAst);
+                        // NOTE: do not pass the ArgumentAst; it will fail validation in BindParameters if there
+                        // are multiple arguments (array) but encodedArgs is an encoded string.
+                        parameters[i] = CommandParameterInternal.CreateArgument(encodedArgs);
                     }
                 }
                 else


### PR DESCRIPTION
Fixes https://github.com/PowerShell/PowerShell/issues/5733
Parameter binding has an assert that expects the argument value to be an array when the AST for the argument is an array.  This assertion fails when the argument is encoded, such as when the -encodedarguments command-line parameter is used.  The assert causes a process crash when running tests for debug builds.

The fix removes this assert since the method does not know the name of the argument being bound.

## PR Checklist

Note: Please mark anything not applicable to this PR `NA`.

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [X] Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ NA] User facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [NA] Issue filed 
- [X] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [ NA] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
    - [X] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.

  