### PR TITLE
CimDscParser: Add better error message when a file is not found

### DIFF
--- a/src/System.Management.Automation/DscSupport/CimDSCParser.cs
+++ b/src/System.Management.Automation/DscSupport/CimDSCParser.cs
@@ -368,7 +368,8 @@ namespace Microsoft.PowerShell.DesiredStateConfiguration
 
             if (!File.Exists(fullFilePath))
             {
-                throw PSTraceSource.NewArgumentException("fullFilePath");
+                var errorMessage = string.Format(CultureInfo.CurrentCulture, ParserStrings.FileNotFound, fullFilePath);
+                throw PSTraceSource.NewArgumentException("fullFilePath", errorMessage);
             }
 
             using (FileStream fs = File.OpenRead(fullFilePath))

--- a/src/System.Management.Automation/DscSupport/CimDSCParser.cs
+++ b/src/System.Management.Automation/DscSupport/CimDSCParser.cs
@@ -369,7 +369,7 @@ namespace Microsoft.PowerShell.DesiredStateConfiguration
             if (!File.Exists(fullFilePath))
             {
                 var errorMessage = string.Format(CultureInfo.CurrentCulture, ParserStrings.FileNotFound, fullFilePath);
-                throw PSTraceSource.NewArgumentException("fullFilePath", errorMessage);
+                throw PSTraceSource.NewArgumentException(nameof(fullFilePath), errorMessage);
             }
 
             using (FileStream fs = File.OpenRead(fullFilePath))


### PR DESCRIPTION
## PR Summary

- Make DSC Parser say what file it cannot find when it cannot find a file

Filed doc issue to document that the error indicates that WMF 5.1 is needed to run this code.

## PR Checklist

Note: Please mark anything not applicable to this PR `NA`.

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [x] Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] User facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [x] Issue filed - Issue link: https://github.com/PowerShell/PowerShell-Docs/issues/2025
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [NA] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
    - [NA] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.

  
  