### PR TITLE
Set-Location should use path with wildcard characters if it exists instead of globbing

### DIFF
--- a/src/System.Management.Automation/engine/SessionStateLocationAPIs.cs
+++ b/src/System.Management.Automation/engine/SessionStateLocationAPIs.cs
@@ -287,12 +287,6 @@ namespace System.Management.Automation
 
             Collection<PathInfo> workingPath = null;
 
-            // if the directory exists, it might contain wildcard characters, so suppress wildcard expansion
-            if (Utils.NativeDirectoryExists(path))
-            {
-                context.SuppressWildcardExpansion = true;
-            }
-
             try
             {
                 workingPath =

--- a/src/System.Management.Automation/engine/SessionStateLocationAPIs.cs
+++ b/src/System.Management.Automation/engine/SessionStateLocationAPIs.cs
@@ -287,6 +287,12 @@ namespace System.Management.Automation
 
             Collection<PathInfo> workingPath = null;
 
+            // if the directory exists, it might contain wildcard characters, so suppress wildcard expansion
+            if (Utils.NativeDirectoryExists(path))
+            {
+                context.SuppressWildcardExpansion = true;
+            }
+
             try
             {
                 workingPath =

--- a/src/System.Management.Automation/namespaces/LocationGlobber.cs
+++ b/src/System.Management.Automation/namespaces/LocationGlobber.cs
@@ -502,7 +502,8 @@ namespace System.Management.Automation
 
             Collection<string> stringResult = new Collection<string>();
 
-            if (!context.SuppressWildcardExpansion)
+            // if the directory contains wildcard characters, but exists, just return it
+            if (!context.SuppressWildcardExpansion && !Utils.NativeDirectoryExists(userPath))
             {
                 // See if the provider will expand the wildcard
                 if (CmdletProviderManagementIntrinsics.CheckProviderCapabilities(

--- a/src/System.Management.Automation/namespaces/LocationGlobber.cs
+++ b/src/System.Management.Automation/namespaces/LocationGlobber.cs
@@ -502,8 +502,21 @@ namespace System.Management.Automation
 
             Collection<string> stringResult = new Collection<string>();
 
-            // if the directory contains wildcard characters, but exists, just return it
-            if (!context.SuppressWildcardExpansion && !Utils.NativeDirectoryExists(userPath))
+            // if the directory exists, just return it
+            try
+            {
+                if (Utils.NativeDirectoryExists(userPath))
+                {
+                    result.Add(new PathInfo(drive, provider, userPath, _sessionState));
+                    return result;
+                }
+            }
+            catch
+            {
+                // in cases of Access Denied or other errors, fallback to previous behavior and let provider handle it
+            }
+
+            if (!context.SuppressWildcardExpansion)
             {
                 // See if the provider will expand the wildcard
                 if (CmdletProviderManagementIntrinsics.CheckProviderCapabilities(

--- a/test/powershell/Host/Base-Directory.Tests.ps1
+++ b/test/powershell/Host/Base-Directory.Tests.ps1
@@ -118,6 +118,7 @@ Describe "Configuration file locations" -tags "CI","Slow" {
 
 Describe "Working directory on startup" -Tag "CI" {
     BeforeAll {
+        $powershell = Join-Path -Path $PSHOME -ChildPath "pwsh"
         $testPath = New-Item -ItemType Directory -Path "$TestDrive\test[dir]"
         $currentDirectory = Get-Location
     }
@@ -128,6 +129,12 @@ Describe "Working directory on startup" -Tag "CI" {
 
     It "Can start in directory where name contains wildcard characters" {
         Set-Location -LiteralPath $testPath.FullName
-        & $powershell -noprofile -c get-location | Should BeExactly $testPath.FullName
+        if ($IsMacOS) {
+            # on macOS, /tmp is a symlink to /private so the real path is under /private/tmp
+            $expectedPath = "/private" + $testPath.FullName
+        } else {
+            $expectedPath = $testPath.FullName
+        }
+        & $powershell -noprofile -c { $PWD.Path } | Should BeExactly $expectedPath
     }
 }

--- a/test/powershell/Host/Base-Directory.Tests.ps1
+++ b/test/powershell/Host/Base-Directory.Tests.ps1
@@ -115,3 +115,19 @@ Describe "Configuration file locations" -tags "CI","Slow" {
         }
     }
 }
+
+Describe "Working directory on startup" -Tag "CI" {
+    BeforeAll {
+        $testPath = New-Item -ItemType Directory -Path "$TestDrive\test[dir]"
+        $currentDirectory = Get-Location
+    }
+
+    AfterAll {
+        Set-Location $currentDirectory
+    }
+
+    It "Can start in directory where name contains wildcard characters" {
+        Set-Location -LiteralPath $testPath.FullName
+        & $powershell -noprofile -c get-location | Should BeExactly $testPath.FullName
+    }
+}

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Location.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Location.Tests.ps1
@@ -41,6 +41,16 @@ Describe "Set-Location" -Tags "CI" {
         $result | Should BeOfType System.Management.Automation.PathInfo
     }
 
+    It "Should accept path containing wildcard characters" {
+        $null = New-Item -ItemType Directory -Path "$TestDrive\aa"
+        $null = New-Item -ItemType Directory -Path "$TestDrive\ba"
+        $testPath = New-Item -ItemType Directory -Path "$TestDrive\[ab]a"
+
+        Set-Location $TestDrive
+        Set-Location -Path "[ab]a"
+        $(Get-Location).Path | Should BeExactly $testPath.FullName
+    }
+
     Context 'Set-Location with no arguments' {
 
         It 'Should go to $env:HOME when Set-Location run with no arguments from FileSystem provider' {


### PR DESCRIPTION
## PR Summary
When InitialSessionState initializes it tries to SetLocation to current working directory,
but if the directory name contains PowerShell wildcard characters, it fails and reverts
to $PSHOME.  
The change affects Set-Location in that if the path exists (even if containing wildcard characters), just use it.

Fix https://github.com/PowerShell/PowerShell/issues/5752


<!-- summarize your PR between here and the checklist -->

## PR Checklist

Note: Please mark anything not applicable to this PR `NA`.

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [X] Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [na] User facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [ ] Issue filed - Issue link:
- [X] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [X] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
    - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
