### PR TITLE
WIP - Fix performance and memory allocation issues in ReadPdhMultiString.

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Diagnostics/PdhHelper.cs
+++ b/src/Microsoft.PowerShell.Commands.Diagnostics/PdhHelper.cs
@@ -3,6 +3,7 @@
 //
 
 using System;
+using System.Text;
 using System.Diagnostics;
 using System.Globalization;
 using System.Runtime.InteropServices;
@@ -485,7 +486,7 @@ namespace Microsoft.Powershell.Commands.GetCounter.PdhNative
         {
             Debug.Assert(strSize >= 2);
             int offset = 0;
-            string allSubstringsWithNulls = "";
+            StringBuilder sb = new StringBuilder(strSize);
             while (offset <= ((strSize * sizeof(char)) - 4))
             {
                 Int32 next4 = Marshal.ReadInt32(strNative, offset);
@@ -494,14 +495,19 @@ namespace Microsoft.Powershell.Commands.GetCounter.PdhNative
                     break;
                 }
 
-                allSubstringsWithNulls += (char)next4;
+                char nextChar = (char)next4;
+                if (nextChar == '\0')
+                {
+                    strColl.Add(sb.ToString());
+                    sb.Clear();
+                }
+                else
+                {
+                    sb.Append(nextChar);
+                }
 
                 offset += 2;
             }
-
-            allSubstringsWithNulls = allSubstringsWithNulls.TrimEnd('\0');
-
-            strColl.AddRange(allSubstringsWithNulls.Split('\0'));
         }
 
 


### PR DESCRIPTION
## PR Summary

String concats in ReadPdhMultiString have been replaced with a StringBuilder to significantly reduce heap allocation and GC.

ReadPdhMultiString reads characters one by one from a pointer location into a string, then splits that string into a string collection (on the null character '\0'). However, it does this through a looped string concat, allocating a new string on the heap for each character read in.  This has significant GC implications for large strings.  The string concats have been replaced with a string builder, and the strings are split and added to the StringCollection on the fly.

## PR Checklist

Note: Please mark anything not applicable to this PR `NA`.

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [x] Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [NA ] User facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [ NA] Issue filed - Issue link:
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
