### PR TITLE
Handle spaces in a path in RegisterManifest.ps1

### DIFF
--- a/src/PowerShell.Core.Instrumentation/RegisterManifest.ps1
+++ b/src/PowerShell.Core.Instrumentation/RegisterManifest.ps1
@@ -79,7 +79,7 @@ foreach ($file in $files)
     }
 }
 
-[string] $command = "wevtutil um {0}" -f $manifest.FullName
+[string] $command = 'wevtutil um "{0}"' -f $manifest.FullName
 
 # Unregister if present. Avoids warnings when registering the manifest
 # and it is already registered.
@@ -88,7 +88,7 @@ Start-NativeExecution {Invoke-Expression $command} $true
 
 if (-not $Unregister)
 {
-    $command = "wevtutil.exe im {0} /rf:{1} /mf:{1}" -f $manifest.FullName, $binary.FullName
+    $command = 'wevtutil.exe im "{0}" /rf:"{1}" /mf:"{1}"' -f $manifest.FullName, $binary.FullName
     Write-Verbose -Message "Register the manifest: $command"
     Start-NativeExecution { Invoke-Expression $command }
 }


### PR DESCRIPTION
## PR Summary

<!-- summarize your PR between here and the checklist -->
Fix #5858
This change is to handle spaces in a given path and to successfully register / unregister the ETW manifest with RegisterManifest.ps1 on the default install path.

## PR Checklist

Note: Please mark anything not applicable to this PR `NA`.

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [x] Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [`NA`] User facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [x] Issue filed - Issue link: https://github.com/PowerShell/PowerShell/issues/5858
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [`NA`] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
    - [`NA`] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.


## Description

On Windows, PowerShell 6 is installed into `C:\Program Files\PowerShell\6.0.0` by default. RegisterManifest.ps1, which expected to take a path of this location, does not work with the path because it uses the path for `wevtutil` without quoting it. This results in multiple parameters like  `C:\Program` `Files\PowerShell\6.0.0`, which is invalid for `wevtutil`.

This change simply add double quotes when the pass is used for  `wevtutil`.