### PR TITLE
[Feature] Remove HelpSystem old formatting code

### DIFF
--- a/src/System.Management.Automation/engine/Types_Ps1Xml.cs
+++ b/src/System.Management.Automation/engine/Types_Ps1Xml.cs
@@ -1089,30 +1089,7 @@ namespace System.Management.Automation.Runspaces
           $ProgressPreference = 'SilentlyContinue'
           try
           {
-          if ($psversiontable.psversion.Major -lt 3)
-          {
-          # ok to cast CommandTypes enum to HelpCategory because string/identifier for
-          # cmdlet,function,filter,alias,externalscript is identical.
-          # it is ok to fail for other enum values (i.e. for Application)
-          $commandName = $this.Name
-          if ($this.ModuleName)
-          {
-          $commandName = ""{0}\{1}"" -f $this.ModuleName,$commandName
-          }
-
-          $helpObject = get-help -Name $commandName -Category ([string]($this.CommandType)) -ErrorAction SilentlyContinue
-
-          # return first non-null uri (and try not to hit any strict mode things)
-          if ($null -eq $helpObject) { return $null }
-          if ($null -eq $helpObject.psobject.properties['relatedLinks']) { return $null }
-          if ($null -eq $helpObject.relatedLinks.psobject.properties['navigationLink']) { return $null }
-          $helpUri = [string]$( $helpObject.relatedLinks.navigationLink | ForEach-Object { if ($null -ne $_.psobject.properties['uri']) { $_.uri } } | Where-Object { $_ } | Select-Object -first 1 )
-          return $helpUri
-          }
-          else
-          {
           [Microsoft.PowerShell.Commands.GetHelpCodeMethods]::GetHelpUri($this)
-          }
           }
           catch {}
           finally

--- a/src/System.Management.Automation/engine/hostifaces/HostUtilities.cs
+++ b/src/System.Management.Automation/engine/hostifaces/HostUtilities.cs
@@ -943,11 +943,6 @@ namespace System.Management.Automation
                 [string] $PSEditFunction
             )
 
-            if ($PSVersionTable.PSVersion -lt ([version] '3.0'))
-            {
-                throw (new-object System.NotSupportedException)
-            }
-
             Register-EngineEvent -SourceIdentifier PSISERemoteSessionOpenFile -Forward
 
             if ((Test-Path -Path 'function:\global:PSEdit') -eq $false)
@@ -960,11 +955,6 @@ namespace System.Management.Automation
         /// RemovePSEditFunction script string.
         /// </summary>
         public const string RemovePSEditFunction = @"
-            if ($PSVersionTable.PSVersion -lt ([version] '3.0'))
-            {
-                throw (new-object System.NotSupportedException)
-            }
-
             if ((Test-Path -Path 'function:\global:PSEdit') -eq $true)
             {
                 Remove-Item -Path 'function:\global:PSEdit' -Force


### PR DESCRIPTION
## PR Summary

Remove HelpSystem old formatting code for `CommandInfo`. This code was intended for the PowerShell 2.0 version which deprecated currently.
Also now we use new HTTPS HelpUri links, and old HTTP HelpUri links for PS 2.0 may no longer work.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [x] Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [NA] User facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [NA] Issue filed - Issue link:
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [NA] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
    - [x] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
