### PR TITLE
Encoding for New-ModuleManifest on all platforms should be UTF-8 NoBOM

### DIFF
--- a/src/System.Management.Automation/engine/Modules/NewModuleManifestCommand.cs
+++ b/src/System.Management.Automation/engine/Modules/NewModuleManifestCommand.cs
@@ -941,7 +941,7 @@ namespace Microsoft.PowerShell.Commands
                 PathUtils.MasterStreamOpen(
                     cmdlet : this,
                     filePath : filePath,
-                    resolvedEncoding : new UTF8Encoding(false), // UTF-8, no BOM
+                    resolvedEncoding : new UTF8Encoding(encoderShouldEmitUTF8Identifier : false),
                     defaultEncoding : false,
                     Append : false,
                     Force : false,

--- a/src/System.Management.Automation/engine/Modules/NewModuleManifestCommand.cs
+++ b/src/System.Management.Automation/engine/Modules/NewModuleManifestCommand.cs
@@ -941,11 +941,7 @@ namespace Microsoft.PowerShell.Commands
                 PathUtils.MasterStreamOpen(
                     this,
                     filePath,
-#if UNIX
                     new UTF8Encoding(false), // UTF-8, no BOM
-#else
-                    EncodingConversion.Unicode, // UTF-16 with BOM
-#endif
                     /* defaultEncoding */ false,
                     /* Append */ false,
                     /* Force */ false,

--- a/src/System.Management.Automation/engine/Modules/NewModuleManifestCommand.cs
+++ b/src/System.Management.Automation/engine/Modules/NewModuleManifestCommand.cs
@@ -939,17 +939,17 @@ namespace Microsoft.PowerShell.Commands
 
                 // Now open the output file...
                 PathUtils.MasterStreamOpen(
-                    this,
-                    filePath,
-                    new UTF8Encoding(false), // UTF-8, no BOM
-                    /* defaultEncoding */ false,
-                    /* Append */ false,
-                    /* Force */ false,
-                    /* NoClobber */ false,
-                    out fileStream,
-                    out streamWriter,
-                    out readOnlyFileInfo,
-                    false
+                    cmdlet : this,
+                    filePath : filePath,
+                    resolvedEncoding : new UTF8Encoding(false), // UTF-8, no BOM
+                    defaultEncoding : false,
+                    Append : false,
+                    Force : false,
+                    NoClobber : false,
+                    fileStream : out fileStream,
+                    streamWriter : out streamWriter,
+                    readOnlyFileInfo : out readOnlyFileInfo,
+                    isLiteralPath : false
                 );
 
                 try

--- a/test/powershell/engine/Module/NewModuleManifest.Tests.ps1
+++ b/test/powershell/engine/Module/NewModuleManifest.Tests.ps1
@@ -9,7 +9,11 @@ Describe "New-ModuleManifest tests" -tags "CI" {
     }
 
     BeforeAll {
-        $ExpectedManifestBytes = @(35,10)
+        if ($IsWindows) {
+            $ExpectedManifestBytes = @(35,13) # CR
+        } else {
+            $ExpectedManifestBytes = @(35,10) # LF
+        }
     }
 
     It "Uris with spaces are allowed and escaped correctly" {

--- a/test/powershell/engine/Module/NewModuleManifest.Tests.ps1
+++ b/test/powershell/engine/Module/NewModuleManifest.Tests.ps1
@@ -1,6 +1,6 @@
 Describe "New-ModuleManifest tests" -tags "CI" {
     BeforeEach {
-        New-Item -ItemType Directory -Path testdrive:/module
+        $null = New-Item -ItemType Directory -Path testdrive:/module
         $testModulePath = "testdrive:/module/test.psd1"
     }
 

--- a/test/powershell/engine/Module/NewModuleManifest.Tests.ps1
+++ b/test/powershell/engine/Module/NewModuleManifest.Tests.ps1
@@ -9,14 +9,7 @@ Describe "New-ModuleManifest tests" -tags "CI" {
     }
 
     BeforeAll {
-        if ($IsWindows)
-        {
-            $ExpectedManifestBytes = @(255,254,35,0,13,0,10,0)
-        }
-        else
-        {
-            $ExpectedManifestBytes = @(35,10)
-        }
+        $ExpectedManifestBytes = @(35,10)
     }
 
     It "Uris with spaces are allowed and escaped correctly" {
@@ -38,10 +31,9 @@ Describe "New-ModuleManifest tests" -tags "CI" {
     }
 
     It "Verify module manifest encoding" {
-        
+
         # verify first line of the manifest:
-        # on Windows platforms - 3 characters - '#' '\r' '\n' - in UTF-16 with BOM - this should be @(255,254,35,0,13,0,10,0)
-        # on non-Windows platforms - 2 characters - '#' '\n' - in UTF-8 no BOM - this should be @(35,10)
+        # 2 characters - '#' '\n' - in UTF-8 no BOM - this should be @(35,10)
         TestNewModuleManifestEncoding -expected $ExpectedManifestBytes
     }
 


### PR DESCRIPTION
## PR Summary

When we decided not to take https://github.com/PowerShell/PowerShell/pull/4119 it meant that the file encoding for `New-ModuleManifest` on Windows stayed as UTF-16 w/ BOM.  
We had decided to adopt UTF-8 NoBOM as standard in PSCore6.  
The fix is to remove Windows specific logic in the code and in the test for UTF-16 w/ BOM.

## PR Checklist

Note: Please mark anything not applicable to this PR `NA`.

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [X] Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] User facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [X] Issue filed - Issue link: https://github.com/PowerShell/PowerShell-Docs/pull/2064
- [ ] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [X] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
    - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
