### PR TITLE
Add null check to avoid null reference exception in Enter-PSHostProcess

### DIFF
--- a/src/System.Management.Automation/engine/remoting/commands/EnterPSHostProcessCommand.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/EnterPSHostProcessCommand.cs
@@ -198,10 +198,7 @@ namespace Microsoft.PowerShell.Commands
             try
             {
                 remoteRunspace.Open();
-                if (remoteRunspace.Debugger != null)
-                {
-                    remoteRunspace.Debugger.SetDebugMode(DebugModes.LocalScript | DebugModes.RemoteScript);
-                }
+                remoteRunspace.Debugger?.SetDebugMode(DebugModes.LocalScript | DebugModes.RemoteScript);
             }
             catch (RuntimeException e)
             {

--- a/src/System.Management.Automation/engine/remoting/commands/EnterPSHostProcessCommand.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/EnterPSHostProcessCommand.cs
@@ -198,7 +198,10 @@ namespace Microsoft.PowerShell.Commands
             try
             {
                 remoteRunspace.Open();
-                remoteRunspace.Debugger.SetDebugMode(DebugModes.LocalScript | DebugModes.RemoteScript);
+                if (remoteRunspace.Debugger != null)
+                {
+                    remoteRunspace.Debugger.SetDebugMode(DebugModes.LocalScript | DebugModes.RemoteScript);
+                }
             }
             catch (RuntimeException e)
             {


### PR DESCRIPTION
## PR Summary

I found this issue while debugging remote script.  There are some cases where an OutOfProc server session of PowerShell starts with remote debugging disabled.  In this case the RemoteRunspace.Debugger property is null and Enter-PSHostProcess will throw a null reference exception when trying to access the property.
The fix is to add a null check.

## PR Checklist

Note: Please mark anything not applicable to this PR `NA`.

- [ x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [ x] Use the present tense and imperative mood when describing your changes
- [x ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [`NA` ] User facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [ ] Issue filed - Issue link:
- [x ] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- ['NA' ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
    - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
- [x ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
