### PR TITLE
Change Microsoft.PowerShell.Commands.SetDateCommand.SystemTime to struct.

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/SetDateCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/SetDateCommand.cs
@@ -117,7 +117,7 @@ namespace Microsoft.PowerShell.Commands
         internal static class NativeMethods
         {
             [StructLayout(LayoutKind.Sequential)]
-            public class SystemTime
+            public struct SystemTime
             {
                 public UInt16 Year;
                 public UInt16 Month;

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Set-Date.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Set-Date.Tests.ps1
@@ -10,6 +10,12 @@ Describe "Set-Date" -Tag "CI" {
         { get-date | set-date } | Should not throw
     }
 
+    It "Set-Date should be able to set the date with -Date parameter" -Skip:(! $IsElevated) {
+        $target = Get-Date
+        $expected = $target
+        Set-Date -Date $target | Should be $expected
+    }
+
     It "Set-Date should produce an error in a non-elevated context" -Skip:($IsElevated) {
         { get-date | set-date} | should throw
         $Error[0].FullyQualifiedErrorId | should be "System.ComponentModel.Win32Exception,Microsoft.PowerShell.Commands.SetDateCommand"

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Set-Date.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Set-Date.Tests.ps1
@@ -7,17 +7,17 @@ Describe "Set-Date" -Tag "CI" {
     }
 
     It "Set-Date should be able to set the date in an elevated context" -Skip:(! $IsElevated) {
-        { get-date | set-date } | Should not throw
+        { Get-Date | Set-Date } | Should Not Throw
     }
 
     It "Set-Date should be able to set the date with -Date parameter" -Skip:(! $IsElevated) {
         $target = Get-Date
         $expected = $target
-        Set-Date -Date $target | Should be $expected
+        Set-Date -Date $target | Should Be $expected
     }
 
     It "Set-Date should produce an error in a non-elevated context" -Skip:($IsElevated) {
-        { get-date | set-date} | should throw
-        $Error[0].FullyQualifiedErrorId | should be "System.ComponentModel.Win32Exception,Microsoft.PowerShell.Commands.SetDateCommand"
+        { Get-Date | Set-Date } | Should Throw
+        $Error[0].FullyQualifiedErrorId | Should Be "System.ComponentModel.Win32Exception,Microsoft.PowerShell.Commands.SetDateCommand"
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Set-Date.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Set-Date.Tests.ps1
@@ -17,7 +17,6 @@ Describe "Set-Date" -Tag "CI" {
     }
 
     It "Set-Date should produce an error in a non-elevated context" -Skip:($IsElevated) {
-        { Get-Date | Set-Date } | Should Throw
-        $Error[0].FullyQualifiedErrorId | Should Be "System.ComponentModel.Win32Exception,Microsoft.PowerShell.Commands.SetDateCommand"
+        { Get-Date | Set-Date } | ShouldBeErrorId "System.ComponentModel.Win32Exception,Microsoft.PowerShell.Commands.SetDateCommand"
     }
 }


### PR DESCRIPTION
## PR Summary

Fix #5163 .
Fix #3099 .

Currently, `Microsoft.PowerShell.Commands.SetDateCommand.SystemTime` is defined as class.
Therefore, [SetLocalTime](https://msdn.microsoft.com/en-us/library/windows/desktop/ms724936.aspx) function is causing a parameter error (error code 0x00000057).
I changed `Microsoft.PowerShell.Commands.SetDateCommand.SystemTime` class to struct and resolve the error.  

<!-- summarize your PR between here and the checklist -->

## PR Checklist

Note: Please mark anything not applicable to this PR `NA`.

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [x] Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] User facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [x] Issue filed - Issue link: [Set-Date did not work](https://github.com/PowerShell/PowerShell/issues/5163)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
    - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
