### PR TITLE
Add -SkipHeaderValidation Support to ContentType on Web Cmdlets

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -1188,7 +1188,8 @@ namespace Microsoft.PowerShell.Commands
                         }
                         catch (FormatException ex)
                         {
-                            ErrorRecord er = new ErrorRecord(ex, "WebCmdletContentTypeException", ErrorCategory.InvalidArgument, ContentType);
+                            var outerEx = new ValidationMetadataException(WebCmdletStrings.ContentTypeException, ex);
+                            ErrorRecord er = new ErrorRecord(outerEx, "WebCmdletContentTypeException", ErrorCategory.InvalidArgument, ContentType);
                             ThrowTerminatingError(er);
                         }
                     }
@@ -1503,7 +1504,8 @@ namespace Microsoft.PowerShell.Commands
                 {
                     if (!SkipHeaderValidation)
                     {
-                        ErrorRecord er = new ErrorRecord(ex, "WebCmdletContentTypeException", ErrorCategory.InvalidArgument, ContentType);
+                        var outerEx = new ValidationMetadataException(WebCmdletStrings.ContentTypeException, ex);
+                        ErrorRecord er = new ErrorRecord(outerEx, "WebCmdletContentTypeException", ErrorCategory.InvalidArgument, ContentType);
                         ThrowTerminatingError(er);
                     }
                 }
@@ -1511,7 +1513,8 @@ namespace Microsoft.PowerShell.Commands
                 {
                     if (!SkipHeaderValidation)
                     {
-                        ErrorRecord er = new ErrorRecord(ex, "WebCmdletEncodingException", ErrorCategory.InvalidArgument, ContentType);
+                        var outerEx = new ValidationMetadataException(WebCmdletStrings.ContentTypeException, ex);
+                        ErrorRecord er = new ErrorRecord(outerEx, "WebCmdletContentTypeException", ErrorCategory.InvalidArgument, ContentType);
                         ThrowTerminatingError(er);
                     }
                 }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -1182,7 +1182,15 @@ namespace Microsoft.PowerShell.Commands
                     }
                     else
                     {
-                        request.Content.Headers.Add(entry.Key, entry.Value);
+                        try
+                        {
+                            request.Content.Headers.Add(entry.Key, entry.Value);
+                        }
+                        catch (FormatException ex)
+                        {
+                            ErrorRecord er = new ErrorRecord(ex, "WebCmdletContentTypeException", ErrorCategory.InvalidArgument, ContentType);
+                            ThrowTerminatingError(er);
+                        }
                     }
                 }
             }

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/WebCmdletStrings.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/WebCmdletStrings.resx
@@ -144,6 +144,9 @@
   <data name="FormInFileConflict" xml:space="preserve">
     <value>The cmdlet cannot run because the following conflicting parameters are specified: InFile and Form. Specify either InFile or Form, then retry.  </value>
   </data>
+  <data name="ContentTypeException" xml:space="preserve">
+    <value>The cmdlet cannot run because the -ContentType parameter is not a valid Content-Type header. Specify a valid Content-Type for -ContentType, then retry. To suppress header validation, supply the -SkipHeaderValidation parameter.</value>
+  </data>
   <data name="CredentialConflict" xml:space="preserve">
     <value>The cmdlet cannot run because the following conflicting parameters are specified: Credential and UseDefaultCredentials. Specify either Credential or UseDefaultCredentials, then retry.</value>
   </data>

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -915,7 +915,7 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
             $uri = Get-WebListenerUrl -Test 'Post'
 
             { Invoke-WebRequest -Uri $uri -Method 'Post' -ContentType $contentType -InFile $Testfile -ErrorAction 'Stop' } |
-                ShouldBeErrorId "System.FormatException,Microsoft.PowerShell.Commands.InvokeWebRequestCommand"
+                ShouldBeErrorId "WebCmdletContentTypeException,Microsoft.PowerShell.Commands.InvokeWebRequestCommand"
         }
 
         It "Verifies Invoke-WebRequest default ContentType handling reports no error is returned for an invalid Content-Type header value, -Infile, and -SkipHeaderValidation" {
@@ -2101,7 +2101,7 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
             $uri = Get-WebListenerUrl -Test 'Post'
 
             { Invoke-RestMethod -Uri $uri -Method 'Post' -ContentType $contentType -InFile $Testfile -ErrorAction 'Stop' } |
-                ShouldBeErrorId "System.FormatException,Microsoft.PowerShell.Commands.InvokeRestMethodCommand"
+                ShouldBeErrorId "WebCmdletContentTypeException,Microsoft.PowerShell.Commands.InvokeRestMethodCommand"
         }
 
         It "Verifies Invoke-RestMethod default ContentType handling reports no error is returned for an invalid Content-Type header value, -Infile, and -SkipHeaderValidation" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -801,67 +801,67 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
 
     #endregion Redirect tests
 
-    #region SkipHeaderVerification Tests
+    Context "Invoke-WebRequest SkipHeaderVerification Tests" {
+        It "Verifies Invoke-WebRequest default header handling with no errors" {
+            $uri = Get-WebListenerUrl -Test 'Get'
+            $headers = @{"If-Match" = "*"}
+            $response = ExecuteRequestWithCustomHeaders -Uri $uri -headers $headers
 
-    It "Verifies Invoke-WebRequest default header handling with no errors" {
-        $uri = Get-WebListenerUrl -Test 'Get'
-        $headers = @{"If-Match" = "*"}
-        $response = ExecuteRequestWithCustomHeaders -Uri $uri -headers $headers
+            $response.Error | Should BeNullOrEmpty
+            $response.Content.Headers."If-Match" | Should BeExactly "*"
+        }
 
-        $response.Error | Should BeNullOrEmpty
-        $response.Content.Headers."If-Match" | Should BeExactly "*"
+        It "Verifies Invoke-WebRequest default header handling reports an error is returned for an invalid If-Match header value" {
+            $uri = Get-WebListenerUrl -Test 'Get'
+            $headers = @{"If-Match" = "12345"}
+            $response = ExecuteRequestWithCustomHeaders -Uri $uri -headers $headers
+
+            $response.Error | Should Not BeNullOrEmpty
+            $response.Error.FullyQualifiedErrorId | Should Be "System.FormatException,Microsoft.PowerShell.Commands.InvokeWebRequestCommand"
+            $response.Error.Exception.Message | Should Be "The format of value '12345' is invalid."
+        }
+
+        It "Verifies Invoke-WebRequest header handling does not report an error when using -SkipHeaderValidation" {
+            $uri = Get-WebListenerUrl -Test 'Get'
+            $headers = @{"If-Match" = "12345"}
+            $response = ExecuteRequestWithCustomHeaders -Uri $uri -headers $headers -SkipHeaderValidation
+
+            $response.Error | Should BeNullOrEmpty
+            $response.Content.Headers."If-Match" | Should BeExactly "12345"
+        }
+
+        It "Verifies Invoke-WebRequest default UserAgent handling with no errors" {
+            $uri = Get-WebListenerUrl -Test 'Get'
+            $UserAgent = [Microsoft.PowerShell.Commands.PSUserAgent]::InternetExplorer
+            $response = ExecuteRequestWithCustomUserAgent -Uri $uri -UserAgent $UserAgent -Cmdlet "Invoke-WebRequest"
+
+            $response.Error | Should BeNullOrEmpty
+            $Pattern = [regex]::Escape($UserAgent)
+            $response.Content.Headers."User-Agent" | Should Match $Pattern
+        }
+
+        It "Verifies Invoke-WebRequest default UserAgent handling reports an error is returned for an invalid UserAgent value" {
+            $uri = Get-WebListenerUrl -Test 'Get'
+            $UserAgent = 'Invalid:Agent'
+            $response = ExecuteRequestWithCustomUserAgent -Uri $uri -UserAgent $UserAgent  -Cmdlet "Invoke-WebRequest"
+
+            $response.Error | Should Not BeNullOrEmpty
+            $response.Error.FullyQualifiedErrorId | Should Be "System.FormatException,Microsoft.PowerShell.Commands.InvokeWebRequestCommand"
+            $response.Error.Exception.Message | Should Be "The format of value 'Invalid:Agent' is invalid."
+        }
+
+        It "Verifies Invoke-WebRequest UserAgent handling does not report an error when using -SkipHeaderValidation" {
+            $uri = Get-WebListenerUrl -Test 'Get'
+            $UserAgent = 'Invalid:Agent'
+            $response = ExecuteRequestWithCustomUserAgent -Uri $uri -UserAgent $UserAgent  -SkipHeaderValidation -Cmdlet "Invoke-WebRequest"
+
+            $response.Error | Should BeNullOrEmpty
+            $Pattern = [regex]::Escape($UserAgent)
+            $response.Content.Headers."User-Agent" | Should Match $Pattern
+        }
+
+        It
     }
-
-    It "Verifies Invoke-WebRequest default header handling reports an error is returned for an invalid If-Match header value" {
-        $uri = Get-WebListenerUrl -Test 'Get'
-        $headers = @{"If-Match" = "12345"}
-        $response = ExecuteRequestWithCustomHeaders -Uri $uri -headers $headers
-
-        $response.Error | Should Not BeNullOrEmpty
-        $response.Error.FullyQualifiedErrorId | Should Be "System.FormatException,Microsoft.PowerShell.Commands.InvokeWebRequestCommand"
-        $response.Error.Exception.Message | Should Be "The format of value '12345' is invalid."
-    }
-
-    It "Verifies Invoke-WebRequest header handling does not report an error when using -SkipHeaderValidation" {
-        $uri = Get-WebListenerUrl -Test 'Get'
-        $headers = @{"If-Match" = "12345"}
-        $response = ExecuteRequestWithCustomHeaders -Uri $uri -headers $headers -SkipHeaderValidation
-
-        $response.Error | Should BeNullOrEmpty
-        $response.Content.Headers."If-Match" | Should BeExactly "12345"
-    }
-
-    It "Verifies Invoke-WebRequest default UserAgent handling with no errors" {
-        $uri = Get-WebListenerUrl -Test 'Get'
-        $UserAgent = [Microsoft.PowerShell.Commands.PSUserAgent]::InternetExplorer
-        $response = ExecuteRequestWithCustomUserAgent -Uri $uri -UserAgent $UserAgent -Cmdlet "Invoke-WebRequest"
-
-        $response.Error | Should BeNullOrEmpty
-        $Pattern = [regex]::Escape($UserAgent)
-        $response.Content.Headers."User-Agent" | Should Match $Pattern
-    }
-
-    It "Verifies Invoke-WebRequest default UserAgent handling reports an error is returned for an invalid UserAgent value" {
-        $uri = Get-WebListenerUrl -Test 'Get'
-        $UserAgent = 'Invalid:Agent'
-        $response = ExecuteRequestWithCustomUserAgent -Uri $uri -UserAgent $UserAgent  -Cmdlet "Invoke-WebRequest"
-
-        $response.Error | Should Not BeNullOrEmpty
-        $response.Error.FullyQualifiedErrorId | Should Be "System.FormatException,Microsoft.PowerShell.Commands.InvokeWebRequestCommand"
-        $response.Error.Exception.Message | Should Be "The format of value 'Invalid:Agent' is invalid."
-    }
-
-    It "Verifies Invoke-WebRequest UserAgent handling does not report an error when using -SkipHeaderValidation" {
-        $uri = Get-WebListenerUrl -Test 'Get'
-        $UserAgent = 'Invalid:Agent'
-        $response = ExecuteRequestWithCustomUserAgent -Uri $uri -UserAgent $UserAgent  -SkipHeaderValidation -Cmdlet "Invoke-WebRequest"
-
-        $response.Error | Should BeNullOrEmpty
-        $Pattern = [regex]::Escape($UserAgent)
-        $response.Content.Headers."User-Agent" | Should Match $Pattern
-    }
-
-    #endregion SkipHeaderVerification Tests
 
     #region charset encoding tests
 
@@ -1922,67 +1922,65 @@ Describe "Invoke-RestMethod tests" -Tags "Feature" {
 
     #endregion Redirect tests
 
-    #region SkipHeaderVerification tests
+    Context "Invoke-RestMethod SkipHeaderVerification Tests" {
+        It "Verifies Invoke-RestMethod default header handling with no errors" {
+            $uri = Get-WebListenerUrl -Test 'Get'
+            $headers = @{"If-Match" = "*"}
+            $response = ExecuteRequestWithCustomHeaders -Uri $uri -headers $headers -Cmdlet "Invoke-RestMethod"
 
-    It "Verifies Invoke-RestMethod default header handling with no errors" {
-        $uri = Get-WebListenerUrl -Test 'Get'
-        $headers = @{"If-Match" = "*"}
-        $response = ExecuteRequestWithCustomHeaders -Uri $uri -headers $headers -Cmdlet "Invoke-RestMethod"
+            $response.Error | Should BeNullOrEmpty
+            $response.Content.Headers."If-Match" | Should BeExactly "*"
+        }
 
-        $response.Error | Should BeNullOrEmpty
-        $response.Content.Headers."If-Match" | Should BeExactly "*"
+        It "Verifies Invoke-RestMethod default header handling reports an error is returned for an invalid If-Match header value" {
+            $uri = Get-WebListenerUrl -Test 'Get'
+            $headers = @{"If-Match" = "12345"}
+            $response = ExecuteRequestWithCustomHeaders -Uri $uri -headers $headers -Cmdlet "Invoke-RestMethod"
+
+            $response.Error | Should Not BeNullOrEmpty
+            $response.Error.FullyQualifiedErrorId | Should Be "System.FormatException,Microsoft.PowerShell.Commands.InvokeRestMethodCommand"
+            $response.Error.Exception.Message | Should Be "The format of value '12345' is invalid."
+        }
+
+        It "Verifies Invoke-RestMethod header handling does not report an error when using -SkipHeaderValidation" {
+            $uri = Get-WebListenerUrl -Test 'Get'
+            $headers = @{"If-Match" = "12345"}
+            $response = ExecuteRequestWithCustomHeaders -Uri $uri -headers $headers -SkipHeaderValidation -Cmdlet "Invoke-RestMethod"
+
+            $response.Error | Should BeNullOrEmpty
+            $response.Content.Headers."If-Match" | Should BeExactly "12345"
+        }
+
+        It "Verifies Invoke-RestMethod default UserAgent handling with no errors" {
+            $uri = Get-WebListenerUrl -Test 'Get'
+            $UserAgent = [Microsoft.PowerShell.Commands.PSUserAgent]::InternetExplorer
+            $response = ExecuteRequestWithCustomUserAgent -Uri $uri -UserAgent $UserAgent -Cmdlet "Invoke-RestMethod"
+
+            $response.Error | Should BeNullOrEmpty
+            $Pattern = [regex]::Escape($UserAgent)
+            $response.Content.Headers."User-Agent" | Should Match $Pattern
+        }
+
+        It "Verifies Invoke-RestMethod default UserAgent handling reports an error is returned for an invalid UserAgent value" {
+            $uri = Get-WebListenerUrl -Test 'Get'
+            $UserAgent = 'Invalid:Agent'
+            $response = ExecuteRequestWithCustomUserAgent -Uri $uri -UserAgent $UserAgent  -Cmdlet "Invoke-RestMethod"
+
+            $response.Error | Should Not BeNullOrEmpty
+            $response.Error.FullyQualifiedErrorId | Should Be "System.FormatException,Microsoft.PowerShell.Commands.InvokeRestMethodCommand"
+            $response.Error.Exception.Message | Should Be "The format of value 'Invalid:Agent' is invalid."
+        }
+
+        It "Verifies Invoke-RestMethod UserAgent handling does not report an error when using -SkipHeaderValidation" {
+            $uri = Get-WebListenerUrl -Test 'Get'
+            $UserAgent = 'Invalid:Agent'
+            $response = ExecuteRequestWithCustomUserAgent -Uri $uri -UserAgent $UserAgent  -SkipHeaderValidation -Cmdlet "Invoke-RestMethod"
+
+            $response.Error | Should BeNullOrEmpty
+            $Pattern = [regex]::Escape($UserAgent)
+            $response.Content.Headers."User-Agent" | Should Match $Pattern
+        }
     }
-
-    It "Verifies Invoke-RestMethod default header handling reports an error is returned for an invalid If-Match header value" {
-        $uri = Get-WebListenerUrl -Test 'Get'
-        $headers = @{"If-Match" = "12345"}
-        $response = ExecuteRequestWithCustomHeaders -Uri $uri -headers $headers -Cmdlet "Invoke-RestMethod"
-
-        $response.Error | Should Not BeNullOrEmpty
-        $response.Error.FullyQualifiedErrorId | Should Be "System.FormatException,Microsoft.PowerShell.Commands.InvokeRestMethodCommand"
-        $response.Error.Exception.Message | Should Be "The format of value '12345' is invalid."
-    }
-
-    It "Verifies Invoke-RestMethod header handling does not report an error when using -SkipHeaderValidation" {
-        $uri = Get-WebListenerUrl -Test 'Get'
-        $headers = @{"If-Match" = "12345"}
-        $response = ExecuteRequestWithCustomHeaders -Uri $uri -headers $headers -SkipHeaderValidation -Cmdlet "Invoke-RestMethod"
-
-        $response.Error | Should BeNullOrEmpty
-        $response.Content.Headers."If-Match" | Should BeExactly "12345"
-    }
-
-    It "Verifies Invoke-RestMethod default UserAgent handling with no errors" {
-        $uri = Get-WebListenerUrl -Test 'Get'
-        $UserAgent = [Microsoft.PowerShell.Commands.PSUserAgent]::InternetExplorer
-        $response = ExecuteRequestWithCustomUserAgent -Uri $uri -UserAgent $UserAgent -Cmdlet "Invoke-RestMethod"
-
-        $response.Error | Should BeNullOrEmpty
-        $Pattern = [regex]::Escape($UserAgent)
-        $response.Content.Headers."User-Agent" | Should Match $Pattern
-    }
-
-    It "Verifies Invoke-RestMethod default UserAgent handling reports an error is returned for an invalid UserAgent value" {
-        $uri = Get-WebListenerUrl -Test 'Get'
-        $UserAgent = 'Invalid:Agent'
-        $response = ExecuteRequestWithCustomUserAgent -Uri $uri -UserAgent $UserAgent  -Cmdlet "Invoke-RestMethod"
-
-        $response.Error | Should Not BeNullOrEmpty
-        $response.Error.FullyQualifiedErrorId | Should Be "System.FormatException,Microsoft.PowerShell.Commands.InvokeRestMethodCommand"
-        $response.Error.Exception.Message | Should Be "The format of value 'Invalid:Agent' is invalid."
-    }
-
-    It "Verifies Invoke-RestMethod UserAgent handling does not report an error when using -SkipHeaderValidation" {
-        $uri = Get-WebListenerUrl -Test 'Get'
-        $UserAgent = 'Invalid:Agent'
-        $response = ExecuteRequestWithCustomUserAgent -Uri $uri -UserAgent $UserAgent  -SkipHeaderValidation -Cmdlet "Invoke-RestMethod"
-
-        $response.Error | Should BeNullOrEmpty
-        $Pattern = [regex]::Escape($UserAgent)
-        $response.Content.Headers."User-Agent" | Should Match $Pattern
-    }
-
-    #endregion SkipHeaderVerification tests
 
     Context "HTTPS Tests" {
         It "Validate Invoke-RestMethod -SkipCertificateCheck" {


### PR DESCRIPTION
## PR Summary

* Extends `-SkipHeaderValidation` to work with `-ContentType` to allow `Content-Type` headers which are not standards compliant,
* moves existing `-SkipHeaderValidation` tests to a context
* Adds tests
* closes #6002 

Documentation will need to be updated to reflect that `-SkipHeaderValidation` works with  `-ContentType`

## PR Checklist

Note: Please mark anything not applicable to this PR `NA`.

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [X] Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] User facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [x] Issue filed - Issue link: PowerShell/PowerShell-Docs#2083
- [X] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [X] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
    - [X] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
