### PR TITLE
Skip tests that use ExecutionPolicy cmdlets on Unix

### DIFF
--- a/test/powershell/Host/ConsoleHost.Tests.ps1
+++ b/test/powershell/Host/ConsoleHost.Tests.ps1
@@ -252,23 +252,28 @@ Describe "ConsoleHost unit tests" -tags "Feature" {
     Context "-SettingsFile Commandline switch" {
 
         BeforeAll {
-            $CustomSettingsFile = Join-Path -Path $TestDrive -ChildPath 'Powershell.test.json'
-            $DefaultExecutionPolicy = 'RemoteSigned'
+            if ($IsWindows) {
+                $CustomSettingsFile = Join-Path -Path $TestDrive -ChildPath 'Powershell.test.json'
+                $DefaultExecutionPolicy = 'RemoteSigned'
+            }
         }
         BeforeEach {
-            # reset the content of the settings file to a known state.
-            Set-Content -Path $CustomSettingsfile -Value "{`"Microsoft.PowerShell:ExecutionPolicy`":`"$DefaultExecutionPolicy`"}" -ErrorAction Stop
+            if ($IsWindows) {
+                # reset the content of the settings file to a known state.
+                Set-Content -Path $CustomSettingsfile -Value "{`"Microsoft.PowerShell:ExecutionPolicy`":`"$DefaultExecutionPolicy`"}" -ErrorAction Stop
+            }
         }
 
         # NOTE: The -settingsFile command-line option only reads settings for the local machine. As a result, the tests that use Set/Get-ExecutionPolicy
         # must use an explicit scope of LocalMachine to ensure the setting is written to the expected file.
+        # Skip the tests on Unix platforms because *-ExecutionPolicy cmdlets don't work by design.
 
-        It "Verifies PowerShell reads from the custom -settingsFile" {
+        It "Verifies PowerShell reads from the custom -settingsFile" -skip:(!$IsWindows) {
             $actualValue = & $powershell -NoProfile -SettingsFile $CustomSettingsFile -Command {(Get-ExecutionPolicy -Scope LocalMachine).ToString()}
             $actualValue  | Should Be $DefaultExecutionPolicy
         }
 
-        It "Verifies PowerShell writes to the custom -settingsFile" {
+        It "Verifies PowerShell writes to the custom -settingsFile" -skip:(!$IsWindows) {
             $expectedValue = 'AllSigned'
 
             # Update the execution policy; this should update the settings file.
@@ -283,7 +288,7 @@ Describe "ConsoleHost unit tests" -tags "Feature" {
             $actualValue  | Should Be $expectedValue
         }
 
-        It "Verify PowerShell removes a setting from the custom -settingsFile" {
+        It "Verify PowerShell removes a setting from the custom -settingsFile" -skip:(!$IsWindows) {
             # Remove the LocalMachine execution policy; this should update the settings file.
             & $powershell -NoProfile -SettingsFile $CustomSettingsFile -Command {Set-ExecutionPolicy -ExecutionPolicy Undefined -Scope LocalMachine }
 
@@ -291,7 +296,6 @@ Describe "ConsoleHost unit tests" -tags "Feature" {
             $content = (Get-Content -Path $CustomSettingsFile | ConvertFrom-Json)
             $content.'Microsoft.PowerShell:ExecutionPolicy' | Should Be $null
         }
-
     }
 
     Context "Pipe to/from powershell" {


### PR DESCRIPTION
## PR Summary

Fix the daily Travis CI builds.
Three tests for `pwsh -settingsfile` are failing on Unix platforms because they use `*-ExecutionPolicy` cmdlets for verification. The `ExecutionPolicy` cmdlets are not supported on Unit platforms, and thus causes the tests to fail.

## PR Checklist

Note: Please mark anything not applicable to this PR `NA`.

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [x] Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] User facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [ ] Issue filed - Issue link:
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
    - [x] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
