### PR TITLE
Use TRAVIS_PULL_REQUEST_SHA to get the accurate commit message

### DIFF
--- a/tools/travis.ps1
+++ b/tools/travis.ps1
@@ -157,9 +157,9 @@ $isPR = $env:TRAVIS_EVENT_TYPE -eq 'pull_request'
 # For PRs, Travis-ci strips out [ and ] so read the message directly from git
 if($env:TRAVIS_EVENT_TYPE -eq 'pull_request')
 {
-    # Get the second log entry body
-    # The first log is a merge for a PR
-    $commitMessage = git log --format=%B -n 1 --skip=1
+    # If the current job is a pull request, the env variable 'TRAVIS_PULL_REQUEST_SHA' contains
+    # the commit SHA of the HEAD commit of the PR.
+    $commitMessage = git log --format=%B -n 1 $env:TRAVIS_PULL_REQUEST_SHA
 }
 else
 {


### PR DESCRIPTION
## PR Summary

See comment https://github.com/PowerShell/PowerShell/pull/5920#issuecomment-360559223
The current way to get commit message for the head commit of a PR in Travis CI is not reliable. When push merge happens, we may get back the wrong commit message.

As suggested by @TravisEz13, we can use `TRAVIS_PULL_REQUEST_SHA` to get the commit SHA of the HEAD commit of the PR, and then use it to get the commit message accurately.

## PR Checklist

Note: Please mark anything not applicable to this PR `NA`.

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [x] Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] User facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [ ] Issue filed - Issue link:
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
    - [x] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
