### PR TITLE
Add ScriptBlock substitution overload to -replace operator

### DIFF
--- a/test/powershell/Language/Operators/ReplaceOperator.Tests.ps1
+++ b/test/powershell/Language/Operators/ReplaceOperator.Tests.ps1
@@ -1,0 +1,64 @@
+Describe "Replace Operator" -Tags CI {
+    Context "Replace operator" {
+        It "Replace operator can replace string values using regular expressions" {
+            $res = "Get-Process" -replace "Get", "Stop"
+            $res | Should BeExactly "Stop-Process"
+
+            $res = "image.gif" -replace "\.gif$",".jpg"
+            $res | Should BeExactly "image.jpg"
+        }
+
+        It "Replace operator can be case-insensitive and case-sensitive" {
+            $res = "book" -replace "B","C"
+            $res | Should BeExactly "Cook"
+
+            $res = "book" -ireplace "B","C"
+            $res | Should BeExactly "Cook"
+
+            $res = "book" -creplace "B","C"
+            $res | Should BeExactly "book"
+        }
+
+        It "Replace operator can take 2 arguments, a mandatory pattern, and an optional substitution" {
+            $res = "PowerPoint" -replace "Point","Shell"
+            $res | Should BeExactly "PowerShell"
+
+            $res = "PowerPoint" -replace "Point"
+            $res | Should BeExactly "Power"
+        }
+    }
+
+    Context "Replace operator substitutions" {
+        It "Replace operator supports numbered substitution groups using ```$n" {
+            $res = "domain.example" -replace ".*\.(\w+)$","Tld of '`$0' is - '`$1'"
+            $res | Should BeExactly "Tld of 'domain.example' is - 'example'"
+        }
+
+        It "Replace operator supports named substitution groups using ```${name}" {
+            $res = "domain.example" -replace ".*\.(?<tld>\w+)$","`${tld}"
+            $res | Should BeExactly "example"
+        }
+
+        It "Replace operator can take a ScriptBlock in place of a substitution string" {
+            $res = "ID ABC123" -replace "\b[A-C]+", {return "X" * $args[0].Value.Length}
+            $res | Should BeExactly "ID XXX123"
+        }
+
+        It "Replace operator can take a MatchEvaluator in place of a substitution string" {
+            $matchEvaluator = {return "X" * $args[0].Value.Length} -as [System.Text.RegularExpressions.MatchEvaluator]
+            $res = "ID ABC123" -replace "\b[A-C]+", $matchEvaluator
+            $res | Should BeExactly "ID XXX123"
+        }
+
+        It "Replace operator can take a static PSMethod in place of a substitution string" {
+            class R {
+                static [string] Replace([System.Text.RegularExpressions.Match]$Match) {
+                    return "X" * $Match.Value.Length
+                }
+            }
+            $substitutionMethod = [R]::Replace
+            $res = "ID 0000123" -replace "\b0+", $substitutionMethod
+            $res | Should BeExactly "ID XXXX123"
+        }
+    }
+}

--- a/test/powershell/Language/Operators/ReplaceOperator.Tests.ps1
+++ b/test/powershell/Language/Operators/ReplaceOperator.Tests.ps1
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
 Describe "Replace Operator" -Tags CI {
     Context "Replace operator" {
         It "Replace operator can replace string values using regular expressions" {
@@ -40,7 +43,7 @@ Describe "Replace Operator" -Tags CI {
         }
 
         It "Replace operator can take a ScriptBlock in place of a substitution string" {
-            $res = "ID ABC123" -replace "\b[A-C]+", {return "X" * $args[0].Value.Length}
+            $res = "ID ABC123" -replace "\b[A-C]+", {return "X" * $_[0].Value.Length}
             $res | Should BeExactly "ID XXX123"
         }
 


### PR DESCRIPTION
## PR Summary

Fix #6164.

This PR adds rudimentary lambda support to the `-replace` operator:

    PS C:\> "ID 0000123" -replace "\b0+", {return " " * $args[0].Value.Length}
    ID     123

----

The current `-replace` operator implementation has the following syntax:

    <value> -replace <pattern>[, <substitution>]

This (functionally) maps directly onto:

    Regex.Replace(<value>, <pattern>, <substitution>)

`Regex.Replace()` already has an overload that supports a [`MatchEvaluator` delegate](https://docs.microsoft.com/en-us/dotnet/api/system.text.regularexpressions.matchevaluator?view=netframework-4.7.1), which in turn allows us to pass a scriptblock instead of a string value as the substitution pattern.

Since only wiring is required, we can accomplish this with:


    if `<substitution>` argument is a ScriptBlock
        convert `<substitution>` to a `MatchEvaluator` instance
        pass MatchEvaluator to Regex.Replace() instead of "`<substitution>`"

**Update:**

To support arbitrary delegates  (like existing `MatchEvaluator`s and `PSMethod`s), 

    if `<substitution>` argument is not a string
        attempt to convert `<substitution>` to a `MatchEvaluator` instance
        pass MatchEvaluator to Regex.Replace() instead of "`<substitution>`"
