### PR TITLE
Use 'RequireAdminOnWindows' tag in Set-Date tests

### DIFF
--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Set-Date.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Set-Date.Tests.ps1
@@ -1,9 +1,10 @@
 Describe "Set-Date for admin" -Tag @('CI', 'RequireAdminOnWindows') {
-    It "Set-Date should be able to set the date in an elevated context" {
+    # Currently, CI tests on Linux/macOS are always run as normal user. So we need to skip these tests on non-Windows platform.
+    It "Set-Date should be able to set the date in an elevated context" -Skip:(!$IsWindows) {
         { Get-Date | Set-Date } | Should Not Throw
     }
 
-    It "Set-Date should be able to set the date with -Date parameter" {
+    It "Set-Date should be able to set the date with -Date parameter" -Skip:(!$IsWindows) {
         $target = Get-Date
         $expected = $target
         Set-Date -Date $target | Should Be $expected
@@ -11,8 +12,7 @@ Describe "Set-Date for admin" -Tag @('CI', 'RequireAdminOnWindows') {
 }
 
 Describe "Set-Date" -Tag 'CI' {
-    # Currently CI tests on Linux/macOS are always run as sudo, so we need to skip this test on non-Windows platform.
-    It "Set-Date should produce an error in a non-elevated context" -Skip:(!$IsWindows) {
+    It "Set-Date should produce an error in a non-elevated context" {
         { Get-Date | Set-Date } | ShouldBeErrorId "System.ComponentModel.Win32Exception,Microsoft.PowerShell.Commands.SetDateCommand"
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Set-Date.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Set-Date.Tests.ps1
@@ -1,5 +1,7 @@
 Describe "Set-Date for admin" -Tag @('CI', 'RequireAdminOnWindows') {
     # Currently, CI tests on Linux/macOS are always run as normal user. So we need to skip these tests on non-Windows platform.
+    # CI tests in root privilege on Linux/macOS is not supported.
+    # See : https://github.com/PowerShell/PowerShell/issues/5645
     It "Set-Date should be able to set the date in an elevated context" -Skip:(!$IsWindows) {
         { Get-Date | Set-Date } | Should Not Throw
     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Set-Date.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Set-Date.Tests.ps1
@@ -1,22 +1,18 @@
-# first check to see which platform we're on. If we're on windows we should be able
-# to be sure whether we're running elevated. If we're on Linux, we can use whoami to
-# determine whether we're elevated
-Describe "Set-Date" -Tag "CI" {
-    BeforeAll {
-        $IsElevated = Test-IsElevated
-    }
-
-    It "Set-Date should be able to set the date in an elevated context" -Skip:(! $IsElevated) {
+Describe "Set-Date for admin" -Tag @('CI', 'RequireAdminOnWindows') {
+    It "Set-Date should be able to set the date in an elevated context" {
         { Get-Date | Set-Date } | Should Not Throw
     }
 
-    It "Set-Date should be able to set the date with -Date parameter" -Skip:(! $IsElevated) {
+    It "Set-Date should be able to set the date with -Date parameter" {
         $target = Get-Date
         $expected = $target
         Set-Date -Date $target | Should Be $expected
     }
+}
 
-    It "Set-Date should produce an error in a non-elevated context" -Skip:($IsElevated) {
+Describe "Set-Date" -Tag 'CI' {
+    # Currently CI tests on Linux/macOS are always run as sudo, so we need to skip this test on non-Windows platform.
+    It "Set-Date should produce an error in a non-elevated context" -Skip:(!$IsWindows) {
         { Get-Date | Set-Date } | ShouldBeErrorId "System.ComponentModel.Win32Exception,Microsoft.PowerShell.Commands.SetDateCommand"
     }
 }


### PR DESCRIPTION
## PR Summary

Fix #3099

Currently `Set-Date.Tests.ps1` dose not have `RequireAdminOnWindows` tag, so CI tests requiring elevated privilege are always skipped.
Using `RequireAdminOnWindows` tag instead of `Test-Elevated` function, I fix the problem.

## PR Checklist

Note: Please mark anything not applicable to this PR `NA`.

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [x] Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] User facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [x] Issue filed - Issue link: [Set-Date don't work and admin-elevated test is silently skipped](https://github.com/PowerShell/PowerShell/issues/3099)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
    - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
