### PR TITLE
Add Environment Variable override of telemetry

### DIFF
--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/Telemetry.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/Telemetry.cs
@@ -73,14 +73,14 @@ namespace Microsoft.PowerShell
             try
             {
                 // if the semaphore file exists, try to send telemetry
-                var Enabled = Utils.NativeFileExists(TelemetrySemaphoreFilePath) && !GetEnvironmentVariableAsBool(TelemetryOptoutEnvVar, false);
+                var enabled = Utils.NativeFileExists(TelemetrySemaphoreFilePath) && !GetEnvironmentVariableAsBool(TelemetryOptoutEnvVar, false);
 
-                if ( ! Enabled )
+                if (!enabled)
                 {
                     return;
                 }
 
-                if ( _telemetryClient == null )
+                if (_telemetryClient == null)
                 {
                     _telemetryClient = new TelemetryClient();
                 }

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/Telemetry.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/Telemetry.cs
@@ -21,7 +21,7 @@ namespace Microsoft.PowerShell
         // The name of the file by when present in $PSHOME will enable telemetry.
         // If this file is not present, no telemetry will be sent.
         private const string TelemetrySemaphoreFilename = "DELETE_ME_TO_DISABLE_CONSOLEHOST_TELEMETRY";
-        private const string TelemetryOptout = "POWERSHELL_TELEMETRY_OPTOUT";
+        private const string TelemetryOptoutEnvVar = "POWERSHELL_TELEMETRY_OPTOUT";
 
         // The path to the semaphore file which enables telemetry
         private static string TelemetrySemaphoreFilePath = Path.Combine(
@@ -73,7 +73,7 @@ namespace Microsoft.PowerShell
             try
             {
                 // if the semaphore file exists, try to send telemetry
-                var Enabled = Utils.NativeFileExists(TelemetrySemaphoreFilePath) && !GetEnvironmentVariableAsBool(TelemetryOptout, false);
+                var Enabled = Utils.NativeFileExists(TelemetrySemaphoreFilePath) && !GetEnvironmentVariableAsBool(TelemetryOptoutEnvVar, false);
 
                 if ( ! Enabled )
                 {

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/Telemetry.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/Telemetry.cs
@@ -43,7 +43,7 @@ namespace Microsoft.PowerShell
             TelemetryConfiguration.Active.TelemetryChannel.DeveloperMode = _developerMode;
         }
 
-        internal static bool GetEnvironmentVariableAsBool(string name, bool defaultValue) {
+        private static bool GetEnvironmentVariableAsBool(string name, bool defaultValue) {
             var str = Environment.GetEnvironmentVariable(name);
             if (string.IsNullOrEmpty(str))
             {

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/Telemetry.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/Telemetry.cs
@@ -21,6 +21,7 @@ namespace Microsoft.PowerShell
         // The name of the file by when present in $PSHOME will enable telemetry.
         // If this file is not present, no telemetry will be sent.
         private const string TelemetrySemaphoreFilename = "DELETE_ME_TO_DISABLE_CONSOLEHOST_TELEMETRY";
+        private const string TelemetryOptout = "POWERSHELL_TELEMETRY_OPTOUT";
 
         // The path to the semaphore file which enables telemetry
         private static string TelemetrySemaphoreFilePath = Path.Combine(
@@ -42,6 +43,28 @@ namespace Microsoft.PowerShell
             TelemetryConfiguration.Active.TelemetryChannel.DeveloperMode = _developerMode;
         }
 
+        internal static bool GetEnvironmentVariableAsBool(string name, bool defaultValue) {
+            var str = Environment.GetEnvironmentVariable(name);
+            if (string.IsNullOrEmpty(str))
+            {
+                return defaultValue;
+            }
+
+            switch (str.ToLowerInvariant())
+            {
+                case "true":
+                case "1":
+                case "yes":
+                    return true;
+                case "false":
+                case "0":
+                case "no":
+                    return false;
+                default:
+                    return defaultValue;
+            }
+        }
+
         /// <summary>
         /// Send the telemetry
         /// </summary>
@@ -50,14 +73,18 @@ namespace Microsoft.PowerShell
             try
             {
                 // if the semaphore file exists, try to send telemetry
-                if (Utils.NativeFileExists(TelemetrySemaphoreFilePath))
+                var Enabled = Utils.NativeFileExists(TelemetrySemaphoreFilePath) && !GetEnvironmentVariableAsBool(TelemetryOptout, false);
+
+                if ( ! Enabled )
                 {
-                    if ( _telemetryClient == null )
-                    {
-                        _telemetryClient = new TelemetryClient();
-                    }
-                    _telemetryClient.TrackEvent(eventName, payload, null);
+                    return;
                 }
+
+                if ( _telemetryClient == null )
+                {
+                    _telemetryClient = new TelemetryClient();
+                }
+                _telemetryClient.TrackEvent(eventName, payload, null);
             }
             catch (Exception)
             {


### PR DESCRIPTION
## PR Summary

Inspired by dotnet cli, and allows for Telemetry optout on packaing systems such as AppImage and Snapcraft where the filesystem is immutable.

## PR Checklist

Note: Please mark anything not applicable to this PR `NA`.

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [x] Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] User facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [x] Issue filed - Issue link: https://github.com/PowerShell/PowerShell-Docs/issues/2088
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [NA] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
    - [NA] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
