### PR TITLE
update test framework and tests to support 4x version of Pester

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -662,7 +662,8 @@ function Restore-PSModuleToBuild
 
     if($CI.IsPresent)
     {
-        Restore-PSPester -Destination $modulesDir
+        # take the latest version of pester and install it so it may be used
+        Save-Module -Path $modulesDir -Name Pester
     }
 }
 
@@ -987,7 +988,7 @@ function Start-PSPester {
         Write-Warning @"
 Pester module not found.
 Restore the module to '$Pester' by running:
-    Restore-PSPester
+    Save-Module Pester -Path '$binDir/Modules'
 "@
         return;
     }

--- a/docs/testing-guidelines/WritingPesterTests.md
+++ b/docs/testing-guidelines/WritingPesterTests.md
@@ -1,7 +1,11 @@
 ### Writing Pester Tests
-Note that this document does not replace the documents found in the [Pester](https://github.com/pester/pester "Pester") project. This is just
-some quick tips and suggestions for creating Pester tests for this project. The Pester community is vibrant and active, if you have questions
-about Pester or creating tests, the [Pester Wiki](https://github.com/pester/pester/wiki) has a lot of great information.
+Note that this document does not replace the documents found in the [Pester](https://github.com/pester/pester "Pester") project.
+This is just some quick tips and suggestions for creating Pester tests for this project.
+The Pester community is vibrant and active, if you have questions about Pester or creating tests, the [Pester Wiki](https://github.com/pester/pester/wiki) has a lot of great information.
+As of January 2018, PowerShell Core is using Pester version 4x which has some changes from earlier versions.
+See [Migrating from Pester 3 to Pester 4](https://github.com/pester/Pester/wiki/Migrating-from-Pester-3-to-Pester-4) for more information.
+
+
 
 When creating tests, keep the following in mind:
 * Tests should not be overly complicated and test too many things
@@ -16,7 +20,7 @@ Here's the simplest of tests
 Describe "A variable can be assigned and retrieved" {
     It "Create a variable and make sure its value is correct" {
        $a = 1
-       $a | Should be 1
+       $a | Should Be 1
    }
 }
 ```
@@ -27,7 +31,7 @@ If you need to do type checking, that can be done as well
 Describe "One is really one" {
     It "Compare 1 to 1" {
        $a = 1
-       $a | Should be 1
+       $a | Should Be 1
     }
     It "1 is really an int" {
        $i = 1
@@ -42,7 +46,7 @@ alternatively, you could do the following:
 Describe "One is really one" {
     It "Compare 1 to 1" {
        $a = 1
-       $a | Should be 1
+       $a | Should Be 1
     }
     It "1 is really an int" {
        $i = 1
@@ -136,7 +140,7 @@ $testCases = @(
 Describe "A test" {
     It "<a> -xor <b> should be <expectedresult>" -testcase $testcases {
         param ($a, $b, $ExpectedResult)
-        $a -xor $b | Should be $ExpectedResult
+        $a -xor $b | Should Be $ExpectedResult
     }
 }
 ```
@@ -151,7 +155,7 @@ The following example illustrates simple use:
 Context "Get-Random is not random" {
         Mock Get-Random { return 3 }
         It "Get-Random returns 3" {
-            Get-Random | Should be 3
+            Get-Random | Should Be 3
         }
     }
 ```

--- a/docs/testing-guidelines/WritingPesterTests.md
+++ b/docs/testing-guidelines/WritingPesterTests.md
@@ -2,7 +2,7 @@
 Note that this document does not replace the documents found in the [Pester](https://github.com/pester/pester "Pester") project.
 This is just some quick tips and suggestions for creating Pester tests for this project.
 The Pester community is vibrant and active, if you have questions about Pester or creating tests, the [Pester Wiki](https://github.com/pester/pester/wiki) has a lot of great information.
-As of January 2018, PowerShell Core is using Pester version 4x which has some changes from earlier versions.
+As of January 2018, PowerShell Core is using Pester version 4 which has some changes from earlier versions.
 See [Migrating from Pester 3 to Pester 4](https://github.com/pester/Pester/wiki/Migrating-from-Pester-3-to-Pester-4) for more information.
 
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Import-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Import-Module.Tests.ps1
@@ -42,7 +42,7 @@
 
     It "should only load the specified version" {
         Import-Module TestModule -RequiredVersion 1.1
-        (Get-Module TestModule).Version | Should Be "1.1"
+        (Get-Module TestModule).Version | Should BeIn "1.1"
     }
 }
 
@@ -192,7 +192,7 @@ Describe "Import-Module should be case insensitive" -Tags 'CI' {
         Import-Module testMODULE
         $m = Get-Module TESTmodule
         $m | Should BeOfType "System.Management.Automation.PSModuleInfo"
-        $m.Name | Should Be "TESTMODULE"
+        $m.Name | Should BeIn "TESTMODULE"
         mytest | Should BeExactly "hello"
         Remove-Module TestModule
         Get-Module tESTmODULE | Should BeNullOrEmpty

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Out-Default.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Out-Default.Tests.ps1
@@ -15,7 +15,7 @@ Describe "Out-Default Tests" -tag CI {
 "@
 
         & $powershell -noprofile -command $script | Should BeExactly 'bye'
-        "TestDrive:\transcript.txt" | Should Contain 'hello'
+        "TestDrive:\transcript.txt" | Should FileContentMatch 'hello'
     }
 
     It "Out-Default reverts transcription state when used more than once in a pipeline" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Clear-Content.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Clear-Content.Tests.ps1
@@ -64,7 +64,7 @@ Describe "Clear-Content cmdlet tests" -Tags "CI" {
     # we could suppress the WhatIf output here if we use the testhost, but it's not necessary
     It "The filesystem provider supports should process" -skip:(!$IsWindows) {
       clear-content TESTDRIVE:\$file2 -WhatIf
-      "TESTDRIVE:\$file2" | should contain "This is content"
+      "TESTDRIVE:\$file2" | should FileContentMatch "This is content"
     }
 
     It "The filesystem provider should support ShouldProcess (reference ProviderSupportsShouldProcess member)" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
@@ -378,8 +378,7 @@ Describe "Handling of globbing patterns" -Tags "CI" {
         BeforeEach {
             $file = New-Item -ItemType File -Path $filePath -Force
         }
-        AfterEach
-        {
+        AfterEach {
             Remove-Item -Force -Recurse -Path $dirPath -ErrorAction SilentlyContinue
             Remove-Item -Force -LiteralPath $newPath -ErrorAction SilentlyContinue
         }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
@@ -1391,7 +1391,7 @@ Describe "UNC paths" -Tags 'CI' {
             $testPath = Join-Path "\\localhost" $systemDrive
             & $cmdlet $testPath
             Get-Location | Should BeExactly "Microsoft.PowerShell.Core\FileSystem::$testPath"
-            $children = { Get-ChildItem -ErrorAction Stop } | Should Not Throw
+            $children = Get-ChildItem -ErrorAction Stop
             $children.Count | Should BeGreaterThan 0
         }
         finally {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Move-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Move-Item.Tests.ps1
@@ -9,7 +9,7 @@ Describe "Move-Item tests" -Tag "CI" {
         Move-Item $source $target
         test-path $source | Should be $false
         test-path $target | Should be $true
-        "$target" | Should ContainExactly "This is content"
+        "$target" | Should FileContentMatchExactly "This is content"
     }
 
     Context "Move-Item with filters" {
@@ -49,7 +49,7 @@ Describe "Move-Item tests" -Tag "CI" {
             $newBarPath | Should Exist
             $booPath | Should Exist
             $fooPath | Should Exist
-            $newBarPath | Should ContainExactly $barContent
+            $newBarPath | Should FileContentMatchExactly $barContent
         }
         It "Can move to different directory, filtered with -Exclude" {
             Move-Item -Path $filePath -Destination $moveToPath -Exclude "b*" -ErrorVariable e -ErrorAction SilentlyContinue
@@ -58,7 +58,7 @@ Describe "Move-Item tests" -Tag "CI" {
             $newFooPath | Should Exist
             $booPath | Should Exist
             $barPath | Should Exist
-            $newFooPath | Should ContainExactly $fooContent
+            $newFooPath | Should FileContentMatchExactly $fooContent
         }
         It "Can move to different directory, filtered with -Filter" {
             Move-Item -Path $filePath -Destination $moveToPath -Filter "bo*" -ErrorVariable e -ErrorAction SilentlyContinue
@@ -67,7 +67,7 @@ Describe "Move-Item tests" -Tag "CI" {
             $newBooPath | Should Exist
             $barPath | Should Exist
             $fooPath | Should Exist
-            $newBooPath | Should ContainExactly $booContent
+            $newBooPath | Should FileContentMatchExactly $booContent
         }
 
         It "Can rename via move, filtered with -Include" {
@@ -77,7 +77,7 @@ Describe "Move-Item tests" -Tag "CI" {
             $barPath | Should Not Exist
             $booPath | Should Exist
             $fooPath | Should Exist
-            $renameToPath | Should ContainExactly $barContent
+            $renameToPath | Should FileContentMatchExactly $barContent
         }
         It "Can rename via move, filtered with -Exclude" {
             Move-Item -Path $filePath -Destination $renameToPath -Exclude "b*" -ErrorVariable e -ErrorAction SilentlyContinue
@@ -86,7 +86,7 @@ Describe "Move-Item tests" -Tag "CI" {
             $fooPath | Should Not Exist
             $booPath | Should Exist
             $barPath | Should Exist
-            $renameToPath | Should ContainExactly $fooContent
+            $renameToPath | Should FileContentMatchExactly $fooContent
         }
         It "Can rename via move, filtered with -Filter" {
             Move-Item -Path $filePath -Destination $renameToPath -Filter "bo*" -ErrorVariable e -ErrorAction SilentlyContinue
@@ -95,7 +95,7 @@ Describe "Move-Item tests" -Tag "CI" {
             $booPath | Should Not Exist
             $fooPath | Should Exist
             $barPath | Should Exist
-            $renameToPath | Should ContainExactly $booContent
+            $renameToPath | Should FileContentMatchExactly $booContent
         }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Rename-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Rename-Item.Tests.ps1
@@ -9,6 +9,6 @@ Describe "Rename-Item tests" -Tag "CI" {
         Rename-Item $source $target
         test-path $source | Should be $false
         test-path $target | Should be $true
-        "$target" | Should ContainExactly "This is content"
+        "$target" | Should FileContentMatchExactly "This is content"
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/TimeZone.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/TimeZone.Tests.ps1
@@ -63,7 +63,7 @@ Describe "Get-Timezone test cases" -Tags "CI" {
     It "Call with ListAvailable switch returns a list containing TimeZoneInfo.Local" {
         $observedIdList = Get-TimeZone -ListAvailable | Select-Object -ExpandProperty BaseUtcOffset
         $oneExpectedOffset = ([System.TimeZoneInfo]::Local).BaseUtcOffset
-        $observedIdList -eq $oneExpectedOffset | Should Be $oneExpectedOffset
+        $oneExpectedOffset | Should BeIn $observedIdList
     }
 
     ## The local time zone could be set to UTC or GMT*. In this case, the .NET API returns the region ID
@@ -71,7 +71,7 @@ Describe "Get-Timezone test cases" -Tags "CI" {
     It "Call with ListAvailable switch returns a list containing one returned by Get-TimeZone" {
         $observedIdList = Get-TimeZone -ListAvailable | Select-Object -ExpandProperty BaseUtcOffset
         $oneExpectedOffset = (Get-TimeZone).BaseUtcOffset
-        $observedIdList -eq $oneExpectedOffset | Should Be $oneExpectedOffset
+        $oneExpectedOffset | Should BeIn $observedIdList
     }
 
     It "Call Get-TimeZone using ID param and single item" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertFrom-StringData.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertFrom-StringData.Tests.ps1
@@ -65,8 +65,9 @@ bazz = 2
     It "Should work for multiple lines" {
 	{ ConvertFrom-StringData -StringData $sampleData } | Should Not Throw
 
-	$(ConvertFrom-StringData -StringData $sampleData).Keys   | Should Be "foo", "bar", "bazz"
+    # keys are not order guaranteed
+	$(ConvertFrom-StringData -StringData $sampleData).Keys   | Should BeIn @("foo", "bar", "bazz")
 
-	$(ConvertFrom-StringData -StringData $sampleData).Values | Should Be "0","1","2"
+	$(ConvertFrom-StringData -StringData $sampleData).Values | Should BeIn @("0","1","2")
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Html.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Html.Tests.ps1
@@ -138,7 +138,9 @@ After the object
 
     It "Test ConvertTo-HTML meta with invalid properties should throw warning" {
         $parms = @{"authors"="John Doe";"keywords"="PowerShell,PSv6"}
-        ($customObject | ConvertTo-HTML -Meta $parms 3>&1) -match $parms["authors"]  | Should Be $true
+        # make this a string, rather than an array of string so match will behave
+        [string]$observedProperties = $customObject | ConvertTo-HTML -Meta $parms 3>&1
+        $observedProperties | Should Match $parms["authors"]
     }
 
     It "Test ConvertTo-HTML charset"{

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Export-Alias.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Export-Alias.Tests.ps1
@@ -63,46 +63,46 @@ Describe "Export-Alias DRT Unit Tests" -Tags "CI" {
 
 	It "Export-Alias for Default"{
 		Export-Alias $fulltestpath abcd01 -passthru
-		$fulltestpath| Should ContainExactly '"abcd01","efgh01","","None"'
+		$fulltestpath| Should FileContentMatchExactly '"abcd01","efgh01","","None"'
     }
 
 	It "Export-Alias As CSV"{
 		Export-Alias $fulltestpath abcd01 -As CSV -passthru
-		$fulltestpath| Should ContainExactly '"abcd01","efgh01","","None"'
+		$fulltestpath| Should FileContentMatchExactly '"abcd01","efgh01","","None"'
     }
 
 	It "Export-Alias As CSV With Description"{
 		Export-Alias $fulltestpath abcd01 -As CSV -description "My Aliases" -passthru
-		$fulltestpath| Should ContainExactly '"abcd01","efgh01","","None"'
-		$fulltestpath| Should ContainExactly "My Aliases"
+		$fulltestpath| Should FileContentMatchExactly '"abcd01","efgh01","","None"'
+		$fulltestpath| Should FileContentMatchExactly "My Aliases"
     }
 
 	It "Export-Alias As CSV With Multiline Description"{
 		Export-Alias $fulltestpath abcd01 -As CSV -description "My Aliases\nYour Aliases\nEveryones Aliases" -passthru
-		$fulltestpath| Should ContainExactly '"abcd01","efgh01","","None"'
-		$fulltestpath| Should ContainExactly "My Aliases"
-		$fulltestpath| Should ContainExactly "Your Aliases"
-		$fulltestpath| Should ContainExactly "Everyones Aliases"
+		$fulltestpath| Should FileContentMatchExactly '"abcd01","efgh01","","None"'
+		$fulltestpath| Should FileContentMatchExactly "My Aliases"
+		$fulltestpath| Should FileContentMatchExactly "Your Aliases"
+		$fulltestpath| Should FileContentMatchExactly "Everyones Aliases"
     }
 
 	It "Export-Alias As Script"{
 		Export-Alias $fulltestpath abcd01 -As Script -passthru
-		$fulltestpath| Should ContainExactly 'set-alias -Name:"abcd01" -Value:"efgh01" -Description:"" -Option:"None"'
+		$fulltestpath| Should FileContentMatchExactly 'set-alias -Name:"abcd01" -Value:"efgh01" -Description:"" -Option:"None"'
     }
 
 	It "Export-Alias As Script With Multiline Description"{
 		Export-Alias $fulltestpath abcd01 -As Script -description "My Aliases\nYour Aliases\nEveryones Aliases" -passthru
-		$fulltestpath| Should ContainExactly 'set-alias -Name:"abcd01" -Value:"efgh01" -Description:"" -Option:"None"'
-		$fulltestpath| Should ContainExactly "My Aliases"
-		$fulltestpath| Should ContainExactly "Your Aliases"
-		$fulltestpath| Should ContainExactly "Everyones Aliases"
+		$fulltestpath| Should FileContentMatchExactly 'set-alias -Name:"abcd01" -Value:"efgh01" -Description:"" -Option:"None"'
+		$fulltestpath| Should FileContentMatchExactly "My Aliases"
+		$fulltestpath| Should FileContentMatchExactly "Your Aliases"
+		$fulltestpath| Should FileContentMatchExactly "Everyones Aliases"
     }
 
 	It "Export-Alias for Force Test"{
 		Export-Alias $fulltestpath abcd01
 		Export-Alias $fulltestpath abcd02 -force
-		$fulltestpath| Should Not ContainExactly '"abcd01","efgh01","","None"'
-		$fulltestpath| Should ContainExactly '"abcd02","efgh02","","None"'
+		$fulltestpath| Should Not FileContentMatchExactly '"abcd01","efgh01","","None"'
+		$fulltestpath| Should FileContentMatchExactly '"abcd02","efgh02","","None"'
     }
 
 	It "Export-Alias for Force ReadOnly Test" {
@@ -124,9 +124,9 @@ Describe "Export-Alias DRT Unit Tests" -Tags "CI" {
 			$_.FullyQualifiedErrorId | Should be "FileOpenFailure,Microsoft.PowerShell.Commands.ExportAliasCommand"
 		}
 		Export-Alias $fulltestpath abcd03 -force
-		$fulltestpath| Should Not ContainExactly '"abcd01","efgh01","","None"'
-		$fulltestpath| Should Not ContainExactly '"abcd02","efgh02","","None"'
-		$fulltestpath| Should ContainExactly '"abcd03","efgh03","","None"'
+		$fulltestpath| Should Not FileContentMatchExactly '"abcd01","efgh01","","None"'
+		$fulltestpath| Should Not FileContentMatchExactly '"abcd02","efgh02","","None"'
+		$fulltestpath| Should FileContentMatchExactly '"abcd03","efgh03","","None"'
 
 		if ( $IsWindows )
 		{

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Variable.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Variable.Tests.ps1
@@ -145,7 +145,8 @@ Describe "Get-Variable" -Tags "CI" {
 	It "Should not be able to clear a global scope variable using the local switch" {
 	    New-Variable globalVar -Value 1 -Scope global -Force
 
-	    Get-Variable -Name globalVar -Scope local -ErrorAction SilentlyContinue | Should Throw
+	    Get-Variable -Name globalVar -Scope local -ErrorAction SilentlyContinue -ErrorVariable removeGlobalAsLocal
+        $removeGlobalAsLocal.FullyQualifiedErrorId | Should Be "VariableNotFound,Microsoft.PowerShell.Commands.GetVariableCommand"
 	}
 
 	It "Should be able to get a global variable when there's one in the script scope" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Variable.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Variable.Tests.ps1
@@ -146,7 +146,7 @@ Describe "Get-Variable" -Tags "CI" {
 	    New-Variable globalVar -Value 1 -Scope global -Force
 
 	    Get-Variable -Name globalVar -Scope local -ErrorAction SilentlyContinue -ErrorVariable removeGlobalAsLocal
-        $removeGlobalAsLocal.FullyQualifiedErrorId | Should Be "VariableNotFound,Microsoft.PowerShell.Commands.GetVariableCommand"
+	    $removeGlobalAsLocal.FullyQualifiedErrorId | Should Be "VariableNotFound,Microsoft.PowerShell.Commands.GetVariableCommand"
 	}
 
 	It "Should be able to get a global variable when there's one in the script scope" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Invoke-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Invoke-Item.Tests.ps1
@@ -67,7 +67,8 @@ Describe "Invoke-Item basic tests" -Tags "Feature" {
                 Get-Process -Name $notepadProcessName | Stop-Process -Force
                 Invoke-Item -Path $notepad
                 $notepadProcess = Get-Process -Name $notepadProcessName
-                $notepadProcess.Name | Should Be $notepadProcessName
+                # we need BeIn because multiple notepad processes could be running
+                $notepadProcess.Name | Should BeIn $notepadProcessName
                 Stop-Process -InputObject $notepadProcess
             }
         } else {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/New-Variable.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/New-Variable.Tests.ps1
@@ -85,8 +85,9 @@ Describe "New-Variable" -Tags "CI" {
     }
 
     It "Should not be able to set the name of a new variable to that of an old variable within same scope when the Force switch is missing" {
-	New-Variable var1
-	(New-Variable var1 -ErrorAction SilentlyContinue) | Should Throw
+        New-Variable var1
+        New-Variable var1 -ErrorAction SilentlyContinue -ErrorVariable newWhenExists
+        $newWhenExists.FullyQualifiedErrorId | Should Be "VariableAlreadyExists,Microsoft.PowerShell.Commands.NewVariableCommand"
     }
 
     It "Should change the value of an already existing variable using the Force switch" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Out-File.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Out-File.Tests.ps1
@@ -11,8 +11,8 @@ Describe "Out-File DRT Unit Tests" -Tags "CI" {
         $tempFile = Join-Path -Path $TestDrive -ChildPath "outfileAppendTest.txt"
         { 'This is first line.' | out-file $tempFile } | Should Not Throw
         { 'This is second line.' | out-file -append $tempFile } | Should Not Throw
-        $tempFile |Should Contain "first"
-        $tempFile |Should Contain "second"
+        $tempFile |Should FileContentMatch "first"
+        $tempFile |Should FileContentMatch "second"
         Remove-Item $tempFile -Force
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Remove-Event.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Remove-Event.Tests.ps1
@@ -12,7 +12,7 @@ Describe "Remove-Event" -Tags "CI" {
 
 	It "Should remove an event given a sourceidentifier" {
 	    { Remove-Event -sourceidentifier PesterTimer }
-	    { Get-Event -ErrorAction SilentlyContinue | Should Not Contain PesterTimer }
+	    { Get-Event -ErrorAction SilentlyContinue | Should Not FileMatchContent PesterTimer }
 	}
 
 	It "Should remove an event given an event identifier" {
@@ -20,19 +20,19 @@ Describe "Remove-Event" -Tags "CI" {
 	    { $events = $events.EventIdentifier }
 	    { Remove-Event -EventIdentifier $events }
 	    { $events = Get-Event -ErrorAction SilentlyContinue}
-	    { $events.SourceIdentifier | Should Not Contain "PesterTimer" }
+	    { $events.SourceIdentifier | Should Not FileMatchContent "PesterTimer" }
 	}
 
 	It "Should be able to remove an event given a pipe from Get-Event" {
 	    { Get-Event -sourceidentifier PesterTimer | Remove-Event }
-	    { Get-Event -ErrorAction SilentlyContinue | Should Not Contain "PesterTimer" }
+	    { Get-Event -ErrorAction SilentlyContinue | Should Not FileMatchContent "PesterTimer" }
 
 	}
 
 	It "Should NOT remove an event given the whatif flag" {
 	    { Remove-Event -sourceidentifier PesterTimer -whatif }
 	    { $events = Get-Event }
-	    { $events.SourceIdentifier  | Should Contain "PesterTimer" }
+	    { $events.SourceIdentifier  | Should FileContentMatch "PesterTimer" }
 	}
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Remove-Variable.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Remove-Variable.Tests.ps1
@@ -5,7 +5,7 @@ Describe "Remove-Variable" -Tags "CI" {
     It "Should throw an error when a dollar sign is used in the variable name place" {
 	New-Variable -Name var1 -Value 4
 
-	Remove-Variable $var1 -ErrorAction SilentlyContinue | Should Throw
+	{ Remove-Variable $var1 -ErrorAction Stop } | Should Throw
     }
 
     It "Should not throw error when used without the Name field, and named variable is properly specified and exists" {
@@ -25,7 +25,7 @@ Describe "Remove-Variable" -Tags "CI" {
     }
 
     It "Should throw error when used with Name field, and named variable does not exist" {
-	Remove-Variable -Name nonexistentVariable -ErrorAction SilentlyContinue | Should Throw
+	{ Remove-Variable -Name nonexistentVariable -ErrorAction Stop } | Should Throw
     }
 
     It "Should be able to remove a set of variables using wildcard characters" {
@@ -87,7 +87,7 @@ Describe "Remove-Variable" -Tags "CI" {
     It "Should throw an error when attempting to remove a read-only variable and the Force switch is not used" {
 	New-Variable -Name var1 -Value 2 -Option ReadOnly
 
-	Remove-Variable -Name var1 -ErrorAction SilentlyContinue | Should Throw
+	{ Remove-Variable -Name var1 -ErrorAction Stop } | Should Throw
 
 	$var1 | Should Be 2
 
@@ -99,7 +99,7 @@ Describe "Remove-Variable" -Tags "CI" {
 
 	Remove-Variable -Name var1 -Force
 
-	$var1 | Should Be # Nothing.  It should be nothing at all.
+	$var1 | Should BeNullOrEmpty
     }
 
     Context "Scope Tests" {
@@ -108,73 +108,73 @@ Describe "Remove-Variable" -Tags "CI" {
 
 	    Remove-Variable -Name var1 -Scope global
 
-	    $var1 | Should Be #Nothing.
+	    $var1 | Should BeNullOrEmpty
 	}
 
 	It "Should not be able to clear a global variable using the local switch" {
 	    New-Variable -Name var1 -Value "context" -Scope global
 
-	    Remove-Variable -Name var1 -Scope local -ErrorAction SilentlyContinue | Should Throw
+	    { Remove-Variable -Name var1 -Scope local -ErrorAction Stop } | Should Throw
 
 	    $var1 | Should Be "context"
 
 	    Remove-Variable -Name var1 -Scope global
-	    $var1 | Should Be # Nothing
+	    $var1 | Should BeNullOrEmpty
 	}
 
 	It "Should not be able to clear a global variable using the script switch" {
 	    New-Variable -Name var1 -Value "context" -Scope global
 
-	    Remove-Variable -Name var1 -Scope local -ErrorAction SilentlyContinue | Should Throw
+	    { Remove-Variable -Name var1 -Scope local -ErrorAction Stop } | Should Throw
 
 	    $var1 | Should Be "context"
 
 	    Remove-Variable -Name var1 -Scope global
-	    $var1 | Should Be # Nothing
+	    $var1 | Should BeNullOrEmpty
 	}
 
 	It "Should be able to remove an item locally using the local switch" {
 	    New-Variable -Name var1 -Value "context" -Scope local
 
-	    Remove-Variable -Name var1 -Scope local -ErrorAction SilentlyContinue | Should Throw
+	    { Remove-Variable -Name var1 -Scope local -ErrorAction Stop } | Should Throw
 
-	    $var1 | Should Be # Nothing
+	    $var1 | Should be context
 	}
 
 	It "Should be able to remove an item locally using the global switch" {
 	    New-Variable -Name var1 -Value "context" -Scope local
 
-	    Remove-Variable -Name var1 -Scope global -ErrorAction SilentlyContinue | Should Throw
+	    { Remove-Variable -Name var1 -Scope global -ErrorAction Stop } | Should Throw
 
 	    $var1 | Should Be "context"
 
 	    Remove-Variable -Name var1 -Scope local
-	    $var1 | Should Be # Nothing
+	    $var1 | Should BeNullOrEmpty
 	}
 
 	It "Should be able to remove a local variable using the script scope switch" {
 	    New-Variable -Name var1 -Value "context" -Scope local
 
-	    Remove-Variable -Name var1 -Scope script -ErrorAction SilentlyContinue | Should Throw
+	    { Remove-Variable -Name var1 -Scope script -ErrorAction Stop } | Should Throw
 
 	    $var1 | Should Be "context"
 
 	    Remove-Variable -Name var1 -Scope local
-	    $var1 | Should Be # Nothing
+	    $var1 | Should BeNullOrEmpty
 	}
 
 	It "Should be able to remove a script variable created using the script switch" {
 	    New-Variable -Name var1 -Value "context" -Scope script
 
-	    Remove-Variable -Name var1 -Scope script | Should Throw
+	    { Remove-Variable -Name var1 -Scope script } | Should Not Throw
 
-	    $var1 | Should Be # Nothing
+	    $var1 | Should BeNullOrEmpty
 	}
 
 	It "Should not be able to remove a global script variable that was created using the script scope switch" {
 	    New-Variable -Name var1 -Value "context" -Scope script
 
-	    Remove-Variable -Name var1 -Scope global -ErrorAction SilentlyContinue | Should Throw
+	    { Remove-Variable -Name var1 -Scope global -ErrorAction Stop } | Should Throw
 
 	    $var1 | Should Be "context"
 	}

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Remove-Variable.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Remove-Variable.Tests.ps1
@@ -5,7 +5,8 @@ Describe "Remove-Variable" -Tags "CI" {
     It "Should throw an error when a dollar sign is used in the variable name place" {
 	New-Variable -Name var1 -Value 4
 
-	{ Remove-Variable $var1 -ErrorAction Stop } | Should Throw
+	Remove-Variable $var1 -ErrorAction SilentlyContinue -ErrorVariable err
+	$err.FullyQualifiedErrorId | Should Be "VariableNotFound,Microsoft.PowerShell.Commands.RemoveVariableCommand"
     }
 
     It "Should not throw error when used without the Name field, and named variable is properly specified and exists" {
@@ -138,7 +139,7 @@ Describe "Remove-Variable" -Tags "CI" {
 
 	    { Remove-Variable -Name var1 -Scope local -ErrorAction Stop } | Should Throw
 
-	    $var1 | Should be context
+	    $var1 | Should Be context
 	}
 
 	It "Should be able to remove an item locally using the global switch" {
@@ -200,7 +201,7 @@ Describe "Remove-Variable basic functionality" -Tags "CI" {
 		catch
 		{
 			$_.CategoryInfo | Should Match "SessionStateUnauthorizedAccessException"
-			$_.FullyQualifiedErrorId | Should be "VariableNotRemovable,Microsoft.PowerShell.Commands.RemoveVariableCommand"
+			$_.FullyQualifiedErrorId | Should Be "VariableNotRemovable,Microsoft.PowerShell.Commands.RemoveVariableCommand"
 		}
 	}
 
@@ -214,7 +215,7 @@ Describe "Remove-Variable basic functionality" -Tags "CI" {
 		catch
 		{
 			$_.CategoryInfo| Should Match "SessionStateUnauthorizedAccessException"
-			$_.FullyQualifiedErrorId | Should be "VariableNotRemovable,Microsoft.PowerShell.Commands.RemoveVariableCommand"
+			$_.FullyQualifiedErrorId | Should Be "VariableNotRemovable,Microsoft.PowerShell.Commands.RemoveVariableCommand"
 		}
 		Remove-Variable foo -Force
 		$var1 = Get-Variable -Name foo -EA SilentlyContinue
@@ -231,7 +232,7 @@ Describe "Remove-Variable basic functionality" -Tags "CI" {
 		catch
 		{
 			$_.CategoryInfo | Should Match "SessionStateUnauthorizedAccessException"
-			$_.FullyQualifiedErrorId | Should be "VariableNotRemovable,Microsoft.PowerShell.Commands.RemoveVariableCommand"
+			$_.FullyQualifiedErrorId | Should Be "VariableNotRemovable,Microsoft.PowerShell.Commands.RemoveVariableCommand"
 		}
 
 		try
@@ -242,7 +243,7 @@ Describe "Remove-Variable basic functionality" -Tags "CI" {
 		catch
 		{
 			$_.CategoryInfo | Should Match "SessionStateUnauthorizedAccessException"
-			$_.FullyQualifiedErrorId | Should be "VariableNotRemovable,Microsoft.PowerShell.Commands.RemoveVariableCommand"
+			$_.FullyQualifiedErrorId | Should Be "VariableNotRemovable,Microsoft.PowerShell.Commands.RemoveVariableCommand"
 		}
 	}
 
@@ -258,7 +259,7 @@ Describe "Remove-Variable basic functionality" -Tags "CI" {
 			catch
 			{
 				$_.CategoryInfo | Should Match "ItemNotFoundException"
-				$_.FullyQualifiedErrorId | Should be "VariableNotFound,Microsoft.PowerShell.Commands.GetVariableCommand"
+				$_.FullyQualifiedErrorId | Should Be "VariableNotFound,Microsoft.PowerShell.Commands.GetVariableCommand"
 			}
 		}
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-String.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-String.Tests.ps1
@@ -104,7 +104,7 @@ Describe "Select-String" -Tags "CI" {
 	It "Should return the name of the file and the string that 'string' is found if there is only one lines that has a match" {
 	    $expected = $testInputFile + ":1:This is a text string, and another string"
 
-	    Select-String $(Split-Path $testInputFile -NoQualifier) -Pattern "string" | Should Be $expected
+	    Select-String $testInputFile -Pattern "string" | Should Be $expected
 	}
 
 	It "Should return all strings where 'second' is found in testfile1 if there is only one lines that has a match" {
@@ -148,8 +148,7 @@ Describe "Select-String" -Tags "CI" {
 	    $expected  = "testfile1.txt:3:This is the third line"
 
 	    $relativePath = Join-Path -Path $testDirectory -ChildPath ".."
-	    $relativePath = Join-Path -Path $relativePath -ChildPath ".."
-	    $relativePath = Join-Path -Path $relativePath -ChildPath (Split-Path $testDirectory -NoQualifier)
+	    $relativePath = Join-Path -Path $relativePath -ChildPath $TestDirectory.Name
 	    $relativePath = Join-Path -Path $relativePath -ChildPath testfile1.txt
 	    Select-String third $relativePath  | Should Match $expected
 	}

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Set-PSBreakpoint.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Set-PSBreakpoint.Tests.ps1
@@ -67,8 +67,8 @@ set-psbreakpoint -command foo
 
     It "-script and -line can take multiple items" {
         $brk = sbp -line 11,12,13 -column 1 -script $scriptFileName,$scriptFileName
-        $brk.Line | Should Be 11,12,13
-        $brk.Column | Should Be 1
+        $brk.Line | Should BeIn 11,12,13
+        $brk.Column | Should BeIn 1
         Remove-PSBreakPoint -Id $brk.Id
     }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Error.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Error.Tests.ps1
@@ -75,14 +75,12 @@ Describe "Write-Error Tests" -Tags "CI" {
         $e.CategoryInfo.GetMessage() | Should Be 'NotSpecified: (fooTargetName:fooTargetType) [fooAct], fooReason'
     }
 
-    It "Should be able to throw" {
-    	Write-Error "test throw" -ErrorAction SilentlyContinue | Should Throw
+    It "Should be able to throw with -ErrorAction stop" {
+    	{ Write-Error "test throw" -ErrorAction Stop } | Should Throw
     }
 
     It "Should throw a non-terminating error" {
-        Write-Error "test throw" -ErrorAction SilentlyContinue
-
-        1 + 1 | Should Be 2
+        { Write-Error "test throw" -ErrorAction SilentlyContinue } | Should Not Throw
     }
 
     It "Should trip an exception using the exception switch" {
@@ -106,17 +104,17 @@ Describe "Write-Error Tests" -Tags "CI" {
         $theError = "Error: Too many input values."
         write-error -message $theError -category InvalidArgument -ErrorAction SilentlyContinue
 
-        $error[0]| Should Be $theError
+        [string]$error[0]| Should Be $theError
     }
 
-    It "ErrorRecord should not be truncated" {
+    It "ErrorRecord should not be truncated or have inserted newlines when redirected from another process" {
         $longtext = "0123456789"
         while ($longtext.Length -lt [console]::WindowWidth) {
             $longtext += $longtext
         }
-        pwsh -c Write-Error -Message $longtext 2>&1 > $testdrive\error.txt
-        $e = Get-Content -Path $testdrive\error.txt
-        $e.Count | Should BeExactly 4
-        $e[0] | Should Match $longtext
+        $pwsh = $pshome + "/pwsh"
+        $result = & $pwsh -c Write-Error -Message $longtext 2>&1
+        $result.Count | Should BeExactly 4
+        $result[0] | Should Match $longtext
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Output.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Output.Tests.ps1
@@ -16,7 +16,8 @@ Describe "Write-Output DRT Unit Tests" -Tags "CI" {
 
     It "Works with NoEnumerate switch" {
         $objectWritten = 1, 2.2, @("John", "Smith", 10), "abc"
-        Write-Output $objectWritten -NoEnumerate 6>&1 | Should be  '1 2.2 System.Object[] abc'
+        [string]$s = Write-Output $objectWritten -NoEnumerate 6>&1 
+        $s | Should be  '1 2.2 System.Object[] abc'
     }
 }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Stream.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Stream.Tests.ps1
@@ -74,7 +74,7 @@ Describe "Stream writer tests" -Tags "CI" {
             $result | Should BeOfType System.Management.Automation.InformationRecord
 
             # Use Match instead of Be so we can avoid dealing with a potential domain name
-            $result.Computer | Should Match "^($([environment]::MachineName)){1}(\.[a-zA-Z0-9]+)*$"
+            $result.Computer | Should Match "^($([environment]::MachineName)){1}(\.[a-zA-Z0-9]+)*$|^localhost$"
             if ($IsWindows)
             {
                 $result.User | Should Match ".*${env:USERNAME}"

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Stream.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Stream.Tests.ps1
@@ -15,15 +15,6 @@ Describe "Stream writer tests" -Tags "CI" {
 
     }
 
-    function Get-OutputResults
-    {
-        # Get the contents of the targetfile.
-        # Make the array a string for less brittle testing
-        $output = $(Get-Content $args[0])
-        [String]::Join([Environment]::NewLine, $output )
-
-        return $output
-    }
     Context "Redirect Stream Tests" {
         # These tests validate that a stream is actually being written to by redirecting the output of that stream
 
@@ -36,28 +27,20 @@ Describe "Stream writer tests" -Tags "CI" {
 
         It "Should write error messages to the error stream" {
             Write-Error "Testing Error" 2>&1 > $targetfile
-
-            $result = Get-OutputResults $targetfile
             # The contents of the error stream should contain the expected text
-            $result -match ": Testing Error" | Should Be $true
+            $targetfile | Should FileContentMatch ": Testing Error"
         }
 
         It "Should write debug messages to the debug stream" {
             Write-Messages -Debug -EA SilentlyContinue 5>&1 > $targetfile
-
-            $result = Get-OutputResults $targetfile
-
             # The contents of the debug stream should contain the expected text
-            $result -match "Debug Message" | Should Be $true
+            $targetfile | Should FileContentMatch "Debug Message"
         }
 
         It "Should write messages to the verbose stream" {
             Write-Messages -Verbose 4>&1 > $targetfile
-
-            $result = Get-OutputResults $targetfile
-
             # The contents of the debug stream should contain the expected text
-            $result -match "Verbose Message" | Should Be $true
+            $targetfile | Should FileContentMatch "Verbose Message"
         }
     }
 
@@ -83,7 +66,7 @@ Describe "Stream writer tests" -Tags "CI" {
             $ps.Dispose()
         }
 
-       It "Write-Information outputs an information object" -Pending:($IsMacOS) {
+       It "Write-Information outputs an information object" {
             # redirect the streams is sufficient
             $result = Write-Information "Test Message" *>&1
             $result.NativeThreadId | Should Not Be 0

--- a/test/powershell/Modules/Microsoft.Powershell.Host/Start-Transcript.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.Powershell.Host/Start-Transcript.Tests.ps1
@@ -32,9 +32,9 @@ Describe "Start-Transcript, Stop-Transcript tests" -tags "CI" {
                     $ps.addscript("Stop-Transcript").Invoke()
 
                     Test-Path $outputFilePath | Should be $true
-                    $outputFilePath | should contain "Get-Date"
+                    $outputFilePath | should FileContentMatch "Get-Date"
                     if($append) {
-                        $outputFilePath | Should contain $content
+                        $outputFilePath | Should FileContentMatch $content
                     }
                 }
             } finally {
@@ -122,7 +122,7 @@ Describe "Start-Transcript, Stop-Transcript tests" -tags "CI" {
         }
 
         Test-Path $transcriptFilePath | Should be $true
-        $transcriptFilePath | Should contain "After Dispose"
+        $transcriptFilePath | Should FileContentMatch "After Dispose"
     }
 
     It "Transcription should be closed if the only runspace gets closed" {
@@ -131,8 +131,8 @@ Describe "Start-Transcript, Stop-Transcript tests" -tags "CI" {
         Invoke-Expression $powerShellCommand
 
         Test-Path $transcriptFilePath | Should be $true
-        $transcriptFilePath | Should contain "Before Dispose"
-        $transcriptFilePath | Should contain "PowerShell transcript end"
+        $transcriptFilePath | Should FileContentMatch "Before Dispose"
+        $transcriptFilePath | Should FileContentMatch "PowerShell transcript end"
     }
 
     It "Transcription should record native command output" {
@@ -144,6 +144,6 @@ Describe "Start-Transcript, Stop-Transcript tests" -tags "CI" {
         Test-Path $transcriptFilePath | Should be $true
 
         $machineName = [System.Environment]::MachineName
-        $transcriptFilePath | Should contain $machineName
+        $transcriptFilePath | Should FileContentMatch $machineName
     }
 }

--- a/test/powershell/engine/Basic/CommandDiscovery.Tests.ps1
+++ b/test/powershell/engine/Basic/CommandDiscovery.Tests.ps1
@@ -90,7 +90,7 @@
 
         foreach($command in $commands)
         {
-            $command.GetType().Name | should be @("AliasInfo","FunctionInfo","CmdletInfo","FilterInfo")
+            $command.GetType().Name | Should BeIn @("AliasInfo","FunctionInfo","CmdletInfo","FilterInfo")
         }
     }
 


### PR DESCRIPTION
Use the latest version of Pester from the Gallery to invoke our tests. A number of test changes needed to be made because some assertions were dropped in the 4x version of Pester.
I have left the Restore-PSPester function in the case that someone would like to have the older version. This can certainly be removed if desired.