### PR TITLE
Fix "Pull Request Process" dead link in GOVERNANCE.md

### DIFF
--- a/docs/community/governance.md
+++ b/docs/community/governance.md
@@ -132,6 +132,6 @@ See our [Pull Request Process][pull-request-process]
 [ci-system]: ../testing-guidelines/testing-guidelines.md#ci-system
 [breaking-changes]: ../dev-process/breaking-change-contract.md
 [issue-process]: ../maintainers/issue-management.md
-[pull-request-process]: ../maintainers/pull-request-process.md
+[pull-request-process]: ../../.github/CONTRIBUTING.md#lifecycle-of-a-pull-request
 [docs-contributing]: https://github.com/PowerShell/PowerShell-Docs/blob/staging/CONTRIBUTING.md
 [maintainers]: ../maintainers/README.md


### PR DESCRIPTION
## PR Summary

In the project governance document, the current "Pull Request Process" anchor links to a non-existing document. 

The closest I could find was the Pull Request section in the CONTRIBUTING.md guide, so I've added that in the link section.


## PR Checklist

Note: Please mark anything not applicable to this PR `NA`.

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [X] Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] User facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [ ] Issue filed - Issue link:
- [X] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
    - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.