### PR TITLE
Fix filtering of analytic events on Unix platforms.

### DIFF
--- a/src/System.Management.Automation/engine/PSConfiguration.cs
+++ b/src/System.Management.Automation/engine/PSConfiguration.cs
@@ -247,8 +247,6 @@ namespace System.Management.Automation.Configuration
         /// </summary>
         const string LogDefaultValue = "default";
 
-        const PSChannel DefaultChannels = PSChannel.Operational;
-
         /// <summary>
         /// Gets the bitmask of the PSChannel values to log.
         /// </summary>
@@ -282,14 +280,11 @@ namespace System.Management.Automation.Configuration
 
             if (result == 0)
             {
-                result = DefaultChannels;
+                result = PSSysLogProvider.DefaultChannels;
             }
 
             return result;
         }
-
-        // by default, do not include analytic events.
-        const PSKeyword DefaultKeywords = (PSKeyword) (0xFFFFFFFFFFFFFFFF & ~(ulong)PSKeyword.UseAlwaysAnalytic);
 
         /// <summary>
         /// Gets the bitmask of keywords to log.
@@ -324,7 +319,7 @@ namespace System.Management.Automation.Configuration
 
             if (result == 0)
             {
-                result = DefaultKeywords;
+                result = PSSysLogProvider.DefaultKeywords;
             }
 
             return result;

--- a/src/System.Management.Automation/engine/PSConfiguration.cs
+++ b/src/System.Management.Automation/engine/PSConfiguration.cs
@@ -280,7 +280,7 @@ namespace System.Management.Automation.Configuration
 
             if (result == 0)
             {
-                result = PSSysLogProvider.DefaultChannels;
+                result = System.Management.Automation.Tracing.PSSysLogProvider.DefaultChannels;
             }
 
             return result;
@@ -319,7 +319,7 @@ namespace System.Management.Automation.Configuration
 
             if (result == 0)
             {
-                result = PSSysLogProvider.DefaultKeywords;
+                result = System.Management.Automation.Tracing.PSSysLogProvider.DefaultKeywords;
             }
 
             return result;

--- a/src/System.Management.Automation/engine/remoting/common/PSETWTracer.cs
+++ b/src/System.Management.Automation/engine/remoting/common/PSETWTracer.cs
@@ -198,8 +198,16 @@ namespace System.Management.Automation.Internal
     [Flags]
     internal enum PSChannel : byte
     {
+    #if UNIX
+        // On Windows, PSChannel is the numeric channel id value.
+        // On Linux, PSChannel it is used to filter events and 
+        // the underlying channel bitmask values are used instead.
+        Operational = 0x80,
+        Analytic = 0x40
+    #else
         Operational = 0x10,
         Analytic = 0x11
+    #endif   
     }
 
     /// <summary>

--- a/src/System.Management.Automation/engine/remoting/common/PSETWTracer.cs
+++ b/src/System.Management.Automation/engine/remoting/common/PSETWTracer.cs
@@ -195,20 +195,26 @@ namespace System.Management.Automation.Internal
     /// <summary>
     /// Defines enumerations for channels
     /// </summary>
+    /// <remarks>
+    /// On Windows, PSChannel is the numeric channel id value.
+    /// On Non-Windows, PSChannel is used to filter events and
+    /// the underlying channel bitmask values are used instead.
+    /// The bit values are the same as used on Windows.
+    /// </remarks>
+#if UNIX
     [Flags]
     internal enum PSChannel : byte
     {
-    #if UNIX
-        // On Windows, PSChannel is the numeric channel id value.
-        // On Non-Windows, PSChannel it is used to filter events and 
-        // the underlying channel bitmask values are used instead.
         Operational = 0x80,
         Analytic = 0x40
-    #else
+    }
+#else
+    internal enum PSChannel : byte
+    {
         Operational = 0x10,
         Analytic = 0x11
-    #endif   
     }
+#endif
 
     /// <summary>
     /// Defines enumerations for tasks

--- a/src/System.Management.Automation/engine/remoting/common/PSETWTracer.cs
+++ b/src/System.Management.Automation/engine/remoting/common/PSETWTracer.cs
@@ -200,7 +200,7 @@ namespace System.Management.Automation.Internal
     {
     #if UNIX
         // On Windows, PSChannel is the numeric channel id value.
-        // On Linux, PSChannel it is used to filter events and 
+        // On Non-Windows, PSChannel it is used to filter events and 
         // the underlying channel bitmask values are used instead.
         Operational = 0x80,
         Analytic = 0x40

--- a/src/System.Management.Automation/engine/runtime/CompiledScriptBlock.cs
+++ b/src/System.Management.Automation/engine/runtime/CompiledScriptBlock.cs
@@ -1405,7 +1405,7 @@ namespace System.Management.Automation
                         // attacker seeing potentially sensitive data. Because if they aren't detected, then
                         // they can just wait on the compromised box and see the sensitive data eventually anyways.
                         string errorMessage = StringUtil.Format(SecuritySupportStrings.CouldNotUseCertificate, error.ToString());
-                        PSEtwLog.LogOperationalError(PSEventId.ScriptBlock_Compile_Detail, PSOpcode.Create, PSTask.ExecuteCommand, PSKeyword.UseAlwaysAnalytic,
+                        PSEtwLog.LogOperationalError(PSEventId.ScriptBlock_Compile_Detail, PSOpcode.Create, PSTask.ExecuteCommand, PSKeyword.UseAlwaysOperational,
                                         0, 0, errorMessage, scriptBlock.Id.ToString(), scriptBlock.File ?? String.Empty);
 
                         return true;
@@ -1430,7 +1430,7 @@ namespace System.Management.Automation
                             }
 
                             string errorMessage = StringUtil.Format(SecuritySupportStrings.CertificateContainsPrivateKey, certificateForLog);
-                            PSEtwLog.LogOperationalError(PSEventId.ScriptBlock_Compile_Detail, PSOpcode.Create, PSTask.ExecuteCommand, PSKeyword.UseAlwaysAnalytic,
+                            PSEtwLog.LogOperationalError(PSEventId.ScriptBlock_Compile_Detail, PSOpcode.Create, PSTask.ExecuteCommand, PSKeyword.UseAlwaysOperational,
                                             0, 0, errorMessage, scriptBlock.Id.ToString(), scriptBlock.File ?? String.Empty);
                         }
                     }
@@ -1794,7 +1794,7 @@ namespace System.Management.Automation
 
             if (GetScriptBlockLoggingSetting()?.EnableScriptBlockInvocationLogging == true)
             {
-                PSEtwLog.LogOperationalVerbose(PSEventId.ScriptBlock_Invoke_Start_Detail, PSOpcode.Create, PSTask.CommandStart, PSKeyword.UseAlwaysAnalytic,
+                PSEtwLog.LogOperationalVerbose(PSEventId.ScriptBlock_Invoke_Start_Detail, PSOpcode.Create, PSTask.CommandStart, PSKeyword.UseAlwaysOperational,
                     scriptBlock.Id.ToString(), runspaceId.ToString());
             }
         }
@@ -1803,7 +1803,7 @@ namespace System.Management.Automation
         {
             if (GetScriptBlockLoggingSetting()?.EnableScriptBlockInvocationLogging == true)
             {
-                PSEtwLog.LogOperationalVerbose(PSEventId.ScriptBlock_Invoke_Complete_Detail, PSOpcode.Create, PSTask.CommandStop, PSKeyword.UseAlwaysAnalytic,
+                PSEtwLog.LogOperationalVerbose(PSEventId.ScriptBlock_Invoke_Complete_Detail, PSOpcode.Create, PSTask.CommandStop, PSKeyword.UseAlwaysOperational,
                     scriptBlock.Id.ToString(), runspaceId.ToString());
             }
         }

--- a/src/System.Management.Automation/engine/runtime/CompiledScriptBlock.cs
+++ b/src/System.Management.Automation/engine/runtime/CompiledScriptBlock.cs
@@ -1321,7 +1321,7 @@ namespace System.Management.Automation
                             // they can just wait on the compromised box and see the sensitive data eventually anyways.
 
                             string errorMessage = StringUtil.Format(SecuritySupportStrings.CouldNotEncryptContent, textToLog, error.ToString());
-                            PSEtwLog.LogOperationalError(PSEventId.ScriptBlock_Compile_Detail, PSOpcode.Create, PSTask.ExecuteCommand, PSKeyword.UseAlwaysAnalytic,
+                            PSEtwLog.LogOperationalError(PSEventId.ScriptBlock_Compile_Detail, PSOpcode.Create, PSTask.ExecuteCommand, PSKeyword.UseAlwaysOperational,
                                             0, 0, errorMessage, scriptBlock.Id.ToString(), scriptBlock.File ?? String.Empty);
                         }
                         else
@@ -1334,12 +1334,12 @@ namespace System.Management.Automation
 
             if (scriptBlock._scriptBlockData.HasSuspiciousContent)
             {
-                PSEtwLog.LogOperationalWarning(PSEventId.ScriptBlock_Compile_Detail, PSOpcode.Create, PSTask.ExecuteCommand, PSKeyword.UseAlwaysAnalytic,
+                PSEtwLog.LogOperationalWarning(PSEventId.ScriptBlock_Compile_Detail, PSOpcode.Create, PSTask.ExecuteCommand, PSKeyword.UseAlwaysOperational,
                     segment + 1, segments, textToLog, scriptBlock.Id.ToString(), scriptBlock.File ?? String.Empty);
             }
             else
             {
-                PSEtwLog.LogOperationalVerbose(PSEventId.ScriptBlock_Compile_Detail, PSOpcode.Create, PSTask.ExecuteCommand, PSKeyword.UseAlwaysAnalytic,
+                PSEtwLog.LogOperationalVerbose(PSEventId.ScriptBlock_Compile_Detail, PSOpcode.Create, PSTask.ExecuteCommand, PSKeyword.UseAlwaysOperational,
                     segment + 1, segments, textToLog, scriptBlock.Id.ToString(), scriptBlock.File ?? String.Empty);
             }
 

--- a/src/System.Management.Automation/utils/tracing/PSSysLogProvider.cs
+++ b/src/System.Management.Automation/utils/tracing/PSSysLogProvider.cs
@@ -17,8 +17,11 @@ namespace System.Management.Automation.Tracing
     {
         private static SysLogProvider s_provider;
 
-        // by default, do not include analytic events
-        internal const PSKeyword DefaultKeywords = (PSKeyword) (0xFFFFFFFFFFFFFFFF & ~(ulong)PSKeyword.UseAlwaysAnalytic);
+        // by default, do not include channel bits
+        internal const PSKeyword DefaultKeywords = (PSKeyword) (0x00FFFFFFFFFFFFFF);
+
+        // the default enabled channel(s)
+        internal const PSChannel DefaultChannels = PSChannel.Operational;
 
         /// <summary>
         /// Class constructor.

--- a/src/System.Management.Automation/utils/tracing/SysLogProvider.cs
+++ b/src/System.Management.Automation/utils/tracing/SysLogProvider.cs
@@ -169,7 +169,7 @@ namespace System.Management.Automation.Tracing
         /// <param name="keywords">The PSKeyword to check.</param>
         /// <returns>true if the specified level and keywords are enabled for logging.</returns>
         internal bool IsEnabled(PSLevel level, PSKeyword keywords)
-        {           
+        {
             return ( ((ulong) keywords & _keywordFilter) != 0 &&
                      ((int) level <= _levelFilter) );
         }

--- a/src/System.Management.Automation/utils/tracing/SysLogProvider.cs
+++ b/src/System.Management.Automation/utils/tracing/SysLogProvider.cs
@@ -102,6 +102,14 @@ namespace System.Management.Automation.Tracing
             _keywordFilter = (ulong)keywords;
             _levelFilter = (byte) level;
             _channelFilter = (byte) channels;
+            if ((_channelFilter & (ulong) PSChannel.Operational) != 0)
+            {
+                _keywordFilter |= (ulong) PSKeyword.UseAlwaysOperational;
+            }
+            if ((_channelFilter & (ulong) PSChannel.Analytic) != 0)
+            {
+                _keywordFilter |= (ulong) PSKeyword.UseAlwaysAnalytic;
+            }
         }
 
         /// <summary>
@@ -161,7 +169,7 @@ namespace System.Management.Automation.Tracing
         /// <param name="keywords">The PSKeyword to check.</param>
         /// <returns>true if the specified level and keywords are enabled for logging.</returns>
         internal bool IsEnabled(PSLevel level, PSKeyword keywords)
-        {
+        {           
             return ( ((ulong) keywords & _keywordFilter) != 0 &&
                      ((int) level <= _levelFilter) );
         }
@@ -313,13 +321,6 @@ namespace System.Management.Automation.Tracing
         /// <param name="args">The payload for the log message.</param>
         public void Log(PSEventId eventId, PSChannel channel, PSTask task, PSOpcode opcode, PSLevel level, PSKeyword keyword, params object[] args)
         {
-            if (keyword == PSKeyword.UseAlwaysAnalytic)
-            {
-                // Use the 'DefaultKeywords' to work around the default keyword filter.
-                // Note that the PSKeyword argument is not really used in writing SysLog.
-                keyword = PSSysLogProvider.DefaultKeywords;
-            }
-
             if (ShouldLog(level, keyword, channel))
             {
                 int threadId = Thread.CurrentThread.ManagedThreadId;


### PR DESCRIPTION
## PR Summary

Fix: https://github.com/PowerShell/PowerShell/issues/5695 and #6032

The original fix for this issue caused analytic events to always be logged on Unix systems, flooding syslog and os_log with unwanted output.

There are three underlying problems:

1: The fix for the issue stripped off the channel keyword when analytic was specified causing it to be interpreted as operational output.

This change was removed.

2: The declaration of PSChannel used the ETW channel id as a bitmask to test for writing to the channel.  This doesn't work because channel ids are integer values that are incremented.  Instead, the associated channel bit mask must be used for filtering. 

PSChannel was updated for UNIX builds to use the channel mask instead of the channel id to enable bitwise operations for filtering.

3: Calling code does not use keywords correctly; passing either the operational or analytic channel masks as keywords,  instead of using the well-defined keywords.

Instead of attempting to fix all callers, the change adds the channel mask to the keyword filter to ensure the caller's intent is met.   This is a workaround pending refactoring PowerShell logging initialization (see https://github.com/PowerShell/PowerShell/issues/6085).

## PR Checklist

Note: Please mark anything not applicable to this PR `NA`.

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [X] Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [NA] User facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [X ] Issue filed - Issue link: https://github.com/PowerShell/PowerShell/issues/5695
- [X ] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [ PENDING] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
    - [NA] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
- [X ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
