### PR TITLE
Msi installer: smoke test

### DIFF
--- a/tools/appveyor.psm1
+++ b/tools/appveyor.psm1
@@ -475,7 +475,7 @@ function Invoke-AppveyorFinish
         }
 
         # test MSI installer
-        Write-Verbose "Smoke-Testing MSI installer"
+        Write-Verbose "Smoke-Testing MSI installer" -Verbose
         $msi = $artifacts | Where-Object { $_.EndsWith(".msi") }
         & $msi /q /l*vx msiLog.txt
         if ($LASTEXITCODE -ne 0)
@@ -483,6 +483,7 @@ function Invoke-AppveyorFinish
             Push-AppveyorArtifact msiLog.txt
             throw "MSI installer failed and returned error code $LASTEXITCODE. Log was uploaded as artifact."
         }
+        Write-Verbose "MSI smoke test was successful" -Verbose
 
         # only publish assembly nuget packages if it is a daily build and tests passed
         if((Test-DailyBuild) -and $env:TestPassed -eq 'True')

--- a/tools/appveyor.psm1
+++ b/tools/appveyor.psm1
@@ -484,7 +484,7 @@ function Invoke-AppveyorFinish
         {
             Push-AppveyorArtifact msiLog.txt
             $exitCode = $msiExecProcess.ExitCode
-            throw "MSI installer failed and returned error code $($msiExecProcess.ExitCode). MSI Log was uploaded as artifact."
+            throw "MSI installer failed and returned error code $exitCode. MSI Log was uploaded as artifact."
         }
         Write-Verbose "MSI smoke test was successful" -Verbose
 

--- a/tools/appveyor.psm1
+++ b/tools/appveyor.psm1
@@ -474,6 +474,16 @@ function Invoke-AppveyorFinish
             $preReleaseVersion = "$previewPrefix-$previewLabel.$env:APPVEYOR_BUILD_NUMBER"
         }
 
+        # test MSI installer
+        Write-Verbose "Smoke-Testing MSI installer"
+        $msi = $artifacts | Where-Object { $_.EndsWith(".msi") }
+        & $msi /q /l*vx msiLog.txt
+        if ($LASTEXITCODE -ne 0)
+        {
+            Push-AppveyorArtifact msiLog.txt
+            throw "MSI installer failed and returned error code $LASTEXITCODE. Log was uploaded as artifact."
+        }
+
         # only publish assembly nuget packages if it is a daily build and tests passed
         if((Test-DailyBuild) -and $env:TestPassed -eq 'True')
         {

--- a/tools/appveyor.psm1
+++ b/tools/appveyor.psm1
@@ -542,6 +542,12 @@ function Invoke-AppveyorFinish
         Write-Host -Foreground Red $_
     }
     finally {
+        # A throw statement would not make the build fail. This function is AppVeyor specific
+        # and is the only command executed in 'on_finish' phase, so it's safe that we request
+        # the current runspace to exit with the specified exit code. If the exit code is non-zero,
+        # AppVeyor will fail the build.
+        # See this link for details:
+        # https://help.appveyor.com/discussions/problems/4498-powershell-exception-in-test_script-does-not-fail-build
         $host.SetShouldExit($exitCode)
     }
 }

--- a/tools/appveyor.psm1
+++ b/tools/appveyor.psm1
@@ -477,8 +477,9 @@ function Invoke-AppveyorFinish
         # test MSI installer
         Write-Verbose "Smoke-Testing MSI installer" -Verbose
         $msi = $artifacts | Where-Object { $_.EndsWith(".msi") }
-        & $msi /q /l*vx msiLog.txt
-        if ($LASTEXITCODE -ne 0)
+        $msiLog = Join-Path (Get-Location) 'msilog.txt'
+        $msiExecProcess =Start-Process msiexec.exe -Wait -ArgumentList "/I $msi /quiet /l*vx $msiLog" -NoNewWindow
+        if ($msiExecProcess.ExitCode -ne 0)
         {
             Push-AppveyorArtifact msiLog.txt
             throw "MSI installer failed and returned error code $LASTEXITCODE. Log was uploaded as artifact."


### PR DESCRIPTION
## PR Summary

[PR 6043](https://github.com/PowerShell/PowerShell/pull/6043) broke the installer (issue #6095). To prevent this from happening in the future, add a smoke test that installs the msi in appveyor build and make build fail if installation failed.
It uses the exit code to determine the success. The reason why it does not fail in the current state is because as I pointed out [here](https://github.com/PowerShell/PowerShell/pull/6099#issuecomment-363075516), the failing custom action is not returning its exit code.

## PR Checklist

Note: Please mark anything not applicable to this PR `NA`.

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [x] Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] NA User facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [ ] Issue filed - Issue link:
- [ ] NA [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [ ] NA [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
    - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
