### PR TITLE
Add Password parameter to Get-PfxCertificate cmdlet

### DIFF
--- a/src/Microsoft.PowerShell.Security/security/CertificateCommands.cs
+++ b/src/Microsoft.PowerShell.Security/security/CertificateCommands.cs
@@ -74,7 +74,7 @@ namespace Microsoft.PowerShell.Commands
         /// Do not prompt for password if not given.
         /// </summary>
         [Parameter(Mandatory = false)]
-        public SwitchParameter NoPasswordPrompt { get; set; }
+        public SwitchParameter NoPromptForPassword { get; set; }
 
         //
         // list of files that were not found
@@ -142,7 +142,7 @@ namespace Microsoft.PowerShell.Commands
                     }
                     else
                     {
-                        if (Password == null && !NoPasswordPrompt.IsPresent) 
+                        if (Password == null && !NoPromptForPassword.IsPresent) 
                         {
                             try 
                             {

--- a/src/Microsoft.PowerShell.Security/security/CertificateCommands.cs
+++ b/src/Microsoft.PowerShell.Security/security/CertificateCommands.cs
@@ -144,18 +144,18 @@ namespace Microsoft.PowerShell.Commands
                     {
                         if (Password == null && !Force.IsPresent) 
                         {
-							try 
-							{
-								cert = GetCertFromPfxFile(resolvedProviderPath, null);
-								WriteObject(cert);
-								continue;
-							} 
-							catch (CryptographicException) 
-							{
+                            try 
+                            {
+                                cert = GetCertFromPfxFile(resolvedProviderPath, null);
+                                WriteObject(cert);
+                                continue;
+                            } 
+                            catch (CryptographicException) 
+                            {
                                 Password = SecurityUtils.PromptForSecureString(
                                     Host.UI,
                                     CertificateCommands.GetPfxCertPasswordPrompt);
-							}                            
+                            }                            
                         }
                         
                         try

--- a/src/Microsoft.PowerShell.Security/security/CertificateCommands.cs
+++ b/src/Microsoft.PowerShell.Security/security/CertificateCommands.cs
@@ -65,7 +65,7 @@ namespace Microsoft.PowerShell.Commands
         private bool _isLiteralPath = false;
 
         /// <summary>
-        /// Gets or sets the password for unlocking the certificate
+        /// Gets or sets the password for unlocking the certificate.
         /// </summary>
         [Parameter(Mandatory = false)]
         public SecureString Password { get; set; }
@@ -190,7 +190,6 @@ namespace Microsoft.PowerShell.Commands
 
         private static X509Certificate2 GetCertFromPfxFile(string path, SecureString password)
         {
-            // Passing null password and DefaultKeySet here is equivalent to calling "new X509Certificate2(path)"
             var cert = new X509Certificate2(path, password, X509KeyStorageFlags.DefaultKeySet);
             return cert;
         }

--- a/src/Microsoft.PowerShell.Security/security/CertificateCommands.cs
+++ b/src/Microsoft.PowerShell.Security/security/CertificateCommands.cs
@@ -68,19 +68,7 @@ namespace Microsoft.PowerShell.Commands
         /// Gets or sets the password for unlocking the certificate
         /// </summary>
         [Parameter(Mandatory = false)]
-        public SecureString Password
-        {
-            get
-            {
-                return _password;
-            }
-
-            set
-            {
-                _password = value;
-            }
-        }
-        private SecureString _password = null;
+        public SecureString Password { get; set; }
 
         //
         // list of files that were not found
@@ -150,7 +138,7 @@ namespace Microsoft.PowerShell.Commands
                     {
                         try
                         {
-                            cert = GetCertFromPfxFile(resolvedProviderPath, _password);
+                            cert = GetCertFromPfxFile(resolvedProviderPath, Password);
                         }
                         catch (CryptographicException e)
                         {

--- a/src/Microsoft.PowerShell.Security/security/CertificateCommands.cs
+++ b/src/Microsoft.PowerShell.Security/security/CertificateCommands.cs
@@ -70,6 +70,12 @@ namespace Microsoft.PowerShell.Commands
         [Parameter(Mandatory = false)]
         public SecureString Password { get; set; }
 
+        /// <summary>
+        /// Do not prompt for password if not given.
+        /// </summary>
+        [Parameter(Mandatory = false)]
+        public SwitchParameter Force { get; set; }
+
         //
         // list of files that were not found
         //
@@ -136,6 +142,22 @@ namespace Microsoft.PowerShell.Commands
                     }
                     else
                     {
+                        if (Password == null && !Force.IsPresent) 
+                        {
+							try 
+							{
+								cert = GetCertFromPfxFile(resolvedProviderPath, null);
+								WriteObject(cert);
+								continue;
+							} 
+							catch (CryptographicException) 
+							{
+                                Password = SecurityUtils.PromptForSecureString(
+                                    Host.UI,
+                                    CertificateCommands.GetPfxCertPasswordPrompt);
+							}                            
+                        }
+                        
                         try
                         {
                             cert = GetCertFromPfxFile(resolvedProviderPath, Password);

--- a/src/Microsoft.PowerShell.Security/security/CertificateCommands.cs
+++ b/src/Microsoft.PowerShell.Security/security/CertificateCommands.cs
@@ -74,7 +74,7 @@ namespace Microsoft.PowerShell.Commands
         /// Do not prompt for password if not given.
         /// </summary>
         [Parameter(Mandatory = false)]
-        public SwitchParameter Force { get; set; }
+        public SwitchParameter NoPasswordPrompt { get; set; }
 
         //
         // list of files that were not found
@@ -142,7 +142,7 @@ namespace Microsoft.PowerShell.Commands
                     }
                     else
                     {
-                        if (Password == null && !Force.IsPresent) 
+                        if (Password == null && !NoPasswordPrompt.IsPresent) 
                         {
                             try 
                             {

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/CmsMessage.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/CmsMessage.Tests.ps1
@@ -28,7 +28,7 @@ Describe "CmsMessage cmdlets and Get-PfxCertificate basic tests" -Tags "CI" {
     It "Verify Get-PfxCertificate right password" {
         $pass = ConvertTo-SecureString "password" -AsPlainText -Force
         $cert = Get-PfxCertificate $protectedCertLocation -Password $pass
-        $cert.Subject | Should Be "CN=MyDataEnciphermentCert"
+        $cert.Subject | Should Be "CN=localhost"
     }
 
     It "Verify Get-PfxCertificate wrong password" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/CmsMessage.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/CmsMessage.Tests.ps1
@@ -34,8 +34,7 @@ Describe "CmsMessage cmdlets and Get-PfxCertificate basic tests" -Tags "CI" {
     It "Verify Get-PfxCertificate wrong password" {
         $pass = ConvertTo-SecureString "wrongpass" -AsPlainText -Force
         $e = { Get-PfxCertificate $protectedCertLocation -Password $pass -ErrorAction Stop } | ShouldBeErrorId "GetPfxCertificateUnknownCryptoError,Microsoft.PowerShell.Commands.GetPfxCertificateCommand"
-        $e.Exception.HResult | Should Be -2147024810
-
+        $e.Exception.Message | Should Match "password is not correct"
     }
 
     It "Verify CMS message recipient resolution by path" -Skip:(!$IsWindows) {

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/CmsMessage.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/CmsMessage.Tests.ps1
@@ -1,10 +1,13 @@
 Import-Module (Join-Path -Path $PSScriptRoot 'certificateCommon.psm1') -Force
 
 Describe "CmsMessage cmdlets and Get-PfxCertificate basic tests" -Tags "CI" {
-    
+
     BeforeAll {
         $certLocation = New-GoodCertificate
         $certLocation | Should Not BeNullOrEmpty | Out-Null
+
+        $protectedCertLocation = New-ProtectedCertificate
+        $protectedCertLocation | Should Not BeNullOrEmpty | Out-Null
     }
 
     It "Verify Get-PfxCertificate -FilePath" {
@@ -20,6 +23,19 @@ Describe "CmsMessage cmdlets and Get-PfxCertificate basic tests" -Tags "CI" {
     It "Verify Get-PfxCertificate positional argument" {
         $cert = Get-PfxCertificate $certLocation
         $cert.Subject | Should Be "CN=MyDataEnciphermentCert"
+    }
+
+    It "Verify Get-PfxCertificate right password" {
+        $pass = ConvertTo-SecureString "password" -AsPlainText -Force
+        $cert = Get-PfxCertificate $protectedCertLocation -Password $pass
+        $cert.Subject | Should Be "CN=MyDataEnciphermentCert"
+    }
+
+    It "Verify Get-PfxCertificate wrong password" {
+        $pass = ConvertTo-SecureString "wrongpass" -AsPlainText -Force
+        $e = { Get-PfxCertificate $protectedCertLocation -Password $pass -ErrorAction Stop } | ShouldBeErrorId "GetPfxCertificateUnknownCryptoError,Microsoft.PowerShell.Commands.GetPfxCertificateCommand"
+        $e.Exception.HResult | Should Be -2147024810
+
     }
 
     It "Verify CMS message recipient resolution by path" -Skip:(!$IsWindows) {
@@ -71,9 +87,9 @@ Describe "CmsMessage cmdlets thorough tests" -Tags "Feature" {
             # Skip for non-Windows platforms
             $defaultParamValues = $PSdefaultParameterValues.Clone()
             $PSdefaultParameterValues = @{ "it:skip" = $true }
-        }        
+        }
     }
-    
+
     AfterAll {
         if($IsWindows)
         {
@@ -318,7 +334,7 @@ Describe "CmsMessage cmdlets thorough tests" -Tags "Feature" {
 
         # Validate they all match the EKU
         $correctMatching = $foundCerts | Where-Object {
-            ($_.EnhancedKeyUsageList.Count -gt 0) -and 
+            ($_.EnhancedKeyUsageList.Count -gt 0) -and
             ($_.EnhancedKeyUsageList[0].ObjectId -eq '1.3.6.1.4.1.311.80.1')
         }
         # "All Document Encryption Cert should have had correct EKU"

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/CmsMessage.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/CmsMessage.Tests.ps1
@@ -34,7 +34,6 @@ Describe "CmsMessage cmdlets and Get-PfxCertificate basic tests" -Tags "CI" {
     It "Verify Get-PfxCertificate wrong password" {
         $pass = ConvertTo-SecureString "wrongpass" -AsPlainText -Force
         $e = { Get-PfxCertificate $protectedCertLocation -Password $pass -ErrorAction Stop } | ShouldBeErrorId "GetPfxCertificateUnknownCryptoError,Microsoft.PowerShell.Commands.GetPfxCertificateCommand"
-        $e.Exception.Message | Should Match "password is not correct"
     }
 
     It "Verify CMS message recipient resolution by path" -Skip:(!$IsWindows) {

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/certificateCommon.psm1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/certificateCommon.psm1
@@ -66,6 +66,46 @@ OksttXT1kXf+aez9EzDlsgQU4ck78h0WTy01zHLwSKNWK4wFFQM=
     return $certLocation
 }
 
+Function New-ProtectedCertificate
+{
+    <#
+    .SYNOPSIS
+    Write to disk expired password-protected pfx certificate
+
+    .NOTES
+    Password: "password"
+    #>
+
+    $protectedCert = "
+MIIECQIBAzCCA88GCSqGSIb3DQEHAaCCA8AEggO8MIIDuDCCAdcGCSqGSIb3DQEHBqCCAcgwggHE
+AgEAMIIBvQYJKoZIhvcNAQcBMBwGCiqGSIb3DQEMAQYwDgQI9rPW9m+pkz0CAggAgIIBkMrPJ7+l
+ZzdnMxxodZgAglSPD8iHSYkr3pEVqGI2vZTjpVxDPGFKL2grHlmllD1HPVMmdTS4vAoaHeR8r2rZ
+76rcm5eaWuOsoDLF24hYyXnmKZzhEhVxhghgCMLa99cIVcPKEznxXJ3UZxk4aUZDSLGjGhtMVS3f
+xQIQ3YPHvdvKkL83eGavL+ltMJo4Y0oP+NzU9TQw6jAnotmRtbbwqfZCXOf3BOyYHi3wXsPddcl7
+PRqtL+aiISqsdd69q+LYs8dAx6JJeglutUxmtJ1u1wvS+yTzcqgKkxZvdBlzyyr6/nKvzz2U7yQv
+qZiyazLv/u/a0DCJu7Pc7+nVNwjO8ZYJnOccQopO00lMPchXjMj+gS1tu+yTT6otg0/3ej48fpWw
+qqfEWdASndC3nGA6XmkOYvL9ydItz9gSKqj0eVvJZHzhq5ihCnB8NfgKj3e5vwHz5w7LKaDKinRV
+S029VyLZNZarivWvP4I5t5C3n6DXE9XB8QJLJcadJXMFSMr2sAje6q3f5RwuSZ5UlDM0xTIwggHZ
+BgkqhkiG9w0BBwGgggHKBIIBxjCCAcIwggG+BgsqhkiG9w0BDAoBAqCCAYYwggGCMBwGCiqGSIb3
+DQEMAQMwDgQIlpNJ+M/gSzECAggABIIBYGS5bGAY105/oqUpum2OCw2zCvh2VW5Q7AnTFFf1jSo/
+l4aSb9u73Owhl72aWm+xsj86IqnxgXd7I4I+opJH31gTKlbxEZGyfv7N0hlTlYweIxtuZ3YSAt/q
+RtP31T475ID8C2U44dS5F2SaVC6MVu4RyTXCUTm8Y5R4pwfajkzmFi0dosBKquYUGdCz6b9j36BH
+Ls9LOoRmeXBv48qo5mTyS5QnRAQ5BABaz4rb5v/fs0Xhb1dvEyMAQeuQxNayfhqibEcOl/lV0TPh
+ZTQzdyfQ9WuyHu85RENWsYp1No7E8/F6lP0o02QIRnfGpyJTUtBBByHip8YHEVbcFcqLCnybH+2i
+Y0YpzsSIt6P1F/+e2yLLHklhgD4yXLJmafuiIQLP2Jf4Yj20MHF2By8ngJokBdjSO/y3PJ2P6Bec
+Y0btFBIA7u2INRpOTkZKkIWIfdrYRGjWxYbTxUJwsTsHFigxJTAjBgkqhkiG9w0BCRUxFgQULexg
+8Da086lTrBiE7Jt1JpBRGk4wMTAhMAkGBSsOAwIaBQAEFIVA18AQ5NUwdMnm0wckAd0hOK9lBAj5
+Ab1TGwBPbgICCAA=
+"
+
+    $protectedCert = $protectedCert -replace '\s',''
+    $certBytes = [Convert]::FromBase64String($protectedCert)
+    $certLocation = Join-Path $TestDrive "PassProtectedCert.pfx"
+    [IO.File]::WriteAllBytes($certLocation, $certBytes)
+
+    return $certLocation
+}
+
 Function New-BadCertificate
 {
     $codeSigningCert = "

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/certificateCommon.psm1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/certificateCommon.psm1
@@ -70,38 +70,13 @@ Function New-ProtectedCertificate
 {
     <#
     .SYNOPSIS
-    Write to disk expired password-protected pfx certificate
+    Return existing password-protected pfx certificate
 
     .NOTES
     Password: "password"
     #>
 
-    $protectedCert = "
-MIIECQIBAzCCA88GCSqGSIb3DQEHAaCCA8AEggO8MIIDuDCCAdcGCSqGSIb3DQEHBqCCAcgwggHE
-AgEAMIIBvQYJKoZIhvcNAQcBMBwGCiqGSIb3DQEMAQYwDgQI9rPW9m+pkz0CAggAgIIBkMrPJ7+l
-ZzdnMxxodZgAglSPD8iHSYkr3pEVqGI2vZTjpVxDPGFKL2grHlmllD1HPVMmdTS4vAoaHeR8r2rZ
-76rcm5eaWuOsoDLF24hYyXnmKZzhEhVxhghgCMLa99cIVcPKEznxXJ3UZxk4aUZDSLGjGhtMVS3f
-xQIQ3YPHvdvKkL83eGavL+ltMJo4Y0oP+NzU9TQw6jAnotmRtbbwqfZCXOf3BOyYHi3wXsPddcl7
-PRqtL+aiISqsdd69q+LYs8dAx6JJeglutUxmtJ1u1wvS+yTzcqgKkxZvdBlzyyr6/nKvzz2U7yQv
-qZiyazLv/u/a0DCJu7Pc7+nVNwjO8ZYJnOccQopO00lMPchXjMj+gS1tu+yTT6otg0/3ej48fpWw
-qqfEWdASndC3nGA6XmkOYvL9ydItz9gSKqj0eVvJZHzhq5ihCnB8NfgKj3e5vwHz5w7LKaDKinRV
-S029VyLZNZarivWvP4I5t5C3n6DXE9XB8QJLJcadJXMFSMr2sAje6q3f5RwuSZ5UlDM0xTIwggHZ
-BgkqhkiG9w0BBwGgggHKBIIBxjCCAcIwggG+BgsqhkiG9w0BDAoBAqCCAYYwggGCMBwGCiqGSIb3
-DQEMAQMwDgQIlpNJ+M/gSzECAggABIIBYGS5bGAY105/oqUpum2OCw2zCvh2VW5Q7AnTFFf1jSo/
-l4aSb9u73Owhl72aWm+xsj86IqnxgXd7I4I+opJH31gTKlbxEZGyfv7N0hlTlYweIxtuZ3YSAt/q
-RtP31T475ID8C2U44dS5F2SaVC6MVu4RyTXCUTm8Y5R4pwfajkzmFi0dosBKquYUGdCz6b9j36BH
-Ls9LOoRmeXBv48qo5mTyS5QnRAQ5BABaz4rb5v/fs0Xhb1dvEyMAQeuQxNayfhqibEcOl/lV0TPh
-ZTQzdyfQ9WuyHu85RENWsYp1No7E8/F6lP0o02QIRnfGpyJTUtBBByHip8YHEVbcFcqLCnybH+2i
-Y0YpzsSIt6P1F/+e2yLLHklhgD4yXLJmafuiIQLP2Jf4Yj20MHF2By8ngJokBdjSO/y3PJ2P6Bec
-Y0btFBIA7u2INRpOTkZKkIWIfdrYRGjWxYbTxUJwsTsHFigxJTAjBgkqhkiG9w0BCRUxFgQULexg
-8Da086lTrBiE7Jt1JpBRGk4wMTAhMAkGBSsOAwIaBQAEFIVA18AQ5NUwdMnm0wckAd0hOK9lBAj5
-Ab1TGwBPbgICCAA=
-"
-
-    $protectedCert = $protectedCert -replace '\s',''
-    $certBytes = [Convert]::FromBase64String($protectedCert)
-    $certLocation = Join-Path $TestDrive "PassProtectedCert.pfx"
-    [IO.File]::WriteAllBytes($certLocation, $certBytes)
+    $certLocation = ".\test\tools\Modules\WebListener\ServerCert.pfx"
 
     return $certLocation
 }


### PR DESCRIPTION
## PR Summary

<!-- summarize your PR between here and the checklist -->
Add Password parameter to Get-PfxCertificate cmdlet to allow automatization instead of prompting for password every time.

Fix #3970

Possibly breaking change: 
Calling cmdlet without -Password parameter assumes passing empty password instead of prompting for pass as before. In order to avoid breaking change cmdlet can ask for password if Password is missed but it will be more complicated to use empty password string in automated scripts.

Also about tests:
How it's better to create password-protected PFX certificate to test not-null password? Store as raw bytes in certificateCommon.psm1?

## PR Checklist

Note: Please mark anything not applicable to this PR `NA`.

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [x] Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] User facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [x] Issue filed - Issue link: PowerShell/PowerShell-Docs#2150
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
    - [NA] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
