### PR TITLE
Improve table view for Certs and Signatures by adding EnhancedKeyUsageList and StatusMessage

### DIFF
--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/Certificate_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/Certificate_format_ps1xml.cs
@@ -51,12 +51,12 @@ namespace System.Management.Automation.Runspaces
                 TableControl.Create()
                     .GroupByProperty("PSParentPath")
                     .AddHeader(width: 41)
-                    .AddHeader()
-                    .AddHeader()
+                    .AddHeader(width: 20)
+                    .AddHeader(label: "EnhancedKeyUsageList")
                     .StartRowDefinition()
                         .AddPropertyColumn("Thumbprint")
                         .AddPropertyColumn("Subject")
-                        .AddPropertyColumn("EnhancedKeyUsageList")
+                        .AddScriptBlockColumn("$_.EnhancedKeyUsageList.FriendlyName")
                     .EndRowDefinition()
                 .EndTable());
         }

--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/Certificate_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/Certificate_format_ps1xml.cs
@@ -52,9 +52,11 @@ namespace System.Management.Automation.Runspaces
                     .GroupByProperty("PSParentPath")
                     .AddHeader(width: 41)
                     .AddHeader()
+                    .AddHeader()
                     .StartRowDefinition()
                         .AddPropertyColumn("Thumbprint")
                         .AddPropertyColumn("Subject")
+                        .AddPropertyColumn("EnhancedKeyUsageList")
                     .EndRowDefinition()
                 .EndTable());
         }
@@ -84,7 +86,7 @@ namespace System.Management.Automation.Runspaces
             yield return new FormatViewDefinition("ThumbprintWide",
                 WideControl.Create()
                     .GroupByProperty("PSParentPath")
-                    .AddPropertyEntry("ThumbPrint")
+                    .AddPropertyEntry("Thumbprint")
                 .EndWideControl());
 
             yield return new FormatViewDefinition("PathOnly",
@@ -108,10 +110,12 @@ namespace System.Management.Automation.Runspaces
                     .GroupByScriptBlock("split-path $_.Path", customControl: sharedControls[0])
                     .AddHeader(label: "SignerCertificate", width: 41)
                     .AddHeader()
+                    .AddHeader()
                     .AddHeader(label: "Path")
                     .StartRowDefinition()
                         .AddScriptBlockColumn("$_.SignerCertificate.Thumbprint")
                         .AddPropertyColumn("Status")
+                        .AddPropertyColumn("StatusMessage")
                         .AddScriptBlockColumn("split-path $_.Path -leaf")
                     .EndRowDefinition()
                 .EndTable());


### PR DESCRIPTION
## PR Summary

While investigating https://github.com/PowerShell/PowerShell/issues/1752 it was inconvenient to not be able to just do a `dir` and find the code signing cert.  And when `set-authenticodesignature` failed, `Status` just showed `UnknownError` and the real useful property was `StatusMessage`.

Fix is to expose `EnhancedKeyUsageList` in the table view for X509Certificate and `StatusMessage` for cert Signature types.

Also fixed an incorrect casing of `Thumbprint`.

Set width of `Subject` to 20, so that more of the `EnhancedKeyUsageList` can show up as I find that more useful when finding a cert.  Using script to just show `FriendlyName` of `EnhancedKeyUsageList`.

```none
Thumbprint                                Subject              EnhancedKeyUsageList
----------                                -------              --------------------
FBC22CDCE5C3883FE36674993ED003C8438C0A79  CN=testcert.steve    Code Signing
9552B870CF7AB1D0506BC7E3EA89BC8A279E0723  CN=testcert.steve    {Client Authentication, Server Authentication}
```

The change to `Signature` (used as output type for `Set-AuthenticodeSignature` now looks like:

```none
PS C:\Users\steve\test> Set-AuthenticodeSignature -Certificate $cert -FilePath .\test.ps1 -TimestampServer http://sha256ti
mestamp.ws.symantec.com/sha256/timestamp


    Directory: C:\Users\steve\test


SignerCertificate                         Status                     StatusMessage              Path
-----------------                         ------                     -------------              ----
                                          UnknownError               ASN1 bad tag value met     test.ps1
```

## PR Checklist

Note: Please mark anything not applicable to this PR `NA`.

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [X] Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [NA] User facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [ ] Issue filed - Issue link:
- [X] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [NA] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
    - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
