### PR TITLE
Enable $env:PAGER to work correctly if arguments are used

### DIFF
--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -4764,7 +4764,7 @@ $OutputEncoding = if ([System.Management.Automation.Platform]::IsNanoServer -or 
 
 # Respect PAGER, use more on Windows, and use less on Linux
 if (Test-Path env:PAGER) {
-    $pager,$moreArgs = $env:PAGER -split ' ',2
+    $pager,$moreArgs = $env:PAGER -split '\s+'
     $moreCommand = (Get-Command -CommandType Application $pager | Select-Object -First 1).Definition
 } elseif ($IsWindows) {
     $moreCommand = (Get-Command -CommandType Application more | Select-Object -First 1).Definition

--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -4764,7 +4764,8 @@ $OutputEncoding = if ([System.Management.Automation.Platform]::IsNanoServer -or 
 
 # Respect PAGER, use more on Windows, and use less on Linux
 if (Test-Path env:PAGER) {
-    $moreCommand = (Get-Command -CommandType Application $env:PAGER | Select-Object -First 1).Definition
+    $pager,$moreArgs = $env:PAGER -split ' ',2
+    $moreCommand = (Get-Command -CommandType Application $pager | Select-Object -First 1).Definition
 } elseif ($IsWindows) {
     $moreCommand = (Get-Command -CommandType Application more | Select-Object -First 1).Definition
 } else {
@@ -4773,9 +4774,9 @@ if (Test-Path env:PAGER) {
 
 if($paths) {
     foreach ($file in $paths) {
-        Get-Content $file | & $moreCommand
+        Get-Content $file | & $moreCommand $moreArgs
     }
-} else { $input | & $moreCommand }
+} else { $input | & $moreCommand $moreArgs }
 ";
 
         internal const string DefaultSetDriveFunctionText = "Set-Location $MyInvocation.MyCommand.Name";


### PR DESCRIPTION
## PR Summary

If `$env:PAGER` is a command with args, it doesn't work correctly as the current code tries to find a command matching `$env:PAGER` which fails due to the args.  Fix is to split `$env:PAGER` into the command and the args, find the first occurrence of the command and pass back the args.

No tests as this is interactive only.  Manually validated with `less -w` which highlights the first lien of a new page.

Fix https://github.com/PowerShell/PowerShell/issues/6142

## PR Checklist

Note: Please mark anything not applicable to this PR `NA`.

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [X] Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [NA] User facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [ ] Issue filed - Issue link:
- [X] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [NA] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
    - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
