### PR TITLE
Docker package tests updates

### DIFF
--- a/docker/tests/Templates/centos7/Dockerfile
+++ b/docker/tests/Templates/centos7/Dockerfile
@@ -1,9 +1,10 @@
 FROM centos:7
 
-ARG PSVERSIONSTUB
-ARG PSVERSIONSTUBRPM
+ARG PSVERSIONSTUB=6.0.1
+ARG PSVERSIONSTUBRPM=6.0.1
 ARG PACKAGELOCATIONSTUB
-ARG TESTLISTSTUB
+ARG TESTLISTSTUB=/PowerShell/test/powershell/Modules/PackageManagement/PackageManagement.Tests.ps1,/PowerShell/test/powershell/engine/Module
+ARG GITLOCATION=https://github.com/PowerShell/PowerShell.git
 
 # Install dependencies
 RUN yum install -y \
@@ -18,5 +19,5 @@ RUN localedef --charmap=UTF-8 --inputfile=en_US $LANG
 
 RUN curl -L -o powershell-$PSVERSIONSTUBRPM-1.rhel.7.x86_64.rpm $PACKAGELOCATIONSTUB/powershell-$PSVERSIONSTUBRPM-1.rhel.7.x86_64.rpm
 RUN yum install -y powershell-$PSVERSIONSTUBRPM-1.rhel.7.x86_64.rpm
-RUN git clone --recursive https://github.com/PowerShell/PowerShell.git
-RUN pwsh -c "Import-Module /PowerShell/build.psm1;Restore-PSPester -Destination /usr/local/share/powershell/Modules;exit (Invoke-Pester $TESTLISTSTUB -PassThru).FailedCount"
+RUN git clone --recursive $GITLOCATION
+RUN pwsh -c "Import-Module /PowerShell/build.psm1;\$dir='/usr/local/share/powershell/Modules';New-Item -Type Directory -Path \$dir -ErrorAction SilentlyContinue;Restore-PSPester -Destination \$dir;exit (Invoke-Pester $TESTLISTSTUB -PassThru).FailedCount"

--- a/docker/tests/Templates/debian.8/Dockerfile
+++ b/docker/tests/Templates/debian.8/Dockerfile
@@ -1,9 +1,10 @@
 FROM debian:jessie
 
-ARG PSVERSIONSTUB
-ARG PSVERSIONSTUBRPM
+ARG PSVERSIONSTUB=6.0.1
+ARG PSVERSIONSTUBRPM=6.0.1
 ARG PACKAGELOCATIONSTUB
-ARG TESTLISTSTUB
+ARG TESTLISTSTUB=/PowerShell/test/powershell/Modules/PackageManagement/PackageManagement.Tests.ps1,/PowerShell/test/powershell/engine/Module
+ARG GITLOCATION=https://github.com/PowerShell/PowerShell.git
 
 # Install dependencies
 RUN apt-get update \
@@ -23,5 +24,5 @@ RUN locale-gen $LANG && update-locale
 RUN curl -L -o powershell_$PSVERSIONSTUB-1.debian.8_amd64.deb $PACKAGELOCATIONSTUB/powershell_$PSVERSIONSTUB-1.debian.8_amd64.deb
 RUN dpkg -i powershell_$PSVERSIONSTUB-1.debian.8_amd64.deb || :
 RUN apt-get install -y -f
-RUN git clone --recursive https://github.com/PowerShell/PowerShell.git
-RUN pwsh -c "Import-Module /PowerShell/build.psm1;Restore-PSPester -Destination /usr/local/share/powershell/Modules;exit (Invoke-Pester $TESTLISTSTUB -PassThru).FailedCount"
+RUN git clone --recursive $GITLOCATION
+RUN pwsh -c "Import-Module /PowerShell/build.psm1;\$dir='/usr/local/share/powershell/Modules';New-Item -Type Directory -Path \$dir -ErrorAction SilentlyContinue;Restore-PSPester -Destination \$dir;exit (Invoke-Pester $TESTLISTSTUB -PassThru).FailedCount"

--- a/docker/tests/Templates/debian.9/Dockerfile
+++ b/docker/tests/Templates/debian.9/Dockerfile
@@ -1,9 +1,10 @@
 FROM debian:stretch
 
-ARG PSVERSIONSTUB
-ARG PSVERSIONSTUBRPM
+ARG PSVERSIONSTUB=6.0.1
+ARG PSVERSIONSTUBRPM=6.0.1
 ARG PACKAGELOCATIONSTUB
-ARG TESTLISTSTUB
+ARG TESTLISTSTUB=/PowerShell/test/powershell/Modules/PackageManagement/PackageManagement.Tests.ps1,/PowerShell/test/powershell/engine/Module
+ARG GITLOCATION=https://github.com/PowerShell/PowerShell.git
 
 # Install dependencies
 RUN apt-get update \
@@ -23,5 +24,5 @@ RUN locale-gen $LANG && update-locale
 RUN curl -L -o powershell_$PSVERSIONSTUB-1.debian.9_amd64.deb $PACKAGELOCATIONSTUB/powershell_$PSVERSIONSTUB-1.debian.9_amd64.deb
 RUN dpkg -i powershell_$PSVERSIONSTUB-1.debian.9_amd64.deb || :
 RUN apt-get install -y -f
-RUN git clone --recursive https://github.com/PowerShell/PowerShell.git
-RUN pwsh -c "Import-Module /PowerShell/build.psm1;Restore-PSPester -Destination /usr/local/share/powershell/Modules;exit (Invoke-Pester $TESTLISTSTUB -PassThru).FailedCount"
+RUN git clone --recursive $GITLOCATION
+RUN pwsh -c "Import-Module /PowerShell/build.psm1;\$dir='/usr/local/share/powershell/Modules';New-Item -Type Directory -Path \$dir -ErrorAction SilentlyContinue;Restore-PSPester -Destination \$dir;exit (Invoke-Pester $TESTLISTSTUB -PassThru).FailedCount"

--- a/docker/tests/Templates/fedora26/Dockerfile
+++ b/docker/tests/Templates/fedora26/Dockerfile
@@ -1,9 +1,10 @@
 FROM fedora:26
 
-ARG PSVERSIONSTUB
-ARG PSVERSIONSTUBRPM
+ARG PSVERSIONSTUB=6.0.1
+ARG PSVERSIONSTUBRPM=6.0.1
 ARG PACKAGELOCATIONSTUB
-ARG TESTLISTSTUB
+ARG TESTLISTSTUB=/PowerShell/test/powershell/Modules/PackageManagement/PackageManagement.Tests.ps1,/PowerShell/test/powershell/engine/Module
+ARG GITLOCATION=https://github.com/PowerShell/PowerShell.git
 
 # Install dependencies
 RUN dnf install -y \
@@ -19,5 +20,5 @@ RUN localedef --charmap=UTF-8 --inputfile=en_US $LANG
 
 RUN curl -L -o powershell-$PSVERSIONSTUBRPM-1.rhel.7.x86_64.rpm $PACKAGELOCATIONSTUB/powershell-$PSVERSIONSTUBRPM-1.rhel.7.x86_64.rpm
 RUN dnf install -y powershell-$PSVERSIONSTUBRPM-1.rhel.7.x86_64.rpm
-RUN git clone --recursive https://github.com/PowerShell/PowerShell.git
-RUN pwsh -c "Import-Module /PowerShell/build.psm1;Restore-PSPester -Destination /usr/local/share/powershell/Modules;exit (Invoke-Pester $TESTLISTSTUB -PassThru).FailedCount"
+RUN git clone --recursive $GITLOCATION
+RUN pwsh -c "Import-Module /PowerShell/build.psm1;\$dir='/usr/local/share/powershell/Modules';New-Item -Type Directory -Path \$dir -ErrorAction SilentlyContinue;Restore-PSPester -Destination \$dir;exit (Invoke-Pester $TESTLISTSTUB -PassThru).FailedCount"

--- a/docker/tests/Templates/fedora27/Dockerfile
+++ b/docker/tests/Templates/fedora27/Dockerfile
@@ -1,9 +1,10 @@
 FROM fedora:27
 
-ARG PSVERSIONSTUB
-ARG PSVERSIONSTUBRPM
+ARG PSVERSIONSTUB=6.0.1
+ARG PSVERSIONSTUBRPM=6.0.1
 ARG PACKAGELOCATIONSTUB
-ARG TESTLISTSTUB
+ARG TESTLISTSTUB=/PowerShell/test/powershell/Modules/PackageManagement/PackageManagement.Tests.ps1,/PowerShell/test/powershell/engine/Module
+ARG GITLOCATION=https://github.com/PowerShell/PowerShell.git
 
 # Install dependencies
 RUN dnf install -y \
@@ -18,5 +19,5 @@ RUN localedef --charmap=UTF-8 --inputfile=en_US $LANG
 
 RUN curl -L -o powershell-$PSVERSIONSTUBRPM-1.rhel.7.x86_64.rpm $PACKAGELOCATIONSTUB/powershell-$PSVERSIONSTUBRPM-1.rhel.7.x86_64.rpm
 RUN dnf install -y powershell-$PSVERSIONSTUBRPM-1.rhel.7.x86_64.rpm
-RUN git clone --recursive https://github.com/PowerShell/PowerShell.git
-RUN pwsh -c "Import-Module /PowerShell/build.psm1;Restore-PSPester -Destination /usr/local/share/powershell/Modules;exit (Invoke-Pester $TESTLISTSTUB -PassThru).FailedCount"
+RUN git clone --recursive $GITLOCATION
+RUN pwsh -c "Import-Module /PowerShell/build.psm1;\$dir='/usr/local/share/powershell/Modules';New-Item -Type Directory -Path \$dir -ErrorAction SilentlyContinue;Restore-PSPester -Destination \$dir;exit (Invoke-Pester $TESTLISTSTUB -PassThru).FailedCount"

--- a/docker/tests/Templates/kalilinux/Dockerfile
+++ b/docker/tests/Templates/kalilinux/Dockerfile
@@ -1,9 +1,10 @@
 FROM kalilinux/kali-linux-docker:latest
 
-ARG PSVERSIONSTUB
-ARG PSVERSIONSTUBRPM
+ARG PSVERSIONSTUB=6.0.1
+ARG PSVERSIONSTUBRPM=6.0.1
 ARG PACKAGELOCATIONSTUB
-ARG TESTLISTSTUB
+ARG TESTLISTSTUB=/PowerShell/test/powershell/Modules/PackageManagement/PackageManagement.Tests.ps1,/PowerShell/test/powershell/engine/Module
+ARG GITLOCATION=https://github.com/PowerShell/PowerShell.git
 
 # Install dependencies
 RUN apt-get update \
@@ -25,5 +26,5 @@ RUN curl -L -o powershell_$PSVERSIONSTUB-1.ubuntu.16.04_amd64.deb $PACKAGELOCATI
 RUN dpkg -i libssl1.0.0_1.0.1t-1+deb8u7_amd64.deb || :
 RUN dpkg -i powershell_$PSVERSIONSTUB-1.ubuntu.16.04_amd64.deb || :
 RUN apt-get install -y -f
-RUN git clone --recursive https://github.com/PowerShell/PowerShell.git
-RUN pwsh -c "Import-Module /PowerShell/build.psm1;Restore-PSPester -Destination /usr/local/share/powershell/Modules;exit (Invoke-Pester $TESTLISTSTUB -PassThru).FailedCount"
+RUN git clone --recursive $GITLOCATION
+RUN pwsh -c "Import-Module /PowerShell/build.psm1;\$dir='/usr/local/share/powershell/Modules';New-Item -Type Directory -Path \$dir -ErrorAction SilentlyContinue;Restore-PSPester -Destination \$dir;exit (Invoke-Pester $TESTLISTSTUB -PassThru).FailedCount"

--- a/docker/tests/Templates/opensuse42.2/Dockerfile
+++ b/docker/tests/Templates/opensuse42.2/Dockerfile
@@ -1,9 +1,10 @@
 FROM opensuse:42.2
 
-ARG PSVERSIONSTUB
-ARG PSVERSIONSTUBRPM
+ARG PSVERSIONSTUB=6.0.1
+ARG PSVERSIONSTUBRPM=6.0.1
 ARG PACKAGELOCATIONSTUB
-ARG TESTLISTSTUB
+ARG TESTLISTSTUB=/PowerShell/test/powershell/Modules/PackageManagement/PackageManagement.Tests.ps1,/PowerShell/test/powershell/engine/Module
+ARG GITLOCATION=https://github.com/PowerShell/PowerShell.git
 
 ARG POWERSHELL_LINKFILE=/usr/bin/pwsh
 
@@ -34,5 +35,5 @@ RUN tar zxf powershell-$PSVERSIONSTUB-linux-x64.tar.gz -C /opt/microsoft/powersh
 # Create the symbolic link that points to powershell
 RUN ln -s /opt/microsoft/powershell/$PSVERSIONSTUB/pwsh $POWERSHELL_LINKFILE
 
-RUN git clone --recursive https://github.com/PowerShell/PowerShell.git
-RUN pwsh -c "Import-Module /PowerShell/build.psm1;Restore-PSPester -Destination /usr/local/share/powershell/Modules;exit (Invoke-Pester $TESTLISTSTUB -PassThru).FailedCount"
+RUN git clone --recursive $GITLOCATION
+RUN pwsh -c "Import-Module /PowerShell/build.psm1;\$dir='/usr/local/share/powershell/Modules';New-Item -Type Directory -Path \$dir -ErrorAction SilentlyContinue;Restore-PSPester -Destination \$dir;exit (Invoke-Pester $TESTLISTSTUB -PassThru).FailedCount"

--- a/docker/tests/Templates/ubuntu14.04/Dockerfile
+++ b/docker/tests/Templates/ubuntu14.04/Dockerfile
@@ -1,9 +1,10 @@
 FROM ubuntu:trusty
 
-ARG PSVERSIONSTUB
-ARG PSVERSIONSTUBRPM
+ARG PSVERSIONSTUB=6.0.1
+ARG PSVERSIONSTUBRPM=6.0.1
 ARG PACKAGELOCATIONSTUB
-ARG TESTLISTSTUB
+ARG TESTLISTSTUB=/PowerShell/test/powershell/Modules/PackageManagement/PackageManagement.Tests.ps1,/PowerShell/test/powershell/engine/Module
+ARG GITLOCATION=https://github.com/PowerShell/PowerShell.git
 
 # Install dependencies
 RUN apt-get update \
@@ -23,5 +24,5 @@ RUN locale-gen $LANG && update-locale
 RUN curl -L -o powershell_$PSVERSIONSTUB-1.ubuntu.14.04_amd64.deb $PACKAGELOCATIONSTUB/powershell_$PSVERSIONSTUB-1.ubuntu.14.04_amd64.deb
 RUN dpkg -i powershell_$PSVERSIONSTUB-1.ubuntu.14.04_amd64.deb || :
 RUN apt-get install -y -f
-RUN git clone --recursive https://github.com/PowerShell/PowerShell.git
-RUN pwsh -c "Import-Module /PowerShell/build.psm1;Restore-PSPester -Destination /usr/local/share/powershell/Modules;exit (Invoke-Pester $TESTLISTSTUB -PassThru).FailedCount"
+RUN git clone --recursive $GITLOCATION
+RUN pwsh -c "Import-Module /PowerShell/build.psm1;\$dir='/usr/local/share/powershell/Modules';New-Item -Type Directory -Path \$dir -ErrorAction SilentlyContinue;Restore-PSPester -Destination \$dir;exit (Invoke-Pester $TESTLISTSTUB -PassThru).FailedCount"

--- a/docker/tests/Templates/ubuntu16.04/Dockerfile
+++ b/docker/tests/Templates/ubuntu16.04/Dockerfile
@@ -1,9 +1,10 @@
 FROM ubuntu:xenial
 
-ARG PSVERSIONSTUB
-ARG PSVERSIONSTUBRPM
+ARG PSVERSIONSTUB=6.0.1
+ARG PSVERSIONSTUBRPM=6.0.1
 ARG PACKAGELOCATIONSTUB
-ARG TESTLISTSTUB
+ARG TESTLISTSTUB=/PowerShell/test/powershell/Modules/PackageManagement/PackageManagement.Tests.ps1,/PowerShell/test/powershell/engine/Module
+ARG GITLOCATION=https://github.com/PowerShell/PowerShell.git
 
 # Install dependencies
 RUN apt-get update \
@@ -23,5 +24,5 @@ RUN locale-gen $LANG && update-locale
 RUN curl -L -o powershell_$PSVERSIONSTUB-1.ubuntu.16.04_amd64.deb $PACKAGELOCATIONSTUB/powershell_$PSVERSIONSTUB-1.ubuntu.16.04_amd64.deb
 RUN dpkg -i powershell_$PSVERSIONSTUB-1.ubuntu.16.04_amd64.deb || :
 RUN apt-get install -y -f
-RUN git clone --recursive https://github.com/PowerShell/PowerShell.git
-RUN pwsh -c "Import-Module /PowerShell/build.psm1;Restore-PSPester -Destination /usr/local/share/powershell/Modules;exit (Invoke-Pester $TESTLISTSTUB -PassThru).FailedCount"
+RUN git clone --recursive $GITLOCATION
+RUN pwsh -c "Import-Module /PowerShell/build.psm1;\$dir='/usr/local/share/powershell/Modules';New-Item -Type Directory -Path \$dir -ErrorAction SilentlyContinue;Restore-PSPester -Destination \$dir;exit (Invoke-Pester $TESTLISTSTUB -PassThru).FailedCount"

--- a/docker/tests/Templates/ubuntu17.04/Dockerfile
+++ b/docker/tests/Templates/ubuntu17.04/Dockerfile
@@ -1,9 +1,10 @@
 FROM ubuntu:zesty
 
-ARG PSVERSIONSTUB
-ARG PSVERSIONSTUBRPM
+ARG PSVERSIONSTUB=6.0.1
+ARG PSVERSIONSTUBRPM=6.0.1
 ARG PACKAGELOCATIONSTUB
-ARG TESTLISTSTUB
+ARG TESTLISTSTUB=/PowerShell/test/powershell/Modules/PackageManagement/PackageManagement.Tests.ps1,/PowerShell/test/powershell/engine/Module
+ARG GITLOCATION=https://github.com/PowerShell/PowerShell.git
 
 # Install dependencies
 RUN apt-get update \
@@ -23,5 +24,5 @@ RUN locale-gen $LANG && update-locale
 RUN curl -L -o powershell_$PSVERSIONSTUB-1.ubuntu.17.04_amd64.deb $PACKAGELOCATIONSTUB/powershell_$PSVERSIONSTUB-1.ubuntu.17.04_amd64.deb
 RUN dpkg -i powershell_$PSVERSIONSTUB-1.ubuntu.17.04_amd64.deb || :
 RUN apt-get install -y -f
-RUN git clone --recursive https://github.com/PowerShell/PowerShell.git
-RUN pwsh -c "Import-Module /PowerShell/build.psm1;Restore-PSPester -Destination /usr/local/share/powershell/Modules;exit (Invoke-Pester $TESTLISTSTUB -PassThru).FailedCount"
+RUN git clone --recursive $GITLOCATION
+RUN pwsh -c "Import-Module /PowerShell/build.psm1;\$dir='/usr/local/share/powershell/Modules';New-Item -Type Directory -Path \$dir -ErrorAction SilentlyContinue;Restore-PSPester -Destination \$dir;exit (Invoke-Pester $TESTLISTSTUB -PassThru).FailedCount"

--- a/docker/tests/containerTestCommon.psm1
+++ b/docker/tests/containerTestCommon.psm1
@@ -224,7 +224,9 @@ function Test-PSPackage
         [string]
         $PSVersion = "6.0.1",
         [string]
-        $TestList = "/PowerShell/test/powershell/Modules/PackageManagement/PackageManagement.Tests.ps1,/PowerShell/test/powershell/engine/Module"
+        $TestList = "/PowerShell/test/powershell/Modules/PackageManagement/PackageManagement.Tests.ps1,/PowerShell/test/powershell/engine/Module",
+        [string]
+        $GitLocation = "https://github.com/PowerShell/PowerShell.git"
     )
 
     $PSPackageLocation = $PSPackageLocation.TrimEnd('/','\')
@@ -250,6 +252,8 @@ function Test-PSPackage
     $testlistStubValue = $TestList
     $packageLocationStubName = 'PACKAGELOCATIONSTUB'
     $packageLocationStubValue = $PSPackageLocation
+    $GitLocationStubName = 'GITLOCATION'
+    $GitLocationStubValue = $GitLocation
 
 
     $results = @{}
@@ -263,6 +267,7 @@ function Test-PSPackage
         $buildArgs += "--build-arg","$versionStubName=$versionStubValue"
         $buildArgs += "--build-arg","$testlistStubName=$testlistStubValue"
         $buildArgs += "--build-arg","$packageLocationStubName=$packageLocationStubValue"
+        $buildArgs += "--build-arg","$GitLocationStubName=$GitLocationStubValue"
         $buildArgs += "--no-cache"
         $buildArgs += $dir.FullName
 


### PR DESCRIPTION
## PR Summary

Following updates with this PR:
1) build.psm1 was recently changed to use 'Save-Module' in Restore-PSPester #6112 . This broke Docker package validation tests. This PR fixes this by pre-creating target directory for Pester module.
2) adding default values for dockerfile arguments. This helps with occasional need of manual building of dockerfiles by making command line shorter.
3) making location of PS Git repo a parameter; this implicitly includes support for PATs.

## PR Checklist

Note: Please mark anything not applicable to this PR `NA`.

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [ ] Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [NA] User facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [ ] Issue filed - Issue link:
- [X] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [NA] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
    - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
