### PR TITLE
MeasureInfo: Only display properties with values 

### DIFF
--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
@@ -192,6 +192,14 @@ namespace System.Management.Automation.Runspaces
                 ViewsOf_System_Management_Automation_Job());
 
             yield return new ExtendedTypeDefinition(
+                "Microsoft.PowerShell.Commands.TextMeasureInfo",
+                ViewsOf_Deserialized_Microsoft_PowerShell_Commands_TextMeasureInfo());
+
+            yield return new ExtendedTypeDefinition(
+                "Microsoft.PowerShell.Commands.GenericMeasureInfo",
+                ViewsOf_Deserialized_Microsoft_PowerShell_Commands_GenericMeasureInfo());
+
+            yield return new ExtendedTypeDefinition(
                 "Deserialized.Microsoft.PowerShell.Commands.TextMeasureInfo",
                 ViewsOf_Deserialized_Microsoft_PowerShell_Commands_TextMeasureInfo());
 
@@ -1062,11 +1070,11 @@ namespace System.Management.Automation.Runspaces
                 ListControl.Create()
                     .StartEntry()
                         .AddItemProperty(@"Count")
-                        .AddItemProperty(@"Average")
-                        .AddItemProperty(@"Sum")
-                        .AddItemProperty(@"Maximum")
-                        .AddItemProperty(@"Minimum")
-                        .AddItemProperty(@"Property")
+                        .AddItemProperty(@"Average",  itemSelectionContition: DisplayEntry.CreatePropertyEntry("Average"))
+                        .AddItemProperty(@"Sum",      itemSelectionContition: DisplayEntry.CreatePropertyEntry("Sum"))
+                        .AddItemProperty(@"Maximum",  itemSelectionContition: DisplayEntry.CreatePropertyEntry("Maximum"))
+                        .AddItemProperty(@"Minimum",  itemSelectionContition: DisplayEntry.CreatePropertyEntry("Minimum"))
+                        .AddItemProperty(@"Property", itemSelectionContition: DisplayEntry.CreatePropertyEntry("Property"))
                     .EndEntry()
                 .EndList());
         }

--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
@@ -1070,11 +1070,11 @@ namespace System.Management.Automation.Runspaces
                 ListControl.Create()
                     .StartEntry()
                         .AddItemProperty(@"Count")
-                        .AddItemProperty(@"Average",  itemSelectionContition: DisplayEntry.CreatePropertyEntry("Average"))
-                        .AddItemProperty(@"Sum",      itemSelectionContition: DisplayEntry.CreatePropertyEntry("Sum"))
-                        .AddItemProperty(@"Maximum",  itemSelectionContition: DisplayEntry.CreatePropertyEntry("Maximum"))
-                        .AddItemProperty(@"Minimum",  itemSelectionContition: DisplayEntry.CreatePropertyEntry("Minimum"))
-                        .AddItemProperty(@"Property", itemSelectionContition: DisplayEntry.CreatePropertyEntry("Property"))
+                        .AddItemPropertyIfSet(@"Average")
+                        .AddItemPropertyIfSet(@"Sum")
+                        .AddItemPropertyIfSet(@"Maximum")
+                        .AddItemPropertyIfSet(@"Minimum")
+                        .AddItemPropertyIfSet(@"Property")
                     .EndEntry()
                 .EndList());
         }

--- a/src/System.Management.Automation/FormatAndOutput/common/DisplayDatabase/displayDescriptionData.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/DisplayDatabase/displayDescriptionData.cs
@@ -789,7 +789,7 @@ namespace System.Management.Automation
         }
 
         /// <summary>
-        /// Creates a DisplayEntry for the given scriptblock
+        /// Creates a DisplayEntry for the given scriptblock.
         /// </summary>
         /// <param name="scriptblock">The content of the scriptblock</param>
         public static DisplayEntry CreateScriptBlockEntry(string scriptblock)
@@ -798,7 +798,7 @@ namespace System.Management.Automation
         }
 
         /// <summary>
-        /// Creates a DisplayEntry for the given property name
+        /// Creates a DisplayEntry for the given property name.
         /// </summary>
         /// <param name="property">the name of the property</param>
         public static DisplayEntry CreatePropertyEntry(string property)

--- a/src/System.Management.Automation/FormatAndOutput/common/DisplayDatabase/displayDescriptionData.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/DisplayDatabase/displayDescriptionData.cs
@@ -788,6 +788,24 @@ namespace System.Management.Automation
             ValueType = type;
         }
 
+        /// <summary>
+        /// Creates a DisplayEntry for the given scriptblock
+        /// </summary>
+        /// <param name="scriptblock">The content of the scriptblock</param>
+        public static DisplayEntry CreateScriptBlockEntry(string scriptblock)
+        {
+            return new DisplayEntry(scriptblock, DisplayEntryValueType.ScriptBlock);
+        }
+
+        /// <summary>
+        /// Creates a DisplayEntry for the given property name
+        /// </summary>
+        /// <param name="property">the name of the property</param>
+        public static DisplayEntry CreatePropertyEntry(string property)
+        {
+            return new DisplayEntry(property, DisplayEntryValueType.Property);
+        }
+
         /// <summary/>
         public override string ToString()
         {

--- a/src/System.Management.Automation/FormatAndOutput/common/DisplayDatabase/displayDescriptionData_List.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/DisplayDatabase/displayDescriptionData_List.cs
@@ -387,7 +387,7 @@ namespace System.Management.Automation
         }
 
         /// <summary></summary>
-        public ListEntryBuilder AddItemScriptBlock(string scriptBlock, string label = null, string format = null, DisplayEntry itemSelectionContition = null )
+        public ListEntryBuilder AddItemScriptBlock(string scriptBlock, string label = null, string format = null, DisplayEntry itemSelectionContition = null)
         {
             return AddItem(scriptBlock, label, DisplayEntryValueType.ScriptBlock, format, itemSelectionContition);
         }
@@ -395,6 +395,13 @@ namespace System.Management.Automation
         /// <summary></summary>
         public ListEntryBuilder AddItemProperty(string property, string label = null, string format = null, DisplayEntry itemSelectionContition = null)
         {
+            return AddItem(property, label, DisplayEntryValueType.Property, format, itemSelectionContition);
+        }
+
+        /// <summary></summary>
+        public ListEntryBuilder AddItemPropertyIfSet(string property, string label = null, string format = null)
+        {
+            var itemSelectionContition = DisplayEntry.CreatePropertyEntry(property);
             return AddItem(property, label, DisplayEntryValueType.Property, format, itemSelectionContition);
         }
 

--- a/src/System.Management.Automation/FormatAndOutput/common/DisplayDatabase/displayDescriptionData_List.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/DisplayDatabase/displayDescriptionData_List.cs
@@ -370,7 +370,7 @@ namespace System.Management.Automation
             _listEntry = listEntry;
         }
 
-        private ListEntryBuilder AddItem(string value, string label, DisplayEntryValueType kind, string format)
+        private ListEntryBuilder AddItem(string value, string label, DisplayEntryValueType kind, string format, DisplayEntry itemSelectionContition)
         {
             if (string.IsNullOrEmpty(value))
                 throw PSTraceSource.NewArgumentNullException("property");
@@ -379,22 +379,23 @@ namespace System.Management.Automation
             {
                 DisplayEntry = new DisplayEntry(value, kind),
                 Label = label,
-                FormatString = format
+                FormatString = format,
+                ItemSelectionCondition = itemSelectionContition,
             });
 
             return this;
         }
 
         /// <summary></summary>
-        public ListEntryBuilder AddItemScriptBlock(string scriptBlock, string label = null, string format = null)
+        public ListEntryBuilder AddItemScriptBlock(string scriptBlock, string label = null, string format = null, DisplayEntry itemSelectionContition = null )
         {
-            return AddItem(scriptBlock, label, DisplayEntryValueType.ScriptBlock, format);
+            return AddItem(scriptBlock, label, DisplayEntryValueType.ScriptBlock, format, itemSelectionContition);
         }
 
         /// <summary></summary>
-        public ListEntryBuilder AddItemProperty(string property, string label = null, string format = null)
+        public ListEntryBuilder AddItemProperty(string property, string label = null, string format = null, DisplayEntry itemSelectionContition = null)
         {
-            return AddItem(property, label, DisplayEntryValueType.Property, format);
+            return AddItem(property, label, DisplayEntryValueType.Property, format, itemSelectionContition);
         }
 
         /// <summary></summary>

--- a/src/System.Management.Automation/FormatAndOutput/common/DisplayDatabase/typeDataXmlLoader.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/DisplayDatabase/typeDataXmlLoader.cs
@@ -883,6 +883,11 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                     fpt.expression = expression;
                     fpt.fieldFormattingDirective.formatString = listItem.FormatString;
                     lvid.formatTokenList.Add(fpt);
+                    if (listItem.ItemSelectionCondition != null)
+                    {
+                        var conditionToken = LoadExpressionFromObjectModel(listItem.ItemSelectionCondition, viewIndex, typeName);
+                        lvid.conditionToken = conditionToken;
+                    }
                 }
 
                 if (!String.IsNullOrEmpty(listItem.Label))

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/object.tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/object.tests.ps1
@@ -98,5 +98,13 @@ Describe "Object cmdlets" -Tags "CI" {
             $gmi = "abc",[Datetime]::Now | measure  -sum -max -ev err -ea silentlycontinue
             $gmi.Count | Should Be 2
         }
+
+        It 'should only display fields that are set' {
+            $text = 1, 2, 3 | Measure-Object -sum -Average | format-list | out-string
+            $text -match "min|max" | should -BeFalse
+
+            $text = 1, 2, 3 | Measure-Object -Minimum -Maximum | format-list | out-string
+            $text -match "min|max" | should -BeTrue
+        }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/object.tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/object.tests.ps1
@@ -100,11 +100,11 @@ Describe "Object cmdlets" -Tags "CI" {
         }
 
         It 'should only display fields that are set' {
-            $text = 1, 2, 3 | Measure-Object -sum -Average | format-list | out-string
-            $text -match "min|max" | should -BeFalse
+            $text = 1, 2, 3 | Measure-Object -sum -Average | Format-List | Out-String
+            $text -match "min|max" | Should -BeFalse
 
-            $text = 1, 2, 3 | Measure-Object -Minimum -Maximum | format-list | out-string
-            $text -match "min|max" | should -BeTrue
+            $text = 1, 2, 3 | Measure-Object -Minimum -Maximum | Format-List | Out-String
+            $text -match "min|max" | Should -BeTrue
         }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/object.tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/object.tests.ps1
@@ -100,7 +100,7 @@ Describe "Object cmdlets" -Tags "CI" {
         }
 
         It 'should only display fields that are set' {
-            $text = 1, 2, 3 | Measure-Object -sum -Average | Format-List | Out-String
+            $text = 1, 2, 3 | Measure-Object -Sum -Average | Format-List | Out-String
             $text -match "min|max" | Should -BeFalse
 
             $text = 1, 2, 3 | Measure-Object -Minimum -Maximum | Format-List | Out-String


### PR DESCRIPTION
## PR Summary

Adding Item selection conditions to the list formatting info for `MeasureInfo` so that only the properties with values gets displayed



## PR Checklist

Note: Please mark anything not applicable to this PR `NA`.

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [X] Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] User facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [ ] Issue filed - Issue link:
- [X] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [X] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
    - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
