### PR TITLE
Set pipeline thread stack size

### DIFF
--- a/src/System.Management.Automation/engine/hostifaces/LocalPipeline.cs
+++ b/src/System.Management.Automation/engine/hostifaces/LocalPipeline.cs
@@ -158,17 +158,11 @@ namespace System.Management.Automation.Runspaces
                 case PSThreadOptions.Default:
                 case PSThreadOptions.UseNewThread:
                     {
-#if CORECLR
-                        //Start execution of pipeline in another thread
-                        // No ApartmentState/ThreadStackSize In CoreCLR
+                        // Start execution of pipeline in another thread
                         Thread invokeThread = new Thread(new ThreadStart(this.InvokeThreadProc), DefaultPipelineStackSize);
                         SetupInvokeThread(invokeThread, true);
-#else
-                        //Start execution of pipeline in another thread
-                        // 2004/05/02-JonN Specify maxStack parameter
-                        Thread invokeThread = new Thread(new ThreadStart(this.InvokeThreadProc), DefaultPipelineStackSize);
-                        SetupInvokeThread(invokeThread, true);
-
+#if !CORECLR
+                        // No ApartmentState in CoreCLR
                         ApartmentState apartmentState;
 
                         if (InvocationSettings != null && InvocationSettings.ApartmentState != ApartmentState.Unknown)
@@ -1197,7 +1191,7 @@ namespace System.Management.Automation.Runspaces
 #else
         internal PipelineThread(ApartmentState apartmentState)
         {
-            _worker = new Thread(WorkerProc, DefaultPipelineStackSize);
+            _worker = new Thread(WorkerProc, LocalPipeline.DefaultPipelineStackSize);
             _workItem = null;
             _workItemReady = new AutoResetEvent(false);
             _closed = false;

--- a/src/System.Management.Automation/engine/hostifaces/LocalPipeline.cs
+++ b/src/System.Management.Automation/engine/hostifaces/LocalPipeline.cs
@@ -20,13 +20,12 @@ namespace System.Management.Automation.Runspaces
     /// </summary>
     internal sealed class LocalPipeline : PipelineBase
     {
-        // Default stack size in bytes for local pipeline threads.
-        //
-        // Each platform uses different default for the thread stack size:
+        // Each OS platform uses different default stack size for threads:
         //      - Windows 2 MB
         //      - Linux   8 Mb
         //      - MacOs   512 KB
-        // We should use the same default for all platforms to get predictable behavior.
+        // We should use the same stack size for pipeline threads on all platforms to get predictable behavior.
+        // The stack size we use for pipeline threads is 10MB, which is inherited from Windows PowerShell.
         internal const int DefaultPipelineStackSize = 10_000_000;
 
         #region constructors


### PR DESCRIPTION
## PR Summary

Fix #4268 
Overlap #5927 (see PowerShell Committee conclusion)

Set default stack size in 10 MB for local pipeline threads.

Each platform uses different default for the thread stack size:
      - Windows 2 MB
      - Linux   8 Mb
      - MacOs   512 KB
 
We should use the same default for all platforms to get predictable behavior.

## PR Checklist

Note: Please mark anything not applicable to this PR `NA`.

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [x] Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] User facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [ ] Issue filed - Issue link:
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
    - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
