### PR TITLE
Update CimDSCParser to fix Configuration compilation for DSC

### DIFF
--- a/src/System.Management.Automation/DscSupport/CimDSCParser.cs
+++ b/src/System.Management.Automation/DscSupport/CimDSCParser.cs
@@ -668,26 +668,11 @@ namespace Microsoft.PowerShell.DesiredStateConfiguration.Internal
             else
             {
                 // DSC SxS scenario
-                //var psAssembly = Assembly.GetEntryAssembly();
                 var configSystemPath = Utils.DefaultPowerShellAppBase;
                 var systemResourceRoot = Path.Combine(configSystemPath, "Configuration");
-                //var inboxModulePath = "Modules\\PSDesiredStateConfiguration";
-                ExecutionContext context = null;
-                CommandInfo commandInfo = new CmdletInfo("Get-Module", typeof(Microsoft.PowerShell.Commands.GetModuleCommand), null, null, context);
-                System.Management.Automation.Runspaces.Command getModuleCommand = new System.Management.Automation.Runspaces.Command(commandInfo);
-                var psDesiredStateConfigurationModule = System.Management.Automation.PowerShell.Create(RunspaceMode.CurrentRunspace)
-                .AddCommand(getModuleCommand)
-                    .AddParameter("List", true)
-                    .AddParameter("Name", "PSDesiredStateConfiguration")
-                    .AddParameter("ErrorAction", ActionPreference.Ignore)
-                    .AddParameter("WarningAction", ActionPreference.Ignore)
-                    .AddParameter("InformationAction", ActionPreference.Ignore)
-                    .AddParameter("Verbose", false)
-                    .AddParameter("Debug", false)
-                    .Invoke<PSModuleInfo>();
-                var inboxModulePath = psDesiredStateConfigurationModule[0].Path;
+                var inboxModulePath = "Modules\\PSDesiredStateConfiguration";
 
-                if(!Directory.Exists(systemResourceRoot))
+                if (!Directory.Exists(systemResourceRoot))
                 {
                      configSystemPath = Platform.GetFolderPath(Environment.SpecialFolder.System);
                      systemResourceRoot = Path.Combine(configSystemPath, "Configuration");

--- a/src/System.Management.Automation/DscSupport/CimDSCParser.cs
+++ b/src/System.Management.Automation/DscSupport/CimDSCParser.cs
@@ -667,7 +667,18 @@ namespace Microsoft.PowerShell.DesiredStateConfiguration.Internal
             }
             else
             {
-                var systemResourceRoot = Path.Combine(Platform.GetFolderPath(Environment.SpecialFolder.System), "Configuration");
+                // DSC SxS scenario
+                var psAssembly = Assembly.GetEntryAssembly();
+                var configSystemPath = Path.GetDirectoryName(psAssembly.Location);
+                var systemResourceRoot = Path.Combine(configSystemPath, "Configuration");
+                var inboxModulePath = "Modules\\PSDesiredStateConfiguration";
+                if( !Directory.Exists(systemResourceRoot))
+                {
+                     configSystemPath = Platform.GetFolderPath(Environment.SpecialFolder.System);
+                     systemResourceRoot = Path.Combine(configSystemPath, "Configuration");
+                     inboxModulePath = InboxDscResourceModulePath;
+                }
+
                 var programFilesDirectory = Platform.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
                 Debug.Assert(programFilesDirectory != null, "Program Files environment variable does not exist!");
                 var customResourceRoot = Path.Combine(programFilesDirectory, "WindowsPowerShell\\Configuration");
@@ -708,7 +719,7 @@ namespace Microsoft.PowerShell.DesiredStateConfiguration.Internal
                 List<string> modulePaths = new List<string>();
                 if (modulePathList == null || modulePathList.Count == 0)
                 {
-                    modulePaths.Add(Path.Combine(Platform.GetFolderPath(Environment.SpecialFolder.System), InboxDscResourceModulePath));
+                    modulePaths.Add(Path.Combine(configSystemPath, inboxModulePath));
                     isInboxResource = true;
                 }
                 else

--- a/src/System.Management.Automation/DscSupport/CimDSCParser.cs
+++ b/src/System.Management.Automation/DscSupport/CimDSCParser.cs
@@ -668,11 +668,26 @@ namespace Microsoft.PowerShell.DesiredStateConfiguration.Internal
             else
             {
                 // DSC SxS scenario
-                var psAssembly = Assembly.GetEntryAssembly();
-                var configSystemPath = Path.GetDirectoryName(psAssembly.Location);
+                //var psAssembly = Assembly.GetEntryAssembly();
+                var configSystemPath = Utils.DefaultPowerShellAppBase;
                 var systemResourceRoot = Path.Combine(configSystemPath, "Configuration");
-                var inboxModulePath = "Modules\\PSDesiredStateConfiguration";
-                if( !Directory.Exists(systemResourceRoot))
+                //var inboxModulePath = "Modules\\PSDesiredStateConfiguration";
+                ExecutionContext context = null;
+                CommandInfo commandInfo = new CmdletInfo("Get-Module", typeof(Microsoft.PowerShell.Commands.GetModuleCommand), null, null, context);
+                System.Management.Automation.Runspaces.Command getModuleCommand = new System.Management.Automation.Runspaces.Command(commandInfo);
+                var psDesiredStateConfigurationModule = System.Management.Automation.PowerShell.Create(RunspaceMode.CurrentRunspace)
+                .AddCommand(getModuleCommand)
+                    .AddParameter("List", true)
+                    .AddParameter("Name", "PSDesiredStateConfiguration")
+                    .AddParameter("ErrorAction", ActionPreference.Ignore)
+                    .AddParameter("WarningAction", ActionPreference.Ignore)
+                    .AddParameter("InformationAction", ActionPreference.Ignore)
+                    .AddParameter("Verbose", false)
+                    .AddParameter("Debug", false)
+                    .Invoke<PSModuleInfo>();
+                var inboxModulePath = psDesiredStateConfigurationModule[0].Path;
+
+                if(!Directory.Exists(systemResourceRoot))
                 {
                      configSystemPath = Platform.GetFolderPath(Environment.SpecialFolder.System);
                      systemResourceRoot = Path.Combine(configSystemPath, "Configuration");


### PR DESCRIPTION
## PR Summary

Some of the file paths have changed in PS Core, so Configuration compilation was failing on machines without WMF installed. This PR updates those paths.

## PR Checklist

Note: Please mark anything not applicable to this PR `NA`.

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [x] Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] Issue filed - Issue link: #4525
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting): change is only applicable on 2012R2 and 2012 machines without WMF installed.
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
