### PR TITLE
Upgrade Pester tests in test\powershell\Host folder to dashed v4 syntax

### DIFF
--- a/test/powershell/Host/Base-Directory.Tests.ps1
+++ b/test/powershell/Host/Base-Directory.Tests.ps1
@@ -46,7 +46,7 @@ Describe "Configuration file locations" -tags "CI","Slow" {
         It @ItArgs "PSModulePath should contain the correct path" {
             $env:PSModulePath = ""
             $actual = & $powershell -noprofile -c `$env:PSModulePath
-            $actual | Should Match ([regex]::Escape($expectedModule))
+            $actual | Should-Match ([regex]::Escape($expectedModule))
         }
 
         It @ItArgs "PSReadLine history save location should be correct" {
@@ -98,7 +98,7 @@ Describe "Configuration file locations" -tags "CI","Slow" {
             $env:XDG_DATA_HOME = $TestDrive
             $expected = [IO.Path]::Combine($TestDrive, "powershell", "Modules")
             $actual = & $powershell -noprofile -c `$env:PSModulePath
-            $actual | Should Match $expected
+            $actual | Should-Match $expected
         }
 
         It @ItArgs "PSReadLine history should respect XDG_DATA_HOME" {

--- a/test/powershell/Host/Base-Directory.Tests.ps1
+++ b/test/powershell/Host/Base-Directory.Tests.ps1
@@ -46,7 +46,7 @@ Describe "Configuration file locations" -tags "CI","Slow" {
         It @ItArgs "PSModulePath should contain the correct path" {
             $env:PSModulePath = ""
             $actual = & $powershell -noprofile -c `$env:PSModulePath
-            $actual | Should-Match ([regex]::Escape($expectedModule))
+            $actual | Should -Match ([regex]::Escape($expectedModule))
         }
 
         It @ItArgs "PSReadLine history save location should be correct" {
@@ -98,7 +98,7 @@ Describe "Configuration file locations" -tags "CI","Slow" {
             $env:XDG_DATA_HOME = $TestDrive
             $expected = [IO.Path]::Combine($TestDrive, "powershell", "Modules")
             $actual = & $powershell -noprofile -c `$env:PSModulePath
-            $actual | Should-Match $expected
+            $actual | Should -Match $expected
         }
 
         It @ItArgs "PSReadLine history should respect XDG_DATA_HOME" {

--- a/test/powershell/Host/Base-Directory.Tests.ps1
+++ b/test/powershell/Host/Base-Directory.Tests.ps1
@@ -57,7 +57,7 @@ Describe "Configuration file locations" -tags "CI","Slow" {
         It "JIT cache should be created correctly" -Skip {
             Remove-Item -ErrorAction SilentlyContinue $expectedCache
             & $powershell -noprofile { exit }
-            $expectedCache | Should Exist
+            $expectedCache | Should -Exist
         }
 
         # The ModuleAnalysisCache cannot be forced to exist, thus we cannot test it
@@ -113,7 +113,7 @@ Describe "Configuration file locations" -tags "CI","Slow" {
             $expected = [IO.Path]::Combine($TestDrive, "powershell", "StartupProfileData-NonInteractive")
             Remove-Item -ErrorAction SilentlyContinue $expected
             & $powershell -noprofile { exit }
-            $expected | Should Exist
+            $expected | Should -Exist
         }
     }
 }

--- a/test/powershell/Host/Base-Directory.Tests.ps1
+++ b/test/powershell/Host/Base-Directory.Tests.ps1
@@ -40,7 +40,7 @@ Describe "Configuration file locations" -tags "CI","Slow" {
         }
 
         It @ItArgs "Profile location should be correct" {
-            & $powershell -noprofile -c `$PROFILE | Should Be $expectedProfile
+            & $powershell -noprofile -c `$PROFILE | Should -Be $expectedProfile
         }
 
         It @ItArgs "PSModulePath should contain the correct path" {
@@ -50,7 +50,7 @@ Describe "Configuration file locations" -tags "CI","Slow" {
         }
 
         It @ItArgs "PSReadLine history save location should be correct" {
-            & $powershell -noprofile { (Get-PSReadlineOption).HistorySavePath } | Should Be $expectedReadline
+            & $powershell -noprofile { (Get-PSReadlineOption).HistorySavePath } | Should -Be $expectedReadline
         }
 
         # This feature (and thus test) has been disabled because of the AssemblyLoadContext scenario
@@ -90,7 +90,7 @@ Describe "Configuration file locations" -tags "CI","Slow" {
         It @ItArgs "Profile should respect XDG_CONFIG_HOME" {
             $env:XDG_CONFIG_HOME = $TestDrive
             $expected = [IO.Path]::Combine($TestDrive, "powershell", $profileName)
-            & $powershell -noprofile -c `$PROFILE | Should Be $expected
+            & $powershell -noprofile -c `$PROFILE | Should -Be $expected
         }
 
         It @ItArgs "PSModulePath should respect XDG_DATA_HOME" {
@@ -104,7 +104,7 @@ Describe "Configuration file locations" -tags "CI","Slow" {
         It @ItArgs "PSReadLine history should respect XDG_DATA_HOME" {
             $env:XDG_DATA_HOME = $TestDrive
             $expected = [IO.Path]::Combine($TestDrive, "powershell", "PSReadLine", "ConsoleHost_history.txt")
-            & $powershell -noprofile { (Get-PSReadlineOption).HistorySavePath } | Should Be $expected
+            & $powershell -noprofile { (Get-PSReadlineOption).HistorySavePath } | Should -Be $expected
         }
 
         # This feature (and thus test) has been disabled because of the AssemblyLoadContext scenario
@@ -137,6 +137,6 @@ Describe "Working directory on startup" -Tag "CI" {
         } else {
             $expectedPath = $testPath.FullName
         }
-        & $powershell -noprofile -c { $PWD.Path } | Should BeExactly $expectedPath
+        & $powershell -noprofile -c { $PWD.Path } | Should -BeExactly $expectedPath
     }
 }

--- a/test/powershell/Host/ConsoleHost.Tests.ps1
+++ b/test/powershell/Host/ConsoleHost.Tests.ps1
@@ -128,7 +128,7 @@ Describe "ConsoleHost unit tests" -tags "Feature" {
             {
                 $a="blahblah"
                 $a | & $powershell -noprofile -out text -com { $input }
-            } | Should Not Throw
+            } | Should -Not Throw
         }
 
         It "Verify Parsing Error Input Format Single Shell should throw exception" {
@@ -154,7 +154,7 @@ Describe "ConsoleHost unit tests" -tags "Feature" {
         }
         foreach ($x in "--help", "-help", "-h", "-?", "--he", "-hel", "--HELP", "-hEl") {
             It "Accepts '$x' as a parameter for help" {
-                & $powershell -noprofile $x | Where-Object { $_ -match "pwsh[.exe] -Help | -? | /?" } | Should Not BeNullOrEmpty
+                & $powershell -noprofile $x | Where-Object { $_ -match "pwsh[.exe] -Help | -? | /?" } | Should -Not BeNullOrEmpty
             }
         }
 

--- a/test/powershell/Host/ConsoleHost.Tests.ps1
+++ b/test/powershell/Host/ConsoleHost.Tests.ps1
@@ -154,7 +154,7 @@ Describe "ConsoleHost unit tests" -tags "Feature" {
         }
         foreach ($x in "--help", "-help", "-h", "-?", "--he", "-hel", "--HELP", "-hEl") {
             It "Accepts '$x' as a parameter for help" {
-                & $powershell -noprofile $x | Where-Object { $_ -match "pwsh[.exe] -Help | -? | /?" } | Should -Not BeNullOrEmpty
+                & $powershell -noprofile $x | Where-Object { $_ -match "pwsh[.exe] -Help | -? | /?" } | Should -Not -BeNullOrEmpty
             }
         }
 

--- a/test/powershell/Host/ConsoleHost.Tests.ps1
+++ b/test/powershell/Host/ConsoleHost.Tests.ps1
@@ -125,7 +125,9 @@ Describe "ConsoleHost unit tests" -tags "Feature" {
         }
 
         It "Verify Validate Output Format As Text Explicitly Child Single Shell does not throw" {
-            "blahblah" | & $powershell -noprofile -out text -com { $input }
+            {
+                "blahblah" | & $powershell -noprofile -out text -com { $input }
+            } | Should -Not -Throw
         }
 
         It "Verify Parsing Error Input Format Single Shell should throw exception" {

--- a/test/powershell/Host/ConsoleHost.Tests.ps1
+++ b/test/powershell/Host/ConsoleHost.Tests.ps1
@@ -124,11 +124,8 @@ Describe "ConsoleHost unit tests" -tags "Feature" {
             }
         }
 
-        It "Verify Validate Output Format As Text Explicitly Child Single Shell should works" {
-            {
-                $a="blahblah"
-                $a | & $powershell -noprofile -out text -com { $input }
-            } | Should -Not Throw
+        It "Verify Validate Output Format As Text Explicitly Child Single Shell doess not throw" {
+            "blahblah" | & $powershell -noprofile -out text -com { $input }
         }
 
         It "Verify Parsing Error Input Format Single Shell should throw exception" {

--- a/test/powershell/Host/ConsoleHost.Tests.ps1
+++ b/test/powershell/Host/ConsoleHost.Tests.ps1
@@ -115,7 +115,7 @@ Describe "ConsoleHost unit tests" -tags "Feature" {
             }
             catch
             {
-                $_.ToString() | Should-Match "wgwg-wrwrhqwrhrh35h3h3"
+                $_.ToString() | Should -Match "wgwg-wrwrhqwrhrh35h3h3"
                 $_.FullyQualifiedErrorId | Should -Be "CommandNotFoundException"
             }
             finally
@@ -536,7 +536,7 @@ foo
 
     Context "PATH environment variable" {
         It "`$PSHOME should be in front so that pwsh.exe starts current running PowerShell" {
-            pwsh -v | Should-Match $psversiontable.GitCommitId
+            pwsh -v | Should -Match $psversiontable.GitCommitId
         }
 
         It "powershell starts if PATH is not set" -Skip:($IsWindows) {
@@ -555,7 +555,7 @@ foo
             $outString = [String]::Join(",", $output)
             foreach ($expectedMatch in $expectedMatches)
             {
-                $outString | Should-Match $expectedMatch
+                $outString | Should -Match $expectedMatch
             }
         }
     }

--- a/test/powershell/Host/ConsoleHost.Tests.ps1
+++ b/test/powershell/Host/ConsoleHost.Tests.ps1
@@ -115,7 +115,7 @@ Describe "ConsoleHost unit tests" -tags "Feature" {
             }
             catch
             {
-                $_.ToString() | Should Match "wgwg-wrwrhqwrhrh35h3h3"
+                $_.ToString() | Should-Match "wgwg-wrwrhqwrhrh35h3h3"
                 $_.FullyQualifiedErrorId | Should -Be "CommandNotFoundException"
             }
             finally
@@ -536,7 +536,7 @@ foo
 
     Context "PATH environment variable" {
         It "`$PSHOME should be in front so that pwsh.exe starts current running PowerShell" {
-            pwsh -v | Should Match $psversiontable.GitCommitId
+            pwsh -v | Should-Match $psversiontable.GitCommitId
         }
 
         It "powershell starts if PATH is not set" -Skip:($IsWindows) {
@@ -555,7 +555,7 @@ foo
             $outString = [String]::Join(",", $output)
             foreach ($expectedMatch in $expectedMatches)
             {
-                $outString | Should Match $expectedMatch
+                $outString | Should-Match $expectedMatch
             }
         }
     }

--- a/test/powershell/Host/ConsoleHost.Tests.ps1
+++ b/test/powershell/Host/ConsoleHost.Tests.ps1
@@ -18,23 +18,23 @@ Describe 'minishell for native executables' -Tag 'CI' {
 
         It 'gets a hashtable object from minishell' {
             $output = & $powershell -noprofile { @{'a' = 'b'} }
-            ($output | Measure-Object).Count | Should Be 1
-            $output | Should BeOfType 'Hashtable'
-            $output['a'] | Should Be 'b'
+            ($output | Measure-Object).Count | Should -Be 1
+            $output | Should -BeOfType 'Hashtable'
+            $output['a'] | Should -Be 'b'
         }
 
         It 'gets the error stream from minishell' {
             $output = & $powershell -noprofile { Write-Error 'foo' } 2>&1
-            ($output | Measure-Object).Count | Should Be 1
-            $output | Should BeOfType 'System.Management.Automation.ErrorRecord'
-            $output.FullyQualifiedErrorId | Should Be 'Microsoft.PowerShell.Commands.WriteErrorException'
+            ($output | Measure-Object).Count | Should -Be 1
+            $output | Should -BeOfType 'System.Management.Automation.ErrorRecord'
+            $output.FullyQualifiedErrorId | Should -Be 'Microsoft.PowerShell.Commands.WriteErrorException'
         }
 
         It 'gets the information stream from minishell' {
             $output = & $powershell -noprofile { Write-Information 'foo' } 6>&1
-            ($output | Measure-Object).Count | Should Be 1
-            $output | Should BeOfType 'System.Management.Automation.InformationRecord'
-            $output | Should Be 'foo'
+            ($output | Measure-Object).Count | Should -Be 1
+            $output | Should -BeOfType 'System.Management.Automation.InformationRecord'
+            $output | Should -Be 'foo'
         }
     }
 
@@ -42,10 +42,10 @@ Describe 'minishell for native executables' -Tag 'CI' {
         It "passes input into minishell" {
             $a = 1,2,3
             $val  = $a | & $powershell -noprofile -command { $input }
-            $val.Count | Should Be 3
-            $val[0] | Should Be 1
-            $val[1] | Should Be 2
-            $val[2] | Should Be 3
+            $val.Count | Should -Be 3
+            $val[0] | Should -Be 1
+            $val[1] | Should -Be 2
+            $val[2] | Should -Be 3
         }
     }
 }
@@ -81,7 +81,7 @@ Describe "ConsoleHost unit tests" -tags "Feature" {
 
             if (!$process.HasExited)
             {
-                $process.HasExited | Should Be $true
+                $process.HasExited | Should -Be $true
                 $process.Kill()
             }
         }
@@ -100,7 +100,7 @@ Describe "ConsoleHost unit tests" -tags "Feature" {
             }
             catch
             {
-                $_.FullyQualifiedErrorId | Should Be "IncorrectValueForFormatParameter"
+                $_.FullyQualifiedErrorId | Should -Be "IncorrectValueForFormatParameter"
             }
         }
 
@@ -116,7 +116,7 @@ Describe "ConsoleHost unit tests" -tags "Feature" {
             catch
             {
                 $_.ToString() | Should Match "wgwg-wrwrhqwrhrh35h3h3"
-                $_.FullyQualifiedErrorId | Should Be "CommandNotFoundException"
+                $_.FullyQualifiedErrorId | Should -Be "CommandNotFoundException"
             }
             finally
             {
@@ -139,18 +139,18 @@ Describe "ConsoleHost unit tests" -tags "Feature" {
             }
             catch
             {
-                $_.FullyQualifiedErrorId | Should Be "IncorrectValueForFormatParameter"
+                $_.FullyQualifiedErrorId | Should -Be "IncorrectValueForFormatParameter"
             }
         }
     }
     Context "CommandLine" {
         It "simple -args" {
-            & $powershell -noprofile { $args[0] } -args "hello world" | Should Be "hello world"
+            & $powershell -noprofile { $args[0] } -args "hello world" | Should -Be "hello world"
         }
 
         It "array -args" {
-            & $powershell -noprofile { $args[0] } -args 1,(2,3) | Should Be 1
-            (& $powershell -noprofile { $args[1] } -args 1,(2,3))[1]  | Should Be 3
+            & $powershell -noprofile { $args[0] } -args 1,(2,3) | Should -Be 1
+            (& $powershell -noprofile { $args[1] } -args 1,(2,3))[1]  | Should -Be 3
         }
         foreach ($x in "--help", "-help", "-h", "-?", "--he", "-hel", "--HELP", "-hEl") {
             It "Accepts '$x' as a parameter for help" {
@@ -164,7 +164,7 @@ Describe "ConsoleHost unit tests" -tags "Feature" {
             # We don't compare to `Get-Location` directly because object and formatted output comparisons are difficult
             $expected = & $powershell -noprofile -command $commandString
             $actual = & $powershell -noprofile -EncodedCommand $encodedCommand
-            $actual | Should Be $expected
+            $actual | Should -Be $expected
         }
 
         It "-Version should return the engine version using: -version <value>" -TestCases @(
@@ -174,14 +174,14 @@ Describe "ConsoleHost unit tests" -tags "Feature" {
         ) {
             $currentVersion = "PowerShell " + $PSVersionTable.GitCommitId.ToString()
             $observed = & $powershell -version $value 2>&1
-            $observed | should be $currentVersion
-            $LASTEXITCODE | Should Be 0
+            $observed | Should -Be $currentVersion
+            $LASTEXITCODE | Should -Be 0
         }
 
         It "-File should be default parameter" {
             Set-Content -Path $testdrive/test -Value "'hello'"
             $observed = & $powershell -NoProfile $testdrive/test
-            $observed | Should Be "hello"
+            $observed | Should -Be "hello"
         }
 
         It "-File accepts scripts with and without .ps1 extension: <Filename>" -TestCases @(
@@ -191,15 +191,15 @@ Describe "ConsoleHost unit tests" -tags "Feature" {
             param($Filename)
             Set-Content -Path $testdrive/$Filename -Value "'hello'"
             $observed = & $powershell -NoProfile -File $testdrive/$Filename
-            $observed | Should Be "hello"
+            $observed | Should -Be "hello"
         }
 
         It "-File should pass additional arguments to script" {
             Set-Content -Path $testdrive/script.ps1 -Value 'foreach($arg in $args){$arg}'
             $observed = & $powershell -NoProfile $testdrive/script.ps1 foo bar
-            $observed.Count | Should Be 2
-            $observed[0] | Should Be "foo"
-            $observed[1] | Should Be "bar"
+            $observed.Count | Should -Be 2
+            $observed[0] | Should -Be "foo"
+            $observed[1] | Should -Be "bar"
         }
 
         It "-File should be able to pass bool string values as string to parameters: <BoolString>" -TestCases @(
@@ -212,7 +212,7 @@ Describe "ConsoleHost unit tests" -tags "Feature" {
             param([string]$BoolString)
             Set-Content -Path $testdrive/test.ps1 -Value 'param([string]$bool) $bool'
             $observed = & $powershell -NoProfile -Nologo -File $testdrive/test.ps1 -Bool $BoolString
-            $observed | Should Be $BoolString
+            $observed | Should -Be $BoolString
         }
 
         It "-File should be able to pass bool string values as string to positional parameters: <BoolString>" -TestCases @(
@@ -225,7 +225,7 @@ Describe "ConsoleHost unit tests" -tags "Feature" {
             param([string]$BoolString)
             Set-Content -Path $testdrive/test.ps1 -Value 'param([string]$bool) $bool'
             $observed = & $powershell -NoProfile -Nologo -File $testdrive/test.ps1 $BoolString
-            $observed | Should BeExactly $BoolString
+            $observed | Should -BeExactly $BoolString
         }
 
         It "-File should be able to pass bool string values as bool to switches: <BoolString>" -TestCases @(
@@ -237,7 +237,7 @@ Describe "ConsoleHost unit tests" -tags "Feature" {
             param([string]$BoolString, [string]$BoolValue)
             Set-Content -Path $testdrive/test.ps1 -Value 'param([switch]$switch) $switch.IsPresent'
             $observed = & $powershell -NoProfile -Nologo -File $testdrive/test.ps1 -switch:$BoolString
-            $observed | Should Be $BoolValue
+            $observed | Should -Be $BoolValue
         }
 
         It "-File '<filename>' should return exit code from script"  -TestCases @(
@@ -247,7 +247,7 @@ Describe "ConsoleHost unit tests" -tags "Feature" {
             param($Filename)
             Set-Content -Path $testdrive/$Filename -Value 'exit 123'
             & $powershell $testdrive/$Filename
-            $LASTEXITCODE | Should Be 123
+            $LASTEXITCODE | Should -Be 123
         }
     }
 
@@ -272,7 +272,7 @@ Describe "ConsoleHost unit tests" -tags "Feature" {
 
         It "Verifies PowerShell reads from the custom -settingsFile" -skip:(!$IsWindows) {
             $actualValue = & $powershell -NoProfile -SettingsFile $CustomSettingsFile -Command {(Get-ExecutionPolicy -Scope LocalMachine).ToString()}
-            $actualValue  | Should Be $DefaultExecutionPolicy
+            $actualValue  | Should -Be $DefaultExecutionPolicy
         }
 
         It "Verifies PowerShell writes to the custom -settingsFile" -skip:(!$IsWindows) {
@@ -283,11 +283,11 @@ Describe "ConsoleHost unit tests" -tags "Feature" {
 
             # ensure the setting was written to the settings file.
             $content = (Get-Content -Path $CustomSettingsFile | ConvertFrom-Json)
-            $content.'Microsoft.PowerShell:ExecutionPolicy' | Should Be $expectedValue
+            $content.'Microsoft.PowerShell:ExecutionPolicy' | Should -Be $expectedValue
 
             # ensure the setting is applied on next run
             $actualValue = & $powershell -NoProfile -SettingsFile $CustomSettingsFile -Command {(Get-ExecutionPolicy -Scope LocalMachine).ToString()}
-            $actualValue  | Should Be $expectedValue
+            $actualValue  | Should -Be $expectedValue
         }
 
         It "Verify PowerShell removes a setting from the custom -settingsFile" -skip:(!$IsWindows) {
@@ -296,7 +296,7 @@ Describe "ConsoleHost unit tests" -tags "Feature" {
 
             # ensure the setting was removed from the settings file.
             $content = (Get-Content -Path $CustomSettingsFile | ConvertFrom-Json)
-            $content.'Microsoft.PowerShell:ExecutionPolicy' | Should Be $null
+            $content.'Microsoft.PowerShell:ExecutionPolicy' | Should -Be $null
         }
     }
 
@@ -304,23 +304,23 @@ Describe "ConsoleHost unit tests" -tags "Feature" {
         $p = [PSCustomObject]@{X=10;Y=20}
 
         It "xml input" {
-            $p | & $powershell -noprofile { $input | Foreach-Object {$a = 0} { $a += $_.X + $_.Y } { $a } } | Should Be 30
-            $p | & $powershell -noprofile -inputFormat xml { $input | Foreach-Object {$a = 0} { $a += $_.X + $_.Y } { $a } } | Should Be 30
+            $p | & $powershell -noprofile { $input | Foreach-Object {$a = 0} { $a += $_.X + $_.Y } { $a } } | Should -Be 30
+            $p | & $powershell -noprofile -inputFormat xml { $input | Foreach-Object {$a = 0} { $a += $_.X + $_.Y } { $a } } | Should -Be 30
         }
 
         It "text input" {
             # Join (multiple lines) and remove whitespace (we don't care about spacing) to verify we converted to string (by generating a table)
-            $p | & $powershell -noprofile -inputFormat text { -join ($input -replace "\s","") } | Should Be "XY--1020"
+            $p | & $powershell -noprofile -inputFormat text { -join ($input -replace "\s","") } | Should -Be "XY--1020"
         }
 
         It "xml output" {
-            & $powershell -noprofile { [PSCustomObject]@{X=10;Y=20} } | Foreach-Object {$a = 0} { $a += $_.X + $_.Y } { $a } | Should Be 30
-            & $powershell -noprofile -outputFormat xml { [PSCustomObject]@{X=10;Y=20} } | Foreach-Object {$a = 0} { $a += $_.X + $_.Y } { $a } | Should Be 30
+            & $powershell -noprofile { [PSCustomObject]@{X=10;Y=20} } | Foreach-Object {$a = 0} { $a += $_.X + $_.Y } { $a } | Should -Be 30
+            & $powershell -noprofile -outputFormat xml { [PSCustomObject]@{X=10;Y=20} } | Foreach-Object {$a = 0} { $a += $_.X + $_.Y } { $a } | Should -Be 30
         }
 
         It "text output" {
             # Join (multiple lines) and remove whitespace (we don't care about spacing) to verify we converted to string (by generating a table)
-            -join (& $powershell -noprofile -outputFormat text { [PSCustomObject]@{X=10;Y=20} }) -replace "\s","" | Should Be "XY--1020"
+            -join (& $powershell -noprofile -outputFormat text { [PSCustomObject]@{X=10;Y=20} }) -replace "\s","" | Should -Be "XY--1020"
         }
     }
 
@@ -328,7 +328,7 @@ Describe "ConsoleHost unit tests" -tags "Feature" {
         It "Simple redirected output" {
             $si = NewProcessStartInfo "-noprofile -c 1+1"
             $process = RunPowerShell $si
-            $process.StandardOutput.ReadToEnd() | Should Be 2
+            $process.StandardOutput.ReadToEnd() | Should -Be 2
             EnsureChildHasExited $process
         }
     }
@@ -341,28 +341,28 @@ Describe "ConsoleHost unit tests" -tags "Feature" {
         It "Redirected input w/ implicit -Command w/ -NonInteractive" {
             $si = NewProcessStartInfo "-NonInteractive -noprofile -c 1+1" -RedirectStdIn
             $process = RunPowerShell $si
-            $process.StandardOutput.ReadToEnd() | Should Be 2
+            $process.StandardOutput.ReadToEnd() | Should -Be 2
             EnsureChildHasExited $process
         }
 
         It "Redirected input w/ implicit -Command w/o -NonInteractive" {
             $si = NewProcessStartInfo "-noprofile -c 1+1" -RedirectStdIn
             $process = RunPowerShell $si
-            $process.StandardOutput.ReadToEnd() | Should Be 2
+            $process.StandardOutput.ReadToEnd() | Should -Be 2
             EnsureChildHasExited $process
         }
 
         It "Redirected input w/ explicit -Command w/ -NonInteractive" {
             $si = NewProcessStartInfo "-NonInteractive -noprofile -Command 1+1" -RedirectStdIn
             $process = RunPowerShell $si
-            $process.StandardOutput.ReadToEnd() | Should Be 2
+            $process.StandardOutput.ReadToEnd() | Should -Be 2
             EnsureChildHasExited $process
         }
 
         It "Redirected input w/ explicit -Command w/o -NonInteractive" {
             $si = NewProcessStartInfo "-noprofile -Command 1+1" -RedirectStdIn
             $process = RunPowerShell $si
-            $process.StandardOutput.ReadToEnd() | Should Be 2
+            $process.StandardOutput.ReadToEnd() | Should -Be 2
             EnsureChildHasExited $process
         }
 
@@ -370,7 +370,7 @@ Describe "ConsoleHost unit tests" -tags "Feature" {
             '1+1' | Out-File -Encoding Ascii -FilePath TestDrive:test.ps1 -Force
             $si = NewProcessStartInfo "-noprofile -NonInteractive -File $testDrive\test.ps1" -RedirectStdIn
             $process = RunPowerShell $si
-            $process.StandardOutput.ReadToEnd() | Should Be 2
+            $process.StandardOutput.ReadToEnd() | Should -Be 2
             EnsureChildHasExited $process
         }
 
@@ -378,7 +378,7 @@ Describe "ConsoleHost unit tests" -tags "Feature" {
             '1+1' | Out-File -Encoding Ascii -FilePath TestDrive:test.ps1 -Force
             $si = NewProcessStartInfo "-noprofile -File $testDrive\test.ps1" -RedirectStdIn
             $process = RunPowerShell $si
-            $process.StandardOutput.ReadToEnd() | Should Be 2
+            $process.StandardOutput.ReadToEnd() | Should -Be 2
             EnsureChildHasExited $process
         }
     }
@@ -400,19 +400,19 @@ Describe "ConsoleHost unit tests" -tags "Feature" {
             $process.StandardInput.Write("`$function:prompt = { 'PS> ' }`n")
             $null = $process.StandardOutput.ReadLine()
             $process.StandardInput.Write("1+1`n")
-            $process.StandardOutput.ReadLine() | Should Be "PS> 1+1"
-            $process.StandardOutput.ReadLine() | Should Be "2"
+            $process.StandardOutput.ReadLine() | Should -Be "PS> 1+1"
+            $process.StandardOutput.ReadLine() | Should -Be "2"
             $process.StandardInput.Write("1+2`n")
-            $process.StandardOutput.ReadLine() | Should Be "PS> 1+2"
-            $process.StandardOutput.ReadLine() | Should Be "3"
+            $process.StandardOutput.ReadLine() | Should -Be "PS> 1+2"
+            $process.StandardOutput.ReadLine() | Should -Be "3"
 
             # Backspace should work as expected
             $process.StandardInput.Write("1+2`b3`n")
             # A real console should render 2`b3 as just 3, but we're just capturing exactly what is written
-            $process.StandardOutput.ReadLine() | Should Be "PS> 1+2`b3"
-            $process.StandardOutput.ReadLine() | Should Be "4"
+            $process.StandardOutput.ReadLine() | Should -Be "PS> 1+2`b3"
+            $process.StandardOutput.ReadLine() | Should -Be "4"
             $process.StandardInput.Close()
-            $process.StandardOutput.ReadToEnd() | Should Be "PS> "
+            $process.StandardOutput.ReadToEnd() | Should -Be "PS> "
             EnsureChildHasExited $process
         }
 
@@ -420,13 +420,13 @@ Describe "ConsoleHost unit tests" -tags "Feature" {
             $si = NewProcessStartInfo "-noprofile -noexit -c ""`$function:prompt = { 'PS> ' }""" -RedirectStdIn
             $process = RunPowerShell $si
             $process.StandardInput.Write("1+1`n")
-            $process.StandardOutput.ReadLine() | Should Be "PS> 1+1"
-            $process.StandardOutput.ReadLine() | Should Be "2"
+            $process.StandardOutput.ReadLine() | Should -Be "PS> 1+1"
+            $process.StandardOutput.ReadLine() | Should -Be "2"
             $process.StandardInput.Write("1+2`n")
-            $process.StandardOutput.ReadLine() | Should Be "PS> 1+2"
-            $process.StandardOutput.ReadLine() | Should Be "3"
+            $process.StandardOutput.ReadLine() | Should -Be "PS> 1+2"
+            $process.StandardOutput.ReadLine() | Should -Be "3"
             $process.StandardInput.Close()
-            $process.StandardOutput.ReadToEnd() | Should Be "PS> "
+            $process.StandardOutput.ReadToEnd() | Should -Be "PS> "
             EnsureChildHasExited $process
         }
 
@@ -436,10 +436,10 @@ Describe "ConsoleHost unit tests" -tags "Feature" {
             $process.StandardInput.Write("`$function:prompt = { 'PS> ' }`n")
             $null = $process.StandardOutput.ReadLine()
             $process.StandardInput.Write("1+1`n")
-            $process.StandardOutput.ReadLine() | Should Be "PS> 1+1"
-            $process.StandardOutput.ReadLine() | Should Be "2"
+            $process.StandardOutput.ReadLine() | Should -Be "PS> 1+1"
+            $process.StandardOutput.ReadLine() | Should -Be "2"
             $process.StandardInput.Close()
-            $process.StandardOutput.ReadToEnd() | Should Be "PS> "
+            $process.StandardOutput.ReadToEnd() | Should -Be "PS> "
             EnsureChildHasExited $process
         }
 
@@ -447,11 +447,11 @@ Describe "ConsoleHost unit tests" -tags "Feature" {
             $si = NewProcessStartInfo "-noprofile -Command -" -RedirectStdIn
             $process = RunPowerShell $si
             $process.StandardInput.Write("1+1`n")
-            $process.StandardOutput.ReadLine() | Should Be "2"
+            $process.StandardOutput.ReadLine() | Should -Be "2"
 
             # Multi-line input
             $process.StandardInput.Write("if (1)`n{`n    42`n}`n`n")
-            $process.StandardOutput.ReadLine() | Should Be "42"
+            $process.StandardOutput.ReadLine() | Should -Be "42"
             $process.StandardInput.Write(@"
 function foo
 {
@@ -461,17 +461,17 @@ function foo
 foo
 
 "@)
-            $process.StandardOutput.ReadLine() | Should Be "in foo"
+            $process.StandardOutput.ReadLine() | Should -Be "in foo"
 
             # Backspace sent through stdin should be in the final string
             $process.StandardInput.Write("`"a`bc`".Length`n")
-            $process.StandardOutput.ReadLine() | Should Be "3"
+            $process.StandardOutput.ReadLine() | Should -Be "3"
 
             # Last command with no newline - should be accepted and
             # produce output after closing stdin.
             $process.StandardInput.Write('22 + 22')
             $process.StandardInput.Close()
-            $process.StandardOutput.ReadLine() | Should Be "44"
+            $process.StandardOutput.ReadLine() | Should -Be "44"
 
             EnsureChildHasExited $process
         }
@@ -480,11 +480,11 @@ foo
             $si = NewProcessStartInfo "-noprofile -noexit -c ""`$function:prompt = { 'PS' + ('>'*(`$nestedPromptLevel+1)) + ' ' }""" -RedirectStdIn
             $process = RunPowerShell $si
             $process.StandardInput.Write("`$host.EnterNestedPrompt()`n")
-            $process.StandardOutput.ReadLine() | Should Be "PS> `$host.EnterNestedPrompt()"
+            $process.StandardOutput.ReadLine() | Should -Be "PS> `$host.EnterNestedPrompt()"
             $process.StandardInput.Write("exit`n")
-            $process.StandardOutput.ReadLine() | Should Be "PS>> exit"
+            $process.StandardOutput.ReadLine() | Should -Be "PS>> exit"
             $process.StandardInput.Close()
-            $process.StandardOutput.ReadToEnd() | Should Be "PS> "
+            $process.StandardOutput.ReadToEnd() | Should -Be "PS> "
             EnsureChildHasExited $process
         }
     }
@@ -504,7 +504,7 @@ foo
             }
             catch
             {
-                $_.FullyQualifiedErrorId | Should Be "CallDepthOverflow"
+                $_.FullyQualifiedErrorId | Should -Be "CallDepthOverflow"
             }
         }
     }
@@ -527,13 +527,13 @@ foo
             $env:XDG_DATA_HOME = "/dev/cpu"
             $env:XDG_CONFIG_HOME = "/dev/cpu"
             $output = & $powershell -noprofile -Command { (get-command).count }
-            [int]$output | Should BeGreaterThan 0
+            [int]$output | Should -BeGreaterThan 0
         }
     }
 
     Context "HOME environment variable" {
         It "Should start if HOME is not defined" -skip:($IsWindows) {
-            bash -c "unset HOME;$powershell -c '1+1'" | Should BeExactly 2
+            bash -c "unset HOME;$powershell -c '1+1'" | Should -BeExactly 2
         }
     }
 
@@ -543,7 +543,7 @@ foo
         }
 
         It "powershell starts if PATH is not set" -Skip:($IsWindows) {
-            bash -c "unset PATH;$powershell -c '1+1'" | Should BeExactly 2
+            bash -c "unset PATH;$powershell -c '1+1'" | Should -BeExactly 2
         }
     }
 
@@ -554,7 +554,7 @@ foo
         ) {
             param($testArg, $expectedMatches)
             $output = & $powershell $testArg -File foo 2>&1
-            $LASTEXITCODE | Should Be $ExitCodeBadCommandLineParameter
+            $LASTEXITCODE | Should -Be $ExitCodeBadCommandLineParameter
             $outString = [String]::Join(",", $output)
             foreach ($expectedMatch in $expectedMatches)
             {
@@ -627,13 +627,13 @@ public enum ShowWindowCommands : int
             Start-Sleep -Milliseconds 100
             $showCmd = ([Test.User32]::GetPlacement($ps.MainWindowHandle)).showCmd
         }
-        $showCmd | Should BeExactly $WindowStyle
+        $showCmd | Should -BeExactly $WindowStyle
         $ps | Stop-Process -Force
     }
 
     It "Invalid -WindowStyle returns error" {
         pwsh -WindowStyle invalid
-        $LASTEXITCODE | Should Be $ExitCodeBadCommandLineParameter
+        $LASTEXITCODE | Should -Be $ExitCodeBadCommandLineParameter
     }
 }
 
@@ -659,7 +659,7 @@ Describe "Console host api tests" -Tag CI {
 
         It "Should properly calculate buffer cell width of '<Name>'" -TestCases $testCases {
             param($InputObject, $Length)
-            $host.UI.RawUI.LengthInBufferCells($InputObject) | Should Be $Length
+            $host.UI.RawUI.LengthInBufferCells($InputObject) | Should -Be $Length
         }
     }
 }

--- a/test/powershell/Host/ConsoleHost.Tests.ps1
+++ b/test/powershell/Host/ConsoleHost.Tests.ps1
@@ -124,7 +124,7 @@ Describe "ConsoleHost unit tests" -tags "Feature" {
             }
         }
 
-        It "Verify Validate Output Format As Text Explicitly Child Single Shell doess not throw" {
+        It "Verify Validate Output Format As Text Explicitly Child Single Shell does not throw" {
             "blahblah" | & $powershell -noprofile -out text -com { $input }
         }
 

--- a/test/powershell/Host/ConsoleHost.Tests.ps1
+++ b/test/powershell/Host/ConsoleHost.Tests.ps1
@@ -81,7 +81,7 @@ Describe "ConsoleHost unit tests" -tags "Feature" {
 
             if (!$process.HasExited)
             {
-                $process.HasExited | Should -Be $true
+                $process.HasExited | Should -BeTrue
                 $process.Kill()
             }
         }

--- a/test/powershell/Host/HostUtilities.Tests.ps1
+++ b/test/powershell/Host/HostUtilities.Tests.ps1
@@ -16,7 +16,7 @@ Describe "InvokeOnRunspace method argument error handling" -tags "Feature" {
         }
         catch
         {
-            $_.FullyQualifiedErrorId | Should Be "PSArgumentNullException"
+            $_.FullyQualifiedErrorId | Should -Be "PSArgumentNullException"
         }
     }
 
@@ -29,7 +29,7 @@ Describe "InvokeOnRunspace method argument error handling" -tags "Feature" {
         }
         catch
         {
-            $_.FullyQualifiedErrorId | Should Be "PSArgumentNullException"
+            $_.FullyQualifiedErrorId | Should -Be "PSArgumentNullException"
         }
     }
 }
@@ -44,7 +44,7 @@ Describe "InvokeOnRunspace method as nested command" -tags "Feature" {
 
         $results = [System.Management.Automation.HostUtilities]::InvokeOnRunspace($command, $currentRunspace)
 
-        $results[0] | Should Be "Hello!"
+        $results[0] | Should -Be "Hello!"
     }
 }
 
@@ -71,6 +71,6 @@ Describe "InvokeOnRunspace method on remote runspace" -tags "Feature" {
 
         $results = [System.Management.Automation.HostUtilities]::InvokeOnRunspace($command, $script:remoteRunspace)
 
-        $results[0] | Should Be "Hello!"
+        $results[0] | Should -Be "Hello!"
     }
 }

--- a/test/powershell/Host/PSVersionTable.Tests.ps1
+++ b/test/powershell/Host/PSVersionTable.Tests.ps1
@@ -25,51 +25,51 @@ Describe "PSVersionTable" -Tags "CI" {
     }
 
     It "Should have version table entries" {
-       $PSVersionTable.Count | Should Be 9
+       $PSVersionTable.Count | Should -Be 9
     }
 
     It "Should have the right version table entries" {
-       $PSVersionTable.ContainsKey("PSVersion")                 | Should Be True
-       $PSVersionTable.ContainsKey("PSEdition")                 | Should Be True
-       $PSVersionTable.ContainsKey("WSManStackVersion")         | Should Be True
-       $PSVersionTable.ContainsKey("SerializationVersion")      | Should Be True
-       $PSVersionTable.ContainsKey("PSCompatibleVersions")      | Should Be True
-       $PSVersionTable.ContainsKey("PSRemotingProtocolVersion") | Should Be True
-       $PSVersionTable.ContainsKey("GitCommitId")               | Should Be True
-       $PSVersionTable.ContainsKey("Platform")                  | Should Be True
-       $PSVersionTable.ContainsKey("OS")                        | Should Be True
+       $PSVersionTable.ContainsKey("PSVersion")                 | Should -Be True
+       $PSVersionTable.ContainsKey("PSEdition")                 | Should -Be True
+       $PSVersionTable.ContainsKey("WSManStackVersion")         | Should -Be True
+       $PSVersionTable.ContainsKey("SerializationVersion")      | Should -Be True
+       $PSVersionTable.ContainsKey("PSCompatibleVersions")      | Should -Be True
+       $PSVersionTable.ContainsKey("PSRemotingProtocolVersion") | Should -Be True
+       $PSVersionTable.ContainsKey("GitCommitId")               | Should -Be True
+       $PSVersionTable.ContainsKey("Platform")                  | Should -Be True
+       $PSVersionTable.ContainsKey("OS")                        | Should -Be True
 
     }
 
     It "PSVersion property" {
-       $PSVersionTable.PSVersion | Should BeOfType "System.Management.Automation.SemanticVersion"
-       $PSVersionTable.PSVersion | Should BeExactly $expectedPSVersion
+       $PSVersionTable.PSVersion | Should -BeOfType "System.Management.Automation.SemanticVersion"
+       $PSVersionTable.PSVersion | Should -BeExactly $expectedPSVersion
        $PSVersionTable.PSVersion | Should Match $expectedVersionPattern
-       $PSVersionTable.PSVersion.Major | Should Be 6
+       $PSVersionTable.PSVersion.Major | Should -Be 6
     }
 
     It "GitCommitId property" {
-       $PSVersionTable.GitCommitId | Should BeOfType "System.String"
+       $PSVersionTable.GitCommitId | Should -BeOfType "System.String"
        $PSVersionTable.GitCommitId | Should Match $expectedGitCommitIdPattern
        $PSVersionTable.GitCommitId | Should Not Match $unexpectectGitCommitIdPattern
-       $PSVersionTable.GitCommitId | Should BeExactly $rawGitCommitId
+       $PSVersionTable.GitCommitId | Should -BeExactly $rawGitCommitId
     }
 
     It "Should have the correct platform info" {
        $platform = [String][System.Environment]::OSVersion.Platform
-       [String]$PSVersionTable["Platform"] | Should Be $platform
+       [String]$PSVersionTable["Platform"] | Should -Be $platform
     }
 
     It "Should have the correct OS info" {
        if ($IsCoreCLR)
        {
            $OSDescription = [String][System.Runtime.InteropServices.RuntimeInformation]::OSDescription
-           [String]$PSVersionTable["OS"] | Should Be $OSDescription
+           [String]$PSVersionTable["OS"] | Should -Be $OSDescription
        }
        else
        {
            $OSDescription = [String][System.Environment]::OSVersion
-           [String]$PSVersionTable["OS"] | Should Be $OSDescription
+           [String]$PSVersionTable["OS"] | Should -Be $OSDescription
        }
     }
 
@@ -81,20 +81,20 @@ Describe "PSVersionTable" -Tags "CI" {
         {
             $edition = "Desktop"
         }
-        $PSVersionTable["PSEdition"] | Should Be $edition
+        $PSVersionTable["PSEdition"] | Should -Be $edition
     }
 
     It "Verify `$PSVersionTable is ordered and 'PSVersion' is on first place" {
         $PSVersionName = "PSVersion"
         $keys1 = ($PSVersionTable | Format-Table -HideTableHeaders -Property Name | Out-String) -split [System.Environment]::NewLine | Where-Object {$_} | ForEach-Object {$_.Trim()}
 
-        $keys1[0] | Should Be "PSVersion"
-        $keys1[1] | Should Be "PSEdition"
+        $keys1[0] | Should -Be "PSVersion"
+        $keys1[1] | Should -Be "PSEdition"
 
         $keys1last = $keys1[2..($keys1.length-1)]
         $keys1sortedlast = $keys1last | Sort-Object
 
-        Compare-Object -ReferenceObject $keys1last -DifferenceObject $keys1sortedlast -SyncWindow 0 | Should Be $null
+        Compare-Object -ReferenceObject $keys1last -DifferenceObject $keys1sortedlast -SyncWindow 0 | Should -Be $null
     }
 
     It "Verify `$PSVersionTable can be formatted correctly when it has non-string key" {
@@ -113,12 +113,12 @@ Describe "PSVersionTable" -Tags "CI" {
             $PSVersionTable.Remove("PSVersion")
 
             $keys1 = ($PSVersionTable | Format-Table -HideTableHeaders -Property Name | Out-String) -split [System.Environment]::NewLine | Where-Object {$_} | ForEach-Object {$_.Trim()}
-            $keys1[0] | Should Be "PSEdition"
-            $keys1.Length | Should Be $PSVersionTable.Count
+            $keys1[0] | Should -Be "PSEdition"
+            $keys1.Length | Should -Be $PSVersionTable.Count
 
             $keys1last = $keys1[1..($keys1.length-1)]
             $keys1sortedlast = $keys1last | Sort-Object
-            Compare-Object -ReferenceObject $keys1last -DifferenceObject $keys1sortedlast -SyncWindow 0 | Should Be $null
+            Compare-Object -ReferenceObject $keys1last -DifferenceObject $keys1sortedlast -SyncWindow 0 | Should -Be $null
         } finally {
             $PSVersionTable.Add("PSVersion", $VersionValue)
         }
@@ -130,12 +130,12 @@ Describe "PSVersionTable" -Tags "CI" {
             $PSVersionTable.Remove("PSEdition")
 
             $keys1 = ($PSVersionTable | Format-Table -HideTableHeaders -Property Name | Out-String) -split [System.Environment]::NewLine | Where-Object {$_} | ForEach-Object {$_.Trim()}
-            $keys1[0] | Should Be "PSVersion"
-            $keys1.Length | Should Be $PSVersionTable.Count
+            $keys1[0] | Should -Be "PSVersion"
+            $keys1.Length | Should -Be $PSVersionTable.Count
 
             $keys1last = $keys1[1..($keys1.length-1)]
             $keys1sortedlast = $keys1last | Sort-Object
-            Compare-Object -ReferenceObject $keys1last -DifferenceObject $keys1sortedlast -SyncWindow 0 | Should Be $null
+            Compare-Object -ReferenceObject $keys1last -DifferenceObject $keys1sortedlast -SyncWindow 0 | Should -Be $null
         } finally {
             $PSVersionTable.Add("PSEdition", $EditionValue)
         }
@@ -149,10 +149,10 @@ Describe "PSVersionTable" -Tags "CI" {
             $PSVersionTable.Remove("PSEdition")
 
             $keys1 = ($PSVersionTable | Format-Table -HideTableHeaders -Property Name | Out-String) -split [System.Environment]::NewLine | Where-Object {$_} | ForEach-Object {$_.Trim()}
-            $keys1.Length | Should Be $PSVersionTable.Count
+            $keys1.Length | Should -Be $PSVersionTable.Count
 
             $keys1sortedlast = $keys1 | Sort-Object
-            Compare-Object -ReferenceObject $keys1 -DifferenceObject $keys1sortedlast -SyncWindow 0 | Should Be $null
+            Compare-Object -ReferenceObject $keys1 -DifferenceObject $keys1sortedlast -SyncWindow 0 | Should -Be $null
         } finally {
             $PSVersionTable.Add("PSVersion", $VersionValue)
             $PSVersionTable.Add("PSEdition", $EditionValue)

--- a/test/powershell/Host/PSVersionTable.Tests.ps1
+++ b/test/powershell/Host/PSVersionTable.Tests.ps1
@@ -51,7 +51,7 @@ Describe "PSVersionTable" -Tags "CI" {
     It "GitCommitId property" {
        $PSVersionTable.GitCommitId | Should -BeOfType "System.String"
        $PSVersionTable.GitCommitId | Should -Match $expectedGitCommitIdPattern
-       $PSVersionTable.GitCommitId | Should -Not-Match $unexpectectGitCommitIdPattern
+       $PSVersionTable.GitCommitId | Should -Not -Match $unexpectectGitCommitIdPattern
        $PSVersionTable.GitCommitId | Should -BeExactly $rawGitCommitId
     }
 

--- a/test/powershell/Host/PSVersionTable.Tests.ps1
+++ b/test/powershell/Host/PSVersionTable.Tests.ps1
@@ -44,14 +44,14 @@ Describe "PSVersionTable" -Tags "CI" {
     It "PSVersion property" {
        $PSVersionTable.PSVersion | Should -BeOfType "System.Management.Automation.SemanticVersion"
        $PSVersionTable.PSVersion | Should -BeExactly $expectedPSVersion
-       $PSVersionTable.PSVersion | Should Match $expectedVersionPattern
+       $PSVersionTable.PSVersion | Should-Match $expectedVersionPattern
        $PSVersionTable.PSVersion.Major | Should -Be 6
     }
 
     It "GitCommitId property" {
        $PSVersionTable.GitCommitId | Should -BeOfType "System.String"
-       $PSVersionTable.GitCommitId | Should Match $expectedGitCommitIdPattern
-       $PSVersionTable.GitCommitId | Should -Not Match $unexpectectGitCommitIdPattern
+       $PSVersionTable.GitCommitId | Should-Match $expectedGitCommitIdPattern
+       $PSVersionTable.GitCommitId | Should -Not-Match $unexpectectGitCommitIdPattern
        $PSVersionTable.GitCommitId | Should -BeExactly $rawGitCommitId
     }
 

--- a/test/powershell/Host/PSVersionTable.Tests.ps1
+++ b/test/powershell/Host/PSVersionTable.Tests.ps1
@@ -101,7 +101,7 @@ Describe "PSVersionTable" -Tags "CI" {
         try {
             $key = Get-Item $PSScriptRoot
             $PSVersionTable.Add($key, "TEST")
-            { $PSVersionTable | Format-Table } | Should -Not Throw
+            $PSVersionTable | Format-Table
         } finally {
             $PSVersionTable.Remove($key)
         }

--- a/test/powershell/Host/PSVersionTable.Tests.ps1
+++ b/test/powershell/Host/PSVersionTable.Tests.ps1
@@ -44,13 +44,13 @@ Describe "PSVersionTable" -Tags "CI" {
     It "PSVersion property" {
        $PSVersionTable.PSVersion | Should -BeOfType "System.Management.Automation.SemanticVersion"
        $PSVersionTable.PSVersion | Should -BeExactly $expectedPSVersion
-       $PSVersionTable.PSVersion | Should-Match $expectedVersionPattern
+       $PSVersionTable.PSVersion | Should -Match $expectedVersionPattern
        $PSVersionTable.PSVersion.Major | Should -Be 6
     }
 
     It "GitCommitId property" {
        $PSVersionTable.GitCommitId | Should -BeOfType "System.String"
-       $PSVersionTable.GitCommitId | Should-Match $expectedGitCommitIdPattern
+       $PSVersionTable.GitCommitId | Should -Match $expectedGitCommitIdPattern
        $PSVersionTable.GitCommitId | Should -Not-Match $unexpectectGitCommitIdPattern
        $PSVersionTable.GitCommitId | Should -BeExactly $rawGitCommitId
     }

--- a/test/powershell/Host/PSVersionTable.Tests.ps1
+++ b/test/powershell/Host/PSVersionTable.Tests.ps1
@@ -29,15 +29,15 @@ Describe "PSVersionTable" -Tags "CI" {
     }
 
     It "Should have the right version table entries" {
-       $PSVersionTable.ContainsKey("PSVersion")                 | Should -Be True
-       $PSVersionTable.ContainsKey("PSEdition")                 | Should -Be True
-       $PSVersionTable.ContainsKey("WSManStackVersion")         | Should -Be True
-       $PSVersionTable.ContainsKey("SerializationVersion")      | Should -Be True
-       $PSVersionTable.ContainsKey("PSCompatibleVersions")      | Should -Be True
-       $PSVersionTable.ContainsKey("PSRemotingProtocolVersion") | Should -Be True
-       $PSVersionTable.ContainsKey("GitCommitId")               | Should -Be True
-       $PSVersionTable.ContainsKey("Platform")                  | Should -Be True
-       $PSVersionTable.ContainsKey("OS")                        | Should -Be True
+       $PSVersionTable.ContainsKey("PSVersion")                 | Should -BeTrue
+       $PSVersionTable.ContainsKey("PSEdition")                 | Should -BeTrue
+       $PSVersionTable.ContainsKey("WSManStackVersion")         | Should -BeTrue
+       $PSVersionTable.ContainsKey("SerializationVersion")      | Should -BeTrue
+       $PSVersionTable.ContainsKey("PSCompatibleVersions")      | Should -BeTrue
+       $PSVersionTable.ContainsKey("PSRemotingProtocolVersion") | Should -BeTrue
+       $PSVersionTable.ContainsKey("GitCommitId")               | Should -BeTrue
+       $PSVersionTable.ContainsKey("Platform")                  | Should -BeTrue
+       $PSVersionTable.ContainsKey("OS")                        | Should -BeTrue
 
     }
 

--- a/test/powershell/Host/PSVersionTable.Tests.ps1
+++ b/test/powershell/Host/PSVersionTable.Tests.ps1
@@ -51,7 +51,7 @@ Describe "PSVersionTable" -Tags "CI" {
     It "GitCommitId property" {
        $PSVersionTable.GitCommitId | Should -BeOfType "System.String"
        $PSVersionTable.GitCommitId | Should Match $expectedGitCommitIdPattern
-       $PSVersionTable.GitCommitId | Should Not Match $unexpectectGitCommitIdPattern
+       $PSVersionTable.GitCommitId | Should -Not Match $unexpectectGitCommitIdPattern
        $PSVersionTable.GitCommitId | Should -BeExactly $rawGitCommitId
     }
 
@@ -101,7 +101,7 @@ Describe "PSVersionTable" -Tags "CI" {
         try {
             $key = Get-Item $PSScriptRoot
             $PSVersionTable.Add($key, "TEST")
-            { $PSVersionTable | Format-Table } | Should Not Throw
+            { $PSVersionTable | Format-Table } | Should -Not Throw
         } finally {
             $PSVersionTable.Remove($key)
         }

--- a/test/powershell/Host/PSVersionTable.Tests.ps1
+++ b/test/powershell/Host/PSVersionTable.Tests.ps1
@@ -101,7 +101,7 @@ Describe "PSVersionTable" -Tags "CI" {
         try {
             $key = Get-Item $PSScriptRoot
             $PSVersionTable.Add($key, "TEST")
-            $PSVersionTable | Format-Table
+            { $PSVersionTable | Format-Table } | Should -Not -Throw
         } finally {
             $PSVersionTable.Remove($key)
         }

--- a/test/powershell/Host/Read-Host.Tests.ps1
+++ b/test/powershell/Host/Read-Host.Tests.ps1
@@ -16,7 +16,7 @@ Describe "Read-Host" -Tags "Slow","Feature" {
 
         It @ItArgs "Should output correctly" {
             & (Join-Path $assetsDir "Read-Host.Output.expect") $powershell | Out-Null
-            $LASTEXITCODE | Should Be 0
+            $LASTEXITCODE | Should -Be 0
         }
     }
 }

--- a/test/powershell/Host/TabCompletion/BugFix.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/BugFix.Tests.ps1
@@ -4,28 +4,28 @@ Describe "Tab completion bug fix" -Tags "CI" {
 
     It "Issue#682 - '[system.manage<tab>' should work" {
         $result = TabExpansion2 -inputScript "[system.manage" -cursorColumn "[system.manage".Length
-        $result | Should -Not BeNullOrEmpty
+        $result | Should -Not -BeNullOrEmpty
         $result.CompletionMatches.Count | Should -Be 1
         $result.CompletionMatches[0].CompletionText | Should -Be "System.Management"
     }
 
     It "Issue#1350 - '1 -sp<tab>' should work" {
         $result = TabExpansion2 -inputScript "1 -sp" -cursorColumn "1 -sp".Length
-        $result | Should -Not BeNullOrEmpty
+        $result | Should -Not -BeNullOrEmpty
         $result.CompletionMatches.Count | Should -Be 1
         $result.CompletionMatches[0].CompletionText | Should -Be "-split"
     }
 
     It "Issue#1350 - '1 -a<tab>' should work" {
         $result = TabExpansion2 -inputScript "1 -a" -cursorColumn "1 -a".Length
-        $result | Should -Not BeNullOrEmpty
+        $result | Should -Not -BeNullOrEmpty
         $result.CompletionMatches.Count | Should -Be 2
         $result.CompletionMatches[0].CompletionText | Should -Be "-and"
         $result.CompletionMatches[1].CompletionText | Should -Be "-as"
     }
     It "Issue#2295 - '[pscu<tab>' should expand to [pscustomobject]" {
         $result = TabExpansion2 -inputScript "[pscu" -cursorColumn "[pscu".Length
-        $result | Should -Not BeNullOrEmpty
+        $result | Should -Not -BeNullOrEmpty
         $result.CompletionMatches.Count | Should -Be 1
         $result.CompletionMatches[0].CompletionText | Should -Be "pscustomobject"
     }

--- a/test/powershell/Host/TabCompletion/BugFix.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/BugFix.Tests.ps1
@@ -4,28 +4,28 @@ Describe "Tab completion bug fix" -Tags "CI" {
 
     It "Issue#682 - '[system.manage<tab>' should work" {
         $result = TabExpansion2 -inputScript "[system.manage" -cursorColumn "[system.manage".Length
-        $result | Should Not BeNullOrEmpty
+        $result | Should -Not BeNullOrEmpty
         $result.CompletionMatches.Count | Should -Be 1
         $result.CompletionMatches[0].CompletionText | Should -Be "System.Management"
     }
 
     It "Issue#1350 - '1 -sp<tab>' should work" {
         $result = TabExpansion2 -inputScript "1 -sp" -cursorColumn "1 -sp".Length
-        $result | Should Not BeNullOrEmpty
+        $result | Should -Not BeNullOrEmpty
         $result.CompletionMatches.Count | Should -Be 1
         $result.CompletionMatches[0].CompletionText | Should -Be "-split"
     }
 
     It "Issue#1350 - '1 -a<tab>' should work" {
         $result = TabExpansion2 -inputScript "1 -a" -cursorColumn "1 -a".Length
-        $result | Should Not BeNullOrEmpty
+        $result | Should -Not BeNullOrEmpty
         $result.CompletionMatches.Count | Should -Be 2
         $result.CompletionMatches[0].CompletionText | Should -Be "-and"
         $result.CompletionMatches[1].CompletionText | Should -Be "-as"
     }
     It "Issue#2295 - '[pscu<tab>' should expand to [pscustomobject]" {
         $result = TabExpansion2 -inputScript "[pscu" -cursorColumn "[pscu".Length
-        $result | Should Not BeNullOrEmpty
+        $result | Should -Not BeNullOrEmpty
         $result.CompletionMatches.Count | Should -Be 1
         $result.CompletionMatches[0].CompletionText | Should -Be "pscustomobject"
     }

--- a/test/powershell/Host/TabCompletion/BugFix.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/BugFix.Tests.ps1
@@ -5,37 +5,37 @@ Describe "Tab completion bug fix" -Tags "CI" {
     It "Issue#682 - '[system.manage<tab>' should work" {
         $result = TabExpansion2 -inputScript "[system.manage" -cursorColumn "[system.manage".Length
         $result | Should Not BeNullOrEmpty
-        $result.CompletionMatches.Count | Should Be 1
-        $result.CompletionMatches[0].CompletionText | Should Be "System.Management"
+        $result.CompletionMatches.Count | Should -Be 1
+        $result.CompletionMatches[0].CompletionText | Should -Be "System.Management"
     }
 
     It "Issue#1350 - '1 -sp<tab>' should work" {
         $result = TabExpansion2 -inputScript "1 -sp" -cursorColumn "1 -sp".Length
         $result | Should Not BeNullOrEmpty
-        $result.CompletionMatches.Count | Should Be 1
-        $result.CompletionMatches[0].CompletionText | Should Be "-split"
+        $result.CompletionMatches.Count | Should -Be 1
+        $result.CompletionMatches[0].CompletionText | Should -Be "-split"
     }
 
     It "Issue#1350 - '1 -a<tab>' should work" {
         $result = TabExpansion2 -inputScript "1 -a" -cursorColumn "1 -a".Length
         $result | Should Not BeNullOrEmpty
-        $result.CompletionMatches.Count | Should Be 2
-        $result.CompletionMatches[0].CompletionText | Should Be "-and"
-        $result.CompletionMatches[1].CompletionText | Should Be "-as"
+        $result.CompletionMatches.Count | Should -Be 2
+        $result.CompletionMatches[0].CompletionText | Should -Be "-and"
+        $result.CompletionMatches[1].CompletionText | Should -Be "-as"
     }
     It "Issue#2295 - '[pscu<tab>' should expand to [pscustomobject]" {
         $result = TabExpansion2 -inputScript "[pscu" -cursorColumn "[pscu".Length
         $result | Should Not BeNullOrEmpty
-        $result.CompletionMatches.Count | Should Be 1
-        $result.CompletionMatches[0].CompletionText | Should Be "pscustomobject"
+        $result.CompletionMatches.Count | Should -Be 1
+        $result.CompletionMatches[0].CompletionText | Should -Be "pscustomobject"
     }
     It "Issue#1345 - 'Import-Module -n<tab>' should work" {
         $cmd = "Import-Module -n"
         $result = TabExpansion2 -inputScript $cmd -cursorColumn $cmd.Length
-        $result.CompletionMatches.Count | Should Be 3
-        $result.CompletionMatches[0].CompletionText | Should Be "-Name"
-        $result.CompletionMatches[1].CompletionText | Should Be "-NoClobber"
-        $result.CompletionMatches[2].CompletionText | Should Be "-NoOverwrite"
+        $result.CompletionMatches.Count | Should -Be 3
+        $result.CompletionMatches[0].CompletionText | Should -Be "-Name"
+        $result.CompletionMatches[1].CompletionText | Should -Be "-NoClobber"
+        $result.CompletionMatches[2].CompletionText | Should -Be "-NoOverwrite"
     }
     Context "Issue#3416 - 'Select-Object'" {
         BeforeAll {
@@ -44,25 +44,25 @@ Describe "Tab completion bug fix" -Tags "CI" {
         It "Issue#3416 - 'Select-Object -ExcludeProperty <tab>' should work" {
             $cmd = "Get-Date | Select-Object -ExcludeProperty "
             $result = TabExpansion2 -inputScript $cmd -cursorColumn $cmd.Length
-            $result.CompletionMatches.Count | Should Be $DatetimeProperties.Count
-            $result.CompletionMatches[0].CompletionText | Should Be $DatetimeProperties[0].Name # Date
-            $result.CompletionMatches[1].CompletionText | Should Be $DatetimeProperties[1].Name # DateTime
+            $result.CompletionMatches.Count | Should -Be $DatetimeProperties.Count
+            $result.CompletionMatches[0].CompletionText | Should -Be $DatetimeProperties[0].Name # Date
+            $result.CompletionMatches[1].CompletionText | Should -Be $DatetimeProperties[1].Name # DateTime
        }
        It "Issue#3416 - 'Select-Object -ExpandProperty <tab>' should work" {
            $cmd = "Get-Date | Select-Object -ExpandProperty "
            $result = TabExpansion2 -inputScript $cmd -cursorColumn $cmd.Length
-           $result.CompletionMatches.Count | Should Be $DatetimeProperties.Count
-           $result.CompletionMatches[0].CompletionText | Should Be $DatetimeProperties[0].Name # Date
-           $result.CompletionMatches[1].CompletionText | Should Be $DatetimeProperties[1].Name # DateTime
+           $result.CompletionMatches.Count | Should -Be $DatetimeProperties.Count
+           $result.CompletionMatches[0].CompletionText | Should -Be $DatetimeProperties[0].Name # Date
+           $result.CompletionMatches[1].CompletionText | Should -Be $DatetimeProperties[1].Name # DateTime
        }
     }
                 
     It "Issue#3628 - 'Sort-Object @{<tab>' should work" {
         $cmd = "Get-Date | Sort-Object @{"
         $result = TabExpansion2 -inputScript $cmd -cursorColumn $cmd.Length
-        $result.CompletionMatches.Count | Should Be 3
-        $result.CompletionMatches[0].CompletionText | Should Be 'Expression'
-        $result.CompletionMatches[1].CompletionText | Should Be 'Ascending'
-        $result.CompletionMatches[2].CompletionText | Should Be 'Descending'
+        $result.CompletionMatches.Count | Should -Be 3
+        $result.CompletionMatches[0].CompletionText | Should -Be 'Expression'
+        $result.CompletionMatches[1].CompletionText | Should -Be 'Ascending'
+        $result.CompletionMatches[2].CompletionText | Should -Be 'Descending'
     }
 }

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -7,44 +7,44 @@ Describe "TabCompletion" -Tags CI {
 
     It 'Should complete Command' {
         $res = TabExpansion2 -inputScript 'Get-Com' -cursorColumn 'Get-Com'.Length
-        $res.CompletionMatches[0].CompletionText | Should be Get-Command
+        $res.CompletionMatches[0].CompletionText | Should -Be Get-Command
     }
 
     It 'Should complete native exe' -Skip:(!$IsWindows) {
         $res = TabExpansion2 -inputScript 'notep' -cursorColumn 'notep'.Length
-        $res.CompletionMatches[0].CompletionText | Should be notepad.exe
+        $res.CompletionMatches[0].CompletionText | Should -Be notepad.exe
     }
 
     It 'Should complete dotnet method' {
         $res = TabExpansion2 -inputScript '(1).ToSt' -cursorColumn '(1).ToSt'.Length
-        $res.CompletionMatches[0].CompletionText | Should be 'ToString('
+        $res.CompletionMatches[0].CompletionText | Should -Be 'ToString('
     }
 
     It 'Should complete Magic foreach' {
         $res = TabExpansion2 -inputScript '(1..10).Fo' -cursorColumn '(1..10).Fo'.Length
-        $res.CompletionMatches[0].CompletionText | Should be 'Foreach('
+        $res.CompletionMatches[0].CompletionText | Should -Be 'Foreach('
     }
 
     It "Should complete Magic where" {
         $res = TabExpansion2 -inputScript '(1..10).wh' -cursorColumn '(1..10).wh'.Length
-        $res.CompletionMatches[0].CompletionText | Should be 'Where('
+        $res.CompletionMatches[0].CompletionText | Should -Be 'Where('
     }
 
     It 'Should complete types' {
         $res = TabExpansion2 -inputScript '[pscu' -cursorColumn '[pscu'.Length
-        $res.CompletionMatches[0].CompletionText | Should be 'pscustomobject'
+        $res.CompletionMatches[0].CompletionText | Should -Be 'pscustomobject'
     }
 
     It 'Should complete namespaces' {
         $res = TabExpansion2 -inputScript 'using namespace Sys' -cursorColumn 'using namespace Sys'.Length
-        $res.CompletionMatches[0].CompletionText | Should be 'System'
+        $res.CompletionMatches[0].CompletionText | Should -Be 'System'
     }
 
     It 'Should complete format-table hashtable' {
         $res = TabExpansion2 -inputScript 'Get-ChildItem | Format-Table @{ ' -cursorColumn 'Get-ChildItem | Format-Table @{ '.Length
-        $res.CompletionMatches.Count | Should Be 5
+        $res.CompletionMatches.Count | Should -Be 5
         $completionText = $res.CompletionMatches.CompletionText | Sort-Object
-        $completionText -join ' ' | Should Be 'Alignment Expression FormatString Label Width'
+        $completionText -join ' ' | Should -Be 'Alignment Expression FormatString Label Width'
     }
 
     It 'Should complete format-* hashtable on GroupBy: <cmd>' -TestCases (
@@ -55,44 +55,44 @@ Describe "TabCompletion" -Tags CI {
     ) {
         param($cmd)
         $res = TabExpansion2 -inputScript "Get-ChildItem | $cmd -GroupBy @{ " -cursorColumn "Get-ChildItem | $cmd -GroupBy @{ ".Length
-        $res.CompletionMatches.Count | Should Be 3
+        $res.CompletionMatches.Count | Should -Be 3
         $completionText = $res.CompletionMatches.CompletionText | Sort-Object
-        $completionText -join ' ' | Should Be 'Expression FormatString Label'
+        $completionText -join ' ' | Should -Be 'Expression FormatString Label'
     }
 
     It 'Should complete format-list hashtable' {
         $res = TabExpansion2 -inputScript 'Get-ChildItem | Format-List @{ ' -cursorColumn 'Get-ChildItem | Format-List @{ '.Length
-        $res.CompletionMatches.Count | Should Be 3
+        $res.CompletionMatches.Count | Should -Be 3
         $completionText = $res.CompletionMatches.CompletionText | Sort-Object
-        $completionText -join ' ' | Should Be 'Expression FormatString Label'
+        $completionText -join ' ' | Should -Be 'Expression FormatString Label'
     }
 
     It 'Should complete format-wide hashtable' {
         $res = TabExpansion2 -inputScript 'Get-ChildItem | Format-Wide @{ ' -cursorColumn 'Get-ChildItem | Format-Wide @{ '.Length
-        $res.CompletionMatches.Count | Should Be 2
+        $res.CompletionMatches.Count | Should -Be 2
         $completionText = $res.CompletionMatches.CompletionText | Sort-Object
-        $completionText -join ' ' | Should Be 'Expression FormatString'
+        $completionText -join ' ' | Should -Be 'Expression FormatString'
     }
 
     It 'Should complete format-custom hashtable' {
         $res = TabExpansion2 -inputScript 'Get-ChildItem | Format-Custom @{ ' -cursorColumn 'Get-ChildItem | Format-Custom @{ '.Length
-        $res.CompletionMatches.Count | Should Be 2
+        $res.CompletionMatches.Count | Should -Be 2
         $completionText = $res.CompletionMatches.CompletionText | Sort-Object
-        $completionText -join ' ' | Should Be 'Depth Expression'
+        $completionText -join ' ' | Should -Be 'Depth Expression'
     }
 
     It 'Should complete Select-Object hashtable' {
         $res = TabExpansion2 -inputScript 'Get-ChildItem | Select-Object @{ ' -cursorColumn 'Get-ChildItem | Select-Object @{ '.Length
-        $res.CompletionMatches.Count | Should Be 2
+        $res.CompletionMatches.Count | Should -Be 2
         $completionText = $res.CompletionMatches.CompletionText | Sort-Object
-        $completionText -join ' '| Should Be 'Expression Name'
+        $completionText -join ' '| Should -Be 'Expression Name'
     }
 
     It 'Should complete Sort-Object hashtable' {
         $res = TabExpansion2 -inputScript 'Get-ChildItem | Sort-Object @{ ' -cursorColumn 'Get-ChildItem | Sort-Object @{ '.Length
-        $res.CompletionMatches.Count | Should Be 3
+        $res.CompletionMatches.Count | Should -Be 3
         $completionText = $res.CompletionMatches.CompletionText | Sort-Object
-        $completionText -join ' '| Should Be 'Ascending Descending Expression'
+        $completionText -join ' '| Should -Be 'Ascending Descending Expression'
     }
 
     It 'Should complete New-Object hashtable' {
@@ -102,22 +102,22 @@ Describe "TabCompletion" -Tags CI {
             $C
         }
         $res = TabExpansion2 -inputScript 'New-Object -TypeName X -Property @{ ' -cursorColumn 'New-Object -TypeName X -Property @{ '.Length
-        $res.CompletionMatches.Count | Should Be 3
-        $res.CompletionMatches.CompletionText -join ' ' | Should Be 'A B C'
+        $res.CompletionMatches.Count | Should -Be 3
+        $res.CompletionMatches.CompletionText -join ' ' | Should -Be 'A B C'
     }
 
     It 'Should complete "Get-Process -Id " with Id and name in tooltip' {
         Set-StrictMode -Version latest
         $cmd = 'Get-Process -Id '
         [System.Management.Automation.CommandCompletion]$res = TabExpansion2 -inputScript $cmd  -cursorColumn $cmd.Length
-        $res.CompletionMatches[0].CompletionText -match '^\d+$' | Should be true
-        $res.CompletionMatches[0].ListItemText -match '^\d+ -' | Should be true
-        $res.CompletionMatches[0].ToolTip -match '^\d+ -' | Should be true
+        $res.CompletionMatches[0].CompletionText -match '^\d+$' | Should -Be true
+        $res.CompletionMatches[0].ListItemText -match '^\d+ -' | Should -Be true
+        $res.CompletionMatches[0].ToolTip -match '^\d+ -' | Should -Be true
     }
 
     It 'Should complete keyword' -skip {
         $res = TabExpansion2 -inputScript 'using nam' -cursorColumn 'using nam'.Length
-        $res.CompletionMatches[0].CompletionText | Should Be 'namespace'
+        $res.CompletionMatches[0].CompletionText | Should -Be 'namespace'
     }
 
     Context NativeCommand {
@@ -136,8 +136,8 @@ Describe "TabCompletion" -Tags CI {
             }
             $line = "$nativeCommand -"
             $res = TabExpansion2 -inputScript $line -cursorColumn $line.Length
-            $res.CompletionMatches.Count | Should Be 1
-            $res.CompletionMatches.CompletionText | Should Be "-flag"
+            $res.CompletionMatches.Count | Should -Be 1
+            $res.CompletionMatches.CompletionText | Should -Be "-flag"
         }
 
         It 'Completes native commands with --' {
@@ -152,8 +152,8 @@ Describe "TabCompletion" -Tags CI {
             }
             $line = "$nativeCommand --"
             $res = TabExpansion2 -inputScript $line -cursorColumn $line.Length
-            $res.CompletionMatches.Count | Should Be 1
-            $res.CompletionMatches.CompletionText | Should Be "--flag"
+            $res.CompletionMatches.Count | Should -Be 1
+            $res.CompletionMatches.CompletionText | Should -Be "--flag"
         }
 
         It 'Completes native commands with --f' {
@@ -168,8 +168,8 @@ Describe "TabCompletion" -Tags CI {
             }
             $line = "$nativeCommand --f"
             $res = TaBexpansion2 -inputScript $line -cursorColumn $line.Length
-            $res.CompletionMatches.Count | Should Be 1
-            $res.CompletionMatches.CompletionText | Should Be "--flag"
+            $res.CompletionMatches.Count | Should -Be 1
+            $res.CompletionMatches.CompletionText | Should -Be "--flag"
         }
 
         It 'Completes native commands with -o' {
@@ -184,16 +184,16 @@ Describe "TabCompletion" -Tags CI {
             }
             $line = "$nativeCommand -o"
             $res = TaBexpansion2 -inputScript $line -cursorColumn $line.Length
-            $res.CompletionMatches.Count | Should Be 1
-            $res.CompletionMatches.CompletionText | Should Be "-option"
+            $res.CompletionMatches.Count | Should -Be 1
+            $res.CompletionMatches.CompletionText | Should -Be "-option"
         }
     }
 
     It 'Should complete "Export-Counter -FileFormat" with available output formats' -Pending {
         $res = TabExpansion2 -inputScript 'Export-Counter -FileFormat ' -cursorColumn 'Export-Counter -FileFormat '.Length
-        $res.CompletionMatches.Count | Should Be 3
+        $res.CompletionMatches.Count | Should -Be 3
         $completionText = $res.CompletionMatches.CompletionText | Sort-Object
-        $completionText -join ' '| Should Be 'blg csv tsv'
+        $completionText -join ' '| Should -Be 'blg csv tsv'
     }
 
     Context "File name completion" {
@@ -247,8 +247,8 @@ Describe "TabCompletion" -Tags CI {
 
             Push-Location -Path $tempDir
             $res = TabExpansion2 -inputScript $inputStr -cursorColumn $inputStr.Length
-            $res.CompletionMatches.Count | Should BeGreaterThan 0
-            $res.CompletionMatches[0].CompletionText | Should Be $localExpected
+            $res.CompletionMatches.Count | Should -BeGreaterThan 0
+            $res.CompletionMatches[0].CompletionText | Should -Be $localExpected
         }
 
         It "Input '<inputStr>' should successfully complete with relative path '..\'" -TestCases $testCases {
@@ -257,8 +257,8 @@ Describe "TabCompletion" -Tags CI {
             Push-Location -Path $oneSubDir
             $inputStr = "..\${inputStr}"
             $res = TabExpansion2 -inputScript $inputStr -cursorColumn $inputStr.Length
-            $res.CompletionMatches.Count | Should BeGreaterThan 0
-            $res.CompletionMatches[0].CompletionText | Should Be $oneSubExpected
+            $res.CompletionMatches.Count | Should -BeGreaterThan 0
+            $res.CompletionMatches[0].CompletionText | Should -Be $oneSubExpected
         }
 
         It "Input '<inputStr>' should successfully complete with relative path '..\..\'" -TestCases $testCases {
@@ -267,8 +267,8 @@ Describe "TabCompletion" -Tags CI {
             Push-Location -Path $twoSubDir
             $inputStr = "../../${inputStr}"
             $res = TabExpansion2 -inputScript $inputStr -cursorColumn $inputStr.Length
-            $res.CompletionMatches.Count | Should BeGreaterThan 0
-            $res.CompletionMatches[0].CompletionText | Should Be $twoSubExpected
+            $res.CompletionMatches.Count | Should -BeGreaterThan 0
+            $res.CompletionMatches[0].CompletionText | Should -Be $twoSubExpected
         }
 
         It "Input '<inputStr>' should successfully complete with relative path '..\..\..\ba*\'" -TestCases $testCases {
@@ -277,8 +277,8 @@ Describe "TabCompletion" -Tags CI {
             Push-Location -Path $twoSubDir
             $inputStr = "..\..\..\ba*\${inputStr}"
             $res = TabExpansion2 -inputScript $inputStr -cursorColumn $inputStr.Length
-            $res.CompletionMatches.Count | Should BeGreaterThan 0
-            $res.CompletionMatches[0].CompletionText | Should Be $twoSubExpected
+            $res.CompletionMatches.Count | Should -BeGreaterThan 0
+            $res.CompletionMatches[0].CompletionText | Should -Be $twoSubExpected
         }
 
         It "Test relative path" {
@@ -286,8 +286,8 @@ Describe "TabCompletion" -Tags CI {
             $beforeTab = "twoSubDir/../../pri"
             $afterTab = "..${separator}prime"
             $res = TabExpansion2 -inputScript $beforeTab -cursorColumn $beforeTab.Length
-            $res.CompletionMatches.Count | Should Be 1
-            $res.CompletionMatches[0].CompletionText | Should Be $afterTab
+            $res.CompletionMatches.Count | Should -Be 1
+            $res.CompletionMatches[0].CompletionText | Should -Be $afterTab
         }
 
         It "Test path with both '\' and '/'" {
@@ -295,8 +295,8 @@ Describe "TabCompletion" -Tags CI {
             $beforeTab = "..\../..\ba*/ab"
             $afterTab = "..${separator}..${separator}abc"
             $res = TabExpansion2 -inputScript $beforeTab -cursorColumn $beforeTab.Length
-            $res.CompletionMatches.Count | Should Be 1
-            $res.CompletionMatches[0].CompletionText | Should Be $afterTab
+            $res.CompletionMatches.Count | Should -Be 1
+            $res.CompletionMatches[0].CompletionText | Should -Be $afterTab
         }
     }
 
@@ -326,7 +326,7 @@ Describe "TabCompletion" -Tags CI {
             param($inputStr, $expected)
 
             $res = TabExpansion2 -inputScript $inputStr -cursorColumn $inputStr.Length
-            $res.CompletionMatches[0].CompletionText | Should Be $expected
+            $res.CompletionMatches[0].CompletionText | Should -Be $expected
         }
     }
 
@@ -445,8 +445,8 @@ Describe "TabCompletion" -Tags CI {
 
             if ($null -ne $setup) { . $setup }
             $res = TabExpansion2 -inputScript $inputStr -cursorColumn $inputStr.Length
-            $res.CompletionMatches.Count | Should BeGreaterThan 0
-            $res.CompletionMatches[0].CompletionText | Should Be $expected
+            $res.CompletionMatches.Count | Should -BeGreaterThan 0
+            $res.CompletionMatches[0].CompletionText | Should -Be $expected
         }
 
         It "Tab completion UNC path" -Skip:(!$IsWindows) {
@@ -454,24 +454,24 @@ Describe "TabCompletion" -Tags CI {
             $beforeTab = "\\localhost\$homeDrive\wind"
             $afterTab = "& '\\localhost\$homeDrive\Windows'"
             $res = TabExpansion2 -inputScript $beforeTab -cursorColumn $beforeTab.Length
-            $res.CompletionMatches.Count | Should BeGreaterThan 0
-            $res.CompletionMatches[0].CompletionText | Should Be $afterTab
+            $res.CompletionMatches.Count | Should -BeGreaterThan 0
+            $res.CompletionMatches[0].CompletionText | Should -Be $afterTab
         }
 
         It "Tab completion for registry" -Skip:(!$IsWindows) {
             $beforeTab = 'registry::HKEY_l'
             $afterTab = 'registry::HKEY_LOCAL_MACHINE'
             $res = TabExpansion2 -inputScript $beforeTab -cursorColumn $beforeTab.Length
-            $res.CompletionMatches.Count | Should BeExactly 1
-            $res.CompletionMatches[0].CompletionText | Should Be $afterTab
+            $res.CompletionMatches.Count | Should -BeExactly 1
+            $res.CompletionMatches[0].CompletionText | Should -Be $afterTab
         }
 
         It "Tab completion for wsman provider" -Skip:(!$IsWindows) {
             $beforeTab = 'wsman::localh'
             $afterTab = 'wsman::localhost'
             $res = TabExpansion2 -inputScript $beforeTab -cursorColumn $beforeTab.Length
-            $res.CompletionMatches.Count | Should BeExactly 1
-            $res.CompletionMatches[0].CompletionText | Should Be $afterTab
+            $res.CompletionMatches.Count | Should -BeExactly 1
+            $res.CompletionMatches[0].CompletionText | Should -Be $afterTab
         }
 
         It "Tab completion for filesystem provider qualified path" {
@@ -483,8 +483,8 @@ Describe "TabCompletion" -Tags CI {
                 $afterTab = 'filesystem::/usr' -f $env:SystemDrive
             }
             $res = TabExpansion2 -inputScript $beforeTab -cursorColumn $beforeTab.Length
-            $res.CompletionMatches.Count | Should BeGreaterThan 0
-            $res.CompletionMatches[0].CompletionText | Should Be $afterTab
+            $res.CompletionMatches.Count | Should -BeGreaterThan 0
+            $res.CompletionMatches[0].CompletionText | Should -Be $afterTab
         }
 
         It "Tab completion dynamic parameter of a custom function" {
@@ -511,10 +511,10 @@ Describe "TabCompletion" -Tags CI {
 
             $inputStr = "Test-DynamicParam -D"
             $res = TabExpansion2 -inputScript $inputStr -cursorColumn $inputStr.Length
-            $res.CompletionMatches.Count | Should BeGreaterThan 3
-            $res.CompletionMatches[0].CompletionText | Should Be '-DeFirst'
-            $res.CompletionMatches[1].CompletionText | Should Be '-DeSecond'
-            $res.CompletionMatches[2].CompletionText | Should Be '-DeThird'
+            $res.CompletionMatches.Count | Should -BeGreaterThan 3
+            $res.CompletionMatches[0].CompletionText | Should -Be '-DeFirst'
+            $res.CompletionMatches[1].CompletionText | Should -Be '-DeSecond'
+            $res.CompletionMatches[2].CompletionText | Should -Be '-DeThird'
         }
 
         It "Tab completion dynamic parameter '-CodeSigningCert'" -Skip:(!$IsWindows) {
@@ -522,7 +522,7 @@ Describe "TabCompletion" -Tags CI {
                 Push-Location cert:\
                 $inputStr = "gci -co"
                 $res = TabExpansion2 -inputScript $inputStr -cursorColumn $inputStr.Length
-                $res.CompletionMatches[0].CompletionText | Should Be '-CodeSigningCert'
+                $res.CompletionMatches[0].CompletionText | Should -Be '-CodeSigningCert'
             } finally {
                 Pop-Location
             }
@@ -536,9 +536,9 @@ Describe "TabCompletion" -Tags CI {
 
                 $inputStr = "myf"
                 $res = TabExpansion2 -inputScript $inputStr -cursorColumn $inputStr.Length
-                $res.CompletionMatches.Count | Should BeExactly 2
-                $res.CompletionMatches[0].CompletionText | Should Be (Resolve-Path myf -Relative)
-                $res.CompletionMatches[1].CompletionText | Should Be "MyFunction"
+                $res.CompletionMatches.Count | Should -BeExactly 2
+                $res.CompletionMatches[0].CompletionText | Should -Be (Resolve-Path myf -Relative)
+                $res.CompletionMatches[1].CompletionText | Should -Be "MyFunction"
             } finally {
                 Remove-Item -Path myf -Force
                 Pop-Location
@@ -549,40 +549,40 @@ Describe "TabCompletion" -Tags CI {
             function foo { param([ValidateSet('cat','dog')]$p) }
             $inputStr = "foo "
             $res = TabExpansion2 -inputScript $inputStr -cursorColumn $inputStr.Length
-            $res.CompletionMatches.Count | Should BeExactly 2
-            $res.CompletionMatches[0].CompletionText | Should be 'cat'
-            $res.CompletionMatches[1].CompletionText | Should be 'dog'
+            $res.CompletionMatches.Count | Should -BeExactly 2
+            $res.CompletionMatches[0].CompletionText | Should -Be 'cat'
+            $res.CompletionMatches[1].CompletionText | Should -Be 'dog'
         }
 
         It "Tab completion for enum type parameter of a custom function" {
             function baz ([consolecolor]$name, [ValidateSet('cat','dog')]$p){}
             $inputStr = "baz -name "
             $res = TabExpansion2 -inputScript $inputStr -cursorColumn $inputStr.Length
-            $res.CompletionMatches.Count | Should BeExactly 16
-            $res.CompletionMatches[0].CompletionText | Should Be 'Black'
+            $res.CompletionMatches.Count | Should -BeExactly 16
+            $res.CompletionMatches[0].CompletionText | Should -Be 'Black'
 
             $inputStr = "baz Black "
             $res = TabExpansion2 -inputScript $inputStr -cursorColumn $inputStr.Length
-            $res.CompletionMatches.Count | Should BeExactly 2
-            $res.CompletionMatches[0].CompletionText | Should be 'cat'
-            $res.CompletionMatches[1].CompletionText | Should be 'dog'
+            $res.CompletionMatches.Count | Should -BeExactly 2
+            $res.CompletionMatches[0].CompletionText | Should -Be 'cat'
+            $res.CompletionMatches[1].CompletionText | Should -Be 'dog'
         }
 
         It "Tab completion for enum members after comma" {
             $inputStr = "Get-Command -Type Alias,c"
             $res = TabExpansion2 -inputScript $inputStr -cursorColumn $inputStr.Length
-            $res.CompletionMatches.Count | Should BeExactly 2
-            $res.CompletionMatches[0].CompletionText | Should Be 'Cmdlet'
-            $res.CompletionMatches[1].CompletionText | Should Be 'Configuration'
+            $res.CompletionMatches.Count | Should -BeExactly 2
+            $res.CompletionMatches[0].CompletionText | Should -Be 'Cmdlet'
+            $res.CompletionMatches[1].CompletionText | Should -Be 'Configuration'
         }
 
         It "Test [CommandCompletion]::GetNextResult" {
             $inputStr = "Get-Command -Type Alias,c"
             $res = TabExpansion2 -inputScript $inputStr -cursorColumn $inputStr.Length
-            $res.CompletionMatches.Count | Should BeExactly 2
-            $res.GetNextResult($false).CompletionText | Should Be 'Configuration'
-            $res.GetNextResult($true).CompletionText | Should Be 'Cmdlet'
-            $res.GetNextResult($true).CompletionText | Should Be 'Configuration'
+            $res.CompletionMatches.Count | Should -BeExactly 2
+            $res.GetNextResult($false).CompletionText | Should -Be 'Configuration'
+            $res.GetNextResult($true).CompletionText | Should -Be 'Cmdlet'
+            $res.GetNextResult($true).CompletionText | Should -Be 'Configuration'
         }
 
         It "Test history completion" {
@@ -596,16 +596,16 @@ Describe "TabCompletion" -Tags CI {
             }
             Add-History -InputObject $history
             $res = TabExpansion2 -inputScript "#" -cursorColumn 1
-            $res.CompletionMatches.Count | Should BeGreaterThan 0
-            $res.CompletionMatches[0].CompletionText | Should Be "Test history completion"
+            $res.CompletionMatches.Count | Should -BeGreaterThan 0
+            $res.CompletionMatches[0].CompletionText | Should -Be "Test history completion"
         }
 
         It "Test Attribute member completion" {
             $inputStr = "function bar { [parameter(]param() }"
             $res = TabExpansion2 -inputScript $inputStr -cursorColumn ($inputStr.IndexOf('(') + 1)
-            $res.CompletionMatches.Count | Should Be 10
+            $res.CompletionMatches.Count | Should -Be 10
             $entry = $res.CompletionMatches | Where-Object CompletionText -EQ "Position"
-            $entry.CompletionText | Should Be "Position"
+            $entry.CompletionText | Should -Be "Position"
         }
 
         It "Test completion with line continuation" {
@@ -614,8 +614,8 @@ dir -Recurse `
 -Lite
 '@
             $res = TabExpansion2 -inputScript $inputStr -cursorColumn $inputStr.Length
-            $res.CompletionMatches.Count | Should Be 1
-            $res.CompletionMatches[0].CompletionText | Should Be "-LiteralPath"
+            $res.CompletionMatches.Count | Should -Be 1
+            $res.CompletionMatches[0].CompletionText | Should -Be "-LiteralPath"
         }
     }
 
@@ -636,22 +636,22 @@ dir -Recurse `
         It "Test complete module file name" {
             $inputStr = "using module test"
             $res = TabExpansion2 -inputScript $inputStr -cursorColumn $inputStr.Length
-            $res.CompletionMatches.Count | Should Be 1
-            $res.CompletionMatches[0].CompletionText | Should Be ".${separator}testModule.psm1"
+            $res.CompletionMatches.Count | Should -Be 1
+            $res.CompletionMatches[0].CompletionText | Should -Be ".${separator}testModule.psm1"
         }
 
         It "Test complete module name" {
             $inputStr = "using module PSRead"
             $res = TabExpansion2 -inputScript $inputStr -cursorColumn $inputStr.Length
-            $res.CompletionMatches.Count | Should BeGreaterThan 0
-            $res.CompletionMatches[0].CompletionText | Should Be "PSReadLine"
+            $res.CompletionMatches.Count | Should -BeGreaterThan 0
+            $res.CompletionMatches[0].CompletionText | Should -Be "PSReadLine"
         }
 
         It "Test complete module name with wildcard" {
             $inputStr = "using module *ReadLi"
             $res = TabExpansion2 -inputScript $inputStr -cursorColumn $inputStr.Length
-            $res.CompletionMatches.Count | Should BeGreaterThan 0
-            $res.CompletionMatches[0].CompletionText | Should Be "PSReadLine"
+            $res.CompletionMatches.Count | Should -BeGreaterThan 0
+            $res.CompletionMatches[0].CompletionText | Should -Be "PSReadLine"
         }
     }
 
@@ -682,30 +682,30 @@ dir -Recurse `
             $inputStr = "dir .\commaA.txt,"
             $expected = ".${separator}commaA.txt"
             $res = TabExpansion2 -inputScript $inputStr -cursorColumn $inputStr.Length
-            $res.CompletionMatches.Count | Should Be 1
-            $res.CompletionMatches[0].CompletionText | Should Be $expected
+            $res.CompletionMatches.Count | Should -Be 1
+            $res.CompletionMatches[0].CompletionText | Should -Be $expected
         }
 
         It "Test comma with Enum array element" {
             $inputStr = "gcm -CommandType Cmdlet,"
             $res = TabExpansion2 -inputScript $inputStr -cursorColumn $inputStr.Length
-            $res.CompletionMatches.Count | Should Be ([System.Enum]::GetNames([System.Management.Automation.CommandTypes]).Count)
-            $res.CompletionMatches[0].CompletionText | Should Be "Alias"
+            $res.CompletionMatches.Count | Should -Be ([System.Enum]::GetNames([System.Management.Automation.CommandTypes]).Count)
+            $res.CompletionMatches[0].CompletionText | Should -Be "Alias"
         }
 
         It "Test redirection operator '<inputStr>'" -TestCases $redirectionTestCases {
             param($inputStr, $expected)
 
             $res = TabExpansion2 -inputScript $inputStr -cursorColumn $inputStr.Length
-            $res.CompletionMatches.Count | Should Be 1
-            $res.CompletionMatches[0].CompletionText | Should Be $expected
+            $res.CompletionMatches.Count | Should -Be 1
+            $res.CompletionMatches[0].CompletionText | Should -Be $expected
         }
 
         It "Test complete the minus token to operators" {
             $inputStr = "55 -"
             $res = TabExpansion2 -inputScript $inputStr -cursorColumn $inputStr.Length
-            $res.CompletionMatches.Count | Should Be ([System.Management.Automation.CompletionCompleters]::CompleteOperator("").Count)
-            $res.CompletionMatches[0].CompletionText | Should Be '-and'
+            $res.CompletionMatches.Count | Should -Be ([System.Management.Automation.CompletionCompleters]::CompleteOperator("").Count)
+            $res.CompletionMatches[0].CompletionText | Should -Be '-and'
         }
     }
 
@@ -739,15 +739,15 @@ dir -Recurse `
             param($inputStr, $expected)
 
             $res = TabExpansion2 -inputScript $inputStr -cursorColumn $inputStr.Length
-            $res.CompletionMatches.Count | Should BeGreaterThan 0
-            $res.CompletionMatches[0].CompletionText | Should Be $expected
+            $res.CompletionMatches.Count | Should -BeGreaterThan 0
+            $res.CompletionMatches[0].CompletionText | Should -Be $expected
         }
 
         It "Complete file name starting with special char" {
             $inputStr = ")"
             $res = TabExpansion2 -inputScript $inputStr -cursorColumn $inputStr.Length
-            $res.CompletionMatches.Count | Should Be 1
-            $res.CompletionMatches[0].CompletionText | Should Be "& '.${separator})file.txt'"
+            $res.CompletionMatches.Count | Should -Be 1
+            $res.CompletionMatches[0].CompletionText | Should -Be "& '.${separator})file.txt'"
         }
     }
 
@@ -771,8 +771,8 @@ dir -Recurse `
             )
 
             $res = TabExpansion2 -ast $ast -tokens $tokens -positionOfCursor $elementAst.Extent.EndScriptPosition
-            $res.CompletionMatches.Count | Should BeGreaterThan 0
-            $res.CompletionMatches[0].CompletionText | Should Be $expected
+            $res.CompletionMatches.Count | Should -BeGreaterThan 0
+            $res.CompletionMatches[0].CompletionText | Should -Be $expected
         }
     }
 
@@ -784,8 +784,8 @@ dir -Recurse `
 
             $inputStr = '$pid.'
             $res = [System.Management.Automation.CommandCompletion]::CompleteInput($inputStr, $inputst.Length, $null)
-            $res.CompletionMatches.Count | Should BeExactly 1
-            $res.CompletionMatches[0].CompletionText | Should Be 'Overridden-TabExpansion-Function'
+            $res.CompletionMatches.Count | Should -BeExactly 1
+            $res.CompletionMatches[0].CompletionText | Should -Be 'Overridden-TabExpansion-Function'
         }
 
         It "Override TabExpansion with alias" {
@@ -796,8 +796,8 @@ dir -Recurse `
 
             $inputStr = '$pid.'
             $res = [System.Management.Automation.CommandCompletion]::CompleteInput($inputStr, $inputst.Length, $null)
-            $res.CompletionMatches.Count | Should BeExactly 1
-            $res.CompletionMatches[0].CompletionText | Should Be "Overridden-TabExpansion-Alias"
+            $res.CompletionMatches.Count | Should -BeExactly 1
+            $res.CompletionMatches[0].CompletionText | Should -Be "Overridden-TabExpansion-Alias"
         }
     }
 
@@ -814,7 +814,7 @@ dir -Recurse `
             param($inputStr)
 
             $res = TabExpansion2 -inputScript $inputStr -cursorColumn $inputStr.Length
-            $res.CompletionMatches.Count | Should BeExactly 0
+            $res.CompletionMatches.Count | Should -BeExactly 0
         }
     }
 
@@ -878,8 +878,8 @@ dir -Recurse `
             param($inputStr, $expected)
 
             $res = TabExpansion2 -inputScript $inputStr -cursorColumn $inputStr.Length
-            $res.CompletionMatches.Count | Should BeGreaterThan 0
-            $res.CompletionMatches[0].CompletionText | Should Be $expected
+            $res.CompletionMatches.Count | Should -BeGreaterThan 0
+            $res.CompletionMatches[0].CompletionText | Should -Be $expected
         }
     }
 
@@ -918,8 +918,8 @@ dir -Recurse `
             param($inputStr, $expected)
 
             $res = TabExpansion2 -inputScript $inputStr -cursorColumn $inputStr.Length
-            $res.CompletionMatches.Count | Should BeGreaterThan 0
-            $res.CompletionMatches[0].CompletionText | Should Be $expected
+            $res.CompletionMatches.Count | Should -BeGreaterThan 0
+            $res.CompletionMatches[0].CompletionText | Should -Be $expected
         }
     }
 
@@ -929,12 +929,12 @@ dir -Recurse `
         ) {
             param($cmd, $expected)
             $res = TabExpansion2 -inputScript $cmd -cursorColumn $cmd.Length
-            $res.CompletionMatches.Count | Should Be $expected.Count
+            $res.CompletionMatches.Count | Should -Be $expected.Count
             $completionOptions = ""
             foreach ($completion in $res.CompletionMatches) {
                 $completionOptions += $completion.ListItemText
             }
-            $completionOptions | Should Be ([string]::Join("", $expected))
+            $completionOptions | Should -Be ([string]::Join("", $expected))
         }
     }
 }
@@ -951,8 +951,8 @@ Describe "Tab completion help test" -Tags @('RequireAdminOnWindows', 'CI') {
         }
 
         $res = TabExpansion2 -inputScript 'get-help about_spla' -cursorColumn 'get-help about_spla'.Length
-        $res.CompletionMatches.Count | Should Be 1
-        $res.CompletionMatches[0].CompletionText | Should BeExactly 'about_Splatting'
+        $res.CompletionMatches.Count | Should -Be 1
+        $res.CompletionMatches[0].CompletionText | Should -BeExactly 'about_Splatting'
     }
 }
 
@@ -991,8 +991,8 @@ Describe "Tab completion tests with remote Runspace" -Tags Feature {
     It "Input '<inputStr>' should successfully complete in remote runspace" -TestCases $testCases {
         param($inputStr, $expected)
         $res = [System.Management.Automation.CommandCompletion]::CompleteInput($inputStr, $inputStr.Length, $null, $powershell)
-        $res.CompletionMatches.Count | Should BeGreaterThan 0
-        $res.CompletionMatches[0].CompletionText | Should Be $expected
+        $res.CompletionMatches.Count | Should -BeGreaterThan 0
+        $res.CompletionMatches[0].CompletionText | Should -Be $expected
     }
 
     It "Input '<inputStr>' should successfully complete via AST in remote runspace" -TestCases $testCasesWithAst {
@@ -1006,8 +1006,8 @@ Describe "Tab completion tests with remote Runspace" -Tags Feature {
         )
 
         $res = [System.Management.Automation.CommandCompletion]::CompleteInput($ast, $tokens, $elementAst.Extent.EndScriptPosition, $null, $powershell)
-        $res.CompletionMatches.Count | Should BeGreaterThan 0
-        $res.CompletionMatches[0].CompletionText | Should Be $expected
+        $res.CompletionMatches.Count | Should -BeGreaterThan 0
+        $res.CompletionMatches[0].CompletionText | Should -Be $expected
     }
 }
 
@@ -1026,9 +1026,9 @@ Describe "WSMan Config Provider tab complete tests" -Tags Feature,RequireAdminOn
         $path = "wsman:\localhost\listener\listener"
         $res = TabExpansion2 -inputScript $path -cursorColumn $path.Length
         $listener = Get-ChildItem WSMan:\localhost\Listener
-        $res.CompletionMatches.Count | Should Be $listener.Count
+        $res.CompletionMatches.Count | Should -Be $listener.Count
         for ($i = 0; $i -lt $res.CompletionMatches.Count; $i++) {
-            $res.CompletionMatches[$i].ListItemText | Should Be $listener[$i].Name
+            $res.CompletionMatches[$i].ListItemText | Should -Be $listener[$i].Name
         }
     }
 
@@ -1057,12 +1057,12 @@ Describe "WSMan Config Provider tab complete tests" -Tags Feature,RequireAdminOn
         param($path, $parameter, $expected)
         $script = "new-item wsman:\$path $parameter"
         $res = TabExpansion2 -inputScript $script -cursorColumn $script.Length
-        $res.CompletionMatches.Count | Should Be $expected.Count
+        $res.CompletionMatches.Count | Should -Be $expected.Count
         $completionOptions = ""
         foreach ($completion in $res.CompletionMatches) {
             $completionOptions += $completion.ListItemText
         }
-        $completionOptions | Should Be ([string]::Join("", $expected))
+        $completionOptions | Should -Be ([string]::Join("", $expected))
     }
 
     It "Tab completion get dynamic parameters for initialization parameters" -Pending -TestCases @(

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -110,9 +110,9 @@ Describe "TabCompletion" -Tags CI {
         Set-StrictMode -Version latest
         $cmd = 'Get-Process -Id '
         [System.Management.Automation.CommandCompletion]$res = TabExpansion2 -inputScript $cmd  -cursorColumn $cmd.Length
-        $res.CompletionMatches[0].CompletionText -match '^\d+$' | Should -Be true
-        $res.CompletionMatches[0].ListItemText -match '^\d+ -' | Should -Be true
-        $res.CompletionMatches[0].ToolTip -match '^\d+ -' | Should -Be true
+        $res.CompletionMatches[0].CompletionText -match '^\d+$' | Should -BeTrue
+        $res.CompletionMatches[0].ListItemText -match '^\d+ -' | Should -BeTrue
+        $res.CompletionMatches[0].ToolTip -match '^\d+ -' | Should -BeTrue
     }
 
     It 'Should complete keyword' -skip {


### PR DESCRIPTION
## PR Summary

Fixes a subset of #6245
Use new dashed Pester v4 operators for tests in `test\powershell\Host`

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [NA] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [x] Not Applicable or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
