### PR TITLE
Fix the terse output on Windows for unelevated test run

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -1098,7 +1098,7 @@ Restore the module to '$Pester' by running:
             $script:inerror = $false
         }
         elseif ($trimmedline -match "\d+ms") {
-            continue
+            return
         }
         else {
             if ($script:nonewline) {

--- a/build.psm1
+++ b/build.psm1
@@ -1097,7 +1097,8 @@ Restore the module to '$Pester' by running:
             $script:nonewline = $true
             $script:inerror = $false
         }
-        elseif ($trimmedline -match "^\d+ms$") {
+        elseif ($trimmedline -match "^\d+(\.\d+)?m?s$") {
+            # Skip the time elapse like '12ms', '1ms', '1.2s' and '12.53s'
             return
         }
         else {

--- a/build.psm1
+++ b/build.psm1
@@ -1097,7 +1097,7 @@ Restore the module to '$Pester' by running:
             $script:nonewline = $true
             $script:inerror = $false
         }
-        elseif ($trimmedline -match "\d+ms") {
+        elseif ($trimmedline -match "^\d+ms$") {
             return
         }
         else {

--- a/build.psm1
+++ b/build.psm1
@@ -1097,6 +1097,9 @@ Restore the module to '$Pester' by running:
             $script:nonewline = $true
             $script:inerror = $false
         }
+        elseif ($trimmedline -match "\d+ms") {
+            continue
+        }
         else {
             if ($script:nonewline) {
                 Write-Host "`n" -NoNewline


### PR DESCRIPTION
## PR Summary

After switching to Pester 4.3.1, the format of redirected output when running tests with `runas.exe /trustlevel:0x20000 pwsh ...` is changed, which causes `Write-Terse` to write out the elapsed time for each test case. As a result, the test-run log for AppVeyor builds is super long and rendering it in the browser takes a long time. See the screenshot below:

![image](https://user-images.githubusercontent.com/127450/36702476-19fbe42c-1b0c-11e8-916b-869a51557b87.png)


Before switching to Pester 4.3.1
```
Executing script F:\tmp\temp\abc.tests.ps1

  Describing abc
    [+] it 622ms
Tests completed in 622ms
Tests Passed: 1, Failed: 0, Skipped: 0, Pending: 0, Inconclusive: 0
```
After switching to Pester 4.3.1.
```
PS> runas.exe /trustlevel:0x20000 "f:\pscore\pwsh.exe -noprofile -c invoke-pester F:\tmp\temp *> f:\outputbuff"

Executing script F:\tmp\temp\abc.tests.ps1

  Describing abc
    [+] it
453ms
Tests completed in 453ms
Tests Passed: 1,
Failed: 0,
Skipped: 0,
Pending: 0,
Inconclusive: 0
```
The fix is to skip the elapsed time for each test run.
The RegEx pattern used to identify test-run time elapse is `"^\d+(\.\d+)?m?s$"`.
```
PS:131> $pattern = "^\d+(\.\d+)?m?s$"
PS:132> "1ms" -match $pattern
True
PS:133> "12ms" -match $pattern
True
PS:134> "12s" -match $pattern
True
PS:135> "1s" -match $pattern
True
PS:137> "1.1s" -match $pattern
True
PS:138> "1.15s" -match $pattern
True
PS:139> "12.15s" -match $pattern
True
```

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [x] Not Applicable or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
