### PR TITLE
Upgrade Pester tests in Microsoft.PowerShell.Security folder to dashed v4 syntax

### DIFF
--- a/test/powershell/Modules/Microsoft.PowerShell.Security/AclCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/AclCmdlets.Tests.ps1
@@ -11,7 +11,7 @@ Describe "Acl cmdlets are available and operate properly" -Tag CI {
         $acl = get-acl $directory
         $accessRule = [System.Security.AccessControl.FileSystemAccessRule]::New("Everyone","FullControl","ContainerInherit,ObjectInherit","None","Allow")
         $acl.AddAccessRule($accessRule)
-        { $acl | Set-Acl $directory } | Should Not -Throw
+        { $acl | Set-Acl $directory } | Should -Not -Throw
 
         $newacl = get-acl $directory
         $newrule = $newacl.Access | Where-Object { $accessrule.FileSystemRights -eq $_.FileSystemRights -and $accessrule.AccessControlType -eq $_.AccessControlType -and $accessrule.IdentityReference -eq $_.IdentityReference }

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/AclCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/AclCmdlets.Tests.ps1
@@ -11,7 +11,7 @@ Describe "Acl cmdlets are available and operate properly" -Tag CI {
         $acl = get-acl $directory
         $accessRule = [System.Security.AccessControl.FileSystemAccessRule]::New("Everyone","FullControl","ContainerInherit,ObjectInherit","None","Allow")
         $acl.AddAccessRule($accessRule)
-        $acl | Set-Acl $directory
+        { $acl | Set-Acl $directory } | Should Not -Throw
 
         $newacl = get-acl $directory
         $newrule = $newacl.Access | Where-Object { $accessrule.FileSystemRights -eq $_.FileSystemRights -and $accessrule.AccessControlType -eq $_.AccessControlType -and $accessrule.IdentityReference -eq $_.IdentityReference }

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/AclCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/AclCmdlets.Tests.ps1
@@ -3,7 +3,7 @@
 Describe "Acl cmdlets are available and operate properly" -Tag CI {
     It "Get-Acl returns an ACL object" -pending:(!$IsWindows) {
         $ACL = get-acl $TESTDRIVE
-        $ACL | Should BeOfType "System.Security.AccessControl.DirectorySecurity"
+        $ACL | Should -BeOfType "System.Security.AccessControl.DirectorySecurity"
     }
     It "Set-Acl can set the ACL of a directory" -pending {
         Setup -d testdir
@@ -11,10 +11,10 @@ Describe "Acl cmdlets are available and operate properly" -Tag CI {
         $acl = get-acl $directory
         $accessRule = [System.Security.AccessControl.FileSystemAccessRule]::New("Everyone","FullControl","ContainerInherit,ObjectInherit","None","Allow")
         $acl.AddAccessRule($accessRule)
-        { $acl | Set-Acl $directory } | should not throw
+        $acl | Set-Acl $directory
 
         $newacl = get-acl $directory
         $newrule = $newacl.Access | Where-Object { $accessrule.FileSystemRights -eq $_.FileSystemRights -and $accessrule.AccessControlType -eq $_.AccessControlType -and $accessrule.IdentityReference -eq $_.IdentityReference }
-        $newrule |Should not benullorempty
+        $newrule | Should -Not -BeNullOrEmpty
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/CertificateProvider.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/CertificateProvider.Tests.ps1
@@ -44,7 +44,7 @@ Describe "Certificate Provider tests" -Tags "CI" {
     }
 
     Context "Get-Item tests" {
-        it "Should be able to get a certificate store, path: <path>" -TestCases $testLocations {
+        it "Should be able to get a certificate store, path: <path>" -TestCases $testLocations -Pending {
             param([string] $path)
             $expectedResolvedPath = Resolve-Path -LiteralPath $path
             $result = Get-Item -LiteralPath $path

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/CertificateProvider.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/CertificateProvider.Tests.ps1
@@ -44,7 +44,7 @@ Describe "Certificate Provider tests" -Tags "CI" {
     }
 
     Context "Get-Item tests" {
-        it "Should be able to get a certificate store, path: <path>" -TestCases $testLocations -Pending {
+        it "Should be able to get a certificate store, path: <path>" -TestCases $currentUserMyLocations {
             param([string] $path)
             $expectedResolvedPath = Resolve-Path -LiteralPath $path
             $result = Get-Item -LiteralPath $path

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/CertificateProvider.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/CertificateProvider.Tests.ps1
@@ -48,18 +48,18 @@ Describe "Certificate Provider tests" -Tags "CI" {
             param([string] $path)
             $expectedResolvedPath = Resolve-Path -LiteralPath $path
             $result = Get-Item -LiteralPath $path
-            $result | should not be null
+            $result | Should -Not -BeNullOrEmpty
             $result | ForEach-Object {
                 $resolvedPath = Resolve-Path $_.PSPath
-                $resolvedPath.Provider | should be $expectedResolvedPath.Provider
-                $resolvedPath.ProviderPath.TrimStart('\') | should be $expectedResolvedPath.ProviderPath.TrimStart('\')
+                $resolvedPath.Provider | Should -Be $expectedResolvedPath.Provider
+                $resolvedPath.ProviderPath.TrimStart('\') | Should -Be $expectedResolvedPath.ProviderPath.TrimStart('\')
             }
         }
         it "Should return two items at the root of the provider" {
-            (Get-Item -Path cert:\*).Count | should be 2
+            (Get-Item -Path cert:\*).Count | Should -Be 2
         }
         it "Should be able to get multiple items explictly" {
-            (get-item cert:\LocalMachine , cert:\CurrentUser).Count | should be 2
+            (get-item cert:\LocalMachine , cert:\CurrentUser).Count | Should -Be 2
         }
         it "Should return PathNotFound when getting a non-existant certificate store" {
             {Get-Item cert:\IDONTEXIST -ErrorAction Stop} | ShouldBeErrorId "PathNotFound,Microsoft.PowerShell.Commands.GetItemCommand"
@@ -70,10 +70,10 @@ Describe "Certificate Provider tests" -Tags "CI" {
     }
     Context "Get-ChildItem tests"{
         it "should be able to get a container using a wildcard" {
-            (Get-ChildItem Cert:\CurrentUser\M?).PSPath | should be 'Microsoft.PowerShell.Security\Certificate::CurrentUser\My'
+            (Get-ChildItem Cert:\CurrentUser\M?).PSPath | Should -Be 'Microsoft.PowerShell.Security\Certificate::CurrentUser\My'
         }
         it "Should return two items at the root of the provider" {
-            (Get-ChildItem -Path cert:\).Count | should be 2
+            (Get-ChildItem -Path cert:\).Count | Should -Be 2
         }
     }
 }
@@ -111,8 +111,8 @@ Describe "Certificate Provider tests" -Tags "Feature" {
             $expectedThumbprint = (Get-GoodCertificateObject).Thumbprint
             $leafPath = Join-Path -Path $path -ChildPath $expectedThumbprint
             $cert = (Get-item -LiteralPath $leafPath)
-            $cert | should not be null
-            $cert.Thumbprint | should be $expectedThumbprint
+            $cert | Should -Not -BeNullOrEmpty
+            $cert.Thumbprint | Should -Be $expectedThumbprint
         }
         it "Should be able to get DnsNameList of certifate by path: <path>" -TestCases $currentUserMyLocations {
             param([string] $path)
@@ -121,11 +121,11 @@ Describe "Certificate Provider tests" -Tags "Feature" {
             $expectedEncodedName = (Get-GoodCertificateObject).DnsNameList[0].Punycode
             $leafPath = Join-Path -Path $path -ChildPath $expectedThumbprint
             $cert = (Get-item -LiteralPath $leafPath)
-            $cert | should not be null
-            $cert.DnsNameList | should not be null
-            $cert.DnsNameList.Count | should be 1
-            $cert.DnsNameList[0].Unicode | should be $expectedName
-            $cert.DnsNameList[0].Punycode | should be $expectedEncodedName
+            $cert | Should -Not -BeNullOrEmpty
+            $cert.DnsNameList | Should -Not -BeNullOrEmpty
+            $cert.DnsNameList.Count | Should -Be 1
+            $cert.DnsNameList[0].Unicode | Should -Be $expectedName
+            $cert.DnsNameList[0].Punycode | Should -Be $expectedEncodedName
         }
         it "Should be able to get DNSNameList of certifate by path: <path>" -TestCases $currentUserMyLocations {
             param([string] $path)
@@ -133,38 +133,38 @@ Describe "Certificate Provider tests" -Tags "Feature" {
             $expectedOid = (Get-GoodCertificateObject).EnhancedKeyUsageList[0].ObjectId
             $leafPath = Join-Path -Path $path -ChildPath $expectedThumbprint
             $cert = (Get-item -LiteralPath $leafPath)
-            $cert | should not be null
-            $cert.EnhancedKeyUsageList | should not be null
-            $cert.EnhancedKeyUsageList.Count | should be 1
-            $cert.EnhancedKeyUsageList[0].ObjectId.Length | should not be 0
-            $cert.EnhancedKeyUsageList[0].ObjectId | should be $expectedOid
+            $cert | Should -Not -BeNullOrEmpty
+            $cert.EnhancedKeyUsageList | Should -Not -BeNullOrEmpty
+            $cert.EnhancedKeyUsageList.Count | Should -Be 1
+            $cert.EnhancedKeyUsageList[0].ObjectId.Length | Should -Not -Be 0
+            $cert.EnhancedKeyUsageList[0].ObjectId | Should -Be $expectedOid
         }
         it "Should filter to codesign certificates" {
             $allCerts = get-item cert:\CurrentUser\My\*
             $codeSignCerts = get-item cert:\CurrentUser\My\* -CodeSigningCert
-            $codeSignCerts | should not be null
-            $allCerts | should not be null
+            $codeSignCerts | Should -Not -BeNullOrEmpty
+            $allCerts | Should -Not -BeNullOrEmpty
             $nonCodeSignCertCount = $allCerts.Count - $codeSignCerts.Count
-            $nonCodeSignCertCount | should not be 0
+            $nonCodeSignCertCount | Should -Not -Be 0
         }
         it "Should be able to exclude by thumbprint" {
             $allCerts = get-item cert:\CurrentUser\My\*
             $testThumbprint = (Get-GoodCertificateObject).Thumbprint
             $allCertsExceptOne = (Get-Item "cert:\currentuser\my\*" -Exclude $testThumbprint)
-            $allCerts | should not be null
-            $allCertsExceptOne | should not be null
+            $allCerts | Should -Not -BeNullOrEmpty
+            $allCertsExceptOne | Should -Not -BeNullOrEmpty
             $countDifference = $allCerts.Count - $allCertsExceptOne.Count
-            $countDifference | should be 1
+            $countDifference | Should -Be 1
         }
     }
     Context "Get-ChildItem tests"{
         it "Should filter to codesign certificates" {
             $allCerts = get-ChildItem cert:\CurrentUser\My
             $codeSignCerts = get-ChildItem cert:\CurrentUser\My -CodeSigningCert
-            $codeSignCerts | should not be null
-            $allCerts | should not be null
+            $codeSignCerts | Should -Not -BeNullOrEmpty
+            $allCerts | Should -Not -BeNullOrEmpty
             $nonCodeSignCertCount = $allCerts.Count - $codeSignCerts.Count
-            $nonCodeSignCertCount | should not be 0
+            $nonCodeSignCertCount | Should -Not -Be 0
         }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/CertificateProvider.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/CertificateProvider.Tests.ps1
@@ -44,11 +44,11 @@ Describe "Certificate Provider tests" -Tags "CI" {
     }
 
     Context "Get-Item tests" {
-        it "Should be able to get a certificate store, path: <path>" -TestCases $currentUserMyLocations {
+        it "Should be able to get a certificate store, path: <path>" -TestCases $testLocations {
             param([string] $path)
             $expectedResolvedPath = Resolve-Path -LiteralPath $path
             $result = Get-Item -LiteralPath $path
-            $result | Should -Not -BeNullOrEmpty
+            $result | should not be null
             $result | ForEach-Object {
                 $resolvedPath = Resolve-Path $_.PSPath
                 $resolvedPath.Provider | Should -Be $expectedResolvedPath.Provider
@@ -111,7 +111,7 @@ Describe "Certificate Provider tests" -Tags "Feature" {
             $expectedThumbprint = (Get-GoodCertificateObject).Thumbprint
             $leafPath = Join-Path -Path $path -ChildPath $expectedThumbprint
             $cert = (Get-item -LiteralPath $leafPath)
-            $cert | Should -Not -BeNullOrEmpty
+            $cert | should not be null
             $cert.Thumbprint | Should -Be $expectedThumbprint
         }
         it "Should be able to get DnsNameList of certifate by path: <path>" -TestCases $currentUserMyLocations {
@@ -121,8 +121,8 @@ Describe "Certificate Provider tests" -Tags "Feature" {
             $expectedEncodedName = (Get-GoodCertificateObject).DnsNameList[0].Punycode
             $leafPath = Join-Path -Path $path -ChildPath $expectedThumbprint
             $cert = (Get-item -LiteralPath $leafPath)
-            $cert | Should -Not -BeNullOrEmpty
-            $cert.DnsNameList | Should -Not -BeNullOrEmpty
+            $cert | should not be null
+            $cert.DnsNameList | should not be null
             $cert.DnsNameList.Count | Should -Be 1
             $cert.DnsNameList[0].Unicode | Should -Be $expectedName
             $cert.DnsNameList[0].Punycode | Should -Be $expectedEncodedName
@@ -133,8 +133,8 @@ Describe "Certificate Provider tests" -Tags "Feature" {
             $expectedOid = (Get-GoodCertificateObject).EnhancedKeyUsageList[0].ObjectId
             $leafPath = Join-Path -Path $path -ChildPath $expectedThumbprint
             $cert = (Get-item -LiteralPath $leafPath)
-            $cert | Should -Not -BeNullOrEmpty
-            $cert.EnhancedKeyUsageList | Should -Not -BeNullOrEmpty
+            $cert | should not be null
+            $cert.EnhancedKeyUsageList | should not be null
             $cert.EnhancedKeyUsageList.Count | Should -Be 1
             $cert.EnhancedKeyUsageList[0].ObjectId.Length | Should -Not -Be 0
             $cert.EnhancedKeyUsageList[0].ObjectId | Should -Be $expectedOid
@@ -142,8 +142,8 @@ Describe "Certificate Provider tests" -Tags "Feature" {
         it "Should filter to codesign certificates" {
             $allCerts = get-item cert:\CurrentUser\My\*
             $codeSignCerts = get-item cert:\CurrentUser\My\* -CodeSigningCert
-            $codeSignCerts | Should -Not -BeNullOrEmpty
-            $allCerts | Should -Not -BeNullOrEmpty
+            $codeSignCerts | should not be null
+            $allCerts | should not be null
             $nonCodeSignCertCount = $allCerts.Count - $codeSignCerts.Count
             $nonCodeSignCertCount | Should -Not -Be 0
         }
@@ -151,8 +151,8 @@ Describe "Certificate Provider tests" -Tags "Feature" {
             $allCerts = get-item cert:\CurrentUser\My\*
             $testThumbprint = (Get-GoodCertificateObject).Thumbprint
             $allCertsExceptOne = (Get-Item "cert:\currentuser\my\*" -Exclude $testThumbprint)
-            $allCerts | Should -Not -BeNullOrEmpty
-            $allCertsExceptOne | Should -Not -BeNullOrEmpty
+            $allCerts | should not be null
+            $allCertsExceptOne | should not be null
             $countDifference = $allCerts.Count - $allCertsExceptOne.Count
             $countDifference | Should -Be 1
         }
@@ -161,8 +161,8 @@ Describe "Certificate Provider tests" -Tags "Feature" {
         it "Should filter to codesign certificates" {
             $allCerts = get-ChildItem cert:\CurrentUser\My
             $codeSignCerts = get-ChildItem cert:\CurrentUser\My -CodeSigningCert
-            $codeSignCerts | Should -Not -BeNullOrEmpty
-            $allCerts | Should -Not -BeNullOrEmpty
+            $codeSignCerts | should not be null
+            $allCerts | should not be null
             $nonCodeSignCertCount = $allCerts.Count - $codeSignCerts.Count
             $nonCodeSignCertCount | Should -Not -Be 0
         }

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/CmsMessage.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/CmsMessage.Tests.ps1
@@ -6,31 +6,31 @@ Describe "CmsMessage cmdlets and Get-PfxCertificate basic tests" -Tags "CI" {
 
     BeforeAll {
         $certLocation = New-GoodCertificate
-        $certLocation | Should Not BeNullOrEmpty | Out-Null
+        $certLocation | Should -Not -BeNullOrEmpty | Out-Null
 
         $protectedCertLocation = New-ProtectedCertificate
-        $protectedCertLocation | Should Not BeNullOrEmpty | Out-Null
+        $protectedCertLocation | Should -Not -BeNullOrEmpty | Out-Null
     }
 
     It "Verify Get-PfxCertificate -FilePath" {
         $cert = Get-PfxCertificate -FilePath $certLocation
-        $cert.Subject | Should Be "CN=MyDataEnciphermentCert"
+        $cert.Subject | Should -Be "CN=MyDataEnciphermentCert"
     }
 
     It "Verify Get-PfxCertificate -LiteralPath" {
         $cert = Get-PfxCertificate -LiteralPath $certLocation
-        $cert.Subject | Should Be "CN=MyDataEnciphermentCert"
+        $cert.Subject | Should -Be "CN=MyDataEnciphermentCert"
     }
 
     It "Verify Get-PfxCertificate positional argument" {
         $cert = Get-PfxCertificate $certLocation
-        $cert.Subject | Should Be "CN=MyDataEnciphermentCert"
+        $cert.Subject | Should -Be "CN=MyDataEnciphermentCert"
     }
 
     It "Verify Get-PfxCertificate right password" {
         $pass = ConvertTo-SecureString "password" -AsPlainText -Force
         $cert = Get-PfxCertificate $protectedCertLocation -Password $pass
-        $cert.Subject | Should Be "CN=localhost"
+        $cert.Subject | Should -Be "CN=localhost"
     }
 
     It "Verify Get-PfxCertificate wrong password" {
@@ -43,8 +43,8 @@ Describe "CmsMessage cmdlets and Get-PfxCertificate basic tests" -Tags "CI" {
         $recipient = [System.Management.Automation.CmsMessageRecipient] $certLocation
         $recipient.Resolve($ExecutionContext.SessionState, "Encryption", [ref] $errors)
 
-        $recipient.Certificates.Count | Should Be 1
-        $recipient.Certificates[0].Subject | Should Match 'CN=MyDataEnciphermentCert'
+        $recipient.Certificates.Count | Should -Be 1
+        $recipient.Certificates[0].Subject | Should -Match 'CN=MyDataEnciphermentCert'
     }
 
     It "Verify CMS message recipient resolution by cert" -Skip:(!$IsWindows) {
@@ -53,24 +53,24 @@ Describe "CmsMessage cmdlets and Get-PfxCertificate basic tests" -Tags "CI" {
         $recipient = [System.Management.Automation.CmsMessageRecipient] $cert
         $recipient.Resolve($ExecutionContext.SessionState, "Encryption", [ref] $errors)
 
-        $recipient.Certificates.Count | Should Be 1
-        $recipient.Certificates[0].Subject | Should Match 'CN=MyDataEnciphermentCert'
+        $recipient.Certificates.Count | Should -Be 1
+        $recipient.Certificates[0].Subject | Should -Match 'CN=MyDataEnciphermentCert'
     }
 
     It "Verify a CMS message can be protected / unprotected" -Skip:(!$IsWindows) {
         $protected = "Hello World","How are you?" | Protect-CmsMessage -To $certLocation
-        $protected.IndexOf("-----BEGIN CMS-----") | Should Be 0
+        $protected.IndexOf("-----BEGIN CMS-----") | Should -Be 0
 
         $message = $protected | Get-CmsMessage
-        $message.Recipients.Count | Should Be 1
-        $message.Recipients[0].IssuerName | Should Be "CN=MyDataEnciphermentCert"
+        $message.Recipients.Count | Should -Be 1
+        $message.Recipients[0].IssuerName | Should -Be "CN=MyDataEnciphermentCert"
 
         $expected = "Hello World" + [System.Environment]::NewLine + "How are you?"
         $decrypted = $message | Unprotect-CmsMessage -To $certLocation
-        $decrypted | Should Be $expected
+        $decrypted | Should -Be $expected
 
         $decrypted = $protected | Unprotect-CmsMessage -To $certLocation
-        $decrypted | Should Be $expected
+        $decrypted | Should -Be $expected
     }
 }
 
@@ -129,8 +129,8 @@ Describe "CmsMessage cmdlets thorough tests" -Tags "Feature" {
             $recipient = [System.Management.Automation.CmsMessageRecipient] $certContent
             $recipient.Resolve($ExecutionContext.SessionState, "Encryption", [ref] $errors)
 
-            $recipient.Certificates.Count | Should Be 1
-            $recipient.Certificates[0].Subject | Should Match 'CN=MyDataEnciphermentCert'
+            $recipient.Certificates.Count | Should -Be 1
+            $recipient.Certificates[0].Subject | Should -Match 'CN=MyDataEnciphermentCert'
     }
 
     It "Verify wildcarded recipient resolution by path [Decryption]" {
@@ -139,7 +139,7 @@ Describe "CmsMessage cmdlets thorough tests" -Tags "Feature" {
         $recipient.Resolve($ExecutionContext.SessionState, "Decryption", [ref] $errors)
 
         # Should have resolved single cert
-        $recipient.Certificates.Count | Should Be 1
+        $recipient.Certificates.Count | Should -Be 1
     }
 
     It "Verify wildcarded recipient resolution by path [Encryption]" {
@@ -147,7 +147,7 @@ Describe "CmsMessage cmdlets thorough tests" -Tags "Feature" {
         $recipient = [System.Management.Automation.CmsMessageRecipient] ((Get-GoodCertificateLocation) + "*")
         $recipient.Resolve($ExecutionContext.SessionState, "Encryption", [ref] $errors)
 
-        $recipient.Certificates.Count | Should Be 1
+        $recipient.Certificates.Count | Should -Be 1
     }
 
     It "Verify resolution by directory" {
@@ -161,7 +161,7 @@ Describe "CmsMessage cmdlets thorough tests" -Tags "Feature" {
         $recipient = [System.Management.Automation.CmsMessageRecipient] $protectedEventLoggingCertPath
         $recipient.Resolve($executionContext.SessionState, "Decryption", [ref] $errors)
 
-        $recipient.Certificates.Count | Should Be 1
+        $recipient.Certificates.Count | Should -Be 1
     }
 
     It "Verify resolution by thumbprint" {
@@ -170,8 +170,8 @@ Describe "CmsMessage cmdlets thorough tests" -Tags "Feature" {
         $recipient.Resolve($ExecutionContext.SessionState, "Decryption", [ref] $errors)
 
         # "Should have certs from thumbprint in 'My' store"
-        $recipient.Certificates.Count | Should Be 1
-        $recipient.Certificates[0].Thumbprint | Should Be (Get-GoodCertificateObject).Thumbprint
+        $recipient.Certificates.Count | Should -Be 1
+        $recipient.Certificates[0].Thumbprint | Should -Be (Get-GoodCertificateObject).Thumbprint
     }
 
     It "Verify resolution by subject name" {
@@ -179,8 +179,8 @@ Describe "CmsMessage cmdlets thorough tests" -Tags "Feature" {
         $recipient = [System.Management.Automation.CmsMessageRecipient] (Get-GoodCertificateObject).Subject
         $recipient.Resolve($ExecutionContext.SessionState, "Decryption", [ref] $errors)
 
-        $recipient.Certificates.Count | Should Be 1
-        $recipient.Certificates[0].Thumbprint | Should Be (Get-GoodCertificateObject).Thumbprint
+        $recipient.Certificates.Count | Should -Be 1
+        $recipient.Certificates[0].Thumbprint | Should -Be (Get-GoodCertificateObject).Thumbprint
     }
 
     It "Verify error when no cert found in encryption for encryption" {
@@ -188,8 +188,8 @@ Describe "CmsMessage cmdlets thorough tests" -Tags "Feature" {
         $recipient = [System.Management.Automation.CmsMessageRecipient] "SomeCertificateThatDoesNotExist*"
         $recipient.Resolve($ExecutionContext.SessionState, "Encryption", [ref] $errors)
 
-        $errors.Count | Should Be 1
-        $errors[0].FullyQualifiedErrorId | Should Be "NoCertificateFound"
+        $errors.Count | Should -Be 1
+        $errors[0].FullyQualifiedErrorId | Should -Be "NoCertificateFound"
     }
 
     It "Verify error when encrypting to non-wildcarded identifier for decryption" {
@@ -197,8 +197,8 @@ Describe "CmsMessage cmdlets thorough tests" -Tags "Feature" {
         $recipient = [System.Management.Automation.CmsMessageRecipient] "SomeCertificateThatDoesNotExist"
         $recipient.Resolve($ExecutionContext.SessionState, "Decryption", [ref] $errors)
 
-        $errors.Count | Should Be 1
-        $errors[0].FullyQualifiedErrorId | Should Be "NoCertificateFound"
+        $errors.Count | Should -Be 1
+        $errors[0].FullyQualifiedErrorId | Should -Be "NoCertificateFound"
     }
 
     It "Verify error when encrypting to wrong cert" {
@@ -206,8 +206,8 @@ Describe "CmsMessage cmdlets thorough tests" -Tags "Feature" {
         $recipient = [System.Management.Automation.CmsMessageRecipient] (Get-BadCertificateObject).Thumbprint
         $recipient.Resolve($ExecutionContext.SessionState, "Encryption", [ref] $errors)
 
-        $errors.Count | Should Be 1
-        $errors[0].FullyQualifiedErrorId | Should Be "CertificateCannotBeUsedForEncryption"
+        $errors.Count | Should -Be 1
+        $errors[0].FullyQualifiedErrorId | Should -Be "CertificateCannotBeUsedForEncryption"
     }
 
     It "Verify no error when encrypting to wildcarded identifier for decryption" {
@@ -215,8 +215,8 @@ Describe "CmsMessage cmdlets thorough tests" -Tags "Feature" {
         $recipient = [System.Management.Automation.CmsMessageRecipient] "SomeCertificateThatDoesNotExist*"
         $recipient.Resolve($ExecutionContext.SessionState, "Decryption", [ref] $errors)
 
-        $errors | Should Be $null
-        $recipient.Certificates.Count | Should Be 0
+        $errors | Should -Be $null
+        $recipient.Certificates.Count | Should -Be 0
     }
 
     It "Verify Protect-CmsMessage emits recipient errors" {
@@ -224,7 +224,7 @@ Describe "CmsMessage cmdlets thorough tests" -Tags "Feature" {
             "Hello World" | Protect-CmsMessage -To "SomeThumbprintThatDoesNotExist" -ErrorAction Stop
             throw "No Exception!"
         } catch {
-            $_.FullyQualifiedErrorId | Should Be "NoCertificateFound,Microsoft.PowerShell.Commands.ProtectCmsMessageCommand"
+            $_.FullyQualifiedErrorId | Should -Be "NoCertificateFound,Microsoft.PowerShell.Commands.ProtectCmsMessageCommand"
         }
     }
 
@@ -238,15 +238,15 @@ Describe "CmsMessage cmdlets thorough tests" -Tags "Feature" {
             Protect-CmsMessage -Path $tempPath -To (Get-GoodCertificateLocation) -OutFile $encryptedPath
 
             $message = Get-CmsMessage -LiteralPath $encryptedPath
-            $message.Recipients.Count | Should Be 1
-            $message.Recipients[0].IssuerName | Should Be "CN=MyDataEnciphermentCert"
+            $message.Recipients.Count | Should -Be 1
+            $message.Recipients[0].IssuerName | Should -Be "CN=MyDataEnciphermentCert"
 
             $expected = "Hello World" + [System.Environment]::NewLine + "How are you?" + [System.Environment]::NewLine
             $decrypted = $message | Unprotect-CmsMessage -To (Get-GoodCertificateLocation)
-            $decrypted | Should Be $expected
+            $decrypted | Should -Be $expected
 
             $decrypted = Unprotect-CmsMessage -Path $encryptedPath -To (Get-GoodCertificateLocation)
-            $decrypted | Should Be $expected
+            $decrypted | Should -Be $expected
         } finally {
             Remove-Item $tempPath, $encryptedPath -Force -ErrorAction SilentlyContinue
         }
@@ -260,7 +260,7 @@ Describe "CmsMessage cmdlets thorough tests" -Tags "Feature" {
 
             # Decrypt using $importedCert in the Cert store
             $decrypted = Unprotect-CmsMessage -Path $tempPath
-            $decrypted | Should Be "Hello World"
+            $decrypted | Should -Be "Hello World"
         } finally {
             Remove-Item $tempPath -Force -ErrorAction SilentlyContinue
         }
@@ -271,7 +271,7 @@ Describe "CmsMessage cmdlets thorough tests" -Tags "Feature" {
             "" | Unprotect-CmsMessage -To "SomeThumbprintThatDoesNotExist" -IncludeContext -ErrorAction Stop
             throw "No Exception!"
         } catch {
-            $_.FullyQualifiedErrorId | Should Be "NoCertificateFound,Microsoft.PowerShell.Commands.UnprotectCmsMessageCommand"
+            $_.FullyQualifiedErrorId | Should -Be "NoCertificateFound,Microsoft.PowerShell.Commands.UnprotectCmsMessageCommand"
         }
     }
 
@@ -280,7 +280,7 @@ Describe "CmsMessage cmdlets thorough tests" -Tags "Feature" {
             "Hello World" | Unprotect-CmsMessage -ErrorAction Stop
             throw "No Exception!"
         } catch {
-            $_.FullyQualifiedErrorId | Should Be "InputContainedNoEncryptedContentIncludeContext,Microsoft.PowerShell.Commands.UnprotectCmsMessageCommand"
+            $_.FullyQualifiedErrorId | Should -Be "InputContainedNoEncryptedContentIncludeContext,Microsoft.PowerShell.Commands.UnprotectCmsMessageCommand"
         }
     }
 
@@ -289,14 +289,14 @@ Describe "CmsMessage cmdlets thorough tests" -Tags "Feature" {
             "Hello World" | Get-CmsMessage -ErrorAction Stop
             throw "No Exception!"
         } catch {
-            $_.FullyQualifiedErrorId | Should Be "InputContainedNoEncryptedContent,Microsoft.PowerShell.Commands.GetCmsMessageCommand"
+            $_.FullyQualifiedErrorId | Should -Be "InputContainedNoEncryptedContent,Microsoft.PowerShell.Commands.GetCmsMessageCommand"
         }
     }
 
     It "Verify 'Unprotect-CmsMessage -IncludeContext' with no encrypted input" {
         # Should have round-tripped content
         $result = "Hello World" | Unprotect-CmsMessage -IncludeContext
-        $result | Should Be "Hello World"
+        $result | Should -Be "Hello World"
     }
 
     It "Verify Unprotect-CmsMessage lets you include context" {
@@ -306,10 +306,10 @@ Describe "CmsMessage cmdlets thorough tests" -Tags "Feature" {
         $decryptedNoContext = $adjustedProtected | Unprotect-CmsMessage -To (Get-GoodCertificateLocation)
         $decryptedWithContext = $adjustedProtected | Unprotect-CmsMessage -To (Get-GoodCertificateLocation) -IncludeContext
 
-        $decryptedNoContext | Should Be "Hello World"
+        $decryptedNoContext | Should -Be "Hello World"
 
         $expected = "Pre content" + [System.Environment]::NewLine + "Hello World" + [System.Environment]::NewLine + "Post content"
-        $decryptedWithContext | Should Be $expected
+        $decryptedWithContext | Should -Be $expected
     }
 
     It "Verify Unprotect-CmsMessage treats event logs as a first class citizen" {
@@ -320,11 +320,11 @@ Describe "CmsMessage cmdlets thorough tests" -Tags "Feature" {
 
         $expected = "Encrypted Message1" + [System.Environment]::NewLine + "Encrypted Message2"
         $decrypted = $virtualEventLog | Unprotect-CmsMessage -To (Get-GoodCertificateLocation)
-        $decrypted | Should Be $expected
+        $decrypted | Should -Be $expected
 
         $processed = $virtualEventLog | Unprotect-CmsMessage -To (Get-GoodCertificateLocation) -IncludeContext
-        $processed.Id | Should Be $savedId
-        $processed.Message | Should Be $expected
+        $processed.Id | Should -Be $savedId
+        $processed.Message | Should -Be $expected
     }
 
     # Pending due to #3847
@@ -337,13 +337,13 @@ Describe "CmsMessage cmdlets thorough tests" -Tags "Feature" {
             ($_.EnhancedKeyUsageList[0].ObjectId -eq '1.3.6.1.4.1.311.80.1')
         }
         # "All Document Encryption Cert should have had correct EKU"
-        @($foundCerts).Count | Should Be @($correctMatching).Count
+        @($foundCerts).Count | Should -Be @($correctMatching).Count
     }
 
     It "Verify protect message using OutString" {
         $protected = Get-Process -Id $pid | Protect-CmsMessage -To (Get-GoodCertificateLocation)
         $decrypted = $protected | Unprotect-CmsMessage -To (Get-GoodCertificateLocation)
         # Should have had PID in output
-        $decrypted | Should Match $pid
+        $decrypted | Should -Match $pid
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/ConstrainedLanguageRestriction.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/ConstrainedLanguageRestriction.Tests.ps1
@@ -10,7 +10,7 @@
 ## Test Note:
 ## ----------
 ## Since these tests change session and system state (constrained language and system lockdown)
-## they will all use try/finally blocks instead of Pester AfterEach/AfterAll to ensure session 
+## they will all use try/finally blocks instead of Pester AfterEach/AfterAll to ensure session
 ## and system state is restored.
 ## Pester AfterEach, AfterAll is not reliable when the session is constrained language or locked down.
 ##
@@ -69,7 +69,7 @@ if ($IsWindows)
             set { revertLockdownMode = value; }
         }
         private SwitchParameter revertLockdownMode;
-        
+
         protected override void BeginProcessing()
         {
             if (enableFullLanguageMode)
@@ -90,7 +90,7 @@ if ($IsWindows)
             if (revertLockdownMode)
             {
                 Environment.SetEnvironmentVariable("__PSLockdownPolicy", null, EnvironmentVariableTarget.Machine);
-            }            
+            }
         }
     }
 '@
@@ -104,9 +104,9 @@ if ($IsWindows)
             $null = New-Item -ItemType Directory $moduleDirectory -Force
         }
 
-        try 
-        { 
-            Add-Type -TypeDefinition $code -OutputAssembly $moduleDirectory\TestCmdletForConstrainedLanguage.dll -ErrorAction Ignore 
+        try
+        {
+            Add-Type -TypeDefinition $code -OutputAssembly $moduleDirectory\TestCmdletForConstrainedLanguage.dll -ErrorAction Ignore
         } catch {}
 
         Import-Module -Name $moduleDirectory\TestCmdletForConstrainedLanguage.dll
@@ -142,7 +142,7 @@ try
                 Invoke-LanguageModeTestingSupportCmdlet -EnableFullLanguageMode
             }
 
-            $result.Count | Should BeGreaterThan 0
+            $result.Count | Should -BeGreaterThan 0
         }
     }
 
@@ -167,7 +167,7 @@ try
                     Invoke-LanguageModeTestingSupportCmdlet -RevertLockdownMode
                 }
 
-                $expectedError.FullyQualifiedErrorId | Should Match "MethodInvocationNotSupportedInConstrainedLanguage"
+                $expectedError.FullyQualifiedErrorId | Should -Match "MethodInvocationNotSupportedInConstrainedLanguage"
             }
         }
 
@@ -182,7 +182,7 @@ try
                     Start-Job { [object]::Equals("A", "B") }
                     throw "No Exception!"
                 }
-                catch 
+                catch
                 {
                     $exception = $_
                 }
@@ -191,7 +191,7 @@ try
                     Invoke-LanguageModeTestingSupportCmdlet -EnableFullLanguageMode
                 }
 
-                $exception.FullyQualifiedErrorId | Should Match "CannotStartJobInconsistentLanguageMode"
+                $exception.FullyQualifiedErrorId | Should -Match "CannotStartJobInconsistentLanguageMode"
             }
         }
     }
@@ -216,12 +216,12 @@ try
                 Invoke-LanguageModeTestingSupportCmdlet -EnableFullLanguageMode
             }
 
-            $exception.FullyQualifiedErrorId | Should Match "CannotDefineNewType"
+            $exception.FullyQualifiedErrorId | Should -Match "CannotDefineNewType"
         }
 
         It "Verifies Add-Type works back in full language mode again" {
             Add-Type -TypeDefinition 'public class AfterFullLanguageTest { public static string Hello = "HelloAfter"; }'
-            [AfterFullLanguageTest]::Hello | Should Be "HelloAfter"
+            [AfterFullLanguageTest]::Hello | Should -Be "HelloAfter"
         }
     }
 
@@ -242,7 +242,7 @@ try
                     Invoke-LanguageModeTestingSupportCmdlet -EnableFullLanguageMode
                 }
 
-                $resultString | Should Be "Hello"
+                $resultString | Should -Be "Hello"
             }
 
             It "Verifies New-Object throws error in constrained language for disallowed IntPtr type" {
@@ -263,12 +263,12 @@ try
                     Invoke-LanguageModeTestingSupportCmdlet -EnableFullLanguageMode
                 }
 
-                $exception.FullyQualifiedErrorId | Should Match "CannotCreateTypeConstrainedLanguage"
+                $exception.FullyQualifiedErrorId | Should -Match "CannotCreateTypeConstrainedLanguage"
             }
 
             It "Verifies New-Object works for IntPtr type back in full language mode again" {
 
-                New-Object System.IntPtr 1234 | Should Be 1234
+                New-Object System.IntPtr 1234 | Should -Be 1234
             }
         }
 
@@ -294,13 +294,13 @@ try
                     Invoke-LanguageModeTestingSupportCmdlet -RevertLockdownMode -EnableFullLanguageMode
                 }
 
-                $exception.FullyQualifiedErrorId | Should Match "CannotCreateComTypeConstrainedLanguage"
+                $exception.FullyQualifiedErrorId | Should -Match "CannotCreateComTypeConstrainedLanguage"
             }
 
             It "Verifies New-Object with COM types works back in full language mode again" {
 
                 $result = New-Object -ComObject ADODB.Parameter
-                $result.Direction | Should Be 1
+                $result.Direction | Should -Be 1
             }
         }
     }
@@ -325,7 +325,7 @@ try
                 Invoke-LanguageModeTestingSupportCmdlet -EnableFullLanguageMode
             }
 
-            $exception.FullyQualifiedErrorId | Should Match "NotSupported"
+            $exception.FullyQualifiedErrorId | Should -Match "NotSupported"
         }
     }
 
@@ -350,9 +350,9 @@ try
                 Invoke-LanguageModeTestingSupportCmdlet -EnableFullLanguageMode
             }
 
-            $exception.FullyQualifiedErrorId | Should Match "CannotSetBreakpointInconsistentLanguageMode"
+            $exception.FullyQualifiedErrorId | Should -Match "CannotSetBreakpointInconsistentLanguageMode"
         }
-        
+
         # TODO
         # Test is pending because PowerShell Core currently stubs out Windows system lockdown APIs
         It "Verifies that a debugging breakpoint can be set in constrained language with system lockdown" -Pending {
@@ -371,7 +371,7 @@ try
                 Invoke-LanguageModeTestingSupportCmdlet -RevertLockdownMode -EnableFullLanguageMode
             }
 
-            $Global:DebuggingOk | Should Be "DebuggingOk"
+            $Global:DebuggingOk | Should -Be "DebuggingOk"
         }
 
         # TODO
@@ -400,7 +400,7 @@ try
                 Invoke-LanguageModeTestingSupportCmdlet -RevertLockdownMode -EnableFullLanguageMode
             }
 
-            $exception.FullyQualifiedErrorId | Should Match "MethodInvocationNotSupportedInConstrainedLanguage"
+            $exception.FullyQualifiedErrorId | Should -Match "MethodInvocationNotSupportedInConstrainedLanguage"
         }
 
         # TODO
@@ -437,10 +437,10 @@ try
                 Invoke-LanguageModeTestingSupportCmdlet -RevertLockdownMode -EnableFullLanguageMode
             }
 
-            $env:pwnd_738057 | Should Not Be "Pwnd"
+            $env:pwnd_738057 | Should -Not -Be "Pwnd"
         }
     }
-    
+
     Describe "Engine events in constrained language mode" -Tags 'Feature','RequireAdminOnWindows' {
 
         It "Verifies engine event in constrained language mode, its action runs as constrained" {
@@ -459,7 +459,7 @@ try
                 Invoke-LanguageModeTestingSupportCmdlet -EnableFullLanguageMode
             }
 
-            $job.Error.FullyQualifiedErrorId | Should Match "MethodInvocationNotSupportedInConstrainedLanguage"
+            $job.Error.FullyQualifiedErrorId | Should -Match "MethodInvocationNotSupportedInConstrainedLanguage"
         }
     }
 
@@ -485,7 +485,7 @@ try
                 Invoke-LanguageModeTestingSupportCmdlet -EnableFullLanguageMode
             }
 
-            $exception.FullyQualifiedErrorId | Should Match "MethodInvocationNotSupportedInConstrainedLanguage"
+            $exception.FullyQualifiedErrorId | Should -Match "MethodInvocationNotSupportedInConstrainedLanguage"
         }
     }
 
@@ -513,7 +513,7 @@ try
                 $rs.Dispose()
             }
 
-            $exception.FullyQualifiedErrorId | Should Match "DriveNotFoundException"
+            $exception.FullyQualifiedErrorId | Should -Match "DriveNotFoundException"
         }
     }
 
@@ -530,7 +530,7 @@ try
             $result = $pl.Invoke()
             $rs.Dispose()
 
-            $result[0] | Should BeNullOrEmpty
+            $result[0] | Should -BeNullOrEmpty
         }
     }
 
@@ -559,7 +559,7 @@ try
                 $rs.Dispose()
             }
 
-            $exception.FullyQualifiedErrorId | Should Match "CmdletInvocationException"
+            $exception.FullyQualifiedErrorId | Should -Match "CmdletInvocationException"
         }
     }
 
@@ -570,9 +570,9 @@ try
             function VulnerableFunctionFromFullLanguage { Invoke-Expression $Args[0] }
 
             $TestCasesIEX = @(
-                @{testName = "Verifies direct Invoke-Expression does not bypass constrained language mode"; 
+                @{testName = "Verifies direct Invoke-Expression does not bypass constrained language mode";
                   scriptblock = { Invoke-Expression '[object]::Equals("A", "B")' } }
-                @{testName = "Verifies indirect Invoke-Expression does not bypass constrained language mode"; 
+                @{testName = "Verifies indirect Invoke-Expression does not bypass constrained language mode";
                   scriptblock = { VulnerableFunctionFromFullLanguage '[object]::Equals("A", "B")' } }
             )
         }
@@ -597,7 +597,7 @@ try
                 Invoke-LanguageModeTestingSupportCmdlet -EnableFullLanguageMode
             }
 
-            $exception.FullyQualifiedErrorId | Should Match "MethodInvocationNotSupportedInConstrainedLanguage"
+            $exception.FullyQualifiedErrorId | Should -Match "MethodInvocationNotSupportedInConstrainedLanguage"
         }
     }
 
@@ -623,7 +623,7 @@ try
                 Invoke-LanguageModeTestingSupportCmdlet -EnableFullLanguageMode
             }
 
-            $exception.FullyQualifiedErrorId | Should Match "MethodInvocationNotSupportedInConstrainedLanguage"
+            $exception.FullyQualifiedErrorId | Should -Match "MethodInvocationNotSupportedInConstrainedLanguage"
         }
 
         It "Verifies dynamic methods invocation does not bypass constrained language mode" {
@@ -646,7 +646,7 @@ try
                 Invoke-LanguageModeTestingSupportCmdlet -EnableFullLanguageMode
             }
 
-            $exception.FullyQualifiedErrorId | Should Match "MethodInvocationNotSupportedInConstrainedLanguage"
+            $exception.FullyQualifiedErrorId | Should -Match "MethodInvocationNotSupportedInConstrainedLanguage"
         }
     }
 
@@ -665,14 +665,14 @@ try
                 Invoke-LanguageModeTestingSupportCmdlet -EnableFullLanguageMode
             }
 
-            $result.Count | Should Be 0
+            $result.Count | Should -Be 0
         }
     }
 
     Describe "Variable AllScope in constrained language mode" -Tags 'Feature','RequireAdminOnWindows' {
 
         It "Verifies Set-Variable cannot create AllScope in constrained language" {
-        
+
             try
             {
                 Invoke-LanguageModeTestingSupportCmdlet -EnableConstrainedLanguageMode
@@ -689,11 +689,11 @@ try
                 Invoke-LanguageModeTestingSupportCmdlet -EnableFullLanguageMode
             }
 
-            $exception.FullyQualifiedErrorId | Should Match "NotSupported"
+            $exception.FullyQualifiedErrorId | Should -Match "NotSupported"
         }
 
         It "Verifies New-Variable cannot create AllScope in constrained language" {
-        
+
             try
             {
                 Invoke-LanguageModeTestingSupportCmdlet -EnableConstrainedLanguageMode
@@ -710,7 +710,7 @@ try
                 Invoke-LanguageModeTestingSupportCmdlet -EnableFullLanguageMode
             }
 
-            $exception.FullyQualifiedErrorId | Should Match "NotSupported"
+            $exception.FullyQualifiedErrorId | Should -Match "NotSupported"
         }
     }
 
@@ -746,8 +746,8 @@ try
                 Invoke-LanguageModeTestingSupportCmdlet -EnableFullLanguageMode
             }
 
-            $exception1.FullyQualifiedErrorId | Should Match "DataSectionAllowedCommandDisallowed"
-            $exception2.FullyQualifiedErrorId | Should Match "DataSectionAllowedCommandDisallowed"
+            $exception1.FullyQualifiedErrorId | Should -Match "DataSectionAllowedCommandDisallowed"
+            $exception2.FullyQualifiedErrorId | Should -Match "DataSectionAllowedCommandDisallowed"
         }
 
         It "Verifies data section with no-constant expression Add-Type additional command is disallowed in constrained language" {
@@ -769,7 +769,7 @@ try
                 Invoke-LanguageModeTestingSupportCmdlet -EnableFullLanguageMode
             }
 
-            $exception.FullyQualifiedErrorId | Should Match "DataSectionAllowedCommandDisallowed"
+            $exception.FullyQualifiedErrorId | Should -Match "DataSectionAllowedCommandDisallowed"
         }
     }
 
@@ -795,7 +795,7 @@ try
                 Invoke-LanguageModeTestingSupportCmdlet -EnableFullLanguageMode
             }
 
-            $exception.FullyQualifiedErrorId | Should Match "CannotDefineSupportedCommand"
+            $exception.FullyQualifiedErrorId | Should -Match "CannotDefineSupportedCommand"
         }
     }
 
@@ -877,7 +877,7 @@ try
                 @{testName = "Verify foreach statement with embedded method call in constrained language is disallowed"; script = $script3 }
                 @{testName = "Verify where statement with embedded method call in constrained language is disallowed"; script = $script4 }
             )
-        }        
+        }
 
         It "<testName>" -TestCases $TestCasesForeach {
 
@@ -903,7 +903,7 @@ try
                 Invoke-LanguageModeTestingSupportCmdlet -EnableFullLanguageMode
             }
 
-            $exception.FullyQualifiedErrorId | Should Match "MethodInvocationNotSupportedInConstrainedLanguage"
+            $exception.FullyQualifiedErrorId | Should -Match "MethodInvocationNotSupportedInConstrainedLanguage"
         }
     }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/ExecutionPolicy.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/ExecutionPolicy.Tests.ps1
@@ -8,23 +8,23 @@ Describe "ExecutionPolicy" -Tags "CI" {
 
     Context "Check Get-ExecutionPolicy behavior" {
         It "Should unrestricted when not on Windows" -Skip:$IsWindows {
-            Get-ExecutionPolicy | Should Be Unrestricted
+            Get-ExecutionPolicy | Should -Be Unrestricted
         }
 
         It "Should return Microsoft.Powershell.ExecutionPolicy PSObject on Windows" -Skip:($IsLinux -Or $IsMacOS) {
-            Get-ExecutionPolicy | Should BeOfType Microsoft.Powershell.ExecutionPolicy
+            Get-ExecutionPolicy | Should -BeOfType Microsoft.Powershell.ExecutionPolicy
         }
     }
 
     Context "Check Set-ExecutionPolicy behavior" {
         It "Should throw PlatformNotSupported when not on Windows" -Skip:$IsWindows {
-            { Set-ExecutionPolicy Unrestricted } | Should Throw "Operation is not supported on this platform."
+            { Set-ExecutionPolicy Unrestricted } | Should -Throw "Operation is not supported on this platform."
         }
 
         It "Should succeed on Windows" -Skip:($IsLinux -Or $IsMacOS) {
             # We use the Process scope to avoid affecting the system
             # Unrestricted is assumed "safe", otherwise these tests would not be running
-            { Set-ExecutionPolicy -Force -Scope Process -ExecutionPolicy Unrestricted } | Should Not Throw
+            Set-ExecutionPolicy -Force -Scope Process -ExecutionPolicy Unrestricted
         }
     }
 }
@@ -63,10 +63,10 @@ try {
 
                     # 'Get-Help Get-Disk' should return one result back
                     Set-ExecutionPolicy -ExecutionPolicy Restricted -Force -ErrorAction Stop
-                    (Get-Help -Name Get-Disk -ErrorAction Stop).Name | Should Be 'Get-Disk'
+                    (Get-Help -Name Get-Disk -ErrorAction Stop).Name | Should -Be 'Get-Disk'
                 }
                 catch {
-                    $_.ToString | should be null
+                    $_.ToString | Should -Be null
                 }
                 finally
                 {
@@ -528,10 +528,10 @@ ZoneId=$FileType
 
         Context "Prereq: Validate that 'Microsoft.PowerShell.Archive' is signed" {
             It "'Microsoft.PowerShell.Archive' should have a signature" {
-                $script:archiveAllCert | should not be null
+                $script:archiveAllCert | Should -Not -BeNullOrEmpty
             }
             It "'Microsoft.PowerShell.Archive' should have a valid signature" {
-                $script:archiveCert | should not be null
+                $script:archiveCert | Should -Not -BeNullOrEmpty
             }
         }
 
@@ -568,12 +568,12 @@ ZoneId=$FileType
                         $exception = $_
                     }
 
-                    $exception.Exception | Should Not BeNullOrEmpty
+                    $exception.Exception | Should -Not -BeNullOrEmpty
 
                     $exceptionType = $exception.Exception.getType()
                     $result = $exceptionType
 
-                    $result |  Should be "System.Management.Automation.PSSecurityException"
+                    $result | Should -Be "System.Management.Automation.PSSecurityException"
                 }
             }
 
@@ -638,7 +638,7 @@ ZoneId=$FileType
 
                     $result = & $scriptName
 
-                    $result |  Should be $expected
+                    $result | Should -Be $expected
                 }
             }
 
@@ -688,7 +688,7 @@ ZoneId=$FileType
                 }
                 else
                 {
-                    $testScript | Should Not throw
+                    $testScript | Should -Not -throw
                 }
             }
         }
@@ -719,7 +719,7 @@ ZoneId=$FileType
                     $result = & $scriptName
                     return $result
 
-                    $result |  Should be $expected
+                    $result | Should -Be $expected
                 }
             }
 
@@ -773,7 +773,7 @@ ZoneId=$FileType
                     $scriptName=$testScript
 
                     $scriptResult = $null
-                    $exception = $null
+                    $exception    = $null
 
                     try
                     {
@@ -787,19 +787,19 @@ ZoneId=$FileType
                     $errorType = $null
                     if($null -ne $exception)
                     {
-                        $errorType = $exception.exception.getType()
+                        $errorType    = $exception.exception.getType()
                         $scriptResult = $null
                     }
                     $result = @{
-                        "result" = $scriptResult
+                        "result"    = $scriptResult
                         "exception" = $errorType
                     }
 
                     $actualResult = $result."result"
-                    $actualError = $result."exception"
+                    $actualError  = $result."exception"
 
-                    $actualResult |  Should be $expected
-                    $actualError | Should be $error
+                    $actualResult | Should -Be $expected
+                    $actualError  | Should -Be $error
                 }
             }
             $message = "Hello"
@@ -933,7 +933,7 @@ ZoneId=$FileType
                 }
                 else
                 {
-                    $testScript | Should Not throw
+                    $testScript | Should -Not -Throw
                 }
             }
 
@@ -1025,14 +1025,14 @@ ZoneId=$FileType
             )
             It "$TestTypePrefix Running <testScript> Script should throw '<error>'" -TestCases $testData  {
                 param([string]$testScript, [string]$error)
-                $testScript | should exist
+                $testScript | Should -Exist
                 if($error)
                 {
                     {& $testScript} | ShouldBeErrorId $error
                 }
                 else
                 {
-                    {& $testScript} | Should Not throw
+                    {& $testScript} | Should -Not -Throw
                 }
             }
         }
@@ -1049,7 +1049,7 @@ ZoneId=$FileType
             throw "No Exception!"
         }
         catch {
-            $_.FullyQualifiedErrorId | Should Be "CantSetGroupPolicy,Microsoft.PowerShell.Commands.SetExecutionPolicyCommand"
+            $_.FullyQualifiedErrorId | Should -Be "CantSetGroupPolicy,Microsoft.PowerShell.Commands.SetExecutionPolicyCommand"
         }
     }
 
@@ -1124,12 +1124,12 @@ ZoneId=$FileType
 
         It "-Scope Process is Settable" {
             Set-ExecutionPolicy -Scope Process -ExecutionPolicy ByPass
-            Get-ExecutionPolicy -Scope Process | Should Be "ByPass"
+            Get-ExecutionPolicy -Scope Process | Should -Be "ByPass"
         }
 
         It "-Scope CurrentUser is Settable" {
             Set-ExecutionPolicy -Scope CurrentUser -ExecutionPolicy ByPass
-            Get-ExecutionPolicy -Scope CurrentUser | Should Be "ByPass"
+            Get-ExecutionPolicy -Scope CurrentUser | Should -Be "ByPass"
         }
     }
 
@@ -1170,10 +1170,10 @@ ZoneId=$FileType
                 throw "Expected exception: ExecutionPolicyOverride"
             }
             catch [System.Security.SecurityException] {
-                $_.FullyQualifiedErrorId | Should Be 'ExecutionPolicyOverride,Microsoft.PowerShell.Commands.SetExecutionPolicyCommand'
+                $_.FullyQualifiedErrorId | Should -Be 'ExecutionPolicyOverride,Microsoft.PowerShell.Commands.SetExecutionPolicyCommand'
             }
 
-            Get-ExecutionPolicy -Scope LocalMachine | Should Be "ByPass"
+            Get-ExecutionPolicy -Scope LocalMachine | Should -Be "ByPass"
         }
 
         It '-Scope LocalMachine is Settable' {
@@ -1183,7 +1183,7 @@ ZoneId=$FileType
             Set-ExecutionPolicy -Scope CurrentUser -ExecutionPolicy Undefined
 
             Set-ExecutionPolicy -Scope LocalMachine -ExecutionPolicy ByPass
-            Get-ExecutionPolicy -Scope LocalMachine | Should Be "ByPass"
+            Get-ExecutionPolicy -Scope LocalMachine | Should -Be "ByPass"
         }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/ExecutionPolicy.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/ExecutionPolicy.Tests.ps1
@@ -24,7 +24,7 @@ Describe "ExecutionPolicy" -Tags "CI" {
         It "Should succeed on Windows" -Skip:($IsLinux -Or $IsMacOS) {
             # We use the Process scope to avoid affecting the system
             # Unrestricted is assumed "safe", otherwise these tests would not be running
-            { Set-ExecutionPolicy -Force -Scope Process -ExecutionPolicy Unrestricted } | -Should -Not -Throw
+            { Set-ExecutionPolicy -Force -Scope Process -ExecutionPolicy Unrestricted } | Should -Not -Throw
         }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/ExecutionPolicy.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/ExecutionPolicy.Tests.ps1
@@ -688,7 +688,7 @@ ZoneId=$FileType
                 }
                 else
                 {
-                    $testScript  | Should -Not -Throw
+                    $testScript | Should -Not -Throw
                 }
             }
         }

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/ExecutionPolicy.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/ExecutionPolicy.Tests.ps1
@@ -688,7 +688,7 @@ ZoneId=$FileType
                 }
                 else
                 {
-                    $testScript | Should -Not -Throw
+                    {& $testScript} | Should -Not -Throw
                 }
             }
         }
@@ -933,7 +933,7 @@ ZoneId=$FileType
                 }
                 else
                 {
-                    $testScript | Should Not throw
+                    {& $testScript} | Should -Not -Throw
                 }
             }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/ExecutionPolicy.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/ExecutionPolicy.Tests.ps1
@@ -688,7 +688,7 @@ ZoneId=$FileType
                 }
                 else
                 {
-                    $testScript | Should -Not -throw
+                    & $testScript
                 }
             }
         }
@@ -933,7 +933,7 @@ ZoneId=$FileType
                 }
                 else
                 {
-                    $testScript | Should -Not -Throw
+                    & $testScript
                 }
             }
 
@@ -1032,7 +1032,7 @@ ZoneId=$FileType
                 }
                 else
                 {
-                    {& $testScript} | Should -Not -Throw
+                    {& $testScript}
                 }
             }
         }

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/ExecutionPolicy.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/ExecutionPolicy.Tests.ps1
@@ -24,7 +24,7 @@ Describe "ExecutionPolicy" -Tags "CI" {
         It "Should succeed on Windows" -Skip:($IsLinux -Or $IsMacOS) {
             # We use the Process scope to avoid affecting the system
             # Unrestricted is assumed "safe", otherwise these tests would not be running
-            Set-ExecutionPolicy -Force -Scope Process -ExecutionPolicy Unrestricted
+            { Set-ExecutionPolicy -Force -Scope Process -ExecutionPolicy Unrestricted } | -Should -Not -Throw
         }
     }
 }
@@ -528,10 +528,10 @@ ZoneId=$FileType
 
         Context "Prereq: Validate that 'Microsoft.PowerShell.Archive' is signed" {
             It "'Microsoft.PowerShell.Archive' should have a signature" {
-                $script:archiveAllCert | Should -Not -BeNullOrEmpty
+                $script:archiveAllCert | should not be null
             }
             It "'Microsoft.PowerShell.Archive' should have a valid signature" {
-                $script:archiveCert | Should -Not -BeNullOrEmpty
+                $script:archiveCert | should not be null
             }
         }
 
@@ -688,7 +688,7 @@ ZoneId=$FileType
                 }
                 else
                 {
-                    & $testScript
+                    $testScript  | Should -Not -Throw
                 }
             }
         }
@@ -773,7 +773,7 @@ ZoneId=$FileType
                     $scriptName=$testScript
 
                     $scriptResult = $null
-                    $exception    = $null
+                    $exception = $null
 
                     try
                     {
@@ -787,19 +787,19 @@ ZoneId=$FileType
                     $errorType = $null
                     if($null -ne $exception)
                     {
-                        $errorType    = $exception.exception.getType()
+                        $errorType = $exception.exception.getType()
                         $scriptResult = $null
                     }
                     $result = @{
-                        "result"    = $scriptResult
+                        "result" = $scriptResult
                         "exception" = $errorType
                     }
 
                     $actualResult = $result."result"
-                    $actualError  = $result."exception"
+                    $actualError = $result."exception"
 
                     $actualResult | Should -Be $expected
-                    $actualError  | Should -Be $error
+                    $actualError | Should -Be $error
                 }
             }
             $message = "Hello"
@@ -933,7 +933,7 @@ ZoneId=$FileType
                 }
                 else
                 {
-                    & $testScript
+                    $testScript | Should Not throw
                 }
             }
 
@@ -1032,7 +1032,7 @@ ZoneId=$FileType
                 }
                 else
                 {
-                    {& $testScript}
+                    {& $testScript} | Should -Not -Throw
                 }
             }
         }

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/FileCatalog.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/FileCatalog.Tests.ps1
@@ -60,7 +60,7 @@ Describe "Test suite for NewFileCatalogAndTestFileCatalogCmdlets" -Tags "CI" {
             }
 
             # Validate result properties
-            $result | Should -Be $false
+            $result | Should -BeFalse
         }
 
         It "NewFileCatalogFolder" {
@@ -316,8 +316,8 @@ Describe "Test suite for NewFileCatalogAndTestFileCatalogCmdlets" -Tags "CI" {
             $result.Status | Should -Be "ValidationFailed"
             $result.CatalogItems.Count | Should -Be 9
             $result.PathItems.Count | Should -Be 10
-            $result.CatalogItems.ContainsKey("DSCResources\NewFile.txt") | Should -Be $false
-            $result.PathItems.ContainsKey("DSCResources\NewFile.txt") | Should -Be $true
+            $result.CatalogItems.ContainsKey("DSCResources\NewFile.txt") | Should -BeFalse
+            $result.PathItems.ContainsKey("DSCResources\NewFile.txt") | Should -BeTrue
 
             # By Skipping the new added file validation will pass
             $result = Test-FileCatalog -Path $env:temp\UserConfigProv -CatalogFilePath $script:catalogPath -Detailed -FilesToSkip "NewFile.txt"
@@ -335,8 +335,8 @@ Describe "Test suite for NewFileCatalogAndTestFileCatalogCmdlets" -Tags "CI" {
             $result.Status | Should -Be "ValidationFailed"
             $result.CatalogItems.Count | Should -Be 9
             $result.PathItems.Count | Should -Be 8
-            $result.CatalogItems.ContainsKey("DSCResources\UserConfigProviderModVersion1\UserConfigProviderModVersion1.psm1") | Should -Be $true
-            $result.PathItems.ContainsKey("DSCResources\UserConfigProviderModVersion1\UserConfigProviderModVersion1.psm1") | Should -Be $false
+            $result.CatalogItems.ContainsKey("DSCResources\UserConfigProviderModVersion1\UserConfigProviderModVersion1.psm1") | Should -BeTrue
+            $result.PathItems.ContainsKey("DSCResources\UserConfigProviderModVersion1\UserConfigProviderModVersion1.psm1") | Should -BeFalse
 
             # By Skipping the deleted file validation will pass
             $result = Test-FileCatalog -Path $env:temp\UserConfigProv -CatalogFilePath $script:catalogPath -Detailed -FilesToSkip "UserConfigProviderModVersion1.psm1"
@@ -356,7 +356,7 @@ Describe "Test suite for NewFileCatalogAndTestFileCatalogCmdlets" -Tags "CI" {
             $result.PathItems.Count | Should -Be 9
             $catalogHashValue = $result.CatalogItems["DSCResources\UserConfigProviderModVersion1\UserConfigProviderModVersion1.psm1"]
             $pathHashValue = $result.PathItems["DSCResources\UserConfigProviderModVersion1\UserConfigProviderModVersion1.psm1"]
-            ($catalogHashValue -eq $pathHashValue) | Should -Be $false
+            ($catalogHashValue -eq $pathHashValue) | Should -BeFalse
 
             # By Skipping the file with modifed contents validation will pass
             $result = Test-FileCatalog -Path $env:temp\UserConfigProv -CatalogFilePath $script:catalogPath -Detailed -FilesToSkip "UserConfigProviderModVersion1.psm1"

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/FileCatalog.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/FileCatalog.Tests.ps1
@@ -27,7 +27,7 @@ Describe "Test suite for NewFileCatalogAndTestFileCatalogCmdlets" -Tags "CI" {
             if($hashTable2.ContainsKey($key))
             {
                 $keyValue2 = $hashTable2["$key"]
-                $keyValue1 | Should Be $keyValue2
+                $keyValue1 | Should -Be $keyValue2
             }
             else
             {
@@ -60,7 +60,7 @@ Describe "Test suite for NewFileCatalogAndTestFileCatalogCmdlets" -Tags "CI" {
             }
 
             # Validate result properties
-            $result | Should Be $false
+            $result | Should -Be $false
         }
 
         It "NewFileCatalogFolder" {
@@ -79,9 +79,9 @@ Describe "Test suite for NewFileCatalogAndTestFileCatalogCmdlets" -Tags "CI" {
             }
 
             # Validate result properties
-            $result.Status | Should Be "Valid"
-            $result.Signature.Status | Should Be "NotSigned"
-            $result.HashAlgorithm | Should Be "SHA1"
+            $result.Status | Should -Be "Valid"
+            $result.Signature.Status | Should -Be "NotSigned"
+            $result.HashAlgorithm | Should -Be "SHA1"
         }
 
         It "NewFileCatalogFolderWithSubFolders" {
@@ -101,9 +101,9 @@ Describe "Test suite for NewFileCatalogAndTestFileCatalogCmdlets" -Tags "CI" {
             }
 
             # Validate result properties
-            $result.Status | Should Be "Valid"
-            $result.Signature.Status | Should Be "NotSigned"
-            $result.HashAlgorithm | Should Be "SHA1"
+            $result.Status | Should -Be "Valid"
+            $result.Signature.Status | Should -Be "NotSigned"
+            $result.HashAlgorithm | Should -Be "SHA1"
         }
 
         It "NewFileCatalogWithSingleFile" {
@@ -122,7 +122,7 @@ Describe "Test suite for NewFileCatalogAndTestFileCatalogCmdlets" -Tags "CI" {
             }
 
             # Validate result properties
-            $result | Should Be "Valid"
+            $result | Should -Be "Valid"
         }
 
         It "NewFileCatalogForFilesThatDoNotSupportEmbeddedSignatures" {
@@ -143,9 +143,9 @@ Describe "Test suite for NewFileCatalogAndTestFileCatalogCmdlets" -Tags "CI" {
                 Remove-Item "$catalogPath" -Force -ErrorAction SilentlyContinue -Recurse
             }
 
-            $result.Status | Should Be "Valid"
-            $result.CatalogItems.Count | Should Be 2
-            $result.PathItems.Count | Should Be 2
+            $result.Status | Should -Be "Valid"
+            $result.CatalogItems.Count | Should -Be 2
+            $result.PathItems.Count | Should -Be 2
             CompareHashTables $result.CatalogItems $result.PathItems
             CompareHashTables $result.CatalogItems $expectedPathsAndHashes
         }
@@ -178,11 +178,11 @@ Describe "Test suite for NewFileCatalogAndTestFileCatalogCmdlets" -Tags "CI" {
                 Remove-Item "$catalogPath" -Force -ErrorAction SilentlyContinue
             }
 
-            $result.Status | Should Be "Valid"
-            $result.Signature.Status | Should Be "NotSigned"
-            $result.HashAlgorithm | Should Be "SHA1"
-            $result.CatalogItems.Count | Should Be 11
-            $result.PathItems.Count | Should Be 11
+            $result.Status | Should -Be "Valid"
+            $result.Signature.Status | Should -Be "NotSigned"
+            $result.HashAlgorithm | Should -Be "SHA1"
+            $result.CatalogItems.Count | Should -Be 11
+            $result.PathItems.Count | Should -Be 11
 
             CompareHashTables $result.CatalogItems $result.PathItems
             CompareHashTables $result.CatalogItems $expectedPathsAndHashes
@@ -217,11 +217,11 @@ Describe "Test suite for NewFileCatalogAndTestFileCatalogCmdlets" -Tags "CI" {
                 Remove-Item "$catalogPath" -Force -ErrorAction SilentlyContinue
             }
 
-            $result.Status | Should Be "Valid"
-            $result.Signature.Status | Should Be "NotSigned"
-            $result.HashAlgorithm | Should Be "SHA256"
-            $result.CatalogItems.Count | Should Be 12
-            $result.PathItems.Count | Should Be 12
+            $result.Status | Should -Be "Valid"
+            $result.Signature.Status | Should -Be "NotSigned"
+            $result.HashAlgorithm | Should -Be "SHA256"
+            $result.CatalogItems.Count | Should -Be 12
+            $result.PathItems.Count | Should -Be 12
             CompareHashTables $result.CatalogItems $result.PathItems
             CompareHashTables $result.CatalogItems $expectedPathsAndHashes
         }
@@ -244,7 +244,7 @@ Describe "Test suite for NewFileCatalogAndTestFileCatalogCmdlets" -Tags "CI" {
                 Remove-Item "$env:temp\UserConfigProv\" -Force -ErrorAction SilentlyContinue -Recurse
             }
 
-            $result | Should Be "Valid"
+            $result | Should -Be "Valid"
         }
 
         It "NewFileCatalogWithUnicodeCharactersInFileNames" -Pending {
@@ -287,11 +287,11 @@ Describe "Test suite for NewFileCatalogAndTestFileCatalogCmdlets" -Tags "CI" {
                 Remove-Item "$catalogPath" -Force -ErrorAction SilentlyContinue
             }
 
-            $result.Status | Should Be "Valid"
-            $result.Signature.Status | Should Be "NotSigned"
-            $result.HashAlgorithm | Should Be "SHA256"
-            $result.CatalogItems.Count | Should Be 11
-            $result.PathItems.Count | Should Be 11
+            $result.Status | Should -Be "Valid"
+            $result.Signature.Status | Should -Be "NotSigned"
+            $result.HashAlgorithm | Should -Be "SHA256"
+            $result.CatalogItems.Count | Should -Be 11
+            $result.PathItems.Count | Should -Be 11
             CompareHashTables $result.CatalogItems $result.PathItems
             CompareHashTables $result.CatalogItems $expectedPathsAndHashes
         }
@@ -313,15 +313,15 @@ Describe "Test suite for NewFileCatalogAndTestFileCatalogCmdlets" -Tags "CI" {
             Add-Content $env:temp\UserConfigProv\DSCResources\NewFile.txt -Value "More Data" -force
             $result = Test-FileCatalog -Path $env:temp\UserConfigProv -CatalogFilePath $script:catalogPath -Detailed
 
-            $result.Status | Should Be "ValidationFailed"
-            $result.CatalogItems.Count | Should Be 9
-            $result.PathItems.Count | Should Be 10
-            $result.CatalogItems.ContainsKey("DSCResources\NewFile.txt") | Should Be $false
-            $result.PathItems.ContainsKey("DSCResources\NewFile.txt") | Should Be $true
+            $result.Status | Should -Be "ValidationFailed"
+            $result.CatalogItems.Count | Should -Be 9
+            $result.PathItems.Count | Should -Be 10
+            $result.CatalogItems.ContainsKey("DSCResources\NewFile.txt") | Should -Be $false
+            $result.PathItems.ContainsKey("DSCResources\NewFile.txt") | Should -Be $true
 
             # By Skipping the new added file validation will pass
             $result = Test-FileCatalog -Path $env:temp\UserConfigProv -CatalogFilePath $script:catalogPath -Detailed -FilesToSkip "NewFile.txt"
-            $result.Status | Should Be "Valid"
+            $result.Status | Should -Be "Valid"
         }
 
         It "TestCatalogWhenNewFileDeletedFromFolderBeforeValidation" {
@@ -332,15 +332,15 @@ Describe "Test suite for NewFileCatalogAndTestFileCatalogCmdlets" -Tags "CI" {
             del $env:temp\UserConfigProv\DSCResources\UserConfigProviderModVersion1\UserConfigProviderModVersion1.psm1 -force -ErrorAction SilentlyContinue
             $result = Test-FileCatalog -Path $env:temp\UserConfigProv -CatalogFilePath $script:catalogPath -Detailed
 
-            $result.Status | Should Be "ValidationFailed"
-            $result.CatalogItems.Count | Should Be 9
-            $result.PathItems.Count | Should Be 8
-            $result.CatalogItems.ContainsKey("DSCResources\UserConfigProviderModVersion1\UserConfigProviderModVersion1.psm1") | Should Be $true
-            $result.PathItems.ContainsKey("DSCResources\UserConfigProviderModVersion1\UserConfigProviderModVersion1.psm1") | Should Be $false
+            $result.Status | Should -Be "ValidationFailed"
+            $result.CatalogItems.Count | Should -Be 9
+            $result.PathItems.Count | Should -Be 8
+            $result.CatalogItems.ContainsKey("DSCResources\UserConfigProviderModVersion1\UserConfigProviderModVersion1.psm1") | Should -Be $true
+            $result.PathItems.ContainsKey("DSCResources\UserConfigProviderModVersion1\UserConfigProviderModVersion1.psm1") | Should -Be $false
 
             # By Skipping the deleted file validation will pass
             $result = Test-FileCatalog -Path $env:temp\UserConfigProv -CatalogFilePath $script:catalogPath -Detailed -FilesToSkip "UserConfigProviderModVersion1.psm1"
-            $result.Status | Should Be "Valid"
+            $result.Status | Should -Be "Valid"
         }
 
         It "TestCatalogWhenFileContentModifiedBeforeValidation" {
@@ -351,16 +351,16 @@ Describe "Test suite for NewFileCatalogAndTestFileCatalogCmdlets" -Tags "CI" {
             Add-Content $env:temp\UserConfigProv\DSCResources\UserConfigProviderModVersion1\UserConfigProviderModVersion1.psm1 -Value "More Data" -Force
             $result = Test-FileCatalog -Path $env:temp\UserConfigProv -CatalogFilePath $script:catalogPath -Detailed
 
-            $result.Status | Should Be "ValidationFailed"
-            $result.CatalogItems.Count | Should Be 9
-            $result.PathItems.Count | Should Be 9
+            $result.Status | Should -Be "ValidationFailed"
+            $result.CatalogItems.Count | Should -Be 9
+            $result.PathItems.Count | Should -Be 9
             $catalogHashValue = $result.CatalogItems["DSCResources\UserConfigProviderModVersion1\UserConfigProviderModVersion1.psm1"]
             $pathHashValue = $result.PathItems["DSCResources\UserConfigProviderModVersion1\UserConfigProviderModVersion1.psm1"]
-            ($catalogHashValue -eq $pathHashValue) | Should Be $false
+            ($catalogHashValue -eq $pathHashValue) | Should -Be $false
 
             # By Skipping the file with modifed contents validation will pass
             $result = Test-FileCatalog -Path $env:temp\UserConfigProv -CatalogFilePath $script:catalogPath -Detailed -FilesToSkip "UserConfigProviderModVersion1.psm1"
-            $result.Status | Should Be "Valid"
+            $result.Status | Should -Be "Valid"
         }
     }
 
@@ -375,7 +375,7 @@ Describe "Test suite for NewFileCatalogAndTestFileCatalogCmdlets" -Tags "CI" {
             $script:catalogPath = "$env:TEMP\TestCatalogSkipSingleFileDuringValidation.cat"
             $null = New-FileCatalog -Path $testDataPath\UserConfigProv\ -CatalogFilePath $script:catalogPath -CatalogVersion 2.0
             $result = Test-FileCatalog -Path $testDataPath\UserConfigProv\ -CatalogFilePath $script:catalogPath -FilesToSkip "scriptdsc.schema"
-            $result | Should Be "Valid"
+            $result | Should -Be "Valid"
         }
 
         It "TestCatalogSkipCertainFileTypeDuringValidation" {
@@ -383,7 +383,7 @@ Describe "Test suite for NewFileCatalogAndTestFileCatalogCmdlets" -Tags "CI" {
             $script:catalogPath = "$env:TEMP\TestCatalogSkipCertainFileTypeDuringValidation.cat"
             $null = New-FileCatalog -Path $testDataPath\UserConfigProv\ -CatalogFilePath $script:catalogPath -CatalogVersion 2.0
             $result = Test-FileCatalog -Path $testDataPath\UserConfigProv\ -CatalogFilePath $script:catalogPath -FilesToSkip "*.mof"
-            $result | Should Be "Valid"
+            $result | Should -Be "Valid"
         }
 
         It "TestCatalogSkipWildCardPatternDuringValidation" {
@@ -391,7 +391,7 @@ Describe "Test suite for NewFileCatalogAndTestFileCatalogCmdlets" -Tags "CI" {
             $script:catalogPath = "$env:TEMP\TestCatalogSkipWildCardPatternDuringValidation.cat"
             $null = New-FileCatalog -Path $testDataPath\UserConfigProv\ -CatalogFilePath $script:catalogPath -CatalogVersion 1.0
             $result = Test-FileCatalog -Path $testDataPath\UserConfigProv\ -CatalogFilePath $script:catalogPath -FilesToSkip "UserConfigProvider*.psm1"
-            $result | Should Be "Valid"
+            $result | Should -Be "Valid"
         }
 
         It "TestCatalogSkipMultiplePattensDuringValidation" {
@@ -399,7 +399,7 @@ Describe "Test suite for NewFileCatalogAndTestFileCatalogCmdlets" -Tags "CI" {
             $script:catalogPath = "$env:TEMP\TestCatalogSkipMultiplePattensDuringValidation.cat"
             $null = New-FileCatalog -Path $testDataPath\UserConfigProv\ -CatalogFilePath $script:catalogPath -CatalogVersion 1.0
             $result = Test-FileCatalog -Path $testDataPath\UserConfigProv\ -CatalogFilePath $script:catalogPath -FilesToSkip "*.psd1","UserConfigProviderModVersion2.psm1","*ModVersion1.schema.mof"
-            $result | Should Be "Valid"
+            $result | Should -Be "Valid"
         }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/GetCredential.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/GetCredential.Tests.ps1
@@ -21,75 +21,75 @@ Describe "Get-Credential Test" -tag "CI" {
     }
     It "Get-Credential with message, produces a credential object" {
         $cred = $ps.AddScript("Get-Credential -UserName Joe -Message Foo").Invoke() | Select-Object -First 1
-        $cred | Should BeOfType System.Management.Automation.PSCredential
+        $cred | Should -BeOfType System.Management.Automation.PSCredential
         $netcred = $cred.GetNetworkCredential()
-        $netcred.UserName | Should be "Joe"
-        $netcred.Password | Should be "this is a test"
-        $th.ui.Streams.Prompt[-1] | Should Match "Credential:[^:]+:Foo"
+        $netcred.UserName | Should -Be "Joe"
+        $netcred.Password | Should -Be "this is a test"
+        $th.ui.Streams.Prompt[-1] | Should -Match "Credential:[^:]+:Foo"
     }
     It "Get-Credential with title, produces a credential object" {
         $cred = $ps.AddScript("Get-Credential -UserName Joe -Title CustomTitle").Invoke() | Select-Object -First 1
-        $cred | Should BeOfType System.Management.Automation.PSCredential
+        $cred | Should -BeOfType System.Management.Automation.PSCredential
         $netcred = $cred.GetNetworkCredential()
-        $netcred.UserName | Should be "Joe"
-        $netcred.Password | Should be "this is a test"
-        $th.ui.Streams.Prompt[-1] | should Match "Credential:CustomTitle:[^:]+"
+        $netcred.UserName | Should -Be "Joe"
+        $netcred.Password | Should -Be "this is a test"
+        $th.ui.Streams.Prompt[-1] | Should -Match "Credential:CustomTitle:[^:]+"
     }
     It "Get-Credential with only username, produces a credential object" {
         $cred = $ps.AddScript("Get-Credential -UserName Joe").Invoke() | Select-Object -First 1
-        $cred | Should BeOfType System.Management.Automation.PSCredential
+        $cred | Should -BeOfType System.Management.Automation.PSCredential
         $netcred = $cred.GetNetworkCredential()
-        $netcred.UserName | Should be "Joe"
-        $netcred.Password | Should be "this is a test"
-        $th.ui.Streams.Prompt[-1] | Should Match "Credential:[^:]+:[^:]+"
+        $netcred.UserName | Should -Be "Joe"
+        $netcred.Password | Should -Be "this is a test"
+        $th.ui.Streams.Prompt[-1] | Should -Match "Credential:[^:]+:[^:]+"
     }
     It "Get-Credential with title and message, produces a credential object" {
         $cred = $ps.AddScript("Get-Credential -UserName Joe -Message Foo -Title CustomTitle").Invoke() | Select-Object -First 1
-        $cred | Should BeOfType System.Management.Automation.PSCredential
+        $cred | Should -BeOfType System.Management.Automation.PSCredential
         $netcred = $cred.GetNetworkCredential()
-        $netcred.UserName | Should be "Joe"
-        $netcred.Password | Should be "this is a test"
-        $th.ui.Streams.Prompt[-1] | should be "Credential:CustomTitle:Foo"
+        $netcred.UserName | Should -Be "Joe"
+        $netcred.Password | Should -Be "this is a test"
+        $th.ui.Streams.Prompt[-1] | Should -Be "Credential:CustomTitle:Foo"
     }
     It "Get-Credential without parameters" {
         $cred = $ps.AddScript("Get-Credential").Invoke() | Select-Object -First 1
-        $cred | Should BeOfType System.Management.Automation.PSCredential
+        $cred | Should -BeOfType System.Management.Automation.PSCredential
         $netcred = $cred.GetNetworkCredential()
-        $netcred.UserName | Should be "John"
-        $netcred.Password | Should be "This is a test"
-        $th.ui.Streams.Prompt[-1] | Should Match "Credential:[^:]+:[^:]+"
+        $netcred.UserName | Should -Be "John"
+        $netcred.Password | Should -Be "This is a test"
+        $th.ui.Streams.Prompt[-1] | Should -Match "Credential:[^:]+:[^:]+"
     }
     It "Get-Credential `$null" {
         $cred = $ps.AddScript("Get-Credential `$null").Invoke() | Select-Object -First 1
-        $cred | Should BeOfType System.Management.Automation.PSCredential
+        $cred | Should -BeOfType System.Management.Automation.PSCredential
         $netcred = $cred.GetNetworkCredential()
-        $netcred.UserName | Should be "John"
-        $netcred.Password | Should be "This is a test"
-        $th.ui.Streams.Prompt[-1] | Should Match "Credential:[^:]+:[^:]+"
+        $netcred.UserName | Should -Be "John"
+        $netcred.Password | Should -Be "This is a test"
+        $th.ui.Streams.Prompt[-1] | Should -Match "Credential:[^:]+:[^:]+"
     }
     It "Get-Credential -Credential `$null" {
         $cred = $ps.AddScript("Get-Credential -Credential `$null").Invoke() | Select-Object -First 1
-        $cred | Should BeOfType System.Management.Automation.PSCredential
+        $cred | Should -BeOfType System.Management.Automation.PSCredential
         $netcred = $cred.GetNetworkCredential()
-        $netcred.UserName | Should be "John"
-        $netcred.Password | Should be "This is a test"
-        $th.ui.Streams.Prompt[-1] | Should Match "Credential:[^:]+:[^:]+"
+        $netcred.UserName | Should -Be "John"
+        $netcred.Password | Should -Be "This is a test"
+        $th.ui.Streams.Prompt[-1] | Should -Match "Credential:[^:]+:[^:]+"
     }
     it "Get-Credential Joe" {
         $cred = $ps.AddScript("Get-Credential Joe").Invoke() | Select-Object -First 1
-        $cred | Should BeOfType System.Management.Automation.PSCredential
+        $cred | Should -BeOfType System.Management.Automation.PSCredential
         $netcred = $cred.GetNetworkCredential()
-        $netcred.UserName | Should be "Joe"
-        $netcred.Password | Should be "This is a test"
-        $th.ui.Streams.Prompt[-1] | Should Match "Credential:[^:]+:[^:]+"
+        $netcred.UserName | Should -Be "Joe"
+        $netcred.Password | Should -Be "This is a test"
+        $th.ui.Streams.Prompt[-1] | Should -Match "Credential:[^:]+:[^:]+"
     }
     it "Get-Credential -Credential Joe" {
         $cred = $ps.AddScript("Get-Credential Joe").Invoke() | Select-Object -First 1
-        $cred | Should BeOfType System.Management.Automation.PSCredential
+        $cred | Should -BeOfType System.Management.Automation.PSCredential
         $netcred = $cred.GetNetworkCredential()
-        $netcred.UserName | Should be "Joe"
-        $netcred.Password | Should be "This is a test"
-        $th.ui.Streams.Prompt[-1] | Should Match "Credential:[^:]+:[^:]+"
+        $netcred.UserName | Should -Be "Joe"
+        $netcred.Password | Should -Be "This is a test"
+        $th.ui.Streams.Prompt[-1] | Should -Match "Credential:[^:]+:[^:]+"
     }
     it "Get-Credential `$credential" {
         #[SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Demo/doc/test secret.")]
@@ -97,9 +97,9 @@ Describe "Get-Credential Test" -tag "CI" {
         $credential = [pscredential]::new("John", $password)
 
         $cred = Get-Credential $credential
-        $cred | Should BeOfType System.Management.Automation.PSCredential
+        $cred | Should -BeOfType System.Management.Automation.PSCredential
         $netcred = $cred.GetNetworkCredential()
-        $netcred.UserName | Should be "John"
-        $netcred.Password | Should be "CredTest"
+        $netcred.UserName | Should -Be "John"
+        $netcred.Password | Should -Be "CredTest"
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/SecureString.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/SecureString.Tests.ps1
@@ -19,7 +19,7 @@ Describe "SecureString conversion tests" -Tags "CI" {
             throw "No Exception!"
         }
         catch {
-            $_.FullyQualifiedErrorId | should be "ParameterArgumentValidationErrorNullNotAllowed,Microsoft.PowerShell.Commands.ConvertFromSecureStringCommand"
+            $_.FullyQualifiedErrorId | Should -Be "ParameterArgumentValidationErrorNullNotAllowed,Microsoft.PowerShell.Commands.ConvertFromSecureStringCommand"
         }
 
     }
@@ -31,18 +31,18 @@ Describe "SecureString conversion tests" -Tags "CI" {
             throw "Command did not throw exception"
         }
         catch {
-            $_.FullyQualifiedErrorId | should be "Argument,Microsoft.PowerShell.Commands.ConvertFromSecureStringCommand"
+            $_.FullyQualifiedErrorId | Should -Be "Argument,Microsoft.PowerShell.Commands.ConvertFromSecureStringCommand"
         }
     }
 
     It "Can convert to a secure string" {
         $ss = ConvertTo-SecureString -AsPlainText -Force abcd
-        $ss | Should BeOfType SecureString
+        $ss | Should -BeOfType SecureString
     }
     It "can convert back from a secure string" {
         $secret = "abcd"
         $ss1 = ConvertTo-SecureString -AsPlainText -Force $secret
         $ss2 = convertfrom-securestring $ss1 | convertto-securestring
-        [pscredential]::New("user",$ss2).GetNetworkCredential().Password | should be $secret
+        [pscredential]::New("user",$ss2).GetNetworkCredential().Password | Should -Be $secret
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/certificateCommon.psm1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/certificateCommon.psm1
@@ -113,10 +113,10 @@ nMbw+XY4C8xdDnHfS6mF+Hol98dURB/MC/x3sZ3gSjKo
 function Install-TestCertificates
 {
     $script:certLocation = New-GoodCertificate
-    $script:certLocation | Should Not BeNullOrEmpty | Out-Null
+    $script:certLocation | Should -Not -BeNullOrEmpty | Out-Null
 
     $script:badCertLocation = New-BadCertificate
-    $script:badCertLocation | Should Not BeNullOrEmpty | Out-Null
+    $script:badCertLocation | Should -Not -BeNullOrEmpty | Out-Null
 
     if ($IsCoreCLR -and $IsWindows)
     {
@@ -132,7 +132,7 @@ Import-PfxCertificate $script:certLocation -CertStoreLocation cert:\CurrentUser\
 Import-Certificate $script:badCertLocation -CertStoreLocation Cert:\CurrentUser\My | ForEach-Object PSPath
 "@
             $certPaths = & $fullPowerShell -NoProfile -NonInteractive -Command $command
-            $certPaths.Count | Should Be 2 | Out-Null
+            $certPaths.Count | Should -Be 2 | Out-Null
 
             $script:importedCert = Get-ChildItem $certPaths[0]
             $script:testBadCert  = Get-ChildItem $certPaths[1]


### PR DESCRIPTION
## PR Summary
Fixes subset of #6245 
Use new dashed Pester v4 operators for tests in `Microsoft.PowerShell.Security`

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [NA] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [X] Not Applicable
    - **OR**
    - [NA] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [NA] Issue filed - Issue link:
- **Testing - New and feature**
    - [X] Not Applicable or can only be tested interactively
    - **OR**
    - [NA] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [NA] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
