### PR TITLE
Use new Pester syntax: -Parameter for Pester tests in Microsoft.PowerShell.Management module.

### DIFF
--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Add-Content.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Add-Content.Tests.ps1
@@ -7,7 +7,7 @@ Describe "Add-Content cmdlet tests" -Tags "CI" {
   Context "Add-Content should actually add content" {
     It "should Add-Content to testdrive:\$file1" {
       $result=add-content -path testdrive:\$file1 -value "ExpectedContent" -passthru
-      $result| Should -Be "ExpectedContent"
+      $result| Should -BeExactly "ExpectedContent"
     }
     It "should return expected string from testdrive:\$file1" {
       $result = get-content -path testdrive:\$file1
@@ -37,7 +37,7 @@ Describe "Add-Content cmdlet tests" -Tags "CI" {
     }
     #[BugId(BugDatabase.WindowsOutOfBandReleases, 906022)]
     It "should throw 'NotSupportedException' when you add-content to an unsupported provider" -Skip:($IsLinux -Or $IsMacOS) {
-      Try {add-content -path HKLM:\\software\\microsoft -value "ShouldNotWorkBecausePathIsUnsupported" -ea stop; Throw "Previous statement unexpectedly succeeded..."
+      Try {add-content -path HKLM:\\software\\microsoft -value "ShouldNotWorkBecausePathIsUnsupported" -ErrorAction stop; Throw "Previous statement unexpectedly succeeded..."
       } Catch {$_.FullyQualifiedErrorId | Should -Be "NotSupported,Microsoft.PowerShell.Commands.AddContentCommand"}
     }
     #[BugId(BugDatabase.WindowsOutOfBandReleases, 9058182)]
@@ -45,8 +45,8 @@ Describe "Add-Content cmdlet tests" -Tags "CI" {
       "hello","world"|add-content testdrive:\dynamicfile2.txt
       $result=get-content testdrive:\dynamicfile2.txt
       $result.length | Should -Be 2
-      $result[0]     | Should -Be "hello"
-      $result[1]     | Should -Be "world"
+      $result[0]     | Should -BeExactly "hello"
+      $result[1]     | Should -BeExactly "world"
     }
   }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Add-Content.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Add-Content.Tests.ps1
@@ -7,46 +7,46 @@ Describe "Add-Content cmdlet tests" -Tags "CI" {
   Context "Add-Content should actually add content" {
     It "should Add-Content to testdrive:\$file1" {
       $result=add-content -path testdrive:\$file1 -value "ExpectedContent" -passthru
-      $result| Should be "ExpectedContent"
+      $result| Should -Be "ExpectedContent"
     }
     It "should return expected string from testdrive:\$file1" {
       $result = get-content -path testdrive:\$file1
-      $result | Should BeExactly "ExpectedContent"
+      $result | Should -BeExactly "ExpectedContent"
     }
     It "should Add-Content to testdrive:\dynamicfile.txt with dynamic parameters" -Pending:($IsLinux -Or $IsMacOS) {#https://github.com/PowerShell/PowerShell/issues/891
       $result=add-content -path testdrive:\dynamicfile.txt -value "ExpectedContent" -passthru
-      $result| Should BeExactly "ExpectedContent"
+      $result| Should -BeExactly "ExpectedContent"
     }
     It "should return expected string from testdrive:\dynamicfile.txt" -Pending:($IsLinux -Or $IsMacOS) {#https://github.com/PowerShell/PowerShell/issues/891
       $result = get-content -path testdrive:\dynamicfile.txt
-      $result | Should BeExactly "ExpectedContent"
+      $result | Should -BeExactly "ExpectedContent"
     }
     It "should Add-Content to testdrive:\$file1 even when -Value is `$null" {
       $AsItWas=get-content testdrive:\$file1
-      {add-content -path testdrive:\$file1 -value $null -ea stop} | Should Not Throw
-      get-content testdrive:\$file1 | Should BeExactly $AsItWas
+      {add-content -path testdrive:\$file1 -value $null -ea stop} | Should -Not -Throw
+      get-content testdrive:\$file1 | Should -BeExactly $AsItWas
     }
     It "should throw 'ParameterArgumentValidationErrorNullNotAllowed' when -Path is `$null" {
       Try {add-content -path $null -value "ShouldNotWorkBecausePathIsNull" -ea stop; Throw "Previous statement unexpectedly succeeded..."
-      } Catch {$_.FullyQualifiedErrorId | Should Be "ParameterArgumentValidationErrorNullNotAllowed,Microsoft.PowerShell.Commands.AddContentCommand"}
+      } Catch {$_.FullyQualifiedErrorId | Should -Be "ParameterArgumentValidationErrorNullNotAllowed,Microsoft.PowerShell.Commands.AddContentCommand"}
     }
     #[BugId(BugDatabase.WindowsOutOfBandReleases, 903880)]
     It "should throw `"Cannot bind argument to parameter 'Path'`" when -Path is `$()" {
       Try {add-content -path $() -value "ShouldNotWorkBecausePathIsInvalid" -ea stop; Throw "Previous statement unexpectedly succeeded..."
-      } Catch {$_.FullyQualifiedErrorId | Should Be "ParameterArgumentValidationErrorNullNotAllowed,Microsoft.PowerShell.Commands.AddContentCommand"}
+      } Catch {$_.FullyQualifiedErrorId | Should -Be "ParameterArgumentValidationErrorNullNotAllowed,Microsoft.PowerShell.Commands.AddContentCommand"}
     }
     #[BugId(BugDatabase.WindowsOutOfBandReleases, 906022)]
     It "should throw 'NotSupportedException' when you add-content to an unsupported provider" -Skip:($IsLinux -Or $IsMacOS) {
       Try {add-content -path HKLM:\\software\\microsoft -value "ShouldNotWorkBecausePathIsUnsupported" -ea stop; Throw "Previous statement unexpectedly succeeded..."
-      } Catch {$_.FullyQualifiedErrorId | Should Be "NotSupported,Microsoft.PowerShell.Commands.AddContentCommand"}
+      } Catch {$_.FullyQualifiedErrorId | Should -Be "NotSupported,Microsoft.PowerShell.Commands.AddContentCommand"}
     }
     #[BugId(BugDatabase.WindowsOutOfBandReleases, 9058182)]
     It "should be able to pass multiple [string]`$objects to Add-Content through the pipeline to output a dynamic Path file" -Pending:($IsLinux -Or $IsMacOS) {#https://github.com/PowerShell/PowerShell/issues/891
       "hello","world"|add-content testdrive:\dynamicfile2.txt
       $result=get-content testdrive:\dynamicfile2.txt
-      $result.length |Should be 2
-      $result[0]     |Should be "hello"
-      $result[1]     |Should be "world"
+      $result.length | Should -Be 2
+      $result[0]     | Should -Be "hello"
+      $result[1]     | Should -Be "world"
     }
   }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Add-Content.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Add-Content.Tests.ps1
@@ -23,22 +23,19 @@ Describe "Add-Content cmdlet tests" -Tags "CI" {
     }
     It "should Add-Content to testdrive:\$file1 even when -Value is `$null" {
       $AsItWas=get-content testdrive:\$file1
-      {add-content -path testdrive:\$file1 -value $null -ea stop} | Should -Not -Throw
+      {add-content -path testdrive:\$file1 -value $null -ErrorAction Stop} | Should -Not -Throw
       get-content testdrive:\$file1 | Should -BeExactly $AsItWas
     }
     It "should throw 'ParameterArgumentValidationErrorNullNotAllowed' when -Path is `$null" {
-      Try {add-content -path $null -value "ShouldNotWorkBecausePathIsNull" -ea stop; Throw "Previous statement unexpectedly succeeded..."
-      } Catch {$_.FullyQualifiedErrorId | Should -Be "ParameterArgumentValidationErrorNullNotAllowed,Microsoft.PowerShell.Commands.AddContentCommand"}
+      { Add-Content -Path $null -Value "ShouldNotWorkBecausePathIsNull" -ErrorAction Stop } | Should -Throw -ErrorId "ParameterArgumentValidationErrorNullNotAllowed,Microsoft.PowerShell.Commands.AddContentCommand"
     }
     #[BugId(BugDatabase.WindowsOutOfBandReleases, 903880)]
     It "should throw `"Cannot bind argument to parameter 'Path'`" when -Path is `$()" {
-      Try {add-content -path $() -value "ShouldNotWorkBecausePathIsInvalid" -ea stop; Throw "Previous statement unexpectedly succeeded..."
-      } Catch {$_.FullyQualifiedErrorId | Should -Be "ParameterArgumentValidationErrorNullNotAllowed,Microsoft.PowerShell.Commands.AddContentCommand"}
+      { Add-Content -Path $() -Value "ShouldNotWorkBecausePathIsInvalid" -ErrorAction Stop } | Should -Throw -ErrorId "ParameterArgumentValidationErrorNullNotAllowed,Microsoft.PowerShell.Commands.AddContentCommand"
     }
     #[BugId(BugDatabase.WindowsOutOfBandReleases, 906022)]
     It "should throw 'NotSupportedException' when you add-content to an unsupported provider" -Skip:($IsLinux -Or $IsMacOS) {
-      Try {add-content -path HKLM:\\software\\microsoft -value "ShouldNotWorkBecausePathIsUnsupported" -ErrorAction stop; Throw "Previous statement unexpectedly succeeded..."
-      } Catch {$_.FullyQualifiedErrorId | Should -Be "NotSupported,Microsoft.PowerShell.Commands.AddContentCommand"}
+      { Add-Content -Path HKLM:\\software\\microsoft -Value "ShouldNotWorkBecausePathIsUnsupported" -ErrorAction Stop } | Should -Throw -ErrorId "NotSupported,Microsoft.PowerShell.Commands.AddContentCommand"
     }
     #[BugId(BugDatabase.WindowsOutOfBandReleases, 9058182)]
     It "should be able to pass multiple [string]`$objects to Add-Content through the pipeline to output a dynamic Path file" -Pending:($IsLinux -Or $IsMacOS) {#https://github.com/PowerShell/PowerShell/issues/891

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Alias.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Alias.Tests.ps1
@@ -21,17 +21,17 @@ Describe "Basic Alias Provider Tests" -Tags "CI" {
 
     It "Test alias dir" {
         $dirAlias = Get-Item "Alias:\dir"
-        $dirAlias.CommandType | Should -Be "Alias"
-        $dirAlias.Name | Should -Be "dir"
-        $dirAlias.Definition | Should -Be "Get-ChildItem"
+        $dirAlias.CommandType | Should -BeExactly "Alias"
+        $dirAlias.Name | Should -BeExactly "dir"
+        $dirAlias.Definition | Should -BeExactly "Get-ChildItem"
     }
 
     It "Test creating new alias" {
         try {
             $newAlias = New-Item -Path "Alias:\" -Name "NewTestAlias" -Value $testAliasValue
-            $newAlias.CommandType | Should -Be "Alias"
-            $newAlias.Name | Should -Be "NewTestAlias"
-            $newAlias.Definition | Should -Be $testAliasValue
+            $newAlias.CommandType | Should -BeExactly "Alias"
+            $newAlias.Name | Should -BeExactly "NewTestAlias"
+            $newAlias.Definition | Should -BeExactly $testAliasValue
         }
         finally {
             Remove-Item -Path "Alias:\NewTestAlias" -Force -ErrorAction SilentlyContinue
@@ -40,14 +40,14 @@ Describe "Basic Alias Provider Tests" -Tags "CI" {
 
     It "Test Get-Item on alias provider" {
         $alias = Get-Item -Path "Alias:\${testAliasName}"
-        $alias.CommandType | Should -Be "Alias"
-        $alias.Name | Should -Be $testAliasName
-        $alias.Definition | Should -Be $testAliasValue
+        $alias.CommandType | Should -BeExactly "Alias"
+        $alias.Name | Should -BeExactly $testAliasName
+        $alias.Definition | Should -BeExactly $testAliasValue
     }
 
     It "Test Test-Path on alias provider" {
         $aliasExists = Test-Path "Alias:\testAlias"
-        $aliasExists | Should -Be $true
+        $aliasExists | Should -BeTrue
     }
 
     It "Test executing the new alias" {
@@ -78,35 +78,35 @@ Describe "Extended Alias Provider Tests" -Tags "Feature" {
             $before = (Get-Item -Path "Alias:\${testAliasName}").Definition
             Set-Item -Path "Alias:\${testAliasName}" -Value "Get-Location" -Whatif
             $after = (Get-Item -Path "Alias:\${testAliasName}").Definition
-            $after | Should -Be $before # Definition should not have changed
+            $after | Should -BeExactly $before # Definition should not have changed
         }
 
         It "Verifying Confirm can be bypassed" {
             Set-Item -Path "Alias:\${testAliasName}" -Value "Get-Location" -Confirm:$false
             $result = Get-Item -Path "Alias:\${testAliasName}"
-            $result.Definition | Should -Be "Get-Location"
+            $result.Definition | Should -BeExactly "Get-Location"
         }
 
         It "Verifying Force" {
             Set-Item -Path "Alias:\${testAliasName}" -Value "Get-Location" -Force
             $result =  Get-Item -Path "Alias:\${testAliasName}"
-            $result.Definition | Should -Be "Get-Location"
+            $result.Definition | Should -BeExactly "Get-Location"
         }
 
         It "Verifying Include" {
             Set-Item -Path "Alias:\*" -Value "Get-Location" -Include "TestAlias*"
             $alias1 = Get-Item -Path "Alias:\${testAliasName}"
             $alias2 = Get-Item -Path "Alias:\${testAliasName2}"
-            $alias1.Definition | Should -Be "Get-Location"
-            $alias2.Definition | Should -Be "Get-Location"
+            $alias1.Definition | Should -BeExactly "Get-Location"
+            $alias2.Definition | Should -BeExactly "Get-Location"
         }
 
         It "Verifying Exclude" {
             Set-Item -Path "Alias:\TestAlias*" -Value "Get-Location" -Exclude "*2"
             $alias1 = Get-Item -Path "Alias:\${testAliasName}"
             $alias2 = Get-Item -Path "Alias:\${testAliasName2}"
-            $alias1.Definition | Should -Be "Get-Location"
-            $alias2.Definition | Should -Be "Get-Date"
+            $alias1.Definition | Should -BeExactly "Get-Location"
+            $alias2.Definition | Should -BeExactly "Get-Date"
         }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Alias.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Alias.Tests.ps1
@@ -52,7 +52,7 @@ Describe "Basic Alias Provider Tests" -Tags "CI" {
 
     It "Test executing the new alias" {
         $result = Invoke-Expression $testAliasName
-        $result | Should -BeOfType DateTime
+        $result | Should -BeOfType [DateTime]
     }
 }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Alias.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Alias.Tests.ps1
@@ -16,22 +16,22 @@ Describe "Basic Alias Provider Tests" -Tags "CI" {
 
     It "Test number of alias not Zero" {
         $aliases = @(Get-ChildItem "Alias:\")
-        $aliases.Count | Should Not Be 0
+        $aliases.Count | Should -Not -Be 0
     }
 
     It "Test alias dir" {
         $dirAlias = Get-Item "Alias:\dir"
-        $dirAlias.CommandType | Should Be "Alias"
-        $dirAlias.Name | Should Be "dir"
-        $dirAlias.Definition | Should Be "Get-ChildItem"
+        $dirAlias.CommandType | Should -Be "Alias"
+        $dirAlias.Name | Should -Be "dir"
+        $dirAlias.Definition | Should -Be "Get-ChildItem"
     }
 
     It "Test creating new alias" {
         try {
             $newAlias = New-Item -Path "Alias:\" -Name "NewTestAlias" -Value $testAliasValue
-            $newAlias.CommandType | Should Be "Alias"
-            $newAlias.Name | Should Be "NewTestAlias"
-            $newAlias.Definition | Should Be $testAliasValue
+            $newAlias.CommandType | Should -Be "Alias"
+            $newAlias.Name | Should -Be "NewTestAlias"
+            $newAlias.Definition | Should -Be $testAliasValue
         }
         finally {
             Remove-Item -Path "Alias:\NewTestAlias" -Force -ErrorAction SilentlyContinue
@@ -40,19 +40,19 @@ Describe "Basic Alias Provider Tests" -Tags "CI" {
 
     It "Test Get-Item on alias provider" {
         $alias = Get-Item -Path "Alias:\${testAliasName}"
-        $alias.CommandType | Should Be "Alias"
-        $alias.Name | Should Be $testAliasName
-        $alias.Definition | Should Be $testAliasValue
+        $alias.CommandType | Should -Be "Alias"
+        $alias.Name | Should -Be $testAliasName
+        $alias.Definition | Should -Be $testAliasValue
     }
 
     It "Test Test-Path on alias provider" {
         $aliasExists = Test-Path "Alias:\testAlias"
-        $aliasExists | Should Be $true
+        $aliasExists | Should -Be $true
     }
 
     It "Test executing the new alias" {
         $result = Invoke-Expression $testAliasName
-        $result | Should BeOfType DateTime
+        $result | Should -BeOfType DateTime
     }
 }
 
@@ -78,35 +78,35 @@ Describe "Extended Alias Provider Tests" -Tags "Feature" {
             $before = (Get-Item -Path "Alias:\${testAliasName}").Definition
             Set-Item -Path "Alias:\${testAliasName}" -Value "Get-Location" -Whatif
             $after = (Get-Item -Path "Alias:\${testAliasName}").Definition
-            $after | Should Be $before # Definition should not have changed
+            $after | Should -Be $before # Definition should not have changed
         }
 
         It "Verifying Confirm can be bypassed" {
             Set-Item -Path "Alias:\${testAliasName}" -Value "Get-Location" -Confirm:$false
             $result = Get-Item -Path "Alias:\${testAliasName}"
-            $result.Definition | Should Be "Get-Location"
+            $result.Definition | Should -Be "Get-Location"
         }
 
         It "Verifying Force" {
             Set-Item -Path "Alias:\${testAliasName}" -Value "Get-Location" -Force
             $result =  Get-Item -Path "Alias:\${testAliasName}"
-            $result.Definition | Should Be "Get-Location"
+            $result.Definition | Should -Be "Get-Location"
         }
 
         It "Verifying Include" {
             Set-Item -Path "Alias:\*" -Value "Get-Location" -Include "TestAlias*"
             $alias1 = Get-Item -Path "Alias:\${testAliasName}"
             $alias2 = Get-Item -Path "Alias:\${testAliasName2}"
-            $alias1.Definition | Should Be "Get-Location"
-            $alias2.Definition | Should Be "Get-Location"
+            $alias1.Definition | Should -Be "Get-Location"
+            $alias2.Definition | Should -Be "Get-Location"
         }
 
         It "Verifying Exclude" {
             Set-Item -Path "Alias:\TestAlias*" -Value "Get-Location" -Exclude "*2"
             $alias1 = Get-Item -Path "Alias:\${testAliasName}"
             $alias2 = Get-Item -Path "Alias:\${testAliasName2}"
-            $alias1.Definition | Should Be "Get-Location"
-            $alias2.Definition | Should Be "Get-Date"
+            $alias1.Definition | Should -Be "Get-Location"
+            $alias2.Definition | Should -Be "Get-Date"
         }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Clear-Content.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Clear-Content.Tests.ps1
@@ -55,13 +55,13 @@ Describe "Clear-Content cmdlet tests" -Tags "CI" {
 
   Context "Clear-Content should actually clear content" {
     It "should clear-Content of testdrive:\$file1" {
-      set-content -path testdrive:\$file1 -value "ExpectedContent" -passthru | Should -Be "ExpectedContent"
+      set-content -path testdrive:\$file1 -value "ExpectedContent" -passthru | Should -BeExactly "ExpectedContent"
       clear-content -Path testdrive:\$file1
     }
 
     It "shouldn't get any content from testdrive:\$file1" {
       $result = get-content -path testdrive:\$file1
-      $result | Should -BeExactly $null
+      $result | Should -BeNullOrEmpty
     }
 
     # we could suppress the WhatIf output here if we use the testhost, but it's not necessary
@@ -72,24 +72,24 @@ Describe "Clear-Content cmdlet tests" -Tags "CI" {
 
     It "The filesystem provider should support ShouldProcess (reference ProviderSupportsShouldProcess member)" {
       $cci = ((get-command clear-content).ImplementingType)::new()
-      $cci.SupportsShouldProcess | Should -Be $true
+      $cci.SupportsShouldProcess | Should -BeTrue
     }
 
     It "Alternate streams should be cleared with clear-content" -skip:(!$IsWindows) {
       # make sure that the content is correct
       # this is here rather than BeforeAll because only windows can write to an alternate stream
       set-content -path "TESTDRIVE:/$file3" -stream $streamName -value $streamContent
-      get-content -path "TESTDRIVE:/$file3" | Should -Be $content2
-      get-content -Path "TESTDRIVE:/$file3" -stream $streamName | Should -Be $streamContent
+      get-content -path "TESTDRIVE:/$file3" | Should -BeExactly $content2
+      get-content -Path "TESTDRIVE:/$file3" -stream $streamName | Should -BeExactly $streamContent
       clear-content -PATH "TESTDRIVE:/$file3" -stream $streamName
-      get-content -Path "TESTDRIVE:/$file3" | Should -Be $content2
+      get-content -Path "TESTDRIVE:/$file3" | Should -BeExactly $content2
       get-content -Path "TESTDRIVE:/$file3" -stream $streamName | Should -BeNullOrEmpty
     }
 
     It "the '-Stream' dynamic parameter is visible to get-command in the filesystem" -Skip:(!$IsWindows) {
       try {
         push-location TESTDRIVE:
-        (get-command clear-content -stream foo).parameters.keys -eq "stream" | Should -Be "stream"
+        (get-command clear-content -stream foo).parameters.keys | Should -Be "stream"
       }
       finally {
         pop-location

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Clear-Content.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Clear-Content.Tests.ps1
@@ -89,7 +89,7 @@ Describe "Clear-Content cmdlet tests" -Tags "CI" {
     It "the '-Stream' dynamic parameter is visible to get-command in the filesystem" -Skip:(!$IsWindows) {
       try {
         push-location TESTDRIVE:
-        (get-command clear-content -stream foo).parameters.keys -eq "stream" | should be "stream"`
+        (get-command clear-content -stream foo).parameters.keys -eq "stream" | Should -Be "stream"
       }
       finally {
         pop-location

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Clear-Content.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Clear-Content.Tests.ps1
@@ -89,7 +89,7 @@ Describe "Clear-Content cmdlet tests" -Tags "CI" {
     It "the '-Stream' dynamic parameter is visible to get-command in the filesystem" -Skip:(!$IsWindows) {
       try {
         push-location TESTDRIVE:
-        (get-command clear-content -stream foo).parameters.keys | Should -Be "stream"
+        (get-command clear-content -stream foo).parameters.keys -eq "stream" | should be "stream"`
       }
       finally {
         pop-location

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Clear-Content.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Clear-Content.Tests.ps1
@@ -114,7 +114,7 @@ Describe "Clear-Content cmdlet tests" -Tags "CI" {
   Context "Proper errors should be delivered when bad locations are specified" {
     It "should throw `"Cannot bind argument to parameter 'Path'`" when -Path is `$null" {
       try {
-        clear-content -path $null -ea stop
+        clear-content -path $null -ErrorAction Stop
         throw "expected exception was not delivered"
       }
       catch {
@@ -124,7 +124,7 @@ Describe "Clear-Content cmdlet tests" -Tags "CI" {
     #[BugId(BugDatabase.WindowsOutOfBandReleases, 903880)]
     It "should throw `"Cannot bind argument to parameter 'Path'`" when -Path is `$()" {
       try {
-        clear-content -path $() -ea stop
+        clear-content -path $() -ErrorAction Stop
         throw "expected exception was not delivered"
       }
       catch {
@@ -136,7 +136,7 @@ Describe "Clear-Content cmdlet tests" -Tags "CI" {
       $functionName = Get-NonExistantFunctionName
       $null = new-item function:$functionName -Value { 1 }
       try {
-        clear-content -path function:$functionName -ea Stop
+        clear-content -path function:$functionName -ErrorAction Stop
         throw "Expected exception was not thrown"
       }
       catch {
@@ -146,7 +146,7 @@ Describe "Clear-Content cmdlet tests" -Tags "CI" {
     It "should throw FileNotFound error when referencing a non-existant file" {
       try {
         $badFile = "TESTDRIVE:/badfilename.txt"
-        clear-content -path $badFile -ea Stop
+        clear-content -path $badFile -ErrorAction Stop
         throw "ExpectedExceptionNotDelivered"
       }
       catch {
@@ -156,7 +156,7 @@ Describe "Clear-Content cmdlet tests" -Tags "CI" {
     It "should throw DriveNotFound error when referencing a non-existant drive" {
        try {
          $badDrive = "{0}:/file.txt" -f (Get-NonExistantDriveName)
-         clear-content -path $badDrive -ea Stop
+         clear-content -path $badDrive -ErrorAction Stop
          thow "ExpectedExceptionNotDelivered"
        }
        catch {
@@ -167,7 +167,7 @@ Describe "Clear-Content cmdlet tests" -Tags "CI" {
     It "should throw ProviderNotFound error when referencing a non-existant provider" {
        try {
          $badProviderPath = "{0}::C:/file.txt" -f (Get-NonExistantProviderName)
-         clear-content -path $badProviderPath -ea Stop
+         clear-content -path $badProviderPath -ErrorAction Stop
          thow "ExpectedExceptionNotDelivered"
        }
        catch {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Clear-Content.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Clear-Content.Tests.ps1
@@ -55,41 +55,41 @@ Describe "Clear-Content cmdlet tests" -Tags "CI" {
 
   Context "Clear-Content should actually clear content" {
     It "should clear-Content of testdrive:\$file1" {
-      set-content -path testdrive:\$file1 -value "ExpectedContent" -passthru | Should be "ExpectedContent"
+      set-content -path testdrive:\$file1 -value "ExpectedContent" -passthru | Should -Be "ExpectedContent"
       clear-content -Path testdrive:\$file1
     }
 
     It "shouldn't get any content from testdrive:\$file1" {
       $result = get-content -path testdrive:\$file1
-      $result | Should BeExactly $null
+      $result | Should -BeExactly $null
     }
 
     # we could suppress the WhatIf output here if we use the testhost, but it's not necessary
     It "The filesystem provider supports should process" -skip:(!$IsWindows) {
       clear-content TESTDRIVE:\$file2 -WhatIf
-      "TESTDRIVE:\$file2" | should FileContentMatch "This is content"
+      "TESTDRIVE:\$file2" | Should -FileContentMatch "This is content"
     }
 
     It "The filesystem provider should support ShouldProcess (reference ProviderSupportsShouldProcess member)" {
       $cci = ((get-command clear-content).ImplementingType)::new()
-      $cci.SupportsShouldProcess | should be $true
+      $cci.SupportsShouldProcess | Should -Be $true
     }
 
     It "Alternate streams should be cleared with clear-content" -skip:(!$IsWindows) {
       # make sure that the content is correct
       # this is here rather than BeforeAll because only windows can write to an alternate stream
       set-content -path "TESTDRIVE:/$file3" -stream $streamName -value $streamContent
-      get-content -path "TESTDRIVE:/$file3" | Should be $content2
-      get-content -Path "TESTDRIVE:/$file3" -stream $streamName | should be $streamContent
+      get-content -path "TESTDRIVE:/$file3" | Should -Be $content2
+      get-content -Path "TESTDRIVE:/$file3" -stream $streamName | Should -Be $streamContent
       clear-content -PATH "TESTDRIVE:/$file3" -stream $streamName
-      get-content -Path "TESTDRIVE:/$file3" | should be $content2
-      get-content -Path "TESTDRIVE:/$file3" -stream $streamName | should BeNullOrEmpty
+      get-content -Path "TESTDRIVE:/$file3" | Should -Be $content2
+      get-content -Path "TESTDRIVE:/$file3" -stream $streamName | Should -BeNullOrEmpty
     }
 
     It "the '-Stream' dynamic parameter is visible to get-command in the filesystem" -Skip:(!$IsWindows) {
       try {
         push-location TESTDRIVE:
-        (get-command clear-content -stream foo).parameters.keys -eq "stream" | should be "stream"
+        (get-command clear-content -stream foo).parameters.keys -eq "stream" | Should -Be "stream"
       }
       finally {
         pop-location
@@ -103,7 +103,7 @@ Describe "Clear-Content cmdlet tests" -Tags "CI" {
         throw "ExpectedExceptionNotDelivered"
       }
       catch {
-        $_.FullyQualifiedErrorId | should be "NamedParameterNotFound,Microsoft.PowerShell.Commands.GetCommandCommand"
+        $_.FullyQualifiedErrorId | Should -Be "NamedParameterNotFound,Microsoft.PowerShell.Commands.GetCommandCommand"
       }
       finally {
         pop-location
@@ -118,7 +118,7 @@ Describe "Clear-Content cmdlet tests" -Tags "CI" {
         throw "expected exception was not delivered"
       }
       catch {
-        $_.FullyQualifiedErrorId | should be "ParameterArgumentValidationErrorNullNotAllowed,Microsoft.PowerShell.Commands.ClearContentCommand"
+        $_.FullyQualifiedErrorId | Should -Be "ParameterArgumentValidationErrorNullNotAllowed,Microsoft.PowerShell.Commands.ClearContentCommand"
       }
     }
     #[BugId(BugDatabase.WindowsOutOfBandReleases, 903880)]
@@ -128,7 +128,7 @@ Describe "Clear-Content cmdlet tests" -Tags "CI" {
         throw "expected exception was not delivered"
       }
       catch {
-        $_.FullyQualifiedErrorId | should be "ParameterArgumentValidationErrorNullNotAllowed,Microsoft.PowerShell.Commands.ClearContentCommand"
+        $_.FullyQualifiedErrorId | Should -Be "ParameterArgumentValidationErrorNullNotAllowed,Microsoft.PowerShell.Commands.ClearContentCommand"
       }
     }
     #[DRT][BugId(BugDatabase.WindowsOutOfBandReleases, 906022)]
@@ -140,7 +140,7 @@ Describe "Clear-Content cmdlet tests" -Tags "CI" {
         throw "Expected exception was not thrown"
       }
       catch {
-        $_.FullyQualifiedErrorId | should be "NotSupported,Microsoft.PowerShell.Commands.ClearContentCommand"
+        $_.FullyQualifiedErrorId | Should -Be "NotSupported,Microsoft.PowerShell.Commands.ClearContentCommand"
       }
     }
     It "should throw FileNotFound error when referencing a non-existant file" {
@@ -150,7 +150,7 @@ Describe "Clear-Content cmdlet tests" -Tags "CI" {
         throw "ExpectedExceptionNotDelivered"
       }
       catch {
-        $_.FullyQualifiedErrorId | should be "PathNotFound,Microsoft.PowerShell.Commands.ClearContentCommand"
+        $_.FullyQualifiedErrorId | Should -Be "PathNotFound,Microsoft.PowerShell.Commands.ClearContentCommand"
       }
     }
     It "should throw DriveNotFound error when referencing a non-existant drive" {
@@ -160,7 +160,7 @@ Describe "Clear-Content cmdlet tests" -Tags "CI" {
          thow "ExpectedExceptionNotDelivered"
        }
        catch {
-         $_.FullyQualifiedErrorId | Should be "DriveNotFound,Microsoft.PowerShell.Commands.ClearContentCommand"
+         $_.FullyQualifiedErrorId | Should -Be "DriveNotFound,Microsoft.PowerShell.Commands.ClearContentCommand"
        }
     }
     # we'll use a provider qualified path to produce this error
@@ -171,7 +171,7 @@ Describe "Clear-Content cmdlet tests" -Tags "CI" {
          thow "ExpectedExceptionNotDelivered"
        }
        catch {
-         $_.FullyQualifiedErrorId | Should be "ProviderNotFound,Microsoft.PowerShell.Commands.ClearContentCommand"
+         $_.FullyQualifiedErrorId | Should -Be "ProviderNotFound,Microsoft.PowerShell.Commands.ClearContentCommand"
        }
     }
   }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Clear-EventLog.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Clear-EventLog.Tests.ps1
@@ -13,22 +13,22 @@ Describe "Clear-EventLog cmdlet tests" -Tags @('CI', 'RequireAdminOnWindows') {
 
     It "should be able to Clear-EventLog" -Pending:($True) {
       Remove-EventLog -LogName TestLog -ea Ignore
-      {New-EventLog -LogName TestLog -Source TestSource -ea Stop} | Should Not Throw
-      {Write-EventLog -LogName TestLog -Source TestSource -Message "Test" -EventID 1 -ea stop } | Should Not Throw
-      {$result=Get-EventLog -LogName TestLog}                     | Should Not Throw
-      ($result.Count)                                             | Should be 1
-      {Clear-EventLog -LogName TestLog}                           | Should Not Throw
+      {New-EventLog -LogName TestLog -Source TestSource -ea Stop} | Should -Not -Throw
+      {Write-EventLog -LogName TestLog -Source TestSource -Message "Test" -EventID 1 -ea stop } | Should -Not -Throw
+      {$result=Get-EventLog -LogName TestLog}                     | Should -Not -Throw
+      ($result.Count)                                             | Should -Be 1
+      {Clear-EventLog -LogName TestLog}                           | Should -Not -Throw
       $result=Get-EventLog -LogName TestLog -ea Ignore
-      ($result.Count)                                             | Should be 0
-      {Remove-EventLog -LogName TestLog -ea Stop}                 | Should Not Throw
+      ($result.Count)                                             | Should -Be 0
+      {Remove-EventLog -LogName TestLog -ea Stop}                 | Should -Not -Throw
     }
     It "should throw 'The Log name 'MissingTestLog' does not exist' when asked to clear a log that does not exist" -Pending:($True) {
       Remove-EventLog -LogName MissingTestLog -ea Ignore
       try {Clear-EventLog -LogName MissingTestLog -ea stop; Throw "Previous statement unexpectedly succeeded..."
-      } catch {$_.FullyQualifiedErrorId      | Should Be "Microsoft.PowerShell.Commands.ClearEventLogCommand"}
+      } catch {$_.FullyQualifiedErrorId      | Should -Be "Microsoft.PowerShell.Commands.ClearEventLogCommand"}
     }
     It "should throw 'System.InvalidOperationException' when asked to clear a log that does not exist" -Pending:($True) {
       try {Clear-EventLog -LogName MissingTestLog -ea stop; Throw "Previous statement unexpectedly succeeded..."
-      } catch {$_.FullyQualifiedErrorId      | Should Be "Microsoft.PowerShell.Commands.ClearEventLogCommand"}
+      } catch {$_.FullyQualifiedErrorId      | Should -Be "Microsoft.PowerShell.Commands.ClearEventLogCommand"}
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Clear-EventLog.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Clear-EventLog.Tests.ps1
@@ -13,22 +13,20 @@ Describe "Clear-EventLog cmdlet tests" -Tags @('CI', 'RequireAdminOnWindows') {
 
     It "should be able to Clear-EventLog" -Pending:($True) {
       Remove-EventLog -LogName TestLog -ea Ignore
-      {New-EventLog -LogName TestLog -Source TestSource -ea Stop} | Should -Not -Throw
-      {Write-EventLog -LogName TestLog -Source TestSource -Message "Test" -EventID 1 -ea stop } | Should -Not -Throw
+      {New-EventLog -LogName TestLog -Source TestSource -ErrorAction Stop} | Should -Not -Throw
+      {Write-EventLog -LogName TestLog -Source TestSource -Message "Test" -EventID 1 -ErrorAction Stop } | Should -Not -Throw
       {$result=Get-EventLog -LogName TestLog}                     | Should -Not -Throw
       ($result.Count)                                             | Should -Be 1
       {Clear-EventLog -LogName TestLog}                           | Should -Not -Throw
       $result=Get-EventLog -LogName TestLog -ea Ignore
       ($result.Count)                                             | Should -Be 0
-      {Remove-EventLog -LogName TestLog -ea Stop}                 | Should -Not -Throw
+      {Remove-EventLog -LogName TestLog -ErrorAction Stop}        | Should -Not -Throw
     }
     It "should throw 'The Log name 'MissingTestLog' does not exist' when asked to clear a log that does not exist" -Pending:($True) {
       Remove-EventLog -LogName MissingTestLog -ea Ignore
-      try {Clear-EventLog -LogName MissingTestLog -ea stop; Throw "Previous statement unexpectedly succeeded..."
-      } catch {$_.FullyQualifiedErrorId      | Should -Be "Microsoft.PowerShell.Commands.ClearEventLogCommand"}
+      { Clear-EventLog -LogName MissingTestLog -ErrorAction Stop } | Should -Throw -ErrorId "Microsoft.PowerShell.Commands.ClearEventLogCommand"
     }
     It "should throw 'System.InvalidOperationException' when asked to clear a log that does not exist" -Pending:($True) {
-      try {Clear-EventLog -LogName MissingTestLog -ea stop; Throw "Previous statement unexpectedly succeeded..."
-      } catch {$_.FullyQualifiedErrorId      | Should -Be "Microsoft.PowerShell.Commands.ClearEventLogCommand"}
+      { Clear-EventLog -LogName MissingTestLog -ErrorAction Stop } | Should -Throw -ErrorId "Microsoft.PowerShell.Commands.ClearEventLogCommand"
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Clear-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Clear-Item.Tests.ps1
@@ -5,9 +5,9 @@ Describe "Clear-Item tests" -Tag "CI" {
         ${myClearItemVariableTest} = "Value is here"
     }
     It "Clear-Item can clear an item" {
-        $myClearItemVariableTest | Should be "Value is here"
+        $myClearItemVariableTest | Should -Be "Value is here"
         Clear-Item variable:myClearItemVariableTest
-        test-path variable:myClearItemVariableTest | should be $true
-        $myClearItemVariableTest | Should BeNullOrEmpty
+        test-path variable:myClearItemVariableTest | Should -Be $true
+        $myClearItemVariableTest | Should -BeNullOrEmpty
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Clear-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Clear-Item.Tests.ps1
@@ -5,9 +5,9 @@ Describe "Clear-Item tests" -Tag "CI" {
         ${myClearItemVariableTest} = "Value is here"
     }
     It "Clear-Item can clear an item" {
-        $myClearItemVariableTest | Should -Be "Value is here"
+        $myClearItemVariableTest | Should -BeExactly "Value is here"
         Clear-Item variable:myClearItemVariableTest
-        test-path variable:myClearItemVariableTest | Should -Be $true
+        test-path variable:myClearItemVariableTest | Should -BeTrue
         $myClearItemVariableTest | Should -BeNullOrEmpty
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/ControlService.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/ControlService.Tests.ps1
@@ -42,18 +42,18 @@ Describe "Control Service cmdlet tests" -Tags "Feature","RequireAdminOnWindows" 
         $wasStopped = $true
         $spooler = Start-Service Spooler -PassThru
       }
-      $spooler.Status | Should -Be "Running"
+      $spooler.Status | Should -BeExactly "Running"
       $spooler = Stop-Service Spooler -PassThru
-      $spooler.Status | Should -Be "Stopped"
-      (Get-Service Spooler).Status | Should -Be "Stopped"
+      $spooler.Status | Should -BeExaclty "Stopped"
+      (Get-Service Spooler).Status | Should -BeExactly "Stopped"
       $spooler = Start-Service Spooler -PassThru
-      $spooler.Status | Should -Be "Running"
-      (Get-Service Spooler).Status | Should -Be "Running"
+      $spooler.Status | Should -BeExactly "Running"
+      (Get-Service Spooler).Status | Should -BeExactly "Running"
       Stop-Service Spooler
-      (Get-Service Spooler).Status | Should -Be "Stopped"
+      (Get-Service Spooler).Status | Should -BeExactly "Stopped"
       $spooler = Restart-Service Spooler -PassThru
-      $spooler.Status | Should -Be "Running"
-      (Get-Service Spooler).Status | Should -Be "Running"
+      $spooler.Status | Should -BeExactly "Running"
+      (Get-Service Spooler).Status | Should -BeExactly "Running"
     } finally {
       if ($wasStopped) {
         Stop-Service Spooler
@@ -72,9 +72,9 @@ Describe "Control Service cmdlet tests" -Tags "Feature","RequireAdminOnWindows" 
       }
       $service | Should -Not -BeNullOrEmpty
       Suspend-Service $serviceName
-      (Get-Service $serviceName).Status | Should -Be "Paused"
+      (Get-Service $serviceName).Status | Should -BeExactly "Paused"
       Resume-Service $serviceName
-      (Get-Service $serviceName).Status | Should -Be "Running"
+      (Get-Service $serviceName).Status | Should -BeExactly "Running"
     } finally {
       Set-Service $serviceName -Status $originalState
     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/ControlService.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/ControlService.Tests.ps1
@@ -20,7 +20,7 @@ Describe "Control Service cmdlet tests" -Tags "Feature","RequireAdminOnWindows" 
     param($parameter, $value)
     $stopservicecmd = [Microsoft.PowerShell.Commands.StopServiceCommand]::new()
     $stopservicecmd.$parameter = $value
-    $stopservicecmd.$parameter | Should Be $value
+    $stopservicecmd.$parameter | Should -Be $value
   }
 
   It "RestartServiceCommand can be used as API for '<parameter>' with '<value>'" -TestCases @(
@@ -30,30 +30,30 @@ Describe "Control Service cmdlet tests" -Tags "Feature","RequireAdminOnWindows" 
     param($parameter, $value)
     $restartservicecmd = [Microsoft.PowerShell.Commands.RestartServiceCommand]::new()
     $restartservicecmd.$parameter = $value
-    $restartservicecmd.$parameter | Should Be $value
+    $restartservicecmd.$parameter | Should -Be $value
   }
 
   It "Stop/Start/Restart-Service works" {
     $wasStopped = $false
     try {
       $spooler = Get-Service Spooler
-      $spooler | Should Not BeNullOrEmpty
+      $spooler | Should -Not -BeNullOrEmpty
       if ($spooler.Status -ne "Running") {
         $wasStopped = $true
         $spooler = Start-Service Spooler -PassThru
       }
-      $spooler.Status | Should Be "Running"
+      $spooler.Status | Should -Be "Running"
       $spooler = Stop-Service Spooler -PassThru
-      $spooler.Status | Should Be "Stopped"
-      (Get-Service Spooler).Status | Should Be "Stopped"
+      $spooler.Status | Should -Be "Stopped"
+      (Get-Service Spooler).Status | Should -Be "Stopped"
       $spooler = Start-Service Spooler -PassThru
-      $spooler.Status | Should Be "Running"
-      (Get-Service Spooler).Status | Should Be "Running"
+      $spooler.Status | Should -Be "Running"
+      (Get-Service Spooler).Status | Should -Be "Running"
       Stop-Service Spooler
-      (Get-Service Spooler).Status | Should Be "Stopped"
+      (Get-Service Spooler).Status | Should -Be "Stopped"
       $spooler = Restart-Service Spooler -PassThru
-      $spooler.Status | Should Be "Running"
-      (Get-Service Spooler).Status | Should Be "Running"
+      $spooler.Status | Should -Be "Running"
+      (Get-Service Spooler).Status | Should -Be "Running"
     } finally {
       if ($wasStopped) {
         Stop-Service Spooler
@@ -70,11 +70,11 @@ Describe "Control Service cmdlet tests" -Tags "Feature","RequireAdminOnWindows" 
         $originalState = $service.Status
         Start-Service $serviceName
       }
-      $service | Should Not BeNullOrEmpty
+      $service | Should -Not -BeNullOrEmpty
       Suspend-Service $serviceName
-      (Get-Service $serviceName).Status | Should Be "Paused"
+      (Get-Service $serviceName).Status | Should -Be "Paused"
       Resume-Service $serviceName
-      (Get-Service $serviceName).Status | Should Be "Running"
+      (Get-Service $serviceName).Status | Should -Be "Running"
     } finally {
       Set-Service $serviceName -Status $originalState
     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/ControlService.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/ControlService.Tests.ps1
@@ -44,7 +44,7 @@ Describe "Control Service cmdlet tests" -Tags "Feature","RequireAdminOnWindows" 
       }
       $spooler.Status | Should -BeExactly "Running"
       $spooler = Stop-Service Spooler -PassThru
-      $spooler.Status | Should -BeExaclty "Stopped"
+      $spooler.Status | Should -BeExactly "Stopped"
       (Get-Service Spooler).Status | Should -BeExactly "Stopped"
       $spooler = Start-Service Spooler -PassThru
       $spooler.Status | Should -BeExactly "Running"

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Convert-Path.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Convert-Path.Tests.ps1
@@ -2,16 +2,16 @@
 # Licensed under the MIT License.
 Describe "Convert-Path tests" -Tag CI {
     It "Convert-Path should handle provider qualified paths" {
-        Convert-Path "FileSystem::${TESTDRIVE}" | should be "${TESTDRIVE}"
+        Convert-Path "FileSystem::${TESTDRIVE}" | Should -Be "${TESTDRIVE}"
     }
     It "Convert-Path should return the proper path" {
-        Convert-Path "$TESTDRIVE" | Should be "$TESTDRIVE"
+        Convert-Path "$TESTDRIVE" | Should -Be "$TESTDRIVE"
     }
     It "Convert-Path supports pipelined input" {
-        "$TESTDRIVE" | Convert-Path | Should be "$TESTDRIVE"
+        "$TESTDRIVE" | Convert-Path | Should -Be "$TESTDRIVE"
     }
     It "Convert-Path supports pipelined input by property name" {
-        get-item $TESTDRIVE | Convert-Path | Should be "$TESTDRIVE"
+        get-item $TESTDRIVE | Convert-Path | Should -Be "$TESTDRIVE"
     }
     It "Convert-Path without arguments is an error" {
         try {
@@ -20,7 +20,7 @@ Describe "Convert-Path tests" -Tag CI {
             throw "Execution should not have reached here"
         }
         catch {
-            $_.fullyqualifiederrorid | should be ParameterBindingException
+            $_.fullyqualifiederrorid | Should -Be ParameterBindingException
         }
     }
     It "Convert-Path with null path is an error" {
@@ -29,7 +29,7 @@ Describe "Convert-Path tests" -Tag CI {
             throw "Execution should not have reached here"
         }
         catch {
-            $_.fullyqualifiederrorid | should be "ParameterArgumentValidationErrorEmptyStringNotAllowed,Microsoft.PowerShell.Commands.ConvertPathCommand"
+            $_.fullyqualifiederrorid | Should -Be "ParameterArgumentValidationErrorEmptyStringNotAllowed,Microsoft.PowerShell.Commands.ConvertPathCommand"
         }
     }
     It "Convert-Path with non-existing non-filesystem path is an error" {
@@ -38,17 +38,17 @@ Describe "Convert-Path tests" -Tag CI {
             throw "Execution should not have reached here"
         }
         catch {
-            $_.fullyqualifiederrorid | should be "PathNotFound,Microsoft.PowerShell.Commands.ConvertPathCommand"
+            $_.fullyqualifiederrorid | Should -Be "PathNotFound,Microsoft.PowerShell.Commands.ConvertPathCommand"
         }
     }
     It "Convert-Path can handle multiple directories" {
         $d1 = Setup -D dir1 -pass
         $d2 = Setup -D dir2 -pass
         $result = convert-path "${TESTDRIVE}/dir?"
-        $result.count | Should be 2
-        $result -join "," | should be (@("$d1","$d2") -join ",")
+        $result.count | Should -Be 2
+        $result -join "," | Should -Be (@("$d1","$d2") -join ",")
     }
     It "Convert-Path should return something which exists" {
-        Convert-Path $TESTDRIVE | Test-Path | should be $true
+        Convert-Path $TESTDRIVE | Test-Path | Should -Be $true
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Convert-Path.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Convert-Path.Tests.ps1
@@ -2,16 +2,16 @@
 # Licensed under the MIT License.
 Describe "Convert-Path tests" -Tag CI {
     It "Convert-Path should handle provider qualified paths" {
-        Convert-Path "FileSystem::${TESTDRIVE}" | Should -Be "${TESTDRIVE}"
+        Convert-Path "FileSystem::${TESTDRIVE}" | Should -BeExactly "${TESTDRIVE}"
     }
     It "Convert-Path should return the proper path" {
-        Convert-Path "$TESTDRIVE" | Should -Be "$TESTDRIVE"
+        Convert-Path "$TESTDRIVE" | Should -BeExactly "$TESTDRIVE"
     }
     It "Convert-Path supports pipelined input" {
-        "$TESTDRIVE" | Convert-Path | Should -Be "$TESTDRIVE"
+        "$TESTDRIVE" | Convert-Path | Should -BeExactly "$TESTDRIVE"
     }
     It "Convert-Path supports pipelined input by property name" {
-        get-item $TESTDRIVE | Convert-Path | Should -Be "$TESTDRIVE"
+        get-item $TESTDRIVE | Convert-Path | Should -BeExactly "$TESTDRIVE"
     }
     It "Convert-Path without arguments is an error" {
         try {
@@ -46,9 +46,9 @@ Describe "Convert-Path tests" -Tag CI {
         $d2 = Setup -D dir2 -pass
         $result = convert-path "${TESTDRIVE}/dir?"
         $result.count | Should -Be 2
-        $result -join "," | Should -Be (@("$d1","$d2") -join ",")
+        $result -join "," | Should -BeExactly (@("$d1","$d2") -join ",")
     }
     It "Convert-Path should return something which exists" {
-        Convert-Path $TESTDRIVE | Test-Path | Should -Be $true
+        Convert-Path $TESTDRIVE | Test-Path | Should -BeTrue
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Convert-Path.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Convert-Path.Tests.ps1
@@ -14,32 +14,14 @@ Describe "Convert-Path tests" -Tag CI {
         get-item $TESTDRIVE | Convert-Path | Should -BeExactly "$TESTDRIVE"
     }
     It "Convert-Path without arguments is an error" {
-        try {
-            $ps = [powershell]::Create()
-            $ps.AddCommand("Convert-Path").Invoke()
-            throw "Execution should not have reached here"
-        }
-        catch {
-            $_.fullyqualifiederrorid | Should -Be ParameterBindingException
-        }
+        $ps = [powershell]::Create()
+        { $ps.AddCommand("Convert-Path").Invoke() } | Should -Throw -ErrorId "ParameterBindingException"
     }
     It "Convert-Path with null path is an error" {
-        try {
-            Convert-Path -path ""
-            throw "Execution should not have reached here"
-        }
-        catch {
-            $_.fullyqualifiederrorid | Should -Be "ParameterArgumentValidationErrorEmptyStringNotAllowed,Microsoft.PowerShell.Commands.ConvertPathCommand"
-        }
+        { Convert-Path -path "" } | Should -Throw -ErrorId "ParameterArgumentValidationErrorEmptyStringNotAllowed,Microsoft.PowerShell.Commands.ConvertPathCommand"
     }
     It "Convert-Path with non-existing non-filesystem path is an error" {
-        try {
-            Convert-Path -path "env:thisvariableshouldnotexist" -ea stop
-            throw "Execution should not have reached here"
-        }
-        catch {
-            $_.fullyqualifiederrorid | Should -Be "PathNotFound,Microsoft.PowerShell.Commands.ConvertPathCommand"
-        }
+        { Convert-Path -path "env:thisvariableshouldnotexist" -ErrorAction Stop } | Should -Throw -ErrorId "PathNotFound,Microsoft.PowerShell.Commands.ConvertPathCommand"
     }
     It "Convert-Path can handle multiple directories" {
         $d1 = Setup -D dir1 -pass

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Convert-Path.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Convert-Path.Tests.ps1
@@ -31,6 +31,6 @@ Describe "Convert-Path tests" -Tag CI {
         $result -join "," | Should -BeExactly (@("$d1","$d2") -join ",")
     }
     It "Convert-Path should return something which exists" {
-        Convert-Path $TESTDRIVE | Test-Path | Should -BeTrue
+        Convert-Path $TESTDRIVE | Should -Exist
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Copy.Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Copy.Item.Tests.ps1
@@ -36,21 +36,21 @@ Describe "Validate Copy-Item Remotely" -Tags "CI" {
             $copiedFilePath = Join-Path $destination $fileName
         }
 
-        $copiedFilePath | should Exist
+        $copiedFilePath | Should -Exist
 
         # Validate file attributes
         $originalFile = Get-Item $filePath -Force
         $newFile = Get-Item $copiedFilePath -Force
 
         # Validate file Length
-        $newFile.Length | should be  $originalFile.Length
+        $newFile.Length | Should -Be  $originalFile.Length
 
         # Validate LastWriteTime
-        $newFile.LastWriteTime | should be  $originalFile.LastWriteTime
-        $newFile.LastWriteTimeUtc | should be  $originalFile.LastWriteTimeUtc
+        $newFile.LastWriteTime | Should -Be  $originalFile.LastWriteTime
+        $newFile.LastWriteTimeUtc | Should -Be  $originalFile.LastWriteTimeUtc
 
         # Validate Attributes
-        $newFile.Attributes.value__ | Should Be $originalFile.Attributes.value__
+        $newFile.Attributes.value__ | Should -Be $originalFile.Attributes.value__
     }
 
     # Validate a copy item operation.
@@ -61,12 +61,12 @@ Describe "Validate Copy-Item Remotely" -Tags "CI" {
         param ([string]$filePath, $streamName, $expectedStreamContent)
 
         $copiedFilePath = ([string]$filePath).Replace("SourceDirectory", "DestinationDirectory")
-        $copiedFilePath | should Exist
-        (Get-Item $copiedFilePath).Length | should be (Get-Item $filePath).Length
+        $copiedFilePath | Should -Exist
+        (Get-Item $copiedFilePath).Length | Should -Be (Get-Item $filePath).Length
 
         # Validate the stream
         $actualStreamContent = Get-Content -Path $copiedFilePath -Stream $streamName -ea SilentlyContinue
-        $actualStreamContent | Should Match $expectedStreamContent
+        $actualStreamContent | Should -Match $expectedStreamContent
     }
 
     BeforeAll {
@@ -258,7 +258,7 @@ Describe "Validate Copy-Item Remotely" -Tags "CI" {
             foreach ($file in $testObject.Files)
             {
                 $copiedFilePath = ([string]$file).Replace("SourceDirectory", "DestinationDirectory\SourceDirectory")
-                $copiedFilePath | should Exist
+                $copiedFilePath | Should -Exist
             }
         }
     }
@@ -297,8 +297,8 @@ Describe "Validate Copy-Item Remotely" -Tags "CI" {
             foreach ($file in $testObject.Files)
             {
                 $copiedFilePath = ([string]$file).Replace("SourceDirectory", "DestinationDirectory\SourceDirectory")
-                $copiedFilePath | should Exist
-                (Get-Item $copiedFilePath).Length | should be (Get-Item $file).Length
+                $copiedFilePath | Should -Exist
+
             }
         }
 
@@ -310,8 +310,8 @@ Describe "Validate Copy-Item Remotely" -Tags "CI" {
             foreach ($file in $testObject.Files)
             {
                 $copiedFilePath = ([string]$file).Replace("SourceDirectory", "DestinationDirectory\SourceDirectory")
-                $copiedFilePath | should Exist
-                (Get-Item $copiedFilePath).Length | should be (Get-Item $file).Length
+
+                (Get-Item $copiedFilePath).Length | Should -Be (Get-Item $file).Length
             }
         }
 
@@ -329,7 +329,7 @@ Describe "Validate Copy-Item Remotely" -Tags "CI" {
             }
             catch
             {
-                $_.FullyQualifiedErrorId | should be $expectedFullyQualifiedErrorId
+                $_.FullyQualifiedErrorId | Should -Be $expectedFullyQualifiedErrorId
             }
         }
 
@@ -342,8 +342,8 @@ Describe "Validate Copy-Item Remotely" -Tags "CI" {
             foreach ($file in $testObject.Files)
             {
                 $copiedFilePath = ([string]$file).Replace("SourceDirectory", "DestinationDirectory\FoderThatDoesNotExist")
-                $copiedFilePath | should Exist
-                (Get-Item $copiedFilePath).Length | should be (Get-Item $file).Length
+                $copiedFilePath | Should -Exist
+                (Get-Item $copiedFilePath).Length | Should -Be (Get-Item $file).Length
             }
         }
 
@@ -352,10 +352,10 @@ Describe "Validate Copy-Item Remotely" -Tags "CI" {
             $filePath = CreateTestFile -emptyFile
             $destinationFolderPath = GetDestinationFolderPath
             $copiedFilePath = ([string]$filePath).Replace("SourceDirectory", "DestinationDirectory")
-            $copiedFilePath | should Not Exist
+            $copiedFilePath | Should -Not -Exist
             Copy-Item -Path $filePath  -ToSession $s -Destination $destinationFolderPath
-            $copiedFilePath | should Exist
-            (Get-Item $copiedFilePath).Length | should be (Get-Item $filePath).Length
+            $copiedFilePath | Should -Exist
+            (Get-Item $copiedFilePath).Length | Should -Be (Get-Item $filePath).Length
         }
 
         It "Copy-Item to session supports alternate data streams." {
@@ -377,7 +377,7 @@ Describe "Validate Copy-Item Remotely" -Tags "CI" {
             $filePath = CreateTestFile
             $destinationFolderPath = GetDestinationFolderPath
             $copiedFilePath = ([string]$filePath).Replace("SourceDirectory", "DestinationDirectory")
-            $copiedFilePath | should Not Exist
+            $copiedFilePath | Should -Not -Exist
             Copy-Item -Path $filePath  -FromSession $s -Destination $destinationFolderPath
             ValidateCopyItemOperation -filePath $filePath
         }
@@ -387,7 +387,7 @@ Describe "Validate Copy-Item Remotely" -Tags "CI" {
             $filePath = CreateTestFile -emptyFile
             $destinationFolderPath = GetDestinationFolderPath
             $copiedFilePath = ([string]$filePath).Replace("SourceDirectory", "DestinationDirectory")
-            $copiedFilePath | should Not Exist
+            $copiedFilePath | Should -Not -Exist
             Copy-Item -Path $filePath  -FromSession $s -Destination $destinationFolderPath
             ValidateCopyItemOperation -filePath $filePath
         }
@@ -402,8 +402,8 @@ Describe "Validate Copy-Item Remotely" -Tags "CI" {
             foreach ($file in $testObject.Files)
             {
                 $copiedFilePath = ([string]$file).Replace("SourceDirectory", "DestinationDirectory\SourceDirectory")
-                $copiedFilePath | should Exist
-                (Get-Item $copiedFilePath).Length | should be (Get-Item $file).Length
+                $copiedFilePath | Should -Exist
+                (Get-Item $copiedFilePath).Length | Should -Be (Get-Item $file).Length
             }
         }
 
@@ -420,7 +420,7 @@ Describe "Validate Copy-Item Remotely" -Tags "CI" {
             }
             catch
             {
-                $_.FullyQualifiedErrorId | should be $expectedFullyQualifiedErrorId
+                $_.FullyQualifiedErrorId | Should -Be $expectedFullyQualifiedErrorId
             }
         }
 
@@ -435,8 +435,8 @@ Describe "Validate Copy-Item Remotely" -Tags "CI" {
             foreach ($file in $testObject.Files)
             {
                 $copiedFilePath = ([string]$file).Replace("SourceDirectory", "DestinationDirectory\FoderThatDoesNotExist")
-                $copiedFilePath | should Exist
-                (Get-Item $copiedFilePath).Length | should be (Get-Item $file).Length
+                $copiedFilePath | Should -Exist
+                (Get-Item $copiedFilePath).Length | Should -Be (Get-Item $file).Length
             }
         }
 
@@ -498,8 +498,8 @@ Describe "Validate Copy-Item Remotely" -Tags "CI" {
             foreach ($file in $sourceFiles)
             {
                 $copiedFilePath = Join-Path $destinationFolderPath (Split-Path $file -Leaf)
-                $copiedFilePath | Should Exist
-                (Get-Item $copiedFilePath).Length | Should Be (Get-Item $file).Length
+                $copiedFilePath | Should -Exist
+                (Get-Item $copiedFilePath).Length | Should -Be (Get-Item $file).Length
             }
         }
 
@@ -514,8 +514,8 @@ Describe "Validate Copy-Item Remotely" -Tags "CI" {
             foreach ($file in $sourceFiles)
             {
                 $copiedFilePath = Join-Path $destinationFolderPath (Split-Path $file -Leaf)
-                $copiedFilePath | Should Exist
-                (Get-Item $copiedFilePath).Length | Should Be (Get-Item $file).Length
+                $copiedFilePath | Should -Exist
+                (Get-Item $copiedFilePath).Length | Should -Be (Get-Item $file).Length
             }
         }
     }
@@ -546,7 +546,7 @@ Describe "Validate Copy-Item Remotely" -Tags "CI" {
                     }
                     catch
                     {
-                        $_.FullyQualifiedErrorId | should be $expectedFullyQualifiedErrorId
+                        $_.FullyQualifiedErrorId | Should -Be $expectedFullyQualifiedErrorId
                     }
                 }
             }
@@ -560,7 +560,7 @@ Describe "Validate Copy-Item Remotely" -Tags "CI" {
                     }
                     catch
                     {
-                        $_.FullyQualifiedErrorId | should be $expectedFullyQualifiedErrorId
+                        $_.FullyQualifiedErrorId | Should -Be $expectedFullyQualifiedErrorId
                     }
                 }
             }
@@ -681,7 +681,7 @@ Describe "Validate Copy-Item error for target sessions not in FullLanguageMode."
             $testSession = New-PSSession -ConfigurationName $sessionName
 
             # Validate that the session is opened.
-            $testSession.State | Should Be "Opened"
+            $testSession.State | Should -Be "Opened"
 
             # Add the new session to the list.
             $testSessions[$languageMode] = $testSession
@@ -714,7 +714,7 @@ Describe "Validate Copy-Item error for target sessions not in FullLanguageMode."
             }
             catch
             {
-                $_.FullyQualifiedErrorId | should be "SessionIsNotInFullLanguageMode,Microsoft.PowerShell.Commands.CopyItemCommand"
+                $_.FullyQualifiedErrorId | Should -Be "SessionIsNotInFullLanguageMode,Microsoft.PowerShell.Commands.CopyItemCommand"
             }
 
             # ToSession
@@ -725,7 +725,7 @@ Describe "Validate Copy-Item error for target sessions not in FullLanguageMode."
             }
             catch
             {
-                $_.FullyQualifiedErrorId | should be "SessionIsNotInFullLanguageMode,Microsoft.PowerShell.Commands.CopyItemCommand"
+                $_.FullyQualifiedErrorId | Should -Be "SessionIsNotInFullLanguageMode,Microsoft.PowerShell.Commands.CopyItemCommand"
             }
         }
     }
@@ -755,19 +755,19 @@ Describe "Copy-Item can use Recurse and Exclude together" -Tags "Feature" {
         It "can exclude files at sub directory" {
             Copy-Item -Path TestDrive:\Parent\* -Recurse -Exclude s*.txt -Destination TestDrive:\Temp -Force
             $copiedFiles = Get-ChildItem -Recurse -Path TestDrive:\Temp
-            $copiedFiles.Count | Should Be 3
+            $copiedFiles.Count | Should -Be 3
         }
 
         It "can exclude files at sub directory to a session" {
             Copy-Item -Path TestDrive:\Parent\* -Recurse -Exclude s*.txt -Destination $TestDrive\Temp2 -Force -ToSession $s
             $copiedFiles = Get-ChildItem -Recurse -Path TestDrive:\Temp
-            $copiedFiles.Count | Should Be 3
+            $copiedFiles.Count | Should -Be 3
         }
 
         It "can exclude files at sub directory from a session" {
             Copy-Item -Path $TestDrive\Parent\* -Recurse -Exclude s*.txt -Destination TestDrive:\Temp3 -FromSession $s
             $copiedFiles = Get-ChildItem -Recurse -Path TestDrive:\Temp2
-            $copiedFiles.Count | Should Be 3
+            $copiedFiles.Count | Should -Be 3
         }
 
         AfterAll {
@@ -818,7 +818,7 @@ Describe "Copy-Item remotely bug fixes" -Tags "Feature" {
 
             # Validate the the file was overwritten
             $fileContent = Get-Content "TestDrive:\Destination\testFile1.txt" -ea SilentlyContinue -Raw
-            $fileContent | Should Match $newContent
+            $fileContent | Should -Match $newContent
         }
 
         It "Copy item -fromsession overwrites the content of an existing file." {
@@ -828,7 +828,7 @@ Describe "Copy-Item remotely bug fixes" -Tags "Feature" {
 
             # Validate the the file was overwritten
             $fileContent = Get-Content "TestDrive:\Destination\testFile1.txt" -ea SilentlyContinue -Raw
-            $fileContent | Should Match $newContent
+            $fileContent | Should -Match $newContent
         }
     }
 
@@ -843,7 +843,7 @@ Describe "Copy-Item remotely bug fixes" -Tags "Feature" {
             $null = New-Item -ItemType Directory -Path "TestDrive:\AnotherDestination"
 
             # Ensure the file does not exist
-            "TestDrive:\AnotherDestination\FileThatDoesNotExist.txt" | Should Not Exist
+            "TestDrive:\AnotherDestination\FileThatDoesNotExist.txt" | Should -Not -Exist
         }
 
         It "Copy-Item -tosession creates the file if it does not exist on the remote destination." {
@@ -852,7 +852,7 @@ Describe "Copy-Item remotely bug fixes" -Tags "Feature" {
             Copy-Item -Path "TestDrive:\Source\testFile1.txt" -Destination "$TestDrive\AnotherDestination\FileThatDoesNotExist.txt" -ToSession $s
 
             # Verify that the file was created
-            "TestDrive:\AnotherDestination\FileThatDoesNotExist.txt" | Should Exist
+            "TestDrive:\AnotherDestination\FileThatDoesNotExist.txt" | Should -Exist
         }
 
         It "Copy-Item -fromsession creates the file if it does not exist on the local machine." {
@@ -861,7 +861,7 @@ Describe "Copy-Item remotely bug fixes" -Tags "Feature" {
             Copy-Item -Path "$TestDrive\Source\testFile1.txt" -Destination "TestDrive:\AnotherDestination\FileThatDoesNotExist.txt" -FromSession $s
 
             # Verify that the file was created
-            "TestDrive:\AnotherDestination\FileThatDoesNotExist.txt" | Should Exist
+            "TestDrive:\AnotherDestination\FileThatDoesNotExist.txt" | Should -Exist
         }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Copy.Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Copy.Item.Tests.ps1
@@ -298,7 +298,7 @@ Describe "Validate Copy-Item Remotely" -Tags "CI" {
             {
                 $copiedFilePath = ([string]$file).Replace("SourceDirectory", "DestinationDirectory\SourceDirectory")
                 $copiedFilePath | Should -Exist
-
+		(Get-Item $copiedFilePath).Length | Should -Be (Get-Item $file).Length
             }
         }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Copy.Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Copy.Item.Tests.ps1
@@ -709,7 +709,7 @@ Describe "Validate Copy-Item error for target sessions not in FullLanguageMode."
             # FromSession
             try
             {
-                Copy-Item -Path $testFilePath -FromSession $session -Destination $destination -Force -Verbose -ea Stop
+                Copy-Item -Path $testFilePath -FromSession $session -Destination $destination -Force -Verbose -ErrorAction Stop
                 throw "CodeExecuted"
             }
             catch
@@ -720,7 +720,7 @@ Describe "Validate Copy-Item error for target sessions not in FullLanguageMode."
             # ToSession
             try
             {
-                Copy-Item -Path $testFilePath -ToSession $session -Destination $destination -Force -Verbose -ea Stop
+                Copy-Item -Path $testFilePath -ToSession $session -Destination $destination -Force -Verbose -ErrorAction Stop
                 throw "CodeExecuted"
             }
             catch

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Copy.Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Copy.Item.Tests.ps1
@@ -310,7 +310,7 @@ Describe "Validate Copy-Item Remotely" -Tags "CI" {
             foreach ($file in $testObject.Files)
             {
                 $copiedFilePath = ([string]$file).Replace("SourceDirectory", "DestinationDirectory\SourceDirectory")
-
+		$copiedFilePath | Should -Exist
                 (Get-Item $copiedFilePath).Length | Should -Be (Get-Item $file).Length
             }
         }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
@@ -551,7 +551,7 @@ Describe "Hard link and symbolic link tests" -Tags "CI", "RequireAdminOnWindows"
             $filenamePattern = "AlphaFile[12]\.txt"
             New-Item -ItemType SymbolicLink -Path $alphaLink -Value $alphaDir
             $ci = Get-ChildItem $alphaLink
-            $ci.Count | Should -BeExactly 3
+            $ci.Count | Should -Be 3
             $ci[1].Name | Should -MatchExactly $filenamePattern
             $ci[2].Name | Should -MatchExactly $filenamePattern
         }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
@@ -40,62 +40,62 @@ Describe "Basic FileSystem Provider Tests" -Tags "CI" {
         It "Verify New-Item for directory" {
             $newDir = New-Item -Path $newTestDir -ItemType Directory
             $directoryExists = Test-Path $newTestDir
-            $directoryExists | Should Be $true
-            $newDir.Name | Should Be $newTestDir
+            $directoryExists | Should -Be $true
+            $newDir.Name | Should -Be $newTestDir
         }
 
         It "Verify New-Item for file" {
             $newFile = New-Item -Path $newTestFile -ItemType File
             $fileExists = Test-Path $newTestFile
-            $fileExists | Should Be $true
-            $newFile.Name | Should Be $newTestFile
+            $fileExists | Should -Be $true
+            $newFile.Name | Should -Be $newTestFile
         }
 
         It "Verify Remove-Item for directory" {
             $existsBefore = Test-Path $testDir
             Remove-Item -Path $testDir -Recurse -Force
             $existsAfter = Test-Path $testDir
-            $existsBefore | Should Be $true
-            $existsAfter | Should Be $false
+            $existsBefore | Should -Be $true
+            $existsAfter | Should -Be $false
         }
 
         It "Verify Remove-Item for file" {
             $existsBefore = Test-Path $testFile
             Remove-Item -Path $testFile -Force
             $existsAfter = Test-Path $testFile
-            $existsBefore | Should Be $true
-            $existsAfter | Should Be $false
+            $existsBefore | Should -Be $true
+            $existsAfter | Should -Be $false
         }
 
         It "Verify Rename-Item for file" {
             Rename-Item -Path $testFile -NewName $newTestFile -ErrorAction Stop
-            $testFile | Should Not Exist
-            $newTestFile | Should Exist
+            $testFile | Should -Not -Exist
+            $newTestFile | Should -Exist
         }
 
         It "Verify Rename-Item for directory" {
             Rename-Item -Path $testDir -NewName $newTestDir -ErrorAction Stop
-            $testDir | Should Not Exist
-            $newTestDir | Should Exist
+            $testDir | Should -Not -Exist
+            $newTestDir | Should -Exist
         }
 
         It "Verify Rename-Item will not rename to an existing name" {
             { Rename-Item -Path $testFile -NewName $testDir -ErrorAction Stop } | ShouldBeErrorId "RenameItemIOError,Microsoft.PowerShell.Commands.RenameItemCommand"
-            $Error[0].Exception | Should BeOfType System.IO.IOException
-            $testFile | Should Exist
+            $Error[0].Exception | Should -BeOfType System.IO.IOException
+            $testFile | Should -Exist
         }
 
         It "Verify Copy-Item" {
             $newFile = Copy-Item -Path $testFile -Destination $newTestFile -PassThru
             $fileExists = Test-Path $newTestFile
-            $fileExists | Should Be $true
-            $newFile.Name | Should Be $newTestFile
+            $fileExists | Should -Be $true
+            $newFile.Name | Should -Be $newTestFile
         }
 
         It "Verify Move-Item for file" {
             Move-Item -Path $testFile -Destination $testDir -ErrorAction Stop
-            $testFile | Should Not Exist
-            "$testDir/$testFile" | Should Exist
+            $testFile | Should -Not -Exist
+            "$testDir/$testFile" | Should -Exist
         }
 
         It "Verify Move-Item for directory" {
@@ -103,47 +103,47 @@ Describe "Basic FileSystem Provider Tests" -Tags "CI" {
             New-Item -Path $destDir -ItemType Directory -ErrorAction Stop >$null
             Move-Item -Path $testFile -Destination $testDir
             Move-Item -Path $testDir -Destination $destDir
-            $testDir | Should Not Exist
-            "$destDir/$testDir" | Should Exist
-            "$destDir/$testDir/$testFile" | Should Exist
+            $testDir | Should -Not -Exist
+            "$destDir/$testDir" | Should -Exist
+            "$destDir/$testDir/$testFile" | Should -Exist
         }
 
         It "Verify Move-Item will not move to an existing file" {
             { Move-Item -Path $testDir -Destination $testFile -ErrorAction Stop } | ShouldBeErrorId "MoveDirectoryItemIOError,Microsoft.PowerShell.Commands.MoveItemCommand"
-            $Error[0].Exception | Should BeOfType System.IO.IOException
-            $testDir | Should Exist
+            $Error[0].Exception | Should -BeOfType System.IO.IOException
+            $testDir | Should -Exist
         }
 
         It "Verify Move-Item as substitute for Rename-Item" {
             $newFile = Move-Item -Path $testFile -Destination $newTestFile -PassThru
             $fileExists = Test-Path $newTestFile
-            $fileExists | Should Be $true
-            $newFile.Name | Should Be $newTestFile
+            $fileExists | Should -Be $true
+            $newFile.Name | Should -Be $newTestFile
         }
 
         It "Verify Get-ChildItem" {
             $dirContents = Get-ChildItem "."
-            $dirContents.Count | Should Be 2
+            $dirContents.Count | Should -Be 2
         }
 
         It "Verify Get-ChildItem can get the name of a specified item." {
             $fileName = Get-ChildItem $testFile -Name
             $fileInfo = Get-ChildItem $testFile
-            $fileName | Should BeExactly $fileInfo.Name
+            $fileName | Should -BeExactly $fileInfo.Name
         }
 
         It "Set-Content to a file" {
             $content =  Set-Content -Value $testContent -Path $testFile -PassThru
-            $content | Should BeExactly $testContent
+            $content | Should -BeExactly $testContent
         }
 
         It "Add-Content to a file" {
             $content = Set-Content -Value $testContent -Path $testFile -PassThru
             $addContent = Add-Content -Value $testContent2 -Path $testFile -PassThru
             $fullContent = Get-Content -Path $testFile
-            $content | Should Match $testContent
-            $addContent | Should Match $testContent2
-            ($fullContent[0] + $fullContent[1]) | Should Match ($testContent + $testContent2)
+            $content | Should -Match $testContent
+            $addContent | Should -Match $testContent2
+            ($fullContent[0] + $fullContent[1]) | Should -Match ($testContent + $testContent2)
         }
 
         It "Clear-Content of a file" {
@@ -151,8 +151,8 @@ Describe "Basic FileSystem Provider Tests" -Tags "CI" {
             $contentBefore = Get-Content -Path $testFile
             Clear-Content -Path $testFile
             $contentAfter = Get-Content -Path $testFile
-            $contentBefore.Count | Should Be 1
-            $contentAfter.Count | Should Be 0
+            $contentBefore.Count | Should -Be 1
+            $contentAfter.Count | Should -Be 0
         }
 
          It "Copy-Item on Windows rejects Windows reserved device names" -Skip:(-not $IsWindows) {
@@ -180,7 +180,7 @@ Describe "Basic FileSystem Provider Tests" -Tags "CI" {
              foreach ($deviceName in $reservedNames)
              {
                 Copy-Item -Path $testFile -Destination $deviceName -Force -ErrorAction SilentlyContinue
-                Test-Path $deviceName | Should Be $true
+                Test-Path $deviceName | Should -Be $true
              }
          }
 
@@ -188,7 +188,7 @@ Describe "Basic FileSystem Provider Tests" -Tags "CI" {
              foreach ($deviceName in $reservedNames)
              {
                 Move-Item -Path $testFile -Destination $deviceName -Force -ErrorAction SilentlyContinue
-                Test-Path $deviceName | Should Be $true
+                Test-Path $deviceName | Should -Be $true
                 New-Item -Path $testFile -ItemType File -Force -ErrorAction SilentlyContinue
              }
          }
@@ -197,7 +197,7 @@ Describe "Basic FileSystem Provider Tests" -Tags "CI" {
              foreach ($deviceName in $reservedNames)
              {
                 Rename-Item -Path $testFile -NewName $deviceName -Force -ErrorAction SilentlyContinue
-                Test-Path $deviceName | Should Be $true
+                Test-Path $deviceName | Should -Be $true
                 New-Item -Path $testFile -ItemType File -Force -ErrorAction SilentlyContinue
              }
          }
@@ -212,7 +212,7 @@ Describe "Basic FileSystem Provider Tests" -Tags "CI" {
                 New-Item -Path "$testdrive$path" -ItemType Directory > $null
                 Set-Location "$testdrive"
                 Set-Location ".$path"
-                (Get-Location).Path | Should Be "$testdrive/$($path.Substring(1,$path.Length-1))"
+                (Get-Location).Path | Should -Be "$testdrive/$($path.Substring(1,$path.Length-1))"
             }
             finally {
                 Remove-Item -Path "$testdrive$path" -ErrorAction SilentlyContinue
@@ -230,9 +230,9 @@ Describe "Basic FileSystem Provider Tests" -Tags "CI" {
                 New-Item -Path "$testPath" -ItemType Directory > $null
                 Set-Content -Path "$testPath$path" -Value "Hello"
                 $files = Get-ChildItem "$testPath"
-                $files.Count | Should Be 1
-                $files[0].Name | Should BeExactly $path.Substring(1,$path.Length-1)
-                $files[0] | Get-Content | Should BeExactly "Hello"
+                $files.Count | Should -Be 1
+                $files[0].Name | Should -BeExactly $path.Substring(1,$path.Length-1)
+                $files[0] | Get-Content | Should -BeExactly "Hello"
             }
             finally {
                 Remove-Item -Path $testPath -Recurse -Force -ErrorAction SilentlyContinue
@@ -275,7 +275,7 @@ Describe "Basic FileSystem Provider Tests" -Tags "CI" {
             Wait-FileToBePresent -File $doneFile -TimeoutInSeconds 15 -IntervalInMilliseconds 100
 
             $err = Get-Content $errFile
-            $err | Should Be $expectedError
+            $err | Should -Be $expectedError
         }
     }
 
@@ -300,9 +300,9 @@ Describe "Basic FileSystem Provider Tests" -Tags "CI" {
             $level1Loc = Get-Location
             Set-Location $level2_0
             $level2Loc = Get-Location
-            $currentLoc.Path | Should Be $root
-            $level1Loc.Path | Should Be $level1_0Full
-            $level2Loc.Path | Should Be $level2_0Full
+            $currentLoc.Path | Should -Be $root
+            $level1Loc.Path | Should -Be $level1_0Full
+            $level2Loc.Path | Should -Be $level2_0Full
         }
 
         It "Verify Push-Location and Pop-Location" {
@@ -327,44 +327,44 @@ Describe "Basic FileSystem Provider Tests" -Tags "CI" {
             Pop-Location
             $pop2 = Get-Location
 
-            $pop0.Path | Should Be $push2.Path
-            $pop1.Path | Should Be $push1.Path
-            $pop2.Path | Should Be $push0.Path
+            $pop0.Path | Should -Be $push2.Path
+            $pop1.Path | Should -Be $push1.Path
+            $pop2.Path | Should -Be $push0.Path
         }
     }
 
     Context "Validate Basic Path Cmdlets" {
         It "Verify Convert-Path" {
             $result = Convert-Path "."
-            ($result.TrimEnd('/\')) | Should Be "$TESTDRIVE"
+            ($result.TrimEnd('/\')) | Should -Be "$TESTDRIVE"
         }
 
         It "Verify Join-Path" {
             $result = Join-Path -Path "TestDrive:" -ChildPath "temp"
 
             if ($IsWindows) {
-                $result | Should BeExactly "TestDrive:\temp"
+                $result | Should -BeExactly "TestDrive:\temp"
             }
             else {
-                $result | Should BeExactly "TestDrive:/temp"
+                $result | Should -BeExactly "TestDrive:/temp"
             }
         }
 
         It "Verify Split-Path" {
             $testPath = Join-Path "TestDrive:" "MyTestFile.txt"
             $result = Split-Path $testPath -Qualifier
-            $result | Should BeExactly "TestDrive:"
+            $result | Should -BeExactly "TestDrive:"
         }
 
         It "Verify Test-Path" {
             $result = Test-Path $HOME
-            $result | Should Be $true
+            $result | Should -Be $true
         }
 
         It "Verify HOME" {
             $homePath = $HOME
             $tildePath = (Resolve-Path -Path ~).Path
-            $homePath | Should Be $tildePath
+            $homePath | Should -Be $tildePath
         }
     }
 }
@@ -387,26 +387,26 @@ Describe "Handling of globbing patterns" -Tags "CI" {
 
         It "Rename-Item -LiteralPath can rename a file with Unix globbing characters" {
             Rename-Item -LiteralPath $file.FullName -NewName $newPath
-            Test-Path -LiteralPath $file.FullName | Should Be $false
-            Test-Path -LiteralPath $newPath | Should Be $true
+            Test-Path -LiteralPath $file.FullName | Should -Be $false
+            Test-Path -LiteralPath $newPath | Should -Be $true
         }
 
         It "Remove-Item -LiteralPath can delete a file with Unix globbing characters" {
             Remove-Item -LiteralPath $file.FullName
-            Test-Path -LiteralPath $file.FullName | Should Be $false
+            Test-Path -LiteralPath $file.FullName | Should -Be $false
         }
 
         It "Move-Item -LiteralPath can move a file with Unix globbing characters" {
             $dir = New-Item -ItemType Directory -Path $dirPath
             Move-Item -LiteralPath $file.FullName -Destination $dir.FullName
-            Test-Path -LiteralPath $file.FullName | Should Be $false
+            Test-Path -LiteralPath $file.FullName | Should -Be $false
             $newPath = Join-Path $dir.FullName $file.Name
-            Test-Path -LiteralPath $newPath | Should Be $true
+            Test-Path -LiteralPath $newPath | Should -Be $true
         }
 
         It "Copy-Item -LiteralPath can copy a file with Unix globbing characters" {
             Copy-Item -LiteralPath $file.FullName -Destination $newPath
-            Test-Path -LiteralPath $newPath | Should Be $true
+            Test-Path -LiteralPath $newPath | Should -Be $true
         }
     }
 
@@ -420,12 +420,12 @@ Describe "Handling of globbing patterns" -Tags "CI" {
             $testPath2 = "$testdrive\foo*2"
             New-Item -Path $testPath -ItemType File
             New-Item -Path $testPath2 -ItemType File
-            Test-Path -LiteralPath $testPath | Should Be $true
-            Test-Path -LiteralPath $testPath2 | Should Be $true
-            { Remove-Item -LiteralPath $testPath } | Should Not Throw
-            Test-Path -LiteralPath $testPath | Should Be $false
+            Test-Path -LiteralPath $testPath | Should -Be $true
+            Test-Path -LiteralPath $testPath2 | Should -Be $true
+            { Remove-Item -LiteralPath $testPath } | Should -Not -Throw
+            Test-Path -LiteralPath $testPath | Should -Be $false
             # make sure wildcard wasn't applied so this file should still exist
-            Test-Path -LiteralPath $testPath2 | Should Be $true
+            Test-Path -LiteralPath $testPath2 | Should -Be $true
         }
     }
 }
@@ -464,50 +464,50 @@ Describe "Hard link and symbolic link tests" -Tags "CI", "RequireAdminOnWindows"
     Context "New-Item and hard/symbolic links" {
         It "New-Item can create a hard link to a file" {
             New-Item -ItemType HardLink -Path $hardLinkToFile -Value $realFile
-            Test-Path $hardLinkToFile | Should Be $true
+            Test-Path $hardLinkToFile | Should -Be $true
             $link = Get-Item -Path $hardLinkToFile
-            $link.LinkType | Should BeExactly "HardLink"
-            Get-Content -Path $hardLinkToFile | Should be $fileContent
+            $link.LinkType | Should -BeExactly "HardLink"
+            Get-Content -Path $hardLinkToFile | Should -Be $fileContent
         }
         It "New-Item can create symbolic link to file" {
             New-Item -ItemType SymbolicLink -Path $symLinkToFile -Value $realFile
-            Test-Path $symLinkToFile | Should Be $true
+            Test-Path $symLinkToFile | Should -Be $true
             $real = Get-Item -Path $realFile
             $link = Get-Item -Path $symLinkToFile
-            $link.LinkType | Should BeExactly "SymbolicLink"
-            $link.Target | Should Be $real.FullName
-            Get-Content -Path $symLinkToFile | Should be $fileContent
+            $link.LinkType | Should -BeExactly "SymbolicLink"
+            $link.Target | Should -Be $real.FullName
+            Get-Content -Path $symLinkToFile | Should -Be $fileContent
         }
         It "New-Item can create a symbolic link to nothing" {
             New-Item -ItemType SymbolicLink -Path $symLinkToNothing -Value $nonFile
-            Test-Path $symLinkToNothing | Should Be $true
+            Test-Path $symLinkToNothing | Should -Be $true
             $link = Get-Item -Path $symLinkToNothing
-            $link.LinkType | Should BeExactly "SymbolicLink"
-            $link.Target | Should Be $nonFile
+            $link.LinkType | Should -BeExactly "SymbolicLink"
+            $link.Target | Should -Be $nonFile
         }
         It "New-Item emits an error when path to symbolic link already exists." {
             { New-Item -ItemType SymbolicLink -Path $realDir -Value $symLinkToDir -ErrorAction Stop } | ShouldBeErrorId "SymLinkExists,Microsoft.PowerShell.Commands.NewItemCommand"
         }
         It "New-Item can create a symbolic link to a directory" -Skip:($IsWindows) {
             New-Item -ItemType SymbolicLink -Path $symLinkToDir -Value $realDir
-            Test-Path $symLinkToDir | Should Be $true
+            Test-Path $symLinkToDir | Should -Be $true
             $real = Get-Item -Path $realDir
             $link = Get-Item -Path $symLinkToDir
-            $link.LinkType | Should BeExactly "SymbolicLink"
-            $link.Target | Should Be $real.FullName
+            $link.LinkType | Should -BeExactly "SymbolicLink"
+            $link.Target | Should -Be $real.FullName
         }
         It "New-Item can create a directory symbolic link to a directory" -Skip:(-Not $IsWindows) {
             New-Item -ItemType SymbolicLink -Path $symLinkToDir -Value $realDir
-            Test-Path $symLinkToDir | Should Be $true
+            Test-Path $symLinkToDir | Should -Be $true
             $real = Get-Item -Path $realDir
             $link = Get-Item -Path $symLinkToDir
-            $link | Should BeOfType System.IO.DirectoryInfo
-            $link.LinkType | Should BeExactly "SymbolicLink"
-            $link.Target | Should Be $real.FullName
+            $link | Should -BeOfType System.IO.DirectoryInfo
+            $link.LinkType | Should -BeExactly "SymbolicLink"
+            $link.Target | Should -Be $real.FullName
         }
         It "New-Item can create a directory junction to a directory" -Skip:(-Not $IsWindows) {
             New-Item -ItemType Junction -Path $junctionToDir -Value $realDir
-            Test-Path $junctionToDir | Should Be $true
+            Test-Path $junctionToDir | Should -Be $true
         }
     }
 
@@ -521,8 +521,8 @@ Describe "Hard link and symbolic link tests" -Tags "CI", "RequireAdminOnWindows"
             $omegaDir = Join-Path $TestDrive "sub-omega"
             $omegaFile1 = Join-Path $omegaDir "OmegaFile1"
             $omegaFile2 = Join-Path $omegaDir "OmegaFile2"
-            $betaDir = Join-Path $alphaDir "sub-beta"
-            $betaLink = Join-Path $alphaDir "link-beta"
+            $betaDir = Join-Path $alphaDir "sub-Beta"
+            $betaLink = Join-Path $alphaDir "link-Beta"
             $betaFile1 = Join-Path $betaDir "BetaFile1.txt"
             $betaFile2 = Join-Path $betaDir "BetaFile2.txt"
             $betaFile3 = Join-Path $betaDir "BetaFile3.txt"
@@ -551,14 +551,14 @@ Describe "Hard link and symbolic link tests" -Tags "CI", "RequireAdminOnWindows"
             $filenamePattern = "AlphaFile[12]\.txt"
             New-Item -ItemType SymbolicLink -Path $alphaLink -Value $alphaDir
             $ci = Get-ChildItem $alphaLink
-            $ci.Count | Should BeExactly 3
-            $ci[1].Name | Should MatchExactly $filenamePattern
-            $ci[2].Name | Should MatchExactly $filenamePattern
+            $ci.Count | Should -BeExactly 3
+            $ci[1].Name | Should -MatchExactly $filenamePattern
+            $ci[2].Name | Should -MatchExactly $filenamePattern
         }
         It "Get-ChildItem does not recurse into symbolic links not explicitly given on the command line" {
             New-Item -ItemType SymbolicLink -Path $betaLink -Value $betaDir
             $ci = Get-ChildItem $alphaLink -Recurse
-            $ci.Count | Should BeExactly 7
+            $ci.Count | Should -BeExactly 7
         }
         It "Get-ChildItem will recurse into symlinks given -FollowSymlink, avoiding link loops" {
             New-Item -ItemType Directory -Path $gammaDir
@@ -566,8 +566,8 @@ Describe "Hard link and symbolic link tests" -Tags "CI", "RequireAdminOnWindows"
             New-Item -ItemType SymbolicLink -Path $uptwoLink -Value $alphaDir
             New-Item -ItemType SymbolicLink -Path $omegaLink -Value $omegaDir
             $ci = Get-ChildItem -Path $alphaDir -FollowSymlink -Recurse -WarningVariable w -WarningAction SilentlyContinue
-            $ci.Count | Should BeExactly 13
-            $w.Count | Should BeExactly 3
+            $ci.Count | Should -BeExactly 13
+            $w.Count | Should -BeExactly 3
         }
     }
 
@@ -622,8 +622,8 @@ Describe "Hard link and symbolic link tests" -Tags "CI", "RequireAdminOnWindows"
                 )
 
                 Remove-Item -Path $Link -ErrorAction SilentlyContinue >$null
-                Test-Path -Path $Link | Should Be $false
-                Test-Path -Path $Target | Should Be $true
+                Test-Path -Path $Link | Should -Be $false
+                Test-Path -Path $Target | Should -Be $true
             }
         }
 
@@ -667,9 +667,9 @@ Describe "Hard link and symbolic link tests" -Tags "CI", "RequireAdminOnWindows"
             $childA = Get-Childitem $folder
             Remove-Item -Path $link -Recurse
             $childB = Get-ChildItem $folder
-            $childB.Count | Should Be 1
-            $childB.Count | Should BeExactly $childA.Count
-            $childB.Name | Should BeExactly $childA.Name
+            $childB.Count | Should -Be 1
+            $childB.Count | Should -BeExactly $childA.Count
+            $childB.Name | Should -BeExactly $childA.Name
         }
     }
 }
@@ -728,14 +728,14 @@ Describe "Copy-Item can avoid copying an item onto itself" -Tags "CI", "RequireA
         It "Copy-Item can copy to file name differing only by case" {
             if ($isCaseSensitive)
             {
-                Copy-Item -Path $sourcePath -Destination $destinationPath -ErrorAction SilentlyContinue | Should Be $null
-                Test-Path -Path $destinationPath | Should Be $true
+                Copy-Item -Path $sourcePath -Destination $destinationPath -ErrorAction SilentlyContinue | Should -Be $null
+                Test-Path -Path $destinationPath | Should -Be $true
             }
             else
             {
                 { Copy-Item -Path $sourcePath -Destination $destinationPath -ErrorAction Stop } | ShouldBeErrorId "CopyError,Microsoft.PowerShell.Commands.CopyItemCommand"
-                $Error[0].Exception | Should BeOfType System.IO.IOException
-                $Error[0].Exception.Data[$selfCopyKey] | Should Not Be $null
+                $Error[0].Exception | Should -BeOfType System.IO.IOException
+                $Error[0].Exception.Data[$selfCopyKey] | Should -Not -Be $null
             }
         }
     }
@@ -797,8 +797,8 @@ Describe "Copy-Item can avoid copying an item onto itself" -Tags "CI", "RequireA
                 )
 
                 { Copy-Item -Path $Source -Destination $Destination -ErrorAction Stop } | ShouldBeErrorId "CopyError,Microsoft.PowerShell.Commands.CopyItemCommand"
-                $Error[0].Exception | Should BeOfType System.IO.IOException
-                $Error[0].Exception.Data[$selfCopyKey] | Should Not Be $null
+                $Error[0].Exception | Should -BeOfType System.IO.IOException
+                $Error[0].Exception.Data[$selfCopyKey] | Should -Not -Be $null
             }
         }
 
@@ -844,24 +844,24 @@ Describe "Handling long paths" -Tags "CI" {
 
     It "Can remove a file via a long path" {
         Remove-Item -Path $longFilePath -ErrorVariable e -ErrorAction SilentlyContinue
-        $e | Should BeNullOrEmpty
-        $longFilePath | Should Not Exist
+        $e | Should -BeNullOrEmpty
+        $longFilePath | Should -Not -Exist
     }
     It "Can rename a file via a long path" {
         $newFileName = "new-file.txt"
         $newPath = Join-Path $longDirPath $newFileName
         Rename-Item -Path $longFilePath -NewName $newFileName
-        $longFilePath | Should Not Exist
-        $newPath | Should Exist
+        $longFilePath | Should -Not -Exist
+        $newPath | Should -Exist
     }
     It "Can change into a directory via a long path" {
         Set-Location -Path $longDirPath -ErrorVariable e -ErrorAction SilentlyContinue
-        $e | Should BeNullOrEmpty
+        $e | Should -BeNullOrEmpty
         $c = Get-Location
-        $fileName | Should Exist
+        $fileName | Should -Exist
     }
     It "Can use Test-Path to check for a file via a long path" {
-        Test-Path $longFilePath | Should Be $true
+        Test-Path $longFilePath | Should -Be $true
     }
 }
 
@@ -903,52 +903,52 @@ Describe "Extended FileSystem Item/Content Cmdlet Provider Tests" -Tags "Feature
                 Get-Item -Path $testDir -ErrorAction Stop
                 throw "Expected exception not thrown"
             }
-            catch { $_.FullyQualifiedErrorId | Should Be "PathNotFound,Microsoft.PowerShell.Commands.GetItemCommand" }
+            catch { $_.FullyQualifiedErrorId | Should -Be "PathNotFound,Microsoft.PowerShell.Commands.GetItemCommand" }
         }
 
         It "Verify Directory + Confirm bypass" {
             $result = New-Item -Path . -ItemType Directory -Name $testDir -Confirm:$false
-            $result.Name | Should Be $testDir
+            $result.Name | Should -Be $testDir
         }
 
         It "Verify Directory + Force" {
             New-Item -Path . -ItemType Directory -Name $testDir > $null
             $result = New-Item -Path . -ItemType Directory -Name $testDir -Force #would normally fail without force
-            $result.Name | Should Be $testDir
+            $result.Name | Should -Be $testDir
         }
 
         It "Verify File + Value" {
             $result = New-Item -Path . -ItemType File -Name $testFile -Value "Some String"
             $content = Get-Content -Path $testFile
-            $result.Name | Should Be $testFile
-            $content | Should Be "Some String"
+            $result.Name | Should -Be $testFile
+            $content | Should -Be "Some String"
         }
     }
 
     Context "Valdiate Get-Item parameters" {
         It "Verify Force" {
             $result = Get-Item -Path $testFile -Force
-            $result.Name | Should Be $testFile
+            $result.Name | Should -Be $testFile
         }
 
         It "Verify Path Wildcard" {
             $result = Get-Item -Path "*2.txt"
-            $result.Name | Should Be $testFile2
+            $result.Name | Should -Be $testFile2
         }
 
         It "Verify Include" {
             $result = Get-Item -Path "TestDrive:\*" -Include "*2.txt"
-            $result.Name | Should Be $testFile2
+            $result.Name | Should -Be $testFile2
         }
 
         It "Verify Include and Exclude Intersection" {
             $result = Get-Item -Path "TestDrive:\*" -Include "*.txt" -Exclude "*2*"
-            $result.Name | Should Be $testFile
+            $result.Name | Should -Be $testFile
         }
 
         It "Verify Filter" {
             $result = Get-Item -Path "TestDrive:\*" -filter "*2.txt"
-            $result.Name | Should Be $testFile2
+            $result.Name | Should -Be $testFile2
         }
 
         It "Verify -LiteralPath with wildcard fails for file that doesn't exist" {
@@ -958,7 +958,7 @@ Describe "Extended FileSystem Item/Content Cmdlet Provider Tests" -Tags "Feature
         It "Verify -LiteralPath with wildcard succeeds for file" -Skip:($IsWindows) {
             New-Item -Path "$testdrive\a*b.txt" -ItemType File > $null
             $file = Get-Item -LiteralPath "$testdrive\a*b.txt"
-            $file.Name | Should BeExactly "a*b.txt"
+            $file.Name | Should -BeExactly "a*b.txt"
         }
     }
 
@@ -982,7 +982,7 @@ Describe "Extended FileSystem Item/Content Cmdlet Provider Tests" -Tags "Feature
                 Get-Item -Path $altTestFile -ErrorAction Stop
                 throw "Expected exception not thrown"
             }
-            catch { $_.FullyQualifiedErrorId | Should Be "PathNotFound,Microsoft.PowerShell.Commands.GetItemCommand" }
+            catch { $_.FullyQualifiedErrorId | Should -Be "PathNotFound,Microsoft.PowerShell.Commands.GetItemCommand" }
         }
 
         It "Verify Include and Exclude Intersection" {
@@ -990,16 +990,16 @@ Describe "Extended FileSystem Item/Content Cmdlet Provider Tests" -Tags "Feature
             Move-Item -Path "TestDrive:\*" -Destination "TestDrive:\dest" -Include "*.txt" -Exclude "*2*"
             $file1 = Get-Item "TestDrive:\dest\$testFile2" -ErrorAction SilentlyContinue
             $file2 = Get-Item "TestDrive:\dest\$testFile" -ErrorAction SilentlyContinue
-            $file1 | Should BeNullOrEmpty
-            $file2.Name | Should Be $testFile
+            $file1 | Should -BeNullOrEmpty
+            $file2.Name | Should -Be $testFile
         }
 
         It "Verify Filter" {
             Move-Item -Path "TestDrive:\*" -Filter "*2.txt" -Destination $altTestFile
             $file1 = Get-Item $testFile2 -ErrorAction SilentlyContinue
             $file2 = Get-Item $altTestFile -ErrorAction SilentlyContinue
-            $file1 | Should BeNullOrEmpty
-            $file2.Name | Should Be $altTestFile
+            $file1 | Should -BeNullOrEmpty
+            $file2.Name | Should -Be $altTestFile
         }
     }
 
@@ -1014,15 +1014,15 @@ Describe "Extended FileSystem Item/Content Cmdlet Provider Tests" -Tags "Feature
                 Get-Item -Path $newFile -ErrorAction Stop
                 throw "Expected exception not thrown"
             }
-            catch { $_.FullyQualifiedErrorId | Should Be "PathNotFound,Microsoft.PowerShell.Commands.GetItemCommand" }
+            catch { $_.FullyQualifiedErrorId | Should -Be "PathNotFound,Microsoft.PowerShell.Commands.GetItemCommand" }
         }
 
         It "Verify Confirm can be bypassed" {
             Rename-Item -Path $testFile -NewName $newFile -Confirm:$false
             $file1 = Get-Item -Path $testFile -ErrorAction SilentlyContinue
             $file2 = Get-Item -Path $newFile -ErrorAction SilentlyContinue
-            $file1 | Should BeNullOrEmpty
-            $file2.Name | Should Be $newFile
+            $file1 | Should -BeNullOrEmpty
+            $file2.Name | Should -Be $newFile
         }
     }
 
@@ -1030,7 +1030,7 @@ Describe "Extended FileSystem Item/Content Cmdlet Provider Tests" -Tags "Feature
         It "Verify WhatIf" {
             Remove-Item $testFile -WhatIf
             $result = Get-Item $testFile
-            $result.Name | Should Be $testFile
+            $result.Name | Should -Be $testFile
         }
 
         It "Verify Confirm can be bypassed" {
@@ -1039,7 +1039,7 @@ Describe "Extended FileSystem Item/Content Cmdlet Provider Tests" -Tags "Feature
                 Get-Item $testFile -ErrorAction Stop
                 throw "Expected exception not thrown"
             }
-            catch { $_.FullyQualifiedErrorId | Should Be "PathNotFound,Microsoft.PowerShell.Commands.GetItemCommand" }
+            catch { $_.FullyQualifiedErrorId | Should -Be "PathNotFound,Microsoft.PowerShell.Commands.GetItemCommand" }
         }
 
         It "Verify LiteralPath" {
@@ -1048,13 +1048,13 @@ Describe "Extended FileSystem Item/Content Cmdlet Provider Tests" -Tags "Feature
                 Get-Item $testFile -ErrorAction Stop
                 throw "Expected exception not thrown"
             }
-            catch { $_.FullyQualifiedErrorId | Should Be "PathNotFound,Microsoft.PowerShell.Commands.GetItemCommand" }
+            catch { $_.FullyQualifiedErrorId | Should -Be "PathNotFound,Microsoft.PowerShell.Commands.GetItemCommand" }
         }
 
         It "Verify Filter" {
             Remove-Item "TestDrive:\*" -Filter "*.txt"
             $result = Get-Item "TestDrive:\*.txt"
-            $result | Should BeNullOrEmpty
+            $result | Should -BeNullOrEmpty
         }
 
         It "Verify Include" {
@@ -1063,21 +1063,21 @@ Describe "Extended FileSystem Item/Content Cmdlet Provider Tests" -Tags "Feature
                 Get-Item $testFile2 -ErrorAction Stop
                 throw "Expected exception not thrown"
             }
-            catch { $_.FullyQualifiedErrorId | Should Be "PathNotFound,Microsoft.PowerShell.Commands.GetItemCommand" }
+            catch { $_.FullyQualifiedErrorId | Should -Be "PathNotFound,Microsoft.PowerShell.Commands.GetItemCommand" }
         }
 
         It "Verify Include and Exclude Intersection" {
             Remove-Item "TestDrive:\*" -Include "*.txt" -exclude "*2*"
             $file1 = Get-Item $testFile -ErrorAction SilentlyContinue
             $file2 = Get-Item $testFile2 -ErrorAction SilentlyContinue
-            $file1 | Should BeNullOrEmpty
-            $file2.Name | Should Be $testFile2
+            $file1 | Should -BeNullOrEmpty
+            $file2.Name | Should -Be $testFile2
         }
 
         It "Verify Path can accept wildcard" {
             Remove-Item "TestDrive:\*.txt" -Recurse -Force
             $result = Get-ChildItem "TestDrive:\*.txt"
-            $result | Should BeNullOrEmpty
+            $result | Should -BeNullOrEmpty
         }
 
         It "Verify no error if wildcard doesn't match: <path>" -TestCases @(
@@ -1086,7 +1086,7 @@ Describe "Extended FileSystem Item/Content Cmdlet Provider Tests" -Tags "Feature
             @{path="TestDrive:\z.*"}
         ) {
             param($path)
-            { Remove-Item $path } | Should Not Throw
+            { Remove-Item $path } | Should -Not -Throw
         }
     }
 
@@ -1095,50 +1095,50 @@ Describe "Extended FileSystem Item/Content Cmdlet Provider Tests" -Tags "Feature
             Set-Content -Path @($testFile,$testFile2) -Value @($testContent,$testContent2)
             $content1 = Get-Content $testFile
             $content2 = Get-Content $testFile2
-            $content1 | Should Be $content2
-            ($content1[0] + $content1[1]) | Should Be ($testContent + $testContent2)
+            $content1 | Should -Be $content2
+            ($content1[0] + $content1[1]) | Should -Be ($testContent + $testContent2)
         }
 
         It "Validate LiteralPath" {
             Set-Content -LiteralPath "TestDrive:\$testFile" -Value $testContent
             $content = Get-Content $testFile
-            $content | Should Be $testContent
+            $content | Should -Be $testContent
         }
 
         It "Validate Confirm can be bypassed" {
             Set-Content -Path $testFile -Value $testContent -Confirm:$false
             $content = Get-Content $testFile
-            $content | Should Be $testContent
+            $content | Should -Be $testContent
         }
 
         It "Validate WhatIf" {
             Set-Content -Path $testFile -Value $testContent -WhatIf
             $content = Get-Content $testFile
-            $content | Should BeNullOrEmpty
+            $content | Should -BeNullOrEmpty
         }
 
         It "Validate Include" {
             Set-Content -Path "TestDrive:\*" -Value $testContent -Include "*2.txt"
             $content1 = Get-Content $testFile
             $content2 = Get-Content $testFile2
-            $content1 | Should BeNullOrEmpty
-            $content2 | Should Be $testContent
+            $content1 | Should -BeNullOrEmpty
+            $content2 | Should -Be $testContent
         }
 
         It "Validate Exclude" {
             Set-Content -Path "TestDrive:\*" -Value $testContent -Exclude "*2.txt"
             $content1 = Get-Content $testFile
             $content2 = Get-Content $testFile2
-            $content1 | Should Be $testContent
-            $content2 | Should BeNullOrEmpty
+            $content1 | Should -Be $testContent
+            $content2 | Should -BeNullOrEmpty
         }
 
         It "Validate Filter" {
             Set-Content -Path "TestDrive:\*" -Value $testContent -Filter "*2.txt"
             $content1 = Get-Content $testFile
             $content2 = Get-Content $testFile2
-            $content1 | Should BeNullOrEmpty
-            $content2 | Should Be $testContent
+            $content1 | Should -BeNullOrEmpty
+            $content2 | Should -Be $testContent
         }
     }
 
@@ -1150,52 +1150,52 @@ Describe "Extended FileSystem Item/Content Cmdlet Provider Tests" -Tags "Feature
 
         It "Validate Array Input for Path" {
             $result = Get-Content -Path @($testFile,$testFile2)
-            $result[0] | Should Be $testContent
-            $result[1] | Should Be $testContent2
+            $result[0] | Should -Be $testContent
+            $result[1] | Should -Be $testContent2
         }
 
         It "Validate Include" {
             $result = Get-Content -Path "TestDrive:\*" -Include "*2.txt"
-            $result | Should Be $testContent2
+            $result | Should -Be $testContent2
         }
 
         It "Validate Exclude" {
             $result = Get-Content -Path "TestDrive:\*" -Exclude "*2.txt"
-            $result | Should Be $testContent
+            $result | Should -Be $testContent
         }
 
         It "Validate Filter" {
             $result = Get-Content -Path "TestDrive:\*" -Filter "*2.txt"
-            $result | Should Be $testContent2
+            $result | Should -Be $testContent2
         }
 
         It "Validate ReadCount" {
             Set-Content -Path $testFile -Value "Test Line 1`nTest Line 2`nTest Line 3`nTest Line 4`nTest Line 5`nTest Line 6"
             $result = (Get-Content -Path $testFile -ReadCount 2)
-            $result[0][0] | Should Be "Test Line 1"
-            $result[0][1] | Should Be "Test Line 2"
-            $result[1][0] | Should Be "Test Line 3"
-            $result[1][1] | Should Be "Test Line 4"
-            $result[2][0] | Should Be "Test Line 5"
-            $result[2][1] | Should Be "Test Line 6"
+            $result[0][0] | Should -Be "Test Line 1"
+            $result[0][1] | Should -Be "Test Line 2"
+            $result[1][0] | Should -Be "Test Line 3"
+            $result[1][1] | Should -Be "Test Line 4"
+            $result[2][0] | Should -Be "Test Line 5"
+            $result[2][1] | Should -Be "Test Line 6"
         }
 
         It "Validate TotalCount" {
             Set-Content -Path $testFile -Value "Test Line 1`nTest Line 2`nTest Line 3`nTest Line 4`nTest Line 5`nTest Line 6"
             $result = Get-Content -Path $testFile -TotalCount 4
-            $result[0] | Should Be "Test Line 1"
-            $result[1] | Should Be "Test Line 2"
-            $result[2] | Should Be "Test Line 3"
-            $result[3] | Should Be "Test Line 4"
-            $result[4] | Should BeNullOrEmpty
+            $result[0] | Should -Be "Test Line 1"
+            $result[1] | Should -Be "Test Line 2"
+            $result[2] | Should -Be "Test Line 3"
+            $result[3] | Should -Be "Test Line 4"
+            $result[4] | Should -BeNullOrEmpty
         }
 
         It "Validate Tail" {
             Set-Content -Path $testFile -Value "Test Line 1`nTest Line 2`nTest Line 3`nTest Line 4`nTest Line 5`nTest Line 6"
             $result = Get-Content -Path $testFile -Tail 2
-            $result[0] | Should Be "Test Line 5"
-            $result[1] | Should Be "Test Line 6"
-            $result[2] | Should BeNullOrEmpty
+            $result[0] | Should -Be "Test Line 5"
+            $result[1] | Should -Be "Test Line 6"
+            $result[2] | Should -BeNullOrEmpty
         }
     }
 }
@@ -1236,12 +1236,12 @@ Describe "Extended FileSystem Path/Location Cmdlet Provider Tests" -Tags "Featur
     Context "Validate Resolve-Path Cmdlet Parameters" {
         It "Verify LiteralPath" {
             $result = Resolve-Path -LiteralPath "TestDrive:\"
-            ($result.Path.TrimEnd('/\')) | Should Be "TestDrive:"
+            ($result.Path.TrimEnd('/\')) | Should -Be "TestDrive:"
         }
 
         It "Verify relative" {
             $relativePath = Resolve-Path -Path . -Relative
-            $relativePath | Should Be (Join-Path "." "")
+            $relativePath | Should -Be (Join-Path "." "")
         }
     }
 
@@ -1249,10 +1249,10 @@ Describe "Extended FileSystem Path/Location Cmdlet Provider Tests" -Tags "Featur
         It "Validate Resolve" {
             $result = Join-Path -Path . -ChildPath $level1_0 -Resolve
             if ($IsWindows) {
-                $result | Should BeExactly "TestDrive:\$level1_0"
+                $result | Should -BeExactly "TestDrive:\$level1_0"
             }
             else {
-                $result | Should BeExactly "TestDrive:/$level1_0"
+                $result | Should -BeExactly "TestDrive:/$level1_0"
             }
         }
     }
@@ -1260,63 +1260,63 @@ Describe "Extended FileSystem Path/Location Cmdlet Provider Tests" -Tags "Featur
     Context "Validate Split-Path Cmdlet Parameters" {
         It "Validate Parent" {
             $result = Split-Path -Path $level1_0Full -Parent -Resolve
-            ($result.TrimEnd('/\')) | Should Be "TestDrive:"
+            ($result.TrimEnd('/\')) | Should -Be "TestDrive:"
         }
 
         It "Validate IsAbsolute" {
             $resolved = Split-Path -Path . -Resolve -IsAbsolute
             $unresolved = Split-Path -Path . -IsAbsolute
-            $resolved | Should Be $true
-            $unresolved | Should Be $false
+            $resolved | Should -Be $true
+            $unresolved | Should -Be $false
         }
 
         It "Validate Leaf" {
             $result = Split-Path -Path $level1_0Full -Leaf
-            $result | Should Be $level1_0
+            $result | Should -Be $level1_0
         }
 
         It 'Validate LeafBase' {
             $result = Split-Path -Path "$level2_1Full$fileExt" -LeafBase
-            $result | Should Be $level2_1
+            $result | Should -Be $level2_1
         }
         It 'Validate LeafBase is not over-zealous' {
 
             $result = Split-Path -Path "$level2_1Full$fileExt$fileExt" -LeafBase
-            $result | Should Be "$level2_1$fileExt"
+            $result | Should -Be "$level2_1$fileExt"
         }
 
         It 'Validate LeafBase' {
             $result = Split-Path -Path "$level2_1Full$fileExt" -Extension
-            $result | Should Be $fileExt
+            $result | Should -Be $fileExt
         }
 
         It "Validate NoQualifier" {
             $result = Split-Path -Path $level1_0Full -NoQualifier
-            ($result.TrimStart('/\')) | Should Be $level1_0
+            ($result.TrimStart('/\')) | Should -Be $level1_0
         }
 
         It "Validate Qualifier" {
             $result = Split-Path -Path $level1_0Full -Qualifier
-            $result | Should Be "TestDrive:"
+            $result | Should -Be "TestDrive:"
         }
     }
 
     Context "Valdiate Set-Location Cmdlets Parameters" {
         It "Without Passthru Doesn't Return a Path" {
             $result = Set-Location -Path $level1_0
-            $result | Should BeNullOrEmpty
+            $result | Should -BeNullOrEmpty
         }
 
         It "By LiteralPath" {
             $result = Set-Location -LiteralPath $level1_0Full -PassThru
-            $result.Path | Should Be $level1_0Full
+            $result.Path | Should -Be $level1_0Full
         }
 
         It "To Default Location Stack Does Nothing" {
             $beforeLoc = Get-Location
             Set-Location -StackName ""
             $afterLoc = Get-Location
-            $beforeLoc.Path | Should Be $afterLoc.Path
+            $beforeLoc.Path | Should -Be $afterLoc.Path
         }
 
         It "WhatIf is Not Supported" {
@@ -1324,7 +1324,7 @@ Describe "Extended FileSystem Path/Location Cmdlet Provider Tests" -Tags "Featur
                 Set-Location $level1_0 -WhatIf
                 throw "Expected exception not thrown"
             }
-            catch { $_.FullyQualifiedErrorId | Should Be "NamedParameterNotFound,Microsoft.PowerShell.Commands.SetLocationCommand" }
+            catch { $_.FullyQualifiedErrorId | Should -Be "NamedParameterNotFound,Microsoft.PowerShell.Commands.SetLocationCommand" }
         }
     }
 
@@ -1338,9 +1338,9 @@ Describe "Extended FileSystem Path/Location Cmdlet Provider Tests" -Tags "Featur
             Pop-Location
             $location3 = Get-Location
 
-            $location1.Path | Should Be $level2_0Full
-            $location2.Path | Should Be $level1_0Full
-            $location3.Path | Should Be $root
+            $location1.Path | Should -Be $level2_0Full
+            $location2.Path | Should -Be $level1_0Full
+            $location3.Path | Should -Be $root
         }
 
         It "Verify Push + PassThru" {
@@ -1352,9 +1352,9 @@ Describe "Extended FileSystem Path/Location Cmdlet Provider Tests" -Tags "Featur
             Set-Location $level2_0
             $location3 = Get-Location
 
-            $location1.Path | Should Be $passThru1.Path
-            $location2.Path | Should Be $passThru2.Path
-            $location3.Path | Should Be $level2_0Full
+            $location1.Path | Should -Be $passThru1.Path
+            $location2.Path | Should -Be $passThru2.Path
+            $location3.Path | Should -Be $level2_0Full
         }
 
         It "Verify Push + LiteralPath" {
@@ -1366,9 +1366,9 @@ Describe "Extended FileSystem Path/Location Cmdlet Provider Tests" -Tags "Featur
             Pop-Location
             $location3 = Get-Location
 
-            $location1.Path | Should Be $level2_0Full
-            $location2.Path | Should Be $level1_0Full
-            $location3.Path | Should Be $root
+            $location1.Path | Should -Be $level2_0Full
+            $location2.Path | Should -Be $level1_0Full
+            $location3.Path | Should -Be $root
         }
 
         It "Verify Pop + Invalid Stack Name" {
@@ -1376,7 +1376,7 @@ Describe "Extended FileSystem Path/Location Cmdlet Provider Tests" -Tags "Featur
                 Pop-Location -StackName UnknownStackName -ErrorAction Stop
                 throw "Expected exception not thrown"
             }
-            catch { $_.FullyQualifiedErrorId | Should Be "Argument,Microsoft.PowerShell.Commands.PopLocationCommand" }
+            catch { $_.FullyQualifiedErrorId | Should -Be "Argument,Microsoft.PowerShell.Commands.PopLocationCommand" }
         }
     }
 }
@@ -1392,9 +1392,9 @@ Describe "UNC paths" -Tags 'CI' {
             $systemDrive = ($env:SystemDrive).Replace(":","$")
             $testPath = Join-Path "\\localhost" $systemDrive
             & $cmdlet $testPath
-            Get-Location | Should BeExactly "Microsoft.PowerShell.Core\FileSystem::$testPath"
+            Get-Location | Should -BeExactly "Microsoft.PowerShell.Core\FileSystem::$testPath"
             $children = Get-ChildItem -ErrorAction Stop
-            $children.Count | Should BeGreaterThan 0
+            $children.Count | Should -BeGreaterThan 0
         }
         finally {
             Set-Location $originalLocation

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
@@ -40,31 +40,31 @@ Describe "Basic FileSystem Provider Tests" -Tags "CI" {
         It "Verify New-Item for directory" {
             $newDir = New-Item -Path $newTestDir -ItemType Directory
             $directoryExists = Test-Path $newTestDir
-            $directoryExists | Should -Be $true
-            $newDir.Name | Should -Be $newTestDir
+            $directoryExists | Should -BeTrue
+            $newDir.Name | Should -BeExactly $newTestDir
         }
 
         It "Verify New-Item for file" {
             $newFile = New-Item -Path $newTestFile -ItemType File
             $fileExists = Test-Path $newTestFile
-            $fileExists | Should -Be $true
-            $newFile.Name | Should -Be $newTestFile
+            $fileExists | Should -BeTrue
+            $newFile.Name | Should -BeExactly $newTestFile
         }
 
         It "Verify Remove-Item for directory" {
             $existsBefore = Test-Path $testDir
             Remove-Item -Path $testDir -Recurse -Force
             $existsAfter = Test-Path $testDir
-            $existsBefore | Should -Be $true
-            $existsAfter | Should -Be $false
+            $existsBefore | Should -BeTrue
+            $existsAfter | Should -BeFalse
         }
 
         It "Verify Remove-Item for file" {
             $existsBefore = Test-Path $testFile
             Remove-Item -Path $testFile -Force
             $existsAfter = Test-Path $testFile
-            $existsBefore | Should -Be $true
-            $existsAfter | Should -Be $false
+            $existsBefore | Should -BeTrue
+            $existsAfter | Should -BeFalse
         }
 
         It "Verify Rename-Item for file" {
@@ -88,8 +88,8 @@ Describe "Basic FileSystem Provider Tests" -Tags "CI" {
         It "Verify Copy-Item" {
             $newFile = Copy-Item -Path $testFile -Destination $newTestFile -PassThru
             $fileExists = Test-Path $newTestFile
-            $fileExists | Should -Be $true
-            $newFile.Name | Should -Be $newTestFile
+            $fileExists | Should -BeTrue
+            $newFile.Name | Should -BeExactly $newTestFile
         }
 
         It "Verify Move-Item for file" {
@@ -117,7 +117,7 @@ Describe "Basic FileSystem Provider Tests" -Tags "CI" {
         It "Verify Move-Item as substitute for Rename-Item" {
             $newFile = Move-Item -Path $testFile -Destination $newTestFile -PassThru
             $fileExists = Test-Path $newTestFile
-            $fileExists | Should -Be $true
+            $fileExists | Should -BeTrue
             $newFile.Name | Should -Be $newTestFile
         }
 
@@ -180,7 +180,7 @@ Describe "Basic FileSystem Provider Tests" -Tags "CI" {
              foreach ($deviceName in $reservedNames)
              {
                 Copy-Item -Path $testFile -Destination $deviceName -Force -ErrorAction SilentlyContinue
-                Test-Path $deviceName | Should -Be $true
+                Test-Path $deviceName | Should -BeTrue
              }
          }
 
@@ -188,7 +188,7 @@ Describe "Basic FileSystem Provider Tests" -Tags "CI" {
              foreach ($deviceName in $reservedNames)
              {
                 Move-Item -Path $testFile -Destination $deviceName -Force -ErrorAction SilentlyContinue
-                Test-Path $deviceName | Should -Be $true
+                Test-Path $deviceName | Should -BeTrue
                 New-Item -Path $testFile -ItemType File -Force -ErrorAction SilentlyContinue
              }
          }
@@ -197,7 +197,7 @@ Describe "Basic FileSystem Provider Tests" -Tags "CI" {
              foreach ($deviceName in $reservedNames)
              {
                 Rename-Item -Path $testFile -NewName $deviceName -Force -ErrorAction SilentlyContinue
-                Test-Path $deviceName | Should -Be $true
+                Test-Path $deviceName | Should -BeTrue
                 New-Item -Path $testFile -ItemType File -Force -ErrorAction SilentlyContinue
              }
          }
@@ -212,7 +212,7 @@ Describe "Basic FileSystem Provider Tests" -Tags "CI" {
                 New-Item -Path "$testdrive$path" -ItemType Directory > $null
                 Set-Location "$testdrive"
                 Set-Location ".$path"
-                (Get-Location).Path | Should -Be "$testdrive/$($path.Substring(1,$path.Length-1))"
+                (Get-Location).Path | Should -BeExactly "$testdrive/$($path.Substring(1,$path.Length-1))"
             }
             finally {
                 Remove-Item -Path "$testdrive$path" -ErrorAction SilentlyContinue
@@ -300,9 +300,9 @@ Describe "Basic FileSystem Provider Tests" -Tags "CI" {
             $level1Loc = Get-Location
             Set-Location $level2_0
             $level2Loc = Get-Location
-            $currentLoc.Path | Should -Be $root
-            $level1Loc.Path | Should -Be $level1_0Full
-            $level2Loc.Path | Should -Be $level2_0Full
+            $currentLoc.Path | Should -BeExactly $root
+            $level1Loc.Path | Should -BeExactly $level1_0Full
+            $level2Loc.Path | Should -BeExactly $level2_0Full
         }
 
         It "Verify Push-Location and Pop-Location" {
@@ -327,16 +327,16 @@ Describe "Basic FileSystem Provider Tests" -Tags "CI" {
             Pop-Location
             $pop2 = Get-Location
 
-            $pop0.Path | Should -Be $push2.Path
-            $pop1.Path | Should -Be $push1.Path
-            $pop2.Path | Should -Be $push0.Path
+            $pop0.Path | Should -BeExactly $push2.Path
+            $pop1.Path | Should -BeExactly $push1.Path
+            $pop2.Path | Should -BeExactly $push0.Path
         }
     }
 
     Context "Validate Basic Path Cmdlets" {
         It "Verify Convert-Path" {
             $result = Convert-Path "."
-            ($result.TrimEnd('/\')) | Should -Be "$TESTDRIVE"
+            ($result.TrimEnd('/\')) | Should -BeExactly "$TESTDRIVE"
         }
 
         It "Verify Join-Path" {
@@ -358,13 +358,13 @@ Describe "Basic FileSystem Provider Tests" -Tags "CI" {
 
         It "Verify Test-Path" {
             $result = Test-Path $HOME
-            $result | Should -Be $true
+            $result | Should -BeTrue
         }
 
         It "Verify HOME" {
             $homePath = $HOME
             $tildePath = (Resolve-Path -Path ~).Path
-            $homePath | Should -Be $tildePath
+            $homePath | Should -BeExactly $tildePath
         }
     }
 }
@@ -387,26 +387,26 @@ Describe "Handling of globbing patterns" -Tags "CI" {
 
         It "Rename-Item -LiteralPath can rename a file with Unix globbing characters" {
             Rename-Item -LiteralPath $file.FullName -NewName $newPath
-            Test-Path -LiteralPath $file.FullName | Should -Be $false
-            Test-Path -LiteralPath $newPath | Should -Be $true
+            Test-Path -LiteralPath $file.FullName | Should -BeFalse
+            Test-Path -LiteralPath $newPath | Should -BeTrue
         }
 
         It "Remove-Item -LiteralPath can delete a file with Unix globbing characters" {
             Remove-Item -LiteralPath $file.FullName
-            Test-Path -LiteralPath $file.FullName | Should -Be $false
+            Test-Path -LiteralPath $file.FullName | Should -BeFalse
         }
 
         It "Move-Item -LiteralPath can move a file with Unix globbing characters" {
             $dir = New-Item -ItemType Directory -Path $dirPath
             Move-Item -LiteralPath $file.FullName -Destination $dir.FullName
-            Test-Path -LiteralPath $file.FullName | Should -Be $false
+            Test-Path -LiteralPath $file.FullName | Should -BeFalse
             $newPath = Join-Path $dir.FullName $file.Name
-            Test-Path -LiteralPath $newPath | Should -Be $true
+            Test-Path -LiteralPath $newPath | Should -BeTrue
         }
 
         It "Copy-Item -LiteralPath can copy a file with Unix globbing characters" {
             Copy-Item -LiteralPath $file.FullName -Destination $newPath
-            Test-Path -LiteralPath $newPath | Should -Be $true
+            Test-Path -LiteralPath $newPath | Should -BeTrue
         }
     }
 
@@ -420,12 +420,12 @@ Describe "Handling of globbing patterns" -Tags "CI" {
             $testPath2 = "$testdrive\foo*2"
             New-Item -Path $testPath -ItemType File
             New-Item -Path $testPath2 -ItemType File
-            Test-Path -LiteralPath $testPath | Should -Be $true
-            Test-Path -LiteralPath $testPath2 | Should -Be $true
+            Test-Path -LiteralPath $testPath | Should -BeTrue
+            Test-Path -LiteralPath $testPath2 | Should -BeTrue
             { Remove-Item -LiteralPath $testPath } | Should -Not -Throw
-            Test-Path -LiteralPath $testPath | Should -Be $false
+            Test-Path -LiteralPath $testPath | Should -BeFalse
             # make sure wildcard wasn't applied so this file should still exist
-            Test-Path -LiteralPath $testPath2 | Should -Be $true
+            Test-Path -LiteralPath $testPath2 | Should -BeTrue
         }
     }
 }
@@ -464,14 +464,14 @@ Describe "Hard link and symbolic link tests" -Tags "CI", "RequireAdminOnWindows"
     Context "New-Item and hard/symbolic links" {
         It "New-Item can create a hard link to a file" {
             New-Item -ItemType HardLink -Path $hardLinkToFile -Value $realFile
-            Test-Path $hardLinkToFile | Should -Be $true
+            Test-Path $hardLinkToFile | Should -BeTrue
             $link = Get-Item -Path $hardLinkToFile
             $link.LinkType | Should -BeExactly "HardLink"
             Get-Content -Path $hardLinkToFile | Should -Be $fileContent
         }
         It "New-Item can create symbolic link to file" {
             New-Item -ItemType SymbolicLink -Path $symLinkToFile -Value $realFile
-            Test-Path $symLinkToFile | Should -Be $true
+            Test-Path $symLinkToFile | Should -BeTrue
             $real = Get-Item -Path $realFile
             $link = Get-Item -Path $symLinkToFile
             $link.LinkType | Should -BeExactly "SymbolicLink"
@@ -480,7 +480,7 @@ Describe "Hard link and symbolic link tests" -Tags "CI", "RequireAdminOnWindows"
         }
         It "New-Item can create a symbolic link to nothing" {
             New-Item -ItemType SymbolicLink -Path $symLinkToNothing -Value $nonFile
-            Test-Path $symLinkToNothing | Should -Be $true
+            Test-Path $symLinkToNothing | Should -BeTrue
             $link = Get-Item -Path $symLinkToNothing
             $link.LinkType | Should -BeExactly "SymbolicLink"
             $link.Target | Should -Be $nonFile
@@ -490,7 +490,7 @@ Describe "Hard link and symbolic link tests" -Tags "CI", "RequireAdminOnWindows"
         }
         It "New-Item can create a symbolic link to a directory" -Skip:($IsWindows) {
             New-Item -ItemType SymbolicLink -Path $symLinkToDir -Value $realDir
-            Test-Path $symLinkToDir | Should -Be $true
+            Test-Path $symLinkToDir | Should -BeTrue
             $real = Get-Item -Path $realDir
             $link = Get-Item -Path $symLinkToDir
             $link.LinkType | Should -BeExactly "SymbolicLink"
@@ -498,16 +498,16 @@ Describe "Hard link and symbolic link tests" -Tags "CI", "RequireAdminOnWindows"
         }
         It "New-Item can create a directory symbolic link to a directory" -Skip:(-Not $IsWindows) {
             New-Item -ItemType SymbolicLink -Path $symLinkToDir -Value $realDir
-            Test-Path $symLinkToDir | Should -Be $true
+            Test-Path $symLinkToDir | Should -BeTrue
             $real = Get-Item -Path $realDir
             $link = Get-Item -Path $symLinkToDir
             $link | Should -BeOfType System.IO.DirectoryInfo
             $link.LinkType | Should -BeExactly "SymbolicLink"
-            $link.Target | Should -Be $real.FullName
+            $link.Target | Should -BeExactly $real.FullName
         }
         It "New-Item can create a directory junction to a directory" -Skip:(-Not $IsWindows) {
             New-Item -ItemType Junction -Path $junctionToDir -Value $realDir
-            Test-Path $junctionToDir | Should -Be $true
+            Test-Path $junctionToDir | Should -BeTrue
         }
     }
 
@@ -622,8 +622,8 @@ Describe "Hard link and symbolic link tests" -Tags "CI", "RequireAdminOnWindows"
                 )
 
                 Remove-Item -Path $Link -ErrorAction SilentlyContinue >$null
-                Test-Path -Path $Link | Should -Be $false
-                Test-Path -Path $Target | Should -Be $true
+                Test-Path -Path $Link | Should -BeFalse
+                Test-Path -Path $Target | Should -BeTrue
             }
         }
 
@@ -728,14 +728,14 @@ Describe "Copy-Item can avoid copying an item onto itself" -Tags "CI", "RequireA
         It "Copy-Item can copy to file name differing only by case" {
             if ($isCaseSensitive)
             {
-                Copy-Item -Path $sourcePath -Destination $destinationPath -ErrorAction SilentlyContinue | Should -Be $null
-                Test-Path -Path $destinationPath | Should -Be $true
+                Copy-Item -Path $sourcePath -Destination $destinationPath -ErrorAction SilentlyContinue | Should -BeNullOrEmpty
+                Test-Path -Path $destinationPath | Should -BeTrue
             }
             else
             {
                 { Copy-Item -Path $sourcePath -Destination $destinationPath -ErrorAction Stop } | ShouldBeErrorId "CopyError,Microsoft.PowerShell.Commands.CopyItemCommand"
                 $Error[0].Exception | Should -BeOfType System.IO.IOException
-                $Error[0].Exception.Data[$selfCopyKey] | Should -Not -Be $null
+                $Error[0].Exception.Data[$selfCopyKey] | Should -Not -BeNullOrEmpty
             }
         }
     }
@@ -798,7 +798,7 @@ Describe "Copy-Item can avoid copying an item onto itself" -Tags "CI", "RequireA
 
                 { Copy-Item -Path $Source -Destination $Destination -ErrorAction Stop } | ShouldBeErrorId "CopyError,Microsoft.PowerShell.Commands.CopyItemCommand"
                 $Error[0].Exception | Should -BeOfType System.IO.IOException
-                $Error[0].Exception.Data[$selfCopyKey] | Should -Not -Be $null
+                $Error[0].Exception.Data[$selfCopyKey] | Should -Not -BeNullOrEmpty
             }
         }
 
@@ -861,7 +861,7 @@ Describe "Handling long paths" -Tags "CI" {
         $fileName | Should -Exist
     }
     It "Can use Test-Path to check for a file via a long path" {
-        Test-Path $longFilePath | Should -Be $true
+        Test-Path $longFilePath | Should -BeTrue
     }
 }
 
@@ -908,47 +908,47 @@ Describe "Extended FileSystem Item/Content Cmdlet Provider Tests" -Tags "Feature
 
         It "Verify Directory + Confirm bypass" {
             $result = New-Item -Path . -ItemType Directory -Name $testDir -Confirm:$false
-            $result.Name | Should -Be $testDir
+            $result.Name | Should -BeExactly $testDir
         }
 
         It "Verify Directory + Force" {
             New-Item -Path . -ItemType Directory -Name $testDir > $null
             $result = New-Item -Path . -ItemType Directory -Name $testDir -Force #would normally fail without force
-            $result.Name | Should -Be $testDir
+            $result.Name | Should -BeExactly $testDir
         }
 
         It "Verify File + Value" {
             $result = New-Item -Path . -ItemType File -Name $testFile -Value "Some String"
             $content = Get-Content -Path $testFile
-            $result.Name | Should -Be $testFile
-            $content | Should -Be "Some String"
+            $result.Name | Should -BeExactly $testFile
+            $content | Should -BeExactly "Some String"
         }
     }
 
     Context "Valdiate Get-Item parameters" {
         It "Verify Force" {
             $result = Get-Item -Path $testFile -Force
-            $result.Name | Should -Be $testFile
+            $result.Name | Should -BeExactly $testFile
         }
 
         It "Verify Path Wildcard" {
             $result = Get-Item -Path "*2.txt"
-            $result.Name | Should -Be $testFile2
+            $result.Name | Should -BeExactly $testFile2
         }
 
         It "Verify Include" {
             $result = Get-Item -Path "TestDrive:\*" -Include "*2.txt"
-            $result.Name | Should -Be $testFile2
+            $result.Name | Should -BeExactly $testFile2
         }
 
         It "Verify Include and Exclude Intersection" {
             $result = Get-Item -Path "TestDrive:\*" -Include "*.txt" -Exclude "*2*"
-            $result.Name | Should -Be $testFile
+            $result.Name | Should -BeExactly $testFile
         }
 
         It "Verify Filter" {
             $result = Get-Item -Path "TestDrive:\*" -filter "*2.txt"
-            $result.Name | Should -Be $testFile2
+            $result.Name | Should -BeExactly $testFile2
         }
 
         It "Verify -LiteralPath with wildcard fails for file that doesn't exist" {
@@ -991,7 +991,7 @@ Describe "Extended FileSystem Item/Content Cmdlet Provider Tests" -Tags "Feature
             $file1 = Get-Item "TestDrive:\dest\$testFile2" -ErrorAction SilentlyContinue
             $file2 = Get-Item "TestDrive:\dest\$testFile" -ErrorAction SilentlyContinue
             $file1 | Should -BeNullOrEmpty
-            $file2.Name | Should -Be $testFile
+            $file2.Name | Should -BeExactly $testFile
         }
 
         It "Verify Filter" {
@@ -999,7 +999,7 @@ Describe "Extended FileSystem Item/Content Cmdlet Provider Tests" -Tags "Feature
             $file1 = Get-Item $testFile2 -ErrorAction SilentlyContinue
             $file2 = Get-Item $altTestFile -ErrorAction SilentlyContinue
             $file1 | Should -BeNullOrEmpty
-            $file2.Name | Should -Be $altTestFile
+            $file2.Name | Should -BeExactly $altTestFile
         }
     }
 
@@ -1022,7 +1022,7 @@ Describe "Extended FileSystem Item/Content Cmdlet Provider Tests" -Tags "Feature
             $file1 = Get-Item -Path $testFile -ErrorAction SilentlyContinue
             $file2 = Get-Item -Path $newFile -ErrorAction SilentlyContinue
             $file1 | Should -BeNullOrEmpty
-            $file2.Name | Should -Be $newFile
+            $file2.Name | Should -BeExactly $newFile
         }
     }
 
@@ -1030,7 +1030,7 @@ Describe "Extended FileSystem Item/Content Cmdlet Provider Tests" -Tags "Feature
         It "Verify WhatIf" {
             Remove-Item $testFile -WhatIf
             $result = Get-Item $testFile
-            $result.Name | Should -Be $testFile
+            $result.Name | Should -BeExactly $testFile
         }
 
         It "Verify Confirm can be bypassed" {
@@ -1071,7 +1071,7 @@ Describe "Extended FileSystem Item/Content Cmdlet Provider Tests" -Tags "Feature
             $file1 = Get-Item $testFile -ErrorAction SilentlyContinue
             $file2 = Get-Item $testFile2 -ErrorAction SilentlyContinue
             $file1 | Should -BeNullOrEmpty
-            $file2.Name | Should -Be $testFile2
+            $file2.Name | Should -BeExactly $testFile2
         }
 
         It "Verify Path can accept wildcard" {
@@ -1095,20 +1095,20 @@ Describe "Extended FileSystem Item/Content Cmdlet Provider Tests" -Tags "Feature
             Set-Content -Path @($testFile,$testFile2) -Value @($testContent,$testContent2)
             $content1 = Get-Content $testFile
             $content2 = Get-Content $testFile2
-            $content1 | Should -Be $content2
-            ($content1[0] + $content1[1]) | Should -Be ($testContent + $testContent2)
+            $content1 | Should -BeExactly $content2
+            ($content1[0] + $content1[1]) | Should -BeExactly ($testContent + $testContent2)
         }
 
         It "Validate LiteralPath" {
             Set-Content -LiteralPath "TestDrive:\$testFile" -Value $testContent
             $content = Get-Content $testFile
-            $content | Should -Be $testContent
+            $content | Should -BeExactly $testContent
         }
 
         It "Validate Confirm can be bypassed" {
             Set-Content -Path $testFile -Value $testContent -Confirm:$false
             $content = Get-Content $testFile
-            $content | Should -Be $testContent
+            $content | Should -BeExactly $testContent
         }
 
         It "Validate WhatIf" {
@@ -1122,14 +1122,14 @@ Describe "Extended FileSystem Item/Content Cmdlet Provider Tests" -Tags "Feature
             $content1 = Get-Content $testFile
             $content2 = Get-Content $testFile2
             $content1 | Should -BeNullOrEmpty
-            $content2 | Should -Be $testContent
+            $content2 | Should -BeExactly $testContent
         }
 
         It "Validate Exclude" {
             Set-Content -Path "TestDrive:\*" -Value $testContent -Exclude "*2.txt"
             $content1 = Get-Content $testFile
             $content2 = Get-Content $testFile2
-            $content1 | Should -Be $testContent
+            $content1 | Should -BeExactly $testContent
             $content2 | Should -BeNullOrEmpty
         }
 
@@ -1138,7 +1138,7 @@ Describe "Extended FileSystem Item/Content Cmdlet Provider Tests" -Tags "Feature
             $content1 = Get-Content $testFile
             $content2 = Get-Content $testFile2
             $content1 | Should -BeNullOrEmpty
-            $content2 | Should -Be $testContent
+            $content2 | Should -BeExactly $testContent
         }
     }
 
@@ -1150,51 +1150,51 @@ Describe "Extended FileSystem Item/Content Cmdlet Provider Tests" -Tags "Feature
 
         It "Validate Array Input for Path" {
             $result = Get-Content -Path @($testFile,$testFile2)
-            $result[0] | Should -Be $testContent
-            $result[1] | Should -Be $testContent2
+            $result[0] | Should -BeExactly $testContent
+            $result[1] | Should -BeExactly $testContent2
         }
 
         It "Validate Include" {
             $result = Get-Content -Path "TestDrive:\*" -Include "*2.txt"
-            $result | Should -Be $testContent2
+            $result | Should -BeExactly $testContent2
         }
 
         It "Validate Exclude" {
             $result = Get-Content -Path "TestDrive:\*" -Exclude "*2.txt"
-            $result | Should -Be $testContent
+            $result | Should -BeExactly $testContent
         }
 
         It "Validate Filter" {
             $result = Get-Content -Path "TestDrive:\*" -Filter "*2.txt"
-            $result | Should -Be $testContent2
+            $result | Should -BeExactly $testContent2
         }
 
         It "Validate ReadCount" {
             Set-Content -Path $testFile -Value "Test Line 1`nTest Line 2`nTest Line 3`nTest Line 4`nTest Line 5`nTest Line 6"
             $result = (Get-Content -Path $testFile -ReadCount 2)
-            $result[0][0] | Should -Be "Test Line 1"
-            $result[0][1] | Should -Be "Test Line 2"
-            $result[1][0] | Should -Be "Test Line 3"
-            $result[1][1] | Should -Be "Test Line 4"
-            $result[2][0] | Should -Be "Test Line 5"
-            $result[2][1] | Should -Be "Test Line 6"
+            $result[0][0] | Should -BeExactly "Test Line 1"
+            $result[0][1] | Should -BeExactly "Test Line 2"
+            $result[1][0] | Should -BeExactly "Test Line 3"
+            $result[1][1] | Should -BeExactly "Test Line 4"
+            $result[2][0] | Should -BeExactly "Test Line 5"
+            $result[2][1] | Should -BeExactly "Test Line 6"
         }
 
         It "Validate TotalCount" {
             Set-Content -Path $testFile -Value "Test Line 1`nTest Line 2`nTest Line 3`nTest Line 4`nTest Line 5`nTest Line 6"
             $result = Get-Content -Path $testFile -TotalCount 4
-            $result[0] | Should -Be "Test Line 1"
-            $result[1] | Should -Be "Test Line 2"
-            $result[2] | Should -Be "Test Line 3"
-            $result[3] | Should -Be "Test Line 4"
+            $result[0] | Should -BeExactly "Test Line 1"
+            $result[1] | Should -BeExactly "Test Line 2"
+            $result[2] | Should -BeExactly "Test Line 3"
+            $result[3] | Should -BeExactly "Test Line 4"
             $result[4] | Should -BeNullOrEmpty
         }
 
         It "Validate Tail" {
             Set-Content -Path $testFile -Value "Test Line 1`nTest Line 2`nTest Line 3`nTest Line 4`nTest Line 5`nTest Line 6"
             $result = Get-Content -Path $testFile -Tail 2
-            $result[0] | Should -Be "Test Line 5"
-            $result[1] | Should -Be "Test Line 6"
+            $result[0] | Should -BeExactly "Test Line 5"
+            $result[1] | Should -BeExactly "Test Line 6"
             $result[2] | Should -BeNullOrEmpty
         }
     }
@@ -1236,12 +1236,12 @@ Describe "Extended FileSystem Path/Location Cmdlet Provider Tests" -Tags "Featur
     Context "Validate Resolve-Path Cmdlet Parameters" {
         It "Verify LiteralPath" {
             $result = Resolve-Path -LiteralPath "TestDrive:\"
-            ($result.Path.TrimEnd('/\')) | Should -Be "TestDrive:"
+            ($result.Path.TrimEnd('/\')) | Should -BeExactly "TestDrive:"
         }
 
         It "Verify relative" {
             $relativePath = Resolve-Path -Path . -Relative
-            $relativePath | Should -Be (Join-Path "." "")
+            $relativePath | Should -BeExactly (Join-Path "." "")
         }
     }
 
@@ -1260,44 +1260,44 @@ Describe "Extended FileSystem Path/Location Cmdlet Provider Tests" -Tags "Featur
     Context "Validate Split-Path Cmdlet Parameters" {
         It "Validate Parent" {
             $result = Split-Path -Path $level1_0Full -Parent -Resolve
-            ($result.TrimEnd('/\')) | Should -Be "TestDrive:"
+            ($result.TrimEnd('/\')) | Should -BeExactly "TestDrive:"
         }
 
         It "Validate IsAbsolute" {
             $resolved = Split-Path -Path . -Resolve -IsAbsolute
             $unresolved = Split-Path -Path . -IsAbsolute
-            $resolved | Should -Be $true
-            $unresolved | Should -Be $false
+            $resolved | Should -BeTrue
+            $unresolved | Should -BeFalse
         }
 
         It "Validate Leaf" {
             $result = Split-Path -Path $level1_0Full -Leaf
-            $result | Should -Be $level1_0
+            $result | Should -BeExactly $level1_0
         }
 
         It 'Validate LeafBase' {
             $result = Split-Path -Path "$level2_1Full$fileExt" -LeafBase
-            $result | Should -Be $level2_1
+            $result | Should -BeExactly $level2_1
         }
         It 'Validate LeafBase is not over-zealous' {
 
             $result = Split-Path -Path "$level2_1Full$fileExt$fileExt" -LeafBase
-            $result | Should -Be "$level2_1$fileExt"
+            $result | Should -BeExactly "$level2_1$fileExt"
         }
 
         It 'Validate LeafBase' {
             $result = Split-Path -Path "$level2_1Full$fileExt" -Extension
-            $result | Should -Be $fileExt
+            $result | Should -BeExactly $fileExt
         }
 
         It "Validate NoQualifier" {
             $result = Split-Path -Path $level1_0Full -NoQualifier
-            ($result.TrimStart('/\')) | Should -Be $level1_0
+            ($result.TrimStart('/\')) | Should -BeExactly $level1_0
         }
 
         It "Validate Qualifier" {
             $result = Split-Path -Path $level1_0Full -Qualifier
-            $result | Should -Be "TestDrive:"
+            $result | Should -BeExactly "TestDrive:"
         }
     }
 
@@ -1309,14 +1309,14 @@ Describe "Extended FileSystem Path/Location Cmdlet Provider Tests" -Tags "Featur
 
         It "By LiteralPath" {
             $result = Set-Location -LiteralPath $level1_0Full -PassThru
-            $result.Path | Should -Be $level1_0Full
+            $result.Path | Should -BeExactly $level1_0Full
         }
 
         It "To Default Location Stack Does Nothing" {
             $beforeLoc = Get-Location
             Set-Location -StackName ""
             $afterLoc = Get-Location
-            $beforeLoc.Path | Should -Be $afterLoc.Path
+            $beforeLoc.Path | Should -BeExactly $afterLoc.Path
         }
 
         It "WhatIf is Not Supported" {
@@ -1338,9 +1338,9 @@ Describe "Extended FileSystem Path/Location Cmdlet Provider Tests" -Tags "Featur
             Pop-Location
             $location3 = Get-Location
 
-            $location1.Path | Should -Be $level2_0Full
-            $location2.Path | Should -Be $level1_0Full
-            $location3.Path | Should -Be $root
+            $location1.Path | Should -BeExactly $level2_0Full
+            $location2.Path | Should -BeExactly $level1_0Full
+            $location3.Path | Should -BeExactly $root
         }
 
         It "Verify Push + PassThru" {
@@ -1352,9 +1352,9 @@ Describe "Extended FileSystem Path/Location Cmdlet Provider Tests" -Tags "Featur
             Set-Location $level2_0
             $location3 = Get-Location
 
-            $location1.Path | Should -Be $passThru1.Path
-            $location2.Path | Should -Be $passThru2.Path
-            $location3.Path | Should -Be $level2_0Full
+            $location1.Path | Should -BeExactly $passThru1.Path
+            $location2.Path | Should -BeExactly $passThru2.Path
+            $location3.Path | Should -BeExactly $level2_0Full
         }
 
         It "Verify Push + LiteralPath" {
@@ -1366,9 +1366,9 @@ Describe "Extended FileSystem Path/Location Cmdlet Provider Tests" -Tags "Featur
             Pop-Location
             $location3 = Get-Location
 
-            $location1.Path | Should -Be $level2_0Full
-            $location2.Path | Should -Be $level1_0Full
-            $location3.Path | Should -Be $root
+            $location1.Path | Should -BeExactly $level2_0Full
+            $location2.Path | Should -BeExactly $level1_0Full
+            $location3.Path | Should -BeExactly $root
         }
 
         It "Verify Pop + Invalid Stack Name" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
@@ -46,8 +46,7 @@ Describe "Basic FileSystem Provider Tests" -Tags "CI" {
 
         It "Verify New-Item for file" {
             $newFile = New-Item -Path $newTestFile -ItemType File
-            $fileExists = Test-Path $newTestFile
-            $fileExists | Should -BeTrue
+            $newTestFile | Should -Exist
             $newFile.Name | Should -BeExactly $newTestFile
         }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ChildItem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ChildItem.Tests.ps1
@@ -65,22 +65,22 @@ Describe "Get-ChildItem" -Tags "CI" {
 
         It "Should list hidden files as well when 'Force' parameter is used" {
             $files = Get-ChildItem -path $TestDrive -Force
-            $files | Should -Not -Be $null
+            $files | Should -Not -BeNullOrEmpty
             $files.Count | Should -Be 6
-            $files.Name.Contains($item_F) | Should -Be $true
+            $files.Name.Contains($item_F) | Should -BeTrue
         }
 
         It "Should list only hidden files when 'Hidden' parameter is used" {
             $files = Get-ChildItem -path $TestDrive -Hidden
-            $files | Should -Not -Be $null
+            $files | Should -Not -BeNullOrEmpty
             $files.Count | Should -Be 1
-            $files[0].Name | Should -Be $item_F
+            $files[0].Name | Should -BeExactly $item_F
         }
         It "Should find the hidden file if specified with hidden switch" {
             $file = Get-ChildItem -Path (Join-Path $TestDrive $item_F) -Hidden
             $file | Should -Not -BeNullOrEmpty
             $file.Count | Should -Be 1
-            $file.Name | Should -Be $item_F
+            $file.Name | Should -BeExactly $item_F
         }
 
         It "Should list items in current directory only with depth set to 0" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ChildItem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ChildItem.Tests.ps1
@@ -35,64 +35,64 @@ Describe "Get-ChildItem" -Tags "CI" {
         }
 
         It "Should list the contents of the current folder" {
-            (Get-ChildItem .).Name.Length | Should BeGreaterThan 0
+            (Get-ChildItem .).Name.Length | Should -BeGreaterThan 0
         }
 
         It "Should list the contents of the home directory" {
             pushd $HOME
-            (Get-ChildItem .).Name.Length | Should BeGreaterThan 0
+            (Get-ChildItem .).Name.Length | Should -BeGreaterThan 0
             popd
         }
 
         It "Should have a the proper fields and be populated" {
             $var = Get-Childitem .
 
-            $var.Name.Length   | Should BeGreaterThan 0
-            $var.Mode.Length   | Should BeGreaterThan 0
-            $var.LastWriteTime | Should BeGreaterThan 0
-            $var.Length.Length | Should BeGreaterThan 0
+            $var.Name.Length   | Should -BeGreaterThan 0
+            $var.Mode.Length   | Should -BeGreaterThan 0
+            $var.LastWriteTime | Should -BeGreaterThan 0
+            $var.Length.Length | Should -BeGreaterThan 0
 
         }
 
         It "Should list files in sorted order" {
             $files = Get-ChildItem -Path $TestDrive
-            $files[0].Name     | Should Be $item_E
-            $files[1].Name     | Should Be $item_a
-            $files[2].Name     | Should Be $item_B
-            $files[3].Name     | Should Be $item_c
-            $files[4].Name     | Should Be $item_D
+            $files[0].Name     | Should -Be $item_E
+            $files[1].Name     | Should -Be $item_a
+            $files[2].Name     | Should -Be $item_B
+            $files[3].Name     | Should -Be $item_c
+            $files[4].Name     | Should -Be $item_D
         }
 
         It "Should list hidden files as well when 'Force' parameter is used" {
             $files = Get-ChildItem -path $TestDrive -Force
-            $files | Should not be $null
-            $files.Count | Should be 6
-            $files.Name.Contains($item_F) | Should Be $true
+            $files | Should -Not -Be $null
+            $files.Count | Should -Be 6
+            $files.Name.Contains($item_F) | Should -Be $true
         }
 
         It "Should list only hidden files when 'Hidden' parameter is used" {
             $files = Get-ChildItem -path $TestDrive -Hidden
-            $files | Should not be $null
-            $files.Count | Should be 1
-            $files[0].Name | Should Be $item_F
+            $files | Should -Not -Be $null
+            $files.Count | Should -Be 1
+            $files[0].Name | Should -Be $item_F
         }
         It "Should find the hidden file if specified with hidden switch" {
             $file = Get-ChildItem -Path (Join-Path $TestDrive $item_F) -Hidden
-            $file | Should Not BeNullOrEmpty
-            $file.Count | Should be 1
-            $file.Name | Should be $item_F
+            $file | Should -Not -BeNullOrEmpty
+            $file.Count | Should -Be 1
+            $file.Name | Should -Be $item_F
         }
 
         It "Should list items in current directory only with depth set to 0" {
-            (Get-ChildItem -Path $TestDrive -Depth 0).Count | Should Be 5
-            (Get-ChildItem -Path $TestDrive -Depth 0 -Include *).Count | Should Be 5
-            (Get-ChildItem -Path $TestDrive -Depth 0 -Exclude IntentionallyNonexistent).Count | Should Be 5
+            (Get-ChildItem -Path $TestDrive -Depth 0).Count | Should -Be 5
+            (Get-ChildItem -Path $TestDrive -Depth 0 -Include *).Count | Should -Be 5
+            (Get-ChildItem -Path $TestDrive -Depth 0 -Exclude IntentionallyNonexistent).Count | Should -Be 5
         }
 
         It "Should return items recursively when using 'Include' or 'Exclude' parameters" {
-            (Get-ChildItem -Path $TestDrive -Depth 1).Count | Should Be 6
-            (Get-ChildItem -Path $TestDrive -Depth 1 -Include $item_G).Count | Should Be 1
-            (Get-ChildItem -Path $TestDrive -Depth 1 -Exclude $item_a).Count | Should Be 5
+            (Get-ChildItem -Path $TestDrive -Depth 1).Count | Should -Be 6
+            (Get-ChildItem -Path $TestDrive -Depth 1 -Include $item_G).Count | Should -Be 1
+            (Get-ChildItem -Path $TestDrive -Depth 1 -Exclude $item_a).Count | Should -Be 5
         }
 
         It "get-childitem path wildcard - <title>" -TestCases $PathWildCardTestCases {
@@ -100,18 +100,18 @@ Describe "Get-ChildItem" -Tags "CI" {
 
             $null = New-Item $file1 -Force -ItemType File
 
-            (Get-ChildItem @Parameters).Count | Should Be $ExpectedCount
+            (Get-ChildItem @Parameters).Count | Should -Be $ExpectedCount
         }
 
         It "get-childitem with and without file in search root" {
             $null = New-Item $file2 -Force -ItemType File
 
-            (Get-ChildItem -Path $searchRoot -File -Recurse).Count | Should be 2
-            (Get-ChildItem -Path $searchRoot -Directory -Recurse).Count | Should be 1
+            (Get-ChildItem -Path $searchRoot -File -Recurse).Count | Should -Be 2
+            (Get-ChildItem -Path $searchRoot -Directory -Recurse).Count | Should -Be 1
 
             Remove-Item $file2 -ErrorAction SilentlyContinue -Force
-            (Get-ChildItem -Path $searchRoot -File -Recurse).Count | Should be 1
-            (Get-ChildItem -Path $searchRoot -Directory -Recurse).Count | Should be 1
+            (Get-ChildItem -Path $searchRoot -File -Recurse).Count | Should -Be 1
+            (Get-ChildItem -Path $searchRoot -Directory -Recurse).Count | Should -Be 1
         }
     }
 
@@ -125,7 +125,7 @@ Describe "Get-ChildItem" -Tags "CI" {
 
                 $foobar = Get-Childitem env: | Where-Object {$_.Name -eq '__foobar'}
                 $count = if ($IsWindows) { 1 } else { 2 }
-                ($foobar | measure).Count | Should Be $count
+                ($foobar | measure).Count | Should -Be $count
             }
             catch
             {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ComputerInfo.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ComputerInfo.Tests.ps1
@@ -1063,7 +1063,7 @@ try {
                 $expectedProperties = @("BiosBIOSVersion")
                 $propertyFilter = "BiosBIOSVersion"
                 $computerInfoWithProp = Get-ComputerInfoForTest -properties $propertyFilter
-                $computerInfoWithProp | Should -Beoftype [pscustomobject]
+                $computerInfoWithProp | Should -BeOfType [pscustomobject]
                 @($computerInfoWithProp.psobject.properties).count | Should -Be 1
                 $computerInfoWithProp.$propertyFilter | Should -Be $expected.$propertyFilter
             }
@@ -1076,7 +1076,7 @@ try {
                 $expectedProperties = @("BiosBIOSVersion","BiosBuildNumber","BiosCaption")
                 $propertyFilter = @("BiosBIOSVersion","BiosBuildNumber","BiosCaption")
                 $computerInfoWithProp = Get-ComputerInfoForTest -properties $propertyFilter
-                $computerInfoWithProp | Should -Beoftype [pscustomobject]
+                $computerInfoWithProp | Should -BeOfType [pscustomobject]
                 @($computerInfoWithProp.psobject.properties).count | Should -Be 3
                 foreach($property in $propertyFilter) {
                     $ComputerInfoWithProp.$property | Should -Be $Expected.$property
@@ -1091,7 +1091,7 @@ try {
                 $expectedProperties = $null
                 $propertyFilter = @("BiosBIOSVersionXXX")
                 $computerInfoWithProp = Get-ComputerInfoForTest -properties $propertyFilter
-                $computerInfoWithProp | Should -Beoftype [pscustomobject]
+                $computerInfoWithProp | Should -BeOfType [pscustomobject]
                 @($computerInfoWithProp.psobject.properties).count | Should -Be 0
             }
 
@@ -1103,7 +1103,7 @@ try {
                 $expectedProperties = $null
                 $propertyFilter = @("BiosBIOSVersionXXX","InvalidProperty1","InvalidProperty2","InvalidProperty3")
                 $computerInfoWithProp = Get-ComputerInfoForTest -properties $propertyFilter
-                $computerInfoWithProp | Should -Beoftype [pscustomobject]
+                $computerInfoWithProp | Should -BeOfType [pscustomobject]
                 @($computerInfoWithProp.psobject.properties).count | Should -Be 0
             }
 
@@ -1115,7 +1115,7 @@ try {
                 $expectedProperties = @("BiosCodeSet","BiosCurrentLanguage","BiosDescription")
                 $propertyFilter = @("InvalidProperty1","BiosCodeSet","BiosCurrentLanguage","BiosDescription")
                 $computerInfoWithProp = Get-ComputerInfoForTest -properties $propertyFilter
-                $computerInfoWithProp | Should -Beoftype [pscustomobject]
+                $computerInfoWithProp | Should -BeOfType [pscustomobject]
                 $realProperties  = $propertyFilter | Where-Object { $_ -notmatch "^InvalidProperty[0-9]+" }
                 @($computerInfoWithProp.psobject.properties).count | Should -Be $realProperties.Count
                 foreach ( $property in $realProperties )
@@ -1132,7 +1132,7 @@ try {
                 $expectedProperties = @("BiosCodeSet","BiosCurrentLanguage","BiosDescription")
                 $propertyFilter = @("BiosCodeSet","InvalidProperty1","BiosCurrentLanguage","BiosDescription","InvalidProperty2")
                 $computerInfoWithProp = Get-ComputerInfoForTest -properties $propertyFilter
-                $computerInfoWithProp | Should -Beoftype [pscustomobject]
+                $computerInfoWithProp | Should -BeOfType [pscustomobject]
                 $realProperties  = $propertyFilter | Where-Object { $_ -notmatch "^InvalidProperty[0-9]+" }
                 @($computerInfoWithProp.psobject.properties).count | Should -Be $realProperties.Count
                 foreach ( $property in $realProperties )
@@ -1149,7 +1149,7 @@ try {
                 $expectedProperties = @("BiosCaption","BiosCharacteristics","BiosCodeSet","BiosCurrentLanguage")
                 $propertyFilter = @("BiosC*")
                 $computerInfoWithProp = Get-ComputerInfoForTest -properties $propertyFilter
-                $computerInfoWithProp | Should -Beoftype [pscustomobject]
+                $computerInfoWithProp | Should -BeOfType [pscustomobject]
                 @($computerInfoWithProp.psobject.properties).count | Should -Be $expectedProperties.Count
                 foreach ( $property in $expectedProperties )
                 {
@@ -1165,7 +1165,7 @@ try {
                 $expectedProperties = @("BiosCaption","BiosCharacteristics","BiosCodeSet","BiosCurrentLanguage","CsCaption")
                 $propertyFilter = @("BiosC*","CsCaption")
                 $computerInfoWithProp = Get-ComputerInfoForTest -properties $propertyFilter
-                $computerInfoWithProp | Should -Beoftype [pscustomobject]
+                $computerInfoWithProp | Should -BeOfType [pscustomobject]
                 @($computerInfoWithProp.psobject.properties).count | Should -Be $expectedProperties.Count
                 foreach ( $property in $expectedProperties )
                 {
@@ -1181,7 +1181,7 @@ try {
                 $expectedProperties = @("BiosCaption","BiosCharacteristics","BiosCodeSet","BiosCurrentLanguage","CsCaption")
                 $propertyFilter = @("CsCaption","InvalidProperty1","BiosC*")
                 $computerInfoWithProp = Get-ComputerInfoForTest -properties $propertyFilter
-                $computerInfoWithProp | Should -Beoftype [pscustomobject]
+                $computerInfoWithProp | Should -BeOfType [pscustomobject]
                 @($computerInfoWithProp.psobject.properties).count | Should -Be $expectedProperties.Count
                 foreach ( $property in $expectedProperties )
                 {
@@ -1197,7 +1197,7 @@ try {
                 $expectedProperties = $null
                 $propertyFilter = @("BiosBIOSVersionX*")
                 $computerInfoWithProp = Get-ComputerInfoForTest -properties $propertyFilter
-                $computerInfoWithProp | Should -Beoftype [pscustomobject]
+                $computerInfoWithProp | Should -BeOfType [pscustomobject]
                 @($computerInfoWithProp.psobject.properties).count | Should -Be 0
             }
         }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ComputerInfo.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ComputerInfo.Tests.ps1
@@ -1275,12 +1275,12 @@ try {
             if (-not (HasDeviceGuardLicense))
             {
                 $observed.DeviceGuardSmartStatus | Should -Be 0
-                $observed.DeviceGuardRequiredSecurityProperties | Should -Be $null
-                $observed.DeviceGuardAvailableSecurityProperties | Should -Be $null
-                $observed.DeviceGuardSecurityServicesConfigured | Should -Be $null
-                $observed.DeviceGuardSecurityServicesRunning | Should -Be $null
-                $observed.DeviceGuardCodeIntegrityPolicyEnforcementStatus | Should -Be $null
-                $observed.DeviceGuardUserModeCodeIntegrityPolicyEnforcementStatus | Should -Be $null
+                $observed.DeviceGuardRequiredSecurityProperties | Should -BeNullOrEmpty
+                $observed.DeviceGuardAvailableSecurityProperties | Should -BeNullOrEmpty
+                $observed.DeviceGuardSecurityServicesConfigured | Should -BeNullOrEmpty
+                $observed.DeviceGuardSecurityServicesRunning | Should -BeNullOrEmpty
+                $observed.DeviceGuardCodeIntegrityPolicyEnforcementStatus | Should -BeNullOrEmpty
+                $observed.DeviceGuardUserModeCodeIntegrityPolicyEnforcementStatus | Should -BeNullOrEmpty
             }
             else
             {
@@ -1335,15 +1335,15 @@ try {
         #
 
         It "(special case) Test for property = OsFreePhysicalMemory" {
-            ($observed.OsFreePhysicalMemory -gt 0) | Should -Be $true
+            ($observed.OsFreePhysicalMemory -gt 0) | Should -BeTrue
         }
 
         It "(special case) Test for property = OsFreeSpaceInPagingFiles" -Skip:([System.Management.Automation.Platform]::IsIoT -or !$IsWindows) {
-            ($observed.OsFreeSpaceInPagingFiles -gt 0) | Should -Be $true
+            ($observed.OsFreeSpaceInPagingFiles -gt 0) | Should -BeTrue
         }
 
         It "(special case) Test for property = OsFreeVirtualMemory" {
-            ($observed.OsFreeVirtualMemory -gt 0) | Should -Be $true
+            ($observed.OsFreeVirtualMemory -gt 0) | Should -BeTrue
         }
 
 
@@ -1355,19 +1355,19 @@ try {
         }
 
         It "(special case) Test for property = OsMaxNumberOfProcesses" {
-            ($observed.OsMaxNumberOfProcesses -gt 0) | Should -Be $true
+            ($observed.OsMaxNumberOfProcesses -gt 0) | Should -BeTrue
         }
 
         It "(special case) Test for property = OsNumberOfProcesses" {
-            ($observed.OsNumberOfProcesses -gt 0) | Should -Be $true
+            ($observed.OsNumberOfProcesses -gt 0) | Should -BeTrue
         }
 
         It "(special case) Test for property = OsUptime" {
-            ($observed.OsUptime.Ticks -gt 0) | Should -Be $true
+            ($observed.OsUptime.Ticks -gt 0) | Should -BeTrue
         }
 
         It "(special case) Test for property = OsInUseVirtualMemory" {
-            ($observed.OsInUseVirtualMemory -gt 0) | Should -Be $true
+            ($observed.OsInUseVirtualMemory -gt 0) | Should -BeTrue
         }
 
         It "(special case) Test for Filter Property - Property filter with special wild card * and fixed" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ComputerInfo.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ComputerInfo.Tests.ps1
@@ -1007,7 +1007,7 @@ try {
 
         It "Verify type returned by Get-ComputerInfo" {
             $computerInfo = Get-ComputerInfo
-            $computerInfo | Should BeOfType Microsoft.PowerShell.Commands.ComputerInfo
+            $computerInfo | Should -BeOfType Microsoft.PowerShell.Commands.ComputerInfo
         }
     }
 
@@ -1036,7 +1036,7 @@ try {
                     $ObservedList = $ComputerInformation.$property
                     $ExpectedList = $Expected.$property
                     $SpecialPropertyList = ($ObservedList)[0].psobject.properties.name
-                    Compare-Object $ObservedList $ExpectedList -property $SpecialPropertyList | should BeNullOrEmpty
+                    Compare-Object $ObservedList $ExpectedList -property $SpecialPropertyList | Should -BeNullOrEmpty
                 }
                 else
                 {
@@ -1048,7 +1048,7 @@ try {
                         $left = $left -join ":"
                         $right = $right -join ":"
                     }
-                    $left | should be $right
+                    $left | Should -Be $right
                 }
             }
         }
@@ -1062,9 +1062,9 @@ try {
                 $expectedProperties = @("BiosBIOSVersion")
                 $propertyFilter = "BiosBIOSVersion"
                 $computerInfoWithProp = Get-ComputerInfoForTest -properties $propertyFilter
-                $computerInfoWithProp | should beoftype [pscustomobject]
-                @($computerInfoWithProp.psobject.properties).count | should be 1
-                $computerInfoWithProp.$propertyFilter | Should be $expected.$propertyFilter
+                $computerInfoWithProp | Should -Beoftype [pscustomobject]
+                @($computerInfoWithProp.psobject.properties).count | Should -Be 1
+                $computerInfoWithProp.$propertyFilter | Should -Be $expected.$propertyFilter
             }
 
             #
@@ -1075,10 +1075,10 @@ try {
                 $expectedProperties = @("BiosBIOSVersion","BiosBuildNumber","BiosCaption")
                 $propertyFilter = @("BiosBIOSVersion","BiosBuildNumber","BiosCaption")
                 $computerInfoWithProp = Get-ComputerInfoForTest -properties $propertyFilter
-                $computerInfoWithProp | should beoftype [pscustomobject]
-                @($computerInfoWithProp.psobject.properties).count | should be 3
+                $computerInfoWithProp | Should -Beoftype [pscustomobject]
+                @($computerInfoWithProp.psobject.properties).count | Should -Be 3
                 foreach($property in $propertyFilter) {
-                    $ComputerInfoWithProp.$property | Should Be $Expected.$property
+                    $ComputerInfoWithProp.$property | Should -Be $Expected.$property
                 }
             }
 
@@ -1090,8 +1090,8 @@ try {
                 $expectedProperties = $null
                 $propertyFilter = @("BiosBIOSVersionXXX")
                 $computerInfoWithProp = Get-ComputerInfoForTest -properties $propertyFilter
-                $computerInfoWithProp | should beoftype [pscustomobject]
-                @($computerInfoWithProp.psobject.properties).count | should be 0
+                $computerInfoWithProp | Should -Beoftype [pscustomobject]
+                @($computerInfoWithProp.psobject.properties).count | Should -Be 0
             }
 
             #
@@ -1102,8 +1102,8 @@ try {
                 $expectedProperties = $null
                 $propertyFilter = @("BiosBIOSVersionXXX","InvalidProperty1","InvalidProperty2","InvalidProperty3")
                 $computerInfoWithProp = Get-ComputerInfoForTest -properties $propertyFilter
-                $computerInfoWithProp | should beoftype [pscustomobject]
-                @($computerInfoWithProp.psobject.properties).count | should be 0
+                $computerInfoWithProp | Should -Beoftype [pscustomobject]
+                @($computerInfoWithProp.psobject.properties).count | Should -Be 0
             }
 
             #
@@ -1114,12 +1114,12 @@ try {
                 $expectedProperties = @("BiosCodeSet","BiosCurrentLanguage","BiosDescription")
                 $propertyFilter = @("InvalidProperty1","BiosCodeSet","BiosCurrentLanguage","BiosDescription")
                 $computerInfoWithProp = Get-ComputerInfoForTest -properties $propertyFilter
-                $computerInfoWithProp | should beoftype [pscustomobject]
+                $computerInfoWithProp | Should -Beoftype [pscustomobject]
                 $realProperties  = $propertyFilter | Where-Object { $_ -notmatch "^InvalidProperty[0-9]+" }
-                @($computerInfoWithProp.psobject.properties).count | should be $realProperties.Count
+                @($computerInfoWithProp.psobject.properties).count | Should -Be $realProperties.Count
                 foreach ( $property in $realProperties )
                 {
-                    $computerInfoWithProp.$property | Should Be $expected.$property
+                    $computerInfoWithProp.$property | Should -Be $expected.$property
                 }
             }
 
@@ -1131,12 +1131,12 @@ try {
                 $expectedProperties = @("BiosCodeSet","BiosCurrentLanguage","BiosDescription")
                 $propertyFilter = @("BiosCodeSet","InvalidProperty1","BiosCurrentLanguage","BiosDescription","InvalidProperty2")
                 $computerInfoWithProp = Get-ComputerInfoForTest -properties $propertyFilter
-                $computerInfoWithProp | should beoftype [pscustomobject]
+                $computerInfoWithProp | Should -Beoftype [pscustomobject]
                 $realProperties  = $propertyFilter | Where-Object { $_ -notmatch "^InvalidProperty[0-9]+" }
-                @($computerInfoWithProp.psobject.properties).count | should be $realProperties.Count
+                @($computerInfoWithProp.psobject.properties).count | Should -Be $realProperties.Count
                 foreach ( $property in $realProperties )
                 {
-                    $computerInfoWithProp.$property | Should Be $expected.$property
+                    $computerInfoWithProp.$property | Should -Be $expected.$property
                 }
             }
 
@@ -1148,11 +1148,11 @@ try {
                 $expectedProperties = @("BiosCaption","BiosCharacteristics","BiosCodeSet","BiosCurrentLanguage")
                 $propertyFilter = @("BiosC*")
                 $computerInfoWithProp = Get-ComputerInfoForTest -properties $propertyFilter
-                $computerInfoWithProp | should beoftype [pscustomobject]
-                @($computerInfoWithProp.psobject.properties).count | should be $expectedProperties.Count
+                $computerInfoWithProp | Should -Beoftype [pscustomobject]
+                @($computerInfoWithProp.psobject.properties).count | Should -Be $expectedProperties.Count
                 foreach ( $property in $expectedProperties )
                 {
-                    $computerInfoWithProp.$property | Should Be $expected.$property
+                    $computerInfoWithProp.$property | Should -Be $expected.$property
                 }
             }
 
@@ -1164,11 +1164,11 @@ try {
                 $expectedProperties = @("BiosCaption","BiosCharacteristics","BiosCodeSet","BiosCurrentLanguage","CsCaption")
                 $propertyFilter = @("BiosC*","CsCaption")
                 $computerInfoWithProp = Get-ComputerInfoForTest -properties $propertyFilter
-                $computerInfoWithProp | should beoftype [pscustomobject]
-                @($computerInfoWithProp.psobject.properties).count | should be $expectedProperties.Count
+                $computerInfoWithProp | Should -Beoftype [pscustomobject]
+                @($computerInfoWithProp.psobject.properties).count | Should -Be $expectedProperties.Count
                 foreach ( $property in $expectedProperties )
                 {
-                    $computerInfoWithProp.$property | Should Be $expected.$property
+                    $computerInfoWithProp.$property | Should -Be $expected.$property
                 }
             }
 
@@ -1180,11 +1180,11 @@ try {
                 $expectedProperties = @("BiosCaption","BiosCharacteristics","BiosCodeSet","BiosCurrentLanguage","CsCaption")
                 $propertyFilter = @("CsCaption","InvalidProperty1","BiosC*")
                 $computerInfoWithProp = Get-ComputerInfoForTest -properties $propertyFilter
-                $computerInfoWithProp | should beoftype [pscustomobject]
-                @($computerInfoWithProp.psobject.properties).count | should be $expectedProperties.Count
+                $computerInfoWithProp | Should -Beoftype [pscustomobject]
+                @($computerInfoWithProp.psobject.properties).count | Should -Be $expectedProperties.Count
                 foreach ( $property in $expectedProperties )
                 {
-                    $computerInfoWithProp.$property | Should Be $expected.$property
+                    $computerInfoWithProp.$property | Should -Be $expected.$property
                 }
             }
 
@@ -1196,8 +1196,8 @@ try {
                 $expectedProperties = $null
                 $propertyFilter = @("BiosBIOSVersionX*")
                 $computerInfoWithProp = Get-ComputerInfoForTest -properties $propertyFilter
-                $computerInfoWithProp | should beoftype [pscustomobject]
-                @($computerInfoWithProp.psobject.properties).count | should be 0
+                $computerInfoWithProp | Should -Beoftype [pscustomobject]
+                @($computerInfoWithProp.psobject.properties).count | Should -Be 0
             }
         }
 
@@ -1273,13 +1273,13 @@ try {
         It "Test for DeviceGuard properties" -Pending {
             if (-not (HasDeviceGuardLicense))
             {
-                $observed.DeviceGuardSmartStatus | Should Be 0
-                $observed.DeviceGuardRequiredSecurityProperties | Should Be $null
-                $observed.DeviceGuardAvailableSecurityProperties | Should Be $null
-                $observed.DeviceGuardSecurityServicesConfigured | Should Be $null
-                $observed.DeviceGuardSecurityServicesRunning | Should Be $null
-                $observed.DeviceGuardCodeIntegrityPolicyEnforcementStatus | Should Be $null
-                $observed.DeviceGuardUserModeCodeIntegrityPolicyEnforcementStatus | Should Be $null
+                $observed.DeviceGuardSmartStatus | Should -Be 0
+                $observed.DeviceGuardRequiredSecurityProperties | Should -Be $null
+                $observed.DeviceGuardAvailableSecurityProperties | Should -Be $null
+                $observed.DeviceGuardSecurityServicesConfigured | Should -Be $null
+                $observed.DeviceGuardSecurityServicesRunning | Should -Be $null
+                $observed.DeviceGuardCodeIntegrityPolicyEnforcementStatus | Should -Be $null
+                $observed.DeviceGuardUserModeCodeIntegrityPolicyEnforcementStatus | Should -Be $null
             }
             else
             {
@@ -1303,29 +1303,29 @@ try {
                     "1" = "CredentialGuard"
                     "2" = "HypervisorEnforcedCodeIntegrity"
                 }
-                $observed.DeviceGuardSmartStatus | Should Be (Get-StringValuesFromValueMap -valuemap $smartStatusValues -values $deviceGuard.SmartStatus)
+                $observed.DeviceGuardSmartStatus | Should -Be (Get-StringValuesFromValueMap -valuemap $smartStatusValues -values $deviceGuard.SmartStatus)
                 if ($deviceGuard.RequiredSecurityProperties -eq $null)
                 {
-                    $observed.DeviceGuardRequiredSecurityProperties | Should BeNullOrEmpty
+                    $observed.DeviceGuardRequiredSecurityProperties | Should -BeNullOrEmpty
                 }
                 else
                 {
-                    $observed.DeviceGuardRequiredSecurityProperties | Should Not BeNullOrEmpty
-                    [string]::Join(",", $observed.DeviceGuardRequiredSecurityProperties) | Should Be (Get-StringValuesFromValueMap -valuemap $requiredSecurityPropertiesValues -values $deviceGuard.RequiredSecurityProperties)
+                    $observed.DeviceGuardRequiredSecurityProperties | Should -Not -BeNullOrEmpty
+                    [string]::Join(",", $observed.DeviceGuardRequiredSecurityProperties) | Should -Be (Get-StringValuesFromValueMap -valuemap $requiredSecurityPropertiesValues -values $deviceGuard.RequiredSecurityProperties)
                 }
-                $observed.DeviceGuardAvailableSecurityProperties | Should Be $deviceGuard.AvailableSecurityProperties
-                $observed.DeviceGuardSecurityServicesConfigured | Should Be $deviceGuard.SecurityServicesConfigured
+                $observed.DeviceGuardAvailableSecurityProperties | Should -Be $deviceGuard.AvailableSecurityProperties
+                $observed.DeviceGuardSecurityServicesConfigured | Should -Be $deviceGuard.SecurityServicesConfigured
                 if ($deviceGuard.SecurityServicesRunning -eq $null)
                 {
-                    $observed.DeviceGuardSecurityServicesRunning | Should BeNullOrEmpty
+                    $observed.DeviceGuardSecurityServicesRunning | Should -BeNullOrEmpty
                 }
                 else
                 {
-                    $observed.DeviceGuardSecurityServicesRunning | Should Not BeNullOrEmpty
-                    [string]::Join(",", $observed.DeviceGuardSecurityServicesRunning) | Should Be (Get-StringValuesFromValueMap -valuemap $securityServicesRunningValues -values $deviceGuard.SecurityServicesRunning)
+                    $observed.DeviceGuardSecurityServicesRunning | Should -Not -BeNullOrEmpty
+                    [string]::Join(",", $observed.DeviceGuardSecurityServicesRunning) | Should -Be (Get-StringValuesFromValueMap -valuemap $securityServicesRunningValues -values $deviceGuard.SecurityServicesRunning)
                 }
-                $observed.DeviceGuardCodeIntegrityPolicyEnforcementStatus | Should Be $deviceGuard.CodeIntegrityPolicyEnforcementStatus
-                $observed.DeviceGuardUserModeCodeIntegrityPolicyEnforcementStatus | Should Be $deviceGuard.UserModeCodeIntegrityPolicyEnforcementStatus
+                $observed.DeviceGuardCodeIntegrityPolicyEnforcementStatus | Should -Be $deviceGuard.CodeIntegrityPolicyEnforcementStatus
+                $observed.DeviceGuardUserModeCodeIntegrityPolicyEnforcementStatus | Should -Be $deviceGuard.UserModeCodeIntegrityPolicyEnforcementStatus
             }
         }
 
@@ -1334,42 +1334,42 @@ try {
         #
 
         It "(special case) Test for property = OsFreePhysicalMemory" {
-            ($observed.OsFreePhysicalMemory -gt 0) | Should Be $true
+            ($observed.OsFreePhysicalMemory -gt 0) | Should -Be $true
         }
 
         It "(special case) Test for property = OsFreeSpaceInPagingFiles" -Skip:([System.Management.Automation.Platform]::IsIoT -or !$IsWindows) {
-            ($observed.OsFreeSpaceInPagingFiles -gt 0) | Should Be $true
+            ($observed.OsFreeSpaceInPagingFiles -gt 0) | Should -Be $true
         }
 
         It "(special case) Test for property = OsFreeVirtualMemory" {
-            ($observed.OsFreeVirtualMemory -gt 0) | Should Be $true
+            ($observed.OsFreeVirtualMemory -gt 0) | Should -Be $true
         }
 
         It "(special case) Test for property = OsLocalDateTime" -Pending:$true {
             $computerInfo = Get-ComputerInfo
-            $computerInfo | Should BeOfType "ComputerInfo"
+            $computerInfo | Should -BeOfType "ComputerInfo"
         }
 
         It "(special case) Test for property = OsMaxNumberOfProcesses" {
-            ($observed.OsMaxNumberOfProcesses -gt 0) | Should Be $true
+            ($observed.OsMaxNumberOfProcesses -gt 0) | Should -Be $true
         }
 
         It "(special case) Test for property = OsNumberOfProcesses" {
-            ($observed.OsNumberOfProcesses -gt 0) | Should Be $true
+            ($observed.OsNumberOfProcesses -gt 0) | Should -Be $true
         }
 
         It "(special case) Test for property = OsUptime" {
-            ($observed.OsUptime.Ticks -gt 0) | Should Be $true
+            ($observed.OsUptime.Ticks -gt 0) | Should -Be $true
         }
 
         It "(special case) Test for property = OsInUseVirtualMemory" {
-            ($observed.OsInUseVirtualMemory -gt 0) | Should Be $true
+            ($observed.OsInUseVirtualMemory -gt 0) | Should -Be $true
         }
 
         It "(special case) Test for Filter Property - Property filter with special wild card * and fixed" {
             $propertyFilter = @("BiosC*","*")
             $computerInfo = Get-ComputerInfo -Property $propertyFilter
-            $computerInfo | Should BeOfType Microsoft.PowerShell.Commands.ComputerInfo
+            $computerInfo | Should -BeOfType Microsoft.PowerShell.Commands.ComputerInfo
         }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ComputerInfo.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ComputerInfo.Tests.ps1
@@ -1008,7 +1008,7 @@ try {
 
         It "Verify type returned by Get-ComputerInfo" {
             $computerInfo = Get-ComputerInfo
-            $computerInfo | Should -BeOfType Microsoft.PowerShell.Commands.ComputerInfo
+            $computerInfo | Should -BeOfType 'Microsoft.PowerShell.Commands.ComputerInfo'
         }
     }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Content.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Content.Tests.ps1
@@ -165,7 +165,7 @@ baz
         Set-Content -Path $testPath $testContent
         $result = Get-Content @GetContentParams
         $result.Length | Should -Be $expectedLength
-        $result -eq $expectedContent
+        $result | Should -BeExactly $expectedContent
     }
 
     It "should Get-Content with a variety of -Delimiter and -Tail: <test>" -TestCases @(

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Content.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Content.Tests.ps1
@@ -36,7 +36,7 @@ Describe "Get-Content" -Tags "CI" {
 
     It "Should return an Object when listing only a single line and the correct information from a file" {
         $content = (Get-Content -Path $testPath)
-        $content | Should -Be $testString
+        $content | Should -BeExactly $testString
         $content.Count | Should -Be 1
         $content | Should -BeOfType "System.String"
     }
@@ -48,40 +48,40 @@ Describe "Get-Content" -Tags "CI" {
     }
 
     It "Should be able to return a specific line from a file" {
-        (Get-Content -Path $testPath2)[1] | Should -Be $secondline
+        (Get-Content -Path $testPath2)[1] | Should -BeExactly $secondline
     }
 
     It "Should be able to specify the number of lines to get the content of using the TotalCount switch" {
         $returnArray    = (Get-Content -Path $testPath2 -TotalCount 2)
-        $returnArray[0] | Should -Be $firstline
-        $returnArray[1] | Should -Be $secondline
+        $returnArray[0] | Should -BeExactly $firstline
+        $returnArray[1] | Should -BeExactly $secondline
     }
 
     It "Should be able to specify the number of lines to get the content of using the Head switch" {
         $returnArray    = (Get-Content -Path $testPath2 -Head 2)
-        $returnArray[0] | Should -Be $firstline
-        $returnArray[1] | Should -Be $secondline
+        $returnArray[0] | Should -BeExactly $firstline
+        $returnArray[1] | Should -BeExactly $secondline
     }
 
     It "Should be able to specify the number of lines to get the content of using the First switch" {
         $returnArray    = (Get-Content -Path $testPath2 -First 2)
-        $returnArray[0] | Should -Be $firstline
-        $returnArray[1] | Should -Be $secondline
+        $returnArray[0] | Should -BeExactly $firstline
+        $returnArray[1] | Should -BeExactly $secondline
     }
 
     It "Should return the last line of a file using the Tail switch" {
-        Get-Content -Path $testPath -Tail 1 | Should -Be $testString
+        Get-Content -Path $testPath -Tail 1 | Should -BeExactly $testString
     }
 
     It "Should return the last lines of a file using the Last alias" {
-        Get-Content -Path $testPath2 -Last 1 | Should -Be $fifthline
+        Get-Content -Path $testPath2 -Last 1 | Should -BeExactly $fifthline
     }
 
     It "Should be able to get content within a different drive" {
         Push-Location env:
         $expectedoutput = [Environment]::GetEnvironmentVariable("PATH");
         { Get-Content PATH } | Should -Not -Throw
-        Get-Content PATH     | Should -Be $expectedoutput
+        Get-Content PATH     | Should -BeExactly $expectedoutput
         Pop-Location
     }
 
@@ -124,9 +124,9 @@ baz
         $expected = 'foo'
 
         $actual = Get-Content -Path $testPath -Tail $tailCount -Encoding $encodingName
-        $actual.GetType() | Should -Be "System.Object[]"
+        $actual | Should -BeOfType "[string]"
         $actual.Length | Should -Be $tailCount
-        $actual[0] | Should -Be $expected
+        $actual[0] | Should -BeExactly $expected
     }
 
     It "should Get-Content with a variety of -Tail and -ReadCount: <test>" -TestCases @(
@@ -226,11 +226,11 @@ baz
 
     It "Should support NTFS streams using -Stream" -Skip:(!$IsWindows) {
         Set-Content -Path $testPath -Stream hello -Value World
-        Get-Content -Path $testPath | Should -Be $testString
-        Get-Content -Path $testPath -Stream hello | Should -Be "World"
+        Get-Content -Path $testPath | Should -BeExactly $testString
+        Get-Content -Path $testPath -Stream hello | Should -BeExactly "World"
         $item = Get-Item -Path $testPath -Stream hello
-        $item | Should -BeOfType System.Management.Automation.Internal.AlternateStreamData
-        $item.Stream | Should -Be "hello"
+        $item | Should -BeOfType 'System.Management.Automation.Internal.AlternateStreamData'
+        $item.Stream | Should -BeExactly "hello"
         Clear-Content -Path $testPath -Stream hello
         Get-Content -Path $testPath -Stream hello | Should -BeNullOrEmpty
         Remove-Item -Path $testPath -Stream hello

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Content.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Content.Tests.ps1
@@ -256,11 +256,11 @@ baz
     }
  
     It "Should return no content when an empty path is used with -Raw switch" {
-        Get-ChildItem $TestDrive -Filter "*.raw" | Get-Content -Raw | Should -Be $null
+        Get-ChildItem $TestDrive -Filter "*.raw" | Get-Content -Raw | Should -BeNullOrEmpty
     }
 
     It "Should return no content when -TotalCount value is 0" {
-        Get-Content -Path $testPath -TotalCount 0 | Should -Be $null
+        Get-Content -Path $testPath -TotalCount 0 | Should -BeNullOrEmpty
     }
 
     It "Should throw TailAndHeadCannotCoexist when both -Tail and -TotalCount are used" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Content.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Content.Tests.ps1
@@ -124,7 +124,7 @@ baz
         $expected = 'foo'
 
         $actual = Get-Content -Path $testPath -Tail $tailCount -Encoding $encodingName
-        $actual | Should -BeOfType "[string]"
+        $actual | Should -BeOfType [string]
         $actual.Length | Should -Be $tailCount
         $actual[0] | Should -BeExactly $expected
     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Content.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Content.Tests.ps1
@@ -87,7 +87,7 @@ Describe "Get-Content" -Tags "CI" {
 
     #[BugId(BugDatabase.WindowsOutOfBandReleases, 906022)]
     It "should throw 'PSNotSupportedException' when you Set-Content to an unsupported provider" -Skip:($IsLinux -Or $IsMacOS) {
-        {Get-Content -Path HKLM:\\software\\microsoft -EA stop} | Should -Throw "IContentCmdletProvider interface is not implemented"
+        {Get-Content -Path HKLM:\\software\\microsoft -ErrorAction Stop} | Should -Throw "IContentCmdletProvider interface is not implemented"
     }
 
     It 'Verifies -Tail reports a TailNotSupported error for unsupported providers' {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Content.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Content.Tests.ps1
@@ -30,64 +30,64 @@ Describe "Get-Content" -Tags "CI" {
             throw "No Exception!"
         }
         catch {
-            $_.FullyQualifiedErrorId | should be "GetContentReaderUnauthorizedAccessError,Microsoft.PowerShell.Commands.GetContentCommand"
+            $_.FullyQualifiedErrorId | Should -Be "GetContentReaderUnauthorizedAccessError,Microsoft.PowerShell.Commands.GetContentCommand"
         }
     }
 
     It "Should return an Object when listing only a single line and the correct information from a file" {
         $content = (Get-Content -Path $testPath)
-        $content | Should Be $testString
-        $content.Count | Should Be 1
-        $content | Should BeOfType "System.String"
+        $content | Should -Be $testString
+        $content.Count | Should -Be 1
+        $content | Should -BeOfType "System.String"
     }
 
     It "Should deliver an array object when listing a file with multiple lines and the correct information from a file" {
         $content = (Get-Content -Path $testPath2)
-        @(Compare-Object $content $testString2.Split($nl) -SyncWindow 0).Length | Should Be 0
-        ,$content | Should BeOfType "System.Array"
+        @(Compare-Object $content $testString2.Split($nl) -SyncWindow 0).Length | Should -Be 0
+        ,$content | Should -BeOfType "System.Array"
     }
 
     It "Should be able to return a specific line from a file" {
-        (Get-Content -Path $testPath2)[1] | Should be $secondline
+        (Get-Content -Path $testPath2)[1] | Should -Be $secondline
     }
 
     It "Should be able to specify the number of lines to get the content of using the TotalCount switch" {
         $returnArray    = (Get-Content -Path $testPath2 -TotalCount 2)
-        $returnArray[0] | Should Be $firstline
-        $returnArray[1] | Should Be $secondline
+        $returnArray[0] | Should -Be $firstline
+        $returnArray[1] | Should -Be $secondline
     }
 
     It "Should be able to specify the number of lines to get the content of using the Head switch" {
         $returnArray    = (Get-Content -Path $testPath2 -Head 2)
-        $returnArray[0] | Should Be $firstline
-        $returnArray[1] | Should Be $secondline
+        $returnArray[0] | Should -Be $firstline
+        $returnArray[1] | Should -Be $secondline
     }
 
     It "Should be able to specify the number of lines to get the content of using the First switch" {
         $returnArray    = (Get-Content -Path $testPath2 -First 2)
-        $returnArray[0] | Should Be $firstline
-        $returnArray[1] | Should Be $secondline
+        $returnArray[0] | Should -Be $firstline
+        $returnArray[1] | Should -Be $secondline
     }
 
     It "Should return the last line of a file using the Tail switch" {
-        Get-Content -Path $testPath -Tail 1 | Should Be $testString
+        Get-Content -Path $testPath -Tail 1 | Should -Be $testString
     }
 
     It "Should return the last lines of a file using the Last alias" {
-        Get-Content -Path $testPath2 -Last 1 | Should Be $fifthline
+        Get-Content -Path $testPath2 -Last 1 | Should -Be $fifthline
     }
 
     It "Should be able to get content within a different drive" {
         Push-Location env:
         $expectedoutput = [Environment]::GetEnvironmentVariable("PATH");
-        { Get-Content PATH } | Should Not Throw
-        Get-Content PATH     | Should Be $expectedoutput
+        { Get-Content PATH } | Should -Not -Throw
+        Get-Content PATH     | Should -Be $expectedoutput
         Pop-Location
     }
 
     #[BugId(BugDatabase.WindowsOutOfBandReleases, 906022)]
     It "should throw 'PSNotSupportedException' when you Set-Content to an unsupported provider" -Skip:($IsLinux -Or $IsMacOS) {
-        {Get-Content -Path HKLM:\\software\\microsoft -EA stop} | Should Throw "IContentCmdletProvider interface is not implemented"
+        {Get-Content -Path HKLM:\\software\\microsoft -EA stop} | Should -Throw "IContentCmdletProvider interface is not implemented"
     }
 
     It 'Verifies -Tail reports a TailNotSupported error for unsupported providers' {
@@ -124,9 +124,9 @@ baz
         $expected = 'foo'
 
         $actual = Get-Content -Path $testPath -Tail $tailCount -Encoding $encodingName
-        $actual.GetType() | Should Be "System.Object[]"
-        $actual.Length | Should Be $tailCount
-        $actual[0] | Should Be $expected
+        $actual.GetType() | Should -Be "System.Object[]"
+        $actual.Length | Should -Be $tailCount
+        $actual[0] | Should -Be $expected
     }
 
     It "should Get-Content with a variety of -Tail and -ReadCount: <test>" -TestCases @(
@@ -164,7 +164,7 @@ baz
         param($GetContentParams, $expectedLength, $expectedContent)
         Set-Content -Path $testPath $testContent
         $result = Get-Content @GetContentParams
-        $result.Length | Should Be $expectedLength
+        $result.Length | Should -Be $expectedLength
         $result -eq $expectedContent
     }
 
@@ -183,8 +183,8 @@ baz
         param($GetContentParams, $expectedLength, $expectedContent)
         Set-Content -Path $testPath $testDelimiterContent
         $result = Get-Content @GetContentParams
-        $result.Length | Should Be $expectedLength
-        $result | Should BeExactly $expectedContent
+        $result.Length | Should -Be $expectedLength
+        $result | Should -BeExactly $expectedContent
     }
 
     It "should Get-Content with a variety of -Tail values and -AsByteStream parameter" -TestCases @(
@@ -200,11 +200,11 @@ baz
         param($GetContentParams, $expectedLength, $expectedWindowsContent, $expectedNotWindowsContent)
         Set-Content -Path $testPath $testContent
         $result = Get-Content @GetContentParams
-        $result.Length | Should Be $expectedLength
+        $result.Length | Should -Be $expectedLength
         if ($isWindows) {
-            $result | Should BeExactly $expectedWindowsContent
+            $result | Should -BeExactly $expectedWindowsContent
         } else {
-            $result | Should BeExactly $expectedNotWindowsContent
+            $result | Should -BeExactly $expectedNotWindowsContent
         }
     }
 
@@ -212,35 +212,35 @@ baz
     It "should Get-Content that matches the input string"{
         Set-Content $testPath "Hello,llllWorlld","Hello2,llllWorlld2"
         $result=Get-Content $testPath -Delimiter "ll"
-        $result.Length    | Should Be 9
+        $result.Length    | Should -Be 9
         $expected = 'He', 'o,', '', 'Wor', "d${nl}He", 'o2,', '', 'Wor', "d2${nl}"
-        for ($i = 0; $i -lt $result.Length ; $i++) { $result[$i]    | Should BeExactly $expected[$i]}
+        for ($i = 0; $i -lt $result.Length ; $i++) { $result[$i]    | Should -BeExactly $expected[$i]}
     }
 
     It "Should support NTFS streams using colon syntax" -Skip:(!$IsWindows) {
         Set-Content "${testPath}:Stream" -Value "Foo"
         { Test-Path "${testPath}:Stream" | ShouldBeErrorId "ItemExistsNotSupportedError,Microsoft.PowerShell.Commands,TestPathCommand" }
-        Get-Content "${testPath}:Stream" | Should BeExactly "Foo"
-        Get-Content $testPath | Should BeExactly $testString
+        Get-Content "${testPath}:Stream" | Should -BeExactly "Foo"
+        Get-Content $testPath | Should -BeExactly $testString
     }
 
     It "Should support NTFS streams using -Stream" -Skip:(!$IsWindows) {
         Set-Content -Path $testPath -Stream hello -Value World
-        Get-Content -Path $testPath | Should Be $testString
-        Get-Content -Path $testPath -Stream hello | Should Be "World"
+        Get-Content -Path $testPath | Should -Be $testString
+        Get-Content -Path $testPath -Stream hello | Should -Be "World"
         $item = Get-Item -Path $testPath -Stream hello
-        $item | Should BeOfType System.Management.Automation.Internal.AlternateStreamData
-        $item.Stream | Should Be "hello"
+        $item | Should -BeOfType System.Management.Automation.Internal.AlternateStreamData
+        $item.Stream | Should -Be "hello"
         Clear-Content -Path $testPath -Stream hello
-        Get-Content -Path $testPath -Stream hello | Should BeNullOrEmpty
+        Get-Content -Path $testPath -Stream hello | Should -BeNullOrEmpty
         Remove-Item -Path $testPath -Stream hello
         { Get-Content -Path $testPath -Stream hello | ShouldBeErrorId "GetContentReaderFileNotFoundError,Microsoft.PowerShell.Commands.GetContentCommand" }
     }
 
     It "Should support colons in filename on Linux/Mac" -Skip:($IsWindows) {
         Set-Content "${testPath}:Stream" -Value "Hello"
-        "${testPath}:Stream" | Should Exist
-        Get-Content "${testPath}:Stream" | Should BeExactly "Hello"
+        "${testPath}:Stream" | Should -Exist
+        Get-Content "${testPath}:Stream" | Should -BeExactly "Hello"
     }
 
     It "-Stream is not a valid parameter for <cmdlet> on Linux/Mac" -Skip:($IsWindows) -TestCases @(
@@ -252,15 +252,15 @@ baz
         @{cmdlet="Remove-Item"}
     ) {
         param($cmdlet)
-        (Get-Command $cmdlet).Parameters["stream"] | Should BeNullOrEmpty
+        (Get-Command $cmdlet).Parameters["stream"] | Should -BeNullOrEmpty
     }
  
     It "Should return no content when an empty path is used with -Raw switch" {
-        Get-ChildItem $TestDrive -Filter "*.raw" | Get-Content -Raw | Should Be $null
+        Get-ChildItem $TestDrive -Filter "*.raw" | Get-Content -Raw | Should -Be $null
     }
 
     It "Should return no content when -TotalCount value is 0" {
-        Get-Content -Path $testPath -TotalCount 0 | Should Be $null
+        Get-Content -Path $testPath -TotalCount 0 | Should -Be $null
     }
 
     It "Should throw TailAndHeadCannotCoexist when both -Tail and -TotalCount are used" {
@@ -296,51 +296,51 @@ baz
         }
         It "Should return all lines when -Tail value is more than number of lines in the file"{
             $result = Get-Content -Path $testPath -ReadCount -1 -Tail 5 -Encoding UTF7
-            $result.Length | Should Be 4
+            $result.Length | Should -Be 4
             $expected = $fileContent
-            Compare-Object -ReferenceObject $expected -DifferenceObject $result | Should BeNullOrEmpty
+            Compare-Object -ReferenceObject $expected -DifferenceObject $result | Should -BeNullOrEmpty
         }
         It "Should return last three lines at one time for -ReadCount 0 and -Tail 3"{
             $result = Get-Content -Path $testPath -ReadCount 0 -Tail 3 -Encoding UTF7
-            $result.Length | Should Be 3
+            $result.Length | Should -Be 3
             $expected = $secondLine,$thirdLine,$fourthLine
-            Compare-Object -ReferenceObject $expected -DifferenceObject $result | Should BeNullOrEmpty
+            Compare-Object -ReferenceObject $expected -DifferenceObject $result | Should -BeNullOrEmpty
         }
         It "Should return last three lines reading one at a time for -ReadCount 1 and -Tail 3"{
             $result = Get-Content -Path $testPath -ReadCount 1 -Tail 3 -Encoding UTF7
-            $result.Length | Should Be 3
+            $result.Length | Should -Be 3
             $expected = $secondLine,$thirdLine,$fourthLine
-            Compare-Object -ReferenceObject $expected -DifferenceObject $result | Should BeNullOrEmpty
+            Compare-Object -ReferenceObject $expected -DifferenceObject $result | Should -BeNullOrEmpty
         }
         It "Should return last three lines at one time for -ReadCount 99999 and -Tail 3"{
             $result = Get-Content -Path $testPath -ReadCount 99999 -Tail 3 -Encoding UTF7
-            $result.Length | Should Be 3
+            $result.Length | Should -Be 3
             $expected = $secondLine,$thirdLine,$fourthLine
-            Compare-Object -ReferenceObject $expected -DifferenceObject $result | Should BeNullOrEmpty
+            Compare-Object -ReferenceObject $expected -DifferenceObject $result | Should -BeNullOrEmpty
         }
         It "Should return last three lines two lines at a time for -ReadCount 2 and -Tail 3"{
             $result = Get-Content -Path $testPath -ReadCount 2 -Tail 3 -Encoding UTF7
-            $result.Length | Should Be 2
+            $result.Length | Should -Be 2
             $expected = New-Object System.Array[] 2
             $expected[0] = ($secondLine,$thirdLine)
             $expected[1] = $fourthLine
-            Compare-Object -ReferenceObject $expected -DifferenceObject $result | Should BeNullOrEmpty
+            Compare-Object -ReferenceObject $expected -DifferenceObject $result | Should -BeNullOrEmpty
         }
         It "Should not return any content when -TotalCount 0"{
             $result = Get-Content -Path $testPath -TotalCount 0 -ReadCount 1 -Encoding UTF7
-            $result.Length | Should Be 0
+            $result.Length | Should -Be 0
         }
         It "Should return first three lines two lines at a time for -TotalCount 3 and -ReadCount 2"{
             $result = Get-Content -Path $testPath -TotalCount 3 -ReadCount 2 -Encoding UTF7
-            $result.Length | Should Be 2
+            $result.Length | Should -Be 2
             $expected = New-Object System.Array[] 2
             $expected[0] = ($firstLine,$secondLine)
             $expected[1] = $thirdLine
-            Compare-Object -ReferenceObject $expected -DifferenceObject $result | Should BeNullOrEmpty
+            Compare-Object -ReferenceObject $expected -DifferenceObject $result | Should -BeNullOrEmpty
         }
         It "A warning should be emitted if both -AsByteStream and -Encoding are used together" {
             [byte[]][char[]]"test" | Set-Content -Encoding Unicode -AsByteStream "${TESTDRIVE}\bfile.txt" -WarningVariable contentWarning *>$null
-            $contentWarning.Message | Should Match "-AsByteStream"
+            $contentWarning.Message | Should -Match "-AsByteStream"
         }
     }
 }
@@ -355,6 +355,6 @@ Describe "Get-Content -Raw test" -Tags "CI" {
     ) {
         param ($character, $filename)
         Set-Content -Encoding Ascii -NoNewline "$TestDrive\$filename" -Value $character
-        Get-Content -Raw "$TestDrive\$filename" | Should BeExactly $character
+        Get-Content -Raw "$TestDrive\$filename" | Should -BeExactly $character
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-EventLog.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-EventLog.Tests.ps1
@@ -16,7 +16,7 @@ Describe "Get-EventLog cmdlet tests" -Tags @('CI', 'RequireAdminOnWindows') {
       {$result=Get-EventLog -AsString -ea stop}    | Should -Not -Throw
       $result | Should -Not -BeNullOrEmpty
       ,$result                                     | Should -BeOfType "System.Array"
-      $result -eq "Application"                    | Should -Be "Application"
+      $result                                      | Should -BeExactly "Application"
       $result.Count -ge 3                          | Should -BeTrue
     }
     It "should return a list of eventlog objects when called with -List parameter" -Pending:($True) {
@@ -24,11 +24,11 @@ Describe "Get-EventLog cmdlet tests" -Tags @('CI', 'RequireAdminOnWindows') {
       $result | Should -Not -BeNullOrEmpty
       ,$result                                     | Should -BeOfType "System.Array"
       {$logs=$result | Select-Object -ExpandProperty Log}   | Should -Not -Throw
-      $logs -eq "System"                           | Should -Be "System"
+      $logs                                        | Should -BeExactly "System"
       $logs.Count -ge 3                            | Should -BeTrue
     }
     It "should be able to Get-EventLog -LogName Application -Newest 100" -Pending:($True) {
-      {$result=get-eventlog -LogName Application -Newest 100 -ea stop} | Should -Not -Throw
+      {$result=get-eventlog -LogName Application -Newest 100 -ErrorAction stop} | Should -Not -Throw
       $result                                      | Should -Not -BeNullOrEmpty
       $result.Length -le 100                       | Should -BeTrue
       $result[0]                                   | Should -BeOfType "EventLogEntry"
@@ -40,7 +40,7 @@ Describe "Get-EventLog cmdlet tests" -Tags @('CI', 'RequireAdminOnWindows') {
     It "should be able to Get-EventLog -LogName * with multiple matches" -Pending:($True) {
       {$result=get-eventlog -LogName *  -ea stop}  | Should -Not -Throw
       $result                                      | Should -Not -BeNullOrEmpty
-      $result -eq "Security"                       | Should -Be "Security"
+      $result                                      | Should -BeExactly "Security"
       $result.Count -ge 3                          | Should -BeTrue
     }
     It "should throw 'InvalidOperationException' when asked to get a log that does not exist" -Pending:($True) {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-EventLog.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-EventLog.Tests.ps1
@@ -17,7 +17,7 @@ Describe "Get-EventLog cmdlet tests" -Tags @('CI', 'RequireAdminOnWindows') {
       $result                                              | Should -Not -BeNullOrEmpty
       ,$result                                             | Should -BeOfType "System.Array"
       $result                                              | Should -BeExactly "Application"
-      $result.Count -ge 3                                  | Should -BeTrue
+      $result.Count                                        | Should -BeGreaterThan 3
     }
     It "should return a list of eventlog objects when called with -List parameter" -Pending:($True) {
       { $result=Get-EventLog -List -ErrorAction Stop }      | Should -Not -Throw
@@ -25,12 +25,12 @@ Describe "Get-EventLog cmdlet tests" -Tags @('CI', 'RequireAdminOnWindows') {
       ,$result                                              | Should -BeOfType "System.Array"
       {$logs=$result | Select-Object -ExpandProperty Log}   | Should -Not -Throw
       $logs                                                 | Should -BeExactly "System"
-      $logs.Count -ge 3                                     | Should -BeTrue
+      $logs.Count                                           | Should -BeGreaterThan 3
     }
     It "should be able to Get-EventLog -LogName Application -Newest 100" -Pending:($True) {
       { $result=get-eventlog -LogName Application -Newest 100 -ErrorAction Stop } | Should -Not -Throw
       $result                                                                     | Should -Not -BeNullOrEmpty
-      $result.Length -le 100                                                      | Should -BeTrue
+      $result.Length                                                              | Should -BeLessThan 100
       $result[0]                                                                  | Should -BeOfType "EventLogEntry"
     }
     It "should throw 'AmbiguousParameterSetException' when called with both -LogName and -List parameters" -Pending:($True) {
@@ -40,7 +40,7 @@ Describe "Get-EventLog cmdlet tests" -Tags @('CI', 'RequireAdminOnWindows') {
       { $result=get-eventlog -LogName *  -ErrorAction Stop }  | Should -Not -Throw
       $result                                                 | Should -Not -BeNullOrEmpty
       $result                                                 | Should -BeExactly "Security"
-      $result.Count -ge 3                                     | Should -BeTrue
+      $result.Count                                           | Should -BeGreaterThan 3
     }
     It "should throw 'InvalidOperationException' when asked to get a log that does not exist" -Pending:($True) {
       { Get-EventLog  -LogName MissingTestLog -ErrorAction Stop } | Should -Throw -ErrorId "System.InvalidOperationException,Microsoft.PowerShell.Commands.GetEventLogCommand"

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-EventLog.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-EventLog.Tests.ps1
@@ -13,38 +13,36 @@ Describe "Get-EventLog cmdlet tests" -Tags @('CI', 'RequireAdminOnWindows') {
 
     #CmdLets are not yet implemented, so these cases are -Pending:($True) for now...
     It "should return an array of eventlogs objects when called with -AsString parameter" -Pending:($True) {
-      {$result=Get-EventLog -AsString -ea stop}    | Should -Not -Throw
-      $result | Should -Not -BeNullOrEmpty
-      ,$result                                     | Should -BeOfType "System.Array"
-      $result                                      | Should -BeExactly "Application"
-      $result.Count -ge 3                          | Should -BeTrue
+      { $result=Get-EventLog -AsString -ErrorAction Stop } | Should -Not -Throw
+      $result                                              | Should -Not -BeNullOrEmpty
+      ,$result                                             | Should -BeOfType "System.Array"
+      $result                                              | Should -BeExactly "Application"
+      $result.Count -ge 3                                  | Should -BeTrue
     }
     It "should return a list of eventlog objects when called with -List parameter" -Pending:($True) {
-      {$result=Get-EventLog -List -ea stop}        | Should -Not -Throw
-      $result | Should -Not -BeNullOrEmpty
-      ,$result                                     | Should -BeOfType "System.Array"
+      { $result=Get-EventLog -List -ErrorAction Stop }      | Should -Not -Throw
+      $result                                               | Should -Not -BeNullOrEmpty
+      ,$result                                              | Should -BeOfType "System.Array"
       {$logs=$result | Select-Object -ExpandProperty Log}   | Should -Not -Throw
-      $logs                                        | Should -BeExactly "System"
-      $logs.Count -ge 3                            | Should -BeTrue
+      $logs                                                 | Should -BeExactly "System"
+      $logs.Count -ge 3                                     | Should -BeTrue
     }
     It "should be able to Get-EventLog -LogName Application -Newest 100" -Pending:($True) {
-      {$result=get-eventlog -LogName Application -Newest 100 -ErrorAction stop} | Should -Not -Throw
-      $result                                      | Should -Not -BeNullOrEmpty
-      $result.Length -le 100                       | Should -BeTrue
-      $result[0]                                   | Should -BeOfType "EventLogEntry"
+      { $result=get-eventlog -LogName Application -Newest 100 -ErrorAction Stop } | Should -Not -Throw
+      $result                                                                     | Should -Not -BeNullOrEmpty
+      $result.Length -le 100                                                      | Should -BeTrue
+      $result[0]                                                                  | Should -BeOfType "EventLogEntry"
     }
     It "should throw 'AmbiguousParameterSetException' when called with both -LogName and -List parameters" -Pending:($True) {
-      try {Get-EventLog -LogName System -List -ea stop; Throw "Previous statement unexpectedly succeeded..."
-      } catch {echo $_.FullyQualifiedErrorId       | Should -Be "AmbiguousParameterSet,Microsoft.PowerShell.Commands.GetEventLogCommand"}
+      { Get-EventLog -LogName System -List -ErrorAction Stop } | Should -Throw -ErrorId "AmbiguousParameterSet,Microsoft.PowerShell.Commands.GetEventLogCommand"
     }
     It "should be able to Get-EventLog -LogName * with multiple matches" -Pending:($True) {
-      {$result=get-eventlog -LogName *  -ea stop}  | Should -Not -Throw
-      $result                                      | Should -Not -BeNullOrEmpty
-      $result                                      | Should -BeExactly "Security"
-      $result.Count -ge 3                          | Should -BeTrue
+      { $result=get-eventlog -LogName *  -ErrorAction Stop }  | Should -Not -Throw
+      $result                                                 | Should -Not -BeNullOrEmpty
+      $result                                                 | Should -BeExactly "Security"
+      $result.Count -ge 3                                     | Should -BeTrue
     }
     It "should throw 'InvalidOperationException' when asked to get a log that does not exist" -Pending:($True) {
-      try {Get-EventLog  -LogName MissingTestLog -ea stop; Throw "Previous statement unexpectedly succeeded..."
-      } catch {echo $_.FullyQualifiedErrorId      | Should -Be "System.InvalidOperationException,Microsoft.PowerShell.Commands.GetEventLogCommand"}
+      { Get-EventLog  -LogName MissingTestLog -ErrorAction Stop } | Should -Throw -ErrorId "System.InvalidOperationException,Microsoft.PowerShell.Commands.GetEventLogCommand"
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-EventLog.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-EventLog.Tests.ps1
@@ -13,38 +13,38 @@ Describe "Get-EventLog cmdlet tests" -Tags @('CI', 'RequireAdminOnWindows') {
 
     #CmdLets are not yet implemented, so these cases are -Pending:($True) for now...
     It "should return an array of eventlogs objects when called with -AsString parameter" -Pending:($True) {
-      {$result=Get-EventLog -AsString -ea stop}    | Should Not Throw
-      $result | Should Not BeNullOrEmpty
-      ,$result                                     | Should BeOfType "System.Array"
-      $result -eq "Application"                    | Should Be "Application"
-      $result.Count -ge 3                          | Should Be $true
+      {$result=Get-EventLog -AsString -ea stop}    | Should -Not -Throw
+      $result | Should -Not -BeNullOrEmpty
+      ,$result                                     | Should -BeOfType "System.Array"
+      $result -eq "Application"                    | Should -Be "Application"
+      $result.Count -ge 3                          | Should -Be $true
     }
     It "should return a list of eventlog objects when called with -List parameter" -Pending:($True) {
-      {$result=Get-EventLog -List -ea stop}        | Should Not Throw
-      $result | Should Not BeNullOrEmpty
-      ,$result                                     | Should BeOfType "System.Array"
-      {$logs=$result | Select-Object -ExpandProperty Log}   | Should Not Throw
-      $logs -eq "System"                           | Should Be "System"
-      $logs.Count -ge 3                            | Should Be $true
+      {$result=Get-EventLog -List -ea stop}        | Should -Not -Throw
+      $result | Should -Not -BeNullOrEmpty
+      ,$result                                     | Should -BeOfType "System.Array"
+      {$logs=$result | Select-Object -ExpandProperty Log}   | Should -Not -Throw
+      $logs -eq "System"                           | Should -Be "System"
+      $logs.Count -ge 3                            | Should -Be $true
     }
     It "should be able to Get-EventLog -LogName Application -Newest 100" -Pending:($True) {
-      {$result=get-eventlog -LogName Application -Newest 100 -ea stop} | Should Not Throw
-      $result                                      | Should Not BeNullOrEmpty
-      $result.Length -le 100                       | Should Be $true
-      $result[0]                                   | Should BeOfType "EventLogEntry"
+      {$result=get-eventlog -LogName Application -Newest 100 -ea stop} | Should -Not -Throw
+      $result                                      | Should -Not -BeNullOrEmpty
+      $result.Length -le 100                       | Should -Be $true
+      $result[0]                                   | Should -BeOfType "EventLogEntry"
     }
     It "should throw 'AmbiguousParameterSetException' when called with both -LogName and -List parameters" -Pending:($True) {
       try {Get-EventLog -LogName System -List -ea stop; Throw "Previous statement unexpectedly succeeded..."
-      } catch {echo $_.FullyQualifiedErrorId       | Should Be "AmbiguousParameterSet,Microsoft.PowerShell.Commands.GetEventLogCommand"}
+      } catch {echo $_.FullyQualifiedErrorId       | Should -Be "AmbiguousParameterSet,Microsoft.PowerShell.Commands.GetEventLogCommand"}
     }
     It "should be able to Get-EventLog -LogName * with multiple matches" -Pending:($True) {
-      {$result=get-eventlog -LogName *  -ea stop}  | Should Not Throw
-      $result                                      | Should Not BeNullOrEmpty
-      $result -eq "Security"                       | Should Be "Security"
-      $result.Count -ge 3                          | Should Be $true
+      {$result=get-eventlog -LogName *  -ea stop}  | Should -Not -Throw
+      $result                                      | Should -Not -BeNullOrEmpty
+      $result -eq "Security"                       | Should -Be "Security"
+      $result.Count -ge 3                          | Should -Be $true
     }
     It "should throw 'InvalidOperationException' when asked to get a log that does not exist" -Pending:($True) {
       try {Get-EventLog  -LogName MissingTestLog -ea stop; Throw "Previous statement unexpectedly succeeded..."
-      } catch {echo $_.FullyQualifiedErrorId      | Should Be "System.InvalidOperationException,Microsoft.PowerShell.Commands.GetEventLogCommand"}
+      } catch {echo $_.FullyQualifiedErrorId      | Should -Be "System.InvalidOperationException,Microsoft.PowerShell.Commands.GetEventLogCommand"}
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-EventLog.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-EventLog.Tests.ps1
@@ -17,7 +17,7 @@ Describe "Get-EventLog cmdlet tests" -Tags @('CI', 'RequireAdminOnWindows') {
       $result | Should -Not -BeNullOrEmpty
       ,$result                                     | Should -BeOfType "System.Array"
       $result -eq "Application"                    | Should -Be "Application"
-      $result.Count -ge 3                          | Should -Be $true
+      $result.Count -ge 3                          | Should -BeTrue
     }
     It "should return a list of eventlog objects when called with -List parameter" -Pending:($True) {
       {$result=Get-EventLog -List -ea stop}        | Should -Not -Throw
@@ -25,12 +25,12 @@ Describe "Get-EventLog cmdlet tests" -Tags @('CI', 'RequireAdminOnWindows') {
       ,$result                                     | Should -BeOfType "System.Array"
       {$logs=$result | Select-Object -ExpandProperty Log}   | Should -Not -Throw
       $logs -eq "System"                           | Should -Be "System"
-      $logs.Count -ge 3                            | Should -Be $true
+      $logs.Count -ge 3                            | Should -BeTrue
     }
     It "should be able to Get-EventLog -LogName Application -Newest 100" -Pending:($True) {
       {$result=get-eventlog -LogName Application -Newest 100 -ea stop} | Should -Not -Throw
       $result                                      | Should -Not -BeNullOrEmpty
-      $result.Length -le 100                       | Should -Be $true
+      $result.Length -le 100                       | Should -BeTrue
       $result[0]                                   | Should -BeOfType "EventLogEntry"
     }
     It "should throw 'AmbiguousParameterSetException' when called with both -LogName and -List parameters" -Pending:($True) {
@@ -41,7 +41,7 @@ Describe "Get-EventLog cmdlet tests" -Tags @('CI', 'RequireAdminOnWindows') {
       {$result=get-eventlog -LogName *  -ea stop}  | Should -Not -Throw
       $result                                      | Should -Not -BeNullOrEmpty
       $result -eq "Security"                       | Should -Be "Security"
-      $result.Count -ge 3                          | Should -Be $true
+      $result.Count -ge 3                          | Should -BeTrue
     }
     It "should throw 'InvalidOperationException' when asked to get a log that does not exist" -Pending:($True) {
       try {Get-EventLog  -LogName MissingTestLog -ea stop; Throw "Previous statement unexpectedly succeeded..."

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Item.Tests.ps1
@@ -11,20 +11,20 @@ Describe "Get-Item" -Tags "CI" {
     }
     It "Should list all the items in the current working directory when asterisk is used" {
         $items = Get-Item (Join-Path -Path $PSScriptRoot -ChildPath "*")
-        ,$items | Should BeOfType 'System.Object[]'
+        ,$items | Should -BeOfType 'System.Object[]'
     }
 
     It "Should return the name of the current working directory when a dot is used" {
         $item = Get-Item $PSScriptRoot
-        $item | Should BeOfType 'System.IO.DirectoryInfo'
-        $item.Name | Should Be (Split-Path $PSScriptRoot -Leaf)
+        $item | Should -BeOfType 'System.IO.DirectoryInfo'
+        $item.Name | Should -Be (Split-Path $PSScriptRoot -Leaf)
     }
 
     It "Should return the proper Name and BaseType for directory objects vs file system objects" {
         $rootitem = Get-Item $PSScriptRoot
-        $rootitem | Should BeOfType 'System.IO.DirectoryInfo'
+        $rootitem | Should -BeOfType 'System.IO.DirectoryInfo'
         $childitem = (Get-Item (Join-Path -Path $PSScriptRoot -ChildPath Get-Item.Tests.ps1))
-        $childitem | Should BeOfType 'System.IO.FileInfo'
+        $childitem | Should -BeOfType 'System.IO.FileInfo'
     }
 
     It "Using -literalpath should find no additional files" {
@@ -32,12 +32,12 @@ Describe "Get-Item" -Tags "CI" {
         $null = New-Item -type file "$TESTDRIVE/filea.txt"
         # if literalpath is not correct we would see filea.txt
         $item = Get-Item -literalpath "$TESTDRIVE/file[abc].txt"
-        @($item).Count | Should Be 1
-        $item.Name | Should Be 'file[abc].txt'
+        @($item).Count | Should -Be 1
+        $item.Name | Should -Be 'file[abc].txt'
     }
 
     It "Should have mode flags set" {
-        Get-ChildItem $PSScriptRoot | foreach-object { $_.Mode | Should Not BeNullOrEmpty }
+        Get-ChildItem $PSScriptRoot | foreach-object { $_.Mode | Should -Not -BeNullOrEmpty }
     }
 
     It "Should not return the item unless force is used if hidden" {
@@ -47,9 +47,9 @@ Describe "Get-Item" -Tags "CI" {
             attrib +h "$hiddenFile"
         }
         ${result} = Get-Item "${hiddenFile}" -ErrorAction SilentlyContinue
-        ${result} | Should BeNullOrEmpty
+        ${result} | Should -BeNullOrEmpty
         ${result} = Get-Item -force "${hiddenFile}" -ErrorAction SilentlyContinue
-        ${result}.FullName | Should Be ${item}.FullName
+        ${result}.FullName | Should -Be ${item}.FullName
     }
 
     Context "Test for Include, Exclude, and Filter" {
@@ -61,23 +61,23 @@ Describe "Get-Item" -Tags "CI" {
         }
         It "Should respect -Exclude" {
             $result = Get-Item "${testBaseDir}/*" -Exclude "file2.txt"
-            ($result).Count | Should Be 1
-            $result.Name | should be "file1.txt"
+            ($result).Count | Should -Be 1
+            $result.Name | Should -Be "file1.txt"
         }
         It "Should respect -Include" {
             $result = Get-Item "${testBaseDir}/*" -Include "file2.txt"
-            ($result).Count | Should Be 1
-            $result.Name | should be "file2.txt"
+            ($result).Count | Should -Be 1
+            $result.Name | Should -Be "file2.txt"
         }
         It "Should respect -Filter" {
             $result = Get-Item "${testBaseDir}/*" -Filter "*2*"
-            ($result).Count | Should Be 1
-            $result.Name | should be "file2.txt"
+            ($result).Count | Should -Be 1
+            $result.Name | Should -Be "file2.txt"
         }
         It "Should respect combinations of filter, include, and exclude" {
             $result = get-item "${testBaseDir}/*" -filter *.txt -include "file[12].txt" -exclude file2.txt
-            ($result).Count | Should Be 1
-            $result.Name | should be "file1.txt"
+            ($result).Count | Should -Be 1
+            $result.Name | Should -Be "file1.txt"
         }
     }
 
@@ -105,15 +105,15 @@ Describe "Get-Item" -Tags "CI" {
         }
         It "Should find an alternate stream if present" -skip:$skipNotWindows {
             $result = Get-Item $altStreamPath -Stream $streamName
-            $result.Length | Should Be ($stringData.Length + [Environment]::NewLine.Length)
-            $result.Stream | Should Be $streamName
+            $result.Length | Should -Be ($stringData.Length + [Environment]::NewLine.Length)
+            $result.Stream | Should -Be $streamName
         }
     }
 
     Context "Registry Provider" {
         It "Can retrieve an item from registry" -skip:$skipNotWindows {
             ${result} = Get-Item HKLM:/Software
-            ${result} | Should BeOfType "Microsoft.Win32.RegistryKey"
+            ${result} | Should -BeOfType "Microsoft.Win32.RegistryKey"
         }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Item.Tests.ps1
@@ -17,7 +17,7 @@ Describe "Get-Item" -Tags "CI" {
     It "Should return the name of the current working directory when a dot is used" {
         $item = Get-Item $PSScriptRoot
         $item | Should -BeOfType 'System.IO.DirectoryInfo'
-        $item.Name | Should -Be (Split-Path $PSScriptRoot -Leaf)
+        $item.Name | Should -BeExactly (Split-Path $PSScriptRoot -Leaf)
     }
 
     It "Should return the proper Name and BaseType for directory objects vs file system objects" {
@@ -33,7 +33,7 @@ Describe "Get-Item" -Tags "CI" {
         # if literalpath is not correct we would see filea.txt
         $item = Get-Item -literalpath "$TESTDRIVE/file[abc].txt"
         @($item).Count | Should -Be 1
-        $item.Name | Should -Be 'file[abc].txt'
+        $item.Name | Should -BeExactly 'file[abc].txt'
     }
 
     It "Should have mode flags set" {
@@ -49,7 +49,7 @@ Describe "Get-Item" -Tags "CI" {
         ${result} = Get-Item "${hiddenFile}" -ErrorAction SilentlyContinue
         ${result} | Should -BeNullOrEmpty
         ${result} = Get-Item -force "${hiddenFile}" -ErrorAction SilentlyContinue
-        ${result}.FullName | Should -Be ${item}.FullName
+        ${result}.FullName | Should -BeExactly ${item}.FullName
     }
 
     Context "Test for Include, Exclude, and Filter" {
@@ -62,22 +62,22 @@ Describe "Get-Item" -Tags "CI" {
         It "Should respect -Exclude" {
             $result = Get-Item "${testBaseDir}/*" -Exclude "file2.txt"
             ($result).Count | Should -Be 1
-            $result.Name | Should -Be "file1.txt"
+            $result.Name | Should -BeExactly "file1.txt"
         }
         It "Should respect -Include" {
             $result = Get-Item "${testBaseDir}/*" -Include "file2.txt"
             ($result).Count | Should -Be 1
-            $result.Name | Should -Be "file2.txt"
+            $result.Name | Should -BeExactly "file2.txt"
         }
         It "Should respect -Filter" {
             $result = Get-Item "${testBaseDir}/*" -Filter "*2*"
             ($result).Count | Should -Be 1
-            $result.Name | Should -Be "file2.txt"
+            $result.Name | Should -BeExactly "file2.txt"
         }
         It "Should respect combinations of filter, include, and exclude" {
             $result = get-item "${testBaseDir}/*" -filter *.txt -include "file[12].txt" -exclude file2.txt
             ($result).Count | Should -Be 1
-            $result.Name | Should -Be "file1.txt"
+            $result.Name | Should -BeExactly "file1.txt"
         }
     }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ItemProperty.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ItemProperty.Tests.ps1
@@ -11,44 +11,44 @@ Describe "Get-ItemProperty" -Tags "CI" {
     New-Item $testfile -ItemType file -Force
 
     It "Should be able to be called on in the current directory" {
-	$(Get-ItemProperty $PSScriptRoot).Name | Should Be $currentDirectory
+	$(Get-ItemProperty $PSScriptRoot).Name | Should -Be $currentDirectory
     }
 
     It "Should be able to be called on a parent directory" {
-	(Get-ItemProperty $PSScriptRoot/..).Name | Should Be $parentDirectory
+	(Get-ItemProperty $PSScriptRoot/..).Name | Should -Be $parentDirectory
     }
 
     It "Should be able to be called on a directory using the path switch" {
-	{ Get-ItemProperty -Path $tempDirectory } | Should Not Throw
+	{ Get-ItemProperty -Path $tempDirectory } | Should -Not -Throw
     }
 
     It "Should be able to be called on a file using the path switch" {
-	{ Get-ItemProperty -Path $testfile } | Should Not Throw
+	{ Get-ItemProperty -Path $testfile } | Should -Not -Throw
     }
 
     It "Should be able to access a property using the Path and name switches" {
-	{ Get-ItemProperty -Path $testfile -Name fullname } | Should Not Throw
+	{ Get-ItemProperty -Path $testfile -Name fullname } | Should -Not -Throw
 
 	$output = Get-ItemProperty -Path $testfile -Name fullname
 
-	$output.PSPath | Should Not BeNullOrEmpty
+	$output.PSPath | Should -Not -BeNullOrEmpty
 
-	$output.PSDrive | Should Be $testprovider
+	$output.PSDrive | Should -Be $testprovider
 
-	$output.PSProvider.Name | Should Be "FileSystem"
+	$output.PSProvider.Name | Should -Be "FileSystem"
     }
 
     It "Should be able to use the gp alias without error" {
-	{ gp . }  | Should Not Throw
-	{ gp .. } | Should Not Throw
+	{ gp . }  | Should -Not -Throw
+	{ gp .. } | Should -Not -Throw
     }
 
     It "Should have the same results between alias and cmdlet" {
 	$alias  = gp -Path $testfile -Name fullname
 	$cmdlet = Get-ItemProperty -Path $testfile -Name fullname
 
-	$alias.PSPath          | Should Be $cmdlet.PSPath
-	$alias.PSDrive         | Should Be $cmdlet.PSDrive
-	$alias.PSProvider.Name | Should Be $cmdlet.PSProvider.Name
+	$alias.PSPath          | Should -Be $cmdlet.PSPath
+	$alias.PSDrive         | Should -Be $cmdlet.PSDrive
+	$alias.PSProvider.Name | Should -Be $cmdlet.PSProvider.Name
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ItemProperty.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ItemProperty.Tests.ps1
@@ -11,11 +11,11 @@ Describe "Get-ItemProperty" -Tags "CI" {
     New-Item $testfile -ItemType file -Force
 
     It "Should be able to be called on in the current directory" {
-	$(Get-ItemProperty $PSScriptRoot).Name | Should -Be $currentDirectory
+	$(Get-ItemProperty $PSScriptRoot).Name | Should -BeExactly $currentDirectory
     }
 
     It "Should be able to be called on a parent directory" {
-	(Get-ItemProperty $PSScriptRoot/..).Name | Should -Be $parentDirectory
+	(Get-ItemProperty $PSScriptRoot/..).Name | Should -BeExactly $parentDirectory
     }
 
     It "Should be able to be called on a directory using the path switch" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Location.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Location.Tests.ps1
@@ -12,10 +12,10 @@ Describe "Get-Location" -Tags "CI" {
 
     It "Should list the output of the current working directory" {
 
-	(Get-Location).Path | Should Be $currentDirectory
+	(Get-Location).Path | Should -Be $currentDirectory
     }
 
     It "Should do exactly the same thing as its alias" {
-	(pwd).Path | Should Be (Get-Location).Path
+	(pwd).Path | Should -Be (Get-Location).Path
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Location.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Location.Tests.ps1
@@ -12,10 +12,10 @@ Describe "Get-Location" -Tags "CI" {
 
     It "Should list the output of the current working directory" {
 
-	(Get-Location).Path | Should -Be $currentDirectory
+	(Get-Location).Path | Should -BeExactly $currentDirectory
     }
 
     It "Should do exactly the same thing as its alias" {
-	(pwd).Path | Should -Be (Get-Location).Path
+	(pwd).Path | Should -BeExactly (Get-Location).Path
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-PSDrive.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-PSDrive.Tests.ps1
@@ -19,7 +19,7 @@ Describe "Get-PSDrive" -Tags "CI" {
 
     It "Should be the same output between Get-PSDrive and gdr" {
 	$alias  = gdr
-	$actual = "Get-PSDrive"
+	$actual = Get-PSDrive
 
 
 	$alias | Should -BeExactly $actual

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-PSDrive.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-PSDrive.Tests.ps1
@@ -19,23 +19,24 @@ Describe "Get-PSDrive" -Tags "CI" {
 
     It "Should be the same output between Get-PSDrive and gdr" {
 	$alias  = gdr
-	$actual = Get-PSDrive
+	$actual = "Get-PSDrive"
 
-	$alias | Should -Be $actual
+
+	$alias | Should -BeExactly $actual
     }
 
     It "Should return drive info"{
-        (Get-PSDrive Env).Name        | Should -Be Env
-        (Get-PSDrive Alias).Name      | Should -Be Alias
+        (Get-PSDrive Env).Name        | Should -BeExactly Env
+        (Get-PSDrive Alias).Name      | Should -BeExactly Alias
 
         if ($IsWindows)
         {
             (Get-PSDrive Cert).Root       | Should -Be \
-            (Get-PSDrive C).Provider.Name | Should -Be FileSystem
+            (Get-PSDrive C).Provider.Name | Should -BeExactly FileSystem
         }
         else
         {
-            (Get-PSDrive /).Provider.Name | Should -Be FileSystem
+            (Get-PSDrive /).Provider.Name | Should -BeExactly FileSystem
         }
     }
 
@@ -44,15 +45,15 @@ Describe "Get-PSDrive" -Tags "CI" {
     }
 
     It "Should return true that a drive that does not exist"{
-	!(Get-PSDrive fake -ErrorAction SilentlyContinue) | Should -Be $True
+	!(Get-PSDrive fake -ErrorAction SilentlyContinue) | Should -BeTrue
 	Get-PSDrive fake -ErrorAction SilentlyContinue    | Should -BeNullOrEmpty
     }
     It "Should be able to determine the amount of free space of a drive" {
         $dInfo = Get-PSDrive TESTDRIVE
-        $dInfo.Free -ge 0 | Should -Be $true
+        $dInfo.Free -ge 0 | Should -BeTrue
     }
     It "Should be able to determine the amount of Used space of a drive" {
         $dInfo = Get-PSDrive TESTDRIVE
-        $dInfo.Used -ge 0 | Should -Be $true
+        $dInfo.Used -ge 0 | Should -BeTrue
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-PSDrive.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-PSDrive.Tests.ps1
@@ -3,56 +3,56 @@
 Describe "Get-PSDrive" -Tags "CI" {
 
     It "Should not throw" {
-	Get-PSDrive | Should Not BeNullOrEmpty
+	Get-PSDrive | Should -Not -BeNullOrEmpty
     }
 
     It "Should have a name and a length property" {
-	(Get-PSDrive).Name        | Should Not BeNullOrEmpty
-	(Get-PSDrive).Root.Length | Should Not BeLessThan 1
+	(Get-PSDrive).Name        | Should -Not -BeNullOrEmpty
+	(Get-PSDrive).Root.Length | Should -Not -BeLessThan 1
     }
 
     It "Should be able to be called with the gdr alias" {
-	{ gdr } | Should Not Throw
+	{ gdr } | Should -Not -Throw
 
-	gdr | Should Not BeNullOrEmpty
+	gdr | Should -Not -BeNullOrEmpty
     }
 
     It "Should be the same output between Get-PSDrive and gdr" {
 	$alias  = gdr
 	$actual = Get-PSDrive
 
-	$alias | Should Be $actual
+	$alias | Should -Be $actual
     }
 
     It "Should return drive info"{
-        (Get-PSDrive Env).Name        | Should Be Env
-        (Get-PSDrive Alias).Name      | Should Be Alias
+        (Get-PSDrive Env).Name        | Should -Be Env
+        (Get-PSDrive Alias).Name      | Should -Be Alias
 
         if ($IsWindows)
         {
-            (Get-PSDrive Cert).Root       | Should Be \
-            (Get-PSDrive C).Provider.Name | Should Be FileSystem
+            (Get-PSDrive Cert).Root       | Should -Be \
+            (Get-PSDrive C).Provider.Name | Should -Be FileSystem
         }
         else
         {
-            (Get-PSDrive /).Provider.Name | Should Be FileSystem
+            (Get-PSDrive /).Provider.Name | Should -Be FileSystem
         }
     }
 
     It "Should be able to access a drive using the PSProvider switch" {
-	(Get-PSDrive -PSProvider FileSystem).Name.Length | Should BeGreaterThan 0
+	(Get-PSDrive -PSProvider FileSystem).Name.Length | Should -BeGreaterThan 0
     }
 
     It "Should return true that a drive that does not exist"{
-	!(Get-PSDrive fake -ErrorAction SilentlyContinue) | Should Be $True
-	Get-PSDrive fake -ErrorAction SilentlyContinue    | Should BeNullOrEmpty
+	!(Get-PSDrive fake -ErrorAction SilentlyContinue) | Should -Be $True
+	Get-PSDrive fake -ErrorAction SilentlyContinue    | Should -BeNullOrEmpty
     }
     It "Should be able to determine the amount of free space of a drive" {
         $dInfo = Get-PSDrive TESTDRIVE
-        $dInfo.Free -ge 0 | Should be $true
+        $dInfo.Free -ge 0 | Should -Be $true
     }
     It "Should be able to determine the amount of Used space of a drive" {
         $dInfo = Get-PSDrive TESTDRIVE
-        $dInfo.Used -ge 0 | Should be $true
+        $dInfo.Used -ge 0 | Should -Be $true
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-PSProvider.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-PSProvider.Tests.ps1
@@ -2,26 +2,26 @@
 # Licensed under the MIT License.
 Describe "Get-PSProvider" -Tags "CI" {
     It "Should be able to call with no parameters without error" {
-	{ Get-PSProvider } | Should Not Throw
+	{ Get-PSProvider } | Should -Not -Throw
     }
 
     It "Should be able to call the filesystem provider" {
-	{ Get-PSProvider FileSystem } | Should Not Throw
+	{ Get-PSProvider FileSystem } | Should -Not -Throw
 
 	$actual = Get-PSProvider FileSystem
 
-	$actual.Name | Should Be "FileSystem"
+	$actual.Name | Should -Be "FileSystem"
 
-	$actual.Capabilities | Should Be "Filter, ShouldProcess, Credentials"
+	$actual.Capabilities | Should -Be "Filter, ShouldProcess, Credentials"
     }
 
     It "Should be able to call a provider with a wildcard expression" {
-	{ Get-PSProvider File*m } | Should Not Throw
+	{ Get-PSProvider File*m } | Should -Not -Throw
     }
 
     It "Should be able to pipe the output" {
 	$actual = Get-PSProvider
 
-	{ $actual | Format-List } | Should Not Throw
+	{ $actual | Format-List } | Should -Not -Throw
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-PSProvider.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-PSProvider.Tests.ps1
@@ -10,9 +10,9 @@ Describe "Get-PSProvider" -Tags "CI" {
 
 	$actual = Get-PSProvider FileSystem
 
-	$actual.Name | Should -Be "FileSystem"
+	$actual.Name | Should -BeExactly "FileSystem"
 
-	$actual.Capabilities | Should -Be "Filter, ShouldProcess, Credentials"
+	$actual.Capabilities | Should -BeExactly "Filter, ShouldProcess, Credentials"
     }
 
     It "Should be able to call a provider with a wildcard expression" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Process.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Process.Tests.ps1
@@ -90,7 +90,7 @@ Describe "Get-Process Formatting" -Tags "Feature" {
 Describe "Process Parent property" -Tags "CI" {
     It "Has Parent process property" {
         $powershellexe = (get-process -id $PID).mainmodule.filename
-        & $powershellexe -noprofile -command '(Get-Process -Id $pid).Parent' | Should -Not -Be $null
+        & $powershellexe -noprofile -command '(Get-Process -Id $pid).Parent' | Should -Not -BeNullOrEmpty
     }
 
     It "Has valid parent process ID property" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Process.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Process.Tests.ps1
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 Describe "Get-Process for admin" -Tags @('CI', 'RequireAdminOnWindows') {
     It "Should support -IncludeUserName" {
-        (Get-Process -Id $pid -IncludeUserName).UserName | Should Match $env:USERNAME
+        (Get-Process -Id $pid -IncludeUserName).UserName | Should -Match $env:USERNAME
     }
 }
 
@@ -12,11 +12,11 @@ Describe "Get-Process" -Tags "CI" {
         $ps = Get-Process
     }
     It "Should return a type of Object[] for Get-Process cmdlet" -Pending:$IsMacOS {
-        ,$ps | Should BeOfType "System.Object[]"
+        ,$ps | Should -BeOfType "System.Object[]"
     }
 
     It "Should have not empty Name flags set for Get-Process object" -Pending:$IsMacOS {
-        $ps | foreach-object { $_.Name | Should Not BeNullOrEmpty }
+        $ps | foreach-object { $_.Name | Should -Not -BeNullOrEmpty }
     }
 }
 
@@ -28,9 +28,9 @@ Describe "Get-Process Formatting" -Tags "Feature" {
             $formatData = Get-FormatData -TypeName $type -PowerShellVersion $PSVersionTable.PSVersion
             $tableControls = $formatData.FormatViewDefinition | Where-Object {$_.Control -is "System.Management.Automation.TableControl"}
             foreach ($tableControl in $tableControls) {
-                $tableControl.Control.Headers.Label -match "Handle*" | Should BeNullOrEmpty
+                $tableControl.Control.Headers.Label -match "Handle*" | Should -BeNullOrEmpty
                 # verify that rows without headers isn't the handlecount (as PowerShell will create a header that matches the property name)
-                $tableControl.Control.Rows.Columns.DisplayEntry.Value -eq "HandleCount" | Should BeNullOrEmpty
+                $tableControl.Control.Rows.Columns.DisplayEntry.Value -eq "HandleCount" | Should -BeNullOrEmpty
             }
         }
     }
@@ -39,12 +39,12 @@ Describe "Get-Process Formatting" -Tags "Feature" {
 Describe "Process Parent property" -Tags "CI" {
     It "Has Parent process property" {
         $powershellexe = (get-process -id $PID).mainmodule.filename
-        & $powershellexe -noprofile -command '(Get-Process -Id $pid).Parent' | Should Not be $null
+        & $powershellexe -noprofile -command '(Get-Process -Id $pid).Parent' | Should -Not -Be $null
     }
 
     It "Has valid parent process ID property" {
         $powershellexe = (get-process -id $PID).mainmodule.filename
-        & $powershellexe -noprofile -command '(Get-Process -Id $pid).Parent.Id' | Should Be $pid
+        & $powershellexe -noprofile -command '(Get-Process -Id $pid).Parent.Id' | Should -Be $pid
     }
 }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Service.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Service.Tests.ps1
@@ -58,7 +58,7 @@ Describe "Get-Service cmdlet tests" -Tags "CI" {
 
     $getservicecmd = [Microsoft.PowerShell.Commands.GetServiceCommand]::new()
     $getservicecmd.$parameter = $value
-    $getservicecmd.$parameter | Should -Be $value
+    $getservicecmd.$parameter | Should -BeExactly $value
   }
 
   It "Get-Service filtering works for '<script>'" -TestCases @(

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Service.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Service.Tests.ps1
@@ -26,7 +26,7 @@ Describe "Get-Service cmdlet tests" -Tags "CI" {
         throw 'Expected error on previous command'
       }
       catch {
-        $_.FullyQualifiedErrorId | Should Be 'ParameterArgumentValidationError,Microsoft.Powershell.Commands.GetServiceCommand'
+        $_.FullyQualifiedErrorId | Should -Be 'ParameterArgumentValidationError,Microsoft.Powershell.Commands.GetServiceCommand'
       }
     }
   }
@@ -39,7 +39,7 @@ Describe "Get-Service cmdlet tests" -Tags "CI" {
         throw 'Expected error on previous command'
       }
       catch {
-        $_.FullyQualifiedErrorId | Should Be 'ParameterArgumentValidationError,Microsoft.Powershell.Commands.GetServiceCommand'
+        $_.FullyQualifiedErrorId | Should -Be 'ParameterArgumentValidationError,Microsoft.Powershell.Commands.GetServiceCommand'
       }
     }
   }
@@ -58,7 +58,7 @@ Describe "Get-Service cmdlet tests" -Tags "CI" {
 
     $getservicecmd = [Microsoft.PowerShell.Commands.GetServiceCommand]::new()
     $getservicecmd.$parameter = $value
-    $getservicecmd.$parameter | Should Be $value
+    $getservicecmd.$parameter | Should -Be $value
   }
 
   It "Get-Service filtering works for '<script>'" -TestCases @(
@@ -76,9 +76,9 @@ Describe "Get-Service cmdlet tests" -Tags "CI" {
       $servicesCheck = & $expected
     }
     if ($servicesCheck -ne $null) {
-      Compare-object $services $servicesCheck | Out-String | Should BeNullOrEmpty
+      Compare-object $services $servicesCheck | Out-String | Should -BeNullOrEmpty
     } else {
-      $services | Should BeNullOrEmpty
+      $services | Should -BeNullOrEmpty
     }
   }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Hierarchical-Path.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Hierarchical-Path.Tests.ps1
@@ -8,41 +8,41 @@ Describe "Hierarchical paths" -Tags "CI" {
 
     It "should work with Join-Path " {
         $testPath = Join-Path $TestDrive testFile.txt
-        Get-Content $testPath | Should -Be $data
+        Get-Content $testPath | Should -BeExactly $data
     }
 
     It "should work with platform's slashes" {
         $testPath = "$TestDrive$([IO.Path]::DirectorySeparatorChar)testFile.txt"
-        Get-Content $testPath | Should -Be $data
+        Get-Content $testPath | Should -BeExactly $data
     }
 
     It "should work with forward slashes" {
         $testPath = "$TestDrive/testFile.txt"
-        Get-Content $testPath | Should -Be $data
+        Get-Content $testPath | Should -BeExactly $data
     }
 
     It "should work with backward slashes" {
         $testPath = "$TestDrive\testFile.txt"
-        Get-Content $testPath | Should -Be $data
+        Get-Content $testPath | Should -BeExactly $data
     }
 
     It "should work with backward slashes for each separator" {
         $testPath = "$TestDrive\testFile.txt".Replace("/","\")
-        Get-Content $testPath | Should -Be $data
+        Get-Content $testPath | Should -BeExactly $data
     }
 
     It "should work with forward slashes for each separator" {
         $testPath = "$TestDrive/testFile.txt".Replace("\","/")
-        Get-Content $testPath | Should -Be $data
+        Get-Content $testPath | Should -BeExactly $data
     }
 
     It "should work even if there are too many forward slashes" {
         $testPath = "$TestDrive//////testFile.txt"
-        Get-Content $testPath | Should -Be $data
+        Get-Content $testPath | Should -BeExactly $data
     }
 
     It "should work even if there are too many backward slashes" {
         $testPath = "$TestDrive\\\\\\\testFile.txt"
-        Get-Content $testPath | Should -Be $data
+        Get-Content $testPath | Should -BeExactly $data
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Hierarchical-Path.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Hierarchical-Path.Tests.ps1
@@ -8,41 +8,41 @@ Describe "Hierarchical paths" -Tags "CI" {
 
     It "should work with Join-Path " {
         $testPath = Join-Path $TestDrive testFile.txt
-        Get-Content $testPath | Should Be $data
+        Get-Content $testPath | Should -Be $data
     }
 
     It "should work with platform's slashes" {
         $testPath = "$TestDrive$([IO.Path]::DirectorySeparatorChar)testFile.txt"
-        Get-Content $testPath | Should Be $data
+        Get-Content $testPath | Should -Be $data
     }
 
     It "should work with forward slashes" {
         $testPath = "$TestDrive/testFile.txt"
-        Get-Content $testPath | Should Be $data
+        Get-Content $testPath | Should -Be $data
     }
 
     It "should work with backward slashes" {
         $testPath = "$TestDrive\testFile.txt"
-        Get-Content $testPath | Should Be $data
+        Get-Content $testPath | Should -Be $data
     }
 
     It "should work with backward slashes for each separator" {
         $testPath = "$TestDrive\testFile.txt".Replace("/","\")
-        Get-Content $testPath | should be $data
+        Get-Content $testPath | Should -Be $data
     }
 
     It "should work with forward slashes for each separator" {
         $testPath = "$TestDrive/testFile.txt".Replace("\","/")
-        Get-Content $testPath | should be $data
+        Get-Content $testPath | Should -Be $data
     }
 
     It "should work even if there are too many forward slashes" {
         $testPath = "$TestDrive//////testFile.txt"
-        Get-Content $testPath | should be $data
+        Get-Content $testPath | Should -Be $data
     }
 
     It "should work even if there are too many backward slashes" {
         $testPath = "$TestDrive\\\\\\\testFile.txt"
-        Get-Content $testPath | should be $data
+        Get-Content $testPath | Should -Be $data
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/ItemProperty.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/ItemProperty.Tests.ps1
@@ -2,14 +2,14 @@
 # Licensed under the MIT License.
 Describe "Simple ItemProperty Tests" -Tag "CI" {
     It "Can retrieve the PropertyValue with Get-ItemPropertyValue" {
-        Get-ItemPropertyValue -path $TESTDRIVE -Name Attributes | should be "Directory"
+        Get-ItemPropertyValue -path $TESTDRIVE -Name Attributes | Should -Be "Directory"
     }
     It "Can clear the PropertyValue with Clear-ItemProperty" {
         setup -f file1.txt
         Set-ItemProperty $TESTDRIVE/file1.txt -Name Attributes -Value ReadOnly
-        Get-ItemPropertyValue -path $TESTDRIVE/file1.txt -Name Attributes | should match "ReadOnly"
+        Get-ItemPropertyValue -path $TESTDRIVE/file1.txt -Name Attributes | Should -Match "ReadOnly"
         Clear-ItemProperty $TESTDRIVE/file1.txt -Name Attributes
-        Get-ItemPropertyValue -path $TESTDRIVE/file1.txt -Name Attributes | should not match "ReadOnly"
+        Get-ItemPropertyValue -path $TESTDRIVE/file1.txt -Name Attributes | Should -Not -Match "ReadOnly"
     }
     # these cmdlets are targeted at the windows registry, and don't have an linux equivalent
     Context "Registry targeted cmdlets" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Join-Path.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Join-Path.Tests.ps1
@@ -10,44 +10,44 @@ Describe "Join-Path cmdlet tests" -Tags "CI" {
   }
   It "should output multiple paths when called with multiple -Path targets" {
     Setup -Dir SubDir1
-    (Join-Path -Path TestDrive:,$TestDrive -ChildPath "SubDir1" -resolve).Length | Should be 2
+    (Join-Path -Path TestDrive:,$TestDrive -ChildPath "SubDir1" -resolve).Length | Should -Be 2
   }
   It "should throw 'DriveNotFound' when called with -Resolve and drive does not exist" {
     try {Join-Path bogusdrive:\\somedir otherdir -resolve -ea stop; Throw "Previous statement unexpectedly succeeded..."
-    } catch {$_.FullyQualifiedErrorId | Should Be "DriveNotFound,Microsoft.PowerShell.Commands.JoinPathCommand"}
+    } catch {$_.FullyQualifiedErrorId | Should -Be "DriveNotFound,Microsoft.PowerShell.Commands.JoinPathCommand"}
   }
   It "should throw 'PathNotFound' when called with -Resolve and item does not exist" {
     try {Join-Path "Bogus" "Path" -resolve -ea stop; Throw "Previous statement unexpectedly succeeded..."
-    } catch {$_.FullyQualifiedErrorId | Should Be "PathNotFound,Microsoft.PowerShell.Commands.JoinPathCommand"}
+    } catch {$_.FullyQualifiedErrorId | Should -Be "PathNotFound,Microsoft.PowerShell.Commands.JoinPathCommand"}
   }
   #[BugId(BugDatabase.WindowsOutOfBandReleases, 905237)] Note: Result should be the same on non-Windows platforms too
   It "should return one object when called with a Windows FileSystem::Redirector" {
     set-location ("env:"+$SepChar)
     $result=join-path FileSystem::windir system32
-    $result.Count | Should be 1
-    $result       | Should BeExactly ("FileSystem::windir"+$SepChar+"system32")
+    $result.Count | Should -Be 1
+    $result       | Should -BeExactly ("FileSystem::windir"+$SepChar+"system32")
   }
   #[BugId(BugDatabase.WindowsOutOfBandReleases, 913084)]
   It "should be able to join-path special string 'Variable:' with 'foo'" {
     $result=Join-Path "Variable:" "foo"
-    $result.Count | Should be 1
-    $result       | Should BeExactly ("Variable:"+$SepChar+"foo")
+    $result.Count | Should -Be 1
+    $result       | Should -BeExactly ("Variable:"+$SepChar+"foo")
   }
   #[BugId(BugDatabase.WindowsOutOfBandReleases, 913084)]
   It "should be able to join-path special string 'Alias:' with 'foo'" {
     $result=Join-Path "Alias:" "foo"
-    $result.Count | Should be 1
-    $result       | Should BeExactly ("Alias:"+$SepChar+"foo")
+    $result.Count | Should -Be 1
+    $result       | Should -BeExactly ("Alias:"+$SepChar+"foo")
   }
   #[BugId(BugDatabase.WindowsOutOfBandReleases, 913084)]
   It "should be able to join-path special string 'Env:' with 'foo'" {
     $result=Join-Path "Env:" "foo"
-    $result.Count | Should be 1
-    $result       | Should BeExactly ("Env:"+$SepChar+"foo")
+    $result.Count | Should -Be 1
+    $result       | Should -BeExactly ("Env:"+$SepChar+"foo")
   }
   It "should be able to join multiple child paths passed by position with remaining arguments" {
     $result = Join-Path one two three four five
-    $result.Count | Should Be 1
-    $result       | Should BeExactly "one${sepChar}two${sepChar}three${sepChar}four${sepChar}five"
+    $result.Count | Should -Be 1
+    $result       | Should -BeExactly "one${sepChar}two${sepChar}three${sepChar}four${sepChar}five"
   }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Join-Path.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Join-Path.Tests.ps1
@@ -13,11 +13,11 @@ Describe "Join-Path cmdlet tests" -Tags "CI" {
     (Join-Path -Path TestDrive:,$TestDrive -ChildPath "SubDir1" -resolve).Length | Should -Be 2
   }
   It "should throw 'DriveNotFound' when called with -Resolve and drive does not exist" {
-    try {Join-Path bogusdrive:\\somedir otherdir -resolve -ea stop; Throw "Previous statement unexpectedly succeeded..."
+    try {Join-Path bogusdrive:\\somedir otherdir -resolve -ErrorAction Stop; Throw "Previous statement unexpectedly succeeded..."
     } catch {$_.FullyQualifiedErrorId | Should -Be "DriveNotFound,Microsoft.PowerShell.Commands.JoinPathCommand"}
   }
   It "should throw 'PathNotFound' when called with -Resolve and item does not exist" {
-    try {Join-Path "Bogus" "Path" -resolve -ea stop; Throw "Previous statement unexpectedly succeeded..."
+    try {Join-Path "Bogus" "Path" -resolve -ErrorAction Stop; Throw "Previous statement unexpectedly succeeded..."
     } catch {$_.FullyQualifiedErrorId | Should -Be "PathNotFound,Microsoft.PowerShell.Commands.JoinPathCommand"}
   }
   #[BugId(BugDatabase.WindowsOutOfBandReleases, 905237)] Note: Result should be the same on non-Windows platforms too

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Move-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Move-Item.Tests.ps1
@@ -9,9 +9,9 @@ Describe "Move-Item tests" -Tag "CI" {
     }
     It "Move-Item will move a file" {
         Move-Item $source $target
-        test-path $source | Should be $false
-        test-path $target | Should be $true
-        "$target" | Should FileContentMatchExactly "This is content"
+        test-path $source | Should -Be $false
+        test-path $target | Should -Be $true
+        "$target" | Should -FileContentMatchExactly "This is content"
     }
 
     Context "Move-Item with filters" {
@@ -46,58 +46,58 @@ Describe "Move-Item tests" -Tag "CI" {
         }
         It "Can move to different directory, filtered with -Include" {
             Move-Item -Path $filePath -Destination $moveToPath -Include "bar*" -ErrorVariable e -ErrorAction SilentlyContinue
-            $e | Should BeNullOrEmpty
-            $barPath | Should Not Exist
-            $newBarPath | Should Exist
-            $booPath | Should Exist
-            $fooPath | Should Exist
-            $newBarPath | Should FileContentMatchExactly $barContent
+            $e | Should -BeNullOrEmpty
+            $barPath | Should -Not -Exist
+            $newBarPath | Should -Exist
+            $booPath | Should -Exist
+            $fooPath | Should -Exist
+            $newBarPath | Should -FileContentMatchExactly $barContent
         }
         It "Can move to different directory, filtered with -Exclude" {
             Move-Item -Path $filePath -Destination $moveToPath -Exclude "b*" -ErrorVariable e -ErrorAction SilentlyContinue
-            $e | Should BeNullOrEmpty
-            $fooPath | Should Not Exist
-            $newFooPath | Should Exist
-            $booPath | Should Exist
-            $barPath | Should Exist
-            $newFooPath | Should FileContentMatchExactly $fooContent
+            $e | Should -BeNullOrEmpty
+            $fooPath | Should -Not -Exist
+            $newFooPath | Should -Exist
+            $booPath | Should -Exist
+            $barPath | Should -Exist
+            $newFooPath | Should -FileContentMatchExactly $fooContent
         }
         It "Can move to different directory, filtered with -Filter" {
             Move-Item -Path $filePath -Destination $moveToPath -Filter "bo*" -ErrorVariable e -ErrorAction SilentlyContinue
-            $e | Should BeNullOrEmpty
-            $booPath | Should Not Exist
-            $newBooPath | Should Exist
-            $barPath | Should Exist
-            $fooPath | Should Exist
-            $newBooPath | Should FileContentMatchExactly $booContent
+            $e | Should -BeNullOrEmpty
+            $booPath | Should -Not -Exist
+            $newBooPath | Should -Exist
+            $barPath | Should -Exist
+            $fooPath | Should -Exist
+            $newBooPath | Should -FileContentMatchExactly $booContent
         }
 
         It "Can rename via move, filtered with -Include" {
             Move-Item -Path $filePath -Destination $renameToPath -Include "bar*" -ErrorVariable e -ErrorAction SilentlyContinue
-            $e | Should BeNullOrEmpty
-            $renameToPath | Should Exist
-            $barPath | Should Not Exist
-            $booPath | Should Exist
-            $fooPath | Should Exist
-            $renameToPath | Should FileContentMatchExactly $barContent
+            $e | Should -BeNullOrEmpty
+            $renameToPath | Should -Exist
+            $barPath | Should -Not -Exist
+            $booPath | Should -Exist
+            $fooPath | Should -Exist
+            $renameToPath | Should -FileContentMatchExactly $barContent
         }
         It "Can rename via move, filtered with -Exclude" {
             Move-Item -Path $filePath -Destination $renameToPath -Exclude "b*" -ErrorVariable e -ErrorAction SilentlyContinue
-            $e | Should BeNullOrEmpty
-            $renameToPath | Should Exist
-            $fooPath | Should Not Exist
-            $booPath | Should Exist
-            $barPath | Should Exist
-            $renameToPath | Should FileContentMatchExactly $fooContent
+            $e | Should -BeNullOrEmpty
+            $renameToPath | Should -Exist
+            $fooPath | Should -Not -Exist
+            $booPath | Should -Exist
+            $barPath | Should -Exist
+            $renameToPath | Should -FileContentMatchExactly $fooContent
         }
         It "Can rename via move, filtered with -Filter" {
             Move-Item -Path $filePath -Destination $renameToPath -Filter "bo*" -ErrorVariable e -ErrorAction SilentlyContinue
-            $e | Should BeNullOrEmpty
-            $renameToPath | Should Exist
-            $booPath | Should Not Exist
-            $fooPath | Should Exist
-            $barPath | Should Exist
-            $renameToPath | Should FileContentMatchExactly $booContent
+            $e | Should -BeNullOrEmpty
+            $renameToPath | Should -Exist
+            $booPath | Should -Not -Exist
+            $fooPath | Should -Exist
+            $barPath | Should -Exist
+            $renameToPath | Should -FileContentMatchExactly $booContent
         }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Move-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Move-Item.Tests.ps1
@@ -9,8 +9,8 @@ Describe "Move-Item tests" -Tag "CI" {
     }
     It "Move-Item will move a file" {
         Move-Item $source $target
-        test-path $source | Should -Be $false
-        test-path $target | Should -Be $true
+        test-path $source | Should -BeFalse
+        test-path $target | Should -BeTrue
         "$target" | Should -FileContentMatchExactly "This is content"
     }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Move-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Move-Item.Tests.ps1
@@ -9,8 +9,8 @@ Describe "Move-Item tests" -Tag "CI" {
     }
     It "Move-Item will move a file" {
         Move-Item $source $target
-        test-path $source | Should -BeFalse
-        test-path $target | Should -BeTrue
+        $source | Should -Not -Exist
+        $target | Should -Exist
         "$target" | Should -FileContentMatchExactly "This is content"
     }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/New-EventLog.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/New-EventLog.Tests.ps1
@@ -19,37 +19,37 @@ Describe "New-EventLog cmdlet tests" -Tags @('CI', 'RequireAdminOnWindows') {
     }
 
     It "should be able to create a New-EventLog with a -Source parameter" -Skip:($True) {
-      {New-EventLog -LogName TestLog -Source TestSource -ea stop} | Should Not Throw
-      {Write-EventLog -LogName TestLog -Source TestSource -Message "Test" -EventID 1 -ea stop} | Should Not Throw
+      {New-EventLog -LogName TestLog -Source TestSource -ea stop} | Should -Not -Throw
+      {Write-EventLog -LogName TestLog -Source TestSource -Message "Test" -EventID 1 -ea stop} | Should -Not -Throw
       $result=Get-EventLog -LogName TestLog
-      $result.Count   | Should be 1
+      $result.Count   | Should -Be 1
     }
     It "should be able to create a New-EventLog with a -ComputerName parameter" -Skip:($True) {
-      {New-EventLog -LogName TestLog -Source TestSource -ComputerName $env:COMPUTERNAME -ea stop} | Should Not Throw
-      {Write-EventLog -LogName TestLog -Source TestSource -Message "Test" -EventID 1 -ea stop} | Should Not Throw
+      {New-EventLog -LogName TestLog -Source TestSource -ComputerName $env:COMPUTERNAME -ea stop} | Should -Not -Throw
+      {Write-EventLog -LogName TestLog -Source TestSource -Message "Test" -EventID 1 -ea stop} | Should -Not -Throw
       $result=Get-EventLog -LogName TestLog
-      $result.Count   | Should be 1
-      $result.EventID | Should be 1
+      $result.Count   | Should -Be 1
+      $result.EventID | Should -Be 1
     }
     It "should be able to create a New-EventLog with a -CategoryResourceFile parameter" -Skip:($True) {
-      {New-EventLog -LogName TestLog -Source TestSource -CategoryResourceFile "CategoryMessageFile" -ea stop} | Should Not Throw
-      {Write-EventLog -LogName TestLog -Source TestSource -Message "Test" -EventID 2 -ea stop} | Should Not Throw
+      {New-EventLog -LogName TestLog -Source TestSource -CategoryResourceFile "CategoryMessageFile" -ea stop} | Should -Not -Throw
+      {Write-EventLog -LogName TestLog -Source TestSource -Message "Test" -EventID 2 -ea stop} | Should -Not -Throw
       $result=Get-EventLog -LogName TestLog
-      $result.Count   | Should be 1
-      $result.EventID | Should be 2
+      $result.Count   | Should -Be 1
+      $result.EventID | Should -Be 2
     }
     It "should be able to create a New-EventLog with a -MessageResourceFile parameter" -Skip:($True) {
-      {New-EventLog -LogName TestLog -Source TestSource -MessageResourceFile "ResourceMessageFile" -ea stop} | Should Not Throw
-      {Write-EventLog -LogName TestLog -Source TestSource -Message "Test" -EventID 3 -ea stop} | Should Not Throw
+      {New-EventLog -LogName TestLog -Source TestSource -MessageResourceFile "ResourceMessageFile" -ea stop} | Should -Not -Throw
+      {Write-EventLog -LogName TestLog -Source TestSource -Message "Test" -EventID 3 -ea stop} | Should -Not -Throw
       $result=Get-EventLog -LogName TestLog
-      $result.Count   | Should be 1
-      $result.EventID | Should be 3
+      $result.Count   | Should -Be 1
+      $result.EventID | Should -Be 3
     }
     It "should be able to create a New-EventLog with a -ParameterResourceFile parameter" -Skip:($True) {
-      {New-EventLog -LogName TestLog -Source TestSource -ParameterResourceFile "ParameterMessageFile" -ea stop} | Should Not Throw
-      {Write-EventLog -LogName TestLog -Source TestSource -Message "Test" -EventID 4 -ea stop} | Should Not Throw
+      {New-EventLog -LogName TestLog -Source TestSource -ParameterResourceFile "ParameterMessageFile" -ea stop} | Should -Not -Throw
+      {Write-EventLog -LogName TestLog -Source TestSource -Message "Test" -EventID 4 -ea stop} | Should -Not -Throw
       $result=Get-EventLog -LogName TestLog
-      $result.Count   | Should be 1
-      $result.EventID | Should be 4
+      $result.Count   | Should -Be 1
+      $result.EventID | Should -Be 4
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/New-EventLog.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/New-EventLog.Tests.ps1
@@ -19,35 +19,35 @@ Describe "New-EventLog cmdlet tests" -Tags @('CI', 'RequireAdminOnWindows') {
     }
 
     It "should be able to create a New-EventLog with a -Source parameter" -Skip:($True) {
-      {New-EventLog -LogName TestLog -Source TestSource -ea stop} | Should -Not -Throw
-      {Write-EventLog -LogName TestLog -Source TestSource -Message "Test" -EventID 1 -ea stop} | Should -Not -Throw
+      {New-EventLog -LogName TestLog -Source TestSource -ErrorAction Stop} | Should -Not -Throw
+      {Write-EventLog -LogName TestLog -Source TestSource -Message "Test" -EventID 1 -ErrorAction Stop} | Should -Not -Throw
       $result=Get-EventLog -LogName TestLog
       $result.Count   | Should -Be 1
     }
     It "should be able to create a New-EventLog with a -ComputerName parameter" -Skip:($True) {
-      {New-EventLog -LogName TestLog -Source TestSource -ComputerName $env:COMPUTERNAME -ea stop} | Should -Not -Throw
-      {Write-EventLog -LogName TestLog -Source TestSource -Message "Test" -EventID 1 -ea stop} | Should -Not -Throw
+      {New-EventLog -LogName TestLog -Source TestSource -ComputerName $env:COMPUTERNAME -ErrorAction Stop} | Should -Not -Throw
+      {Write-EventLog -LogName TestLog -Source TestSource -Message "Test" -EventID 1 -ErrorAction Stop} | Should -Not -Throw
       $result=Get-EventLog -LogName TestLog
       $result.Count   | Should -Be 1
       $result.EventID | Should -Be 1
     }
     It "should be able to create a New-EventLog with a -CategoryResourceFile parameter" -Skip:($True) {
-      {New-EventLog -LogName TestLog -Source TestSource -CategoryResourceFile "CategoryMessageFile" -ea stop} | Should -Not -Throw
-      {Write-EventLog -LogName TestLog -Source TestSource -Message "Test" -EventID 2 -ea stop} | Should -Not -Throw
+      {New-EventLog -LogName TestLog -Source TestSource -CategoryResourceFile "CategoryMessageFile" -ErrorAction Stop} | Should -Not -Throw
+      {Write-EventLog -LogName TestLog -Source TestSource -Message "Test" -EventID 2 -ErrorAction Stop} | Should -Not -Throw
       $result=Get-EventLog -LogName TestLog
       $result.Count   | Should -Be 1
       $result.EventID | Should -Be 2
     }
     It "should be able to create a New-EventLog with a -MessageResourceFile parameter" -Skip:($True) {
-      {New-EventLog -LogName TestLog -Source TestSource -MessageResourceFile "ResourceMessageFile" -ea stop} | Should -Not -Throw
-      {Write-EventLog -LogName TestLog -Source TestSource -Message "Test" -EventID 3 -ea stop} | Should -Not -Throw
+      {New-EventLog -LogName TestLog -Source TestSource -MessageResourceFile "ResourceMessageFile" -ErrorAction Stop} | Should -Not -Throw
+      {Write-EventLog -LogName TestLog -Source TestSource -Message "Test" -EventID 3 -ErrorAction Stop} | Should -Not -Throw
       $result=Get-EventLog -LogName TestLog
       $result.Count   | Should -Be 1
       $result.EventID | Should -Be 3
     }
     It "should be able to create a New-EventLog with a -ParameterResourceFile parameter" -Skip:($True) {
-      {New-EventLog -LogName TestLog -Source TestSource -ParameterResourceFile "ParameterMessageFile" -ea stop} | Should -Not -Throw
-      {Write-EventLog -LogName TestLog -Source TestSource -Message "Test" -EventID 4 -ea stop} | Should -Not -Throw
+      {New-EventLog -LogName TestLog -Source TestSource -ParameterResourceFile "ParameterMessageFile" -ErrorAction Stop} | Should -Not -Throw
+      {Write-EventLog -LogName TestLog -Source TestSource -Message "Test" -EventID 4 -ErrorAction Stop} | Should -Not -Throw
       $result=Get-EventLog -LogName TestLog
       $result.Count   | Should -Be 1
       $result.EventID | Should -Be 4

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/New-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/New-Item.Tests.ps1
@@ -32,90 +32,90 @@ Describe "New-Item" -Tags "CI" {
     }
 
     It "should call the function without error" {
-        { New-Item -Name $testfile -Path $tmpDirectory -ItemType file } | Should Not Throw
+        { New-Item -Name $testfile -Path $tmpDirectory -ItemType file } | Should -Not -Throw
     }
 
     It "Should create a file without error" {
         New-Item -Name $testfile -Path $tmpDirectory -ItemType file
 
-        Test-Path $FullyQualifiedFile | Should Be $true
+        Test-Path $FullyQualifiedFile | Should -Be $true
 
         $fileInfo = Get-ChildItem $FullyQualifiedFile
-        $fileInfo.Target | Should Be $null
-        $fileInfo.LinkType | Should Be $null
+        $fileInfo.Target | Should -Be $null
+        $fileInfo.LinkType | Should -Be $null
     }
 
     It "Should create a folder without an error" {
         New-Item -Name newDirectory -Path $tmpDirectory -ItemType directory
 
-        Test-Path $FullyQualifiedFolder | Should Be $true
+        Test-Path $FullyQualifiedFolder | Should -Be $true
     }
 
     It "Should create a file using the ni alias" {
         ni -Name $testfile -Path $tmpDirectory -ItemType file
 
-        Test-Path $FullyQualifiedFile | Should Be $true
+        Test-Path $FullyQualifiedFile | Should -Be $true
     }
 
     It "Should create a file using the Type alias instead of ItemType" {
         New-Item -Name $testfile -Path $tmpDirectory -Type file
 
-        Test-Path $FullyQualifiedFile | Should Be $true
+        Test-Path $FullyQualifiedFile | Should -Be $true
     }
 
     It "Should create a file with sample text inside the file using the Value switch" {
         $expected = "This is test string"
         New-Item -Name $testfile -Path $tmpDirectory -ItemType file -Value $expected
 
-        Test-Path $FullyQualifiedFile | Should Be $true
+        Test-Path $FullyQualifiedFile | Should -Be $true
 
-        Get-Content $FullyQualifiedFile | Should Be $expected
+        Get-Content $FullyQualifiedFile | Should -Be $expected
     }
 
     It "Should not create a file when the Name switch is not used and only a directory specified" {
         #errorAction used because permissions issue in Windows
         New-Item -Path $tmpDirectory -ItemType file -ErrorAction SilentlyContinue
 
-        Test-Path $FullyQualifiedFile | Should Be $false
+        Test-Path $FullyQualifiedFile | Should -Be $false
 
     }
 
     It "Should create a file when the Name switch is not used but a fully qualified path is specified" {
         New-Item -Path $FullyQualifiedFile -ItemType file
 
-        Test-Path $FullyQualifiedFile | Should Be $true
+        Test-Path $FullyQualifiedFile | Should -Be $true
     }
 
     It "Should be able to create a multiple items in different directories" {
         $FullyQualifiedFile2 = Join-Path -Path $tmpDirectory -ChildPath test2.txt
         New-Item -ItemType file -Path $FullyQualifiedFile, $FullyQualifiedFile2
 
-        Test-Path $FullyQualifiedFile  | Should Be $true
-        Test-Path $FullyQualifiedFile2 | Should Be $true
+        Test-Path $FullyQualifiedFile  | Should -Be $true
+        Test-Path $FullyQualifiedFile2 | Should -Be $true
 
         Remove-Item $FullyQualifiedFile2
     }
 
     It "Should be able to call the whatif switch without error" {
-        { New-Item -Name testfile.txt -Path $tmpDirectory -ItemType file -WhatIf } | Should Not Throw
+        { New-Item -Name testfile.txt -Path $tmpDirectory -ItemType file -WhatIf } | Should -Not -Throw
     }
 
     It "Should not create a new file when the whatif switch is used" {
         New-Item -Name $testfile -Path $tmpDirectory -ItemType file -WhatIf
 
-        Test-Path $FullyQualifiedFile | Should Be $false
+        Test-Path $FullyQualifiedFile | Should -Be $false
     }
 
     It "Should create a hard link of a file without error" {
         New-Item -Name $testfile -Path $tmpDirectory -ItemType file
-        Test-Path $FullyQualifiedFile | Should Be $true
+        Test-Path $FullyQualifiedFile | Should -Be $true
 
         New-Item -ItemType HardLink -Target $FullyQualifiedFile -Name $testlink -Path $tmpDirectory
-        Test-Path $FullyQualifiedLink | Should Be $true
+        Test-Path $FullyQualifiedLink | Should -Be $true
 
         $fileInfo = Get-ChildItem $FullyQualifiedLink
-        $fileInfo.Target | Should Be $null
-        $fileInfo.LinkType | Should Be "HardLink"
+        $fileInfo.Target | Should -Be $null
+        $fileInfo.LinkType | Should -Be "HardLink"
     }
 }
 
@@ -140,40 +140,40 @@ Describe "New-Item with links" -Tags @('CI', 'RequireAdminOnWindows') {
 
     It "Should create a symbolic link of a file without error" {
         New-Item -Name $testfile -Path $tmpDirectory -ItemType file
-        Test-Path $FullyQualifiedFile | Should Be $true
+        Test-Path $FullyQualifiedFile | Should -Be $true
 
         New-Item -ItemType SymbolicLink -Target $FullyQualifiedFile -Name $testlink -Path $tmpDirectory
-        Test-Path $FullyQualifiedLink | Should Be $true
+        Test-Path $FullyQualifiedLink | Should -Be $true
 
         $fileInfo = Get-ChildItem $FullyQualifiedLink
-        $fileInfo.Target | Should Match ([regex]::Escape($FullyQualifiedFile))
-        $fileInfo.LinkType | Should Be "SymbolicLink"
-        $fileInfo.Attributes -band $DirLinkMask | Should Be $SymLinkMask
+        $fileInfo.Target | Should -Match ([regex]::Escape($FullyQualifiedFile))
+        $fileInfo.LinkType | Should -Be "SymbolicLink"
+        $fileInfo.Attributes -band $DirLinkMask | Should -Be $SymLinkMask
     }
 
     It "Should create a symbolic link to a non-existing file without error" {
         $target = Join-Path $tmpDirectory "totallyBogusFile"
         New-Item -ItemType SymbolicLink -Target $target -Name $testlink -Path $tmpDirectory
-        Test-Path $FullyQualifiedLink | Should Be $true
+        Test-Path $FullyQualifiedLink | Should -Be $true
 
         $fileInfo = Get-ChildItem $FullyQualifiedLink
-        $fileInfo.Target | Should Be $target
-        Test-Path $fileInfo.Target | Should be $false
-        $fileInfo.LinkType | Should Be "SymbolicLink"
-        $fileInfo.Attributes -band $DirLinkMask | Should Be $SymLinkMask
+        $fileInfo.Target | Should -Be $target
+        Test-Path $fileInfo.Target | Should -Be $false
+        $fileInfo.LinkType | Should -Be "SymbolicLink"
+        $fileInfo.Attributes -band $DirLinkMask | Should -Be $SymLinkMask
     }
 
     It "Should create a symbolic link to directory without error" {
         New-Item -Name $testFolder -Path $tmpDirectory -ItemType directory
-        Test-Path $FullyQualifiedFolder | Should Be $true
+        Test-Path $FullyQualifiedFolder | Should -Be $true
 
         New-Item -ItemType SymbolicLink -Target $FullyQualifiedFolder -Name $testlink -Path $tmpDirectory
-        Test-Path $FullyQualifiedLink | Should Be $true
+        Test-Path $FullyQualifiedLink | Should -Be $true
 
         $fileInfo = Get-Item $FullyQualifiedLink
-        $fileInfo.Target | Should Match ([regex]::Escape($FullyQualifiedFolder))
-        $fileInfo.LinkType | Should Be "SymbolicLink"
-        $fileInfo.Attributes -band $DirLinkMask | Should Be $DirLinkMask
+        $fileInfo.Target | Should -Match ([regex]::Escape($FullyQualifiedFolder))
+        $fileInfo.LinkType | Should -Be "SymbolicLink"
+        $fileInfo.Attributes -band $DirLinkMask | Should -Be $DirLinkMask
 
         # Remove the link explicitly to avoid broken symlink issue
         Remove-Item $FullyQualifiedLink -Force
@@ -185,13 +185,13 @@ Describe "New-Item with links" -Tags @('CI', 'RequireAdminOnWindows') {
             New-Item -ItemType SymbolicLink -Path "/sbin/powershell-test" -Target $FullyQualifiedFolder -ErrorAction Stop
             throw "Execution OK"
         } catch {
-            $_.FullyQualifiedErrorId | Should Be "NewItemSymbolicLinkElevationRequired,Microsoft.PowerShell.Commands.NewItemCommand"
+            $_.FullyQualifiedErrorId | Should -Be "NewItemSymbolicLinkElevationRequired,Microsoft.PowerShell.Commands.NewItemCommand"
         }
     }
 
     It "New-Item -ItemType SymbolicLink should understand directory path ending with slash" {
         $folderName = [System.IO.Path]::GetRandomFileName()            
         $symbolicLinkPath = New-Item -ItemType SymbolicLink -Path "$tmpDirectory/$folderName/" -Value "/bar/"
-        $symbolicLinkPath | Should Not Be $null
+        $symbolicLinkPath | Should -Not -Be $null
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/New-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/New-Item.Tests.ps1
@@ -181,7 +181,8 @@ Describe "New-Item with links" -Tags @('CI', 'RequireAdminOnWindows') {
 
     It "Should error correctly when failing to create a symbolic link" -Skip:($IsWindows -or $IsElevated) {
         # This test expects that /sbin exists but is not writable by the user
-        { New-Item -ItemType SymbolicLink -Path "/sbin/powershell-test" -Target $FullyQualifiedFolder -ErrorAction Stop } | Should -Throw -ErrorId "NewItemSymbolicLinkElevationRequired,Microsoft.PowerShell.Commands.NewItemCommand"
+        { New-Item -ItemType SymbolicLink -Path "/sbin/powershell-test" -Target $FullyQualifiedFolder -ErrorAction Stop } |
+		Should -Throw -ErrorId "NewItemSymbolicLinkElevationRequired,Microsoft.PowerShell.Commands.NewItemCommand"
     }
 
     It "New-Item -ItemType SymbolicLink should understand directory path ending with slash" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/New-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/New-Item.Tests.ps1
@@ -115,7 +115,7 @@ Describe "New-Item" -Tags "CI" {
 
         $fileInfo = Get-ChildItem $FullyQualifiedLink
         $fileInfo.Target | Should -BeNullOrEmpty
-        $fileInfo.LinkType | Should -Be "HardLink"
+        $fileInfo.LinkType | Should -BeExactly "HardLink"
     }
 }
 
@@ -147,8 +147,8 @@ Describe "New-Item with links" -Tags @('CI', 'RequireAdminOnWindows') {
 
         $fileInfo = Get-ChildItem $FullyQualifiedLink
         $fileInfo.Target | Should -Match ([regex]::Escape($FullyQualifiedFile))
-        $fileInfo.LinkType | Should -Be "SymbolicLink"
-        $fileInfo.Attributes -band $DirLinkMask | Should -Be $SymLinkMask
+        $fileInfo.LinkType | Should -BeExactly "SymbolicLink"
+        $fileInfo.Attributes -band $DirLinkMask | Should -BeExactly $SymLinkMask
     }
 
     It "Should create a symbolic link to a non-existing file without error" {
@@ -159,8 +159,8 @@ Describe "New-Item with links" -Tags @('CI', 'RequireAdminOnWindows') {
         $fileInfo = Get-ChildItem $FullyQualifiedLink
         $fileInfo.Target | Should -Be $target
         Test-Path $fileInfo.Target | Should -BeFalse
-        $fileInfo.LinkType | Should -Be "SymbolicLink"
-        $fileInfo.Attributes -band $DirLinkMask | Should -Be $SymLinkMask
+        $fileInfo.LinkType | Should -BeExactly "SymbolicLink"
+        $fileInfo.Attributes -band $DirLinkMask | Should -BeExactly $SymLinkMask
     }
 
     It "Should create a symbolic link to directory without error" {
@@ -172,7 +172,7 @@ Describe "New-Item with links" -Tags @('CI', 'RequireAdminOnWindows') {
 
         $fileInfo = Get-Item $FullyQualifiedLink
         $fileInfo.Target | Should -Match ([regex]::Escape($FullyQualifiedFolder))
-        $fileInfo.LinkType | Should -Be "SymbolicLink"
+        $fileInfo.LinkType | Should -BeExactly "SymbolicLink"
         $fileInfo.Attributes -band $DirLinkMask | Should -Be $DirLinkMask
 
         # Remove the link explicitly to avoid broken symlink issue

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/New-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/New-Item.Tests.ps1
@@ -181,12 +181,7 @@ Describe "New-Item with links" -Tags @('CI', 'RequireAdminOnWindows') {
 
     It "Should error correctly when failing to create a symbolic link" -Skip:($IsWindows -or $IsElevated) {
         # This test expects that /sbin exists but is not writable by the user
-        try {
-            New-Item -ItemType SymbolicLink -Path "/sbin/powershell-test" -Target $FullyQualifiedFolder -ErrorAction Stop
-            throw "Execution OK"
-        } catch {
-            $_.FullyQualifiedErrorId | Should -Be "NewItemSymbolicLinkElevationRequired,Microsoft.PowerShell.Commands.NewItemCommand"
-        }
+        { New-Item -ItemType SymbolicLink -Path "/sbin/powershell-test" -Target $FullyQualifiedFolder -ErrorAction Stop } | Should -Throw -ErrorId "NewItemSymbolicLinkElevationRequired,Microsoft.PowerShell.Commands.NewItemCommand"
     }
 
     It "New-Item -ItemType SymbolicLink should understand directory path ending with slash" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/New-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/New-Item.Tests.ps1
@@ -38,36 +38,36 @@ Describe "New-Item" -Tags "CI" {
     It "Should create a file without error" {
         New-Item -Name $testfile -Path $tmpDirectory -ItemType file
 
-        Test-Path $FullyQualifiedFile | Should -Be $true
+        Test-Path $FullyQualifiedFile | Should -BeTrue
 
         $fileInfo = Get-ChildItem $FullyQualifiedFile
-        $fileInfo.Target | Should -Be $null
-        $fileInfo.LinkType | Should -Be $null
+        $fileInfo.Target | Should -BeNullOrEmpty
+        $fileInfo.LinkType | Should -BeNullOrEmpty
     }
 
     It "Should create a folder without an error" {
         New-Item -Name newDirectory -Path $tmpDirectory -ItemType directory
 
-        Test-Path $FullyQualifiedFolder | Should -Be $true
+        Test-Path $FullyQualifiedFolder | Should -BeTrue
     }
 
     It "Should create a file using the ni alias" {
         ni -Name $testfile -Path $tmpDirectory -ItemType file
 
-        Test-Path $FullyQualifiedFile | Should -Be $true
+        Test-Path $FullyQualifiedFile | Should -BeTrue
     }
 
     It "Should create a file using the Type alias instead of ItemType" {
         New-Item -Name $testfile -Path $tmpDirectory -Type file
 
-        Test-Path $FullyQualifiedFile | Should -Be $true
+        Test-Path $FullyQualifiedFile | Should -BeTrue
     }
 
     It "Should create a file with sample text inside the file using the Value switch" {
         $expected = "This is test string"
         New-Item -Name $testfile -Path $tmpDirectory -ItemType file -Value $expected
 
-        Test-Path $FullyQualifiedFile | Should -Be $true
+        Test-Path $FullyQualifiedFile | Should -BeTrue
 
         Get-Content $FullyQualifiedFile | Should -Be $expected
     }
@@ -76,22 +76,22 @@ Describe "New-Item" -Tags "CI" {
         #errorAction used because permissions issue in Windows
         New-Item -Path $tmpDirectory -ItemType file -ErrorAction SilentlyContinue
 
-        Test-Path $FullyQualifiedFile | Should -Be $false
+        Test-Path $FullyQualifiedFile | Should -BeFalse
 
     }
 
     It "Should create a file when the Name switch is not used but a fully qualified path is specified" {
         New-Item -Path $FullyQualifiedFile -ItemType file
 
-        Test-Path $FullyQualifiedFile | Should -Be $true
+        Test-Path $FullyQualifiedFile | Should -BeTrue
     }
 
     It "Should be able to create a multiple items in different directories" {
         $FullyQualifiedFile2 = Join-Path -Path $tmpDirectory -ChildPath test2.txt
         New-Item -ItemType file -Path $FullyQualifiedFile, $FullyQualifiedFile2
 
-        Test-Path $FullyQualifiedFile  | Should -Be $true
-        Test-Path $FullyQualifiedFile2 | Should -Be $true
+        Test-Path $FullyQualifiedFile  | Should -BeTrue
+        Test-Path $FullyQualifiedFile2 | Should -BeTrue
 
         Remove-Item $FullyQualifiedFile2
     }
@@ -103,18 +103,18 @@ Describe "New-Item" -Tags "CI" {
     It "Should not create a new file when the whatif switch is used" {
         New-Item -Name $testfile -Path $tmpDirectory -ItemType file -WhatIf
 
-        Test-Path $FullyQualifiedFile | Should -Be $false
+        Test-Path $FullyQualifiedFile | Should -BeFalse
     }
 
     It "Should create a hard link of a file without error" {
         New-Item -Name $testfile -Path $tmpDirectory -ItemType file
-        Test-Path $FullyQualifiedFile | Should -Be $true
+        Test-Path $FullyQualifiedFile | Should -BeTrue
 
         New-Item -ItemType HardLink -Target $FullyQualifiedFile -Name $testlink -Path $tmpDirectory
-        Test-Path $FullyQualifiedLink | Should -Be $true
+        Test-Path $FullyQualifiedLink | Should -BeTrue
 
         $fileInfo = Get-ChildItem $FullyQualifiedLink
-        $fileInfo.Target | Should -Be $null
+        $fileInfo.Target | Should -BeNullOrEmpty
         $fileInfo.LinkType | Should -Be "HardLink"
     }
 }
@@ -140,10 +140,10 @@ Describe "New-Item with links" -Tags @('CI', 'RequireAdminOnWindows') {
 
     It "Should create a symbolic link of a file without error" {
         New-Item -Name $testfile -Path $tmpDirectory -ItemType file
-        Test-Path $FullyQualifiedFile | Should -Be $true
+        Test-Path $FullyQualifiedFile | Should -BeTrue
 
         New-Item -ItemType SymbolicLink -Target $FullyQualifiedFile -Name $testlink -Path $tmpDirectory
-        Test-Path $FullyQualifiedLink | Should -Be $true
+        Test-Path $FullyQualifiedLink | Should -BeTrue
 
         $fileInfo = Get-ChildItem $FullyQualifiedLink
         $fileInfo.Target | Should -Match ([regex]::Escape($FullyQualifiedFile))
@@ -154,21 +154,21 @@ Describe "New-Item with links" -Tags @('CI', 'RequireAdminOnWindows') {
     It "Should create a symbolic link to a non-existing file without error" {
         $target = Join-Path $tmpDirectory "totallyBogusFile"
         New-Item -ItemType SymbolicLink -Target $target -Name $testlink -Path $tmpDirectory
-        Test-Path $FullyQualifiedLink | Should -Be $true
+        Test-Path $FullyQualifiedLink | Should -BeTrue
 
         $fileInfo = Get-ChildItem $FullyQualifiedLink
         $fileInfo.Target | Should -Be $target
-        Test-Path $fileInfo.Target | Should -Be $false
+        Test-Path $fileInfo.Target | Should -BeFalse
         $fileInfo.LinkType | Should -Be "SymbolicLink"
         $fileInfo.Attributes -band $DirLinkMask | Should -Be $SymLinkMask
     }
 
     It "Should create a symbolic link to directory without error" {
         New-Item -Name $testFolder -Path $tmpDirectory -ItemType directory
-        Test-Path $FullyQualifiedFolder | Should -Be $true
+        Test-Path $FullyQualifiedFolder | Should -BeTrue
 
         New-Item -ItemType SymbolicLink -Target $FullyQualifiedFolder -Name $testlink -Path $tmpDirectory
-        Test-Path $FullyQualifiedLink | Should -Be $true
+        Test-Path $FullyQualifiedLink | Should -BeTrue
 
         $fileInfo = Get-Item $FullyQualifiedLink
         $fileInfo.Target | Should -Match ([regex]::Escape($FullyQualifiedFolder))
@@ -192,6 +192,6 @@ Describe "New-Item with links" -Tags @('CI', 'RequireAdminOnWindows') {
     It "New-Item -ItemType SymbolicLink should understand directory path ending with slash" {
         $folderName = [System.IO.Path]::GetRandomFileName()            
         $symbolicLinkPath = New-Item -ItemType SymbolicLink -Path "$tmpDirectory/$folderName/" -Value "/bar/"
-        $symbolicLinkPath | Should -Not -Be $null
+        $symbolicLinkPath | Should -Not -BeNullOrEmpty
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/New-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/New-Item.Tests.ps1
@@ -165,7 +165,7 @@ Describe "New-Item with links" -Tags @('CI', 'RequireAdminOnWindows') {
 
     It "Should create a symbolic link to directory without error" {
         New-Item -Name $testFolder -Path $tmpDirectory -ItemType directory
-        Test-Path $FullyQualifiedFolder | Should -BeTrue
+        $FullyQualifiedFolder | Should -Exist
 
         New-Item -ItemType SymbolicLink -Target $FullyQualifiedFolder -Name $testlink -Path $tmpDirectory
         Test-Path $FullyQualifiedLink | Should -BeTrue

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/PSDrive.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/PSDrive.Tests.ps1
@@ -42,8 +42,8 @@ Describe "Basic Alias Provider Tests" -Tags "CI" {
 
         It "Verify 'Used' and 'Free' script properties" {
             $drive = Get-PSDrive -Name $psDriveName
-            $null -eq $drive.Used | Should -BeFalse
-            $null -eq $drive.Free | Should -BeFalse
+            $drive.Used | Should -Not -BeNullOrEmpty
+            $drive.Free | Should -Not -BeNullOrEmpty
         }
     }
 }
@@ -62,7 +62,7 @@ Describe "Extended Alias Provider Tests" -Tags "Feature" {
 
         It "Verify Description" {
             $result = New-PSDrive -Name $psDriveName -PSProvider FileSystem -Root $psDriveRoot -Description "Test PSDrive to remove"
-            $result.Description | Should -Be "Test PSDrive to remove"
+            $result.Description | Should -BeExactly "Test PSDrive to remove"
         }
 
         It "Verify Confirm can be bypassed" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/PSDrive.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/PSDrive.Tests.ps1
@@ -72,22 +72,14 @@ Describe "Extended Alias Provider Tests" -Tags "Feature" {
 
         It "Verify WhatIf" {
             New-PSDrive -Name $psDriveName -PSProvider FileSystem -Root $psDriveRoot -WhatIf > $null
-            try {
-                Get-PSDrive -Name $psDriveName -ErrorAction Stop
-                throw "Expected exception not thrown"
-            }
-            catch { $_.FullyQualifiedErrorId | Should -Be "GetLocationNoMatchingDrive,Microsoft.PowerShell.Commands.GetPSDriveCommand" }
+            { Get-PSDrive -Name $psDriveName -ErrorAction Stop } | Should -Throw -ErrorId "GetLocationNoMatchingDrive,Microsoft.PowerShell.Commands.GetPSDriveCommand"
         }
 
         It "Verify Scope" {
             New-PSDrive -Name $psDriveName -PSProvider FileSystem -Root $psDriveRoot -Description "Test PSDrive to remove" -Scope Local > $null
             $foundGlobal = $true
-            try {
-               $globalDrive = Get-PSDrive -Name $psDriveName -Scope Global -ErrorAction Stop
-            }
-            catch { $foundGlobal = $false }
+            { $globalDrive = Get-PSDrive -Name $psDriveName -Scope Global -ErrorAction Stop } | Should -Throw -ErrorId "GetDriveNoMatchingDrive,Microsoft.PowerShell.Commands.GetPSDriveCommand"
             $localDrive = Get-PSDrive -Name $psDriveName -Scope Local
-            $foundGlobal | Should -BeFalse
             $localDrive.Name | Should -BeExactly $psDriveName
         }
     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/PSDrive.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/PSDrive.Tests.ps1
@@ -19,8 +19,8 @@ Describe "Basic Alias Provider Tests" -Tags "CI" {
         It "Create a new PSDrive" {
             try {
                 $newDrive = New-PSDrive -Name "NewDifferentPSDrive" -PSProvider FileSystem -Root $psDriveRoot
-                $newDrive.Name | Should Be "NewDifferentPSDrive"
-                $newDrive.Root | Should Be (Convert-Path $psDriveRoot)
+                $newDrive.Name | Should -Be "NewDifferentPSDrive"
+                $newDrive.Root | Should -Be (Convert-Path $psDriveRoot)
             }
             finally {
                 Remove-PSDrive -Name "NewDifferentPSDrive" -Force -ErrorAction SilentlyContinue
@@ -29,21 +29,21 @@ Describe "Basic Alias Provider Tests" -Tags "CI" {
 
         It "Read data from a PSDrive" {
             $driveProp = Get-ItemProperty ${psDriveName}:
-            $driveProp.PSDrive.Name | Should Be $psDriveName
+            $driveProp.PSDrive.Name | Should -Be $psDriveName
         }
 
         It "Remove the PSDrive" {
             $existsBefore = Test-Path "${psDriveName}:\"
             Remove-PSDrive -Name ${psDriveName} -ErrorAction SilentlyContinue
             $existsAfter = Test-Path "${psDriveName}:\"
-            $existsBefore | Should Be $true
-            $existsAfter | Should Be $false
+            $existsBefore | Should -Be $true
+            $existsAfter | Should -Be $false
         }
 
         It "Verify 'Used' and 'Free' script properties" {
             $drive = Get-PSDrive -Name $psDriveName
-            $null -eq $drive.Used | Should Be $false
-            $null -eq $drive.Free | Should Be $false
+            $null -eq $drive.Used | Should -Be $false
+            $null -eq $drive.Free | Should -Be $false
         }
     }
 }
@@ -62,12 +62,12 @@ Describe "Extended Alias Provider Tests" -Tags "Feature" {
 
         It "Verify Description" {
             $result = New-PSDrive -Name $psDriveName -PSProvider FileSystem -Root $psDriveRoot -Description "Test PSDrive to remove"
-            $result.Description | Should Be "Test PSDrive to remove"
+            $result.Description | Should -Be "Test PSDrive to remove"
         }
 
         It "Verify Confirm can be bypassed" {
             $result = New-PSDrive -Name $psDriveName -PSProvider FileSystem -Root $psDriveRoot -Confirm:$false
-            $result.Name | Should Be $psDriveName
+            $result.Name | Should -Be $psDriveName
         }
 
         It "Verify WhatIf" {
@@ -76,7 +76,7 @@ Describe "Extended Alias Provider Tests" -Tags "Feature" {
                 Get-PSDrive -Name $psDriveName -ErrorAction Stop
                 throw "Expected exception not thrown"
             }
-            catch { $_.FullyQualifiedErrorId | Should Be "GetLocationNoMatchingDrive,Microsoft.PowerShell.Commands.GetPSDriveCommand" }
+            catch { $_.FullyQualifiedErrorId | Should -Be "GetLocationNoMatchingDrive,Microsoft.PowerShell.Commands.GetPSDriveCommand" }
         }
 
         It "Verify Scope" {
@@ -87,8 +87,8 @@ Describe "Extended Alias Provider Tests" -Tags "Feature" {
             }
             catch { $foundGlobal = $false }
             $localDrive = Get-PSDrive -Name $psDriveName -Scope Local
-            $foundGlobal | Should Be $false
-            $localDrive.Name | Should Be $psDriveName
+            $foundGlobal | Should -Be $false
+            $localDrive.Name | Should -Be $psDriveName
         }
     }
 
@@ -103,17 +103,17 @@ Describe "Extended Alias Provider Tests" -Tags "Feature" {
 
         It "Verify Name" {
             $result = Get-PSDrive -Name $psDriveName
-            $result.Name | Should Be $psDriveName
+            $result.Name | Should -Be $psDriveName
         }
 
         It "Verify PSProvider" {
             $result = Get-PSDrive -PSProvider "Alias"
-            $result.Name | Should Be "Alias"
+            $result.Name | Should -Be "Alias"
         }
 
         It "Verify Scope" {
             $result = Get-PSDrive -Scope 1 #scope 1 because drive was created in BeforeAll
-            $result.Name -contains $psDriveName | Should Be $true
+            $result.Name -contains $psDriveName | Should -Be $true
         }
     }
 
@@ -129,13 +129,13 @@ Describe "Extended Alias Provider Tests" -Tags "Feature" {
         It "Verify Confirm can be bypassed" {
             Remove-PSDrive $psDriveName -Confirm:$false
             $exists = Test-Path -Path $psDriveName
-            $exists | Should Be $false
+            $exists | Should -Be $false
         }
 
         It "Verify WhatIf" {
             Remove-PSDrive $psDriveName -WhatIf
             $exists = Test-Path -Path "${psDriveName}:"
-            $exists | Should Be $true
+            $exists | Should -Be $true
         }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/PSDrive.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/PSDrive.Tests.ps1
@@ -36,14 +36,14 @@ Describe "Basic Alias Provider Tests" -Tags "CI" {
             $existsBefore = Test-Path "${psDriveName}:\"
             Remove-PSDrive -Name ${psDriveName} -ErrorAction SilentlyContinue
             $existsAfter = Test-Path "${psDriveName}:\"
-            $existsBefore | Should -Be $true
-            $existsAfter | Should -Be $false
+            $existsBefore | Should -BeTrue
+            $existsAfter | Should -BeFalse
         }
 
         It "Verify 'Used' and 'Free' script properties" {
             $drive = Get-PSDrive -Name $psDriveName
-            $null -eq $drive.Used | Should -Be $false
-            $null -eq $drive.Free | Should -Be $false
+            $null -eq $drive.Used | Should -BeFalse
+            $null -eq $drive.Free | Should -BeFalse
         }
     }
 }
@@ -87,7 +87,7 @@ Describe "Extended Alias Provider Tests" -Tags "Feature" {
             }
             catch { $foundGlobal = $false }
             $localDrive = Get-PSDrive -Name $psDriveName -Scope Local
-            $foundGlobal | Should -Be $false
+            $foundGlobal | Should -BeFalse
             $localDrive.Name | Should -Be $psDriveName
         }
     }
@@ -113,7 +113,7 @@ Describe "Extended Alias Provider Tests" -Tags "Feature" {
 
         It "Verify Scope" {
             $result = Get-PSDrive -Scope 1 #scope 1 because drive was created in BeforeAll
-            $result.Name -contains $psDriveName | Should -Be $true
+            $result.Name -contains $psDriveName | Should -BeTrue
         }
     }
 
@@ -129,13 +129,13 @@ Describe "Extended Alias Provider Tests" -Tags "Feature" {
         It "Verify Confirm can be bypassed" {
             Remove-PSDrive $psDriveName -Confirm:$false
             $exists = Test-Path -Path $psDriveName
-            $exists | Should -Be $false
+            $exists | Should -BeFalse
         }
 
         It "Verify WhatIf" {
             Remove-PSDrive $psDriveName -WhatIf
             $exists = Test-Path -Path "${psDriveName}:"
-            $exists | Should -Be $true
+            $exists | Should -BeTrue
         }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/PSDrive.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/PSDrive.Tests.ps1
@@ -19,8 +19,8 @@ Describe "Basic Alias Provider Tests" -Tags "CI" {
         It "Create a new PSDrive" {
             try {
                 $newDrive = New-PSDrive -Name "NewDifferentPSDrive" -PSProvider FileSystem -Root $psDriveRoot
-                $newDrive.Name | Should -Be "NewDifferentPSDrive"
-                $newDrive.Root | Should -Be (Convert-Path $psDriveRoot)
+                $newDrive.Name | Should -BeExactly "NewDifferentPSDrive"
+                $newDrive.Root | Should -BeExactly (Convert-Path $psDriveRoot)
             }
             finally {
                 Remove-PSDrive -Name "NewDifferentPSDrive" -Force -ErrorAction SilentlyContinue
@@ -29,7 +29,7 @@ Describe "Basic Alias Provider Tests" -Tags "CI" {
 
         It "Read data from a PSDrive" {
             $driveProp = Get-ItemProperty ${psDriveName}:
-            $driveProp.PSDrive.Name | Should -Be $psDriveName
+            $driveProp.PSDrive.Name | Should -BeExactly $psDriveName
         }
 
         It "Remove the PSDrive" {
@@ -67,7 +67,7 @@ Describe "Extended Alias Provider Tests" -Tags "Feature" {
 
         It "Verify Confirm can be bypassed" {
             $result = New-PSDrive -Name $psDriveName -PSProvider FileSystem -Root $psDriveRoot -Confirm:$false
-            $result.Name | Should -Be $psDriveName
+            $result.Name | Should -BeExactly $psDriveName
         }
 
         It "Verify WhatIf" {
@@ -88,7 +88,7 @@ Describe "Extended Alias Provider Tests" -Tags "Feature" {
             catch { $foundGlobal = $false }
             $localDrive = Get-PSDrive -Name $psDriveName -Scope Local
             $foundGlobal | Should -BeFalse
-            $localDrive.Name | Should -Be $psDriveName
+            $localDrive.Name | Should -BeExactly $psDriveName
         }
     }
 
@@ -103,12 +103,12 @@ Describe "Extended Alias Provider Tests" -Tags "Feature" {
 
         It "Verify Name" {
             $result = Get-PSDrive -Name $psDriveName
-            $result.Name | Should -Be $psDriveName
+            $result.Name | Should -BeExactly $psDriveName
         }
 
         It "Verify PSProvider" {
             $result = Get-PSDrive -PSProvider "Alias"
-            $result.Name | Should -Be "Alias"
+            $result.Name | Should -BeExactly "Alias"
         }
 
         It "Verify Scope" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Pester.Commands.Cmdlets.NoNewlineParameter.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Pester.Commands.Cmdlets.NoNewlineParameter.Tests.ps1
@@ -9,19 +9,19 @@ Describe "Tests for -NoNewline parameter of Out-File, Add-Content and Set-Conten
     It "NoNewline parameter works on Out-File" {
          $temp = "${TESTDRIVE}/test1.txt"
          1..5 | Out-File $temp -Encoding 'ASCII' -NoNewline
-         (Get-Content $temp -AsByteStream).Count | Should Be 5
+         (Get-Content $temp -AsByteStream).Count | Should -Be 5
     }
 
     It "NoNewline parameter works on Set-Content" {
          $temp = "${TESTDRIVE}/test2.txt"
          Set-Content -Path $temp -Value 'a','b','c' -Encoding 'ASCII' -NoNewline
-         (Get-Content $temp -AsByteStream).Count | Should Be 3
+         (Get-Content $temp -AsByteStream).Count | Should -Be 3
     }
 
     It "NoNewline parameter works on Add-Content" {
          $temp = "${TESTDRIVE}/test3.txt"
          $temp = New-TemporaryFile
          1..9 | ForEach-Object {Add-Content -Path $temp -Value $_ -Encoding 'ASCII' -NoNewline}
-         (Get-Content $temp -AsByteStream).Count | Should Be 9
+         (Get-Content $temp -AsByteStream).Count | Should -Be 9
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Pop-Location.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Pop-Location.Tests.ps1
@@ -6,11 +6,11 @@ Describe "Pop-Location" -Tags "CI" {
     BeforeEach { Set-Location $startDirectory }
 
     It "Should be able to be called without error" {
-	{ Pop-Location } | Should Not Throw
+	{ Pop-Location } | Should -Not -Throw
     }
 
     It "Should not take a parameter" {
-	{ Pop-Location .. } | Should Throw
+	{ Pop-Location .. } | Should -Throw
     }
 
     It "Should be able pop multiple times" {
@@ -22,7 +22,7 @@ Describe "Pop-Location" -Tags "CI" {
 	Pop-Location
 	Pop-Location
 
-	$(Get-Location).Path | Should Be $startDirectory
+	$(Get-Location).Path | Should -Be $startDirectory
 
     }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Push-Location.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Push-Location.Tests.ps1
@@ -45,7 +45,7 @@ Describe "Test-Push-Location" -Tags "CI" {
 	Push-Location ..
 	$cmdletDirectory = $(Get-Location).Path
 
-	$aliasDirectory | Should -Be $cmdletDirectory
+	$aliasDirectory | Should -BeExactly $cmdletDirectory
     }
 
     It "Should produce a pathinfo object when the passthru parameter is used" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Push-Location.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Push-Location.Tests.ps1
@@ -19,7 +19,7 @@ Describe "Test-Push-Location" -Tags "CI" {
     }
 
     It "Should be able to use relative path to grandparent" {
-	Test-Path ../.. | Should -Be $true
+	Test-Path ../.. | Should -BeTrue
 
 	{ Push-Location ../.. } | Should -Not -Throw
     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Push-Location.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Push-Location.Tests.ps1
@@ -6,35 +6,35 @@ Describe "Test-Push-Location" -Tags "CI" {
     BeforeEach { cd $startDirectory }
 
     It "Should be called without error" {
-	{ Push-Location } | Should Not Throw
+	{ Push-Location } | Should -Not -Throw
     }
 
     It "Should be able to push to the root directory" {
 	# this works cross-platform
-	{ Push-Location / } | Should Not Throw
+	{ Push-Location / } | Should -Not -Throw
     }
 
     It "Should be able to use relative path to parent" {
-	{ Push-Location .. } | Should Not Throw
+	{ Push-Location .. } | Should -Not -Throw
     }
 
     It "Should be able to use relative path to grandparent" {
-	Test-Path ../.. | Should Be $true
+	Test-Path ../.. | Should -Be $true
 
-	{ Push-Location ../.. } | Should Not Throw
+	{ Push-Location ../.. } | Should -Not -Throw
     }
 
     It "Should be able to push twice" {
-	{ Push-Location .. } | Should Not Throw
-	{ Push-Location .. } | Should Not Throw
+	{ Push-Location .. } | Should -Not -Throw
+	{ Push-Location .. } | Should -Not -Throw
     }
 
     It "Should be able to take a piped variable" {
-	{ ".." | Push-Location } | Should Not Throw
+	{ ".." | Push-Location } | Should -Not -Throw
     }
 
     It "Should be able to call the pushd alias" {
-	{ pushd } | Should Not Throw
+	{ pushd } | Should -Not -Throw
     }
 
     It "Should be able to push to the same location between the alias and the cmdlet" {
@@ -45,11 +45,11 @@ Describe "Test-Push-Location" -Tags "CI" {
 	Push-Location ..
 	$cmdletDirectory = $(Get-Location).Path
 
-	$aliasDirectory | Should Be $cmdletDirectory
+	$aliasDirectory | Should -Be $cmdletDirectory
     }
 
     It "Should produce a pathinfo object when the passthru parameter is used" {
-        Push-Location .. -PassThru | ForEach-Object { $_ | Should BeOfType "System.Management.Automation.PathInfo" }
+        Push-Location .. -PassThru | ForEach-Object { $_ | Should -BeOfType "System.Management.Automation.PathInfo" }
     }
 
     # final cleanup

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Registry.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Registry.Tests.ps1
@@ -244,11 +244,7 @@ Describe "Extended Registry Provider Tests" -Tags @("Feature", "RequireAdminOnWi
         }
 
         It "Verify Filter" {
-            try {
-                $result = New-ItemProperty -Path ".\*" -Filter "Test*" -Name $testPropertyName -Value $testPropertyValue -ErrorAction Stop
-                throw "Expected exception not thrown"
-            }
-            catch { $_.FullyQualifiedErrorId | Should -Be "NotSupported,Microsoft.PowerShell.Commands.NewItemPropertyCommand" }
+            { $result = New-ItemProperty -Path ".\*" -Filter "Test*" -Name $testPropertyName -Value $testPropertyValue -ErrorAction Stop } | Should -Throw -ErrorId "NotSupported,Microsoft.PowerShell.Commands.NewItemPropertyCommand"
         }
 
         It "Verify Include" {
@@ -289,11 +285,7 @@ Describe "Extended Registry Provider Tests" -Tags @("Feature", "RequireAdminOnWi
         }
 
         It "Verify Filter" {
-            try {
-                $result = Get-ItemProperty -Path ".\*" -Filter "*Test*" -ErrorAction Stop
-                throw "Expected exception not thrown"
-            }
-            catch { $_.FullyQualifiedErrorId | Should -Be "NotSupported,Microsoft.PowerShell.Commands.GetItemPropertyCommand" }
+            { $result = Get-ItemProperty -Path ".\*" -Filter "*Test*" -ErrorAction Stop } | Should -Throw -ErrorId "NotSupported,Microsoft.PowerShell.Commands.GetItemPropertyCommand"
         }
 
         It "Verify Include" {
@@ -378,11 +370,7 @@ Describe "Extended Registry Provider Tests" -Tags @("Feature", "RequireAdminOnWi
 
         It "Verify WhatIf" {
             Copy-ItemProperty -Path $testKey -Name $testPropertyName -Destination $testKey2 -WhatIf
-            try {
-                Get-ItemProperty -Path $testKey2 -Name $testPropertyName -ErrorAction Stop
-                throw "Expected exception not thrown"
-            }
-            catch { $_.FullyQualifiedErrorId | Should -Be "System.Management.Automation.PSArgumentException,Microsoft.PowerShell.Commands.GetItemPropertyCommand" }
+            { Get-ItemProperty -Path $testKey2 -Name $testPropertyName -ErrorAction Stop } | Should -Throw -ErrorId "System.Management.Automation.PSArgumentException,Microsoft.PowerShell.Commands.GetItemPropertyCommand"
         }
     }
 
@@ -458,11 +446,7 @@ Describe "Extended Registry Provider Tests" -Tags @("Feature", "RequireAdminOnWi
     Context "Valdiate Remove-ItemProperty Parameters" {
         It "Verify Confirm can be bypassed" {
             Remove-ItemProperty -Path $testKey -Name $testPropertyName -Confirm:$false
-            try {
-                Get-ItemProperty -Path $testKey -Name $testPropertyName -ErrorAction Stop
-                throw "Expected exception not thrown"
-            }
-            catch { $_.FullyQualifiedErrorId | Should -Be "System.Management.Automation.PSArgumentException,Microsoft.PowerShell.Commands.GetItemPropertyCommand" }
+            { Get-ItemProperty -Path $testKey -Name $testPropertyName -ErrorAction Stop } | Should -Throw -ErrorId "System.Management.Automation.PSArgumentException,Microsoft.PowerShell.Commands.GetItemPropertyCommand"
         }
 
         It "Verify WhatIf" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Registry.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Registry.Tests.ps1
@@ -80,19 +80,19 @@ Describe "Basic Registry Provider Tests" -Tags @("CI", "RequireAdminOnWindows") 
         It "Verify New-Item" {
             $newKey = New-Item -Path "NewItemTest"
             Test-Path "NewItemTest" | Should -BeTrue
-            Split-Path $newKey.Name -Leaf | Should -Be "NewItemTest"
+            Split-Path $newKey.Name -Leaf | Should -BeExactly "NewItemTest"
         }
 
         It "Verify Copy-Item" {
             $copyKey = Copy-Item -Path $testKey -Destination "CopiedKey" -PassThru
             Test-Path "CopiedKey" | Should -BeTrue
-            Split-Path $copyKey.Name -Leaf | Should -Be "CopiedKey"
+            Split-Path $copyKey.Name -Leaf | Should -BeExactly "CopiedKey"
         }
 
         It "Verify Move-Item" {
             $movedKey = Move-Item -Path $testKey -Destination "MovedKey" -PassThru
             Test-Path "MovedKey" | Should -BeTrue
-            Split-Path $movedKey.Name -Leaf | Should -Be "MovedKey"
+            Split-Path $movedKey.Name -Leaf | Should -BeExactly "MovedKey"
         }
 
         It "Verify Rename-Item" {
@@ -102,7 +102,7 @@ Describe "Basic Registry Provider Tests" -Tags @("CI", "RequireAdminOnWindows") 
             $existBefore | Should -BeTrue
             $existAfter | Should -BeFalse
             Test-Path "RenamedKey" | Should -BeTrue
-            Split-Path $renamedKey.Name -Leaf | Should -Be "RenamedKey"
+            Split-Path $renamedKey.Name -Leaf | Should -BeExactly "RenamedKey"
         }
     }
 
@@ -111,7 +111,7 @@ Describe "Basic Registry Provider Tests" -Tags @("CI", "RequireAdminOnWindows") 
             New-ItemProperty -Path $testKey -Name "NewTestEntry" -Value 99 > $null
             $property = Get-ItemProperty -Path $testKey -Name "NewTestEntry"
             $property.NewTestEntry | Should -Be 99
-            $property.PSChildName | Should -Be $testKey
+            $property.PSChildName | Should -BeExactly $testKey
         }
 
         It "Verify Set-ItemProperty" {
@@ -142,9 +142,9 @@ Describe "Basic Registry Provider Tests" -Tags @("CI", "RequireAdminOnWindows") 
             Copy-ItemProperty -Path $testKey -Name $testPropertyName -Destination $testKey2
             $property1 = Get-ItemProperty -Path $testKey -Name $testPropertyName -ErrorAction SilentlyContinue
             $property2 = Get-ItemProperty -Path $testKey2 -Name $testPropertyName -ErrorAction SilentlyContinue
-            $property2."$testPropertyName" | Should -Be $property1."$testPropertyName"
-            $property1.PSChildName | Should -Be $testKey
-            $property2.PSChildName | Should -Be $testKey2
+            $property2."$testPropertyName" | Should -BeExactly $property1."$testPropertyName"
+            $property1.PSChildName | Should -BeExactly $testKey
+            $property2.PSChildName | Should -BeExactly $testKey2
         }
 
         It "Verify Move-ItemProperty" {
@@ -152,8 +152,8 @@ Describe "Basic Registry Provider Tests" -Tags @("CI", "RequireAdminOnWindows") 
             $property1 = Get-ItemProperty -Path $testKey -Name $testPropertyName -ErrorAction SilentlyContinue
             $property2 = Get-ItemProperty -Path $testKey2 -Name $testPropertyName -ErrorAction SilentlyContinue
             $property1 | Should -BeNullOrEmpty
-            $property2."$testPropertyName" | Should -Be $testPropertyValue
-            $property2.PSChildName | Should -Be $testKey2
+            $property2."$testPropertyName" | Should -BeExactly $testPropertyValue
+            $property2.PSChildName | Should -BeExactly $testKey2
         }
 
         It "Verify Rename-ItemProperty" {
@@ -161,8 +161,8 @@ Describe "Basic Registry Provider Tests" -Tags @("CI", "RequireAdminOnWindows") 
             $property1 = Get-ItemProperty -Path $testKey -Name $testPropertyName -ErrorAction SilentlyContinue
             $property2 = Get-ItemProperty -Path $testKey -Name "RenamedProperty" -ErrorAction SilentlyContinue
             $property1 | Should -BeNullOrEmpty
-            $property2.RenamedProperty | Should -Be $testPropertyValue
-            $property2.PSChildName | Should -Be $testKey
+            $property2.RenamedProperty | Should -BeExactly $testPropertyValue
+            $property2.PSChildName | Should -BeExactly $testKey
         }
 
         It "Verify Clear-ItemProperty" {
@@ -254,19 +254,19 @@ Describe "Extended Registry Provider Tests" -Tags @("Feature", "RequireAdminOnWi
         It "Verify Include" {
             $result = New-ItemProperty -Path ".\*" -Include "*2" -Name $testPropertyName -Value $testPropertyValue
             $result."$testPropertyName" | Should -Be $testPropertyValue
-            $result.PSChildName | Should -Be $testKey2
+            $result.PSChildName | Should -BeExactly $testKey2
         }
 
         It "Verify Exclude" {
             $result = New-ItemProperty -Path ".\*" -Exclude "*2" -Name $testPropertyName -Value $testPropertyValue
             $result."$testPropertyName" | Should -Be $testPropertyValue
-            $result.PSChildName | Should -Be $testKey
+            $result.PSChildName | Should -BeExactly $testKey
         }
 
         It "Verify Confirm can be bypassed" {
             $result = New-ItemProperty -Path $testKey -Name $testPropertyName -Value $testPropertyValue -force -Confirm:$false
             $result."$testPropertyName" | Should -Be $testPropertyValue
-            $result.PSChildName | Should -Be $testKey
+            $result.PSChildName | Should -BeExactly $testKey
         }
 
         It "Verify WhatIf" {
@@ -279,13 +279,13 @@ Describe "Extended Registry Provider Tests" -Tags @("Feature", "RequireAdminOnWi
         It "Verify Name" {
             $result = Get-ItemProperty -Path $testKey -Name $testPropertyName
             $result."$testPropertyName" | Should -Be $testPropertyValue
-            $result.PSChildName | Should -Be $testKey
+            $result.PSChildName | Should -BeExactly $testKey
         }
 
         It "Verify Path but no Name" {
             $result = Get-ItemProperty -Path $testKey
             $result."$testPropertyName" | Should -Be $testPropertyValue
-            $result.PSChildName | Should -Be $testKey
+            $result.PSChildName | Should -BeExactly $testKey
         }
 
         It "Verify Filter" {
@@ -299,13 +299,13 @@ Describe "Extended Registry Provider Tests" -Tags @("Feature", "RequireAdminOnWi
         It "Verify Include" {
             $result = Get-ItemProperty -Path ".\*" -Include "*2"
             $result."$testPropertyName" | Should -Be $testPropertyValue
-            $result.PSChildName | Should -Be $testKey2
+            $result.PSChildName | Should -BeExactly $testKey2
         }
 
         It "Verify Exclude" {
             $result = Get-ItemProperty -Path ".\*" -Exclude "*2"
             $result."$testPropertyName" | Should -Be $testPropertyValue
-            $result.PSChildName | Should -Be $testKey
+            $result.PSChildName | Should -BeExactly $testKey
         }
     }
 
@@ -363,8 +363,8 @@ Describe "Extended Registry Provider Tests" -Tags @("Feature", "RequireAdminOnWi
             $property1 = Copy-ItemProperty -Path $testKey -Name $testPropertyName -Destination $testKey2 -PassThru
             $property2 = Get-ItemProperty -Path $testKey2 -Name $testPropertyName -ErrorAction SilentlyContinue
             $property2."$testPropertyName" | Should -Be $property1."$testPropertyName"
-            $property1.PSChildName | Should -Be $testKey
-            $property2.PSChildName | Should -Be $testKey2
+            $property1.PSChildName | Should -BeExactly $testKey
+            $property2.PSChildName | Should -BeExactly $testKey2
         }
 
         It "Verify Confirm can be bypassed" {
@@ -372,8 +372,8 @@ Describe "Extended Registry Provider Tests" -Tags @("Feature", "RequireAdminOnWi
             $property1 = Get-ItemProperty -Path $testKey -Name $testPropertyName -ErrorAction SilentlyContinue
             $property2 = Get-ItemProperty -Path $testKey2 -Name $testPropertyName -ErrorAction SilentlyContinue
             $property2."$testPropertyName" | Should -Be $property1."$testPropertyName"
-            $property1.PSChildName | Should -Be $testKey
-            $property2.PSChildName | Should -Be $testKey2
+            $property1.PSChildName | Should -BeExactly $testKey
+            $property2.PSChildName | Should -BeExactly $testKey2
         }
 
         It "Verify WhatIf" {
@@ -397,7 +397,7 @@ Describe "Extended Registry Provider Tests" -Tags @("Feature", "RequireAdminOnWi
             $property1 = Get-ItemProperty -Path $testKey -Name $testPropertyName -ErrorAction SilentlyContinue
             $property1 | Should -BeNullOrEmpty
             $property2."$testPropertyName" | Should -Be $testPropertyValue
-            $property2.PSChildName | Should -Be $testKey2
+            $property2.PSChildName | Should -BeExactly $testKey2
         }
 
         It "Verify Confirm can be bypassed" {
@@ -406,7 +406,7 @@ Describe "Extended Registry Provider Tests" -Tags @("Feature", "RequireAdminOnWi
             $property2 = Get-ItemProperty -Path $testKey2 -Name $testPropertyName -ErrorAction SilentlyContinue
             $property1 | Should -BeNullOrEmpty
             $property2."$testPropertyName" | Should -Be $testPropertyValue
-            $property2.PSChildName | Should -Be $testKey2
+            $property2.PSChildName | Should -BeExactly $testKey2
         }
 
         It "Verify WhatIf" {
@@ -414,7 +414,7 @@ Describe "Extended Registry Provider Tests" -Tags @("Feature", "RequireAdminOnWi
             $property1 = Get-ItemProperty -Path $testKey -Name $testPropertyName -ErrorAction SilentlyContinue
             $property2 = Get-ItemProperty -Path $testKey2 -Name $testPropertyName -ErrorAction SilentlyContinue
             $property1."$testPropertyName" | Should -Be $testPropertyValue
-            $property1.PSChildName | Should -Be $testKey
+            $property1.PSChildName | Should -BeExactly $testKey
             $property2 | Should -BeNullOrEmpty
         }
     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Registry.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Registry.Tests.ps1
@@ -50,8 +50,8 @@ Describe "Basic Registry Provider Tests" -Tags @("CI", "RequireAdminOnWindows") 
 
     Context "Validate basic registry provider Cmdlets" {
         It "Verify Test-Path" {
-            Test-Path -IsValid Registry::HKCU/Software | Should -Be $true
-            Test-Path -IsValid Registry::foo/Softare | Should -Be $false
+            Test-Path -IsValid Registry::HKCU/Software | Should -BeTrue
+            Test-Path -IsValid Registry::foo/Softare | Should -BeFalse
         }
 
         It "Verify Get-Item" {
@@ -66,32 +66,32 @@ Describe "Basic Registry Provider Tests" -Tags @("CI", "RequireAdminOnWindows") 
         It "Verify Get-ChildItem" {
             $items = Get-ChildItem
             $items.Count | Should -BeExactly 2
-            $Items.PSChildName -contains $testKey | Should -Be $true
-            $Items.PSChildName -contains $testKey2 | Should -Be $true
+            $Items.PSChildName -contains $testKey | Should -BeTrue
+            $Items.PSChildName -contains $testKey2 | Should -BeTrue
         }
 
         It "Verify Get-ChildItem can get subkey names" {
             $items = Get-ChildItem -Name
             $items.Count | Should -BeExactly 2
-            $items -contains $testKey | Should -Be $true
-            $items -contains $testKey2 | Should -Be $true
+            $items -contains $testKey | Should -BeTrue
+            $items -contains $testKey2 | Should -BeTrue
         }
 
         It "Verify New-Item" {
             $newKey = New-Item -Path "NewItemTest"
-            Test-Path "NewItemTest" | Should -Be $true
+            Test-Path "NewItemTest" | Should -BeTrue
             Split-Path $newKey.Name -Leaf | Should -Be "NewItemTest"
         }
 
         It "Verify Copy-Item" {
             $copyKey = Copy-Item -Path $testKey -Destination "CopiedKey" -PassThru
-            Test-Path "CopiedKey" | Should -Be $true
+            Test-Path "CopiedKey" | Should -BeTrue
             Split-Path $copyKey.Name -Leaf | Should -Be "CopiedKey"
         }
 
         It "Verify Move-Item" {
             $movedKey = Move-Item -Path $testKey -Destination "MovedKey" -PassThru
-            Test-Path "MovedKey" | Should -Be $true
+            Test-Path "MovedKey" | Should -BeTrue
             Split-Path $movedKey.Name -Leaf | Should -Be "MovedKey"
         }
 
@@ -99,9 +99,9 @@ Describe "Basic Registry Provider Tests" -Tags @("CI", "RequireAdminOnWindows") 
             $existBefore = Test-Path $testKey
             $renamedKey = Rename-Item -path $testKey -NewName "RenamedKey" -PassThru
             $existAfter = Test-Path $testKey
-            $existBefore | Should -Be $true
-            $existAfter | Should -Be $false
-            Test-Path "RenamedKey" | Should -Be $true
+            $existBefore | Should -BeTrue
+            $existAfter | Should -BeFalse
+            Test-Path "RenamedKey" | Should -BeTrue
             Split-Path $renamedKey.Name -Leaf | Should -Be "RenamedKey"
         }
     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Registry.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Registry.Tests.ps1
@@ -50,13 +50,13 @@ Describe "Basic Registry Provider Tests" -Tags @("CI", "RequireAdminOnWindows") 
 
     Context "Validate basic registry provider Cmdlets" {
         It "Verify Test-Path" {
-            Test-Path -IsValid Registry::HKCU/Software | Should Be $true
-            Test-Path -IsValid Registry::foo/Softare | Should Be $false
+            Test-Path -IsValid Registry::HKCU/Software | Should -Be $true
+            Test-Path -IsValid Registry::foo/Softare | Should -Be $false
         }
 
         It "Verify Get-Item" {
             $item = Get-Item $testKey
-            $item.PSChildName | Should BeExactly $testKey
+            $item.PSChildName | Should -BeExactly $testKey
         }
 
         It "Verify Get-Item on inaccessible path" {
@@ -65,44 +65,44 @@ Describe "Basic Registry Provider Tests" -Tags @("CI", "RequireAdminOnWindows") 
 
         It "Verify Get-ChildItem" {
             $items = Get-ChildItem
-            $items.Count | Should BeExactly 2
-            $Items.PSChildName -contains $testKey | Should Be $true
-            $Items.PSChildName -contains $testKey2 | Should Be $true
+            $items.Count | Should -BeExactly 2
+            $Items.PSChildName -contains $testKey | Should -Be $true
+            $Items.PSChildName -contains $testKey2 | Should -Be $true
         }
 
         It "Verify Get-ChildItem can get subkey names" {
             $items = Get-ChildItem -Name
-            $items.Count | Should BeExactly 2
-            $items -contains $testKey | Should Be $true
-            $items -contains $testKey2 | Should Be $true
+            $items.Count | Should -BeExactly 2
+            $items -contains $testKey | Should -Be $true
+            $items -contains $testKey2 | Should -Be $true
         }
 
         It "Verify New-Item" {
             $newKey = New-Item -Path "NewItemTest"
-            Test-Path "NewItemTest" | Should Be $true
-            Split-Path $newKey.Name -Leaf | Should Be "NewItemTest"
+            Test-Path "NewItemTest" | Should -Be $true
+            Split-Path $newKey.Name -Leaf | Should -Be "NewItemTest"
         }
 
         It "Verify Copy-Item" {
             $copyKey = Copy-Item -Path $testKey -Destination "CopiedKey" -PassThru
-            Test-Path "CopiedKey" | Should Be $true
-            Split-Path $copyKey.Name -Leaf | Should Be "CopiedKey"
+            Test-Path "CopiedKey" | Should -Be $true
+            Split-Path $copyKey.Name -Leaf | Should -Be "CopiedKey"
         }
 
         It "Verify Move-Item" {
             $movedKey = Move-Item -Path $testKey -Destination "MovedKey" -PassThru
-            Test-Path "MovedKey" | Should Be $true
-            Split-Path $movedKey.Name -Leaf | Should Be "MovedKey"
+            Test-Path "MovedKey" | Should -Be $true
+            Split-Path $movedKey.Name -Leaf | Should -Be "MovedKey"
         }
 
         It "Verify Rename-Item" {
             $existBefore = Test-Path $testKey
             $renamedKey = Rename-Item -path $testKey -NewName "RenamedKey" -PassThru
             $existAfter = Test-Path $testKey
-            $existBefore | Should Be $true
-            $existAfter | Should Be $false
-            Test-Path "RenamedKey" | Should Be $true
-            Split-Path $renamedKey.Name -Leaf | Should Be "RenamedKey"
+            $existBefore | Should -Be $true
+            $existAfter | Should -Be $false
+            Test-Path "RenamedKey" | Should -Be $true
+            Split-Path $renamedKey.Name -Leaf | Should -Be "RenamedKey"
         }
     }
 
@@ -110,65 +110,65 @@ Describe "Basic Registry Provider Tests" -Tags @("CI", "RequireAdminOnWindows") 
         It "Verify New-ItemProperty" {
             New-ItemProperty -Path $testKey -Name "NewTestEntry" -Value 99 > $null
             $property = Get-ItemProperty -Path $testKey -Name "NewTestEntry"
-            $property.NewTestEntry | Should Be 99
-            $property.PSChildName | Should Be $testKey
+            $property.NewTestEntry | Should -Be 99
+            $property.PSChildName | Should -Be $testKey
         }
 
         It "Verify Set-ItemProperty" {
             Set-ItemProperty -Path $testKey -Name $testPropertyName -Value 2
             $property = Get-ItemProperty -Path $testKey -Name $testPropertyName
-            $property."$testPropertyName" | Should Be 2
+            $property."$testPropertyName" | Should -Be 2
         }
 
         It "Verify Set-Item" {
             Set-Item -Path $testKey -Value $defaultPropertyValue
             $property = Get-ItemProperty -Path $testKey -Name $defaultPropertyName
-            $property."$defaultPropertyName" | Should BeExactly $defaultPropertyValue
+            $property."$defaultPropertyName" | Should -BeExactly $defaultPropertyValue
         }
 
         It "Verify Set-Item with -WhatIf" {
             Set-Item -Path $testKey -Value $defaultPropertyValue
             Set-Item -Path $testKey -Value $otherPropertyValue -WhatIf
             $property = Get-ItemProperty -Path $testKey -Name $defaultPropertyName
-            $property."$defaultPropertyName" | Should BeExactly $defaultPropertyValue
+            $property."$defaultPropertyName" | Should -BeExactly $defaultPropertyValue
         }
 
         It "Verify Get-ItemPropertyValue" {
             $propertyValue = Get-ItemPropertyValue -Path $testKey -Name $testPropertyName
-            $propertyValue | Should Be $testPropertyValue
+            $propertyValue | Should -Be $testPropertyValue
         }
 
         It "Verify Copy-ItemProperty" {
             Copy-ItemProperty -Path $testKey -Name $testPropertyName -Destination $testKey2
             $property1 = Get-ItemProperty -Path $testKey -Name $testPropertyName -ErrorAction SilentlyContinue
             $property2 = Get-ItemProperty -Path $testKey2 -Name $testPropertyName -ErrorAction SilentlyContinue
-            $property2."$testPropertyName" | Should Be $property1."$testPropertyName"
-            $property1.PSChildName | Should Be $testKey
-            $property2.PSChildName | Should Be $testKey2
+            $property2."$testPropertyName" | Should -Be $property1."$testPropertyName"
+            $property1.PSChildName | Should -Be $testKey
+            $property2.PSChildName | Should -Be $testKey2
         }
 
         It "Verify Move-ItemProperty" {
             Move-ItemProperty -Path $testKey -Name $testPropertyName -Destination $testKey2
             $property1 = Get-ItemProperty -Path $testKey -Name $testPropertyName -ErrorAction SilentlyContinue
             $property2 = Get-ItemProperty -Path $testKey2 -Name $testPropertyName -ErrorAction SilentlyContinue
-            $property1 | Should BeNullOrEmpty
-            $property2."$testPropertyName" | Should Be $testPropertyValue
-            $property2.PSChildName | Should Be $testKey2
+            $property1 | Should -BeNullOrEmpty
+            $property2."$testPropertyName" | Should -Be $testPropertyValue
+            $property2.PSChildName | Should -Be $testKey2
         }
 
         It "Verify Rename-ItemProperty" {
             Rename-ItemProperty -Path $testKey -Name $testPropertyName -NewName "RenamedProperty"
             $property1 = Get-ItemProperty -Path $testKey -Name $testPropertyName -ErrorAction SilentlyContinue
             $property2 = Get-ItemProperty -Path $testKey -Name "RenamedProperty" -ErrorAction SilentlyContinue
-            $property1 | Should BeNullOrEmpty
-            $property2.RenamedProperty | Should Be $testPropertyValue
-            $property2.PSChildName | Should Be $testKey
+            $property1 | Should -BeNullOrEmpty
+            $property2.RenamedProperty | Should -Be $testPropertyValue
+            $property2.PSChildName | Should -Be $testKey
         }
 
         It "Verify Clear-ItemProperty" {
             Clear-ItemProperty -Path $testKey -Name $testPropertyName
             $property = Get-ItemProperty -Path $testKey -Name $testPropertyName
-            $property."$testPropertyName" | Should Be 0
+            $property."$testPropertyName" | Should -Be 0
         }
 
         It "Verify Clear-Item" {
@@ -176,7 +176,7 @@ Describe "Basic Registry Provider Tests" -Tags @("CI", "RequireAdminOnWindows") 
             Set-Item -Path $testKey -Value $defaultPropertyValue
             Clear-Item -Path $testKey
             $key = Get-Item -Path $testKey
-            $key.Property.Length | Should BeExactly 0
+            $key.Property.Length | Should -BeExactly 0
         }
 
         It "Verify Clear-Item with -WhatIf" {
@@ -184,13 +184,13 @@ Describe "Basic Registry Provider Tests" -Tags @("CI", "RequireAdminOnWindows") 
             Set-Item -Path $testKey -Value $defaultPropertyValue
             Clear-Item -Path $testKey -WhatIf
             $key = Get-Item -Path $testKey
-            $key.Property.Length | Should BeExactly 2
+            $key.Property.Length | Should -BeExactly 2
         }
 
         It "Verify Remove-ItemProperty" {
             Remove-ItemProperty -Path $testKey -Name $testPropertyName
             $properties = @(Get-ItemProperty -Path $testKey)
-            $properties.Count | Should Be 0
+            $properties.Count | Should -Be 0
         }
     }
 }
@@ -248,44 +248,44 @@ Describe "Extended Registry Provider Tests" -Tags @("Feature", "RequireAdminOnWi
                 $result = New-ItemProperty -Path ".\*" -Filter "Test*" -Name $testPropertyName -Value $testPropertyValue -ErrorAction Stop
                 throw "Expected exception not thrown"
             }
-            catch { $_.FullyQualifiedErrorId | Should Be "NotSupported,Microsoft.PowerShell.Commands.NewItemPropertyCommand" }
+            catch { $_.FullyQualifiedErrorId | Should -Be "NotSupported,Microsoft.PowerShell.Commands.NewItemPropertyCommand" }
         }
 
         It "Verify Include" {
             $result = New-ItemProperty -Path ".\*" -Include "*2" -Name $testPropertyName -Value $testPropertyValue
-            $result."$testPropertyName" | Should Be $testPropertyValue
-            $result.PSChildName | Should Be $testKey2
+            $result."$testPropertyName" | Should -Be $testPropertyValue
+            $result.PSChildName | Should -Be $testKey2
         }
 
         It "Verify Exclude" {
             $result = New-ItemProperty -Path ".\*" -Exclude "*2" -Name $testPropertyName -Value $testPropertyValue
-            $result."$testPropertyName" | Should Be $testPropertyValue
-            $result.PSChildName | Should Be $testKey
+            $result."$testPropertyName" | Should -Be $testPropertyValue
+            $result.PSChildName | Should -Be $testKey
         }
 
         It "Verify Confirm can be bypassed" {
             $result = New-ItemProperty -Path $testKey -Name $testPropertyName -Value $testPropertyValue -force -Confirm:$false
-            $result."$testPropertyName" | Should Be $testPropertyValue
-            $result.PSChildName | Should Be $testKey
+            $result."$testPropertyName" | Should -Be $testPropertyValue
+            $result.PSChildName | Should -Be $testKey
         }
 
         It "Verify WhatIf" {
             $result = New-ItemProperty -Path $testKey -Name $testPropertyName -Value $testPropertyValue -whatif
-            $result | Should BeNullOrEmpty
+            $result | Should -BeNullOrEmpty
         }
     }
 
     Context "Valdiate Get-ItemProperty Parameters" {
         It "Verify Name" {
             $result = Get-ItemProperty -Path $testKey -Name $testPropertyName
-            $result."$testPropertyName" | Should Be $testPropertyValue
-            $result.PSChildName | Should Be $testKey
+            $result."$testPropertyName" | Should -Be $testPropertyValue
+            $result.PSChildName | Should -Be $testKey
         }
 
         It "Verify Path but no Name" {
             $result = Get-ItemProperty -Path $testKey
-            $result."$testPropertyName" | Should Be $testPropertyValue
-            $result.PSChildName | Should Be $testKey
+            $result."$testPropertyName" | Should -Be $testPropertyValue
+            $result.PSChildName | Should -Be $testKey
         }
 
         It "Verify Filter" {
@@ -293,26 +293,26 @@ Describe "Extended Registry Provider Tests" -Tags @("Feature", "RequireAdminOnWi
                 $result = Get-ItemProperty -Path ".\*" -Filter "*Test*" -ErrorAction Stop
                 throw "Expected exception not thrown"
             }
-            catch { $_.FullyQualifiedErrorId | Should Be "NotSupported,Microsoft.PowerShell.Commands.GetItemPropertyCommand" }
+            catch { $_.FullyQualifiedErrorId | Should -Be "NotSupported,Microsoft.PowerShell.Commands.GetItemPropertyCommand" }
         }
 
         It "Verify Include" {
             $result = Get-ItemProperty -Path ".\*" -Include "*2"
-            $result."$testPropertyName" | Should Be $testPropertyValue
-            $result.PSChildName | Should Be $testKey2
+            $result."$testPropertyName" | Should -Be $testPropertyValue
+            $result.PSChildName | Should -Be $testKey2
         }
 
         It "Verify Exclude" {
             $result = Get-ItemProperty -Path ".\*" -Exclude "*2"
-            $result."$testPropertyName" | Should Be $testPropertyValue
-            $result.PSChildName | Should Be $testKey
+            $result."$testPropertyName" | Should -Be $testPropertyValue
+            $result.PSChildName | Should -Be $testKey
         }
     }
 
     Context "Valdiate Get-ItemPropertyValue Parameters" {
         It "Verify Name" {
             $result = Get-ItemPropertyValue -Path $testKey -Name $testPropertyName
-            $result | Should Be $testPropertyValue
+            $result | Should -Be $testPropertyValue
         }
     }
 
@@ -324,31 +324,31 @@ Describe "Extended Registry Provider Tests" -Tags @("Feature", "RequireAdminOnWi
         It "Verify Name" {
             Set-ItemProperty -Path $testKey -Name $testPropertyName -Value $newPropertyValue
             $result = Get-ItemProperty -Path $testKey -Name $testPropertyName
-            $result."$testPropertyName" | Should Be $newPropertyValue
+            $result."$testPropertyName" | Should -Be $newPropertyValue
         }
 
         It "Verify PassThru" {
             $result = Set-ItemProperty -Path $testKey -Name $testPropertyName -Value $newPropertyValue -PassThru
-            $result."$testPropertyName" | Should Be $newPropertyValue
+            $result."$testPropertyName" | Should -Be $newPropertyValue
         }
 
         It "Verify Piped Default Parameter" {
             $prop = Get-ItemProperty -Path $testKey -Name $testPropertyName
             $prop | Set-ItemProperty -Name $testPropertyName -Value $newPropertyValue
             $result = Get-ItemProperty -Path $testKey -Name $testPropertyName
-            $result."$testPropertyName" | Should Be $newPropertyValue
+            $result."$testPropertyName" | Should -Be $newPropertyValue
         }
 
         It "Verify WhatIf" {
             $result = Set-ItemProperty -Path $testKey -Name $testPropertyName -Value $newPropertyValue -PassThru -WhatIf
             $result = Get-ItemProperty -Path $testKey -Name $testPropertyName
-            $result."$testPropertyName" | Should Be $testPropertyValue
+            $result."$testPropertyName" | Should -Be $testPropertyValue
         }
 
         It "Verify Confirm can be bypassed" {
             $result = Set-ItemProperty -Path $testKey -Name $testPropertyName -Value $newPropertyValue -PassThru -Confirm:$false
             $result = Get-ItemProperty -Path $testKey -Name $testPropertyName
-            $result."$testPropertyName" | Should Be $newPropertyValue
+            $result."$testPropertyName" | Should -Be $newPropertyValue
         }
     }
 
@@ -362,18 +362,18 @@ Describe "Extended Registry Provider Tests" -Tags @("Feature", "RequireAdminOnWi
             #passthru returns the property on testKey not testKey2
             $property1 = Copy-ItemProperty -Path $testKey -Name $testPropertyName -Destination $testKey2 -PassThru
             $property2 = Get-ItemProperty -Path $testKey2 -Name $testPropertyName -ErrorAction SilentlyContinue
-            $property2."$testPropertyName" | Should Be $property1."$testPropertyName"
-            $property1.PSChildName | Should Be $testKey
-            $property2.PSChildName | Should Be $testKey2
+            $property2."$testPropertyName" | Should -Be $property1."$testPropertyName"
+            $property1.PSChildName | Should -Be $testKey
+            $property2.PSChildName | Should -Be $testKey2
         }
 
         It "Verify Confirm can be bypassed" {
             Copy-ItemProperty -Path $testKey -Name $testPropertyName -Destination $testKey2 -Confirm:$false
             $property1 = Get-ItemProperty -Path $testKey -Name $testPropertyName -ErrorAction SilentlyContinue
             $property2 = Get-ItemProperty -Path $testKey2 -Name $testPropertyName -ErrorAction SilentlyContinue
-            $property2."$testPropertyName" | Should Be $property1."$testPropertyName"
-            $property1.PSChildName | Should Be $testKey
-            $property2.PSChildName | Should Be $testKey2
+            $property2."$testPropertyName" | Should -Be $property1."$testPropertyName"
+            $property1.PSChildName | Should -Be $testKey
+            $property2.PSChildName | Should -Be $testKey2
         }
 
         It "Verify WhatIf" {
@@ -382,7 +382,7 @@ Describe "Extended Registry Provider Tests" -Tags @("Feature", "RequireAdminOnWi
                 Get-ItemProperty -Path $testKey2 -Name $testPropertyName -ErrorAction Stop
                 throw "Expected exception not thrown"
             }
-            catch { $_.FullyQualifiedErrorId | Should Be "System.Management.Automation.PSArgumentException,Microsoft.PowerShell.Commands.GetItemPropertyCommand" }
+            catch { $_.FullyQualifiedErrorId | Should -Be "System.Management.Automation.PSArgumentException,Microsoft.PowerShell.Commands.GetItemPropertyCommand" }
         }
     }
 
@@ -395,27 +395,27 @@ Describe "Extended Registry Provider Tests" -Tags @("Feature", "RequireAdminOnWi
         It "Verify PassThru" {
             $property2 = Move-ItemProperty -Path $testKey -Name $testPropertyName -Destination $testKey2 -PassThru
             $property1 = Get-ItemProperty -Path $testKey -Name $testPropertyName -ErrorAction SilentlyContinue
-            $property1 | Should BeNullOrEmpty
-            $property2."$testPropertyName" | Should Be $testPropertyValue
-            $property2.PSChildName | Should Be $testKey2
+            $property1 | Should -BeNullOrEmpty
+            $property2."$testPropertyName" | Should -Be $testPropertyValue
+            $property2.PSChildName | Should -Be $testKey2
         }
 
         It "Verify Confirm can be bypassed" {
             Move-ItemProperty -Path $testKey -Name $testPropertyName -Destination $testKey2 -Confirm:$false
             $property1 = Get-ItemProperty -Path $testKey -Name $testPropertyName -ErrorAction SilentlyContinue
             $property2 = Get-ItemProperty -Path $testKey2 -Name $testPropertyName -ErrorAction SilentlyContinue
-            $property1 | Should BeNullOrEmpty
-            $property2."$testPropertyName" | Should Be $testPropertyValue
-            $property2.PSChildName | Should Be $testKey2
+            $property1 | Should -BeNullOrEmpty
+            $property2."$testPropertyName" | Should -Be $testPropertyValue
+            $property2.PSChildName | Should -Be $testKey2
         }
 
         It "Verify WhatIf" {
             Move-ItemProperty -Path $testKey -Name $testPropertyName -Destination $testKey2 -WhatIf
             $property1 = Get-ItemProperty -Path $testKey -Name $testPropertyName -ErrorAction SilentlyContinue
             $property2 = Get-ItemProperty -Path $testKey2 -Name $testPropertyName -ErrorAction SilentlyContinue
-            $property1."$testPropertyName" | Should Be $testPropertyValue
-            $property1.PSChildName | Should Be $testKey
-            $property2 | Should BeNullOrEmpty
+            $property1."$testPropertyName" | Should -Be $testPropertyValue
+            $property1.PSChildName | Should -Be $testKey
+            $property2 | Should -BeNullOrEmpty
         }
     }
 
@@ -428,16 +428,16 @@ Describe "Extended Registry Provider Tests" -Tags @("Feature", "RequireAdminOnWi
             Rename-ItemProperty -Path $testKey -Name $testPropertyName -NewName $newPropertyName -Confirm:$false
             $property1 = Get-ItemProperty -Path $testKey -Name $testPropertyName -ErrorAction SilentlyContinue
             $property2 = Get-ItemProperty -Path $testKey -Name $newPropertyName -ErrorAction SilentlyContinue
-            $property1 | Should BeNullOrEmpty
-            $property2."$newPropertyName" | Should Be $testPropertyValue
+            $property1 | Should -BeNullOrEmpty
+            $property2."$newPropertyName" | Should -Be $testPropertyValue
         }
 
         It "Verify WhatIf" {
             Rename-ItemProperty -Path $testKey -Name $testPropertyName -NewName $newPropertyName -WhatIf
             $property1 = Get-ItemProperty -Path $testKey -Name $testPropertyName -ErrorAction SilentlyContinue
             $property2 = Get-ItemProperty -Path $testKey -Name $newPropertyName -ErrorAction SilentlyContinue
-            $property1."$testPropertyName" | Should Be $testPropertyValue
-            $property2 | Should BeNullOrEmpty
+            $property1."$testPropertyName" | Should -Be $testPropertyValue
+            $property2 | Should -BeNullOrEmpty
         }
     }
 
@@ -445,13 +445,13 @@ Describe "Extended Registry Provider Tests" -Tags @("Feature", "RequireAdminOnWi
         It "Verify Confirm can be bypassed" {
             Clear-ItemProperty -Path $testKey -Name $testPropertyName -Confirm:$false
             $result = Get-ItemProperty -Path $testKey -Name $testPropertyName
-            $result."$testPropertyName" | Should Be 0
+            $result."$testPropertyName" | Should -Be 0
         }
 
         It "Verify WhatIf" {
             Clear-ItemProperty -Path $testKey -Name $testPropertyName -WhatIf
             $result = Get-ItemProperty -Path $testKey -Name $testPropertyName
-            $result."$testPropertyName" | Should Be $testPropertyValue
+            $result."$testPropertyName" | Should -Be $testPropertyValue
         }
     }
 
@@ -462,13 +462,13 @@ Describe "Extended Registry Provider Tests" -Tags @("Feature", "RequireAdminOnWi
                 Get-ItemProperty -Path $testKey -Name $testPropertyName -ErrorAction Stop
                 throw "Expected exception not thrown"
             }
-            catch { $_.FullyQualifiedErrorId | Should Be "System.Management.Automation.PSArgumentException,Microsoft.PowerShell.Commands.GetItemPropertyCommand" }
+            catch { $_.FullyQualifiedErrorId | Should -Be "System.Management.Automation.PSArgumentException,Microsoft.PowerShell.Commands.GetItemPropertyCommand" }
         }
 
         It "Verify WhatIf" {
             Remove-ItemProperty -Path $testKey -Name $testPropertyName -WhatIf
             $result = Get-ItemProperty -Path $testKey -Name $testPropertyName
-            $result."$testPropertyName" | Should Be $testPropertyValue
+            $result."$testPropertyName" | Should -Be $testPropertyValue
         }
     }
 
@@ -478,9 +478,9 @@ Describe "Extended Registry Provider Tests" -Tags @("Feature", "RequireAdminOnWi
                 $tempPath = "HKCU:\_tmp"
                 $testPath = "$tempPath\*\sub"
                 $null = New-Item -Force $testPath
-                $testPath | Should Exist
+                $testPath | Should -Exist
                 Remove-Item -LiteralPath $testPath
-                $testPath | Should Not Exist
+                $testPath | Should -Not -Exist
             }
             finally {
                 Remove-Item -Recurse $tempPath -ErrorAction SilentlyContinue

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Remove-EventLog.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Remove-EventLog.Tests.ps1
@@ -15,24 +15,24 @@ Describe "New-EventLog cmdlet tests" -Tags @('CI', 'RequireAdminOnWindows') {
     BeforeEach {
         if ($IsNotSkipped) {
             Remove-EventLog -LogName TestLog -ea Ignore
-            {New-EventLog -LogName TestLog -Source TestSource -ea Stop}                              | Should Not Throw
-            {Write-EventLog -LogName TestLog -Source TestSource -Message "Test" -EventID 1 -ea Stop} | Should Not Throw
+            {New-EventLog -LogName TestLog -Source TestSource -ea Stop}                              | Should -Not -Throw
+            {Write-EventLog -LogName TestLog -Source TestSource -Message "Test" -EventID 1 -ea Stop} | Should -Not -Throw
         }
     }
     #CmdLet is NYI - change to -Skip:($NonWinAdmin) when implemented
     It "should be able to Remove-EventLog -LogName <string> -ComputerName <string>" -Pending:($True) {
-      {Remove-EventLog -LogName TestLog -ComputerName $env:COMPUTERNAME -ea Stop}              | Should Not Throw
+      {Remove-EventLog -LogName TestLog -ComputerName $env:COMPUTERNAME -ea Stop}              | Should -Not -Throw
       try {Write-EventLog -LogName TestLog -Source TestSource -Message "Test" -EventID 1 -ea Stop; Throw "Previous statement unexpectedly succeeded..."
-      } catch {$_.FullyQualifiedErrorId             | Should Be "Microsoft.PowerShell.Commands.WriteEventLogCommand"}
+      } catch {$_.FullyQualifiedErrorId             | Should -Be "Microsoft.PowerShell.Commands.WriteEventLogCommand"}
       try {Get-EventLog -LogName TestLog -ea Stop; Throw "Previous statement unexpectedly succeeded..."
-      } catch {$_.FullyQualifiedErrorId             | Should Be "System.InvalidOperationException,Microsoft.PowerShell.Commands.GetEventLogCommand"}
+      } catch {$_.FullyQualifiedErrorId             | Should -Be "System.InvalidOperationException,Microsoft.PowerShell.Commands.GetEventLogCommand"}
     }
     #CmdLet is NYI - change to -Skip:($NonWinAdmin) when implemented
     It "should be able to Remove-EventLog -Source <string> -ComputerName <string>"  -Pending:($True) {
-      {Remove-EventLog -Source TestSource -ComputerName $env:COMPUTERNAME -ea Stop} | Should Not Throw
+      {Remove-EventLog -Source TestSource -ComputerName $env:COMPUTERNAME -ea Stop} | Should -Not -Throw
       try {Write-EventLog -LogName TestLog -Source TestSource -Message "Test" -EventID 1 -ea Stop; Throw "Previous statement unexpectedly succeeded..."
-      } catch {$_.FullyQualifiedErrorId             | Should Be "Microsoft.PowerShell.Commands.WriteEventLogCommand"}
+      } catch {$_.FullyQualifiedErrorId             | Should -Be "Microsoft.PowerShell.Commands.WriteEventLogCommand"}
       try {Get-EventLog -LogName TestLog -ea Stop; Throw "Previous statement unexpectedly succeeded..."
-      } catch {$_.FullyQualifiedErrorId             | Should Be "System.InvalidOperationException,Microsoft.PowerShell.Commands.GetEventLogCommand"}
+      } catch {$_.FullyQualifiedErrorId             | Should -Be "System.InvalidOperationException,Microsoft.PowerShell.Commands.GetEventLogCommand"}
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Remove-EventLog.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Remove-EventLog.Tests.ps1
@@ -21,7 +21,7 @@ Describe "New-EventLog cmdlet tests" -Tags @('CI', 'RequireAdminOnWindows') {
     }
     #CmdLet is NYI - change to -Skip:($NonWinAdmin) when implemented
     It "should be able to Remove-EventLog -LogName <string> -ComputerName <string>" -Pending:($True) {
-      {Remove-EventLog -LogName TestLog -ComputerName $env:COMPUTERNAME -ErrorAction Stop}              | Should -Not -Throw
+      { Remove-EventLog -LogName TestLog -ComputerName $env:COMPUTERNAME -ErrorAction Stop }              | Should -Not -Throw
       { Write-EventLog -LogName TestLog -Source TestSource -Message "Test" -EventID 1 -ErrorAction Stop } | Should -Throw -ErrorId "Microsoft.PowerShell.Commands.WriteEventLogCommand"
       { Get-EventLog -LogName TestLog -ErrorAction Stop } | Should -Throw -ErrorId "System.InvalidOperationException,Microsoft.PowerShell.Commands.GetEventLogCommand"
     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Remove-EventLog.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Remove-EventLog.Tests.ps1
@@ -22,17 +22,13 @@ Describe "New-EventLog cmdlet tests" -Tags @('CI', 'RequireAdminOnWindows') {
     #CmdLet is NYI - change to -Skip:($NonWinAdmin) when implemented
     It "should be able to Remove-EventLog -LogName <string> -ComputerName <string>" -Pending:($True) {
       {Remove-EventLog -LogName TestLog -ComputerName $env:COMPUTERNAME -ErrorAction Stop}              | Should -Not -Throw
-      try {Write-EventLog -LogName TestLog -Source TestSource -Message "Test" -EventID 1 -ErrorAction Stop; Throw "Previous statement unexpectedly succeeded..."
-      } catch {$_.FullyQualifiedErrorId             | Should -Be "Microsoft.PowerShell.Commands.WriteEventLogCommand"}
-      try {Get-EventLog -LogName TestLog -ErrorAction Stop; Throw "Previous statement unexpectedly succeeded..."
-      } catch {$_.FullyQualifiedErrorId             | Should -Be "System.InvalidOperationException,Microsoft.PowerShell.Commands.GetEventLogCommand"}
+      { Write-EventLog -LogName TestLog -Source TestSource -Message "Test" -EventID 1 -ErrorAction Stop } | Should -Throw -ErrorId "Microsoft.PowerShell.Commands.WriteEventLogCommand"
+      { Get-EventLog -LogName TestLog -ErrorAction Stop } | Should -Throw -ErrorId "System.InvalidOperationException,Microsoft.PowerShell.Commands.GetEventLogCommand"
     }
     #CmdLet is NYI - change to -Skip:($NonWinAdmin) when implemented
     It "should be able to Remove-EventLog -Source <string> -ComputerName <string>"  -Pending:($True) {
       {Remove-EventLog -Source TestSource -ComputerName $env:COMPUTERNAME -ErrorAction Stop} | Should -Not -Throw
-      try {Write-EventLog -LogName TestLog -Source TestSource -Message "Test" -EventID 1 -ErrorAction Stop; Throw "Previous statement unexpectedly succeeded..."
-      } catch {$_.FullyQualifiedErrorId             | Should -Be "Microsoft.PowerShell.Commands.WriteEventLogCommand"}
-      try {Get-EventLog -LogName TestLog -ErrorAction Stop; Throw "Previous statement unexpectedly succeeded..."
-      } catch {$_.FullyQualifiedErrorId             | Should -Be "System.InvalidOperationException,Microsoft.PowerShell.Commands.GetEventLogCommand"}
+      { Write-EventLog -LogName TestLog -Source TestSource -Message "Test" -EventID 1 -ErrorAction Stop } | Should -Throw -ErrorId "Microsoft.PowerShell.Commands.WriteEventLogCommand"
+      { Get-EventLog -LogName TestLog -ErrorAction Stop; } | Should -Throw -ErrorId "System.InvalidOperationException,Microsoft.PowerShell.Commands.GetEventLogCommand"
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Remove-EventLog.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Remove-EventLog.Tests.ps1
@@ -15,24 +15,24 @@ Describe "New-EventLog cmdlet tests" -Tags @('CI', 'RequireAdminOnWindows') {
     BeforeEach {
         if ($IsNotSkipped) {
             Remove-EventLog -LogName TestLog -ea Ignore
-            {New-EventLog -LogName TestLog -Source TestSource -ea Stop}                              | Should -Not -Throw
-            {Write-EventLog -LogName TestLog -Source TestSource -Message "Test" -EventID 1 -ea Stop} | Should -Not -Throw
+            {New-EventLog -LogName TestLog -Source TestSource -ErrorAction Stop}                              | Should -Not -Throw
+            {Write-EventLog -LogName TestLog -Source TestSource -Message "Test" -EventID 1 -ErrorAction Stop} | Should -Not -Throw
         }
     }
     #CmdLet is NYI - change to -Skip:($NonWinAdmin) when implemented
     It "should be able to Remove-EventLog -LogName <string> -ComputerName <string>" -Pending:($True) {
-      {Remove-EventLog -LogName TestLog -ComputerName $env:COMPUTERNAME -ea Stop}              | Should -Not -Throw
-      try {Write-EventLog -LogName TestLog -Source TestSource -Message "Test" -EventID 1 -ea Stop; Throw "Previous statement unexpectedly succeeded..."
+      {Remove-EventLog -LogName TestLog -ComputerName $env:COMPUTERNAME -ErrorAction Stop}              | Should -Not -Throw
+      try {Write-EventLog -LogName TestLog -Source TestSource -Message "Test" -EventID 1 -ErrorAction Stop; Throw "Previous statement unexpectedly succeeded..."
       } catch {$_.FullyQualifiedErrorId             | Should -Be "Microsoft.PowerShell.Commands.WriteEventLogCommand"}
-      try {Get-EventLog -LogName TestLog -ea Stop; Throw "Previous statement unexpectedly succeeded..."
+      try {Get-EventLog -LogName TestLog -ErrorAction Stop; Throw "Previous statement unexpectedly succeeded..."
       } catch {$_.FullyQualifiedErrorId             | Should -Be "System.InvalidOperationException,Microsoft.PowerShell.Commands.GetEventLogCommand"}
     }
     #CmdLet is NYI - change to -Skip:($NonWinAdmin) when implemented
     It "should be able to Remove-EventLog -Source <string> -ComputerName <string>"  -Pending:($True) {
-      {Remove-EventLog -Source TestSource -ComputerName $env:COMPUTERNAME -ea Stop} | Should -Not -Throw
-      try {Write-EventLog -LogName TestLog -Source TestSource -Message "Test" -EventID 1 -ea Stop; Throw "Previous statement unexpectedly succeeded..."
+      {Remove-EventLog -Source TestSource -ComputerName $env:COMPUTERNAME -ErrorAction Stop} | Should -Not -Throw
+      try {Write-EventLog -LogName TestLog -Source TestSource -Message "Test" -EventID 1 -ErrorAction Stop; Throw "Previous statement unexpectedly succeeded..."
       } catch {$_.FullyQualifiedErrorId             | Should -Be "Microsoft.PowerShell.Commands.WriteEventLogCommand"}
-      try {Get-EventLog -LogName TestLog -ea Stop; Throw "Previous statement unexpectedly succeeded..."
+      try {Get-EventLog -LogName TestLog -ErrorAction Stop; Throw "Previous statement unexpectedly succeeded..."
       } catch {$_.FullyQualifiedErrorId             | Should -Be "System.InvalidOperationException,Microsoft.PowerShell.Commands.GetEventLogCommand"}
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Remove-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Remove-Item.Tests.ps1
@@ -8,44 +8,44 @@ Describe "Remove-Item" -Tags "CI" {
 	BeforeEach {
 	    New-Item -Name $testfile -Path $testpath -ItemType "file" -Value "lorem ipsum" -Force
 
-	    Test-Path $testfilepath | Should -Be $true
+	    Test-Path $testfilepath | Should -BeTrue
 
 	}
 
 	It "Should be able to be called on a regular file without error using the Path switch" {
 	    { Remove-Item -Path $testfilepath } | Should -Not -Throw
 
-	    Test-Path $testfilepath | Should -Be $false
+	    Test-Path $testfilepath | Should -BeFalse
 	}
 
 	It "Should be able to be called on a file without the Path switch" {
 	    { Remove-Item $testfilepath } | Should -Not -Throw
 
-	    Test-Path $testfilepath | Should -Be $false
+	    Test-Path $testfilepath | Should -BeFalse
 	}
 
 	It "Should be able to call the rm alias" {
 	    { rm $testfilepath } | Should -Not -Throw
 
-	    Test-Path $testfilepath | Should -Be $false
+	    Test-Path $testfilepath | Should -BeFalse
 	}
 
 	It "Should be able to call the del alias" {
 	    { del $testfilepath } | Should -Not -Throw
 
-	    Test-Path $testfilepath | Should -Be $false
+	    Test-Path $testfilepath | Should -BeFalse
 	}
 
 	It "Should be able to call the erase alias" {
 	    { erase $testfilepath } | Should -Not -Throw
 
-	    Test-Path $testfilepath | Should -Be $false
+	    Test-Path $testfilepath | Should -BeFalse
 	}
 
 	It "Should be able to call the ri alias" {
 	    { ri $testfilepath } | Should -Not -Throw
 
-	    Test-Path $testfilepath | Should -Be $false
+	    Test-Path $testfilepath | Should -BeFalse
 	}
 
 	It "Should not be able to remove a read-only document without using the force switch" {
@@ -56,13 +56,13 @@ Describe "Remove-Item" -Tags "CI" {
 	    { Remove-Item $testfilepath -ErrorAction SilentlyContinue } | Should -Not -Throw
 
 	    # validate
-	    Test-Path $testfilepath | Should -Be $true
+	    Test-Path $testfilepath | Should -BeTrue
 
 	    # remove using the -force switch on the readonly object
 	    Remove-Item  $testfilepath -Force
 
 	    # Validate
-	    Test-Path $testfilepath | Should -Be $false
+	    Test-Path $testfilepath | Should -BeFalse
 	}
 
 	It "Should be able to remove all files matching a regular expression with the include switch" {
@@ -75,15 +75,15 @@ Describe "Remove-Item" -Tags "CI" {
 	    # Delete the specific string
 	    Remove-Item (Join-Path -Path $testpath -ChildPath "*") -Include file*.txt
 	    # validate that the string under test was deleted, and the nonmatching strings still exist
-	    Test-path (Join-Path -Path $testpath -ChildPath file1.txt) | Should -Be $false
-	    Test-path (Join-Path -Path $testpath -ChildPath file2.txt) | Should -Be $false
-	    Test-path (Join-Path -Path $testpath -ChildPath file3.txt) | Should -Be $false
-	    Test-Path $testfilepath  | Should -Be $true
+	    Test-path (Join-Path -Path $testpath -ChildPath file1.txt) | Should -BeFalse
+	    Test-path (Join-Path -Path $testpath -ChildPath file2.txt) | Should -BeFalse
+	    Test-path (Join-Path -Path $testpath -ChildPath file3.txt) | Should -BeFalse
+	    Test-Path $testfilepath  | Should -BeTrue
 
 	    # Delete the non-matching strings
 	    Remove-Item $testfilepath
 
-	    Test-Path $testfilepath  | Should -Be $false
+	    Test-Path $testfilepath  | Should -BeFalse
 	}
 
 	It "Should be able to not remove any files matching a regular expression with the exclude switch" {
@@ -98,16 +98,16 @@ Describe "Remove-Item" -Tags "CI" {
 	    Remove-Item (Join-Path -Path $testpath -ChildPath "file*") -Exclude *.wav -Include *.txt
 
 	    # validate that the string under test was deleted, and the nonmatching strings still exist
-	    Test-Path (Join-Path -Path $testpath -ChildPath file1.wav) | Should -Be $true
-	    Test-Path (Join-Path -Path $testpath -ChildPath file2.wav) | Should -Be $true
-	    Test-Path (Join-Path -Path $testpath -ChildPath file1.txt) | Should -Be $false
+	    Test-Path (Join-Path -Path $testpath -ChildPath file1.wav) | Should -BeTrue
+	    Test-Path (Join-Path -Path $testpath -ChildPath file2.wav) | Should -BeTrue
+	    Test-Path (Join-Path -Path $testpath -ChildPath file1.txt) | Should -BeFalse
 
 	    # Delete the non-matching strings
 	    Remove-Item (Join-Path -Path $testpath -ChildPath file1.wav)
 	    Remove-Item (Join-Path -Path $testpath -ChildPath file2.wav)
 
-	    Test-Path (Join-Path -Path $testpath -ChildPath file1.wav) | Should -Be $false
-	    Test-Path (Join-Path -Path $testpath -ChildPath file2.wav) | Should -Be $false
+	    Test-Path (Join-Path -Path $testpath -ChildPath file1.wav) | Should -BeFalse
+	    Test-Path (Join-Path -Path $testpath -ChildPath file2.wav) | Should -BeFalse
 	}
     }
 
@@ -117,13 +117,13 @@ Describe "Remove-Item" -Tags "CI" {
 	BeforeEach {
 	    New-Item -Name "testdir" -Path $testpath -ItemType "directory" -Force
 
-	    Test-Path $testdirectory | Should -Be $true
+	    Test-Path $testdirectory | Should -BeTrue
 	}
 
 	It "Should be able to remove a directory" {
 	    { Remove-Item $testdirectory } | Should -Not -Throw
 
-	    Test-Path $testdirectory | Should -Be $false
+	    Test-Path $testdirectory | Should -BeFalse
 	}
 
 	It "Should be able to recursively delete subfolders" {
@@ -131,11 +131,11 @@ Describe "Remove-Item" -Tags "CI" {
 	    New-Item -Name $testfile -Path $testsubdirectory -ItemType "file" -Value "lorem ipsum"
 
 	    $complexDirectory = Join-Path -Path $testsubdirectory -ChildPath $testfile
-	    test-path $complexDirectory | Should -Be $true
+	    test-path $complexDirectory | Should -BeTrue
 
 	    { Remove-Item $testdirectory -Recurse} | Should -Not -Throw
 
-	    Test-Path $testdirectory | Should -Be $false
+	    Test-Path $testdirectory | Should -BeFalse
 	}
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Remove-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Remove-Item.Tests.ps1
@@ -8,44 +8,44 @@ Describe "Remove-Item" -Tags "CI" {
 	BeforeEach {
 	    New-Item -Name $testfile -Path $testpath -ItemType "file" -Value "lorem ipsum" -Force
 
-	    Test-Path $testfilepath | Should Be $true
+	    Test-Path $testfilepath | Should -Be $true
 
 	}
 
 	It "Should be able to be called on a regular file without error using the Path switch" {
-	    { Remove-Item -Path $testfilepath } | Should Not Throw
+	    { Remove-Item -Path $testfilepath } | Should -Not -Throw
 
-	    Test-Path $testfilepath | Should Be $false
+	    Test-Path $testfilepath | Should -Be $false
 	}
 
 	It "Should be able to be called on a file without the Path switch" {
-	    { Remove-Item $testfilepath } | Should Not Throw
+	    { Remove-Item $testfilepath } | Should -Not -Throw
 
-	    Test-Path $testfilepath | Should Be $false
+	    Test-Path $testfilepath | Should -Be $false
 	}
 
 	It "Should be able to call the rm alias" {
-	    { rm $testfilepath } | Should Not Throw
+	    { rm $testfilepath } | Should -Not -Throw
 
-	    Test-Path $testfilepath | Should Be $false
+	    Test-Path $testfilepath | Should -Be $false
 	}
 
 	It "Should be able to call the del alias" {
-	    { del $testfilepath } | Should Not Throw
+	    { del $testfilepath } | Should -Not -Throw
 
-	    Test-Path $testfilepath | Should Be $false
+	    Test-Path $testfilepath | Should -Be $false
 	}
 
 	It "Should be able to call the erase alias" {
-	    { erase $testfilepath } | Should Not Throw
+	    { erase $testfilepath } | Should -Not -Throw
 
-	    Test-Path $testfilepath | Should Be $false
+	    Test-Path $testfilepath | Should -Be $false
 	}
 
 	It "Should be able to call the ri alias" {
-	    { ri $testfilepath } | Should Not Throw
+	    { ri $testfilepath } | Should -Not -Throw
 
-	    Test-Path $testfilepath | Should Be $false
+	    Test-Path $testfilepath | Should -Be $false
 	}
 
 	It "Should not be able to remove a read-only document without using the force switch" {
@@ -53,16 +53,16 @@ Describe "Remove-Item" -Tags "CI" {
 	    Set-ItemProperty -Path $testfilepath -Name IsReadOnly -Value $true
 
 	    # attempt to remove the file
-	    { Remove-Item $testfilepath -ErrorAction SilentlyContinue } | Should Not Throw
+	    { Remove-Item $testfilepath -ErrorAction SilentlyContinue } | Should -Not -Throw
 
 	    # validate
-	    Test-Path $testfilepath | Should Be $true
+	    Test-Path $testfilepath | Should -Be $true
 
 	    # remove using the -force switch on the readonly object
 	    Remove-Item  $testfilepath -Force
 
 	    # Validate
-	    Test-Path $testfilepath | Should Be $false
+	    Test-Path $testfilepath | Should -Be $false
 	}
 
 	It "Should be able to remove all files matching a regular expression with the include switch" {
@@ -75,15 +75,15 @@ Describe "Remove-Item" -Tags "CI" {
 	    # Delete the specific string
 	    Remove-Item (Join-Path -Path $testpath -ChildPath "*") -Include file*.txt
 	    # validate that the string under test was deleted, and the nonmatching strings still exist
-	    Test-path (Join-Path -Path $testpath -ChildPath file1.txt) | Should Be $false
-	    Test-path (Join-Path -Path $testpath -ChildPath file2.txt) | Should Be $false
-	    Test-path (Join-Path -Path $testpath -ChildPath file3.txt) | Should Be $false
-	    Test-Path $testfilepath  | Should Be $true
+	    Test-path (Join-Path -Path $testpath -ChildPath file1.txt) | Should -Be $false
+	    Test-path (Join-Path -Path $testpath -ChildPath file2.txt) | Should -Be $false
+	    Test-path (Join-Path -Path $testpath -ChildPath file3.txt) | Should -Be $false
+	    Test-Path $testfilepath  | Should -Be $true
 
 	    # Delete the non-matching strings
 	    Remove-Item $testfilepath
 
-	    Test-Path $testfilepath  | Should Be $false
+	    Test-Path $testfilepath  | Should -Be $false
 	}
 
 	It "Should be able to not remove any files matching a regular expression with the exclude switch" {
@@ -98,16 +98,16 @@ Describe "Remove-Item" -Tags "CI" {
 	    Remove-Item (Join-Path -Path $testpath -ChildPath "file*") -Exclude *.wav -Include *.txt
 
 	    # validate that the string under test was deleted, and the nonmatching strings still exist
-	    Test-Path (Join-Path -Path $testpath -ChildPath file1.wav) | Should Be $true
-	    Test-Path (Join-Path -Path $testpath -ChildPath file2.wav) | Should Be $true
-	    Test-Path (Join-Path -Path $testpath -ChildPath file1.txt) | Should Be $false
+	    Test-Path (Join-Path -Path $testpath -ChildPath file1.wav) | Should -Be $true
+	    Test-Path (Join-Path -Path $testpath -ChildPath file2.wav) | Should -Be $true
+	    Test-Path (Join-Path -Path $testpath -ChildPath file1.txt) | Should -Be $false
 
 	    # Delete the non-matching strings
 	    Remove-Item (Join-Path -Path $testpath -ChildPath file1.wav)
 	    Remove-Item (Join-Path -Path $testpath -ChildPath file2.wav)
 
-	    Test-Path (Join-Path -Path $testpath -ChildPath file1.wav) | Should Be $false
-	    Test-Path (Join-Path -Path $testpath -ChildPath file2.wav) | Should Be $false
+	    Test-Path (Join-Path -Path $testpath -ChildPath file1.wav) | Should -Be $false
+	    Test-Path (Join-Path -Path $testpath -ChildPath file2.wav) | Should -Be $false
 	}
     }
 
@@ -117,13 +117,13 @@ Describe "Remove-Item" -Tags "CI" {
 	BeforeEach {
 	    New-Item -Name "testdir" -Path $testpath -ItemType "directory" -Force
 
-	    Test-Path $testdirectory | Should Be $true
+	    Test-Path $testdirectory | Should -Be $true
 	}
 
 	It "Should be able to remove a directory" {
-	    { Remove-Item $testdirectory } | Should Not Throw
+	    { Remove-Item $testdirectory } | Should -Not -Throw
 
-	    Test-Path $testdirectory | Should Be $false
+	    Test-Path $testdirectory | Should -Be $false
 	}
 
 	It "Should be able to recursively delete subfolders" {
@@ -131,11 +131,11 @@ Describe "Remove-Item" -Tags "CI" {
 	    New-Item -Name $testfile -Path $testsubdirectory -ItemType "file" -Value "lorem ipsum"
 
 	    $complexDirectory = Join-Path -Path $testsubdirectory -ChildPath $testfile
-	    test-path $complexDirectory | Should Be $true
+	    test-path $complexDirectory | Should -Be $true
 
-	    { Remove-Item $testdirectory -Recurse} | Should Not Throw
+	    { Remove-Item $testdirectory -Recurse} | Should -Not -Throw
 
-	    Test-Path $testdirectory | Should Be $false
+	    Test-Path $testdirectory | Should -Be $false
 	}
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Rename-Computer.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Rename-Computer.Tests.ps1
@@ -29,7 +29,7 @@ try
             Set-TesthookResult -testhookName $RenameResultName -value $defaultResultValue
             $newname = "mynewname"
             $result = Rename-Computer -ErrorAction Stop -ComputerName . -NewName "$newname" -Pass -WarningAction SilentlyContinue
-            $result.HasSucceeded | Should -Be $true
+            $result.HasSucceeded | Should -BeTrue
             $result.NewComputerName | Should -Be $newname
         }
 
@@ -47,7 +47,7 @@ try
             Set-TesthookResult -testhookName $RenameResultName -value $defaultResultValue
             $newname = "mynewname"
             $result = Rename-Computer -ErrorAction Stop -ComputerName . -NewName "$newname" -Pass -WarningAction SilentlyContinue -WarningVariable WarnVar -Restart
-            $result.HasSucceeded | Should -Be $true
+            $result.HasSucceeded | Should -BeTrue
             $result.NewComputerName | Should -Be $newname
             $WarnVar | Should -BeNullOrEmpty
         }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Rename-Computer.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Rename-Computer.Tests.ps1
@@ -29,8 +29,8 @@ try
             Set-TesthookResult -testhookName $RenameResultName -value $defaultResultValue
             $newname = "mynewname"
             $result = Rename-Computer -ErrorAction Stop -ComputerName . -NewName "$newname" -Pass -WarningAction SilentlyContinue
-            $result.HasSucceeded | should be $true
-            $result.NewComputerName | should be $newname
+            $result.HasSucceeded | Should -Be $true
+            $result.NewComputerName | Should -Be $newname
         }
 
         # we can't really look for the string "reboot" as it will change
@@ -40,16 +40,16 @@ try
             Set-TesthookResult -testhookName $RenameResultName -value $defaultResultValue
             $newname = "mynewname"
             $result = Rename-Computer -ErrorAction Stop -ComputerName . -NewName "$newname" -Pass -WarningAction SilentlyContinue -WarningVariable WarnVar
-            $WarnVar.Message | should match $result.OldComputerName
+            $WarnVar.Message | Should -match $result.OldComputerName
         }
 
         It "Should not produce a reboot warning when renaming a computer with the reboot flag" {
             Set-TesthookResult -testhookName $RenameResultName -value $defaultResultValue
             $newname = "mynewname"
             $result = Rename-Computer -ErrorAction Stop -ComputerName . -NewName "$newname" -Pass -WarningAction SilentlyContinue -WarningVariable WarnVar -Restart
-            $result.HasSucceeded | should be $true
-            $result.NewComputerName | should be $newname
-            $WarnVar | should BeNullOrEmpty
+            $result.HasSucceeded | Should -Be $true
+            $result.NewComputerName | Should -Be $newname
+            $WarnVar | Should -BeNullOrEmpty
         }
 
         Context "Rename-Computer Error Conditions" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Rename-Computer.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Rename-Computer.Tests.ps1
@@ -30,7 +30,7 @@ try
             $newname = "mynewname"
             $result = Rename-Computer -ErrorAction Stop -ComputerName . -NewName "$newname" -Pass -WarningAction SilentlyContinue
             $result.HasSucceeded | Should -BeTrue
-            $result.NewComputerName | Should -Be $newname
+            $result.NewComputerName | Should -BeExactly $newname
         }
 
         # we can't really look for the string "reboot" as it will change
@@ -40,7 +40,7 @@ try
             Set-TesthookResult -testhookName $RenameResultName -value $defaultResultValue
             $newname = "mynewname"
             $result = Rename-Computer -ErrorAction Stop -ComputerName . -NewName "$newname" -Pass -WarningAction SilentlyContinue -WarningVariable WarnVar
-            $WarnVar.Message | Should -match $result.OldComputerName
+            $WarnVar.Message | Should -Match $result.OldComputerName
         }
 
         It "Should not produce a reboot warning when renaming a computer with the reboot flag" {
@@ -48,7 +48,7 @@ try
             $newname = "mynewname"
             $result = Rename-Computer -ErrorAction Stop -ComputerName . -NewName "$newname" -Pass -WarningAction SilentlyContinue -WarningVariable WarnVar -Restart
             $result.HasSucceeded | Should -BeTrue
-            $result.NewComputerName | Should -Be $newname
+            $result.NewComputerName | Should -BeExactly $newname
             $WarnVar | Should -BeNullOrEmpty
         }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Rename-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Rename-Item.Tests.ps1
@@ -9,8 +9,8 @@ Describe "Rename-Item tests" -Tag "CI" {
     }
     It "Rename-Item will rename a file" {
         Rename-Item $source $target
-        test-path $source | Should -Be $false
-        test-path $target | Should -Be $true
+        test-path $source | Should -BeFalse
+        test-path $target | Should -BeTrue
         "$target" | Should -FileContentMatchExactly "This is content"
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Rename-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Rename-Item.Tests.ps1
@@ -9,8 +9,8 @@ Describe "Rename-Item tests" -Tag "CI" {
     }
     It "Rename-Item will rename a file" {
         Rename-Item $source $target
-        test-path $source | Should be $false
-        test-path $target | Should be $true
-        "$target" | Should FileContentMatchExactly "This is content"
+        test-path $source | Should -Be $false
+        test-path $target | Should -Be $true
+        "$target" | Should -FileContentMatchExactly "This is content"
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Resolve-Path.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Resolve-Path.Tests.ps1
@@ -19,7 +19,7 @@ Describe "Resolve-Path returns proper path" -Tag "CI" {
     }
     It "Resolve-Path -Path should return correct drive path" {
         $result = Resolve-Path -Path "TestDrive:\\\\\"
-        ($result.Path.TrimEnd('/\')) | Should -BeiExactly "TestDrive:"
+        ($result.Path.TrimEnd('/\')) | Should -BeExactly "TestDrive:"
     }
     It "Resolve-Path -LiteralPath should return correct drive path" {
         $result = Resolve-Path -LiteralPath "TestDrive:\\\\\"

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Resolve-Path.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Resolve-Path.Tests.ps1
@@ -2,11 +2,11 @@
 # Licensed under the MIT License.
 Describe "Resolve-Path returns proper path" -Tag "CI" {
     It "Resolve-Path returns resolved paths" {
-        Resolve-Path $TESTDRIVE | Should -Be "$TESTDRIVE"
+        Resolve-Path $TESTDRIVE | Should -BeExactly "$TESTDRIVE"
     }
     It "Resolve-Path handles provider qualified paths" {
         $result = Resolve-Path Filesystem::$TESTDRIVE
-        $result.providerpath | Should -Be "$TESTDRIVE"
+        $result.providerpath | Should -BeExactly "$TESTDRIVE"
     }
     It "Resolve-Path provides proper error on invalid location" {
         try {
@@ -14,15 +14,15 @@ Describe "Resolve-Path returns proper path" -Tag "CI" {
             throw "execution OK"
         }
         catch {
-            $_.fullyqualifiederrorid | Should -Be "PathNotFound,Microsoft.PowerShell.Commands.ResolvePathCommand"
+            $_.fullyqualifiederrorid | Should -BeExactly "PathNotFound,Microsoft.PowerShell.Commands.ResolvePathCommand"
         }
     }
     It "Resolve-Path -Path should return correct drive path" {
         $result = Resolve-Path -Path "TestDrive:\\\\\"
-        ($result.Path.TrimEnd('/\')) | Should -Be "TestDrive:"
+        ($result.Path.TrimEnd('/\')) | Should -BeiExactly "TestDrive:"
     }
     It "Resolve-Path -LiteralPath should return correct drive path" {
         $result = Resolve-Path -LiteralPath "TestDrive:\\\\\"
-        ($result.Path.TrimEnd('/\')) | Should -Be "TestDrive:"
+        ($result.Path.TrimEnd('/\')) | Should -BeExactly "TestDrive:"
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Resolve-Path.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Resolve-Path.Tests.ps1
@@ -2,11 +2,11 @@
 # Licensed under the MIT License.
 Describe "Resolve-Path returns proper path" -Tag "CI" {
     It "Resolve-Path returns resolved paths" {
-        Resolve-Path $TESTDRIVE | Should be "$TESTDRIVE"
+        Resolve-Path $TESTDRIVE | Should -Be "$TESTDRIVE"
     }
     It "Resolve-Path handles provider qualified paths" {
         $result = Resolve-Path Filesystem::$TESTDRIVE
-        $result.providerpath | should be "$TESTDRIVE"
+        $result.providerpath | Should -Be "$TESTDRIVE"
     }
     It "Resolve-Path provides proper error on invalid location" {
         try {
@@ -14,15 +14,15 @@ Describe "Resolve-Path returns proper path" -Tag "CI" {
             throw "execution OK"
         }
         catch {
-            $_.fullyqualifiederrorid | should be "PathNotFound,Microsoft.PowerShell.Commands.ResolvePathCommand"
+            $_.fullyqualifiederrorid | Should -Be "PathNotFound,Microsoft.PowerShell.Commands.ResolvePathCommand"
         }
     }
     It "Resolve-Path -Path should return correct drive path" {
         $result = Resolve-Path -Path "TestDrive:\\\\\"
-        ($result.Path.TrimEnd('/\')) | Should Be "TestDrive:"
+        ($result.Path.TrimEnd('/\')) | Should -Be "TestDrive:"
     }
     It "Resolve-Path -LiteralPath should return correct drive path" {
         $result = Resolve-Path -LiteralPath "TestDrive:\\\\\"
-        ($result.Path.TrimEnd('/\')) | Should Be "TestDrive:"
+        ($result.Path.TrimEnd('/\')) | Should -Be "TestDrive:"
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Resolve-Path.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Resolve-Path.Tests.ps1
@@ -10,7 +10,7 @@ Describe "Resolve-Path returns proper path" -Tag "CI" {
     }
     It "Resolve-Path provides proper error on invalid location" {
         try {
-            Resolve-Path $TESTDRIVE/this.directory.is.invalid -ea stop
+            Resolve-Path $TESTDRIVE/this.directory.is.invalid -ErrorAction Stop
             throw "execution OK"
         }
         catch {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Resolve-Path.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Resolve-Path.Tests.ps1
@@ -9,13 +9,7 @@ Describe "Resolve-Path returns proper path" -Tag "CI" {
         $result.providerpath | Should -BeExactly "$TESTDRIVE"
     }
     It "Resolve-Path provides proper error on invalid location" {
-        try {
-            Resolve-Path $TESTDRIVE/this.directory.is.invalid -ErrorAction Stop
-            throw "execution OK"
-        }
-        catch {
-            $_.fullyqualifiederrorid | Should -BeExactly "PathNotFound,Microsoft.PowerShell.Commands.ResolvePathCommand"
-        }
+        { Resolve-Path $TESTDRIVE/this.directory.is.invalid -ErrorAction Stop } | Should -Throw -ErrorId "PathNotFound,Microsoft.PowerShell.Commands.ResolvePathCommand"
     }
     It "Resolve-Path -Path should return correct drive path" {
         $result = Resolve-Path -Path "TestDrive:\\\\\"

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Restart-Computer.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Restart-Computer.Tests.ps1
@@ -26,19 +26,19 @@ try
 
         It "Should restart the local computer" {
             Set-TesthookResult -testhookName $restartTesthookResultName -value $defaultResultValue
-            Restart-Computer -ErrorAction Stop| Should BeNullOrEmpty
+            Restart-Computer -ErrorAction Stop| Should -BeNullOrEmpty
         }
 
         It "Should support -computer parameter" {
             Set-TesthookResult -testhookName $restartTesthookResultName -value $defaultResultValue
             $computerNames = "localhost","${env:COMPUTERNAME}"
-            Restart-Computer -Computer $computerNames -ErrorAction Stop| Should BeNullOrEmpty
+            Restart-Computer -Computer $computerNames -ErrorAction Stop| Should -BeNullOrEmpty
         }
 
         It "Should support WsmanAuthentication types" {
             $authChoices = "Default","Basic","Negotiate","CredSSP","Digest","Kerberos"
             foreach ( $auth in $authChoices ) {
-                Restart-Computer -WsmanAuthentication $auth | Should BeNullOrEmpty
+                Restart-Computer -WsmanAuthentication $auth | Should -BeNullOrEmpty
             }
         }
 
@@ -55,14 +55,14 @@ try
                     $pPref = $ProgressPreference
                     $ProgressPreference="SilentlyContinue"
                     $duration = Measure-Command {
-                        Restart-Computer -computer localhost -Wait -Timeout $timeout -ErrorAction stop | Should BeNullOrEmpty
+                        Restart-Computer -computer localhost -Wait -Timeout $timeout -ErrorAction stop | Should -BeNullOrEmpty
                     }
                 }
                 finally
                 {
                     $ProgressPreference=$pPref
                 }
-                $duration.TotalSeconds | Should BeGreaterThan $timeout
+                $duration.TotalSeconds | Should -BeGreaterThan $timeout
             }
             finally
             {
@@ -74,7 +74,7 @@ try
             It "Should return the proper error when it occurs" {
                 Set-TesthookResult -testhookName $restartTesthookResultName -value 0x300000
                 Restart-Computer -ErrorVariable RestartError 2>$null
-                $RestartError.Exception.Message | Should match 0x300000
+                $RestartError.Exception.Message | Should -Match 0x300000
             }
 
             It "Should produce an error when 'Delay' is specified" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Restart-Computer.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Restart-Computer.Tests.ps1
@@ -55,7 +55,7 @@ try
                     $pPref = $ProgressPreference
                     $ProgressPreference="SilentlyContinue"
                     $duration = Measure-Command {
-                        Restart-Computer -computer localhost -Wait -Timeout $timeout -ErrorAction stop | Should -BeNullOrEmpty
+                        Restart-Computer -computer localhost -Wait -Timeout $timeout -ErrorAction Stop | Should -BeNullOrEmpty
                     }
                 }
                 finally

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Content.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Content.Tests.ps1
@@ -12,7 +12,7 @@ Describe "Set-Content cmdlet tests" -Tags "CI" {
         $testfile = "${TESTDRIVE}\bfile.txt"
         "test" | Set-Content $testfile
         $result = Get-Content -AsByteStream -Encoding Unicode -Path $testfile -WarningVariable contentWarning *>$null
-        $contentWarning.Message | Should Match "-AsByteStream"
+        $contentWarning.Message | Should -Match "-AsByteStream"
     }
 
     Context "Set-Content should create a file if it does not exist" {
@@ -22,7 +22,7 @@ Describe "Set-Content cmdlet tests" -Tags "CI" {
         It "should create a file if it does not exist" {
             Set-Content -Path $filePath1 -Value "$file1"
             $result = Get-Content -Path $filePath1
-            $result| Should be "$file1"
+            $result| Should -Be "$file1"
         }
     }
     Context "Set-Content/Get-Content should set/get the content of an exisiting file" {
@@ -32,27 +32,27 @@ Describe "Set-Content cmdlet tests" -Tags "CI" {
         It "should set-Content of testdrive\$file1" {
             Set-Content -Path $filePath1 -Value "ExpectedContent"
             $result = Get-Content -Path $filePath1
-            $result| Should be "ExpectedContent"
+            $result| Should -Be "ExpectedContent"
         }
         It "should return expected string from testdrive\$file1" {
             $result = Get-Content -Path $filePath1
-            $result | Should BeExactly "ExpectedContent"
+            $result | Should -BeExactly "ExpectedContent"
         }
         It "should Set-Content to testdrive\dynamicfile.txt with dynamic parameters" {
             Set-Content -Path $testdrive\dynamicfile.txt -Value "ExpectedContent"
             $result = Get-Content -Path $testdrive\dynamicfile.txt
-            $result| Should BeExactly "ExpectedContent"
+            $result| Should -BeExactly "ExpectedContent"
         }
         It "should return expected string from testdrive\dynamicfile.txt" {
             $result = Get-Content -Path $testdrive\dynamicfile.txt
-            $result | Should BeExactly "ExpectedContent"
+            $result | Should -BeExactly "ExpectedContent"
         }
         It "should remove existing content from testdrive\$file1 when the -Value is `$null" {
             $AsItWas=Get-Content $filePath1
-            $AsItWas |Should BeExactly "ExpectedContent"
+            $AsItWas |Should -BeExactly "ExpectedContent"
             Set-Content -Path $filePath1 -Value $null -EA stop
             $AsItIs=Get-Content $filePath1
-            $AsItIs| Should Not Be $AsItWas
+            $AsItIs| Should -Not -Be $AsItWas
         }
         It "should throw 'ParameterArgumentValidationErrorNullNotAllowed' when -Path is `$null" {
             try {
@@ -60,7 +60,7 @@ Describe "Set-Content cmdlet tests" -Tags "CI" {
                 Throw "Previous statement unexpectedly succeeded..."
             }
             catch {
-                $_.FullyQualifiedErrorId | Should Be "ParameterArgumentValidationErrorNullNotAllowed,Microsoft.PowerShell.Commands.SetContentCommand"
+                $_.FullyQualifiedErrorId | Should -Be "ParameterArgumentValidationErrorNullNotAllowed,Microsoft.PowerShell.Commands.SetContentCommand"
             }
         }
         It "should throw 'ParameterArgumentValidationErrorNullNotAllowed' when -Path is `$()" {
@@ -69,7 +69,7 @@ Describe "Set-Content cmdlet tests" -Tags "CI" {
                 Throw "Previous statement unexpectedly succeeded..."
             }
             catch {
-                $_.FullyQualifiedErrorId | Should Be "ParameterArgumentValidationErrorNullNotAllowed,Microsoft.PowerShell.Commands.SetContentCommand"
+                $_.FullyQualifiedErrorId | Should -Be "ParameterArgumentValidationErrorNullNotAllowed,Microsoft.PowerShell.Commands.SetContentCommand"
             }
         }
         It "should throw 'PSNotSupportedException' when you Set-Content to an unsupported provider" -skip:$skipRegistry {
@@ -78,16 +78,16 @@ Describe "Set-Content cmdlet tests" -Tags "CI" {
                 Throw "Previous statement unexpectedly succeeded..."
             }
             catch {
-                $_.FullyQualifiedErrorId | Should Be "NotSupported,Microsoft.PowerShell.Commands.SetContentCommand"
+                $_.FullyQualifiedErrorId | Should -Be "NotSupported,Microsoft.PowerShell.Commands.SetContentCommand"
             }
         }
         #[BugId(BugDatabase.WindowsOutOfBandReleases, 9058182)]
         It "should be able to pass multiple [string]`$objects to Set-Content through the pipeline to output a dynamic Path file" {
             "hello","world"|Set-Content $testdrive\dynamicfile2.txt
             $result=Get-Content $testdrive\dynamicfile2.txt
-            $result.length |Should be 2
-            $result[0]     |Should be "hello"
-            $result[1]     |Should be "world"
+            $result.length |Should -Be 2
+            $result[0]     |Should -Be "hello"
+            $result[1]     |Should -Be "world"
         }
     }
 }
@@ -109,7 +109,7 @@ Describe "Set-Content should work for PSDrive with UNC path as root" -Tags @('CI
             New-PSDrive -Name Foo -Root \\localhost\testshare -PSProvider FileSystem
             Set-Content -Path Foo:\$file1 -Value "$file1"
             $result = Get-Content -Path Foo:\$file1
-            $result| Should be "$file1"
+            $result| Should -Be "$file1"
         }
         finally
         {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Content.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Content.Tests.ps1
@@ -50,13 +50,13 @@ Describe "Set-Content cmdlet tests" -Tags "CI" {
         It "should remove existing content from testdrive\$file1 when the -Value is `$null" {
             $AsItWas=Get-Content $filePath1
             $AsItWas |Should -BeExactly "ExpectedContent"
-            Set-Content -Path $filePath1 -Value $null -EA stop
+            Set-Content -Path $filePath1 -Value $null -ErrorAction Stop
             $AsItIs=Get-Content $filePath1
             $AsItIs| Should -Not -Be $AsItWas
         }
         It "should throw 'ParameterArgumentValidationErrorNullNotAllowed' when -Path is `$null" {
             try {
-                Set-Content -Path $null -Value "ShouldNotWorkBecausePathIsNull" -EA stop
+                Set-Content -Path $null -Value "ShouldNotWorkBecausePathIsNull" -ErrorAction Stop
                 Throw "Previous statement unexpectedly succeeded..."
             }
             catch {
@@ -65,7 +65,7 @@ Describe "Set-Content cmdlet tests" -Tags "CI" {
         }
         It "should throw 'ParameterArgumentValidationErrorNullNotAllowed' when -Path is `$()" {
             try {
-                Set-Content -Path $() -Value "ShouldNotWorkBecausePathIsInvalid" -EA stop
+                Set-Content -Path $() -Value "ShouldNotWorkBecausePathIsInvalid" -ErrorAction Stop
                 Throw "Previous statement unexpectedly succeeded..."
             }
             catch {
@@ -74,7 +74,7 @@ Describe "Set-Content cmdlet tests" -Tags "CI" {
         }
         It "should throw 'PSNotSupportedException' when you Set-Content to an unsupported provider" -skip:$skipRegistry {
             try {
-                Set-Content -Path HKLM:\\software\\microsoft -Value "ShouldNotWorkBecausePathIsUnsupported" -EA stop
+                Set-Content -Path HKLM:\\software\\microsoft -Value "ShouldNotWorkBecausePathIsUnsupported" -ErrorAction Stop
                 Throw "Previous statement unexpectedly succeeded..."
             }
             catch {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Content.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Content.Tests.ps1
@@ -55,31 +55,13 @@ Describe "Set-Content cmdlet tests" -Tags "CI" {
             $AsItIs| Should -Not -Be $AsItWas
         }
         It "should throw 'ParameterArgumentValidationErrorNullNotAllowed' when -Path is `$null" {
-            try {
-                Set-Content -Path $null -Value "ShouldNotWorkBecausePathIsNull" -ErrorAction Stop
-                Throw "Previous statement unexpectedly succeeded..."
-            }
-            catch {
-                $_.FullyQualifiedErrorId | Should -Be "ParameterArgumentValidationErrorNullNotAllowed,Microsoft.PowerShell.Commands.SetContentCommand"
-            }
+            { Set-Content -Path $null -Value "ShouldNotWorkBecausePathIsNull" -ErrorAction Stop } | Should -Throw -ErrorId "ParameterArgumentValidationErrorNullNotAllowed,Microsoft.PowerShell.Commands.SetContentCommand"
         }
         It "should throw 'ParameterArgumentValidationErrorNullNotAllowed' when -Path is `$()" {
-            try {
-                Set-Content -Path $() -Value "ShouldNotWorkBecausePathIsInvalid" -ErrorAction Stop
-                Throw "Previous statement unexpectedly succeeded..."
-            }
-            catch {
-                $_.FullyQualifiedErrorId | Should -Be "ParameterArgumentValidationErrorNullNotAllowed,Microsoft.PowerShell.Commands.SetContentCommand"
-            }
+            { Set-Content -Path $() -Value "ShouldNotWorkBecausePathIsInvalid" -ErrorAction Stop } | Should -Throw -ErrorId "ParameterArgumentValidationErrorNullNotAllowed,Microsoft.PowerShell.Commands.SetContentCommand"
         }
         It "should throw 'PSNotSupportedException' when you Set-Content to an unsupported provider" -skip:$skipRegistry {
-            try {
-                Set-Content -Path HKLM:\\software\\microsoft -Value "ShouldNotWorkBecausePathIsUnsupported" -ErrorAction Stop
-                Throw "Previous statement unexpectedly succeeded..."
-            }
-            catch {
-                $_.FullyQualifiedErrorId | Should -Be "NotSupported,Microsoft.PowerShell.Commands.SetContentCommand"
-            }
+            { Set-Content -Path HKLM:\\software\\microsoft -Value "ShouldNotWorkBecausePathIsUnsupported" -ErrorAction Stop } | Should -Throw -ErrorId "NotSupported,Microsoft.PowerShell.Commands.SetContentCommand"
         }
         #[BugId(BugDatabase.WindowsOutOfBandReleases, 9058182)]
         It "should be able to pass multiple [string]`$objects to Set-Content through the pipeline to output a dynamic Path file" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Content.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Content.Tests.ps1
@@ -85,9 +85,9 @@ Describe "Set-Content cmdlet tests" -Tags "CI" {
         It "should be able to pass multiple [string]`$objects to Set-Content through the pipeline to output a dynamic Path file" {
             "hello","world"|Set-Content $testdrive\dynamicfile2.txt
             $result=Get-Content $testdrive\dynamicfile2.txt
-            $result.length |Should -Be 2
-            $result[0]     |Should -Be "hello"
-            $result[1]     |Should -Be "world"
+            $result.length | Should -Be 2
+            $result[0]     | Should -BeExactly "hello"
+            $result[1]     | Should -BeExactly "world"
         }
     }
 }
@@ -109,7 +109,7 @@ Describe "Set-Content should work for PSDrive with UNC path as root" -Tags @('CI
             New-PSDrive -Name Foo -Root \\localhost\testshare -PSProvider FileSystem
             Set-Content -Path Foo:\$file1 -Value "$file1"
             $result = Get-Content -Path Foo:\$file1
-            $result| Should -Be "$file1"
+            $result| Should -BeExactly "$file1"
         }
         finally
         {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Item.Tests.ps1
@@ -1,10 +1,10 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 Describe "Set-Item" -Tag "CI" {
-    $testCases = @{ Path = "variable:SetItemTestCase"; Value = "TestData"; Validate = { $SetItemTestCase | Should be "TestData" }; Reset = {remove-item variable:SetItemTestCase} },
-        @{ Path = "alias:SetItemTestCase"; Value = "Get-Alias"; Validate = { (Get-Alias SetItemTestCase).Definition | should be "Get-Alias"}; Reset = { remove-item alias:SetItemTestCase } },
-        @{ Path = "function:SetItemTestCase"; Value = { 1 }; Validate = { SetItemTestCase | should be 1 }; Reset = { remove-item function:SetItemTestCase } },
-        @{ Path = "env:SetItemTestCase"; Value = { 1 }; Validate = { $env:SetItemTestCase | should be 1 }; Reset = { remove-item env:SetItemTestCase } }
+    $testCases = @{ Path = "variable:SetItemTestCase"; Value = "TestData"; Validate = { $SetItemTestCase | Should -Be "TestData" }; Reset = {remove-item variable:SetItemTestCase} },
+        @{ Path = "alias:SetItemTestCase"; Value = "Get-Alias"; Validate = { (Get-Alias SetItemTestCase).Definition | Should -Be "Get-Alias"}; Reset = { remove-item alias:SetItemTestCase } },
+        @{ Path = "function:SetItemTestCase"; Value = { 1 }; Validate = { SetItemTestCase | Should -Be 1 }; Reset = { remove-item function:SetItemTestCase } },
+        @{ Path = "env:SetItemTestCase"; Value = { 1 }; Validate = { $env:SetItemTestCase | Should -Be 1 }; Reset = { remove-item env:SetItemTestCase } }
 
     It "Set-Item should be able to handle <Path>" -TestCase $testCases {
         param ( $Path, $Value, $Validate, $Reset )

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Location.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Location.Tests.ps1
@@ -31,7 +31,7 @@ Describe "Set-Location" -Tags "CI" {
     It "Should have the correct current location when using the set-location cmdlet" {
         Set-Location $startDirectory
 
-        $(Get-Location).Path | Should -Be $startDirectory.Path
+        $(Get-Location).Path | Should -BeExactly $startDirectory.Path
     }
 
     It "Should be able to use the Path switch" {
@@ -58,13 +58,13 @@ Describe "Set-Location" -Tags "CI" {
         It 'Should go to $env:HOME when Set-Location run with no arguments from FileSystem provider' {
             Set-Location 'TestDrive:\'
             Set-Location
-            (Get-Location).Path | Should -Be (Get-PSProvider FileSystem).Home
+            (Get-Location).Path | Should -BeExactly (Get-PSProvider FileSystem).Home
         }
 
         It 'Should go to $env:HOME when Set-Location run with no arguments from Env: provider' {
             Set-Location 'Env:'
             Set-Location
-            (Get-Location).Path | Should -Be (Get-PSProvider FileSystem).Home
+            (Get-Location).Path | Should -BeExactly (Get-PSProvider FileSystem).Home
         }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Location.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Location.Tests.ps1
@@ -20,27 +20,27 @@ Describe "Set-Location" -Tags "CI" {
     }
 
     It "Should be able to be called without error" {
-        { Set-Location $target }    | Should Not Throw
+        { Set-Location $target }    | Should -Not -Throw
     }
 
     It "Should be able to be called on different providers" {
-        { Set-Location alias: } | Should Not Throw
-        { Set-Location env: }   | Should Not Throw
+        { Set-Location alias: } | Should -Not -Throw
+        { Set-Location env: }   | Should -Not -Throw
     }
 
     It "Should have the correct current location when using the set-location cmdlet" {
         Set-Location $startDirectory
 
-        $(Get-Location).Path | Should Be $startDirectory.Path
+        $(Get-Location).Path | Should -Be $startDirectory.Path
     }
 
     It "Should be able to use the Path switch" {
-        { Set-Location -Path $target } | Should Not Throw
+        { Set-Location -Path $target } | Should -Not -Throw
     }
 
     It "Should generate a pathinfo object when using the Passthru switch" {
         $result = Set-Location $target -PassThru
-        $result | Should BeOfType System.Management.Automation.PathInfo
+        $result | Should -BeOfType System.Management.Automation.PathInfo
     }
 
     It "Should accept path containing wildcard characters" {
@@ -50,7 +50,7 @@ Describe "Set-Location" -Tags "CI" {
 
         Set-Location $TestDrive
         Set-Location -Path "[ab]a"
-        $(Get-Location).Path | Should BeExactly $testPath.FullName
+        $(Get-Location).Path | Should -BeExactly $testPath.FullName
     }
 
     Context 'Set-Location with no arguments' {
@@ -58,13 +58,13 @@ Describe "Set-Location" -Tags "CI" {
         It 'Should go to $env:HOME when Set-Location run with no arguments from FileSystem provider' {
             Set-Location 'TestDrive:\'
             Set-Location
-            (Get-Location).Path | Should Be (Get-PSProvider FileSystem).Home
+            (Get-Location).Path | Should -Be (Get-PSProvider FileSystem).Home
         }
 
         It 'Should go to $env:HOME when Set-Location run with no arguments from Env: provider' {
             Set-Location 'Env:'
             Set-Location
-            (Get-Location).Path | Should Be (Get-PSProvider FileSystem).Home
+            (Get-Location).Path | Should -Be (Get-PSProvider FileSystem).Home
         }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Service.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Service.Tests.ps1
@@ -45,10 +45,10 @@ Describe "Set/New/Remove-Service cmdlet tests" -Tags "Feature", "RequireAdminOnW
         }
         $setServiceCommand.$parameter = $value
         if ($expectedNull -eq $true) {
-            $setServiceCommand.$parameter | Should BeNullOrEmpty
+            $setServiceCommand.$parameter | Should -BeNullOrEmpty
         }
         else {
-            $setServiceCommand.$parameter | Should Be $value
+            $setServiceCommand.$parameter | Should -Be $value
         }
     }
 
@@ -81,10 +81,10 @@ Describe "Set/New/Remove-Service cmdlet tests" -Tags "Feature", "RequireAdminOnW
                 $expected = $value
             }
             if ($parameter -eq "StartupType") {
-                $updatedService.StartMode | Should Be $expected
+                $updatedService.StartMode | Should -Be $expected
             }
             else {
-                $updatedService.$parameter | Should Be $expected
+                $updatedService.$parameter | Should -Be $expected
             }
         }
         finally {
@@ -96,7 +96,7 @@ Describe "Set/New/Remove-Service cmdlet tests" -Tags "Feature", "RequireAdminOnW
             }
             $setServiceCommand.Invoke()
             $updatedService = Get-CimInstance -ClassName Win32_Service -Filter "Name='spooler'"
-            $updatedService.$parameter | Should Be $currentService.$parameter
+            $updatedService.$parameter | Should -Be $currentService.$parameter
         }
     }
 
@@ -119,7 +119,7 @@ Describe "Set/New/Remove-Service cmdlet tests" -Tags "Feature", "RequireAdminOnW
 
         $newServiceCommand = [Microsoft.PowerShell.Commands.NewServiceCommand]::new()
         $newServiceCommand.$parameter = $value
-        $newServiceCommand.$parameter | Should Be $value
+        $newServiceCommand.$parameter | Should -Be $value
     }
 
     It "Set-Service can change credentials of a service" {
@@ -139,14 +139,14 @@ Describe "Set/New/Remove-Service cmdlet tests" -Tags "Feature", "RequireAdminOnW
                 Credential     = $creds
             }
             $service = New-Service @parameters
-            $service | Should Not BeNullOrEmpty
+            $service | Should -Not -BeNullOrEmpty
             $service = Get-CimInstance Win32_Service -Filter "name='$servicename'"
-            $service.StartName | Should BeExactly $creds.UserName
+            $service.StartName | Should -BeExactly $creds.UserName
 
             $creds = [pscredential]::new(".\$endUsername", $password)
             Set-Service -Name $servicename -Credential $creds
             $service = Get-CimInstance Win32_Service -Filter "name='$servicename'"
-            $service.StartName | Should BeExactly $creds.UserName
+            $service.StartName | Should -BeExactly $creds.UserName
         }
         finally {
             Get-CimInstance Win32_Service -Filter "name='$servicename'" | Remove-CimInstance -ErrorAction SilentlyContinue
@@ -174,11 +174,11 @@ Describe "Set/New/Remove-Service cmdlet tests" -Tags "Feature", "RequireAdminOnW
                 $parameters += @{displayname = $displayname}
             }
             $service = New-Service @parameters
-            $service | Should Not BeNullOrEmpty
+            $service | Should -Not -BeNullOrEmpty
             $service = Get-CimInstance Win32_Service -Filter "name='$name'"
-            $service | Should Not BeNullOrEmpty
-            $service.Name | Should Be $name
-            $service.Description | Should Be $description
+            $service | Should -Not -BeNullOrEmpty
+            $service.Name | Should -Be $name
+            $service.Description | Should -Be $description
             $expectedStartup = $(
                 switch ($startupType) {
                     "Automatic" {"Auto"}
@@ -187,12 +187,12 @@ Describe "Set/New/Remove-Service cmdlet tests" -Tags "Feature", "RequireAdminOnW
                     default { throw "Unsupported StartupType in TestCases" }
                 }
             )
-            $service.StartMode | Should Be $expectedStartup
+            $service.StartMode | Should -Be $expectedStartup
             if ($displayname -eq $null) {
-                $service.DisplayName | Should Be $name
+                $service.DisplayName | Should -Be $name
             }
             else {
-                $service.DisplayName | Should Be $displayname
+                $service.DisplayName | Should -Be $displayname
             }
         }
         finally {
@@ -211,10 +211,10 @@ Describe "Set/New/Remove-Service cmdlet tests" -Tags "Feature", "RequireAdminOnW
                 BinaryPathName = "$PSHOME\pwsh.exe"
             }
             $service = New-Service @parameters
-            $service | Should Not BeNullOrEmpty
+            $service | Should -Not -BeNullOrEmpty
             Remove-Service -Name $servicename
             $service = Get-Service -Name $servicename -ErrorAction SilentlyContinue
-            $service | Should BeNullOrEmpty
+            $service | Should -BeNullOrEmpty
         }
         finally {
             Get-CimInstance Win32_Service -Filter "name='$servicename'" | Remove-CimInstance -ErrorAction SilentlyContinue
@@ -229,10 +229,10 @@ Describe "Set/New/Remove-Service cmdlet tests" -Tags "Feature", "RequireAdminOnW
                 BinaryPathName = "$PSHOME\pwsh.exe"
             }
             $service = New-Service @parameters
-            $service | Should Not BeNullOrEmpty
+            $service | Should -Not -BeNullOrEmpty
             Get-Service -Name $servicename | Remove-Service
             $service = Get-Service -Name $servicename -ErrorAction SilentlyContinue
-            $service | Should BeNullOrEmpty
+            $service | Should -BeNullOrEmpty
         }
         finally {
             Get-CimInstance Win32_Service -Filter "name='$servicename'" | Remove-CimInstance -ErrorAction SilentlyContinue
@@ -261,9 +261,9 @@ Describe "Set/New/Remove-Service cmdlet tests" -Tags "Feature", "RequireAdminOnW
                 $startparameters.$property = $value
             }
             $service = New-Service @startparameters
-            $service | Should Not BeNullOrEmpty
+            $service | Should -Not -BeNullOrEmpty
             $service = Get-Service -Name $servicename
-            $service.$property | Should BeExactly $value
+            $service.$property | Should -BeExactly $value
         }
         finally {
             Get-CimInstance Win32_Service -Filter "name='$servicename'" | Remove-CimInstance -ErrorAction SilentlyContinue
@@ -279,10 +279,10 @@ Describe "Set/New/Remove-Service cmdlet tests" -Tags "Feature", "RequireAdminOnW
                 BinaryPathName = "$PSHOME\pwsh.exe"
             }
             $service = New-Service @parameters
-            $service | Should Not BeNullOrEmpty
+            $service | Should -Not -BeNullOrEmpty
             Get-Service -Name $servicename | Set-Service -DisplayName $newdisplayname
             $service = Get-Service -Name $servicename
-            $service.DisplayName | Should BeExactly $newdisplayname
+            $service.DisplayName | Should -BeExactly $newdisplayname
         }
         finally {
             Get-CimInstance Win32_Service -Filter "name='$servicename'" | Remove-CimInstance -ErrorAction SilentlyContinue
@@ -298,11 +298,11 @@ Describe "Set/New/Remove-Service cmdlet tests" -Tags "Feature", "RequireAdminOnW
                 BinaryPathName = "$PSHOME\pwsh.exe"
             }
             $service = New-Service @parameters
-            $service | Should Not BeNullOrEmpty
+            $service | Should -Not -BeNullOrEmpty
             $script = { Set-Service $service -DisplayName $newdisplayname }
-            { & $script } | Should Not Throw
+            { & $script } | Should -Not -Throw
             $service = Get-Service -Name $servicename
-            $service.DisplayName | Should BeExactly $newdisplayname
+            $service.DisplayName | Should -BeExactly $newdisplayname
         }
         finally {
             Get-CimInstance Win32_Service -Filter "name='$servicename'" | Remove-CimInstance -ErrorAction SilentlyContinue

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Split-Path.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Split-Path.Tests.ps1
@@ -87,6 +87,6 @@ Describe "Split-Path" -Tags "CI" {
     }
 
     It 'Does not split a drive leter'{
-    Split-Path -Path 'C:\' | Should -Be ''
+    Split-Path -Path 'C:\' | Should -BeNullOrEmpty
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Split-Path.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Split-Path.Tests.ps1
@@ -48,8 +48,8 @@ Describe "Split-Path" -Tags "CI" {
 
         New-Item -ItemType file -Path $testFilePath1, $testFilePath2 -Force
 
-        Test-Path $testFilePath1 | Should -Be $true
-        Test-Path $testFilePath2 | Should -Be $true
+        Test-Path $testFilePath1 | Should -BeTrue
+        Test-Path $testFilePath2 | Should -BeTrue
 
         $actual = ( Split-Path (Join-Path -Path $testDir -ChildPath "testfile*.ps1") -Leaf -Resolve ) | Sort-Object
         $actual.Count                   | Should -Be 2
@@ -59,15 +59,15 @@ Describe "Split-Path" -Tags "CI" {
     }
 
     It "Should be able to tell if a given path is an absolute path" {
-	Split-Path -IsAbsolute fs:/usr/bin | Should -Be $true
-	Split-Path -IsAbsolute ..          | Should -Be $false
+	Split-Path -IsAbsolute fs:/usr/bin | Should -BeTrue
+	Split-Path -IsAbsolute ..          | Should -BeFalse
 	Split-Path -IsAbsolute /usr/..     | Should -Be (!$IsWindows)
-	Split-Path -IsAbsolute fs:/usr/../ | Should -Be $true
-	Split-Path -IsAbsolute ../         | Should -Be $false
-	Split-Path -IsAbsolute .           | Should -Be $false
-	Split-Path -IsAbsolute ~/          | Should -Be $false
-	Split-Path -IsAbsolute ~/..        | Should -Be $false
-	Split-Path -IsAbsolute ~/../..     | Should -Be $false
+	Split-Path -IsAbsolute fs:/usr/../ | Should -BeTrue
+	Split-Path -IsAbsolute ../         | Should -BeFalse
+	Split-Path -IsAbsolute .           | Should -BeFalse
+	Split-Path -IsAbsolute ~/          | Should -BeFalse
+	Split-Path -IsAbsolute ~/..        | Should -BeFalse
+	Split-Path -IsAbsolute ~/../..     | Should -BeFalse
     }
 
     It "Should support piping" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Split-Path.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Split-Path.Tests.ps1
@@ -24,19 +24,19 @@ Describe "Split-Path" -Tags "CI" {
     }
 
     It "Should return the path when the noqualifier switch is used" {
-	Split-Path env:PATH -NoQualifier | Should -Be "PATH"
+	Split-Path env:PATH -NoQualifier | Should -BeExactly "PATH"
     }
 
     It "Should return the base name when the leaf switch is used" {
-	Split-Path -Leaf /usr/bin                  | Should -Be "bin"
-	Split-Path -Leaf fs:/usr/local/bin         | Should -Be "bin"
-	Split-Path -Leaf usr/bin                   | Should -Be "bin"
-	Split-Path -Leaf ./bin                     | Should -Be "bin"
-	Split-Path -Leaf bin                       | Should -Be "bin"
-	Split-Path -Leaf "C:\Temp\Folder1"         | Should -Be "Folder1"
-	Split-Path -Leaf "C:\Temp"                 | Should -Be "Temp"
-	Split-Path -Leaf "\\server1\share1\folder" | Should -Be "folder"
-	Split-Path -Leaf "\\server1\share1"        | Should -Be "share1"
+	Split-Path -Leaf /usr/bin                  | Should -BeExactly "bin"
+	Split-Path -Leaf fs:/usr/local/bin         | Should -BeExactly "bin"
+	Split-Path -Leaf usr/bin                   | Should -BeExactly "bin"
+	Split-Path -Leaf ./bin                     | Should -BeExactly "bin"
+	Split-Path -Leaf bin                       | Should -BeExactly "bin"
+	Split-Path -Leaf "C:\Temp\Folder1"         | Should -BeExactly "Folder1"
+	Split-Path -Leaf "C:\Temp"                 | Should -BeExactly "Temp"
+	Split-Path -Leaf "\\server1\share1\folder" | Should -BeExactly "folder"
+	Split-Path -Leaf "\\server1\share1"        | Should -BeExactly "share1"
     }
 
     It "Should be able to accept regular expression input and output an array for multiple objects" {
@@ -53,8 +53,8 @@ Describe "Split-Path" -Tags "CI" {
 
         $actual = ( Split-Path (Join-Path -Path $testDir -ChildPath "testfile*.ps1") -Leaf -Resolve ) | Sort-Object
         $actual.Count                   | Should -Be 2
-        $actual[0]                      | Should -Be $testFile1
-        $actual[1]                      | Should -Be $testFile2
+        $actual[0]                      | Should -BeExactly $testFile1
+        $actual[1]                      | Should -BeExactly $testFile2
         ,$actual                        | Should -BeOfType "System.Array"
     }
 
@@ -76,14 +76,14 @@ Describe "Split-Path" -Tags "CI" {
 
     It "Should return the path up to the parent of the directory when Parent switch is used" {
         $dirSep = [string]([System.IO.Path]::DirectorySeparatorChar)
-	Split-Path -Parent "fs:/usr/bin"             | Should -Be "fs:${dirSep}usr"
-	Split-Path -Parent "/usr/bin"                | Should -Be "${dirSep}usr"
-	Split-Path -Parent "/usr/local/bin"          | Should -Be "${dirSep}usr${dirSep}local"
-	Split-Path -Parent "usr/local/bin"           | Should -Be "usr${dirSep}local"
-	Split-Path -Parent "C:\Temp\Folder1"         | Should -Be "C:${dirSep}Temp"
-	Split-Path -Parent "C:\Temp"                 | Should -Be "C:${dirSep}"
-	Split-Path -Parent "\\server1\share1\folder" | Should -Be "${dirSep}${dirSep}server1${dirSep}share1"
-	Split-Path -Parent "\\server1\share1"        | Should -Be "${dirSep}${dirSep}server1"
+	Split-Path -Parent "fs:/usr/bin"             | Should -BeExactly "fs:${dirSep}usr"
+	Split-Path -Parent "/usr/bin"                | Should -BeExactly "${dirSep}usr"
+	Split-Path -Parent "/usr/local/bin"          | Should -BeExactly "${dirSep}usr${dirSep}local"
+	Split-Path -Parent "usr/local/bin"           | Should -BeExactly "usr${dirSep}local"
+	Split-Path -Parent "C:\Temp\Folder1"         | Should -BeExactly "C:${dirSep}Temp"
+	Split-Path -Parent "C:\Temp"                 | Should -BeExactly "C:${dirSep}"
+	Split-Path -Parent "\\server1\share1\folder" | Should -BeExactly "${dirSep}${dirSep}server1${dirSep}share1"
+	Split-Path -Parent "\\server1\share1"        | Should -BeExactly "${dirSep}${dirSep}server1"
     }
 
     It 'Does not split a drive leter'{

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Split-Path.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Split-Path.Tests.ps1
@@ -4,39 +4,39 @@ Describe "Split-Path" -Tags "CI" {
 
     It "Should return a string object when invoked" {
         $result = Split-Path .
-        $result | Should BeOfType String
+        $result | Should -BeOfType String
 
         $result = Split-Path . -Leaf
-        $result | Should BeOfType String
+        $result | Should -BeOfType String
 
         $result = Split-Path . -Resolve
-        $result | Should BeOfType String
+        $result | Should -BeOfType String
     }
 
     It "Should return the name of the drive when the qualifier switch is used" {
-	Split-Path -Qualifier env:     | Should Be "env:"
-	Split-Path -Qualifier env:PATH | Should Be "env:"
+	Split-Path -Qualifier env:     | Should -Be "env:"
+	Split-Path -Qualifier env:PATH | Should -Be "env:"
     }
 
     It "Should error when using the qualifier switch and no qualifier in the path" {
-        { Split-Path -Qualifier -ErrorAction Stop /Users } | Should Throw
-	{ Split-Path -Qualifier -ErrorAction Stop abcdef } | Should Throw
+        { Split-Path -Qualifier -ErrorAction Stop /Users } | Should -Throw
+	{ Split-Path -Qualifier -ErrorAction Stop abcdef } | Should -Throw
     }
 
     It "Should return the path when the noqualifier switch is used" {
-	Split-Path env:PATH -NoQualifier | Should Be "PATH"
+	Split-Path env:PATH -NoQualifier | Should -Be "PATH"
     }
 
     It "Should return the base name when the leaf switch is used" {
-	Split-Path -Leaf /usr/bin                  | Should be "bin"
-	Split-Path -Leaf fs:/usr/local/bin         | Should be "bin"
-	Split-Path -Leaf usr/bin                   | Should be "bin"
-	Split-Path -Leaf ./bin                     | Should be "bin"
-	Split-Path -Leaf bin                       | Should be "bin"
-	Split-Path -Leaf "C:\Temp\Folder1"         | Should be "Folder1"
-	Split-Path -Leaf "C:\Temp"                 | Should be "Temp"
-	Split-Path -Leaf "\\server1\share1\folder" | Should be "folder"
-	Split-Path -Leaf "\\server1\share1"        | Should be "share1"
+	Split-Path -Leaf /usr/bin                  | Should -Be "bin"
+	Split-Path -Leaf fs:/usr/local/bin         | Should -Be "bin"
+	Split-Path -Leaf usr/bin                   | Should -Be "bin"
+	Split-Path -Leaf ./bin                     | Should -Be "bin"
+	Split-Path -Leaf bin                       | Should -Be "bin"
+	Split-Path -Leaf "C:\Temp\Folder1"         | Should -Be "Folder1"
+	Split-Path -Leaf "C:\Temp"                 | Should -Be "Temp"
+	Split-Path -Leaf "\\server1\share1\folder" | Should -Be "folder"
+	Split-Path -Leaf "\\server1\share1"        | Should -Be "share1"
     }
 
     It "Should be able to accept regular expression input and output an array for multiple objects" {
@@ -48,45 +48,45 @@ Describe "Split-Path" -Tags "CI" {
 
         New-Item -ItemType file -Path $testFilePath1, $testFilePath2 -Force
 
-        Test-Path $testFilePath1 | Should Be $true
-        Test-Path $testFilePath2 | Should Be $true
+        Test-Path $testFilePath1 | Should -Be $true
+        Test-Path $testFilePath2 | Should -Be $true
 
         $actual = ( Split-Path (Join-Path -Path $testDir -ChildPath "testfile*.ps1") -Leaf -Resolve ) | Sort-Object
-        $actual.Count                   | Should Be 2
-        $actual[0]                      | Should Be $testFile1
-        $actual[1]                      | Should Be $testFile2
-        ,$actual                        | Should BeOfType "System.Array"
+        $actual.Count                   | Should -Be 2
+        $actual[0]                      | Should -Be $testFile1
+        $actual[1]                      | Should -Be $testFile2
+        ,$actual                        | Should -BeOfType "System.Array"
     }
 
     It "Should be able to tell if a given path is an absolute path" {
-	Split-Path -IsAbsolute fs:/usr/bin | Should Be $true
-	Split-Path -IsAbsolute ..          | Should Be $false
-	Split-Path -IsAbsolute /usr/..     | Should Be (!$IsWindows)
-	Split-Path -IsAbsolute fs:/usr/../ | Should Be $true
-	Split-Path -IsAbsolute ../         | Should Be $false
-	Split-Path -IsAbsolute .           | Should Be $false
-	Split-Path -IsAbsolute ~/          | Should Be $false
-	Split-Path -IsAbsolute ~/..        | Should Be $false
-	Split-Path -IsAbsolute ~/../..     | Should Be $false
+	Split-Path -IsAbsolute fs:/usr/bin | Should -Be $true
+	Split-Path -IsAbsolute ..          | Should -Be $false
+	Split-Path -IsAbsolute /usr/..     | Should -Be (!$IsWindows)
+	Split-Path -IsAbsolute fs:/usr/../ | Should -Be $true
+	Split-Path -IsAbsolute ../         | Should -Be $false
+	Split-Path -IsAbsolute .           | Should -Be $false
+	Split-Path -IsAbsolute ~/          | Should -Be $false
+	Split-Path -IsAbsolute ~/..        | Should -Be $false
+	Split-Path -IsAbsolute ~/../..     | Should -Be $false
     }
 
     It "Should support piping" {
-        "usr/bin" | Split-Path | Should Be "usr"
+        "usr/bin" | Split-Path | Should -Be "usr"
     }
 
     It "Should return the path up to the parent of the directory when Parent switch is used" {
         $dirSep = [string]([System.IO.Path]::DirectorySeparatorChar)
-	Split-Path -Parent "fs:/usr/bin"             | Should Be "fs:${dirSep}usr"
-	Split-Path -Parent "/usr/bin"                | Should Be "${dirSep}usr"
-	Split-Path -Parent "/usr/local/bin"          | Should Be "${dirSep}usr${dirSep}local"
-	Split-Path -Parent "usr/local/bin"           | Should Be "usr${dirSep}local"
-	Split-Path -Parent "C:\Temp\Folder1"         | Should be "C:${dirSep}Temp"
-	Split-Path -Parent "C:\Temp"                 | Should be "C:${dirSep}"
-	Split-Path -Parent "\\server1\share1\folder" | Should be "${dirSep}${dirSep}server1${dirSep}share1"
-	Split-Path -Parent "\\server1\share1"        | Should be "${dirSep}${dirSep}server1"
+	Split-Path -Parent "fs:/usr/bin"             | Should -Be "fs:${dirSep}usr"
+	Split-Path -Parent "/usr/bin"                | Should -Be "${dirSep}usr"
+	Split-Path -Parent "/usr/local/bin"          | Should -Be "${dirSep}usr${dirSep}local"
+	Split-Path -Parent "usr/local/bin"           | Should -Be "usr${dirSep}local"
+	Split-Path -Parent "C:\Temp\Folder1"         | Should -Be "C:${dirSep}Temp"
+	Split-Path -Parent "C:\Temp"                 | Should -Be "C:${dirSep}"
+	Split-Path -Parent "\\server1\share1\folder" | Should -Be "${dirSep}${dirSep}server1${dirSep}share1"
+	Split-Path -Parent "\\server1\share1"        | Should -Be "${dirSep}${dirSep}server1"
     }
 
     It 'Does not split a drive leter'{
-    Split-Path -Path 'C:\' | Should be ''
+    Split-Path -Path 'C:\' | Should -Be ''
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Start-Process.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Start-Process.Tests.ps1
@@ -25,32 +25,32 @@ Describe "Start-Process" -Tags @("Feature") {
     It "Should process arguments without error" {
 	    $process = Start-Process ping -ArgumentList $pingParam -PassThru -RedirectStandardOutput "$TESTDRIVE/output"
 
-	    $process.Length      | Should Be 1
-	    $process.Id          | Should BeGreaterThan 1
+	    $process.Length      | Should -Be 1
+	    $process.Id          | Should -BeGreaterThan 1
 	    # $process.ProcessName | Should Be "ping"
     }
 
     It "Should work correctly when used with full path name" {
 	    $process = Start-Process $pingCommand -ArgumentList $pingParam -PassThru -RedirectStandardOutput "$TESTDRIVE/output"
 
-	    $process.Length      | Should Be 1
-	    $process.Id          | Should BeGreaterThan 1
+	    $process.Length      | Should -Be 1
+	    $process.Id          | Should -BeGreaterThan 1
 	    # $process.ProcessName | Should Be "ping"
     }
 
     It "Should invoke correct path when used with FilePath argument" {
 	    $process = Start-Process -FilePath $pingCommand -ArgumentList $pingParam -PassThru -RedirectStandardOutput "$TESTDRIVE/output"
 
-	    $process.Length      | Should Be 1
-	    $process.Id          | Should BeGreaterThan 1
+	    $process.Length      | Should -Be 1
+	    $process.Id          | Should -BeGreaterThan 1
 	    # $process.ProcessName | Should Be "ping"
     }
 
     It "Should invoke correct path when used with Path alias argument" {
 	    $process = Start-Process -Path $pingCommand -ArgumentList $pingParam -PassThru -RedirectStandardOutput "$TESTDRIVE/output"
 
-	    $process.Length | Should Be 1
-	    $process.Id     | Should BeGreaterThan 1
+	    $process.Length | Should -Be 1
+	    $process.Id     | Should -BeGreaterThan 1
     }
 
     It "Should wait for command completion if used with Wait argument" {
@@ -60,30 +60,30 @@ Describe "Start-Process" -Tags @("Feature") {
     It "Should work correctly with WorkingDirectory argument" {
 	    $process = Start-Process ping -WorkingDirectory $pingDirectory -ArgumentList $pingParam -PassThru -RedirectStandardOutput "$TESTDRIVE/output"
 
-	    $process.Length      | Should Be 1
-	    $process.Id          | Should BeGreaterThan 1
+	    $process.Length      | Should -Be 1
+	    $process.Id          | Should -BeGreaterThan 1
 	    # $process.ProcessName | Should Be "ping"
     }
 
     It "Should handle stderr redirection without error" {
 	    $process = Start-Process ping -ArgumentList $pingParam -PassThru -RedirectStandardError $tempFile -RedirectStandardOutput "$TESTDRIVE/output"
 
-	    $process.Length      | Should Be 1
-	    $process.Id          | Should BeGreaterThan 1
+	    $process.Length      | Should -Be 1
+	    $process.Id          | Should -BeGreaterThan 1
 	    # $process.ProcessName | Should Be "ping"
     }
 
     It "Should handle stdout redirection without error" {
 	    $process = Start-Process ping -ArgumentList $pingParam -Wait -RedirectStandardOutput $tempFile
 	    $dirEntry = get-childitem $tempFile
-	    $dirEntry.Length | Should BeGreaterThan 0
+	    $dirEntry.Length | Should -BeGreaterThan 0
     }
 
     # Marking this test 'pending' to unblock daily builds. Filed issue : https://github.com/PowerShell/PowerShell/issues/2396
     It "Should handle stdin redirection without error" -Pending {
 	    $process = Start-Process sort -Wait -RedirectStandardOutput $tempFile -RedirectStandardInput $assetsFile
 	    $dirEntry = get-childitem $tempFile
-	    $dirEntry.Length | Should BeGreaterThan 0
+	    $dirEntry.Length | Should -BeGreaterThan 0
     }
 
     ## -Verb is supported in PowerShell core on Windows full desktop.
@@ -103,25 +103,25 @@ Describe "Start-Process" -Tags @("Feature") {
     It "Should start cmd.exe with Verb 'open' and WindowStyle 'Minimized'" -Skip:(!$isFullWin) {
         $fileToWrite = Join-Path $TestDrive "VerbTest.txt"
         $process = Start-Process cmd.exe -ArgumentList "/c echo abc > $fileToWrite" -Verb open -WindowStyle Minimized -PassThru
-        $process.Name | Should Be "cmd"
+        $process.Name | Should -Be "cmd"
         $process.WaitForExit()
-        Test-Path $fileToWrite | Should Be $true
+        Test-Path $fileToWrite | Should -Be $true
     }
 
     It "Should start notepad.exe with ShellExecute" -Skip:(!$isFullWin) {
         $process = Start-Process notepad -PassThru -WindowStyle Normal
-        $process.Name | Should Be "notepad"
+        $process.Name | Should -Be "notepad"
         $process | Stop-Process
     }
 
     It "Should be able to use the -WhatIf switch without performing the actual action" {
         $pingOutput = Join-Path $TestDrive "pingOutput.txt"
-        { Start-Process -Wait $pingCommand -ArgumentList $pingParam -RedirectStandardOutput $pingOutput -WhatIf -ErrorAction Stop } | Should Not Throw
-        $pingOutput | Should Not Exist
+        { Start-Process -Wait $pingCommand -ArgumentList $pingParam -RedirectStandardOutput $pingOutput -WhatIf -ErrorAction Stop } | Should -Not -Throw
+        $pingOutput | Should -Not -Exist
     }
 
     It "Should return null when using -WhatIf switch with -PassThru" {
-        Start-Process $pingCommand -ArgumentList $pingParam -PassThru -WhatIf | Should Be $null
+        Start-Process $pingCommand -ArgumentList $pingParam -PassThru -WhatIf | Should -Be $null
    }
 }
 
@@ -145,7 +145,7 @@ Describe "Start-Process tests requiring admin" -Tags "Feature","RequireAdminOnWi
 
         Wait-FileToBePresent -File "$testdrive\foo.txt" -TimeoutInSeconds 10 -IntervalInMilliseconds 100
 
-        "$testdrive\foo.txt" | Should Exist
-        Get-Content $testdrive\foo.txt | Should BeExactly $fooFile
+        "$testdrive\foo.txt" | Should -Exist
+        Get-Content $testdrive\foo.txt | Should -BeExactly $fooFile
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Start-Process.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Start-Process.Tests.ps1
@@ -105,7 +105,7 @@ Describe "Start-Process" -Tags @("Feature") {
         $process = Start-Process cmd.exe -ArgumentList "/c echo abc > $fileToWrite" -Verb open -WindowStyle Minimized -PassThru
         $process.Name | Should -Be "cmd"
         $process.WaitForExit()
-        Test-Path $fileToWrite | Should -Be $true
+        Test-Path $fileToWrite | Should -BeTrue
     }
 
     It "Should start notepad.exe with ShellExecute" -Skip:(!$isFullWin) {
@@ -121,7 +121,7 @@ Describe "Start-Process" -Tags @("Feature") {
     }
 
     It "Should return null when using -WhatIf switch with -PassThru" {
-        Start-Process $pingCommand -ArgumentList $pingParam -PassThru -WhatIf | Should -Be $null
+        Start-Process $pingCommand -ArgumentList $pingParam -PassThru -WhatIf | Should -BeNullOrEmpty
    }
 }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Stop-Computer.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Stop-Computer.Tests.ps1
@@ -27,19 +27,19 @@ try
 
         It "Should stop the local computer" {
             Set-TesthookResult -testhookName $stopTesthookResultName -Value $defaultResultValue
-            Stop-Computer -ErrorAction Stop| Should BeNullOrEmpty
+            Stop-Computer -ErrorAction Stop| Should -BeNullOrEmpty
         }
 
         It "Should support -Computer parameter" {
             Set-TesthookResult -testhookName $stopTesthookResultName -Value $defaultResultValue
             $computerNames = "localhost","${env:COMPUTERNAME}"
-            Stop-Computer -Computer $computerNames -ErrorAction Stop| Should BeNullOrEmpty
+            Stop-Computer -Computer $computerNames -ErrorAction Stop| Should -BeNullOrEmpty
         }
 
         It "Should support WsmanAuthentication types" {
             $authChoices = "Default","Basic","Negotiate","CredSSP","Digest","Kerberos"
             foreach ( $auth in $authChoices ) {
-                Stop-Computer -WsmanAuthentication $auth | Should BeNullOrEmpty
+                Stop-Computer -WsmanAuthentication $auth | Should -BeNullOrEmpty
             }
         }
 
@@ -47,7 +47,7 @@ try
             It "Should return the proper error when it occurs" {
                 Set-TesthookResult -testhookName $stopTesthookResultName -Value 0x300000
                 Stop-Computer -ErrorVariable StopError 2>$null
-                $StopError.Exception.Message | Should match 0x300000
+                $StopError.Exception.Message | Should -Match 0x300000
             }
         }
     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Path.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Path.Tests.ps1
@@ -23,8 +23,8 @@ Describe "Test-Path" -Tags "CI" {
     It "Should allow piping objects to it" {
 	{ $testdirectory | Test-Path  } | Should -Not -Throw
 
-	$testdirectory                  | Test-Path | Should -Be $true
-	$nonExistentDir                 | Test-Path | Should -Be $false
+	$testdirectory                  | Test-Path | Should -BeTrue
+	$nonExistentDir                 | Test-Path | Should -BeFalse
     }
 
     It "Should be called on a nonexistent path without error" {
@@ -32,11 +32,11 @@ Describe "Test-Path" -Tags "CI" {
     }
 
     It "Should return false for a nonexistent path" {
-	Test-Path -Path $nonExistentPath | Should -Be $false
+	Test-Path -Path $nonExistentPath | Should -BeFalse
     }
 
     It "Should return true for an existing path" {
-	{ Test-Path -Path $testdirectory } | Should -Be $true
+	{ Test-Path -Path $testdirectory } | Should -BeTrue
     }
 
     It "Should be able to accept a regular expression" {
@@ -45,53 +45,53 @@ Describe "Test-Path" -Tags "CI" {
     }
 
     It "Should be able to return the correct result when a regular expression is used" {
-	Test-Path -Path (Join-Path -Path $testdirectory -ChildPath "u*")               | Should -Be $true
-	Test-Path -Path (Join-Path -Path $testdirectory -ChildPath "u[a-z]*")          | Should -Be $true
+	Test-Path -Path (Join-Path -Path $testdirectory -ChildPath "u*")               | Should -BeTrue
+	Test-Path -Path (Join-Path -Path $testdirectory -ChildPath "u[a-z]*")          | Should -BeTrue
 
-	Test-Path -Path (Join-Path -Path $testdirectory -ChildPath "aoeu*")            | Should -Be $false
-	Test-Path -Path (Join-Path -Path $testdirectory -ChildPath "u[A-Z]")           | Should -Be $false
+	Test-Path -Path (Join-Path -Path $testdirectory -ChildPath "aoeu*")            | Should -BeFalse
+	Test-Path -Path (Join-Path -Path $testdirectory -ChildPath "u[A-Z]")           | Should -BeFalse
     }
 
     It "Should return false when the Leaf pathtype is used on a directory" {
-	Test-Path -Path $testdirectory -PathType Leaf | Should -Be $false
+	Test-Path -Path $testdirectory -PathType Leaf | Should -BeFalse
     }
 
     It "Should return true when the Leaf pathtype is used on an existing endpoint" {
-	Test-Path -Path $testfilename -PathType Leaf | Should -Be $true
+	Test-Path -Path $testfilename -PathType Leaf | Should -BeTrue
     }
 
     It "Should return false when the Leaf pathtype is used on a nonexistent file" {
-	Test-Path -Path "aoeu" -PathType Leaf | Should -Be $false
+	Test-Path -Path "aoeu" -PathType Leaf | Should -BeFalse
     }
 
     It "Should return true when the Leaf pathtype is used on a file using the Type alias instead of PathType" {
-	Test-Path -Path $testfilename -Type Leaf | Should -Be $true
+	Test-Path -Path $testfilename -Type Leaf | Should -BeTrue
     }
 
     It "Should be able to search multiple regular expressions using the include switch" {
-	{ Test-Path -Path (Join-Path -Path $testdirectory -ChildPath "*") -Include t* } | Should -Be $true
+	{ Test-Path -Path (Join-Path -Path $testdirectory -ChildPath "*") -Include t* } | Should -BeTrue
     }
 
     It "Should be able to exclude a regular expression using the exclude switch" {
-	{ Test-Path -Path (Join-Path -Path $testdirectory -ChildPath "*") -Exclude v* } | Should -Be $true
+	{ Test-Path -Path (Join-Path -Path $testdirectory -ChildPath "*") -Exclude v* } | Should -BeTrue
     }
 
     It "Should be able to exclude multiple regular expressions using the exclude switch" {
 	# tests whether there's any files in the usr directory that don't start with 'd' or 'g'
-	{ Test-Path -Path $testfilename -Exclude d*, g* } | Should -Be $true
+	{ Test-Path -Path $testfilename -Exclude d*, g* } | Should -BeTrue
     }
 
     It "Should return true if the syntax of the path is correct when using the IsValid switch" {
-	{ Test-Path -Path $nonExistentPath -IsValid } | Should -Be $true
+	{ Test-Path -Path $nonExistentPath -IsValid } | Should -BeTrue
     }
 
     It "Should return false if the syntax of the path is incorrect when using the IsValid switch" {
 	$badPath = " :;!@#$%^&*(){}?+|_-"
-	Test-Path -Path $badPath -IsValid | Should -Be $false
+	Test-Path -Path $badPath -IsValid | Should -BeFalse
     }
 
     It "Should return true on paths containing spaces when the path is surrounded in quotes" {
-	Test-Path -Path "/totally a valid/path" -IsValid | Should -Be $true
+	Test-Path -Path "/totally a valid/path" -IsValid | Should -BeTrue
     }
 
     It "Should throw on paths containing spaces when the path is not surrounded in quotes" {
@@ -99,26 +99,26 @@ Describe "Test-Path" -Tags "CI" {
     }
 
     It "Should return true if a directory leads or trails with a space when surrounded by quotes" {
-	Test-Path -Path "/a path / with/funkyspaces" -IsValid | Should -Be $true
+	Test-Path -Path "/a path / with/funkyspaces" -IsValid | Should -BeTrue
     }
 
     It "Should return true on a valid path when the LiteralPath switch is used" {
-	Test-Path -LiteralPath $testfilename | Should -Be $true
+	Test-Path -LiteralPath $testfilename | Should -BeTrue
     }
 
     It "Should return false if regular expressions are used with the LiteralPath switch" {
-	Test-Path -LiteralPath (Join-Path -Path $testdirectory -ChildPath "u*")            | Should -Be $false
-	Test-Path -LiteralPath (Join-Path -Path $testdirectory -ChildPath "u[a-z]r")       | Should -Be $false
+	Test-Path -LiteralPath (Join-Path -Path $testdirectory -ChildPath "u*")            | Should -BeFalse
+	Test-Path -LiteralPath (Join-Path -Path $testdirectory -ChildPath "u[a-z]r")       | Should -BeFalse
     }
 
     It "Should return false if regular expressions are used with the LiteralPath alias PSPath switch" {
-	Test-Path -PSPath (Join-Path -Path $testdirectory -ChildPath "u*")            | Should -Be $false
-	Test-Path -PSPath (Join-Path -Path $testdirectory -ChildPath "u[a-z]r")       | Should -Be $false
+	Test-Path -PSPath (Join-Path -Path $testdirectory -ChildPath "u*")            | Should -BeFalse
+	Test-Path -PSPath (Join-Path -Path $testdirectory -ChildPath "u[a-z]r")       | Should -BeFalse
     }
 
     It "Should return true if used on components other than filesystem objects" {
-	Test-Path Alias:\gci | Should -Be $true
-	Test-Path Env:\PATH  | Should -Be $true
+	Test-Path Alias:\gci | Should -BeTrue
+	Test-Path Env:\PATH  | Should -BeTrue
     }
 
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Path.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Path.Tests.ps1
@@ -95,7 +95,7 @@ Describe "Test-Path" -Tags "CI" {
     }
 
     It "Should throw on paths containing spaces when the path is not surrounded in quotes" {
-	{ Test-Path -Path /a path/without quotes/around/it -IsValid } | Should -Throw
+	{ Test-Path -Path /a path/without quotes/around/it -IsValid } | Should -Throw -ErrorId "PositionalParameterNotFound,Microsoft.PowerShell.Commands.TestPathCommand"
     }
 
     It "Should return true if a directory leads or trails with a space when surrounded by quotes" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Path.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Path.Tests.ps1
@@ -15,110 +15,110 @@ Describe "Test-Path" -Tags "CI" {
     }
 
     It "Should be called on an existing path without error" {
-	{ Test-Path $testdirectory }              | Should Not Throw
-	{ Test-Path -Path $testdirectory }        | Should Not Throw
-	{ Test-Path -LiteralPath $testdirectory } | Should Not Throw
+	{ Test-Path $testdirectory }              | Should -Not -Throw
+	{ Test-Path -Path $testdirectory }        | Should -Not -Throw
+	{ Test-Path -LiteralPath $testdirectory } | Should -Not -Throw
     }
 
     It "Should allow piping objects to it" {
-	{ $testdirectory | Test-Path  } | Should Not Throw
+	{ $testdirectory | Test-Path  } | Should -Not -Throw
 
-	$testdirectory                  | Test-Path | Should Be $true
-	$nonExistentDir                 | Test-Path | Should Be $false
+	$testdirectory                  | Test-Path | Should -Be $true
+	$nonExistentDir                 | Test-Path | Should -Be $false
     }
 
     It "Should be called on a nonexistent path without error" {
-	{ Test-Path -Path $nonExistentPath } | Should Not Throw
+	{ Test-Path -Path $nonExistentPath } | Should -Not -Throw
     }
 
     It "Should return false for a nonexistent path" {
-	Test-Path -Path $nonExistentPath | Should Be $false
+	Test-Path -Path $nonExistentPath | Should -Be $false
     }
 
     It "Should return true for an existing path" {
-	{ Test-Path -Path $testdirectory } | Should Be $true
+	{ Test-Path -Path $testdirectory } | Should -Be $true
     }
 
     It "Should be able to accept a regular expression" {
-	{ Test-Path -Path (Join-Path -Path $testdirectory -ChildPath "u*") }           | Should Not Throw
-	{ Test-Path -Path (Join-Path -Path $testdirectory -ChildPath "u[a-z]r") }      | Should Not Throw
+	{ Test-Path -Path (Join-Path -Path $testdirectory -ChildPath "u*") }           | Should -Not -Throw
+	{ Test-Path -Path (Join-Path -Path $testdirectory -ChildPath "u[a-z]r") }      | Should -Not -Throw
     }
 
     It "Should be able to return the correct result when a regular expression is used" {
-	Test-Path -Path (Join-Path -Path $testdirectory -ChildPath "u*")               | Should Be $true
-	Test-Path -Path (Join-Path -Path $testdirectory -ChildPath "u[a-z]*")          | Should Be $true
+	Test-Path -Path (Join-Path -Path $testdirectory -ChildPath "u*")               | Should -Be $true
+	Test-Path -Path (Join-Path -Path $testdirectory -ChildPath "u[a-z]*")          | Should -Be $true
 
-	Test-Path -Path (Join-Path -Path $testdirectory -ChildPath "aoeu*")            | Should Be $false
-	Test-Path -Path (Join-Path -Path $testdirectory -ChildPath "u[A-Z]")           | Should Be $false
+	Test-Path -Path (Join-Path -Path $testdirectory -ChildPath "aoeu*")            | Should -Be $false
+	Test-Path -Path (Join-Path -Path $testdirectory -ChildPath "u[A-Z]")           | Should -Be $false
     }
 
     It "Should return false when the Leaf pathtype is used on a directory" {
-	Test-Path -Path $testdirectory -PathType Leaf | Should Be $false
+	Test-Path -Path $testdirectory -PathType Leaf | Should -Be $false
     }
 
     It "Should return true when the Leaf pathtype is used on an existing endpoint" {
-	Test-Path -Path $testfilename -PathType Leaf | Should Be $true
+	Test-Path -Path $testfilename -PathType Leaf | Should -Be $true
     }
 
     It "Should return false when the Leaf pathtype is used on a nonexistent file" {
-	Test-Path -Path "aoeu" -PathType Leaf | Should Be $false
+	Test-Path -Path "aoeu" -PathType Leaf | Should -Be $false
     }
 
     It "Should return true when the Leaf pathtype is used on a file using the Type alias instead of PathType" {
-	Test-Path -Path $testfilename -Type Leaf | Should Be $true
+	Test-Path -Path $testfilename -Type Leaf | Should -Be $true
     }
 
     It "Should be able to search multiple regular expressions using the include switch" {
-	{ Test-Path -Path (Join-Path -Path $testdirectory -ChildPath "*") -Include t* } | Should Be $true
+	{ Test-Path -Path (Join-Path -Path $testdirectory -ChildPath "*") -Include t* } | Should -Be $true
     }
 
     It "Should be able to exclude a regular expression using the exclude switch" {
-	{ Test-Path -Path (Join-Path -Path $testdirectory -ChildPath "*") -Exclude v* } | Should Be $true
+	{ Test-Path -Path (Join-Path -Path $testdirectory -ChildPath "*") -Exclude v* } | Should -Be $true
     }
 
     It "Should be able to exclude multiple regular expressions using the exclude switch" {
 	# tests whether there's any files in the usr directory that don't start with 'd' or 'g'
-	{ Test-Path -Path $testfilename -Exclude d*, g* } | Should Be $true
+	{ Test-Path -Path $testfilename -Exclude d*, g* } | Should -Be $true
     }
 
     It "Should return true if the syntax of the path is correct when using the IsValid switch" {
-	{ Test-Path -Path $nonExistentPath -IsValid } | Should Be $true
+	{ Test-Path -Path $nonExistentPath -IsValid } | Should -Be $true
     }
 
     It "Should return false if the syntax of the path is incorrect when using the IsValid switch" {
 	$badPath = " :;!@#$%^&*(){}?+|_-"
-	Test-Path -Path $badPath -IsValid | Should Be $false
+	Test-Path -Path $badPath -IsValid | Should -Be $false
     }
 
     It "Should return true on paths containing spaces when the path is surrounded in quotes" {
-	Test-Path -Path "/totally a valid/path" -IsValid | Should Be $true
+	Test-Path -Path "/totally a valid/path" -IsValid | Should -Be $true
     }
 
     It "Should throw on paths containing spaces when the path is not surrounded in quotes" {
-	{ Test-Path -Path /a path/without quotes/around/it -IsValid } | Should Throw
+	{ Test-Path -Path /a path/without quotes/around/it -IsValid } | Should -Throw
     }
 
     It "Should return true if a directory leads or trails with a space when surrounded by quotes" {
-	Test-Path -Path "/a path / with/funkyspaces" -IsValid | Should Be $true
+	Test-Path -Path "/a path / with/funkyspaces" -IsValid | Should -Be $true
     }
 
     It "Should return true on a valid path when the LiteralPath switch is used" {
-	Test-Path -LiteralPath $testfilename | Should Be $true
+	Test-Path -LiteralPath $testfilename | Should -Be $true
     }
 
     It "Should return false if regular expressions are used with the LiteralPath switch" {
-	Test-Path -LiteralPath (Join-Path -Path $testdirectory -ChildPath "u*")            | Should Be $false
-	Test-Path -LiteralPath (Join-Path -Path $testdirectory -ChildPath "u[a-z]r")       | Should Be $false
+	Test-Path -LiteralPath (Join-Path -Path $testdirectory -ChildPath "u*")            | Should -Be $false
+	Test-Path -LiteralPath (Join-Path -Path $testdirectory -ChildPath "u[a-z]r")       | Should -Be $false
     }
 
     It "Should return false if regular expressions are used with the LiteralPath alias PSPath switch" {
-	Test-Path -PSPath (Join-Path -Path $testdirectory -ChildPath "u*")            | Should Be $false
-	Test-Path -PSPath (Join-Path -Path $testdirectory -ChildPath "u[a-z]r")       | Should Be $false
+	Test-Path -PSPath (Join-Path -Path $testdirectory -ChildPath "u*")            | Should -Be $false
+	Test-Path -PSPath (Join-Path -Path $testdirectory -ChildPath "u[a-z]r")       | Should -Be $false
     }
 
     It "Should return true if used on components other than filesystem objects" {
-	Test-Path Alias:\gci | Should Be $true
-	Test-Path Env:\PATH  | Should Be $true
+	Test-Path Alias:\gci | Should -Be $true
+	Test-Path Env:\PATH  | Should -Be $true
     }
 
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/TimeZone.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/TimeZone.Tests.ps1
@@ -21,7 +21,7 @@ function Assert-ListsSame
     {
         $observedList = ([string]::Join("|",$observed))
         $expectedList = ([string]::Join("|",$expected))
-        $observedList | Should Be $expectedList
+        $observedList | Should -Be $expectedList
     }
 }
 
@@ -41,20 +41,20 @@ Describe "Get-Timezone test cases" -Tags "CI" {
     It "Call without ListAvailable switch returns current TimeZoneInfo" {
         $observed = (Get-TimeZone).Id
         $expected = ([System.TimeZoneInfo]::Local).Id
-        $observed | Should Be $expected
+        $observed | Should -Be $expected
     }
 
     It "Call without ListAvailable switch returns an object of type TimeZoneInfo" {
         $result = Get-TimeZone
-        $result | Should BeOfType TimeZoneInfo
+        $result | Should -BeOfType TimeZoneInfo
     }
 
     It "Call WITH ListAvailable switch returns ArrayList of TimeZoneInfo objects where the list is greater than 0 item" {
         $list = Get-TimeZone -ListAvailable
-        $list.Count | Should BeGreaterThan 0
+        $list.Count | Should -BeGreaterThan 0
 
-        ,$list | Should BeOfType "Object[]"
-        $list[0] | Should BeOfType "TimeZoneInfo"
+        ,$list | Should -BeOfType "Object[]"
+        $list[0] | Should -BeOfType "TimeZoneInfo"
     }
 
     ## The local time zone could be set to UTC or GMT*. In this case, the .NET API returns the region ID
@@ -62,7 +62,7 @@ Describe "Get-Timezone test cases" -Tags "CI" {
     It "Call with ListAvailable switch returns a list containing TimeZoneInfo.Local" {
         $observedIdList = Get-TimeZone -ListAvailable | Select-Object -ExpandProperty BaseUtcOffset
         $oneExpectedOffset = ([System.TimeZoneInfo]::Local).BaseUtcOffset
-        $oneExpectedOffset | Should BeIn $observedIdList
+        $oneExpectedOffset | Should -BeIn $observedIdList
     }
 
     ## The local time zone could be set to UTC or GMT*. In this case, the .NET API returns the region ID
@@ -70,12 +70,12 @@ Describe "Get-Timezone test cases" -Tags "CI" {
     It "Call with ListAvailable switch returns a list containing one returned by Get-TimeZone" {
         $observedIdList = Get-TimeZone -ListAvailable | Select-Object -ExpandProperty BaseUtcOffset
         $oneExpectedOffset = (Get-TimeZone).BaseUtcOffset
-        $oneExpectedOffset | Should BeIn $observedIdList
+        $oneExpectedOffset | Should -BeIn $observedIdList
     }
 
     It "Call Get-TimeZone using ID param and single item" {
         $selectedTZ = $TimeZonesAvailable[0]
-        (Get-TimeZone -Id $selectedTZ.Id).Id | Should Be $selectedTZ.Id
+        (Get-TimeZone -Id $selectedTZ.Id).Id | Should -Be $selectedTZ.Id
     }
 
     It "Call Get-TimeZone using ID param and multiple items" {
@@ -88,8 +88,8 @@ Describe "Get-Timezone test cases" -Tags "CI" {
         $selectedTZ = $TimeZonesAvailable[0].Id
         $null = Get-TimeZone -Id @("Cape Verde Standard",$selectedTZ,"Azores Standard") `
                              -ErrorVariable errVar -ErrorAction SilentlyContinue
-        $errVar.Count | Should Be 2
-        $errVar[0].FullyQualifiedErrorID | Should Be "TimeZoneNotFound,Microsoft.PowerShell.Commands.GetTimeZoneCommand"
+        $errVar.Count | Should -Be 2
+        $errVar[0].FullyQualifiedErrorID | Should -Be "TimeZoneNotFound,Microsoft.PowerShell.Commands.GetTimeZoneCommand"
     }
 
     It "Call Get-TimeZone using ID param and multiple items, one is wild card but error action ignore works as expected" {
@@ -103,7 +103,7 @@ Describe "Get-Timezone test cases" -Tags "CI" {
         $timezoneList = Get-TimeZone -ListAvailable
         $timezoneName = $timezoneList[0].StandardName
         $observed = Get-TimeZone -Name $timezoneName
-        $observed.StandardName | Should Be $timezoneName
+        $observed.StandardName | Should -Be $timezoneName
     }
 
     It "Call Get-TimeZone using Name param with wild card" {
@@ -122,7 +122,7 @@ Describe "Get-Timezone test cases" -Tags "CI" {
         $timezoneList = Get-TimeZone -ListAvailable
         $timezone = $timezoneList[0]
         $observed = $timezone | Get-TimeZone
-        $observed.StandardName | Should Be $timezone.StandardName
+        $observed.StandardName | Should -Be $timezone.StandardName
     }
 }
 
@@ -154,7 +154,7 @@ try {
             }
             Set-TimeZone -Id $testTimezone.Id
             $observed = Get-TimeZone
-            $testTimezone.Id | Should Be $observed.Id
+            $testTimezone.Id | Should -Be $observed.Id
         }
     }
 
@@ -177,7 +177,7 @@ try {
                 throw "No Exception!"
             }
             catch {
-                $_.FullyQualifiedErrorID | Should Be "TimeZoneNotFound,Microsoft.PowerShell.Commands.SetTimeZoneCommand"
+                $_.FullyQualifiedErrorID | Should -Be "TimeZoneNotFound,Microsoft.PowerShell.Commands.SetTimeZoneCommand"
             }
         }
 
@@ -193,7 +193,7 @@ try {
             }
             Set-TimeZone -Name $testTimezone.StandardName
             $observed = Get-TimeZone
-            $testTimezone.StandardName | Should Be $observed.StandardName
+            $testTimezone.StandardName | Should -Be $observed.StandardName
         }
 
         It "Call Set-TimeZone with invalid Name" {
@@ -202,7 +202,7 @@ try {
                 throw "No Exception!"
             }
             catch {
-                $_.FullyQualifiedErrorID | Should Be "TimeZoneNotFound,Microsoft.PowerShell.Commands.SetTimeZoneCommand"
+                $_.FullyQualifiedErrorID | Should -Be "TimeZoneNotFound,Microsoft.PowerShell.Commands.SetTimeZoneCommand"
             }
         }
 
@@ -219,7 +219,7 @@ try {
 
             $testTimezone | Set-TimeZone
             $observed = Get-TimeZone
-            $observed.ID | Should Be $testTimezone.Id
+            $observed.ID | Should -Be $testTimezone.Id
         }
 
         It "Call Set-TimeZone from pipeline input object of type TimeZoneInfo, verify supports whatif" {
@@ -235,7 +235,7 @@ try {
 
             Set-TimeZone -Id $testTimezone.Id -WhatIf > $null
             $observed = Get-TimeZone
-            $observed.Id | Should Be $origTimeZoneID
+            $observed.Id | Should -Be $origTimeZoneID
         }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/TimeZone.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/TimeZone.Tests.ps1
@@ -172,13 +172,7 @@ try {
         }
 
         It "Call Set-TimeZone with invalid Id" {
-            try {
-                Set-TimeZone -Id "zzInvalidID"
-                throw "No Exception!"
-            }
-            catch {
-                $_.FullyQualifiedErrorID | Should -Be "TimeZoneNotFound,Microsoft.PowerShell.Commands.SetTimeZoneCommand"
-            }
+            { Set-TimeZone -Id "zzInvalidID" } | Should -Throw -ErrorId "TimeZoneNotFound,Microsoft.PowerShell.Commands.SetTimeZoneCommand"
         }
 
         It "Call Set-TimeZone by Name" {
@@ -197,13 +191,7 @@ try {
         }
 
         It "Call Set-TimeZone with invalid Name" {
-            try {
-                Set-TimeZone -Name "zzINVALID_Name"
-                throw "No Exception!"
-            }
-            catch {
-                $_.FullyQualifiedErrorID | Should -Be "TimeZoneNotFound,Microsoft.PowerShell.Commands.SetTimeZoneCommand"
-            }
+            { Set-TimeZone -Name "zzINVALID_Name" } | Should -Throw -ErrorId "TimeZoneNotFound,Microsoft.PowerShell.Commands.SetTimeZoneCommand"
         }
 
         It "Call Set-TimeZone from pipeline input object of type TimeZoneInfo" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Unimplemented-Cmdlet.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Unimplemented-Cmdlet.Tests.ps1
@@ -23,7 +23,7 @@ Describe "Unimplemented Management Cmdlet Tests" -Tags "CI" {
 
     foreach ($Command in $Commands) {
         It "$Command should only be available on Windows" {
-            [bool](Get-Command $Command -ErrorAction SilentlyContinue) | Should Be $IsWindows
+            [bool](Get-Command $Command -ErrorAction SilentlyContinue) | Should -Be $IsWindows
         }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Variable.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Variable.Tests.ps1
@@ -48,8 +48,8 @@ Describe "Validate basic Variable provider cmdlets" -Tags "CI" {
         $existsBefore = Test-Path "Variable:${testVarName}"
         Remove-Item -Path "Variable:${testVarName}"
         $existsAfter = Test-Path "Variable:${testVarName}"
-        $existsBefore | Should -Be $true
-        $existsAfter | Should -Be $false
+        $existsBefore | Should -BeTrue
+        $existsAfter | Should -BeFalse
     }
 
     It "Verify Rename-Item" {
@@ -57,8 +57,8 @@ Describe "Validate basic Variable provider cmdlets" -Tags "CI" {
         Rename-Item -Path "Variable:${testVarName}" -NewName "${testVarName}_Rename"
         $existsAfter = Test-Path "Variable:${testVarName}"
         $result = Get-Item "Variable:${testVarName}_Rename"
-        $existsBefore | Should -Be $true
-        $existsAfter | Should -Be $false
+        $existsBefore | Should -BeTrue
+        $existsAfter | Should -BeFalse
         $result.Name | Should -Be "${testVarName}_Rename"
         $result.Value | Should -Be $testVarValue
     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Variable.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Variable.Tests.ps1
@@ -17,39 +17,39 @@ Describe "Validate basic Variable provider cmdlets" -Tags "CI" {
 
     It "Verify Get-Item" {
         $result = Get-Item "Variable:${testVarName}"
-        $result.Name | Should Be $testVarName
-        $result.Value | Should Be $testVarValue
+        $result.Name | Should -Be $testVarName
+        $result.Value | Should -Be $testVarValue
     }
 
     It "Verify New-Item" {
         $result = New-Item -Name "MyTestVariable" -Value 5 -Path "Variable:"
-        $result.Name | Should Be "MyTestVariable"
-        $result.Value | Should Be 5
+        $result.Name | Should -Be "MyTestVariable"
+        $result.Value | Should -Be 5
     }
 
     It "Verify Clear-Item" {
         $valueBefore = (Get-Item "Variable:${testVarName}").Value
         Clear-Item "Variable:${testVarName}"
         $valueAfter = (Get-Item "Variable:${testVarName}").Value
-        $valueBefore | Should Be $testVarValue
-        $valueAfter | Should BeNullOrEmpty
+        $valueBefore | Should -Be $testVarValue
+        $valueAfter | Should -BeNullOrEmpty
     }
 
     It "Verify Copy-Item" {
         Copy-Item -Path "Variable:${testVarName}" -Destination "Variable:${testVarName}_Copy"
         $original = Get-Item "Variable:${testVarName}"
         $copy = Get-Item "Variable:${testVarName}_Copy"
-        $original.Name | Should Be $testVarName
-        $copy.Name | Should Be "${testVarName}_Copy"
-        $original.Value | Should Be $copy.Value
+        $original.Name | Should -Be $testVarName
+        $copy.Name | Should -Be "${testVarName}_Copy"
+        $original.Value | Should -Be $copy.Value
     }
 
     It "Verify Remove-Item" {
         $existsBefore = Test-Path "Variable:${testVarName}"
         Remove-Item -Path "Variable:${testVarName}"
         $existsAfter = Test-Path "Variable:${testVarName}"
-        $existsBefore | Should Be $true
-        $existsAfter | Should Be $false
+        $existsBefore | Should -Be $true
+        $existsAfter | Should -Be $false
     }
 
     It "Verify Rename-Item" {
@@ -57,10 +57,10 @@ Describe "Validate basic Variable provider cmdlets" -Tags "CI" {
         Rename-Item -Path "Variable:${testVarName}" -NewName "${testVarName}_Rename"
         $existsAfter = Test-Path "Variable:${testVarName}"
         $result = Get-Item "Variable:${testVarName}_Rename"
-        $existsBefore | Should Be $true
-        $existsAfter | Should Be $false
-        $result.Name | Should Be "${testVarName}_Rename"
-        $result.Value | Should Be $testVarValue
+        $existsBefore | Should -Be $true
+        $existsAfter | Should -Be $false
+        $result.Name | Should -Be "${testVarName}_Rename"
+        $result.Value | Should -Be $testVarValue
     }
 }
 
@@ -84,7 +84,7 @@ Describe "Validate basic negative test cases for Variable provider cmdlets" -Tag
             New-Item -Name $testVarName -Value 5 -Path "Variable:" -ErrorAction Stop
             throw "Expected exception not thrown"
         }
-        catch { $_.FullyQualifiedErrorId | Should be "Argument,Microsoft.PowerShell.Commands.NewItemCommand" }
+        catch { $_.FullyQualifiedErrorId | Should -Be "Argument,Microsoft.PowerShell.Commands.NewItemCommand" }
     }
 
     It "Verify Negative Move-Item" {
@@ -93,7 +93,7 @@ Describe "Validate basic negative test cases for Variable provider cmdlets" -Tag
             Move-Item -Path "Variable:${testVarName}" -Destination "Variable:alreadyExistsVar" -ErrorAction Stop
             throw "Expected exception not thrown"
         }
-        catch { $_.FullyQualifiedErrorId | Should be "GetDynamicParametersException,Microsoft.PowerShell.Commands.MoveItemCommand" }
+        catch { $_.FullyQualifiedErrorId | Should -Be "GetDynamicParametersException,Microsoft.PowerShell.Commands.MoveItemCommand" }
     }
 
     It "Verify Negative Invoke-Item" {
@@ -101,7 +101,7 @@ Describe "Validate basic negative test cases for Variable provider cmdlets" -Tag
             Invoke-Item -Path "Variable:${testVarName}" -ErrorAction Stop
             throw "Expected exception not thrown"
         }
-        catch { $_.FullyQualifiedErrorId | Should be "NotSupported,Microsoft.PowerShell.Commands.InvokeItemCommand" }
+        catch { $_.FullyQualifiedErrorId | Should -Be "NotSupported,Microsoft.PowerShell.Commands.InvokeItemCommand" }
     }
 
     It "Verify Negative Get-ItemPropertyValue" {
@@ -109,6 +109,6 @@ Describe "Validate basic negative test cases for Variable provider cmdlets" -Tag
             Get-ItemPropertyValue -Path "Variable:" -Name $testVarName -ErrorAction Stop
             throw "Expected exception not thrown"
         }
-        catch { $_.FullyQualifiedErrorId | Should be "NotSupported,Microsoft.PowerShell.Commands.GetItemPropertyValueCommand" }
+        catch { $_.FullyQualifiedErrorId | Should -Be "NotSupported,Microsoft.PowerShell.Commands.GetItemPropertyValueCommand" }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Variable.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Variable.Tests.ps1
@@ -80,35 +80,19 @@ Describe "Validate basic negative test cases for Variable provider cmdlets" -Tag
     }
 
     It "Verify Negative New-Item" {
-        try {
-            New-Item -Name $testVarName -Value 5 -Path "Variable:" -ErrorAction Stop
-            throw "Expected exception not thrown"
-        }
-        catch { $_.FullyQualifiedErrorId | Should -Be "Argument,Microsoft.PowerShell.Commands.NewItemCommand" }
+        { New-Item -Name $testVarName -Value 5 -Path "Variable:" -ErrorAction Stop } | Should -Throw -ErrorId "Argument,Microsoft.PowerShell.Commands.NewItemCommand"
     }
 
     It "Verify Negative Move-Item" {
         $alreadyExistsVar = 2
-        try {
-            Move-Item -Path "Variable:${testVarName}" -Destination "Variable:alreadyExistsVar" -ErrorAction Stop
-            throw "Expected exception not thrown"
-        }
-        catch { $_.FullyQualifiedErrorId | Should -Be "GetDynamicParametersException,Microsoft.PowerShell.Commands.MoveItemCommand" }
+        { Move-Item -Path "Variable:${testVarName}" -Destination "Variable:alreadyExistsVar" -ErrorAction Stop } | Should -Throw -ErrorId "GetDynamicParametersException,Microsoft.PowerShell.Commands.MoveItemCommand"
     }
 
     It "Verify Negative Invoke-Item" {
-        try {
-            Invoke-Item -Path "Variable:${testVarName}" -ErrorAction Stop
-            throw "Expected exception not thrown"
-        }
-        catch { $_.FullyQualifiedErrorId | Should -Be "NotSupported,Microsoft.PowerShell.Commands.InvokeItemCommand" }
+        { Invoke-Item -Path "Variable:${testVarName}" -ErrorAction Stop } | Should -Throw -ErrorId "NotSupported,Microsoft.PowerShell.Commands.InvokeItemCommand"
     }
 
     It "Verify Negative Get-ItemPropertyValue" {
-        try {
-            Get-ItemPropertyValue -Path "Variable:" -Name $testVarName -ErrorAction Stop
-            throw "Expected exception not thrown"
-        }
-        catch { $_.FullyQualifiedErrorId | Should -Be "NotSupported,Microsoft.PowerShell.Commands.GetItemPropertyValueCommand" }
+        { Get-ItemPropertyValue -Path "Variable:" -Name $testVarName -ErrorAction Stop } | Should -Throw -ErrorId "NotSupported,Microsoft.PowerShell.Commands.GetItemPropertyValueCommand"
     }
 }


### PR DESCRIPTION
## PR Summary

Use new Pester syntax: -Parameter for Pester tests in Microsoft.PowerShell.Management module.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [x] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
