### PR TITLE
Add support for Debian in installpsh-debian.sh

### DIFF
--- a/tools/installpsh-debian.sh
+++ b/tools/installpsh-debian.sh
@@ -130,12 +130,12 @@ curl https://packages.microsoft.com/keys/microsoft.asc | $SUDO apt-key add -
 case $DISTRIB_ID in
     ubuntu)
         case $DISTRIB_RELEASE in
-            17.10|17.04|16.10|16.04|15.10|14.04)
+            17.10|16.10|16.04|15.10|14.04)
                 curl https://packages.microsoft.com/config/ubuntu/$DISTRIB_RELEASE/prod.list | $SUDO tee /etc/apt/sources.list.d/microsoft.list
             ;;
             *)
                 echo "ERROR: unsupported Ubuntu version ($DISTRIB_RELEASE)." >&2
-                echo "Supported versions: 14.04, 15.10, 16.04, 16.10, 17.04, 17.10." >&2
+                echo "Supported versions: 14.04, 15.10, 16.04, 16.10, 17.10." >&2
                 exit 1
             ;;
         esac

--- a/tools/installpsh-debian.sh
+++ b/tools/installpsh-debian.sh
@@ -5,7 +5,7 @@
 #bash <(wget -O - https://raw.githubusercontent.com/PowerShell/PowerShell/master/tools/installpsh-debian.sh) ARGUMENTS
 #bash <(curl -s https://raw.githubusercontent.com/PowerShell/PowerShell/master/tools/installpsh-debian.sh) <ARGUMENTS>
 
-#Usage - if you do not have the ability to run scripts directly from the web, 
+#Usage - if you do not have the ability to run scripts directly from the web,
 #        pull all files in this repo folder and execute, this script
 #        automatically prefers local copies of sub-scripts
 
@@ -25,7 +25,7 @@ thisinstallerdistro=debian
 repobased=true
 gitscriptname="installpsh-debian.psh"
 
-echo ; 
+echo ;
 echo "*** PowerShell Core Development Environment Installer $VERSION for $thisinstallerdistro"
 echo "***    Current PowerShell Core Version: $currentpshversion"
 echo "***    Original script is at: $gitreposcriptroot/$gitscriptname"
@@ -104,7 +104,8 @@ if [[ "$SUDO" -eq "sudo" && ! ("'$*'" =~ skip-sudo-check) ]]; then
 fi
 
 #Collect any variation details if required for this distro
-REV=`cat /etc/lsb-release | grep '^DISTRIB_RELEASE' | sed 's/^[^"]*"//;s/\..*$//'`
+. /etc/lsb-release
+DISTRIB_ID=`lowercase $DISTRIB_ID`
 #END Collect any variation details if required for this distro
 
 #If there are known incompatible versions of this distro, put the test, message and script exit here:
@@ -126,11 +127,35 @@ echo "*** Setting up PowerShell Core repo..."
 # Import the public repository GPG keys
 curl https://packages.microsoft.com/keys/microsoft.asc | $SUDO apt-key add -
 #Add the Repo
-case $REV in
-    8) $SUDO sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-debian-jessie-prod jessie main" > /etc/apt/sources.list.d/microsoft.list' ;;
-    9) $SUDO sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-debian-stretch-prod stretch main" > /etc/apt/sources.list.d/microsoft.list' ;;
+case $DISTRIB_ID in
+    ubuntu)
+        case $DISTRIB_RELEASE in
+            17.10|17.04|16.10|16.04|15.10|14.04)
+                curl https://packages.microsoft.com/config/ubuntu/$DISTRIB_RELEASE/prod.list | $SUDO tee /etc/apt/sources.list.d/microsoft.list
+            ;;
+            *)
+                echo "ERROR: unsupported Ubuntu version ($DISTRIB_RELEASE)." >&2
+                echo "Supported versions: 14.04, 15.10, 16.04, 16.10, 17.04, 17.10." >&2
+                exit 1
+            ;;
+        esac
+    ;;
+    debian)
+        DISTRIB_RELEASE=${DISTRIB_RELEASE%%.*}
+        case $DISTRIB_RELEASE in
+            8|9)
+                curl https://packages.microsoft.com/config/debian/$DISTRIB_RELEASE/prod.list | $SUDO tee /etc/apt/sources.list.d/microsoft.list
+            ;;
+            *)
+                echo "ERROR: unsupported Debian version ($DISTRIB_RELEASE)." >&2
+                echo "Supported versions: 8, 9." >&2
+                exit 1
+            ;;
+        esac
+    ;;
     *)
-        echo "ERROR: unsupported Debian version ($REV). Only versions 8 and 9 are supported." >&2
+        echo "ERROR: unsupported Debian-based distribution ($DISTRIB_ID)." >&2
+        echo "Supported distributions: Debian, Ubuntu." >&2
         exit 1
     ;;
 esac
@@ -168,7 +193,7 @@ fi
 if [[ "'$*'" =~ -interactivetesting ]] ; then
     echo "*** Loading test code in VS Code"
     curl -O ./testpowershell.ps1 https://raw.githubusercontent.com/DarwinJS/CloudyWindowsAutomationCode/master/pshcoredevenv/testpowershell.ps1
-    code ./testpowershell.ps1        
+    code ./testpowershell.ps1
 fi
 
 if [[ "$repobased" == true ]] ; then

--- a/tools/installpsh-debian.sh
+++ b/tools/installpsh-debian.sh
@@ -104,7 +104,7 @@ if [[ "$SUDO" -eq "sudo" && ! ("'$*'" =~ skip-sudo-check) ]]; then
 fi
 
 #Collect any variation details if required for this distro
-REV=`cat /etc/lsb-release | grep '^DISTRIB_RELEASE' | awk -F=  '{ print $2 }'`
+REV=`cat /etc/lsb-release | grep '^DISTRIB_RELEASE' | sed 's/^[^"]*"//;s/\..*$//'`
 #END Collect any variation details if required for this distro
 
 #If there are known incompatible versions of this distro, put the test, message and script exit here:
@@ -126,7 +126,15 @@ echo "*** Setting up PowerShell Core repo..."
 # Import the public repository GPG keys
 curl https://packages.microsoft.com/keys/microsoft.asc | $SUDO apt-key add -
 #Add the Repo
-curl https://packages.microsoft.com/config/ubuntu/$REV/prod.list | $SUDO tee /etc/apt/sources.list.d/microsoft.list
+case $REV in
+    8) $SUDO sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-debian-jessie-prod jessie main" > /etc/apt/sources.list.d/microsoft.list' ;;
+    9) $SUDO sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-debian-stretch-prod stretch main" > /etc/apt/sources.list.d/microsoft.list' ;;
+    *)
+        echo "ERROR: unsupported Debian version ($REV). Only versions 8 and 9 are supported." >&2
+        exit 1
+    ;;
+esac
+
 # Update apt-get
 $SUDO apt-get update
 # Install PowerShell


### PR DESCRIPTION
Related issue:  #5700

## PR Summary

The script `installpsh-debian` only works for Ubuntu distributions. This PR adds support for Debian as well.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - **These changes are based on the docs**
- **Testing - New and feature**
    - [x] Not Applicable or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
