### PR TITLE
make Linux packages use correct version scheme for preview releases

### DIFF
--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -1975,8 +1975,6 @@ function Get-LinuxPackageSemanticVersion
     } elseif ($packageVersionTokens.Count -ge 2) {
         $packageRevisionTokens = ($packageVersionTokens[1..($packageVersionTokens.Count-1)] -join '-')
         $packageSemanticVersion = ('{0}~{1}' -f  $packageVersionTokens[0], $packageRevisionTokens)
-    } else {
-        throw "Cannot create Semantic Version from the string $Version containing 4 or more tokens"
     }
 
     $packageSemanticVersion


### PR DESCRIPTION
## PR Summary

Fixes #6315 

make Linux packages use correct version scheme for preview releases
    - Now uses `<Major>.<Minor>.<Patch>~<PreviewName>` instead of `<Major>.<Minor>.<Patch>-<PreviewName>` as the `-` was interpretted as an iteration of the release not a preview.

I've manually tested for `apt` by:

1. Building a `v6.1.0` and a `v6.1.0-preview` package
1. Verified that the versions showed up in the packages as `6.1.0` and `6.1.0~preview`
1. publishing them to an Aptly repo
1. connecting a client and verifying that `v6.1.0` is the offered package and `v6.1.0-preview` is available.

Update: I've done similar verification for CentOS

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [x] Not Applicable or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
