### PR TITLE
Fix error in windows provider when the environment as an existing set of variables name that only differs by case

### DIFF
--- a/src/System.Management.Automation/namespaces/EnvironmentProvider.cs
+++ b/src/System.Management.Automation/namespaces/EnvironmentProvider.cs
@@ -198,7 +198,15 @@ namespace Microsoft.PowerShell.Commands
             IDictionary environmentTable = Environment.GetEnvironmentVariables();
             foreach (DictionaryEntry entry in environmentTable)
             {
-                providerTable.Add((string)entry.Key, entry);
+                // Windows only: duplicate key (variable name that differs only in case)
+                // NOTE: Even though this shouldn't happen, it can, e.g. when npm
+                //       creates duplicate environment variables that differ only in case -
+                //       see https://github.com/PowerShell/PowerShell/issues/6305.
+                //       However, because retrieval *by name* later is invariably
+                //       case-Insensitive, in effect only a *single* variable exists.
+                //       We simply ask Environment.GetEnvironmentVariable() which value is
+                //       the effective one, and use that.
+                providerTable.TryAdd((string)entry.Key, entry);
             }
 
             return providerTable;

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Item.Tests.ps1
@@ -129,7 +129,7 @@ Describe "Get-Item" -Tags "CI" {
         }
 
         It "get-item testVar" {
-            $env:testVar | Should -BeExactly "a"
+            (get-item env:\testVar).Value | Should -BeExactly "a"
         }
 
         It "get-item is case-sensitive/insensitive as appropriate" {
@@ -139,7 +139,7 @@ Describe "Get-Item" -Tags "CI" {
                 $expectedValue = "a"
             }
 
-            $env:testvar | Should -BeExactly $expectedValue
+            (get-item env:\testvar).Value | Should -BeExactly $expectedValue
         }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Item.Tests.ps1
@@ -116,4 +116,31 @@ Describe "Get-Item" -Tags "CI" {
             ${result} | Should BeOfType "Microsoft.Win32.RegistryKey"
         }
     }
+
+    Context "Environment provider" -tag "CI" {
+        BeforeAll {
+            $env:testvar="b"
+            $env:testVar="a"
+        }
+
+        AfterAll {
+            Clear-Item -Path env:testvar -ErrorAction SilentlyContinue
+            Clear-Item -Path env:testVar -ErrorAction SilentlyContinue
+        }
+
+        It "get-item testVar" {
+            $env:testVar | should -BeExactly "a"
+        }
+
+        It "get-item is case-sensitive/insensitive as appropriate" {
+            $expectedValue = "b"
+            if($IsWindows)
+            {
+                $expectedValue = "a"
+            }
+
+            $env:testvar | should -BeExactly $expectedValue
+        }
+
+    }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Item.Tests.ps1
@@ -129,7 +129,7 @@ Describe "Get-Item" -Tags "CI" {
         }
 
         It "get-item testVar" {
-            $env:testVar | should -BeExactly "a"
+            $env:testVar | Should -BeExactly "a"
         }
 
         It "get-item is case-sensitive/insensitive as appropriate" {
@@ -139,8 +139,7 @@ Describe "Get-Item" -Tags "CI" {
                 $expectedValue = "a"
             }
 
-            $env:testvar | should -BeExactly $expectedValue
+            $env:testvar | Should -BeExactly $expectedValue
         }
-
     }
 }


### PR DESCRIPTION
## PR Summary

fix error in windows provider when the environment as an existing set of variables name that only differs by case
    - make the provider storage for the environment on windows ignore duplicates
    - add tests to verify existing environment get-item behavior

fixes #6305 

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [x] Not Applicable or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
