### PR TITLE
Make Relative Redirect URI Absolute When Authorization Header Present

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -1257,7 +1257,7 @@ namespace Microsoft.PowerShell.Commands
 
                 // recreate the HttpClient with redirection enabled since the first call suppressed redirection
                 using (client = GetHttpClient(false))
-                using (HttpRequestMessage redirectRequest = GetRequest(response.Headers.Location, stripAuthorization:true))
+                using (HttpRequestMessage redirectRequest = GetRequest(new Uri(request.RequestUri, response.Headers.Location), stripAuthorization:true))
                 {
                     FillRequestStream(redirectRequest);
                     _cancelToken = new CancellationTokenSource();

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -363,6 +363,8 @@ $redirectTests = @(
 
     @{redirectType = 'TemporaryRedirect'; redirectedMethod = 'GET'}
     @{redirectType = 'RedirectKeepVerb'; redirectedMethod = 'GET'} # Synonym for TemporaryRedirect
+
+    @{redirectType = 'relative'; redirectedMethod = 'GET'}
 )
 
 $PendingCertificateTest = $false

--- a/test/tools/WebListener/Controllers/RedirectController.cs
+++ b/test/tools/WebListener/Controllers/RedirectController.cs
@@ -30,11 +30,18 @@ namespace mvc.Controllers
                 url = $"{url}/Redirect/{nextHop}";
             }
 
-            if (Request.Query.TryGetValue("type", out StringValues type) && Enum.TryParse(type.FirstOrDefault(), out HttpStatusCode status))
+            var typeIsPresent = Request.Query.TryGetValue("type", out StringValues type);
+
+            if (typeIsPresent && Enum.TryParse(type.FirstOrDefault(), out HttpStatusCode status))
             {
                 Response.StatusCode = (int)status;
                 url = $"{url}?type={type.FirstOrDefault()}";
                 Response.Headers.Add("Location", url);
+            }
+            else if (typeIsPresent && String.Equals(type.FirstOrDefault(), "relative", StringComparison.InvariantCultureIgnoreCase))
+            {
+                url = new Uri($"{url}?type={type.FirstOrDefault()}").PathAndQuery;
+                Response.Redirect(url, false);
             }
             else
             {

--- a/test/tools/WebListener/README.md
+++ b/test/tools/WebListener/README.md
@@ -489,6 +489,7 @@ Invoke-RestMethod -Uri $uri -Body $body -Method 'Put'
 
 Will `302` redirect to `/Get/`. If a number is supplied, redirect will occur that many times. Can be used to test maximum redirects.
 If the `type` query field is supplied the corresponding `System.Net.HttpStatusCode` will be returned instead of `302`.
+If `type` is `relative`, the redirect URI will be relative instead of absolute.
 
 ```powershell
 $uri = Get-WebListenerUrl -Test 'Redirect' -TestValue '2'


### PR DESCRIPTION
## PR Summary

Fix #5967

Fix `Invalid URI: The hostname could not be parsed.` error from Web Cmdlets when `Authorization` request header is present, `-PreserveAuthorizationOnRedirect` is not present, and the `Location` response header is a relative URI. 

Switches the URI constructor to [Uri(Uri, Uri)](https://docs.microsoft.com/en-us/dotnet/api/system.uri.-ctor?view=netcore-2.0#System_Uri__ctor_System_Uri_System_Uri_)  to support the creation of an absolute URI with the request uri and the response location.

Added and documented the `relative` option for `type` on the WebListener Redirect controller. 


## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [X] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [X] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [X] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
