### PR TITLE
WebRequestPsCmdlet: handle link relation keys case-insensitively

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -1616,7 +1616,8 @@ namespace Microsoft.PowerShell.Commands
         {
             if (_relationLink == null)
             {
-                _relationLink = new Dictionary<string, string>();
+                // Must ignore the case of relation links. See RFC 8288 (https://tools.ietf.org/html/rfc8288)
+                _relationLink = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             }
             else
             {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -733,6 +733,28 @@ Describe "Invoke-WebRequest tests" -Tags "Feature" {
         $result.Output.RelationLink["self"] | Should -BeExactly "${baseUri}?maxlinks=5&linknumber=2&type=multiple"
     }
 
+
+    It "Validate Invoke-WebRequest RelationLink keys are treated case-insensitively" {
+        $uri = Get-WebListenerUrl -Test 'Link' -Query @{maxlinks = 5; linknumber = 2; type = 'multiple'}
+        $command = "Invoke-WebRequest -Uri '$uri'"
+        $result = ExecuteWebCommand -command $command
+
+        $result.Output.RelationLink["next"] | Should -Not -BeNullOrEmpty
+        $result.Output.RelationLink["next"] | Should -BeExactly $result.Output.RelationLink["Next"]
+
+        $result.Output.RelationLink["last"] | Should -Not -BeNullOrEmpty
+        $result.Output.RelationLink["last"] | Should -BeExactly $result.Output.RelationLink["LAST"]
+
+        $result.Output.RelationLink["prev"] | Should -Not -BeNullOrEmpty
+        $result.Output.RelationLink["prev"] | Should -BeExactly $result.Output.RelationLink["preV"]
+
+        $result.Output.RelationLink["first"] | Should -Not -BeNullOrEmpty
+        $result.Output.RelationLink["first"] | Should -BeExactly $result.Output.RelationLink["FiRsT"]
+
+        $result.Output.RelationLink["self"] | Should -Not -BeNullOrEmpty
+        $result.Output.RelationLink["self"] | Should -BeExactly $result.Output.RelationLink["self"]
+    }
+
     It "Validate Invoke-WebRequest quietly ignores invalid Link Headers in RelationLink property: <type>" -TestCases @(
         @{ type = "noUrl" }
         @{ type = "malformed" }


### PR DESCRIPTION
## PR Summary
* Fix #6146, where web request cmdlets use case-sensitive keys for link relations, contrary to [RFC 8288](https://tools.ietf.org/html/rfc8288).
* Add tests to monitor this property.

All credit goes to @markekraus.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [x] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
