### PR TITLE
Use new Pester syntax: -Parameter for Pester tests in Modules/Microsoft.PowerShell.Core.

### DIFF
--- a/test/powershell/Modules/Microsoft.PowerShell.Core/History.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/History.Tests.ps1
@@ -21,20 +21,20 @@ Describe "History cmdlet test cases" -Tags "CI" {
         It "Get-History returns proper history" {
             # for this case, we'll *not* add to history
             $result = $ps.AddCommand("Get-History").Invoke()
-            $result.Count | should be 3
-            $result[0].CommandLine | should be "Get-Date"
-            $result[1].CommandLine | should be "1+1"
-            $result[2].CommandLine | should be "Get-Location"
+            $result.Count | Should -Be 3
+            $result[0].CommandLine | Should -Be "Get-Date"
+            $result[1].CommandLine | Should -Be "1+1"
+            $result[2].CommandLine | Should -Be "Get-Location"
         }
         It "Invoke-History invokes proper command" {
             $result = $ps.AddScript("Invoke-History 2").Invoke()
-            $result | Should be 2
+            $result | Should -Be 2
         }
         It "Clear-History removes history" {
             $ps.AddCommand("Clear-History").Invoke()
             $ps.commands.clear()
             $result = $ps.AddCommand("Get-History").Invoke()
-            $result | should BeNullOrEmpty
+            $result | Should -BeNullOrEmpty
         }
         It "Add-History actually adds to history" {
             # add this invocation to history
@@ -42,9 +42,9 @@ Describe "History cmdlet test cases" -Tags "CI" {
             # that's 4 history lines * 2
             $ps.Commands.Clear()
             $result = $ps.AddCommand("Get-History").Invoke()
-            $result.Count | Should be 8
+            $result.Count | Should -Be 8
             for($i = 0; $i -lt 4; $i++) {
-                $result[$i+4].CommandLine | Should be $result[$i].CommandLine
+                $result[$i+4].CommandLine | Should -Be $result[$i].CommandLine
             }
         }
     }
@@ -90,7 +90,7 @@ Describe "History cmdlet test cases" -Tags "CI" {
         $ps.Dispose()
 
         ## Twice per stream - once for the original invocation, and once for the re-invocation
-        $outputCount | Should be 12
+        $outputCount | Should -Be 12
     }
 
 	It "Tests Invoke-History on a private command" {
@@ -108,6 +108,6 @@ Describe "History cmdlet test cases" -Tags "CI" {
         $errorResult = $ps.Streams.Error[0].FullyQualifiedErrorId
         $ps.Dispose()
 
-        $errorResult | Should be CommandNotFoundException
+        $errorResult | Should -Be CommandNotFoundException
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/History.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/History.Tests.ps1
@@ -22,9 +22,9 @@ Describe "History cmdlet test cases" -Tags "CI" {
             # for this case, we'll *not* add to history
             $result = $ps.AddCommand("Get-History").Invoke()
             $result.Count | Should -Be 3
-            $result[0].CommandLine | Should -Be "Get-Date"
+            $result[0].CommandLine | Should -BeExactly "Get-Date"
             $result[1].CommandLine | Should -Be "1+1"
-            $result[2].CommandLine | Should -Be "Get-Location"
+            $result[2].CommandLine | Should -BeExactly "Get-Location"
         }
         It "Invoke-History invokes proper command" {
             $result = $ps.AddScript("Invoke-History 2").Invoke()

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/History.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/History.Tests.ps1
@@ -44,7 +44,7 @@ Describe "History cmdlet test cases" -Tags "CI" {
             $result = $ps.AddCommand("Get-History").Invoke()
             $result.Count | Should -Be 8
             for($i = 0; $i -lt 4; $i++) {
-                $result[$i+4].CommandLine | Should -Be $result[$i].CommandLine
+                $result[$i+4].CommandLine | Should -BeExactly $result[$i].CommandLine
             }
         }
     }
@@ -108,6 +108,6 @@ Describe "History cmdlet test cases" -Tags "CI" {
         $errorResult = $ps.Streams.Error[0].FullyQualifiedErrorId
         $ps.Dispose()
 
-        $errorResult | Should -Be CommandNotFoundException
+        $errorResult | Should -BeExactly 'CommandNotFoundException'
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Import-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Import-Module.Tests.ps1
@@ -17,34 +17,34 @@ Describe "Import-Module" -Tags "CI" {
 
     BeforeEach {
         Remove-Module -Name $moduleName -Force
-        (Get-Module -Name $moduleName).Name | Should BeNullOrEmpty
+        (Get-Module -Name $moduleName).Name | Should -BeNullOrEmpty
     }
 
     AfterEach {
         Import-Module -Name $moduleName -Force
-        (Get-Module -Name $moduleName).Name | Should Be $moduleName
+        (Get-Module -Name $moduleName).Name | Should -Be $moduleName
     }
 
     It "should be able to add a module with using Name switch" {
-        { Import-Module -Name $moduleName } | Should Not Throw
-        (Get-Module -Name $moduleName).Name | Should Be $moduleName
+        { Import-Module -Name $moduleName } | Should -Not -Throw
+        (Get-Module -Name $moduleName).Name | Should -Be $moduleName
     }
 
     It "should be able to add a module with using ModuleInfo switch" {
         $a = Get-Module -ListAvailable $moduleName
-        { Import-Module -ModuleInfo $a } | Should Not Throw
-        (Get-Module -Name $moduleName).Name | Should Be $moduleName
+        { Import-Module -ModuleInfo $a } | Should -Not -Throw
+        (Get-Module -Name $moduleName).Name | Should -Be $moduleName
     }
 
     It "should be able to load an already loaded module" {
         Import-Module $moduleName
-        { $script:module = Import-Module $moduleName -PassThru -ErrorAction Stop } | Should Not Throw
-        Get-Module -Name $moduleName | Should Be $script:module
+        { $script:module = Import-Module $moduleName -PassThru -ErrorAction Stop } | Should -Not -Throw
+        Get-Module -Name $moduleName | Should -Be $script:module
     }
 
     It "should only load the specified version" {
         Import-Module TestModule -RequiredVersion 1.1
-        (Get-Module TestModule).Version | Should BeIn "1.1"
+        (Get-Module TestModule).Version | Should -BeIn "1.1"
     }
 }
 
@@ -85,7 +85,7 @@ Describe "Import-Module with ScriptsToProcess" -Tags "CI" {
     It "Verify ScriptsToProcess are executed <TestNameSuffix>" -TestCases $testCases {
         param($TestNameSuffix,$ipmoParms,$Expected)
         Import-Module @ipmoParms
-        Get-Content out.txt | Should Be $Expected
+        Get-Content out.txt | Should -Be $Expected
     }
 }
 
@@ -109,7 +109,7 @@ Describe "Import-Module for Binary Modules in GAC" -Tags 'CI' {
         It "Load PSScheduledJob from Windows Powershell Modules folder" -Skip:(-not $IsWindows) {
             $modulePath = Join-Path $env:windir "System32/WindowsPowershell/v1.0/Modules/PSScheduledJob"
             Import-Module $modulePath
-            (Get-Command New-JobTrigger).Name | Should Be 'New-JobTrigger'
+            (Get-Command New-JobTrigger).Name | Should -Be 'New-JobTrigger'
         }
     }
 }
@@ -138,8 +138,8 @@ namespace ModuleCmdlets
 
     #Ignore slash format difference under windows/Unix
     $path = (Get-ChildItem $TESTDRIVE\System.dll).FullName
-    $results[0] | Should Be $path
-    $results[1] | Should BeExactly "BinaryModuleCmdlet1 exported by the ModuleCmdlets module."
+    $results[0] | Should -Be $path
+    $results[1] | Should -BeExactly "BinaryModuleCmdlet1 exported by the ModuleCmdlets module."
     }
 
     It "PS should try to load the assembly from assembly name if file path doesn't exist" {
@@ -150,9 +150,9 @@ namespace ModuleCmdlets
         try
         {
             $module = Import-Module $psdFile -PassThru
-            $module.NestedModules | Should Not BeNullOrEmpty
+            $module.NestedModules | Should -Not -BeNullOrEmpty
             $assemblyLocation = [Microsoft.PowerShell.Commands.AddTypeCommand].Assembly.Location
-            $module.NestedModules.ImplementingAssembly.Location | Should Be $assemblyLocation
+            $module.NestedModules.ImplementingAssembly.Location | Should -Be $assemblyLocation
         }
         finally
         {
@@ -193,10 +193,10 @@ Describe "Import-Module should be case insensitive" -Tags 'CI' {
         Set-Content -Path "$modulesPath/$modulePath/TESTMODULE.psm1" -Value "function mytest { 'hello' }"
         Import-Module testMODULE
         $m = Get-Module TESTmodule
-        $m | Should BeOfType "System.Management.Automation.PSModuleInfo"
-        $m.Name | Should BeIn "TESTMODULE"
-        mytest | Should BeExactly "hello"
+        $m | Should -BeOfType "System.Management.Automation.PSModuleInfo"
+        $m.Name | Should -BeIn "TESTMODULE"
+        mytest | Should -BeExactly "hello"
         Remove-Module TestModule
-        Get-Module tESTmODULE | Should BeNullOrEmpty
+        Get-Module tESTmODULE | Should -BeNullOrEmpty
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Import-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Import-Module.Tests.ps1
@@ -22,24 +22,24 @@ Describe "Import-Module" -Tags "CI" {
 
     AfterEach {
         Import-Module -Name $moduleName -Force
-        (Get-Module -Name $moduleName).Name | Should -Be $moduleName
+        (Get-Module -Name $moduleName).Name | Should -BeExactly $moduleName
     }
 
     It "should be able to add a module with using Name switch" {
         { Import-Module -Name $moduleName } | Should -Not -Throw
-        (Get-Module -Name $moduleName).Name | Should -Be $moduleName
+        (Get-Module -Name $moduleName).Name | Should -BeExactly $moduleName
     }
 
     It "should be able to add a module with using ModuleInfo switch" {
         $a = Get-Module -ListAvailable $moduleName
         { Import-Module -ModuleInfo $a } | Should -Not -Throw
-        (Get-Module -Name $moduleName).Name | Should -Be $moduleName
+        (Get-Module -Name $moduleName).Name | Should -BeExactly $moduleName
     }
 
     It "should be able to load an already loaded module" {
         Import-Module $moduleName
         { $script:module = Import-Module $moduleName -PassThru -ErrorAction Stop } | Should -Not -Throw
-        Get-Module -Name $moduleName | Should -Be $script:module
+        Get-Module -Name $moduleName | Should -BeExactly $script:module
     }
 
     It "should only load the specified version" {
@@ -85,7 +85,7 @@ Describe "Import-Module with ScriptsToProcess" -Tags "CI" {
     It "Verify ScriptsToProcess are executed <TestNameSuffix>" -TestCases $testCases {
         param($TestNameSuffix,$ipmoParms,$Expected)
         Import-Module @ipmoParms
-        Get-Content out.txt | Should -Be $Expected
+        Get-Content out.txt | Should -BeExactly $Expected
     }
 }
 
@@ -109,7 +109,7 @@ Describe "Import-Module for Binary Modules in GAC" -Tags 'CI' {
         It "Load PSScheduledJob from Windows Powershell Modules folder" -Skip:(-not $IsWindows) {
             $modulePath = Join-Path $env:windir "System32/WindowsPowershell/v1.0/Modules/PSScheduledJob"
             Import-Module $modulePath
-            (Get-Command New-JobTrigger).Name | Should -Be 'New-JobTrigger'
+            (Get-Command New-JobTrigger).Name | Should -BeExactly 'New-JobTrigger'
         }
     }
 }
@@ -138,7 +138,7 @@ namespace ModuleCmdlets
 
     #Ignore slash format difference under windows/Unix
     $path = (Get-ChildItem $TESTDRIVE\System.dll).FullName
-    $results[0] | Should -Be $path
+    $results[0] | Should -BeExactly $path
     $results[1] | Should -BeExactly "BinaryModuleCmdlet1 exported by the ModuleCmdlets module."
     }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Job.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Job.Tests.ps1
@@ -130,7 +130,7 @@ Describe "Job Cmdlet Tests" -Tag "CI" {
         It "Receive-Job will retrieve partial output" {
             $result1 = GetResults $j 5 $false
             $result2 = GetResults $j 5 $false
-            CheckContent ($result1 + $result2) | Should -Be $true
+            CheckContent ($result1 + $result2) | Should -BeTrue
         }
         It "Receive-Job will retrieve partial output, including -Keep results" {
             $result1 = GetResults $j 5 $true

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Job.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Job.Tests.ps1
@@ -10,7 +10,7 @@ Describe "Job Cmdlet Tests" -Tag "CI" {
         }
         It "Start-Job produces a job object" {
             $j | Should -BeOfType "System.Management.Automation.Job"
-            $j.Name | Should -Be "My Job"
+            $j.Name | Should -BeExactly "My Job"
         }
         It "Get-Job retrieves a job object" {
             (Get-Job -Id $j.Id) | Should -BeOfType "System.Management.Automation.Job"
@@ -52,15 +52,15 @@ Describe "Job Cmdlet Tests" -Tag "CI" {
         It "Wait-Job will wait for a job" {
             $result = Wait-Job $j
             $result | Should -Be $j
-            $j.State | Should -Be "Completed"
+            $j.State | Should -BeExactly "Completed"
         }
         It "Wait-Job will timeout waiting for a job" {
             $result = Wait-Job -Timeout 2 $j
-            $result | Should -Be $null
+            $result | Should -BeNullOrEmpty
         }
         It "Stop-Job will stop a job" {
             Stop-Job -Id $j.Id
-            $j.State | Should -Be "Stopped"
+            $j.State | Should -BeExactly "Stopped"
         }
         It "Remove-Job will not remove a running job" {
             $id = $j.Id
@@ -72,7 +72,7 @@ Describe "Job Cmdlet Tests" -Tag "CI" {
             $id = $j.Id
             Remove-Job $j -Force
             $job = Get-Job -Id $id -ErrorAction SilentlyContinue
-            $job | Should -Be $null
+            $job | Should -BeNullOrEmpty
         }
     }
     Context "Retrieving partial output from jobs" {
@@ -135,7 +135,7 @@ Describe "Job Cmdlet Tests" -Tag "CI" {
         It "Receive-Job will retrieve partial output, including -Keep results" {
             $result1 = GetResults $j 5 $true
             $result2 = GetResults $j ($result1.Count + 5) $false
-            Compare-Object -SyncWindow 0 -PassThru $result1 $result2[0..($result1.Count-1)] | Should -Be $null
+            Compare-Object -SyncWindow 0 -PassThru $result1 $result2[0..($result1.Count-1)] | Should -BeNullOrEmpty
             $result2[$result1.Count - 1] + 1 | Should -Be $result2[$result1.Count]
         }
     }
@@ -210,12 +210,12 @@ Describe "Ampersand background test" -tag "CI","Slow" {
         }
         It "Test that output redirection is done in the background job" {
             $j = Write-Output hello > $TESTDRIVE/hello.txt &
-            Receive-Job -Wait $j | Should -Be $null
+            Receive-Job -Wait $j | Should -BeNullOrEmpty
             Get-Content $TESTDRIVE/hello.txt | Should -BeExactly "hello"
         }
         It "Test that error redirection is done in the background job" {
             $j = Write-Error MyError 2> $TESTDRIVE/myerror.txt &
-            Receive-Job -Wait $j | Should -Be $null
+            Receive-Job -Wait $j | Should -BeNullOrEmpty
             Get-Content -Raw $TESTDRIVE/myerror.txt | Should -Match "MyError"
         }
     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Job.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Job.Tests.ps1
@@ -9,19 +9,19 @@ Describe "Job Cmdlet Tests" -Tag "CI" {
             Get-Job | Remove-Job -Force
         }
         It "Start-Job produces a job object" {
-            $j | Should BeOfType "System.Management.Automation.Job"
-            $j.Name | Should Be "My Job"
+            $j | Should -BeOfType "System.Management.Automation.Job"
+            $j.Name | Should -Be "My Job"
         }
         It "Get-Job retrieves a job object" {
-            (Get-Job -Id $j.Id) | Should BeOfType "System.Management.Automation.Job"
+            (Get-Job -Id $j.Id) | Should -BeOfType "System.Management.Automation.Job"
         }
         It "Get-Job retrieves an array of job objects" {
             Start-Job -ScriptBlock { 2 * 2 }
             $jobs = Get-Job
-            $jobs.Count | Should Be 2
+            $jobs.Count | Should -Be 2
             foreach ($job in $jobs)
             {
-                $job | Should BeOfType "System.Management.Automation.Job"
+                $job | Should -BeOfType "System.Management.Automation.Job"
             }
         }
         It "Remove-Job can remove a job" {
@@ -29,17 +29,17 @@ Describe "Job Cmdlet Tests" -Tag "CI" {
             { Get-Job $j -ErrorAction Stop } | ShouldBeErrorId "JobWithSpecifiedNameNotFound,Microsoft.PowerShell.Commands.GetJobCommand"
         }
         It "Receive-Job can retrieve job results" {
-            Wait-Job -Timeout 60 -id $j.id | Should Not BeNullOrEmpty
-            receive-job -id $j.id | Should be 2
+            Wait-Job -Timeout 60 -id $j.id | Should -Not -BeNullOrEmpty
+            receive-job -id $j.id | Should -Be 2
         }
     }
     Context "Jobs with arguments" {
         It "Start-Job accepts arguments" {
             $sb = { Write-Output $args[1]; Write-Output $args[0] }
             $j = Start-Job -ScriptBlock $sb -ArgumentList "$TestDrive", 42
-            Wait-job -Timeout (5 * 60) $j | Should Be $j
+            Wait-job -Timeout (5 * 60) $j | Should -Be $j
             $r = Receive-Job $j
-            $r -Join "," | Should Be "42,$TestDrive"
+            $r -Join "," | Should -Be "42,$TestDrive"
         }
     }
     Context "jobs which take time" {
@@ -51,28 +51,28 @@ Describe "Job Cmdlet Tests" -Tag "CI" {
         }
         It "Wait-Job will wait for a job" {
             $result = Wait-Job $j
-            $result | Should Be $j
-            $j.State | Should Be "Completed"
+            $result | Should -Be $j
+            $j.State | Should -Be "Completed"
         }
         It "Wait-Job will timeout waiting for a job" {
             $result = Wait-Job -Timeout 2 $j
-            $result | Should Be $null
+            $result | Should -Be $null
         }
         It "Stop-Job will stop a job" {
             Stop-Job -Id $j.Id
-            $j.State | Should Be "Stopped"
+            $j.State | Should -Be "Stopped"
         }
         It "Remove-Job will not remove a running job" {
             $id = $j.Id
             Remove-Job $j -ErrorAction SilentlyContinue
             $job = Get-Job -Id $id
-            $job | Should Be $j
+            $job | Should -Be $j
         }
         It "Remove-Job -Force will remove a running job" {
             $id = $j.Id
             Remove-Job $j -Force
             $job = Get-Job -Id $id -ErrorAction SilentlyContinue
-            $job | Should Be $null
+            $job | Should -Be $null
         }
     }
     Context "Retrieving partial output from jobs" {
@@ -130,13 +130,13 @@ Describe "Job Cmdlet Tests" -Tag "CI" {
         It "Receive-Job will retrieve partial output" {
             $result1 = GetResults $j 5 $false
             $result2 = GetResults $j 5 $false
-            CheckContent ($result1 + $result2) | Should Be $true
+            CheckContent ($result1 + $result2) | Should -Be $true
         }
         It "Receive-Job will retrieve partial output, including -Keep results" {
             $result1 = GetResults $j 5 $true
             $result2 = GetResults $j ($result1.Count + 5) $false
-            Compare-Object -SyncWindow 0 -PassThru $result1 $result2[0..($result1.Count-1)] | Should Be $null
-            $result2[$result1.Count - 1] + 1 | Should Be $result2[$result1.Count]
+            Compare-Object -SyncWindow 0 -PassThru $result1 $result2[0..($result1.Count-1)] | Should -Be $null
+            $result2[$result1.Count - 1] + 1 | Should -Be $result2[$result1.Count]
         }
     }
 }
@@ -158,13 +158,13 @@ Describe "Debug-job test" -tag "Feature" {
     It "Debug-Job will break into debugger" -pending {
         $ps.AddScript('$job = start-job { 1..300 | ForEach-Object { sleep 1 } }').Invoke()
         $ps.Commands.Clear()
-        $ps.Runspace.Debugger.GetCallStack() | Should BeNullOrEmpty
+        $ps.Runspace.Debugger.GetCallStack() | Should -BeNullOrEmpty
         Start-Sleep 3
         $asyncResult = $ps.AddScript('debug-job $job').BeginInvoke()
         $ps.commands.clear()
         Start-Sleep 2
         $result = $ps.runspace.Debugger.GetCallStack()
-        $result.Command | Should be "<ScriptBlock>"
+        $result.Command | Should -Be "<ScriptBlock>"
     }
 }
 
@@ -175,7 +175,7 @@ Describe "Ampersand background test" -tag "CI","Slow" {
         }
         It "Background with & produces a job object" {
             $j = Write-Output Hi &
-            $j | Should BeOfType System.Management.Automation.Job
+            $j | Should -BeOfType System.Management.Automation.Job
         }
     }
     Context "Variable tests" {
@@ -185,38 +185,38 @@ Describe "Ampersand background test" -tag "CI","Slow" {
         It "doesn't cause error when variable is missing" {
             Remove-Item variable:name -ErrorAction Ignore
             $j = write-output "Hi $name" &
-            Receive-Job $j -Wait | Should BeExactly "Hi "
+            Receive-Job $j -Wait | Should -BeExactly "Hi "
         }
         It "Copies variables to the child process" {
             $n1 = "Bob"
             $n2 = "Mary"
             ${n 3} = "Bill"
             $j = Write-Output "Hi $n1! Hi ${n2}! Hi ${n 3}!" &
-            Receive-Job $j -Wait | Should BeExactly "Hi Bob! Hi Mary! Hi Bill!"
+            Receive-Job $j -Wait | Should -BeExactly "Hi Bob! Hi Mary! Hi Bill!"
         }
         It 'Make sure that $PID from the parent process does not overwrite $PID in the child process' {
             $j = Write-Output $pid &
             $cpid = Receive-Job $j -Wait
-            $pid | Should Not BeExactly $cpid
+            $pid | Should -Not -BeExactly $cpid
         }
         It 'Make sure that $global:PID from the parent process does not overwrite $global:PID in the child process' {
             $j = Write-Output $global:pid &
             $cpid = Receive-Job -Wait $j
-            $pid | Should Not BeExactly $cpid
+            $pid | Should -Not -BeExactly $cpid
         }
         It "starts in the current directory" {
             $j = Get-Location | Foreach-Object -MemberName Path &
-            Receive-Job -Wait $j | Should Be ($pwd.Path)
+            Receive-Job -Wait $j | Should -Be ($pwd.Path)
         }
         It "Test that output redirection is done in the background job" {
             $j = Write-Output hello > $TESTDRIVE/hello.txt &
-            Receive-Job -Wait $j | Should Be $null
-            Get-Content $TESTDRIVE/hello.txt | Should BeExactly "hello"
+            Receive-Job -Wait $j | Should -Be $null
+            Get-Content $TESTDRIVE/hello.txt | Should -BeExactly "hello"
         }
         It "Test that error redirection is done in the background job" {
             $j = Write-Error MyError 2> $TESTDRIVE/myerror.txt &
-            Receive-Job -Wait $j | Should Be $null
-            Get-Content -Raw $TESTDRIVE/myerror.txt | Should Match "MyError"
+            Receive-Job -Wait $j | Should -Be $null
+            Get-Content -Raw $TESTDRIVE/myerror.txt | Should -Match "MyError"
         }
     }
     Context "Backgrounding expressions" {
@@ -225,11 +225,11 @@ Describe "Ampersand background test" -tag "CI","Slow" {
         }
         It "handles backgrounding expressions" {
             $j = 2+3 &
-            Receive-Job $j -Wait | Should Be 5
+            Receive-Job $j -Wait | Should -Be 5
         }
         It "handles backgrounding mixed expressions" {
             $j = 1..10 | ForEach-Object -Begin {$s=0} -Process {$s += $_} -End {$s} &
-            Receive-Job -Wait $j | Should Be 55
+            Receive-Job -Wait $j | Should -Be 55
         }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Job.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Job.Tests.ps1
@@ -164,7 +164,7 @@ Describe "Debug-job test" -tag "Feature" {
         $ps.commands.clear()
         Start-Sleep 2
         $result = $ps.runspace.Debugger.GetCallStack()
-        $result.Command | Should -Be "<ScriptBlock>"
+        $result.Command | Should -BeExactly "<ScriptBlock>"
     }
 }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Out-Default.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Out-Default.Tests.ps1
@@ -16,16 +16,16 @@ Describe "Out-Default Tests" -tag CI {
             `$null = Stop-Transcript
 "@
 
-        & $powershell -noprofile -command $script | Should BeExactly 'bye'
-        "TestDrive:\transcript.txt" | Should FileContentMatch 'hello'
+        & $powershell -noprofile -command $script | Should -BeExactly 'bye'
+        "TestDrive:\transcript.txt" | Should -FileContentMatch 'hello'
     }
 
     It "Out-Default reverts transcription state when used more than once in a pipeline" {
-        & $powershell -noprofile -command "Out-Default -Transcript | Out-Default -Transcript; 'Hello'" | Should BeExactly "Hello"
+        & $powershell -noprofile -command "Out-Default -Transcript | Out-Default -Transcript; 'Hello'" | Should -BeExactly "Hello"
     }
 
     It "Out-Default reverts transcription state when exception occurs in pipeline" {
-        & $powershell -noprofile -command "try { & { throw } | Out-Default -Transcript } catch {}; 'Hello'" | Should BeExactly "Hello"
+        & $powershell -noprofile -command "try { & { throw } | Out-Default -Transcript } catch {}; 'Hello'" | Should -BeExactly "Hello"
     }
 
     It "Out-Default reverts transcription state even if Dispose() isn't called" {
@@ -37,6 +37,6 @@ Describe "Out-Default Tests" -tag CI {
             [GC]::WaitForPendingFinalizers();
             'hello'
 "@
-        & $powershell -noprofile -command $script | Should BeExactly 'hello'
+        & $powershell -noprofile -command $script | Should -BeExactly 'hello'
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Out-Host.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Out-Host.Tests.ps1
@@ -22,6 +22,6 @@ Describe "Out-Host Tests" -tag CI {
         $stringExpected = "::$($stringToWrite):NewLine"
         $result = $ps.AddScript("Out-Host -inputobject '$stringToWrite'").Invoke()
         $th.UI.Streams.ConsoleOutput.Count | Should -Be 1
-        $th.UI.Streams.ConsoleOutput[0] | Should -Be $stringExpected
+        $th.UI.Streams.ConsoleOutput[0] | Should -BeExactly $stringExpected
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Out-Host.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Out-Host.Tests.ps1
@@ -21,7 +21,7 @@ Describe "Out-Host Tests" -tag CI {
         $stringToWrite = "thing to write"
         $stringExpected = "::$($stringToWrite):NewLine"
         $result = $ps.AddScript("Out-Host -inputobject '$stringToWrite'").Invoke()
-        $th.UI.Streams.ConsoleOutput.Count | should be 1
-        $th.UI.Streams.ConsoleOutput[0] | should be $stringExpected
+        $th.UI.Streams.ConsoleOutput.Count | Should -Be 1
+        $th.UI.Streams.ConsoleOutput[0] | Should -Be $stringExpected
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/PSSessionConfiguration.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/PSSessionConfiguration.Tests.ps1
@@ -128,7 +128,7 @@ try
 
                     $Result = Get-PSSessionConfiguration
 
-                    $Result.Name -contains $endpointName | Should -Be $true
+                    $Result.Name -contains $endpointName | Should -BeTrue
                     $Result.PSVersion | Should -BeExactly $expectedPSVersion
                 }
 
@@ -146,7 +146,7 @@ try
 
                     $Result = Get-PSSessionConfiguration -Name $endpointWildcard
 
-                    $Result.Name -contains $endpointName | Should -Be $true
+                    $Result.Name -contains $endpointName | Should -BeTrue
                     $Result.PSVersion | Should -BeExactly $expectedPSVersion
                 }
 
@@ -495,7 +495,7 @@ namespace PowershellTestConfigNamespace
                     $Result.Session.Name | Should -Be $TestSessionConfigName
                     $Result.Session.SessionType | Should -Be "Default"
                     $Result.Session.PSVersion | Should -BeExactly $expectedPSVersion
-                    $Result.Session.Enabled | Should -Be $true
+                    $Result.Session.Enabled | Should -BeTrue
                     $Result.Session.lang | Should -Be $Result.Culture
                     $Result.Session.pssessionthreadoptions | Should -Be $pssessionthreadoptions
                     $Result.Session.psmaximumreceivedobjectsizemb | Should -Be $psmaximumreceivedobjectsizemb
@@ -571,7 +571,7 @@ namespace PowershellTestConfigNamespace
 
                     $Result.Session.Name | Should -Be $TestSessionConfigName
                     $Result.Session.PSVersion | Should -BeExactly $expectedPSVersion
-                    $Result.Session.Enabled | Should -Be $true
+                    $Result.Session.Enabled | Should -BeTrue
                     $Result.Session.lang | Should -Be $result.Culture
                     $Result.Session.pssessionthreadoptions | Should -Be $pssessionthreadoptions
                     $Result.Session.psmaximumreceivedobjectsizemb | Should -Be $psmaximumreceivedobjectsizemb
@@ -646,7 +646,7 @@ namespace PowershellTestConfigNamespace
 
             # The default created hashtable in the session configuration file would have the
             # following keys which we are validating below.
-            $resultContent.ContainsKey("SessionType") -and $resultContent.ContainsKey("SchemaVersion") -and $resultContent.ContainsKey("Guid") -and $resultContent.ContainsKey("Author") | Should -Be $true
+            $resultContent.ContainsKey("SessionType") -and $resultContent.ContainsKey("SchemaVersion") -and $resultContent.ContainsKey("Guid") -and $resultContent.ContainsKey("Author") | Should -BeTrue
         }
     }
 
@@ -783,7 +783,7 @@ namespace PowershellTestConfigNamespace
             $configFilePath = join-path $TestDrive "SamplePSSessionConfigurationFile.pssc"
             "InvalidData" | Out-File $configFilePath
 
-            Test-PSSessionConfigurationFile $configFilePath -Verbose -ErrorAction Stop | Should -Be $false
+            Test-PSSessionConfigurationFile $configFilePath -Verbose -ErrorAction Stop | Should -BeFalse
         }
 
         It "Test case verifies that the generated config file passes validation" {
@@ -862,7 +862,7 @@ namespace PowershellTestConfigNamespace
                 }
             }
 
-            $result | Should -Be $true
+            $result | Should -BeTrue
         }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/PSSessionConfiguration.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/PSSessionConfiguration.Tests.ps1
@@ -105,7 +105,7 @@ try
                     function CreateTestConfigFile {
 
                         $TestConfigFileLoc = join-path $TestDrive "Remoting"
-                        if(-Not (Test-path $TestConfigFileLoc))
+                        if(-not (Test-path $TestConfigFileLoc))
                         {
                             $null = New-Item -Path $TestConfigFileLoc -ItemType Directory -Force -ErrorAction Stop
                         }
@@ -270,7 +270,7 @@ try
                             $Result.Error = $_.Exception
                         }
 
-                        if(-Not $Result.Error)
+                        if(-not $Result.Error)
                         {
                             $ValidEndpoints = [PSObject]@(Get-PSSessionConfiguration)
 
@@ -398,7 +398,7 @@ Export-ModuleMember IsTestModuleImported
 "@
                         $TestModuleFileLoc = $script:TestDir
 
-                        if(-Not (Test-path $TestModuleFileLoc))
+                        if(-not (Test-path $TestModuleFileLoc))
                         {
                             $null = New-Item -Path $TestModuleFileLoc -ItemType Directory -Force -ErrorAction Stop
                         }
@@ -442,13 +442,13 @@ namespace PowershellTestConfigNamespace
                     }
 
                     $script:TestDir = join-path $TestDrive "Remoting"
-                    if(-Not (Test-Path $script:TestDir))
+                    if(-not (Test-Path $script:TestDir))
                     {
                         $null = New-Item -path $script:TestDir -ItemType Directory
                     }
 
                     $script:TestAssemblyDir = [System.IO.Path]::GetTempPath()
-                    if(-Not (Test-Path $script:TestAssemblyDir))
+                    if(-not (Test-Path $script:TestAssemblyDir))
                     {
                         $null = New-Item -path $script:TestAssemblyDir -ItemType Directory
                     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/PSSessionConfiguration.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/PSSessionConfiguration.Tests.ps1
@@ -633,7 +633,7 @@ namespace PowershellTestConfigNamespace
             }
 
             $resultContent = invoke-expression ($result)
-            $resultContent.GetType().ToString() | Should -Be "System.Collections.Hashtable"
+            $resultContent | Should -BeOfType "System.Collections.Hashtable"
 
             # The default created hashtable in the session configuration file would have the
             # following keys which we are validating below.

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/PSSessionConfiguration.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/PSSessionConfiguration.Tests.ps1
@@ -644,8 +644,8 @@ namespace PowershellTestConfigNamespace
     Describe "Feature tests for New-PSSessionConfigurationFile Cmdlet" -Tags @("Feature", 'RequireAdminOnWindows') {
 
         It "Validate FullyQualifiedErrorId from New-PSSessionConfigurationFile when invalid path is provided as input" {
-	    $filePath = "cert:\foo.pssc"
-            { New-PSSessionConfigurationFile $filePath } | Should -Throw -ErrorId "InvalidPSSessionConfigurationFilePath,Microsoft.PowerShell.Commands.NewPSSessionConfigurationFileCommand"
+            { New-PSSessionConfigurationFile "cert:\foo.pssc" } |
+		Should -Throw -ErrorId "InvalidPSSessionConfigurationFilePath,Microsoft.PowerShell.Commands.NewPSSessionConfigurationFileCommand"
         }
     }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/PSSessionConfiguration.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/PSSessionConfiguration.Tests.ps1
@@ -51,8 +51,8 @@ try
                 $null = Register-PSSessionConfiguration -Name $ConfigurationName -TransportOption $Transport
                 $result = Get-PSSessionConfiguration -Name $ConfigurationName
 
-                $result.MaxShells | Should Be 40
-                $result.IdleTimeoutms | Should Be 3600000
+                $result.MaxShells | Should -Be 40
+                $result.IdleTimeoutms | Should -Be 3600000
             }
         }
         Describe "Validate Get-PSSessionConfiguration, Enable-PSSessionConfiguration, Disable-PSSessionConfiguration, Unregister-PSSessionConfiguration cmdlets" -Tags @("CI", 'RequireAdminOnWindows') {
@@ -105,7 +105,7 @@ try
                     function CreateTestConfigFile {
 
                         $TestConfigFileLoc = join-path $TestDrive "Remoting"
-                        if(-not (Test-path $TestConfigFileLoc))
+                        if(-Not (Test-path $TestConfigFileLoc))
                         {
                             $null = New-Item -Path $TestConfigFileLoc -ItemType Directory -Force -ErrorAction Stop
                         }
@@ -128,16 +128,16 @@ try
 
                     $Result = Get-PSSessionConfiguration
 
-                    $Result.Name -contains $endpointName | Should Be $true
-                    $Result.PSVersion | Should BeExactly $expectedPSVersion
+                    $Result.Name -contains $endpointName | Should -Be $true
+                    $Result.PSVersion | Should -BeExactly $expectedPSVersion
                 }
 
                 It "Get-PSSessionConfiguration with Name parameter" {
 
                     $Result = Get-PSSessionConfiguration -Name $endpointName
 
-                    $Result.Name | Should Be $endpointName
-                    $Result.PSVersion | Should BeExactly $expectedPSVersion
+                    $Result.Name | Should -Be $endpointName
+                    $Result.PSVersion | Should -BeExactly $expectedPSVersion
                 }
 
                 It "Get-PSSessionConfiguration -Name with wildcard character" {
@@ -146,8 +146,8 @@ try
 
                     $Result = Get-PSSessionConfiguration -Name $endpointWildcard
 
-                    $Result.Name -contains $endpointName | Should Be $true
-                    $Result.PSVersion | Should BeExactly $expectedPSVersion
+                    $Result.Name -contains $endpointName | Should -Be $true
+                    $Result.PSVersion | Should -BeExactly $expectedPSVersion
                 }
 
                 It "Get-PSSessionConfiguration -Name with Non-Existent session configuration" {
@@ -159,7 +159,7 @@ try
                     }
                     catch
                     {
-                        $_.FullyQualifiedErrorId | Should Be "Microsoft.PowerShell.Commands.WriteErrorException"
+                        $_.FullyQualifiedErrorId | Should -Be "Microsoft.PowerShell.Commands.WriteErrorException"
                     }
                 }
             }
@@ -209,8 +209,8 @@ try
 
                         UnregisterPSSessionConfiguration -Name $SessionConfigName
 
-                        $TestConfigStateBeforeChange | Should be "$InitialSessionStateEnabled"
-                        $TestConfigStateAfterChange | Should be "$FinalSessionStateEnabled"
+                        $TestConfigStateBeforeChange | Should -Be "$InitialSessionStateEnabled"
+                        $TestConfigStateAfterChange | Should -Be "$FinalSessionStateEnabled"
                     }
                 }
 
@@ -270,7 +270,7 @@ try
                             $Result.Error = $_.Exception
                         }
 
-                        if(-not $Result.Error)
+                        if(-Not $Result.Error)
                         {
                             $ValidEndpoints = [PSObject]@(Get-PSSessionConfiguration)
 
@@ -290,8 +290,8 @@ try
                             $Result.Output = $false
                         }
 
-                        $Result.Output | Should Match $ExpectedOutput
-                        $Result.Error | Should Match $ExpectedError
+                        $Result.Output | Should -Match $ExpectedOutput
+                        $Result.Error | Should -Match $ExpectedError
                     }
                 }
 
@@ -365,8 +365,8 @@ try
                                 $sn = $null
                             }
                         }
-                        $Result.Output | Should be $ExpectedOutput
-                        $Result.Error | Should be $null
+                        $Result.Output | Should -Be $ExpectedOutput
+                        $Result.Error | Should -Be $null
                     }
 
                     # Create Test Startup Script
@@ -398,7 +398,7 @@ Export-ModuleMember IsTestModuleImported
 "@
                         $TestModuleFileLoc = $script:TestDir
 
-                        if(-not (Test-path $TestModuleFileLoc))
+                        if(-Not (Test-path $TestModuleFileLoc))
                         {
                             $null = New-Item -Path $TestModuleFileLoc -ItemType Directory -Force -ErrorAction Stop
                         }
@@ -442,13 +442,13 @@ namespace PowershellTestConfigNamespace
                     }
 
                     $script:TestDir = join-path $TestDrive "Remoting"
-                    if(-not (Test-Path $script:TestDir))
+                    if(-Not (Test-Path $script:TestDir))
                     {
                         $null = New-Item -path $script:TestDir -ItemType Directory
                     }
 
                     $script:TestAssemblyDir = [System.IO.Path]::GetTempPath()
-                    if(-not (Test-Path $script:TestAssemblyDir))
+                    if(-Not (Test-Path $script:TestAssemblyDir))
                     {
                         $null = New-Item -path $script:TestAssemblyDir -ItemType Directory
                     }
@@ -492,15 +492,15 @@ namespace PowershellTestConfigNamespace
                     Register-PSSessionConfiguration -Name $TestSessionConfigName -path $LocalConfigFilePath -MaximumReceivedObjectSizeMB $psmaximumreceivedobjectsizemb -MaximumReceivedDataSizePerCommandMB $psmaximumreceiveddatasizepercommandmb -UseSharedProcess:$UseSharedProcess -ThreadOptions $pssessionthreadoptions
                     $Result = [PSObject]@{Session = Get-PSSessionConfiguration -Name $TestSessionConfigName; Culture = (Get-Item WSMan:\localhost\Plugin\$endpointName\lang -ea SilentlyContinue).value}
 
-                    $Result.Session.Name | Should be $TestSessionConfigName
-                    $Result.Session.SessionType | Should be "Default"
-                    $Result.Session.PSVersion | Should BeExactly $expectedPSVersion
-                    $Result.Session.Enabled | Should be $true
-                    $Result.Session.lang | Should be $Result.Culture
-                    $Result.Session.pssessionthreadoptions | Should be $pssessionthreadoptions
-                    $Result.Session.psmaximumreceivedobjectsizemb | Should be $psmaximumreceivedobjectsizemb
-                    $Result.Session.psmaximumreceiveddatasizepercommandmb | Should be $psmaximumreceiveddatasizepercommandmb
-                    $Result.Session.UseSharedProcess | Should be $UseSharedProcess
+                    $Result.Session.Name | Should -Be $TestSessionConfigName
+                    $Result.Session.SessionType | Should -Be "Default"
+                    $Result.Session.PSVersion | Should -BeExactly $expectedPSVersion
+                    $Result.Session.Enabled | Should -Be $true
+                    $Result.Session.lang | Should -Be $Result.Culture
+                    $Result.Session.pssessionthreadoptions | Should -Be $pssessionthreadoptions
+                    $Result.Session.psmaximumreceivedobjectsizemb | Should -Be $psmaximumreceivedobjectsizemb
+                    $Result.Session.psmaximumreceiveddatasizepercommandmb | Should -Be $psmaximumreceiveddatasizepercommandmb
+                    $Result.Session.UseSharedProcess | Should -Be $UseSharedProcess
                 }
 
                 It "Validate Register-PSSessionConfiguration -PSVersion" {
@@ -508,8 +508,8 @@ namespace PowershellTestConfigNamespace
                     Register-PSSessionConfiguration -Name $TestSessionConfigName -PSVersion 5.1
                     $Session = Get-PSSessionConfiguration -Name $TestSessionConfigName
 
-                    $Session.Name | Should be $TestSessionConfigName
-                    $Session.PSVersion | Should BeExactly 5.1
+                    $Session.Name | Should -Be $TestSessionConfigName
+                    $Session.PSVersion | Should -BeExactly 5.1
                 }
 
                 It "Validate Register-PSSessionConfiguration -startupscript parameter" -Pending {
@@ -569,14 +569,14 @@ namespace PowershellTestConfigNamespace
                     Set-PSSessionConfiguration -Name $TestSessionConfigName -MaximumReceivedObjectSizeMB $psmaximumreceivedobjectsizemb -MaximumReceivedDataSizePerCommandMB $psmaximumreceiveddatasizepercommandmb -UseSharedProcess:$UseSharedProcess -ThreadOptions $pssessionthreadoptions -NoServiceRestart
                     $Result = [PSObject]@{Session = (Get-PSSessionConfiguration -Name $TestSessionConfigName) ; Culture = (Get-Item WSMan:\localhost\Plugin\microsoft.powershell\lang -ea SilentlyContinue).value}
 
-                    $Result.Session.Name | Should be $TestSessionConfigName
-                    $Result.Session.PSVersion | Should BeExactly $expectedPSVersion
-                    $Result.Session.Enabled | Should be $true
-                    $Result.Session.lang | Should be $result.Culture
-                    $Result.Session.pssessionthreadoptions | Should be $pssessionthreadoptions
-                    $Result.Session.psmaximumreceivedobjectsizemb | Should be $psmaximumreceivedobjectsizemb
-                    $Result.Session.psmaximumreceiveddatasizepercommandmb | Should be $psmaximumreceiveddatasizepercommandmb
-                    $Result.Session.UseSharedProcess | Should be $UseSharedProcess
+                    $Result.Session.Name | Should -Be $TestSessionConfigName
+                    $Result.Session.PSVersion | Should -BeExactly $expectedPSVersion
+                    $Result.Session.Enabled | Should -Be $true
+                    $Result.Session.lang | Should -Be $result.Culture
+                    $Result.Session.pssessionthreadoptions | Should -Be $pssessionthreadoptions
+                    $Result.Session.psmaximumreceivedobjectsizemb | Should -Be $psmaximumreceivedobjectsizemb
+                    $Result.Session.psmaximumreceiveddatasizepercommandmb | Should -Be $psmaximumreceiveddatasizepercommandmb
+                    $Result.Session.UseSharedProcess | Should -Be $UseSharedProcess
                 }
 
                 It "Validate Set-PSSessionConfiguration -PSVersion" {
@@ -584,8 +584,8 @@ namespace PowershellTestConfigNamespace
                     Set-PSSessionConfiguration -Name $TestSessionConfigName -PSVersion 5.1
                     $Session = (Get-PSSessionConfiguration -Name $TestSessionConfigName)
 
-                    $Session.Name | Should be $TestSessionConfigName
-                    $Session.PSVersion | Should BeExactly 5.1
+                    $Session.Name | Should -Be $TestSessionConfigName
+                    $Session.PSVersion | Should -BeExactly 5.1
                 }
 
                 It "Validate Set-PSSessionConfiguration -startupscript parameter" -Pending {
@@ -642,11 +642,11 @@ namespace PowershellTestConfigNamespace
             }
 
             $resultContent = invoke-expression ($result)
-            $resultContent.GetType().ToString() | Should Be "System.Collections.Hashtable"
+            $resultContent.GetType().ToString() | Should -Be "System.Collections.Hashtable"
 
             # The default created hashtable in the session configuration file would have the
             # following keys which we are validating below.
-            $resultContent.ContainsKey("SessionType") -and $resultContent.ContainsKey("SchemaVersion") -and $resultContent.ContainsKey("Guid") -and $resultContent.ContainsKey("Author") | Should Be $true
+            $resultContent.ContainsKey("SessionType") -and $resultContent.ContainsKey("SchemaVersion") -and $resultContent.ContainsKey("Guid") -and $resultContent.ContainsKey("Author") | Should -Be $true
         }
     }
 
@@ -662,7 +662,7 @@ namespace PowershellTestConfigNamespace
             }
             catch
             {
-                $_.FullyQualifiedErrorId | Should Be "InvalidPSSessionConfigurationFilePath,Microsoft.PowerShell.Commands.NewPSSessionConfigurationFileCommand"
+                $_.FullyQualifiedErrorId | Should -Be "InvalidPSSessionConfigurationFilePath,Microsoft.PowerShell.Commands.NewPSSessionConfigurationFileCommand"
             }
         }
     }
@@ -774,7 +774,7 @@ namespace PowershellTestConfigNamespace
             }
             catch
             {
-                $_.FullyQualifiedErrorId | Should Be "PSSessionConfigurationFileNotFound,Microsoft.PowerShell.Commands.TestPSSessionConfigurationFileCommand"
+                $_.FullyQualifiedErrorId | Should -Be "PSSessionConfigurationFileNotFound,Microsoft.PowerShell.Commands.TestPSSessionConfigurationFileCommand"
             }
         }
 
@@ -783,7 +783,7 @@ namespace PowershellTestConfigNamespace
             $configFilePath = join-path $TestDrive "SamplePSSessionConfigurationFile.pssc"
             "InvalidData" | Out-File $configFilePath
 
-            Test-PSSessionConfigurationFile $configFilePath -Verbose -ErrorAction Stop | Should Be $false
+            Test-PSSessionConfigurationFile $configFilePath -Verbose -ErrorAction Stop | Should -Be $false
         }
 
         It "Test case verifies that the generated config file passes validation" {
@@ -862,7 +862,7 @@ namespace PowershellTestConfigNamespace
                 }
             }
 
-            $result | Should Be $true
+            $result | Should -Be $true
         }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/PSSessionConfiguration.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/PSSessionConfiguration.Tests.ps1
@@ -151,16 +151,7 @@ try
                 }
 
                 It "Get-PSSessionConfiguration -Name with Non-Existent session configuration" {
-
-                    try
-                    {
-                        Get-PSSessionConfiguration -Name "NonExistantSessionConfiguration" -ErrorAction Stop
-                        throw "No Exception!"
-                    }
-                    catch
-                    {
-                        $_.FullyQualifiedErrorId | Should -Be "Microsoft.PowerShell.Commands.WriteErrorException"
-                    }
+                    { Get-PSSessionConfiguration -Name "NonExistantSessionConfiguration" -ErrorAction Stop } | Should -Throw -ErrorId "Microsoft.PowerShell.Commands.WriteErrorException"
                 }
             }
 
@@ -653,17 +644,8 @@ namespace PowershellTestConfigNamespace
     Describe "Feature tests for New-PSSessionConfigurationFile Cmdlet" -Tags @("Feature", 'RequireAdminOnWindows') {
 
         It "Validate FullyQualifiedErrorId from New-PSSessionConfigurationFile when invalid path is provided as input" {
-
-            try
-            {
-                $filePath = "cert:\foo.pssc"
-                New-PSSessionConfigurationFile $filePath
-                throw "No Exception!"
-            }
-            catch
-            {
-                $_.FullyQualifiedErrorId | Should -Be "InvalidPSSessionConfigurationFilePath,Microsoft.PowerShell.Commands.NewPSSessionConfigurationFileCommand"
-            }
+	    $filePath = "cert:\foo.pssc"
+            { New-PSSessionConfigurationFile $filePath } | Should -Throw -ErrorId "InvalidPSSessionConfigurationFilePath,Microsoft.PowerShell.Commands.NewPSSessionConfigurationFileCommand"
         }
     }
 
@@ -766,16 +748,7 @@ namespace PowershellTestConfigNamespace
         }
 
         It "Validate FullyQualifiedErrorId from Test-PSSessionConfigurationFile when invalid path is provided as input" {
-
-            try
-            {
-                Test-PSSessionConfigurationFile "cert:\foo.pssc" -ErrorAction Stop
-                throw "No Exception!"
-            }
-            catch
-            {
-                $_.FullyQualifiedErrorId | Should -Be "PSSessionConfigurationFileNotFound,Microsoft.PowerShell.Commands.TestPSSessionConfigurationFileCommand"
-            }
+            { Test-PSSessionConfigurationFile "cert:\foo.pssc" -ErrorAction Stop } | Should -Throw -ErrorId "PSSessionConfigurationFileNotFound,Microsoft.PowerShell.Commands.TestPSSessionConfigurationFileCommand"
         }
 
         It "Validate FullyQualifiedErrorId from Test-PSSessionConfigurationFile when an invalid pssc file is provided as input and -Verbose parameter is specified" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/PSSessionConfiguration.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/PSSessionConfiguration.Tests.ps1
@@ -366,7 +366,7 @@ try
                             }
                         }
                         $Result.Output | Should -Be $ExpectedOutput
-                        $Result.Error | Should -Be $null
+                        $Result.Error | Should -BeNullOrEmpty
                     }
 
                     # Create Test Startup Script

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/PSSessionConfiguration.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/PSSessionConfiguration.Tests.ps1
@@ -136,7 +136,7 @@ try
 
                     $Result = Get-PSSessionConfiguration -Name $endpointName
 
-                    $Result.Name | Should -Be $endpointName
+                    $Result.Name | Should -BeExactly $endpointName
                     $Result.PSVersion | Should -BeExactly $expectedPSVersion
                 }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Pester.Commands.Cmdlets.GetCommand.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Pester.Commands.Cmdlets.GetCommand.Tests.ps1
@@ -21,16 +21,16 @@ Describe "Tests Get-Command with relative paths and wildcards" -Tag "CI" {
         $driveOffset = $pathName.IndexOf(":")
         $pathName = $pathName.Substring($driveOffset + 1)
         $result = Get-Command -Name $pathName
-        $result | Should Not Be $null
-        $result.Name | Should Be WildCardCommandA.exe
+        $result | Should -Not -Be $null
+        $result.Name | Should -Be WildCardCommandA.exe
     }
 
     It "Test wildcard with relative directory path" {
         push-location $TestDrive
         $result = Get-Command -Name .\WildCardCommandA*
         pop-location
-        $result | Should Not Be $null
-        $result | Should Be WildCardCommandA.exe
+        $result | Should -Not -Be $null
+        $result | Should -Be WildCardCommandA.exe
     }
 
     It "Test with PowerShell wildcard and relative path" {
@@ -38,13 +38,13 @@ Describe "Tests Get-Command with relative paths and wildcards" -Tag "CI" {
 
         # This should use the wildcard to find WildCardCommandA.exe
         $result = Get-Command -Name .\WildCardCommand[A].exe
-        $result | Should Not Be $null
-        $result | Should Be WildCardCommandA.exe
+        $result | Should -Not -Be $null
+        $result | Should -Be WildCardCommandA.exe
 
         # This should find the file WildCardCommand[B].exe
         $result = Get-Command -Name .\WildCardCommand[B].exe
-        $result | Should Not Be $null
-        $result | Should Be WildCardCommand[B].exe
+        $result | Should -Not -Be $null
+        $result | Should -Be WildCardCommand[B].exe
 
         Pop-Location
     }
@@ -52,12 +52,12 @@ Describe "Tests Get-Command with relative paths and wildcards" -Tag "CI" {
     It "Get-Command -ShowCommandInfo property field test" {
         $properties = ($commandInfo | Get-Member -MemberType NoteProperty)
         $propertiesAsString =  $properties.name | out-string
-        $propertiesAsString | Should MatchExactly 'CommandType'
-        $propertiesAsString | Should MatchExactly 'Definition'
-        $propertiesAsString | Should MatchExactly 'Module'
-        $propertiesAsString | Should MatchExactly 'ModuleName'
-        $propertiesAsString | Should MatchExactly 'Name'
-        $propertiesAsString | Should MatchExactly 'ParameterSets'
+        $propertiesAsString | Should -MatchExactly 'CommandType'
+        $propertiesAsString | Should -MatchExactly 'Definition'
+        $propertiesAsString | Should -MatchExactly 'Module'
+        $propertiesAsString | Should -MatchExactly 'ModuleName'
+        $propertiesAsString | Should -MatchExactly 'Name'
+        $propertiesAsString | Should -MatchExactly 'ParameterSets'
     }
 
     $testcases = @(
@@ -73,27 +73,27 @@ Describe "Tests Get-Command with relative paths and wildcards" -Tag "CI" {
             $observed,
             $result
         )
-        $observed | Should BeExactly $result
+        $observed | Should -BeExactly $result
     }
 
     It "Get-Command -ShowCommandInfo ParameterSets property field test" {
         $properties = ($commandInfo.ParameterSets[0] | Get-Member -MemberType NoteProperty)
         $propertiesAsString =  $properties.name | out-string
-        $propertiesAsString | Should MatchExactly 'IsDefault'
-        $propertiesAsString | Should MatchExactly 'Name'
-        $propertiesAsString | Should MatchExactly 'Parameters'
+        $propertiesAsString | Should -MatchExactly 'IsDefault'
+        $propertiesAsString | Should -MatchExactly 'Name'
+        $propertiesAsString | Should -MatchExactly 'Parameters'
     }
 
     It "Get-Command -ShowCommandInfo Parameters property field test" {
         $properties = ($commandInfo.ParameterSets[0].Parameters | Get-Member -MemberType NoteProperty)
         $propertiesAsString =  $properties.name | out-string
-        $propertiesAsString | Should MatchExactly 'HasParameterSet'
-        $propertiesAsString | Should MatchExactly 'IsMandatory'
-        $propertiesAsString | Should MatchExactly 'Name'
-        $propertiesAsString | Should MatchExactly 'ParameterType'
-        $propertiesAsString | Should MatchExactly 'Position'
-        $propertiesAsString | Should MatchExactly 'ValidParamSetValues'
-        $propertiesAsString | Should MatchExactly 'ValueFromPipeline'
+        $propertiesAsString | Should -MatchExactly 'HasParameterSet'
+        $propertiesAsString | Should -MatchExactly 'IsMandatory'
+        $propertiesAsString | Should -MatchExactly 'Name'
+        $propertiesAsString | Should -MatchExactly 'ParameterType'
+        $propertiesAsString | Should -MatchExactly 'Position'
+        $propertiesAsString | Should -MatchExactly 'ValidParamSetValues'
+        $propertiesAsString | Should -MatchExactly 'ValueFromPipeline'
     }
 
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Pester.Commands.Cmdlets.GetCommand.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Pester.Commands.Cmdlets.GetCommand.Tests.ps1
@@ -21,7 +21,7 @@ Describe "Tests Get-Command with relative paths and wildcards" -Tag "CI" {
         $driveOffset = $pathName.IndexOf(":")
         $pathName = $pathName.Substring($driveOffset + 1)
         $result = Get-Command -Name $pathName
-        $result | Should -Not -Be $null
+        $result | Should -Not -BeNullOrEmpty
         $result.Name | Should -Be WildCardCommandA.exe
     }
 
@@ -29,7 +29,7 @@ Describe "Tests Get-Command with relative paths and wildcards" -Tag "CI" {
         push-location $TestDrive
         $result = Get-Command -Name .\WildCardCommandA*
         pop-location
-        $result | Should -Not -Be $null
+        $result | Should -Not -BeNullOrEmpty
         $result | Should -Be WildCardCommandA.exe
     }
 
@@ -38,12 +38,12 @@ Describe "Tests Get-Command with relative paths and wildcards" -Tag "CI" {
 
         # This should use the wildcard to find WildCardCommandA.exe
         $result = Get-Command -Name .\WildCardCommand[A].exe
-        $result | Should -Not -Be $null
+        $result | Should -Not -BeNullOrEmpty
         $result | Should -Be WildCardCommandA.exe
 
         # This should find the file WildCardCommand[B].exe
         $result = Get-Command -Name .\WildCardCommand[B].exe
-        $result | Should -Not -Be $null
+        $result | Should -Not -BeNullOrEmpty
         $result | Should -Be WildCardCommand[B].exe
 
         Pop-Location

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/RemoteGetModule.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/RemoteGetModule.Tests.ps1
@@ -38,8 +38,8 @@ Describe "Remote module tests" -Tags 'Feature','RequireAdminOnWindows' {
             $parameters += @{name=$name}
         }
         $modules = Get-Module @parameters
-        $modules | Should Not BeNullOrEmpty
-        $modules[0] | Should BeOfType "System.Management.Automation.PSModuleInfo"
+        $modules | Should -Not -BeNullOrEmpty
+        $modules[0] | Should -BeOfType "System.Management.Automation.PSModuleInfo"
     }
 
     It "Get-Module can be called as an API with '<parameter>' = '<value>'" -TestCases @(
@@ -64,11 +64,11 @@ Describe "Remote module tests" -Tags 'Feature','RequireAdminOnWindows' {
         $getModuleCommand = [Microsoft.PowerShell.Commands.GetModuleCommand]::new()
         $getModuleCommand.$parameter = $value
         if ($parameter -eq "FullyQualifiedName") {
-            $getModuleCommand.FullyQualifiedName | Should BeOfType "Microsoft.PowerShell.Commands.ModuleSpecification"
-            $getModuleCommand.FullyQualifiedName.Name | Should Be "foo"
-            $getModuleCommand.FullyQualifiedName.Version | Should Be "1.2.3"
+            $getModuleCommand.FullyQualifiedName | Should -BeOfType "Microsoft.PowerShell.Commands.ModuleSpecification"
+            $getModuleCommand.FullyQualifiedName.Name | Should -Be "foo"
+            $getModuleCommand.FullyQualifiedName.Version | Should -Be "1.2.3"
         } else {
-            $getModuleCommand.$parameter | Should Be $value
+            $getModuleCommand.$parameter | Should -Be $value
         }
     }
 
@@ -78,7 +78,7 @@ Describe "Remote module tests" -Tags 'Feature','RequireAdminOnWindows' {
 
     It "Get-Module supports pipeline" {
         $module = Get-Module -Name Microsoft.PowerShell.Utility
-        Compare-Object $module ($module | Get-Module) | Should BeNullOrEmpty
+        Compare-Object $module ($module | Get-Module) | Should -BeNullOrEmpty
     }
 
     It "New-CimSession works" -Pending {

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/RemoteGetModule.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/RemoteGetModule.Tests.ps1
@@ -65,7 +65,7 @@ Describe "Remote module tests" -Tags 'Feature','RequireAdminOnWindows' {
         $getModuleCommand.$parameter = $value
         if ($parameter -eq "FullyQualifiedName") {
             $getModuleCommand.FullyQualifiedName | Should -BeOfType "Microsoft.PowerShell.Commands.ModuleSpecification"
-            $getModuleCommand.FullyQualifiedName.Name | Should -Be "foo"
+            $getModuleCommand.FullyQualifiedName.Name | Should -BeExactly "foo"
             $getModuleCommand.FullyQualifiedName.Version | Should -Be "1.2.3"
         } else {
             $getModuleCommand.$parameter | Should -Be $value

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/RemoteImportModule.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/RemoteImportModule.Tests.ps1
@@ -70,14 +70,14 @@ Describe "Remote import-module tests" -Tags 'Feature','RequireAdminOnWindows' {
         }
         $importModuleCommand.$parameter = $value
         if ($parameter -eq "FullyQualifiedName") {
-            $importModuleCommand.FullyQualifiedName.Count | Should BeExactly 2
-            $importModuleCommand.FullyQualifiedName | Should BeOfType "Microsoft.PowerShell.Commands.ModuleSpecification"
-            $importModuleCommand.FullyQualifiedName[0].Name | Should Be "foo"
-            $importModuleCommand.FullyQualifiedName[0].RequiredVersion | Should Be "0.0"
-            $importModuleCommand.FullyQualifiedName[1].Name | Should Be "bar"
-            $importModuleCommand.FullyQualifiedName[1].RequiredVersion | Should Be "1.1"
+            $importModuleCommand.FullyQualifiedName.Count | Should -BeExactly 2
+            $importModuleCommand.FullyQualifiedName | Should -BeOfType "Microsoft.PowerShell.Commands.ModuleSpecification"
+            $importModuleCommand.FullyQualifiedName[0].Name | Should -Be "foo"
+            $importModuleCommand.FullyQualifiedName[0].RequiredVersion | Should -Be "0.0"
+            $importModuleCommand.FullyQualifiedName[1].Name | Should -Be "bar"
+            $importModuleCommand.FullyQualifiedName[1].RequiredVersion | Should -Be "1.1"
         } else {
-            $importModuleCommand.$parameter | Should BeExactly $value
+            $importModuleCommand.$parameter | Should -BeExactly $value
         }
     }
 
@@ -96,18 +96,18 @@ Describe "Remote import-module tests" -Tags 'Feature','RequireAdminOnWindows' {
         param ($test, $parameters, $errorid)
 
         Invoke-Command -Session $pssession -ScriptBlock { $env:PSModulePath += ";$(Split-Path $using:modulePath)"}
-        Get-Module TestImport | Should BeNullOrEmpty
+        Get-Module TestImport | Should -BeNullOrEmpty
         if ($errorid) {
             { Import-Module @parameters -ErrorAction Stop } | ShouldBeErrorId $errorid
         } else {
             Import-Module @parameters
             $module = Get-Module TestImport
-            $module.Name | Should BeExactly "TestImport"
+            $module.Name | Should -BeExactly "TestImport"
 
             # generated proxy module always uses 1.0
-            $module.Version | Should BeExactly "1.0"
+            $module.Version | Should -BeExactly "1.0"
 
-            test-hello | Should BeExactly "world"
+            test-hello | Should -BeExactly "world"
         }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/RemoteImportModule.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/RemoteImportModule.Tests.ps1
@@ -72,9 +72,9 @@ Describe "Remote import-module tests" -Tags 'Feature','RequireAdminOnWindows' {
         if ($parameter -eq "FullyQualifiedName") {
             $importModuleCommand.FullyQualifiedName.Count | Should -BeExactly 2
             $importModuleCommand.FullyQualifiedName | Should -BeOfType "Microsoft.PowerShell.Commands.ModuleSpecification"
-            $importModuleCommand.FullyQualifiedName[0].Name | Should -Be "foo"
+            $importModuleCommand.FullyQualifiedName[0].Name | Should -BeExactly "foo"
             $importModuleCommand.FullyQualifiedName[0].RequiredVersion | Should -Be "0.0"
-            $importModuleCommand.FullyQualifiedName[1].Name | Should -Be "bar"
+            $importModuleCommand.FullyQualifiedName[1].Name | Should -BeExactly "bar"
             $importModuleCommand.FullyQualifiedName[1].RequiredVersion | Should -Be "1.1"
         } else {
             $importModuleCommand.$parameter | Should -BeExactly $value

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/RemotingCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/RemotingCmdlets.Tests.ps1
@@ -11,7 +11,7 @@ Describe "SSH Remoting Cmdlet Tests" -Tags "Feature" {
         }
         catch
         {
-            $_.FullyQualifiedErrorId | Should Be "PathNotFound,Microsoft.PowerShell.Commands.EnterPSSessionCommand"
+            $_.FullyQualifiedErrorId | Should -Be "PathNotFound,Microsoft.PowerShell.Commands.EnterPSSessionCommand"
         }
     }
 
@@ -24,7 +24,7 @@ Describe "SSH Remoting Cmdlet Tests" -Tags "Feature" {
         }
         catch
         {
-            $_.FullyQualifiedErrorId | Should Be "PathNotFound,Microsoft.PowerShell.Commands.NewPSSessionCommand"
+            $_.FullyQualifiedErrorId | Should -Be "PathNotFound,Microsoft.PowerShell.Commands.NewPSSessionCommand"
         }
     }
 
@@ -37,7 +37,7 @@ Describe "SSH Remoting Cmdlet Tests" -Tags "Feature" {
         }
         catch
         {
-            $_.FullyQualifiedErrorId | Should Be "PathNotFound,Microsoft.PowerShell.Commands.InvokeCommandCommand"
+            $_.FullyQualifiedErrorId | Should -Be "PathNotFound,Microsoft.PowerShell.Commands.InvokeCommandCommand"
         }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/RemotingCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/RemotingCmdlets.Tests.ps1
@@ -3,41 +3,17 @@
 Describe "SSH Remoting Cmdlet Tests" -Tags "Feature" {
 
     It "Enter-PSSession HostName parameter set should throw error for invalid key path" {
-
-        try
-        {
-            Enter-PSSession -HostName localhost -UserName User -KeyFilePath NoKeyFile
-            throw "Enter-PSSession did not throw expected PathNotFound exception."
-        }
-        catch
-        {
-            $_.FullyQualifiedErrorId | Should -Be "PathNotFound,Microsoft.PowerShell.Commands.EnterPSSessionCommand"
-        }
+        { Enter-PSSession -HostName localhost -UserName User -KeyFilePath NoKeyFile } |
+            Should -Throw -ErrorId "PathNotFound,Microsoft.PowerShell.Commands.EnterPSSessionCommand"
     }
 
     It "New-PSSession HostName parameter set should throw error for invalid key path" {
-
-        try
-        {
-            New-PSSession -HostName localhost -UserName User -KeyFilePath NoKeyFile
-            throw "New-PSSession did not throw expected PathNotFound exception."
-        }
-        catch
-        {
-            $_.FullyQualifiedErrorId | Should -Be "PathNotFound,Microsoft.PowerShell.Commands.NewPSSessionCommand"
-        }
+        { New-PSSession -HostName localhost -UserName User -KeyFilePath NoKeyFile } |
+            Should -Throw -ErrorId "PathNotFound,Microsoft.PowerShell.Commands.NewPSSessionCommand"
     }
 
     It "Invoke-Command HostName parameter set should throw error for invalid key path" {
-
-        try
-        {
-            Invoke-Command -HostName localhost -UserName User -KeyFilePath NoKeyFile -ScriptBlock {1}
-            throw "Invoke-Command did not throw expected PathNotFound exception."
-        }
-        catch
-        {
-            $_.FullyQualifiedErrorId | Should -Be "PathNotFound,Microsoft.PowerShell.Commands.InvokeCommandCommand"
-        }
+        { Invoke-Command -HostName localhost -UserName User -KeyFilePath NoKeyFile -ScriptBlock {1} } |
+            Should -Throw -ErrorId "PathNotFound,Microsoft.PowerShell.Commands.InvokeCommandCommand"
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Remove-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Remove-Module.Tests.ps1
@@ -5,18 +5,18 @@ Describe "Remove-Module" -Tags "CI" {
 
     BeforeEach {
         Import-Module -Name $moduleName -Force
-        (Get-Module -Name $moduleName).Name | Should be $moduleName
+        (Get-Module -Name $moduleName).Name | Should -Be $moduleName
     }
 
     It "should be able to remove a module with using Name switch" {
-        { Remove-Module -Name $moduleName } | Should Not Throw
-        (Get-Module -Name $moduleName).Name | Should BeNullOrEmpty
+        { Remove-Module -Name $moduleName } | Should -Not -Throw
+        (Get-Module -Name $moduleName).Name | Should -BeNullOrEmpty
     }
 
     It "should be able to remove a module with using ModuleInfo switch" {
         $a = Get-Module -Name $moduleName
-        { Remove-Module -ModuleInfo $a } | Should Not Throw
-        (Get-Module -Name $moduleName).Name | Should BeNullOrEmpty
+        { Remove-Module -ModuleInfo $a } | Should -Not -Throw
+        (Get-Module -Name $moduleName).Name | Should -BeNullOrEmpty
     }
 
 	AfterEach {

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Remove-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Remove-Module.Tests.ps1
@@ -5,7 +5,7 @@ Describe "Remove-Module" -Tags "CI" {
 
     BeforeEach {
         Import-Module -Name $moduleName -Force
-        (Get-Module -Name $moduleName).Name | Should -Be $moduleName
+        (Get-Module -Name $moduleName).Name | Should -BeExactly $moduleName
     }
 
     It "should be able to remove a module with using Name switch" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Set-PSDebug.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Set-PSDebug.Tests.ps1
@@ -7,13 +7,13 @@ Describe "Set-PSDebug" -Tags "CI" {
         }
 
         It "Should be able to go through the tracing options" -Skip:($env:APPVEYOR -eq "TRUE") {
-            { Set-PSDebug -Trace 0 } | Should Not Throw
-            { Set-PSDebug -Trace 1 } | Should Not Throw
-            { Set-PSDebug -Trace 2 } | Should Not Throw
+            { Set-PSDebug -Trace 0 } | Should -Not -Throw
+            { Set-PSDebug -Trace 1 } | Should -Not -Throw
+            { Set-PSDebug -Trace 2 } | Should -Not -Throw
         }
 
         It "Should be able to set strict" -Skip:($env:APPVEYOR -eq "TRUE") {
-            { Set-PSDebug -Strict } | Should Not Throw
+            { Set-PSDebug -Strict } | Should -Not -Throw
         }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/TestGetCommand.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/TestGetCommand.Tests.ps1
@@ -150,14 +150,14 @@ Describe "Get-Command Tests" -Tags "CI" {
             foreach($paramName in $parameterNames)
             {
                 $foundParam = GetDynamicParameter -cmdlet $cmdlet -parameterName $paramName
-                $foundParam.Name | Should Be $paramName
+                $foundParam.Name | Should -Be $paramName
             }
         }
 
         function VerifyParameterType($cmdlet, $parameterName, $ParameterType)
         {
             $foundParam = GetDynamicParameter -cmdlet $cmdlet -parameterName $parameterName
-            $foundParam.ParameterType | Should Be $ParameterType
+            $foundParam.ParameterType | Should -Be $ParameterType
         }
     }
 
@@ -174,7 +174,7 @@ Describe "Get-Command Tests" -Tags "CI" {
         $dynamicParameter = "Wait", "Encoding", "Delimiter"
         foreach ($dynamicPara in $dynamicParameter)
         {
-            $results[0].ParameterSets.Parameters.Name -contains $dynamicPara | Should be $false
+            $results[0].ParameterSets.Parameters.Name -contains $dynamicPara | Should -Be $false
         }
     }
 
@@ -216,9 +216,9 @@ Describe "Get-Command Tests" -Tags "CI" {
 
     It "Verify Single Cmdlet Using Verb&Noun ParameterSet With Usage" {
         $results =  Get-Command -Verb get -Noun content -Encoding Unicode -Syntax
-        $results.ToString() | Should Match "-Encoding"
-        $results.ToString() | Should Match "-Wait"
-        $results.ToString() | Should Match "-Delimiter"
+        $results.ToString() | Should -Match "-Encoding"
+        $results.ToString() | Should -Match "-Wait"
+        $results.ToString() | Should -Match "-Delimiter"
     }
 
     It "Test Script Lookup Positive Script Info" {
@@ -227,8 +227,8 @@ Describe "Get-Command Tests" -Tags "CI" {
         "$a = dir" > $fullPath
         $results = Get-Command $fullPath
 
-        $results.Name | Should Be $tempFile
-        $results.Definition | Should Be $fullPath
+        $results.Name | Should -Be $tempFile
+        $results.Definition | Should -Be $fullPath
     }
 
     It "Two dynamic parameters are created properly" {
@@ -247,7 +247,7 @@ Describe "Get-Command Tests" -Tags "CI" {
         }
         catch
         {
-            $_.FullyQualifiedErrorId | Should Be "GetCommandMetadataError,Microsoft.PowerShell.Commands.GetCommandCommand"
+            $_.FullyQualifiedErrorId | Should -Be "GetCommandMetadataError,Microsoft.PowerShell.Commands.GetCommandCommand"
         }
     }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/TestGetCommand.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/TestGetCommand.Tests.ps1
@@ -150,7 +150,7 @@ Describe "Get-Command Tests" -Tags "CI" {
             foreach($paramName in $parameterNames)
             {
                 $foundParam = GetDynamicParameter -cmdlet $cmdlet -parameterName $paramName
-                $foundParam.Name | Should -Be $paramName
+                $foundParam.Name | Should -BeExactly $paramName
             }
         }
 
@@ -227,8 +227,8 @@ Describe "Get-Command Tests" -Tags "CI" {
         "$a = dir" > $fullPath
         $results = Get-Command $fullPath
 
-        $results.Name | Should -Be $tempFile
-        $results.Definition | Should -Be $fullPath
+        $results.Name | Should -BeExactly $tempFile
+        $results.Definition | Should -BeExactly $fullPath
     }
 
     It "Two dynamic parameters are created properly" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/TestGetCommand.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/TestGetCommand.Tests.ps1
@@ -174,7 +174,7 @@ Describe "Get-Command Tests" -Tags "CI" {
         $dynamicParameter = "Wait", "Encoding", "Delimiter"
         foreach ($dynamicPara in $dynamicParameter)
         {
-            $results[0].ParameterSets.Parameters.Name -contains $dynamicPara | Should -Be $false
+            $results[0].ParameterSets.Parameters.Name -contains $dynamicPara | Should -BeFalse
         }
     }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/TestGetCommand.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/TestGetCommand.Tests.ps1
@@ -240,15 +240,8 @@ Describe "Get-Command Tests" -Tags "CI" {
     }
 
     It "Throw an Exception when set TestToRun to 'returnduplicateparameter'" {
-        try
-        {
-            Get-Command TestGetCommand-DynamicParametersDCR -TestToRun returnduplicateparameter -ErrorAction Stop
-            throw "No Exception!"
-        }
-        catch
-        {
-            $_.FullyQualifiedErrorId | Should -Be "GetCommandMetadataError,Microsoft.PowerShell.Commands.GetCommandCommand"
-        }
+        { Get-Command TestGetCommand-DynamicParametersDCR -TestToRun returnduplicateparameter -ErrorAction Stop } |
+            Should -Throw -ErrorId "GetCommandMetadataError,Microsoft.PowerShell.Commands.GetCommandCommand"
     }
 
     It "verify if get the proper dynamic parameter type skipped by issue #1430" -Pending {


### PR DESCRIPTION
## PR Summary

Use new Pester syntax: -Parameter for Pester tests in Modules/Microsoft.PowerShell.Core.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [x] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
