### PR TITLE
Use new Pester syntax: -Parameter for Pester tests in Modules/Microsoft.PowerShell.Diagnostics.

### DIFF
--- a/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/CounterTestHelperFunctions.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/CounterTestHelperFunctions.ps1
@@ -275,13 +275,13 @@ function CompareCounterSets
         $setA[$i].CounterSamples.Length | Should -Be $setB[$i].CounterSamples.Length
         $samplesA = ($setA[$i].CounterSamples | sort -Property Path)
         $samplesB = ($setB[$i].CounterSamples | sort -Property Path)
-        (DateTimesAreEqualish $setA[$i].TimeStamp $setB[$i].TimeStamp) | Should -Be $true
+        (DateTimesAreEqualish $setA[$i].TimeStamp $setB[$i].TimeStamp) | Should -BeTrue
         for ($j = 0; $j -lt $samplesA.Length; $j++)
         {
             $sampleA = $samplesA[$j]
             $sampleB = $samplesB[$j]
-            (DateTimesAreEqualish $sampleA.TimeStamp $sampleB.TimeStamp) | Should -Be $true
-            $sampleA.Path | Should -Be $sampleB.Path
+            (DateTimesAreEqualish $sampleA.TimeStamp $sampleB.TimeStamp) | Should -BeTrue
+            $sampleA.Path | Should -BeExactly $sampleB.Path
             $sampleA.CookedValue | Should -Be $sampleB.CookedValue
         }
     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/CounterTestHelperFunctions.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/CounterTestHelperFunctions.ps1
@@ -261,7 +261,7 @@ function CompareCounterSets
         $setB
     )
 
-    $setA.Length | Should Be $setB.Length
+    $setA.Length | Should -Be $setB.Length
 
     # Depending on the kinds of counters used, the first record in
     # exported counters are likely to have embty items, so we'll
@@ -272,17 +272,17 @@ function CompareCounterSets
     # PDH functions that perform the actual exporting of counter data.
     for ($i = 1; $i -lt $setA.Length; $i++)
     {
-        $setA[$i].CounterSamples.Length | Should Be $setB[$i].CounterSamples.Length
+        $setA[$i].CounterSamples.Length | Should -Be $setB[$i].CounterSamples.Length
         $samplesA = ($setA[$i].CounterSamples | sort -Property Path)
         $samplesB = ($setB[$i].CounterSamples | sort -Property Path)
-        (DateTimesAreEqualish $setA[$i].TimeStamp $setB[$i].TimeStamp) | Should Be $true
+        (DateTimesAreEqualish $setA[$i].TimeStamp $setB[$i].TimeStamp) | Should -Be $true
         for ($j = 0; $j -lt $samplesA.Length; $j++)
         {
             $sampleA = $samplesA[$j]
             $sampleB = $samplesB[$j]
-            (DateTimesAreEqualish $sampleA.TimeStamp $sampleB.TimeStamp) | Should Be $true
-            $sampleA.Path | Should Be $sampleB.Path
-            $sampleA.CookedValue | Should Be $sampleB.CookedValue
+            (DateTimesAreEqualish $sampleA.TimeStamp $sampleB.TimeStamp) | Should -Be $true
+            $sampleA.Path | Should -Be $sampleB.Path
+            $sampleA.CookedValue | Should -Be $sampleB.CookedValue
         }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/Export-Counter.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/Export-Counter.Tests.ps1
@@ -98,16 +98,8 @@ function RunTest($testCase)
             else
             {
                 # Here we expect and want the command to fail
-                try
-                {
-                    $sb = [ScriptBlock]::Create($cmd)
-                    &$sb
-                    throw "Did not throw expected exception"
-                }
-                catch
-                {
-                    $_.FullyQualifiedErrorId | Should -Be $testCase.ExpectedErrorId
-                }
+                $sb = [ScriptBlock]::Create($cmd)
+                { &$sb } | Should -Throw -ErrorId $testCase.ExpectedErrorId
             }
         }
         finally

--- a/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/Export-Counter.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/Export-Counter.Tests.ps1
@@ -29,7 +29,7 @@ $counterValues = $null
 # counters and comparing the two sets
 function CheckExportResults
 {
-    Test-Path $filePath | Should Be $true
+    Test-Path $filePath | Should -Be $true
     $importedCounterValues = Import-Counter $filePath
 
     CompareCounterSets $counterValues $importedCounterValues
@@ -106,7 +106,7 @@ function RunTest($testCase)
                 }
                 catch
                 {
-                    $_.FullyQualifiedErrorId | Should Be $testCase.ExpectedErrorId
+                    $_.FullyQualifiedErrorId | Should -Be $testCase.ExpectedErrorId
                 }
             }
         }
@@ -202,7 +202,7 @@ Describe "Feature tests for Export-Counter cmdlet" -Tags "Feature" {
             @{
                 Name = "Can force overwriting existing file"
                 Parameters = "-Force"
-                Script = { Test-Path $filePath | Should Be $true }
+                Script = { Test-Path $filePath | Should -Be $true }
             }
             @{
                 Name = "Can export BLG format"

--- a/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/Export-Counter.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/Export-Counter.Tests.ps1
@@ -80,7 +80,7 @@ function RunTest($testCase)
 
         if ($testCase.CreateFileFirst)
         {
-            if (-Not (Test-Path $filePath))
+            if (-not (Test-Path $filePath))
             {
                 New-Item $filePath -ItemType file
             }

--- a/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/Export-Counter.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/Export-Counter.Tests.ps1
@@ -29,7 +29,7 @@ $counterValues = $null
 # counters and comparing the two sets
 function CheckExportResults
 {
-    Test-Path $filePath | Should -Be $true
+    Test-Path $filePath | Should -BeTrue
     $importedCounterValues = Import-Counter $filePath
 
     CompareCounterSets $counterValues $importedCounterValues
@@ -80,7 +80,7 @@ function RunTest($testCase)
 
         if ($testCase.CreateFileFirst)
         {
-            if (-not (Test-Path $filePath))
+            if (-Not (Test-Path $filePath))
             {
                 New-Item $filePath -ItemType file
             }
@@ -202,7 +202,7 @@ Describe "Feature tests for Export-Counter cmdlet" -Tags "Feature" {
             @{
                 Name = "Can force overwriting existing file"
                 Parameters = "-Force"
-                Script = { Test-Path $filePath | Should -Be $true }
+                Script = { Test-Path $filePath | Should -BeTrue }
             }
             @{
                 Name = "Can export BLG format"

--- a/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/Get-Counter.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/Get-Counter.Tests.ps1
@@ -21,7 +21,7 @@ $counterPaths = @{
     Bad = $badName
 }
 
-$nonEnglishCulture = (-not (Get-Culture).Name.StartsWith("en-", [StringComparison]::InvariantCultureIgnoreCase))
+$nonEnglishCulture = (-Not (Get-Culture).Name.StartsWith("en-", [StringComparison]::InvariantCultureIgnoreCase))
 
 function ValidateParameters($testCase)
 {
@@ -55,7 +55,7 @@ Describe "CI Tests for Get-Counter cmdlet" -Tags "CI" {
     It "Get-Counter with no parameters returns data for a default set of counters" -Skip:$(SkipCounterTests) {
         $counterData = Get-Counter
         # At the very least we should get processor and memory
-        $counterData.CounterSamples.Length | should -BeGreaterThan 1
+        $counterData.CounterSamples.Length | Should -BeGreaterThan 1
     }
 
     It "Can retrieve the specified counter" -Skip:$(SkipCounterTests) {
@@ -227,7 +227,7 @@ Describe "Feature tests for Get-Counter cmdlet" -Tags "Feature" {
             $counterSets.Length | Should -BeGreaterThan 1    # should get at least "Processor" and "Process"
             foreach ($counterSet in $counterSets)
             {
-                $counterSet.CounterSetName.ToLower().Contains($wildcardBase.ToLower()) | Should -Be $true
+                $counterSet.CounterSetName.ToLower().Contains($wildcardBase.ToLower()) | Should -BeTrue
             }
         }
 
@@ -243,7 +243,7 @@ Describe "Feature tests for Get-Counter cmdlet" -Tags "Feature" {
             foreach ($counterSet in $counterSets)
             {
                 ($counterSet.CounterSetName.ToLower().Contains($wildcardBases[0].ToLower()) -Or
-                 $counterSet.CounterSetName.ToLower().Contains($wildcardBases[1].ToLower())) | Should -Be $true
+                 $counterSet.CounterSetName.ToLower().Contains($wildcardBases[1].ToLower())) | Should -BeTrue
             }
         }
     }
@@ -251,7 +251,7 @@ Describe "Feature tests for Get-Counter cmdlet" -Tags "Feature" {
 
 Describe "Get-Counter cmdlet does not run on IoT" -Tags "CI" {
 
-    It "Get-Counter throws PlatformNotSupportedException" -Skip:$(-not [System.Management.Automation.Platform]::IsIoT)  {
+    It "Get-Counter throws PlatformNotSupportedException" -Skip:$(-Not [System.Management.Automation.Platform]::IsIoT)  {
 
         try
         {
@@ -260,7 +260,7 @@ Describe "Get-Counter cmdlet does not run on IoT" -Tags "CI" {
         }
         catch
         {
-            $_.FullyQualifiedErrorId | should -be "System.PlatformNotSupportedException,Microsoft.PowerShell.Commands.GetCounterCommand"
+            $_.FullyQualifiedErrorId | Should -Be "System.PlatformNotSupportedException,Microsoft.PowerShell.Commands.GetCounterCommand"
         }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/Get-Counter.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/Get-Counter.Tests.ps1
@@ -197,15 +197,15 @@ Describe "Feature tests for Get-Counter cmdlet" -Tags "Feature" {
             $counterSetName = "Memory"
             $counterSet = Get-Counter -ListSet $counterSetName
             $counterSet.Length | Should -Be 1
-            $counterSet.CounterSetName | Should -Be $counterSetName
+            $counterSet.CounterSetName | Should -BeExactly $counterSetName
         }
 
         It "Can process an array of counter set names" -Skip:$(SkipCounterTests) {
             $counterSetNames = @("Memory", "Processor")
             $counterSets = Get-Counter -ListSet $counterSetNames
             $counterSets.Length | Should -Be 2
-            $counterSets[0].CounterSetName | Should -Be $counterSetNames[0]
-            $counterSets[1].CounterSetName | Should -Be $counterSetNames[1]
+            $counterSets[0].CounterSetName | Should -BeExactly $counterSetNames[0]
+            $counterSets[1].CounterSetName | Should -BeExactly $counterSetNames[1]
         }
 
         # This test will be skipped for non-English languages, since

--- a/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/Get-Counter.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/Get-Counter.Tests.ps1
@@ -37,16 +37,8 @@ function ValidateParameters($testCase)
         # Use $cmd to debug a test failure
         # Write-Host "Command to run: $cmd"
 
-        try
-        {
-            $sb = [scriptblock]::Create($cmd)
-            &$sb
-            throw "Did not throw expected exception"
-        }
-        catch
-        {
-            $_.FullyQualifiedErrorId | Should -Be $testCase.ExpectedErrorId
-        }
+        $sb = [scriptblock]::Create($cmd)
+        { &$sb } Should -Throw -ErrorId $testCase.ExpectedErrorId
     }
 }
 
@@ -252,15 +244,6 @@ Describe "Feature tests for Get-Counter cmdlet" -Tags "Feature" {
 Describe "Get-Counter cmdlet does not run on IoT" -Tags "CI" {
 
     It "Get-Counter throws PlatformNotSupportedException" -Skip:$(-Not [System.Management.Automation.Platform]::IsIoT)  {
-
-        try
-        {
-            Get-Counter
-            throw "'Get-Counter' on IoT is expected to throw a PlatformNotSupportedException, and it did not."
-        }
-        catch
-        {
-            $_.FullyQualifiedErrorId | Should -Be "System.PlatformNotSupportedException,Microsoft.PowerShell.Commands.GetCounterCommand"
-        }
+        { Get-Counter } | Should -Throw -ErrorId "System.PlatformNotSupportedException,Microsoft.PowerShell.Commands.GetCounterCommand"
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/Get-Counter.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/Get-Counter.Tests.ps1
@@ -21,7 +21,7 @@ $counterPaths = @{
     Bad = $badName
 }
 
-$nonEnglishCulture = (-Not (Get-Culture).Name.StartsWith("en-", [StringComparison]::InvariantCultureIgnoreCase))
+$nonEnglishCulture = (-not (Get-Culture).Name.StartsWith("en-", [StringComparison]::InvariantCultureIgnoreCase))
 
 function ValidateParameters($testCase)
 {

--- a/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/Get-Counter.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/Get-Counter.Tests.ps1
@@ -45,7 +45,7 @@ function ValidateParameters($testCase)
         }
         catch
         {
-            $_.FullyQualifiedErrorId | Should Be $testCase.ExpectedErrorId
+            $_.FullyQualifiedErrorId | Should -Be $testCase.ExpectedErrorId
         }
     }
 }
@@ -55,15 +55,15 @@ Describe "CI Tests for Get-Counter cmdlet" -Tags "CI" {
     It "Get-Counter with no parameters returns data for a default set of counters" -Skip:$(SkipCounterTests) {
         $counterData = Get-Counter
         # At the very least we should get processor and memory
-        $counterData.CounterSamples.Length | should BeGreaterThan 1
+        $counterData.CounterSamples.Length | should -BeGreaterThan 1
     }
 
     It "Can retrieve the specified counter" -Skip:$(SkipCounterTests) {
         $counterPath = $counterPaths.MemoryBytes
         $counterData = Get-Counter -Counter $counterPath
-        $counterData.Length | Should Be 1
+        $counterData.Length | Should -Be 1
         $retrievedPath = RemoveMachineName $counterData[0].CounterSamples[0].Path
-        [string]::Compare($retrievedPath, $counterPath, $true) | Should Be 0
+        [string]::Compare($retrievedPath, $counterPath, $true) | Should -Be 0
     }
 }
 
@@ -178,7 +178,7 @@ Describe "Feature tests for Get-Counter cmdlet" -Tags "Feature" {
             $counterPath = $counterPaths.MemoryBytes
             $counterCount = 5
             $counterData = Get-Counter -Counter $counterPath -MaxSamples $counterCount
-            $counterData.Length | Should Be $counterCount
+            $counterData.Length | Should -Be $counterCount
         }
 
         It "Can specify the sample interval" -Skip:$(SkipCounterTests) {
@@ -188,15 +188,15 @@ Describe "Feature tests for Get-Counter cmdlet" -Tags "Feature" {
             $startTime = Get-Date
             $counterData = Get-Counter -Counter $counterPath -SampleInterval $sampleInterval -MaxSamples $counterCount
             $endTime = Get-Date
-            $counterData.Length | Should Be $counterCount
-            ($endTime - $startTime).TotalSeconds | Should Not BeLessThan ($counterCount * $sampleInterval)
+            $counterData.Length | Should -Be $counterCount
+            ($endTime - $startTime).TotalSeconds | Should -Not -BeLessThan ($counterCount * $sampleInterval)
         }
 
         It "Can process array of counter names" -Skip:$(SkipCounterTests) {
             $counterPaths = @((TranslateCounterPath "\PhysicalDisk(_Total)\Disk Read Bytes/sec"),
                               (TranslateCounterPath "\Memory\Available bytes"))
             $counterData = Get-Counter -Counter $counterPaths
-            $counterData.CounterSamples.Length | Should Be $counterPaths.Length
+            $counterData.CounterSamples.Length | Should -Be $counterPaths.Length
         }
     }
 
@@ -204,16 +204,16 @@ Describe "Feature tests for Get-Counter cmdlet" -Tags "Feature" {
         It "Can retrieve specified counter set" -Skip:$(SkipCounterTests) {
             $counterSetName = "Memory"
             $counterSet = Get-Counter -ListSet $counterSetName
-            $counterSet.Length | Should Be 1
-            $counterSet.CounterSetName | Should Be $counterSetName
+            $counterSet.Length | Should -Be 1
+            $counterSet.CounterSetName | Should -Be $counterSetName
         }
 
         It "Can process an array of counter set names" -Skip:$(SkipCounterTests) {
             $counterSetNames = @("Memory", "Processor")
             $counterSets = Get-Counter -ListSet $counterSetNames
-            $counterSets.Length | Should Be 2
-            $counterSets[0].CounterSetName | Should Be $counterSetNames[0]
-            $counterSets[1].CounterSetName | Should Be $counterSetNames[1]
+            $counterSets.Length | Should -Be 2
+            $counterSets[0].CounterSetName | Should -Be $counterSetNames[0]
+            $counterSets[1].CounterSetName | Should -Be $counterSetNames[1]
         }
 
         # This test will be skipped for non-English languages, since
@@ -224,10 +224,10 @@ Describe "Feature tests for Get-Counter cmdlet" -Tags "Feature" {
             $wildcardBase = "roc"
             $counterSetName = "*$wildcardBase*"
             $counterSets = Get-Counter -ListSet $counterSetName
-            $counterSets.Length | Should BeGreaterThan 1    # should get at least "Processor" and "Process"
+            $counterSets.Length | Should -BeGreaterThan 1    # should get at least "Processor" and "Process"
             foreach ($counterSet in $counterSets)
             {
-                $counterSet.CounterSetName.ToLower().Contains($wildcardBase.ToLower()) | Should Be $true
+                $counterSet.CounterSetName.ToLower().Contains($wildcardBase.ToLower()) | Should -Be $true
             }
         }
 
@@ -239,11 +239,11 @@ Describe "Feature tests for Get-Counter cmdlet" -Tags "Feature" {
             $wildcardBases = @("Memory", "roc")
             $counterSetNames = @($wildcardBases[0], ("*" + $wildcardBases[1] + "*"))
             $counterSets = Get-Counter -ListSet $counterSetNames
-            $counterSets.Length | Should BeGreaterThan 2    # should get at least "Memory", "Processor" and "Process"
+            $counterSets.Length | Should -BeGreaterThan 2    # should get at least "Memory", "Processor" and "Process"
             foreach ($counterSet in $counterSets)
             {
                 ($counterSet.CounterSetName.ToLower().Contains($wildcardBases[0].ToLower()) -Or
-                 $counterSet.CounterSetName.ToLower().Contains($wildcardBases[1].ToLower())) | Should Be $true
+                 $counterSet.CounterSetName.ToLower().Contains($wildcardBases[1].ToLower())) | Should -Be $true
             }
         }
     }
@@ -260,7 +260,7 @@ Describe "Get-Counter cmdlet does not run on IoT" -Tags "CI" {
         }
         catch
         {
-            $_.FullyQualifiedErrorId | should be "System.PlatformNotSupportedException,Microsoft.PowerShell.Commands.GetCounterCommand"
+            $_.FullyQualifiedErrorId | should -be "System.PlatformNotSupportedException,Microsoft.PowerShell.Commands.GetCounterCommand"
         }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/Get-Counter.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/Get-Counter.Tests.ps1
@@ -38,7 +38,7 @@ function ValidateParameters($testCase)
         # Write-Host "Command to run: $cmd"
 
         $sb = [scriptblock]::Create($cmd)
-        { &$sb } Should -Throw -ErrorId $testCase.ExpectedErrorId
+        { &$sb } | Should -Throw -ErrorId $testCase.ExpectedErrorId
     }
 }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/Get-WinEvent.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/Get-WinEvent.Tests.ps1
@@ -44,7 +44,7 @@ Describe 'Get-WinEvent' -Tags "CI" {
             # we sample the first 20 results, as this could be very large
             $results = Get-WinEvent -provider $providerForTests.Name -max 20
             foreach($event in $results ) {
-                $event.providername | Should -Be $providerForTests.name
+                $event.providername | Should -BeExactly $providerForTests.name
             }
         }
         It 'Get-WinEvent can get events via logname' {

--- a/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/Get-WinEvent.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/Get-WinEvent.Tests.ps1
@@ -16,12 +16,12 @@ Describe 'Get-WinEvent' -Tags "CI" {
     Context "Get-WinEvent ListProvider parameter" {
         It 'Get-WinEvent can list the providers' {
             $result = Get-WinEvent -listprovider * -erroraction ignore
-            $result | should not BeNullOrEmpty
+            $result | should -not -BeNullOrEmpty
         }
         It 'Get-WinEvent can get a provider by name' {
             $providers = Get-WinEvent -listprovider * -erroraction ignore
             $result = Get-WinEvent -listprovider ($providers[0].name)
-            $result | should not BeNullOrEmpty
+            $result | should -not -BeNullOrEmpty
         }
 
     }
@@ -44,36 +44,36 @@ Describe 'Get-WinEvent' -Tags "CI" {
             # we sample the first 20 results, as this could be very large
             $results = Get-WinEvent -provider $providerForTests.Name -max 20
             foreach($event in $results ) {
-                $event.providername | should be $providerForTests.name
+                $event.providername | should -be $providerForTests.name
             }
         }
         It 'Get-WinEvent can get events via logname' {
             $results = get-winevent -logname $providerForTests.LogLinks.LogName -MaxEvents 10
-            $results | should not BeNullOrEmpty
+            $results | should -not -BeNullOrEmpty
         }
         It 'Get-WinEvent can use the simplest of filters' {
             $filter = @{ ProviderName = $providerForTests.Name }
             $testEvents = Get-WinEvent -filterhashtable $filter
-            $testEvents.Count | should be $events.Count
+            $testEvents.Count | should -be $events.Count
         }
         It 'Get-WinEvent can use a filter which includes two items' {
             $filter = @{ ProviderName = $providerForTests.Name; Id = $events[0].Id}
             $results = Get-WinEvent -filterHashtable $filter
-            $results | Should not BeNullOrEmpty
+            $results | Should -not -BeNullOrEmpty
         }
         It 'Get-WinEvent can retrieve event via XmlQuery' {
             $level = $events[0].Level
             $logname = $providerForTests.loglinks.logname
             $filter = "<QueryList><Query><Select Path='${logname}'>*[System[Level=${level}]]</Select></Query></QueryList>"
             $results = Get-WinEvent -filterXml $filter -max 3
-            $results | should Not BeNullOrEmpty
+            $results | should -Not -BeNullOrEmpty
         }
         It 'Get-WinEvent can retrieve event via XPath' {
             $level = $events[0].Level
             $logname  = $providerForTests.loglinks.logname
             $xpathFilter = "*[System[Level=$level]]"
             $results = Get-WinEvent -logname $logname -filterXPath $xpathFilter -max 3
-            $results | should Not BeNullOrEmpty
+            $results | should -Not -BeNullOrEmpty
         }
 
     }
@@ -84,8 +84,8 @@ Describe 'Get-WinEvent' -Tags "CI" {
             $eventLogFile = [io.path]::Combine($PSScriptRoot, "assets", "Saved-Events.evtx")
             $filter = "<QueryList><Query><Select Path='file://$eventLogFile'>*[UserData/*/Param2='Windows x64']</Select></Query></QueryList>"
             $results = Get-WinEvent -FilterXml $filter -ea silentlycontinue
-            @($results).Count | Should be 1
-            $results.RecordId | should be 10
+            @($results).Count | Should -be 1
+            $results.RecordId | should -be 10
         }
         It 'Get-WinEvent can retrieve events with UserData queries using FilterHashtable (one value)' {
             # this relies on apriori knowledge about the log file
@@ -93,8 +93,8 @@ Describe 'Get-WinEvent' -Tags "CI" {
             $eventLogFile = [io.path]::Combine($PSScriptRoot, "assets", "Saved-Events.evtx")
             $filter = @{ path = "$eventLogFile"; Param2 = "Windows x64"}
             $results = Get-WinEvent -filterHashtable $filter -ea silentlycontinue
-            @($results).Count | Should be 1
-            $results.RecordId | should be 10
+            @($results).Count | Should -be 1
+            $results.RecordId | should -be 10
         }
         It 'Get-WinEvent can retrieve events with UserData queries using FilterHashtable (array of values)' {
             # this relies on apriori knowledge about the log file
@@ -102,9 +102,9 @@ Describe 'Get-WinEvent' -Tags "CI" {
             $eventLogFile = [io.path]::Combine($PSScriptRoot, "assets", "Saved-Events.evtx")
             $filter = @{ path = "$eventLogFile"; DriverName = "Remote Desktop Easy Print", "Microsoft enhanced Point and Print compatibility driver" }
             $results = Get-WinEvent -filterHashtable $filter -ea silentlycontinue
-            @($results).Count | Should be 2
-            ($results.RecordId -contains 9) | should be $true
-            ($results.RecordId -contains 11) | should be $true
+            @($results).Count | Should -be 2
+            ($results.RecordId -contains 9) | should -be $true
+            ($results.RecordId -contains 11) | should -be $true
         }
         It 'Get-WinEvent can retrieve events with UserData queries using FilterHashtable (multiple named params)' {
             # this relies on apriori knowledge about the log file
@@ -112,9 +112,9 @@ Describe 'Get-WinEvent' -Tags "CI" {
             $eventLogFile = [io.path]::Combine($PSScriptRoot, "assets", "Saved-Events.evtx")
             $filter = @{ path = "$eventLogFile"; PackageAware="Not package aware"; DriverName = "Remote Desktop Easy Print", "Microsoft enhanced Point and Print compatibility driver" }
             $results = Get-WinEvent -filterHashtable $filter -ea silentlycontinue
-            @($results).Count | Should be 2
-            ($results.RecordId -contains 9) | should be $true
-            ($results.RecordId -contains 11) | should be $true
+            @($results).Count | Should -be 2
+            ($results.RecordId -contains 9) | should -be $true
+            ($results.RecordId -contains 11) | should -be $true
         }
         It 'Get-WinEvent can retrieve events with UserData queries using FilterXPath' {
             # this relies on apriori knowledge about the log file
@@ -122,8 +122,8 @@ Describe 'Get-WinEvent' -Tags "CI" {
             $eventLogFile = [io.path]::Combine($PSScriptRoot, "assets", "Saved-Events.evtx")
             $filter = "*/UserData/*/Param2='Windows x64'"
             $results = Get-WinEvent -path $eventLogFile -filterXPath $filter -ea silentlycontinue
-            @($results).Count | Should be 1
-            $results.RecordId | should be 10
+            @($results).Count | Should -be 1
+            $results.RecordId | should -be 10
         }
     }
     Context "Get-WinEvent Queries with SuppressHashFilter" {
@@ -135,8 +135,8 @@ Describe 'Get-WinEvent' -Tags "CI" {
             $results = Get-WinEvent -filterHashtable $filter -ea silentlycontinue
             $filterSuppress = @{ path = "$eventLogFile";  SuppressHashFilter=@{Id=370}}
             $resultsSuppress = Get-WinEvent -filterHashtable $filterSuppress -ea silentlycontinue
-            @($results).Count | Should be 3
-            @($resultsSuppress).Count | Should be 2
+            @($results).Count | Should -be 3
+            @($resultsSuppress).Count | Should -be 2
         }
         It 'Get-WinEvent can suppress events by UserData' {
             # this relies on apriori knowledge about the log file
@@ -146,11 +146,11 @@ Describe 'Get-WinEvent' -Tags "CI" {
             $results = Get-WinEvent -filterHashtable $filter -ea silentlycontinue
             $filterSuppress = @{ path = "$eventLogFile";  SuppressHashFilter=@{Param2 = "Windows x64"}}
             $resultsSuppress = Get-WinEvent -filterHashtable $filterSuppress -ea silentlycontinue
-            @($results).Count | Should be 3
-            @($resultsSuppress).Count | Should be 2
+            @($results).Count | Should -be 3
+            @($resultsSuppress).Count | Should -be 2
         }
     }
     It 'can query a System log' {
-        Get-WinEvent -LogName System -MaxEvents 1 | Should Not BeNullOrEmpty
+        Get-WinEvent -LogName System -MaxEvents 1 | Should -Not -BeNullOrEmpty
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/Get-WinEvent.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/Get-WinEvent.Tests.ps1
@@ -16,12 +16,12 @@ Describe 'Get-WinEvent' -Tags "CI" {
     Context "Get-WinEvent ListProvider parameter" {
         It 'Get-WinEvent can list the providers' {
             $result = Get-WinEvent -listprovider * -erroraction ignore
-            $result | should -not -BeNullOrEmpty
+            $result | Should -Not -BeNullOrEmpty
         }
         It 'Get-WinEvent can get a provider by name' {
             $providers = Get-WinEvent -listprovider * -erroraction ignore
             $result = Get-WinEvent -listprovider ($providers[0].name)
-            $result | should -not -BeNullOrEmpty
+            $result | Should -Not -BeNullOrEmpty
         }
 
     }
@@ -44,36 +44,36 @@ Describe 'Get-WinEvent' -Tags "CI" {
             # we sample the first 20 results, as this could be very large
             $results = Get-WinEvent -provider $providerForTests.Name -max 20
             foreach($event in $results ) {
-                $event.providername | should -be $providerForTests.name
+                $event.providername | Should -Be $providerForTests.name
             }
         }
         It 'Get-WinEvent can get events via logname' {
             $results = get-winevent -logname $providerForTests.LogLinks.LogName -MaxEvents 10
-            $results | should -not -BeNullOrEmpty
+            $results | Should -Not -BeNullOrEmpty
         }
         It 'Get-WinEvent can use the simplest of filters' {
             $filter = @{ ProviderName = $providerForTests.Name }
             $testEvents = Get-WinEvent -filterhashtable $filter
-            $testEvents.Count | should -be $events.Count
+            $testEvents.Count | Should -Be $events.Count
         }
         It 'Get-WinEvent can use a filter which includes two items' {
             $filter = @{ ProviderName = $providerForTests.Name; Id = $events[0].Id}
             $results = Get-WinEvent -filterHashtable $filter
-            $results | Should -not -BeNullOrEmpty
+            $results | Should -Not -BeNullOrEmpty
         }
         It 'Get-WinEvent can retrieve event via XmlQuery' {
             $level = $events[0].Level
             $logname = $providerForTests.loglinks.logname
             $filter = "<QueryList><Query><Select Path='${logname}'>*[System[Level=${level}]]</Select></Query></QueryList>"
             $results = Get-WinEvent -filterXml $filter -max 3
-            $results | should -Not -BeNullOrEmpty
+            $results | Should -Not -BeNullOrEmpty
         }
         It 'Get-WinEvent can retrieve event via XPath' {
             $level = $events[0].Level
             $logname  = $providerForTests.loglinks.logname
             $xpathFilter = "*[System[Level=$level]]"
             $results = Get-WinEvent -logname $logname -filterXPath $xpathFilter -max 3
-            $results | should -Not -BeNullOrEmpty
+            $results | Should -Not -BeNullOrEmpty
         }
 
     }
@@ -84,8 +84,8 @@ Describe 'Get-WinEvent' -Tags "CI" {
             $eventLogFile = [io.path]::Combine($PSScriptRoot, "assets", "Saved-Events.evtx")
             $filter = "<QueryList><Query><Select Path='file://$eventLogFile'>*[UserData/*/Param2='Windows x64']</Select></Query></QueryList>"
             $results = Get-WinEvent -FilterXml $filter -ea silentlycontinue
-            @($results).Count | Should -be 1
-            $results.RecordId | should -be 10
+            @($results).Count | Should -Be 1
+            $results.RecordId | Should -Be 10
         }
         It 'Get-WinEvent can retrieve events with UserData queries using FilterHashtable (one value)' {
             # this relies on apriori knowledge about the log file
@@ -93,8 +93,8 @@ Describe 'Get-WinEvent' -Tags "CI" {
             $eventLogFile = [io.path]::Combine($PSScriptRoot, "assets", "Saved-Events.evtx")
             $filter = @{ path = "$eventLogFile"; Param2 = "Windows x64"}
             $results = Get-WinEvent -filterHashtable $filter -ea silentlycontinue
-            @($results).Count | Should -be 1
-            $results.RecordId | should -be 10
+            @($results).Count | Should -Be 1
+            $results.RecordId | Should -Be 10
         }
         It 'Get-WinEvent can retrieve events with UserData queries using FilterHashtable (array of values)' {
             # this relies on apriori knowledge about the log file
@@ -102,9 +102,9 @@ Describe 'Get-WinEvent' -Tags "CI" {
             $eventLogFile = [io.path]::Combine($PSScriptRoot, "assets", "Saved-Events.evtx")
             $filter = @{ path = "$eventLogFile"; DriverName = "Remote Desktop Easy Print", "Microsoft enhanced Point and Print compatibility driver" }
             $results = Get-WinEvent -filterHashtable $filter -ea silentlycontinue
-            @($results).Count | Should -be 2
-            ($results.RecordId -contains 9) | should -be $true
-            ($results.RecordId -contains 11) | should -be $true
+            @($results).Count | Should -Be 2
+            ($results.RecordId -contains 9) | Should -BeTrue
+            ($results.RecordId -contains 11) | Should -BeTrue
         }
         It 'Get-WinEvent can retrieve events with UserData queries using FilterHashtable (multiple named params)' {
             # this relies on apriori knowledge about the log file
@@ -112,9 +112,9 @@ Describe 'Get-WinEvent' -Tags "CI" {
             $eventLogFile = [io.path]::Combine($PSScriptRoot, "assets", "Saved-Events.evtx")
             $filter = @{ path = "$eventLogFile"; PackageAware="Not package aware"; DriverName = "Remote Desktop Easy Print", "Microsoft enhanced Point and Print compatibility driver" }
             $results = Get-WinEvent -filterHashtable $filter -ea silentlycontinue
-            @($results).Count | Should -be 2
-            ($results.RecordId -contains 9) | should -be $true
-            ($results.RecordId -contains 11) | should -be $true
+            @($results).Count | Should -Be 2
+            ($results.RecordId -contains 9) | Should -BeTrue
+            ($results.RecordId -contains 11) | Should -BeTrue
         }
         It 'Get-WinEvent can retrieve events with UserData queries using FilterXPath' {
             # this relies on apriori knowledge about the log file
@@ -122,8 +122,8 @@ Describe 'Get-WinEvent' -Tags "CI" {
             $eventLogFile = [io.path]::Combine($PSScriptRoot, "assets", "Saved-Events.evtx")
             $filter = "*/UserData/*/Param2='Windows x64'"
             $results = Get-WinEvent -path $eventLogFile -filterXPath $filter -ea silentlycontinue
-            @($results).Count | Should -be 1
-            $results.RecordId | should -be 10
+            @($results).Count | Should -Be 1
+            $results.RecordId | Should -Be 10
         }
     }
     Context "Get-WinEvent Queries with SuppressHashFilter" {
@@ -135,8 +135,8 @@ Describe 'Get-WinEvent' -Tags "CI" {
             $results = Get-WinEvent -filterHashtable $filter -ea silentlycontinue
             $filterSuppress = @{ path = "$eventLogFile";  SuppressHashFilter=@{Id=370}}
             $resultsSuppress = Get-WinEvent -filterHashtable $filterSuppress -ea silentlycontinue
-            @($results).Count | Should -be 3
-            @($resultsSuppress).Count | Should -be 2
+            @($results).Count | Should -Be 3
+            @($resultsSuppress).Count | Should -Be 2
         }
         It 'Get-WinEvent can suppress events by UserData' {
             # this relies on apriori knowledge about the log file
@@ -146,8 +146,8 @@ Describe 'Get-WinEvent' -Tags "CI" {
             $results = Get-WinEvent -filterHashtable $filter -ea silentlycontinue
             $filterSuppress = @{ path = "$eventLogFile";  SuppressHashFilter=@{Param2 = "Windows x64"}}
             $resultsSuppress = Get-WinEvent -filterHashtable $filterSuppress -ea silentlycontinue
-            @($results).Count | Should -be 3
-            @($resultsSuppress).Count | Should -be 2
+            @($results).Count | Should -Be 3
+            @($resultsSuppress).Count | Should -Be 2
         }
     }
     It 'can query a System log' {

--- a/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/Import-Counter.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/Import-Counter.Tests.ps1
@@ -213,7 +213,7 @@ function RunExpectedFailureTest($testCase)
         {
             # Here we expect and want the command to fail
             $sb = [ScriptBlock]::Create($cmd)
-            $e = { &$sb }
+            $e = { &$sb } | Should -Throw
             if ($testCase.ExpectedErrorId)
             {
                 $e.FullyQualifiedErrorId | Should -BeExactly $testCase.ExpectedErrorId

--- a/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/Import-Counter.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/Import-Counter.Tests.ps1
@@ -212,22 +212,15 @@ function RunExpectedFailureTest($testCase)
         else
         {
             # Here we expect and want the command to fail
-            try
+            $sb = [ScriptBlock]::Create($cmd)
+            $e = { &$sb }
+            if ($testCase.ExpectedErrorId)
             {
-                $sb = [ScriptBlock]::Create($cmd)
-                &$sb
-                throw "Did not throw expected exception"
+                $e.FullyQualifiedErrorId | Should -Be $testCase.ExpectedErrorId
             }
-            catch
+            if ($testCase.ExpectedErrorCategory)
             {
-                if ($testCase.ExpectedErrorId)
-                {
-                    $_.FullyQualifiedErrorId | Should -Be $testCase.ExpectedErrorId
-                }
-                if ($testCase.ExpectedErrorCategory)
-                {
-                    $_.CategoryInfo.Category | Should -Be $testCase.ExpectedErrorCategory
-                }
+                $e.CategoryInfo.Category | Should -Be $testCase.ExpectedErrorCategory
             }
         }
     }
@@ -473,15 +466,7 @@ Describe "Feature tests for Import-Counter cmdlet" -Tags "Feature" {
 Describe "Import-Counter cmdlet does not run on IoT" -Tags "CI" {
 
     It "Import-Counter throws PlatformNotSupportedException" -Skip:$(-not [System.Management.Automation.Platform]::IsIoT)  {
-
-        try
-        {
-            Import-Counter -Path "$testDrive\ProcessorData.blg"
-            throw "'Import-Counter -Path $testDrive\ProcessorData.blg' on IoT is expected to throw a PlatformNotSupportedException, and it did not."
-        }
-        catch
-        {
-            $_.FullyQualifiedErrorId | Should -Be "System.PlatformNotSupportedException,Microsoft.PowerShell.Commands.ImportCounterCommand"
-        }
+        { Import-Counter -Path "$testDrive\ProcessorData.blg" } |
+	    Should -Throw -ErrorId "System.PlatformNotSupportedException,Microsoft.PowerShell.Commands.ImportCounterCommand"
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/Import-Counter.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/Import-Counter.Tests.ps1
@@ -213,11 +213,7 @@ function RunExpectedFailureTest($testCase)
         {
             # Here we expect and want the command to fail
             $sb = [ScriptBlock]::Create($cmd)
-            $e = { &$sb } | Should -Throw
-            if ($testCase.ExpectedErrorId)
-            {
-                $e.FullyQualifiedErrorId | Should -BeExactly $testCase.ExpectedErrorId
-            }
+            $e = { &$sb } | Should -Throw -ErrorId $testCase.ExpectedErrorId -PassThru
             if ($testCase.ExpectedErrorCategory)
             {
                 $e.CategoryInfo.Category | Should -BeExactly $testCase.ExpectedErrorCategory

--- a/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/Import-Counter.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/Import-Counter.Tests.ps1
@@ -216,11 +216,11 @@ function RunExpectedFailureTest($testCase)
             $e = { &$sb }
             if ($testCase.ExpectedErrorId)
             {
-                $e.FullyQualifiedErrorId | Should -Be $testCase.ExpectedErrorId
+                $e.FullyQualifiedErrorId | Should -BeExactly $testCase.ExpectedErrorId
             }
             if ($testCase.ExpectedErrorCategory)
             {
-                $e.CategoryInfo.Category | Should -Be $testCase.ExpectedErrorCategory
+                $e.CategoryInfo.Category | Should -BeExactly $testCase.ExpectedErrorCategory
             }
         }
     }
@@ -362,8 +362,8 @@ Describe "Feature tests for Import-Counter cmdlet" -Tags "Feature" {
             $errVar.Count | Should -Be 5
             foreach ($err in $errVar)
             {
-                $err.CategoryInfo.Category | Should -Be "InvalidResult"
-                $err.FullyQualifiedErrorId | SHould -Be "CounterApiError,Microsoft.PowerShell.Commands.ImportCounterCommand"
+                $err.CategoryInfo.Category | Should -BeExactly "InvalidResult"
+                $err.FullyQualifiedErrorId | SHould -BeExactly "CounterApiError,Microsoft.PowerShell.Commands.ImportCounterCommand"
             }
         }
     }
@@ -398,7 +398,7 @@ Describe "Feature tests for Import-Counter cmdlet" -Tags "Feature" {
                 Parameters = "-ListSet $($setNames.Memory)"
                 Script = {
                     $result.Length | Should -Be 1
-                    $result[0].CounterSetName | Should -Be $setNames.Memory
+                    $result[0].CounterSetName | Should -BeExactly $setNames.Memory
                 }
             }
             @{

--- a/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/Import-Counter.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/Import-Counter.Tests.ps1
@@ -131,7 +131,7 @@ function RunTest($testCase)
         $errVar = $null
         $sb = [scriptblock]::Create($cmd)
         $result = &$sb
-        $errVar | Should BeNullOrEmpty
+        $errVar | Should -BeNullOrEmpty
 
         if ($testCase.ContainsKey("Script"))
         {
@@ -222,11 +222,11 @@ function RunExpectedFailureTest($testCase)
             {
                 if ($testCase.ExpectedErrorId)
                 {
-                    $_.FullyQualifiedErrorId | Should Be $testCase.ExpectedErrorId
+                    $_.FullyQualifiedErrorId | Should -Be $testCase.ExpectedErrorId
                 }
                 if ($testCase.ExpectedErrorCategory)
                 {
-                    $_.CategoryInfo.Category | Should Be $testCase.ExpectedErrorCategory
+                    $_.CategoryInfo.Category | Should -Be $testCase.ExpectedErrorCategory
                 }
             }
         }
@@ -244,7 +244,7 @@ Describe "CI tests for Import-Counter cmdlet" -Tags "CI" {
             Name = "Can import all samples from known sample sets"
             UseKnownSamples = $true
             Script = {
-                $result.Length | Should Be 25
+                $result.Length | Should -Be 25
             }
         }
         @{
@@ -252,9 +252,9 @@ Describe "CI tests for Import-Counter cmdlet" -Tags "CI" {
             UseKnownSamples = $true
             Parameters = "-Summary"
             Script = {
-                $result.SampleCount | Should Be 25
-                $result.OldestRecord | Should Be (Get-Date -Year 2016 -Month 11 -Day 26 -Hour 13 -Minute 46 -Second 30 -Millisecond 874)
-                $result.NewestRecord | Should Be (Get-Date -Year 2016 -Month 11 -Day 26 -Hour 13 -Minute 47 -Second 42 -Millisecond 983)
+                $result.SampleCount | Should -Be 25
+                $result.OldestRecord | Should -Be (Get-Date -Year 2016 -Month 11 -Day 26 -Hour 13 -Minute 46 -Second 30 -Millisecond 874)
+                $result.NewestRecord | Should -Be (Get-Date -Year 2016 -Month 11 -Day 26 -Hour 13 -Minute 47 -Second 42 -Millisecond 983)
             }
         }
     )
@@ -365,12 +365,12 @@ Describe "Feature tests for Import-Counter cmdlet" -Tags "Feature" {
         It "Multiple errors when BLG file contains bad sample data" -Skip:$(SkipCounterTests) {
             $errVar = $null
             $result = Import-Counter $badSamplesBlgPath -ErrorVariable errVar -ErrorAction SilentlyContinue
-            $result.Length | Should Be 275
-            $errVar.Count | Should Be 5
+            $result.Length | Should -Be 275
+            $errVar.Count | Should -Be 5
             foreach ($err in $errVar)
             {
-                $err.CategoryInfo.Category | Should Be "InvalidResult"
-                $err.FullyQualifiedErrorId | SHould Be "CounterApiError,Microsoft.PowerShell.Commands.ImportCounterCommand"
+                $err.CategoryInfo.Category | Should -Be "InvalidResult"
+                $err.FullyQualifiedErrorId | SHould -Be "CounterApiError,Microsoft.PowerShell.Commands.ImportCounterCommand"
             }
         }
     }
@@ -404,8 +404,8 @@ Describe "Feature tests for Import-Counter cmdlet" -Tags "Feature" {
                 UseKnownSamples = $true
                 Parameters = "-ListSet $($setNames.Memory)"
                 Script = {
-                    $result.Length | Should Be 1
-                    $result[0].CounterSetName | Should Be $setNames.Memory
+                    $result.Length | Should -Be 1
+                    $result[0].CounterSetName | Should -Be $setNames.Memory
                 }
             }
             @{
@@ -413,14 +413,14 @@ Describe "Feature tests for Import-Counter cmdlet" -Tags "Feature" {
                 UseKnownSamples = $true
                 Parameters = "-ListSet $(TranslateCounterName 'memory'), $(TranslateCounterName 'processor')"
                 Script = {
-                    $result.Length | Should Be 2
+                    $result.Length | Should -Be 2
                     $names = @()
                     foreach ($set in $result)
                     {
                         $names = $names + $set.CounterSetName
                     }
-                    $names -Contains $setNames.Memory | Should Be $true
-                    $names -Contains $setNames.Processor | Should Be $true
+                    $names -Contains $setNames.Memory | Should -Be $true
+                    $names -Contains $setNames.Processor | Should -Be $true
                 }
             }
             @{
@@ -433,14 +433,14 @@ Describe "Feature tests for Import-Counter cmdlet" -Tags "Feature" {
                 UseKnownSamples = $true
                 Parameters = "-ListSet p*"
                 Script = {
-                    $result.Length | Should BeGreaterThan 1
+                    $result.Length | Should -BeGreaterThan 1
                     $names = @()
                     foreach ($set in $result)
                     {
                         $names = $names + $set.CounterSetName
                     }
-                    $names -Contains "physicaldisk" | Should Be $true
-                    $names -Contains "processor" | Should Be $true
+                    $names -Contains "physicaldisk" | Should -Be $true
+                    $names -Contains "processor" | Should -Be $true
                 }
             }
             @{
@@ -453,12 +453,12 @@ Describe "Feature tests for Import-Counter cmdlet" -Tags "Feature" {
                 UseKnownSamples = $true
                 Parameters = "-ListSet memory, p*"
                 Script = {
-                    $result.Length | Should BeGreaterThan 2
+                    $result.Length | Should -BeGreaterThan 2
                     $names = @()
                     foreach ($set in $result) { $names = $names + $set.CounterSetName }
-                    $names -Contains "memory" | Should Be $true
-                    $names -Contains "processor" | Should Be $true
-                    $names -Contains "physicaldisk" | Should Be $true
+                    $names -Contains "memory" | Should -Be $true
+                    $names -Contains "processor" | Should -Be $true
+                    $names -Contains "physicaldisk" | Should -Be $true
                 }
             }
         )
@@ -481,7 +481,7 @@ Describe "Import-Counter cmdlet does not run on IoT" -Tags "CI" {
         }
         catch
         {
-            $_.FullyQualifiedErrorId | should be "System.PlatformNotSupportedException,Microsoft.PowerShell.Commands.ImportCounterCommand"
+            $_.FullyQualifiedErrorId | should -be "System.PlatformNotSupportedException,Microsoft.PowerShell.Commands.ImportCounterCommand"
         }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/Import-Counter.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/Import-Counter.Tests.ps1
@@ -419,8 +419,8 @@ Describe "Feature tests for Import-Counter cmdlet" -Tags "Feature" {
                     {
                         $names = $names + $set.CounterSetName
                     }
-                    $names -Contains $setNames.Memory | Should -Be $true
-                    $names -Contains $setNames.Processor | Should -Be $true
+                    $names -Contains $setNames.Memory | Should -BeTrue
+                    $names -Contains $setNames.Processor | Should -BeTrue
                 }
             }
             @{
@@ -439,8 +439,8 @@ Describe "Feature tests for Import-Counter cmdlet" -Tags "Feature" {
                     {
                         $names = $names + $set.CounterSetName
                     }
-                    $names -Contains "physicaldisk" | Should -Be $true
-                    $names -Contains "processor" | Should -Be $true
+                    $names -Contains "physicaldisk" | Should -BeTrue
+                    $names -Contains "processor" | Should -BeTrue
                 }
             }
             @{
@@ -456,9 +456,9 @@ Describe "Feature tests for Import-Counter cmdlet" -Tags "Feature" {
                     $result.Length | Should -BeGreaterThan 2
                     $names = @()
                     foreach ($set in $result) { $names = $names + $set.CounterSetName }
-                    $names -Contains "memory" | Should -Be $true
-                    $names -Contains "processor" | Should -Be $true
-                    $names -Contains "physicaldisk" | Should -Be $true
+                    $names -Contains "memory" | Should -BeTrue
+                    $names -Contains "processor" | Should -BeTrue
+                    $names -Contains "physicaldisk" | Should -BeTrue
                 }
             }
         )
@@ -481,7 +481,7 @@ Describe "Import-Counter cmdlet does not run on IoT" -Tags "CI" {
         }
         catch
         {
-            $_.FullyQualifiedErrorId | should -be "System.PlatformNotSupportedException,Microsoft.PowerShell.Commands.ImportCounterCommand"
+            $_.FullyQualifiedErrorId | Should -Be "System.PlatformNotSupportedException,Microsoft.PowerShell.Commands.ImportCounterCommand"
         }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/New-WinEvent.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Diagnostics/New-WinEvent.Tests.ps1
@@ -22,7 +22,7 @@ Describe 'New-WinEvent' -Tags "CI" {
         It 'Simple New-WinEvent without any payload' {
             New-WinEvent -ProviderName $ProviderName -Id $SimpleEventId -Version 1
             $filter = @{ ProviderName = $ProviderName; Id = $SimpleEventId}
-            (Get-WinEvent -filterHashtable $filter).Count | Should BeGreaterThan 0
+            (Get-WinEvent -filterHashtable $filter).Count | Should -BeGreaterThan 0
         }
         
         It 'No provider found error' {
@@ -45,7 +45,7 @@ Describe 'New-WinEvent' -Tags "CI" {
             $logPath = join-path $TestDrive 'testlog1.txt'
             # this will print the warning with expected event template to the file
             New-WinEvent -ProviderName $ProviderName -Id $ComplexEventId *> $logPath
-            Get-Content $logPath -Raw | Should Match 'data name="FragmentPayload"'
+            Get-Content $logPath -Raw | Should -Match 'data name="FragmentPayload"'
         }
     }
 }


### PR DESCRIPTION
## PR Summary

Use new Pester syntax: -Parameter for Pester tests in Modules/Microsoft.PowerShell.Diagnostics.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [x] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
