### PR TITLE
Fix the link configuration for Linux packaging

### DIFF
--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -627,7 +627,7 @@ function New-UnixPackage {
 
         # Destination for symlink to powershell executable
         $Link = if ($Environment.IsLinux) {
-            "/usr/bin/"
+            "/usr/bin/pwsh"
         } elseif ($Environment.IsMacOS) {
             "/usr/local/bin/"
         }

--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -629,7 +629,7 @@ function New-UnixPackage {
         $Link = if ($Environment.IsLinux) {
             "/usr/bin/pwsh"
         } elseif ($Environment.IsMacOS) {
-            "/usr/local/bin/"
+            "/usr/local/bin/pwsh"
         }
         $linkSource = "/tmp/pwsh"
 


### PR DESCRIPTION
## PR Summary

Fix the link configuration for Linux packaging.
The fpm 1.9.3 introduces a change that requires the target link string contains the binary name on Linux.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [x] Not Applicable or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
