### PR TITLE
Fix 'PropertyOnlyAdapter' to allow calling base methods

### DIFF
--- a/src/System.Management.Automation/engine/CoreAdapter.cs
+++ b/src/System.Management.Automation/engine/CoreAdapter.cs
@@ -38,19 +38,6 @@ namespace System.Management.Automation
     internal abstract class Adapter
     {
         /// <summary>
-        /// The member type that a callsite binder operates on.
-        /// </summary>
-        /// <remarks>
-        /// An adapter can decide whether the binder can optimize the operations
-        /// on an object member based on the type of the member.
-        /// </remarks>
-        internal enum SiteBinderOperatesOn
-        {
-            Property,
-            Method,
-        }
-
-        /// <summary>
         /// tracer for this and derivate classes
         /// </summary>
         [TraceSource("ETS", "Extended Type System")]
@@ -59,7 +46,7 @@ namespace System.Management.Automation
 
         #region member
 
-        internal virtual bool CanSiteBinderOptimize(SiteBinderOperatesOn opType) { return false; }
+        internal virtual bool CanSiteBinderOptimize(MemberTypes typeToOperateOn) { return false; }
 
         protected static IEnumerable<string> GetDotNetTypeNameHierarchy(Type type)
         {
@@ -3532,7 +3519,7 @@ namespace System.Management.Automation
 
         #region member
 
-        internal override bool CanSiteBinderOptimize(SiteBinderOperatesOn opType) { return true; }
+        internal override bool CanSiteBinderOptimize(MemberTypes typeToOperateOn) { return true; }
 
         private static ConcurrentDictionary<Type, ConsolidatedString> s_typeToTypeNameDictionary =
             new ConcurrentDictionary<Type, ConsolidatedString>();
@@ -4564,16 +4551,16 @@ namespace System.Management.Automation
         /// So, the binder can optimize on method calls for objects that map to a
         /// custom PropertyOnlyAdapter.
         /// </summary>
-        internal override bool CanSiteBinderOptimize(SiteBinderOperatesOn opType)
+        internal override bool CanSiteBinderOptimize(MemberTypes typeToOperateOn)
         {
-            switch (opType)
+            switch (typeToOperateOn)
             {
-                case SiteBinderOperatesOn.Property:
+                case MemberTypes.Property:
                     return false;
-                case SiteBinderOperatesOn.Method:
+                case MemberTypes.Method:
                     return true;
                 default:
-                    throw new InvalidOperationException("Should be unreachable. Update this code if new members are added to 'SiteBinderOperation'");
+                    throw new InvalidOperationException("Should be unreachable. Update code if other member types need to be handled here.");
             }
         }
 

--- a/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
+++ b/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
@@ -5053,7 +5053,7 @@ namespace System.Management.Automation.Language
 
             bool canOptimize;
             Type aliasConversionType;
-            memberInfo = GetPSMemberInfo(target, out restrictions, out canOptimize, out aliasConversionType, Adapter.SiteBinderOperatesOn.Property);
+            memberInfo = GetPSMemberInfo(target, out restrictions, out canOptimize, out aliasConversionType, MemberTypes.Property);
 
             if (!canOptimize)
             {
@@ -5416,7 +5416,7 @@ namespace System.Management.Automation.Language
             }
 
             PSMemberInfo result = binder.GetPSMemberInfo(target, out restrictions, out canOptimize, out aliasConversionType,
-                                                         Adapter.SiteBinderOperatesOn.Property, aliases, aliasRestrictions);
+                                                         MemberTypes.Property, aliases, aliasRestrictions);
             return result;
         }
 
@@ -5424,7 +5424,7 @@ namespace System.Management.Automation.Language
                                               out BindingRestrictions restrictions,
                                               out bool canOptimize,
                                               out Type aliasConversionType,
-                                              Adapter.SiteBinderOperatesOn binderOperatesOn,
+                                              MemberTypes memberTypeToOperateOn,
                                               HashSet<string> aliases = null,
                                               List<BindingRestrictions> aliasRestrictions = null)
         {
@@ -5494,7 +5494,7 @@ namespace System.Management.Automation.Language
             var adapterSet = PSObject.GetMappedAdapter(value, typeTable);
             if (memberInfo == null)
             {
-                canOptimize = adapterSet.OriginalAdapter.CanSiteBinderOptimize(binderOperatesOn);
+                canOptimize = adapterSet.OriginalAdapter.CanSiteBinderOptimize(memberTypeToOperateOn);
                 // Don't bother looking for the member if we're not going to use it.
                 if (canOptimize)
                 {
@@ -5970,7 +5970,7 @@ namespace System.Management.Automation.Language
             BindingRestrictions restrictions;
             bool canOptimize;
             Type aliasConversionType;
-            memberInfo = _getMemberBinder.GetPSMemberInfo(target, out restrictions, out canOptimize, out aliasConversionType, Adapter.SiteBinderOperatesOn.Property);
+            memberInfo = _getMemberBinder.GetPSMemberInfo(target, out restrictions, out canOptimize, out aliasConversionType, MemberTypes.Property);
 
             restrictions = restrictions.Merge(value.PSGetTypeRestriction());
 
@@ -6465,7 +6465,7 @@ namespace System.Management.Automation.Language
             BindingRestrictions restrictions;
             bool canOptimize;
             Type aliasConversionType;
-            var methodInfo = _getMemberBinder.GetPSMemberInfo(target, out restrictions, out canOptimize, out aliasConversionType, Adapter.SiteBinderOperatesOn.Method) as PSMethodInfo;
+            var methodInfo = _getMemberBinder.GetPSMemberInfo(target, out restrictions, out canOptimize, out aliasConversionType, MemberTypes.Method) as PSMethodInfo;
             restrictions = args.Aggregate(restrictions, (current, arg) => current.Merge(arg.PSGetMethodArgumentRestriction()));
 
             // If the process has ever used ConstrainedLanguage, then we need to add the language mode

--- a/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
+++ b/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
@@ -5053,7 +5053,7 @@ namespace System.Management.Automation.Language
 
             bool canOptimize;
             Type aliasConversionType;
-            memberInfo = GetPSMemberInfo(target, out restrictions, out canOptimize, out aliasConversionType);
+            memberInfo = GetPSMemberInfo(target, out restrictions, out canOptimize, out aliasConversionType, Adapter.SiteBinderOperatesOn.Property);
 
             if (!canOptimize)
             {
@@ -5415,8 +5415,8 @@ namespace System.Management.Automation.Language
                 return null;
             }
 
-            PSMemberInfo result = binder.GetPSMemberInfo(target, out restrictions, out canOptimize, out aliasConversionType, aliases, aliasRestrictions);
-
+            PSMemberInfo result = binder.GetPSMemberInfo(target, out restrictions, out canOptimize, out aliasConversionType,
+                                                         Adapter.SiteBinderOperatesOn.Property, aliases, aliasRestrictions);
             return result;
         }
 
@@ -5424,6 +5424,7 @@ namespace System.Management.Automation.Language
                                               out BindingRestrictions restrictions,
                                               out bool canOptimize,
                                               out Type aliasConversionType,
+                                              Adapter.SiteBinderOperatesOn binderOperatesOn,
                                               HashSet<string> aliases = null,
                                               List<BindingRestrictions> aliasRestrictions = null)
         {
@@ -5493,7 +5494,7 @@ namespace System.Management.Automation.Language
             var adapterSet = PSObject.GetMappedAdapter(value, typeTable);
             if (memberInfo == null)
             {
-                canOptimize = adapterSet.OriginalAdapter.SiteBinderCanOptimize;
+                canOptimize = adapterSet.OriginalAdapter.CanSiteBinderOptimize(binderOperatesOn);
                 // Don't bother looking for the member if we're not going to use it.
                 if (canOptimize)
                 {
@@ -5969,7 +5970,7 @@ namespace System.Management.Automation.Language
             BindingRestrictions restrictions;
             bool canOptimize;
             Type aliasConversionType;
-            memberInfo = _getMemberBinder.GetPSMemberInfo(target, out restrictions, out canOptimize, out aliasConversionType);
+            memberInfo = _getMemberBinder.GetPSMemberInfo(target, out restrictions, out canOptimize, out aliasConversionType, Adapter.SiteBinderOperatesOn.Property);
 
             restrictions = restrictions.Merge(value.PSGetTypeRestriction());
 
@@ -6464,7 +6465,7 @@ namespace System.Management.Automation.Language
             BindingRestrictions restrictions;
             bool canOptimize;
             Type aliasConversionType;
-            var methodInfo = _getMemberBinder.GetPSMemberInfo(target, out restrictions, out canOptimize, out aliasConversionType) as PSMethodInfo;
+            var methodInfo = _getMemberBinder.GetPSMemberInfo(target, out restrictions, out canOptimize, out aliasConversionType, Adapter.SiteBinderOperatesOn.Method) as PSMethodInfo;
             restrictions = args.Aggregate(restrictions, (current, arg) => current.Merge(arg.PSGetMethodArgumentRestriction()));
 
             // If the process has ever used ConstrainedLanguage, then we need to add the language mode

--- a/test/powershell/engine/ETS/Adapter.Tests.ps1
+++ b/test/powershell/engine/ETS/Adapter.Tests.ps1
@@ -315,3 +315,49 @@ Describe "DataRow and DataRowView Adapter tests" -tags "CI" {
         }
     }
 }
+
+Describe "Base method call on object mapped to PropertyOnlyAdapter should work" -tags "CI" {
+    It "Base method call on object of a subclass of 'XmlDocument' -- Add-Type" {
+        $code =@'
+namespace BaseMethodCallTest.OnXmlDocument {
+    public class Foo : System.Xml.XmlDocument {
+        public string MyName { get; set; }
+        public override void LoadXml(string content) {
+            MyName = content;
+        }
+    }
+}
+'@
+        try {
+            $null = [BaseMethodCallTest.OnXmlDocument.Foo]
+        } catch {
+            Add-Type -TypeDefinition $code
+        }
+
+        $foo = [BaseMethodCallTest.OnXmlDocument.Foo]::new()
+        $foo.LoadXml('<test>bar</test>')
+        $foo.MyName | Should -Be '<test>bar</test>'
+        $foo.ChildNodes.Count | Should -Be 0
+
+        ([System.Xml.XmlDocument]$foo).LoadXml('<test>bar</test>')
+        $foo.test | Should -Be 'bar'
+        $foo.ChildNodes.Count | Should -Be 1
+    }
+
+    It "Base method call on object of a subclass of 'XmlDocument' -- PowerShell Class" {
+        class XmlDocChild : System.Xml.XmlDocument {
+            [string] $MyName
+            [void] LoadXml([string]$content) {
+                $this.MyName = $content
+                # Try to call the base type's .LoadXml() method.
+                ([System.Xml.XmlDocument] $this).LoadXml($content)
+            }
+        }
+
+        $child = [XmlDocChild]::new()
+        $child.LoadXml('<test>bar</test>')
+        $child.MyName | Should -Be '<test>bar</test>'
+        $child.test | Should -Be 'bar'
+        $child.ChildNodes.Count | Should -Be 1
+    }
+}

--- a/test/powershell/engine/ETS/Adapter.Tests.ps1
+++ b/test/powershell/engine/ETS/Adapter.Tests.ps1
@@ -336,11 +336,11 @@ namespace BaseMethodCallTest.OnXmlDocument {
 
         $foo = [BaseMethodCallTest.OnXmlDocument.Foo]::new()
         $foo.LoadXml('<test>bar</test>')
-        $foo.MyName | Should -Be '<test>bar</test>'
+        $foo.MyName | Should -BeExactly '<test>bar</test>'
         $foo.ChildNodes.Count | Should -Be 0
 
         ([System.Xml.XmlDocument]$foo).LoadXml('<test>bar</test>')
-        $foo.test | Should -Be 'bar'
+        $foo.test | Should -BeExactly 'bar'
         $foo.ChildNodes.Count | Should -Be 1
     }
 
@@ -356,8 +356,8 @@ namespace BaseMethodCallTest.OnXmlDocument {
 
         $child = [XmlDocChild]::new()
         $child.LoadXml('<test>bar</test>')
-        $child.MyName | Should -Be '<test>bar</test>'
-        $child.test | Should -Be 'bar'
+        $child.MyName | Should -BeExactly '<test>bar</test>'
+        $child.test | Should -BeExactly 'bar'
         $child.ChildNodes.Count | Should -Be 1
     }
 }


### PR DESCRIPTION
## PR Summary

Fix #6386
For a PropertyOnlyAdapter, the property may come from various sources, but methods, including parameterized properties, still come from DotNetAdapter. So, the binder should be able to optimize on method calls for objects that map to a custom PropertyOnlyAdapter.

Therefore, the original `SiteBinderCanOptimize` property is changed to a method `CanSiteBinderOptimize(MemberTypes typeToOperateOn)`. For `PropertyOnlyAdapter`, the method returns `false` for property operations and `true` for method operations.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [x] Issue filed - Issue link:
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [x] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
