### PR TITLE
Stop stream variables (e.g. OutVariable) becoming ArrayLists

### DIFF
--- a/test/powershell/Language/Scripting/OutErrorVariable.Tests.ps1
+++ b/test/powershell/Language/Scripting/OutErrorVariable.Tests.ps1
@@ -75,6 +75,46 @@ Describe "Tests OutVariable only" -Tags "CI" {
         $script:a | Should Be 'foo'
         $b | Should Be @("bar", "foo")
     }
+
+    It "OutVariable type test: <Name>" -TestCases @(
+                                @{ Name = 'Pass single object through OutVariable';
+                                    Value = 'a';
+                                    Expected = 'a';
+                                    ExpectedType = 'System.String'
+                                    },
+                                @{ Name = 'Pass array of objects through OutVariable';
+                                    Value = @(1, 2, 3);
+                                    Expected = @(1, 2, 3);
+                                    ExpectedType = 'System.Object[]'
+                                    },
+                                @{ Name = 'Pass collection of objects through OutVariable';
+                                    Value = [System.Collections.ArrayList]::new(@(1, 2, 3));
+                                    Expected = @(1, 2, 3);
+                                    ExpectedType = 'System.Object[]'
+                                    },
+                                @{ Name = 'Pass lifted collection of object through OutVariable';
+                                    Value = @(, [System.Collections.ArrayList]::new(@(1, 2, 3)));
+                                    Expected = @(1, 2, 3);
+                                    ExpectedType = 'System.Collections.ArrayList'
+                                    },
+                                @{ Name = 'Pass $null through OutVariable';
+                                    Value = $null;
+                                    Expected = $null
+                                    },
+                                @{ Name = 'Pass AutomationNull.Value through OutVariable';
+                                    Value = [System.Management.Automation.Internal.AutomationNull]::Value;
+                                    Expected = $null
+                                    }
+    ) {
+        param($Name, $Value, $Expected, $ExpectedType)
+
+        $null = Write-Output -OutVariable outVar $Value
+        $outVar | Should -BeExactly $Expected
+        if ($Value)
+        {
+            $outVar.GetType().FullName | Should -BeExactly $ExpectedType
+        }
+    }
 }
 
 Describe "Test ErrorVariable only" -Tags "CI" {


### PR DESCRIPTION
## PR Summary
Fixes #3154 and #3773.

Currently, when a value is passed out of a command using `-OutVariable`, we use an `ArrayList` to collect the value to give back to the user, but we leak that detail so that the variable comes back as an `ArrayList` and not `object[]` or as itself.

This PR fixes this, so that implementation differences between
```powershell
$null = Write-Output -OutVariable x $value; $x
```
and
```powershell
Write-Output $value
```
are transparent.

To summarize:

| Input | Non-OutVar Result Type | Old Result Type | New Result Type |
| :-: | :-: | :-: | :-: |
| `'Hello'` | System.String | System.Collections.ArrayList | System.String |
| `@(1, 2)` | object[] | System.Collections.ArrayList | object[] |
| `[System.Collections.ArrayList]::new(@(1,2))` | object[] | System.Collections.ArrayList | object[] |
| `@(,[System.Collections.ArrayList]::new(@(1,2))` | System.Collections.ArrayList | System.Collections.ArrayList | System.Collections.ArrayList |
| `$null` | ⊥ | System.Collections.ArrayList | ⊥ |

This is technically a **breaking change**. The PowerShell commitee reviewed it in #3154. A suggested classification was as a class-3 unlikely grey area change, where the new behaviour is more likely to be expected.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [x] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
