### PR TITLE
NanoServer: Set PATH to pwsh.exe for all users

### DIFF
--- a/docker/release/nanoserver/Dockerfile
+++ b/docker/release/nanoserver/Dockerfile
@@ -51,7 +51,9 @@ COPY --from=installer-env ["\\PowerShell\\", "$ProgramFiles\\PowerShell"]
 # Persist %PSCORE% ENV variable for user convenience
 ENV PSCORE="$ProgramFiles\PowerShell\pwsh.exe"
 
-# Set the path
-RUN setx PATH "%PATH%;%ProgramFiles%\PowerShell"
+# Set the path for all users
+USER ContainerAdministrator
+RUN setx /M PATH "%PATH%;%ProgramFiles%\PowerShell"
+USER ContainerUser
 
 CMD ["pwsh.exe"]


### PR DESCRIPTION
## PR Summary

This PR improves the Windows Nanoserver 1709 Docker image to set the PATH to PowerShell `pwsh.exe` for all container users. The current `Dockerfile` only sets PATH for the current ContainerUser account. When you want to run privileged commands (like writing HKLM registry keys etc.) in another `Dockerfile` then `pwsh.exe` could not be found.

This PR fixes this by setting the PATH system wide. This can only be done by changing the container user to ContainerAdministrator and switching back after the setx command to ContainerUser.

I couldn't find a test for the Docker images, but it can be tested with

```
docker build --build-arg WindowsServerCoreVersion=1709 -t powershell .
docker run powershell pwsh -c '$psversiontable'
docker run --user ContainerAdministrator powershell pwsh -c '$psversiontable'
```

The last command fails with the current Dockerfile / Docker image `microsoft/powershell:nanoserver` on Windows Server 1709.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)