### PR TITLE
Fix the NullRefException when using '-PipelineVariable' with 'DynamicParam' block

### DIFF
--- a/src/System.Management.Automation/engine/MshCommandRuntime.cs
+++ b/src/System.Management.Automation/engine/MshCommandRuntime.cs
@@ -3698,7 +3698,9 @@ namespace System.Management.Automation
             if (this.PipelineVariable != null)
             {
                 this.OutputPipe.RemovePipelineVariable();
-                _state.PSVariable.Remove(this.PipelineVariable);
+                // '_state' could be null when a 'DynamicParam' block runs because the 'DynamicParam' block runs in 'DoPrepare',
+                // before 'PipelineProcessor.SetupParameterVariables' is called, where '_state' is initialized.
+                _state?.PSVariable.Remove(this.PipelineVariable);
             }
         }
     }

--- a/test/powershell/engine/ParameterBinding/ParameterBinding.Tests.ps1
+++ b/test/powershell/engine/ParameterBinding/ParameterBinding.Tests.ps1
@@ -283,6 +283,17 @@ Describe "Parameter Binding Tests" -Tags "CI" {
         }
     }
 
+    It "PipelineVariable shouldn't cause a NullRef exception when 'DynamicParam' block is present" {
+        function DynamicParamTest {
+            [CmdletBinding()]
+            param()
+            dynamicparam { }
+            process { 'hi' }
+        }
+
+        DynamicParamTest -PipelineVariable bar | ForEach-Object { $bar } | Should -Be "hi"
+    }
+
     Context "Use automatic variables as default value for parameters" {
         BeforeAll {
             ## Explicit use of 'CmdletBinding' make it a script cmdlet


### PR DESCRIPTION
## PR Summary

Fix #6420

Fix the NullRefException when using '-PipelineVariable' with 'DynamicParam' block.
The [`_state`](https://github.com/PowerShell/PowerShell/blob/master/src/System.Management.Automation/engine/MshCommandRuntime.cs#L38) could be null when a `DynamicParam` block runs because the `DynamicParam` block runs in [`DoPrepare`](https://github.com/PowerShell/PowerShell/blob/master/src/System.Management.Automation/engine/pipeline.cs#L1029), before [`PipelineProcessor.SetupParameterVariables`](https://github.com/PowerShell/PowerShell/blob/master/src/System.Management.Automation/engine/pipeline.cs#L1033) is called, where `_state` is initialized.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [x] Issue filed - Issue link:
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
