### PR TITLE
Throw better parsing error when statements should be put in named block

### DIFF
--- a/src/System.Management.Automation/engine/parser/Parser.cs
+++ b/src/System.Management.Automation/engine/parser/Parser.cs
@@ -1631,10 +1631,17 @@ namespace System.Management.Automation.Language
                     default:
                         // Next token is unexpected.
                         // ErrorRecovery: if 'lCurly' is present, pretend we saw a closing curly; otherwise, eat the unexpected token.
-                        if (lCurly != null) { UngetToken(blockNameToken); }
+                        if (lCurly != null)
+                        {
+                            UngetToken(blockNameToken);
+                            scriptBlockExtent = ExtentOf(startExtent, endExtent);
+                        }
+                        else
+                        {
+                            // If "lCurly == null", then it's a ps1/psm1 file, and thus the extent is the whole file.
+                            scriptBlockExtent = _tokenizer.GetScriptExtent();
+                        }
 
-                        // If 'lCurly == null", then it's a ps1/psm1 file, and thus the extent is the whole file.
-                        scriptBlockExtent = lCurly != null ? ExtentOf(startExtent, endExtent) : _tokenizer.GetScriptExtent();
                         // Report error about the unexpected token.
                         ReportError(blockNameToken.Extent, () => ParserStrings.MissingNamedBlocks, blockNameToken.Text);
                         goto return_script_block_ast;

--- a/src/System.Management.Automation/engine/parser/Parser.cs
+++ b/src/System.Management.Automation/engine/parser/Parser.cs
@@ -1632,11 +1632,10 @@ namespace System.Management.Automation.Language
                         UngetToken(blockNameToken);
                         extent = ExtentOf(startExtent, endExtent);
 
-                        // If 'lCurly' is null, then handle the next token in 'CompleteScriptBlockBody'.
-                        if (lCurly == null) { goto finished_named_block_list; }
-                        // Otherwise, we handle the unexpected next token here.
+                        // If 'lCurly == null", then it's a ps1/psm1 file, then the extent is the whole file.
+                        scriptBlockExtent = lCurly != null ? extent : _tokenizer.GetScriptExtent();
+                        // Handle the unexpected next token.
                         ReportError(blockNameToken.Extent, () => ParserStrings.MissingNamedBlocks, blockNameToken.Text);
-                        scriptBlockExtent = extent;
                         goto return_script_block_ast;
 
                     case TokenKind.RCurly:

--- a/src/System.Management.Automation/engine/parser/Parser.cs
+++ b/src/System.Management.Automation/engine/parser/Parser.cs
@@ -1629,11 +1629,12 @@ namespace System.Management.Automation.Language
                 switch (blockNameToken.Kind)
                 {
                     default:
-                        UngetToken(blockNameToken);
-                        extent = ExtentOf(startExtent, endExtent);
+                        // Next token is unexpected.
+                        // ErrorRecovery: if 'lCurly' is present, pretent we saw a closing curly, otherwise, eat the unexpected token.
+                        if (lCurly != null) { UngetToken(blockNameToken); }
 
                         // If 'lCurly == null", then it's a ps1/psm1 file, then the extent is the whole file.
-                        scriptBlockExtent = lCurly != null ? extent : _tokenizer.GetScriptExtent();
+                        scriptBlockExtent = lCurly != null ? ExtentOf(startExtent, endExtent) : _tokenizer.GetScriptExtent();
                         // Handle the unexpected next token.
                         ReportError(blockNameToken.Extent, () => ParserStrings.MissingNamedBlocks, blockNameToken.Text);
                         goto return_script_block_ast;

--- a/src/System.Management.Automation/engine/parser/Parser.cs
+++ b/src/System.Management.Automation/engine/parser/Parser.cs
@@ -1526,11 +1526,9 @@ namespace System.Management.Automation.Language
 
                     UngetToken(rCurly);
                     endScriptBlock = bodyExtent ?? lCurly.Extent;
-                    Expression<Func<string>> errorExpr = () => ParserStrings.MissingEndCurlyBrace;
-                    if (calledFromNamedBlockRule)
-                    {
-                        errorExpr = () => ParserStrings.MissingEndCurlyBraceOrNamedBlock;
-                    }
+                    var errorExpr = calledFromNamedBlockRule
+                        ? (Expression<Func<string>>)(() => ParserStrings.MissingEndCurlyBraceOrNamedBlocks)
+                        : (Expression<Func<string>>)(() => ParserStrings.MissingEndCurlyBrace);
                     ReportIncompleteInput(lCurly.Extent, rCurly.Extent, errorExpr);
                 }
                 else

--- a/src/System.Management.Automation/engine/parser/Parser.cs
+++ b/src/System.Management.Automation/engine/parser/Parser.cs
@@ -1630,12 +1630,12 @@ namespace System.Management.Automation.Language
                 {
                     default:
                         // Next token is unexpected.
-                        // ErrorRecovery: if 'lCurly' is present, pretent we saw a closing curly, otherwise, eat the unexpected token.
+                        // ErrorRecovery: if 'lCurly' is present, pretend we saw a closing curly; otherwise, eat the unexpected token.
                         if (lCurly != null) { UngetToken(blockNameToken); }
 
-                        // If 'lCurly == null", then it's a ps1/psm1 file, then the extent is the whole file.
+                        // If 'lCurly == null", then it's a ps1/psm1 file, and thus the extent is the whole file.
                         scriptBlockExtent = lCurly != null ? ExtentOf(startExtent, endExtent) : _tokenizer.GetScriptExtent();
-                        // Handle the unexpected next token.
+                        // Report error about the unexpected token.
                         ReportError(blockNameToken.Extent, () => ParserStrings.MissingNamedBlocks, blockNameToken.Text);
                         goto return_script_block_ast;
 

--- a/src/System.Management.Automation/resources/ParserStrings.resx
+++ b/src/System.Management.Automation/resources/ParserStrings.resx
@@ -493,6 +493,9 @@ The correct form is: foreach ($a in $b) {...}</value>
   <data name="DuplicateScriptCommandClause" xml:space="preserve">
     <value>Script command clause '{0}' has already been defined.</value>
   </data>
+  <data name="MissingEndCurlyBraceOrNamedBlock" xml:space="preserve">
+    <value>Missing closing '}' in script block. If you meant to continue with the script block, please note that new statements should be put in named blocks after a named block has been declared.</value>
+  </data>
   <data name="MissingEndCurlyBrace" xml:space="preserve">
     <value>Missing closing '}' in statement block or type definition.</value>
   </data>

--- a/src/System.Management.Automation/resources/ParserStrings.resx
+++ b/src/System.Management.Automation/resources/ParserStrings.resx
@@ -493,8 +493,8 @@ The correct form is: foreach ($a in $b) {...}</value>
   <data name="DuplicateScriptCommandClause" xml:space="preserve">
     <value>Script command clause '{0}' has already been defined.</value>
   </data>
-  <data name="MissingEndCurlyBraceOrNamedBlock" xml:space="preserve">
-    <value>Missing closing '}' in script block. If you meant to continue with the script block, please note that new statements should be put in named blocks after a named block has been declared.</value>
+  <data name="MissingEndCurlyBraceOrNamedBlocks" xml:space="preserve">
+    <value>Missing closing '}' in script block. If you meant to add more statements to the script block, put the statements in one or more named blocks.</value>
   </data>
   <data name="MissingEndCurlyBrace" xml:space="preserve">
     <value>Missing closing '}' in statement block or type definition.</value>

--- a/src/System.Management.Automation/resources/ParserStrings.resx
+++ b/src/System.Management.Automation/resources/ParserStrings.resx
@@ -494,7 +494,7 @@ The correct form is: foreach ($a in $b) {...}</value>
     <value>Script command clause '{0}' has already been defined.</value>
   </data>
   <data name="MissingEndCurlyBraceOrNamedBlocks" xml:space="preserve">
-    <value>Missing closing '}' in script block. If you meant to add more statements to the script block, put the statements in one or more named blocks.</value>
+    <value>Missing closing '}' in script block. If you meant to add more statements to the script block, put the statements in begin, process, or end blocks.</value>
   </data>
   <data name="MissingEndCurlyBrace" xml:space="preserve">
     <value>Missing closing '}' in statement block or type definition.</value>

--- a/src/System.Management.Automation/resources/ParserStrings.resx
+++ b/src/System.Management.Automation/resources/ParserStrings.resx
@@ -493,8 +493,8 @@ The correct form is: foreach ($a in $b) {...}</value>
   <data name="DuplicateScriptCommandClause" xml:space="preserve">
     <value>Script command clause '{0}' has already been defined.</value>
   </data>
-  <data name="MissingEndCurlyBraceOrNamedBlocks" xml:space="preserve">
-    <value>Missing closing '}' in script block. If you meant to add more statements to the script block, put the statements in begin, process, or end blocks.</value>
+  <data name="MissingNamedBlocks" xml:space="preserve">
+    <value>unexpected token '{0}', expected 'begin', 'process', 'end', or 'dynamicparam'.</value>
   </data>
   <data name="MissingEndCurlyBrace" xml:space="preserve">
     <value>Missing closing '}' in statement block or type definition.</value>

--- a/test/powershell/Language/Parser/Parser.Tests.ps1
+++ b/test/powershell/Language/Parser/Parser.Tests.ps1
@@ -917,7 +917,12 @@ foo``u{2195}abc
     }
 
     It "Throw better error message when statement should be put in named blocks" {
-        $err = { ExecuteCommand "Function foo { [CmdletBinding()] param() DynamicParam {} Hi" } | Should -Throw -ErrorId "IncompleteParseException" -PassThru
-        $err.Exception.InnerException.ErrorRecord.FullyQualifiedErrorId | Should -BeExactly "MissingEndCurlyBraceOrNamedBlocks"
+        $err = { ExecuteCommand "Function foo { [CmdletBinding()] param() DynamicParam {} Hi" } | Should -Throw -ErrorId "ParseException" -PassThru
+        $err.Exception.InnerException.ErrorRecord.FullyQualifiedErrorId | Should -BeExactly "MissingNamedBlocks"
+    }
+
+    It "IncompleteParseException should be thrown when only ending curly is missing" {
+        $err = { ExecuteCommand "Function foo { [CmdletBinding()] param() DynamicParam {} " } | Should -Throw -ErrorId "IncompleteParseException" -PassThru
+        $err.Exception.InnerException.ErrorRecord.FullyQualifiedErrorId | Should -BeExactly "MissingEndCurlyBrace"
     }
 }

--- a/test/powershell/Language/Parser/Parser.Tests.ps1
+++ b/test/powershell/Language/Parser/Parser.Tests.ps1
@@ -917,12 +917,7 @@ foo``u{2195}abc
     }
 
     It "Throw better error message when statement should be put in named blocks" {
-        try {
-            ExecuteCommand "Function foo { [CmdletBinding()] param() DynamicParam {} Hi"
-            throw "Execution OK"
-        }
-        catch {
-            $_.Exception.InnerException.ErrorRecord.FullyQualifiedErrorId | Should -Be "MissingEndCurlyBraceOrNamedBlocks"
-        }
+        $err = { ExecuteCommand "Function foo { [CmdletBinding()] param() DynamicParam {} Hi" } | Should -Throw -PassThru
+        $err.Exception.InnerException.ErrorRecord.FullyQualifiedErrorId | Should -BeExactly "MissingEndCurlyBraceOrNamedBlocks"
     }
 }

--- a/test/powershell/Language/Parser/Parser.Tests.ps1
+++ b/test/powershell/Language/Parser/Parser.Tests.ps1
@@ -917,7 +917,7 @@ foo``u{2195}abc
     }
 
     It "Throw better error message when statement should be put in named blocks" {
-        $err = { ExecuteCommand "Function foo { [CmdletBinding()] param() DynamicParam {} Hi" } | Should -Throw -PassThru
+        $err = { ExecuteCommand "Function foo { [CmdletBinding()] param() DynamicParam {} Hi" } | Should -Throw -ErrorId "IncompleteParseException" -PassThru
         $err.Exception.InnerException.ErrorRecord.FullyQualifiedErrorId | Should -BeExactly "MissingEndCurlyBraceOrNamedBlocks"
     }
 }

--- a/test/powershell/Language/Parser/Parser.Tests.ps1
+++ b/test/powershell/Language/Parser/Parser.Tests.ps1
@@ -922,7 +922,7 @@ foo``u{2195}abc
             throw "Execution OK"
         }
         catch {
-            $_.Exception.InnerException.ErrorRecord.FullyQualifiedErrorId | Should -Be "MissingEndCurlyBraceOrNamedBlock"
+            $_.Exception.InnerException.ErrorRecord.FullyQualifiedErrorId | Should -Be "MissingEndCurlyBraceOrNamedBlocks"
         }
     }
 }

--- a/test/powershell/Language/Parser/Parser.Tests.ps1
+++ b/test/powershell/Language/Parser/Parser.Tests.ps1
@@ -916,8 +916,14 @@ foo``u{2195}abc
         { ExecuteCommand "`$herestr=@`"`n'`"'`n`"@" } | Should Not Throw
     }
 
-    It "Throw better error message when statement should be put in named blocks" {
-        $err = { ExecuteCommand "Function foo { [CmdletBinding()] param() DynamicParam {} Hi" } | Should -Throw -ErrorId "ParseException" -PassThru
+    It "Throw better error when statement should be put in named blocks - <name>" -TestCases @(
+        @{ script = "Function foo { [CmdletBinding()] param() DynamicParam {} Hi"; name = "function" }
+        @{ script = "{ begin {} Hi"; name = "script-block" }
+        @{ script = "begin {} Hi"; name = "script-file" }
+    ) {
+        param($script)
+
+        $err = { ExecuteCommand $script } | Should -Throw -ErrorId "ParseException" -PassThru
         $err.Exception.InnerException.ErrorRecord.FullyQualifiedErrorId | Should -BeExactly "MissingNamedBlocks"
     }
 

--- a/test/powershell/Language/Parser/Parser.Tests.ps1
+++ b/test/powershell/Language/Parser/Parser.Tests.ps1
@@ -915,4 +915,14 @@ foo``u{2195}abc
         # Issue #2780
         { ExecuteCommand "`$herestr=@`"`n'`"'`n`"@" } | Should Not Throw
     }
+
+    It "Throw better error message when statement should be put in named blocks" {
+        try {
+            ExecuteCommand "Function foo { [CmdletBinding()] param() DynamicParam {} Hi"
+            throw "Execution OK"
+        }
+        catch {
+            $_.Exception.InnerException.ErrorRecord.FullyQualifiedErrorId | Should -Be "MissingEndCurlyBraceOrNamedBlock"
+        }
+    }
 }


### PR DESCRIPTION
## PR Summary

Fix #6431 
Throw better parsing error when statements should be put in named block.
Now the error looks like this:

```powershell
PS:24> Function foo {
>>     [CmdletBinding()] param()
>>     DynamicParam {
>>     }
>>
>>     'hi'
At line:7 char:5
+     'hi'
+     ~~~~
unexpected token ''hi'', expected 'begin', 'process', 'end', or 'dynamicparam'.
+ CategoryInfo          : ParserError: (:) [], ParentContainsErrorRecordException
+ FullyQualifiedErrorId : MissingNamedBlocks
```

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [x] Issue filed - Issue link:
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [x] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
