### PR TITLE
Where-Object: add parameter 'Not'

### DIFF
--- a/src/System.Management.Automation/engine/InternalCommands.cs
+++ b/src/System.Management.Automation/engine/InternalCommands.cs
@@ -813,6 +813,7 @@ namespace Microsoft.PowerShell.Commands
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "CaseSensitiveNotInSet")]
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "IsSet")]
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "IsNotSet")]
+        [Parameter(Mandatory = true, Position = 0, ParameterSetName = "Not")]
         [ValidateNotNullOrEmpty]
         public string Property
         {
@@ -1199,6 +1200,16 @@ namespace Microsoft.PowerShell.Commands
             get { return _binaryOperator == TokenKind.IsNot; }
         }
 
+        /// <summary>
+        /// Binary operator -Not
+        /// </summary>
+        [Parameter(Mandatory = true, ParameterSetName = "Not")]
+        public SwitchParameter Not
+        {
+            set { _binaryOperator = TokenKind.Not; }
+            get { return _binaryOperator == TokenKind.Not; }
+        }
+
         #endregion binary operator parameters
 
         private readonly CallSite<Func<CallSite, object, bool>> _toBoolSite =
@@ -1209,6 +1220,16 @@ namespace Microsoft.PowerShell.Commands
         {
             var site = CallSite<Func<CallSite, object, object, object>>.Create(PSBinaryOperationBinder.Get(expressionType, ignoreCase));
             return (x, y) => site.Target.Invoke(site, x, y);
+        }
+
+        private static Func<object, object, object> GetCallSiteDelegateBoolean(ExpressionType expressionType, bool ignoreCase)
+        {
+            // flip 'lval' and 'rval' in the scenario '... | Where-Object property' so as to make it
+            // equivalent to '... | Where-Object {$true -eq property}'. Because we want the property to
+            // be compared under the bool context. So that '"string" | Where-Object Length' would behave
+            // just like '"string" | Where-Object {$_.Length}'.
+            var site = CallSite<Func<CallSite, object, object, object>>.Create(binder: PSBinaryOperationBinder.Get(expressionType, ignoreCase));
+            return (x, y) => site.Target.Invoke(site, y, x);
         }
 
         private static Tuple<CallSite<Func<CallSite, object, IEnumerator>>, CallSite<Func<CallSite, object, object, object>>> GetContainsCallSites(bool ignoreCase)
@@ -1261,12 +1282,7 @@ namespace Microsoft.PowerShell.Commands
                     }
                     else
                     {
-                        // flip 'lval' and 'rval' in the scenario '... | Where-Object property' so as to make it
-                        // equivalent to '... | Where-Object {$true -eq property}'. Because we want the property to
-                        // be compared under the bool context. So that '"string" | Where-Object Length' would behave
-                        // just like '"string" | Where-Object {$_.Length}'.
-                        var site = CallSite<Func<CallSite, object, object, object>>.Create(PSBinaryOperationBinder.Get(ExpressionType.Equal, true));
-                        _operationDelegate = (x, y) => site.Target.Invoke(site, y, x);
+                        _operationDelegate = GetCallSiteDelegateBoolean(ExpressionType.Equal, ignoreCase: true);
                     }
                     break;
                 case TokenKind.Ceq:
@@ -1337,6 +1353,9 @@ namespace Microsoft.PowerShell.Commands
                     CheckLanguageMode();
                     _operationDelegate =
                         (lval, rval) => ParserOps.MatchOperator(Context, PositionUtilities.EmptyExtent, lval, rval, notMatch: true, ignoreCase: false);
+                    break;
+                case TokenKind.Not:
+                    _operationDelegate = GetCallSiteDelegateBoolean(ExpressionType.NotEqual, ignoreCase: true);
                     break;
                 // the second to last parameter in ContainsOperator has flipped semantics compared to others.
                 // "true" means "contains" while "false" means "notcontains"
@@ -1463,7 +1482,7 @@ namespace Microsoft.PowerShell.Commands
             else
             {
                 // Both -Property and -Value need to be specified if the user specifies the binary operation
-                if (_valueNotSpecified && (_binaryOperator != TokenKind.Ieq || !_forceBooleanEvaluation))
+                if (_valueNotSpecified && ((_binaryOperator != TokenKind.Ieq && _binaryOperator != TokenKind.Not) || !_forceBooleanEvaluation))
                 {
                     // The binary operation is specified explicitly by the user and the -Value parameter is
                     // not specified

--- a/src/System.Management.Automation/engine/InternalCommands.cs
+++ b/src/System.Management.Automation/engine/InternalCommands.cs
@@ -1201,7 +1201,7 @@ namespace Microsoft.PowerShell.Commands
         }
 
         /// <summary>
-        /// Binary operator -Not
+        /// Binary operator -Not.
         /// </summary>
         [Parameter(Mandatory = true, ParameterSetName = "Not")]
         public SwitchParameter Not

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Where-Object.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Where-Object.Tests.ps1
@@ -1,5 +1,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
+
 Describe "Where-Object" -Tags "CI" {
     BeforeAll {
         $Computers = @(
@@ -25,105 +26,103 @@ Describe "Where-Object" -Tags "CI" {
 
     It "Where-Object -Not Prop" {
         $Result = $Computers | Where-Object -Not 'IPAddress'
-        $Result.Count | Should -BeExactly 2
+        $Result.Count | Should -Be 2
     }
 
     It 'Where-Object -FilterScript {$true -ne $_.Prop}' {
         $Result = $Computers | Where-Object -FilterScript {$true -ne $_.IPAddress}
-        $Result.Count | Should -BeExactly 2
+        $Result.Count | Should -Be 2
     }
 
     It "Where-Object Prop" {
         $Result = $Computers | Where-Object 'IPAddress'
-        $Result.Count | Should -BeExactly 1
+        $Result.Count | Should -Be 1
     }
 
     It 'Where-Object -FilterScript {$true -eq $_.Prop}' {
         $Result = $Computers | Where-Object -FilterScript {$true -eq $_.IPAddress}
-        $Result.Count | Should -BeExactly 1
+        $Result.Count | Should -Be 1
     }
 
     It 'Where-Object -FilterScript {$_.Prop -contains Value}' {
         $Result = $Computers | Where-Object -FilterScript {$_.Drives -contains 'D'}
-        $Result.Count | Should -BeExactly 2
+        $Result.Count | Should -Be 2
     }
 
     It 'Where-Object Prop -contains Value' {
         $Result = $Computers | Where-Object Drives -contains 'D'
-        $Result.Count | Should -BeExactly 2
+        $Result.Count | Should -Be 2
     }
 
     It 'Where-Object -FilterScript {$_.Prop -in $Array}' {
         $Array = 'SPC-1234','BGP-5678'
         $Result = $Computers | Where-Object -FilterScript {$_.ComputerName -in $Array}
-        $Result.Count | Should -BeExactly 2
+        $Result.Count | Should -Be 2
     }
 
     It 'Where-Object $Array -in Prop' {
         $Array = 'SPC-1234','BGP-5678'
         $Result = $Computers | Where-Object ComputerName -in $Array
-        $Result.Count | Should -BeExactly 2
+        $Result.Count | Should -Be 2
     }
 
     It 'Where-Object -FilterScript {$_.Prop -ge 2}' {
         $Result = $Computers | Where-Object -FilterScript {$_.NumberOfCores -ge 2}
-        $Result.Count | Should -BeExactly 2
+        $Result.Count | Should -Be 2
     }
 
     It 'Where-Object Prop -ge 2' {
         $Result = $Computers | Where-Object NumberOfCores -ge 2
-        $Result.Count | Should -BeExactly 2
+        $Result.Count | Should -Be 2
     }
 
     It 'Where-Object -FilterScript {$_.Prop -gt 2}' {
         $Result = $Computers | Where-Object -FilterScript {$_.NumberOfCores -gt 2}
-        $Result.Count | Should -BeExactly 1
+        $Result.Count | Should -Be 1
     }
 
     It 'Where-Object Prop -gt 2' {
         $Result = $Computers | Where-Object NumberOfCores -gt 2
-        $Result.Count | Should -BeExactly 1
+        $Result.Count | Should -Be 1
     }
 
     It 'Where-Object -FilterScript {$_.Prop -le 2}' {
         $Result = $Computers | Where-Object -FilterScript {$_.NumberOfCores -le 2}
-        $Result.Count | Should -BeExactly 2
+        $Result.Count | Should -Be 2
     }
 
     It 'Where-Object Prop -le 2' {
         $Result = $Computers | Where-Object NumberOfCores -le 2
-        $Result.Count | Should -BeExactly 2
+        $Result.Count | Should -Be 2
     }
 
     It 'Where-Object -FilterScript {$_.Prop -lt 2}' {
         $Result = $Computers | Where-Object -FilterScript {$_.NumberOfCores -lt 2}
-        $Result.Count | Should -BeExactly 1
+        $Result.Count | Should -Be 1
     }
 
     It 'Where-Object Prop -lt 2' {
         $Result = $Computers | Where-Object NumberOfCores -lt 2
-        $Result.Count | Should -BeExactly 1
+        $Result.Count | Should -Be 1
     }
 
-    # Like Match
     It 'Where-Object -FilterScript {$_.Prop -Like Value}' {
         $Result = $Computers | Where-Object -FilterScript {$_.ComputerName -like 'MGC-9101'}
-        $Result.Count | Should -BeExactly 1
+        $Result.Count | Should -Be 1
     }
 
     It 'Where-Object Prop -like Value' {
         $Result = $Computers | Where-Object ComputerName -like 'MGC-9101'
-        $Result.Count | Should -BeExactly 1
+        $Result.Count | Should -Be 1
     }
 
     It 'Where-Object -FilterScript {$_.Prop -Match Pattern}' {
         $Result = $Computers | Where-Object -FilterScript {$_.ComputerName -match '^MGC.+'}
-        $Result.Count | Should -BeExactly 1
+        $Result.Count | Should -Be 1
     }
 
     It 'Where-Object Prop -like Value' {
         $Result = $Computers | Where-Object ComputerName -match '^MGC.+'
-        $Result.Count | Should -BeExactly 1
+        $Result.Count | Should -Be 1
     }
 }
-

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Where-Object.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Where-Object.Tests.ps1
@@ -1,0 +1,129 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+Describe "Where-Object" -Tags "CI" {
+    BeforeAll {
+        $Computers = @(
+            [PSCustomObject]@{
+                ComputerName = "SPC-1234"
+                IPAddress = "192.168.0.1"
+                NumberOfCores = 1
+                Drives = 'C','D'
+            },
+            [PSCustomObject]@{
+                ComputerName = "BGP-5678"
+                IPAddress = ""
+                NumberOfCores = 2
+                Drives = 'C','D','E'
+            },
+            [PSCustomObject]@{
+                ComputerName = "MGC-9101"
+                NumberOfCores = 3
+                Drives = 'C'
+            }
+        )
+    }
+
+    It "Where-Object -Not Prop" {
+        $Result = $Computers | Where-Object -Not 'IPAddress'
+        $Result.Count | Should -BeExactly 2
+    }
+
+    It 'Where-Object -FilterScript {$true -ne $_.Prop}' {
+        $Result = $Computers | Where-Object -FilterScript {$true -ne $_.IPAddress}
+        $Result.Count | Should -BeExactly 2
+    }
+
+    It "Where-Object Prop" {
+        $Result = $Computers | Where-Object 'IPAddress'
+        $Result.Count | Should -BeExactly 1
+    }
+
+    It 'Where-Object -FilterScript {$true -eq $_.Prop}' {
+        $Result = $Computers | Where-Object -FilterScript {$true -eq $_.IPAddress}
+        $Result.Count | Should -BeExactly 1
+    }
+
+    It 'Where-Object -FilterScript {$_.Prop -contains Value}' {
+        $Result = $Computers | Where-Object -FilterScript {$_.Drives -contains 'D'}
+        $Result.Count | Should -BeExactly 2
+    }
+
+    It 'Where-Object Prop -contains Value' {
+        $Result = $Computers | Where-Object Drives -contains 'D'
+        $Result.Count | Should -BeExactly 2
+    }
+
+    It 'Where-Object -FilterScript {$_.Prop -in $Array}' {
+        $Array = 'SPC-1234','BGP-5678'
+        $Result = $Computers | Where-Object -FilterScript {$_.ComputerName -in $Array}
+        $Result.Count | Should -BeExactly 2
+    }
+
+    It 'Where-Object $Array -in Prop' {
+        $Array = 'SPC-1234','BGP-5678'
+        $Result = $Computers | Where-Object ComputerName -in $Array
+        $Result.Count | Should -BeExactly 2
+    }
+
+    It 'Where-Object -FilterScript {$_.Prop -ge 2}' {
+        $Result = $Computers | Where-Object -FilterScript {$_.NumberOfCores -ge 2}
+        $Result.Count | Should -BeExactly 2
+    }
+
+    It 'Where-Object Prop -ge 2' {
+        $Result = $Computers | Where-Object NumberOfCores -ge 2
+        $Result.Count | Should -BeExactly 2
+    }
+
+    It 'Where-Object -FilterScript {$_.Prop -gt 2}' {
+        $Result = $Computers | Where-Object -FilterScript {$_.NumberOfCores -gt 2}
+        $Result.Count | Should -BeExactly 1
+    }
+
+    It 'Where-Object Prop -gt 2' {
+        $Result = $Computers | Where-Object NumberOfCores -gt 2
+        $Result.Count | Should -BeExactly 1
+    }
+
+    It 'Where-Object -FilterScript {$_.Prop -le 2}' {
+        $Result = $Computers | Where-Object -FilterScript {$_.NumberOfCores -le 2}
+        $Result.Count | Should -BeExactly 2
+    }
+
+    It 'Where-Object Prop -le 2' {
+        $Result = $Computers | Where-Object NumberOfCores -le 2
+        $Result.Count | Should -BeExactly 2
+    }
+
+    It 'Where-Object -FilterScript {$_.Prop -lt 2}' {
+        $Result = $Computers | Where-Object -FilterScript {$_.NumberOfCores -lt 2}
+        $Result.Count | Should -BeExactly 1
+    }
+
+    It 'Where-Object Prop -lt 2' {
+        $Result = $Computers | Where-Object NumberOfCores -lt 2
+        $Result.Count | Should -BeExactly 1
+    }
+
+    # Like Match
+    It 'Where-Object -FilterScript {$_.Prop -Like Value}' {
+        $Result = $Computers | Where-Object -FilterScript {$_.ComputerName -like 'MGC-9101'}
+        $Result.Count | Should -BeExactly 1
+    }
+
+    It 'Where-Object Prop -like Value' {
+        $Result = $Computers | Where-Object ComputerName -like 'MGC-9101'
+        $Result.Count | Should -BeExactly 1
+    }
+
+    It 'Where-Object -FilterScript {$_.Prop -Match Pattern}' {
+        $Result = $Computers | Where-Object -FilterScript {$_.ComputerName -match '^MGC.+'}
+        $Result.Count | Should -BeExactly 1
+    }
+
+    It 'Where-Object Prop -like Value' {
+        $Result = $Computers | Where-Object ComputerName -match '^MGC.+'
+        $Result.Count | Should -BeExactly 1
+    }
+}
+


### PR DESCRIPTION
## PR Summary

Add parameter Not to Where-Object

Allows following example:
`Get-Service | Where-Object -Not DependentServices`
Returns all services without any dependent services.

Fix #3529 

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [x] Issue filed - Issue link: PowerShell/PowerShell-Docs#2199
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
