### PR TITLE
Fix error in windows provider when the environment has accidental duplicates that differ only by case

### DIFF
--- a/src/System.Management.Automation/namespaces/EnvironmentProvider.cs
+++ b/src/System.Management.Automation/namespaces/EnvironmentProvider.cs
@@ -198,15 +198,33 @@ namespace Microsoft.PowerShell.Commands
             IDictionary environmentTable = Environment.GetEnvironmentVariables();
             foreach (DictionaryEntry entry in environmentTable)
             {
-                // Windows only: duplicate key (variable name that differs only in case)
-                // NOTE: Even though this shouldn't happen, it can, e.g. when npm
-                //       creates duplicate environment variables that differ only in case -
-                //       see https://github.com/PowerShell/PowerShell/issues/6305.
-                //       However, because retrieval *by name* later is invariably
-                //       case-Insensitive, in effect only a *single* variable exists.
-                //       We simply ask Environment.GetEnvironmentVariable() which value is
-                //       the effective one, and use that.
-                providerTable.TryAdd((string)entry.Key, entry);
+                try
+                {
+                    providerTable.Add((string)entry.Key, entry);
+                }
+                catch (System.ArgumentException)
+                {   // Windows only: duplicate key (variable name that differs only in case)
+                    // NOTE: Even though this shouldn't happen, it can, e.g. when npm
+                    //       creates duplicate environment variables that differ only in case -
+                    //       see https://github.com/PowerShell/PowerShell/issues/6305.
+                    //       However, because retrieval *by name* later is invariably
+                    //       case-INsensitive, in effect only a *single* variable exists.
+                    //       We simply ask Environment.GetEnvironmentVariable() for the effective value 
+                    //       and use that as the only entry, because for a given key 'foo' (and all its case variations),
+                    //       that is guaranteed to match what $env:FOO and [environment]::GetEnvironmentVariable('foo') return. 
+                    //       (If, by contrast, we just used `entry` as-is every time a duplicate is encountered,
+                    //        it could - intermittently - represent a value *other* than the effective one.)
+                    string effectiveValue = Environment.GetEnvironmentVariable((string)entry.Key);
+                    if (((string)entry.Value).Equals(effectiveValue, StringComparison.Ordinal)) { // We've found the effective definition.
+                        // Note: We *recreate* the entry so that the specific name casing of the
+                        //       effective definition is also reflected. However, if the case variants
+                        //       define the same value, it is unspecified which name variant is reflected
+                        //       in Get-Item env: output; given the always case-insensitive nature of the retrieval, 
+                        //       that shouldn't matter.
+                        providerTable.Remove((string)entry.Key);
+                        providerTable.Add((string)entry.Key, entry);
+                    }
+                }
             }
 
             return providerTable;

--- a/src/System.Management.Automation/namespaces/EnvironmentProvider.cs
+++ b/src/System.Management.Automation/namespaces/EnvironmentProvider.cs
@@ -198,11 +198,7 @@ namespace Microsoft.PowerShell.Commands
             IDictionary environmentTable = Environment.GetEnvironmentVariables();
             foreach (DictionaryEntry entry in environmentTable)
             {
-                try
-                {
-                    providerTable.Add((string)entry.Key, entry);
-                }
-                catch (System.ArgumentException)
+                if (!providerTable.TryAdd((string)entry.Key, entry))
                 {   // Windows only: duplicate key (variable name that differs only in case)
                     // NOTE: Even though this shouldn't happen, it can, e.g. when npm
                     //       creates duplicate environment variables that differ only in case -

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Item.Tests.ps1
@@ -141,9 +141,7 @@ Describe "Get-Item" -Tags "CI" {
 
             (get-item env:\testvar).Value | Should -BeExactly $expectedValue
         }
-
     }
-
 }
 
 Describe "Get-Item environment provider on Windows with accidental case-variant duplicates" -Tags "Scenario" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Item.Tests.ps1
@@ -141,5 +141,24 @@ Describe "Get-Item" -Tags "CI" {
 
             (get-item env:\testvar).Value | Should -BeExactly $expectedValue
         }
+
+        It "get-item reports the effective value among accidental case-variant duplicates on Windows" -skip:(-not $isWindows) {
+            if (-not (Get-Command -ErrorAction Ignore node.exe)) {
+                Write-Warning "Test skipped, because Node.js is required to run it."
+            } else {
+                $valDirect, $valGetItem, $unused = node.exe -pe @"
+                    env = {}
+                    env.testVar = process.env.testVar // include the original case variant with its original value.
+                    env.TESTVAR = 'c' // redefine with a case variant name and different value
+                    // Note: Which value will win is not deterministic(!); what matters, however, is that both
+                    //       $env:testvar and Get-Item env:testvar report the same value.
+                    //       The nondeterministic behavior makes it hard to prove that the values are *always* the
+                    //       same, however.
+                    require('child_process').execSync(\"\\\"$($PSHOME -replace '\\', '/')/pwsh.exe\\\" -noprofile -command `$env:testvar, (Get-Item env:testvar).Value\", { env: env }).toString()
+"@
+                $valGetItem | Should -BeExactly $valDirect
+
+            }
+        }
     }
 }


### PR DESCRIPTION
## PR Summary

Fix error in windows provider when the environment has accidental duplicates that differ only by case.

- Make the provider storage for the environment on windows ignore duplicates  and only report the _effective_ value.
- Add tests to verify existing environment get-item behavior and to ensure that `Get-Item env:<var>` reports the same as `$env:<var>`, namely the effective value.

Fixes #6305 and supersedes #6320 based on discussion in #6460.


## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
