### PR TITLE
Use new Pester syntax: -Parameter for Pester in SDK and Provider tests

### DIFF
--- a/test/powershell/Provider/Pester.AutomountedDrives.Tests.ps1
+++ b/test/powershell/Provider/Pester.AutomountedDrives.Tests.ps1
@@ -35,23 +35,23 @@ Describe "Test suite for validating automounted PowerShell drives" -Tags @('Feat
     Context "Validating automounting FileSystem drives" {
 
         It "Test automounting using subst.exe" -Skip:$SubstNotFound {
-           & $powershell -noprofile -command "& '$AutomountSubstDriveScriptPath' -FullPath '$substDir'" | Should Be "Drive found"
+           & $powershell -noprofile -command "& '$AutomountSubstDriveScriptPath' -FullPath '$substDir'" | Should -BeExactly "Drive found"
         }
 
         It "Test automounting using New-VHD/Mount-VHD" -Skip:$VHDToolsNotFound {
-            & $powershell -noprofile -command "& '$AutomountVHDDriveScriptPath' -VHDPath '$vhdPath'" | Should Be "Drive found"
+            & $powershell -noprofile -command "& '$AutomountVHDDriveScriptPath' -VHDPath '$vhdPath'" | Should -BeExactly "Drive found"
         }
     }
 
     Context "Validating automounting FileSystem drives from modules" {
 
         It "Test automounting using subst.exe" -Skip:$SubstNotFound {
-           & $powershell -noprofile -command "& '$AutomountSubstDriveScriptPath' -useModule -FullPath '$substDir'" | Should Be "Drive found"
+           & $powershell -noprofile -command "& '$AutomountSubstDriveScriptPath' -useModule -FullPath '$substDir'" | Should -BeExactly "Drive found"
         }
 
         It "Test automounting using New-VHD/Mount-VHD" -Skip:$VHDToolsNotFound {
             $vhdPath = Join-Path $TestDrive 'TestAutomountVHD.vhd'
-            & $powershell -noprofile -command "& '$AutomountVHDDriveScriptPath' -useModule -VHDPath '$vhdPath'" | Should Be "Drive found"
+            & $powershell -noprofile -command "& '$AutomountVHDDriveScriptPath' -useModule -VHDPath '$vhdPath'" | Should -BeExactly "Drive found"
         }
     }
 }

--- a/test/powershell/Provider/ProviderIntrinsics.Tests.ps1
+++ b/test/powershell/Provider/ProviderIntrinsics.Tests.ps1
@@ -5,19 +5,14 @@ Describe "ProviderIntrinsics Tests" -tags "CI" {
         setup -d TestDir
     }
     It 'If a childitem exists, HasChild method returns $true' {
-        $ExecutionContext.InvokeProvider.ChildItem.HasChild("$TESTDRIVE") | Should be $true
+        $ExecutionContext.InvokeProvider.ChildItem.HasChild("$TESTDRIVE") | Should -BeTrue
     }
     It 'If a childitem does not exist, HasChild method returns $false' {
-        $ExecutionContext.InvokeProvider.ChildItem.HasChild("$TESTDRIVE/TestDir") | Should be $false
+        $ExecutionContext.InvokeProvider.ChildItem.HasChild("$TESTDRIVE/TestDir") | Should -BeFalse
     }
     It 'If the path does not exist, HasChild throws an exception' {
-        try {
-            $ExecutionContext.InvokeProvider.ChildItem.HasChild("TESTDRIVE/ThisDirectoryDoesNotExist")
-            throw "Execution OK"
-        }
-        catch {
-            $_.fullyqualifiederrorid | should be "ItemNotFoundException"
-        }
+        {$ExecutionContext.InvokeProvider.ChildItem.HasChild("TESTDRIVE/ThisDirectoryDoesNotExist")} |
+            Should -Throw -ErrorId 'ItemNotFoundException'
     }
 }
 

--- a/test/powershell/Provider/ProviderIntrinsics.Tests.ps1
+++ b/test/powershell/Provider/ProviderIntrinsics.Tests.ps1
@@ -11,7 +11,7 @@ Describe "ProviderIntrinsics Tests" -tags "CI" {
         $ExecutionContext.InvokeProvider.ChildItem.HasChild("$TESTDRIVE/TestDir") | Should -BeFalse
     }
     It 'If the path does not exist, HasChild throws an exception' {
-        {$ExecutionContext.InvokeProvider.ChildItem.HasChild("TESTDRIVE/ThisDirectoryDoesNotExist")} |
+        { $ExecutionContext.InvokeProvider.ChildItem.HasChild("TESTDRIVE/ThisDirectoryDoesNotExist") } |
             Should -Throw -ErrorId 'ItemNotFoundException'
     }
 }

--- a/test/powershell/SDK/Json.Tests.ps1
+++ b/test/powershell/SDK/Json.Tests.ps1
@@ -11,26 +11,26 @@ Describe "Json.NET LINQ Parsing" -tags "CI" {
     }
 
     It "Should return data via Item()" {
-	[string]$json.Item("Name") | Should Be "Zaphod Beeblebrox"
+	[string]$json.Item("Name") | Should -BeExactly "Zaphod Beeblebrox"
     }
 
     It "Should return data via []" {
-	[string]$json["Planet"] | Should Be "Betelgeuse"
+	[string]$json["Planet"] | Should -BeExactly "Betelgeuse"
     }
 
     It "Should return nested data via Item().Item()" {
-	[int]$json.Item("Appendages").Item("Heads") | Should Be 2
+	[int]$json.Item("Appendages").Item("Heads") | Should -Be 2
     }
 
     It "Should return nested data via [][]" {
-	[int]$json["Appendages"]["Arms"] | Should Be 3
+	[int]$json["Appendages"]["Arms"] | Should -Be 3
     }
 
     It "Should return correct array count" {
-	$json["Achievements"].Count | Should Be 4
+	$json["Achievements"].Count | Should -Be 4
     }
 
     It "Should return array data via [n]" {
-	[string]$json["Achievements"][3] | Should Be "One hoopy frood"
+	[string]$json["Achievements"][3] | Should -BeExactly "One hoopy frood"
     }
 }

--- a/test/powershell/SDK/PSDebugging.Tests.ps1
+++ b/test/powershell/SDK/PSDebugging.Tests.ps1
@@ -200,7 +200,7 @@ Describe "Runspace Debugging API tests" -tag CI {
         }
 
         It "PSStandaloneMonitorRunspaceInfo should throw when called with a null argument to the constructor" {
-            {[PSStandaloneMonitorRunspaceInfo]::new($null)} |
+            { [PSStandaloneMonitorRunspaceInfo]::new($null) } |
                 Should -Throw -ErrorId 'PSArgumentNullException'
         }
 
@@ -229,20 +229,20 @@ Describe "Runspace Debugging API tests" -tag CI {
         }
 
         It "DebuggerUtils StartMonitoringRunspace requires non-null debugger" {
-            {[DebuggerUtils]::StartMonitoringRunspace($null,$runspaceInfo)} |
+            { [DebuggerUtils]::StartMonitoringRunspace($null,$runspaceInfo) } |
                 Should -Throw -ErrorId 'PSArgumentNullException'
         }
         It "DebuggerUtils StartMonitoringRunspace requires non-null runspaceInfo" {
-            {[DebuggerUtils]::StartMonitoringRunspace($runspace.Debugger,$null)} |
+            { [DebuggerUtils]::StartMonitoringRunspace($runspace.Debugger,$null) } |
                 Should -Throw -ErrorId 'PSArgumentNullException'
         }
 
         It "DebuggerUtils EndMonitoringRunspace requires non-null debugger" {
-            {[DebuggerUtils]::EndMonitoringRunspace($null,$runspaceInfo)} |
+            { [DebuggerUtils]::EndMonitoringRunspace($null,$runspaceInfo) } |
                 Should -Throw -ErrorId 'PSArgumentNullException'
         }
         It "DebuggerUtils EndMonitoringRunspace requires non-null runspaceInfo" {
-            {[DebuggerUtils]::EndMonitoringRunspace($runspace.Debugger,$null)} |
+            { [DebuggerUtils]::EndMonitoringRunspace($runspace.Debugger,$null) } |
                 Should -Throw -ErrorId 'PSArgumentNullException'
         }
 

--- a/test/powershell/SDK/PSDebugging.Tests.ps1
+++ b/test/powershell/SDK/PSDebugging.Tests.ps1
@@ -206,7 +206,7 @@ Describe "Runspace Debugging API tests" -tag CI {
 
         it "PSStandaloneMonitorRunspaceInfo properties should have proper values" {
             $monitorInfo.Runspace.InstanceId | Should -Be $InstanceId
-            $monitorInfo.RunspaceType | Should -BeExactly "StandAlone"
+            $monitorInfo.RunspaceType | Should -BeExactly "Standalone"
             $monitorInfo.NestedDebugger | Should -BeNullOrEmpty
         }
 

--- a/test/powershell/SDK/PSDebugging.Tests.ps1
+++ b/test/powershell/SDK/PSDebugging.Tests.ps1
@@ -33,7 +33,7 @@ Describe "PowerShell Command Debugging" -tags "CI" {
 
         if (!$process.HasExited)
         {
-            $process.HasExited | Should Be $true
+            $process.HasExited | Should -BeTrue
             $process.Kill()
         }
     }
@@ -54,7 +54,7 @@ Describe "PowerShell Command Debugging" -tags "CI" {
         $process.StandardInput.Close()
 
         EnsureChildHasExited $process
-        $process.ExitCode | Should Be 0
+        $process.ExitCode | Should -Be 0
     }
 
     It "Should be able to continue into debugging" {
@@ -71,7 +71,7 @@ Describe "PowerShell Command Debugging" -tags "CI" {
         $process.StandardInput.Close()
 
         EnsureChildHasExited $process
-        $process.ExitCode | Should Be 0
+        $process.ExitCode | Should -Be 0
     }
 
     It -Pending "Should be able to list help for debugging" {
@@ -93,7 +93,7 @@ Describe "PowerShell Command Debugging" -tags "CI" {
         $process.StandardInput.Close()
 
         EnsureChildHasExited $process
-        $line | Should Be  "For instructions about how to customize your debugger prompt, type `"help about_prompt`"."
+        $line | Should -BeExactly  "For instructions about how to customize your debugger prompt, type `"help about_prompt`"."
     }
 
     It "Should be able to step over debugging" {
@@ -109,7 +109,7 @@ Describe "PowerShell Command Debugging" -tags "CI" {
         $process.StandardInput.Close()
 
         EnsureChildHasExited $process
-        $process.ExitCode | Should Be 0
+        $process.ExitCode | Should -Be 0
     }
 
     It "Should be able to step out of debugging" {
@@ -123,7 +123,7 @@ Describe "PowerShell Command Debugging" -tags "CI" {
         $process.StandardInput.Close()
 
         EnsureChildHasExited $process
-        $process.ExitCode | Should Be 0
+        $process.ExitCode | Should -Be 0
     }
 
     It "Should be able to quit debugging" {
@@ -137,7 +137,7 @@ Describe "PowerShell Command Debugging" -tags "CI" {
         $process.StandardInput.Close()
 
         EnsureChildHasExited $process
-        $process.ExitCode | Should Be 0
+        $process.ExitCode | Should -Be 0
     }
 
     It -Pending "Should be able to list source code in debugging" {
@@ -156,7 +156,7 @@ Describe "PowerShell Command Debugging" -tags "CI" {
         $process.StandardInput.Write("`n")
         $process.StandardInput.Write("`n")
 
-        $line | Should Be "    1:* `$function:foo = { 'bar' }"
+        $line | Should -BeExactly "    1:* `$function:foo = { 'bar' }"
         $process.StandardInput.Close()
         EnsureChildHasExited $process
 
@@ -174,7 +174,7 @@ Describe "PowerShell Command Debugging" -tags "CI" {
             $line = $process.StandardOutput.ReadLine()
         }
 
-        $line | Should Be "foo           {}        <No file>"
+        $line | Should -BeExactly "foo           {}        <No file>"
         $process.StandardInput.Close()
         EnsureChildHasExited $process
 
@@ -200,26 +200,21 @@ Describe "Runspace Debugging API tests" -tag CI {
         }
 
         It "PSStandaloneMonitorRunspaceInfo should throw when called with a null argument to the constructor" {
-            try {
-                [PSStandaloneMonitorRunspaceInfo]::new($null)
-                throw "Execution should have thrown"
-            }
-            Catch {
-                $_.FullyQualifiedErrorId | should be PSArgumentNullException
-            }
+            {[PSStandaloneMonitorRunspaceInfo]::new($null)} |
+                Should -Throw -ErrorId 'PSArgumentNullException'
         }
 
         it "PSStandaloneMonitorRunspaceInfo properties should have proper values" {
-            $monitorInfo.Runspace.InstanceId | Should be $InstanceId
-            $monitorInfo.RunspaceType | Should be "StandAlone"
-            $monitorInfo.NestedDebugger | Should BeNullOrEmpty
+            $monitorInfo.Runspace.InstanceId | Should -Be $InstanceId
+            $monitorInfo.RunspaceType | Should -BeExactly "StandAlone"
+            $monitorInfo.NestedDebugger | Should -BeNullOrEmpty
         }
 
         It "Embedded runspace properties should have proper values" {
-            $embeddedRunspaceInfo.Runspace.InstanceId | should be $InstanceId
-            $embeddedRunspaceInfo.ParentDebuggerId | should be $parentDebuggerId
-            $embeddedRunspaceInfo.Command.InstanceId | should be $ps.InstanceId
-            $embeddedRunspaceInfo.NestedDebugger | Should BeNullOrEmpty
+            $embeddedRunspaceInfo.Runspace.InstanceId | Should -Be $InstanceId
+            $embeddedRunspaceInfo.ParentDebuggerId | Should -Be $parentDebuggerId
+            $embeddedRunspaceInfo.Command.InstanceId | Should -Be $ps.InstanceId
+            $embeddedRunspaceInfo.NestedDebugger | Should -BeNullOrEmpty
         }
     }
     Context "Test Monitor RunspaceInfo API tests" {
@@ -234,41 +229,21 @@ Describe "Runspace Debugging API tests" -tag CI {
         }
 
         It "DebuggerUtils StartMonitoringRunspace requires non-null debugger" {
-            try {
-                [DebuggerUtils]::StartMonitoringRunspace($null,$runspaceInfo)
-                throw "Execution should have thrown"
-            }
-            catch {
-                $_.fullyqualifiederrorid | should be PSArgumentNullException
-            }
+            {[DebuggerUtils]::StartMonitoringRunspace($null,$runspaceInfo)} |
+                Should -Throw -ErrorId 'PSArgumentNullException'
         }
         It "DebuggerUtils StartMonitoringRunspace requires non-null runspaceInfo" {
-            try {
-                [DebuggerUtils]::StartMonitoringRunspace($runspace.Debugger,$null)
-                throw "Execution should have thrown"
-            }
-            catch {
-                $_.fullyqualifiederrorid | should be PSArgumentNullException
-            }
+            {[DebuggerUtils]::StartMonitoringRunspace($runspace.Debugger,$null)} |
+                Should -Throw -ErrorId 'PSArgumentNullException'
         }
 
         It "DebuggerUtils EndMonitoringRunspace requires non-null debugger" {
-            try {
-                [DebuggerUtils]::EndMonitoringRunspace($null,$runspaceInfo)
-                throw "Execution should have thrown"
-            }
-            catch {
-                $_.fullyqualifiederrorid | should be PSArgumentNullException
-            }
+            {[DebuggerUtils]::EndMonitoringRunspace($null,$runspaceInfo)} |
+                Should -Throw -ErrorId 'PSArgumentNullException'
         }
         It "DebuggerUtils EndMonitoringRunspace requires non-null runspaceInfo" {
-            try {
-                [DebuggerUtils]::EndMonitoringRunspace($runspace.Debugger,$null)
-                throw "Execution should have thrown"
-            }
-            catch {
-                $_.fullyqualifiederrorid | should be PSArgumentNullException
-            }
+            {[DebuggerUtils]::EndMonitoringRunspace($runspace.Debugger,$null)} |
+                Should -Throw -ErrorId 'PSArgumentNullException'
         }
 
     }


### PR DESCRIPTION
## PR Summary
Use new Pester syntax: -Parameter for Pester in SDK and Provider tests
Resolves part of #6245
## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [X] Not Applicable
    - **OR**
    - [NA] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [NA] Issue filed - Issue link:
- **Testing - New and feature**
    - [X] Not Applicable or can only be tested interactively
    - **OR**
    - [NA] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [x] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
