### PR TITLE
Fix error when 'Format-Wide -AutoSize | Out-String' is called.

### DIFF
--- a/src/System.Management.Automation/FormatAndOutput/common/BaseOutputtingCommand.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/BaseOutputtingCommand.cs
@@ -743,6 +743,8 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             _formattingHint = hint;
         }
 
+        static private int _failedToReadConsoleWidth = 0;
+
         static private int GetConsoleWindowWidth(int columnNumber)
         {
             if (columnNumber == int.MaxValue)
@@ -752,13 +754,18 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 // If we detect that int.MaxValue is used, first we try to get the current console window width.
                 // However, if we can't read that (for example, implicit remoting has no console window), we default
                 // to something reasonable: 120 columns.
+                if (_failedToReadConsoleWidth > 0)
+                {
+                    return _failedToReadConsoleWidth;
+                }
                 try
                 {
                     return Console.WindowWidth;
                 }
                 catch
                 {
-                    return 120;
+                    _failedToReadConsoleWidth = 120;
+                    return _failedToReadConsoleWidth;
                 }
             }
             return columnNumber;

--- a/src/System.Management.Automation/FormatAndOutput/common/BaseOutputtingCommand.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/BaseOutputtingCommand.cs
@@ -743,21 +743,25 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             _formattingHint = hint;
         }
 
-        // In cases like implicit remoting, there is no console so reading the console width results in an exception.
-        // We cache this value rather than handling the exception (on the target) everytime as a performance improvement.
+        /// <summary>
+        /// In cases like implicit remoting, there is no console so reading the console width results in an exception. 
+        /// Instead of handling exception every time we cache this value to increase performance. 
+        /// </summary>
         static private bool _noConsole = false;
 
+        /// <summary>
+        /// Tables and Wides need to use spaces for padding to maintain table look even if console window is resized.
+        /// For all other output, we use int.MaxValue if the user didn't explicitly specify a width.
+        /// If we detect that int.MaxValue is used, first we try to get the current console window width.
+        /// However, if we can't read that (for example, implicit remoting has no console window), we default
+        /// to something reasonable: 120 columns.
+        /// </summary>
         static private int GetConsoleWindowWidth(int columnNumber)
         {
             const int defaultConsoleWidth = 120;
 
             if (columnNumber == int.MaxValue)
             {
-                // Tables and Wides need to use spaces for padding to maintain table look even if console window is resized.
-                // For all other output, we use int.MaxValue if the user didn't explicitly specify a width.
-                // If we detect that int.MaxValue is used, first we try to get the current console window width.
-                // However, if we can't read that (for example, implicit remoting has no console window), we default
-                // to something reasonable: 120 columns.
                 if (_noConsole)
                 {
                     return defaultConsoleWidth;

--- a/src/System.Management.Automation/FormatAndOutput/common/BaseOutputtingCommand.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/BaseOutputtingCommand.cs
@@ -743,15 +743,15 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             _formattingHint = hint;
         }
 
-        static private int TryGetColumnsOnTheScreen(int columnNumber)
+        static private int GetConsoleWindowWidth(int columnNumber)
         {
-            // Tables and Wides need to use spaces for padding to maintain table look even if console window is resized.
-            // For all other output, we use int.MaxValue if the user didn't explicitly specify a width.
-            // If we detect that int.MaxValue is used, first we try to get the current console window width.
-            // However, if we can't read that (for example, implicit remoting has no console window), we default
-            // to something reasonable: 120 columns.
             if (columnNumber == int.MaxValue)
             {
+                // Tables and Wides need to use spaces for padding to maintain table look even if console window is resized.
+                // For all other output, we use int.MaxValue if the user didn't explicitly specify a width.
+                // If we detect that int.MaxValue is used, first we try to get the current console window width.
+                // However, if we can't read that (for example, implicit remoting has no console window), we default
+                // to something reasonable: 120 columns.
                 try
                 {
                     return Console.WindowWidth;
@@ -931,7 +931,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                     columnWidthsHint = tableHint.columnWidths;
                 }
 
-                int columnsOnTheScreen = TryGetColumnsOnTheScreen(this.InnerCommand._lo.ColumnNumber);
+                int columnsOnTheScreen = GetConsoleWindowWidth(this.InnerCommand._lo.ColumnNumber);
 
                 int columns = this.CurrentTableHeaderInfo.tableColumnInfoList.Count;
                 if (columns == 0)
@@ -1137,7 +1137,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 // get the header info and the view hint
                 WideFormattingHint hint = this.InnerCommand.RetrieveFormattingHint() as WideFormattingHint;
 
-                int columnsOnTheScreen = TryGetColumnsOnTheScreen(this.InnerCommand._lo.ColumnNumber);
+                int columnsOnTheScreen = GetConsoleWindowWidth(this.InnerCommand._lo.ColumnNumber);
 
                 // give a preference to the hint, if there
                 if (hint != null && hint.maxWidth > 0)

--- a/src/System.Management.Automation/FormatAndOutput/common/BaseOutputtingCommand.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/BaseOutputtingCommand.cs
@@ -1132,10 +1132,23 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 // get the header info and the view hint
                 WideFormattingHint hint = this.InnerCommand.RetrieveFormattingHint() as WideFormattingHint;
 
+                int columnsOnTheScreen = this.InnerCommand._lo.ColumnNumber;
+                if (columnsOnTheScreen == int.MaxValue)
+                {
+                    try
+                    {
+                        columnsOnTheScreen = Console.WindowWidth;
+                    }
+                    catch
+                    {
+                        columnsOnTheScreen = 120;
+                    }
+                }
+
                 // give a preference to the hint, if there
                 if (hint != null && hint.maxWidth > 0)
                 {
-                    itemsPerRow = TableWriter.ComputeWideViewBestItemsPerRowFit(hint.maxWidth, this.InnerCommand._lo.ColumnNumber);
+                    itemsPerRow = TableWriter.ComputeWideViewBestItemsPerRowFit(hint.maxWidth, columnsOnTheScreen);
                 }
                 else if (this.CurrentWideHeaderInfo.columns > 0)
                 {
@@ -1155,7 +1168,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                     alignment[k] = TextAlignment.Left;
                 }
 
-                this.Writer.Initialize(0, this.InnerCommand._lo.ColumnNumber, columnWidths, alignment, false);
+                this.Writer.Initialize(0, columnsOnTheScreen, columnWidths, alignment, false);
             }
 
             /// <summary>

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-Wide.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-Wide.Tests.ps1
@@ -15,6 +15,8 @@ Describe "Format-Wide" -Tags "CI" {
 
     It "Should be able to use the autosize switch" {
         { Get-ChildItem | Format-Wide -Autosize } | Should -Not -Throw
+        # Test for #6471
+        { Get-ChildItem | Format-Wide -Autosize | Out-String } | Should -Not -Throw
     }
 
     It "Should be able to take inputobject instead of pipe" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-Wide.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-Wide.Tests.ps1
@@ -1,14 +1,14 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 Describe "Format-Wide" -Tags "CI" {
-	BeforeAll {
-		1..10 | ForEach-Object { New-Item -Path ("TestDrive:\Testdir{0:00}" -f $_) -ItemType Directory }
-		1..10 | ForEach-Object { New-Item -Path ("TestDrive:\TestFile{0:00}.txt" -f $_) -ItemType File }
-	}
+    BeforeAll {
+        1..10 | ForEach-Object { New-Item -Path ("TestDrive:\Testdir{0:00}" -f $_) -ItemType Directory }
+        1..10 | ForEach-Object { New-Item -Path ("TestDrive:\TestFile{0:00}.txt" -f $_) -ItemType File }
+    }
 
     It "Should have the same output between the alias and the unaliased function" {
         $nonaliased = Get-ChildItem $TestDrive | Format-Wide
-        $aliased    = Get-ChildItem $TestDrive | fw
+        $aliased = Get-ChildItem $TestDrive | fw
 
         $($nonaliased | Out-String).CompareTo($($aliased | Out-String)) | Should -Be 0
     }
@@ -19,8 +19,8 @@ Describe "Format-Wide" -Tags "CI" {
 
     It "Should be able to use the autosize switch" {
         { Get-ChildItem $TestDrive | Format-Wide -Autosize } | Should -Not -Throw
-		# 'Format-Wide -AutoSize | Out-String' fails on PowerShell Core 6.0.1. (issue #6471)
-		# so we add a new test for that.
+        # 'Format-Wide -AutoSize | Out-String' fails on PowerShell Core 6.0.1. (issue #6471)
+        # so we add a new test for that.
         { Get-ChildItem $TestDrive | Format-Wide -Autosize | Out-String } | Should -Not -Throw
     }
 
@@ -33,8 +33,8 @@ Describe "Format-Wide" -Tags "CI" {
     }
 
     It "Should throw an error when property switch and view switch are used together" {
-	{ Format-Wide -InputObject $(Get-ChildItem $TestDrive) -Property CreationTime -View aoeu } |
-	    Should -Throw -ErrorId "FormatCannotSpecifyViewAndProperty,Microsoft.PowerShell.Commands.FormatWideCommand"
+        { Format-Wide -InputObject $(Get-ChildItem $TestDrive) -Property CreationTime -View aoeu } |
+            Should -Throw -ErrorId "FormatCannotSpecifyViewAndProperty,Microsoft.PowerShell.Commands.FormatWideCommand"
     }
 
     It "Should throw and suggest proper input when view is used with invalid input without the property switch" {
@@ -43,74 +43,74 @@ Describe "Format-Wide" -Tags "CI" {
 }
 
 Describe "Format-Wide DRT basic functionality" -Tags "CI" {
-	It "Format-Wide with array should work" {
-		$al = (0..255)
-		$info = @{}
-		$info.array = $al
-		$result = $info | Format-Wide | Out-String
-		$result | Should -Match "array"
-	}
+    It "Format-Wide with array should work" {
+        $al = (0..255)
+        $info = @{}
+        $info.array = $al
+        $result = $info | Format-Wide | Out-String
+        $result | Should -Match "array"
+    }
 
-	It "Format-Wide with No Objects for End-To-End should work"{
-		$p = @{}
-		$result = $p | Format-Wide | Out-String
-		$result | Should -BeNullOrEmpty
-	}
+    It "Format-Wide with No Objects for End-To-End should work" {
+        $p = @{}
+        $result = $p | Format-Wide | Out-String
+        $result | Should -BeNullOrEmpty
+    }
 
-	It "Format-Wide with Null Objects for End-To-End should work"{
-		$p = $null
-		$result = $p | Format-Wide | Out-String
-		$result | Should -BeNullOrEmpty
-	}
+    It "Format-Wide with Null Objects for End-To-End should work" {
+        $p = $null
+        $result = $p | Format-Wide | Out-String
+        $result | Should -BeNullOrEmpty
+    }
 
-	It "Format-Wide with single line string for End-To-End should work"{
-		$p = "single line string"
-		$result = $p | Format-Wide | Out-String
-		$result | Should -Match $p
-	}
+    It "Format-Wide with single line string for End-To-End should work" {
+        $p = "single line string"
+        $result = $p | Format-Wide | Out-String
+        $result | Should -Match $p
+    }
 
-	It "Format-Wide with multiple line string for End-To-End should work"{
-		$p = "Line1\nLine2"
-		$result = $p | Format-Wide | Out-String
-		$result | Should -Match "Line1"
-		$result | Should -Match "Line2"
-	}
+    It "Format-Wide with multiple line string for End-To-End should work" {
+        $p = "Line1\nLine2"
+        $result = $p | Format-Wide | Out-String
+        $result | Should -Match "Line1"
+        $result | Should -Match "Line2"
+    }
 
-	It "Format-Wide with string sequence for End-To-End should work"{
-		$p = "Line1","Line2"
-		$result = $p |Format-Wide | Out-String
-		$result | Should -Match "Line1"
-		$result | Should -Match "Line2"
-	}
+    It "Format-Wide with string sequence for End-To-End should work" {
+        $p = "Line1", "Line2"
+        $result = $p |Format-Wide | Out-String
+        $result | Should -Match "Line1"
+        $result | Should -Match "Line2"
+    }
 
     It "Format-Wide with complex object for End-To-End should work" {
-		Add-Type -TypeDefinition "public enum MyDayOfWeek{Sun,Mon,Tue,Wed,Thu,Fri,Sat}"
-		$eto = New-Object MyDayOfWeek
-		$info = @{}
-		$info.intArray = 1,2,3,4
-		$info.arrayList = "string1","string2"
-		$info.enumerable = [MyDayOfWeek]$eto
-		$info.enumerableTestObject = $eto
-		$result = $info|Format-Wide|Out-String
-		$result | Should -Match "intArray"
-		$result | Should -Match "arrayList"
-		$result | Should -Match "enumerable"
-		$result | Should -Match "enumerableTestObject"
-	}
+        Add-Type -TypeDefinition "public enum MyDayOfWeek{Sun,Mon,Tue,Wed,Thu,Fri,Sat}"
+        $eto = New-Object MyDayOfWeek
+        $info = @{}
+        $info.intArray = 1, 2, 3, 4
+        $info.arrayList = "string1", "string2"
+        $info.enumerable = [MyDayOfWeek]$eto
+        $info.enumerableTestObject = $eto
+        $result = $info|Format-Wide|Out-String
+        $result | Should -Match "intArray"
+        $result | Should -Match "arrayList"
+        $result | Should -Match "enumerable"
+        $result | Should -Match "enumerableTestObject"
+    }
 
-	It "Format-Wide with multiple same class object with grouping should work"{
-		Add-Type -TypeDefinition "public class TestGroupingClass{public TestGroupingClass(string name,int length){Name = name;Length = length;}public string Name;public int Length;public string GroupingKey;}"
-		$testobject1 = [TestGroupingClass]::New('name1',1)
-		$testobject1.GroupingKey = "foo"
-		$testobject2 = [TestGroupingClass]::New('name2',2)
-		$testobject1.GroupingKey = "bar"
-		$testobject3 = [TestGroupingClass]::New('name3',3)
-		$testobject1.GroupingKey = "bar"
-		$testobjects = @($testobject1,$testobject2,$testobject3)
-		$result = $testobjects|Format-Wide -GroupBy GroupingKey|Out-String
-		$result | Should -Match "GroupingKey: bar"
-		$result | Should -Match "name1"
-		$result | Should -Match " GroupingKey:"
-		$result | Should -Match "name2\s+name3"
-	}
+    It "Format-Wide with multiple same class object with grouping should work" {
+        Add-Type -TypeDefinition "public class TestGroupingClass{public TestGroupingClass(string name,int length){Name = name;Length = length;}public string Name;public int Length;public string GroupingKey;}"
+        $testobject1 = [TestGroupingClass]::New('name1', 1)
+        $testobject1.GroupingKey = "foo"
+        $testobject2 = [TestGroupingClass]::New('name2', 2)
+        $testobject1.GroupingKey = "bar"
+        $testobject3 = [TestGroupingClass]::New('name3', 3)
+        $testobject1.GroupingKey = "bar"
+        $testobjects = @($testobject1, $testobject2, $testobject3)
+        $result = $testobjects|Format-Wide -GroupBy GroupingKey|Out-String
+        $result | Should -Match "GroupingKey: bar"
+        $result | Should -Match "name1"
+        $result | Should -Match " GroupingKey:"
+        $result | Should -Match "name2\s+name3"
+    }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-Wide.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-Wide.Tests.ps1
@@ -2,38 +2,37 @@
 # Licensed under the MIT License.
 Describe "Format-Wide" -Tags "CI" {
     BeforeAll {
-        1..10 | ForEach-Object { New-Item -Path ("TestDrive:\Testdir{0:00}" -f $_) -ItemType Directory }
-        1..10 | ForEach-Object { New-Item -Path ("TestDrive:\TestFile{0:00}.txt" -f $_) -ItemType File }
+        1..2 | ForEach-Object { New-Item -Path ("TestDrive:\Testdir{0:00}" -f $_) -ItemType Directory }
+        1..2 | ForEach-Object { New-Item -Path ("TestDrive:\TestFile{0:00}.txt" -f $_) -ItemType File }
+        $pathList = Get-ChildItem $TestDrive
     }
 
     It "Should have the same output between the alias and the unaliased function" {
-        $nonaliased = Get-ChildItem $TestDrive | Format-Wide
-        $aliased = Get-ChildItem $TestDrive | fw
+        $nonaliased = $pathList | Format-Wide
+        $aliased = $pathList | fw
 
         $($nonaliased | Out-String).CompareTo($($aliased | Out-String)) | Should -Be 0
     }
 
     It "Should be able to specify the columns in output using the column switch" {
-        { Get-ChildItem $TestDrive | Format-Wide -Column 3 } | Should -Not -Throw
+        { $pathList | Format-Wide -Column 3 } | Should -Not -Throw
     }
 
     It "Should be able to use the autosize switch" {
-        { Get-ChildItem $TestDrive | Format-Wide -Autosize } | Should -Not -Throw
-        # 'Format-Wide -AutoSize | Out-String' fails on PowerShell Core 6.0.1. (issue #6471)
-        # so we add a new test for that.
-        { Get-ChildItem $TestDrive | Format-Wide -Autosize | Out-String } | Should -Not -Throw
+        { $pathList | Format-Wide -Autosize } | Should -Not -Throw
+        { $pathList | Format-Wide -Autosize | Out-String } | Should -Not -Throw
     }
 
     It "Should be able to take inputobject instead of pipe" {
-        { Format-Wide -InputObject $(Get-ChildItem $TestDrive) } | Should -Not -Throw
+        { Format-Wide -InputObject $pathList } | Should -Not -Throw
     }
 
     It "Should be able to use the property switch" {
-        { Format-Wide -InputObject $(Get-ChildItem $TestDrive) -Property Mode } | Should -Not -Throw
+        { Format-Wide -InputObject $pathList -Property Mode } | Should -Not -Throw
     }
 
     It "Should throw an error when property switch and view switch are used together" {
-        { Format-Wide -InputObject $(Get-ChildItem $TestDrive) -Property CreationTime -View aoeu } |
+        { Format-Wide -InputObject $pathList -Property CreationTime -View aoeu } |
             Should -Throw -ErrorId "FormatCannotSpecifyViewAndProperty,Microsoft.PowerShell.Commands.FormatWideCommand"
     }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-Wide.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-Wide.Tests.ps1
@@ -15,7 +15,8 @@ Describe "Format-Wide" -Tags "CI" {
 
     It "Should be able to use the autosize switch" {
         { Get-ChildItem | Format-Wide -Autosize } | Should -Not -Throw
-        # Test for #6471
+		# 'Format-Wide -AutoSize | Out-String' fails on PowerShell Core 6.0.1. (issue #6471)
+		# so we add a new test for that.
         { Get-ChildItem | Format-Wide -Autosize | Out-String } | Should -Not -Throw
     }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-Wide.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-Wide.Tests.ps1
@@ -1,35 +1,39 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 Describe "Format-Wide" -Tags "CI" {
+	BeforeAll {
+		1..10 | ForEach-Object { New-Item -Path ("TestDrive:\Testdir{0:00}" -f $_) -ItemType Directory }
+		1..10 | ForEach-Object { New-Item -Path ("TestDrive:\TestFile{0:00}.txt" -f $_) -ItemType File }
+	}
 
     It "Should have the same output between the alias and the unaliased function" {
-        $nonaliased = Get-ChildItem | Format-Wide
-        $aliased    = Get-ChildItem | fw
+        $nonaliased = Get-ChildItem $TestDrive | Format-Wide
+        $aliased    = Get-ChildItem $TestDrive | fw
 
         $($nonaliased | Out-String).CompareTo($($aliased | Out-String)) | Should -Be 0
     }
 
     It "Should be able to specify the columns in output using the column switch" {
-        { Get-ChildItem | Format-Wide -Column 3 } | Should -Not -Throw
+        { Get-ChildItem $TestDrive | Format-Wide -Column 3 } | Should -Not -Throw
     }
 
     It "Should be able to use the autosize switch" {
-        { Get-ChildItem | Format-Wide -Autosize } | Should -Not -Throw
+        { Get-ChildItem $TestDrive | Format-Wide -Autosize } | Should -Not -Throw
 		# 'Format-Wide -AutoSize | Out-String' fails on PowerShell Core 6.0.1. (issue #6471)
 		# so we add a new test for that.
-        { Get-ChildItem | Format-Wide -Autosize | Out-String } | Should -Not -Throw
+        { Get-ChildItem $TestDrive | Format-Wide -Autosize | Out-String } | Should -Not -Throw
     }
 
     It "Should be able to take inputobject instead of pipe" {
-        { Format-Wide -InputObject $(Get-ChildItem) } | Should -Not -Throw
+        { Format-Wide -InputObject $(Get-ChildItem $TestDrive) } | Should -Not -Throw
     }
 
     It "Should be able to use the property switch" {
-        { Format-Wide -InputObject $(Get-ChildItem) -Property Mode } | Should -Not -Throw
+        { Format-Wide -InputObject $(Get-ChildItem $TestDrive) -Property Mode } | Should -Not -Throw
     }
 
     It "Should throw an error when property switch and view switch are used together" {
-	{ Format-Wide -InputObject $(Get-ChildItem) -Property CreationTime -View aoeu } |
+	{ Format-Wide -InputObject $(Get-ChildItem $TestDrive) -Property CreationTime -View aoeu } |
 	    Should -Throw -ErrorId "FormatCannotSpecifyViewAndProperty,Microsoft.PowerShell.Commands.FormatWideCommand"
     }
 
@@ -39,7 +43,7 @@ Describe "Format-Wide" -Tags "CI" {
 }
 
 Describe "Format-Wide DRT basic functionality" -Tags "CI" {
-  It "Format-Wide with array should work" {
+	It "Format-Wide with array should work" {
 		$al = (0..255)
 		$info = @{}
 		$info.array = $al
@@ -79,7 +83,7 @@ Describe "Format-Wide DRT basic functionality" -Tags "CI" {
 		$result | Should -Match "Line2"
 	}
 
-   It "Format-Wide with complex object for End-To-End should work" {
+    It "Format-Wide with complex object for End-To-End should work" {
 		Add-Type -TypeDefinition "public enum MyDayOfWeek{Sun,Mon,Tue,Wed,Thu,Fri,Sat}"
 		$eto = New-Object MyDayOfWeek
 		$info = @{}

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-Wide.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-Wide.Tests.ps1
@@ -7,13 +7,6 @@ Describe "Format-Wide" -Tags "CI" {
         $pathList = Get-ChildItem $TestDrive
     }
 
-    It "Should have the same output between the alias and the unaliased function" {
-        $nonaliased = $pathList | Format-Wide
-        $aliased = $pathList | fw
-
-        $($nonaliased | Out-String).CompareTo($($aliased | Out-String)) | Should -Be 0
-    }
-
     It "Should be able to specify the columns in output using the column switch" {
         { $pathList | Format-Wide -Column 3 } | Should -Not -Throw
     }


### PR DESCRIPTION
## PR Summary

<!-- summarize your PR between here and the checklist -->
Fix #6471.

This pull request fixes the error when  `Format-Wide -AutoSize | Out-String` is called.  

From #5193,  `int.MaxValue` is adopted as output width when `Out-String -Width` parameter is not specified.  
`OutCommandInner.TableOutputContext` class is checking output width at initializing.

https://github.com/PowerShell/PowerShell/blob/36b71ba39e36be3b86854b3551ef9f8e2a1de5cc/src/System.Management.Automation/FormatAndOutput/common/BaseOutputtingCommand.cs#L923-L939

This pull request applies the same method to `OutCommandInner.WideOutputContext` class.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [x] Issue filed - Issue link: #6471
- **Testing - New and feature**
    - [] Not Applicable or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
