### PR TITLE
WIP: Use new Pester syntax: -Parameter for Modules/Microsoft.PowerShell.LocalAccounts tests

### DIFF
--- a/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalGroup.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalGroup.Tests.ps1
@@ -328,13 +328,13 @@ try {
             if ($null -eq $result)
             {
                 # Force failing the test because an unexpected outcome occurred
-                $false | Should Be $true
+                $false | Should -BeTrue
             }
             else
             {
-                $result[0] -eq 1 | Should Be true
-                $result[1] -match "GroupNotFound" | Should Be true
-                $result[2] -match "TestGroupGet1" | Should Be true
+                $result[0] | Should -Be 1
+                $result[1] | Should -Match "GroupNotFound"
+                $result[2] | Should -match "TestGroupGet1"
             }
         }
 
@@ -358,7 +358,7 @@ try {
             $localGroupName = 'TestGroupGetNameThatDoesntExist'
             $result = (Get-LocalGroup $localGroupName*).Count
 
-            $result -eq 0 | Should Be true
+            $result | Should -Be 0
         }
     }
 
@@ -709,7 +709,7 @@ try {
             VerifyFailingTest $sb "GroupNotFound,Microsoft.PowerShell.Commands.GetLocalGroupCommand"
 
             $finalCount = (Get-LocalGroup).Count
-            $initialCount -eq $finalCount + 1 | Should Be true
+            $initialCount | Should -Be ($finalCount + 1)
         }
     }
 
@@ -735,7 +735,7 @@ try {
                     VerifyFailingTest $sb "GroupNotFound,Microsoft.PowerShell.Commands.GetLocalGroupCommand"
 
                     $finalCount = (Get-LocalGroup).Count
-                    $initialCount -eq $finalCount + 1 | Should Be true
+                    $initialCount | Should -Be ($finalCount + 1)
                 }
 
                 function VerifyArrayRemoval {
@@ -758,7 +758,7 @@ try {
                     VerifyFailingTest $sb "GroupNotFound,Microsoft.PowerShell.Commands.GetLocalGroupCommand"
 
                     $finalCount = (Get-LocalGroup).Count
-                    $initialCount -eq $finalCount + 2 | Should Be $true
+                    $initialCount | Should -Be ($finalCount + 2)
                 }
             }
         }
@@ -859,7 +859,7 @@ try {
             VerifyFailingTest $sb "GroupNotFound,Microsoft.PowerShell.Commands.GetLocalGroupCommand"
 
             $finalCount = (Get-LocalGroup).Count
-            $initialCount -eq $finalCount + 1 | Should Be true
+            $initialCount | Should -Be ($finalCount + 1)
         }
 
         It "Errors on Remove-LocalGroup by invalid name" {
@@ -872,7 +872,7 @@ try {
             VerifyFailingTest $sb "GroupNotFound,Microsoft.PowerShell.Commands.RemoveLocalGroupCommand"
 
             $finalCount = (Get-LocalGroup).Count
-            $initialCount -eq $finalCount | Should Be true
+            $initialCount | Should -Be $finalCount
         }
 
         It "Errors on Remove-LocalGroup by invalid SID" {
@@ -886,7 +886,7 @@ try {
             VerifyFailingTest $sb "GroupNotFound,Microsoft.PowerShell.Commands.RemoveLocalGroupCommand"
 
             $finalCount = (Get-LocalGroup).Count
-            $initialCount -eq $finalCount + 1 | Should Be $true
+            $initialCount | Should -Be ($finalCount + 1)
         }
 
         It "Can respond to -ErrorAction Stop" {
@@ -902,7 +902,7 @@ try {
 
             # Confirm that the expected errors were caught
             $errCount | Should -Be 2
-            $fqeid | Should Be "GroupNotFound,Microsoft.PowerShell.Commands.RemoveLocalGroupCommand"
+            $fqeid | Should -BeExactly "GroupNotFound,Microsoft.PowerShell.Commands.RemoveLocalGroupCommand"
 
             # confirm that the first group was removed
             $sb = {

--- a/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalGroup.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalGroup.Tests.ps1
@@ -908,7 +908,7 @@ try {
             }
 
             # Confirm that the expected errors were caught
-            $errCount | Should Be 2
+            $errCount | Should -Be 2
             $fqeid | Should Be "GroupNotFound,Microsoft.PowerShell.Commands.RemoveLocalGroupCommand"
 
             # confirm that the first group was removed

--- a/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalGroup.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalGroup.Tests.ps1
@@ -185,7 +185,7 @@ try {
             }
 
             if ($failedCharacters.Count -gt 0) { Write-Host "characters causing test fail: $failedCharacters" }
-            $failedCharacters.Count -eq 0 | Should Be true
+            $failedCharacters | Should -HaveCount 0
         }
 
         It "Error on names containing only spaces" {
@@ -292,16 +292,16 @@ try {
             $result = Get-LocalGroup TestGroupGet*
 
             $result.Count -eq 2 | Should -BeTrue
-            $result.Name -contains "TestGroupGet1" | Should Be true
-            $result.Name -contains "TestGroupGet2" | Should Be true
+            $result.Name | Should -Contain 'TestGroupGet1'
+            $result.Name | Should -Contain 'TestGroupGet2'
         }
 
         It "Can Get-LocalGroup gets by array of names" {
             $result = Get-LocalGroup @("TestGroupGet1", "TestGroupGet2")
 
-            $result.Count -eq 2 | Should Be true
-            $result.Name -contains "TestGroupGet1" | Should Be true
-            $result.Name -contains "TestGroupGet2" | Should Be true
+            $result | Should -HaveCount 2
+            $result.Name | Should -Contain 'TestGroupGet1'
+            $result.Name | Should -Contain 'TestGroupGet2'
         }
 
         It "Can Get-LocalGroups by array of SIDs" {
@@ -309,18 +309,18 @@ try {
             $sid2 = (Get-LocalGroup TestGroupGet2).SID
             $result = Get-LocalGroup -SID @($sid1, $sid2)
 
-            $result.Count -eq 2 | Should Be true
-            $result.Name -contains "TestGroupGet1" | Should Be true
-            $result.Name -contains "TestGroupGet2" | Should Be true
+            $result | Should -HaveCount 2
+            $result.Name | Should -Contain 'TestGroupGet1'
+            $result.Name | Should -Contain 'TestGroupGet2'
         }
 
         It "Can Get-LocalGroups by pipe of an array of Group objects" {
             $testGroups = Get-LocalGroup TestGroupGet*
             $result = @($testGroups, $testGroups) | Get-LocalGroup
 
-            $result.Count -eq 4 | Should Be true
-            $result.Name -contains "TestGroupGet1" | Should Be true
-            $result.Name -contains "TestGroupGet2" | Should Be true
+            $result | Should -HaveCount 4
+            $result.Name | Should -Contain 'TestGroupGet1'
+            $result.Name | Should -Contain 'TestGroupGet2'
         }
 
         It "Can respond to -ErrorAction Stop" {
@@ -627,7 +627,7 @@ try {
 
             #Assert
             if ($failedCharacters.Count -gt 0) { Write-Host "characters causing test fail: $failedCharacters" }
-            $failedCharacters.Count -eq 0 | Should Be true
+            $failedCharacters | Should -HaveCount 0
         }
 
         It "Error on names containing only spaces" {

--- a/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalGroup.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalGroup.Tests.ps1
@@ -68,7 +68,7 @@ try {
         It "Creates New-LocalGroup using only name" {
             $result = New-LocalGroup -Name TestGroupAddRemove
 
-            $result.Name | Should BeExactly TestGroupAddRemove
+            $result.Name | Should -BeExactly 'TestGroupAddRemove'
             $result.ObjectClass | Should Be Group
         }
     }
@@ -84,8 +84,8 @@ try {
         It "Creates New-LocalGroup with name and description" {
             $result = New-LocalGroup -Name TestGroupAddRemove -Description "Test Group New 1 Description"
 
-            $result.Name | Should BeExactly TestGroupAddRemove
-            $result.Description | Should BeExactly "Test Group New 1 Description"
+            $result.Name | Should -BeExactly 'TestGroupAddRemove'
+            $result.Description | Should -BeExactly "Test Group New 1 Description"
             $result.SID | Should Not BeNullOrEmpty
             $result.ObjectClass | Should Be Group
         }
@@ -104,8 +104,8 @@ try {
                 $result = New-LocalGroup -Name $sidName
 
                 $result | Should Not BeNullOrEmpty
-                $result.Name | Should BeExactly $sidName
-                $result.SID | Should Not BeExactly $sidName
+                $result.Name | Should -BeExactly $sidName
+                $result.SID | Should -Not -BeExactly $sidName
                 $result.ObjectClass | Should Be Group
             }
             finally {
@@ -125,8 +125,8 @@ try {
             try {
                 $result = New-LocalGroup -Name $nameMax -Description $desc
 
-                $result.Name | Should BeExactly $nameMax
-                $result.Description | Should BeExactly $desc
+                $result.Name | Should -BeExactly $nameMax
+                $result.Description | Should -BeExactly $desc
                 $result.SID | Should Not BeNullOrEmpty
                 $result.ObjectClass | Should Be Group
             }
@@ -156,7 +156,7 @@ try {
             $descMax = "Test Group Add Description that is longer than 48 characters"
             $result = New-LocalGroup -Name TestGroupAddRemove -Description $descMax
 
-            $result.Description | Should BeExactly $descMax
+            $result.Description | Should -BeExactly $descMax
         }
 
         It "Errors on Invalid characters" {
@@ -394,7 +394,7 @@ try {
             Set-LocalGroup -Name TestGroupSet1 -Description "Test Group Set 1 new description"
             $result = Get-LocalGroup -Name TestGroupSet1
 
-            $result.Description | Should BeExactly "Test Group Set 1 new description"
+            $result.Description | Should -BeExactly "Test Group Set 1 new description"
         }
     }
 
@@ -423,7 +423,7 @@ try {
             Set-LocalGroup -SID $group1SID -Description "Test Group Set 1 newer description"
             $result = Get-LocalGroup -Name TestGroupSet1
 
-            $result.Description | Should BeExactly "Test Group Set 1 newer description"
+            $result.Description | Should -BeExactly "Test Group Set 1 newer description"
         }
 
         It "Can Set-LocalGroup using -InputObject" {
@@ -431,14 +431,14 @@ try {
             Set-LocalGroup -InputObject $group -Description "Test Group Set 1 newer still description"
             $result = Get-LocalGroup TestGroupSet1
 
-            $result.Description | Should BeExactly "Test Group Set 1 newer still description"
+            $result.Description | Should -BeExactly "Test Group Set 1 newer still description"
         }
 
         It "Can Set-LocalGroup using pipeline" {
             Get-LocalGroup TestGroupSet1 | Set-LocalGroup -Description "Test Group Set 1 newer still description"
             $result = Get-LocalGroup TestGroupSet1
 
-            $result.Description | Should BeExactly "Test Group Set 1 newer still description"
+            $result.Description | Should -BeExactly "Test Group Set 1 newer still description"
         }
 
         It "Errors on Set-LocalGroup without specifying a Group" {
@@ -468,7 +468,7 @@ try {
             Set-LocalGroup -Name TestGroupSet1 -Description $desc
             $result = Get-LocalGroup -Name TestGroupSet1
 
-            $result.Description | Should BeExactly $desc
+            $result.Description | Should -BeExactly $desc
         }
     }
 
@@ -505,7 +505,7 @@ try {
             Rename-LocalGroup TestGroupRename1 TestGroupRename1x
             $result = Get-LocalGroup -SID $group1SID
 
-            $result.Name | Should BeExactly TestGroupRename1x
+            $result.Name | Should -BeExactly 'TestGroupRename1x'
         }
     }
 
@@ -542,7 +542,7 @@ try {
             Rename-LocalGroup -SID $group1SID TestGroupRename1x
             $result = Get-LocalGroup -SID $group1SID
 
-            $result.Name | Should BeExactly TestGroupRename1x
+            $result.Name | Should -BeExactly 'TestGroupRename1x'
         }
 
         It "Can Rename-LocalGroup using a valid group -InputObject" {
@@ -551,7 +551,7 @@ try {
             Rename-LocalGroup -InputObject $group -NewName TestGroupRename1x
             $result = Get-LocalGroup -SID $group1SID
 
-            $result.Name | Should BeExactly TestGroupRename1x
+            $result.Name | Should -BeExactly 'TestGroupRename1x'
         }
 
         It "Can Rename-LocalGroup using a valid group sent using pipeline" {
@@ -559,7 +559,7 @@ try {
             Get-LocalGroup TestGroupRename1 | Rename-LocalGroup -NewName TestGroupRename1x
             $result = Get-LocalGroup -SID $group1SID
 
-            $result.Name | Should BeExactly TestGroupRename1x
+            $result.Name | Should -BeExactly 'TestGroupRename1x'
         }
 
         It "Errors on Rename-LocalGroup without specifying a Group" {
@@ -595,8 +595,8 @@ try {
             $group1Name = (Get-LocalGroup -SID $group1SID).Name
             $group2Name = (Get-LocalGroup -SID $group2SID).Name
 
-            $group1Name | Should BeExactly TestGroupRename1
-            $group2Name | Should BeExactly $newName
+            $group1Name | Should -BeExactly 'TestGroupRename1'
+            $group2Name | Should -BeExactly $newName
         }
 
         It "Errors on Invalid characters" {
@@ -668,7 +668,7 @@ try {
             Rename-LocalGroup TestGroupRename1 $newName
             $result = Get-LocalGroup -SID $group1SID
 
-            $result.Name | Should BeExactly $newName
+            $result.Name | Should -BeExactly $newName
         }
 
         It "Errors on Rename-LocalGroup using a valid group name over max length 256" {
@@ -678,7 +678,7 @@ try {
             }
             VerifyFailingTest $sb "InvalidName,Microsoft.PowerShell.Commands.RenameLocalGroupCommand"
 
-            (Get-LocalGroup -SID $group1SID).Name | Should BeExactly TestGroupRename1
+            (Get-LocalGroup -SID $group1SID).Name | Should -BeExactly 'TestGroupRename1'
         }
     }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalGroup.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalGroup.Tests.ps1
@@ -49,11 +49,11 @@ try {
         It "Test command presence" {
             $result = Get-Command -Module Microsoft.PowerShell.LocalAccounts | ForEach-Object Name
 
-            $result -contains "New-LocalGroup" | Should Be $true
-            $result -contains "Set-LocalGroup" | Should Be $true
-            $result -contains "Get-LocalGroup" | Should Be $true
-            $result -contains "Rename-LocalGroup" | Should Be $true
-            $result -contains "Remove-LocalGroup" | Should Be $true
+            $result | Should -Contain 'New-LocalGroup'
+            $result | Should -Contain 'Set-LocalGroup'
+            $result | Should -Contain 'Get-LocalGroup'
+            $result | Should -Contain 'Rename-LocalGroup'
+            $result | Should -Contain 'Remove-LocalGroup'
         }
     }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalGroup.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalGroup.Tests.ps1
@@ -270,7 +270,7 @@ try {
         It "Can Get-LocalGroup of all groups"  {
             $result = Get-LocalGroup
 
-            $result.Count -gt 2 | Should Be true
+            $result.Count -gt 2 | Should -BeTrue
         }
 
         It "Can Get-LocalGroup of a specific group by SID" {
@@ -291,7 +291,7 @@ try {
         It "Can Get-LocalGroup by wildcard" {
             $result = Get-LocalGroup TestGroupGet*
 
-            $result.Count -eq 2 | Should Be true
+            $result.Count -eq 2 | Should -BeTrue
             $result.Name -contains "TestGroupGet1" | Should Be true
             $result.Name -contains "TestGroupGet2" | Should Be true
         }
@@ -705,7 +705,7 @@ try {
 
         It "Can Remove-LocalGroup by name" {
             $initialCount = (Get-LocalGroup).Count
-            $initialCount -gt 1 | Should Be true
+            $initialCount -gt 1 | Should -BeTrue
 
             $removeResult = Remove-LocalGroup TestGroupRemove1 2>&1
             $removeResult | Should -BeNullOrEmpty
@@ -732,7 +732,7 @@ try {
                         [scriptblock]$removalAction
                     )
                     $initialCount = (Get-LocalGroup).Count
-                    $initialCount -gt 1 | Should Be true
+                    $initialCount -gt 1 | Should -BeTrue
 
                     & $removalAction
 
@@ -750,7 +750,7 @@ try {
                         [scriptblock]$removalAction
                     )
                     $initialCount = (Get-LocalGroup).Count
-                    $initialCount -gt 1 | Should Be $true
+                    $initialCount -gt 1 | Should -BeTrue
 
                     & $removalAction
 
@@ -852,7 +852,7 @@ try {
             New-LocalUser TestUserRemove1 -NoPassword | Out-Null
             Add-LocalGroupMember TestGroupRemove1 -Member TestUserRemove1 | Out-Null
             $initialCount = (Get-LocalGroup).Count
-            $initialCount -gt 1 | Should Be true
+            $initialCount -gt 1 | Should -BeTrue
 
             $removeResult = Remove-LocalGroup TestGroupRemove1 2>&1
             $removeResult | Should -BeNullOrEmpty
@@ -871,7 +871,7 @@ try {
 
         It "Errors on Remove-LocalGroup by invalid name" {
             $initialCount = (Get-LocalGroup).Count
-            $initialCount -gt 1 | Should Be true
+            $initialCount -gt 1 | Should -BeTrue
 
             $sb = {
                 Remove-LocalGroup TestGroupRemove1NameThatDoesntExist
@@ -884,7 +884,7 @@ try {
 
         It "Errors on Remove-LocalGroup by invalid SID" {
             $initialCount = (Get-LocalGroup).Count
-            $initialCount -gt 1 | Should Be true
+            $initialCount -gt 1 | Should -BeTrue
 
             $sb = {
                 Remove-LocalGroup -SID $group1SID

--- a/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalGroup.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalGroup.Tests.ps1
@@ -24,14 +24,14 @@ function VerifyFailingTest
     )
 
     $backupEAP = $script:ErrorActionPreference
-    $script:ErrorActionPreference = "Stop"
-
-    try {
-        {& $sb} | Should -Throw -ErrorId $expectedFqeid
-    }
-    finally {
-        $script:ErrorActionPreference = $backupEAP
-    }
+    {
+        $script:ErrorActionPreference = "Stop"
+        try {
+            & $sb
+        } finally {
+             $script:ErrorActionPreference = $backupEAP
+        }
+    } | Should -Throw -ErrorId $expectedFqeid
 }
 
 try {

--- a/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalGroup.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalGroup.Tests.ps1
@@ -263,7 +263,7 @@ try {
         It "Can Get-LocalGroup of all groups"  {
             $result = Get-LocalGroup
 
-            $result.Count -gt 2 | Should -BeTrue
+            $result.Count | Should -BeGreaterThan 2
         }
 
         It "Can Get-LocalGroup of a specific group by SID" {
@@ -284,7 +284,7 @@ try {
         It "Can Get-LocalGroup by wildcard" {
             $result = Get-LocalGroup TestGroupGet*
 
-            $result.Count -eq 2 | Should -BeTrue
+            $result | Should -HaveCount 2
             $result.Name | Should -Contain 'TestGroupGet1'
             $result.Name | Should -Contain 'TestGroupGet2'
         }
@@ -698,7 +698,7 @@ try {
 
         It "Can Remove-LocalGroup by name" {
             $initialCount = (Get-LocalGroup).Count
-            $initialCount -gt 1 | Should -BeTrue
+            $initialCount | Should -BeGreaterThan 1
 
             $removeResult = Remove-LocalGroup TestGroupRemove1 2>&1
             $removeResult | Should -BeNullOrEmpty
@@ -725,7 +725,7 @@ try {
                         [scriptblock]$removalAction
                     )
                     $initialCount = (Get-LocalGroup).Count
-                    $initialCount -gt 1 | Should -BeTrue
+                    $initialCount | Should -BeGreaterThan 1
 
                     & $removalAction
 
@@ -743,7 +743,7 @@ try {
                         [scriptblock]$removalAction
                     )
                     $initialCount = (Get-LocalGroup).Count
-                    $initialCount -gt 1 | Should -BeTrue
+                    $initialCount | Should -BeGreaterThan 1
 
                     & $removalAction
 
@@ -845,7 +845,7 @@ try {
             New-LocalUser TestUserRemove1 -NoPassword | Out-Null
             Add-LocalGroupMember TestGroupRemove1 -Member TestUserRemove1 | Out-Null
             $initialCount = (Get-LocalGroup).Count
-            $initialCount -gt 1 | Should -BeTrue
+            $initialCount | Should -BeGreaterThan 1
 
             $removeResult = Remove-LocalGroup TestGroupRemove1 2>&1
             $removeResult | Should -BeNullOrEmpty
@@ -864,7 +864,7 @@ try {
 
         It "Errors on Remove-LocalGroup by invalid name" {
             $initialCount = (Get-LocalGroup).Count
-            $initialCount -gt 1 | Should -BeTrue
+            $initialCount | Should -BeGreaterThan 1
 
             $sb = {
                 Remove-LocalGroup TestGroupRemove1NameThatDoesntExist
@@ -877,7 +877,7 @@ try {
 
         It "Errors on Remove-LocalGroup by invalid SID" {
             $initialCount = (Get-LocalGroup).Count
-            $initialCount -gt 1 | Should -BeTrue
+            $initialCount | Should -BeGreaterThan 1
 
             $sb = {
                 Remove-LocalGroup -SID $group1SID

--- a/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalGroup.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalGroup.Tests.ps1
@@ -333,8 +333,8 @@ try {
             else
             {
                 $result[0] | Should -Be 1
-                $result[1] | Should -Match "GroupNotFound"
-                $result[2] | Should -match "TestGroupGet1"
+                $result[1] | Should -MatchExactly "GroupNotFound"
+                $result[2] | Should -MatchExactly "TestGroupGet1"
             }
         }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalGroup.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalGroup.Tests.ps1
@@ -86,7 +86,7 @@ try {
 
             $result.Name | Should -BeExactly 'TestGroupAddRemove'
             $result.Description | Should -BeExactly "Test Group New 1 Description"
-            $result.SID | Should Not BeNullOrEmpty
+            $result.SID | Should -Not -BeNullOrEmpty
             $result.ObjectClass | Should Be Group
         }
 
@@ -103,10 +103,10 @@ try {
             try {
                 $result = New-LocalGroup -Name $sidName
 
-                $result | Should Not BeNullOrEmpty
+                $result | Should -Not -BeNullOrEmpty
                 $result.Name | Should -BeExactly $sidName
                 $result.SID | Should -Not -BeExactly $sidName
-                $result.ObjectClass | Should Be Group
+                $result.ObjectClass | Should -BeExactly 'Group'
             }
             finally {
                 RemoveTestGroups -basename $sidName
@@ -127,8 +127,8 @@ try {
 
                 $result.Name | Should -BeExactly $nameMax
                 $result.Description | Should -BeExactly $desc
-                $result.SID | Should Not BeNullOrEmpty
-                $result.ObjectClass | Should Be Group
+                $result.SID | Should -Not -BeNullOrEmpty
+                $result.ObjectClass | Should -BeExactly 'Group'
             }
             finally {
                 RemoveTestGroups -basename $nameMax
@@ -277,7 +277,7 @@ try {
             $result = Get-LocalGroup TestGroupGet1
             $resultBySID = Get-LocalGroup -SID $result.SID
 
-            $resultBySID.SID | Should Not BeNullOrEmpty
+            $resultBySID.SID | Should -Not -BeNullOrEmpty
             $resultBySID.Name | Should Be TestGroupGet1
         }
 
@@ -501,7 +501,7 @@ try {
         }
 
         It "Can Rename-LocalGroup using a valid group name" {
-            $group1SID | Should Not BeNullOrEmpty
+            $group1SID | Should -Not -BeNullOrEmpty
             Rename-LocalGroup TestGroupRename1 TestGroupRename1x
             $result = Get-LocalGroup -SID $group1SID
 
@@ -538,7 +538,7 @@ try {
         }
 
         It "Can Rename-LocalGroup using a valid group SID" {
-            $group1SID | Should Not BeNullOrEmpty
+            $group1SID | Should -Not -BeNullOrEmpty
             Rename-LocalGroup -SID $group1SID TestGroupRename1x
             $result = Get-LocalGroup -SID $group1SID
 
@@ -546,7 +546,7 @@ try {
         }
 
         It "Can Rename-LocalGroup using a valid group -InputObject" {
-            $group1SID | Should Not BeNullOrEmpty
+            $group1SID | Should -Not -BeNullOrEmpty
             $group = Get-LocalGroup TestGroupRename1
             Rename-LocalGroup -InputObject $group -NewName TestGroupRename1x
             $result = Get-LocalGroup -SID $group1SID
@@ -555,7 +555,7 @@ try {
         }
 
         It "Can Rename-LocalGroup using a valid group sent using pipeline" {
-            $group1SID | Should Not BeNullOrEmpty
+            $group1SID | Should -Not -BeNullOrEmpty
             Get-LocalGroup TestGroupRename1 | Rename-LocalGroup -NewName TestGroupRename1x
             $result = Get-LocalGroup -SID $group1SID
 
@@ -708,7 +708,7 @@ try {
             $initialCount -gt 1 | Should Be true
 
             $removeResult = Remove-LocalGroup TestGroupRemove1 2>&1
-            $removeResult | Should BeNullOrEmpty
+            $removeResult | Should -BeNullOrEmpty
 
             $sb = {
                 Get-LocalGroup -SID $group1SID
@@ -788,7 +788,7 @@ try {
         It "Can Remove-LocalGroup by SID" {
             $sb = {
                 $removeResult = Remove-LocalGroup -SID $group1SID 2>&1
-                $removeResult | Should BeNullOrEmpty
+                $removeResult | Should -BeNullOrEmpty
             }
             VerifyBasicRemoval $sb
         }
@@ -797,7 +797,7 @@ try {
             $sb = {
                 $group = Get-LocalGroup TestGroupRemove1
                 $removeResult = Remove-LocalGroup -InputObject $group 2>&1
-                $removeResult | Should BeNullOrEmpty
+                $removeResult | Should -BeNullOrEmpty
             }
             VerifyBasicRemoval $sb
         }
@@ -805,7 +805,7 @@ try {
         It "Can Remove-LocalGroup using pipeline" {
             $sb = {
                 $removeResult = Get-LocalGroup TestGroupRemove1 | Remove-LocalGroup 2>&1
-                $removeResult | Should BeNullOrEmpty
+                $removeResult | Should -BeNullOrEmpty
             }
             VerifyBasicRemoval $sb
         }
@@ -813,7 +813,7 @@ try {
         It "Can Remove-LocalGroup by array of names" {
             $sb = {
                 $removeResult = Remove-LocalGroup @("TestGroupRemove1","TestGroupRemove2") 2>&1
-                $removeResult | Should BeNullOrEmpty
+                $removeResult | Should -BeNullOrEmpty
             }
             VerifyArrayRemoval $sb
         }
@@ -821,7 +821,7 @@ try {
         It "Can Remove-LocalGroup by array of SIDs" {
             $sb = {
                 $removeResult = Remove-LocalGroup -SID @($group1SID, $group2SID) 2>&1
-                $removeResult | Should BeNullOrEmpty
+                $removeResult | Should -BeNullOrEmpty
             }
             VerifyArrayRemoval $sb
         }
@@ -830,7 +830,7 @@ try {
             $sb = {
                 $groups = Get-LocalGroup -Name @("TestGroupRemove1","TestGroupRemove2")
                 $removeResult = Remove-LocalGroup -InputObject $groups 2>&1
-                $removeResult | Should BeNullOrEmpty
+                $removeResult | Should -BeNullOrEmpty
             }
             VerifyArrayRemoval $sb
         }
@@ -838,7 +838,7 @@ try {
         It "Can Remove-LocalGroup by array using pipeline" {
             $sb = {
                 $removeResult = Get-LocalGroup -Name @("TestGroupRemove1","TestGroupRemove2") | Remove-LocalGroup 2>&1
-                $removeResult | Should BeNullOrEmpty
+                $removeResult | Should -BeNullOrEmpty
             }
             VerifyArrayRemoval $sb
         }
@@ -855,7 +855,7 @@ try {
             $initialCount -gt 1 | Should Be true
 
             $removeResult = Remove-LocalGroup TestGroupRemove1 2>&1
-            $removeResult | Should BeNullOrEmpty
+            $removeResult | Should -BeNullOrEmpty
 
             #clean-up
             Remove-LocalUser TestUserRemove1 | Out-Null

--- a/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalGroup.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalGroup.Tests.ps1
@@ -69,7 +69,7 @@ try {
             $result = New-LocalGroup -Name TestGroupAddRemove
 
             $result.Name | Should -BeExactly 'TestGroupAddRemove'
-            $result.ObjectClass | Should Be Group
+            $result.ObjectClass | Should -BeExactly 'Group'
         }
     }
 
@@ -87,7 +87,7 @@ try {
             $result.Name | Should -BeExactly 'TestGroupAddRemove'
             $result.Description | Should -BeExactly "Test Group New 1 Description"
             $result.SID | Should -Not -BeNullOrEmpty
-            $result.ObjectClass | Should Be Group
+            $result.ObjectClass | Should -BeExactly 'Group'
         }
 
         It "Errors on New-LocalGroup with name collision" {
@@ -245,9 +245,9 @@ try {
         It "Can Get-LocalGroup by specific group name" {
             $result = Get-LocalGroup TestGroupGet1
 
-            $result.Name | Should Be "TestGroupGet1"
-            $result.Description | Should Be "Test Group Get 1 Description"
-            $result.ObjectClass | Should Be "Group"
+            $result.Name | Should -BeExactly "TestGroupGet1"
+            $result.Description | Should -BeExactly "Test Group Get 1 Description"
+            $result.ObjectClass | Should -BeExactly "Group"
         }
     }
 
@@ -278,14 +278,14 @@ try {
             $resultBySID = Get-LocalGroup -SID $result.SID
 
             $resultBySID.SID | Should -Not -BeNullOrEmpty
-            $resultBySID.Name | Should Be TestGroupGet1
+            $resultBySID.Name | Should -BeExactly 'TestGroupGet1'
         }
 
         It "Can Get-LocalGroup of a well-known group by SID string" {
             $sid = New-Object System.Security.Principal.SecurityIdentifier -ArgumentList BG
             $guestGroup = Get-LocalGroup -SID BG
 
-            $guestGroup.SID | Should Be $sid.Value
+            $guestGroup.SID | Should -Be $sid.Value
         }
 
         It "Can Get-LocalGroup by wildcard" {

--- a/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalGroup.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalGroup.Tests.ps1
@@ -27,11 +27,7 @@ function VerifyFailingTest
     $script:ErrorActionPreference = "Stop"
 
     try {
-        & $sb
-        throw "Expected FullyQualifiedErrorId: $expectedFqeid"
-    }
-    catch {
-        $_.FullyQualifiedErrorId | Should Be $expectedFqeid
+        {& $sb} | Should -Throw -ErrorId $expectedFqeid
     }
     finally {
         $script:ErrorActionPreference = $backupEAP
@@ -140,11 +136,8 @@ try {
             $desc = "D"*129
 
             try {
-                $shouldBeNull = New-LocalGroup -Name $name -Description $desc
-                throw "An error was expected"
-            }
-            catch {
-                $_.FullyQualifiedErrorId | Should Be "ParameterArgumentValidationError,Microsoft.PowerShell.Commands.NewLocalGroupCommand"
+                {$shouldBeNull = New-LocalGroup -Name $name -Description $desc} |
+                    Should -Throw -ErrorId "ParameterArgumentValidationError,Microsoft.PowerShell.Commands.NewLocalGroupCommand"
             }
             finally {
                 #clean up erroneous creation

--- a/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalGroupMember.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalGroupMember.Tests.ps1
@@ -169,32 +169,32 @@ try {
             Add-LocalGroupMember TestGroup1 -Member @("TestUser1", "TestUser2")
             $result = Get-LocalGroupMember TestGroup1
 
-            $result[0].Name -match ($OptDomainPrefix + "TestUser1") | Should Be $true
-            $result[1].Name -match ($OptDomainPrefix + "TestUser2") | Should Be $true
+            $result[0].Name | Should -Match ($OptDomainPrefix + "TestUser1")
+            $result[1].Name | Should -Match ($OptDomainPrefix + "TestUser2")
         }
 
         It "Can add array of user SIDs to group" {
             Add-LocalGroupMember TestGroup1 -Member @($user1sid, $user2sid)
             $result = Get-LocalGroupMember TestGroup1
 
-            $result[0].Name -match ($OptDomainPrefix + "TestUser1") | Should Be $true
-            $result[1].Name -match ($OptDomainPrefix + "TestUser2") | Should Be $true
+            $result[0].Name | Should -Match ($OptDomainPrefix + "TestUser1")
+            $result[1].Name | Should -Match ($OptDomainPrefix + "TestUser2")
         }
 
         It "Can add array of users names or SIDs to group" {
             Add-LocalGroupMember TestGroup1 -Member @($user1sid, "TestUser2")
             $result = Get-LocalGroupMember TestGroup1
 
-            $result[0].Name -match ($OptDomainPrefix + "TestUser1") | Should Be $true
-            $result[1].Name -match ($OptDomainPrefix + "TestUser2") | Should Be $true
+            $result[0].Name | Should -Match ($OptDomainPrefix + "TestUser1")
+            $result[1].Name | Should -Match ($OptDomainPrefix + "TestUser2")
         }
 
         It "Can add array of user names using pipeline" {
             @("TestUser1", "TestUser2") | Add-LocalGroupMember TestGroup1
             $result = Get-LocalGroupMember TestGroup1
 
-            $result[0].Name -match ($OptDomainPrefix + "TestUser1") | Should Be $true
-            $result[1].Name -match ($OptDomainPrefix + "TestUser2") | Should Be $true
+            $result[0].Name | Should -Match ($OptDomainPrefix + "TestUser1")
+            $result[1].Name | Should -Match ($OptDomainPrefix + "TestUser2")
         }
 
         It "Can add array of existent and nonexistent users names to group" {
@@ -204,7 +204,7 @@ try {
             VerifyFailingTest $sb "PrincipalNotFound,Microsoft.PowerShell.Commands.AddLocalGroupMemberCommand"
 
             $result = Get-LocalGroupMember TestGroup1
-            $result.Name -match ($OptDomainPrefix + "TestUser1") | Should Be $true
+            $result.Name | Should -Match ($OptDomainPrefix + "TestUser1")
             $result.Name -match ($OptDomainPrefix + "TestUser2") | Should Be $false
         }
 
@@ -241,7 +241,7 @@ try {
             VerifyFailingTest $sb "PrincipalNotFound,Microsoft.PowerShell.Commands.AddLocalGroupMemberCommand"
 
             $result = Get-LocalGroupMember TestGroup1
-            $result.Name -match ($OptDomainPrefix + "TestUser1") | Should Be $true
+            $result.Name | Should -Match ($OptDomainPrefix + "TestUser1")
         }
     }
 
@@ -385,8 +385,8 @@ try {
         It "Can get group members by wildcard" {
             $result = Get-LocalGroupMember TestGroupGet1 -Member TestUserGet*
             $result.Count -eq 2 | Should Be $true
-            $result[0].Name -match ($OptDomainPrefix+"TestUserGet1") | Should Be $true
-            $result[1].Name -match ($OptDomainPrefix + "TestUserGet2") | Should Be $true
+            $result[0].Name | Should -Match ($OptDomainPrefix+"TestUserGet1")
+            $result[1].Name | Should -Match ($OptDomainPrefix + "TestUserGet2")
         }
 
         It "Errors on group name being nonexistent" {
@@ -590,7 +590,7 @@ try {
             VerifyFailingTest $sb "PrincipalNotFound,Microsoft.PowerShell.Commands.RemoveLocalGroupMemberCommand"
 
             $result = Get-LocalGroupMember TestGroupRemove1 2>&1
-            $result.Name -match ($OptDomainPrefix + "TestUserRemove2") | Should Be $true
+            $result.Name | Should -Match ($OptDomainPrefix + "TestUserRemove2")
         }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalGroupMember.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalGroupMember.Tests.ps1
@@ -165,32 +165,32 @@ try {
             Add-LocalGroupMember TestGroup1 -Member @("TestUser1", "TestUser2")
             $result = Get-LocalGroupMember TestGroup1
 
-            $result[0].Name | Should -Match ($OptDomainPrefix + "TestUser1")
-            $result[1].Name | Should -Match ($OptDomainPrefix + "TestUser2")
+            $result[0].Name | Should -MatchExactly ($OptDomainPrefix + "TestUser1")
+            $result[1].Name | Should -MatchExactly ($OptDomainPrefix + "TestUser2")
         }
 
         It "Can add array of user SIDs to group" {
             Add-LocalGroupMember TestGroup1 -Member @($user1sid, $user2sid)
             $result = Get-LocalGroupMember TestGroup1
 
-            $result[0].Name | Should -Match ($OptDomainPrefix + "TestUser1")
-            $result[1].Name | Should -Match ($OptDomainPrefix + "TestUser2")
+            $result[0].Name | Should -MatchExactly ($OptDomainPrefix + "TestUser1")
+            $result[1].Name | Should -MatchExactly ($OptDomainPrefix + "TestUser2")
         }
 
         It "Can add array of users names or SIDs to group" {
             Add-LocalGroupMember TestGroup1 -Member @($user1sid, "TestUser2")
             $result = Get-LocalGroupMember TestGroup1
 
-            $result[0].Name | Should -Match ($OptDomainPrefix + "TestUser1")
-            $result[1].Name | Should -Match ($OptDomainPrefix + "TestUser2")
+            $result[0].Name | Should -MatchExactly ($OptDomainPrefix + "TestUser1")
+            $result[1].Name | Should -MatchExactly ($OptDomainPrefix + "TestUser2")
         }
 
         It "Can add array of user names using pipeline" {
             @("TestUser1", "TestUser2") | Add-LocalGroupMember TestGroup1
             $result = Get-LocalGroupMember TestGroup1
 
-            $result[0].Name | Should -Match ($OptDomainPrefix + "TestUser1")
-            $result[1].Name | Should -Match ($OptDomainPrefix + "TestUser2")
+            $result[0].Name | Should -MatchExactly ($OptDomainPrefix + "TestUser1")
+            $result[1].Name | Should -MatchExactly ($OptDomainPrefix + "TestUser2")
         }
 
         It "Can add array of existent and nonexistent users names to group" {
@@ -200,7 +200,7 @@ try {
             VerifyFailingTest $sb "PrincipalNotFound,Microsoft.PowerShell.Commands.AddLocalGroupMemberCommand"
 
             $result = Get-LocalGroupMember TestGroup1
-            $result.Name | Should -Match ($OptDomainPrefix + "TestUser1")
+            $result.Name | Should -MatchExactly ($OptDomainPrefix + "TestUser1")
             $result.Name -match ($OptDomainPrefix + "TestUser2") | Should -BeFalse
         }
 
@@ -237,7 +237,7 @@ try {
             VerifyFailingTest $sb "PrincipalNotFound,Microsoft.PowerShell.Commands.AddLocalGroupMemberCommand"
 
             $result = Get-LocalGroupMember TestGroup1
-            $result.Name | Should -Match ($OptDomainPrefix + "TestUser1")
+            $result.Name | Should -MatchExactly ($OptDomainPrefix + "TestUser1")
         }
     }
 
@@ -381,8 +381,8 @@ try {
         It "Can get group members by wildcard" {
             $result = Get-LocalGroupMember TestGroupGet1 -Member TestUserGet*
             $result | Should -HaveCount 2
-            $result[0].Name | Should -Match ($OptDomainPrefix+"TestUserGet1")
-            $result[1].Name | Should -Match ($OptDomainPrefix + "TestUserGet2")
+            $result[0].Name | Should -MatchExactly ($OptDomainPrefix+"TestUserGet1")
+            $result[1].Name | Should -MatchExactly ($OptDomainPrefix + "TestUserGet2")
         }
 
         It "Errors on group name being nonexistent" {
@@ -586,7 +586,7 @@ try {
             VerifyFailingTest $sb "PrincipalNotFound,Microsoft.PowerShell.Commands.RemoveLocalGroupMemberCommand"
 
             $result = Get-LocalGroupMember TestGroupRemove1 2>&1
-            $result.Name | Should -Match ($OptDomainPrefix + "TestUserRemove2")
+            $result.Name | Should -MatchExactly ($OptDomainPrefix + "TestUserRemove2")
         }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalGroupMember.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalGroupMember.Tests.ps1
@@ -273,7 +273,7 @@ try {
             {
                 $result.PrincipalSource | Should Be Local
             }
-            $result.ObjectClass | Should Be User
+            $result.ObjectClass | Should -BeExactly 'User'
         }
     }
 
@@ -314,14 +314,14 @@ try {
             {
                 $result[0].PrincipalSource | Should Be Local
             }
-            $result[0].ObjectClass | Should Be User
+            $result[0].ObjectClass | Should -BeExactly 'User'
             $result[1].Name.EndsWith("TestUserGet2") | Should Be $true
             $result[1].SID | Should Be $user2sid
             if (IsWin10OrHigher)
             {
                 $result[1].PrincipalSource | Should Be Local
             }
-            $result[1].ObjectClass | Should Be User
+            $result[1].ObjectClass | Should -BeExactly 'User'
         }
 
         It "Can get all group members by SID" {
@@ -333,14 +333,14 @@ try {
             {
                 $result[0].PrincipalSource | Should Be Local
             }
-            $result[0].ObjectClass | Should Be User
+            $result[0].ObjectClass | Should -BeExactly 'User'
             $result[1].Name.EndsWith("TestUserGet2") | Should Be $true
             $result[1].SID | Should Be $user2sid
             if (IsWin10OrHigher)
             {
                 $result[1].PrincipalSource | Should Be Local
             }
-            $result[1].ObjectClass | Should Be User
+            $result[1].ObjectClass | Should -BeExactly 'User'
         }
 
         It "Can get all group members by Group object" {
@@ -353,14 +353,14 @@ try {
             {
                 $result[0].PrincipalSource | Should Be Local
             }
-            $result[0].ObjectClass | Should Be User
+            $result[0].ObjectClass | Should -BeExactly 'User'
             $result[1].Name.EndsWith("TestUserGet2") | Should Be $true
             $result[1].SID | Should Be $user2sid
             if (IsWin10OrHigher)
             {
                 $result[1].PrincipalSource | Should Be Local
             }
-            $result[1].ObjectClass | Should Be User
+            $result[1].ObjectClass | Should -BeExactly 'User'
         }
 
         It "Can get all group members by pipeline" {
@@ -372,14 +372,14 @@ try {
             {
                 $result[0].PrincipalSource | Should Be Local
             }
-            $result[0].ObjectClass | Should Be User
+            $result[0].ObjectClass | Should -BeExactly 'User'
             $result[1].Name.EndsWith("TestUserGet2") | Should Be $true
             $result[1].SID | Should Be $user2sid
             if (IsWin10OrHigher)
             {
                 $result[1].PrincipalSource | Should Be Local
             }
-            $result[1].ObjectClass | Should Be User
+            $result[1].ObjectClass | Should -BeExactly 'User'
         }
 
         It "Can get group members by wildcard" {
@@ -405,7 +405,7 @@ try {
             {
                 $result.PrincipalSource | Should Be Local
             }
-            $result.ObjectClass | Should Be User
+            $result.ObjectClass | Should -BeExactly 'User'
         }
 
         #TODO: 10.A valid user attempts to get membership from a group to which they don't have access

--- a/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalGroupMember.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalGroupMember.Tests.ps1
@@ -93,7 +93,7 @@ try {
             $result = Get-LocalGroupMember TestGroup1
 
             $result.Name.EndsWith("TestUser1") | Should -BeTrue
-            $result.SID | Should Be $user1sid
+            $result.SID | Should -Be $user1sid
         }
     }
 
@@ -124,7 +124,7 @@ try {
             $result = Get-LocalGroupMember TestGroup1
 
             $result.Name.EndsWith("TestUser1") | Should -BeTrue
-            $result.SID | Should Be $user1sid
+            $result.SID | Should -Be $user1sid
         }
 
         It "Can add user to group using group object" {
@@ -133,7 +133,7 @@ try {
             $result = Get-LocalGroupMember TestGroup1
 
             $result.Name.EndsWith("TestUser1") | Should -BeTrue
-            $result.SID | Should Be $user1sid
+            $result.SID | Should -Be $user1sid
         }
 
         It "Can add user to group using pipeline" {
@@ -141,7 +141,7 @@ try {
             $result = Get-LocalGroupMember TestGroup1
 
             $result.Name.EndsWith("TestUser1") | Should -BeTrue
-            $result.SID | Should Be $user1sid
+            $result.SID | Should -Be $user1sid
         }
 
         It "Errors on missing group parameter value missing" {
@@ -217,7 +217,7 @@ try {
 
             $result = Get-LocalGroupMember TestGroup1
             $result.Name.EndsWith("TestUser1") | Should -BeTrue
-            $result.SID | Should Be $user1sid
+            $result.SID | Should -Be $user1sid
         }
 
         It "Errors on adding nonexistent user to group" {
@@ -268,7 +268,7 @@ try {
             $result = Get-LocalGroupMember TestGroupGet1
 
             $result.Name.EndsWith("TestUserGet1") | Should -BeTrue
-            $result.SID | Should Be $user1sid
+            $result.SID | Should -Be $user1sid
             if (IsWin10OrHigher)
             {
                 $result.PrincipalSource | Should -BeExactly 'Local'
@@ -309,14 +309,14 @@ try {
             $result = Get-LocalGroupMember TestGroupGet1
 
             $result[0].Name.EndsWith("TestUserGet1") | Should -BeTrue
-            $result[0].SID | Should Be $user1sid
+            $result[0].SID | Should -Be $user1sid
             if (IsWin10OrHigher)
             {
                 $result[0].PrincipalSource | Should -BeExactly 'Local'
             }
             $result[0].ObjectClass | Should -BeExactly 'User'
             $result[1].Name.EndsWith("TestUserGet2") | Should -BeTrue
-            $result[1].SID | Should Be $user2sid
+            $result[1].SID | Should -Be $user2sid
             if (IsWin10OrHigher)
             {
                 $result[1].PrincipalSource | Should -BeExactly 'Local'
@@ -328,14 +328,14 @@ try {
             $result = Get-LocalGroupMember -SID $group1sid
 
             $result[0].Name.EndsWith("TestUserGet1") | Should -BeTrue
-            $result[0].SID | Should Be $user1sid
+            $result[0].SID | Should -Be $user1sid
             if (IsWin10OrHigher)
             {
                 $result[0].PrincipalSource | Should -BeExactly 'Local'
             }
             $result[0].ObjectClass | Should -BeExactly 'User'
             $result[1].Name.EndsWith("TestUserGet2") | Should -BeTrue
-            $result[1].SID | Should Be $user2sid
+            $result[1].SID | Should -Be $user2sid
             if (IsWin10OrHigher)
             {
                 $result[1].PrincipalSource | Should -BeExactly 'Local'
@@ -348,14 +348,14 @@ try {
             $result = Get-LocalGroupMember -Group $group
 
             $result[0].Name.EndsWith("TestUserGet1") | Should -BeTrue
-            $result[0].SID | Should Be $user1sid
+            $result[0].SID | Should -Be $user1sid
             if (IsWin10OrHigher)
             {
                 $result[0].PrincipalSource | Should -BeExactly 'Local'
             }
             $result[0].ObjectClass | Should -BeExactly 'User'
             $result[1].Name.EndsWith("TestUserGet2") | Should -BeTrue
-            $result[1].SID | Should Be $user2sid
+            $result[1].SID | Should -Be $user2sid
             if (IsWin10OrHigher)
             {
                 $result[1].PrincipalSource | Should -BeExactly 'Local'
@@ -367,14 +367,14 @@ try {
             $result = Get-LocalGroup TestGroupGet1 | Get-LocalGroupMember
 
             $result[0].Name.EndsWith("TestUserGet1") | Should -BeTrue
-            $result[0].SID | Should Be $user1sid
+            $result[0].SID | Should -Be $user1sid
             if (IsWin10OrHigher)
             {
                 $result[0].PrincipalSource | Should -BeExactly 'Local'
             }
             $result[0].ObjectClass | Should -BeExactly 'User'
             $result[1].Name.EndsWith("TestUserGet2") | Should -BeTrue
-            $result[1].SID | Should Be $user2sid
+            $result[1].SID | Should -Be $user2sid
             if (IsWin10OrHigher)
             {
                 $result[1].PrincipalSource | Should -BeExactly 'Local'
@@ -400,7 +400,7 @@ try {
             $result = Get-LocalGroupMember TestGroupGet1 -Member TestUserGet1
 
             $result.Name.EndsWith("TestUserGet1") | Should -BeTrue
-            $result.SID | Should Be $user1sid
+            $result.SID | Should -Be $user1sid
             if (IsWin10OrHigher)
             {
                 $result.PrincipalSource | Should -BeExactly 'Local'

--- a/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalGroupMember.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalGroupMember.Tests.ps1
@@ -44,11 +44,7 @@ function VerifyFailingTest
     $script:ErrorActionPreference = "Stop"
 
     try {
-        & $sb
-        throw "Expected error: $expectedFqeid"
-    }
-    catch {
-        $_.FullyQualifiedErrorId | Should Be $expectedFqeid
+        {& $sb} | Should -Throw -ErrorId $expectedFqeid
     }
     finally {
         $script:ErrorActionPreference = $backupEAP

--- a/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalGroupMember.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalGroupMember.Tests.ps1
@@ -384,7 +384,7 @@ try {
 
         It "Can get group members by wildcard" {
             $result = Get-LocalGroupMember TestGroupGet1 -Member TestUserGet*
-            $result.Count -eq 2 | Should Be $true
+            $result | Should -HaveCount 2
             $result[0].Name | Should -Match ($OptDomainPrefix+"TestUserGet1")
             $result[1].Name | Should -Match ($OptDomainPrefix + "TestUserGet2")
         }

--- a/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalGroupMember.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalGroupMember.Tests.ps1
@@ -66,9 +66,9 @@ try {
         It "Test command presence" {
             $result = Get-Command -Module Microsoft.PowerShell.LocalAccounts | ForEach-Object Name
 
-            $result -contains "Add-LocalGroupMember" | Should Be $true
-            $result -contains "Get-LocalGroupMember" | Should Be $true
-            $result -contains "Remove-LocalGroupMember" | Should Be $true
+            $result | Should -Contain 'Add-LocalGroupMember'
+            $result | Should -Contain 'Get-LocalGroupMember'
+            $result | Should -Contain 'Remove-LocalGroupMember'
         }
     }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalGroupMember.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalGroupMember.Tests.ps1
@@ -434,7 +434,7 @@ try {
             Remove-LocalGroupMember TestGroupRemove1 -Member TestUserRemove1
             $result = Get-LocalGroupMember TestGroupRemove1
 
-            $result | Should Be $null
+            $result | Should -BeNullOrEmpty
         }
     }
 
@@ -524,21 +524,21 @@ try {
             Remove-LocalGroupMember TestGroupRemove1 -Member @("TestUserRemove1", "TestUserRemove2")
             $result = Get-LocalGroupMember TestGroupRemove1
 
-            $result | Should Be $null
+            $result | Should -BeNullOrEmpty
         }
 
         It "Can remove array of user SIDs from group" {
             Remove-LocalGroupMember TestGroupRemove1 -Member @($user1sid, $user2sid)
             $result = Get-LocalGroupMember TestGroupRemove1
 
-            $result | Should Be $null
+            $result | Should -BeNullOrEmpty
         }
 
         It "Can remove array of users names or SIDs from group" {
             Remove-LocalGroupMember TestGroupRemove1 -Member @($user1sid, "TestUserRemove2")
             $result = Get-LocalGroupMember TestGroupRemove1
 
-            $result | Should Be $null
+            $result | Should -BeNullOrEmpty
         }
 
         It "Can remove array of user names using pipeline" {
@@ -547,7 +547,7 @@ try {
             @($name1, $name2) | Remove-LocalGroupMember TestGroupRemove1
             $result = Get-LocalGroupMember TestGroupRemove1
 
-            $result | Should Be $null
+            $result | Should -BeNullOrEmpty
         }
 
         It "Errors on remove nonexistent user from group" {
@@ -573,7 +573,7 @@ try {
             VerifyFailingTest $sb "PrincipalNotFound,Microsoft.PowerShell.Commands.RemoveLocalGroupMemberCommand"
 
             $result = Get-LocalGroupMember TestGroupRemove2
-            $result | Should Be $null
+            $result | Should -BeNullOrEmpty
         }
 
         It "Errors on remove user from nonexistent group" {

--- a/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalGroupMember.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalGroupMember.Tests.ps1
@@ -271,7 +271,7 @@ try {
             $result.SID | Should Be $user1sid
             if (IsWin10OrHigher)
             {
-                $result.PrincipalSource | Should Be Local
+                $result.PrincipalSource | Should -BeExactly 'Local'
             }
             $result.ObjectClass | Should -BeExactly 'User'
         }
@@ -312,14 +312,14 @@ try {
             $result[0].SID | Should Be $user1sid
             if (IsWin10OrHigher)
             {
-                $result[0].PrincipalSource | Should Be Local
+                $result[0].PrincipalSource | Should -BeExactly 'Local'
             }
             $result[0].ObjectClass | Should -BeExactly 'User'
             $result[1].Name.EndsWith("TestUserGet2") | Should Be $true
             $result[1].SID | Should Be $user2sid
             if (IsWin10OrHigher)
             {
-                $result[1].PrincipalSource | Should Be Local
+                $result[1].PrincipalSource | Should -BeExactly 'Local'
             }
             $result[1].ObjectClass | Should -BeExactly 'User'
         }
@@ -331,14 +331,14 @@ try {
             $result[0].SID | Should Be $user1sid
             if (IsWin10OrHigher)
             {
-                $result[0].PrincipalSource | Should Be Local
+                $result[0].PrincipalSource | Should -BeExactly 'Local'
             }
             $result[0].ObjectClass | Should -BeExactly 'User'
             $result[1].Name.EndsWith("TestUserGet2") | Should Be $true
             $result[1].SID | Should Be $user2sid
             if (IsWin10OrHigher)
             {
-                $result[1].PrincipalSource | Should Be Local
+                $result[1].PrincipalSource | Should -BeExactly 'Local'
             }
             $result[1].ObjectClass | Should -BeExactly 'User'
         }
@@ -351,14 +351,14 @@ try {
             $result[0].SID | Should Be $user1sid
             if (IsWin10OrHigher)
             {
-                $result[0].PrincipalSource | Should Be Local
+                $result[0].PrincipalSource | Should -BeExactly 'Local'
             }
             $result[0].ObjectClass | Should -BeExactly 'User'
             $result[1].Name.EndsWith("TestUserGet2") | Should Be $true
             $result[1].SID | Should Be $user2sid
             if (IsWin10OrHigher)
             {
-                $result[1].PrincipalSource | Should Be Local
+                $result[1].PrincipalSource | Should -BeExactly 'Local'
             }
             $result[1].ObjectClass | Should -BeExactly 'User'
         }
@@ -370,14 +370,14 @@ try {
             $result[0].SID | Should Be $user1sid
             if (IsWin10OrHigher)
             {
-                $result[0].PrincipalSource | Should Be Local
+                $result[0].PrincipalSource | Should -BeExactly 'Local'
             }
             $result[0].ObjectClass | Should -BeExactly 'User'
             $result[1].Name.EndsWith("TestUserGet2") | Should Be $true
             $result[1].SID | Should Be $user2sid
             if (IsWin10OrHigher)
             {
-                $result[1].PrincipalSource | Should Be Local
+                $result[1].PrincipalSource | Should -BeExactly 'Local'
             }
             $result[1].ObjectClass | Should -BeExactly 'User'
         }
@@ -403,7 +403,7 @@ try {
             $result.SID | Should Be $user1sid
             if (IsWin10OrHigher)
             {
-                $result.PrincipalSource | Should Be Local
+                $result.PrincipalSource | Should -BeExactly 'Local'
             }
             $result.ObjectClass | Should -BeExactly 'User'
         }

--- a/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalGroupMember.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalGroupMember.Tests.ps1
@@ -41,14 +41,14 @@ function VerifyFailingTest
     )
 
     $backupEAP = $script:ErrorActionPreference
-    $script:ErrorActionPreference = "Stop"
-
-    try {
-        {& $sb} | Should -Throw -ErrorId $expectedFqeid
-    }
-    finally {
-        $script:ErrorActionPreference = $backupEAP
-    }
+    {
+        $script:ErrorActionPreference = "Stop"
+        try {
+            & $sb
+        } finally {
+             $script:ErrorActionPreference = $backupEAP
+        }
+    } | Should -Throw -ErrorId $expectedFqeid
 }
 
 try {

--- a/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalGroupMember.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalGroupMember.Tests.ps1
@@ -92,7 +92,7 @@ try {
             Add-LocalGroupMember TestGroup1 -Member TestUser1
             $result = Get-LocalGroupMember TestGroup1
 
-            $result.Name.EndsWith("TestUser1") | Should Be $true
+            $result.Name.EndsWith("TestUser1") | Should -BeTrue
             $result.SID | Should Be $user1sid
         }
     }
@@ -123,7 +123,7 @@ try {
             Add-LocalGroupMember -SID $group1sid -Member TestUser1
             $result = Get-LocalGroupMember TestGroup1
 
-            $result.Name.EndsWith("TestUser1") | Should Be $true
+            $result.Name.EndsWith("TestUser1") | Should -BeTrue
             $result.SID | Should Be $user1sid
         }
 
@@ -132,7 +132,7 @@ try {
             Add-LocalGroupMember -Group $groupObject -Member TestUser1
             $result = Get-LocalGroupMember TestGroup1
 
-            $result.Name.EndsWith("TestUser1") | Should Be $true
+            $result.Name.EndsWith("TestUser1") | Should -BeTrue
             $result.SID | Should Be $user1sid
         }
 
@@ -140,7 +140,7 @@ try {
             Get-LocalUser TestUser1 | Add-LocalGroupMember -Name TestGroup1
             $result = Get-LocalGroupMember TestGroup1
 
-            $result.Name.EndsWith("TestUser1") | Should Be $true
+            $result.Name.EndsWith("TestUser1") | Should -BeTrue
             $result.SID | Should Be $user1sid
         }
 
@@ -205,7 +205,7 @@ try {
 
             $result = Get-LocalGroupMember TestGroup1
             $result.Name | Should -Match ($OptDomainPrefix + "TestUser1")
-            $result.Name -match ($OptDomainPrefix + "TestUser2") | Should Be $false
+            $result.Name -match ($OptDomainPrefix + "TestUser2") | Should -BeFalse
         }
 
         It "Errors on adding user to group by name twice" {
@@ -216,7 +216,7 @@ try {
             VerifyFailingTest $sb "MemberExists,Microsoft.PowerShell.Commands.AddLocalGroupMemberCommand"
 
             $result = Get-LocalGroupMember TestGroup1
-            $result.Name.EndsWith("TestUser1") | Should Be $true
+            $result.Name.EndsWith("TestUser1") | Should -BeTrue
             $result.SID | Should Be $user1sid
         }
 
@@ -267,7 +267,7 @@ try {
         It "Can get a local group member by name" {
             $result = Get-LocalGroupMember TestGroupGet1
 
-            $result.Name.EndsWith("TestUserGet1") | Should Be $true
+            $result.Name.EndsWith("TestUserGet1") | Should -BeTrue
             $result.SID | Should Be $user1sid
             if (IsWin10OrHigher)
             {
@@ -308,14 +308,14 @@ try {
         It "Can get all group members by name" {
             $result = Get-LocalGroupMember TestGroupGet1
 
-            $result[0].Name.EndsWith("TestUserGet1") | Should Be $true
+            $result[0].Name.EndsWith("TestUserGet1") | Should -BeTrue
             $result[0].SID | Should Be $user1sid
             if (IsWin10OrHigher)
             {
                 $result[0].PrincipalSource | Should -BeExactly 'Local'
             }
             $result[0].ObjectClass | Should -BeExactly 'User'
-            $result[1].Name.EndsWith("TestUserGet2") | Should Be $true
+            $result[1].Name.EndsWith("TestUserGet2") | Should -BeTrue
             $result[1].SID | Should Be $user2sid
             if (IsWin10OrHigher)
             {
@@ -327,14 +327,14 @@ try {
         It "Can get all group members by SID" {
             $result = Get-LocalGroupMember -SID $group1sid
 
-            $result[0].Name.EndsWith("TestUserGet1") | Should Be $true
+            $result[0].Name.EndsWith("TestUserGet1") | Should -BeTrue
             $result[0].SID | Should Be $user1sid
             if (IsWin10OrHigher)
             {
                 $result[0].PrincipalSource | Should -BeExactly 'Local'
             }
             $result[0].ObjectClass | Should -BeExactly 'User'
-            $result[1].Name.EndsWith("TestUserGet2") | Should Be $true
+            $result[1].Name.EndsWith("TestUserGet2") | Should -BeTrue
             $result[1].SID | Should Be $user2sid
             if (IsWin10OrHigher)
             {
@@ -347,14 +347,14 @@ try {
             $group = Get-LocalGroup TestGroupGet1
             $result = Get-LocalGroupMember -Group $group
 
-            $result[0].Name.EndsWith("TestUserGet1") | Should Be $true
+            $result[0].Name.EndsWith("TestUserGet1") | Should -BeTrue
             $result[0].SID | Should Be $user1sid
             if (IsWin10OrHigher)
             {
                 $result[0].PrincipalSource | Should -BeExactly 'Local'
             }
             $result[0].ObjectClass | Should -BeExactly 'User'
-            $result[1].Name.EndsWith("TestUserGet2") | Should Be $true
+            $result[1].Name.EndsWith("TestUserGet2") | Should -BeTrue
             $result[1].SID | Should Be $user2sid
             if (IsWin10OrHigher)
             {
@@ -366,14 +366,14 @@ try {
         It "Can get all group members by pipeline" {
             $result = Get-LocalGroup TestGroupGet1 | Get-LocalGroupMember
 
-            $result[0].Name.EndsWith("TestUserGet1") | Should Be $true
+            $result[0].Name.EndsWith("TestUserGet1") | Should -BeTrue
             $result[0].SID | Should Be $user1sid
             if (IsWin10OrHigher)
             {
                 $result[0].PrincipalSource | Should -BeExactly 'Local'
             }
             $result[0].ObjectClass | Should -BeExactly 'User'
-            $result[1].Name.EndsWith("TestUserGet2") | Should Be $true
+            $result[1].Name.EndsWith("TestUserGet2") | Should -BeTrue
             $result[1].SID | Should Be $user2sid
             if (IsWin10OrHigher)
             {
@@ -399,7 +399,7 @@ try {
         It "Can get specific group member by name" {
             $result = Get-LocalGroupMember TestGroupGet1 -Member TestUserGet1
 
-            $result.Name.EndsWith("TestUserGet1") | Should Be $true
+            $result.Name.EndsWith("TestUserGet1") | Should -BeTrue
             $result.SID | Should Be $user1sid
             if (IsWin10OrHigher)
             {
@@ -466,14 +466,14 @@ try {
             Remove-LocalGroupMember TestGroupRemove1 -Member TestUserRemove2
             $result = Get-LocalGroupMember TestGroupRemove1
 
-            $result.Name.EndsWith("TestUserRemove1") | Should Be $true
+            $result.Name.EndsWith("TestUserRemove1") | Should -BeTrue
         }
 
         It "Can remove a group member by SID" {
             Remove-LocalGroupMember -SID $group1sid -Member TestUserRemove2
             $result = Get-LocalGroupMember TestGroupRemove1
 
-            $result.Name.EndsWith("TestUserRemove1") | Should Be $true
+            $result.Name.EndsWith("TestUserRemove1") | Should -BeTrue
         }
 
         It "Can remove a group member by Group object" {
@@ -481,14 +481,14 @@ try {
             Remove-LocalGroupMember -Group $group -Member TestUserRemove2
             $result = Get-LocalGroupMember TestGroupRemove1
 
-            $result.Name.EndsWith("TestUserRemove1") | Should Be $true
+            $result.Name.EndsWith("TestUserRemove1") | Should -BeTrue
         }
 
         It "Can remove a group member by pipeline" {
             Get-LocalUser TestUserRemove2 | Remove-LocalGroupMember -Name TestGroupRemove1
             $result = Get-LocalGroupMember TestGroupRemove1
 
-            $result.Name.EndsWith("TestUserRemove1") | Should Be $true
+            $result.Name.EndsWith("TestUserRemove1") | Should -BeTrue
         }
 
         It "Errors on group argument missing" {

--- a/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalUser.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalUser.Tests.ps1
@@ -28,14 +28,14 @@ function VerifyFailingTest
     )
 
     $backupEAP = $script:ErrorActionPreference
-    $script:ErrorActionPreference = "Stop"
-
-    try {
-        {& $sb} | Should -Throw -ErrorId $expectedFqeid
-    }
-    finally {
-        $script:ErrorActionPreference = $backupEAP
-    }
+    {
+        $script:ErrorActionPreference = "Stop"
+        try {
+            & $sb
+        } finally {
+             $script:ErrorActionPreference = $backupEAP
+        }
+    } | Should -Throw -ErrorId $expectedFqeid
 }
 
 try {

--- a/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalUser.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalUser.Tests.ps1
@@ -161,7 +161,7 @@ try {
 
             #Assert
             if ($failedCharacters.Count -gt 0) { Write-Host "characters causing test fail: $failedCharacters" }
-            $failedCharacters.Count -eq 0 | Should Be $true
+            $failedCharacters | Should -HaveCount 0
         }
 
         It "Errors on names containing only spaces or periods" {
@@ -462,7 +462,7 @@ try {
         It "Can get users by wildcard" {
             $result = Get-LocalUser TestUserGet*
 
-            $result.Count -eq 2 | Should Be $true
+            $result | Should -HaveCount 2
             $result.Name | Should -Contain 'TestUserGet1'
             $result.Name | Should -Contain 'TestUserGet2'
         }
@@ -470,7 +470,7 @@ try {
         It "Can get a user by array of names" {
             $result = Get-LocalUser @("TestUserGet1", "TestUserGet2")
 
-            $result.Count -eq 2 | Should Be $true
+            $result | Should -HaveCount 2
             $result.Name | Should -Contain 'TestUserGet1'
             $result.Name | Should -Contain 'TestUserGet2'
         }
@@ -480,7 +480,7 @@ try {
             $sid2 = (Get-LocalUser TestUserGet2).SID
             $result = Get-LocalUser -SID @($sid1, $sid2)
 
-            $result.Count -eq 2 | Should Be $true
+            $result | Should -HaveCount 2
             $result.Name | Should -Contain 'TestUserGet1'
             $result.Name | Should -Contain 'TestUserGet2'
         }
@@ -492,7 +492,7 @@ try {
             Catch {
                 # Ignore the execption
             }
-            $outErr.Count -eq 1 | Should Be $true
+            $outErr | Should -HaveCount 1
             $outErr[0].ErrorRecord.CategoryInfo.Reason | Should -Match "UserNotFound"
             $outOut.Name | Should -Match "TestUserGet1"
         }
@@ -958,7 +958,7 @@ try {
 
             #Assert
             if ($failedCharacters.Count -gt 0) { Write-Host "characters causing test fail: $failedCharacters" }
-            $failedCharacters.Count -eq 0 | Should Be $true
+            $failedCharacters | Should -HaveCount 0
         }
 
         It "Errors on names containing only spaces or periods" {

--- a/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalUser.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalUser.Tests.ps1
@@ -97,7 +97,7 @@ try {
         It "Can create New-LocalUser with only name" {
             $result = New-LocalUser TestUserNew1 -NoPassword
 
-            $result.Name | Should BeExactly TestUserNew1
+            $result.Name | Should -BeExactly 'TestUserNew1'
             $result.Description | Should BeNullOrEmpty
             $result.Enabled | Should Be $true
             $result.SID | Should Not BeNullOrEmpty
@@ -118,7 +118,7 @@ try {
             $userName = "S-1-5-32-545"
             $result = New-LocalUser $userName -NoPassword
 
-            $result.Name | Should BeExactly $userName
+            $result.Name | Should -BeExactly $userName
             $result.Description | Should BeNullOrEmpty
             $result.Enabled | Should Be $true
             $result.SID | Should Not BeNullOrEmpty
@@ -212,7 +212,7 @@ try {
             $expiration = $dateInFuture
             $result = New-LocalUser TestUserNew1 -NoPassword -AccountExpires $expiration
 
-            $result.Name | Should BeExactly TestUserNew1
+            $result.Name | Should -BeExactly 'TestUserNew1'
             $result.Description | Should BeNullOrEmpty
             $result.Enabled | Should Be $true
             $result.SID | Should Not BeNullOrEmpty
@@ -224,7 +224,7 @@ try {
             $expiration = $dateInPast
             $result = New-LocalUser TestUserNew1 -NoPassword -AccountExpires $expiration
 
-            $result.Name | Should BeExactly TestUserNew1
+            $result.Name | Should -BeExactly 'TestUserNew1'
             $result.Description | Should BeNullOrEmpty
             $result.Enabled | Should Be $true
             $result.SID | Should Not BeNullOrEmpty
@@ -243,7 +243,7 @@ try {
         It "Can set AccountNeverExpires to create a user with null for AccountExpires date" {
             $result = New-LocalUser TestUserNew1 -NoPassword -AccountNeverExpires
 
-            $result.Name | Should BeExactly TestUserNew1
+            $result.Name | Should -BeExactly 'TestUserNew1'
             $result.Description | Should BeNullOrEmpty
             $result.Enabled | Should Be $true
             $result.SID | Should Not BeNullOrEmpty
@@ -261,8 +261,8 @@ try {
         It "Can set empty string for Description" {
             $result = New-LocalUser TestUserNew1 -NoPassword -Description ""
 
-            $result.Name | Should BeExactly TestUserNew1
-            $result.Description | Should BeExactly ""
+            $result.Name | Should -BeExactly 'TestUserNew1'
+            $result.Description | Should -BeExactly ""
             $result.Enabled | Should Be $true
             $result.SID | Should Not BeNullOrEmpty
             $result.ObjectClass | Should Be User
@@ -271,8 +271,8 @@ try {
         It "Can set with description at max 48" {
             $result = New-LocalUser TestUserNew1 -NoPassword -Description ("A"*48)
 
-            $result.Name | Should BeExactly TestUserNew1
-            $result.Description | Should BeExactly ("A"*48)
+            $result.Name | Should -BeExactly 'TestUserNew1'
+            $result.Description | Should -BeExactly ("A"*48)
             $result.Enabled | Should Be $true
             $result.SID | Should Not BeNullOrEmpty
             $result.ObjectClass | Should Be User
@@ -281,13 +281,13 @@ try {
         It "Can set with description over max 48" {
             $result = New-LocalUser TestUserNew1 -NoPassword -Description ("A"*257)
 
-            $result.Name | Should BeExactly TestUserNew1
+            $result.Name | Should -BeExactly 'TestUserNew1'
         }
 
         It "Enabled is true by default" {
             $result = New-LocalUser TestUserNew1 -NoPassword
 
-            $result.Name | Should BeExactly TestUserNew1
+            $result.Name | Should -BeExactly 'TestUserNew1'
             $result.Description | Should BeNullOrEmpty
             $result.Enabled | Should Be $true
             $result.SID | Should Not BeNullOrEmpty
@@ -297,7 +297,7 @@ try {
         It "Can set enabled to false" {
             $result = New-LocalUser TestUserNew1 -NoPassword -Disabled
 
-            $result.Name | Should BeExactly TestUserNew1
+            $result.Name | Should -BeExactly 'TestUserNew1'
             $result.Description | Should BeNullOrEmpty
             $result.Enabled | Should Be $false
             $result.SID | Should Not BeNullOrEmpty
@@ -307,7 +307,7 @@ try {
         It "Can set empty string for FullName" {
             $result = New-LocalUser TestUserNew1 -NoPassword -FullName ""
 
-            $result.Name | Should BeExactly TestUserNew1
+            $result.Name | Should -BeExactly 'TestUserNew1'
             $result.Description | Should BeNullOrEmpty
             $result.Enabled | Should Be $true
             $result.SID | Should Not BeNullOrEmpty
@@ -318,12 +318,12 @@ try {
         It "Can set string for FullName at 256 characters" {
             $result = New-LocalUser TestUserNew1 -NoPassword -FullName ("A"*256)
 
-            $result.Name | Should BeExactly TestUserNew1
+            $result.Name | Should -BeExactly 'TestUserNew1'
             $result.Description | Should BeNullOrEmpty
             $result.Enabled | Should Be $true
             $result.SID | Should Not BeNullOrEmpty
             $result.ObjectClass | Should Be User
-            $result.FullName | Should BeExactly ("A"*256)
+            $result.FullName | Should -BeExactly ("A"*256)
         }
 
         It "Errors when Password is an empty string" {
@@ -336,7 +336,7 @@ try {
         It "Can set Password value at max 256" {
             $result = New-LocalUser TestUserNew1 -Password (ConvertTo-SecureString ("135@"+"A"*252) -AsPlainText -Force)
 
-            $result.Name | Should BeExactly TestUserNew1
+            $result.Name | Should -BeExactly 'TestUserNew1'
             $result.Description | Should BeNullOrEmpty
             $result.Enabled | Should Be $true
             $result.SID | Should Not BeNullOrEmpty
@@ -364,7 +364,7 @@ try {
         It "Can set UserMayNotChangePassword" {
             $result = New-LocalUser TestUserNew1 -NoPassword -UserMayNotChangePassword
 
-            $result.Name | Should BeExactly TestUserNew1
+            $result.Name | Should -BeExactly 'TestUserNew1'
             $result.Description | Should BeNullOrEmpty
             $result.Enabled | Should Be $true
             $result.SID | Should Not BeNullOrEmpty
@@ -376,7 +376,7 @@ try {
             #[SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Demo/doc/test secret.")]
             $result = New-LocalUser TestUserNew1 -Password (ConvertTo-SecureString "p@ssw0rd" -Asplaintext -Force) -PasswordNeverExpires
 
-            $result.Name | Should BeExactly TestUserNew1
+            $result.Name | Should -BeExactly 'TestUserNew1'
             $result.PasswordExpires | Should BeNullOrEmpty
         }
 
@@ -390,7 +390,7 @@ try {
         It "UserMayChangePassword is true by default" {
             $result = New-LocalUser TestUserNew1 -NoPassword
 
-            $result.Name | Should BeExactly TestUserNew1
+            $result.Name | Should -BeExactly 'TestUserNew1'
             $result.Description | Should BeNullOrEmpty
             $result.Enabled | Should Be $true
             $result.SID | Should Not BeNullOrEmpty
@@ -556,11 +556,11 @@ try {
 
             $result = New-LocalUser TestUserGet3 -NoPassword -AccountExpires $AccountExpires -Description $Description -Disabled -FullName $FullName -UserMayNotChangePassword
 
-            $result.Name | Should BeExactly $Name
+            $result.Name | Should -BeExactly $Name
             $result.AccountExpires | Should Be ([DateTime]$AccountExpires)
-            $result.Description | Should BeExactly $Description
+            $result.Description | Should -BeExactly $Description
             $result.Enabled | Should Be $false
-            $result.FullName | Should BeExactly $FullName
+            $result.FullName | Should -BeExactly $FullName
             $result.ObjectClass -eq "User" | Should be true
             $result.UserMayChangePassword | Should Be $false
             $result.SID | Should Not BeNullOrEmpty
@@ -594,7 +594,7 @@ try {
             Set-LocalUser -Name TestUserSet1 -Description "Test User Set 1 new description"
             $result = Get-LocalUser -Name TestUserSet1
 
-            $result.Description | Should BeExactly "Test User Set 1 new description"
+            $result.Description | Should -BeExactly "Test User Set 1 new description"
         }
     }
 
@@ -624,7 +624,7 @@ try {
             Set-LocalUser -SID $user1SID -Description "Test User Set 1 new description"
             $result = Get-LocalUser -Name TestUserSet1
 
-            $result.Description | Should BeExactly "Test User Set 1 new description"
+            $result.Description | Should -BeExactly "Test User Set 1 new description"
         }
 
         It "Can set user description by -InputObject" {
@@ -632,14 +632,14 @@ try {
             Set-LocalUser -InputObject $user -Description "Test User Set 1 new description"
             $result = Get-LocalUser -Name TestUserSet1
 
-            $result.Description | Should BeExactly "Test User Set 1 new description"
+            $result.Description | Should -BeExactly "Test User Set 1 new description"
         }
 
         It "Can set user description by pipeline" {
             Get-LocalUser -Name TestUserSet1 | Set-LocalUser -Description "Test User Set 1 new description"
             $result = Get-LocalUser -Name TestUserSet1
 
-            $result.Description | Should BeExactly "Test User Set 1 new description"
+            $result.Description | Should -BeExactly "Test User Set 1 new description"
         }
 
         It "Errors on nonexistent user name" {
@@ -661,8 +661,8 @@ try {
             Set-LocalUser -Name TestUserSet1 -AccountExpires $expiration
             $result = Get-LocalUser -Name TestUserSet1
 
-            $result.Name | Should BeExactly TestUserSet1
-            $result.Description | Should BeExactly "Test User Set 1 Description"
+            $result.Name | Should -BeExactly 'TestUserSet1'
+            $result.Description | Should -BeExactly "Test User Set 1 Description"
             $result.Enabled | Should Be $true
             $result.SID | Should Not BeNullOrEmpty
             $result.ObjectClass | Should Be User
@@ -674,8 +674,8 @@ try {
             Set-LocalUser -Name TestUserSet1 -AccountExpires $expiration
             $result = Get-LocalUser -Name TestUserSet1
 
-            $result.Name | Should BeExactly TestUserSet1
-            $result.Description | Should BeExactly "Test User Set 1 Description"
+            $result.Name | Should -BeExactly 'TestUserSet1'
+            $result.Description | Should -BeExactly "Test User Set 1 Description"
             $result.Enabled | Should Be $true
             $result.SID | Should Not BeNullOrEmpty
             $result.ObjectClass | Should Be User
@@ -695,7 +695,7 @@ try {
             Set-LocalUser -Name TestUserSet1 -AccountNeverExpires
             $result = Get-LocalUser -Name TestUserSet1
 
-            $result.Name | Should BeExactly TestUserSet1
+            $result.Name | Should -BeExactly 'TestUserSet1'
             $result.AccountExpires | Should BeNullOrEmpty
         }
 
@@ -710,22 +710,22 @@ try {
             Set-LocalUser -Name TestUserSet1 -Description ""
             $result = Get-LocalUser -Name TestUserSet1
 
-            $result.Description | Should BeExactly ""
+            $result.Description | Should -BeExactly ""
         }
 
         It "Can set empty string for Description" {
             Set-LocalUser -Name TestUserSet1 -Description ""
             $result = Get-LocalUser -Name TestUserSet1
 
-            $result.Description | Should BeExactly ""
+            $result.Description | Should -BeExactly ""
         }
 
         It "Can set string for Description at max 48" {
             Set-LocalUser TestUserSet1 -Description ("A"*48)
             $result = Get-LocalUser TestUserSet1
 
-            $result.Name | Should BeExactly TestUserSet1
-            $result.Description | Should BeExactly ("A"*48)
+            $result.Name | Should -BeExactly 'TestUserSet1'
+            $result.Description | Should -BeExactly ("A"*48)
             $result.SID | Should Not BeNullOrEmpty
             $result.ObjectClass | Should Be User
         }
@@ -734,15 +734,15 @@ try {
             Set-LocalUser -Name TestUserSet1 -FullName ""
             $result = Get-LocalUser -Name TestUserSet1
 
-            $result.FullName | Should BeExactly ""
+            $result.FullName | Should -BeExactly ""
         }
 
         It "Can set string for FullName at 256" {
             Set-LocalUser TestUserSet1 -FullName ("A"*256)
             $result = Get-LocalUser TestUserSet1
 
-            $result.Name | Should BeExactly TestUserSet1
-            $result.FullName | Should BeExactly ("A"*256)
+            $result.Name | Should -BeExactly 'TestUserSet1'
+            $result.FullName | Should -BeExactly ("A"*256)
             $result.SID | Should Not BeNullOrEmpty
             $result.ObjectClass | Should Be User
         }
@@ -765,7 +765,7 @@ try {
             Set-LocalUser -Name TestUserSet1 -Password (ConvertTo-SecureString ("123@"+"A"*252) -asplaintext -Force)
             $result = Get-LocalUser -Name TestUserSet1
 
-            $result.Name | Should BeExactly TestUserSet1
+            $result.Name | Should -BeExactly 'TestUserSet1'
             $result.Enabled | Should Be $true
             $result.SID | Should Not BeNullOrEmpty
             $result.ObjectClass | Should Be User
@@ -784,7 +784,7 @@ try {
             $user | Set-LocalUser -PasswordNeverExpires:$true
             $result = Get-LocalUser TestUserSet2
 
-            $result.Name | Should BeExactly TestUserSet2
+            $result.Name | Should -BeExactly 'TestUserSet2'
             $result.PasswordExpires | Should BeNullOrEmpty
         }
 
@@ -794,7 +794,7 @@ try {
             $user | Set-LocalUser -PasswordNeverExpires:$false
             $result = Get-LocalUser TestUserSet2
 
-            $result.Name | Should BeExactly TestUserSet2
+            $result.Name | Should -BeExactly 'TestUserSet2'
             $result.PasswordExpires | Should Not BeNullOrEmpty
         }
 
@@ -802,7 +802,7 @@ try {
             Set-LocalUser TestUserSet1 -UserMayChangePassword $true
             $result = Get-LocalUser -Name TestUserSet1
 
-            $result.Name | Should BeExactly TestUserSet1
+            $result.Name | Should -BeExactly 'TestUserSet1'
             $result.SID | Should Not BeNullOrEmpty
             $result.ObjectClass | Should Be User
             $result.UserMayChangePassword | Should Be $true
@@ -812,7 +812,7 @@ try {
             Set-LocalUser TestUserSet1 -UserMayChangePassword $false
             $result = Get-LocalUser -Name TestUserSet1
 
-            $result.Name | Should BeExactly TestUserSet1
+            $result.Name | Should -BeExactly 'TestUserSet1'
             $result.SID | Should Not BeNullOrEmpty
             $result.ObjectClass | Should Be User
             $result.UserMayChangePassword | Should Be $false
@@ -845,7 +845,7 @@ try {
             Rename-LocalUser -Name TestUserRename1 -NewName TestUserRename2
             $result = Get-LocalUser -SID $user1SID
 
-            $result.Name | Should BeExactly TestUserRename2
+            $result.Name | Should -BeExactly 'TestUserRename2'
         }
     }
 
@@ -875,7 +875,7 @@ try {
             Rename-LocalUser -SID $user1SID -NewName TestUserRename2
             $result = Get-LocalUser -SID $user1SID
 
-            $result.Name | Should BeExactly TestUserRename2
+            $result.Name | Should -BeExactly 'TestUserRename2'
         }
 
         It "Can rename using -InputObject" {
@@ -883,16 +883,16 @@ try {
             Rename-LocalUser -InputObject $user -NewName TestUserRename2
             $result = Get-LocalUser -SID $user1SID
 
-            $result.Name | Should BeExactly TestUserRename2
-            $result.SID | Should BeExactly $user1SID
+            $result.Name | Should -BeExactly 'TestUserRename2'
+            $result.SID | Should -BeExactly $user1SID
         }
 
         It "Can rename using pipeline" {
             Get-LocalUser -SID $user1SID | Rename-LocalUser -NewName TestUserRename2
             $result = Get-LocalUser -SID $user1SID
 
-            $result.Name | Should BeExactly TestUserRename2
-            $result.SID | Should BeExactly $user1SID
+            $result.Name | Should -BeExactly 'TestUserRename2'
+            $result.SID | Should -BeExactly $user1SID
         }
 
         It "Errors on no name or SID specified" {
@@ -989,7 +989,7 @@ try {
             Rename-LocalUser -Name TestUserRename1 -NewName TestUserRename2
             $result = Get-LocalUser -SID $user1SID
 
-            $result.Name | Should BeExactly TestUserRename2
+            $result.Name | Should -BeExactly 'TestUserRename2'
         }
 
         It "Errors when NewName over max 20" {

--- a/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalUser.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalUser.Tests.ps1
@@ -489,8 +489,8 @@ try {
                 # Ignore the execption
             }
             $outErr | Should -HaveCount 1
-            $outErr[0].ErrorRecord.CategoryInfo.Reason | Should -Match "UserNotFound"
-            $outOut.Name | Should -Match "TestUserGet1"
+            $outErr[0].ErrorRecord.CategoryInfo.Reason | Should -MatchExactly "UserNotFound"
+            $outOut.Name | Should -MatchExactly "TestUserGet1"
         }
 
         It "Error on Name not being supplied an argument" {
@@ -1205,7 +1205,7 @@ try {
             $outError[0].ErrorRecord.FullyQualifiedErrorId | Should -BeExactly "UserNotFound,Microsoft.PowerShell.Commands.RemoveLocalUserCommand"
 
             $getResult = Get-LocalUser TestUserGet1 2>&1
-            $getResult.FullyQualifiedErrorId | Should -Match "UserNotFound"
+            $getResult.FullyQualifiedErrorId | Should -MatchExactly "UserNotFound"
         }
     }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalUser.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalUser.Tests.ps1
@@ -53,13 +53,13 @@ try {
         It "Test command presence" {
             $result = Get-Command -Module Microsoft.PowerShell.LocalAccounts | ForEach-Object Name
 
-            $result -contains "New-LocalUser" | Should Be $true
-            $result -contains "Set-LocalUser" | Should Be $true
-            $result -contains "Get-LocalUser" | Should Be $true
-            $result -contains "Rename-LocalUser" | Should Be $true
-            $result -contains "Remove-LocalUser" | Should Be $true
-            $result -contains "Enable-LocalUser" | Should Be $true
-            $result -contains "Disable-LocalUser" | Should Be $true
+            $result | Should -Contain 'New-LocalUser'
+            $result | Should -Contain 'Set-LocalUser'
+            $result | Should -Contain 'Get-LocalUser'
+            $result | Should -Contain 'Rename-LocalUser'
+            $result | Should -Contain 'Remove-LocalUser'
+            $result | Should -Contain 'Enable-LocalUser'
+            $result | Should -Contain 'Disable-LocalUser'
         }
     }
 
@@ -68,21 +68,21 @@ try {
         It "Test command presence" {
             $result = get-alias | ForEach-Object { if ($_.Source -eq "Microsoft.PowerShell.LocalAccounts") {$_}}
 
-            $result.Name -contains "algm" | Should Be $true
-            $result.Name -contains "dlu" | Should Be $true
-            $result.Name -contains "elu" | Should Be $true
-            $result.Name -contains "glg" | Should Be $true
-            $result.Name -contains "glgm" | Should Be $true
-            $result.Name -contains "glu" | Should Be $true
-            $result.Name -contains "nlg" | Should Be $true
-            $result.Name -contains "nlu" | Should Be $true
-            $result.Name -contains "rlg" | Should Be $true
-            $result.Name -contains "rlgm" | Should Be $true
-            $result.Name -contains "rlu" | Should Be $true
-            $result.Name -contains "rnlg" | Should Be $true
-            $result.Name -contains "rnlu" | Should Be $true
-            $result.Name -contains "slg" | Should Be $true
-            $result.Name -contains "slu" | Should Be $true
+            $result.Name | Should -Contain 'algm'
+            $result.Name | Should -Contain 'dlu'
+            $result.Name | Should -Contain 'elu'
+            $result.Name | Should -Contain 'glg'
+            $result.Name | Should -Contain 'glgm'
+            $result.Name | Should -Contain 'glu'
+            $result.Name | Should -Contain 'nlg'
+            $result.Name | Should -Contain 'nlu'
+            $result.Name | Should -Contain 'rlg'
+            $result.Name | Should -Contain 'rlgm'
+            $result.Name | Should -Contain 'rlu'
+            $result.Name | Should -Contain 'rnlg'
+            $result.Name | Should -Contain 'rnlu'
+            $result.Name | Should -Contain 'slg'
+            $result.Name | Should -Contain 'slu'
         }
     }
 
@@ -463,16 +463,16 @@ try {
             $result = Get-LocalUser TestUserGet*
 
             $result.Count -eq 2 | Should Be $true
-            $result.Name -contains "TestUserGet1" | Should Be $true
-            $result.Name -contains "TestUserGet2" | Should Be $true
+            $result.Name | Should -Contain 'TestUserGet1'
+            $result.Name | Should -Contain 'TestUserGet2'
         }
 
         It "Can get a user by array of names" {
             $result = Get-LocalUser @("TestUserGet1", "TestUserGet2")
 
             $result.Count -eq 2 | Should Be $true
-            $result.Name -contains "TestUserGet1" | Should Be $true
-            $result.Name -contains "TestUserGet2" | Should Be $true
+            $result.Name | Should -Contain 'TestUserGet1'
+            $result.Name | Should -Contain 'TestUserGet2'
         }
 
         It "Can get a user by array of SIDs" {
@@ -481,8 +481,8 @@ try {
             $result = Get-LocalUser -SID @($sid1, $sid2)
 
             $result.Count -eq 2 | Should Be $true
-            $result.Name -contains "TestUserGet1" | Should Be $true
-            $result.Name -contains "TestUserGet2" | Should Be $true
+            $result.Name | Should -Contain 'TestUserGet1'
+            $result.Name | Should -Contain 'TestUserGet2'
         }
 
         It "Can respond to -ErrorAction Stop" {

--- a/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalUser.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalUser.Tests.ps1
@@ -99,7 +99,7 @@ try {
 
             $result.Name | Should -BeExactly 'TestUserNew1'
             $result.Description | Should -BeNullOrEmpty
-            $result.Enabled | Should Be $true
+            $result.Enabled | Should -BeTrue
             $result.SID | Should -Not -BeNullOrEmpty
             $result.ObjectClass | Should -BeExactly 'User'
         }
@@ -120,7 +120,7 @@ try {
 
             $result.Name | Should -BeExactly $userName
             $result.Description | Should -BeNullOrEmpty
-            $result.Enabled | Should Be $true
+            $result.Enabled | Should -BeTrue
             $result.SID | Should -Not -BeNullOrEmpty
             $result.ObjectClass | Should -BeExactly 'User'
         }
@@ -214,7 +214,7 @@ try {
 
             $result.Name | Should -BeExactly 'TestUserNew1'
             $result.Description | Should -BeNullOrEmpty
-            $result.Enabled | Should Be $true
+            $result.Enabled | Should -BeTrue
             $result.SID | Should -Not -BeNullOrEmpty
             $result.ObjectClass | Should -BeExactly 'User'
             $result.AccountExpires | Should Be ([DateTime]$expiration)
@@ -226,7 +226,7 @@ try {
 
             $result.Name | Should -BeExactly 'TestUserNew1'
             $result.Description | Should -BeNullOrEmpty
-            $result.Enabled | Should Be $true
+            $result.Enabled | Should -BeTrue
             $result.SID | Should -Not -BeNullOrEmpty
             $result.ObjectClass | Should -BeExactly 'User'
             $result.AccountExpires | Should Be ([DateTime]$expiration)
@@ -245,7 +245,7 @@ try {
 
             $result.Name | Should -BeExactly 'TestUserNew1'
             $result.Description | Should -BeNullOrEmpty
-            $result.Enabled | Should Be $true
+            $result.Enabled | Should -BeTrue
             $result.SID | Should -Not -BeNullOrEmpty
             $result.ObjectClass | Should -BeExactly 'User'
             $result.AccountExpires | Should -BeNullOrEmpty
@@ -263,7 +263,7 @@ try {
 
             $result.Name | Should -BeExactly 'TestUserNew1'
             $result.Description | Should -BeExactly ""
-            $result.Enabled | Should Be $true
+            $result.Enabled | Should -BeTrue
             $result.SID | Should -Not -BeNullOrEmpty
             $result.ObjectClass | Should -BeExactly 'User'
         }
@@ -273,7 +273,7 @@ try {
 
             $result.Name | Should -BeExactly 'TestUserNew1'
             $result.Description | Should -BeExactly ("A"*48)
-            $result.Enabled | Should Be $true
+            $result.Enabled | Should -BeTrue
             $result.SID | Should -Not -BeNullOrEmpty
             $result.ObjectClass | Should -BeExactly 'User'
         }
@@ -289,7 +289,7 @@ try {
 
             $result.Name | Should -BeExactly 'TestUserNew1'
             $result.Description | Should -BeNullOrEmpty
-            $result.Enabled | Should Be $true
+            $result.Enabled | Should -BeTrue
             $result.SID | Should -Not -BeNullOrEmpty
             $result.ObjectClass | Should -BeExactly 'User'
         }
@@ -299,7 +299,7 @@ try {
 
             $result.Name | Should -BeExactly 'TestUserNew1'
             $result.Description | Should -BeNullOrEmpty
-            $result.Enabled | Should Be $false
+            $result.Enabled | Should -BeFalse
             $result.SID | Should -Not -BeNullOrEmpty
             $result.ObjectClass | Should -BeExactly 'User'
         }
@@ -309,7 +309,7 @@ try {
 
             $result.Name | Should -BeExactly 'TestUserNew1'
             $result.Description | Should -BeNullOrEmpty
-            $result.Enabled | Should Be $true
+            $result.Enabled | Should -BeTrue
             $result.SID | Should -Not -BeNullOrEmpty
             $result.ObjectClass | Should -BeExactly 'User'
             $result.FullName | Should -BeNullOrEmpty
@@ -320,7 +320,7 @@ try {
 
             $result.Name | Should -BeExactly 'TestUserNew1'
             $result.Description | Should -BeNullOrEmpty
-            $result.Enabled | Should Be $true
+            $result.Enabled | Should -BeTrue
             $result.SID | Should -Not -BeNullOrEmpty
             $result.ObjectClass | Should -BeExactly 'User'
             $result.FullName | Should -BeExactly ("A"*256)
@@ -338,7 +338,7 @@ try {
 
             $result.Name | Should -BeExactly 'TestUserNew1'
             $result.Description | Should -BeNullOrEmpty
-            $result.Enabled | Should Be $true
+            $result.Enabled | Should -BeTrue
             $result.SID | Should -Not -BeNullOrEmpty
             $result.ObjectClass | Should -BeExactly 'User'
         }
@@ -366,10 +366,10 @@ try {
 
             $result.Name | Should -BeExactly 'TestUserNew1'
             $result.Description | Should -BeNullOrEmpty
-            $result.Enabled | Should Be $true
+            $result.Enabled | Should -BeTrue
             $result.SID | Should -Not -BeNullOrEmpty
             $result.ObjectClass | Should -BeExactly 'User'
-            $result.UserMayChangePassword | Should Be $false
+            $result.UserMayChangePassword | Should -BeFalse
         }
 
         It "Can set PasswordNeverExpires to create a user with null for PasswordExpires date" {
@@ -392,10 +392,10 @@ try {
 
             $result.Name | Should -BeExactly 'TestUserNew1'
             $result.Description | Should -BeNullOrEmpty
-            $result.Enabled | Should Be $true
+            $result.Enabled | Should -BeTrue
             $result.SID | Should -Not -BeNullOrEmpty
             $result.ObjectClass | Should -BeExactly 'User'
-            $result.UserMayChangePassword | Should Be $true
+            $result.UserMayChangePassword | Should -BeTrue
         }
     }
 
@@ -441,7 +441,7 @@ try {
         It "Get-LocalUser gets all users"  {
             $result = Get-LocalUser
 
-            $result.Count -gt 2 | Should Be $true
+            $result.Count -gt 2 | Should -BeTrue
         }
 
         It "Can get a specific user by SID" {
@@ -559,10 +559,10 @@ try {
             $result.Name | Should -BeExactly $Name
             $result.AccountExpires | Should Be ([DateTime]$AccountExpires)
             $result.Description | Should -BeExactly $Description
-            $result.Enabled | Should Be $false
+            $result.Enabled | Should -BeFalse
             $result.FullName | Should -BeExactly $FullName
             $result.ObjectClass -eq "User" | Should be true
-            $result.UserMayChangePassword | Should Be $false
+            $result.UserMayChangePassword | Should -BeFalse
             $result.SID | Should -Not -BeNullOrEmpty
             $result.ObjectClass | Should -BeExactly 'User'
         }
@@ -663,7 +663,7 @@ try {
 
             $result.Name | Should -BeExactly 'TestUserSet1'
             $result.Description | Should -BeExactly "Test User Set 1 Description"
-            $result.Enabled | Should Be $true
+            $result.Enabled | Should -BeTrue
             $result.SID | Should -Not -BeNullOrEmpty
             $result.ObjectClass | Should -BeExactly 'User'
             $result.AccountExpires | Should Be ([DateTime]$expiration)
@@ -676,7 +676,7 @@ try {
 
             $result.Name | Should -BeExactly 'TestUserSet1'
             $result.Description | Should -BeExactly "Test User Set 1 Description"
-            $result.Enabled | Should Be $true
+            $result.Enabled | Should -BeTrue
             $result.SID | Should -Not -BeNullOrEmpty
             $result.ObjectClass | Should -BeExactly 'User'
             $result.AccountExpires | Should Be ([DateTime]$expiration)
@@ -766,7 +766,7 @@ try {
             $result = Get-LocalUser -Name TestUserSet1
 
             $result.Name | Should -BeExactly 'TestUserSet1'
-            $result.Enabled | Should Be $true
+            $result.Enabled | Should -BeTrue
             $result.SID | Should -Not -BeNullOrEmpty
             $result.ObjectClass | Should -BeExactly 'User'
         }
@@ -805,7 +805,7 @@ try {
             $result.Name | Should -BeExactly 'TestUserSet1'
             $result.SID | Should -Not -BeNullOrEmpty
             $result.ObjectClass | Should -BeExactly 'User'
-            $result.UserMayChangePassword | Should Be $true
+            $result.UserMayChangePassword | Should -BeTrue
         }
 
         It "Can set UserMayChangePassword to false" {
@@ -815,7 +815,7 @@ try {
             $result.Name | Should -BeExactly 'TestUserSet1'
             $result.SID | Should -Not -BeNullOrEmpty
             $result.ObjectClass | Should -BeExactly 'User'
-            $result.UserMayChangePassword | Should Be $false
+            $result.UserMayChangePassword | Should -BeFalse
         }
     }
 
@@ -1024,7 +1024,7 @@ try {
 
         It "Can Remove-LocalUser with only name" {
             $initialCount = (Get-LocalUser).Count
-            $initialCount -gt 1 | Should Be $true
+            $initialCount -gt 1 | Should -BeTrue
 
             $removeResult = Remove-LocalUser TestUserRemove1 2>&1
             $removeResult | Should -BeNullOrEmpty
@@ -1051,7 +1051,7 @@ try {
                         [scriptblock]$removalAction
                     )
                     $initialCount = (Get-LocalUser).Count
-                    $initialCount -gt 1 | Should Be true
+                    $initialCount -gt 1 | Should -BeTrue
 
                     & $removalAction
 
@@ -1069,7 +1069,7 @@ try {
                         [scriptblock]$removalAction
                     )
                     $initialCount = (Get-LocalUser).Count
-                    $initialCount -gt 1 | Should Be true
+                    $initialCount -gt 1 | Should -BeTrue
 
                     & $removalAction
 
@@ -1172,7 +1172,7 @@ try {
 
         It "Errors on remove by invalid name" {
             $initialCount =  (Get-LocalUser).Count
-            $initialCount -gt 1 | Should Be $true
+            $initialCount -gt 1 | Should -BeTrue
 
             $sb = {
                 Remove-LocalUser TestUserRemove1NameThatDoesntExist
@@ -1187,7 +1187,7 @@ try {
             Remove-LocalUser -SID $user1SID
             # This test verifies that it cannot be removed a second time
             $initialCount =  (Get-LocalUser).Count
-            $initialCount -gt 1 | Should Be $true
+            $initialCount -gt 1 | Should -BeTrue
 
             $sb = {
                 Remove-LocalUser -SID $user1SID
@@ -1239,7 +1239,7 @@ try {
             Enable-LocalUser TestUserDisabled1
             $result = Get-LocalUser TestUserDisabled1
 
-            $result.Enabled | Should Be $true
+            $result.Enabled | Should -BeTrue
         }
     }
 
@@ -1279,7 +1279,7 @@ try {
             Enable-LocalUser -SID $disabledUser1SID
             $result = Get-LocalUser -SID $disabledUser1SID
 
-            $result.Enabled | Should Be $true
+            $result.Enabled | Should -BeTrue
         }
 
         It "Can enable a disabled user using -InputObject" {
@@ -1287,43 +1287,43 @@ try {
             Enable-LocalUser -InputObject $user
             $result = Get-LocalUser TestUserDisabled1
 
-            $result.Enabled | Should Be $true
+            $result.Enabled | Should -BeTrue
         }
 
         It "Can enable a disabled user using pipeline" {
             Get-LocalUser TestUserDisabled1 | Enable-LocalUser
             $result = Get-LocalUser TestUserDisabled1
 
-            $result.Enabled | Should Be $true
+            $result.Enabled | Should -BeTrue
         }
 
         It "Can enable a disabled user by array of names" {
             Enable-LocalUser @("TestUserDisabled1", "TestUserDisabled2")
 
-            (Get-LocalUser "TestUserDisabled1").Enabled | Should Be $true
-            (Get-LocalUser "TestUserDisabled2").Enabled | Should Be $true
+            (Get-LocalUser "TestUserDisabled1").Enabled | Should -BeTrue
+            (Get-LocalUser "TestUserDisabled2").Enabled | Should -BeTrue
         }
 
         It "Can enable a disabled user by array of SIDs" {
             Enable-LocalUser -SID @($disabledUser1SID, $disabledUser2SID)
 
-            (Get-LocalUser -SID $disabledUser1SID).Enabled | Should Be $true
-            (Get-LocalUser -SID $disabledUser2SID).Enabled | Should Be $true
+            (Get-LocalUser -SID $disabledUser1SID).Enabled | Should -BeTrue
+            (Get-LocalUser -SID $disabledUser2SID).Enabled | Should -BeTrue
         }
 
         It "Can enable a disabled user by array sent using -InputObject" {
             $users = @((Get-LocalUser "TestUserDisabled1"), (Get-LocalUser "TestUserDisabled2"))
             Enable-LocalUser -InputObject $users
 
-            (Get-LocalUser "TestUserDisabled1").Enabled | Should Be $true
-            (Get-LocalUser "TestUserDisabled2").Enabled | Should Be $true
+            (Get-LocalUser "TestUserDisabled1").Enabled | Should -BeTrue
+            (Get-LocalUser "TestUserDisabled2").Enabled | Should -BeTrue
         }
 
         It "Can enable a disabled user by array sent using pipeline" {
             @((Get-LocalUser "TestUserDisabled1"), (Get-LocalUser "TestUserDisabled2")) | Enable-LocalUser
 
-            (Get-LocalUser "TestUserDisabled1").Enabled | Should Be $true
-            (Get-LocalUser "TestUserDisabled2").Enabled | Should Be $true
+            (Get-LocalUser "TestUserDisabled1").Enabled | Should -BeTrue
+            (Get-LocalUser "TestUserDisabled2").Enabled | Should -BeTrue
         }
 
         It "Errors on no name or SID specified" {
@@ -1337,21 +1337,21 @@ try {
             Enable-LocalUser TestUserEnabled1
             $result = Get-LocalUser TestUserEnabled1
 
-            $result.Enabled | Should Be $true
+            $result.Enabled | Should -BeTrue
         }
 
         It "Can enable an already enabled user by SID" {
             Enable-LocalUser -SID $enabledUser1SID
             $result = Get-LocalUser -SID $enabledUser1SID
 
-            $result.Enabled | Should Be $true
+            $result.Enabled | Should -BeTrue
         }
 
         It "Can enable an already enabled user using the pipeline" {
             Get-LocalUser TestUserEnabled1 | Enable-LocalUser
             $result = Get-LocalUser TestUserEnabled1
 
-            $result.Enabled | Should Be $true
+            $result.Enabled | Should -BeTrue
         }
 
         It "Errors on enabling an invalid user by name" {
@@ -1380,7 +1380,7 @@ try {
             $outError[0].ErrorRecord.FullyQualifiedErrorId | Should Be "UserNotFound,Microsoft.PowerShell.Commands.EnableLocalUserCommand"
 
             $getResult = Get-LocalUser TestUserDisabled1 2>&1
-            $getResult.Enabled | Should Be $true
+            $getResult.Enabled | Should -BeTrue
         }
     }
 
@@ -1410,7 +1410,7 @@ try {
             Disable-LocalUser TestUserEnabled1
             $result = Get-LocalUser TestUserEnabled1
 
-            $result.Enabled | Should Be $false
+            $result.Enabled | Should -BeFalse
         }
     }
 
@@ -1450,7 +1450,7 @@ try {
             Disable-LocalUser -SID $enabledUser1SID
             $result = Get-LocalUser -SID $enabledUser1SID
 
-            $result.Enabled | Should Be $false
+            $result.Enabled | Should -BeFalse
         }
 
         It "Can disable an enabled user using -InputObject" {
@@ -1458,43 +1458,43 @@ try {
             Disable-LocalUser -InputObject $user
             $result = Get-LocalUser TestUserEnabled1
 
-            $result.Enabled | Should Be $false
+            $result.Enabled | Should -BeFalse
         }
 
         It "Can disable an enabled user using pipeline" {
             Get-LocalUser TestUserEnabled1 | Disable-LocalUser
             $result = Get-LocalUser TestUserEnabled1
 
-            $result.Enabled | Should Be $false
+            $result.Enabled | Should -BeFalse
         }
 
         It "Can disable an enabled user by array of names" {
             Disable-LocalUser @("TestUserEnabled1", "TestUserEnabled2")
 
-            (Get-LocalUser "TestUserEnabled1").Enabled | Should Be $false
-            (Get-LocalUser "TestUserEnabled2").Enabled | Should Be $false
+            (Get-LocalUser "TestUserEnabled1").Enabled | Should -BeFalse
+            (Get-LocalUser "TestUserEnabled2").Enabled | Should -BeFalse
         }
 
         It "Can disable an enabled user by array of SIDs" {
             Disable-LocalUser -SID @($enabledUser1SID, $enabledUser2SID)
 
-            (Get-LocalUser -SID $enabledUser1SID).Enabled | Should Be $false
-            (Get-LocalUser -SID $enabledUser2SID).Enabled | Should Be $false
+            (Get-LocalUser -SID $enabledUser1SID).Enabled | Should -BeFalse
+            (Get-LocalUser -SID $enabledUser2SID).Enabled | Should -BeFalse
         }
 
         It "Can disable an enabled user by array sent using pipeline" {
             $users = @((Get-LocalUser "TestUserEnabled1"), (Get-LocalUser "TestUserEnabled2"))
             Disable-LocalUser -InputObject $users
 
-            (Get-LocalUser "TestUserEnabled1").Enabled | Should Be $false
-            (Get-LocalUser "TestUserEnabled2").Enabled | Should Be $false
+            (Get-LocalUser "TestUserEnabled1").Enabled | Should -BeFalse
+            (Get-LocalUser "TestUserEnabled2").Enabled | Should -BeFalse
         }
 
         It "Can disable an enabled user by array sent using pipeline" {
             @((Get-LocalUser "TestUserEnabled1"), (Get-LocalUser "TestUserEnabled2")) | Disable-LocalUser
 
-            (Get-LocalUser "TestUserEnabled1").Enabled | Should Be $false
-            (Get-LocalUser "TestUserEnabled2").Enabled | Should Be $false
+            (Get-LocalUser "TestUserEnabled1").Enabled | Should -BeFalse
+            (Get-LocalUser "TestUserEnabled2").Enabled | Should -BeFalse
         }
 
         It "Errors on no name or SID specified" {
@@ -1507,19 +1507,19 @@ try {
         It "Can disable an already disabled user by name" {
             Disable-LocalUser TestUserDisabled1
 
-            (Get-LocalUser TestUserDisabled1).Enabled | Should Be $false
+            (Get-LocalUser TestUserDisabled1).Enabled | Should -BeFalse
         }
 
         It "Can disable an already disabled user by SID" {
             Disable-LocalUser -SID $disabledUser1SID
 
-            (Get-LocalUser -SID $disabledUser1SID).Enabled | Should Be $false
+            (Get-LocalUser -SID $disabledUser1SID).Enabled | Should -BeFalse
         }
 
         It "Can disable an already disabled user using the pipeline" {
             Get-LocalUser TestUserDisabled1 | Disable-LocalUser
 
-            (Get-LocalUser TestUserDisabled1).Enabled | Should Be $false
+            (Get-LocalUser TestUserDisabled1).Enabled | Should -BeFalse
         }
 
         It "Errors on disabling an invalid user by name" {
@@ -1548,7 +1548,7 @@ try {
             $outError[0].ErrorRecord.FullyQualifiedErrorId | Should Be "UserNotFound,Microsoft.PowerShell.Commands.DisableLocalUserCommand"
 
             $getResult = Get-LocalUser TestUserEnabled1 2>&1
-            $getResult.Enabled | Should Be $false
+            $getResult.Enabled | Should -BeFalse
         }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalUser.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalUser.Tests.ps1
@@ -539,7 +539,7 @@ try {
             $localUserName = 'TestUserGetNameThatDoesntExist'
             $result = Get-LocalGroup $localUserName*
 
-            $result | Should Be $null
+            $result | Should -BeNullOrEmpty
         }
 
         It "Returns the correct property values of a user" {

--- a/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalUser.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalUser.Tests.ps1
@@ -417,9 +417,9 @@ try {
         It "Can Get-LocalUser by only name" {
             $result = Get-LocalUser TestUserGet1
 
-            $result.Name | Should Be "TestUserGet1"
-            $result.Description | Should Be "Test User Get 1 Description"
-            $result.ObjectClass | Should Be "User"
+            $result.Name | Should -BeExactly "TestUserGet1"
+            $result.Description | Should -BeExactly "Test User Get 1 Description"
+            $result.ObjectClass | Should -BeExactly "User"
         }
     }
 
@@ -449,7 +449,7 @@ try {
             $resultBySID = Get-LocalUser -SID $result.SID
 
             $resultBySID.SID | Should -Not -BeNullOrEmpty
-            $resultBySID.Name | Should Be TestUserGet1
+            $resultBySID.Name | Should -BeExactly 'TestUserGet1'
         }
 
         It "Can get a well-known user by SID string" {

--- a/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalUser.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalUser.Tests.ps1
@@ -557,7 +557,7 @@ try {
             $result = New-LocalUser TestUserGet3 -NoPassword -AccountExpires $AccountExpires -Description $Description -Disabled -FullName $FullName -UserMayNotChangePassword
 
             $result.Name | Should -BeExactly $Name
-            $result.AccountExpires | Should Be ([DateTime]$AccountExpires)
+            $result.AccountExpires | Should -Be ([DateTime]$AccountExpires)
             $result.Description | Should -BeExactly $Description
             $result.Enabled | Should -BeFalse
             $result.FullName | Should -BeExactly $FullName
@@ -666,7 +666,7 @@ try {
             $result.Enabled | Should -BeTrue
             $result.SID | Should -Not -BeNullOrEmpty
             $result.ObjectClass | Should -BeExactly 'User'
-            $result.AccountExpires | Should Be ([DateTime]$expiration)
+            $result.AccountExpires | Should -Be ([DateTime]$expiration)
         }
 
         It "Can set AccountExpires to the past" {
@@ -679,7 +679,7 @@ try {
             $result.Enabled | Should -BeTrue
             $result.SID | Should -Not -BeNullOrEmpty
             $result.ObjectClass | Should -BeExactly 'User'
-            $result.AccountExpires | Should Be ([DateTime]$expiration)
+            $result.AccountExpires | Should -Be ([DateTime]$expiration)
         }
 
         It "Errors on AccountExpires being set to invalid date" {

--- a/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalUser.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalUser.Tests.ps1
@@ -101,7 +101,7 @@ try {
             $result.Description | Should -BeNullOrEmpty
             $result.Enabled | Should Be $true
             $result.SID | Should -Not -BeNullOrEmpty
-            $result.ObjectClass | Should Be User
+            $result.ObjectClass | Should -BeExactly 'User'
         }
     }
 
@@ -122,7 +122,7 @@ try {
             $result.Description | Should -BeNullOrEmpty
             $result.Enabled | Should Be $true
             $result.SID | Should -Not -BeNullOrEmpty
-            $result.ObjectClass | Should Be User
+            $result.ObjectClass | Should -BeExactly 'User'
         }
 
         It "Errors on Name argument of empty string or null" {
@@ -216,7 +216,7 @@ try {
             $result.Description | Should -BeNullOrEmpty
             $result.Enabled | Should Be $true
             $result.SID | Should -Not -BeNullOrEmpty
-            $result.ObjectClass | Should Be User
+            $result.ObjectClass | Should -BeExactly 'User'
             $result.AccountExpires | Should Be ([DateTime]$expiration)
         }
 
@@ -228,7 +228,7 @@ try {
             $result.Description | Should -BeNullOrEmpty
             $result.Enabled | Should Be $true
             $result.SID | Should -Not -BeNullOrEmpty
-            $result.ObjectClass | Should Be User
+            $result.ObjectClass | Should -BeExactly 'User'
             $result.AccountExpires | Should Be ([DateTime]$expiration)
         }
 
@@ -247,7 +247,7 @@ try {
             $result.Description | Should -BeNullOrEmpty
             $result.Enabled | Should Be $true
             $result.SID | Should -Not -BeNullOrEmpty
-            $result.ObjectClass | Should Be User
+            $result.ObjectClass | Should -BeExactly 'User'
             $result.AccountExpires | Should -BeNullOrEmpty
         }
 
@@ -265,7 +265,7 @@ try {
             $result.Description | Should -BeExactly ""
             $result.Enabled | Should Be $true
             $result.SID | Should -Not -BeNullOrEmpty
-            $result.ObjectClass | Should Be User
+            $result.ObjectClass | Should -BeExactly 'User'
         }
 
         It "Can set with description at max 48" {
@@ -275,7 +275,7 @@ try {
             $result.Description | Should -BeExactly ("A"*48)
             $result.Enabled | Should Be $true
             $result.SID | Should -Not -BeNullOrEmpty
-            $result.ObjectClass | Should Be User
+            $result.ObjectClass | Should -BeExactly 'User'
         }
 
         It "Can set with description over max 48" {
@@ -291,7 +291,7 @@ try {
             $result.Description | Should -BeNullOrEmpty
             $result.Enabled | Should Be $true
             $result.SID | Should -Not -BeNullOrEmpty
-            $result.ObjectClass | Should Be User
+            $result.ObjectClass | Should -BeExactly 'User'
         }
 
         It "Can set enabled to false" {
@@ -301,7 +301,7 @@ try {
             $result.Description | Should -BeNullOrEmpty
             $result.Enabled | Should Be $false
             $result.SID | Should -Not -BeNullOrEmpty
-            $result.ObjectClass | Should Be User
+            $result.ObjectClass | Should -BeExactly 'User'
         }
 
         It "Can set empty string for FullName" {
@@ -311,7 +311,7 @@ try {
             $result.Description | Should -BeNullOrEmpty
             $result.Enabled | Should Be $true
             $result.SID | Should -Not -BeNullOrEmpty
-            $result.ObjectClass | Should Be User
+            $result.ObjectClass | Should -BeExactly 'User'
             $result.FullName | Should -BeNullOrEmpty
         }
 
@@ -322,7 +322,7 @@ try {
             $result.Description | Should -BeNullOrEmpty
             $result.Enabled | Should Be $true
             $result.SID | Should -Not -BeNullOrEmpty
-            $result.ObjectClass | Should Be User
+            $result.ObjectClass | Should -BeExactly 'User'
             $result.FullName | Should -BeExactly ("A"*256)
         }
 
@@ -340,7 +340,7 @@ try {
             $result.Description | Should -BeNullOrEmpty
             $result.Enabled | Should Be $true
             $result.SID | Should -Not -BeNullOrEmpty
-            $result.ObjectClass | Should Be User
+            $result.ObjectClass | Should -BeExactly 'User'
         }
 
         It "Errors when Password over max 257" {
@@ -368,7 +368,7 @@ try {
             $result.Description | Should -BeNullOrEmpty
             $result.Enabled | Should Be $true
             $result.SID | Should -Not -BeNullOrEmpty
-            $result.ObjectClass | Should Be User
+            $result.ObjectClass | Should -BeExactly 'User'
             $result.UserMayChangePassword | Should Be $false
         }
 
@@ -394,7 +394,7 @@ try {
             $result.Description | Should -BeNullOrEmpty
             $result.Enabled | Should Be $true
             $result.SID | Should -Not -BeNullOrEmpty
-            $result.ObjectClass | Should Be User
+            $result.ObjectClass | Should -BeExactly 'User'
             $result.UserMayChangePassword | Should Be $true
         }
     }
@@ -564,7 +564,7 @@ try {
             $result.ObjectClass -eq "User" | Should be true
             $result.UserMayChangePassword | Should Be $false
             $result.SID | Should -Not -BeNullOrEmpty
-            $result.ObjectClass | Should Be User
+            $result.ObjectClass | Should -BeExactly 'User'
         }
     }
 
@@ -665,7 +665,7 @@ try {
             $result.Description | Should -BeExactly "Test User Set 1 Description"
             $result.Enabled | Should Be $true
             $result.SID | Should -Not -BeNullOrEmpty
-            $result.ObjectClass | Should Be User
+            $result.ObjectClass | Should -BeExactly 'User'
             $result.AccountExpires | Should Be ([DateTime]$expiration)
         }
 
@@ -678,7 +678,7 @@ try {
             $result.Description | Should -BeExactly "Test User Set 1 Description"
             $result.Enabled | Should Be $true
             $result.SID | Should -Not -BeNullOrEmpty
-            $result.ObjectClass | Should Be User
+            $result.ObjectClass | Should -BeExactly 'User'
             $result.AccountExpires | Should Be ([DateTime]$expiration)
         }
 
@@ -727,7 +727,7 @@ try {
             $result.Name | Should -BeExactly 'TestUserSet1'
             $result.Description | Should -BeExactly ("A"*48)
             $result.SID | Should -Not -BeNullOrEmpty
-            $result.ObjectClass | Should Be User
+            $result.ObjectClass | Should -BeExactly 'User'
         }
 
         It "Can set empty string for FullName" {
@@ -744,7 +744,7 @@ try {
             $result.Name | Should -BeExactly 'TestUserSet1'
             $result.FullName | Should -BeExactly ("A"*256)
             $result.SID | Should -Not -BeNullOrEmpty
-            $result.ObjectClass | Should Be User
+            $result.ObjectClass | Should -BeExactly 'User'
         }
 
         It "Errors when Password is an empty string" {
@@ -768,7 +768,7 @@ try {
             $result.Name | Should -BeExactly 'TestUserSet1'
             $result.Enabled | Should Be $true
             $result.SID | Should -Not -BeNullOrEmpty
-            $result.ObjectClass | Should Be User
+            $result.ObjectClass | Should -BeExactly 'User'
         }
 
         It "Errors when Password over max 257" {
@@ -804,7 +804,7 @@ try {
 
             $result.Name | Should -BeExactly 'TestUserSet1'
             $result.SID | Should -Not -BeNullOrEmpty
-            $result.ObjectClass | Should Be User
+            $result.ObjectClass | Should -BeExactly 'User'
             $result.UserMayChangePassword | Should Be $true
         }
 
@@ -814,7 +814,7 @@ try {
 
             $result.Name | Should -BeExactly 'TestUserSet1'
             $result.SID | Should -Not -BeNullOrEmpty
-            $result.ObjectClass | Should Be User
+            $result.ObjectClass | Should -BeExactly 'User'
             $result.UserMayChangePassword | Should Be $false
         }
     }

--- a/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalUser.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalUser.Tests.ps1
@@ -213,7 +213,7 @@ try {
             $result.Enabled | Should -BeTrue
             $result.SID | Should -Not -BeNullOrEmpty
             $result.ObjectClass | Should -BeExactly 'User'
-            $result.AccountExpires | Should Be ([DateTime]$expiration)
+            $result.AccountExpires | Should -Be ([DateTime]$expiration)
         }
 
         It "Can set AccountExpires to the past" {
@@ -225,7 +225,7 @@ try {
             $result.Enabled | Should -BeTrue
             $result.SID | Should -Not -BeNullOrEmpty
             $result.ObjectClass | Should -BeExactly 'User'
-            $result.AccountExpires | Should Be ([DateTime]$expiration)
+            $result.AccountExpires | Should -Be ([DateTime]$expiration)
         }
 
         It "Errors on AccountExpires being set to invalid date" {
@@ -452,7 +452,7 @@ try {
             $sid = New-Object System.Security.Principal.SecurityIdentifier -ArgumentList LG
             $guestUser = Get-LocalUser -SID LG
 
-            $guestUser.SID | Should Be $sid.Value
+            $guestUser.SID | Should -Be $sid.Value
         }
 
         It "Can get users by wildcard" {
@@ -557,7 +557,7 @@ try {
             $result.Description | Should -BeExactly $Description
             $result.Enabled | Should -BeFalse
             $result.FullName | Should -BeExactly $FullName
-            $result.ObjectClass -eq "User" | Should be true
+            $result.ObjectClass | Should -BeExactly 'User'
             $result.UserMayChangePassword | Should -BeFalse
             $result.SID | Should -Not -BeNullOrEmpty
             $result.ObjectClass | Should -BeExactly 'User'
@@ -1031,7 +1031,7 @@ try {
             VerifyFailingTest $sb "UserNotFound,Microsoft.PowerShell.Commands.GetLocalUserCommand"
 
             $finalCount = (Get-LocalUser).Count
-            $initialCount -eq $finalCount + 1 | Should Be $true
+            $initialCount | Should -Be ($finalCount + 1)
         }
     }
 
@@ -1057,7 +1057,7 @@ try {
                     VerifyFailingTest $sb "UserNotFound,Microsoft.PowerShell.Commands.GetLocalUserCommand"
 
                     $finalCount = (Get-LocalUser).Count
-                    $initialCount -eq $finalCount + 1 | Should Be true
+                    $initialCount | Should -Be ($finalCount + 1)
                 }
 
                 function VerifyArrayRemoval {
@@ -1080,7 +1080,7 @@ try {
                     VerifyFailingTest $sb "UserNotFound,Microsoft.PowerShell.Commands.GetLocalUserCommand"
 
                     $finalCount = (Get-LocalUser).Count
-                    $initialCount -eq $finalCount + 2 | Should Be $true
+                    $initialCount | Should -Be ($finalCount + 2)
                 }
             }
         }
@@ -1176,7 +1176,7 @@ try {
             VerifyFailingTest $sb "UserNotFound,Microsoft.PowerShell.Commands.RemoveLocalUserCommand"
 
             $finalCount = (Get-LocalUser).Count
-            $initialCount -eq $finalCount | Should Be $true
+            $initialCount | Should -Be $finalCount
         }
 
         It "Errors on remove by invalid SID" {
@@ -1191,7 +1191,7 @@ try {
             VerifyFailingTest $sb "UserNotFound,Microsoft.PowerShell.Commands.RemoveLocalUserCommand"
 
             $finalCount = (Get-LocalUser).Count
-            $initialCount -eq $finalCount | Should Be $true
+            $initialCount | Should -Be $finalCount
         }
 
         It "Can respond to -ErrorAction Stop" {

--- a/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalUser.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalUser.Tests.ps1
@@ -98,9 +98,9 @@ try {
             $result = New-LocalUser TestUserNew1 -NoPassword
 
             $result.Name | Should -BeExactly 'TestUserNew1'
-            $result.Description | Should BeNullOrEmpty
+            $result.Description | Should -BeNullOrEmpty
             $result.Enabled | Should Be $true
-            $result.SID | Should Not BeNullOrEmpty
+            $result.SID | Should -Not -BeNullOrEmpty
             $result.ObjectClass | Should Be User
         }
     }
@@ -119,9 +119,9 @@ try {
             $result = New-LocalUser $userName -NoPassword
 
             $result.Name | Should -BeExactly $userName
-            $result.Description | Should BeNullOrEmpty
+            $result.Description | Should -BeNullOrEmpty
             $result.Enabled | Should Be $true
-            $result.SID | Should Not BeNullOrEmpty
+            $result.SID | Should -Not -BeNullOrEmpty
             $result.ObjectClass | Should Be User
         }
 
@@ -213,9 +213,9 @@ try {
             $result = New-LocalUser TestUserNew1 -NoPassword -AccountExpires $expiration
 
             $result.Name | Should -BeExactly 'TestUserNew1'
-            $result.Description | Should BeNullOrEmpty
+            $result.Description | Should -BeNullOrEmpty
             $result.Enabled | Should Be $true
-            $result.SID | Should Not BeNullOrEmpty
+            $result.SID | Should -Not -BeNullOrEmpty
             $result.ObjectClass | Should Be User
             $result.AccountExpires | Should Be ([DateTime]$expiration)
         }
@@ -225,9 +225,9 @@ try {
             $result = New-LocalUser TestUserNew1 -NoPassword -AccountExpires $expiration
 
             $result.Name | Should -BeExactly 'TestUserNew1'
-            $result.Description | Should BeNullOrEmpty
+            $result.Description | Should -BeNullOrEmpty
             $result.Enabled | Should Be $true
-            $result.SID | Should Not BeNullOrEmpty
+            $result.SID | Should -Not -BeNullOrEmpty
             $result.ObjectClass | Should Be User
             $result.AccountExpires | Should Be ([DateTime]$expiration)
         }
@@ -244,11 +244,11 @@ try {
             $result = New-LocalUser TestUserNew1 -NoPassword -AccountNeverExpires
 
             $result.Name | Should -BeExactly 'TestUserNew1'
-            $result.Description | Should BeNullOrEmpty
+            $result.Description | Should -BeNullOrEmpty
             $result.Enabled | Should Be $true
-            $result.SID | Should Not BeNullOrEmpty
+            $result.SID | Should -Not -BeNullOrEmpty
             $result.ObjectClass | Should Be User
-            $result.AccountExpires | Should BeNullOrEmpty
+            $result.AccountExpires | Should -BeNullOrEmpty
         }
 
          It "Errors on both AccountExpires and AccountNeverExpires being set" {
@@ -264,7 +264,7 @@ try {
             $result.Name | Should -BeExactly 'TestUserNew1'
             $result.Description | Should -BeExactly ""
             $result.Enabled | Should Be $true
-            $result.SID | Should Not BeNullOrEmpty
+            $result.SID | Should -Not -BeNullOrEmpty
             $result.ObjectClass | Should Be User
         }
 
@@ -274,7 +274,7 @@ try {
             $result.Name | Should -BeExactly 'TestUserNew1'
             $result.Description | Should -BeExactly ("A"*48)
             $result.Enabled | Should Be $true
-            $result.SID | Should Not BeNullOrEmpty
+            $result.SID | Should -Not -BeNullOrEmpty
             $result.ObjectClass | Should Be User
         }
 
@@ -288,9 +288,9 @@ try {
             $result = New-LocalUser TestUserNew1 -NoPassword
 
             $result.Name | Should -BeExactly 'TestUserNew1'
-            $result.Description | Should BeNullOrEmpty
+            $result.Description | Should -BeNullOrEmpty
             $result.Enabled | Should Be $true
-            $result.SID | Should Not BeNullOrEmpty
+            $result.SID | Should -Not -BeNullOrEmpty
             $result.ObjectClass | Should Be User
         }
 
@@ -298,9 +298,9 @@ try {
             $result = New-LocalUser TestUserNew1 -NoPassword -Disabled
 
             $result.Name | Should -BeExactly 'TestUserNew1'
-            $result.Description | Should BeNullOrEmpty
+            $result.Description | Should -BeNullOrEmpty
             $result.Enabled | Should Be $false
-            $result.SID | Should Not BeNullOrEmpty
+            $result.SID | Should -Not -BeNullOrEmpty
             $result.ObjectClass | Should Be User
         }
 
@@ -308,20 +308,20 @@ try {
             $result = New-LocalUser TestUserNew1 -NoPassword -FullName ""
 
             $result.Name | Should -BeExactly 'TestUserNew1'
-            $result.Description | Should BeNullOrEmpty
+            $result.Description | Should -BeNullOrEmpty
             $result.Enabled | Should Be $true
-            $result.SID | Should Not BeNullOrEmpty
+            $result.SID | Should -Not -BeNullOrEmpty
             $result.ObjectClass | Should Be User
-            $result.FullName | Should BeNullOrEmpty
+            $result.FullName | Should -BeNullOrEmpty
         }
 
         It "Can set string for FullName at 256 characters" {
             $result = New-LocalUser TestUserNew1 -NoPassword -FullName ("A"*256)
 
             $result.Name | Should -BeExactly 'TestUserNew1'
-            $result.Description | Should BeNullOrEmpty
+            $result.Description | Should -BeNullOrEmpty
             $result.Enabled | Should Be $true
-            $result.SID | Should Not BeNullOrEmpty
+            $result.SID | Should -Not -BeNullOrEmpty
             $result.ObjectClass | Should Be User
             $result.FullName | Should -BeExactly ("A"*256)
         }
@@ -337,9 +337,9 @@ try {
             $result = New-LocalUser TestUserNew1 -Password (ConvertTo-SecureString ("135@"+"A"*252) -AsPlainText -Force)
 
             $result.Name | Should -BeExactly 'TestUserNew1'
-            $result.Description | Should BeNullOrEmpty
+            $result.Description | Should -BeNullOrEmpty
             $result.Enabled | Should Be $true
-            $result.SID | Should Not BeNullOrEmpty
+            $result.SID | Should -Not -BeNullOrEmpty
             $result.ObjectClass | Should Be User
         }
 
@@ -365,9 +365,9 @@ try {
             $result = New-LocalUser TestUserNew1 -NoPassword -UserMayNotChangePassword
 
             $result.Name | Should -BeExactly 'TestUserNew1'
-            $result.Description | Should BeNullOrEmpty
+            $result.Description | Should -BeNullOrEmpty
             $result.Enabled | Should Be $true
-            $result.SID | Should Not BeNullOrEmpty
+            $result.SID | Should -Not -BeNullOrEmpty
             $result.ObjectClass | Should Be User
             $result.UserMayChangePassword | Should Be $false
         }
@@ -377,7 +377,7 @@ try {
             $result = New-LocalUser TestUserNew1 -Password (ConvertTo-SecureString "p@ssw0rd" -Asplaintext -Force) -PasswordNeverExpires
 
             $result.Name | Should -BeExactly 'TestUserNew1'
-            $result.PasswordExpires | Should BeNullOrEmpty
+            $result.PasswordExpires | Should -BeNullOrEmpty
         }
 
         It "Errors on both NoPassword and PasswordNeverExpires being set" {
@@ -391,9 +391,9 @@ try {
             $result = New-LocalUser TestUserNew1 -NoPassword
 
             $result.Name | Should -BeExactly 'TestUserNew1'
-            $result.Description | Should BeNullOrEmpty
+            $result.Description | Should -BeNullOrEmpty
             $result.Enabled | Should Be $true
-            $result.SID | Should Not BeNullOrEmpty
+            $result.SID | Should -Not -BeNullOrEmpty
             $result.ObjectClass | Should Be User
             $result.UserMayChangePassword | Should Be $true
         }
@@ -448,7 +448,7 @@ try {
             $result = Get-LocalUser TestUserGet1
             $resultBySID = Get-LocalUser -SID $result.SID
 
-            $resultBySID.SID | Should Not BeNullOrEmpty
+            $resultBySID.SID | Should -Not -BeNullOrEmpty
             $resultBySID.Name | Should Be TestUserGet1
         }
 
@@ -563,7 +563,7 @@ try {
             $result.FullName | Should -BeExactly $FullName
             $result.ObjectClass -eq "User" | Should be true
             $result.UserMayChangePassword | Should Be $false
-            $result.SID | Should Not BeNullOrEmpty
+            $result.SID | Should -Not -BeNullOrEmpty
             $result.ObjectClass | Should Be User
         }
     }
@@ -664,7 +664,7 @@ try {
             $result.Name | Should -BeExactly 'TestUserSet1'
             $result.Description | Should -BeExactly "Test User Set 1 Description"
             $result.Enabled | Should Be $true
-            $result.SID | Should Not BeNullOrEmpty
+            $result.SID | Should -Not -BeNullOrEmpty
             $result.ObjectClass | Should Be User
             $result.AccountExpires | Should Be ([DateTime]$expiration)
         }
@@ -677,7 +677,7 @@ try {
             $result.Name | Should -BeExactly 'TestUserSet1'
             $result.Description | Should -BeExactly "Test User Set 1 Description"
             $result.Enabled | Should Be $true
-            $result.SID | Should Not BeNullOrEmpty
+            $result.SID | Should -Not -BeNullOrEmpty
             $result.ObjectClass | Should Be User
             $result.AccountExpires | Should Be ([DateTime]$expiration)
         }
@@ -696,7 +696,7 @@ try {
             $result = Get-LocalUser -Name TestUserSet1
 
             $result.Name | Should -BeExactly 'TestUserSet1'
-            $result.AccountExpires | Should BeNullOrEmpty
+            $result.AccountExpires | Should -BeNullOrEmpty
         }
 
         It "Errors on both AccountExpires and AccountNeverExpires being set" {
@@ -726,7 +726,7 @@ try {
 
             $result.Name | Should -BeExactly 'TestUserSet1'
             $result.Description | Should -BeExactly ("A"*48)
-            $result.SID | Should Not BeNullOrEmpty
+            $result.SID | Should -Not -BeNullOrEmpty
             $result.ObjectClass | Should Be User
         }
 
@@ -743,7 +743,7 @@ try {
 
             $result.Name | Should -BeExactly 'TestUserSet1'
             $result.FullName | Should -BeExactly ("A"*256)
-            $result.SID | Should Not BeNullOrEmpty
+            $result.SID | Should -Not -BeNullOrEmpty
             $result.ObjectClass | Should Be User
         }
 
@@ -767,7 +767,7 @@ try {
 
             $result.Name | Should -BeExactly 'TestUserSet1'
             $result.Enabled | Should Be $true
-            $result.SID | Should Not BeNullOrEmpty
+            $result.SID | Should -Not -BeNullOrEmpty
             $result.ObjectClass | Should Be User
         }
 
@@ -785,7 +785,7 @@ try {
             $result = Get-LocalUser TestUserSet2
 
             $result.Name | Should -BeExactly 'TestUserSet2'
-            $result.PasswordExpires | Should BeNullOrEmpty
+            $result.PasswordExpires | Should -BeNullOrEmpty
         }
 
         It 'Can use PasswordNeverExpires:$false to activate a PasswordExpires date' {
@@ -795,7 +795,7 @@ try {
             $result = Get-LocalUser TestUserSet2
 
             $result.Name | Should -BeExactly 'TestUserSet2'
-            $result.PasswordExpires | Should Not BeNullOrEmpty
+            $result.PasswordExpires | Should -Not -BeNullOrEmpty
         }
 
         It "Can set UserMayChangePassword to true" {
@@ -803,7 +803,7 @@ try {
             $result = Get-LocalUser -Name TestUserSet1
 
             $result.Name | Should -BeExactly 'TestUserSet1'
-            $result.SID | Should Not BeNullOrEmpty
+            $result.SID | Should -Not -BeNullOrEmpty
             $result.ObjectClass | Should Be User
             $result.UserMayChangePassword | Should Be $true
         }
@@ -813,7 +813,7 @@ try {
             $result = Get-LocalUser -Name TestUserSet1
 
             $result.Name | Should -BeExactly 'TestUserSet1'
-            $result.SID | Should Not BeNullOrEmpty
+            $result.SID | Should -Not -BeNullOrEmpty
             $result.ObjectClass | Should Be User
             $result.UserMayChangePassword | Should Be $false
         }
@@ -1027,7 +1027,7 @@ try {
             $initialCount -gt 1 | Should Be $true
 
             $removeResult = Remove-LocalUser TestUserRemove1 2>&1
-            $removeResult | Should BeNullOrEmpty
+            $removeResult | Should -BeNullOrEmpty
 
             $sb = {
                 Get-LocalUser -SID $user1SID
@@ -1105,10 +1105,10 @@ try {
         }
 
         It "Can remove by SID" {
-            $user1SID | Should Not BeNullOrEmpty
+            $user1SID | Should -Not -BeNullOrEmpty
             $sb = {
                 $result = Remove-LocalUser -SID $user1SID 2>&1
-                $result | Should BeNullOrEmpty
+                $result | Should -BeNullOrEmpty
             }
             VerifyBasicRemoval $sb
         }
@@ -1117,7 +1117,7 @@ try {
             $sb = {
                 $user = Get-LocalUser -SID $user1SID
                 $result = Remove-LocalUser -InputObject $user 2>&1
-                $result | Should BeNullOrEmpty
+                $result | Should -BeNullOrEmpty
             }
             VerifyBasicRemoval $sb
         }
@@ -1125,7 +1125,7 @@ try {
         It "Can remove using pipeline" {
             $sb = {
                 $result = Get-LocalUser -SID $user1SID | Remove-LocalUser 2>&1
-                $result | Should BeNullOrEmpty
+                $result | Should -BeNullOrEmpty
             }
             VerifyBasicRemoval $sb
         }
@@ -1140,7 +1140,7 @@ try {
         It "Can remove by array of names" {
             $sb = {
                 $result = Remove-LocalUser @("TestUserRemove1", "TestUserRemove2") 2>&1
-                $result | Should BeNullOrEmpty
+                $result | Should -BeNullOrEmpty
             }
             VerifyArrayRemoval $sb
         }
@@ -1148,7 +1148,7 @@ try {
         It "Can remove by array of SIDs" {
             $sb = {
                 $result = Remove-LocalUser -SID @($user1SID, $user2SID) 2>&1
-                $result | Should BeNullOrEmpty
+                $result | Should -BeNullOrEmpty
             }
             VerifyArrayRemoval $sb
         }
@@ -1157,7 +1157,7 @@ try {
             $sb = {
                 $users = Get-LocalUser @("TestUserRemove1", "TestUserRemove2")
                 $results = Remove-LocalUser -InputObject $users 2>&1
-                $result | Should BeNullOrEmpty
+                $result | Should -BeNullOrEmpty
             }
             VerifyArrayRemoval $sb
         }
@@ -1165,7 +1165,7 @@ try {
         It "Can remove by array using pipeline" {
             $sb = {
                 $result = Get-LocalUser @("TestUserRemove1", "TestUserRemove2") | Remove-LocalUser 2>&1
-                $result | Should BeNullOrEmpty
+                $result | Should -BeNullOrEmpty
             }
             VerifyArrayRemoval $sb
         }

--- a/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalUser.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalUser.Tests.ps1
@@ -31,11 +31,7 @@ function VerifyFailingTest
     $script:ErrorActionPreference = "Stop"
 
     try {
-        & $sb
-        throw "Expected error: $expectedFqeid"
-    }
-    catch {
-        $_.FullyQualifiedErrorId | Should Be $expectedFqeid
+        {& $sb} | Should -Throw -ErrorId $expectedFqeid
     }
     finally {
         $script:ErrorActionPreference = $backupEAP
@@ -1205,8 +1201,8 @@ try {
             catch {
                 # Nothing to do here
             }
-            $outError.Count | Should Be 2
-            $outError[0].ErrorRecord.FullyQualifiedErrorId | Should Be "UserNotFound,Microsoft.PowerShell.Commands.RemoveLocalUserCommand"
+            $outError | Should -HaveCount 2
+            $outError[0].ErrorRecord.FullyQualifiedErrorId | Should -BeExactly "UserNotFound,Microsoft.PowerShell.Commands.RemoveLocalUserCommand"
 
             $getResult = Get-LocalUser TestUserGet1 2>&1
             $getResult.FullyQualifiedErrorId | Should -Match "UserNotFound"
@@ -1376,8 +1372,8 @@ try {
             Catch {
                 # do nothing
             }
-            $outError.Count | Should Be 2
-            $outError[0].ErrorRecord.FullyQualifiedErrorId | Should Be "UserNotFound,Microsoft.PowerShell.Commands.EnableLocalUserCommand"
+            $outError | Should -HaveCount 2
+            $outError[0].ErrorRecord.FullyQualifiedErrorId | Should -BeExactly "UserNotFound,Microsoft.PowerShell.Commands.EnableLocalUserCommand"
 
             $getResult = Get-LocalUser TestUserDisabled1 2>&1
             $getResult.Enabled | Should -BeTrue
@@ -1544,8 +1540,8 @@ try {
             Catch {
                 # Do nothing here
             }
-            $outError.Count | Should Be 2
-            $outError[0].ErrorRecord.FullyQualifiedErrorId | Should Be "UserNotFound,Microsoft.PowerShell.Commands.DisableLocalUserCommand"
+            $outError | Should -HaveCount 2
+            $outError[0].ErrorRecord.FullyQualifiedErrorId | Should -BeExactly "UserNotFound,Microsoft.PowerShell.Commands.DisableLocalUserCommand"
 
             $getResult = Get-LocalUser TestUserEnabled1 2>&1
             $getResult.Enabled | Should -BeFalse

--- a/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalUser.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalUser.Tests.ps1
@@ -493,8 +493,8 @@ try {
                 # Ignore the execption
             }
             $outErr.Count -eq 1 | Should Be $true
-            $outErr[0].ErrorRecord.CategoryInfo.Reason -match "UserNotFound" | Should Be $true
-            $outOut.Name -match "TestUserGet1" | Should Be $true
+            $outErr[0].ErrorRecord.CategoryInfo.Reason | Should -Match "UserNotFound"
+            $outOut.Name | Should -Match "TestUserGet1"
         }
 
         It "Error on Name not being supplied an argument" {
@@ -1209,7 +1209,7 @@ try {
             $outError[0].ErrorRecord.FullyQualifiedErrorId | Should Be "UserNotFound,Microsoft.PowerShell.Commands.RemoveLocalUserCommand"
 
             $getResult = Get-LocalUser TestUserGet1 2>&1
-            $getResult.FullyQualifiedErrorId -match "UserNotFound" | Should Be $true
+            $getResult.FullyQualifiedErrorId | Should -Match "UserNotFound"
         }
     }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalUser.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.LocalAccounts/Pester.Command.Cmdlets.LocalAccounts.LocalUser.Tests.ps1
@@ -437,7 +437,7 @@ try {
         It "Get-LocalUser gets all users"  {
             $result = Get-LocalUser
 
-            $result.Count -gt 2 | Should -BeTrue
+            $result.Count | Should -BeGreaterThan 2
         }
 
         It "Can get a specific user by SID" {
@@ -1020,7 +1020,7 @@ try {
 
         It "Can Remove-LocalUser with only name" {
             $initialCount = (Get-LocalUser).Count
-            $initialCount -gt 1 | Should -BeTrue
+            $initialCount | Should -BeGreaterThan 1
 
             $removeResult = Remove-LocalUser TestUserRemove1 2>&1
             $removeResult | Should -BeNullOrEmpty
@@ -1047,7 +1047,7 @@ try {
                         [scriptblock]$removalAction
                     )
                     $initialCount = (Get-LocalUser).Count
-                    $initialCount -gt 1 | Should -BeTrue
+                    $initialCount | Should -BeGreaterThan 1
 
                     & $removalAction
 
@@ -1065,7 +1065,7 @@ try {
                         [scriptblock]$removalAction
                     )
                     $initialCount = (Get-LocalUser).Count
-                    $initialCount -gt 1 | Should -BeTrue
+                    $initialCount | Should -BeGreaterThan 1
 
                     & $removalAction
 
@@ -1168,7 +1168,7 @@ try {
 
         It "Errors on remove by invalid name" {
             $initialCount =  (Get-LocalUser).Count
-            $initialCount -gt 1 | Should -BeTrue
+            $initialCount | Should -BeGreaterThan 1
 
             $sb = {
                 Remove-LocalUser TestUserRemove1NameThatDoesntExist
@@ -1183,7 +1183,7 @@ try {
             Remove-LocalUser -SID $user1SID
             # This test verifies that it cannot be removed a second time
             $initialCount =  (Get-LocalUser).Count
-            $initialCount -gt 1 | Should -BeTrue
+            $initialCount | Should -BeGreaterThan 1
 
             $sb = {
                 Remove-LocalUser -SID $user1SID


### PR DESCRIPTION
## PR Summary

Use new Pester syntax: -Parameter for Pester in Modules/Microsoft.PowerShell.LocalAccounts
Resolves part of #6245

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [X] Not Applicable
    - **OR**
    - [NA] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [NA] Issue filed - Issue link:
- **Testing - New and feature**
    - [X] Not Applicable or can only be tested interactively
    - **OR**
    - [NA] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [NA] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
