### PR TITLE
Make LanguagePrimitive.GetEnumerable treat 'DataTable' as Enumerable

### DIFF
--- a/src/System.Management.Automation/engine/LanguagePrimitives.cs
+++ b/src/System.Management.Automation/engine/LanguagePrimitives.cs
@@ -476,12 +476,10 @@ namespace System.Management.Automation
             return null;
         }
 
-#if !CORECLR
         private static IEnumerable DataTableEnumerable(object obj)
         {
             return (((DataTable)obj).Rows);
         }
-#endif
 
         private static IEnumerable TypicalEnumerable(object obj)
         {
@@ -517,12 +515,10 @@ namespace System.Management.Automation
 
         private static GetEnumerableDelegate CalculateGetEnumerable(Type objectType)
         {
-#if !CORECLR
             if (typeof(DataTable).IsAssignableFrom(objectType))
             {
                 return LanguagePrimitives.DataTableEnumerable;
             }
-#endif
 
             // Don't treat IDictionary or XmlNode as enumerable...
             if (typeof(IEnumerable).IsAssignableFrom(objectType)

--- a/test/powershell/engine/Api/LanguagePrimitive.Tests.ps1
+++ b/test/powershell/engine/Api/LanguagePrimitive.Tests.ps1
@@ -32,4 +32,18 @@ Describe "Language Primitive Tests" -Tags "CI" {
         $a[0] = $a = [PSObject](,1)
         [System.Management.Automation.LanguagePrimitives]::IsTrue($a) | Should -BeTrue
     }
+
+    It "LanguagePrimitives.GetEnumerable should treat 'DataTable' as Enumerable" {
+        $dt = [System.Data.DataTable]::new("test")
+        $dt.Columns.Add("Name", [string]) > $null
+        $dt.Columns.Add("Age", [string]) > $null
+        $dr = $dt.NewRow(); $dr["Name"] = "John"; $dr["Age"] = "20"
+        $dr2 = $dt.NewRow(); $dr["Name"] = "Susan"; $dr["Age"] = "25"
+        $dt.Rows.Add($dr); $dt.Rows.Add($dr2)
+
+        [System.Management.Automation.LanguagePrimitives]::IsObjectEnumerable($dt) | Should -BeTrue
+        $count = 0
+        [System.Management.Automation.LanguagePrimitives]::GetEnumerable($dt) | ForEach-Object { $cnt++ }
+        $count | Should -Be 2
+    }
 }

--- a/test/powershell/engine/Api/LanguagePrimitive.Tests.ps1
+++ b/test/powershell/engine/Api/LanguagePrimitive.Tests.ps1
@@ -43,7 +43,7 @@ Describe "Language Primitive Tests" -Tags "CI" {
 
         [System.Management.Automation.LanguagePrimitives]::IsObjectEnumerable($dt) | Should -BeTrue
         $count = 0
-        [System.Management.Automation.LanguagePrimitives]::GetEnumerable($dt) | ForEach-Object { $cnt++ }
+        [System.Management.Automation.LanguagePrimitives]::GetEnumerable($dt) | ForEach-Object { $count++ }
         $count | Should -Be 2
     }
 }


### PR DESCRIPTION
## PR Summary

Fix #6453
Remove out-dated `#if !CoreCLR/endif` to make LanguagePrimitive.GetEnumerable treat 'DataTable' as Enumerable.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
