### PR TITLE
Correct use of NullOrEmpty string in Implicit.Remoting.Tests

### DIFF
--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Implicit.Remoting.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Implicit.Remoting.Tests.ps1
@@ -200,7 +200,7 @@ try
                 Invoke-Command $session { Set-Alias BrokenAlias NonExistantCommand }
                 $module = Import-PSSession $session -CommandName:BrokenAlias -CommandType:All -ErrorAction SilentlyContinue -ErrorVariable expectedError -AllowClobber
 
-                $expectedError | Should -Not -Be NullOrEmpty
+                $expectedError | Should -Not -BeNullOrEmpty
                 $expectedError[0].ToString().Contains("BrokenAlias") | Should -BeTrue
             } finally {
                 if ($null -ne $module) { Remove-Module $module -Force -ErrorAction SilentlyContinue }
@@ -344,7 +344,7 @@ try
                 Export-PSSession -Session $session -CommandName Get-Variable -AllowClobber -ModuleName $file -EA SilentlyContinue -ErrorVariable expectedError
             } catch { }
 
-            $expectedError | Should -Not -Be NullOrEmpty
+            $expectedError | Should -Not -BeNullOrEmpty
             # Error contains reference to the directory that already exists
             ([string]($expectedError[0]) -like "*$file*") | Should -BeTrue
         }
@@ -377,7 +377,7 @@ try
 
 	        It "Verfies Remove-Module doesn't remove user's runspace" {
                 Remove-Module $module -Force -ErrorAction SilentlyContinue
-                (Get-PSSession -InstanceId $session.InstanceId) | Should -Not -Be NullOrEmpty
+                (Get-PSSession -InstanceId $session.InstanceId) | Should -Not -BeNullOrEmpty
             }
         }
     }
@@ -764,11 +764,11 @@ try
         }
 
         It "Import-PSSession should return a PSModuleInfo object" {
-            $module | Should -Not -Be NullOrEmpty
+            $module | Should -Not -BeNullOrEmpty
         }
 
         It "Import-PSSession should return a PSModuleInfo object" {
-            ($module -as [System.Management.Automation.PSModuleInfo]) | Should -Not -Be NullOrEmpty
+            ($module -as [System.Management.Automation.PSModuleInfo]) | Should -Not -BeNullOrEmpty
         }
 
         It "Helper functions should not be imported" {
@@ -1333,7 +1333,7 @@ try
                 try {
                     $job = Get-Variable -Name PID -AsJob
 
-                    $job | Should -Not -Be NullOrEmpty
+                    $job | Should -Not -BeNullOrEmpty
                     ($job -is [System.Management.Automation.Job]) | Should -BeTrue
                     ($job.Finished.WaitOne([TimeSpan]::FromSeconds(10), $false)) | Should -BeTrue
                     $job.JobStateInfo.State | Should -Be 'Completed'
@@ -1647,7 +1647,7 @@ try
             try {
                 Invoke-Command $session { function attack(${foo="$(calc)"}){echo "It is done."}}
                 $module = Import-PSSession -Session $session -CommandName attack -ErrorAction SilentlyContinue -ErrorVariable expectedError -AllowClobber
-                $expectedError | Should -Not -Be NullOrEmpty
+                $expectedError | Should -Not -BeNullOrEmpty
             } finally {
                 if ($null -ne $module) { Remove-Module $module -Force -ErrorAction SilentlyContinue }
             }
@@ -1659,7 +1659,7 @@ try
                 Invoke-Command $session { function Get-Command { write-error blah } }
                 $module = Import-PSSession -Session $session -ErrorAction SilentlyContinue -ErrorVariable expectedError -AllowClobber
 
-                $expectedError | Should -Not -Be NullOrEmpty
+                $expectedError | Should -Not -BeNullOrEmpty
 
                 $msg = [string]($expectedError[0])
                 $msg.Contains("blah") | Should -BeTrue
@@ -1675,7 +1675,7 @@ try
                 Invoke-Command $session { function notRequested { "notRequested" }; function Get-Command { Microsoft.PowerShell.Core\Get-Command Get-Variable,notRequested } }
                 $module = Import-PSSession -Session $session Get-Variable -AllowClobber -ErrorAction SilentlyContinue -ErrorVariable expectedError
 
-                $expectedError | Should -Not -Be NullOrEmpty
+                $expectedError | Should -Not -BeNullOrEmpty
 
                 $msg = [string]($expectedError[0])
                 $msg.Contains("notRequested") | Should -BeTrue
@@ -1996,7 +1996,7 @@ try
 
         It "Select -First should work with implicit remoting" {
             $bar = foo | Select-Object -First 2
-            $bar | Should -Not -Be NullOrEmpty
+            $bar | Should -Not -BeNullOrEmpty
             $bar.Count | Should -Be 2
             $bar[0] | Should -BeExactly "a"
             $bar[1] | Should -BeExactly "b"


### PR DESCRIPTION
## PR Summary
resolve the incorrect use of `NullOrEmpty` as a string
resolves #6372

These issues were identified in the Pester syntax remediation but were functional changes outside the scope of that effort.

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [X] Not Applicable
    - **OR**
    - [na] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [na] Issue filed - Issue link:
- **Testing - New and feature**
    - [na] Not Applicable or can only be tested interactively
    - **OR**
    - [X] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [X] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
