### PR TITLE
Remove empty Should -Be statements in Remove-Variable tests

### DIFF
--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Remove-Variable.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Remove-Variable.Tests.ps1
@@ -16,7 +16,9 @@ Describe "Remove-Variable" -Tags "CI" {
 
 	Remove-Variable var1
 
-	$var1 | Should -Be #nothing.  it should be Nothing at all.
+	$var1 | Should -BeNullOrEmpty
+	{ Get-Variable var1 -ErrorAction stop } |
+		Should -Throw -ErrorId 'VariableNotFound,Microsoft.PowerShell.Commands.GetVariableCommand'
     }
 
     It "Should not throw error when used with the Name field, and named variable is specified and exists" {
@@ -24,7 +26,9 @@ Describe "Remove-Variable" -Tags "CI" {
 
 	Remove-Variable -Name var1
 
-	$var1 | Should -Be #nothing.  it should be Nothing at all.
+	$var1 | Should -BeNullOrEmpty
+	{ Get-Variable var1 -ErrorAction stop } |
+		Should -Throw -ErrorId 'VariableNotFound,Microsoft.PowerShell.Commands.GetVariableCommand'
     }
 
     It "Should throw error when used with Name field, and named variable does not exist" {
@@ -42,9 +46,16 @@ Describe "Remove-Variable" -Tags "CI" {
 
 	Remove-Variable -Name tmp*
 
-	$tmpvar1   | Should -Be #nothing.  it should be Nothing at all.
-	$tmpvar2   | Should -Be #nothing.  it should be Nothing at all.
-	$tmpmyvar1 | Should -Be #nothing.  it should be Nothing at all.
+	$tmpvar1   | Should -BeNullOrEmpty
+	$tmpvar2   | Should -BeNullOrEmpty
+	$tmpmyvar1 | Should -BeNullOrEmpty
+
+	{ Get-Variable tmpvar1 -ErrorAction stop } |
+		Should -Throw -ErrorId 'VariableNotFound,Microsoft.PowerShell.Commands.GetVariableCommand'
+	{ Get-Variable tmpvar2 -ErrorAction stop } |
+		Should -Throw -ErrorId 'VariableNotFound,Microsoft.PowerShell.Commands.GetVariableCommand'
+	{ Get-Variable tmpmyvar1 -ErrorAction stop } |
+		Should -Throw -ErrorId 'VariableNotFound,Microsoft.PowerShell.Commands.GetVariableCommand'
     }
 
     It "Should be able to exclude a set of variables to remove using the Exclude switch" {
@@ -58,9 +69,14 @@ Describe "Remove-Variable" -Tags "CI" {
 
 	Remove-Variable -Name tmp* -Exclude *my*
 
-	$tmpvar1   | Should -Be #nothing.  it should be Nothing at all.
-	$tmpvar2   | Should -Be #nothing.  it should be Nothing at all.
+	$tmpvar1   | Should -BeNullOrEmpty
+	$tmpvar2   | Should -BeNullOrEmpty
 	$tmpmyvar1 | Should -Be 234
+
+	{ Get-Variable tmpvar1 -ErrorAction stop } |
+		Should -Throw -ErrorId 'VariableNotFound,Microsoft.PowerShell.Commands.GetVariableCommand'
+	{ Get-Variable tmpvar2 -ErrorAction stop } |
+		Should -Throw -ErrorId 'VariableNotFound,Microsoft.PowerShell.Commands.GetVariableCommand'
     }
 
     It "Should be able to include a set of variables to remove using the Include switch" {
@@ -78,8 +94,11 @@ Describe "Remove-Variable" -Tags "CI" {
 
 	$tmpvar1   | Should -BeExactly "tempvalue"
 	$tmpvar2   | Should -Be 2
-	$tmpmyvar1 | Should -Be #nothing.  it should be Nothing at all.
+	$tmpmyvar1 | Should -BeNullOrEmpty
 	$thevar    | Should -Be 1
+
+	{ Get-Variable tmpmyvar1 -ErrorAction stop } |
+		Should -Throw -ErrorId 'VariableNotFound,Microsoft.PowerShell.Commands.GetVariableCommand'
 
 	Remove-Variable tmpvar1
 	Remove-Variable tmpvar2


### PR DESCRIPTION
## PR Summary
convert empty `Should -Be` to `Should -BeEmptyOrNull`
add `Get-Variable` test for removed variables
resolves #6371

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [X] Not Applicable
    - **OR**
    - [na] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [na] Issue filed - Issue link:
- **Testing - New and feature**
    - [na] Not Applicable or can only be tested interactively
    - **OR**
    - [X] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [X] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
