### PR TITLE
Some fixes  in Get-Date -UFormat

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetDateCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetDateCommand.cs
@@ -393,7 +393,7 @@ namespace Microsoft.PowerShell.Commands
                             break;
 
                         case 'l':
-                            sb.Append(StringUtil.Format("{0,2:0}", dateTime.Hour%12));
+                            sb.Append("{0:%h}");
                             break;
 
                         case 'M':
@@ -425,7 +425,7 @@ namespace Microsoft.PowerShell.Commands
                             break;
 
                         case 's':
-                            sb.Append(StringUtil.Format("{0:0}", dateTime.Subtract(epoch).TotalSeconds));
+                            sb.Append(StringUtil.Format("{0:0}", dateTime.ToUniversalTime().Subtract(epoch).TotalSeconds));
                             break;
 
                         case 'T':
@@ -449,7 +449,11 @@ namespace Microsoft.PowerShell.Commands
                             break;
 
                         case 'V':
-                            sb.Append((dateTime.DayOfYear / 7) + 1);
+                            // FirstFourDayWeek and DayOfWeek.Monday is from ISO 8601
+                            var calender = System.Threading.Thread.CurrentThread.CurrentCulture.Calendar;
+                            sb.Append(StringUtil.Format("{0:00}",calender.GetWeekOfYear(dateTime,
+                                                                                        CalendarWeekRule.FirstFourDayWeek,
+                                                                                        DayOfWeek.Monday)));
                             break;
 
                         case 'G':

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetDateCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetDateCommand.cs
@@ -393,7 +393,7 @@ namespace Microsoft.PowerShell.Commands
                             break;
 
                         case 'l':
-                            sb.Append("{0:%h}");
+                            sb.Append("{0,2:%h}");
                             break;
 
                         case 'M':

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetDateCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetDateCommand.cs
@@ -449,9 +449,32 @@ namespace Microsoft.PowerShell.Commands
                             break;
 
                         case 'V':
+                            // .Net Core doesn't implement ISO 8601.
+                            // So we use workaround from https://blogs.msdn.microsoft.com/shawnste/2006/01/24/iso-8601-week-of-year-format-in-microsoft-net/
+                            // with corrections from comments
+
+                            // Culture doesn't matter since we specify start day of week
+                            var calender = CultureInfo.InvariantCulture.Calendar;
+                            var day = calender.GetDayOfWeek(dateTime);
+                            var normalizedDatetime = dateTime;
+
+                            switch (day)
+                            {
+                                case DayOfWeek.Monday:
+                                case DayOfWeek.Tuesday:
+                                case DayOfWeek.Wednesday:
+                                    normalizedDatetime = dateTime.AddDays(3);
+                                    break;
+
+                                case DayOfWeek.Friday:
+                                case DayOfWeek.Saturday:
+                                case DayOfWeek.Sunday:
+                                    normalizedDatetime = dateTime.AddDays(-3);
+                                    break;
+                            }
+
                             // FirstFourDayWeek and DayOfWeek.Monday is from ISO 8601
-                            var calender = System.Threading.Thread.CurrentThread.CurrentCulture.Calendar;
-                            sb.Append(StringUtil.Format("{0:00}",calender.GetWeekOfYear(dateTime,
+                            sb.Append(StringUtil.Format("{0:00}",calender.GetWeekOfYear(normalizedDatetime,
                                                                                         CalendarWeekRule.FirstFourDayWeek,
                                                                                         DayOfWeek.Monday)));
                             break;

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Date.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Date.Tests.ps1
@@ -37,7 +37,7 @@ Describe "Get-Date DRT Unit Tests" -Tags "CI" {
     }
 
     It "using -uformat 'aAbBcCdDehHIkljmMpr' produces the correct output" {
-        Get-date -Date 1/1/0030 -uformat %a%A%b%B%c%C%d%D%e%h%H%I%k%l%j%m%M%p%r | Should -Be "TueTuesdayJanJanuaryTue 01 Jan 0030 00:00:0000101/01/30 1Jan0012 0120010100AM12:00:00 AM"
+        Get-date -Date 1/1/0030 -uformat %a%A%b%B%c%C%d%D%e%h%H%I%k%l%j%m%M%p%r | Should -Be "TueTuesdayJanJanuaryTue 01 Jan 0030 00:00:0000101/01/30 1Jan0012 012 010100AM12:00:00 AM"
     }
 
     It "using -uformat 'sStTuUVwWxXyYZ' produces the correct output" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Date.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Date.Tests.ps1
@@ -44,17 +44,31 @@ Describe "Get-Date DRT Unit Tests" -Tags "CI" {
         Get-date -Date 1/1/0030 -uformat %S%T%u%U%w%W%x%X%y%Y%% | Should -Be "0000:00:00202001/01/3000:00:00300030%"
     }
 
-    It "using -uformat 'V' produces the correct output" {
-        Get-date -Date 1/1/0030 -uformat %V | Should -BeExactly "01"
-
-        # .Net Core Bug - Should -Be "01"
-        # See 'Last week' in https://en.wikipedia.org/wiki/ISO_week_date#Relation_with_the_Gregorian_calendar
-        # > If 31 December is on a Monday, Tuesday or Wednesday, it is in week 01 of the next year.
-        # '12/31/2007' is 'Monday, December 31, 2007 12:00:00 AM'
-        # There is an indefinite number of similar problems.
-        Get-date -Date 12/31/2007 -uformat %V | Should -BeExactly "53"
-
-        Get-date -Date 1/1/2011 -uformat %V | Should -BeExactly "52"
+    # The 'week of year' test cases is from https://en.wikipedia.org/wiki/ISO_week_date
+    It "using -uformat 'V' produces the correct output" -TestCases @(
+        @{date="2005-01-01"; week = "53"},
+        @{date="2005-01-02"; week = "53"},
+        @{date="2005-12-31"; week = "52"},
+        @{date="2006-01-01"; week = "52"},
+        @{date="2006-01-02"; week = "01"},
+        @{date="2006-12-31"; week = "52"},
+        @{date="2007-01-01"; week = "01"},
+        @{date="2007-12-30"; week = "52"},
+        @{date="2007-12-31"; week = "01"},
+        @{date="2008-01-01"; week = "01"},
+        @{date="2008-12-28"; week = "52"},
+        @{date="2008-12-29"; week = "01"},
+        @{date="2008-12-30"; week = "01"},
+        @{date="2008-12-31"; week = "01"},
+        @{date="2009-01-01"; week = "01"},
+        @{date="2009-12-31"; week = "53"},
+        @{date="2010-01-01"; week = "53"},
+        @{date="2010-01-02"; week = "53"},
+        @{date="2010-01-03"; week = "53"},
+        @{date="2010-01-04"; week = "01"}
+    ) {
+        param($date, $week)
+        Get-date -Date $date -uformat %V | Should -BeExactly $week
     }
 
     It "Passing '<name>' to -uformat produces a descriptive error" -TestCases @(

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Date.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Date.Tests.ps1
@@ -37,7 +37,7 @@ Describe "Get-Date DRT Unit Tests" -Tags "CI" {
     }
 
     It "using -uformat 'aAbBcCdDehHIkljmMpr' produces the correct output" {
-        Get-date -Date 1/1/0030 -uformat %a%A%b%B%c%C%d%D%e%h%H%I%k%l%j%m%M%p%r | Should -Be "TueTuesdayJanJanuaryTue 01 Jan 0030 00:00:0000101/01/30 1Jan0012 012 010100AM12:00:00 AM"
+        Get-date -Date 1/1/0030 -uformat "%a%A%b%B%c%C%d%D%e%h%H%I%k%l%j%m%M%p%r" | Should -Be "TueTuesdayJanJanuaryTue 01 Jan 0030 00:00:0000101/01/30 1Jan0012 0120010100AM12:00:00 AM"
     }
 
     It "using -uformat 'sStTuUVwWxXyYZ' produces the correct output" {


### PR DESCRIPTION
## PR Summary

In #4805 we fixed some formats for `-Uformat`.
Here we collect fixes of returned values for `-Uformat`.

1. Fix %s value
Address the [comment](https://github.com/PowerShell/PowerShell/issues/2195#issuecomment-375897359)
We use local datetime in evaluating %s format and UTC in epoch constant so returned value contains time zone shift compared to the value returned by Unix `date` utility.
In the PR we convert  local datetime to UTC.
https://stackoverflow.com/questions/2883576/how-do-you-convert-epoch-time-in-c

2. Fix %l uformat
Currently we have 0 .. 11 format.
Right format is 1..12 
See http://man7.org/linux/man-pages/man1/date.1.html

3. Fix %V uformat

PowerShell Committee conclusion https://github.com/PowerShell/PowerShell/pull/4508#issuecomment-325052526

Currently we use simple formula.
Right algorifm is described in https://en.wikipedia.org/wiki/ISO_week_date#Relation_with_the_Gregorian_calendar

Output format is changed from 1..53 to 01..53. See http://man7.org/linux/man-pages/man1/date.1.html

[Previous discussion](https://github.com/PowerShell/PowerShell/pull/4508/commits/f13a8b5d7e64ba5ea9c16c7e5408c5ca722f8bf7#r131528088).

.Net haven't ISO-compatible implementation.
I opened Issue in .Net Core repo https://github.com/dotnet/corefx/issues/28808 and get recomendation to use the workaround https://blogs.msdn.microsoft.com/shawnste/2006/01/24/iso-8601-week-of-year-format-in-microsoft-net/ with corrections based on comments.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
