### PR TITLE
Engine: Fix several code cleanup issues

### DIFF
--- a/src/System.Management.Automation/engine/CoreAdapter.cs
+++ b/src/System.Management.Automation/engine/CoreAdapter.cs
@@ -4252,7 +4252,7 @@ namespace System.Management.Automation
             // are ignored.
             if (typeof(T) == typeof(PSMemberInfo))
             {
-                T returnValue = PSObject.dotNetInstanceAdapter.GetDotNetMethod<T>(obj, memberName);
+                T returnValue = base.GetDotNetMethod<T>(obj, memberName);
                 // We only return a method if there is no property by the same name
                 // to match the behavior we have in GetMembers
                 if (returnValue != null && property == null)
@@ -4263,7 +4263,7 @@ namespace System.Management.Automation
 
             if (IsTypeParameterizedProperty(typeof(T)))
             {
-                PSParameterizedProperty parameterizedProperty = PSObject.dotNetInstanceAdapter.GetDotNetProperty<PSParameterizedProperty>(obj, memberName);
+                PSParameterizedProperty parameterizedProperty = base.GetDotNetProperty<PSParameterizedProperty>(obj, memberName);
                 // We only return a parameterized property if there is no property by the same name
                 // to match the behavior we have in GetMembers
                 if (parameterizedProperty != null && property == null)

--- a/src/System.Management.Automation/engine/CoreAdapter.cs
+++ b/src/System.Management.Automation/engine/CoreAdapter.cs
@@ -4604,7 +4604,7 @@ namespace System.Management.Automation
 
             if (typeof(T).IsAssignableFrom(typeof(PSMethod)))
             {
-                T returnValue = PSObject.dotNetInstanceAdapter.GetDotNetMethod<T>(obj, memberName);
+                T returnValue = base.GetDotNetMethod<T>(obj, memberName);
                 // We only return a method if there is no property by the same name
                 // to match the behavior we have in GetMembers
                 if (returnValue != null && property == null)
@@ -4614,7 +4614,7 @@ namespace System.Management.Automation
             }
             if (IsTypeParameterizedProperty(typeof(T)))
             {
-                PSParameterizedProperty parameterizedProperty = PSObject.dotNetInstanceAdapter.GetDotNetProperty<PSParameterizedProperty>(obj, memberName);
+                PSParameterizedProperty parameterizedProperty = base.GetDotNetProperty<PSParameterizedProperty>(obj, memberName);
                 // We only return a parameterized property if there is no property by the same name
                 // to match the behavior we have in GetMembers
                 if (parameterizedProperty != null && property == null)
@@ -4644,11 +4644,11 @@ namespace System.Management.Automation
             {
                 DoAddAllProperties<T>(obj, returnValue);
             }
-            PSObject.dotNetInstanceAdapter.AddAllMethods(obj, returnValue, true);
+            base.AddAllMethods(obj, returnValue, true);
             if (IsTypeParameterizedProperty(typeof(T)))
             {
                 var parameterizedProperties = new PSMemberInfoInternalCollection<PSParameterizedProperty>();
-                PSObject.dotNetInstanceAdapter.AddAllProperties(obj, parameterizedProperties, true);
+                base.AddAllProperties(obj, parameterizedProperties, true);
                 foreach (PSParameterizedProperty parameterizedProperty in parameterizedProperties)
                 {
                     try

--- a/src/System.Management.Automation/engine/EventManager.cs
+++ b/src/System.Management.Automation/engine/EventManager.cs
@@ -2029,7 +2029,7 @@ namespace System.Management.Automation
 
         internal void RegisterJob()
         {
-            // And this event subscriber to the job repository if it's not a support event.
+            // Add this event subscriber to the job repository if it's not a support event.
             if (!SupportEvent)
             {
                 if (this.Action != null)

--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -5219,7 +5219,7 @@ if($paths) {
                 {
                     clone[entry.Key] = (SessionStateProviderEntry)entry.Value.Clone();
                 }
-                s_providerCache.Value[assembly] = providers;
+                s_providerCache.Value[assembly] = clone;
             }
         }
 

--- a/src/System.Management.Automation/engine/MshObject.cs
+++ b/src/System.Management.Automation/engine/MshObject.cs
@@ -171,9 +171,9 @@ namespace System.Management.Automation
         private static PSMemberInfoInternalCollection<T> DotNetGetMembersDelegate<T>(PSObject msjObj) where T : PSMemberInfo
         {
             // Don't lookup dotnet members if the object doesn't insist.
-            if (null != msjObj.InternalAdapterSet.DotNetAdapter)
+            if (null != msjObj.InternalBaseDotNetAdapter)
             {
-                PSMemberInfoInternalCollection<T> retValue = msjObj.InternalAdapterSet.DotNetAdapter.BaseGetMembers<T>(msjObj._immediateBaseObject);
+                PSMemberInfoInternalCollection<T> retValue = msjObj.InternalBaseDotNetAdapter.BaseGetMembers<T>(msjObj._immediateBaseObject);
                 PSObject.memberResolution.WriteLine("DotNet members: {0}.", retValue.VisibleCount);
                 return retValue;
             }
@@ -184,9 +184,9 @@ namespace System.Management.Automation
         private static T DotNetGetMemberDelegate<T>(PSObject msjObj, string name) where T : PSMemberInfo
         {
             // Don't lookup dotnet member if the object doesn't insist.
-            if (null != msjObj.InternalAdapterSet.DotNetAdapter)
+            if (null != msjObj.InternalBaseDotNetAdapter)
             {
-                T retValue = msjObj.InternalAdapterSet.DotNetAdapter.BaseGetMember<T>(msjObj._immediateBaseObject, name);
+                T retValue = msjObj.InternalBaseDotNetAdapter.BaseGetMember<T>(msjObj._immediateBaseObject, name);
                 PSObject.memberResolution.WriteLine("DotNet member: {0}.", retValue == null ? "not found" : retValue.Name);
                 return retValue;
             }

--- a/src/System.Management.Automation/engine/SessionStateProviderAPIs.cs
+++ b/src/System.Management.Automation/engine/SessionStateProviderAPIs.cs
@@ -58,12 +58,11 @@ namespace System.Management.Automation
         /// <param name="providerEntry"></param>
         internal void AddSessionStateEntry(SessionStateProviderEntry providerEntry)
         {
-            ProviderInfo provider = AddProvider(providerEntry.ImplementingType,
-                            providerEntry.Name,
-                            providerEntry.HelpFileName,
-                            providerEntry.PSSnapIn,
-                            providerEntry.Module
-            );
+            AddProvider(providerEntry.ImplementingType,
+                        providerEntry.Name,
+                        providerEntry.HelpFileName,
+                        providerEntry.PSSnapIn,
+                        providerEntry.Module);
         }
 
         private ProviderInfo AddProvider(Type implementingType, string name, string helpFileName, PSSnapInInfo psSnapIn, PSModuleInfo module)


### PR DESCRIPTION
## PR Summary

Some random fixes:
1. `BaseDotNetAdapterForAdaptedObjects` derives from `DotNetAdapter`. However, instead of directly calling the base methods, it calls the methods on a static instance of `DotNetAdapter`.
2. Fix a typo in `EventManager.cs`.
3. A clone is created but not used in `InitialSessionState.cs`.
4. The property `InternalBaseDotNetAdapter` points to `InternalAdapterSet.DotNetAdapter`, so use `InternalBaseDotNetAdapter` to make the code more readable.
5. The assignment is unnecessary in `SessionStateProviderAPIs.cs`.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [x] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
