### PR TITLE
Remove support for file to opt-out of telemetry, only support env var

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,9 +46,6 @@ dotnet-uninstall-debian-packages.sh
 *.nupkg
 *.AppImage
 
-# ignore the telemetry semaphore file
-DELETE_ME_TO_DISABLE_CONSOLEHOST_TELEMETRY
-
 # default location for produced nuget packages
 /nuget-artifacts
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,7 @@ after_success:
 # travis-ci will quit using the cache if an enviroment variable changes
 env:
   - CACHE_VERSION=netcoreapp.2.0.6-sdk.2.1.4
+  - POWERSHELL_TELEMETRY_OPTOUT=1
 
 # timeout uploading cache after 6 minutes (360 seconds)
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,8 +57,9 @@ after_success:
 
 # travis-ci will quit using the cache if an enviroment variable changes
 env:
-  - CACHE_VERSION=netcoreapp.2.0.6-sdk.2.1.4
-  - POWERSHELL_TELEMETRY_OPTOUT=1
+  global:
+    - CACHE_VERSION=netcoreapp.2.0.6-sdk.2.1.4
+    - POWERSHELL_TELEMETRY_OPTOUT=1
 
 # timeout uploading cache after 6 minutes (360 seconds)
 cache:

--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ License: By requesting and using the Container OS Image for Windows containers, 
 ### Telemetry
 
 By default, PowerShell collects the OS description and the version of PowerShell (equivalent to `$PSVersionTable.OS` and `$PSVersionTable.GitCommitId`) using [Application Insights](https://azure.microsoft.com/en-us/services/application-insights/).
-To opt-out of sending telemetry, delete the file `DELETE_ME_TO_DISABLE_CONSOLEHOST_TELEMETRY` before starting PowerShell from the installed location.
+To opt-out of sending telemetry, create an environment variable called `POWERSHELL_TELEMETRY_OPTOUT` set to a value of `1` before starting PowerShell from the installed location.
 The telemetry we collect fall under the [Microsoft Privacy Statement](https://privacy.microsoft.com/en-us/privacystatement/).
 
 ## Governance

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,6 +10,9 @@ cache:
 nuget:
   project_feed: true
 
+environment:
+  POWERSHELL_TELEMETRY_OPTOUT: 1
+
 install:
   - git submodule update --init
   - ps: Import-Module .\tools\Appveyor.psm1

--- a/assets/files.wxs
+++ b/assets/files.wxs
@@ -193,9 +193,6 @@
             <Component Id="cmp06E8C21C125E29603C631488D5EBC1CA" Guid="{41159F5F-FED9-4C2E-8671-57C9CD46A5CF}">
                 <File Id="fil33FE96846639CB621C7B04A56ED64E24" KeyPath="yes" Source="$(env.ProductSourcePath)\hostfxr.dll" />
             </Component>
-            <Component Id="cmp15A47D494DF254A3900DDEF6D2CDFBA2" Guid="{36E0C8A2-F015-400B-83B1-55B72A856270}">
-                <File Id="fil9347D9464088FAEC056F05E3CD93CFFD" KeyPath="yes" Source="$(env.ProductSourcePath)\DELETE_ME_TO_DISABLE_CONSOLEHOST_TELEMETRY" />
-            </Component>
             <Component Id="cmp18FD8ABAE1B131CE3834F0E2BB07E5B8" Guid="{3F9A0E71-7848-49E3-BD35-D5DD1C838B9E}">
                 <File Id="fil4107C2714D75DB3C2AFC183E124E17DB" KeyPath="yes" Source="$(env.ProductSourcePath)\Microsoft.Management.Infrastructure.Native.Unmanaged.dll" />
             </Component>
@@ -1890,7 +1887,6 @@
             <ComponentRef Id="cmp28A6204649AC15DA0210CE3067308BDE" />
             <ComponentRef Id="cmpA4C6AF97A7B02D8D55E1E09AB7F74558" />
             <ComponentRef Id="cmp06E8C21C125E29603C631488D5EBC1CA" />
-            <ComponentRef Id="cmp15A47D494DF254A3900DDEF6D2CDFBA2" />
             <ComponentRef Id="cmp18FD8ABAE1B131CE3834F0E2BB07E5B8" />
             <ComponentRef Id="cmp8552B147D2AAFD164533C72368BFB61C" />
             <ComponentRef Id="cmp33AA41435A9FDD75B7D5FA6869C6F441" />

--- a/build.psm1
+++ b/build.psm1
@@ -1051,7 +1051,9 @@ Restore the module to '$Pester' by running:
     Publish-PSTestTools | ForEach-Object {Write-Host $_}
 
     # All concatenated commands/arguments are suffixed with the delimiter (space)
-    $command = ""
+
+    # Disable telemetry for all startups of pwsh in tests
+    $command = "`$env:POWERSHELL_TELEMETRY_OPTOUT = 1;"
     if ($Terse)
     {
         $command += "`$ProgressPreference = 'silentlyContinue'; "
@@ -1152,6 +1154,8 @@ Restore the module to '$Pester' by running:
     # To ensure proper testing, the module path must not be inherited by the spawned process
     try {
         $originalModulePath = $env:PSModulePath
+        $originalTelemetry = $env:POWERSHELL_TELEMETRY_OPTOUT
+        $env:POWERSHELL_TELEMETRY_OPTOUT = 1
         if ($Unelevate)
         {
             Start-UnelevatedProcess -process $powershell -arguments @('-noprofile', '-c', $Command)
@@ -1228,6 +1232,7 @@ Restore the module to '$Pester' by running:
         }
     } finally {
         $env:PSModulePath = $originalModulePath
+        $env:POWERSHELL_TELEMETRY_OPTOUT = $originalTelemetry
         if ($Unelevate)
         {
             Remove-Item $outputBufferFilePath

--- a/build.psm1
+++ b/build.psm1
@@ -453,9 +453,6 @@ function Start-PSBuild {
         }
     }
 
-    # create the telemetry flag file
-    $null = new-item -force -type file "$psscriptroot/DELETE_ME_TO_DISABLE_CONSOLEHOST_TELEMETRY"
-
     # Add .NET CLI tools to PATH
     Find-Dotnet
 

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/Telemetry.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/Telemetry.cs
@@ -19,17 +19,8 @@ namespace Microsoft.PowerShell
     /// </summary>
     internal static class ApplicationInsightsTelemetry
     {
-        // The semaphore file which indicates whether telemetry should be sent
-        // This is temporary code waiting on the acceptance and implementation of the configuration spec
-        // The name of the file by when present in $PSHOME will enable telemetry.
-        // If this file is not present, no telemetry will be sent.
-        private const string TelemetrySemaphoreFilename = "DELETE_ME_TO_DISABLE_CONSOLEHOST_TELEMETRY";
+        // If this env var is true, yes, or 1, telemetry will NOT be sent.
         private const string TelemetryOptoutEnvVar = "POWERSHELL_TELEMETRY_OPTOUT";
-
-        // The path to the semaphore file which enables telemetry
-        private static string TelemetrySemaphoreFilePath = Path.Combine(
-            Utils.DefaultPowerShellAppBase,
-            TelemetrySemaphoreFilename);
 
         // Telemetry client to be reused when we start sending more telemetry
         private static TelemetryClient _telemetryClient = null;
@@ -76,7 +67,7 @@ namespace Microsoft.PowerShell
             try
             {
                 // if the semaphore file exists, try to send telemetry
-                var enabled = Utils.NativeFileExists(TelemetrySemaphoreFilePath) && !GetEnvironmentVariableAsBool(TelemetryOptoutEnvVar, false);
+                var enabled = GetEnvironmentVariableAsBool(TelemetryOptoutEnvVar, false);
 
                 if (!enabled)
                 {

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/Telemetry.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/Telemetry.cs
@@ -66,8 +66,7 @@ namespace Microsoft.PowerShell
         {
             try
             {
-                // if the semaphore file exists, try to send telemetry
-                var enabled = GetEnvironmentVariableAsBool(TelemetryOptoutEnvVar, false);
+                var enabled = !GetEnvironmentVariableAsBool(name : TelemetryOptoutEnvVar, defaultValue : false);
 
                 if (!enabled)
                 {

--- a/src/powershell-unix/powershell-unix.csproj
+++ b/src/powershell-unix/powershell-unix.csproj
@@ -16,7 +16,7 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
     </Content>
-    <Content Include="..\..\license_thirdparty_proprietary.txt;..\..\DELETE_ME_TO_DISABLE_CONSOLEHOST_TELEMETRY">
+    <Content Include="..\..\license_thirdparty_proprietary.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
     </Content>

--- a/src/powershell-win-core/powershell-win-core.csproj
+++ b/src/powershell-win-core/powershell-win-core.csproj
@@ -20,7 +20,7 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
     </Content>
-    <Content Include="..\..\license_thirdparty_proprietary.txt;..\..\DELETE_ME_TO_DISABLE_CONSOLEHOST_TELEMETRY;..\powershell-native\Install-PowerShellRemoting.ps1;..\PowerShell.Core.Instrumentation\PowerShell.Core.Instrumentation.man;..\PowerShell.Core.Instrumentation\RegisterManifest.ps1">
+    <Content Include="..\..\license_thirdparty_proprietary.txt;..\powershell-native\Install-PowerShellRemoting.ps1;..\PowerShell.Core.Instrumentation\PowerShell.Core.Instrumentation.man;..\PowerShell.Core.Instrumentation\RegisterManifest.ps1">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
     </Content>

--- a/tools/appveyor.psm1
+++ b/tools/appveyor.psm1
@@ -347,11 +347,8 @@ function Invoke-AppVeyorTest
         Write-Host -Foreground Green 'Running all CoreCLR tests..'
     }
 
-    # Remove telemetry semaphore file in CI
-    $telemetrySemaphoreFilepath = Join-Path $env:CoreOutput DELETE_ME_TO_DISABLE_CONSOLEHOST_TELEMETRY
-    if ( Test-Path "${telemetrySemaphoreFilepath}" ) {
-        Remove-Item -Force ${telemetrySemaphoreFilepath}
-    }
+    #  Disable telemetry in CI
+    $env:POWERSHELL_TELEMETRY_OPTOUT = 1
 
     Start-PSPester -Terse -bindir $env:CoreOutput -outputFile $testResultsNonAdminFile -Unelevate -Tag @() -ExcludeTag ($ExcludeTag + @('RequireAdminOnWindows'))
     Write-Host -Foreground Green 'Upload CoreCLR Non-Admin test results'

--- a/tools/appveyor.psm1
+++ b/tools/appveyor.psm1
@@ -347,9 +347,6 @@ function Invoke-AppVeyorTest
         Write-Host -Foreground Green 'Running all CoreCLR tests..'
     }
 
-    #  Disable telemetry in CI
-    $env:POWERSHELL_TELEMETRY_OPTOUT = 1
-
     Start-PSPester -Terse -bindir $env:CoreOutput -outputFile $testResultsNonAdminFile -Unelevate -Tag @() -ExcludeTag ($ExcludeTag + @('RequireAdminOnWindows'))
     Write-Host -Foreground Green 'Upload CoreCLR Non-Admin test results'
     Update-AppVeyorTestResults -resultsFile $testResultsNonAdminFile

--- a/tools/releaseBuild/Images/microsoft_powershell_alpine3/build-and-run-pwsh.sh
+++ b/tools/releaseBuild/Images/microsoft_powershell_alpine3/build-and-run-pwsh.sh
@@ -53,9 +53,6 @@ make -j
 cd ../..
 dotnet restore $dotnetArguments
 
-# Add telemetry file
-touch DELETE_ME_TO_DISABLE_CONSOLEHOST_TELEMETRY
-
 # run ResGen
 cd src/ResGen
 dotnet run

--- a/tools/travis.ps1
+++ b/tools/travis.ps1
@@ -224,11 +224,8 @@ elseif($Stage -eq 'Build')
         $pesterParam['IncludeFailingTest'] = $true
     }
 
-    # Remove telemetry semaphore file in CI
-    $telemetrySemaphoreFilepath = Join-Path $output DELETE_ME_TO_DISABLE_CONSOLEHOST_TELEMETRY
-    if ( Test-Path "${telemetrySemaphoreFilepath}" ) {
-        Remove-Item -force ${telemetrySemaphoreFilepath}
-    }
+    # Disable telemetry in CI
+    $env:POWERSHELL_TELEMETRY_OPTOUT = 1
 
     # Running tests which do not require sudo.
     $pesterPassThruNoSudoObject = Start-PSPester @pesterParam

--- a/tools/travis.ps1
+++ b/tools/travis.ps1
@@ -224,9 +224,6 @@ elseif($Stage -eq 'Build')
         $pesterParam['IncludeFailingTest'] = $true
     }
 
-    # Disable telemetry in CI
-    $env:POWERSHELL_TELEMETRY_OPTOUT = 1
-
     # Running tests which do not require sudo.
     $pesterPassThruNoSudoObject = Start-PSPester @pesterParam
 


### PR DESCRIPTION
## PR Summary

Since a PR added support to opt out of telemetry via an environment variable, we can remove the
always intended to be temporary solution of deleting a file to opt out of telemetry since the
environment variable can be defined at the system level and exist before even installing PowerShell Core.

Because the variable is defined as `opt out`, a value of `true`, `yes`, or `1` means no telemetry is sent.

Fix https://github.com/PowerShell/PowerShell/issues/6078

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [X] User-facing https://github.com/PowerShell/PowerShell-Docs/pull/2316
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [x] Not Applicable or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
