### PR TITLE
Support importing module paths that end in trailing directory separator

### DIFF
--- a/src/System.Management.Automation/engine/Modules/ImportModuleCommand.cs
+++ b/src/System.Management.Automation/engine/Modules/ImportModuleCommand.cs
@@ -629,6 +629,12 @@ namespace Microsoft.PowerShell.Commands
                         }
                         else if (Directory.Exists(rootedPath))
                         {
+                            // If the path ends with a directory separator, remove it
+                            if (rootedPath.EndsWith(Path.DirectorySeparatorChar))
+                            {
+                                rootedPath = Path.GetDirectoryName(rootedPath);
+                            }
+
                             // Load the latest valid version if it is a multi-version module directory
                             foundModule = LoadUsingMultiVersionModuleBase(rootedPath,
                                                                             ManifestProcessingFlags.LoadElements |
@@ -638,11 +644,6 @@ namespace Microsoft.PowerShell.Commands
 
                             if (!found)
                             {
-                                // If the path ends with a directory separator, remove it
-                                if (rootedPath.EndsWith(Path.DirectorySeparatorChar))
-                                {
-                                    rootedPath = Path.GetDirectoryName(rootedPath);
-                                }
                                 // If the path is a directory, double up the end of the string
                                 // then try to load that using extensions...
                                 rootedPath = Path.Combine(rootedPath, Path.GetFileName(rootedPath));

--- a/src/System.Management.Automation/engine/Modules/ImportModuleCommand.cs
+++ b/src/System.Management.Automation/engine/Modules/ImportModuleCommand.cs
@@ -638,6 +638,11 @@ namespace Microsoft.PowerShell.Commands
 
                             if (!found)
                             {
+                                // If the path ends with a directory separator, remove it
+                                if (rootedPath.EndsWith(Path.DirectorySeparatorChar))
+                                {
+                                    rootedPath = Path.GetDirectoryName(rootedPath);
+                                }
                                 // If the path is a directory, double up the end of the string
                                 // then try to load that using extensions...
                                 rootedPath = Path.Combine(rootedPath, Path.GetFileName(rootedPath));

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Import-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Import-Module.Tests.ps1
@@ -18,6 +18,7 @@ Describe "Import-Module" -Tags "CI" {
     BeforeEach {
         Remove-Module -Name $moduleName -Force
         (Get-Module -Name $moduleName).Name | Should -BeNullOrEmpty
+        Remove-Module -Name TestModule -Force -ErrorAction SilentlyContinue
     }
 
     AfterEach {
@@ -30,11 +31,13 @@ Describe "Import-Module" -Tags "CI" {
         (Get-Module -Name $moduleName).Name | Should -BeExactly $moduleName
     }
 
-    It "should be able to load a module with a trailing directory separator" {
-        $modulePath = (Get-Module -ListAvailable $moduleName).ModuleBase + [System.IO.Path]::DirectorySeparatorChar
-        Remove-Module $moduleName
+    It "should be able to load a module with a trailing directory separator: <modulePath>" -TestCases @(
+        @{ modulePath = (Get-Module -ListAvailable $moduleName).ModuleBase + [System.IO.Path]::DirectorySeparatorChar; expectedName = $moduleName },
+        @{ modulePath = Join-Path -Path $TestDrive -ChildPath "\Modules\TestModule\"; expectedName = "TestModule" }
+    ) {
+        param( $modulePath, $expectedName )
         { Import-Module -Name $modulePath -ErrorAction Stop } | Should -Not -Throw
-        (Get-Module -Name $moduleName).Name | Should -BeExactly $moduleName
+        (Get-Module -Name $expectedName).Name | Should -BeExactly $expectedName
     }
 
     It "should be able to add a module with using ModuleInfo switch" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Import-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Import-Module.Tests.ps1
@@ -32,7 +32,8 @@ Describe "Import-Module" -Tags "CI" {
 
     It "should be able to load a module with a trailing directory separator" {
         $modulePath = (Get-Module -ListAvailable $moduleName).ModuleBase + [System.IO.Path]::DirectorySeparatorChar
-        Import-Module -Name $modulePath
+        Remove-Module $moduleName
+        { Import-Module -Name $modulePath -ErrorAction Stop } | Should -Not -Throw
         (Get-Module -Name $moduleName).Name | Should -BeExactly $moduleName
     }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Import-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Import-Module.Tests.ps1
@@ -30,6 +30,12 @@ Describe "Import-Module" -Tags "CI" {
         (Get-Module -Name $moduleName).Name | Should -BeExactly $moduleName
     }
 
+    It "should be able to load a module with a trailing directory separator" {
+        $modulePath = (Get-Module -ListAvailable $moduleName).ModuleBase + [System.IO.Path]::DirectorySeparatorChar
+        Import-Module -Name $modulePath
+        (Get-Module -Name $moduleName).Name | Should -BeExactly $moduleName
+    }
+
     It "should be able to add a module with using ModuleInfo switch" {
         $a = Get-Module -ListAvailable $moduleName
         { Import-Module -ModuleInfo $a } | Should -Not -Throw


### PR DESCRIPTION
## PR Summary

With PSReadLine as default interactive experience, it will always add a trailing directory separator character on tab-complete.  Currently, `Import-Module` fails to load the module if this character
exists as the current logic incorrectly uses `GetFileName` to get the last part of the path which returns
an empty string if the path ends in a directory separator.

Fix is to update the code path that tries to load a module given a directory path and removes the
trailing directory character, if present, so that the logic to expect the module filename to be the same
as the module directory name works.

Fix https://github.com/PowerShell/PowerShell/issues/5533

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
