### PR TITLE
Make a temporary array static to exclude extra allocations

### DIFF
--- a/src/System.Management.Automation/engine/lang/parserutils.cs
+++ b/src/System.Management.Automation/engine/lang/parserutils.cs
@@ -529,15 +529,6 @@ namespace System.Management.Automation
 
         private static RegexOptions parseRegexOptions(SplitOptions options)
         {
-            int[][] map = {
-                new int[] { (int)SplitOptions.CultureInvariant, (int)RegexOptions.CultureInvariant },
-                new int[] { (int)SplitOptions.IgnorePatternWhitespace, (int)RegexOptions.IgnorePatternWhitespace },
-                new int[] { (int)SplitOptions.Multiline, (int)RegexOptions.Multiline },
-                new int[] { (int)SplitOptions.Singleline, (int)RegexOptions.Singleline },
-                new int[] { (int)SplitOptions.IgnoreCase, (int)RegexOptions.IgnoreCase },
-                new int[] { (int)SplitOptions.ExplicitCapture, (int)RegexOptions.ExplicitCapture },
-            };
-
             RegexOptions result = RegexOptions.None;
             foreach (int[] entry in map)
             {
@@ -549,6 +540,15 @@ namespace System.Management.Automation
 
             return result;
         }
+
+        private static readonly int[][] map = {
+            new int[] { (int)SplitOptions.CultureInvariant, (int)RegexOptions.CultureInvariant },
+            new int[] { (int)SplitOptions.IgnorePatternWhitespace, (int)RegexOptions.IgnorePatternWhitespace },
+            new int[] { (int)SplitOptions.Multiline, (int)RegexOptions.Multiline },
+            new int[] { (int)SplitOptions.Singleline, (int)RegexOptions.Singleline },
+            new int[] { (int)SplitOptions.IgnoreCase, (int)RegexOptions.IgnoreCase },
+            new int[] { (int)SplitOptions.ExplicitCapture, (int)RegexOptions.ExplicitCapture },
+        };
 
         internal static object UnarySplitOperator(ExecutionContext context, IScriptExtent errorPosition, object lval)
         {

--- a/src/System.Management.Automation/engine/lang/parserutils.cs
+++ b/src/System.Management.Automation/engine/lang/parserutils.cs
@@ -530,25 +530,33 @@ namespace System.Management.Automation
         private static RegexOptions parseRegexOptions(SplitOptions options)
         {
             RegexOptions result = RegexOptions.None;
-            foreach (int[] entry in map)
+            if ((options & SplitOptions.CultureInvariant) != 0)
             {
-                if (((int)options & entry[0]) != 0)
-                {
-                    result |= (RegexOptions)entry[1];
-                }
+                result |= RegexOptions.CultureInvariant;
+            }
+            if ((options & SplitOptions.IgnorePatternWhitespace) != 0)
+            {
+                result |= RegexOptions.IgnorePatternWhitespace;
+            }
+            if ((options & SplitOptions.Multiline) != 0)
+            {
+                result |= RegexOptions.Multiline;
+            }
+            if ((options & SplitOptions.Singleline) != 0)
+            {
+                result |= RegexOptions.Singleline;
+            }
+            if ((options & SplitOptions.IgnoreCase) != 0)
+            {
+                result |= RegexOptions.IgnoreCase;
+            }
+            if ((options & SplitOptions.ExplicitCapture) != 0)
+            {
+                result |= RegexOptions.ExplicitCapture;
             }
 
             return result;
         }
-
-        private static readonly int[][] map = {
-            new int[] { (int)SplitOptions.CultureInvariant, (int)RegexOptions.CultureInvariant },
-            new int[] { (int)SplitOptions.IgnorePatternWhitespace, (int)RegexOptions.IgnorePatternWhitespace },
-            new int[] { (int)SplitOptions.Multiline, (int)RegexOptions.Multiline },
-            new int[] { (int)SplitOptions.Singleline, (int)RegexOptions.Singleline },
-            new int[] { (int)SplitOptions.IgnoreCase, (int)RegexOptions.IgnoreCase },
-            new int[] { (int)SplitOptions.ExplicitCapture, (int)RegexOptions.ExplicitCapture },
-        };
 
         internal static object UnarySplitOperator(ExecutionContext context, IScriptExtent errorPosition, object lval)
         {


### PR DESCRIPTION
## PR Summary

The `map` array is allocated every the method call and never changed. So replace it with `if` statements to exclude extra allocations.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [x] Not Applicable or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
