### PR TITLE
Use new Pester syntax: -Parameter for Pester tests in module PSDesiredStateConfiguration

### DIFF
--- a/test/powershell/Modules/PSDesiredStateConfiguration/MOF-Compilation.Tests.ps1
+++ b/test/powershell/Modules/PSDesiredStateConfiguration/MOF-Compilation.Tests.ps1
@@ -27,7 +27,7 @@ Describe "DSC MOF Compilation" -tags "CI" {
         }
 
         DSCTestConfig -OutputPath TestDrive:\DscTestConfig1
-"@) | should not throw
+"@) | Should -Not -Throw
 
         "TestDrive:\DscTestConfig1\localhost.mof" | Should -Exist
     }
@@ -49,7 +49,7 @@ Describe "DSC MOF Compilation" -tags "CI" {
         }
 
         DSCTestConfig -OutputPath TestDrive:\DscTestConfig2
-"@) | should not throw
+"@) | Should -Not -Throw
 
         "TestDrive:\DscTestConfig2\localhost.mof" | Should -Exist
     }
@@ -158,7 +158,7 @@ Describe "DSC MOF Compilation" -tags "CI" {
 
     }
         WordPressServer -OutputPath TestDrive:\DscTestConfig3
-"@) | should not throw
+"@) | Should -Not -Throw
 
         "TestDrive:\DscTestConfig3\CentOS.mof" | Should -Exist
     }
@@ -178,7 +178,7 @@ Describe "DSC MOF Compilation" -tags "CI" {
         }
 
         DSCTestConfig -OutputPath TestDrive:\DscTestConfig4
-"@) | should not throw
+"@) | Should -Not -Throw
 
         "TestDrive:\DscTestConfig4\localhost.mof" | Should -Exist
     }
@@ -208,7 +208,7 @@ Describe "DSC MOF Compilation" -tags "CI" {
         }
 
         DSCTestConfig -OutputPath TestDrive:\DscTestConfig5
-"@) | should not throw
+"@) | Should -Not -Throw
 
         "TestDrive:\DscTestConfig5\localhost.mof" | Should -Exist
     }

--- a/test/powershell/Modules/PSDesiredStateConfiguration/MOF-Compilation.Tests.ps1
+++ b/test/powershell/Modules/PSDesiredStateConfiguration/MOF-Compilation.Tests.ps1
@@ -29,7 +29,7 @@ Describe "DSC MOF Compilation" -tags "CI" {
         DSCTestConfig -OutputPath TestDrive:\DscTestConfig1
 "@) | should not throw
 
-        "TestDrive:\DscTestConfig1\localhost.mof" | Should Exist
+        "TestDrive:\DscTestConfig1\localhost.mof" | Should -Exist
     }
 
     It "Should be able to compile a MOF from another basic configuration" -Skip:($IsMacOS -or $IsWindows) {
@@ -51,7 +51,7 @@ Describe "DSC MOF Compilation" -tags "CI" {
         DSCTestConfig -OutputPath TestDrive:\DscTestConfig2
 "@) | should not throw
 
-        "TestDrive:\DscTestConfig2\localhost.mof" | Should Exist
+        "TestDrive:\DscTestConfig2\localhost.mof" | Should -Exist
     }
 
     It "Should be able to compile a MOF from a complex configuration" -Skip:($IsMacOS -or $IsWindows) {
@@ -160,7 +160,7 @@ Describe "DSC MOF Compilation" -tags "CI" {
         WordPressServer -OutputPath TestDrive:\DscTestConfig3
 "@) | should not throw
 
-        "TestDrive:\DscTestConfig3\CentOS.mof" | Should Exist
+        "TestDrive:\DscTestConfig3\CentOS.mof" | Should -Exist
     }
 
     It "Should be able to compile a MOF from a basic configuration on Windows" -Skip:($IsMacOS -or $IsLinux) {
@@ -180,7 +180,7 @@ Describe "DSC MOF Compilation" -tags "CI" {
         DSCTestConfig -OutputPath TestDrive:\DscTestConfig4
 "@) | should not throw
 
-        "TestDrive:\DscTestConfig4\localhost.mof" | Should Exist
+        "TestDrive:\DscTestConfig4\localhost.mof" | Should -Exist
     }
 
     It "Should be able to compile a MOF from a configuration with multiple resources on Windows" -Skip:($IsMacOS -or $IsLinux) {
@@ -210,6 +210,6 @@ Describe "DSC MOF Compilation" -tags "CI" {
         DSCTestConfig -OutputPath TestDrive:\DscTestConfig5
 "@) | should not throw
 
-        "TestDrive:\DscTestConfig5\localhost.mof" | Should Exist
+        "TestDrive:\DscTestConfig5\localhost.mof" | Should -Exist
     }
 }


### PR DESCRIPTION
## PR Summary

Use new Pester syntax: -Parameter for Pester tests in module PSDesiredStateConfiguration

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [x] Not Applicable or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
