### PR TITLE
Use a cache for dash padding

### DIFF
--- a/src/System.Management.Automation/FormatAndOutput/common/TableWriter.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/TableWriter.cs
@@ -180,7 +180,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 // NOTE: we can do this because "-" is a single cell character
                 // on all devices. If changed to some other character, this assumption
                 // would be invalidated
-                breakLine[k] = new string('-', count);
+                breakLine[k] = StringUtil.DashPadding(count);
             }
             GenerateRow(breakLine, lo, false, null, lo.DisplayCells);
         }

--- a/src/System.Management.Automation/utils/StringUtil.cs
+++ b/src/System.Management.Automation/utils/StringUtil.cs
@@ -81,6 +81,24 @@ namespace System.Management.Automation.Internal
 
             return result;
         }
+
+        private const int DashCacheMax = 120;
+        private static readonly string[] DashCache = new string[DashCacheMax];
+        internal static string DashPadding(int count)
+        {
+            if (count >= DashCacheMax)
+                return new string('-', count);
+
+            var result = DashCache[count];
+
+            if (result == null)
+            {
+                Interlocked.CompareExchange(ref DashCache[count], new string('-', count), null);
+                result = DashCache[count];
+            }
+
+            return result;
+        }
     }
 }   // namespace
 


### PR DESCRIPTION
## PR Summary

Add a cache for dash padding to decrease allocations in the formatting system.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [x] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
