### PR TITLE
Update Start-PSPester and Restore-PSPester cmdlets in build.psm1 to check for Pester 4.2

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -992,7 +992,7 @@ function Start-PSPester {
         [switch]$IncludeFailingTest
     )
 
-    if (-not (Get-Module -ListAvailable -Name $Pester -ErrorAction SilentlyContinue | where { $_.Version -ge "4.2" } ))
+    if (-not (Get-Module -ListAvailable -Name $Pester -ErrorAction SilentlyContinue | Where { $_.Version -ge "4.2" } ))
     {
         Write-Warning @"
 Pester module not found.

--- a/build.psm1
+++ b/build.psm1
@@ -683,7 +683,7 @@ function Restore-PSPester
         [ValidateNotNullOrEmpty()]
         [string] $Destination = ([IO.Path]::Combine((Split-Path (Get-PSOptions -DefaultToNew).Output), "Modules"))
     )
-    Save-Module -Name Pester -Path $Destination -Repository PSGallery -MinimumVersion "4.2"
+    Save-Module -Name Pester -Path $Destination -Repository PSGallery -RequiredVersion "4.2"
 }
 
 function Compress-TestContent {

--- a/build.psm1
+++ b/build.psm1
@@ -683,7 +683,7 @@ function Restore-PSPester
         [ValidateNotNullOrEmpty()]
         [string] $Destination = ([IO.Path]::Combine((Split-Path (Get-PSOptions -DefaultToNew).Output), "Modules"))
     )
-    Save-Module -Name Pester -Path $Destination -Repository PSGallery
+    Save-Module -Name Pester -Path $Destination -Repository PSGallery -MinimumVersion "4.2"
 }
 
 function Compress-TestContent {
@@ -992,7 +992,7 @@ function Start-PSPester {
         [switch]$IncludeFailingTest
     )
 
-    if (-not (Get-Module -ListAvailable -Name $Pester -ErrorAction SilentlyContinue))
+    if (-not (Get-Module -ListAvailable -Name $Pester -ErrorAction SilentlyContinue | where { $_.Version -ge "4.2" } ))
     {
         Write-Warning @"
 Pester module not found.

--- a/build.psm1
+++ b/build.psm1
@@ -992,7 +992,8 @@ function Start-PSPester {
         [switch]$IncludeFailingTest
     )
 
-    if (-not (Get-Module -ListAvailable -Name $Pester -ErrorAction SilentlyContinue | Where { $_.Version -ge "4.2" } ))
+    $getModuleResults = Get-Module -ListAvailable -Name $Pester -ErrorAction SilentlyContinue
+    if (-not $getModuleResults)
     {
         Write-Warning @"
 Pester module not found.
@@ -1000,6 +1001,15 @@ Restore the module to '$Pester' by running:
     Restore-PSPester
 "@
         return;
+    }
+
+    if (-not ($getModuleResults | Where-Object { $_.Version -ge "4.2" } )) {
+        Write-Warning @"
+No Pester module of version 4.2 and higher.
+Restore the required module version to '$Pester' by running:
+    Restore-PSPester
+"@
+                return;
     }
 
     if ($IncludeFailingTest.IsPresent)

--- a/build.psm1
+++ b/build.psm1
@@ -1009,7 +1009,7 @@ No Pester module of version 4.2 and higher.
 Restore the required module version to '$Pester' by running:
     Restore-PSPester
 "@
-                return;
+        return;
     }
 
     if ($IncludeFailingTest.IsPresent)


### PR DESCRIPTION
## PR Summary

Update Start-PSPester and Restore-PSPester cmdlets in buil.psm1 to check for Pester 4.2+ to support exception passthru.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [x] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
