### PR TITLE
Update documentation on how to write tests verifying errors conditions

### DIFF
--- a/docs/testing-guidelines/WritingPesterTests.md
+++ b/docs/testing-guidelines/WritingPesterTests.md
@@ -55,25 +55,24 @@ Describe "One is really one" {
 }
 ```
 
-If you are checking for proper errors, use the `ShouldBeErrorId` helper defined in HelpersCommon.psm1 module which is in your path if you import `build.psm1`.
-Checking against `FullyQualifiedErrorId` is recommended because it does not change based on culture as an error message might.
+If you are checking for proper errors, use the `Should -Throw -ErrorId` Pester syntax.
+It checks against `FullyQualifiedErrorId` property, which is recommended because it does not change based on culture as an error message might.
 
 ```powershell
 ...
 It "Get-Item on a nonexisting file should have error PathNotFound" {
-    { Get-Item "ThisFileCannotPossiblyExist" -ErrorAction Stop } | ShouldBeErrorId "PathNotFound,Microsoft.PowerShell.Commands.GetItemCommand"
+    { Get-Item "ThisFileCannotPossiblyExist" -ErrorAction Stop } | Should -Throw -ErrorId "PathNotFound,Microsoft.PowerShell.Commands.GetItemCommand"
 }
 ```
 
-Note that if get-item were to succeed, a different FullyQualifiedErrorId would be thrown and the test will fail.
-This is the suggested path because Pester wants to check the error message, which will likely not work here because of localized builds, but the FullyQualifiedErrorId is constant regardless of the locale.
+Note that if Get-Item were to succeed, the test will fail.
 
-However, if you need to check the `InnerException` or other members of the ErrorRecord, the recommended pattern to use is:
+However, if you need to check the `InnerException` or other members of the ErrorRecord, you should use -PassThru parameter:
 
 ```powershell
 	It "InnerException sample" {
 
-	$e = { Invoke-WebRequest https://expired.badssl.com/ } | ShouldBeErrorId "WebCmdletWebResponseException,Microsoft.PowerShell.Commands.InvokeWebRequestCommand"
+	$e = { Invoke-WebRequest https://expired.badssl.com/ } | Should -Throw -ErrorId "WebCmdletWebResponseException,Microsoft.PowerShell.Commands.InvokeWebRequestCommand" -PassThru
 	$e.Exception.InnerException.NativeErrorCode | Should Be 12175
     ...
 	}

--- a/docs/testing-guidelines/WritingPesterTests.md
+++ b/docs/testing-guidelines/WritingPesterTests.md
@@ -67,7 +67,7 @@ It "Get-Item on a nonexisting file should have error PathNotFound" {
 
 Note that if Get-Item were to succeed, the test will fail.
 
-However, if you need to check the `InnerException` or other members of the ErrorRecord, you should use -PassThru parameter:
+However, if you need to check the `InnerException` or other members of the ErrorRecord, you should use `-PassThru` parameter:
 
 ```powershell
 	It "InnerException sample" {


### PR DESCRIPTION
## PR Summary

Update documentation on how to write tests verifying errors conditions. Replace `ShouldBeErrorId` by Pester `Should -Throw -ErrorId`.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [x] Not Applicable or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
