### PR TITLE
Invalidate script module cache when the underlying module file is changed

### DIFF
--- a/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
@@ -5984,11 +5984,11 @@ namespace Microsoft.PowerShell.Commands
             DateTime lastModuleWriteTimeUtc = GetFileLastWriteTimeUtc(filePath);
 
             // If we have a cache entry and it's up to date, return that
-            if (s_scriptAnalysisCache.TryGetValue(filePath, out ScriptModuleCacheEntry cacheEntry) && lastModuleWriteTimeUtc == cacheEntry.LastFileWriteTimeUtc)
+            if (s_scriptAnalysisCache.TryGetValue(filePath, out ScriptModuleCacheEntry cacheEntry) && lastModuleWriteTimeUtc == cacheEntry.lastFileWriteTimeUtc)
             {
                 // We need to return a cloned version here.
                 // This is because the Get-Module -List -All modifies the returned module info and we do not want the original one changed.
-                return cacheEntry.ModuleInfo.Clone();
+                return cacheEntry.moduleInfo.Clone();
             }
 
             // fake/empty manifestInfo for processing in (!loadElements) mode
@@ -7268,19 +7268,19 @@ namespace Microsoft.PowerShell.Commands
             /// <param name="moduleInfo">the module info describing the module; the analysis result we are caching</param>
             public ScriptModuleCacheEntry(DateTime lastFileWriteTimeUtc, PSModuleInfo moduleInfo)
             {
-                LastFileWriteTimeUtc = lastFileWriteTimeUtc;
-                ModuleInfo = moduleInfo;
+                this.lastFileWriteTimeUtc = lastFileWriteTimeUtc;
+                this.moduleInfo = moduleInfo;
             }
 
             /// <summary>
             /// The last time the file defining the module was written to when we cached the analysis result
             /// </summary>
-            public DateTime LastFileWriteTimeUtc { get; }
+            public readonly DateTime lastFileWriteTimeUtc;
 
             /// <summary>
             /// The actual analysis result describing the script module we analyzed
             /// </summary>
-            public PSModuleInfo ModuleInfo { get; }
+            public readonly PSModuleInfo moduleInfo;
         }
 
     } // end ModuleCmdletBase

--- a/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
@@ -5786,6 +5786,7 @@ namespace Microsoft.PowerShell.Commands
         private void ClearAnalysisCaches()
         {
             s_scriptAnalysisCache.Clear();
+            s_binaryAnalysisCache.Clear();
         }
 
         // Analyzes a binary module implementation for its cmdlets.
@@ -6407,7 +6408,7 @@ namespace Microsoft.PowerShell.Commands
                     }
                     else
                     {
-                        string binaryPath = fileName;
+                       string binaryPath = fileName;
                         modulePath = fileName;
                         if (binaryPath == null)
                         {

--- a/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
@@ -5835,10 +5835,7 @@ namespace Microsoft.PowerShell.Commands
         {
             Tuple<BinaryAnalysisResult, Version> tuple = null;
 
-            lock (s_lockObject)
-            {
-                s_binaryAnalysisCache.TryGetValue(path, out tuple);
-            }
+            s_binaryAnalysisCache.TryGetValue(path, out tuple);
 
             if (tuple != null)
             {
@@ -5885,10 +5882,7 @@ namespace Microsoft.PowerShell.Commands
                 result.DetectedCmdlets = detectedCmdlets;
                 result.DetectedAliases = detectedAliases;
 
-                lock (s_lockObject)
-                {
-                    s_binaryAnalysisCache[path] = Tuple.Create(result, assemblyVersion);
-                }
+                s_binaryAnalysisCache[path] = Tuple.Create(result, assemblyVersion);
 
                 return result;
             }
@@ -5999,7 +5993,7 @@ namespace Microsoft.PowerShell.Commands
             TryGetFileLastWriteTimeUtc(filePath, out lastModuleWriteTimeUtc);
 
             // Return here if the cache is up to date
-            if (cacheEntry.ModuleInfo != null && lastModuleWriteTimeUtc == cacheEntry.LastFileWriteTimeUtc)
+            if (cacheEntry?.ModuleInfo != null && lastModuleWriteTimeUtc == cacheEntry.LastFileWriteTimeUtc)
             {
                 // We need to return a cloned version here.
                 // This is because the Get-Module -List -All modifies the returned module info and we do not want the original one changed.

--- a/test/powershell/engine/Module/ModuleCmdlet.Tests.ps1
+++ b/test/powershell/engine/Module/ModuleCmdlet.Tests.ps1
@@ -265,9 +265,9 @@ class Foo { [string]$Name }
             $modData = New-TestModule -Content $modSrc
 
             $scriptSrc = @"
-using module ${modData.BaseDir}
+using module $($modData.BaseDir.FullName)
 
-class Zoo { [Foo]$Foo }
+class Zoo { [Foo]`$Foo }
 
 [Zoo]::new().GetType().Name
 "@
@@ -281,9 +281,9 @@ class Zoo { [Foo]$Foo }
             Set-Content -Path $modData.Path -Value $modSrcUpdate -Force
 
             $scriptSrcUpdate = @"
-using module ${modData.BaseDir}
+using module $($modData.BaseDir.FullName)
 
-class Zoo { [Foo]$Foo; [Bar]$Bar }
+class Zoo { [Foo]`$Foo; [Bar]`$Bar }
 
 [Zoo]::new().GetType().Name
 "@

--- a/test/powershell/engine/Module/ModuleCmdlet.Tests.ps1
+++ b/test/powershell/engine/Module/ModuleCmdlet.Tests.ps1
@@ -158,7 +158,7 @@ function Test-FirstModuleFunction
 
             $module.ExportedFunctions.Count | Should -Be 1
             $module.ExportedFunctions.Keys  | Should -Contain "Test-FirstModuleFunction"
-            $module.ExportedFunctions.Keys  | Should -Contain "Test-SecondModuleFunction"
+            $module.ExportedFunctions.Keys  | Should -Not -Contain "Test-SecondModuleFunction"
 
             $newModuleContent = (Get-Content $modData.Path | Out-String) + "`nfunction Test-SecondModuleFunction { Write-Output 'SECONDSTRING' }"
             Set-Content -Force -Path $modData.Path -Value $newModuleContent

--- a/test/powershell/engine/Module/ModuleCmdlet.Tests.ps1
+++ b/test/powershell/engine/Module/ModuleCmdlet.Tests.ps1
@@ -94,6 +94,8 @@ function Test-FirstModuleFunction
     Write-Output "TESTSTRING"
 }
 '@
+
+        $newModuleContent = $simpleModContent + "`nfunction Test-SecondModuleFunction { Write-Output 'SECONDSTRING' }"
     }
 
     AfterAll {
@@ -128,10 +130,9 @@ function Test-FirstModuleFunction
             $module.ExportedFunctions.Keys  | Should -Contain "Test-FirstModuleFunction"
             $module.ExportedFunctions.Keys  | Should -Not -Contain "Test-SecondModuleFunction"
 
-            $newModuleContent = (Get-Content $modData.Path | Out-String) + "`nfunction Test-SecondModuleFunction { Write-Output 'SECONDSTRING' }"
             Set-Content -Force -Path $modData.Path -Value $newModuleContent
 
-            $module = Import-Module $modData.Path -PassThru -Force
+            Import-Module $modData.Path -Force
             Test-SecondModuleFunction | Should -BeExactly "SECONDSTRING"
         }
 
@@ -143,7 +144,6 @@ function Test-FirstModuleFunction
             $module.ExportedFunctions.Keys  | Should -Contain "Test-FirstModuleFunction"
             $module.ExportedFunctions.Keys  | Should -Not -Contain "Test-SecondModuleFunction"
 
-            $newModuleContent = (Get-Content $modData.Path | Out-String) + "`nfunction Test-SecondModuleFunction { Write-Output 'SECONDSTRING' }"
             Set-Content -Force -Path $modData.Path -Value $newModuleContent
 
             $module = Import-Module $modData.Path -PassThru -Force
@@ -160,7 +160,6 @@ function Test-FirstModuleFunction
             $module.ExportedFunctions.Keys  | Should -Contain "Test-FirstModuleFunction"
             $module.ExportedFunctions.Keys  | Should -Not -Contain "Test-SecondModuleFunction"
 
-            $newModuleContent = (Get-Content $modData.Path | Out-String) + "`nfunction Test-SecondModuleFunction { Write-Output 'SECONDSTRING' }"
             Set-Content -Force -Path $modData.Path -Value $newModuleContent
 
             $module = Import-Module $modData.Path -AsCustomObject -Force
@@ -194,8 +193,8 @@ function Get-PassedArgsNoRoot { $passedArgs }
 
             Import-Module $modData.Path -ArgumentList 'value2'
             $rootVal = Get-PassedArgsRoot
-            $rootNoVal = Get-PassedArgsNoRoot
-            $rootVal | Should -BeExactly $rootNoVal
+            $noRootVal = Get-PassedArgsNoRoot
+            $rootVal | Should -BeExactly $noRootVal
         }
 
         It "Uses updated class definitions in later imports rather than cached values" {
@@ -225,12 +224,12 @@ class MyObj
             $mod1 = Import-Module $modData.Path -PassThru
 
             Set-Content -Path $modData.Path -Value $modSrc2
-            $mod2 = Import-Module $modData.Path -PassThru
+            $mod2 = Import-Module $modData.Path -PassThru -Force
 
             $firstTypes = $mod1.GetExportedTypeDefinitions()
             $secondTypes = $mod2.GetExportedTypeDefinitions()
 
-            $firstTypes.MyObj.Equals($secondTypes.Sub) | Should -BeFalse
+            $firstTypes.MyObj.Equals($secondTypes.MyObj) | Should -BeFalse
         }
     }
 
@@ -252,16 +251,10 @@ function Test-FirstModuleFunction
 }
 '@
 
-            $ps = [powershell]::Create()
         }
 
         AfterAll {
             TearDownModules
-            $ps.Dispose()
-        }
-
-        AfterEach {
-            $ps.Streams.ClearStreams()
         }
 
         It "Validates a null -<paramName> parameter" -TestCases $validationTests {
@@ -290,6 +283,8 @@ function Test-FirstModuleFunction
     Write-Output "TESTSTRING"
 }
 '@
+
+        $newModuleContent = $simpleModContent + "`nfunction Test-SecondModuleFunction { Write-Output 'SECONDSTRING' }"
     }
 
     AfterAll {
@@ -330,21 +325,19 @@ function Test-FirstModuleFunction
         $module.ExportedFunctions.Keys  | Should -Contain "Test-FirstModuleFunction"
         $module.ExportedFunctions.Keys  | Should -Not -Contain "Test-SecondModuleFunction"
 
-        $newModuleContent = (Get-Content $modData.Path | Out-String) + "`nfunction Test-SecondModuleFunction { Write-Output 'SECONDSTRING' }"
         Set-Content -Force -Path $modData.Path -Value $newModuleContent
 
         Import-Module $modInfo -Force
         Test-SecondModuleFunction | Should -BeExactly "SECONDSTRING"
     }
 
-    It "Re-imports modules from file with new members when -Force is used with -PassThru" -Skip {
+    It "Re-imports modules from file with new members when -Force is used with -PassThru" -Pending {
         $module = Import-Module $modInfo -PassThru
 
         $module.ExportedFunctions.Count | Should -Be 1
         $module.ExportedFunctions.Keys  | Should -Contain "Test-FirstModuleFunction"
         $module.ExportedFunctions.Keys  | Should -Not -Contain "Test-SecondModuleFunction"
 
-        $newModuleContent = (Get-Content $modData.Path | Out-String) + "`nfunction Test-SecondModuleFunction { Write-Output 'SECONDSTRING' }"
         Set-Content -Force -Path $modData.Path -Value $newModuleContent
 
         $module = Import-Module $modInfo -PassThru -Force
@@ -354,14 +347,13 @@ function Test-FirstModuleFunction
         $module.ExportedFunctions.Keys  | Should -Contain "Test-SecondModuleFunction"
     }
 
-    It "Re-imports modules from file with new members when -Force is used with -AsCustomObject" -Skip {
+    It "Re-imports modules from file with new members when -Force is used with -AsCustomObject" -Pending {
         $module = Import-Module $modInfo -PassThru
 
         $module.ExportedFunctions.Count | Should -Be 1
         $module.ExportedFunctions.Keys  | Should -Contain "Test-FirstModuleFunction"
         $module.ExportedFunctions.Keys  | Should -Not -Contain "Test-SecondModuleFunction"
 
-        $newModuleContent = (Get-Content $modData.Path | Out-String) + "`nfunction Test-SecondModuleFunction { Write-Output 'SECONDSTRING' }"
         Set-Content -Force -Path $modData.Path -Value $newModuleContent
 
         $module = Import-Module $modInfo -AsCustomObject -Force

--- a/test/powershell/engine/Module/ModuleCmdlet.Tests.ps1
+++ b/test/powershell/engine/Module/ModuleCmdlet.Tests.ps1
@@ -1,0 +1,518 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+$script:ModuleNames = [System.Collections.ArrayList]::new()
+
+function New-TestModule
+{
+    param(
+        [string]$Content
+    )
+
+    $guid = [guid]::NewGuid()
+    $modBasePath = Join-Path -Path $TestDrive -ChildPath $guid
+    $modName = "$guid.psm1"
+    $modPath = Join-Path -Path $modBasePath -ChildPath $modName
+
+    $modDir = New-Item -Path $modBasePath -ItemType Directory -Force
+    $null = New-Item -Path $modPath -Value $Content -Force
+
+    $null = $script:ModuleNames.Add($modName)
+
+    @{
+        "BaseDir" = $modDir;
+        "Name" = $modName;
+        "Path" = $modPath
+    }
+}
+
+function New-TestModuleWithSubModule
+{
+    param(
+        [string]$MainModContent,
+        [string]$SubModContent
+    )
+
+    $guid = [guid]::NewGuid()
+    $modBasePath = Join-Path -Path $TestDrive -ChildPath $guid
+    $modName = "$guid.psm1"
+    $subModName = "Sub.psm1"
+    $modPath = Join-Path -Path $modBasePath -ChildPath $modName
+    $subModPath = Join-Path -Path $modBasePath -ChildPath $subModName
+
+    $modDir = New-Item -Path $modBasePath -ItemType Directory -Force
+    $null = New-Item -Path $modPath -Value ("using module $subModPath`n" + $MainModContent)
+    $null = New-Item -Path $subModPath -Value $SubModContent
+
+    $null = $script:ModuleNames.Add($modName)
+
+    @{
+        "BaseDir" = $modDir;
+        "Name" = $modName;
+        "SubName" = $subModName;
+        "Path" = $modPath;
+        "SubPath" = $subModPath;
+    }
+}
+
+function Remove-TestModule
+{
+    [cmdletbinding()]
+    param(
+        [parameter(ValueFromPipeline)]
+        [psmoduleinfo]$ModuleInfo
+    )
+
+    process
+    {
+        Remove-Module -ModuleInfo $_ -Force
+        if (Test-Path $_.ModuleBase)
+        {
+            Remove-Item -Path $_.ModuleBase -Recurse -Force
+        }
+    }
+}
+
+function SetupModules
+{
+    $script:ModuleNames = [System.Collections.ArrayList]::new()
+}
+
+function TearDownModules
+{
+    Get-Module $script:ModuleNames | Remove-TestModule
+}
+
+Describe "Import-Module by name" -Tag "Feature" {
+
+    BeforeAll {
+        SetupModules
+
+        $simpleModContent = @'
+function Test-FirstModuleFunction
+{
+    Write-Output "TESTSTRING"
+}
+'@
+    }
+
+    AfterAll {
+        TearDownModules
+    }
+
+    Context "Simple psm1 module" {
+        It "Imports a simple module" {
+            $modData = New-TestModule -Content $simpleModContent
+            Import-Module $modData.Path
+            Test-FirstModuleFunction | Should -BeExactly "TESTSTRING"
+        }
+
+        It "Passes the imported module out when -PassThru is used" {
+            $modData = New-TestModule -Content $simpleModContent
+            $mod = Import-Module $modData.Path -PassThru
+            $mod.ExportedFunctions.Keys | Should -Contain "Test-FirstModuleFunction"
+        }
+
+        It "Passes the imported module out as a custom object when -AsCustomObject is used" {
+            $modData = New-TestModule -Content $simpleModContent
+            $mod = Import-Module $modData.Path -AsCustomObject
+            $mod | Should -BeOfType "PSCustomObject"
+            $mod.'Test-FirstModuleFunction'() | Should -BeExactly "TESTSTRING"
+        }
+
+        It "Re-imports modules from file with new members when -Force is used" {
+            $modData = New-TestModule -Content $simpleModContent
+            $module = Import-Module $modData.Path -PassThru
+
+            $module.ExportedFunctions.Count | Should -Be 1
+            $module.ExportedFunctions.Keys  | Should -Contain "Test-FirstModuleFunction"
+            $module.ExportedFunctions.Keys  | Should -Not -Contain "Test-SecondModuleFunction"
+
+            $newModuleContent = (Get-Content $modData.Path | Out-String) + "`nfunction Test-SecondModuleFunction { Write-Output 'SECONDSTRING' }"
+            Set-Content -Force -Path $modData.Path -Value $newModuleContent
+
+            $module = Import-Module $modData.Path -PassThru -Force
+            Test-SecondModuleFunction | Should -BeExactly "SECONDSTRING"
+        }
+
+        It "Re-imports modules from file with new members when -Force is used with -PassThru" {
+            $modData = New-TestModule -Content $simpleModContent
+            $module = Import-Module $modData.Path -PassThru
+
+            $module.ExportedFunctions.Count                                    | Should -Be 1
+            $module.ExportedFunctions.ContainsKey("Test-FirstModuleFunction")  | Should -BeTrue
+            $module.ExportedFunctions.ContainsKey("Test-SecondModuleFunction") | Should -BeFalse
+
+            $newModuleContent = (Get-Content $modData.Path | Out-String) + "`nfunction Test-SecondModuleFunction { Write-Output 'SECONDSTRING' }"
+            Set-Content -Force -Path $modData.Path -Value $newModuleContent
+
+            $module = Import-Module $modData.Path -PassThru -Force
+            $module.ExportedFunctions.Count                                    | Should -Be 2
+            $module.ExportedFunctions.ContainsKey("Test-FirstModuleFunction")  | Should -BeTrue
+            $module.ExportedFunctions.ContainsKey("Test-SecondModuleFunction") | Should -BeTrue
+        }
+
+        It "Re-imports modules from file with new members when -Force is used with -AsCustomObject" {
+            $modData = New-TestModule -Content $simpleModContent
+            $module = Import-Module $modData.Path -PassThru
+
+            $module.ExportedFunctions.Count                                    | Should -Be 1
+            $module.ExportedFunctions.ContainsKey("Test-FirstModuleFunction")  | Should -BeTrue
+            $module.ExportedFunctions.ContainsKey("Test-SecondModuleFunction") | Should -BeFalse
+
+            $newModuleContent = (Get-Content $modData.Path | Out-String) + "`nfunction Test-SecondModuleFunction { Write-Output 'SECONDSTRING' }"
+            Set-Content -Force -Path $modData.Path -Value $newModuleContent
+
+            $module = Import-Module $modData.Path -AsCustomObject -Force
+            $module.'Test-SecondModuleFunction'() | Should -BeExactly "SECONDSTRING"
+        }
+    }
+
+    Context "Classes in modules" {
+        BeforeAll {
+            SetupModules
+        }
+
+        AfterAll {
+            TearDownModules
+        }
+
+        It "Uses updated class definitions when the module is reloaded" {
+            $content = @'
+$passedArgs = $Args
+class Root { $passedArgs = $passedArgs }
+function Get-PassedArgsRoot { [Root]::new().passedArgs }
+function Get-PassedArgsNoRoot { $passedArgs }
+'@
+
+            $modData = New-TestModule -Content $content
+
+            Import-Module $modData.Path -ArgumentList 'value1'
+            $rootVal = Get-PassedArgsRoot
+            $noRootVal = Get-PassedArgsNoRoot
+            $rootVal | Should -BeExactly $noRootVal
+
+            Import-Module $modData.Path -ArgumentList 'value2'
+            $rootVal = Get-PassedArgsRoot
+            $rootNoVal = Get-PassedArgsNoRoot
+            $rootVal | Should -BeExactly $rootNoVal
+        }
+
+        It "Uses updated class definitions in later imports rather than cached values" {
+            $modSrc1 = @'
+class MyObj
+{
+    [string]$Name
+    MyObj()
+    {
+        $this.Name = "X"
+    }
+}
+'@
+
+            $modSrc2 = @'
+class MyObj
+{
+    [string]$Name
+    MyObj()
+    {
+        $this.Name = "Y"
+    }
+}
+'@
+            $modData = New-TestModule -Content $modSrc1
+
+            $mod1 = Import-Module $modData.Path -PassThru
+
+            Set-Content -Path $modData.Path -Value $modSrc2
+            $mod2 = Import-Module $modData.Path -PassThru
+
+            $firstTypes = $mod1.GetExportedTypeDefinitions()
+            $secondTypes = $mod2.GetExportedTypeDefinitions()
+
+            $firstTypes.MyObj.Equals($secondTypes.Sub) | Should -BeFalse
+        }
+    }
+
+    Context "Parameter handling" {
+        BeforeAll {
+            SetupModules
+
+            $validationTests = @(
+                @{ paramName="Variable" },
+                @{ paramName="Function" },
+                @{ paramName="Cmdlet" },
+                @{ paramName="Variable" }
+            )
+
+            $simpleModContent = @'
+function Test-FirstModuleFunction
+{
+    Write-Output "TESTSTRING"
+}
+'@
+
+            $ps = [powershell]::Create()
+        }
+
+        AfterAll {
+            TearDownModules
+            $ps.Dispose()
+        }
+
+        AfterEach {
+            $ps.Streams.ClearStreams()
+        }
+
+        It "Validates a null -<paramName> parameter" -TestCases $validationTests {
+            param($paramName)
+
+            $modData = New-TestModule $simpleModContent
+            $sb = [scriptblock]::Create("Import-Module $($modData.Path) -$paramName `$null")
+            $sb | Should -Throw -ErrorId "ParameterArgumentValidationError"
+        }
+
+        It "Ignores whitespace -MaximumVersion parameter" {
+            $modData = New-TestModule $simpleModContent
+            Import-Module $modData.Path -MaximumVersion "    "
+            Test-FirstModuleFunction | Should -BeExactly "TESTSTRING"
+        }
+    }
+}
+
+Describe "Import-Module by PSModuleInfo" -Tag "Feature" {
+    BeforeAll {
+        SetupModules
+
+        $simpleModContent = @'
+function Test-FirstModuleFunction
+{
+    Write-Output "TESTSTRING"
+}
+'@
+    }
+
+    AfterAll {
+        TearDownModules
+    }
+
+    BeforeEach {
+        $modData = New-TestModule -Content $simpleModContent
+        $modInfo = Import-Module $modData.Path -PassThru
+        Remove-Module $modInfo
+    }
+
+    It "Imports a module by moduleinfo" {
+        { Test-FirstModuleFunction } | Should -Throw -ErrorId "CommandNotFoundException"
+
+        Import-Module $modInfo
+
+        Test-FirstModuleFunction | Should -BeExactly "TESTSTRING"
+    }
+
+    It "Passes the imported module out when -PassThru is used" {
+        $mod = Import-Module $modInfo -PassThru
+
+        $mod.ExportedFunctions.Keys | Should -Contain "Test-FirstModuleFunction"
+    }
+
+    It "Passes the imported module out as a custom object when -AsCustomObject is used" {
+        $mod = Import-Module $modInfo -AsCustomObject
+
+        $mod                              | Should -BeOfType "PSCustomObject"
+        $mod.'Test-FirstModuleFunction'() | Should -BeExactly "TESTSTRING"
+    }
+
+    It "Re-imports modules from file with new members when -Force is used" {
+        $module = Import-Module $modInfo -PassThru
+
+        $module.ExportedFunctions.Count | Should -Be 1
+        $module.ExportedFunctions.Keys  | Should -Contain "Test-FirstModuleFunction"
+        $module.ExportedFunctions.Keys  | Should -Not -Contain "Test-SecondModuleFunction"
+
+        $newModuleContent = (Get-Content $modData.Path | Out-String) + "`nfunction Test-SecondModuleFunction { Write-Output 'SECONDSTRING' }"
+        Set-Content -Force -Path $modData.Path -Value $newModuleContent
+
+        Import-Module $modInfo -Force
+        Test-SecondModuleFunction | Should -BeExactly "SECONDSTRING"
+    }
+
+    It "Re-imports modules from file with new members when -Force is used with -PassThru" -Skip {
+        $module = Import-Module $modInfo -PassThru
+
+        $module.ExportedFunctions.Count | Should -Be 1
+        $module.ExportedFunctions.Keys  | Should -Contain "Test-FirstModuleFunction"
+        $module.ExportedFunctions.Keys  | Should -Not -Contain "Test-SecondModuleFunction"
+
+        $newModuleContent = (Get-Content $modData.Path | Out-String) + "`nfunction Test-SecondModuleFunction { Write-Output 'SECONDSTRING' }"
+        Set-Content -Force -Path $modData.Path -Value $newModuleContent
+
+        $module = Import-Module $modInfo -PassThru -Force
+
+        $module.ExportedFunctions.Count | Should -Be 2
+        $module.ExportedFunctions.Keys  | Should -Contain "Test-FirstModuleFunction"
+        $module.ExportedFunctions.Keys  | Should -Contain "Test-SecondModuleFunction"
+    }
+
+    It "Re-imports modules from file with new members when -Force is used with -AsCustomObject" -Skip {
+        $module = Import-Module $modInfo -PassThru
+
+        $module.ExportedFunctions.Count | Should -Be 1
+        $module.ExportedFunctions.Keys  | Should -Contain "Test-FirstModuleFunction"
+        $module.ExportedFunctions.Keys  | Should -Not -Contain "Test-SecondModuleFunction"
+
+        $newModuleContent = (Get-Content $modData.Path | Out-String) + "`nfunction Test-SecondModuleFunction { Write-Output 'SECONDSTRING' }"
+        Set-Content -Force -Path $modData.Path -Value $newModuleContent
+
+        $module = Import-Module $modInfo -AsCustomObject -Force
+        $module.'Test-SecondModuleFunction'() | Should -BeExactly "SECONDSTRING"
+    }
+}
+
+Describe "Import-Module with nested modules" -Tag "Feature" {
+    BeforeAll {
+        SetupModules
+    }
+
+    AfterAll {
+        TearDownModules
+    }
+
+    It "Resolves submodule classes with 'using module'" {
+        $modSrc = @"
+function Test-MainModuleFunc
+{
+    [Sub]::new()
+}
+"@
+
+        $subModSrc = @'
+class Sub
+{
+    [string]$Name
+    Sub()
+    {
+        $this.Name = 'CLASSSTRING'
+    }
+}
+'@
+        $modData = New-TestModuleWithSubModule -MainModContent $modSrc -SubModContent $subModSrc
+
+        Import-Module $modData.BaseDir
+
+        $subObj = Test-MainModuleFunc
+        $subObj.Name | Should -BeExactly "CLASSSTRING"
+    }
+
+    It "Does not refresh nested modules when Import-Module -Force is used" {
+        $mainSrc = @'
+function MainFunc
+{
+    SubFunc
+}
+'@
+
+        $sub1Src = @'
+function SubFunc
+{
+    "FIRST"
+}
+'@
+
+        $sub2Src = @'
+function SubFunc
+{
+    "SECOND"
+}
+'@
+        $modData = New-TestModuleWithSubModule -MainModContent $mainSrc -SubModContent $sub1Src
+
+        Import-Module $modData.BaseDir
+
+        MainFunc | Should -BeExactly "FIRST"
+
+        Set-Content -Path $modData.SubPath -Value $sub2Src -Force
+
+        Import-Module $modData.BaseDir -Force
+
+        MainFunc | Should -BeExactly "FIRST"
+    }
+
+    It "Uses cached class definitions in non-force-reloaded submodules" {
+        $mainModSrc = @"
+function Test-SubClassMain { [SubObj]::new().Id }
+"@
+
+        $subModSrc1 = @'
+class SubObj
+{
+    [string]$Id
+    SubObj()
+    {
+        $this.Id = "FIRST"
+    }
+}
+'@
+
+        $subModSrc2 = @'
+class SubObj
+{
+    [string]$Id
+    SubObj()
+    {
+        $this.Id = "SECOND"
+    }
+}
+'@
+        $modData = New-TestModuleWithSubModule -MainModContent $mainModSrc -SubModContent $subModSrc1
+
+        Import-Module $modData.BaseDir
+
+        Test-SubClassMain | Should -BeExactly "FIRST"
+
+        Set-Content -Path $modData.SubPath -Value $subModSrc2 -Force
+
+        Import-Module $modData.BaseDir
+
+        Test-SubClassMain | Should -BeExactly "FIRST"
+    }
+
+    It "Does not use updated class definitions in submodules when Import-Module -Force is used" {
+        $mainModSrc = @"
+function Test-SubClassMain { [SubObj]::new().Id }
+"@
+
+        $subModSrc1 = @'
+class SubObj
+{
+    [string]$Id
+    SubObj()
+    {
+        $this.Id = "FIRST"
+    }
+}
+'@
+
+        $subModSrc2 = @'
+class SubObj
+{
+    [string]$Id
+    SubObj()
+    {
+        $this.Id = "SECOND"
+    }
+}
+'@
+        $modData = New-TestModuleWithSubModule -MainModContent $mainModSrc -SubModContent $subModSrc1
+
+        Import-Module $modData.BaseDir
+
+        Test-SubClassMain | Should -BeExactly "FIRST"
+
+        Set-Content -Path $modData.SubPath -Value $subModSrc2 -Force
+
+        Import-Module -Force $modData.BaseDir
+
+        Test-SubClassMain | Should -BeExactly "FIRST"
+    }
+}

--- a/test/powershell/engine/Module/ModuleCmdlet.Tests.ps1
+++ b/test/powershell/engine/Module/ModuleCmdlet.Tests.ps1
@@ -19,7 +19,7 @@ function New-TestModule
 
     $null = $script:ModuleNames.Add($modName)
 
-    @{
+    return @{
         "BaseDir" = $modDir;
         "Name" = $modName;
         "Path" = $modPath
@@ -46,7 +46,7 @@ function New-TestModuleWithSubModule
 
     $null = $script:ModuleNames.Add($modName)
 
-    @{
+    return @{
         "BaseDir" = $modDir;
         "Name" = $modName;
         "SubName" = $subModName;
@@ -139,26 +139,26 @@ function Test-FirstModuleFunction
             $modData = New-TestModule -Content $simpleModContent
             $module = Import-Module $modData.Path -PassThru
 
-            $module.ExportedFunctions.Count                                    | Should -Be 1
-            $module.ExportedFunctions.ContainsKey("Test-FirstModuleFunction")  | Should -BeTrue
-            $module.ExportedFunctions.ContainsKey("Test-SecondModuleFunction") | Should -BeFalse
+            $module.ExportedFunctions.Count | Should -Be 1
+            $module.ExportedFunctions.Keys  | Should -Contain "Test-FirstModuleFunction"
+            $module.ExportedFunctions.Keys  | Should -Not -Contain "Test-SecondModuleFunction"
 
             $newModuleContent = (Get-Content $modData.Path | Out-String) + "`nfunction Test-SecondModuleFunction { Write-Output 'SECONDSTRING' }"
             Set-Content -Force -Path $modData.Path -Value $newModuleContent
 
             $module = Import-Module $modData.Path -PassThru -Force
-            $module.ExportedFunctions.Count                                    | Should -Be 2
-            $module.ExportedFunctions.ContainsKey("Test-FirstModuleFunction")  | Should -BeTrue
-            $module.ExportedFunctions.ContainsKey("Test-SecondModuleFunction") | Should -BeTrue
+            $module.ExportedFunctions.Count | Should -Be 2
+            $module.ExportedFunctions.Keys  | Should -Contain "Test-FirstModuleFunction"
+            $module.ExportedFunctions.Keys  | Should -Contain "Test-SecondModuleFunction"
         }
 
         It "Re-imports modules from file with new members when -Force is used with -AsCustomObject" {
             $modData = New-TestModule -Content $simpleModContent
             $module = Import-Module $modData.Path -PassThru
 
-            $module.ExportedFunctions.Count                                    | Should -Be 1
-            $module.ExportedFunctions.ContainsKey("Test-FirstModuleFunction")  | Should -BeTrue
-            $module.ExportedFunctions.ContainsKey("Test-SecondModuleFunction") | Should -BeFalse
+            $module.ExportedFunctions.Count | Should -Be 1
+            $module.ExportedFunctions.Keys  | Should -Contain "Test-FirstModuleFunction"
+            $module.ExportedFunctions.Keys  | Should -Contain "Test-SecondModuleFunction"
 
             $newModuleContent = (Get-Content $modData.Path | Out-String) + "`nfunction Test-SecondModuleFunction { Write-Output 'SECONDSTRING' }"
             Set-Content -Force -Path $modData.Path -Value $newModuleContent


### PR DESCRIPTION
## PR Summary

Fix the cache invalidation issue from #2505.

Currently, importing a module for the second time will always import from the cache, even if the underlying file has been changed.

This change makes the cache check the last write time on the underlying file first before proceeding, and if it is different, updates the cache and returns the new module file.

I have also changed the analysis cache dictionaries to use `ConcurrentDictionary` rather than needing to manually use a locking object.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [x] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/powershell/6710)
<!-- Reviewable:end -->
