### PR TITLE
Revert "Fix for files/folders not created when given path is drive root (#5228)"

### DIFF
--- a/src/System.Management.Automation/namespaces/LocationGlobber.cs
+++ b/src/System.Management.Automation/namespaces/LocationGlobber.cs
@@ -2013,9 +2013,6 @@ namespace System.Management.Automation
             // Check to see if the path is relative or absolute
             bool isPathForCurrentDrive = false;
 
-            // Check to see if the path is to the root of a drive
-            bool isPathForRootOfDrive = false;
-
             if (IsAbsolutePath(path, out driveName))
             {
                 Dbg.Diagnostics.Assert(
@@ -2083,12 +2080,6 @@ namespace System.Management.Automation
                         // this is the default behavior for all windows drives, and all non-filesystem
                         // drives on non-windows
                         path = path.Substring(driveName.Length + 1);
-
-                        if (String.IsNullOrEmpty(path))
-                        {
-                            // path was to the root of a drive such as 'c:'
-                            isPathForRootOfDrive = true;
-                        }
                     }
                 }
             }
@@ -2120,23 +2111,14 @@ namespace System.Management.Automation
                 // have access to it.
                 context.Drive = workingDriveForPath;
 
-                string relativePath = String.Empty;
+                string relativePath =
+                    GenerateRelativePath(
+                        workingDriveForPath,
+                        path,
+                        escapeCurrentLocation,
+                        providerInstance,
+                        context);
 
-                if (isPathForRootOfDrive)
-                {
-                    relativePath = context.Drive.Root;
-                }
-                else
-                {
-                    relativePath =
-                        GenerateRelativePath(
-                            workingDriveForPath,
-                            path,
-                            escapeCurrentLocation,
-                            providerInstance,
-                            context);
-                }
-                
                 return relativePath;
             }
             catch (PSNotSupportedException)

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/New-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/New-Item.Tests.ps1
@@ -117,33 +117,6 @@ Describe "New-Item" -Tags "CI" {
         $fileInfo.Target | Should -BeNullOrEmpty
         $fileInfo.LinkType | Should -BeExactly "HardLink"
     }
-
-    It "Should create a file at the root of the drive while the current working directory is not the root" {
-        try {
-            New-Item -Name $testfolder -Path "TestDrive:\" -ItemType directory > $null
-            Push-Location -Path "TestDrive:\$testfolder"
-            New-Item -Name $testfile -Path "TestDrive:\" -ItemType file > $null
-            $FullyQualifiedFile | Should -Exist
-        }
-        finally {
-            Pop-Location
-        }
-    }
-
-    It "Should create a folder at the root of the drive while the current working directory is not the root" {
-        $testfolder2 = "newDirectory2"
-        $FullyQualifiedFolder2 = Join-Path -Path $tmpDirectory -ChildPath $testfolder2
-
-        try {
-            New-Item -Name $testfolder -Path "TestDrive:\" -ItemType directory > $null
-            Push-Location -Path "TestDrive:\$testfolder"
-            New-Item -Name $testfolder2 -Path "TestDrive:\" -ItemType directory > $null
-            $FullyQualifiedFolder2 | Should -Exist
-        }
-        finally {
-            Pop-Location
-        }
-    }
 }
 
 # More precisely these tests require SeCreateSymbolicLinkPrivilege.
@@ -213,7 +186,7 @@ Describe "New-Item with links" -Tags @('CI', 'RequireAdminOnWindows') {
     }
 
     It "New-Item -ItemType SymbolicLink should understand directory path ending with slash" {
-        $folderName = [System.IO.Path]::GetRandomFileName()
+        $folderName = [System.IO.Path]::GetRandomFileName()            
         $symbolicLinkPath = New-Item -ItemType SymbolicLink -Path "$tmpDirectory/$folderName/" -Value "/bar/"
         $symbolicLinkPath | Should -Not -BeNullOrEmpty
     }


### PR DESCRIPTION
Reverts PowerShell/PowerShell#6600.

This caused a regression in drive behaviour where drive paths were not restored. See https://github.com/PowerShell/PowerShell/issues/6749.

We will need to reopen https://github.com/PowerShell/PowerShell/issues/5228.