### PR TITLE
Fix Format-Table where rows were being trimmed unnecessarily if there's only one row of headers

### DIFF
--- a/src/System.Management.Automation/FormatAndOutput/common/TableWriter.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/TableWriter.cs
@@ -363,8 +363,8 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 // for a given row, walk the columns
                 for (int col = 0; col < scArray.Length; col++)
                 {
-                    // if the column is the last column with content, we need to trim trailing whitespace
-                    if (col == lastColWithContent[row])
+                    // if the column is the last column with content, we need to trim trailing whitespace, unless there is only one row
+                    if (col == lastColWithContent[row] && screenRows > 1)
                     {
                         sb.Append(scArray[col][row].TrimEnd());
                     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-Table.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-Table.Tests.ps1
@@ -579,6 +579,15 @@ er
 
 
 
+"@ },
+            @{ view = "Default"; widths = 14,7,7; variation = "value wider than header, left justified"; values = [PSCustomObject]@{First="123456789012345";Second="12345678";Third="12345678"}; wrap = $false; expectedTable = @"
+
+LongLongHeader  Header2  Header3
+--------------  -------  -------
+123456789012345 12345678 12345678
+
+
+
 "@ }
         ) {
             param($view, $widths, $values, $wrap, $expectedTable)

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-Table.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-Table.Tests.ps1
@@ -681,30 +681,33 @@ er
             $output.Replace("`r","").Replace(" ","*").Replace("`n","^") | Should -BeExactly $expectedTable.Replace("`r","").Replace(" ",".").Replace("`n","^")
         }
 
-        It "Should render header correctly where values are wider than header: <variation>" -TestCases @(
-            @{ variation = "first column"; obj = [pscustomobject]@{abc="1234";bcd="123"}; expectedTable = @"
+        It "Should render header/row correctly where values are wider than header w/ implicit autosize: <variation>" -TestCases @(
+            @{ variation = "first column"; obj = [pscustomobject]@{abc="1234";bcd="123"},[pscustomobject]@{abc="1";bcd="1234"}; expectedTable = @"
 
 abc  bcd
 ---  ---
 1234 123
+1    1234
 
 
 
 "@ },
-            @{ variation = "both columns"; obj = [pscustomobject]@{abc="1234";bcd="1234"}; expectedTable = @"
+            @{ variation = "both columns"; obj = [pscustomobject]@{abc="1234";bcd="1234"},[pscustomobject]@{abc="1";bcd="1"}; expectedTable = @"
 
 abc  bcd
 ---  ---
 1234 1234
+1    1
 
 
 
 "@ },
-            @{ variation = "second column"; obj = [pscustomobject]@{abc="123";bcd="1234"}; expectedTable = @"
+            @{ variation = "second column"; obj = [pscustomobject]@{abc="123";bcd="1234"},[pscustomobject]@{abc="1";bcd="123"}; expectedTable = @"
 
 abc bcd
 --- ---
 123 1234
+1   123
 
 
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-Table.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-Table.Tests.ps1
@@ -330,6 +330,16 @@ Left Center Right
         }
 
         It "Format-Table should correctly render headers that span multiple rows: <variation>" -TestCases @(
+            @{ view = "Default"; widths = 7,7,7; variation = "2 row, 1 row, 1 row"; expectedTable = @"
+
+LongLon Header2 Header3
+gHeader
+------- ------- -------
+1       2       3
+
+
+
+"@ },
             @{ view = "Default"; widths = 4,7,4; variation = "4 row, 1 row, 2 row"; expectedTable = @"
 
 Long Header2 Head
@@ -463,7 +473,7 @@ er
                 Write-Verbose $e.ToString() -Verbose
             }
             $ps.HadErrors | Should -BeFalse
-            $output.Replace("`r","").Replace(" ",".").Replace("`n","``") | Should -BeExactly $expectedTable.Replace("`r","").Replace(" ",".").Replace("`n","``")
+            $output.Replace("`r","").Replace(" ",".").Replace("`n","^") | Should -BeExactly $expectedTable.Replace("`r","").Replace(" ",".").Replace("`n","^")
         }
 
         It "Format-Table should correctly render rows: <variation>" -TestCases @(
@@ -579,15 +589,6 @@ er
 
 
 
-"@ },
-            @{ view = "Default"; widths = 14,7,7; variation = "value wider than header, left justified"; values = [PSCustomObject]@{First="123456789012345";Second="12345678";Third="12345678"}; wrap = $false; expectedTable = @"
-
-LongLongHeader  Header2  Header3
---------------  -------  -------
-123456789012345 12345678 12345678
-
-
-
 "@ }
         ) {
             param($view, $widths, $values, $wrap, $expectedTable)
@@ -677,6 +678,40 @@ LongLongHeader  Header2  Header3
                 Write-Verbose $e.ToString() -Verbose
             }
             $ps.HadErrors | Should -BeFalse
-            $output.Replace("`r","").Replace(" ","*").Replace("`n","``") | Should -BeExactly $expectedTable.Replace("`r","").Replace(" ",".").Replace("`n","``")
+            $output.Replace("`r","").Replace(" ","*").Replace("`n","^") | Should -BeExactly $expectedTable.Replace("`r","").Replace(" ",".").Replace("`n","^")
+        }
+
+        It "Should render header correctly where values are wider than header: <variation>" -TestCases @(
+            @{ variation = "first column"; obj = [pscustomobject]@{abc="1234";bcd="123"}; expectedTable = @"
+
+abc  bcd
+---  ---
+1234 123
+
+
+
+"@ },
+            @{ variation = "both columns"; obj = [pscustomobject]@{abc="1234";bcd="1234"}; expectedTable = @"
+
+abc  bcd
+---  ---
+1234 1234
+
+
+
+"@ },
+            @{ variation = "second column"; obj = [pscustomobject]@{abc="123";bcd="1234"}; expectedTable = @"
+
+abc bcd
+--- ---
+123 1234
+
+
+
+"@ }
+        ) {
+            param($obj, $expectedTable)
+            $output = $obj | Format-Table | Out-String
+            $output.Replace("`r","").Replace(" ",".").Replace("`n","^") | Should -BeExactly $expectedTable.Replace("`r","").Replace(" ",".").Replace("`n","^")
         }
     }


### PR DESCRIPTION
## PR Summary

In the case where a row doesn't expand to multiple rows, columns were still being trimmed of whitespace which introduces invalid alignment as the whitespace needs to be retained.
Added new tests to cover this scenario.  Updated some existing tests to use `^` instead of backtick to represent newline making it easier to replace it back with a newline to visualize during debugging when test fails.

Fix https://github.com/PowerShell/PowerShell/issues/6767

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [x] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
