### PR TITLE
Fix crash when terminal is reset

### DIFF
--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterface.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterface.cs
@@ -1791,10 +1791,16 @@ namespace Microsoft.PowerShell
                     }
 
                     // Modify string
-                    if (!insertMode) // then overwrite mode
+                    if (!insertMode && s != "") // then overwrite mode
                     {
                         s = s.Remove(index, 1);
                     }
+
+                    if (index > s.Length)
+                    {
+                        index = s.Length;
+                    }
+
                     s = s.Insert(index, keyInfo.KeyChar.ToString());
                     index++;
 

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterface.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterface.cs
@@ -1797,7 +1797,7 @@ namespace Microsoft.PowerShell
                     }
 
                     // Modify string
-                    if (!insertMode) // then overwrite mode
+                    if (!insertMode && index < s.Length) // then overwrite mode
                     {
                         s = s.Remove(index, 1);
                     }

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterface.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterface.cs
@@ -1790,15 +1790,16 @@ namespace Microsoft.PowerShell
                         continue;
                     }
 
-                    // Modify string
-                    if (!insertMode && s != "") // then overwrite mode
-                    {
-                        s = s.Remove(index, 1);
-                    }
-
+                    // Handle case where terminal gets reset and the index is outside of the buffer
                     if (index > s.Length)
                     {
                         index = s.Length;
+                    }
+
+                    // Modify string
+                    if (!insertMode) // then overwrite mode
+                    {
+                        s = s.Remove(index, 1);
                     }
 
                     s = s.Insert(index, keyInfo.KeyChar.ToString());


### PR DESCRIPTION
## PR Summary

When terminal is reset, the state of the string buffer is wrong so the built-in readline code tries to insert a character beyond the length of the buffer and thus crashes.  Fix is to check if the index is greater than the size of the buffer and set it to the end of the buffer.  Validated manually.

Fix https://github.com/PowerShell/PowerShell/issues/6776

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [x] Not Applicable or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
