### PR TITLE
Rename -Not parameter to -IsNullOrEmpty in Where-Object cmdlet.

### DIFF
--- a/src/System.Management.Automation/engine/InternalCommands.cs
+++ b/src/System.Management.Automation/engine/InternalCommands.cs
@@ -813,7 +813,7 @@ namespace Microsoft.PowerShell.Commands
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "CaseSensitiveNotInSet")]
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "IsSet")]
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "IsNotSet")]
-        [Parameter(Mandatory = true, Position = 0, ParameterSetName = "Not")]
+        [Parameter(Mandatory = true, Position = 0, ParameterSetName = "IsNullOrEmpty")]
         [ValidateNotNullOrEmpty]
         public string Property
         {
@@ -1203,8 +1203,8 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Binary operator -Not.
         /// </summary>
-        [Parameter(Mandatory = true, ParameterSetName = "Not")]
-        public SwitchParameter Not
+        [Parameter(Mandatory = true, ParameterSetName = "IsNullOrEmpty")]
+        public SwitchParameter IsNullOrEmpty
         {
             set { _binaryOperator = TokenKind.Not; }
             get { return _binaryOperator == TokenKind.Not; }

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Where-Object.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Where-Object.Tests.ps1
@@ -24,8 +24,8 @@ Describe "Where-Object" -Tags "CI" {
         )
     }
 
-    It "Where-Object -Not Prop" {
-        $Result = $Computers | Where-Object -Not 'IPAddress'
+    It "Where-Object -IsNullOrEmpty Prop" {
+        $Result = $Computers | Where-Object -IsNullOrEmpty 'IPAddress'
         $Result.Count | Should -Be 2
     }
 


### PR DESCRIPTION
## PR Summary

**-Not** parameter is very ambiguous.
Is it better to rename it to **-IsNullOrEmpty**?

Also, **ParameterSetName** is changed to 'IsNullOrEmpty'.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
