### PR TITLE
Fix Web Cmdlets for .NET Core 2.1

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -1300,7 +1300,7 @@ namespace Microsoft.PowerShell.Commands
 
                 currentUri = new Uri(request.RequestUri, response.Headers.Location);
                 // Continue to handle redirection
-                using (client = GetHttpClient(true))
+                using (client = GetHttpClient(handleRedirect: true))
                 using (HttpRequestMessage redirectRequest = GetRequest(currentUri))
                 {
                     response = GetResponse(client, redirectRequest, keepAuthorization);

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -993,7 +993,7 @@ namespace Microsoft.PowerShell.Commands
             return httpClient;
         }
 
-        internal virtual HttpRequestMessage GetRequest(Uri uri, bool stripAuthorization)
+        internal virtual HttpRequestMessage GetRequest(Uri uri)
         {
             Uri requestUri = PrepareUri(uri);
             HttpMethod httpMethod = null;
@@ -1032,14 +1032,6 @@ namespace Microsoft.PowerShell.Commands
                     }
                     else
                     {
-                        if (stripAuthorization
-                            &&
-                            String.Equals(entry.Key, HttpKnownHeaderNames.Authorization.ToString(), StringComparison.OrdinalIgnoreCase)
-                        )
-                        {
-                            continue;
-                        }
-
                         if (SkipHeaderValidation)
                         {
                             request.Headers.TryAddWithoutValidation(entry.Key, entry.Value);
@@ -1268,15 +1260,15 @@ namespace Microsoft.PowerShell.Commands
                 ||
                 code == HttpStatusCode.RedirectMethod
                 ||
-                code == HttpStatusCode.TemporaryRedirect
-                ||
-                code == HttpStatusCode.RedirectKeepVerb
-                ||
                 code == HttpStatusCode.SeeOther
+                ||
+                code == HttpStatusCode.Ambiguous
+                ||
+                code == HttpStatusCode.MultipleChoices
             );
         }
 
-        internal virtual HttpResponseMessage GetResponse(HttpClient client, HttpRequestMessage request, bool stripAuthorization)
+        internal virtual HttpResponseMessage GetResponse(HttpClient client, HttpRequestMessage request, bool keepAuthorization)
         {
             if (client == null) { throw new ArgumentNullException("client"); }
             if (request == null) { throw new ArgumentNullException("request"); }
@@ -1287,7 +1279,7 @@ namespace Microsoft.PowerShell.Commands
             _cancelToken = new CancellationTokenSource();
             HttpResponseMessage response = client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, _cancelToken.Token).GetAwaiter().GetResult();
 
-            if (stripAuthorization && IsRedirectCode(response.StatusCode) && response.Headers.Location != null)
+            if (keepAuthorization && IsRedirectCode(response.StatusCode) && response.Headers.Location != null)
             {
                 _cancelToken.Cancel();
                 _cancelToken = null;
@@ -1306,14 +1298,12 @@ namespace Microsoft.PowerShell.Commands
                     Method = WebRequestMethod.Get;
                 }
 
-                // recreate the HttpClient with redirection enabled since the first call suppressed redirection
                 currentUri = new Uri(request.RequestUri, response.Headers.Location);
-                using (client = GetHttpClient(false))
-                using (HttpRequestMessage redirectRequest = GetRequest(currentUri, stripAuthorization:true))
+                // Continue to handle redirection
+                using (client = GetHttpClient(true))
+                using (HttpRequestMessage redirectRequest = GetRequest(currentUri))
                 {
-                    FillRequestStream(redirectRequest);
-                    _cancelToken = new CancellationTokenSource();
-                    response = client.SendAsync(redirectRequest, HttpCompletionOption.ResponseHeadersRead, _cancelToken.Token).GetAwaiter().GetResult();
+                    response = GetResponse(client, redirectRequest, keepAuthorization);
                 }
             }
 
@@ -1333,7 +1323,7 @@ namespace Microsoft.PowerShell.Commands
                 // are treated as a standard -OutFile request. This also disables appending local file.
                 Resume = new SwitchParameter(false);
 
-                using (HttpRequestMessage requestWithoutRange = GetRequest(currentUri, stripAuthorization:false))
+                using (HttpRequestMessage requestWithoutRange = GetRequest(currentUri))
                 {
                     FillRequestStream(requestWithoutRange);
                     long requestContentLength = 0;
@@ -1347,7 +1337,7 @@ namespace Microsoft.PowerShell.Commands
                         requestContentLength);
                     WriteVerbose(reqVerboseMsg);
 
-                    return GetResponse(client, requestWithoutRange, stripAuthorization);
+                    return GetResponse(client, requestWithoutRange, keepAuthorization);
                 }
             }
 
@@ -1377,15 +1367,15 @@ namespace Microsoft.PowerShell.Commands
 
                 // if the request contains an authorization header and PreserveAuthorizationOnRedirect is not set,
                 // it needs to be stripped on the first redirect.
-                bool stripAuthorization = null != WebSession
+                bool keepAuthorization = null != WebSession
                                           &&
                                           null != WebSession.Headers
                                           &&
-                                          !PreserveAuthorizationOnRedirect.IsPresent
+                                          PreserveAuthorizationOnRedirect.IsPresent
                                           &&
                                           WebSession.Headers.ContainsKey(HttpKnownHeaderNames.Authorization.ToString());
 
-                using (HttpClient client = GetHttpClient(stripAuthorization))
+                using (HttpClient client = GetHttpClient(keepAuthorization))
                 {
                     int followedRelLink = 0;
                     Uri uri = Uri;
@@ -1399,7 +1389,7 @@ namespace Microsoft.PowerShell.Commands
                             WriteVerbose(linkVerboseMsg);
                         }
 
-                        using (HttpRequestMessage request = GetRequest(uri, stripAuthorization:false))
+                        using (HttpRequestMessage request = GetRequest(uri))
                         {
                             FillRequestStream(request);
                             try
@@ -1415,7 +1405,7 @@ namespace Microsoft.PowerShell.Commands
                                     requestContentLength);
                                 WriteVerbose(reqVerboseMsg);
 
-                                HttpResponseMessage response = GetResponse(client, request, stripAuthorization);
+                                HttpResponseMessage response = GetResponse(client, request, keepAuthorization);
 
                                 string contentType = ContentHelper.GetContentType(response);
                                 string respVerboseMsg = string.Format(CultureInfo.CurrentCulture,


### PR DESCRIPTION
## PR Summary

* closes #6728
* Breaking change approved in #6728 

This PR switches the logic of when the Web Cmdlets handle redirects when the Authorization header is present. .NET Core 2.1 no longer sends the Authorization header by default (dotnet/corefx#26864). however, we introduced the ability to do so leveraging the previous default behavior through the use of the `-PreserveAuthorizationOnRedirect` switch. 

This PR also corrects a bug introduced 6.0.0 where certain redirect types redirect from POST to GET were set which should have passed through POST to POST and some were improperly passing through POST to POST which should have been doing POST to GET. This correction is a breaking change. It was made apparent as now the redirection behavior is being managed by CoreFX which is doing the correct behavior, test were added for both when CoreFX and the Web Cmdlets manage redirection.

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [X] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [X] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [X] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
