### PR TITLE
Have *-Location modify the Environment.CurrentDirectory which changes the cwd on *nix

### DIFF
--- a/src/System.Management.Automation/engine/SessionStateLocationAPIs.cs
+++ b/src/System.Management.Automation/engine/SessionStateLocationAPIs.cs
@@ -5,6 +5,7 @@
 
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.IO;
 using System.Management.Automation.Provider;
 using Dbg = System.Management.Automation;
 
@@ -551,6 +552,13 @@ namespace System.Management.Automation
             // Set the $PWD variable to the new location
 
             this.SetVariable(SpecialVariables.PWDVarPath, this.CurrentLocation, false, true, CommandOrigin.Internal);
+            
+            // Set the cwd/CurrentDirectory to the path - that path must be a file system directory
+            if (Directory.Exists(this.CurrentLocation.Path))
+            {
+                Environment.CurrentDirectory = this.CurrentLocation.Path;
+            }
+            
             return this.CurrentLocation;
         } // SetLocation
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
@@ -236,7 +236,34 @@ Describe "Basic FileSystem Provider Tests" -Tags "CI" {
             finally {
                 Remove-Item -Path $testPath -Recurse -Force -ErrorAction SilentlyContinue
             }
-         }
+        }
+
+        It "Set-Location sets the Environment.CurrentDirectory which maps to cwd on Unix" {
+            Set-Location $TestDrive
+            if ($IsMacOS) {
+                # on macOS, /tmp is a symlink to /private so the real path is under /private/tmp
+                $expectedPath = "/private" + $TestDrive
+            } else {
+                $expectedPath = $TestDrive
+            }
+            [System.Environment]::CurrentDirectory | Should -BeExactly $expectedPath
+            Set-Location $testDir
+            [System.Environment]::CurrentDirectory | Should -BeExactly "$expectedPath/$testDir"
+        }
+        It "Push/Pop-Location sets the Environment.CurrentDirectory which maps to cwd on Unix" {
+            Push-Location $TestDrive
+            if ($IsMacOS) {
+                # on macOS, /tmp is a symlink to /private so the real path is under /private/tmp
+                $expectedPath = "/private" + $TestDrive
+            } else {
+                $expectedPath = $TestDrive
+            }
+            [System.Environment]::CurrentDirectory | Should -BeExactly $expectedPath
+            Push-Location $testDir
+            [System.Environment]::CurrentDirectory | Should -BeExactly "$expectedPath/$testDir"
+            Pop-Location
+            [System.Environment]::CurrentDirectory | Should -BeExactly $expectedPath
+        }
     }
 
     Context "Validate behavior when access is denied" {


### PR DESCRIPTION
## PR Summary

<!-- summarize your PR between here and the checklist -->
I noticed that *-Location doesn't set the environment current directory:
https://msdn.microsoft.com/en-us/library/system.environment.currentdirectory(v=vs.110).aspx

On *nix, this value is mapped to the `cwd` property on the process. In bash, when you change directories, that property changes. To test on *nix:
`lsof -p YOU_PID | grep cwd`

I discovered this when I was trying to add PowerShell support to hypercwd (https://github.com/hharnisc/hypercwd/issues/41) which is a plug-in to [hyper](hyper.is) that, when you open a new tab, preserves the location from the previous tab. In the plug-in, they do this for *nix:
https://github.com/hharnisc/hypercwd/blob/master/setCwd.js#L8

I don't think this is a breaking change.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)