### PR TITLE
Fix tab completions for a hash table

### DIFF
--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
@@ -547,10 +547,15 @@ namespace System.Management.Automation
                                 completionContext.ReplacementLength = replacementLength = 0;
                                 result = GetResultForAttributeArgument(completionContext, ref replacementIndex, ref replacementLength);
                             }
-                            else if (lastAst.Parent is DynamicKeywordStatementAst || lastAst.Parent is CommandExpressionAst)
+                            else if (lastAst is HashtableAst hashTableAst && !(lastAst.Parent is DynamicKeywordStatementAst) && CheckForPendingAssignment(hashTableAst))
                             {
-                                // 1. Handle scenarios such as 'configuration foo { File ab { Attributes ='
-                                // 2. Handle auto completion for enum/dependson property of DSC resource,
+                                // Handle scenarios such as 'gci | Format-Table @{Label=<tab>' if incomplete parsing of the assignment.
+                                return null;
+                            }
+                            else
+                            {
+                                // Handle scenarios such as 'configuration foo { File ab { Attributes ='
+                                // (auto completion for enum/dependson property of DSC resource),
                                 // cursor is right after '=', '(' or '@('
                                 //
                                 // Configuration config
@@ -563,11 +568,6 @@ namespace System.Management.Automation
                                 //
                                 bool unused;
                                 result = GetResultForEnumPropertyValueOfDSCResource(completionContext, string.Empty, ref replacementIndex, ref replacementLength, out unused);
-                            }
-                            else if (lastAst is HashtableAst hashTableAst && CheckForPendingAssignment(hashTableAst))
-                            {
-                                // Handle scenarios such as 'gci | Format-Table @{Label=<tab>' if incomplete parsing of the assignment.
-                                return null;
                             }
                             break;
                         }

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
@@ -475,9 +475,12 @@ namespace System.Management.Automation
 
                     case TokenKind.Semi:
                         // Handle scenarios such as 'gci | Format-Table @{Label=...;<tab>'
-                        result = GetResultForHashtable(completionContext);
-                        replacementIndex += 1;
-                        replacementLength = 0;
+                        if (lastAst is HashtableAst)
+                        {
+                            result = GetResultForHashtable(completionContext);
+                            replacementIndex += 1;
+                            replacementLength = 0;
+                        }
                         break;
 
                     case TokenKind.Number:
@@ -538,28 +541,16 @@ namespace System.Management.Automation
                     case TokenKind.AtParen:
                     case TokenKind.LParen:
                         {
-                            if (tokenAtCursor.Kind == TokenKind.Equals && lastAst is HashtableAst hashTableAst && CheckForPendingAssignment(hashTableAst))
-                            {
-                                if (lastAst.Parent is DynamicKeywordStatementAst)
-                                {
-                                    // Handle scenarios such as 'configuration foo { File ab { Attributes ='
-                                    bool unused;
-                                    result = GetResultForEnumPropertyValueOfDSCResource(completionContext, string.Empty, ref replacementIndex, ref replacementLength, out unused);
-                                    break;
-                                }
-                                // Handle scenarios such as 'gci | Format-Table @{Label=<tab>'
-                                return null;
-                            }
                             if (lastAst is AttributeAst)
                             {
                                 completionContext.ReplacementIndex = replacementIndex += tokenAtCursor.Text.Length;
                                 completionContext.ReplacementLength = replacementLength = 0;
                                 result = GetResultForAttributeArgument(completionContext, ref replacementIndex, ref replacementLength);
                             }
-                            else
+                            else if (lastAst.Parent is DynamicKeywordStatementAst || lastAst.Parent is CommandExpressionAst)
                             {
-                                //
-                                // Handle auto completion for enum/dependson property of DSC resource,
+                                // 1. Handle scenarios such as 'configuration foo { File ab { Attributes ='
+                                // 2. Handle auto completion for enum/dependson property of DSC resource,
                                 // cursor is right after '=', '(' or '@('
                                 //
                                 // Configuration config
@@ -571,8 +562,12 @@ namespace System.Management.Automation
                                 //         DependsOn=(|
                                 //
                                 bool unused;
-                                result = GetResultForEnumPropertyValueOfDSCResource(completionContext, string.Empty,
-                                    ref replacementIndex, ref replacementLength, out unused);
+                                result = GetResultForEnumPropertyValueOfDSCResource(completionContext, string.Empty, ref replacementIndex, ref replacementLength, out unused);
+                            }
+                            else if (lastAst is HashtableAst hashTableAst && CheckForPendingAssignment(hashTableAst))
+                            {
+                                // Handle scenarios such as 'gci | Format-Table @{Label=<tab>' if incomplete parsing of the assignment.
+                                return null;
                             }
                             break;
                         }

--- a/test/powershell/Host/TabCompletion/BugFix.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/BugFix.Tests.ps1
@@ -65,4 +65,19 @@ Describe "Tab completion bug fix" -Tags "CI" {
         $result.CompletionMatches[1].CompletionText | Should -Be 'Ascending'
         $result.CompletionMatches[2].CompletionText | Should -Be 'Descending'
     }
+
+    It "'Get-Date | Sort-Object @{Expression=<tab>' should work without completion" {
+        $cmd = "Get-Date | Sort-Object @{Expression="
+        $result = TabExpansion2 -inputScript $cmd -cursorColumn $cmd.Length
+        $result.CompletionMatches.Count | Should -Be 0
+    }
+
+    It "Issue#5322 - 'Get-Date | Sort-Object @{Expression=...;' should work" {
+        $cmd = "Get-Date | Sort-Object @{Expression=...;"
+        $result = TabExpansion2 -inputScript $cmd -cursorColumn $cmd.Length
+        $result.CompletionMatches.Count | Should -Be 3
+        $result.CompletionMatches[0].CompletionText | Should -Be 'Expression'
+        $result.CompletionMatches[1].CompletionText | Should -Be 'Ascending'
+        $result.CompletionMatches[2].CompletionText | Should -Be 'Descending'
+    }
 }

--- a/test/powershell/Host/TabCompletion/BugFix.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/BugFix.Tests.ps1
@@ -75,7 +75,9 @@ Describe "Tab completion bug fix" -Tags "CI" {
     It "Issue#5322 - 'Get-Date | Sort-Object @{Expression=...;' should work" {
         $cmd = "Get-Date | Sort-Object @{Expression=...;"
         $result = TabExpansion2 -inputScript $cmd -cursorColumn $cmd.Length
-        $result.CompletionMatches.Count | Should -Be 3
+        $result.CurrentMatchIndex | Should -Be -1
+        $result.ReplacementIndex | Should -Be 40
+        $result.CompletionMatches[2].CompletionText | Should -Be 'Descending'
         $result.CompletionMatches[0].CompletionText | Should -Be 'Expression'
         $result.CompletionMatches[1].CompletionText | Should -Be 'Ascending'
         $result.CompletionMatches[2].CompletionText | Should -Be 'Descending'

--- a/test/powershell/Host/TabCompletion/BugFix.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/BugFix.Tests.ps1
@@ -77,7 +77,7 @@ Describe "Tab completion bug fix" -Tags "CI" {
         $result = TabExpansion2 -inputScript $cmd -cursorColumn $cmd.Length
         $result.CurrentMatchIndex | Should -Be -1
         $result.ReplacementIndex | Should -Be 40
-        $result.CompletionMatches[2].CompletionText | Should -Be 'Descending'
+        $result.ReplacementLength | Should -Be 0
         $result.CompletionMatches[0].CompletionText | Should -Be 'Expression'
         $result.CompletionMatches[1].CompletionText | Should -Be 'Ascending'
         $result.CompletionMatches[2].CompletionText | Should -Be 'Descending'


### PR DESCRIPTION
## PR Summary

Fix #5322.

Now working:
- Get-Date | Sort-Object @{Expression=\<tab>
- Get-Date | Sort-Object @{Expression=...;\<tab>

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [x] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
