### PR TITLE
Further improve PSMethod to Delegate conversion

### DIFF
--- a/src/System.Management.Automation/engine/LanguagePrimitives.cs
+++ b/src/System.Management.Automation/engine/LanguagePrimitives.cs
@@ -3445,6 +3445,7 @@ namespace System.Management.Automation
 
         private class ConvertPSMethodToDelegate
         {
+            // Index of the matching overload method.
             private readonly int matchIndex;
             internal ConvertPSMethodToDelegate(int matchIndex)
             {
@@ -4798,6 +4799,10 @@ namespace System.Management.Automation
 
                 if (matchedIndex > -1)
                 {
+                    // We got the index of the matching method signature based on the PSMethod<..> type.
+                    // Signatures in PSMethod<..> type were constructed based on the array of method overloads,
+                    // in the exact order. So we can use this index directly to locate the matching overload in
+                    // the converter, without having to compare the signature again.
                     var converter = new ConvertPSMethodToDelegate(matchedIndex);
                     return CacheConversion<Delegate>(fromType, toType, converter.Convert, ConversionRank.Language);
                 }

--- a/src/System.Management.Automation/engine/LanguagePrimitives.cs
+++ b/src/System.Management.Automation/engine/LanguagePrimitives.cs
@@ -19,7 +19,7 @@ using System.IO;
 using System.Text;
 using System.Management.Automation.Internal;
 using System.Management.Automation.Runspaces;
-using System.Diagnostics.CodeAnalysis; // for fxcop
+using System.Diagnostics.CodeAnalysis;
 using Dbg = System.Management.Automation.Diagnostics;
 using MethodCacheEntry = System.Management.Automation.DotNetAdapter.MethodCacheEntry;
 
@@ -3202,49 +3202,6 @@ namespace System.Management.Automation
                 valueToConvert.ToString(), resultType.ToString(), exception.Message);
         }
 
-        private static Delegate ConvertPSMethodInfoToDelegate(object valueToConvert,
-                                                      Type resultType,
-                                                      bool recurse,
-                                                      PSObject originalValueToConvert,
-                                                      IFormatProvider formatProvider,
-                                                      TypeTable backupTable)
-        {
-            // We can only possibly convert PSMethod instance of the type PSMethod<T>.
-            // Such a PSMethod essentially represents a set of .NET method overloads.
-            var psMethod = (PSMethod)valueToConvert;
-
-            try
-            {
-                var methods = (MethodCacheEntry)psMethod.adapterData;
-                var isStatic = psMethod.instance is Type;
-                var targetMethodInfo = resultType.GetMethod("Invoke");
-                var comparator = new DelegateArgsComparator(targetMethodInfo);
-
-                foreach (var methodInformation in methods.methodInformationStructures)
-                {
-                    var candidate = (MethodInfo)methodInformation.method;
-                    if (comparator.SignatureMatches(candidate.ReturnType, candidate.GetParameters()))
-                    {
-                        return isStatic ? candidate.CreateDelegate(resultType)
-                                        : candidate.CreateDelegate(resultType, psMethod.instance);
-                    }
-                }
-            }
-            catch (Exception e)
-            {
-                typeConversion.WriteLine("PSMethod to Delegate exception: \"{0}\".", e.Message);
-                throw new PSInvalidCastException("InvalidCastExceptionPSMethodToDelegate", e,
-                    ExtendedTypeSystem.InvalidCastExceptionWithInnerException,
-                    valueToConvert.ToString(), resultType.ToString(), e.Message);
-            }
-
-            var msg = String.Format(ExtendedTypeSystem.PSMethodToDelegateNoMatchingOverLoad, psMethod, resultType);
-            typeConversion.WriteLine($"PSMethod to Delegate exception: \"{msg}\".");
-            throw new PSInvalidCastException("InvalidCastExceptionPSMethodToDelegate", null,
-                ExtendedTypeSystem.InvalidCastExceptionWithInnerException,
-                valueToConvert.ToString(), resultType.ToString(), msg);
-        }
-
         private static object ConvertToNullable(object valueToConvert,
                                                 Type resultType,
                                                 bool recursion,
@@ -3484,6 +3441,44 @@ namespace System.Management.Automation
             }
 
             return ConvertStringToEnum(sbResult.ToString(), resultType, recursion, originalValueToConvert, formatProvider, backupTable);
+        }
+
+        private class ConvertPSMethodToDelegate
+        {
+            private readonly int matchIndex;
+            internal ConvertPSMethodToDelegate(int matchIndex)
+            {
+                this.matchIndex = matchIndex;
+            }
+
+            internal Delegate Convert(object valueToConvert,
+                                      Type resultType,
+                                      bool recursion,
+                                      PSObject originalValueToConvert,
+                                      IFormatProvider formatProvider,
+                                      TypeTable backupTable)
+            {
+                // We can only possibly convert PSMethod instance of the type PSMethod<T>.
+                // Such a PSMethod essentially represents a set of .NET method overloads.
+                var psMethod = (PSMethod)valueToConvert;
+
+                try
+                {
+                    var methods = (MethodCacheEntry)psMethod.adapterData;
+                    var isStatic = psMethod.instance is Type;
+
+                    var candidate = (MethodInfo)methods.methodInformationStructures[matchIndex].method;
+                    return isStatic ? candidate.CreateDelegate(resultType)
+                                    : candidate.CreateDelegate(resultType, psMethod.instance);
+                }
+                catch (Exception e)
+                {
+                    typeConversion.WriteLine("PSMethod to Delegate exception: \"{0}\".", e.Message);
+                    throw new PSInvalidCastException("InvalidCastExceptionPSMethodToDelegate", e,
+                        ExtendedTypeSystem.InvalidCastExceptionWithInnerException,
+                        valueToConvert.ToString(), resultType.ToString(), e.Message);
+                }
+            }
         }
 
         private class ConvertViaParseMethod
@@ -4772,66 +4767,134 @@ namespace System.Management.Automation
                 return CacheConversion<object>(fromType, toType, LanguagePrimitives.ConvertIntegerToEnum, ConversionRank.Language);
             }
 
-            if (fromType.IsSubclassOf(typeof(PSMethod)) && toType.IsSubclassOf(typeof(Delegate)))
+            if (fromType.IsSubclassOf(typeof(PSMethod)) && toType.IsSubclassOf(typeof(Delegate)) && !toType.IsAbstract)
             {
-                var mi = toType.GetMethod("Invoke");
-
-                var comparator = new DelegateArgsComparator(mi);
+                var targetMethod = toType.GetMethod("Invoke");
+                var comparator = new SignatureComparator(targetMethod);
                 var signatureEnumerator = new PSMethodSignatureEnumerator(fromType);
+                int index = -1, matchedIndex = -1;
+
                 while (signatureEnumerator.MoveNext())
                 {
-                    var candidate = signatureEnumerator.Current.GetMethod("Invoke");
-                    if (comparator.SignatureMatches(candidate.ReturnType, candidate.GetParameters()))
+                    index ++;
+                    var signatureType = signatureEnumerator.Current;
+                    // Skip the non-bindable signatures
+                    if (signatureType == typeof(Func<PSNonBindableType>)) { continue; }
+
+                    Type[] argumentTypes = signatureType.GenericTypeArguments;
+                    if (comparator.ProjectedSignatureMatchesTarget(argumentTypes, out bool signaturesMatchExactly))
                     {
-                        return CacheConversion<Delegate>(fromType, toType, LanguagePrimitives.ConvertPSMethodInfoToDelegate, ConversionRank.Language);
+                        if (signaturesMatchExactly)
+                        {
+                            // We prefer the signature that exactly matches the target delegate.
+                            matchedIndex = index;
+                            break;
+                        }
+
+                        // If there is no exact match, then we use the compatible that was first found.
+                        if (matchedIndex == -1) { matchedIndex = index; }
                     }
+                }
+
+                if (matchedIndex > -1)
+                {
+                    var converter = new ConvertPSMethodToDelegate(matchedIndex);
+                    return CacheConversion<Delegate>(fromType, toType, converter.Convert, ConversionRank.Language);
                 }
             }
 
             return null;
         }
 
-        struct DelegateArgsComparator
+        private struct SignatureComparator
         {
-            private readonly ParameterInfo[] _targetParametersInfos;
-            private readonly Type _returnType;
-
-            public DelegateArgsComparator(MethodInfo targetMethodInfo)
+            enum TypeMatchingContext
             {
-                _returnType = targetMethodInfo.ReturnType;
-                _targetParametersInfos = targetMethodInfo.GetParameters();
+                ReturnType,
+                ParameterType,
+                OutParameterType
             }
 
-            public bool SignatureMatches(Type returnType, ParameterInfo[] arguments)
+            private readonly ParameterInfo[] targetParameters;
+            private readonly Type targetReturnType;
+
+            internal SignatureComparator(MethodInfo targetMethodInfo)
             {
-                return ReturnTypeMatches(returnType) && ParameterTypesMatches(arguments);
+                targetReturnType = targetMethodInfo.ReturnType;
+                targetParameters = targetMethodInfo.GetParameters();
             }
 
-            private bool ReturnTypeMatches(Type returnType)
+            internal bool ProjectedSignatureMatchesTarget(Type[] argumentTypes, out bool signaturesMatchExactly)
             {
-                return PSMethod.MatchesPSMethodProjectedType(_returnType, returnType, testAssignment: true);
+                signaturesMatchExactly = false;
+                int length = argumentTypes.Length;
+                if (length != targetParameters.Length + 1) { return false; }
+
+                bool typesMatchExactly, allTypesMatchExactly;
+                Type sourceReturnType = argumentTypes[length - 1];
+
+                if (ProjectedTypeMatchesTargetType(sourceReturnType, targetReturnType, TypeMatchingContext.ReturnType, out typesMatchExactly))
+                {
+                    allTypesMatchExactly = typesMatchExactly;
+                    for (int i = 0; i < targetParameters.Length; i++)
+                    {
+                        var targetParam = targetParameters[i];
+                        var sourceType = argumentTypes[i];
+                        var matchContext = targetParam.IsOut ? TypeMatchingContext.OutParameterType : TypeMatchingContext.ParameterType;
+
+                        if (!ProjectedTypeMatchesTargetType(sourceType, targetParam.ParameterType, matchContext, out typesMatchExactly))
+                        {
+                            return false;
+                        }
+                        allTypesMatchExactly &= typesMatchExactly;
+                    }
+
+                    signaturesMatchExactly = allTypesMatchExactly;
+                    return true;
+                }
+
+                return false;
             }
 
-            private bool ParameterTypesMatches(ParameterInfo[] arguments)
+            private static bool ProjectedTypeMatchesTargetType(Type sourceType, Type targetType, TypeMatchingContext matchContext, out bool matchExactly)
             {
-                var argsCount = _targetParametersInfos.Length;
-                // void is encoded as typeof(VOID) in the PSMethod<MethodGroup<>> as the last parameter
-                if (arguments.Length != argsCount)
+                matchExactly = false;
+                if (targetType.IsByRef || targetType.IsPointer)
+                {
+                    if (!sourceType.IsGenericType) { return false; }
+
+                    var sourceTypeDef = sourceType.GetGenericTypeDefinition();
+                    bool isOutParameter = matchContext == TypeMatchingContext.OutParameterType;
+
+                    if (targetType.IsByRef && sourceTypeDef == (isOutParameter ? typeof(PSOutParameter<>) : typeof(PSReference<>)) ||
+                        targetType.IsPointer && sourceTypeDef == typeof(PSPointer<>))
+                    {
+                        // For ref/out parameter types and pointer types, the element types need to match exactly.
+                        if (targetType.GetElementType() == sourceType.GenericTypeArguments[0])
+                        {
+                            matchExactly = true;
+                            return true;
+                        }
+                    }
+                    return false;
+                }
+
+                if (targetType == sourceType ||
+                    targetType == typeof(void) && sourceType == typeof(VOID) ||
+                    targetType == typeof(TypedReference) && sourceType == typeof(PSTypedReference))
+                {
+                    matchExactly = true;
+                    return true;
+                }
+
+                if (targetType == typeof(void) || targetType == typeof(TypedReference))
                 {
                     return false;
                 }
-                for (int i = 0; i < arguments.Length; i++)
-                {
-                    var arg = arguments[i];
-                    var argType = arg.ParameterType;
-                    var targetParamType = _targetParametersInfos[i].ParameterType;
-                    var isOut = (arg.Attributes | ParameterAttributes.Out) == ParameterAttributes.Out;
-                    if (!PSMethod.MatchesPSMethodProjectedType(targetParamType, argType, isOut: isOut))
-                    {
-                        return false;
-                    }
-                }
-                return true;
+
+                return matchContext == TypeMatchingContext.ReturnType
+                    ? targetType.IsAssignableFrom(sourceType)
+                    : sourceType.IsAssignableFrom(targetType);
             }
         }
 

--- a/src/System.Management.Automation/engine/MshMemberInfo.cs
+++ b/src/System.Management.Automation/engine/MshMemberInfo.cs
@@ -2655,43 +2655,56 @@ namespace System.Management.Automation
             return method.PSMethodCtor.Invoke(name, dotNetInstanceAdapter, baseObject, method, isSpecial, isHidden);
         }
 
-        static Type GetMethodGroupType(MethodInfo methodInfo)
+        private static Type GetMethodGroupType(MethodInfo methodInfo)
         {
             if (methodInfo.DeclaringType.IsGenericTypeDefinition)
             {
+                // If the method is from a generic type definition, consider it not convertable
                 return typeof(Func<PSNonBindableType>);
             }
 
             if (methodInfo.IsGenericMethodDefinition)
             {
-                methodInfo = ReplaceGenericTypeArgumentsWithMarkerTypes(methodInfo);
-                if (methodInfo == null)
-                {
-                    // this happens when there are constraints on the generic type parameters
-                    return typeof(Func<PSNonBindableType>);
-                }
+                // For a generic method, it's possible to infer the generic parameters based on the target delegate.
+                // However, we don't yet handle generic methods in PSMethod-to-Delegate conversion, so for now, we
+                // don't produce the metadata type that represent the signature of a generic method.
+                //
+                // Say one day we want to support generic method in PSMethod-to-Delegate conversion and need to produce
+                // the metadata type, we should use the generic parameter types from the MethodInfo directly to construct
+                // the Func<> metadata type. See the concept shown in the following scripts:
+                //    $class = "public class Zoo { public static T GetName<T>(int index, T input) { return default(T); } }"
+                //    Add-Type -TypeDefinition $class
+                //    $method = [Zoo].GetMethod("GetName")
+                //    $allTypes = $method.GetParameters().ParameterType + $method.ReturnType
+                //    $metadataType = [Func`3].MakeGenericType($allTypes)
+                // In this way, '$metadataType.ContainsGenericParameters' returns 'True', indicating it represents a generic method.
+                // And also, given a generic argument type from `$metadataType.GetGenericArguments()`, it's easy to tell if it's a
+                // generic parameter (for example, 'T') based on the property 'IsGenericParameter'.
+                // Moreover, it's also easy to get constraints of the generic parameter, via 'GetGenericParameterConstraints()'
+                // and 'GenericParameterAttributes'.
+                return typeof(Func<PSNonBindableType>);
             }
 
             var parameterInfos = methodInfo.GetParameters();
             if (parameterInfos.Length > 16)
             {
+                // Too many parameters, an unlikely scenario.
                 return typeof(Func<PSNonBindableType>);
             }
 
-            var res = new Type[parameterInfos.Length + 1];
-            for (int i = 0; i < res.Length - 1; i++)
+            var allTypes = new Type[parameterInfos.Length + 1];
+            for (int i = 0; i < parameterInfos.Length; i++)
             {
                 var parameterInfo = parameterInfos[i];
-                var parameterType = parameterInfo.ParameterType;
-                res[i] = GetPSMethodTypeProjection(parameterType,
-                    (parameterInfo.Attributes | ParameterAttributes.Out) == ParameterAttributes.Out);
+                Type parameterType = parameterInfo.ParameterType;
+                allTypes[i] = GetPSMethodProjectedType(parameterType, parameterInfo.IsOut);
             }
-            var returnType = GetPSMethodTypeProjection(methodInfo.ReturnType);
-            res[parameterInfos.Length] = returnType;
+
+            allTypes[parameterInfos.Length] = GetPSMethodProjectedType(methodInfo.ReturnType);
 
             try
             {
-                return DelegateHelpers.MakeDelegate(res);
+                return DelegateHelpers.MakeDelegate(allTypes);
             }
             catch (TypeLoadException)
             {
@@ -2699,92 +2712,30 @@ namespace System.Management.Automation
             }
         }
 
-        private static Type GetPSMethodTypeProjection(Type type, bool isOut = false)
+        private static Type GetPSMethodProjectedType(Type type, bool isOut = false)
         {
             if (type == typeof(void))
             {
                 return typeof(VOID);
             }
+
             if (type == typeof(TypedReference))
             {
                 return typeof(PSTypedReference);
             }
-            var resType = type.IsEnum ? typeof(PSEnum<>).MakeGenericType(type) : type;
-            if (resType.HasElementType) {
-                var psMethodTypeProjection = GetPSMethodTypeProjection(resType.GetElementType());
-                if (type.IsPointer)
-                {
-                    resType = typeof(PSPointer<>).MakeGenericType(psMethodTypeProjection);
-                }
-                if (type.IsByRef)
-                {
-                    resType = isOut ? typeof(PSOutParameter<>).MakeGenericType(psMethodTypeProjection) : typeof(PSReference<>).MakeGenericType(psMethodTypeProjection);
-                }
+
+            if (type.IsByRef)
+            {
+                var elementType = type.GetElementType();
+                type = isOut ? typeof(PSOutParameter<>).MakeGenericType(elementType)
+                             : typeof(PSReference<>).MakeGenericType(elementType);
+            }
+            else if (type.IsPointer)
+            {
+                type = typeof(PSPointer<>).MakeGenericType(type.GetElementType());
             }
 
-            return resType;
-        }
-
-        internal static bool MatchesPSMethodProjectedType(Type targetType, Type projectedSourceType, bool testAssignment = false, bool isOut = false)
-        {
-            var sourceType = projectedSourceType;
-            if (targetType.IsByRef || targetType.IsPointer)
-            {
-                if (!projectedSourceType.IsGenericType) return false;
-                var defType = projectedSourceType.GetGenericTypeDefinition();
-                if (targetType.IsByRef && defType == (isOut ? typeof(PSOutParameter<>) : typeof(PSReference<>))
-                    || targetType.IsPointer && defType == typeof(PSPointer<>))
-                {
-                    return MatchesPSMethodProjectedType(targetType.GetElementType(),
-                        projectedSourceType.GenericTypeArguments[0], testAssignment, isOut);
-                }
-            }
-            if (targetType.IsEnum)
-            {
-                if (sourceType.IsGenericType && sourceType.GetGenericTypeDefinition() != typeof(PSEnum<>))
-                {
-                    return false;
-                }
-                sourceType = sourceType.GenericTypeArguments[0];
-            }
-
-            if (targetType == typeof(void) && sourceType == typeof(VOID))
-            {
-                return true;
-            }
-            if (targetType == typeof(TypedReference) && sourceType == typeof(PSTypedReference))
-            {
-                return true;
-            }
-            if (testAssignment)
-            {
-                return targetType.IsAssignableFrom(sourceType);
-            }
-            return targetType == sourceType;
-        }
-
-        private static MethodInfo ReplaceGenericTypeArgumentsWithMarkerTypes(MethodInfo methodInfo)
-        {
-            if (!methodInfo.ContainsGenericParameters)
-            {
-                return methodInfo;
-            }
-
-            var genArgs = methodInfo.GetGenericArguments();
-            var concrete = new Type[genArgs.Length];
-            for (int i = 0; i < genArgs.Length; i++)
-            {
-                var genArg = genArgs[i];
-                if (genArg.GetGenericParameterConstraints().Length != 0)
-                {
-                    return null;
-                }
-                var gpa = genArg.GenericParameterAttributes;
-                concrete[i] = (gpa & GenericParameterAttributes.NotNullableValueTypeConstraint) == GenericParameterAttributes.NotNullableValueTypeConstraint
-                    ? PSGenericValueType.GetGenericType(i)
-                    : PSGenericType.GetGenericType(i);
-            }
-            return methodInfo.MakeGenericMethod(concrete);
+            return type;
         }
 
         private static Func<string, DotNetAdapter, object, object, bool, bool, PSMethod> CreatePSMethodConstructor(MethodInformation[] methods)
@@ -2829,112 +2780,10 @@ namespace System.Management.Automation
         }
     }
 
-    class PSOutParameter<T> { private PSOutParameter() { }}
-
     abstract class PSNonBindableType { }
-
-    abstract class PSGenericType
-    {
-        public static Type GetGenericType(int i)
-        {
-            switch (i)
-            {
-                case 0: return typeof(PSGenericType0);
-                case 1: return typeof(PSGenericType1);
-                case 2: return typeof(PSGenericType2);
-                case 3: return typeof(PSGenericType3);
-                case 4: return typeof(PSGenericType4);
-                case 5: return typeof(PSGenericType5);
-                case 6: return typeof(PSGenericType6);
-                case 7: return typeof(PSGenericType7);
-                case 8: return typeof(PSGenericType8);
-                case 9: return typeof(PSGenericType9);
-                case 10: return typeof(PSGenericType10);
-                case 11: return typeof(PSGenericType11);
-                case 12: return typeof(PSGenericType12);
-                case 13: return typeof(PSGenericType13);
-                case 14: return typeof(PSGenericType14);
-                case 15: return typeof(PSGenericType15);
-                case 16: return typeof(PSGenericType16);
-                default:
-                    return typeof(PSGenericType<>).MakeGenericType(GetGenericType(i - 1));
-            }
-        }
-    }
-
-    class PSGenericType0 : PSGenericType { internal PSGenericType0() { } }
-    class PSGenericType1 : PSGenericType { internal PSGenericType1() { } }
-    class PSGenericType2 : PSGenericType { internal PSGenericType2() { } }
-    class PSGenericType3 : PSGenericType { internal PSGenericType3() { } }
-    class PSGenericType4 : PSGenericType { internal PSGenericType4() { } }
-    class PSGenericType5 : PSGenericType { internal PSGenericType5() { } }
-    class PSGenericType6 : PSGenericType { internal PSGenericType6() { } }
-    class PSGenericType7 : PSGenericType { internal PSGenericType7() { } }
-    class PSGenericType8 : PSGenericType { internal PSGenericType8() { } }
-    class PSGenericType9 : PSGenericType { internal PSGenericType9() { } }
-    class PSGenericType10 : PSGenericType { internal PSGenericType10() { } }
-    class PSGenericType11 : PSGenericType { internal PSGenericType11() { } }
-    class PSGenericType12 : PSGenericType { internal PSGenericType12() { } }
-    class PSGenericType13 : PSGenericType { internal PSGenericType13() { } }
-    class PSGenericType14 : PSGenericType { internal PSGenericType14() { } }
-    class PSGenericType15 : PSGenericType { internal PSGenericType15() { } }
-    class PSGenericType16 : PSGenericType { internal PSGenericType16() { } }
-
-    class PSGenericType<T> : PSGenericType { internal PSGenericType() { } }
-
-    struct PSGenericValueType
-    {
-        internal static Type GetGenericType(int i)
-        {
-            switch (i)
-            {
-                case 0: return typeof(PSGenericValueType0);
-                case 1: return typeof(PSGenericValueType1);
-                case 2: return typeof(PSGenericValueType2);
-                case 3: return typeof(PSGenericValueType3);
-                case 4: return typeof(PSGenericValueType4);
-                case 5: return typeof(PSGenericValueType5);
-                case 6: return typeof(PSGenericValueType6);
-                case 7: return typeof(PSGenericValueType7);
-                case 8: return typeof(PSGenericValueType8);
-                case 9: return typeof(PSGenericValueType9);
-                case 10: return typeof(PSGenericValueType10);
-                case 11: return typeof(PSGenericValueType11);
-                case 12: return typeof(PSGenericValueType12);
-                case 13: return typeof(PSGenericValueType13);
-                case 14: return typeof(PSGenericValueType14);
-                case 15: return typeof(PSGenericValueType15);
-                case 16: return typeof(PSGenericValueType16);
-                default:
-                    return typeof(PSGenericValueType<>).MakeGenericType(GetGenericType(i - 1));
-            }
-        }
-    }
-
-    struct PSGenericValueType0 { internal int value; }
-    struct PSGenericValueType1 { internal int value; }
-    struct PSGenericValueType2 { internal int value; }
-    struct PSGenericValueType3 { internal int value; }
-    struct PSGenericValueType4 { internal int value; }
-    struct PSGenericValueType5 { internal int value; }
-    struct PSGenericValueType6 { internal int value; }
-    struct PSGenericValueType7 { internal int value; }
-    struct PSGenericValueType8 { internal int value; }
-    struct PSGenericValueType9 { internal int value; }
-    struct PSGenericValueType10 { internal int value; }
-    struct PSGenericValueType11 { internal int value; }
-    struct PSGenericValueType12 { internal int value; }
-    struct PSGenericValueType13 { internal int value; }
-    struct PSGenericValueType14 { internal int value; }
-    struct PSGenericValueType15 { internal int value; }
-    struct PSGenericValueType16 { internal int value; }
-
-    struct PSGenericValueType<T> { internal int value; }
-
-    struct PSEnum<T> { }
-
+    class VOID { }
+    class PSOutParameter<T> { }
     struct PSPointer<T> { }
-
     struct PSTypedReference { }
 
     internal abstract class MethodGroup { }
@@ -2944,11 +2793,6 @@ namespace System.Management.Automation
     internal class MethodGroup<T1, T2, T3, T4, T5, T6, T7, T8> : MethodGroup { }
     internal class MethodGroup<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> : MethodGroup { }
     internal class MethodGroup<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31, T32> : MethodGroup { }
-
-    class VOID
-    {
-        private VOID() { }
-    }
 
     internal struct PSMethodSignatureEnumerator : IEnumerator<Type>
     {
@@ -2985,7 +2829,7 @@ namespace System.Management.Automation
                 var remaining = index - (length - 1);
                 return MoveNext(t, remaining);
             }
-            if (index >= genericTypeArguments.Length)
+            if (index >= length)
             {
                 Current = null;
                 return false;

--- a/src/System.Management.Automation/engine/MshMemberInfo.cs
+++ b/src/System.Management.Automation/engine/MshMemberInfo.cs
@@ -2659,7 +2659,7 @@ namespace System.Management.Automation
         {
             if (methodInfo.DeclaringType.IsGenericTypeDefinition)
             {
-                // If the method is from a generic type definition, consider it not convertable
+                // If the method is from a generic type definition, consider it not convertible.
                 return typeof(Func<PSNonBindableType>);
             }
 
@@ -2667,7 +2667,7 @@ namespace System.Management.Automation
             {
                 // For a generic method, it's possible to infer the generic parameters based on the target delegate.
                 // However, we don't yet handle generic methods in PSMethod-to-Delegate conversion, so for now, we
-                // don't produce the metadata type that represent the signature of a generic method.
+                // don't produce the metadata type that represents the signature of a generic method.
                 //
                 // Say one day we want to support generic method in PSMethod-to-Delegate conversion and need to produce
                 // the metadata type, we should use the generic parameter types from the MethodInfo directly to construct
@@ -2692,19 +2692,19 @@ namespace System.Management.Automation
                 return typeof(Func<PSNonBindableType>);
             }
 
-            var allTypes = new Type[parameterInfos.Length + 1];
+            var methodTypes = new Type[parameterInfos.Length + 1];
             for (int i = 0; i < parameterInfos.Length; i++)
             {
                 var parameterInfo = parameterInfos[i];
                 Type parameterType = parameterInfo.ParameterType;
-                allTypes[i] = GetPSMethodProjectedType(parameterType, parameterInfo.IsOut);
+                methodTypes[i] = GetPSMethodProjectedType(parameterType, parameterInfo.IsOut);
             }
 
-            allTypes[parameterInfos.Length] = GetPSMethodProjectedType(methodInfo.ReturnType);
+            methodTypes[parameterInfos.Length] = GetPSMethodProjectedType(methodInfo.ReturnType);
 
             try
             {
-                return DelegateHelpers.MakeDelegate(allTypes);
+                return DelegateHelpers.MakeDelegate(methodTypes);
             }
             catch (TypeLoadException)
             {
@@ -2780,11 +2780,11 @@ namespace System.Management.Automation
         }
     }
 
-    abstract class PSNonBindableType { }
-    class VOID { }
-    class PSOutParameter<T> { }
-    struct PSPointer<T> { }
-    struct PSTypedReference { }
+    internal abstract class PSNonBindableType { }
+    internal class VOID { }
+    internal class PSOutParameter<T> { }
+    internal struct PSPointer<T> { }
+    internal struct PSTypedReference { }
 
     internal abstract class MethodGroup { }
     internal class MethodGroup<T1> : MethodGroup { }

--- a/src/System.Management.Automation/resources/ExtendedTypeSystem.resx
+++ b/src/System.Management.Automation/resources/ExtendedTypeSystem.resx
@@ -370,7 +370,4 @@ PS&gt; [System.Collections.Generic.Comparer``1]::get_Default()
   <data name="InvalidCastExceptionNonCoreType" xml:space="preserve">
     <value>Cannot convert value to type "{0}". Only core types are supported in this language mode.</value>
   </data>
-  <data name="PSMethodToDelegateNoMatchingOverLoad" xml:space="preserve">
-    <value>No matching overload found from {0} to {1}</value>
-  </data>
 </root>

--- a/test/powershell/Language/Parser/Conversions.Tests.ps1
+++ b/test/powershell/Language/Parser/Conversions.Tests.ps1
@@ -396,4 +396,89 @@ Describe 'method conversion' -Tags 'CI' {
         [Func[timespan, timespan, timespan, timespan, timespan, timespan, timespan, timespan, timespan]] $f72 = [M]::Foo
         $f72.Invoke($timeSpan, [Timespan]::Zero, [Timespan]::Zero, [Timespan]::Zero, [Timespan]::Zero, [Timespan]::Zero, [Timespan]::Zero, [Timespan]::Zero) | Should -Be $timeSpan
     }
+
+    enum E {
+        Day;
+        Week;
+        Year;
+    }
+
+    class N {
+        ## Attempt to convert methods to Func<System.IO.FileInfo, string, object>.
+
+        ## Different methods with same overload signatures.
+        ## The second and third overloads match the target delegate with variance.
+        [string] GetA([int] $i, [string] $s)                           { return "GetA-int-string-string" }
+        [string] GetA([System.IO.FileSystemInfo] $fsinfo, [object] $o) { return "GetA-filesysteminfo-object-string" }
+        [string] GetA([System.IO.FileInfo] $finfo, [object] $o)        { return "GetA-fileinfo-object-string" }
+
+        [string] GetAPrime([int] $i, [string] $s)                           { return "GetAPrime-int-string-string" }
+        [string] GetAPrime([System.IO.FileSystemInfo] $fsinfo, [object] $o) { return "GetAPrime-filesysteminfo-object-string" }
+        [string] GetAPrime([System.IO.FileInfo] $finfo, [object] $o)        { return "GetAPrime-fileinfo-object-string" }
+
+        static [string] GetAStatic([int] $i, [string] $s)                           { return "GetAStatic-int-string-string" }
+        static [string] GetAStatic([System.IO.FileSystemInfo] $fsinfo, [object] $o) { return "GetAStatic-filesysteminfo-object-string" }
+        static [string] GetAStatic([System.IO.FileInfo] $finfo, [object] $o)        { return "GetAStatic-fileinfo-object-string" }
+
+        ## Different methods with same overload signatures.
+        ## The first overload matches the target delegate with variance,
+        ## while the second overload matches the target delegate exactly.
+        [string] GetB([System.IO.FileSystemInfo] $fsinfo, [object] $o) { return "GetB-filesysteminfo-object-string" }
+        [object] GetB([System.IO.FileInfo] $finfo, [string] $s)        { return "GetB-fileinfo-string-object" }
+        [string] GetB([datetime] $d)                                   { return "GetB-datetime-string" }
+
+        [string] GetBPrime([System.IO.FileSystemInfo] $fsinfo, [object] $o) { return "GetBPrime-filesysteminfo-object-string" }
+        [object] GetBPrime([System.IO.FileInfo] $finfo, [string] $s)        { return "GetBPrime-fileinfo-string-object" }
+        [string] GetBPrime([datetime] $d)                                   { return "GetBPrime-datetime-string" }
+
+        static [string] GetBStatic([System.IO.FileSystemInfo] $fsinfo, [object] $o) { return "GetBStatic-filesysteminfo-object-string" }
+        static [object] GetBStatic([System.IO.FileInfo] $finfo, [string] $s)        { return "GetBStatic-fileinfo-string-object" }
+        static [string] GetBStatic([datetime] $d)                                   { return "GetBStatic-datetime-string" }
+
+        ## Test enum parameter type
+        [object] GetC([E] $e) { return $e.ToString() }
+    }
+
+    It "Different method overloads with same signatures/orders should have same PSMethod type" {
+        $n = [N]::new()
+
+        $n.GetA.GetType() | Should -Be ($n.GetAPrime.GetType())
+        $n.GetA.GetType() | Should -Be ([N]::GetAStatic.GetType())
+
+        $n.GetB.GetType() | Should -Be ($n.GetBPrime.GetType())
+        $n.GetB.GetType() | Should -Be ([N]::GetBStatic.GetType())
+    }
+
+    It "Match signature with variance and use the first match when there is no exact match" {
+        $n = [N]::new()
+
+        [Func[[System.IO.FileInfo], [string], [object]]] $f = $n.GetA
+        $f.Invoke($null, $null) | Should -BeExactly "GetA-filesysteminfo-object-string"
+
+        $f = $n.GetAPrime ## $n.GetAPrime has the same type as $n.GetA, so it should hit the conversion cache
+        $f.Invoke([System.IO.FileInfo]::new("aaa"), "bbb") | Should -BeExactly "GetAPrime-filesysteminfo-object-string"
+
+        $f = [N]::GetAStatic ## [N]::GetAStatic has the same type as $n.GetA, so it should hit the conversion cache
+        $f.Invoke($null, "") | Should -BeExactly "GetAStatic-filesysteminfo-object-string"
+    }
+
+    It "Exact match is preferred over match with variance" {
+        $n = [N]::new()
+
+        [Func[[System.IO.FileInfo], [string], [object]]] $f = $n.GetB
+        $f.Invoke($null, $null) | Should -BeExactly "GetB-fileinfo-string-object"
+
+        $f = $n.GetBPrime ## $n.GetBPrime has the same type as $n.GetB, so it should hit the conversion cache
+        $f.Invoke([System.IO.FileInfo]::new("ccc"), "ddd") | Should -BeExactly "GetBPrime-fileinfo-string-object"
+
+        $f = [N]::GetBStatic ## [N]::GetBStatic has the same type as $n.GetB, so it should hit the conversion cache
+        $f.Invoke($null, "") | Should -BeExactly "GetBStatic-fileinfo-string-object"
+    }
+
+    It "Test enum type parameter" {
+        $n = [N]::new()
+
+        [Func[[E], [object]]] $f = $n.GetC
+        $f.Invoke([E]::Week) | Should -BeExactly "Week"
+    }
 }

--- a/test/powershell/Language/Parser/Conversions.Tests.ps1
+++ b/test/powershell/Language/Parser/Conversions.Tests.ps1
@@ -481,4 +481,9 @@ Describe 'method conversion' -Tags 'CI' {
         [Func[[E], [object]]] $f = $n.GetC
         $f.Invoke([E]::Week) | Should -BeExactly "Week"
     }
+
+    It "Test fail-to-convert code path" {
+        $n = [N]::new()
+        { [System.Management.Automation.LanguagePrimitives]::ConvertTo($n.GetC, [Func[[int], [object]]]) } | Should -Throw -ErrorId "PSInvalidCastException"
+    }
 }


### PR DESCRIPTION
## PR Summary

Fix partially #5618
Refactor code to make it easier to maintain and a little faster. Changes are as follows:
1. Support finding a matching signature with [variance](https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/concepts/covariance-contravariance/variance-in-delegates). But make PowerShell prefer exact match over match with variance.

```powershell
class Foo {
    static [string] GetA([System.IO.FileSystemInfo] $fsinfo, [object] $o)
    {
        return "Varaince Match: GetA-filesysteminfo-object-string"
    }

    static [string] GetB([System.IO.FileSystemInfo] $fsinfo, [object] $o)
    {
        return "Variance Match: GetB-filesysteminfo-object-string"
    }
    static [object] GetB([System.IO.FileInfo] $finfo, [string] $s)
    {
        return "Exact Match: GetB-fileinfo-string-object"
    }
}

[Func[[System.IO.FileInfo], [string], [object]]] $f = [Foo]::GetA
$f.Invoke([System.IO.FileInfo]::new("abc"), "string")
>  Varaince Match: GetA-filesysteminfo-object-string

$f = [Foo]::GetB
$f.Invoke([System.IO.FileInfo]::new("abc"), "string")
>  Exact Match: GetB-fileinfo-string-object
```
2. The metadata signatures in `PSMethod<..>` are generated based on the array of method overloads in `MethodCacheEntry.MethodInformationStructures`, in the exact same order. So in `LanguagePrimitive.ConvertViaParseMethod`, when we try to figure out if there is a match using the metadata signatures in `PSMethod<..>`, we can get the index of the matching signature, and the same index should locate the matching metod in `MethodCacheEntry.MethodInformationStructures`. Therefore, we don't need to compare signatures again in the actual conversion method, and instead, we can just leverage the index we found when figuring out conversion in `ConvertViaParseMethod`.
   - This gets rid of the reflection call `GetMethod("Invoke")` and the subsequent signature comparisons in the final conversion method.
   - Also, when comparing signatures using `PSMethod<..>` in `ConvertViaParseMethod`, we can just use the generaic argument types of each `Func<..>` metadata type, instead of calling `GetMethod("Invoke")` and then `GetParameters()`. This makes the code for comparing signatures simpler (the type `SignatureComparator`).
   - Move `MatchesPSMethodProjectedType` from `PSMemberInfo.cs` to the type `SignatureComparator` in `LanguagePrimitives.cs`, as it's closely related to the signature comparison. Also, renamed it to `ProjectedTypeMatchesTargetType`.
   - These changes make PSMethod-to-Delegate conversion a little faster, but no big improvement, as the true bottleneck probably is in delegate creation(?). Actually, the performance of this conversion is not critical at all at this moment because this feature should rarely be used in any hot script path. So this exercise is mainly for fun. If we support extension methods one day, the conversion performance may be more interesting (LINQ extension method calls with predicate delegate). See the measurements on my machine below (both powershell fresh started with `-nopro` on a warm machine, [`measure.ps1.txt`](https://github.com/PowerShell/PowerShell/files/1993043/measure.ps1.txt) is attached):

```powershell
### both built with netcoreapp2.1, and crossgen'ed

####### Before change ######
PS C:\> C:\arena\tmp\measure.ps1
10000 loops per iteration, 10 iterations
Maximum time: 139
Minimum time: 113
Average time: 117.3
PS C:\> C:\arena\tmp\measure.ps1
10000 loops per iteration, 10 iterations
Maximum time: 124
Minimum time: 114
Average time: 117.5
PS C:\>
PS C:\> C:\arena\tmp\measure.ps1
10000 loops per iteration, 10 iterations
Maximum time: 240
Minimum time: 111
Average time: 125.5

###### After Change ######
PS C:\> C:\arena\tmp\measure.ps1
10000 loops per iteration, 10 iterations
Maximum time: 129
Minimum time: 99
Average time: 102.3
PS C:\> C:\arena\tmp\measure.ps1
10000 loops per iteration, 10 iterations
Maximum time: 133
Minimum time: 98
Average time: 105.5
PS C:\> C:\arena\tmp\measure.ps1
10000 loops per iteration, 10 iterations
Maximum time: 104
Minimum time: 98
Average time: 99.4
```
3. Remove `PSEnum<T>`. We can directly use enum types when constructing the metadata type `Func<..>`.
4. Remove the code that generate metadata signatures for generic methods (call `MakeGenericMethod` with fake types like `GenericType0`, `GenericType1`). This is because:
   - We don't support convert generic method to delegate today, so may be better not spending time on preparing the metadata signature types for those methods. 
   - When the day comes that we need to support it, it's better to use generic argument types directly to construct the `Func<..>` metadata types. I left comments in `GetMethodGroupType` method in `PSMemberInfo.cs` to explain why that approach is better.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [x] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
