### PR TITLE
Remove ShouldBeErrorId custom function.

### DIFF
--- a/test/powershell/Language/Scripting/ParameterBinding.Tests.ps1
+++ b/test/powershell/Language/Scripting/ParameterBinding.Tests.ps1
@@ -252,7 +252,7 @@ Describe "Tests for parameter binding" -Tags "CI" {
             $a
         }
 
-        { get-foo -a '' } | ShouldBeErrorID 'ParameterArgumentValidationErrorEmptyStringNotAllowed,get-foo'
+        { get-foo -a '' } | Should -Throw -ErrorId 'ParameterArgumentValidationErrorEmptyStringNotAllowed,get-foo'
     }
 
     It 'Empty string is allowed when AllowEmptyString Attribute is set' {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Trace-Command.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Trace-Command.Tests.ps1
@@ -95,7 +95,7 @@ Describe "Trace-Command" -tags "CI" {
         }
 
         It "Get non-existing trace source" {
-            { '34E7F9FA-EBFB-4D21-A7D2-D7D102E2CC2F' | get-tracesource -ErrorAction Stop} | ShouldBeErrorID 'TraceSourceNotFound,Microsoft.PowerShell.Commands.GetTraceSourceCommand'
+            { '34E7F9FA-EBFB-4D21-A7D2-D7D102E2CC2F' | get-tracesource -ErrorAction Stop} | Should -Throw -ErrorId 'TraceSourceNotFound,Microsoft.PowerShell.Commands.GetTraceSourceCommand'
         }
 
         It "Set-TraceSource to file and RemoveFileListener wildcard" {
@@ -105,11 +105,12 @@ Describe "Trace-Command" -tags "CI" {
         }
 
         It "Trace-Command -Command with error" {
-            { Trace-Command -Name ParameterBinding -Command 'Get-PSDrive' -ArgumentList 'NonExistingDrive' -Option ExecutionFlow -FilePath $filePath -Force -ListenerOption "ProcessId,TimeStamp" -ErrorAction Stop } | ShouldBeErrorID 'GetLocationNoMatchingDrive,Microsoft.PowerShell.Commands.TraceCommandCommand'
+            { Trace-Command -Name ParameterBinding -Command 'Get-PSDrive' -ArgumentList 'NonExistingDrive' -Option ExecutionFlow -FilePath $filePath -Force -ListenerOption "ProcessId,TimeStamp" -ErrorAction Stop } |
+                Should -Throw -ErrorId 'GetLocationNoMatchingDrive,Microsoft.PowerShell.Commands.TraceCommandCommand'
         }
 
         It "Trace-Command fails for non-filesystem paths" {
-            { Trace-Command -Name ParameterBinding -Expression {$null} -FilePath "Env:\Test" -ErrorAction Stop } | ShouldBeErrorID 'FileListenerPathResolutionFailed,Microsoft.PowerShell.Commands.TraceCommandCommand'
+            { Trace-Command -Name ParameterBinding -Expression {$null} -FilePath "Env:\Test" -ErrorAction Stop } | Should -Throw -ErrorId 'FileListenerPathResolutionFailed,Microsoft.PowerShell.Commands.TraceCommandCommand'
         }
 
         It "Trace-Command to readonly file" {

--- a/test/tools/Modules/HelpersCommon/HelpersCommon.psd1
+++ b/test/tools/Modules/HelpersCommon/HelpersCommon.psd1
@@ -16,5 +16,5 @@ Copyright = 'Copyright (c) Microsoft Corporation. All rights reserved.'
 
 Description = 'Temporary module contains functions for using in tests'
 
-FunctionsToExport = 'Wait-UntilTrue', 'Test-IsElevated', 'ShouldBeErrorId', 'Wait-FileToBePresent', 'Get-RandomFileName', 'Enable-Testhook', 'Disable-Testhook', 'Set-TesthookResult', 'Test-TesthookIsSet'
+FunctionsToExport = 'Wait-UntilTrue', 'Test-IsElevated', 'Wait-FileToBePresent', 'Get-RandomFileName', 'Enable-Testhook', 'Disable-Testhook', 'Set-TesthookResult', 'Test-TesthookIsSet'
 }

--- a/test/tools/Modules/HelpersCommon/HelpersCommon.psm1
+++ b/test/tools/Modules/HelpersCommon/HelpersCommon.psm1
@@ -56,30 +56,6 @@ function Test-IsElevated
     }
     return $IsElevated
 }
-#This function follows the pester naming convention
-function ShouldBeErrorId
-{
-    param([Parameter(ValueFromPipeline, Mandatory)]
-        [ScriptBlock]
-        $sb,
-
-        [Parameter(Mandatory, Position=0)]
-        [string]
-        $FullyQualifiedErrorId)
-
-        try
-        {
-            & $sb | Out-Null
-            Throw "No Exception!"
-        }
-        catch
-        {
-            $_.FullyQualifiedErrorId | Should Be $FullyQualifiedErrorId | Out-Null
-            # Write the exception to output that allow us to check later other properies of the exception
-            Write-Output $_
-        }
-}
-
 function Get-RandomFileName
 {
     [System.IO.Path]::GetFileNameWithoutExtension([IO.Path]::GetRandomFileName())
@@ -90,7 +66,7 @@ function Get-RandomFileName
 # note these manipulate private data in the PowerShell engine which will
 # enable us to not actually alter the system or mock returned data
 #
-$SCRIPT:TesthookType = [system.management.automation.internal.internaltesthooks] 
+$SCRIPT:TesthookType = [system.management.automation.internal.internaltesthooks]
 function Test-TesthookIsSet
 {
     param (
@@ -132,7 +108,7 @@ function Set-TesthookResult
     param (
         [ValidateNotNullOrEmpty()]
         [Parameter(Mandatory=$true)]
-        $testhookName, 
+        $testhookName,
         [ValidateNotNullOrEmpty()]
         [Parameter(Mandatory=$true)]
         $value


### PR DESCRIPTION
## PR Summary

Remove ShouldBeErrorId custom function and get rid of ShouldBeErrorId function left across the codebase.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [x] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
