### PR TITLE
Fix conditions for transcription of Write-Information command.

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WriteConsoleCmdlet.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WriteConsoleCmdlet.cs
@@ -137,7 +137,6 @@ namespace Microsoft.PowerShell.Commands
             }
 
             this.WriteInformation(informationMessage, new string[] { "PSHOST" });
-            this.Host.UI.TranscribeResult(result);
         }
 
         private Boolean _notAppendNewline = false;

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterfacePromptForChoice.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterfacePromptForChoice.cs
@@ -417,7 +417,12 @@ namespace Microsoft.PowerShell
             result = ReadLineResult.endedOnEnter;
             return InternalTestHooks.ForcePromptForChoiceDefaultOption
                    ? string.Empty
-                   : ReadLine(false, string.Empty, out result, true, true);
+                   : ReadLine(
+                       endOnTab: false,
+                       initialContent: string.Empty,
+                       result: out result,
+                       calledFromPipeline: true,
+                       transcribeResult: true);
         }
 
         private void ShowChoiceHelp(Collection<ChoiceDescription> choices, string[,] hotkeysAndPlainLabels)

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterfacePromptForChoice.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterfacePromptForChoice.cs
@@ -107,7 +107,7 @@ namespace Microsoft.PowerShell
                     WriteChoicePrompt(hotkeysAndPlainLabels, defaultChoiceKeys, false);
 
                     ReadLineResult rlResult;
-                    string response = ReadLine(false, string.Empty, out rlResult, true, true);
+                    string response = ReadChoiceResponse(out rlResult);
 
                     if (rlResult == ReadLineResult.endedOnBreak)
                     {
@@ -253,7 +253,7 @@ namespace Microsoft.PowerShell
                     WriteToConsole(PromptColor, RawUI.BackgroundColor, WrapToCurrentWindowWidth(choiceMsg));
 
                     ReadLineResult rlResult;
-                    string response = ReadLine(false, string.Empty, out rlResult, true, true);
+                    string response = ReadChoiceResponse(out rlResult);
 
                     if (rlResult == ReadLineResult.endedOnBreak)
                     {
@@ -412,6 +412,14 @@ namespace Microsoft.PowerShell
             WriteToConsole(fg, bg, trimEnd ? text.TrimEnd(null) : text);
         }
 
+        private string ReadChoiceResponse(out ReadLineResult result)
+        {
+            result = ReadLineResult.endedOnEnter;
+            return InternalTestHooks.ForcePromptForChoiceDefaultOption
+                   ? string.Empty
+                   : ReadLine(false, string.Empty, out result, true, true);
+        }
+
         private void ShowChoiceHelp(Collection<ChoiceDescription> choices, string[,] hotkeysAndPlainLabels)
         {
             Dbg.Assert(choices != null, "choices: expected a value");
@@ -473,4 +481,3 @@ namespace Microsoft.PowerShell
         }
     }
 }   // namespace
-

--- a/src/System.Management.Automation/engine/MshCommandRuntime.cs
+++ b/src/System.Management.Automation/engine/MshCommandRuntime.cs
@@ -826,7 +826,7 @@ namespace System.Management.Automation
                 if (!record.Tags.Contains("PSHOST") && (preference == ActionPreference.Continue))
                 {
                     // Only transcribe informational messages here. Transcription of PSHost-targeted messages is done in the InternalUI.Write* methods.
-                    CBhost.InternalUI.TranscribeResult(StringUtil.Format(InternalHostUserInterfaceStrings.InformationFormatString, record.ToString()));
+                    CBhost.InternalUI.TranscribeResult(record.ToString());
                 }
             }
 

--- a/src/System.Management.Automation/engine/MshCommandRuntime.cs
+++ b/src/System.Management.Automation/engine/MshCommandRuntime.cs
@@ -821,12 +821,12 @@ namespace System.Management.Automation
                             CBhost.InternalUI.WriteLine(record.ToString());
                         }
                     }
+                }
                     
-                    if (!record.Tags.Contains("PSHOST") && (preference == ActionPreference.Continue))
-                    {
-                        // Only transcribe informational messages here. Transcription of PSHost-targeted messages is done in the InternalUI.Write* methods.
-                        CBhost.InternalUI.TranscribeResult(StringUtil.Format(InternalHostUserInterfaceStrings.InformationFormatString, record.ToString()));
-                    }
+                if (!record.Tags.Contains("PSHOST") && (preference == ActionPreference.Continue))
+                {
+                    // Only transcribe informational messages here. Transcription of PSHost-targeted messages is done in the InternalUI.Write* methods.
+                    CBhost.InternalUI.TranscribeResult(StringUtil.Format(InternalHostUserInterfaceStrings.InformationFormatString, record.ToString()));
                 }
             }
 

--- a/src/System.Management.Automation/engine/MshCommandRuntime.cs
+++ b/src/System.Management.Automation/engine/MshCommandRuntime.cs
@@ -822,8 +822,8 @@ namespace System.Management.Automation
                         }
                     }
                 }
-                    
-                if (!record.Tags.Contains("PSHOST") && (preference == ActionPreference.Continue))
+
+                if (!record.Tags.Contains("PSHOST") && (preference != ActionPreference.SilentlyContinue))
                 {
                     // Only transcribe informational messages here. Transcription of PSHost-targeted messages is done in the InternalUI.Write* methods.
                     CBhost.InternalUI.TranscribeResult(record.ToString());

--- a/src/System.Management.Automation/engine/MshCommandRuntime.cs
+++ b/src/System.Management.Automation/engine/MshCommandRuntime.cs
@@ -821,7 +821,8 @@ namespace System.Management.Automation
                             CBhost.InternalUI.WriteLine(record.ToString());
                         }
                     }
-                    else
+                    
+                    if (!record.Tags.Contains("PSHOST") && (preference == ActionPreference.Continue))
                     {
                         // Only transcribe informational messages here. Transcription of PSHost-targeted messages is done in the InternalUI.Write* methods.
                         CBhost.InternalUI.TranscribeResult(StringUtil.Format(InternalHostUserInterfaceStrings.InformationFormatString, record.ToString()));

--- a/src/System.Management.Automation/engine/MshCommandRuntime.cs
+++ b/src/System.Management.Automation/engine/MshCommandRuntime.cs
@@ -748,8 +748,7 @@ namespace System.Management.Automation
                     //
                     if (null == Host || null == Host.UI)
                     {
-                        Diagnostics.Assert(false, "No host in CommandBase.WriteInformation()");
-                        throw PSTraceSource.NewInvalidOperationException();
+                        throw PSTraceSource.NewInvalidOperationException("No host in CommandBase.WriteInformation()");
                     }
 
                     CBhost.InternalUI.WriteInformationRecord(record);

--- a/src/System.Management.Automation/engine/MshCommandRuntime.cs
+++ b/src/System.Management.Automation/engine/MshCommandRuntime.cs
@@ -748,7 +748,7 @@ namespace System.Management.Automation
                     //
                     if (null == Host || null == Host.UI)
                     {
-                        Diagnostics.Assert(false, "No host in CommandBase.WriteVerbose()");
+                        Diagnostics.Assert(false, "No host in CommandBase.WriteInformation()");
                         throw PSTraceSource.NewInvalidOperationException();
                     }
 
@@ -823,9 +823,11 @@ namespace System.Management.Automation
                     }
                 }
 
-                if (!record.Tags.Contains("PSHOST") && (preference != ActionPreference.SilentlyContinue))
+                // Both informational and PSHost-targeted messages are transcribed here.
+                // The only difference between these two is that PSHost-targeted messages are transcribed
+                // even if InformationAction is SilentlyContinue.
+                if (record.Tags.Contains("PSHOST") || (preference != ActionPreference.SilentlyContinue))
                 {
-                    // Only transcribe informational messages here. Transcription of PSHost-targeted messages is done in the InternalUI.Write* methods.
                     CBhost.InternalUI.TranscribeResult(record.ToString());
                 }
             }

--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -1496,6 +1496,7 @@ namespace System.Management.Automation.Internal
         internal static bool UseDebugAmsiImplementation;
         internal static bool BypassAppLockerPolicyCaching;
         internal static bool BypassOnlineHelpRetrieval;
+        internal static bool ForcePromptForChoiceDefaultOption;
 
         // Stop/Restart/Rename Computer tests
         internal static bool TestStopComputer;

--- a/src/System.Management.Automation/resources/InternalHostUserInterfaceStrings.resx
+++ b/src/System.Management.Automation/resources/InternalHostUserInterfaceStrings.resx
@@ -186,9 +186,6 @@
   <data name="DebugFormatString" xml:space="preserve">
     <value>DEBUG: {0}</value>
   </data>
-  <data name="InformationFormatString" xml:space="preserve">
-    <value>INFO: {0}</value>
-  </data>
   <data name="HostNotTranscribing" xml:space="preserve">
     <value>The host is not currently transcribing.</value>
   </data>

--- a/test/powershell/Modules/Microsoft.Powershell.Host/Start-Transcript.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.Powershell.Host/Start-Transcript.Tests.ps1
@@ -53,6 +53,7 @@ Describe "Start-Transcript, Stop-Transcript tests" -tags "CI" {
 
     AfterEach {
         Remove-Item $transcriptFilePath -ErrorAction SilentlyContinue
+        [System.Management.Automation.Internal.InternalTestHooks]::SetTestHook('ForcePromptForChoiceDefaultOption', $False)
     }
 
     It "Should create Transcript file at default path" {
@@ -122,7 +123,7 @@ Describe "Start-Transcript, Stop-Transcript tests" -tags "CI" {
             }
         }
 
-        Test-Path $transcriptFilePath | Should -BeTrue
+        $transcriptFilePath | Should -Exist
         $transcriptFilePath | Should -FileContentMatch "After Dispose"
     }
 
@@ -131,7 +132,7 @@ Describe "Start-Transcript, Stop-Transcript tests" -tags "CI" {
         $powerShellCommand = $powerShellPath + ' -c "start-transcript $transcriptFilePath; Write-Host ''Before Dispose'';"'
         Invoke-Expression $powerShellCommand
 
-        Test-Path $transcriptFilePath | Should -BeTrue
+        $transcriptFilePath | Should -Exist
         $transcriptFilePath | Should -FileContentMatch "Before Dispose"
         $transcriptFilePath | Should -FileContentMatch "PowerShell transcript end"
     }
@@ -145,7 +146,7 @@ Describe "Start-Transcript, Stop-Transcript tests" -tags "CI" {
 
         & $script
 
-        Test-Path $transcriptFilePath | Should -BeTrue
+        $transcriptFilePath | Should -Exist
         $machineName = [System.Environment]::MachineName
         $transcriptFilePath | Should -FileContentMatch $machineName
     }
@@ -160,7 +161,7 @@ Describe "Start-Transcript, Stop-Transcript tests" -tags "CI" {
 
         & $script
 
-        Test-Path $transcriptFilePath | Should -BeTrue
+        $transcriptFilePath | Should -Exist
         $transcriptFilePath | Should -Not -FileContentMatch "INFO: "
         $transcriptFilePath | Should -FileContentMatch $message
     }
@@ -175,7 +176,7 @@ Describe "Start-Transcript, Stop-Transcript tests" -tags "CI" {
 
         & $script
 
-        Test-Path $transcriptFilePath | Should -BeTrue
+        $transcriptFilePath | Should -Exist
         $transcriptFilePath | Should -Not -FileContentMatch "INFO: "
         $transcriptFilePath | Should -Not -FileContentMatch $message
     }
@@ -190,7 +191,7 @@ Describe "Start-Transcript, Stop-Transcript tests" -tags "CI" {
 
         & $script
 
-        Test-Path $transcriptFilePath | Should -BeTrue
+        $transcriptFilePath | Should -Exist
         $transcriptFilePath | Should -Not -FileContentMatch "INFO: "
         $transcriptFilePath | Should -Not -FileContentMatch $message
     }
@@ -208,7 +209,7 @@ Describe "Start-Transcript, Stop-Transcript tests" -tags "CI" {
 
         & $script
 
-        Test-Path $transcriptFilePath | Should -BeTrue
+        $transcriptFilePath | Should -Exist
         $transcriptFilePath | Should -Not -FileContentMatch "INFO: "
         $transcriptFilePath | Should -FileContentMatchMultiline $expectedContent
     }
@@ -223,7 +224,7 @@ Describe "Start-Transcript, Stop-Transcript tests" -tags "CI" {
 
         & $script
 
-        Test-Path $transcriptFilePath | Should -BeTrue
+        $transcriptFilePath | Should -Exist
         $transcriptFilePath | Should -FileContentMatch $message
     }
 
@@ -237,7 +238,7 @@ Describe "Start-Transcript, Stop-Transcript tests" -tags "CI" {
 
         & $script
 
-        Test-Path $transcriptFilePath | Should -BeTrue
+        $transcriptFilePath | Should -Exist
         $transcriptFilePath | Should -FileContentMatch $message
     }
 
@@ -251,7 +252,7 @@ Describe "Start-Transcript, Stop-Transcript tests" -tags "CI" {
 
         & $script
 
-        Test-Path $transcriptFilePath | Should -BeTrue
+        $transcriptFilePath | Should -Exist
         $transcriptFilePath | Should -Not -FileContentMatch $message
     }
 
@@ -268,7 +269,7 @@ Describe "Start-Transcript, Stop-Transcript tests" -tags "CI" {
 
         & $script
 
-        Test-Path $transcriptFilePath | Should -BeTrue
+        $transcriptFilePath | Should -Exist
         $transcriptFilePath | Should -FileContentMatchMultiline $expectedContent
     }
 }

--- a/test/powershell/Modules/Microsoft.Powershell.Host/Start-Transcript.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.Powershell.Host/Start-Transcript.Tests.ps1
@@ -220,7 +220,7 @@ Describe "Start-Transcript, Stop-Transcript tests" -tags "CI" {
         $transcriptFilePath | Should -FileContentMatch $message
     }
 
-    It "Transcription should record Write-Host output when InformationAction is set to Ignore" {
+    It "Transcription should not record Write-Host output when InformationAction is set to Ignore" {
         [String]$message = New-Guid
         $script = {
             Start-Transcript -Path $transcriptFilePath
@@ -231,6 +231,6 @@ Describe "Start-Transcript, Stop-Transcript tests" -tags "CI" {
         & $script
 
         Test-Path $transcriptFilePath | Should -BeTrue
-        $transcriptFilePath | Should -FileContentMatch $message
+        $transcriptFilePath | Should -Not -FileContentMatch $message
     }
 }

--- a/test/powershell/Modules/Microsoft.Powershell.Host/Start-Transcript.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.Powershell.Host/Start-Transcript.Tests.ps1
@@ -148,15 +148,39 @@ Describe "Start-Transcript, Stop-Transcript tests" -tags "CI" {
         $transcriptFilePath | Should -FileContentMatch $machineName
     }
 
-    It "Transcription should record Write-Information output when preference is set to Continue" {
+    It "Transcription should record Write-Information output when InformationAction is set to Continue" {
+        [String]$message = New-Guid
         $script = {
             Start-Transcript -Path $transcriptFilePath
-            $InformationPreference = 'Continue'
-            Write-Information 'Continue'
+            Write-Information -Message $message -InformationAction Continue
             Stop-Transcript }
         & $script
         Test-Path $transcriptFilePath | Should -BeTrue
 
-        $transcriptFilePath | Should -FileContentMatch 'Continue'
+        $transcriptFilePath | Should -FileContentMatch $message
+    }
+
+    It "Transcription should not record Write-Information output when InformationAction is set to SilentlyContinue" {
+        [String]$message = New-Guid
+        $script = {
+            Start-Transcript -Path $transcriptFilePath
+            Write-Information -Message $message -InformationAction SilentlyContinue
+            Stop-Transcript }
+        & $script
+        Test-Path $transcriptFilePath | Should -BeTrue
+
+        $transcriptFilePath | Should -Not -FileContentMatch $message
+    }
+
+    It "Transcription should not record Write-Information output when InformationAction is set to Ignore" {
+        [String]$message = New-Guid
+        $script = {
+            Start-Transcript -Path $transcriptFilePath
+            Write-Information -Message $message -InformationAction Ignore
+            Stop-Transcript }
+        & $script
+        Test-Path $transcriptFilePath | Should -BeTrue
+
+        $transcriptFilePath | Should -Not -FileContentMatch $message
     }
 }

--- a/test/powershell/Modules/Microsoft.Powershell.Host/Start-Transcript.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.Powershell.Host/Start-Transcript.Tests.ps1
@@ -142,8 +142,8 @@ Describe "Start-Transcript, Stop-Transcript tests" -tags "CI" {
             hostname
             Stop-Transcript }
         & $script
-        Test-Path $transcriptFilePath | Should -BeTrue
 
+        Test-Path $transcriptFilePath | Should -BeTrue
         $machineName = [System.Environment]::MachineName
         $transcriptFilePath | Should -FileContentMatch $machineName
     }
@@ -155,8 +155,8 @@ Describe "Start-Transcript, Stop-Transcript tests" -tags "CI" {
             Write-Information -Message $message -InformationAction Continue
             Stop-Transcript }
         & $script
-        Test-Path $transcriptFilePath | Should -BeTrue
 
+        Test-Path $transcriptFilePath | Should -BeTrue
         $transcriptFilePath | Should -FileContentMatch $message
     }
 
@@ -167,8 +167,8 @@ Describe "Start-Transcript, Stop-Transcript tests" -tags "CI" {
             Write-Information -Message $message -InformationAction SilentlyContinue
             Stop-Transcript }
         & $script
-        Test-Path $transcriptFilePath | Should -BeTrue
 
+        Test-Path $transcriptFilePath | Should -BeTrue
         $transcriptFilePath | Should -Not -FileContentMatch $message
     }
 
@@ -179,8 +179,8 @@ Describe "Start-Transcript, Stop-Transcript tests" -tags "CI" {
             Write-Information -Message $message -InformationAction Ignore
             Stop-Transcript }
         & $script
-        Test-Path $transcriptFilePath | Should -BeTrue
 
+        Test-Path $transcriptFilePath | Should -BeTrue
         $transcriptFilePath | Should -Not -FileContentMatch $message
     }
 
@@ -191,8 +191,8 @@ Describe "Start-Transcript, Stop-Transcript tests" -tags "CI" {
             Write-Host -Message $message -InformationAction Continue
             Stop-Transcript }
         & $script
-        Test-Path $transcriptFilePath | Should -BeTrue
 
+        Test-Path $transcriptFilePath | Should -BeTrue
         $transcriptFilePath | Should -FileContentMatch $message
     }
 
@@ -203,8 +203,20 @@ Describe "Start-Transcript, Stop-Transcript tests" -tags "CI" {
             Write-Host -Message $message -InformationAction SilentlyContinue
             Stop-Transcript }
         & $script
-        Test-Path $transcriptFilePath | Should -BeTrue
 
+        Test-Path $transcriptFilePath | Should -BeTrue
+        $transcriptFilePath | Should -FileContentMatch $message
+    }
+
+    It "Transcription should record Write-Host output when InformationAction is set to Ignore" {
+        [String]$message = New-Guid
+        $script = {
+            Start-Transcript -Path $transcriptFilePath
+            Write-Host -Message $message -InformationAction Ignore
+            Stop-Transcript }
+        & $script
+
+        Test-Path $transcriptFilePath | Should -BeTrue
         $transcriptFilePath | Should -FileContentMatch $message
     }
 }

--- a/test/powershell/Modules/Microsoft.Powershell.Host/Start-Transcript.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.Powershell.Host/Start-Transcript.Tests.ps1
@@ -147,4 +147,16 @@ Describe "Start-Transcript, Stop-Transcript tests" -tags "CI" {
         $machineName = [System.Environment]::MachineName
         $transcriptFilePath | Should FileContentMatch $machineName
     }
+    
+    It "Transcription should record Write-Information output when preference is set to Continue" {
+        $script = {
+            Start-Transcript -Path $transcriptFilePath
+            $InformationPreference = 'Continue'
+            Write-Information 'Continue'
+            Stop-Transcript }
+        & $script
+        Test-Path $transcriptFilePath | Should -BeTrue
+
+        $transcriptFilePath | Should FileContentMatch 'Continue'
+    }
 }

--- a/test/powershell/Modules/Microsoft.Powershell.Host/Start-Transcript.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.Powershell.Host/Start-Transcript.Tests.ps1
@@ -183,4 +183,28 @@ Describe "Start-Transcript, Stop-Transcript tests" -tags "CI" {
 
         $transcriptFilePath | Should -Not -FileContentMatch $message
     }
+
+    It "Transcription should record Write-Host output when InformationAction is set to Continue" {
+        [String]$message = New-Guid
+        $script = {
+            Start-Transcript -Path $transcriptFilePath
+            Write-Host -Message $message -InformationAction Continue
+            Stop-Transcript }
+        & $script
+        Test-Path $transcriptFilePath | Should -BeTrue
+
+        $transcriptFilePath | Should -FileContentMatch $message
+    }
+
+    It "Transcription should record Write-Host output when InformationAction is set to SilentlyContinue" {
+        [String]$message = New-Guid
+        $script = {
+            Start-Transcript -Path $transcriptFilePath
+            Write-Host -Message $message -InformationAction SilentlyContinue
+            Stop-Transcript }
+        & $script
+        Test-Path $transcriptFilePath | Should -BeTrue
+
+        $transcriptFilePath | Should -FileContentMatch $message
+    }
 }

--- a/test/powershell/Modules/Microsoft.Powershell.Host/Start-Transcript.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.Powershell.Host/Start-Transcript.Tests.ps1
@@ -140,7 +140,9 @@ Describe "Start-Transcript, Stop-Transcript tests" -tags "CI" {
         $script = {
             Start-Transcript -Path $transcriptFilePath
             hostname
-            Stop-Transcript }
+            Stop-Transcript
+        }
+
         & $script
 
         Test-Path $transcriptFilePath | Should -BeTrue
@@ -153,7 +155,9 @@ Describe "Start-Transcript, Stop-Transcript tests" -tags "CI" {
         $script = {
             Start-Transcript -Path $transcriptFilePath
             Write-Information -Message $message -InformationAction Continue
-            Stop-Transcript }
+            Stop-Transcript
+        }
+
         & $script
 
         Test-Path $transcriptFilePath | Should -BeTrue
@@ -165,7 +169,9 @@ Describe "Start-Transcript, Stop-Transcript tests" -tags "CI" {
         $script = {
             Start-Transcript -Path $transcriptFilePath
             Write-Information -Message $message -InformationAction SilentlyContinue
-            Stop-Transcript }
+            Stop-Transcript
+        }
+
         & $script
 
         Test-Path $transcriptFilePath | Should -BeTrue
@@ -177,7 +183,9 @@ Describe "Start-Transcript, Stop-Transcript tests" -tags "CI" {
         $script = {
             Start-Transcript -Path $transcriptFilePath
             Write-Information -Message $message -InformationAction Ignore
-            Stop-Transcript }
+            Stop-Transcript
+        }
+
         & $script
 
         Test-Path $transcriptFilePath | Should -BeTrue
@@ -189,7 +197,9 @@ Describe "Start-Transcript, Stop-Transcript tests" -tags "CI" {
         $script = {
             Start-Transcript -Path $transcriptFilePath
             Write-Host -Message $message -InformationAction Continue
-            Stop-Transcript }
+            Stop-Transcript
+        }
+
         & $script
 
         Test-Path $transcriptFilePath | Should -BeTrue
@@ -201,7 +211,9 @@ Describe "Start-Transcript, Stop-Transcript tests" -tags "CI" {
         $script = {
             Start-Transcript -Path $transcriptFilePath
             Write-Host -Message $message -InformationAction SilentlyContinue
-            Stop-Transcript }
+            Stop-Transcript
+        }
+
         & $script
 
         Test-Path $transcriptFilePath | Should -BeTrue
@@ -213,7 +225,9 @@ Describe "Start-Transcript, Stop-Transcript tests" -tags "CI" {
         $script = {
             Start-Transcript -Path $transcriptFilePath
             Write-Host -Message $message -InformationAction Ignore
-            Stop-Transcript }
+            Stop-Transcript
+        }
+
         & $script
 
         Test-Path $transcriptFilePath | Should -BeTrue

--- a/test/powershell/Modules/Microsoft.Powershell.Host/Start-Transcript.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.Powershell.Host/Start-Transcript.Tests.ps1
@@ -16,7 +16,7 @@ Describe "Start-Transcript, Stop-Transcript tests" -tags "CI" {
                 #Add sample text to the file
                 $content = "This is sample text!"
                 $content | Out-File -FilePath $outputFilePath
-                Test-Path $outputFilePath | Should be $true
+                Test-Path $outputFilePath | Should -BeTrue
             }
 
             try {
@@ -27,16 +27,16 @@ Describe "Start-Transcript, Stop-Transcript tests" -tags "CI" {
 
                 if($expectedError) {
                     $ps.hadErrors | Should -BeTrue
-                    $ps.Streams.Error.FullyQualifiedErrorId | Should be $expectedError
+                    $ps.Streams.Error.FullyQualifiedErrorId | Should -Be $expectedError
                 } else {
                     $ps.addscript("Get-Date").Invoke()
                     $ps.commands.clear()
                     $ps.addscript("Stop-Transcript").Invoke()
 
                     Test-Path $outputFilePath | Should -BeTrue
-                    $outputFilePath | should FileContentMatch "Get-Date"
+                    $outputFilePath | Should -FileContentMatch "Get-Date"
                     if($append) {
-                        $outputFilePath | Should FileContentMatch $content
+                        $outputFilePath | Should -FileContentMatch $content
                     }
                 }
             } finally {
@@ -122,8 +122,8 @@ Describe "Start-Transcript, Stop-Transcript tests" -tags "CI" {
             }
         }
 
-        Test-Path $transcriptFilePath | Should be $true
-        $transcriptFilePath | Should FileContentMatch "After Dispose"
+        Test-Path $transcriptFilePath | Should -BeTrue
+        $transcriptFilePath | Should -FileContentMatch "After Dispose"
     }
 
     It "Transcription should be closed if the only runspace gets closed" {
@@ -132,8 +132,8 @@ Describe "Start-Transcript, Stop-Transcript tests" -tags "CI" {
         Invoke-Expression $powerShellCommand
 
         Test-Path $transcriptFilePath | Should -BeTrue
-        $transcriptFilePath | Should FileContentMatch "Before Dispose"
-        $transcriptFilePath | Should FileContentMatch "PowerShell transcript end"
+        $transcriptFilePath | Should -FileContentMatch "Before Dispose"
+        $transcriptFilePath | Should -FileContentMatch "PowerShell transcript end"
     }
 
     It "Transcription should record native command output" {
@@ -145,9 +145,9 @@ Describe "Start-Transcript, Stop-Transcript tests" -tags "CI" {
         Test-Path $transcriptFilePath | Should -BeTrue
 
         $machineName = [System.Environment]::MachineName
-        $transcriptFilePath | Should FileContentMatch $machineName
+        $transcriptFilePath | Should -FileContentMatch $machineName
     }
-    
+
     It "Transcription should record Write-Information output when preference is set to Continue" {
         $script = {
             Start-Transcript -Path $transcriptFilePath
@@ -157,6 +157,6 @@ Describe "Start-Transcript, Stop-Transcript tests" -tags "CI" {
         & $script
         Test-Path $transcriptFilePath | Should -BeTrue
 
-        $transcriptFilePath | Should FileContentMatch 'Continue'
+        $transcriptFilePath | Should -FileContentMatch 'Continue'
     }
 }


### PR DESCRIPTION
## PR Summary

Fix for #6916.

This change makes transcription of Write-Information command consistent with `$InfomrationPreference` variable.
Currently Write-Information command is being transcribed if `$InfomrationPreference` is set to `'SilentlyContinue'` and not transcribed if set to `'Continue'`.

The problem is in if/else statement which starts here:
https://github.com/PowerShell/PowerShell/blob/948532ac839f3bc7e8bbbd3c9f5f292868ac8687/src/System.Management.Automation/engine/MshCommandRuntime.cs#L757-L758
and has a continuation here:
https://github.com/PowerShell/PowerShell/blob/948532ac839f3bc7e8bbbd3c9f5f292868ac8687/src/System.Management.Automation/engine/MshCommandRuntime.cs#L824-L828

Transcription of Write-Host commands are handled in InternalUI.Write* methods as the comment suggests. These commands are distinguished by "PSHOST" tag.
Transcription of Write-Information commands is supposed to take place in the else statement but code in this statement is being executed only if 
``` C#
(!record.Tags.Contains("PSHOST") || record.Tags.Contains("FORWARDED"))
&&
preference != ActionPreference.Continue)
```
This condition is invalid. Correct condition is:
``` C#
!record.Tags.Contains("PSHOST")
&&
preference == ActionPreference.Continue)
```


## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [x] Issue filed - Issue link: #6916
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
