### PR TITLE
Added logic to create signing XML for NuGet packages

### DIFF
--- a/tools/releaseBuild/generatePackgeSigning.ps1
+++ b/tools/releaseBuild/generatePackgeSigning.ps1
@@ -4,10 +4,11 @@ param(
     [Parameter(Mandatory)]
     [string] $Path,
     [string[]] $AuthenticodeDualFiles,
-    [string[]] $AuthenticodeFiles
+    [string[]] $AuthenticodeFiles,
+    [string[]] $NuPkgFiles
 )
 
-if ((!$AuthenticodeDualFiles -or $AuthenticodeDualFiles.Count -eq 0) -and (!$AuthenticodeFiles -or $AuthenticodeFiles.Count -eq 0))
+if ((!$AuthenticodeDualFiles -or $AuthenticodeDualFiles.Count -eq 0) -and (!$AuthenticodeFiles -or $AuthenticodeFiles.Count -eq 0) -and (!$NuPkgFiles -or $NuPkgFiles.Count -eq 0))
 {
     throw "At least one file must be specified"
 }
@@ -67,6 +68,11 @@ foreach($file in $AuthenticodeDualFiles)
 foreach($file in $AuthenticodeFiles)
 {
     New-FileElement -File $file -SignType 'Authenticode' -XmlDoc $signingXml -Job $job
+}
+
+foreach($file in $NuPkgFiles)
+{
+    New-FileElement -File $file -SignType 'NuGet' -XmlDoc $signingXml -Job $job
 }
 
 $signingXml.Save($path)


### PR DESCRIPTION
## PR Summary

Add ability to generate a signing XML for NuGet packages.

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [X] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [X] Not Applicable or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
