### PR TITLE
Fix for #6855 - Measure-Object should handle scriptblock properties.

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ConvertFrom-StringData.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ConvertFrom-StringData.cs
@@ -19,7 +19,7 @@ namespace Microsoft.PowerShell.Commands
 
         /// <summary>
         /// The list of properties to display
-        /// These take the form of an MshExpression
+        /// These take the form of an PSPropertyExpression
         /// </summary>
         /// <value></value>
         [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true)]

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/OutGridView/ExpressionColumnInfo.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/OutGridView/ExpressionColumnInfo.cs
@@ -10,9 +10,9 @@ namespace Microsoft.PowerShell.Commands
 
     internal class ExpressionColumnInfo : ColumnInfo
     {
-        private MshExpression _expression;
+        private PSPropertyExpression _expression;
 
-        internal ExpressionColumnInfo(string staleObjectPropertyName, string displayName, MshExpression expression)
+        internal ExpressionColumnInfo(string staleObjectPropertyName, string displayName, PSPropertyExpression expression)
             : base(staleObjectPropertyName, displayName)
         {
             _expression = expression;
@@ -20,7 +20,7 @@ namespace Microsoft.PowerShell.Commands
 
         internal override Object GetValue(PSObject liveObject)
         {
-            List<MshExpressionResult> resList = _expression.GetValues(liveObject);
+            List<PSPropertyExpressionResult> resList = _expression.GetValues(liveObject);
 
             if (resList.Count == 0)
             {
@@ -28,7 +28,7 @@ namespace Microsoft.PowerShell.Commands
             }
 
             // Only first element is used.
-            MshExpressionResult result = resList[0];
+            PSPropertyExpressionResult result = resList[0];
             if (result.Exception != null)
             {
                 return null;

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/OutGridView/OutGridViewCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/OutGridView/OutGridViewCommand.cs
@@ -44,7 +44,7 @@ namespace Microsoft.PowerShell.Commands
         private const string DataNotQualifiedForGridView = "DataNotQualifiedForGridView";
         private const string RemotingNotSupported = "RemotingNotSupported";
         private TypeInfoDataBase _typeInfoDataBase;
-        private MshExpressionFactory _expressionFactory;
+        private PSPropertyExpressionFactory _expressionFactory;
         private OutWindowProxy _windowProxy;
         private GridHeader _gridHeader;
 
@@ -110,7 +110,7 @@ namespace Microsoft.PowerShell.Commands
         protected override void BeginProcessing()
         {
             // Set up the ExpressionFactory
-            _expressionFactory = new MshExpressionFactory();
+            _expressionFactory = new PSPropertyExpressionFactory();
 
             // If the value of the Title parameter is valid, use it as a window's title.
             if (this.Title != null)

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/OutGridView/TableView.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/OutGridView/TableView.cs
@@ -13,11 +13,11 @@ namespace Microsoft.PowerShell.Commands
 
     internal class TableView
     {
-        private MshExpressionFactory _expressionFactory;
+        private PSPropertyExpressionFactory _expressionFactory;
         private TypeInfoDataBase _typeInfoDatabase;
         private FormatErrorManager _errorManager;
 
-        internal void Initialize(MshExpressionFactory expressionFactory,
+        internal void Initialize(PSPropertyExpressionFactory expressionFactory,
                                  TypeInfoDataBase db)
         {
             _expressionFactory = expressionFactory;
@@ -78,7 +78,7 @@ namespace Microsoft.PowerShell.Commands
                             }
                             if (fpt.expression.isScriptBlock)
                             {
-                                MshExpression ex = _expressionFactory.CreateFromExpressionToken(fpt.expression);
+                                PSPropertyExpression ex = _expressionFactory.CreateFromExpressionToken(fpt.expression);
                                 // Using the displayName as a propertyName for a stale PSObject.
                                 const string LastWriteTimePropertyName = "LastWriteTime";
 
@@ -132,7 +132,7 @@ namespace Microsoft.PowerShell.Commands
                 if (PSObjectHelper.ShouldShowComputerNameProperty(input))
                 {
                     activeAssociationList.Add(new MshResolvedExpressionParameterAssociation(null,
-                        new MshExpression(RemotingConstants.ComputerNameNoteProperty)));
+                        new PSPropertyExpression(RemotingConstants.ComputerNameNoteProperty)));
                 }
             }
             else

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Measure-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Measure-Object.cs
@@ -271,7 +271,7 @@ namespace Microsoft.PowerShell.Commands
         /// <value></value>
         [ValidateNotNullOrEmpty]
         [Parameter(Position = 0)]
-        public string[] Property { get; set; } = null;
+        public PSPropertyExpression[] Property { get; set; } = null;
 
         #endregion Common parameters in both sets
 
@@ -486,10 +486,9 @@ namespace Microsoft.PowerShell.Commands
 
             // First iterate over the user-specified list of
             // properties...
-            foreach (string p in Property)
+            foreach (var expression in Property)
             {
-                MshExpression expression = new MshExpression(p);
-                List<MshExpression> resolvedNames = expression.ResolveNames(inObj);
+                List<PSPropertyExpression> resolvedNames = expression.ResolveNames(inObj);
                 if (resolvedNames == null || resolvedNames.Count == 0)
                 {
                     // Insert a blank entry so we can track
@@ -506,7 +505,7 @@ namespace Microsoft.PowerShell.Commands
                 // Each property value can potentially refer
                 // to multiple properties via globbing. Iterate over
                 // the actual property names.
-                foreach (MshExpression resolvedName in resolvedNames)
+                foreach (PSPropertyExpression resolvedName in resolvedNames)
                 {
                     string propertyName = resolvedName.ToString();
                     // skip duplicated properties
@@ -515,7 +514,7 @@ namespace Microsoft.PowerShell.Commands
                         continue;
                     }
 
-                    List<MshExpressionResult> tempExprRes = resolvedName.GetValues(inObj);
+                    List<PSPropertyExpressionResult> tempExprRes = resolvedName.GetValues(inObj);
                     if (tempExprRes == null || tempExprRes.Count == 0)
                     {
                         // Shouldn't happen - would somehow mean
@@ -573,7 +572,7 @@ namespace Microsoft.PowerShell.Commands
                 AnalyzeNumber(numValue, stat);
             }
 
-            // Win8:343911 Measure-Object -MAX -MIN should work with ANYTHING that supports CompareTo
+            // Measure-Object -MAX -MIN should work with ANYTHING that supports CompareTo
             if (_measureMin)
             {
                 stat.min = Compare(objValue, stat.min, true);

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Measure-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Measure-Object.cs
@@ -82,8 +82,7 @@ namespace Microsoft.PowerShell.Commands
     /// Class output by Measure-Object.
     /// </summary>
     /// <remarks>
-    /// This class is created for fixing "Measure-Object -MAX -MIN should work with ANYTHING that supports CompareTo"
-    /// bug (Win8:343911).
+    /// This class is created to make 'Measure-Object -MAX -MIN' work with ANYTHING that supports 'CompareTo'.
     /// GenericMeasureInfo class is shipped with PowerShell V2. Fixing this bug requires, changing the type of
     /// Maximum and Minimum properties which would be a breaking change. Hence created a new class to not
     /// have an appcompat issues with PS V2.

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/OrderObjectBase.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/OrderObjectBase.cs
@@ -199,7 +199,7 @@ namespace Microsoft.PowerShell.Commands
         // a string array and allows wildcard.
         // Yes, the Cmdlet is needed. It's used to get the TerminatingErrorContext, WriteError and WriteDebug.
 
-        #region process MshExpression and MshParameter
+        #region process PSPropertyExpression and MshParameter
 
         private static void ProcessExpressionParameter(
             List<PSObject> inputObjects,
@@ -245,7 +245,7 @@ namespace Microsoft.PowerShell.Commands
 
                     foreach (MshParameter unexpandedParameter in _unexpandedParameterList)
                     {
-                        MshExpression mshExpression = (MshExpression)unexpandedParameter.GetEntry(FormatParameterDefinitionKeys.ExpressionEntryKey);
+                        PSPropertyExpression mshExpression = (PSPropertyExpression)unexpandedParameter.GetEntry(FormatParameterDefinitionKeys.ExpressionEntryKey);
                         if (!mshExpression.HasWildCardCharacters) // this special cases 1) script blocks and 2) wildcard-less strings
                         {
                             _mshParameterList.Add(unexpandedParameter);
@@ -274,14 +274,14 @@ namespace Microsoft.PowerShell.Commands
             {
                 foreach (MshParameter unexpandedParameter in unexpandedParameterList)
                 {
-                    MshExpression ex = (MshExpression)unexpandedParameter.GetEntry(FormatParameterDefinitionKeys.ExpressionEntryKey);
+                    PSPropertyExpression ex = (PSPropertyExpression)unexpandedParameter.GetEntry(FormatParameterDefinitionKeys.ExpressionEntryKey);
                     if (!ex.HasWildCardCharacters) // this special cases 1) script blocks and 2) wildcard-less strings
                     {
                         expandedParameterList.Add(unexpandedParameter);
                     }
                     else
                     {
-                        SortedDictionary<string, MshExpression> expandedPropertyNames = new SortedDictionary<string, MshExpression>(StringComparer.OrdinalIgnoreCase);
+                        SortedDictionary<string, PSPropertyExpression> expandedPropertyNames = new SortedDictionary<string, PSPropertyExpression>(StringComparer.OrdinalIgnoreCase);
                         if (inputObjects != null)
                         {
                             foreach (object inputObject in inputObjects)
@@ -291,14 +291,14 @@ namespace Microsoft.PowerShell.Commands
                                     continue;
                                 }
 
-                                foreach (MshExpression resolvedName in ex.ResolveNames(PSObject.AsPSObject(inputObject)))
+                                foreach (PSPropertyExpression resolvedName in ex.ResolveNames(PSObject.AsPSObject(inputObject)))
                                 {
                                     expandedPropertyNames[resolvedName.ToString()] = resolvedName;
                                 }
                             }
                         }
 
-                        foreach (MshExpression expandedExpression in expandedPropertyNames.Values)
+                        foreach (PSPropertyExpression expandedExpression in expandedPropertyNames.Values)
                         {
                             MshParameter expandedParameter = new MshParameter();
                             expandedParameter.hash = (Hashtable)unexpandedParameter.hash.Clone();
@@ -321,20 +321,20 @@ namespace Microsoft.PowerShell.Commands
             {
                 foreach (MshParameter unexpandedParameter in UnexpandedParametersWithWildCardPattern)
                 {
-                    MshExpression ex = (MshExpression)unexpandedParameter.GetEntry(FormatParameterDefinitionKeys.ExpressionEntryKey);
+                    PSPropertyExpression ex = (PSPropertyExpression)unexpandedParameter.GetEntry(FormatParameterDefinitionKeys.ExpressionEntryKey);
 
-                    SortedDictionary<string, MshExpression> expandedPropertyNames = new SortedDictionary<string, MshExpression>(StringComparer.OrdinalIgnoreCase);
+                    SortedDictionary<string, PSPropertyExpression> expandedPropertyNames = new SortedDictionary<string, PSPropertyExpression>(StringComparer.OrdinalIgnoreCase);
                     if (inputObject == null)
                     {
                         continue;
                     }
 
-                    foreach (MshExpression resolvedName in ex.ResolveNames(PSObject.AsPSObject(inputObject)))
+                    foreach (PSPropertyExpression resolvedName in ex.ResolveNames(PSObject.AsPSObject(inputObject)))
                     {
                         expandedPropertyNames[resolvedName.ToString()] = resolvedName;
                     }
 
-                    foreach (MshExpression expandedExpression in expandedPropertyNames.Values)
+                    foreach (PSPropertyExpression expandedExpression in expandedPropertyNames.Values)
                     {
                         MshParameter expandedParameter = new MshParameter();
                         expandedParameter.hash = (Hashtable)unexpandedParameter.hash.Clone();
@@ -364,7 +364,7 @@ namespace Microsoft.PowerShell.Commands
             return props;
         }
 
-        #endregion process MshExpression and MshParameter
+        #endregion process PSPropertyExpression and MshParameter
 
         internal static List<OrderByPropertyEntry> CreateOrderMatrix(
             PSCmdlet cmdlet,
@@ -569,10 +569,10 @@ namespace Microsoft.PowerShell.Commands
             ref bool comparable)
         {
             // NOTE: we assume globbing was not allowed in input
-            MshExpression ex = p.GetEntry(FormatParameterDefinitionKeys.ExpressionEntryKey) as MshExpression;
+            PSPropertyExpression ex = p.GetEntry(FormatParameterDefinitionKeys.ExpressionEntryKey) as PSPropertyExpression;
 
             // get the values, but do not expand aliases
-            List<MshExpressionResult> expressionResults = ex.GetValues(inputObject, false, true);
+            List<PSPropertyExpressionResult> expressionResults = ex.GetValues(inputObject, false, true);
 
             if (expressionResults.Count == 0)
             {
@@ -584,7 +584,7 @@ namespace Microsoft.PowerShell.Commands
             }
             propertyNotFoundMsg = null;
             // we obtained some results, enter them into the list
-            foreach (MshExpressionResult r in expressionResults)
+            foreach (PSPropertyExpressionResult r in expressionResults)
             {
                 if (r.Exception == null)
                 {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/convert-HTML.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/convert-HTML.cs
@@ -43,7 +43,7 @@ namespace Microsoft.PowerShell.Commands
 
         /// <summary>
         /// The list of properties to display
-        /// These take the form of an MshExpression
+        /// These take the form of a PSPropertyExpression
         /// </summary>
         /// <value></value>
         [Parameter(Position = 0)]
@@ -342,9 +342,9 @@ namespace Microsoft.PowerShell.Commands
                 string label = p.GetEntry(ConvertHTMLParameterDefinitionKeys.LabelEntryKey) as string;
                 string alignment = p.GetEntry(ConvertHTMLParameterDefinitionKeys.AlignmentEntryKey) as string;
                 string width = p.GetEntry(ConvertHTMLParameterDefinitionKeys.WidthEntryKey) as string;
-                MshExpression ex = p.GetEntry(FormatParameterDefinitionKeys.ExpressionEntryKey) as MshExpression;
-                List<MshExpression> resolvedNames = ex.ResolveNames(_inputObject);
-                foreach (MshExpression resolvedName in resolvedNames)
+                PSPropertyExpression ex = p.GetEntry(FormatParameterDefinitionKeys.ExpressionEntryKey) as PSPropertyExpression;
+                List<PSPropertyExpression> resolvedNames = ex.ResolveNames(_inputObject);
+                foreach (PSPropertyExpression resolvedName in resolvedNames)
                 {
                     Hashtable ht = CreateAuxPropertyHT(label, alignment, width);
                     ht.Add(FormatParameterDefinitionKeys.ExpressionEntryKey, resolvedName.ToString());
@@ -567,7 +567,7 @@ namespace Microsoft.PowerShell.Commands
             }
             else
             {
-                MshExpression ex = p.GetEntry(FormatParameterDefinitionKeys.ExpressionEntryKey) as MshExpression;
+                PSPropertyExpression ex = p.GetEntry(FormatParameterDefinitionKeys.ExpressionEntryKey) as PSPropertyExpression;
                 Listtag.Append(ex.ToString());
             }
         }
@@ -577,11 +577,11 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         private void WritePropertyValue(StringBuilder Listtag, MshParameter p)
         {
-            MshExpression exValue = p.GetEntry(FormatParameterDefinitionKeys.ExpressionEntryKey) as MshExpression;
+            PSPropertyExpression exValue = p.GetEntry(FormatParameterDefinitionKeys.ExpressionEntryKey) as PSPropertyExpression;
 
             // get the value of the property
-            List<MshExpressionResult> resultList = exValue.GetValues(_inputObject);
-            foreach (MshExpressionResult result in resultList)
+            List<PSPropertyExpressionResult> resultList = exValue.GetValues(_inputObject);
+            foreach (PSPropertyExpressionResult result in resultList)
             {
                 // create comma sep list for multiple results
                 if (result.Result != null)

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/select-object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/select-object.cs
@@ -12,15 +12,15 @@ using System.Diagnostics.CodeAnalysis;
 namespace Microsoft.PowerShell.Commands
 {
     /// <summary>
-    /// helper class to do wildcard matching on MshExpressions
+    /// helper class to do wildcard matching on PSPropertyExpressions
     /// </summary>
-    internal sealed class MshExpressionFilter
+    internal sealed class PSPropertyExpressionFilter
     {
         /// <summary>
         /// construct the class, using an array of patterns
         /// </summary>
         /// <param name="wildcardPatternsStrings">array of pattern strings to use</param>
-        internal MshExpressionFilter(string[] wildcardPatternsStrings)
+        internal PSPropertyExpressionFilter(string[] wildcardPatternsStrings)
         {
             if (wildcardPatternsStrings == null)
             {
@@ -38,9 +38,9 @@ namespace Microsoft.PowerShell.Commands
         /// try to match the expression against the array of wildcard patterns.
         /// the first match shortcircuits the search
         /// </summary>
-        /// <param name="expression">MshExpression to test against</param>
+        /// <param name="expression">PSPropertyExpression to test against</param>
         /// <returns>true if there is a match, else false</returns>
-        internal bool IsMatch(MshExpression expression)
+        internal bool IsMatch(PSPropertyExpression expression)
         {
             for (int k = 0; k < _wildcardPatterns.Length; k++)
             {
@@ -290,7 +290,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         private List<MshParameter> _expandMshParameterList;
 
-        private MshExpressionFilter _exclusionFilter;
+        private PSPropertyExpressionFilter _exclusionFilter;
 
         private class UniquePSObjectHelper
         {
@@ -328,7 +328,7 @@ namespace Microsoft.PowerShell.Commands
 
             if (ExcludeProperty != null)
             {
-                _exclusionFilter = new MshExpressionFilter(ExcludeProperty);
+                _exclusionFilter = new PSPropertyExpressionFilter(ExcludeProperty);
                 // ExcludeProperty implies -Property * for better UX
                 if ((Property == null) || (Property.Length == 0))
                 {
@@ -394,15 +394,15 @@ namespace Microsoft.PowerShell.Commands
         {
             string name = p.GetEntry(NameEntryDefinition.NameEntryKey) as string;
 
-            MshExpression ex = p.GetEntry(FormatParameterDefinitionKeys.ExpressionEntryKey) as MshExpression;
-            List<MshExpressionResult> expressionResults = new List<MshExpressionResult>();
-            foreach (MshExpression resolvedName in ex.ResolveNames(inputObject))
+            PSPropertyExpression ex = p.GetEntry(FormatParameterDefinitionKeys.ExpressionEntryKey) as PSPropertyExpression;
+            List<PSPropertyExpressionResult> expressionResults = new List<PSPropertyExpressionResult>();
+            foreach (PSPropertyExpression resolvedName in ex.ResolveNames(inputObject))
             {
                 if (_exclusionFilter == null || !_exclusionFilter.IsMatch(resolvedName))
                 {
-                    List<MshExpressionResult> tempExprResults = resolvedName.GetValues(inputObject);
+                    List<PSPropertyExpressionResult> tempExprResults = resolvedName.GetValues(inputObject);
                     if (tempExprResults == null) continue;
-                    foreach (MshExpressionResult mshExpRes in tempExprResults)
+                    foreach (PSPropertyExpressionResult mshExpRes in tempExprResults)
                     {
                         expressionResults.Add(mshExpRes);
                     }
@@ -413,7 +413,7 @@ namespace Microsoft.PowerShell.Commands
             // unless noexist-name itself contains wildcards
             if (expressionResults.Count == 0 && !ex.HasWildCardCharacters)
             {
-                expressionResults.Add(new MshExpressionResult(null, ex, null));
+                expressionResults.Add(new PSPropertyExpressionResult(null, ex, null));
             }
 
             // if we have an expansion, renaming is not acceptable
@@ -429,7 +429,7 @@ namespace Microsoft.PowerShell.Commands
                 return;
             }
 
-            foreach (MshExpressionResult r in expressionResults)
+            foreach (PSPropertyExpressionResult r in expressionResults)
             {
                 // filter the exclusions, if any
                 if (_exclusionFilter != null && _exclusionFilter.IsMatch(r.ResolvedExpression))
@@ -462,8 +462,8 @@ namespace Microsoft.PowerShell.Commands
         private void ProcessExpandParameter(MshParameter p, PSObject inputObject,
             List<PSNoteProperty> matchedProperties)
         {
-            MshExpression ex = p.GetEntry(FormatParameterDefinitionKeys.ExpressionEntryKey) as MshExpression;
-            List<MshExpressionResult> expressionResults = ex.GetValues(inputObject);
+            PSPropertyExpression ex = p.GetEntry(FormatParameterDefinitionKeys.ExpressionEntryKey) as PSPropertyExpression;
+            List<PSPropertyExpressionResult> expressionResults = ex.GetValues(inputObject);
 
             if (expressionResults.Count == 0)
             {
@@ -484,7 +484,7 @@ namespace Microsoft.PowerShell.Commands
                 throw new SelectObjectException(errorRecord);
             }
 
-            MshExpressionResult r = expressionResults[0];
+            PSPropertyExpressionResult r = expressionResults[0];
             if (r.Exception == null)
             {
                 // ignore the property value if it's null

--- a/src/System.Management.Automation/FormatAndOutput/common/BaseFormattingCommand.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/BaseFormattingCommand.cs
@@ -82,7 +82,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             // Get the Format Enumeration Limit.
             _enumerationLimit = InnerFormatShapeCommand.FormatEnumerationLimit();
 
-            _expressionFactory = new MshExpressionFactory();
+            _expressionFactory = new PSPropertyExpressionFactory();
 
             _formatObjectDeserializer = new FormatObjectDeserializer(this.TerminatingErrorContext);
         }
@@ -500,7 +500,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             return scriptBlock;
         }
 
-        private MshExpressionFactory _expressionFactory;
+        private PSPropertyExpressionFactory _expressionFactory;
         #endregion
 
         private FormatObjectDeserializer _formatObjectDeserializer;

--- a/src/System.Management.Automation/FormatAndOutput/common/BaseFormattingCommandParameters.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/BaseFormattingCommandParameters.cs
@@ -173,7 +173,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             ScriptBlock sb = val as ScriptBlock;
             if (sb != null)
             {
-                MshExpression ex = new MshExpression(sb);
+                PSPropertyExpression ex = new PSPropertyExpression(sb);
                 return ex;
             }
 
@@ -184,7 +184,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 {
                     ProcessEmptyStringError(originalParameterWasHashTable, invocationContext);
                 }
-                MshExpression ex = new MshExpression(s);
+                PSPropertyExpression ex = new PSPropertyExpression(s);
                 if (_noGlobbing)
                 {
                     if (ex.HasWildCardCharacters)

--- a/src/System.Management.Automation/FormatAndOutput/common/DisplayDatabase/XmlLoaderBase.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/DisplayDatabase/XmlLoaderBase.cs
@@ -702,7 +702,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             }
         }
 
-        protected MshExpressionFactory expressionFactory;
+        protected PSPropertyExpressionFactory expressionFactory;
 
         protected DisplayResourceManagerCache displayResourceManagerCache;
 

--- a/src/System.Management.Automation/FormatAndOutput/common/DisplayDatabase/displayDescriptionData.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/DisplayDatabase/displayDescriptionData.cs
@@ -170,7 +170,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
 
         /// <summary>
         /// string to display in the formatted display (e.g. cell in a table)
-        /// when the evaluation of an MshExpression fails
+        /// when the evaluation of a PSPropertyExpression fails
         /// </summary>
         internal string errorStringInFormattedOutput = "#ERR";
 

--- a/src/System.Management.Automation/FormatAndOutput/common/DisplayDatabase/typeDataManager.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/DisplayDatabase/typeDataManager.cs
@@ -89,7 +89,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 _formatFileList.Add(formatFile);
             }
 
-            MshExpressionFactory expressionFactory = new MshExpressionFactory();
+            PSPropertyExpressionFactory expressionFactory = new PSPropertyExpressionFactory();
             List<XmlLoaderLoggerEntry> logEntries = null;
 
             // load the files
@@ -207,7 +207,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 }
             }
 
-            MshExpressionFactory expressionFactory = new MshExpressionFactory();
+            PSPropertyExpressionFactory expressionFactory = new PSPropertyExpressionFactory();
             List<XmlLoaderLoggerEntry> logEntries = null;
 
             // load the formatting data
@@ -290,7 +290,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 throw PSTraceSource.NewInvalidOperationException(FormatAndOutXmlLoadingStrings.SharedFormatTableCannotBeUpdated);
             }
 
-            MshExpressionFactory expressionFactory = new MshExpressionFactory();
+            PSPropertyExpressionFactory expressionFactory = new PSPropertyExpressionFactory();
             List<XmlLoaderLoggerEntry> logEntries = null;
             LoadFromFile(mshsnapins, expressionFactory, false, authorizationManager, host, preValidated, out logEntries);
         }
@@ -316,7 +316,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         /// <returns>true if we had a successful load</returns>
         internal bool LoadFromFile(
             Collection<PSSnapInTypeAndFormatErrors> files,
-            MshExpressionFactory expressionFactory,
+            PSPropertyExpressionFactory expressionFactory,
             bool acceptLoadingErrors,
             AuthorizationManager authorizationManager,
             PSHost host,
@@ -377,7 +377,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         /// <returns>a database instance loaded from file(s)</returns>
         private static TypeInfoDataBase LoadFromFileHelper(
             Collection<PSSnapInTypeAndFormatErrors> files,
-            MshExpressionFactory expressionFactory,
+            PSPropertyExpressionFactory expressionFactory,
             AuthorizationManager authorizationManager,
             PSHost host,
             bool preValidated,
@@ -445,7 +445,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
 
         private static void LoadFormatDataHelper(
             ExtendedTypeDefinition formatData,
-            MshExpressionFactory expressionFactory, List<XmlLoaderLoggerEntry> logEntries, ref bool success,
+            PSPropertyExpressionFactory expressionFactory, List<XmlLoaderLoggerEntry> logEntries, ref bool success,
             PSSnapInTypeAndFormatErrors file, TypeInfoDataBase db,
             bool isBuiltInFormatData,
             bool isForHelp)
@@ -481,7 +481,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         private static bool ProcessBuiltin(
             PSSnapInTypeAndFormatErrors file,
             TypeInfoDataBase db,
-            MshExpressionFactory expressionFactory,
+            PSPropertyExpressionFactory expressionFactory,
             List<XmlLoaderLoggerEntry> logEntries,
             ref bool success)
         {
@@ -517,7 +517,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         private static void ProcessBuiltinFormatViewDefinitions(
             IEnumerable<ExtendedTypeDefinition> views,
             TypeInfoDataBase db,
-            MshExpressionFactory expressionFactory,
+            PSPropertyExpressionFactory expressionFactory,
             PSSnapInTypeAndFormatErrors file,
             List<XmlLoaderLoggerEntry> logEntries,
             bool isForHelp,

--- a/src/System.Management.Automation/FormatAndOutput/common/DisplayDatabase/typeDataQuery.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/DisplayDatabase/typeDataQuery.cs
@@ -13,10 +13,10 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
 {
     internal static class DisplayCondition
     {
-        internal static bool Evaluate(PSObject obj, MshExpression ex, out MshExpressionResult expressionResult)
+        internal static bool Evaluate(PSObject obj, PSPropertyExpression ex, out PSPropertyExpressionResult expressionResult)
         {
             expressionResult = null;
-            List<MshExpressionResult> res = ex.GetValues(obj);
+            List<PSPropertyExpressionResult> res = ex.GetValues(obj);
             if (res.Count == 0)
                 return false;
             if (res[0].Exception != null)
@@ -84,7 +84,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         }
         #endregion tracer
 
-        internal TypeMatch(MshExpressionFactory expressionFactory, TypeInfoDataBase db, Collection<string> typeNames)
+        internal TypeMatch(PSPropertyExpressionFactory expressionFactory, TypeInfoDataBase db, Collection<string> typeNames)
         {
             _expressionFactory = expressionFactory;
             _db = db;
@@ -92,7 +92,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             _useInheritance = true;
         }
 
-        internal TypeMatch(MshExpressionFactory expressionFactory, TypeInfoDataBase db, Collection<string> typeNames, bool useInheritance)
+        internal TypeMatch(PSPropertyExpressionFactory expressionFactory, TypeInfoDataBase db, Collection<string> typeNames, bool useInheritance)
         {
             _expressionFactory = expressionFactory;
             _db = db;
@@ -130,7 +130,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             int best = BestMatchIndexUndefined;
             foreach (TypeOrGroupReference r in appliesTo.referenceList)
             {
-                MshExpression ex = null;
+                PSPropertyExpression ex = null;
                 if (r.conditionToken != null)
                 {
                     ex = _expressionFactory.CreateFromExpressionToken(r.conditionToken);
@@ -170,7 +170,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             return best;
         }
 
-        private int ComputeBestMatchInGroup(TypeGroupDefinition tgd, PSObject currentObject, MshExpression ex)
+        private int ComputeBestMatchInGroup(TypeGroupDefinition tgd, PSObject currentObject, PSPropertyExpression ex)
         {
             int best = BestMatchIndexUndefined;
             int k = 0;
@@ -189,7 +189,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             return best;
         }
 
-        private int MatchTypeIndex(string typeName, PSObject currentObject, MshExpression ex)
+        private int MatchTypeIndex(string typeName, PSObject currentObject, PSPropertyExpression ex)
         {
             if (string.IsNullOrEmpty(typeName))
                 return BestMatchIndexUndefined;
@@ -208,12 +208,12 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             return BestMatchIndexUndefined;
         }
 
-        private bool MatchCondition(PSObject currentObject, MshExpression ex)
+        private bool MatchCondition(PSObject currentObject, PSPropertyExpression ex)
         {
             if (ex == null)
                 return true;
 
-            MshExpressionResult expressionResult;
+            PSPropertyExpressionResult expressionResult;
             bool retVal = DisplayCondition.Evaluate(currentObject, ex, out expressionResult);
             if (expressionResult != null && expressionResult.Exception != null)
             {
@@ -222,12 +222,12 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             return retVal;
         }
 
-        private MshExpressionFactory _expressionFactory;
+        private PSPropertyExpressionFactory _expressionFactory;
         private TypeInfoDataBase _db;
         private Collection<string> _typeNameHierarchy;
         private bool _useInheritance;
 
-        private List<MshExpressionResult> _failedResultsList = new List<MshExpressionResult>();
+        private List<PSPropertyExpressionResult> _failedResultsList = new List<PSPropertyExpressionResult>();
 
         private int _bestMatchIndex = BestMatchIndexUndefined;
         private TypeMatchItem _bestMatchItem;
@@ -264,7 +264,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         }
         #endregion tracer
 
-        internal static EnumerableExpansion GetEnumerableExpansionFromType(MshExpressionFactory expressionFactory, TypeInfoDataBase db, Collection<string> typeNames)
+        internal static EnumerableExpansion GetEnumerableExpansionFromType(PSPropertyExpressionFactory expressionFactory, TypeInfoDataBase db, Collection<string> typeNames)
         {
             TypeMatch match = new TypeMatch(expressionFactory, db, typeNames);
             foreach (EnumerableExpansionDirective expansionDirective in db.defaultSettingsSection.enumerableExpansionDirectiveList)
@@ -292,7 +292,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             }
         }
 
-        internal static FormatShape GetShapeFromType(MshExpressionFactory expressionFactory, TypeInfoDataBase db, Collection<string> typeNames)
+        internal static FormatShape GetShapeFromType(PSPropertyExpressionFactory expressionFactory, TypeInfoDataBase db, Collection<string> typeNames)
         {
             ShapeSelectionDirectives shapeDirectives = db.defaultSettingsSection.shapeSelectionDirectives;
 
@@ -330,7 +330,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             return FormatShape.List;
         }
 
-        internal static ViewDefinition GetViewByShapeAndType(MshExpressionFactory expressionFactory, TypeInfoDataBase db,
+        internal static ViewDefinition GetViewByShapeAndType(PSPropertyExpressionFactory expressionFactory, TypeInfoDataBase db,
                 FormatShape shape, Collection<string> typeNames, string viewName)
         {
             if (shape == FormatShape.Undefined)
@@ -363,7 +363,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             return GetView(expressionFactory, db, t, typeNames, viewName);
         }
 
-        internal static ViewDefinition GetOutOfBandView(MshExpressionFactory expressionFactory,
+        internal static ViewDefinition GetOutOfBandView(PSPropertyExpressionFactory expressionFactory,
                                                         TypeInfoDataBase db, Collection<string> typeNames)
         {
             TypeMatch match = new TypeMatch(expressionFactory, db, typeNames);
@@ -394,7 +394,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             return result;
         }
 
-        private static ViewDefinition GetView(MshExpressionFactory expressionFactory, TypeInfoDataBase db, System.Type mainControlType, Collection<string> typeNames, string viewName)
+        private static ViewDefinition GetView(PSPropertyExpressionFactory expressionFactory, TypeInfoDataBase db, System.Type mainControlType, Collection<string> typeNames, string viewName)
         {
             TypeMatch match = new TypeMatch(expressionFactory, db, typeNames);
             foreach (ViewDefinition vd in db.viewDefinitionsSection.viewDefinitionList)
@@ -501,7 +501,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             return bestMatchedVD;
         }
 
-        private static ViewDefinition GetDefaultView(MshExpressionFactory expressionFactory, TypeInfoDataBase db, Collection<string> typeNames)
+        private static ViewDefinition GetDefaultView(PSPropertyExpressionFactory expressionFactory, TypeInfoDataBase db, Collection<string> typeNames)
         {
             TypeMatch match = new TypeMatch(expressionFactory, db, typeNames);
 

--- a/src/System.Management.Automation/FormatAndOutput/common/DisplayDatabase/typeDataXmlLoader.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/DisplayDatabase/typeDataXmlLoader.cs
@@ -185,7 +185,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         internal bool LoadXmlFile(
             XmlFileLoadInfo info,
             TypeInfoDataBase db,
-            MshExpressionFactory expressionFactory,
+            PSPropertyExpressionFactory expressionFactory,
             AuthorizationManager authorizationManager,
             PSHost host,
             bool preValidated)
@@ -279,7 +279,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         internal bool LoadFormattingData(
             ExtendedTypeDefinition typeDefinition,
             TypeInfoDataBase db,
-            MshExpressionFactory expressionFactory,
+            PSPropertyExpressionFactory expressionFactory,
             bool isBuiltInFormatData,
             bool isForHelp)
         {

--- a/src/System.Management.Automation/FormatAndOutput/common/DisplayDatabase/typeDataXmlLoader_List.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/DisplayDatabase/typeDataXmlLoader_List.cs
@@ -258,7 +258,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 // add condition
                 lvid.conditionToken = condition;
 
-                // add either the text token or the MshExpression with optional format string
+                // add either the text token or the PSPropertyExpression with optional format string
                 if (match.TextToken != null)
                 {
                     lvid.formatTokenList.Add(match.TextToken);

--- a/src/System.Management.Automation/FormatAndOutput/common/DisplayDatabase/typeDataXmlLoader_Table.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/DisplayDatabase/typeDataXmlLoader_Table.cs
@@ -469,7 +469,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 }
 
                 // finally build the item to return
-                // add either the text token or the MshExpression with optional format string
+                // add either the text token or the PSPropertyExpression with optional format string
                 if (match.TextToken != null)
                 {
                     rid.formatTokenList.Add(match.TextToken);

--- a/src/System.Management.Automation/FormatAndOutput/common/DisplayDatabase/typeDataXmlLoader_Wide.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/DisplayDatabase/typeDataXmlLoader_Wide.cs
@@ -221,7 +221,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 // finally build the item to return
                 List<FormatToken> formatTokenList = new List<FormatToken>();
 
-                // add either the text token or the MshExpression with optional format string
+                // add either the text token or the PSPropertyExpression with optional format string
                 if (match.TextToken != null)
                 {
                     formatTokenList.Add(match.TextToken);

--- a/src/System.Management.Automation/FormatAndOutput/common/FormatGroupManager.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/FormatGroupManager.cs
@@ -20,7 +20,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         /// </summary>
         /// <param name="groupingExpression">name of the grouping property</param>
         /// <param name="displayLabel">display name of the property</param>
-        internal void Initialize(MshExpression groupingExpression, string displayLabel)
+        internal void Initialize(PSPropertyExpression groupingExpression, string displayLabel)
         {
             _groupingKeyExpression = groupingExpression;
             _label = displayLabel;
@@ -51,7 +51,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             if (_groupingKeyExpression == null)
                 return false;
 
-            List<MshExpressionResult> results = _groupingKeyExpression.GetValues(so);
+            List<PSPropertyExpressionResult> results = _groupingKeyExpression.GetValues(so);
 
             // if we have more that one match, we have to select the first one
             if (results.Count > 0 && results[0].Exception == null)
@@ -117,7 +117,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         /// <summary>
         /// name of the current grouping key
         /// </summary>
-        private MshExpression _groupingKeyExpression = null;
+        private PSPropertyExpression _groupingKeyExpression = null;
 
         /// <summary>
         /// the current value of the grouping key

--- a/src/System.Management.Automation/FormatAndOutput/common/FormatViewGenerator.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/FormatViewGenerator.cs
@@ -14,7 +14,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
     internal abstract class ViewGenerator
     {
         internal virtual void Initialize(TerminatingErrorContext terminatingErrorContext,
-                                        MshExpressionFactory mshExpressionFactory,
+                                        PSPropertyExpressionFactory mshExpressionFactory,
                                         TypeInfoDataBase db,
                                         ViewDefinition view,
                                         FormattingCommandLineParameters formatParameters)
@@ -35,7 +35,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         }
 
         internal virtual void Initialize(TerminatingErrorContext terminatingErrorContext,
-                                            MshExpressionFactory mshExpressionFactory,
+                                            PSPropertyExpressionFactory mshExpressionFactory,
                                             PSObject so,
                                             TypeInfoDataBase db,
                                             FormattingCommandLineParameters formatParameters)
@@ -94,7 +94,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             if (parameters != null && parameters.groupByParameter != null)
             {
                 // get the expression to use
-                MshExpression groupingKeyExpression = parameters.groupByParameter.GetEntry(FormatParameterDefinitionKeys.ExpressionEntryKey) as MshExpression;
+                PSPropertyExpression groupingKeyExpression = parameters.groupByParameter.GetEntry(FormatParameterDefinitionKeys.ExpressionEntryKey) as PSPropertyExpression;
 
                 // set the label
                 string label = null;
@@ -121,7 +121,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                     return;
                 }
 
-                MshExpression ex = this.expressionFactory.CreateFromExpressionToken(gb.startGroup.expression, this.dataBaseInfo.view.loadingInfo);
+                PSPropertyExpression ex = this.expressionFactory.CreateFromExpressionToken(gb.startGroup.expression, this.dataBaseInfo.view.loadingInfo);
 
                 _groupingManager = new GroupingInfoManager();
                 _groupingManager.Initialize(ex, null);
@@ -323,22 +323,22 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
 
         protected FormattingCommandLineParameters parameters;
 
-        protected MshExpressionFactory expressionFactory;
+        protected PSPropertyExpressionFactory expressionFactory;
 
         protected DataBaseInfo dataBaseInfo = new DataBaseInfo();
 
         protected List<MshResolvedExpressionParameterAssociation> activeAssociationList = null;
         protected FormattingCommandLineParameters inputParameters = null;
 
-        protected string GetExpressionDisplayValue(PSObject so, int enumerationLimit, MshExpression ex,
+        protected string GetExpressionDisplayValue(PSObject so, int enumerationLimit, PSPropertyExpression ex,
                     FieldFormattingDirective directive)
         {
-            MshExpressionResult resolvedExpression;
+            PSPropertyExpressionResult resolvedExpression;
             return GetExpressionDisplayValue(so, enumerationLimit, ex, directive, out resolvedExpression);
         }
 
-        protected string GetExpressionDisplayValue(PSObject so, int enumerationLimit, MshExpression ex,
-                    FieldFormattingDirective directive, out MshExpressionResult expressionResult)
+        protected string GetExpressionDisplayValue(PSObject so, int enumerationLimit, PSPropertyExpression ex,
+                    FieldFormattingDirective directive, out PSPropertyExpressionResult expressionResult)
         {
             StringFormatError formatErrorObject = null;
             if (_errorManager.DisplayFormatErrorString)
@@ -356,7 +356,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 // we obtained a result, check if there is an error
                 if (expressionResult.Exception != null)
                 {
-                    _errorManager.LogMshExpressionFailedResult(expressionResult, so);
+                    _errorManager.LogPSPropertyExpressionFailedResult(expressionResult, so);
                     if (_errorManager.DisplayErrorStrings)
                     {
                         retVal = _errorManager.ErrorString;
@@ -381,13 +381,13 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             if (conditionToken == null)
                 return true;
 
-            MshExpression ex = this.expressionFactory.CreateFromExpressionToken(conditionToken, this.dataBaseInfo.view.loadingInfo);
-            MshExpressionResult expressionResult;
+            PSPropertyExpression ex = this.expressionFactory.CreateFromExpressionToken(conditionToken, this.dataBaseInfo.view.loadingInfo);
+            PSPropertyExpressionResult expressionResult;
             bool retVal = DisplayCondition.Evaluate(so, ex, out expressionResult);
 
             if (expressionResult != null && expressionResult.Exception != null)
             {
-                _errorManager.LogMshExpressionFailedResult(expressionResult, so);
+                _errorManager.LogPSPropertyExpressionFailedResult(expressionResult, so);
             }
             return retVal;
         }
@@ -403,11 +403,11 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
 
         protected FormatPropertyField GenerateFormatPropertyField(List<FormatToken> formatTokenList, PSObject so, int enumerationLimit)
         {
-            MshExpressionResult result;
+            PSPropertyExpressionResult result;
             return GenerateFormatPropertyField(formatTokenList, so, enumerationLimit, out result);
         }
 
-        protected FormatPropertyField GenerateFormatPropertyField(List<FormatToken> formatTokenList, PSObject so, int enumerationLimit, out MshExpressionResult result)
+        protected FormatPropertyField GenerateFormatPropertyField(List<FormatToken> formatTokenList, PSObject so, int enumerationLimit, out PSPropertyExpressionResult result)
         {
             result = null;
             FormatPropertyField fpf = new FormatPropertyField();
@@ -417,7 +417,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 FieldPropertyToken fpt = token as FieldPropertyToken;
                 if (fpt != null)
                 {
-                    MshExpression ex = this.expressionFactory.CreateFromExpressionToken(fpt.expression, this.dataBaseInfo.view.loadingInfo);
+                    PSPropertyExpression ex = this.expressionFactory.CreateFromExpressionToken(fpt.expression, this.dataBaseInfo.view.loadingInfo);
                     fpf.propertyValue = this.GetExpressionDisplayValue(so, enumerationLimit, ex, fpt.fieldFormattingDirective, out result);
                 }
                 else

--- a/src/System.Management.Automation/FormatAndOutput/common/FormatViewGenerator_Complex.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/FormatViewGenerator_Complex.cs
@@ -12,7 +12,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
 {
     internal sealed class ComplexViewGenerator : ViewGenerator
     {
-        internal override void Initialize(TerminatingErrorContext errorContext, MshExpressionFactory expressionFactory,
+        internal override void Initialize(TerminatingErrorContext errorContext, PSPropertyExpressionFactory expressionFactory,
             PSObject so, TypeInfoDataBase db, FormattingCommandLineParameters parameters)
         {
             base.Initialize(errorContext, expressionFactory, so, db, parameters);
@@ -73,7 +73,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
     {
         internal ComplexControlGenerator(TypeInfoDataBase dataBase,
                                             DatabaseLoadingInfo loadingInfo,
-                                            MshExpressionFactory expressionFactory,
+                                            PSPropertyExpressionFactory expressionFactory,
                                             List<ControlDefinition> controlDefinitionList,
                                             FormatErrorManager resultErrorManager,
                                             int enumerationLimit,
@@ -259,14 +259,14 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                     }
                     else
                     {
-                        MshExpression ex = _expressionFactory.CreateFromExpressionToken(cpt.expression, _loadingInfo);
-                        List<MshExpressionResult> resultList = ex.GetValues(so);
+                        PSPropertyExpression ex = _expressionFactory.CreateFromExpressionToken(cpt.expression, _loadingInfo);
+                        List<PSPropertyExpressionResult> resultList = ex.GetValues(so);
                         if (resultList.Count > 0)
                         {
                             val = resultList[0].Result;
                             if (resultList[0].Exception != null)
                             {
-                                _errorManager.LogMshExpressionFailedResult(resultList[0], so);
+                                _errorManager.LogPSPropertyExpressionFailedResult(resultList[0], so);
                             }
                         }
                     }
@@ -361,20 +361,20 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             if (conditionToken == null)
                 return true;
 
-            MshExpression ex = _expressionFactory.CreateFromExpressionToken(conditionToken, _loadingInfo);
-            MshExpressionResult expressionResult;
+            PSPropertyExpression ex = _expressionFactory.CreateFromExpressionToken(conditionToken, _loadingInfo);
+            PSPropertyExpressionResult expressionResult;
             bool retVal = DisplayCondition.Evaluate(so, ex, out expressionResult);
 
             if (expressionResult != null && expressionResult.Exception != null)
             {
-                _errorManager.LogMshExpressionFailedResult(expressionResult, so);
+                _errorManager.LogPSPropertyExpressionFailedResult(expressionResult, so);
             }
             return retVal;
         }
 
         private TypeInfoDataBase _db;
         private DatabaseLoadingInfo _loadingInfo;
-        private MshExpressionFactory _expressionFactory;
+        private PSPropertyExpressionFactory _expressionFactory;
         private List<ControlDefinition> _controlDefinitionList;
         private FormatErrorManager _errorManager;
         private TerminatingErrorContext _errorContext;
@@ -409,7 +409,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
     /// </summary>
     internal sealed class ComplexViewObjectBrowser
     {
-        internal ComplexViewObjectBrowser(FormatErrorManager resultErrorManager, MshExpressionFactory mshExpressionFactory, int enumerationLimit)
+        internal ComplexViewObjectBrowser(FormatErrorManager resultErrorManager, PSPropertyExpressionFactory mshExpressionFactory, int enumerationLimit)
         {
             _errorManager = resultErrorManager;
             _expressionFactory = mshExpressionFactory;
@@ -536,14 +536,14 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 formatValueList.Add(ftf);
 
                 // compute the value of the entry
-                List<MshExpressionResult> resList = a.ResolvedExpression.GetValues(so);
+                List<PSPropertyExpressionResult> resList = a.ResolvedExpression.GetValues(so);
                 object val = null;
                 if (resList.Count >= 1)
                 {
-                    MshExpressionResult result = resList[0];
+                    PSPropertyExpressionResult result = resList[0];
                     if (result.Exception != null)
                     {
-                        _errorManager.LogMshExpressionFailedResult(result, so);
+                        _errorManager.LogPSPropertyExpressionFailedResult(result, so);
                         if (_errorManager.DisplayErrorStrings)
                         {
                             val = _errorManager.ErrorString;
@@ -760,7 +760,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
 
         private FormatErrorManager _errorManager;
 
-        private MshExpressionFactory _expressionFactory;
+        private PSPropertyExpressionFactory _expressionFactory;
 
         private int _enumerationLimit;
     }

--- a/src/System.Management.Automation/FormatAndOutput/common/FormatViewGenerator_List.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/FormatViewGenerator_List.cs
@@ -13,7 +13,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         // tableBody to use for this instance of the ViewGenerator;
         private ListControlBody _listBody;
 
-        internal override void Initialize(TerminatingErrorContext terminatingErrorContext, MshExpressionFactory mshExpressionFactory, TypeInfoDataBase db, ViewDefinition view, FormattingCommandLineParameters formatParameters)
+        internal override void Initialize(TerminatingErrorContext terminatingErrorContext, PSPropertyExpressionFactory mshExpressionFactory, TypeInfoDataBase db, ViewDefinition view, FormattingCommandLineParameters formatParameters)
         {
             base.Initialize(terminatingErrorContext, mshExpressionFactory, db, view, formatParameters);
             if ((null != this.dataBaseInfo) && (null != this.dataBaseInfo.view))
@@ -22,7 +22,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             }
         }
 
-        internal override void Initialize(TerminatingErrorContext errorContext, MshExpressionFactory expressionFactory,
+        internal override void Initialize(TerminatingErrorContext errorContext, PSPropertyExpressionFactory expressionFactory,
                                     PSObject so, TypeInfoDataBase db, FormattingCommandLineParameters parameters)
         {
             base.Initialize(errorContext, expressionFactory, so, db, parameters);
@@ -94,7 +94,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                     continue;
 
                 ListViewField lvf = new ListViewField();
-                MshExpressionResult result;
+                PSPropertyExpressionResult result;
                 lvf.formatPropertyField = GenerateFormatPropertyField(listItem.formatTokenList, so, enumerationLimit, out result);
 
                 // we need now to provide a label
@@ -112,14 +112,14 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 {
                     // we did fail getting a result (i.e. property does not exist on the object)
 
-                    // we try to fall back and see if we have an un-resolved MshExpression
+                    // we try to fall back and see if we have an un-resolved PSPropertyExpression
                     FormatToken token = listItem.formatTokenList[0];
                     FieldPropertyToken fpt = token as FieldPropertyToken;
                     if (fpt != null)
                     {
-                        MshExpression ex = this.expressionFactory.CreateFromExpressionToken(fpt.expression, this.dataBaseInfo.view.loadingInfo);
+                        PSPropertyExpression ex = this.expressionFactory.CreateFromExpressionToken(fpt.expression, this.dataBaseInfo.view.loadingInfo);
 
-                        // use the un-resolved MshExpression string as a label
+                        // use the un-resolved PSPropertyExpression string as a label
                         lvf.label = ex.ToString();
                     }
                     else

--- a/src/System.Management.Automation/FormatAndOutput/common/FormatViewGenerator_Table.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/FormatViewGenerator_Table.cs
@@ -14,7 +14,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         // tableBody to use for this instance of the ViewGenerator;
         private TableControlBody _tableBody;
 
-        internal override void Initialize(TerminatingErrorContext terminatingErrorContext, MshExpressionFactory mshExpressionFactory, TypeInfoDataBase db, ViewDefinition view, FormattingCommandLineParameters formatParameters)
+        internal override void Initialize(TerminatingErrorContext terminatingErrorContext, PSPropertyExpressionFactory mshExpressionFactory, TypeInfoDataBase db, ViewDefinition view, FormattingCommandLineParameters formatParameters)
         {
             base.Initialize(terminatingErrorContext, mshExpressionFactory, db, view, formatParameters);
             if ((null != this.dataBaseInfo) && (null != this.dataBaseInfo.view))
@@ -23,7 +23,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             }
         }
 
-        internal override void Initialize(TerminatingErrorContext errorContext, MshExpressionFactory expressionFactory,
+        internal override void Initialize(TerminatingErrorContext errorContext, PSPropertyExpressionFactory expressionFactory,
                                         PSObject so, TypeInfoDataBase db,
             FormattingCommandLineParameters parameters)
         {
@@ -56,7 +56,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 if (PSObjectHelper.ShouldShowComputerNameProperty(so))
                 {
                     activeAssociationList.Add(new MshResolvedExpressionParameterAssociation(null,
-                        new MshExpression(RemotingConstants.ComputerNameNoteProperty)));
+                        new PSPropertyExpression(RemotingConstants.ComputerNameNoteProperty)));
                 }
                 return;
             }
@@ -293,9 +293,9 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             }
         }
 
-        private static int ComputeDefaultAlignment(PSObject so, MshExpression ex)
+        private static int ComputeDefaultAlignment(PSObject so, PSPropertyExpression ex)
         {
-            List<MshExpressionResult> rList = ex.GetValues(so);
+            List<PSPropertyExpressionResult> rList = ex.GetValues(so);
 
             if ((rList.Count == 0) || (rList[0].Exception != null))
                 return TextAlignment.Left;

--- a/src/System.Management.Automation/FormatAndOutput/common/FormatViewGenerator_Wide.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/FormatViewGenerator_Wide.cs
@@ -9,7 +9,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
 {
     internal sealed class WideViewGenerator : ViewGenerator
     {
-        internal override void Initialize(TerminatingErrorContext errorContext, MshExpressionFactory expressionFactory,
+        internal override void Initialize(TerminatingErrorContext errorContext, PSPropertyExpressionFactory expressionFactory,
                                 PSObject so, TypeInfoDataBase db, FormattingCommandLineParameters parameters)
         {
             base.Initialize(errorContext, expressionFactory, so, db, parameters);
@@ -171,7 +171,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
 
             // we did not get any properties:
             //try to get the display property of the object
-            MshExpression displayNameExpression = PSObjectHelper.GetDisplayNameExpression(so, this.expressionFactory);
+            PSPropertyExpression displayNameExpression = PSObjectHelper.GetDisplayNameExpression(so, this.expressionFactory);
             if (displayNameExpression != null)
             {
                 this.activeAssociationList = new List<MshResolvedExpressionParameterAssociation>();

--- a/src/System.Management.Automation/FormatAndOutput/common/FormatViewManager.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/FormatViewManager.cs
@@ -7,6 +7,7 @@ using System.Collections.ObjectModel;
 using System.Management.Automation;
 using System.Management.Automation.Internal;
 using System.Text;
+using Microsoft.PowerShell.Commands;
 
 namespace Microsoft.PowerShell.Commands.Internal.Format
 {
@@ -86,7 +87,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         }
 
         internal void Initialize(TerminatingErrorContext errorContext,
-                                    MshExpressionFactory expressionFactory,
+                                    PSPropertyExpressionFactory expressionFactory,
                                     TypeInfoDataBase db,
                                     PSObject so,
                                     FormatShape shape,
@@ -360,7 +361,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
 
         private static ViewGenerator SelectViewGeneratorFromViewDefinition(
                                         TerminatingErrorContext errorContext,
-                                        MshExpressionFactory expressionFactory,
+                                        PSPropertyExpressionFactory expressionFactory,
                                         TypeInfoDataBase db,
                                         ViewDefinition view,
                                         FormattingCommandLineParameters parameters)
@@ -390,7 +391,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
 
         private static ViewGenerator SelectViewGeneratorFromProperties(FormatShape shape, PSObject so,
                                     TerminatingErrorContext errorContext,
-                                    MshExpressionFactory expressionFactory,
+                                    PSPropertyExpressionFactory expressionFactory,
                                     TypeInfoDataBase db,
                                     FormattingCommandLineParameters parameters)
         {
@@ -405,7 +406,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 {
                     // check if we can have a table:
                     // we want to get the # of properties we are going to display
-                    List<MshExpression> expressionList = PSObjectHelper.GetDefaultPropertySet(so);
+                    List<PSPropertyExpression> expressionList = PSObjectHelper.GetDefaultPropertySet(so);
                     if (expressionList.Count == 0)
                     {
                         // we failed to get anything from a property set
@@ -513,7 +514,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             return false;
         }
 
-        internal static FormatEntryData GenerateOutOfBandData(TerminatingErrorContext errorContext, MshExpressionFactory expressionFactory,
+        internal static FormatEntryData GenerateOutOfBandData(TerminatingErrorContext errorContext, PSPropertyExpressionFactory expressionFactory,
                     TypeInfoDataBase db, PSObject so, int enumerationLimit, bool useToStringFallback, out List<ErrorRecord> errors)
         {
             errors = null;
@@ -550,7 +551,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 }
 
                 // we must check we have enough properties for a list view
-                if (new MshExpression("*").ResolveNames(so).Count <= 0)
+                if (new PSPropertyExpression("*").ResolveNames(so).Count <= 0)
                 {
                     return null;
                 }
@@ -585,9 +586,9 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
 
     /// <summary>
     /// Helper class to manage the logging of errors resulting from
-    /// evaluations of MshExpression instances
+    /// evaluations of PSPropertyExpression instances
     ///
-    /// Depending on settings, it queues the failing MshExpressionResult
+    /// Depending on settings, it queues the failing PSPropertyExpressionResult
     /// instances and generates a list of out-of-band FormatEntryData
     /// objects to be sent to the output pipeline
     /// </summary>
@@ -599,15 +600,15 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         }
 
         /// <summary>
-        /// log a failed evaluation of an MshExpression
+        /// log a failed evaluation of an PSPropertyExpression
         /// </summary>
-        /// <param name="result">MshExpressionResult containing the failed evaluation data</param>
-        /// <param name="sourceObject">object used to evaluate the MshExpression</param>
-        internal void LogMshExpressionFailedResult(MshExpressionResult result, object sourceObject)
+        /// <param name="result">PSPropertyExpressionResult containing the failed evaluation data</param>
+        /// <param name="sourceObject">object used to evaluate the PSPropertyExpression</param>
+        internal void LogPSPropertyExpressionFailedResult(PSPropertyExpressionResult result, object sourceObject)
         {
             if (!_formatErrorPolicy.ShowErrorsAsMessages)
                 return;
-            MshExpressionError error = new MshExpressionError();
+            PSPropertyExpressionError error = new PSPropertyExpressionError();
             error.result = result;
             error.sourceObject = sourceObject;
             _formattingErrorList.Add(error);
@@ -679,17 +680,17 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         {
             ErrorRecord errorRecord = null;
             string msg = null;
-            MshExpressionError mshExpressionError = error as MshExpressionError;
-            if (mshExpressionError != null)
+            PSPropertyExpressionError psPropertyExpressionError = error as PSPropertyExpressionError;
+            if (psPropertyExpressionError != null)
             {
                 errorRecord = new ErrorRecord(
-                                mshExpressionError.result.Exception,
-                                "mshExpressionError",
+                                psPropertyExpressionError.result.Exception,
+                                "PSPropertyExpressionError",
                                 ErrorCategory.InvalidArgument,
-                                mshExpressionError.sourceObject);
+                                psPropertyExpressionError.sourceObject);
 
-                msg = StringUtil.Format(FormatAndOut_format_xxx.MshExpressionError,
-                    mshExpressionError.result.ResolvedExpression.ToString());
+                msg = StringUtil.Format(FormatAndOut_format_xxx.PSPropertyExpressionError,
+                    psPropertyExpressionError.result.ResolvedExpression.ToString());
                 errorRecord.ErrorDetails = new ErrorDetails(msg);
             }
 
@@ -712,7 +713,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         private FormatErrorPolicy _formatErrorPolicy;
 
         /// <summary>
-        /// current list of failed MsExpression evaluations
+        /// current list of failed PSPropertyExpression evaluations
         /// </summary>
         private List<FormattingError> _formattingErrorList = new List<FormattingError>();
     }

--- a/src/System.Management.Automation/FormatAndOutput/common/Utilities/MshObjectUtil.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/Utilities/MshObjectUtil.cs
@@ -115,12 +115,12 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         /// if not found, it uses some heuristics to get a "close" match
         /// </summary>
         /// <param name="target">shell object to process</param>
-        /// <param name="expressionFactory">expression factory to create MshExpression</param>
-        /// <returns>resolved MshExpression; null if no match was found</returns>
-        internal static MshExpression GetDisplayNameExpression(PSObject target, MshExpressionFactory expressionFactory)
+        /// <param name="expressionFactory">expression factory to create PSPropertyExpression</param>
+        /// <returns>resolved PSPropertyExpression; null if no match was found</returns>
+        internal static PSPropertyExpression GetDisplayNameExpression(PSObject target, PSPropertyExpressionFactory expressionFactory)
         {
             // first try to get the expression from the object (types.ps1xml data)
-            MshExpression expressionFromObject = GetDefaultNameExpression(target);
+            PSPropertyExpression expressionFromObject = GetDefaultNameExpression(target);
             if (expressionFromObject != null)
             {
                 return expressionFromObject;
@@ -135,8 +135,8 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             // go over the patterns, looking for the first match
             foreach (string pattern in knownPatterns)
             {
-                MshExpression ex = new MshExpression(pattern);
-                List<MshExpression> exprList = ex.ResolveNames(target);
+                PSPropertyExpression ex = new PSPropertyExpression(pattern);
+                List<PSPropertyExpression> exprList = ex.ResolveNames(target);
 
                 while ((exprList.Count > 0) && (
                     exprList[0].ToString().Equals(RemotingConstants.ComputerNameNoteProperty, StringComparison.OrdinalIgnoreCase) ||
@@ -162,17 +162,17 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         /// it gets the display name value
         /// </summary>
         /// <param name="target">shell object to process</param>
-        /// <param name="expressionFactory">expression factory to create MshExpression</param>
-        /// <returns>MshExpressionResult if successful; null otherwise</returns>
-        internal static MshExpressionResult GetDisplayName(PSObject target, MshExpressionFactory expressionFactory)
+        /// <param name="expressionFactory">expression factory to create PSPropertyExpression</param>
+        /// <returns>PSPropertyExpressionResult if successful; null otherwise</returns>
+        internal static PSPropertyExpressionResult GetDisplayName(PSObject target, PSPropertyExpressionFactory expressionFactory)
         {
             // get the expression to evaluate
-            MshExpression ex = GetDisplayNameExpression(target, expressionFactory);
+            PSPropertyExpression ex = GetDisplayNameExpression(target, expressionFactory);
             if (ex == null)
                 return null;
 
             // evaluate the expression
-            List<MshExpressionResult> resList = ex.GetValues(target);
+            List<PSPropertyExpressionResult> resList = ex.GetValues(target);
 
             if (resList.Count == 0 || resList[0].Exception != null)
             {
@@ -203,9 +203,9 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             return LanguagePrimitives.GetEnumerable(obj);
         }
 
-        private static string GetSmartToStringDisplayName(object x, MshExpressionFactory expressionFactory)
+        private static string GetSmartToStringDisplayName(object x, PSPropertyExpressionFactory expressionFactory)
         {
-            MshExpressionResult r = PSObjectHelper.GetDisplayName(PSObjectHelper.AsPSObject(x), expressionFactory);
+            PSPropertyExpressionResult r = PSObjectHelper.GetDisplayName(PSObjectHelper.AsPSObject(x), expressionFactory);
             if ((r != null) && (r.Exception == null))
             {
                 return PSObjectHelper.AsPSObject(r.Result).ToString();
@@ -216,7 +216,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             }
         }
 
-        private static string GetObjectName(object x, MshExpressionFactory expressionFactory)
+        private static string GetObjectName(object x, PSPropertyExpressionFactory expressionFactory)
         {
             string objName;
 
@@ -245,7 +245,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 }
                 else
                 {
-                    MshExpressionResult r = PSObjectHelper.GetDisplayName(PSObjectHelper.AsPSObject(x), expressionFactory);
+                    PSPropertyExpressionResult r = PSObjectHelper.GetDisplayName(PSObjectHelper.AsPSObject(x), expressionFactory);
                     if ((r != null) && (r.Exception == null))
                     {
                         objName = PSObjectHelper.AsPSObject(r.Result).ToString(); ;
@@ -273,11 +273,11 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         /// It takes into account enumerations (use display name)
         /// </summary>
         /// <param name="so">shell object to process</param>
-        /// <param name="expressionFactory">expression factory to create MshExpression</param>
+        /// <param name="expressionFactory">expression factory to create PSPropertyExpression</param>
         /// <param name="enumerationLimit">limit on IEnumerable enumeration</param>
         /// <param name="formatErrorObject">stores errors during string conversion</param>
         /// <returns>string representation</returns>
-        internal static string SmartToString(PSObject so, MshExpressionFactory expressionFactory, int enumerationLimit, StringFormatError formatErrorObject)
+        internal static string SmartToString(PSObject so, PSPropertyExpressionFactory expressionFactory, int enumerationLimit, StringFormatError formatErrorObject)
         {
             if (so == null)
                 return string.Empty;
@@ -385,10 +385,10 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         /// <param name="val">object to format</param>
         /// <param name="enumerationLimit">limit on IEnumerable enumeration</param>
         /// <param name="formatErrorObject">formatting error object, if present</param>
-        /// <param name="expressionFactory">expression factory to create MshExpression</param>
+        /// <param name="expressionFactory">expression factory to create PSPropertyExpression</param>
         /// <returns>string representation</returns>
         internal static string FormatField(FieldFormattingDirective directive, object val, int enumerationLimit,
-            StringFormatError formatErrorObject, MshExpressionFactory expressionFactory)
+            StringFormatError formatErrorObject, PSPropertyExpressionFactory expressionFactory)
         {
             PSObject so = PSObjectHelper.AsPSObject(val);
             if (directive != null && !string.IsNullOrEmpty(directive.formatString))
@@ -451,26 +451,26 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             return members[TypeTable.PSStandardMembers] as PSMemberSet;
         }
 
-        private static List<MshExpression> GetDefaultPropertySet(PSMemberSet standardMembersSet)
+        private static List<PSPropertyExpression> GetDefaultPropertySet(PSMemberSet standardMembersSet)
         {
             if (null != standardMembersSet)
             {
                 PSPropertySet defaultDisplayPropertySet = standardMembersSet.Members[TypeTable.DefaultDisplayPropertySet] as PSPropertySet;
                 if (null != defaultDisplayPropertySet)
                 {
-                    List<MshExpression> retVal = new List<MshExpression>();
+                    List<PSPropertyExpression> retVal = new List<PSPropertyExpression>();
                     foreach (string prop in defaultDisplayPropertySet.ReferencedPropertyNames)
                     {
                         if (!string.IsNullOrEmpty(prop))
                         {
-                            retVal.Add(new MshExpression(prop));
+                            retVal.Add(new PSPropertyExpression(prop));
                         }
                     }
                     return retVal;
                 }
             }
 
-            return new List<MshExpression>();
+            return new List<PSPropertyExpression>();
         }
 
         /// <summary>
@@ -478,9 +478,9 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         /// </summary>
         /// <param name="so">shell object to process</param>
         /// <returns>resolved expression; empty list if not found</returns>
-        internal static List<MshExpression> GetDefaultPropertySet(PSObject so)
+        internal static List<PSPropertyExpression> GetDefaultPropertySet(PSObject so)
         {
-            List<MshExpression> retVal = GetDefaultPropertySet(so.PSStandardMembers);
+            List<PSPropertyExpression> retVal = GetDefaultPropertySet(so.PSStandardMembers);
             if (retVal.Count == 0)
             {
                 retVal = GetDefaultPropertySet(MaskDeserializedAndGetStandardMembers(so));
@@ -489,7 +489,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             return retVal;
         }
 
-        private static MshExpression GetDefaultNameExpression(PSMemberSet standardMembersSet)
+        private static PSPropertyExpression GetDefaultNameExpression(PSMemberSet standardMembersSet)
         {
             if (null != standardMembersSet)
             {
@@ -504,7 +504,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                     }
                     else
                     {
-                        return new MshExpression(expressionString);
+                        return new PSPropertyExpression(expressionString);
                     }
                 }
             }
@@ -512,36 +512,36 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             return null;
         }
 
-        private static MshExpression GetDefaultNameExpression(PSObject so)
+        private static PSPropertyExpression GetDefaultNameExpression(PSObject so)
         {
-            MshExpression retVal = GetDefaultNameExpression(so.PSStandardMembers) ??
+            PSPropertyExpression retVal = GetDefaultNameExpression(so.PSStandardMembers) ??
                                    GetDefaultNameExpression(MaskDeserializedAndGetStandardMembers(so));
 
             return retVal;
         }
 
         /// <summary>
-        /// helper to retrieve the value of an MshExpression and to format it
+        /// helper to retrieve the value of an PSPropertyExpression and to format it
         /// </summary>
         /// <param name="so">shell object to process</param>
         /// <param name="enumerationLimit">limit on IEnumerable enumeration</param>
         /// <param name="ex">expression to use for retrieval</param>
         /// <param name="directive">format directive to use for formatting</param>
         /// <param name="formatErrorObject"></param>
-        /// <param name="expressionFactory">expression factory to create MshExpression</param>
+        /// <param name="expressionFactory">expression factory to create PSPropertyExpression</param>
         /// <param name="result"> not null if an error condition arose</param>
         /// <returns>formatted string</returns>
         internal static string GetExpressionDisplayValue(
             PSObject so,
             int enumerationLimit,
-            MshExpression ex,
+            PSPropertyExpression ex,
             FieldFormattingDirective directive,
             StringFormatError formatErrorObject,
-            MshExpressionFactory expressionFactory,
-            out MshExpressionResult result)
+            PSPropertyExpressionFactory expressionFactory,
+            out PSPropertyExpressionResult result)
         {
             result = null;
-            List<MshExpressionResult> resList = ex.GetValues(so);
+            List<PSPropertyExpressionResult> resList = ex.GetValues(so);
 
             if (resList.Count == 0)
             {
@@ -599,9 +599,9 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         internal object sourceObject;
     }
 
-    internal sealed class MshExpressionError : FormattingError
+    internal sealed class PSPropertyExpressionError : FormattingError
     {
-        internal MshExpressionResult result;
+        internal PSPropertyExpressionResult result;
     }
 
     internal sealed class StringFormatError : FormattingError
@@ -613,9 +613,9 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
     internal delegate ScriptBlock CreateScriptBlockFromString(string scriptBlockString);
 
     /// <summary>
-    /// helper class to create MshExpression's from format.ps1xml data structures
+    /// helper class to create PSPropertyExpression's from format.ps1xml data structures
     /// </summary>
-    internal sealed class MshExpressionFactory
+    internal sealed class PSPropertyExpressionFactory
     {
         /// <exception cref="ParseException"></exception>
         internal void VerifyScriptBlockText(string scriptText)
@@ -629,7 +629,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         /// <param name="et">expression token to use</param>
         /// <returns>constructed expression</returns>
         /// <exception cref="ParseException"></exception>
-        internal MshExpression CreateFromExpressionToken(ExpressionToken et)
+        internal PSPropertyExpression CreateFromExpressionToken(ExpressionToken et)
         {
             return CreateFromExpressionToken(et, null);
         }
@@ -641,14 +641,14 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         /// <param name="loadingInfo">The context from which the file was loaded</param>
         /// <returns>constructed expression</returns>
         /// <exception cref="ParseException"></exception>
-        internal MshExpression CreateFromExpressionToken(ExpressionToken et, DatabaseLoadingInfo loadingInfo)
+        internal PSPropertyExpression CreateFromExpressionToken(ExpressionToken et, DatabaseLoadingInfo loadingInfo)
         {
             if (et.isScriptBlock)
             {
                 // we cache script blocks from expression tokens
                 if (_expressionCache != null)
                 {
-                    MshExpression value;
+                    PSPropertyExpression value;
                     if (_expressionCache.TryGetValue(et, out value))
                     {
                         // got a hit on the cache, just return
@@ -657,7 +657,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 }
                 else
                 {
-                    _expressionCache = new Dictionary<ExpressionToken, MshExpression>();
+                    _expressionCache = new Dictionary<ExpressionToken, PSPropertyExpression>();
                 }
 
                 bool isFullyTrusted = false;
@@ -677,7 +677,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                     sb.LanguageMode = PSLanguageMode.FullLanguage;
                 }
 
-                MshExpression ex = new MshExpression(sb);
+                PSPropertyExpression ex = new PSPropertyExpression(sb);
 
                 _expressionCache.Add(et, ex);
 
@@ -685,10 +685,10 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             }
 
             // we do not cache if it is just a property name
-            return new MshExpression(et.expressionValue);
+            return new PSPropertyExpression(et.expressionValue);
         }
 
-        private Dictionary<ExpressionToken, MshExpression> _expressionCache;
+        private Dictionary<ExpressionToken, PSPropertyExpression> _expressionCache;
     }
 }
 

--- a/src/System.Management.Automation/FormatAndOutput/common/Utilities/MshParameterAssociation.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/Utilities/MshParameterAssociation.cs
@@ -20,7 +20,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                                                 "MshResolvedExpressionParameterAssociation");
         #endregion tracer
 
-        internal MshResolvedExpressionParameterAssociation(MshParameter parameter, MshExpression expression)
+        internal MshResolvedExpressionParameterAssociation(MshParameter parameter, PSPropertyExpression expression)
         {
             if (expression == null)
                 throw PSTraceSource.NewArgumentNullException("expression");
@@ -29,7 +29,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             ResolvedExpression = expression;
         }
 
-        internal MshExpression ResolvedExpression { get; }
+        internal PSPropertyExpression ResolvedExpression { get; }
 
         internal MshParameter OriginatingParameter { get; }
     }
@@ -37,7 +37,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
     internal static class AssociationManager
     {
         internal static List<MshResolvedExpressionParameterAssociation> SetupActiveProperties(List<MshParameter> rawMshParameterList,
-                                                   PSObject target, MshExpressionFactory expressionFactory)
+                                                   PSObject target, PSPropertyExpressionFactory expressionFactory)
         {
             // check if we received properties from the command line
             if (rawMshParameterList != null && rawMshParameterList.Count > 0)
@@ -56,7 +56,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 if (PSObjectHelper.ShouldShowComputerNameProperty(target))
                 {
                     activeAssociationList.Add(new MshResolvedExpressionParameterAssociation(null,
-                        new MshExpression(RemotingConstants.ComputerNameNoteProperty)));
+                        new PSPropertyExpression(RemotingConstants.ComputerNameNoteProperty)));
                 }
 
                 return activeAssociationList;
@@ -77,8 +77,8 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
 
             foreach (MshParameter par in parameters)
             {
-                MshExpression expression = par.GetEntry(FormatParameterDefinitionKeys.ExpressionEntryKey) as MshExpression;
-                List<MshExpression> expandedExpressionList = expression.ResolveNames(target);
+                PSPropertyExpression expression = par.GetEntry(FormatParameterDefinitionKeys.ExpressionEntryKey) as PSPropertyExpression;
+                List<PSPropertyExpression> expandedExpressionList = expression.ResolveNames(target);
 
                 if (!expression.HasWildCardCharacters && expandedExpressionList.Count == 0)
                 {
@@ -86,7 +86,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                     retVal.Add(new MshResolvedExpressionParameterAssociation(par, expression));
                 }
 
-                foreach (MshExpression ex in expandedExpressionList)
+                foreach (PSPropertyExpression ex in expandedExpressionList)
                 {
                     retVal.Add(new MshResolvedExpressionParameterAssociation(par, ex));
                 }
@@ -101,10 +101,10 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
 
             foreach (MshParameter par in parameters)
             {
-                MshExpression expression = par.GetEntry(FormatParameterDefinitionKeys.ExpressionEntryKey) as MshExpression;
-                List<MshExpression> expandedExpressionList = expression.ResolveNames(target);
+                PSPropertyExpression expression = par.GetEntry(FormatParameterDefinitionKeys.ExpressionEntryKey) as PSPropertyExpression;
+                List<PSPropertyExpression> expandedExpressionList = expression.ResolveNames(target);
 
-                foreach (MshExpression ex in expandedExpressionList)
+                foreach (PSPropertyExpression ex in expandedExpressionList)
                 {
                     retVal.Add(new MshResolvedExpressionParameterAssociation(par, ex));
                 }
@@ -113,12 +113,12 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             return retVal;
         }
 
-        internal static List<MshResolvedExpressionParameterAssociation> ExpandDefaultPropertySet(PSObject target, MshExpressionFactory expressionFactory)
+        internal static List<MshResolvedExpressionParameterAssociation> ExpandDefaultPropertySet(PSObject target, PSPropertyExpressionFactory expressionFactory)
         {
             List<MshResolvedExpressionParameterAssociation> retVal = new List<MshResolvedExpressionParameterAssociation>();
-            List<MshExpression> expandedExpressionList = PSObjectHelper.GetDefaultPropertySet(target);
+            List<PSPropertyExpression> expandedExpressionList = PSObjectHelper.GetDefaultPropertySet(target);
 
-            foreach (MshExpression ex in expandedExpressionList)
+            foreach (PSPropertyExpression ex in expandedExpressionList)
             {
                 retVal.Add(new MshResolvedExpressionParameterAssociation(null, ex));
             }
@@ -161,7 +161,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 if (!duplicatesFinder.ContainsKey(property))
                 {
                     duplicatesFinder.Add(property, null);
-                    MshExpression expr = new MshExpression(property, true);
+                    PSPropertyExpression expr = new PSPropertyExpression(property, true);
                     retVal.Add(new MshResolvedExpressionParameterAssociation(null, expr));
                 }
             }

--- a/src/System.Management.Automation/FormatAndOutput/common/Utilities/Mshexpression.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/Utilities/Mshexpression.cs
@@ -10,47 +10,65 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Runtime.CompilerServices;
 
-namespace Microsoft.PowerShell.Commands.Internal.Format
+namespace Microsoft.PowerShell.Commands
 {
     /// <summary>
-    /// class to hold results
-    /// NOTE: we should make it an PSObject eventually
+    /// class that represents the results from evaluating a PSPropertyExpression against an object.
     /// </summary>
-    internal class MshExpressionResult
+    public class PSPropertyExpressionResult
     {
-        internal MshExpressionResult(object res, MshExpression re, Exception e)
+
+        /// <summary>
+        /// Create a property expression result containing the original object, matching property expression
+        /// and any exception generated during the match process.
+        /// </summary>
+        public PSPropertyExpressionResult(object res, PSPropertyExpression re, Exception e)
         {
             Result = res;
             ResolvedExpression = re;
             Exception = e;
         }
 
-        internal object Result { get; } = null;
+        /// <summary>
+        /// The value of the object property matched by this property expression.
+        /// </summary>
+        public object Result { get; } = null;
 
-        internal MshExpression ResolvedExpression { get; } = null;
+        /// <summary>
+        /// The original property expression fully resolved.
+        /// </summary>
+        public PSPropertyExpression ResolvedExpression { get; } = null;
 
-        internal Exception Exception { get; } = null;
+        /// <summary>
+        /// Any exception thrown while evaluating the expression.
+        /// </summary>
+        public Exception Exception { get; } = null;
     }
 
-    internal class MshExpression
+    /// <summary>
+    /// PSPropertyExpression class. This class is used to get the names and/or values of properties
+    /// on an object. A property expression can be constructed using either a wildcard expression string
+    /// or a scriptblock to use to get the property value.
+    /// </summary>
+    public class PSPropertyExpression
     {
         /// <summary>
         /// constructor
         /// </summary>
         /// <param name="s">expression</param>
         /// <exception cref="ArgumentNullException"></exception>
-        internal MshExpression(string s)
+        public PSPropertyExpression(string s)
             : this(s, false)
         {
         }
 
         /// <summary>
-        /// constructor
+        /// Create a property expression with a wildcard pattern.
         /// </summary>
-        /// <param name="s">expression</param>
+        /// <param name="s">Property name pattern to match.</param>
         /// <param name="isResolved"><c>true</c> if no further attempts should be made to resolve wildcards</param>
         /// <exception cref="ArgumentNullException"></exception>
-        internal MshExpression(string s, bool isResolved)
+        public PSPropertyExpression(string s, bool isResolved)
         {
             if (string.IsNullOrEmpty(s))
             {
@@ -61,11 +79,11 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         }
 
         /// <summary>
-        /// constructor
+        /// Create a property expression with a ScriptBlock
         /// </summary>
-        /// <param name="scriptBlock"></param>
+        /// <param name="scriptBlock">ScriptBlock to evaluate when retrieving the property value from an object.</param>
         /// <exception cref="ArgumentNullException"></exception>
-        internal MshExpression(ScriptBlock scriptBlock)
+        public PSPropertyExpression(ScriptBlock scriptBlock)
         {
             if (scriptBlock == null)
             {
@@ -74,8 +92,14 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             Script = scriptBlock;
         }
 
+        /// <summary>
+        /// The ScriptBlock for this expression to use when matching.
+        /// </summary>
         public ScriptBlock Script { get; } = null;
 
+        /// <summary>
+        /// ToString() implementation for the property expression.
+        /// </summary>
         public override string ToString()
         {
             if (Script != null)
@@ -84,12 +108,20 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             return _stringValue;
         }
 
-        internal List<MshExpression> ResolveNames(PSObject target)
+        /// <summary>
+        /// Resolve the names matched by this the expression.
+        /// </summary>
+        /// <param name="target">The object to apply the expression against.</param>
+        public List<PSPropertyExpression> ResolveNames(PSObject target)
         {
             return ResolveNames(target, true);
         }
 
-        internal bool HasWildCardCharacters
+        /// <summary>
+        /// Indicates if the pattern has wildcard characters in it. If the supplied pattern was
+        /// a scriptblock, this will be false.
+        /// </summary>
+        public bool HasWildCardCharacters
         {
             get
             {
@@ -99,9 +131,14 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             }
         }
 
-        internal List<MshExpression> ResolveNames(PSObject target, bool expand)
+        /// <summary>
+        /// Resolve the names matched by this the expression.
+        /// </summary>
+        /// <param name="target">The object to apply the expression against.</param>
+        /// <param name="expand">If the matched properties are property sets, expand them.</param>
+        public List<PSPropertyExpression> ResolveNames(PSObject target, bool expand)
         {
-            List<MshExpression> retVal = new List<MshExpression>();
+            List<PSPropertyExpression> retVal = new List<PSPropertyExpression>();
 
             if (_isResolved)
             {
@@ -112,12 +149,16 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             if (Script != null)
             {
                 // script block, just add it to the list and be done
-                MshExpression ex = new MshExpression(Script);
+                PSPropertyExpression ex = new PSPropertyExpression(Script);
 
                 ex._isResolved = true;
                 retVal.Add(ex);
                 return retVal;
             }
+
+            // If the object passed in is a hashtable, then turn it into a PSCustomObject so
+            // that property expressions can work on it.
+            target = IfHashtableWrapAsPSCustomObject(target);
 
             // we have a string value
             IEnumerable<PSMemberInfo> members = null;
@@ -195,7 +236,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             {
                 if (!hash.ContainsKey(m.Name))
                 {
-                    MshExpression ex = new MshExpression(m.Name);
+                    PSPropertyExpression ex = new PSPropertyExpression(m.Name);
 
                     ex._isResolved = true;
                     retVal.Add(ex);
@@ -206,30 +247,44 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             return retVal;
         }
 
-        internal List<MshExpressionResult> GetValues(PSObject target)
+        /// <summary>
+        /// Gets the values of the object properties matched by this expression.
+        /// </summary>
+        /// <param name="target">The object to match against.</param>
+        public List<PSPropertyExpressionResult> GetValues(PSObject target)
         {
             return GetValues(target, true, true);
         }
 
-        internal List<MshExpressionResult> GetValues(PSObject target, bool expand, bool eatExceptions)
+        /// <summary>
+        /// Gets the values of the object properties matched by this expression.
+        /// </summary>
+        /// <param name="target">The object to match against.</param>
+        /// <param name="expand">If the matched properties are parameter sets, expand them.</param>
+        /// <param name="eatExceptions">If true, any exceptions that occur during the match process are ignored.</param>
+        public List<PSPropertyExpressionResult> GetValues(PSObject target, bool expand, bool eatExceptions)
         {
-            List<MshExpressionResult> retVal = new List<MshExpressionResult>();
+            List<PSPropertyExpressionResult> retVal = new List<PSPropertyExpressionResult>();
+
+            // If the object passed in is a hashtable, then turn it into a PSCustomObject so
+            // that property expressions can work on it.
+            target = IfHashtableWrapAsPSCustomObject(target);
 
             // process the script case
             if (Script != null)
             {
-                MshExpression scriptExpression = new MshExpression(Script);
-                MshExpressionResult r = scriptExpression.GetValue(target, eatExceptions);
+                PSPropertyExpression scriptExpression = new PSPropertyExpression(Script);
+                PSPropertyExpressionResult r = scriptExpression.GetValue(target, eatExceptions);
                 retVal.Add(r);
                 return retVal;
             }
 
             // process the expression
-            List<MshExpression> resolvedExpressionList = this.ResolveNames(target, expand);
+            List<PSPropertyExpression> resolvedExpressionList = this.ResolveNames(target, expand);
 
-            foreach (MshExpression re in resolvedExpressionList)
+            foreach (PSPropertyExpression re in resolvedExpressionList)
             {
-                MshExpressionResult r = re.GetValue(target, eatExceptions);
+                PSPropertyExpressionResult r = re.GetValue(target, eatExceptions);
                 retVal.Add(r);
             }
 
@@ -240,7 +295,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
 
         private CallSite<Func<CallSite, object, object>> _getValueDynamicSite;
 
-        private MshExpressionResult GetValue(PSObject target, bool eatExceptions)
+        private PSPropertyExpressionResult GetValue(PSObject target, bool eatExceptions)
         {
             try
             {
@@ -270,19 +325,31 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                     result = _getValueDynamicSite.Target.Invoke(_getValueDynamicSite, target);
                 }
 
-                return new MshExpressionResult(result, this, null);
+                return new PSPropertyExpressionResult(result, this, null);
             }
             catch (RuntimeException e)
             {
                 if (eatExceptions)
                 {
-                    return new MshExpressionResult(null, this, e);
+                    return new PSPropertyExpressionResult(null, this, e);
                 }
                 else
                 {
                     throw;
                 }
             }
+        }
+        
+        private PSObject IfHashtableWrapAsPSCustomObject(PSObject target)
+        {
+            // If the object passed in is a hashtable, then turn it into a PSCustomObject so
+            // that property expressions can work on it.
+            Hashtable targetAsHash = PSObject.Base(target) as Hashtable;
+            if (targetAsHash != null)
+            {
+                target = (PSObject)(LanguagePrimitives.ConvertPSObjectToType(targetAsHash, typeof(PSObject), false, null, true));
+            }
+            return target;
         }
 
         // private members

--- a/src/System.Management.Automation/FormatAndOutput/common/Utilities/Mshexpression.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/Utilities/Mshexpression.cs
@@ -344,8 +344,7 @@ namespace Microsoft.PowerShell.Commands
         {
             // If the object passed in is a hashtable, then turn it into a PSCustomObject so
             // that property expressions can work on it.
-            Hashtable targetAsHash = PSObject.Base(target) as Hashtable;
-            if (targetAsHash != null)
+            if (PSObject.Base(target) is Hashtable targetAsHash)
             {
                 target = (PSObject)(LanguagePrimitives.ConvertPSObjectToType(targetAsHash, typeof(PSObject), false, null, true));
             }

--- a/src/System.Management.Automation/engine/parser/TypeResolver.cs
+++ b/src/System.Management.Automation/engine/parser/TypeResolver.cs
@@ -756,7 +756,6 @@ namespace System.Management.Automation
                     { typeof(PSListModifier),                              new[] { "pslistmodifier" } },
                     { typeof(PSObject),                                    new[] { "psobject", "pscustomobject" } },
                     { typeof(PSPrimitiveDictionary),                       new[] { "psprimitivedictionary" } },
-                    { typeof(PSPropertyExpression),                        new[] { "pspropertyexpression"} },
                     { typeof(PSReference),                                 new[] { "ref" } },
                     { typeof(PSTypeNameAttribute),                         new[] { "PSTypeNameAttribute" } },
                     { typeof(Regex),                                       new[] { "regex" } },

--- a/src/System.Management.Automation/engine/parser/TypeResolver.cs
+++ b/src/System.Management.Automation/engine/parser/TypeResolver.cs
@@ -756,6 +756,7 @@ namespace System.Management.Automation
                     { typeof(PSListModifier),                              new[] { "pslistmodifier" } },
                     { typeof(PSObject),                                    new[] { "psobject", "pscustomobject" } },
                     { typeof(PSPrimitiveDictionary),                       new[] { "psprimitivedictionary" } },
+                    { typeof(PSPropertyExpression),                        new[] { "pspropertyexpression"} },
                     { typeof(PSReference),                                 new[] { "ref" } },
                     { typeof(PSTypeNameAttribute),                         new[] { "PSTypeNameAttribute" } },
                     { typeof(Regex),                                       new[] { "regex" } },

--- a/src/System.Management.Automation/engine/parser/TypeResolver.cs
+++ b/src/System.Management.Automation/engine/parser/TypeResolver.cs
@@ -858,6 +858,7 @@ namespace System.Management.Automation
             // Add additional utility types that are useful as type accelerators, but aren't
             // fundamentally "core language", or may be unsafe to expose to untrusted input.
             builtinTypeAccelerators.Add("scriptblock", typeof(ScriptBlock));
+            builtinTypeAccelerators.Add("pspropertyexpression", typeof(PSPropertyExpression));
             builtinTypeAccelerators.Add("psvariable", typeof(PSVariable));
             builtinTypeAccelerators.Add("type", typeof(Type));
             builtinTypeAccelerators.Add("psmoduleinfo", typeof(PSModuleInfo));

--- a/src/System.Management.Automation/resources/FormatAndOut_format_xxx.resx
+++ b/src/System.Management.Automation/resources/FormatAndOut_format_xxx.resx
@@ -173,7 +173,7 @@
   <data name="FOD_RecursiveProperty" xml:space="preserve">
     <value>The {0} property is recursive.</value>
   </data>
-  <data name="MshExpressionError" xml:space="preserve">
+  <data name="PSPropertyExpressionError" xml:space="preserve">
     <value>Failed to evaluate expression "{0}".</value>
   </data>
   <data name="FormattingError" xml:space="preserve">

--- a/test/powershell/Language/Parser/TypeAccelerator.Tests.ps1
+++ b/test/powershell/Language/Parser/TypeAccelerator.Tests.ps1
@@ -117,7 +117,7 @@ Describe "Type accelerators" -Tags "CI" {
                 @{
                     Accelerator = 'cimtype'
                     Type        = [Microsoft.Management.Infrastructure.CimType]
-                }           
+                }
                 @{
                     Accelerator = 'cimconverter'
                     Type        = [Microsoft.Management.Infrastructure.CimConverter]
@@ -197,7 +197,7 @@ Describe "Type accelerators" -Tags "CI" {
                 @{
                     Accelerator = 'SupportsWildcards'
                     Type        = [System.Management.Automation.SupportsWildcardsAttribute]
-                }           
+                }
                 @{
                     Accelerator = 'switch'
                     Type        = [System.Management.Automation.SwitchParameter]
@@ -353,7 +353,7 @@ Describe "Type accelerators" -Tags "CI" {
                 @{
                     Accelerator = 'psscriptmethod'
                     Type        = [System.Management.Automation.PSScriptMethod]
-                }  
+                }
                 @{
                     Accelerator = 'psscriptproperty'
                     Type        = [System.Management.Automation.PSScriptProperty]
@@ -370,15 +370,19 @@ Describe "Type accelerators" -Tags "CI" {
                     Accelerator = 'psvariableproperty'
                     Type        = [System.Management.Automation.PSVariableProperty]
                 }
+                @{
+                    Accelerator = 'pspropertyexpression'
+                    Type = [Microsoft.PowerShell.Commands.PSPropertyExpression]
+                }
             )
-        
+
             if ( $IsCoreCLR )
             {
-                $totalAccelerators = 90 
+                $totalAccelerators = 91
             }
             else
             {
-                $totalAccelerators = 94
+                $totalAccelerators = 95
 
                 $extraFullPSAcceleratorTestCases = @(
                     @{
@@ -413,13 +417,13 @@ Describe "Type accelerators" -Tags "CI" {
             param($Accelerator, $Type)
             $TypeAcceleratorsType::Get[$Accelerator] | Should -Be ($Type)
         }
-    
+
         It 'Should have a type accelerator for non-dotnet-core type: <Accelerator>' -Skip:$IsCoreCLR -TestCases $extraFullPSAcceleratorTestCases {
             param($Accelerator, $Type)
             $TypeAcceleratorsType::Get[$Accelerator] | Should -Be ($Type)
         }
     }
-    
+
     Context 'User Defined Accelerators' {
         BeforeAll {
             $TypeAcceleratorsType::Add('userDefinedAcceleratorType', [int])

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Measure-Object.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Measure-Object.Tests.ps1
@@ -488,4 +488,151 @@ Describe "Directly test the PSPropertyExpression type" -Tags "CI" {
         $result = "one", "two", "three", "four", "five" | Test-PSPropertyExpression {($_.ToCharArray() -match 'e').Count}
         $result | Should -Be 4
     }
+
+    It "Measure-Object with multiple lines should work"{
+        $result = "123`n4" | Measure-Object -Line
+        $result.Lines | Should -Be 2
+    }
+
+    It "Measure-Object with ScriptBlock properties should work" {
+        $result = 1..10 | Measure-Object -Sum -Average -Minimum -Maximum -Property {$_ * 10}
+        $result.Count    | Should -Be 10
+        $result.Average  | Should -Be 55
+        $result.Sum      | Should -Be 550
+        $result.Minimum  | Should -Be 10
+        $result.Maximum  | Should -Be 100
+        $result.Property | Should -Be '$_ * 10'
+    }
+
+    It "Measure-Object with ScriptBlock properties should work with -word" {
+        $result = "a,b,c", "d,e" | Measure-Object -Word  {$_ -split ','}
+        $result.Words | Should -Be 5
+    }
+
+    It "Measure-Object ScriptBlock properties should be able to transform input" {
+        $map = @{ one = 1; two = 2; three = 3 }
+        $result = "one", "two", "three" | Measure-Object -Sum {$map[$_]}
+        $result.Sum | Should -Be 6
+    }
+
+    It "Measure-Object should handle hashtables as objects" {
+        $htables = @{foo = 1}, @{foo = 3}, @{foo = 10}
+        $result = $htables | Measure-Object -Sum fo*
+        $result.Sum | Should -Be 14
+    }
+
+    It "Measure-Object should handle hashtables as objects with ScriptBlock properties" {
+        $htables = @{foo = 1}, @{foo = 3}, @{foo = 10}
+        $result = $htables | Measure-Object -Sum {$_.foo * 10 }
+        $result.Sum | Should -Be 140
+    }
+}
+
+# Since PSPropertyExpression is now a public type, it can be tested
+# directly, independent of the Measure-Object cmdlet
+Describe "Directly test the PSPropertyExpression type" -Tags "CI" {
+    # this function is used to test the use of PSPropertyExpression
+    # as a parameter in script,
+    function Test-PSPropertyExpression {
+        [CmdletBinding()]
+        param (
+            [Parameter(Mandatory,Position=0)]
+            [PSPropertyExpression]
+                $pe,
+            [Parameter(ValueFromPipeline)]
+                $InputObject
+        )
+        begin { $sum = 0}
+        process { $sum += $pe.GetValues($InputObject).result }
+        end { $sum }
+    }
+
+    It "Test-PropertyExpression function with a wildcard property expression should sum numbers" {
+        $result = (1..10).foreach{@{value = $_}} | Test-PSPropertyExpression val*
+        $result | Should -Be 55
+    }
+
+    It "Test-PropertyExpression function with a scriptblock property expression should sum numbers" {
+        $result = 1..10 | Test-PSPropertyExpression {$_}
+        $result | Should -Be 55
+    }
+
+    It "Test-PropertyExpression function with a scriptblock property expression should be able to transform input" {
+        # Count the number of 'e's in the words.
+        $result = "one", "two", "three", "four", "five" | Test-PSPropertyExpression {($_.ToCharArray() -match 'e').Count}
+        $result | Should -Be 4
+    }
+    It "Measure-Object with multiple lines should work"{
+        $result = "123`n4" | Measure-Object -Line
+        $result.Lines | Should -Be 2
+    }
+
+    It "Measure-Object with ScriptBlock properties should work" {
+        $result = 1..10 | Measure-Object -Sum -Average -Minimum -Maximum -Property {$_ * 10}
+        $result.Count    | Should -Be 10
+        $result.Average  | Should -Be 55
+        $result.Sum      | Should -Be 550
+        $result.Minimum  | Should -Be 10
+        $result.Maximum  | Should -Be 100
+        $result.Property | Should -Be '$_ * 10'
+    }
+
+    It "Measure-Object with ScriptBlock properties should work with -word" {
+        $result = "a,b,c", "d,e" | Measure-Object -Word  {$_ -split ','}
+        $result.Words | Should -Be 5
+    }
+
+    It "Measure-Object ScriptBlock properties should be able to transform input" {
+        $map = @{ one = 1; two = 2; three = 3 }
+        $result = "one", "two", "three" | Measure-Object -Sum {$map[$_]}
+        $result.Sum | Should -Be 6
+    }
+
+    It "Measure-Object should handle hashtables as objects" {
+        $htables = @{foo = 1}, @{foo = 3}, @{foo = 10}
+        $result = $htables | Measure-Object -Sum fo*
+        $result.Sum | Should -Be 14
+    }
+
+    It "Measure-Object should handle hashtables as objects with ScriptBlock properties" {
+        $htables = @{foo = 1}, @{foo = 3}, @{foo = 10}
+        $result = $htables | Measure-Object -Sum {$_.foo * 10 }
+        $result.Sum | Should -Be 140
+    }
+}
+
+# Since PSPropertyExpression is now a public type, it can be tested
+# directly, independent of the Measure-Object cmdlet
+Describe "Directly test the PSPropertyExpression type" -Tags "CI" {
+    # this function is used to test the use of PSPropertyExpression
+    # as a parameter in script,
+    function Test-PSPropertyExpression {
+        [CmdletBinding()]
+        param (
+            [Parameter(Mandatory,Position=0)]
+            [PSPropertyExpression]
+                $pe,
+            [Parameter(ValueFromPipeline)]
+                $InputObject
+        )
+        begin { $sum = 0}
+        process { $sum += $pe.GetValues($InputObject).result }
+        end { $sum }
+    }
+
+    It "Test-PropertyExpression function with a wildcard property expression should sum numbers" {
+        $result = (1..10).foreach{@{value = $_}} | Test-PSPropertyExpression val*
+        $result | Should -Be 55
+    }
+
+    It "Test-PropertyExpression function with a scriptblock property expression should sum numbers" {
+        $result = 1..10 | Test-PSPropertyExpression {$_}
+        $result | Should -Be 55
+    }
+
+    It "Test-PropertyExpression function with a scriptblock property expression should be able to transform input" {
+        # Count the number of 'e's in the words.
+        $result = "one", "two", "three", "four", "five" | Test-PSPropertyExpression {($_.ToCharArray() -match 'e').Count}
+        $result | Should -Be 4
+    }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Measure-Object.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Measure-Object.Tests.ps1
@@ -349,6 +349,11 @@ Describe "Measure-Object DRT basic functionality" -Tags "CI" {
         }
     }
 
+    It "Measure-Object with multiple lines should work"{
+        $result = "123`n4" | Measure-Object -Line
+        $result.Lines | Should -Be 2
+    }
+
     It "Measure-Object with ScriptBlock properties should work" {
         $result = 1..10 | Measure-Object -Sum -Average -Minimum -Maximum -Property {$_ * 10}
         $result.Count    | Should -Be 10
@@ -360,8 +365,8 @@ Describe "Measure-Object DRT basic functionality" -Tags "CI" {
     }
 
     It "Measure-Object with ScriptBlock properties should work with -word" {
-        $result = "a,b,c" | Measure-Object -Word  {$_ -split ','}
-        $result.Words | Should -Be 3
+        $result = "a,b,c", "d,e" | Measure-Object -Word  {$_ -split ','}
+        $result.Words | Should -Be 5
     }
 
     It "Measure-Object ScriptBlock properties should be able to transform input" {
@@ -381,11 +386,13 @@ Describe "Measure-Object DRT basic functionality" -Tags "CI" {
         $result = $htables | Measure-Object -Sum {$_.foo * 10 }
         $result.Sum | Should -Be 140
     }
+}
 
-    #
-    # Since PSPropertyExtression is now a public type, this function is used to test its
-    # operation as a parameter on a PowerShell function, independent of Measure-Object
-    #
+# Since PSPropertyExpression is now a public type, it can be tested
+# directly, independent of the Measure-Object cmdlet
+Describe "Directly test the PSPropertyExpression type" -Tags "CI" {
+    # this function is used to test the use of PSPropertyExpression
+    # as a parameter in script,
     function Test-PSPropertyExpression {
         [CmdletBinding()]
         param (
@@ -414,9 +421,5 @@ Describe "Measure-Object DRT basic functionality" -Tags "CI" {
         # Count the number of 'e's in the words.
         $result = "one", "two", "three", "four", "five" | Test-PSPropertyExpression {($_.ToCharArray() -match 'e').Count}
         $result | Should -Be 4
-    }
-    It "Measure-Object with multiple lines should work"{
-        $result = "123`n4" | Measure-Object -Line
-        $result.Lines | Should -Be 2
     }
 }


### PR DESCRIPTION
## PR Summary

Fixed issue #6855 by renaming the class that does all the work from `MshExpression` to `PSPropertyExpression`, making the class public and then in `MeasureObjectCommand`, lifting it up to the parameter level. Previously the implementation exposed the `-Property` as `string` then wrapped it internally as a `PSPropertyExpression`. Now the parameter type is `PSPropertyExpression` directly allowing for both wildcard strings and scriptblocks.  Note that this is technically a breaking change (the public type of the parameter has changed) but this was reviewed by the committee and approved. (The vast majority of changes in this PR are due to the renaming. The code changes are relatively small.)

`PSPropertyExpression` now lives in a public namespace where it can be used by cmdlet and script authors to easily add the same type of functionality to their commands. 

I also modified `PSPropertyExpression` to treat hashtables as objects so that
```
@{prop = 3} | measure-object prop
```
and
```
@{prop = 3} | measure-object {$_.prop}
```
will work the identically. (Previously the example using just the property name would just fail.)

#### Breaking Change Summary

This PR brings in a breaking change in an edge case:
> This could be a breaking change when it comes to the ConstrainedLanguage mode.
@{prop = 3} | measure-object Count works in ConstrainedLanguage mode today, but with this change, the conversion from Hashtable to PSCustomObject will throw exception.

It has been reviewed by the committee and agreed to accept this breaking change.
Please see the discussion at https://github.com/PowerShell/PowerShell/pull/6934#discussion_r193243793 for more information.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
