### PR TITLE
Fix xUnit test GetTempFileName

### DIFF
--- a/test/csharp/test_FileSystemProvider.cs
+++ b/test/csharp/test_FileSystemProvider.cs
@@ -138,7 +138,7 @@ namespace PSTests.Parallel
             PSObject psobject1=PSObject.AsPSObject(fileSystemObject1);
             foreach(PSPropertyInfo property in psobject1.Properties)
             {
-                if(property.Name == "Name")
+                if(property.Name == "FullName")
                 {
                     Assert.Equal(testPath, property.Value);
                 }

--- a/test/csharp/test_FileSystemProvider.cs
+++ b/test/csharp/test_FileSystemProvider.cs
@@ -140,7 +140,7 @@ namespace PSTests.Parallel
             {
                 if(property.Name == "Name")
                 {
-                    Assert.Equal("test", property.Value);
+                    Assert.Equal(testPath, property.Value);
                 }
             }
         }

--- a/test/csharp/test_FileSystemProvider.cs
+++ b/test/csharp/test_FileSystemProvider.cs
@@ -25,7 +25,7 @@ namespace PSTests.Parallel
         private string testContent;
         public FileSystemProviderTests()
         {
-            testPath = Path.Combine(Path.GetTempPath(),"test");
+            testPath = Path.GetTempFileName();
             testContent = "test content!";
             if(File.Exists(testPath)) File.Delete(testPath);
             File.AppendAllText(testPath,testContent);


### PR DESCRIPTION
## PR Summary

Use Path.GetTempFileName() to get a temporary file.
Sample the test failure https://ci.appveyor.com/project/PowerShell/powershell/build/v6.1.0-preview.9470#L5321

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
