### PR TITLE
Remove myself from codeowners for parser

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -54,7 +54,7 @@ src/System.Management.Automation/help              @Francisco-Gamino @adityapatw
 # @daxian-dbw @charub
 
 # Area: Language
-src/System.Management.Automation/engine/parser     @daxian-dbw @vors @BrucePay
+src/System.Management.Automation/engine/parser     @daxian-dbw @BrucePay
 
 # Area: Providers
 src/System.Management.Automation/namespaces        @BrucePay @anmenaga


### PR DESCRIPTION
I was not able to provide reviews on the vast majority of the auto-assigned reviews.
I don't see a point to keep this auto-assignment.
