### PR TITLE
Remove dependencies on libcurl, libunwind, matching the .NET Core behavior

### DIFF
--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -979,7 +979,6 @@ function Get-PackageDependencies
         if ($Environment.IsUbuntu -or $Environment.IsDebian) {
             $Dependencies = @(
                 "libc6",
-                "libcurl3",
                 "libgcc1",
                 "libgssapi-krb5-2",
                 "liblttng-ust0",
@@ -990,12 +989,12 @@ function Get-PackageDependencies
             )
 
             switch ($Distribution) {
-                "ubuntu.14.04" { $Dependencies += @("libssl1.0.0", "libicu52") }
-                "ubuntu.16.04" { $Dependencies += @("libssl1.0.0", "libicu55") }
-                "ubuntu.17.10" { $Dependencies += @("libssl1.0.0", "libicu57") }
-                "ubuntu.18.04" { $Dependencies += @("libssl1.0.0", "libicu60") }
-                "debian.8" { $Dependencies += @("libssl1.0.0", "libicu52") }
-                "debian.9" { $Dependencies += @("libssl1.0.2", "libicu57") }
+                "ubuntu.14.04" { $Dependencies += @("libssl1.0.0", "libicu52", "libcurl3" ) }
+                "ubuntu.16.04" { $Dependencies += @("libssl1.0.0", "libicu55", "libcurl3") }
+                "ubuntu.17.10" { $Dependencies += @("libssl1.0.0", "libicu57", "libcurl3") }
+                "ubuntu.18.04" { $Dependencies += @("libssl1.0.0", "libicu60", "libcurl4") }
+                "debian.8" { $Dependencies += @("libssl1.0.0", "libicu52", "libcurl3") }
+                "debian.9" { $Dependencies += @("libssl1.0.2", "libicu57", "libcurl3") }
                 default { throw "Debian distro '$Distribution' is not supported." }
             }
         } elseif ($Environment.IsRedHatFamily) {

--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -989,12 +989,12 @@ function Get-PackageDependencies
             )
 
             switch ($Distribution) {
-                "ubuntu.14.04" { $Dependencies += @("libssl1.0.0", "libicu52", "libcurl3" ) }
-                "ubuntu.16.04" { $Dependencies += @("libssl1.0.0", "libicu55", "libcurl3") }
-                "ubuntu.17.10" { $Dependencies += @("libssl1.0.0", "libicu57", "libcurl3") }
-                "ubuntu.18.04" { $Dependencies += @("libssl1.0.0", "libicu60", "libcurl4") }
-                "debian.8" { $Dependencies += @("libssl1.0.0", "libicu52", "libcurl3") }
-                "debian.9" { $Dependencies += @("libssl1.0.2", "libicu57", "libcurl3") }
+                "ubuntu.14.04" { $Dependencies += @("libssl1.0.0", "libicu52") }
+                "ubuntu.16.04" { $Dependencies += @("libssl1.0.0", "libicu55") }
+                "ubuntu.17.10" { $Dependencies += @("libssl1.0.0", "libicu57") }
+                "ubuntu.18.04" { $Dependencies += @("libssl1.0.0", "libicu60") }
+                "debian.8" { $Dependencies += @("libssl1.0.0", "libicu52") }
+                "debian.9" { $Dependencies += @("libssl1.0.2", "libicu57") }
                 default { throw "Debian distro '$Distribution' is not supported." }
             }
         } elseif ($Environment.IsRedHatFamily) {

--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -983,7 +983,6 @@ function Get-PackageDependencies
                 "libgssapi-krb5-2",
                 "liblttng-ust0",
                 "libstdc++6",
-                "libunwind8",
                 "libuuid1",
                 "zlib1g"
             )

--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -983,7 +983,6 @@ function Get-PackageDependencies
                 "libgssapi-krb5-2",
                 "liblttng-ust0",
                 "libstdc++6",
-                "libuuid1",
                 "zlib1g"
             )
 
@@ -998,8 +997,6 @@ function Get-PackageDependencies
             }
         } elseif ($Environment.IsRedHatFamily) {
             $Dependencies = @(
-                "libunwind",
-                "libcurl",
                 "openssl-libs",
                 "libicu"
             )


### PR DESCRIPTION
In .NET Core 2.1, .NET Core no longer uses libcurl by default.
.NET Core has removed the dependencies on libcurl in their installed and in their Docker images:

- https://github.com/dotnet/core-setup/pull/3967
- https://github.com/dotnet/dotnet-docker/pull/467

The same applies for libunwind.

This PR removes those dependencies.