### PR TITLE
Change packaging to differentiate only between major versions and previews

### DIFF
--- a/tools/appimage.sh
+++ b/tools/appimage.sh
@@ -405,7 +405,7 @@ OPTIONS="-o Debug::NoLocking=1
 -o APT::Install-Suggests=0
 "
 
-cp ../powershell_*ubuntu.14.04_amd64.deb .
+cp ../powershell*ubuntu.14.04_amd64.deb .
 
 # Add local repository so that we can install deb files
 # that were downloaded outside of a repository

--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -617,10 +617,6 @@ function New-UnixPackage {
 
         # Suffix is used for side-by-side preview/release package installation
         $Suffix = if ($IsPreview) { $MajorVersion + "-preview" } else { $MajorVersion }
-        if (!$Suffix) {
-            Write-Verbose "Suffix not given, building primary PowerShell package!"
-            $Suffix = $packageVersion
-        }
 
         # Setup staging directory so we don't change the original source directory
         $Staging = "$PSScriptRoot/staging"

--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -613,7 +613,7 @@ function New-UnixPackage {
 
         # Break the version down into its components, we are interested in the major version
         $VersionMatch = [regex]::Match($Version, '(\d+)(?:.(\d+)(?:.(\d+)(?:-preview(?:.(\d+))?)?)?)?')
-        $MajorVersion = $VersionMatch.Groups[1]
+        $MajorVersion = $VersionMatch.Groups[1].Value
 
         # Suffix is used for side-by-side preview/release package installation
         $Suffix = if ($IsPreview) { $MajorVersion + "-preview" } else { $MajorVersion }

--- a/tools/travis.ps1
+++ b/tools/travis.ps1
@@ -269,8 +269,6 @@ elseif($Stage -eq 'Build')
 
         # Only build packages for branches, not pull requests
         $packages = @(Start-PSPackage @packageParams -SkipReleaseChecks)
-        # Packaging AppImage depends on the deb package
-        $packages += Start-PSPackage  @packageParams -Type AppImage -SkipReleaseChecks
         foreach($package in $packages)
         {
             # Publish the packages to the nuget feed if:


### PR DESCRIPTION
## PR Summary
This is breaking as it changes the symbolic links used to run PowerShell from preview builds to
    * Previews linked to `/usr/bin/pwsh-preview` on linux and `/usr/local/bin/pwsh-preview` on macOS

<!-- summarize your PR between here and the checklist -->
Change the *nix packaging over with the following changes:

* Package name (as used by e.g. `apt`):
    * Non-preview releases are named`powershell`
    * Preview releases are named `powershell-preview`
* Installation path:
    * No longer looks like `/opt/microsoft/powershell/6.1.0/` or `/opt/microsoft/powershell/6.1.0-preview.1/`
    * Non-previews go to a path like `/opt/microsoft/powershell/6/`
    * Previews go to a path like `/opt/microsoft/powershell/6-preview/`
* Path to executable symlink:
    * Allows SxS with preview
    * Non-previews linked to `/usr/bin/pwsh` or `/usr/local/bin/pwsh` on macOS
    * Previews linked to `/usr/bin/pwsh-preview` or `/usr/local/bin/pwsh-preview` on macOS

Implements https://github.com/PowerShell/PowerShell-RFC/pull/115#issuecomment-394542248

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [x] Not Applicable or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
