### PR TITLE
Fix parser to continue parsing key-value pairs after an If-Statement value in a HashExpression

### DIFF
--- a/src/System.Management.Automation/engine/parser/Parser.cs
+++ b/src/System.Management.Automation/engine/parser/Parser.cs
@@ -2420,7 +2420,7 @@ namespace System.Management.Automation.Language
                 //       a = if (1) {}
                 //       b = 10
                 //    }
-                var restorePoint = PeekToken();
+                int restorePoint = _ungotToken == null ? _tokenizer.GetRestorePoint() : _ungotToken.Extent.StartOffset;
                 SkipNewlines();
                 keyword = PeekToken();
 

--- a/src/System.Management.Automation/engine/parser/Parser.cs
+++ b/src/System.Management.Automation/engine/parser/Parser.cs
@@ -2411,6 +2411,16 @@ namespace System.Management.Automation.Language
 
                 clauses.Add(new IfClause(condition, body));
 
+                // Save a restore point here. In case there is no 'elseif' or 'else' following,
+                // we should resync back here to preserve the possible new lines. The new lines
+                // could be important for the following parsing. For example, in case we are in
+                // a HashExpression, a new line might be needed for parsing the key-value that
+                // is following the if statement:
+                //    @{
+                //       a = if (1) {}
+                //       b = 10
+                //    }
+                var restorePoint = PeekToken();
                 SkipNewlines();
                 keyword = PeekToken();
 
@@ -2419,8 +2429,7 @@ namespace System.Management.Automation.Language
                     SkipToken();
                     continue;
                 }
-
-                if (keyword.Kind == TokenKind.Else)
+                else if (keyword.Kind == TokenKind.Else)
                 {
                     SkipToken();
                     SkipNewlines();
@@ -2435,6 +2444,11 @@ namespace System.Management.Automation.Language
                             ParserStrings.MissingStatementBlockAfterElse);
                         return new ErrorStatementAst(ExtentOf(ifToken, keyword), componentAsts);
                     }
+                }
+                else
+                {
+                    // There is no 'elseif' or 'else' following, so resync back to the possible new lines.
+                    Resync(restorePoint);
                 }
                 break;
             }

--- a/test/powershell/Language/Parser/LanguageAndParser.TestFollowup.Tests.ps1
+++ b/test/powershell/Language/Parser/LanguageAndParser.TestFollowup.Tests.ps1
@@ -212,3 +212,22 @@ Describe "Members of System.Type" -Tags "CI" {
         [MyType].ImplementedInterfaces | Should -Be System.Collections.IEnumerable
     }
 }
+
+Describe "Hash expression with if statement as value" -Tags "CI" {
+    It "Key-value pairs after an if-statement-value in a HashExpression should continue to be parsed" {
+        $result = @{
+            a = if (1) {'a'}
+            b = 'b'
+            c = if (0) {2} elseif (1) {'c'}
+            d = 'd'
+            e = if (0) {2} else {'e'}
+            f = 'f'
+        }
+        $result['a'] | Should -BeExactly 'a'
+        $result['b'] | Should -BeExactly 'b'
+        $result['c'] | Should -BeExactly 'c'
+        $result['d'] | Should -BeExactly 'd'
+        $result['e'] | Should -BeExactly 'e'
+        $result['f'] | Should -BeExactly 'f'
+    }
+}

--- a/test/powershell/Language/Parser/LanguageAndParser.TestFollowup.Tests.ps1
+++ b/test/powershell/Language/Parser/LanguageAndParser.TestFollowup.Tests.ps1
@@ -243,9 +243,50 @@ Describe "Hash expression with if statement as value" -Tags "CI" {
             h = 'h'
         }
 
+        # With expanded if-statement
+        $hash3 = @{
+            a = if (1)
+                {
+                    'a'
+                }
+            b = 'b'
+            c = if (0)
+                {
+                    2
+                }
+                elseif (1)
+                {
+                    'c'
+                }
+            d = 'd'
+            e = if (0)
+                {
+                    2
+                }
+                elseif (0)
+                {
+                    2
+                }
+                else
+                {
+                    'e'
+                }
+            f = 'f'
+            g = if (0)
+                {
+                    2
+                }
+                else
+                {
+                    'g'
+                }
+            h = 'h'
+        }
+
         $testCases = @(
             @{ name = "No extra new lines"; hash = $hash1 }
             @{ name = "With extra new lines"; hash = $hash2 }
+            @{ name = "With expanded if-statement"; hash = $hash3 }
         )
     }
 

--- a/test/powershell/Language/Parser/LanguageAndParser.TestFollowup.Tests.ps1
+++ b/test/powershell/Language/Parser/LanguageAndParser.TestFollowup.Tests.ps1
@@ -214,20 +214,51 @@ Describe "Members of System.Type" -Tags "CI" {
 }
 
 Describe "Hash expression with if statement as value" -Tags "CI" {
-    It "Key-value pairs after an if-statement-value in a HashExpression should continue to be parsed" {
-        $result = @{
+    BeforeAll {
+        # With no extra new lines after if-statement
+        $hash1 = @{
             a = if (1) {'a'}
             b = 'b'
             c = if (0) {2} elseif (1) {'c'}
             d = 'd'
-            e = if (0) {2} else {'e'}
+            e = if (0) {2} elseif (0) {2} else {'e'}
             f = 'f'
+            g = if (0) {2} else {'g'}
+            h = 'h'
         }
-        $result['a'] | Should -BeExactly 'a'
-        $result['b'] | Should -BeExactly 'b'
-        $result['c'] | Should -BeExactly 'c'
-        $result['d'] | Should -BeExactly 'd'
-        $result['e'] | Should -BeExactly 'e'
-        $result['f'] | Should -BeExactly 'f'
+
+        # With extra new lines after if-statement
+        $hash2 = @{
+            a = if (1) {'a'}
+
+            b = 'b'
+            c = if (0) {2} elseif (1) {'c'}
+
+            d = 'd'
+            e = if (0) {2} elseif (0) {2} else {'e'}
+
+            f = 'f'
+            g = if (0) {2} else {'g'}
+
+            h = 'h'
+        }
+
+        $testCases = @(
+            @{ name = "No extra new lines"; hash = $hash1 }
+            @{ name = "With extra new lines"; hash = $hash2 }
+        )
+    }
+
+    It "Key-value pairs after an if-statement-value in a HashExpression should continue to be parsed - <name>" -TestCases $testCases {
+        param($hash)
+
+        $hash['a'] | Should -BeExactly 'a'
+        $hash['b'] | Should -BeExactly 'b'
+        $hash['c'] | Should -BeExactly 'c'
+        $hash['d'] | Should -BeExactly 'd'
+        $hash['e'] | Should -BeExactly 'e'
+        $hash['f'] | Should -BeExactly 'f'
+        $hash['g'] | Should -BeExactly 'g'
+        $hash['h'] | Should -BeExactly 'h'
     }
 }


### PR DESCRIPTION
## PR Summary

Fix #6970
After parsing `if () { }`, new lines are skipped in order to see if either `elseif` or `else` is present. When neither is present, we should resync back to the pointer before skipping those possibly available new lines, so that the new line tokens can be utilized by the subsequent parsing.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [x] Issue filed - Issue link:
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [x] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
