### PR TITLE
make setReleaseTag use correct variable for release branch during a release

### DIFF
--- a/tools/releaseBuild/setReleaseTag.ps1
+++ b/tools/releaseBuild/setReleaseTag.ps1
@@ -21,13 +21,15 @@ if($ReleaseTag -eq 'fromBranch' -or !$ReleaseTag)
     # Branch is named release-<semver>
     if($Branch -match '^.*(release-)')
     {
-        $releaseTag = $branchOnly -replace '^.*(release-)'
+        Write-verbose "release branch:" -verbose
+        $releaseTag = $Branch -replace '^.*(release-)'
         $vstsCommandString = "vso[task.setvariable variable=$Variable]$releaseTag"
         Write-Verbose -Message "setting $Variable to $releaseTag" -Verbose
         Write-Host -Object "##$vstsCommandString"
     }
     else
     {
+        Write-verbose "non-release branch" -verbose
         # Branch is named <previewname>
         # Get version from metadata and append -<previewname>
         $metaDataJsonPath = Join-Path $PSScriptRoot -ChildPath '..\metadata.json'


### PR DESCRIPTION

## PR Summary

  There was a regression in the script where a variable meant for non-release branches was used during releases

## PR Checklist

- [ ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
