### PR TITLE
AppVeyor build matrix: more efficient build job split to reduce total time by another 5 minutes

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,6 +8,10 @@ environment:
     Purpose: BuildingAndPackaging
   - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
     Purpose: BuildingAndTesting
+    TestCategory: PesterCI
+  - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+    Purpose: BuildingAndTesting
+    TestCategory: PesterAdminAndOptionallyFeatureTests_xUnit
 
 # Stop all jobs in the matrix if any one them fail
 matrix:
@@ -29,11 +33,11 @@ build_script:
   - ps: if ($env:Purpose -eq 'BuildingAndTesting'){ Invoke-AppveyorBuild }
 
 test_script:
-  - ps: if ($env:Purpose -eq 'BuildingAndTesting'){ Invoke-AppveyorTest }
+  - ps: if ($env:Purpose -eq 'BuildingAndTesting'){ Invoke-AppveyorTest $env:TestCategory }
 
 after_test:
-  - ps: if ($env:Purpose -eq 'BuildingAndTesting'){ Invoke-AppVeyorAfterTest }
+  - ps: if ($env:Purpose -eq 'BuildingAndTesting'){ Invoke-AppVeyorAfterTest $env:TestCategory }
 
 # Run the finish command and delete files which should not be in the cache
 on_finish:
-  - ps: if ($env:Purpose -eq 'BuildingAndPackaging'){ Invoke-AppveyorFinish }
+  - ps: if ($env:Purpose -eq 'BuildingAndPackaging'){ Invoke-AppveyorFinish $env:TestCategory }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,10 +29,10 @@ build_script:
   - ps: Invoke-AppveyorBuild
 
 test_script:
-  - ps: Invoke-AppveyorTest -TestCategory $env:TestCategory
+  - ps: Invoke-AppveyorTest -Purpose $env:Purpose
 
 after_test:
-  - ps: Invoke-AppVeyorAfterTest -TestCategory $env:TestCategory
+  - ps: Invoke-AppVeyorAfterTest -Purpose $env:Purpose
 
 # Packaging
 on_finish:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,7 +28,7 @@ test_script:
   - ps: Invoke-AppveyorTest -Purpose $env:Purpose
 
 after_test:
-  - ps: Invoke-AppVeyorAfterTest -Purpose $env:Purpose
+  - ps: Invoke-AppVeyorAfterTest
 
 # Packaging
 on_finish:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,4 +40,4 @@ after_test:
 
 # Run the finish command and delete files which should not be in the cache
 on_finish:
-  - ps: if ($env:Purpose -eq 'BuildingAndPackaging'){ Invoke-AppveyorFinish $env:TestCategory }
+  - ps: if ($env:Purpose -eq 'BuildingAndPackaging'){ Invoke-AppveyorFinish }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,10 +9,6 @@ environment:
   - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
     Purpose: AdvancedPesterTests_xUnit_Packaging
 
-# Stop all jobs in the matrix if any one them fail
-matrix:
-  fast_finish: true
-
 # cache version - netcoreapp.2.1-sdk.2.1.300
 cache:
   - '%HOMEDRIVE%%HOMEPATH%\.nuget\packages -> appveyor.yml'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,9 +5,9 @@ environment:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
   matrix:
   - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-    Purpose: PesterCI
+    Purpose: UnelevatedPesterTests
   - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-    Purpose: AdvancedPesterTests_xUnit_Packaging
+    Purpose: ElevatedPesterTests_xUnit_Packaging
 
 # cache version - netcoreapp.2.1-sdk.2.1.300
 cache:
@@ -32,4 +32,4 @@ after_test:
 
 # Packaging
 on_finish:
-  - ps: if ($env:Purpose -eq 'AdvancedPesterTests_xUnit_Packaging'){ Invoke-AppveyorFinish }
+  - ps: if ($env:Purpose -eq 'ElevatedPesterTests_xUnit_Packaging'){ Invoke-AppveyorFinish }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,13 +5,9 @@ environment:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
   matrix:
   - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-    Purpose: BuildingAndPackaging
+    Purpose: PesterCI
   - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-    Purpose: BuildingAndTesting
-    TestCategory: PesterCI
-  - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-    Purpose: BuildingAndTesting
-    TestCategory: PesterAdminAndOptionallyFeatureTests_xUnit
+    Purpose: AdvancedPesterTests_xUnit_Packaging
 
 # Stop all jobs in the matrix if any one them fail
 matrix:
@@ -30,14 +26,14 @@ install:
   - ps: Invoke-AppveyorInstall
 
 build_script:
-  - ps: if ($env:Purpose -eq 'BuildingAndTesting'){ Invoke-AppveyorBuild }
+  - ps: Invoke-AppveyorBuild
 
 test_script:
-  - ps: if ($env:Purpose -eq 'BuildingAndTesting'){ Invoke-AppveyorTest $env:TestCategory }
+  - ps: Invoke-AppveyorTest -TestCategory $env:TestCategory
 
 after_test:
-  - ps: if ($env:Purpose -eq 'BuildingAndTesting'){ Invoke-AppVeyorAfterTest $env:TestCategory }
+  - ps: Invoke-AppVeyorAfterTest -TestCategory $env:TestCategory
 
-# Run the finish command and delete files which should not be in the cache
+# Packaging
 on_finish:
-  - ps: if ($env:Purpose -eq 'BuildingAndPackaging'){ Invoke-AppveyorFinish }
+  - ps: if ($env:Purpose -eq 'AdvancedPesterTests_xUnit_Packaging'){ Invoke-AppveyorFinish }

--- a/tools/appveyor.psm1
+++ b/tools/appveyor.psm1
@@ -336,7 +336,7 @@ function Invoke-AppVeyorTest
         throw "CoreCLR pwsh.exe was not built"
     }
 
-    if (-not (Test-DailyBuild) -and $TestCategory -eq 'PesterCI')
+    if (-not (Test-DailyBuild))
     {
         # Pester doesn't allow Invoke-Pester -TagAll@('CI', 'RequireAdminOnWindows') currently
         # https://github.com/pester/Pester/issues/608
@@ -450,12 +450,6 @@ function Get-ReleaseTag
 # Implements AppVeyor 'on_finish' step
 function Invoke-AppveyorFinish
 {
-    [CmdletBinding()]
-    param(
-        [ValidateSet('PesterCI', 'PesterAdminAndOptionallyFeatureTests_xUnit')]
-        [string] $TestCategory
-    )
-
     try {
         $releaseTag = Get-ReleaseTag
 

--- a/tools/appveyor.psm1
+++ b/tools/appveyor.psm1
@@ -383,7 +383,11 @@ function Invoke-AppVeyorTest
 #Implement AppVeyor 'after_test' phase
 function Invoke-AppVeyorAfterTest
 {
-    if (Test-DailyBuild) {
+    [CmdletBinding()]
+    param()
+
+    if (Test-DailyBuild)
+    {
         ## Publish code coverage build, tests and OpenCover module to artifacts, so webhook has the information.
         ## Build webhook is called after 'after_test' phase, hence we need to do this here and not in AppveyorFinish.
         $codeCoverageOutput = Split-Path -Parent (Get-PSOutput -Options (New-PSOptions -Configuration CodeCoverage))

--- a/tools/appveyor.psm1
+++ b/tools/appveyor.psm1
@@ -383,12 +383,6 @@ function Invoke-AppVeyorTest
 #Implement AppVeyor 'after_test' phase
 function Invoke-AppVeyorAfterTest
 {
-    [CmdletBinding()]
-    param(
-        [ValidateSet('UnelevatedPesterTests', 'ElevatedPesterTests_xUnit_Packaging')]
-        [string] $Purpose
-    )
-
     if (Test-DailyBuild) {
         ## Publish code coverage build, tests and OpenCover module to artifacts, so webhook has the information.
         ## Build webhook is called after 'after_test' phase, hence we need to do this here and not in AppveyorFinish.

--- a/tools/appveyor.psm1
+++ b/tools/appveyor.psm1
@@ -350,13 +350,13 @@ function Invoke-AppVeyorTest
         Write-Host -Foreground Green 'Running all CoreCLR tests..'
     }
 
-    if ($TestCategory -eq 'PesterCoreClrNonAdmin') {
+    if ($TestCategory -eq 'PesterCI') {
         Start-PSPester -Terse -bindir $env:CoreOutput -outputFile $testResultsNonAdminFile -Unelevate -Tag @() -ExcludeTag ($ExcludeTag + @('RequireAdminOnWindows'))
         Write-Host -Foreground Green 'Upload CoreCLR Non-Admin test results'
         Update-AppVeyorTestResults -resultsFile $testResultsNonAdminFile
     }
 
-    if ($TestCategory -eq 'PesterCoreClrAdmin_xUnit') {
+    if ($TestCategory -eq 'PesterAdminAndOptionallyFeatureTests_xUnit') {
         Start-PSPester -Terse -bindir $env:CoreOutput -outputFile $testResultsAdminFile -Tag @('RequireAdminOnWindows') -ExcludeTag $ExcludeTag
         Write-Host -Foreground Green 'Upload CoreCLR Admin test results'
         Update-AppVeyorTestResults -resultsFile $testResultsAdminFile

--- a/tools/appveyor.psm1
+++ b/tools/appveyor.psm1
@@ -356,7 +356,7 @@ function Invoke-AppVeyorTest
         Update-AppVeyorTestResults -resultsFile $testResultsNonAdminFile
 
         # Fail the build, if tests failed
-        $testResultsNonAdminFile | Test-PSPesterResults -TestResultsFile $_
+        Test-PSPesterResults -TestResultsFile $testResultsNonAdminFile
     }
 
     if ($Purpose -eq 'AdvancedPesterTests_xUnit_Packaging') {
@@ -370,7 +370,7 @@ function Invoke-AppVeyorTest
         Update-AppVeyorTestResults -resultsFile $ParallelXUnitTestResultsFile
 
         # Fail the build, if tests failed
-        $testResultsAdminFile | Test-PSPesterResults -TestResultsFile $_
+        Test-PSPesterResults -TestResultsFile $testResultsAdminFile
         @(
             $SequentialXUnitTestResultsFile,
             $ParallelXUnitTestResultsFile

--- a/tools/appveyor.psm1
+++ b/tools/appveyor.psm1
@@ -320,7 +320,7 @@ function Invoke-AppVeyorTest
     [CmdletBinding()]
     param(
         [ValidateSet('PesterCI', 'AdvancedPesterTests_xUnit_Packaging')]
-        [string] $TestCategory
+        [string] $Purpose
     )
     #
     # CoreCLR
@@ -350,7 +350,7 @@ function Invoke-AppVeyorTest
         Write-Host -Foreground Green 'Running all CoreCLR tests..'
     }
 
-    if ($TestCategory -eq 'PesterCI') {
+    if ($Purpose -eq 'PesterCI') {
         Start-PSPester -Terse -bindir $env:CoreOutput -outputFile $testResultsNonAdminFile -Unelevate -Tag @() -ExcludeTag ($ExcludeTag + @('RequireAdminOnWindows'))
         Write-Host -Foreground Green 'Upload CoreCLR Non-Admin test results'
         Update-AppVeyorTestResults -resultsFile $testResultsNonAdminFile
@@ -359,7 +359,7 @@ function Invoke-AppVeyorTest
         $testResultsNonAdminFile | Test-PSPesterResults -TestResultsFile $_
     }
 
-    if ($TestCategory -eq 'AdvancedPesterTests_xUnit_Packaging') {
+    if ($Purpose -eq 'AdvancedPesterTests_xUnit_Packaging') {
         Start-PSPester -Terse -bindir $env:CoreOutput -outputFile $testResultsAdminFile -Tag @('RequireAdminOnWindows') -ExcludeTag $ExcludeTag
         Write-Host -Foreground Green 'Upload CoreCLR Admin test results'
         Update-AppVeyorTestResults -resultsFile $testResultsAdminFile
@@ -388,10 +388,10 @@ function Invoke-AppVeyorAfterTest
     [CmdletBinding()]
     param(
         [ValidateSet('PesterCI', 'AdvancedPesterTests_xUnit_Packaging')]
-        [string] $TestCategory
+        [string] $Purpose
     )
 
-    if (Test-DailyBuild -and $TestCategory -eq 'AdvancedPesterTests_xUnit_Packaging')
+    if (Test-DailyBuild -and $Purpose -eq 'AdvancedPesterTests_xUnit_Packaging')
     {
         ## Publish code coverage build, tests and OpenCover module to artifacts, so webhook has the information.
         ## Build webhook is called after 'after_test' phase, hence we need to do this here and not in AppveyorFinish.

--- a/tools/appveyor.psm1
+++ b/tools/appveyor.psm1
@@ -336,16 +336,15 @@ function Invoke-AppVeyorTest
         throw "CoreCLR pwsh.exe was not built"
     }
 
-    if ($Purpose -eq 'ElevatedPesterTests_xUnit_Packaging' -and (Test-DailyBuild)) {
+    # Pester doesn't allow Invoke-Pester -TagAll@('CI', 'RequireAdminOnWindows') currently
+    # https://github.com/pester/Pester/issues/608
+    # To work-around it, we exlude all categories, but 'CI' from the list
+    $ExcludeTag = @('Slow', 'Feature', 'Scenario')
+    if (Test-DailyBuild) {
         $ExcludeTag = @()
         Write-Host -Foreground Green 'Running all CoreCLR tests..'
     }
-    else
-    {
-        # Pester doesn't allow Invoke-Pester -TagAll@('CI', 'RequireAdminOnWindows') currently
-        # https://github.com/pester/Pester/issues/608
-        # To work-around it, we exlude all categories, but 'CI' from the list
-        $ExcludeTag = @('Slow', 'Feature', 'Scenario')
+    else {
         Write-Host -Foreground Green 'Running "CI" CoreCLR tests..'
     }
 
@@ -390,8 +389,7 @@ function Invoke-AppVeyorAfterTest
         [string] $Purpose
     )
 
-    if (Test-DailyBuild -and $Purpose -eq 'ElevatedPesterTests_xUnit_Packaging')
-    {
+    if (Test-DailyBuild) {
         ## Publish code coverage build, tests and OpenCover module to artifacts, so webhook has the information.
         ## Build webhook is called after 'after_test' phase, hence we need to do this here and not in AppveyorFinish.
         $codeCoverageOutput = Split-Path -Parent (Get-PSOutput -Options (New-PSOptions -Configuration CodeCoverage))

--- a/tools/appveyor.psm1
+++ b/tools/appveyor.psm1
@@ -319,7 +319,7 @@ function Invoke-AppVeyorTest
 {
     [CmdletBinding()]
     param(
-        [ValidateSet('PesterCI', 'PesterAdminAndOptionallyFeatureTests_xUnit')]
+        [ValidateSet('PesterCI', 'AdvancedPesterTests_xUnit_Packaging')]
         [string] $TestCategory
     )
     #
@@ -359,7 +359,7 @@ function Invoke-AppVeyorTest
         $testResultsNonAdminFile | Test-PSPesterResults -TestResultsFile $_
     }
 
-    if ($TestCategory -eq 'PesterAdminAndOptionallyFeatureTests_xUnit') {
+    if ($TestCategory -eq 'AdvancedPesterTests_xUnit_Packaging') {
         Start-PSPester -Terse -bindir $env:CoreOutput -outputFile $testResultsAdminFile -Tag @('RequireAdminOnWindows') -ExcludeTag $ExcludeTag
         Write-Host -Foreground Green 'Upload CoreCLR Admin test results'
         Update-AppVeyorTestResults -resultsFile $testResultsAdminFile
@@ -387,11 +387,11 @@ function Invoke-AppVeyorAfterTest
 {
     [CmdletBinding()]
     param(
-        [ValidateSet('PesterCI', 'PesterAdminAndOptionallyFeatureTests_xUnit')]
+        [ValidateSet('PesterCI', 'AdvancedPesterTests_xUnit_Packaging')]
         [string] $TestCategory
     )
 
-    if (Test-DailyBuild -and $TestCategory -eq 'PesterAdminAndOptionallyFeatureTests_xUnit')
+    if (Test-DailyBuild -and $TestCategory -eq 'AdvancedPesterTests_xUnit_Packaging')
     {
         ## Publish code coverage build, tests and OpenCover module to artifacts, so webhook has the information.
         ## Build webhook is called after 'after_test' phase, hence we need to do this here and not in AppveyorFinish.


### PR DESCRIPTION
## PR Summary

Closes #6944 

Following PR #6945 , further reduce the total build time (without any disadvantages) by around **5 minutes** by making sure there is a more even split between the 2 build jobs (the 2nd build job used to be much shorter).
Therefore this PR moves also the `xUnit` and `Pester`-Admin tests into the 2nd build job. If it is a daily/feature test commit, then the feature tests will also happen (only) in the 2nd build job. Because both jobs now run tests, the `failfast` option was removed. The final question from my side is whether running tests in 2 build jobs is OK for the daily build, which uploads code coverage results?

The time to wait for the AppVeyor build results is now 15 +/- 2 minutes, which is a huge improvement to what used to be around 28 minutes before the build matrix was introduced.

In the future, we could possibly run the feature tests in an optional 3rd build job once `AppVeyor` implements conditional build matrices here: https://github.com/appveyor/ci/issues/2299

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [x] Not Applicable or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
