### PR TITLE
Comment about dynamic members for the DotNetAdapter 'GetMember' and 'GetMembers'

### DIFF
--- a/src/System.Management.Automation/engine/CoreAdapter.cs
+++ b/src/System.Management.Automation/engine/CoreAdapter.cs
@@ -3522,12 +3522,19 @@ namespace System.Management.Automation
         }
 
         /// <summary>
-        /// Returns null if memberName is not a member in the adapter or
-        /// the corresponding PSMemberInfo
+        /// Get the .NET member based on the given member name.
         /// </summary>
+        /// <remark>
+        /// Dynamic members of an object that implements IDynamicMetaObjectProvider are not included because
+        ///   1. Dynamic members cannot be invoked via reflection;
+        ///   2. Access to dynamic members is handled by the DLR for free.
+        /// </remark>
         /// <param name="obj">object to retrieve the PSMemberInfo from</param>
         /// <param name="memberName">name of the member to be retrieved</param>
-        /// <returns>The PSMemberInfo corresponding to memberName from obj</returns>
+        /// <returns>
+        /// The PSMemberInfo corresponding to memberName from obj,
+        /// or null if the given member name is not a member in the adapter.
+        /// </returns>
         protected override T GetMember<T>(object obj, string memberName)
         {
             T returnValue = GetDotNetProperty<T>(obj, memberName);
@@ -3545,6 +3552,10 @@ namespace System.Management.Automation
         /// In the case of the DirectoryEntry adapter, this could be a cache of the objectClass
         /// to the properties available in it.
         /// </summary>
+        /// <remark>
+        /// Dynamic members of an object that implements IDynamicMetaObjectProvider are included because
+        /// we want to view the dynamic members via 'Get-Member' and be able to auto-complete those members.
+        /// </remark>
         /// <param name="obj">object to get all the member information from</param>
         /// <returns>all members in obj</returns>
         protected override PSMemberInfoInternalCollection<T> GetMembers<T>(object obj)


### PR DESCRIPTION
## PR Summary

`DotNetAdapter.GetMembers<T>(object obj)` returns dynamic members for an object that implements `IDynamicMetaObjectProvider`, however, `DotNetAdapter.GetMember<T>(object obj, string memberName)` doesn't include dynamic members. I believe this makes sense and thus update the comment to clarify it in the code.

Be noted that, `GetMember<T>(object obj, string memberName)` doesn't return `Event` members either, while `GetMembers<T>(object obj)` does.

### Background

The question about this was raised in https://github.com/PowerShell/PowerShell/pull/6898#discussion_r194849375. After investigation, I found it's because `DotNetAdapter.GetMember<T>(object obj, string memberName)` doesn't return dynamic members, and thus submit this PR to call it out in the code comments.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [x] Not Applicable or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
