### PR TITLE
Make Native globbing on UNIX return an absolute path when it is given an absolute path 

### DIFF
--- a/src/System.Management.Automation/engine/NativeCommandParameterBinder.cs
+++ b/src/System.Management.Automation/engine/NativeCommandParameterBinder.cs
@@ -258,8 +258,8 @@ namespace System.Management.Automation
                 // If it's a filesystem location then expand the wildcards
                 if (cwdinfo.Provider.Name.Equals(FileSystemProvider.ProviderName, StringComparison.OrdinalIgnoreCase))
                 {
-                    // On UNIX, paths starting with ~ are not normalized
-                    bool normalizePath = arg.Length == 0 || arg[0] != '~';
+                    // On UNIX, paths starting with ~ or absolute paths are not normalized
+                    bool normalizePath = arg.Length == 0 || ! (arg[0] == '~' || arg[0] == '/');
 
                     // See if there are any matching paths otherwise just add the pattern as the argument
                     Collection<PSObject> paths = null;

--- a/test/powershell/Language/Scripting/NativeExecution/NativeUnixGlobbing.Tests.ps1
+++ b/test/powershell/Language/Scripting/NativeExecution/NativeUnixGlobbing.Tests.ps1
@@ -47,7 +47,13 @@ Describe 'Native UNIX globbing tests' -tags "CI" {
 
 		$a = $v,$v
 		/bin/ls $a[1] | Should -Match "abc.txt"
-	}
+    }
+    # Test globbing with absolute paths - it shouldn't turn absolute paths into relative paths (#7089)
+    It 'Should not normalize absolute paths' {
+        $matches = /bin/echo /etc/*
+        # Matched path should start with '/etc/' not '../..'
+        $matches.substring(0,5) | Should Be '/etc/'
+    }
 	It 'Globbing should not happen with quoted expressions' {
 	    $v = "$TESTDRIVE/abc*"
 		/bin/echo "$v" | Should -BeExactly $v


### PR DESCRIPTION
## PR Summary

Fix #7089. Native globbing on UNIX was turning absolute paths into relative paths when it shouldn't. The code suppresses  generating a relative path for paths starting with '~'. It also need to do the same for paths starting with '/'.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
