### PR TITLE
Revert "Set the cursor to the place where a user hits tab key"

### DIFF
--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterfaceProgress.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterfaceProgress.cs
@@ -97,12 +97,6 @@ namespace Microsoft.PowerShell
                 // Update the progress pane only when the timer set up the update flag or WriteProgress is completed.
                 // As a result, we do not block WriteProgress and whole script and eliminate unnecessary console locks and updates.
                 _progPane.Show(_pendingProgress);
-
-                // Reset the cursor back to where it started
-                if (record.RecordType == ProgressRecordType.Completed)
-                {
-                    _progPane.Hide();
-                }
             }
         }
 

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ProgressPane.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ProgressPane.cs
@@ -99,20 +99,12 @@ namespace Microsoft.PowerShell
 
                 //if the cursor is at the bottom, create screen buffer space by scrolling
                 int scrollRows = rows - ((_rawui.BufferSize.Height - 1) - _location.Y);
+                for (int i = 0; i < rows; i++)
+                {
+                    Console.Out.Write('\n');
+                }
                 if (scrollRows > 0)
                 {
-                    // The following can be possibly replaced by Console.Write ("\x1b[" + scrollRows + "S");
-                    // For details, see https://docs.microsoft.com/en-us/windows/console/console-virtual-terminal-sequences
-
-                    // Scroll the console screen up by 'scrollRows'
-                    var bottomLocation = _location;
-                    bottomLocation.Y = _rawui.BufferSize.Height;
-                    _rawui.CursorPosition = bottomLocation;
-                    for (int i = 0; i < scrollRows; i++)
-                    {
-                        Console.Out.Write('\n');
-                    }
-
                     _location.Y -= scrollRows;
                     _savedCursor.Y -= scrollRows;
                 }

--- a/src/System.Management.Automation/engine/MshCommandRuntime.cs
+++ b/src/System.Management.Automation/engine/MshCommandRuntime.cs
@@ -2252,7 +2252,7 @@ namespace System.Management.Automation
             {
                 // Only generate these exceptions if a pipeline has already been declared as the 'writing' pipeline.
                 // Otherwise, these are probably infrastructure messages and can be ignored.
-                if (this.PipelineProcessor?._permittedToWrite != null)
+                if (this.PipelineProcessor._permittedToWrite != null)
                 {
                     throw PSTraceSource.NewInvalidOperationException(
                         PipelineStrings.WriteNotPermitted);


### PR DESCRIPTION
Reverts PowerShell/PowerShell#7023 per the discussions at https://github.com/PowerShell/PowerShell/pull/7023#discussion_r196519111

Quoted from the author of the original PR:
> Adding _progPane.Hide(); can cause the screen uncleared while press Ctrl-C  in a time window for nested progress. Please revert the PR

/cc @jianyunt 