### PR TITLE
Fix for #6976 -replace operator slowed down after adding scriptblock support

### DIFF
--- a/src/System.Management.Automation/engine/lang/parserutils.cs
+++ b/src/System.Management.Automation/engine/lang/parserutils.cs
@@ -908,7 +908,7 @@ namespace System.Management.Automation
                     pattern = rList[0];
                     if (rList.Count > 1)
                     {
-                        substitute = rList[1];
+                        substitute = PSObject.Base(rList[1]);
                     }
                 }
             }
@@ -972,6 +972,9 @@ namespace System.Management.Automation
         {
             switch (substitute)
             {
+                case string replacementString:
+                    return regex.Replace(input, replacementString);
+
                 case ScriptBlock sb:
                     MatchEvaluator me = match => {
                         var result = sb.DoInvokeReturnAsIs(


### PR DESCRIPTION
## PR Summary

Fix #6976.

The performance of `-replace` was greatly reduced when scriptblock support was added. This is because of the way the code selected what type of replacement to do. In the old code, the first choice was string. In the modified code, the last choice was string and an earlier clause used `TryConvertTo()` to see if the substitution object was (or could be transformed into) a `MatchEvaluator` object. It was this (very expensive) call to `TryConvertTo()` that was slowing everything down. I added a clause for strings (the most common case) to the beginning of the switch statement so it's fast again. I also added a call to `PSObject.Base()` to make sure the test for strings is correct.  


## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [x] Not Applicable or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
