### PR TITLE
Fix for #7128 Methods with return type [object] should return null for an empty result

### DIFF
--- a/src/System.Management.Automation/engine/lang/scriptblock.cs
+++ b/src/System.Management.Automation/engine/lang/scriptblock.cs
@@ -519,10 +519,18 @@ namespace System.Management.Automation
                                        invocationInfo: null,
                                        propagateAllExceptionsToTop: true,
                                        args: args);
+
+            // This is needed only for the case where the
+            // method returns [object]. If the argument to 'return'
+            // is a pipeline that emits nothing then result.Count will
+            // be zero so we catch that and "convert" it to null. Note that
+            // the return statement is still required in the method, it 
+            // just recieves nothing from it's argument.
             if (result.Count == 0)
             {
                 return default(T);
             }
+
             return (T)result[0];
         }
 

--- a/src/System.Management.Automation/engine/lang/scriptblock.cs
+++ b/src/System.Management.Automation/engine/lang/scriptblock.cs
@@ -519,7 +519,10 @@ namespace System.Management.Automation
                                        invocationInfo: null,
                                        propagateAllExceptionsToTop: true,
                                        args: args);
-            Diagnostics.Assert(result.Count == 1, "Code generation ensures we return the correct type");
+            if (result.Count == 0)
+            {
+                return default(T);
+            }
             return (T)result[0];
         }
 

--- a/test/powershell/Language/Classes/Scripting.Classes.BasicParsing.Tests.ps1
+++ b/test/powershell/Language/Classes/Scripting.Classes.BasicParsing.Tests.ps1
@@ -116,6 +116,16 @@ Describe 'Positive Parse Properties Tests' -Tags "CI" {
         class C9b { [System.Collections.Generic.List[C9b]] f() { return [C9b]::new() } }
         $c9b = [C9b]::new().f()
         It "Expected a System.Collections.Generic.List[C9b] returned" {  $c9b -is [System.Collections.Generic.List[C9b]] | Should -BeTrue }
+        It 'Methods returning object should return $null if no output was produced' {
+            class Foo {
+                [object] Bar1() { return & {} }
+                static [object] Bar2() { return & {} }
+            }
+            # Test instance method
+            [Foo]::new().Bar1() | Should -BeNullOrEmpty
+            # Test static method
+            [foo]::Bar2() | Should -BeNullOrEmpty
+        }
     }
 
     It 'Positive ParseProperty Attributes Test' {


### PR DESCRIPTION
## PR Summary

Fix: #7128

If a method was typed to return [object] but no actual value was returned then you would get an index-out-of-range exception because the code expected a value in the result collection but there was none. The fix is to check to see if the array is empty. If it is, then return default(T).

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
