### PR TITLE
Refactor module code related to 'Get-Module -ListAvailable'

### DIFF
--- a/src/System.Management.Automation/engine/CommandDiscovery.cs
+++ b/src/System.Management.Automation/engine/CommandDiscovery.cs
@@ -1131,7 +1131,7 @@ namespace System.Management.Automation
                         // Get the available module files, preferring modules from $PSHOME so that user modules don't
                         // override system modules during auto-loading
                         if (etwEnabled) CommandDiscoveryEventSource.Log.SearchingForModuleFilesStart();
-                        var defaultAvailableModuleFiles = ModuleUtils.GetDefaultAvailableModuleFiles(true, true, context);
+                        var defaultAvailableModuleFiles = ModuleUtils.GetDefaultAvailableModuleFiles(isForAutoDiscovery: true, context);
                         if (etwEnabled) CommandDiscoveryEventSource.Log.SearchingForModuleFilesStop();
 
                         foreach (string modulePath in defaultAvailableModuleFiles)

--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -2512,7 +2512,7 @@ namespace System.Management.Automation.Runspaces
                         foreach (var unresolvedCommand in commandsToResolve)
                         {
                             // Use the analysis cache to find the first module containing the unresolved command.
-                            foreach (string modulePath in ModuleUtils.GetDefaultAvailableModuleFiles(true, true, context))
+                            foreach (string modulePath in ModuleUtils.GetDefaultAvailableModuleFiles(isForAutoDiscovery: true, context))
                             {
                                 string expandedModulePath = IO.Path.GetFullPath(modulePath);
                                 var exportedCommands = AnalysisCache.GetExportedCommands(expandedModulePath, false, context);

--- a/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
@@ -2635,8 +2635,8 @@ namespace Microsoft.PowerShell.Commands
                 bool needToAnalyzeScriptModules = usedWildcard;
 
                 // We can skip further analysis if 'FunctionsToExport', 'CmdletsToExport' and 'AliasesToExport'
-                // are all declared and no wildcard character is used for them. But if any of them are missing,
-                // we possibly need further analysis depending on the nested/root module types.
+                // are all declared and no wildcard character is used for them. But if any of 'FunctionsToExport',
+                // 'CmdletsToExport' or 'AliasesToExport' were not given, we must check to see if more analysis is needed.
                 if (!needToAnalyzeScriptModules && (!sawExportedCmdlets || !sawExportedFunctions || !sawExportedAliases))
                 {
                     foreach (var nestedModule in nestedModules)

--- a/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
@@ -875,28 +875,10 @@ namespace Microsoft.PowerShell.Commands
             // If no names were passed to this function, then this API will return list of all available modules
             if (names == null || moduleNames.Count > 0)
             {
-                modulesToReturn.AddRange(GetModuleForNonRootedPaths(moduleNames.ToArray(), all, refresh));
+                modulesToReturn.AddRange(GetModuleForNames(moduleNames.ToArray(), all, refresh));
             }
 
             return modulesToReturn;
-        }
-
-        private IEnumerable<PSModuleInfo> GetModuleForNonRootedPaths(string[] names, bool all, bool refresh)
-        {
-            const WildcardOptions wildcardOptions = WildcardOptions.IgnoreCase | WildcardOptions.CultureInvariant;
-            IEnumerable<WildcardPattern> patternList = SessionStateUtilities.CreateWildcardsFromStrings(names, wildcardOptions);
-
-            Dictionary<String, List<PSModuleInfo>> availableModules = GetAvailableLocallyModulesCore(names, all, refresh);
-            foreach (var entry in availableModules)
-            {
-                foreach (PSModuleInfo module in entry.Value)
-                {
-                    if (SessionStateUtilities.MatchesAnyWildcardPattern(module.Name, patternList, true))
-                    {
-                        yield return module;
-                    }
-                }
-            }
         }
 
         private IEnumerable<PSModuleInfo> GetModuleForRootedPaths(string[] modulePaths, bool all, bool refresh)
@@ -950,7 +932,7 @@ namespace Microsoft.PowerShell.Commands
 
                             var availableModuleFiles = all
                                 ? ModuleUtils.GetAllAvailableModuleFiles(resolvedModulePath)
-                                : ModuleUtils.GetModuleVersionsFromAbsolutePath(resolvedModulePath);
+                                : ModuleUtils.GetModuleFilesFromAbsolutePath(resolvedModulePath);
 
                             bool foundModule = false;
                             foreach (string file in availableModuleFiles)
@@ -998,38 +980,31 @@ namespace Microsoft.PowerShell.Commands
             return er;
         }
 
-        private Dictionary<String, List<PSModuleInfo>> GetAvailableLocallyModulesCore(string[] names, bool all, bool refresh)
+        private IEnumerable<PSModuleInfo> GetModuleForNames(string[] names, bool all, bool refresh)
         {
-            var modules = new Dictionary<string, List<PSModuleInfo>>(StringComparer.OrdinalIgnoreCase);
-            var modulePaths = ModuleIntrinsics.GetModulePath(false, Context);
-
+            IEnumerable<PSModuleInfo> allModules = null;
+            HashSet<string> modulePathSet = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             bool cleanupModuleAnalysisAppDomain = Context.TakeResponsibilityForModuleAnalysisAppDomain();
 
             try
             {
                 foreach (string path in ModuleIntrinsics.GetModulePath(false, Context))
                 {
+                    string uniquePath = path.TrimEnd(Utils.Separators.Directory);
+
+                    // Ignore repeated module path.
+                    if (!modulePathSet.Add(uniquePath)) { continue; }
+
                     try
                     {
-                        var availableModules = all
-                            ? GetAllAvailableModules(path, refresh)
-                            : GetDefaultAvailableModules(names, path, refresh);
-
-                        // Add the path in $env:PSModulePath as the keys of the dictionary
-                        // If the paths are repeated, ignore the repetitions
-                        string uniquePath = path.TrimEnd(Utils.Separators.Directory);
-                        if (!modules.ContainsKey(uniquePath))
-                        {
-                            modules.Add(uniquePath, availableModules.OrderBy(m => m.Name).ToList());
-                        }
+                        IEnumerable<PSModuleInfo> modulesFound = GetModulesFromOneModulePath(
+                            names, uniquePath, all, refresh).OrderBy(m => m.Name);
+                        allModules = allModules == null ? modulesFound : allModules.Concat(modulesFound);
                     }
-                    catch (IOException)
+                    catch (Exception e) when (e is IOException || e is UnauthorizedAccessException)
                     {
-                        continue; // ignore directories that can't be accessed
-                    }
-                    catch (UnauthorizedAccessException)
-                    {
-                        continue; // ignore directories that can't be accessed
+                        // ignore directories that can't be accessed
+                        continue;
                     }
                 }
             }
@@ -1041,64 +1016,43 @@ namespace Microsoft.PowerShell.Commands
                 }
             }
 
-            return modules;
+            // Make sure we always return a non-null collection.
+            return allModules ?? Utils.EmptyArray<PSModuleInfo>();
         }
 
         /// <summary>
-        /// Get a list of all modules
-        /// which can be imported just by specifying a non rooted file name of the module
-        /// (Import-Module foo\bar.psm1;  but not Import-Module .\foo\bar.psm1)
+        /// Get modules based on the given names and module files.
         /// </summary>
-        private IEnumerable<PSModuleInfo> GetAllAvailableModules(string directory, bool refresh)
+        private IEnumerable<PSModuleInfo> GetModulesFromOneModulePath(string[] names, string modulePath, bool all, bool refresh)
         {
-            var availableModuleFiles = ModuleUtils.GetAllAvailableModuleFiles(directory);
-
-            foreach (string file in availableModuleFiles)
+            const WildcardOptions options = WildcardOptions.IgnoreCase | WildcardOptions.CultureInvariant;
+            IEnumerable<WildcardPattern> namePatterns = null;
+            if (names != null && names.Length > 0)
             {
-                PSModuleInfo module = CreateModuleInfoForGetModule(file, refresh);
-                if (module != null)
-                {
-                    yield return module;
-                }
+                namePatterns = SessionStateUtilities.CreateWildcardsFromStrings(names, options);
             }
-        }
 
-        /// <summary>
-        /// Get a list of the available modules
-        /// which can be imported just by specifying a non rooted directory name of the module
-        /// (Import-Module foo\bar;  but not Import-Module .\foo\bar or Import-Module .\foo\bar.psm1)
-        /// </summary>
-        private List<PSModuleInfo> GetDefaultAvailableModules(string[] name, string directory, bool refresh)
-        {
-            List<PSModuleInfo> availableModules = new List<PSModuleInfo>();
+            IEnumerable<string> moduleFiles = all
+                ? ModuleUtils.GetAllAvailableModuleFiles(modulePath)
+                : ModuleUtils.GetDefaultAvailableModuleFiles(modulePath);
 
-            const WildcardOptions wildcardOptions = WildcardOptions.IgnoreCase | WildcardOptions.CultureInvariant;
-            IEnumerable<WildcardPattern> patternList = SessionStateUtilities.CreateWildcardsFromStrings(name, wildcardOptions);
-
-            var availableModuleFiles = ModuleUtils.GetDefaultAvailableModuleFiles(directory);
-
-            foreach (string file in availableModuleFiles)
+            foreach (string file in moduleFiles)
             {
-                string actualModuleName = System.IO.Path.GetFileNameWithoutExtension(file);
-                if (SessionStateUtilities.MatchesAnyWildcardPattern(actualModuleName, patternList, true))
+                if (namePatterns == null ||
+                    SessionStateUtilities.MatchesAnyWildcardPattern(
+                        Path.GetFileNameWithoutExtension(file), namePatterns, defaultValue: true))
                 {
                     PSModuleInfo module = CreateModuleInfoForGetModule(file, refresh);
+                    if (module == null) { continue; }
 
-                    if (module != null)
+                    if (all || !ModuleUtils.IsModuleInVersionSubdirectory(file, out Version directoryVersion) || directoryVersion == module.Version)
                     {
-                        Version directoryVersion;
-                        if (!ModuleUtils.IsModuleInVersionSubdirectory(file, out directoryVersion)
-                            || directoryVersion == module.Version)
-                        {
-                            availableModules.Add(module);
-                        }
+                        yield return module;
                     }
                 }
             }
 
             ClearAnalysisCaches();
-
-            return availableModules;
         }
 
         /// <summary>
@@ -1191,10 +1145,10 @@ namespace Microsoft.PowerShell.Commands
                     moduleInfo = LoadModuleManifest(
                             scriptInfo,
                             flags /* - don't write errors, don't load elements */,
-                            null,
-                            null,
-                            null,
-                            null);
+                            minimumVersion: null,
+                            maximumVersion: null,
+                            requiredVersion: null,
+                            requiredModuleGuid: null);
                 }
                 else
                 {
@@ -1202,13 +1156,13 @@ namespace Microsoft.PowerShell.Commands
                     ImportModuleOptions options = new ImportModuleOptions();
                     bool found = false;
 
-                    moduleInfo = LoadModule(file, null, String.Empty, null, ref options, flags, out found);
+                    moduleInfo = LoadModule(file, moduleBase: null, prefix: String.Empty, ss: null, ref options, flags, out found);
                 }
 
                 // return fake PSModuleInfo if can't read the file for any reason
                 if (moduleInfo == null)
                 {
-                    moduleInfo = new PSModuleInfo(file, null, null);
+                    moduleInfo = new PSModuleInfo(file, context: null, sessionState: null);
                     moduleInfo.HadErrorsLoading = true;     // Prevent analysis cache from caching a bad module.
                 }
 
@@ -2677,9 +2631,13 @@ namespace Microsoft.PowerShell.Commands
                     }
                 }
 
-                var needToAnalyzeScriptModules = usedWildcard;
+                // We have to further analyze the module if any wildcard characters are used.
+                bool needToAnalyzeScriptModules = usedWildcard;
 
-                if (!needToAnalyzeScriptModules)
+                // We can skip further analysis if 'FunctionsToExport', 'CmdletsToExport' and 'AliasesToExport'
+                // are all declared and no wildcard character is used for them. But if any of them are missing,
+                // we possibly need further analysis depending on the nested/root module types.
+                if (!needToAnalyzeScriptModules && (!sawExportedCmdlets || !sawExportedFunctions || !sawExportedAliases))
                 {
                     foreach (var nestedModule in nestedModules)
                     {
@@ -3173,9 +3131,9 @@ namespace Microsoft.PowerShell.Commands
                     newManifestInfo.DeclaredCmdletExports = manifestInfo.DeclaredCmdletExports;
                 }
 
-                if (manifestInfo._detectedCmdletExports != null)
+                if (manifestInfo.DetectedCmdletExports != null)
                 {
-                    foreach (string detectedExport in manifestInfo._detectedCmdletExports)
+                    foreach (string detectedExport in manifestInfo.DetectedCmdletExports)
                     {
                         newManifestInfo.AddDetectedCmdletExport(detectedExport);
                     }
@@ -3187,9 +3145,9 @@ namespace Microsoft.PowerShell.Commands
                     newManifestInfo.DeclaredFunctionExports = manifestInfo.DeclaredFunctionExports;
                 }
 
-                if (manifestInfo._detectedFunctionExports != null)
+                if (manifestInfo.DetectedFunctionExports != null)
                 {
-                    foreach (string detectedExport in manifestInfo._detectedFunctionExports)
+                    foreach (string detectedExport in manifestInfo.DetectedFunctionExports)
                     {
                         newManifestInfo.AddDetectedFunctionExport(detectedExport);
                     }
@@ -3200,9 +3158,9 @@ namespace Microsoft.PowerShell.Commands
                     newManifestInfo.DeclaredAliasExports = manifestInfo.DeclaredAliasExports;
                 }
 
-                if (manifestInfo._detectedAliasExports != null)
+                if (manifestInfo.DetectedAliasExports != null)
                 {
-                    foreach (var pair in manifestInfo._detectedAliasExports)
+                    foreach (var pair in manifestInfo.DetectedAliasExports)
                     {
                         newManifestInfo.AddDetectedAliasExport(pair.Key, pair.Value);
                     }
@@ -3269,15 +3227,7 @@ namespace Microsoft.PowerShell.Commands
                         }
                         else
                         {
-                            Collection<string> v = new Collection<string>();
-                            if (manifestInfo.DeclaredFunctionExports != null)
-                            {
-                                foreach (var f in manifestInfo.DeclaredFunctionExports)
-                                {
-                                    v.Add(f);
-                                }
-                            }
-                            UpdateCommandCollection(v, exportedFunctions);
+                            UpdateCommandCollection(manifestInfo.DeclaredFunctionExports, exportedFunctions);
                         }
                     }
 

--- a/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
@@ -869,19 +869,19 @@ namespace Microsoft.PowerShell.Commands
                         moduleNames.Add(n);
                     }
                 }
-                modulesToReturn.AddRange(GetModuleForRootedPaths(modulePaths.ToArray(), all, refresh));
+                modulesToReturn.AddRange(GetModuleForRootedPaths(modulePaths, all, refresh));
             }
 
             // If no names were passed to this function, then this API will return list of all available modules
             if (names == null || moduleNames.Count > 0)
             {
-                modulesToReturn.AddRange(GetModuleForNames(moduleNames.ToArray(), all, refresh));
+                modulesToReturn.AddRange(GetModuleForNames(moduleNames, all, refresh));
             }
 
             return modulesToReturn;
         }
 
-        private IEnumerable<PSModuleInfo> GetModuleForRootedPaths(string[] modulePaths, bool all, bool refresh)
+        private IEnumerable<PSModuleInfo> GetModuleForRootedPaths(List<string> modulePaths, bool all, bool refresh)
         {
             // This is to filter out duplicate modules
             var modules = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -980,7 +980,7 @@ namespace Microsoft.PowerShell.Commands
             return er;
         }
 
-        private IEnumerable<PSModuleInfo> GetModuleForNames(string[] names, bool all, bool refresh)
+        private IEnumerable<PSModuleInfo> GetModuleForNames(List<string> names, bool all, bool refresh)
         {
             IEnumerable<PSModuleInfo> allModules = null;
             HashSet<string> modulePathSet = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -1023,11 +1023,11 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Get modules based on the given names and module files.
         /// </summary>
-        private IEnumerable<PSModuleInfo> GetModulesFromOneModulePath(string[] names, string modulePath, bool all, bool refresh)
+        private IEnumerable<PSModuleInfo> GetModulesFromOneModulePath(List<string> names, string modulePath, bool all, bool refresh)
         {
             const WildcardOptions options = WildcardOptions.IgnoreCase | WildcardOptions.CultureInvariant;
             IEnumerable<WildcardPattern> namePatterns = null;
-            if (names != null && names.Length > 0)
+            if (names != null && names.Count > 0)
             {
                 namePatterns = SessionStateUtilities.CreateWildcardsFromStrings(names, options);
             }

--- a/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
@@ -690,9 +690,9 @@ namespace System.Management.Automation
                 foreach (string subPathToAdd in pathToAdd.Split(Utils.Separators.PathSeparator, StringSplitOptions.RemoveEmptyEntries)) // in case pathToAdd is a 'combined path' (semicolon-separated)
                 {
                     int position = PathContainsSubstring(result.ToString(), subPathToAdd); // searching in effective 'result' value ensures that possible duplicates in pathsToAdd are handled correctly
-                    if (-1 == position) // subPathToAdd not found - add it
+                    if (position == -1) // subPathToAdd not found - add it
                     {
-                        if (-1 == insertPosition) // append subPathToAdd to the end
+                        if (insertPosition == -1) // append subPathToAdd to the end
                         {
                             bool endsWithPathSeparator = false;
                             if (result.Length > 0) endsWithPathSeparator = (result[result.Length - 1] == Path.PathSeparator);
@@ -715,14 +715,12 @@ namespace System.Management.Automation
 
         /// <summary>
         /// Check if the current powershell is likely running in following scenarios:
-        ///  - sxs ps started on windows [machine-wide env:PSModulePath will influence]
-        ///  - sxs ps started from full ps
-        ///  - sxs ps started from inbox nano/iot ps
-        ///  - full ps started from sxs ps
-        ///  - inbox nano/iot ps started from sxs ps
+        ///  - PSCore started on windows [machine-wide env:PSModulePath will influence]
+        ///  - PSCore started from full ps
+        ///  - PSCore started from inbox nano/iot ps
         /// If it's likely one of them, then we need to clear the current process module path.
         /// </summary>
-        private static bool NeedToClearProcessModulePath(string currentProcessModulePath, string personalModulePath, string sharedModulePath, bool runningSxS)
+        private static bool NeedToClearProcessModulePath(string currentProcessModulePath, string personalModulePath, string sharedModulePath)
         {
 #if UNIX
             return false;
@@ -733,30 +731,19 @@ namespace System.Management.Automation
             const string winSxSModuleDirectory = @"PowerShell\Modules";
             const string winLegacyModuleDirectory = @"WindowsPowerShell\Modules";
 
-            if (runningSxS)
-            {
-                // The machine-wide and user-wide environment variables are only meaningful for full ps,
-                // so if the current process module path contains any of them, it's likely that the sxs
-                // ps was started directly on windows, or from full ps. The same goes for the legacy personal
-                // and shared module paths.
-                string hklmModulePath = GetExpandedEnvironmentVariable(Constants.PSModulePathEnvVar, EnvironmentVariableTarget.Machine);
-                string hkcuModulePath = GetExpandedEnvironmentVariable(Constants.PSModulePathEnvVar, EnvironmentVariableTarget.User);
-                string legacyPersonalModulePath = personalModulePath.Replace(winSxSModuleDirectory, winLegacyModuleDirectory);
-                string legacyProgramFilesModulePath = sharedModulePath.Replace(winSxSModuleDirectory, winLegacyModuleDirectory);
+            // The machine-wide and user-wide environment variables are only meaningful for full ps,
+            // so if the current process module path contains any of them, it's likely that the sxs
+            // ps was started directly on windows, or from full ps. The same goes for the legacy personal
+            // and shared module paths.
+            string hklmModulePath = GetExpandedEnvironmentVariable(Constants.PSModulePathEnvVar, EnvironmentVariableTarget.Machine);
+            string hkcuModulePath = GetExpandedEnvironmentVariable(Constants.PSModulePathEnvVar, EnvironmentVariableTarget.User);
+            string legacyPersonalModulePath = personalModulePath.Replace(winSxSModuleDirectory, winLegacyModuleDirectory);
+            string legacyProgramFilesModulePath = sharedModulePath.Replace(winSxSModuleDirectory, winLegacyModuleDirectory);
 
-                return (!string.IsNullOrEmpty(hklmModulePath) && currentProcessModulePath.IndexOf(hklmModulePath, StringComparison.OrdinalIgnoreCase) != -1) ||
-                       (!string.IsNullOrEmpty(hkcuModulePath) && currentProcessModulePath.IndexOf(hkcuModulePath, StringComparison.OrdinalIgnoreCase) != -1) ||
-                       currentProcessModulePath.IndexOf(legacyPersonalModulePath, StringComparison.OrdinalIgnoreCase) != -1 ||
-                       currentProcessModulePath.IndexOf(legacyProgramFilesModulePath, StringComparison.OrdinalIgnoreCase) != -1;
-            }
-
-            // The sxs personal and shared module paths are only meaningful for sxs ps, so if they appear
-            // in the current process module path, it's likely the running ps was started from a sxs ps.
-            string sxsPersonalModulePath = personalModulePath.Replace(winLegacyModuleDirectory, winSxSModuleDirectory);
-            string sxsProgramFilesModulePath = sharedModulePath.Replace(winLegacyModuleDirectory, winSxSModuleDirectory);
-
-            return currentProcessModulePath.IndexOf(sxsPersonalModulePath, StringComparison.OrdinalIgnoreCase) != -1 ||
-                   currentProcessModulePath.IndexOf(sxsProgramFilesModulePath, StringComparison.OrdinalIgnoreCase) != -1;
+            return (!string.IsNullOrEmpty(hklmModulePath) && currentProcessModulePath.IndexOf(hklmModulePath, StringComparison.OrdinalIgnoreCase) != -1) ||
+                   (!string.IsNullOrEmpty(hkcuModulePath) && currentProcessModulePath.IndexOf(hkcuModulePath, StringComparison.OrdinalIgnoreCase) != -1) ||
+                   currentProcessModulePath.IndexOf(legacyPersonalModulePath, StringComparison.OrdinalIgnoreCase) != -1 ||
+                   currentProcessModulePath.IndexOf(legacyProgramFilesModulePath, StringComparison.OrdinalIgnoreCase) != -1;
 #endif
         }
 
@@ -821,17 +808,14 @@ namespace System.Management.Automation
             string personalModulePath = GetPersonalModulePath();
             string sharedModulePath = GetSharedModulePath(); // aka <Program Files> location
             string psHomeModulePath = GetPSHomeModulePath(); // $PSHome\Modules location
-            bool runningSxS = Platform.IsInbox ? false : true;
 
             if (!string.IsNullOrEmpty(currentProcessModulePath) &&
-                NeedToClearProcessModulePath(currentProcessModulePath, personalModulePath, sharedModulePath, runningSxS))
+                NeedToClearProcessModulePath(currentProcessModulePath, personalModulePath, sharedModulePath))
             {
                 // Clear the current process module path in the following cases
-                //  - start sxs ps on windows [machine-wide env:PSModulePath will influence]
-                //  - start sxs ps from full ps
-                //  - start sxs ps from inbox nano/iot ps
-                //  - start full ps from sxs ps
-                //  - start inbox nano/iot ps from sxs ps
+                //  - start PSCore on windows [machine-wide env:PSModulePath will influence]
+                //  - start PSCore from full ps
+                //  - start PSCore from inbox nano/iot ps
                 currentProcessModulePath = null;
             }
 
@@ -860,7 +844,7 @@ namespace System.Management.Automation
             }
             // EVT.Process exists
             // Now handle the case where the environment variable is already set.
-            else if (runningSxS) // The running powershell is an SxS PS instance
+            else
             {
                 // When SxS PS instance A starts SxS PS instance B, A's PSHome module path might be inherited by B. We need to remove that path from B
                 currentProcessModulePath = RemoveSxSPsHomeModulePath(currentProcessModulePath, personalModulePath, sharedModulePath, psHomeModulePath);
@@ -871,87 +855,12 @@ namespace System.Management.Automation
                 currentProcessModulePath = AddToPath(currentProcessModulePath, personalModulePathToUse, 0);
                 currentProcessModulePath = AddToPath(currentProcessModulePath, systemModulePathToUse, -1);
             }
-            else // The running powershell is Full PS or inbox Core PS
-            {
-                // If there is no personal path key, then if the env variable doesn't match the system variable,
-                // the user modified it somewhere, else prepend the default personal module path
-                if (hklmMachineModulePath != null) // EVT.Machine exists
-                {
-                    if (hkcuUserModulePath == null) // EVT.User does Not exist
-                    {
-                        if (!(hklmMachineModulePath).Equals(currentProcessModulePath, StringComparison.OrdinalIgnoreCase))
-                        {
-                            // before returning, use <presence of Windows module path> heuristic to conditionally add <Program Files> location
-                            int psHomePosition = PathContainsSubstring(currentProcessModulePath, psHomeModulePath); // index of $PSHome\Modules in currentProcessModulePath
-                            if (psHomePosition >= 0) // if $PSHome\Modules IS found - insert <Program Files> location before $PSHome\Modules
-                            {
-                                return AddToPath(currentProcessModulePath, sharedModulePath, psHomePosition);
-                            } // if $PSHome\Modules NOT found = <scenario 4> = 'PSModulePath has been constrained by a user to create a sand boxed environment without including System Modules'
-
-                            return null;
-                        }
-                        currentProcessModulePath = personalModulePath + Path.PathSeparator + hklmMachineModulePath; // <SpecialFolder.MyDocuments> + EVT.Machine + inserted <ProgramFiles> later in this function
-                    }
-                    else // EVT.User exists
-                    {
-                        // PSModulePath is designed to have behaviour like 'Path' var in a sense that EVT.User + EVT.Machine are merged to get final value of PSModulePath
-                        string combined = string.Concat(hkcuUserModulePath, Path.PathSeparator, hklmMachineModulePath); // EVT.User + EVT.Machine
-                        if (!((combined).Equals(currentProcessModulePath, StringComparison.OrdinalIgnoreCase) ||
-                            (hklmMachineModulePath).Equals(currentProcessModulePath, StringComparison.OrdinalIgnoreCase) ||
-                            (hkcuUserModulePath).Equals(currentProcessModulePath, StringComparison.OrdinalIgnoreCase)))
-                        {
-                            // before returning, use <presence of Windows module path> heuristic to conditionally add <Program Files> location
-                            int psHomePosition = PathContainsSubstring(currentProcessModulePath, psHomeModulePath); // index of $PSHome\Modules in currentProcessModulePath
-                            if (psHomePosition >= 0) // if $PSHome\Modules IS found - insert <Program Files> location before $PSHome\Modules
-                            {
-                                return AddToPath(currentProcessModulePath, sharedModulePath, psHomePosition);
-                            } // if $PSHome\Modules NOT found = <scenario 4> = 'PSModulePath has been constrained by a user to create a sand boxed environment without including System Modules'
-
-                            return null;
-                        }
-                        currentProcessModulePath = combined; // = EVT.User + EVT.Machine + inserted <ProgramFiles> later in this function
-                    }
-                }
-                else // EVT.Machine does Not exist
-                {
-                    // If there is no system path key, then if the env variable doesn't match the user variable,
-                    // the user modified it somewhere, otherwise append the default system path
-                    if (hkcuUserModulePath != null) // EVT.User exists
-                    {
-                        if (hkcuUserModulePath.Equals(currentProcessModulePath, StringComparison.OrdinalIgnoreCase))
-                        {
-                            currentProcessModulePath = hkcuUserModulePath + Path.PathSeparator + CombineSystemModulePaths(); // = EVT.User + (SharedModulePath + $PSHome\Modules)
-                        }
-                        else
-                        {
-                            // before returning, use <presence of Windows module path> heuristic to conditionally add <Program Files> location
-                            int psHomePosition = PathContainsSubstring(currentProcessModulePath, psHomeModulePath); // index of $PSHome\Modules in currentProcessModulePath
-                            if (psHomePosition >= 0) // if $PSHome\Modules IS found - insert <Program Files> location before $PSHome\Modules
-                            {
-                                return AddToPath(currentProcessModulePath, sharedModulePath, psHomePosition);
-                            } // if $PSHome\Modules NOT found = <scenario 4> = 'PSModulePath has been constrained by a user to create a sand boxed environment without including System Modules'
-
-                            return null;
-                        }
-                    }
-                    else // EVT.User does Not exist
-                    {
-                        // before returning, use <presence of Windows module path> heuristic to conditionally add <Program Files> location
-                        int psHomePosition = PathContainsSubstring(currentProcessModulePath, psHomeModulePath); // index of $PSHome\Modules in currentProcessModulePath
-                        if (psHomePosition >= 0) // if $PSHome\Modules IS found - insert <Program Files> location before $PSHome\Modules
-                        {
-                            return AddToPath(currentProcessModulePath, sharedModulePath, psHomePosition);
-                        } // if $PSHome\Modules NOT found = <scenario 4> = 'PSModulePath has been constrained by a user to create a sand boxed environment without including System Modules'
-
-                        // Neither key is set so go with what the environment variable is already set to
-                        return null;
-                    }
-                }
-            }
 
             // if we reached this point - always add <Program Files> location to EVT.Process
             // everything below is the same behaviour as WMF 4 code
-            int indexOfPSHomeModulePath = PathContainsSubstring(currentProcessModulePath, psHomeModulePath); // index of $PSHome\Modules in currentProcessModulePath
+
+            // index of $PSHome\Modules in currentProcessModulePath
+            int indexOfPSHomeModulePath = PathContainsSubstring(currentProcessModulePath, psHomeModulePath);
             // if $PSHome\Modules not found (psHomePosition == -1) - append <Program Files> location to the end;
             // if $PSHome\Modules IS found (psHomePosition >= 0) - insert <Program Files> location before $PSHome\Modules
             currentProcessModulePath = AddToPath(currentProcessModulePath, sharedModulePath, indexOfPSHomeModulePath);
@@ -969,12 +878,13 @@ namespace System.Management.Automation
             string currentModulePath = GetExpandedEnvironmentVariable(Constants.PSModulePathEnvVar, EnvironmentVariableTarget.Process);
             return currentModulePath;
         }
+
         /// <summary>
         /// Checks if $env:PSModulePath is not set and sets it as appropriate. Note - because these
         /// strings go through the provider, we need to escape any wildcards before passing them
         /// along.
         /// </summary>
-        internal static string SetModulePath()
+        private static string SetModulePath()
         {
             string currentModulePath = GetExpandedEnvironmentVariable(Constants.PSModulePathEnvVar, EnvironmentVariableTarget.Process);
             string systemWideModulePath = PowerShellConfig.Instance.GetModulePath(ConfigScope.SystemWide);

--- a/src/System.Management.Automation/engine/Modules/PSModuleInfo.cs
+++ b/src/System.Management.Automation/engine/Modules/PSModuleInfo.cs
@@ -486,6 +486,15 @@ namespace System.Management.Automation
             internal set;
         }
 
+        internal Collection<string> DeclaredFunctionExports = null;
+        internal Collection<string> DeclaredCmdletExports = null;
+        internal Collection<string> DeclaredAliasExports = null;
+        internal Collection<string> DeclaredVariableExports = null;
+
+        internal List<string> DetectedFunctionExports = new List<string>();
+        internal List<string> DetectedCmdletExports = new List<string>();
+        internal Dictionary<string, string> DetectedAliasExports = new Dictionary<string, string>();
+
         /// <summary>
         /// Lists the functions exported by this module...
         /// </summary>
@@ -496,17 +505,15 @@ namespace System.Management.Automation
                 Dictionary<string, FunctionInfo> exports = new Dictionary<string, FunctionInfo>(StringComparer.OrdinalIgnoreCase);
 
                 // If the module is not binary, it may also have functions...
-                if ((DeclaredFunctionExports != null) && (DeclaredFunctionExports.Count > 0))
+                if (DeclaredFunctionExports != null)
                 {
+                    if (DeclaredFunctionExports.Count == 0) { return exports; }
+
                     foreach (string fn in DeclaredFunctionExports)
                     {
                         FunctionInfo tempFunction = new FunctionInfo(fn, ScriptBlock.EmptyScriptBlock, null) { Module = this };
                         exports[fn] = tempFunction;
                     }
-                }
-                else if ((DeclaredFunctionExports != null) && (DeclaredFunctionExports.Count == 0))
-                {
-                    return exports;
                 }
                 else if (SessionState != null)
                 {
@@ -525,7 +532,7 @@ namespace System.Management.Automation
                 }
                 else
                 {
-                    foreach (var detectedExport in _detectedFunctionExports)
+                    foreach (var detectedExport in DetectedFunctionExports)
                     {
                         if (!exports.ContainsKey(detectedExport))
                         {
@@ -636,9 +643,6 @@ namespace System.Management.Automation
             internal set;
         }
 
-        internal Collection<string> DeclaredFunctionExports = null;
-        internal List<string> _detectedFunctionExports = new List<string>();
-
         /// <summary>
         /// Add function to the fixed exports list
         /// </summary>
@@ -647,9 +651,9 @@ namespace System.Management.Automation
         {
             Dbg.Assert(name != null, "AddDetectedFunctionExport should not be called with a null value");
 
-            if (!_detectedFunctionExports.Contains(name))
+            if (!DetectedFunctionExports.Contains(name))
             {
-                _detectedFunctionExports.Add(name);
+                DetectedFunctionExports.Add(name);
             }
         }
 
@@ -662,17 +666,15 @@ namespace System.Management.Automation
             {
                 Dictionary<string, CmdletInfo> exports = new Dictionary<string, CmdletInfo>(StringComparer.OrdinalIgnoreCase);
 
-                if ((DeclaredCmdletExports != null) && (DeclaredCmdletExports.Count > 0))
+                if (DeclaredCmdletExports != null)
                 {
+                    if (DeclaredCmdletExports.Count == 0) { return exports; }
+
                     foreach (string fn in DeclaredCmdletExports)
                     {
                         CmdletInfo tempCmdlet = new CmdletInfo(fn, null, null, null, null) { Module = this };
                         exports[fn] = tempCmdlet;
                     }
-                }
-                else if ((DeclaredCmdletExports != null) && (DeclaredCmdletExports.Count == 0))
-                {
-                    return exports;
                 }
                 else if ((CompiledExports != null) && (CompiledExports.Count > 0))
                 {
@@ -683,7 +685,7 @@ namespace System.Management.Automation
                 }
                 else
                 {
-                    foreach (string detectedExport in _detectedCmdletExports)
+                    foreach (string detectedExport in DetectedCmdletExports)
                     {
                         if (!exports.ContainsKey(detectedExport))
                         {
@@ -696,8 +698,6 @@ namespace System.Management.Automation
                 return exports;
             }
         }
-        internal Collection<string> DeclaredCmdletExports = null;
-        internal List<string> _detectedCmdletExports = new List<string>();
 
         /// <summary>
         /// Add CmdletInfo to the fixed exports list...
@@ -707,9 +707,9 @@ namespace System.Management.Automation
         {
             Dbg.Assert(cmdlet != null, "AddDetectedCmdletExport should not be called with a null value");
 
-            if (!_detectedCmdletExports.Contains(cmdlet))
+            if (!DetectedCmdletExports.Contains(cmdlet))
             {
-                _detectedCmdletExports.Add(cmdlet);
+                DetectedCmdletExports.Add(cmdlet);
             }
         }
 
@@ -1065,7 +1065,6 @@ namespace System.Management.Automation
                 return exportedVariables;
             }
         }
-        internal Collection<string> DeclaredVariableExports = null;
 
         /// <summary>
         /// Lists the aliases exported by this module.
@@ -1097,9 +1096,9 @@ namespace System.Management.Automation
                     if (SessionState == null)
                     {
                         // Check if we detected any
-                        if (_detectedAliasExports.Count > 0)
+                        if (DetectedAliasExports.Count > 0)
                         {
-                            foreach (var pair in _detectedAliasExports)
+                            foreach (var pair in DetectedAliasExports)
                             {
                                 string detectedExport = pair.Key;
                                 if (!exportedAliases.ContainsKey(detectedExport))
@@ -1129,8 +1128,6 @@ namespace System.Management.Automation
                 return exportedAliases;
             }
         }
-        internal Collection<string> DeclaredAliasExports = null;
-        internal Dictionary<string, string> _detectedAliasExports = new Dictionary<string, string>();
 
         /// <summary>
         /// Add alias to the detected alias list
@@ -1141,7 +1138,7 @@ namespace System.Management.Automation
         {
             Dbg.Assert(name != null, "AddDetectedAliasExport should not be called with a null value");
 
-            _detectedAliasExports[name] = value;
+            DetectedAliasExports[name] = value;
         }
 
         /// <summary>

--- a/src/System.Management.Automation/engine/PSClassSearcher.cs
+++ b/src/System.Management.Automation/engine/PSClassSearcher.cs
@@ -157,7 +157,7 @@ namespace System.Management.Automation
         {
             bool matchFound = false;
 
-            var moduleList = ModuleUtils.GetDefaultAvailableModuleFiles(false, false, _context);
+            var moduleList = ModuleUtils.GetDefaultAvailableModuleFiles(isForAutoDiscovery: false, _context);
 
             foreach (var modulePath in moduleList)
             {

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -1,0 +1,102 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+Describe "Get-Module" -Tags "CI" {
+
+    BeforeAll {
+        $originalPSModulePath = $env:PSModulePath
+
+        New-Item -ItemType Directory -Path "$testdrive\Modules\Foo\1.1" -Force > $null
+        New-Item -ItemType Directory -Path "$testdrive\Modules\Foo\2.0" -Force > $null
+        New-Item -ItemType Directory -Path "$testdrive\Modules\Bar\Download" -Force > $null
+        New-Item -ItemType Directory -Path "$testdrive\Modules\Zoo\Too" -Force > $null
+
+        New-ModuleManifest -Path "$testdrive\Modules\Foo\1.1\Foo.psd1" -ModuleVersion 1.1
+        New-ModuleManifest -Path "$testdrive\Modules\Foo\2.0\Foo.psd1" -ModuleVersion 2.0
+        New-ModuleManifest -Path "$testdrive\Modules\Bar\Bar.psd1"
+        New-ModuleManifest -Path "$testdrive\Modules\Zoo\Zoo.psd1"
+
+        New-Item -ItemType File -Path "$testdrive\Modules\Foo\1.1\Foo.psm1" > $null
+        New-Item -ItemType File -Path "$testdrive\Modules\Foo\2.0\Foo.psm1" > $null
+        New-Item -ItemType File -Path "$testdrive\Modules\Bar\Bar.psm1" > $null
+        New-Item -ItemType File -Path "$testdrive\Modules\Bar\Download\Download.psm1" > $null
+        New-Item -ItemType File -Path "$testdrive\Modules\Zoo\Zoo.psm1" > $null
+        New-Item -ItemType File -Path "$testdrive\Modules\Zoo\Too\Zoo.psm1" > $null
+
+        $env:PSModulePath = Join-Path $testdrive "Modules"
+    }
+
+    AfterAll {
+        $env:PSModulePath = $originalPSModulePath
+    }
+
+    It "Get-Module -ListAvailable" {
+        $modules = Get-Module -ListAvailable
+        $modules.Count | Should -Be 4
+        $modules = $modules | Sort-Object -Property Name, Version
+        $modules.Name -join "," | Should -BeExactly "Bar,Foo,Foo,Zoo"
+        $modules[1].Version | Should -Be "1.1"
+        $modules[2].Version | Should -Be '2.0'
+    }
+
+    It "Get-Module <Name> -ListAvailable" {
+        $modules = Get-Module F* -ListAvailable
+        $modules.Count | Should -Be 2
+        $modules = $modules | Sort-Object -Property Version
+        $modules.Name -join "," | Should -BeExactly "Foo,Foo"
+        $modules[0].Version | Should -Be "1.1"
+        $modules[1].Version | Should -Be "2.0"
+    }
+
+    It "Get-Module -ListAvailable -All" {
+        $modules = Get-Module -ListAvailable -All
+        $modules.Count | Should -Be 10
+        $modules = $modules | Sort-Object -Property Name, Path
+        $modules.Name -join "," | Should -BeExactly "Bar,Bar,Download,Foo,Foo,Foo,Foo,Zoo,Zoo,Zoo"
+
+        $modules[0].ModuleType | Should -BeExactly "Manifest"
+        $modules[1].ModuleType | Should -BeExactly "Script"
+        $modules[2].ModuleType | Should -BeExactly "Script"
+        $modules[3].ModuleType | Should -BeExactly "Manifest"
+        $modules[3].Version | Should -Be "1.1"
+        $modules[4].ModuleType | Should -BeExactly "Script"
+        $modules[5].ModuleType | Should -BeExactly "Manifest"
+        $modules[5].Version | Should -Be "2.0"
+        $modules[6].ModuleType | Should -BeExactly "Script"
+        $modules[7].ModuleType | Should -BeExactly "Script"
+        $modules[7].Path | Should -BeExactly (Resolve-Path "$testdrive\Modules\Zoo\Too\Zoo.psm1").Path
+        $modules[8].ModuleType | Should -BeExactly "Manifest"
+        $modules[8].Path | Should -BeExactly (Resolve-Path "$testdrive\Modules\Zoo\Zoo.psd1").Path
+        $modules[9].ModuleType | Should -BeExactly "Script"
+        $modules[9].Path | Should -BeExactly (Resolve-Path "$testdrive\Modules\Zoo\Zoo.psm1").Path
+    }
+
+    It "Get-Module <Name> -ListAvailable -All" {
+        $modules = Get-Module down*, zoo -ListAvailable -All
+        $modules.Count | Should -Be 4
+        $modules = $modules | Sort-Object -Property Name, Path
+        $modules.Name -join "," | Should -BeExactly "Download,Zoo,Zoo,Zoo"
+
+        $modules[0].Path | Should -BeExactly (Resolve-Path "$testdrive\Modules\Bar\Download\Download.psm1").Path
+        $modules[1].Path | Should -BeExactly (Resolve-Path "$testdrive\Modules\Zoo\Too\Zoo.psm1").Path
+        $modules[2].Path | Should -BeExactly (Resolve-Path "$testdrive\Modules\Zoo\Zoo.psd1").Path
+        $modules[3].Path | Should -BeExactly (Resolve-Path "$testdrive\Modules\Zoo\Zoo.psm1").Path
+    }
+
+    It "Get-Module <Path> -ListAvailable" {
+        $modules = Get-Module "$testdrive\Modules\*" -ListAvailable
+        $modules.Count | Should -Be 4
+        $modules = $modules | Sort-Object -Property Name, Version
+        $modules.Name -join "," | Should -BeExactly "Bar,Foo,Foo,Zoo"
+        $modules[1].Version | Should -Be "1.1"
+        $modules[2].Version | Should -Be '2.0'
+    }
+
+    It "Get-Module <Path> -ListAvailable -All" {
+        $modules = Get-Module "$testdrive\Modules\*" -ListAvailable -All
+        $modules.Count | Should -Be 5
+        $modules = $modules | Sort-Object -Property Name, Path
+        $modules.Name -join "," | Should -BeExactly "Bar,Foo,Foo,Zoo,Zoo"
+        $modules[3].Path | Should -BeExactly (Resolve-Path "$testdrive\Modules\Zoo\Too\Zoo.psm1").Path
+    }
+}


### PR DESCRIPTION
## PR Summary

The major refactoring changes are:
- In `ModuleIntrisic.cs`, remove unneeded Windows-PowerShell-only code.
- In `ModuleUtils.cs`
   - use the new API `Directory.GetDirectories(string path, string searchPattern, EnumerationOptions enumerationOptions)` and `Directory.GetFiles(string path, string searchPattern, EnumerationOptions enumerationOptions)` to enumerate files and sub-directories within a directory path.
   - remove the unused parameter `bool force` from `GetDefaultAvailableModuleFiles(bool force, bool isForAutoDiscovery, ExecutionContext context)`
   - refactor the method `GetModuleVersionsFromAbsolutePath`. Add more comments and rename the method name.
- In `ModuleCmdletBase.cs`, refactor the method `GetModuleForNonRootedPaths` to `GetModuleForNames` to simply its implementation.
- In `PSModuleInfo.cs`
   - group the declarations of `Declared*Exports` fields together
   - rename `_detected*Exports` fields to `Detected*Exports` to group them together. They are internal fields and used outside `PSModuleInfo`.

### Pref improvement

> NOTE: Use Windows PowerShell default module paths to exercies the code with more modules.
> The following measurement are done without the crossgen'ed assemblies.

There is some perf improvement after this refactoring change:
- For `Get-Module -ListAvailable`, there is about 36% speed improvement for 94 default modules.
- For `Get-Module -ListAvailable -All`, there is about 14% speed improvement for totally 600 module files.
- For `Get-Module <name> -ListAvailable -List`, there is over 17x speed improvement for finding 13 modules from 600 modules. This is because we now filter names using the module file before creating a `PSMdouleInfo` object.

#### Before

```powershell
PS> $env:PSModulePath = "C:\Users\dongbow\Documents\WindowsPowerShell\Modules;C:\Program Files\WindowsPowerShell\Modules;C:\windows\system32\WindowsPowerShell\v1.0\Modules"
PS> $time = foreach ($i in 1..20) { Measure-Command { gmo -ListAvailable } | % TotalMilliseconds }
PS> $time | Measure-Object -Maximum -Minimum -Average | select Count, Maximum, Minimum, Average

Count  Maximum  Minimum    Average
-----  -------  -------    -------
   20 701.3139 623.5225 642.628685

PS> $time = foreach ($i in 1..20) { Measure-Command { gmo -ListAvailable -All } | % TotalMilliseconds }
PS> $time | Measure-Object -Maximum -Minimum -Average | select Count, Maximum, Minimum, Average

Count   Maximum   Minimum     Average
-----   -------   -------     -------
   20 1369.1893 1243.1195 1310.147175

PS> $time = foreach ($i in 1..20) { Measure-Command { gmo windows* -ListAvailable -All } | % TotalMilliseconds }
PS> $time | Measure-Object -Maximum -Minimum -Average | select Count, Maximum, Minimum, Average

Count   Maximum   Minimum    Average
-----   -------   -------    -------
   20 1535.3805 1292.2188 1353.62972
```

#### After

```powershell
PS> $env:PSModulePath = "C:\Users\dongbow\Documents\WindowsPowerShell\Modules;C:\Program Files\WindowsPowerShell\Modules;C:\windows\system32\WindowsPowerShell\v1.0\Modules"
PS> $time = foreach ($i in 1..20) { Measure-Command { gmo -ListAvailable } | % TotalMilliseconds }
PS> $time | Measure-Object -Maximum -Minimum -Average | select Count, Maximum, Minimum, Average

Count Maximum  Minimum  Average
----- -------  -------  -------
   20 438.338 393.7476 410.62353

PS> $time = foreach ($i in 1..20) { Measure-Command { gmo -ListAvailable -All } | % TotalMilliseconds }
PS> $time | Measure-Object -Maximum -Minimum -Average | select Count, Maximum, Minimum, Average

Count   Maximum   Minimum Average
-----   -------   -------   -------
   20 1341.5443 1055.1771 1120.4748

PS> $time = foreach ($i in 1..20) { Measure-Command { gmo windows* -ListAvailable -All } | % TotalMilliseconds }
PS> $time | Measure-Object -Maximum -Minimum -Average | select Count, Maximum, Minimum, Average

Count Maximum Minimum Average
----- ------- -------   -------
   20 78.0931 61.9288 66.194415
```

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [x] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
