### PR TITLE
Update build and packaging modules for Alpine

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -419,13 +419,14 @@ function Start-PSBuild {
         # These runtimes must match those in project.json
         # We do not use ValidateScript since we want tab completion
         # If this parameter is not provided it will get determined automatically.
-        [ValidateSet("win7-x64",
-                     "win7-x86",
-                     "osx-x64",
+        [ValidateSet("linux-arm",
+                     "linux-musl-x64",
                      "linux-x64",
-                     "linux-arm",
+                     "osx-x64",
                      "win-arm",
-                     "win-arm64")]
+                     "win-arm64",
+                     "win7-x64",
+                     "win7-x86")]
         [string]$Runtime,
 
         [ValidateSet('Debug', 'Release', 'CodeCoverage', '')] # We might need "Checked" as well
@@ -737,13 +738,14 @@ function New-PSOptions {
         # These are duplicated from Start-PSBuild
         # We do not use ValidateScript since we want tab completion
         [ValidateSet("",
-                     "win7-x86",
-                     "win7-x64",
-                     "osx-x64",
-                     "linux-x64",
                      "linux-arm",
+                     "linux-musl-x64",
+                     "linux-x64",
+                     "osx-x64",
                      "win-arm",
-                     "win-arm64")]
+                     "win-arm64",
+                     "win7-x64",
+                     "win7-x86")]
         [string]$Runtime,
 
         [switch]$CrossGen,
@@ -2160,13 +2162,14 @@ function Start-CrossGen {
         $PublishPath,
 
         [Parameter(Mandatory=$true)]
-        [ValidateSet("win7-x86",
-                     "win7-x64",
-                     "osx-x64",
+        [ValidateSet("linux-arm",
+                     "linux-musl-x64",
                      "linux-x64",
-                     "linux-arm",
+                     "osx-x64",
                      "win-arm",
-                     "win-arm64")]
+                     "win-arm64",
+                     "win7-x64",
+                     "win7-x86")]
         [string]
         $Runtime
     )
@@ -2227,10 +2230,8 @@ function Start-CrossGen {
         }
     } elseif ($Runtime -eq "linux-arm") {
         throw "crossgen is not available for 'linux-arm'"
-    } elseif ($Environment.IsLinux) {
-        "linux-x64"
-    } elseif ($Environment.IsMacOS) {
-        "osx-x64"
+    } else {
+        $Runtime
     }
 
     if (-not $crossGenRuntime) {


### PR DESCRIPTION
## PR Summary

Enable building and packaging for Alpine from within PowerShell.
Added `linux-musl-x64` runtime and `tar-musl` packaging type.
Sorted the runtimes alphabetically

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [x] Not Applicable or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
