### PR TITLE
Make switch statement report correct error position when it fails to evaluate the condition

### DIFF
--- a/src/System.Management.Automation/engine/parser/Compiler.cs
+++ b/src/System.Management.Automation/engine/parser/Compiler.cs
@@ -4189,10 +4189,7 @@ namespace System.Management.Automation.Language
             // $foreach/$switch = GetEnumerator $enumerable
             var enumerable = NewTemp(typeof(object), "enumerable");
             temps.Add(enumerable);
-            if (generatingForeach)
-            {
-                exprs.Add(UpdatePosition(stmt.Condition));
-            }
+            exprs.Add(UpdatePosition(stmt.Condition));
             exprs.Add(
                 Expression.Assign(enumerable,
                                   GetRangeEnumerator(stmt.Condition.GetPureExpression())

--- a/test/powershell/Language/Scripting/ErrorPosition.Tests.ps1
+++ b/test/powershell/Language/Scripting/ErrorPosition.Tests.ps1
@@ -1,0 +1,51 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+Describe "Error position Tests" -Tags "CI" {
+    It "switch condition evaluation failure should report correct error position" {
+        $testFile = Join-Path $TestDrive "SwitchError1.ps1"
+        Set-Content -Path $testFile -Encoding Ascii -Value @'
+$test = 1
+switch ($nullVar[0]) {
+    "a" {};
+}
+'@
+        try { & $testFile } catch { $errorRecord = $_ }
+        $errorRecord | Should -Not -BeNullOrEmpty
+        $errorRecord.ScriptStackTrace | Should -Match "SwitchError1.ps1: line 2"
+    }
+
+    It "swtich condition MoveNext failure should report correct error position" {
+        $code = @'
+using System;
+using System.Collections.Generic;
+namespace SwitchTest
+{
+    public class Test
+    {
+        public static IEnumerable<string> GetName()
+        {
+            yield return "Hello world";
+            throw new ArgumentException();
+        }
+    }
+}
+'@
+        $testFile = Join-Path $TestDrive "SwitchError2.ps1"
+        Set-Content -Path $testFile -Encoding Ascii -Value @'
+$test = 1
+$enumerable = [SwitchTest.Test]::GetName()
+switch ($enumerable) {
+    "hello world" { $test = 1; $_ }
+    "Yay" { $test = 2; $_ }
+}
+'@
+        if (-not ("SwitchTest.Test" -as [type])) {
+            Add-Type -TypeDefinition $code
+        }
+        
+        try { & $testFile > $null } catch { $errorRecord = $_ }
+        $errorRecord | Should -Not -BeNullOrEmpty
+        $errorRecord.ScriptStackTrace | Should -Match "SwitchError2.ps1: line 3"
+    }
+}

--- a/test/powershell/Language/Scripting/ErrorPosition.Tests.ps1
+++ b/test/powershell/Language/Scripting/ErrorPosition.Tests.ps1
@@ -6,7 +6,7 @@ Describe "Error position Tests" -Tags "CI" {
         $testFile = Join-Path $TestDrive "SwitchError1.ps1"
         Set-Content -Path $testFile -Encoding Ascii -Value @'
 $test = 1
-switch ($nullVar[0]) {
+switch ($null[0]) {
     "a" {};
 }
 '@
@@ -15,7 +15,7 @@ switch ($nullVar[0]) {
         $errorRecord.ScriptStackTrace | Should -Match "SwitchError1.ps1: line 2"
     }
 
-    It "swtich condition MoveNext failure should report correct error position" {
+    It "switch condition MoveNext failure should report correct error position" {
         $code = @'
 using System;
 using System.Collections.Generic;


### PR DESCRIPTION
## PR Summary

Fix #7150
Make switch statement report correct error position when it fails to evaluate the condition

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [x] Issue filed - Issue link:
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [x] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
