### PR TITLE
Add test to verify filesystem provider isn't used when accessing root path in psdrive

### DIFF
--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Location.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Location.Tests.ps1
@@ -53,6 +53,22 @@ Describe "Set-Location" -Tags "CI" {
         $(Get-Location).Path | Should -BeExactly $testPath.FullName
     }
 
+    It "Should not use filesystem root folder if not in filesystem provider" -Skip:(!$IsWindows) {
+        # find filesystem root folder that doesn't exist in HKCU:
+        $foundFolder = $false
+        foreach ($folder in (Get-ChildItem "${env:SystemDrive}\" -Directory)) {
+            if (!(Test-Path "HKCU:\$($folder.Name)")) {
+                $testFolder = $folder.Name
+                $foundFolder = $true
+                break
+            }
+        }
+        $foundFolder | Should -BeTrue
+        Set-Location HKCU:\
+        { Set-Location ([System.IO.Path]::DirectorySeparatorChar + $testFolder) -ErrorAction Stop } |
+            Should -Throw -ErrorId "PathNotFound,Microsoft.PowerShell.Commands.SetLocationCommand"
+    }
+
     Context 'Set-Location with no arguments' {
 
         It 'Should go to $env:HOME when Set-Location run with no arguments from FileSystem provider' {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Location.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Location.Tests.ps1
@@ -56,8 +56,8 @@ Describe "Set-Location" -Tags "CI" {
     It "Should not use filesystem root folder if not in filesystem provider" -Skip:(!$IsWindows) {
         # find filesystem root folder that doesn't exist in HKCU:
         $foundFolder = $false
-        foreach ($folder in (Get-ChildItem "${env:SystemDrive}\" -Directory)) {
-            if (!(Test-Path "HKCU:\$($folder.Name)")) {
+        foreach ($folder in Get-ChildItem "${env:SystemDrive}\" -Directory) {
+            if (-Not (Test-Path "HKCU:\$($folder.Name)")) {
                 $testFolder = $folder.Name
                 $foundFolder = $true
                 break


### PR DESCRIPTION
## PR Summary

This was an issue introduced by https://github.com/PowerShell/PowerShell/commit/7459b5463904b7849320b7e834fda4e3274acd05.

When in a PSDrive, and you set-location to a root qualified path, it should be based on the current psdrive and not the filesystem.  Exception is on non-Windows, all paths start with `/` so it's always treated as filesystem.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
