### PR TITLE
Update `Enable-PSRemoting` so configuration name for Preview releases

### DIFF
--- a/src/System.Management.Automation/engine/PSVersionInfo.cs
+++ b/src/System.Management.Automation/engine/PSVersionInfo.cs
@@ -78,11 +78,11 @@ namespace System.Management.Automation
 
             if (productVersion.Contains(" Commits: "))
             {
-                rawGitCommitId = "v" + productVersion.Replace(" Commits: ", "-").Replace(" SHA: ", "-g");
+                rawGitCommitId = productVersion.Replace(" Commits: ", "-").Replace(" SHA: ", "-g");
             }
             else
             {
-                rawGitCommitId = "v" + mainVersion;
+                rawGitCommitId = mainVersion;
             }
 
             s_psV6Version = new SemanticVersion(mainVersion);

--- a/src/System.Management.Automation/engine/remoting/commands/CustomShellCommands.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/CustomShellCommands.cs
@@ -1524,6 +1524,7 @@ else
             {
                 version = version.Substring(1, version.Length - 1);
             }
+            
             return System.String.Concat("PowerShell.", version);
         }
 

--- a/src/System.Management.Automation/engine/remoting/commands/CustomShellCommands.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/CustomShellCommands.cs
@@ -1526,7 +1526,7 @@ else
             // the `v`
             if (version.StartsWith("v"))
             {
-                version = version.Substring(1, version.Length - 1);
+                version = version.Substring(1);
             }
 
             return System.String.Concat("PowerShell.", version);

--- a/src/System.Management.Automation/engine/remoting/commands/CustomShellCommands.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/CustomShellCommands.cs
@@ -1520,11 +1520,15 @@ else
             // TODO: This should be PSVersionInfo.PSVersionName once we get
             // closer to release. Right now it doesn't support alpha versions.
             string version = PSVersionInfo.GitCommitId;
+
+            // We want the resulting endpoint name to be: PowerShell.6
+            // However, the GitCommitId has a `v` like `v6.1.0`, so we need to remove
+            // the `v`
             if (version.StartsWith("v"))
             {
                 version = version.Substring(1, version.Length - 1);
             }
-            
+
             return System.String.Concat("PowerShell.", version);
         }
 
@@ -4895,6 +4899,8 @@ param(
             if ($dotPos -ne -1) {{
                 $powershellVersionMajor = $powershellVersionMajor.Substring(0, $dotPos)
             }}
+            # If we are running a Preview version, we don't want to clobber the generic PowerShell.6 endpoint
+            # but instead creating a PowerShell.6-Preview endpoint
             if ($PSVersionTable.PSVersion.ToString().Contains(""preview""))
             {{
                 $powershellVersionMajor += ""-Preview""

--- a/src/System.Management.Automation/engine/remoting/commands/CustomShellCommands.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/CustomShellCommands.cs
@@ -1529,7 +1529,13 @@ else
                 version = version.Substring(1);
             }
 
-            return System.String.Concat("PowerShell.", version);
+            string shellName = System.String.Concat("PowerShell.", version);
+            if (version.Contains("preview"))
+            {
+                shellName += "-Preview";
+            }
+
+            return shellName;
         }
 
         /// <summary>

--- a/src/System.Management.Automation/engine/remoting/commands/CustomShellCommands.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/CustomShellCommands.cs
@@ -1517,25 +1517,7 @@ else
         internal static string GetWinrmPluginShellName()
         {
             // PowerShell Core uses a versioned directory to hold the plugin
-            // TODO: This should be PSVersionInfo.PSVersionName once we get
-            // closer to release. Right now it doesn't support alpha versions.
-            string version = PSVersionInfo.GitCommitId;
-
-            // We want the resulting endpoint name to be: PowerShell.6
-            // However, the GitCommitId has a `v` like `v6.1.0`, so we need to remove
-            // the `v`
-            if (version.StartsWith("v"))
-            {
-                version = version.Substring(1);
-            }
-
-            string shellName = System.String.Concat("PowerShell.", version);
-            if (version.Contains("preview"))
-            {
-                shellName += "-Preview";
-            }
-
-            return shellName;
+            return System.String.Concat("PowerShell.", PSVersionInfo.GitCommitId);
         }
 
         /// <summary>
@@ -1545,8 +1527,6 @@ else
         internal static string GetWinrmPluginDllPath()
         {
             // PowerShell Core uses its versioned directory instead of system32
-            // TODO: This should be PSVersionInfo.PSVersionName once we get
-            // closer to release. Right now it doesn't support alpha versions.
             string pluginDllDirectory =  System.IO.Path.Combine("%windir%\\system32\\PowerShell", PSVersionInfo.GitCommitId);
             return System.IO.Path.Combine(pluginDllDirectory, RemotingConstants.PSPluginDLLName);
         }
@@ -4909,7 +4889,7 @@ param(
             # but instead creating a PowerShell.6-Preview endpoint
             if ($PSVersionTable.PSVersion.ToString().Contains(""preview""))
             {{
-                $powershellVersionMajor += ""-Preview""
+                $powershellVersionMajor += ""-preview""
             }}
             Register-EndpointIfNotPresent -Name (""PowerShell."" + $powershellVersionMajor) $Force $queryForRegisterDefault $captionForRegisterDefault
 

--- a/src/System.Management.Automation/engine/remoting/commands/CustomShellCommands.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/CustomShellCommands.cs
@@ -1519,7 +1519,12 @@ else
             // PowerShell Core uses a versioned directory to hold the plugin
             // TODO: This should be PSVersionInfo.PSVersionName once we get
             // closer to release. Right now it doesn't support alpha versions.
-            return System.String.Concat("PowerShell.", PSVersionInfo.GitCommitId);
+            string version = PSVersionInfo.GitCommitId;
+            if (version.StartsWith("v"))
+            {
+                version = version.Substring(1, version.Length - 1);
+            }
+            return System.String.Concat("PowerShell.", version);
         }
 
         /// <summary>
@@ -4888,6 +4893,10 @@ param(
             $dotPos = $powershellVersionMajor.IndexOf(""."")
             if ($dotPos -ne -1) {{
                 $powershellVersionMajor = $powershellVersionMajor.Substring(0, $dotPos)
+            }}
+            if ($PSVersionTable.PSVersion.ToString().Contains(""preview""))
+            {{
+                $powershellVersionMajor += ""-Preview""
             }}
             Register-EndpointIfNotPresent -Name (""PowerShell."" + $powershellVersionMajor) $Force $queryForRegisterDefault $captionForRegisterDefault
 

--- a/src/System.Management.Automation/engine/remoting/commands/CustomShellCommands.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/CustomShellCommands.cs
@@ -4886,8 +4886,8 @@ param(
                 $powershellVersionMajor = $powershellVersionMajor.Substring(0, $dotPos)
             }}
             # If we are running a Preview version, we don't want to clobber the generic PowerShell.6 endpoint
-            # but instead creating a PowerShell.6-Preview endpoint
-            if ($PSVersionTable.PSVersion.ToString().Contains(""preview""))
+            # but instead create a PowerShell.6-Preview endpoint
+            if ($PSVersionTable.PSVersion.PreReleaseLabel)
             {{
                 $powershellVersionMajor += ""-preview""
             }}

--- a/test/powershell/Host/ConsoleHost.Tests.ps1
+++ b/test/powershell/Host/ConsoleHost.Tests.ps1
@@ -674,7 +674,7 @@ Describe "Pwsh exe resources tests" -Tag CI {
     It "Resource strings are embedded in the executable" -Skip:(!$IsWindows) {
         $pwsh = Get-Item -Path "$PSHOME\pwsh.exe"
         $pwsh.VersionInfo.FileVersion | Should -BeExactly $PSVersionTable.PSVersion.ToString().Split("-")[0]
-        "v" + $pwsh.VersionInfo.ProductVersion.Replace("-dirty","") | Should -BeExactly $PSVersionTable.GitCommitId
+        $pwsh.VersionInfo.ProductVersion.Replace("-dirty","") | Should -BeExactly $PSVersionTable.GitCommitId
         $pwsh.VersionInfo.ProductName | Should -BeExactly "PowerShell Core 6"
     }
 

--- a/test/powershell/Host/PSVersionTable.Tests.ps1
+++ b/test/powershell/Host/PSVersionTable.Tests.ps1
@@ -7,19 +7,19 @@ Describe "PSVersionTable" -Tags "CI" {
         $formattedVersion = $sma.VersionInfo.ProductVersion
 
         $mainVersionPattern = "(\d+\.\d+\.\d+)(-.+)?"
-        $fullVersionPattern = "^v(\d+\.\d+\.\d+)(-.+)?-(\d+)-g(.+)$"
+        $fullVersionPattern = "^(\d+\.\d+\.\d+)(-.+)?-(\d+)-g(.+)$"
 
         $expectedPSVersion = ($formattedVersion -split " ")[0]
         $expectedVersionPattern = "^$mainVersionPattern$"
 
         if ($formattedVersion.Contains(" Commits: "))
         {
-            $rawGitCommitId = "v" + $formattedVersion.Replace(" Commits: ", "-").Replace(" SHA: ", "-g")
+            $rawGitCommitId = $formattedVersion.Replace(" Commits: ", "-").Replace(" SHA: ", "-g")
             $expectedGitCommitIdPattern = $fullVersionPattern
             $unexpectectGitCommitIdPattern = "qwerty"
         } else {
-            $rawGitCommitId = "v" + ($formattedVersion -split " SHA: ")[0]
-            $expectedGitCommitIdPattern = "^v$mainVersionPattern$"
+            $rawGitCommitId = ($formattedVersion -split " SHA: ")[0]
+            $expectedGitCommitIdPattern = "^$mainVersionPattern$"
             $unexpectectGitCommitIdPattern = $fullVersionPattern
         }
     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/PSSessionConfiguration.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/PSSessionConfiguration.Tests.ps1
@@ -17,7 +17,7 @@ try
     #
     if ($IsNotSkipped)
     {
-        $endpointName = "PowerShell.$($psversiontable.GitCommitId)".Replace("PowerShell.v","PowerShell.")
+        $endpointName = "PowerShell.$($psversiontable.GitCommitId)"
 
         $matchedEndpoint = Get-PSSessionConfiguration $endpointName -ErrorAction SilentlyContinue
 
@@ -839,7 +839,7 @@ namespace PowershellTestConfigNamespace
         }
 
         It "Enable-PSSession Cmdlet creates a PSSession configuration with a name tied to PowerShell version." {
-            $endpointName = "PowerShell." + $PSVersionTable.GitCommitId.ToString().Substring(1) # Remove the v from the beginning
+            $endpointName = "PowerShell." + $PSVersionTable.GitCommitId.ToString()
             $matchedEndpoint = Get-PSSessionConfiguration $endpointName -ErrorAction SilentlyContinue
             $matchedEndpoint | Should -Not -BeNullOrEmpty
         }
@@ -849,7 +849,7 @@ namespace PowershellTestConfigNamespace
             $endpointName = "PowerShell." + $PSVersionTable.PSVersion.ToString().Substring(0, $dotPos)
             if ($PSVersionTable.GitCommitId.Contains("preview"))
             {
-                $endpointName += "-Preview"
+                $endpointName += "-preview"
             }
             $matchedEndpoint = Get-PSSessionConfiguration $endpointName -ErrorAction SilentlyContinue
             $matchedEndpoint | Should -Not -BeNullOrEmpty

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/PSSessionConfiguration.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/PSSessionConfiguration.Tests.ps1
@@ -104,13 +104,13 @@ try
                     # Create new Config File
                     function CreateTestConfigFile {
 
-                        $TestConfigFileLoc = join-path $TestDrive "Remoting"
+                        $TestConfigFileLoc = Join-Path $TestDrive "Remoting"
                         if(-not (Test-path $TestConfigFileLoc))
                         {
                             $null = New-Item -Path $TestConfigFileLoc -ItemType Directory -Force -ErrorAction Stop
                         }
 
-                        $TestConfigFile = join-path $TestConfigFileLoc "TestConfigFile.pssc"
+                        $TestConfigFile = Join-Path $TestConfigFileLoc "TestConfigFile.pssc"
                         $null = New-PSSessionConfigurationFile -Path $TestConfigFile -SessionType Default
 
                         return $TestConfigFile
@@ -366,7 +366,7 @@ try
 `$script:testvariable = "testValue"
 "@
 
-                        $TestScript = join-path $script:TestDir "StartupTestScript.ps1"
+                        $TestScript = Join-Path $script:TestDir "StartupTestScript.ps1"
                         $null = Set-Content -path $TestScript -Value $ScriptContent
 
                         return $TestScript
@@ -375,7 +375,7 @@ try
                     # Create new Config File
                     function CreateTestConfigFile {
 
-                        $TestConfigFile = join-path $script:TestDir "TestConfigFile.pssc"
+                        $TestConfigFile = Join-Path $script:TestDir "TestConfigFile.pssc"
                         $null = New-PSSessionConfigurationFile -Path $TestConfigFile -SessionType Default
                         return $TestConfigFile
                     }
@@ -394,7 +394,7 @@ Export-ModuleMember IsTestModuleImported
                             $null = New-Item -Path $TestModuleFileLoc -ItemType Directory -Force -ErrorAction Stop
                         }
 
-                        $TestModuleFile = join-path $TestModuleFileLoc "TestModule.psm1"
+                        $TestModuleFile = Join-Path $TestModuleFileLoc "TestModule.psm1"
                         $null = Set-Content -path $TestModuleFile -Value $ScriptContent
 
                         return $TestModuleFile
@@ -424,16 +424,21 @@ namespace PowershellTestConfigNamespace
     }
 }
 "@
-                        $script:SourceFile = join-path $script:TestAssemblyDir "PowershellTestConfig.cs"
+                        $script:SourceFile = Join-Path $script:TestAssemblyDir "PowershellTestConfig.cs"
                         $PscConfigDef | out-file $script:SourceFile -Encoding ascii -Force
-                        $TestAssemblyName = "TestAssembly" + (New-Guid) + ".dll"
-                        $TestAssemblyPath = join-path $script:TestAssemblyDir $TestAssemblyName
+                        $TestAssemblyName = "TestAssembly.dll"
+                        $TestAssemblyPath = Join-Path $script:TestAssemblyDir $TestAssemblyName
                         Add-Type -path $script:SourceFile -OutputAssembly $TestAssemblyPath
                         return $TestAssemblyName
                     }
 
-                    $script:TestDir = join-path $TestDrive "Remoting"
-                    $script:TestAssemblyDir = [System.IO.Path]::GetTempPath()
+                    $script:TestDir = Join-Path $TestDrive "Remoting"
+                    if(-not (Test-Path $script:TestDir))
+                    {
+                        $null = New-Item -path $script:TestDir -ItemType Directory
+                    }
+
+                    $script:TestAssemblyDir = Join-Path $TestDrive "AssemblyDir"
                     if(-not (Test-Path $script:TestAssemblyDir))
                     {
                         $null = New-Item -path $script:TestAssemblyDir -ItemType Directory
@@ -608,11 +613,11 @@ namespace PowershellTestConfigNamespace
 
         It "Validate New-PSSessionConfigurationFile can successfully create a valid PSSessionConfigurationFile" {
 
-            $configFilePath = join-path $TestDrive "SamplePSSessionConfigurationFile.pssc"
+            $configFilePath = Join-Path $TestDrive "SamplePSSessionConfigurationFile.pssc"
             try
             {
                 New-PSSessionConfigurationFile $configFilePath
-                $result = get-content $configFilePath | Out-String
+                $result = Get-Content $configFilePath | Out-String
             }
             finally
             {
@@ -740,7 +745,7 @@ namespace PowershellTestConfigNamespace
 
         It "Validate FullyQualifiedErrorId from Test-PSSessionConfigurationFile when an invalid pssc file is provided as input and -Verbose parameter is specified" {
 
-            $configFilePath = join-path $TestDrive "SamplePSSessionConfigurationFile.pssc"
+            $configFilePath = Join-Path $TestDrive "SamplePSSessionConfigurationFile.pssc"
             "InvalidData" | Out-File $configFilePath
 
             Test-PSSessionConfigurationFile $configFilePath -Verbose -ErrorAction Stop | Should -BeFalse
@@ -749,7 +754,7 @@ namespace PowershellTestConfigNamespace
         It "Test case verifies that the generated config file passes validation" {
 
             # Path the config file
-            $configFilePath = join-path $TestDrive "SamplePSSessionConfigurationFile.pssc"
+            $configFilePath = Join-Path $TestDrive "SamplePSSessionConfigurationFile.pssc"
 
             $updatedFunctionDefn = @()
             foreach($currentDefination in $parmMap.FunctionDefinitions)
@@ -834,7 +839,7 @@ namespace PowershellTestConfigNamespace
         }
 
         It "Enable-PSSession Cmdlet creates a PSSession configuration with a name tied to PowerShell version." {
-            $endpointName = ("PowerShell." + $PSVersionTable.GitCommitId.ToString()).Replace("PowerShell.v","PowerShell.")
+            $endpointName = "PowerShell." + $PSVersionTable.GitCommitId.ToString().Substring(1) # Remove the v from the beginning
             $matchedEndpoint = Get-PSSessionConfiguration $endpointName -ErrorAction SilentlyContinue
             $matchedEndpoint | Should -Not -BeNullOrEmpty
         }

--- a/test/powershell/engine/Remoting/RemoteSession.Basic.Tests.ps1
+++ b/test/powershell/engine/Remoting/RemoteSession.Basic.Tests.ps1
@@ -129,8 +129,7 @@ Describe "Remoting loopback tests" -Tags @('CI', 'RequireAdminOnWindows') {
         else
         {
             Enable-PSRemoting -SkipNetworkProfileCheck
-            $psversion = $PSVersionTable.GitCommitId.ToString().Substring(1) # Remove the v from the beginning
-            $endPoint = (Get-PSSessionConfiguration -Name "PowerShell.$psversion").Name
+            $endPoint = (Get-PSSessionConfiguration -Name "PowerShell.$(${PSVersionTable}.GitCommitId)").Name
             $disconnectedSession = New-RemoteSession -ConfigurationName $endPoint -ComputerName localhost | Disconnect-PSSession
             $closedSession = New-RemoteSession -ConfigurationName $endPoint -ComputerName localhost
             $closedSession.Runspace.Close()

--- a/test/powershell/engine/Remoting/RemoteSession.Basic.Tests.ps1
+++ b/test/powershell/engine/Remoting/RemoteSession.Basic.Tests.ps1
@@ -129,7 +129,8 @@ Describe "Remoting loopback tests" -Tags @('CI', 'RequireAdminOnWindows') {
         else
         {
             Enable-PSRemoting -SkipNetworkProfileCheck
-            $endPoint = (Get-PSSessionConfiguration -Name "PowerShell.$(${PSVersionTable}.GitCommitId)").Name
+            $psversion = $PSVersionTable.GitCommitId.ToString().Substring(1) # Remove the v from the beginning
+            $endPoint = (Get-PSSessionConfiguration -Name "PowerShell.$psversion").Name
             $disconnectedSession = New-RemoteSession -ConfigurationName $endPoint -ComputerName localhost | Disconnect-PSSession
             $closedSession = New-RemoteSession -ConfigurationName $endPoint -ComputerName localhost
             $closedSession.Runspace.Close()


### PR DESCRIPTION
## PR Summary

Intent was to have the version of the PSSessionConfiguration name not include the `v` for the version string.  Also, Preview releases should standardize on `PowerShell.6-Preview` instead of clobbering `PowerShell.6` so that stable and preview can co-exist side-by-side.

Need to verify on Win10 IoT if `Install-PowerShellRemoting.ps1` is still needed anymore as it may be possible to run `pwsh -c enable-psremoting` from within Windows PowerShell Core removing the need for that script which duplicates `Enable-PSRemoting` capability.

Update: Not able to get current master build working on Win10 IoT, getting `Invalid access to memory` error.  Will have to investigate this separately from this PR and keep `Install-PowerShellRemoting.ps1` for now.

Fix https://github.com/PowerShell/PowerShell/issues/7119

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)


