### PR TITLE
Update building guide's output folder to netcoreapp2.1

### DIFF
--- a/docs/building/linux.md
+++ b/docs/building/linux.md
@@ -71,7 +71,7 @@ Start-PSBuild
 Congratulations! If everything went right, PowerShell is now built.
 The `Start-PSBuild` script will output the location of the executable:
 
-`./src/powershell-unix/bin/Linux/netcoreapp2.0/linux-x64/publish/pwsh`.
+`./src/powershell-unix/bin/Debug/netcoreapp2.1/linux-x64/publish/pwsh`.
 
 You should now be running the PowerShell Core that you just built, if your run the above executable.
 You can run our cross-platform Pester tests with `Start-PSPester`, and our xUnit tests with `Start-PSxUnit`.

--- a/docs/building/macos.md
+++ b/docs/building/macos.md
@@ -36,5 +36,4 @@ We cannot do this for you in the build module due to #[847][].
 
 Start a PowerShell session by running `pwsh`, and then use `Start-PSBuild` from the module.
 
-After building, PowerShell will be at `./src/powershell-unix/bin/Linux/netcoreapp2.0/osx-x64/publish/powershell`.
-Note that configuration is still `Linux`.
+After building, PowerShell will be at `./src/powershell-unix/bin/Debug/netcoreapp2.1/osx-x64/publish/pwsh`.

--- a/docs/building/windows-core.md
+++ b/docs/building/windows-core.md
@@ -58,11 +58,11 @@ Import-Module ./build.psm1
 Start-PSBuild
 ```
 
-Congratulations! If everything went right, PowerShell is now built and executable as `./src/powershell-win-core/bin/Debug/netcoreapp2.0/win7-x64/publish/pwsh`.
+Congratulations! If everything went right, PowerShell is now built and executable as `./src/powershell-win-core/bin/Debug/netcoreapp2.1/win7-x64/publish/pwsh.exe`.
 
 This location is of the form `./[project]/bin/[configuration]/[framework]/[rid]/publish/[binary name]`,
 and our project is `powershell`, configuration is `Debug` by default,
-framework is `netcoreapp2.0`, runtime identifier is `win7-x64` by default,
+framework is `netcoreapp2.1`, runtime identifier is `win7-x64` by default,
 and binary name is `pwsh`.
 The function `Get-PSOutput` will return the path to the executable;
 thus you can execute the development copy via `& (Get-PSOutput)`.


### PR DESCRIPTION
## PR Summary

This fixes the building guide for windows, linux and macOS in `Powershell/docs/building/` to reflect the actual default output folder when following the instructions. They lead to the executable being created under `./src/[platform]/bin/Debug/netcoreapp2.1/...`, not `./src/[platform]/bin/Debug/netcoreapp2.0/...`.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [x] Not Applicable or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)

---

This should probably be done in the linux and macOS building guides, but I can't verify it for sure since I have a windows machine, let me know if this is the case and I can add an additional commit for them.
