### PR TITLE
Make TabCompletion case-insensitive for file names on Unix (2-nd attempt)

### DIFF
--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -4166,7 +4166,7 @@ namespace System.Management.Automation
                                     string[] entries = null;
                                     try
                                     {
-                                        entries = Directory.GetFileSystemEntries(parentPath, leaf);
+                                        entries = Directory.GetFileSystemEntries(parentPath, leaf, new System.IO.EnumerationOptions { MatchCasing = MatchCasing.CaseInsensitive });
                                     }
                                     catch (Exception)
                                     {

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -263,23 +263,23 @@ Describe "TabCompletion" -Tags CI {
         It "TabCompletion should be case-insensitive for file names on Windows and MacOS" -Skip:($IsLinux) {
             Push-Location -Path $tempDir
             $res = TabExpansion2 -inputScript $oneSubDirLowerTest -cursorColumn $oneSubDirLowerTest.Length
-            $res.CompletionMatches.Count | Should BeGreaterThan 0
-            $res.CompletionMatches[0].CompletionText | Should Be ".${separator}$oneSubDirTest"
+            $res.CompletionMatches.Count | Should -BeGreaterThan 0
+            $res.CompletionMatches[0].CompletionText | Should -BeExactly ".${separator}$oneSubDirTest"
 
             $res = TabExpansion2 -inputScript $oneSubDirUpperTest -cursorColumn $oneSubDirUpperTest.Length
-            $res.CompletionMatches.Count | Should BeGreaterThan 0
-            $res.CompletionMatches[0].CompletionText | Should Be ".${separator}$oneSubDirTest"
+            $res.CompletionMatches.Count | Should -BeGreaterThan 0
+            $res.CompletionMatches[0].CompletionText | Should -BeExactly ".${separator}$oneSubDirTest"
         }
 
         It "TabCompletion should be case-sensitive for file names on Unix" -Skip:(!$IsLinux) {
             Push-Location -Path $tempDir
             $res = TabExpansion2 -inputScript $oneSubDirLowerTest -cursorColumn $oneSubDirLowerTest.Length
-            $res.CompletionMatches.Count | Should BeGreaterThan 0
-            $res.CompletionMatches[0].CompletionText | Should BeExactly ".${separator}$oneSubDirTest"
+            $res.CompletionMatches.Count | Should -BeGreaterThan 0
+            $res.CompletionMatches[0].CompletionText | Should -BeExactly ".${separator}$oneSubDirTest"
 
             $res = TabExpansion2 -inputScript $oneSubDirUpperTest -cursorColumn $oneSubDirUpperTest.Length
-            $res.CompletionMatches.Count | Should BeGreaterThan 0
-            $res.CompletionMatches[0].CompletionText | Should BeExactly ".${separator}$oneSubDirTest2"
+            $res.CompletionMatches.Count | Should -BeGreaterThan 0
+            $res.CompletionMatches[0].CompletionText | Should -BeExactly ".${separator}$oneSubDirTest2"
         }
 
         It "Input '<inputStr>' should successfully complete" -TestCases $testCases {

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -260,7 +260,7 @@ Describe "TabCompletion" -Tags CI {
             Pop-Location
         }
 
-        It "TabCompletion should be case-insensitive for file names on Windows" -Skip:(!$IsWindows) {
+        It "TabCompletion should be case-insensitive for file names on Windows and MacOS" -Skip:($IsLinux) {
             Push-Location -Path $tempDir
             $res = TabExpansion2 -inputScript $oneSubDirLowerTest -cursorColumn $oneSubDirLowerTest.Length
             $res.CompletionMatches.Count | Should BeGreaterThan 0
@@ -271,7 +271,7 @@ Describe "TabCompletion" -Tags CI {
             $res.CompletionMatches[0].CompletionText | Should Be ".${separator}$oneSubDirTest"
         }
 
-        It "TabCompletion should be case-sensitive for file names on Unix" -Skip:($IsWindows) {
+        It "TabCompletion should be case-sensitive for file names on Unix" -Skip:(!$IsLinux) {
             Push-Location -Path $tempDir
             $res = TabExpansion2 -inputScript $oneSubDirLowerTest -cursorColumn $oneSubDirLowerTest.Length
             $res.CompletionMatches.Count | Should BeGreaterThan 0

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -263,22 +263,22 @@ Describe "TabCompletion" -Tags CI {
         It "TabCompletion should be case-insensitive for file names on Windows and MacOS" -Skip:($IsLinux) {
             Push-Location -Path $tempDir
             $res = TabExpansion2 -inputScript $oneSubDirLowerTest -cursorColumn $oneSubDirLowerTest.Length
-            $res.CompletionMatches.Count | Should -BeGreaterThan 0
+            $res.CompletionMatches | Should -HaveCount 1
             $res.CompletionMatches[0].CompletionText | Should -BeExactly ".${separator}$oneSubDirTest"
 
             $res = TabExpansion2 -inputScript $oneSubDirUpperTest -cursorColumn $oneSubDirUpperTest.Length
-            $res.CompletionMatches.Count | Should -BeGreaterThan 0
+            $res.CompletionMatches | Should -HaveCount 1
             $res.CompletionMatches[0].CompletionText | Should -BeExactly ".${separator}$oneSubDirTest"
         }
 
         It "TabCompletion should be case-sensitive for file names on Unix" -Skip:(!$IsLinux) {
             Push-Location -Path $tempDir
             $res = TabExpansion2 -inputScript $oneSubDirLowerTest -cursorColumn $oneSubDirLowerTest.Length
-            $res.CompletionMatches.Count | Should -BeGreaterThan 0
+            $res.CompletionMatches | Should -HaveCount 2
             $res.CompletionMatches[0].CompletionText | Should -BeExactly ".${separator}$oneSubDirTest"
 
             $res = TabExpansion2 -inputScript $oneSubDirUpperTest -cursorColumn $oneSubDirUpperTest.Length
-            $res.CompletionMatches.Count | Should -BeGreaterThan 0
+            $res.CompletionMatches | Should -HaveCount 2
             $res.CompletionMatches[0].CompletionText | Should -BeExactly ".${separator}$oneSubDirTest2"
         }
 


### PR DESCRIPTION
## PR Summary

Attempt to fix #1273.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
