### PR TITLE
Fix Register-EngineEvent test text

### DIFF
--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Register-EngineEvent.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Register-EngineEvent.Tests.ps1
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 Describe "Register-EngineEvent" -Tags "CI" {
 
-    Context "Check return type of Register-ObjectEvent" {
+    Context "Check return type of Register-EngineEvent" {
 	It "Should return System.Management.Automation.PSEventJob as return type of Register-EngineEvent" {
 	    Register-EngineEvent -SourceIdentifier PesterTestRegister -Action {echo registerengineevent} | Should -BeOfType System.Management.Automation.PSEventJob
 	    Unregister-Event -sourceidentifier PesterTestRegister


### PR DESCRIPTION
## PR Summary

The Pester test for Register-EngineEvent says that we're testing the return type of Register-ObjectEvent, when in fact we're testing the return type of Register-EngineEvent

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
