### PR TITLE
Update docs for ArgumentCompleterAttribute class

### DIFF
--- a/src/System.Management.Automation/engine/Attributes.cs
+++ b/src/System.Management.Automation/engine/Attributes.cs
@@ -1259,7 +1259,9 @@ namespace System.Management.Automation
         /// The text representation of the object being validated and the validating regex is passed as
         /// the first and second formatting parameters to the ErrorMessage formatting pattern.
         /// <example>
+        /// <code>
         /// [ValidatePattern("\s+", ErrorMessage="The text '{0}' did not pass validation of regex '{1}'")]
+        /// </code>
         /// </example>
         /// </summary>
         public string ErrorMessage { get; set; }
@@ -1322,7 +1324,9 @@ namespace System.Management.Automation
         /// formatting argument.
         ///
         /// <example>
+        /// <code>
         /// [ValidateScript("$_ % 2", ErrorMessage = "The item '{0}' did not pass validation of script '{1}'")]
+        /// </code>
         /// </example>
         /// </summary>
         public string ErrorMessage { get; set; }
@@ -1569,7 +1573,9 @@ namespace System.Management.Automation
         /// is passed as the first and second formatting argument to the ErrorMessage formatting pattern.
         ///
         /// <example>
+        /// <code>
         /// [ValidateSet("A","B","C", ErrorMessage="The item '{0}' is not part of the set '{1}'.")
+        /// </code>
         /// </example>
         /// </summary>
         public string ErrorMessage { get; set; }

--- a/src/System.Management.Automation/engine/CommandCompletion/ExtensibleCompletion.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/ExtensibleCompletion.cs
@@ -12,9 +12,11 @@ namespace System.Management.Automation
     /// <summary>
     /// This attribute is used to specify an argument completer for a parameter to a cmdlet or function.
     /// <example>
+    /// <code>
     ///     [Parameter()]
     ///     [ArgumentCompleter(typeof(NounArgumentCompleter))]
     ///     public string Noun { get; set; }
+    /// </code>
     /// </example>
     /// </summary>
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]


### PR DESCRIPTION
improves documentation for class.

before:
![image](https://user-images.githubusercontent.com/9786571/42243944-ab7f3ae8-7f1b-11e8-8a21-e6a780f5e057.png)

after:
![image](https://user-images.githubusercontent.com/9786571/42243919-95672860-7f1b-11e8-9689-af98e67173df.png)