### PR TITLE
Type inference for Select-Object, Group-Object, PSObject and Hashtable

### DIFF
--- a/src/System.Management.Automation/engine/CommandInfo.cs
+++ b/src/System.Management.Automation/engine/CommandInfo.cs
@@ -3,11 +3,15 @@
 
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Management.Automation.Language;
 using System.Management.Automation.Runspaces;
 using System.Reflection;
 using System.Runtime.ExceptionServices;
+using System.Text;
+
 using Microsoft.PowerShell.Commands;
 
 namespace System.Management.Automation
@@ -794,6 +798,17 @@ namespace System.Management.Automation
         }
 
         /// <summary>
+        /// This constructor is used when the creating a PSObject with a custom typename.
+        /// </summary>
+        /// <param name="name">The name of the type.</param>
+        /// <param name="type">The real type.</param>
+        internal PSTypeName(string name, Type type)
+        {
+            Name = name;
+            _type = type;
+        }
+
+        /// <summary>
         /// This constructor is used when the type is defined in PowerShell.
         /// </summary>
         /// <param name="typeDefinitionAst">The type definition from the ast.</param>
@@ -899,6 +914,95 @@ namespace System.Management.Automation
         {
             return Name ?? string.Empty;
         }
+    }
+
+    [DebuggerDisplay("{PSTypeName} {Name}")]
+    internal struct PSMemberNameAndType
+    {
+        public readonly string Name;
+
+        public readonly PSTypeName PSTypeName;
+
+        public readonly object Value;
+
+        public PSMemberNameAndType(string name, PSTypeName typeName, object value = null)
+        {
+            Name = name;
+            PSTypeName = typeName;
+            Value = value;
+        }
+    }
+
+    /// <summary>
+    /// Represents dynamic types such as <see cref="System.Management.Automation.PSObject"/>,
+    /// but can be used where a real type might not be available, in which case the name of the type can be used.
+    /// The type encodes the members of dynamic objects in the type name.
+    /// </summary>
+    internal class PSSyntheticTypeName : PSTypeName
+    {
+        internal static PSSyntheticTypeName Create(string typename, IList<PSMemberNameAndType> membersTypes) => Create(new PSTypeName(typename), membersTypes);
+
+        internal static PSSyntheticTypeName Create(Type type, IList<PSMemberNameAndType> membersTypes) => Create(new PSTypeName(type), membersTypes);
+
+        internal static PSSyntheticTypeName Create(PSTypeName typename, IList<PSMemberNameAndType> membersTypes)
+        {
+            var typeName = GetMemberTypeProjection(typename.Name, membersTypes);
+            var members = new List<PSMemberNameAndType>();
+            members.AddRange(membersTypes);
+            members.Sort((c1,c2) =>string.Compare(c1.Name, c2.Name, StringComparison.CurrentCultureIgnoreCase));
+            return new PSSyntheticTypeName(typeName, typename.Type, members);
+        }
+
+        private PSSyntheticTypeName(string typeName, Type type, IList<PSMemberNameAndType> membersTypes)
+        : base(typeName, type)
+        {
+            Members = membersTypes;
+            if (type != typeof(PSObject))
+            {
+                return;
+            }
+
+            for (int i = 0; i < Members.Count; i++)
+            {
+                var psMemberNameAndType = Members[i];
+                if (IsPSTypeName(psMemberNameAndType))
+                {
+                    Members.RemoveAt(i);
+                    break;
+                }
+            }
+        }
+
+        private static bool IsPSTypeName(PSMemberNameAndType member) => string.Compare("PSTypeName", member.Name, StringComparison.CurrentCultureIgnoreCase) == 0;
+
+        private static string GetMemberTypeProjection(string typename, IList<PSMemberNameAndType> members)
+        {
+            if (typename == typeof(PSObject).FullName)
+            {
+                foreach (var mem in members)
+                {
+                    if (IsPSTypeName(mem))
+                    {
+                        typename = mem.Value.ToString();
+                    }
+                }
+            }
+
+            var builder = new StringBuilder(typename, members.Count * 7);
+            builder.Append('#');
+            foreach (var m in members.OrderBy(m => m.Name))
+            {
+                if (!IsPSTypeName(m))
+                {
+                    builder.Append(m.Name).Append(":");
+                }
+            }
+
+            builder.Length--;
+            return builder.ToString();
+        }
+
+        public IList<PSMemberNameAndType> Members { get; }
     }
 
     internal interface IScriptCommandInfo

--- a/src/System.Management.Automation/engine/CommandInfo.cs
+++ b/src/System.Management.Automation/engine/CommandInfo.cs
@@ -802,7 +802,7 @@ namespace System.Management.Automation
         /// </summary>
         /// <param name="name">The name of the type.</param>
         /// <param name="type">The real type.</param>
-        internal PSTypeName(string name, Type type)
+        public PSTypeName(string name, Type type)
         {
             Name = name;
             _type = type;
@@ -973,7 +973,7 @@ namespace System.Management.Automation
             }
         }
 
-        private static bool IsPSTypeName(PSMemberNameAndType member) => string.Compare("PSTypeName", member.Name, StringComparison.CurrentCultureIgnoreCase) == 0;
+        private static bool IsPSTypeName(PSMemberNameAndType member) => member.Name.Equals(nameof(PSTypeName), StringComparison.CurrentCultureIgnoreCase);
 
         private static string GetMemberTypeProjection(string typename, IList<PSMemberNameAndType> members)
         {

--- a/src/System.Management.Automation/engine/MshMemberInfo.cs
+++ b/src/System.Management.Automation/engine/MshMemberInfo.cs
@@ -83,9 +83,13 @@ namespace System.Management.Automation
         /// </summary>
         Dynamic = 4096,
         /// <summary>
+        /// Members that are inferred by type inference for PSObject and hashtable.
+        /// </summary>
+        InferredProperty = 8192,
+        /// <summary>
         /// All property member types
         /// </summary>
-        Properties = AliasProperty | CodeProperty | Property | NoteProperty | ScriptProperty,
+        Properties = AliasProperty | CodeProperty | Property | NoteProperty | ScriptProperty | InferredProperty,
         /// <summary>
         /// All method member types
         /// </summary>
@@ -952,6 +956,34 @@ namespace System.Management.Automation
         }
         #endregion virtual implementation
 
+    }
+
+    /// <summary>
+    /// Type used to capture the properties inferred from Hashtable and PSObject.
+    /// </summary>
+    internal class PSInferredProperty : PSPropertyInfo
+    {
+        public PSInferredProperty(string name, PSTypeName typeName)
+        {
+            this.name = name;
+            TypeName = typeName;
+        }
+
+        internal PSTypeName TypeName { get; }
+
+        public override PSMemberTypes MemberType => PSMemberTypes.InferredProperty;
+
+        public override object Value { get; set; }
+
+        public override string TypeNameOfValue => TypeName.Name;
+
+        public override PSMemberInfo Copy() => new PSInferredProperty(Name, TypeName);
+
+        public override bool IsSettable => false;
+
+        public override bool IsGettable => false;
+
+        public override string ToString() => $"{ToStringCodeMethods.Type(TypeName.Type)} {Name}";
     }
 
     /// <summary>

--- a/src/System.Management.Automation/engine/parser/TypeInferenceVisitor.cs
+++ b/src/System.Management.Automation/engine/parser/TypeInferenceVisitor.cs
@@ -400,8 +400,8 @@ namespace System.Management.Automation
             type = null;
             if (value != null)
             {
-                if (value is IList list
-                    && list.Count > 0)
+                var list = value as IList;
+                if (list != null && list.Count > 0)
                 {
                     value = list[0];
                 }

--- a/src/System.Management.Automation/engine/parser/TypeInferenceVisitor.cs
+++ b/src/System.Management.Automation/engine/parser/TypeInferenceVisitor.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Management.Automation.Language;
 using System.Management.Automation.Runspaces;
 using System.Reflection;
+using System.Text;
 using System.Text.RegularExpressions;
 
 using Microsoft.PowerShell.Commands;
@@ -174,6 +175,14 @@ namespace System.Management.Automation
             List<object> results = new List<object>();
 
             Func<object, bool> filterToCall = filter;
+            if (typename is PSSyntheticTypeName synthetic)
+            {
+                foreach (var mem in synthetic.Members)
+                {
+                    results.Add(new PSInferredProperty(mem.Name, mem.PSTypeName));
+                }
+            }
+
             if (typename.Type != null)
             {
                 AddMembersByInferredTypesClrType(typename, isStatic, filter, filterToCall, results);
@@ -400,8 +409,8 @@ namespace System.Management.Automation
             type = null;
             if (value != null)
             {
-                var list = value as IList;
-                if (list != null && list.Count > 0)
+                if (value is IList list
+                    && list.Count > 0)
                 {
                     value = list[0];
                 }
@@ -515,6 +524,33 @@ namespace System.Management.Automation
 
         object ICustomAstVisitor.VisitHashtable(HashtableAst hashtableAst)
         {
+            if (hashtableAst.KeyValuePairs.Count > 0)
+            {
+                var properties = new List<PSMemberNameAndType>();
+
+                foreach (var kv in hashtableAst.KeyValuePairs)
+                {
+                    if (SafeExprEvaluator.TrySafeEval(kv.Item1, _context.ExecutionContext, out object nameValue))
+                    {
+                        var name = nameValue.ToString();
+                        var typeName = InferTypes(kv.Item2).FirstOrDefault()?.Name ?? "System.Object";
+                        object value = null;
+                        if (kv.Item2 is PipelineAst pipelineAst
+                            && pipelineAst.PipelineElements[0] is CommandExpressionAst commandExpressionAst
+                            && SafeExprEvaluator.TrySafeEval(commandExpressionAst.Expression, _context.ExecutionContext, out object safeValue))
+                        {
+                            value = safeValue;
+                        }
+
+                        var pstypeName = value != null ? new PSTypeName(value.GetType()) : new PSTypeName(typeName);
+
+                        properties.Add(new PSMemberNameAndType(name, pstypeName, value));
+                    }
+                }
+
+                return new[] { PSSyntheticTypeName.Create(typeof(Hashtable), properties) };
+            }
+
             return new[] { new PSTypeName(typeof(Hashtable)) };
         }
 
@@ -581,6 +617,15 @@ namespace System.Management.Automation
         object ICustomAstVisitor.VisitConvertExpression(ConvertExpressionAst convertExpressionAst)
         {
             var type = convertExpressionAst.Type.TypeName.GetReflectionType();
+
+            if (type == typeof(PSObject) && convertExpressionAst.Child is HashtableAst hashtableAst)
+            {
+                if (InferTypes(hashtableAst).FirstOrDefault() is PSSyntheticTypeName syntheticTypeName)
+                {
+                    return new[] { PSSyntheticTypeName.Create(type, syntheticTypeName.Members) };
+                }
+            }
+
             var psTypeName = type != null ? new PSTypeName(type) : new PSTypeName(convertExpressionAst.Type.TypeName.FullName);
             return new[] { psTypeName };
         }
@@ -960,7 +1005,7 @@ namespace System.Management.Automation
         /// <param name="commandAst">The ast to infer types from.</param>
         /// <param name="cmdletInfo">The cmdletInfo.</param>
         /// <param name="pseudoBinding">Pseudo bindings of parameters.</param>
-        /// <returns>List of inferred typenames.</returns>
+        /// <returns>List of inferred type names.</returns>
         private List<PSTypeName> InferTypesFromObjectCmdlets(CommandAst commandAst, CmdletInfo cmdletInfo, PseudoBindingInfo pseudoBinding)
         {
             var inferredTypes = new List<PSTypeName>(16);
@@ -995,9 +1040,14 @@ namespace System.Management.Automation
             }
             else if (cmdletInfo.ImplementingType.FullName.EqualsOrdinalIgnoreCase("Microsoft.PowerShell.Commands.SelectObjectCommand"))
             {
-                // Select-object - yields whatever we saw before where-object in the pipeline.
+                // Select-object - adds whatever we saw before where-object in the pipeline.
                 // unless -property or -excludeproperty
                 InferTypesFromSelectCommand(pseudoBinding, commandAst, inferredTypes);
+            }
+            else if (cmdletInfo.ImplementingType.FullName.EqualsOrdinalIgnoreCase("Microsoft.PowerShell.Commands.GroupObjectCommand"))
+            {
+                // Group-object - annotates the types of Group and Value based on whatever we saw before Group-Object in the pipeline.
+                InferTypesFromGroupCommand(pseudoBinding, commandAst, inferredTypes);
             }
 
             return inferredTypes;
@@ -1072,6 +1122,118 @@ namespace System.Management.Automation
             }
         }
 
+        private void InferTypesFromGroupCommand(PseudoBindingInfo pseudoBinding, CommandAst commandAst, List<PSTypeName> inferredTypes)
+        {
+            if (pseudoBinding.BoundArguments.TryGetValue("AsHashTable", out AstParameterArgumentPair _))
+            {
+                inferredTypes.Add(new PSTypeName(typeof(Hashtable)));
+                return;
+            }
+
+            var noElement = pseudoBinding.BoundArguments.TryGetValue("NoElement", out AstParameterArgumentPair _);
+
+            string[] properties = null;
+            bool scriptBlockProperty = false;
+            if (pseudoBinding.BoundArguments.TryGetValue("Property", out AstParameterArgumentPair propertyArgumentPair))
+            {
+                if (propertyArgumentPair is AstPair astPair)
+                {
+                    switch (astPair.Argument)
+                    {
+                        case StringConstantExpressionAst stringConstant:
+                        {
+                            properties = new[] { stringConstant.Value };
+                            break;
+                        }
+                        case ArrayLiteralAst arrayLiteral:
+                        {
+                            properties = arrayLiteral.Elements.OfType<StringConstantExpressionAst>().Select(c => c.Value).ToArray();
+                            scriptBlockProperty = arrayLiteral.Elements.OfType<StringConstantExpressionAst>().Any();
+                                break;
+                        }
+                        case CommandElementAst _:
+                        {
+                            scriptBlockProperty = true;
+                            break;
+                        }
+                    }
+                }
+            }
+
+            bool IsInPropertyArgument(object o)
+            {
+                if (properties == null)
+                {
+                    return true;
+                }
+
+                string name;
+                switch (o)
+                {
+                    case string s:
+                        name = s;
+                        break;
+                    default:
+                        name = GetMemberName(o);
+                        break;
+                }
+
+                foreach (var propertyName in properties)
+                {
+                    if (string.Compare(name, propertyName, StringComparison.CurrentCultureIgnoreCase) == 0)
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+
+            var previousPipelineElement = GetPreviousPipelineCommand(commandAst);
+            var typeName = "Microsoft.PowerShell.Commands.GroupInfo";
+            var members = new List<PSMemberNameAndType>();
+            foreach (var prevType in InferTypes(previousPipelineElement))
+            {
+                members.Clear();
+                if (noElement)
+                {
+                    members.Add(new PSMemberNameAndType("Values", new PSTypeName(prevType.Name)));
+                    inferredTypes.Add(PSSyntheticTypeName.Create(typeName, members));
+                    continue;
+                }
+
+                var memberNameAndTypes = GetMemberNameAndTypeFromProperties(prevType, IsInPropertyArgument);
+                if (!memberNameAndTypes.Any())
+                {
+                    continue;
+                }
+
+                if (properties != null)
+                {
+                    foreach (var memType in memberNameAndTypes)
+                    {
+                        members.Clear();
+                        members.Add(new PSMemberNameAndType("Group", new PSTypeName(prevType.Name)));
+                        members.Add(new PSMemberNameAndType("Values", new PSTypeName(memType.PSTypeName.Name)));
+                        inferredTypes.Add(PSSyntheticTypeName.Create(typeName, members));
+                    }
+                }
+                else
+                {
+                    // No Property parameter given
+                    // group infers to IList<PrevType>
+                    members.Add(new PSMemberNameAndType("Group", new PSTypeName(prevType.Name)));
+                    // Value infers to IList<PrevType>
+                    if (!scriptBlockProperty)
+                    {
+                        members.Add(new PSMemberNameAndType("Values", new PSTypeName(prevType.Name)));
+                    }
+                }
+
+                inferredTypes.Add(PSSyntheticTypeName.Create(typeName, members));
+            }
+        }
+
         private void InferTypesFromWhereAndSortCommand(CommandAst commandAst, List<PSTypeName> inferredTypes)
         {
             InferTypesFromPreviousCommand(commandAst, inferredTypes);
@@ -1099,15 +1261,97 @@ namespace System.Management.Automation
 
         private void InferTypesFromSelectCommand(PseudoBindingInfo pseudoBinding, CommandAst commandAst, List<PSTypeName> inferredTypes)
         {
-            if (pseudoBinding.BoundArguments.TryGetValue("Property", out _)
-                || pseudoBinding.BoundArguments.TryGetValue("ExcludeProperty", out _))
+            void InferFromSelectProperties(AstParameterArgumentPair astParameterArgumentPair, CommandBaseAst previousPipelineElementAst, bool includeMatchedProperties = true)
             {
-                return;
+                if (astParameterArgumentPair is AstPair astPair)
+                {
+                    object ToWildCardOrString(string value) => WildcardPattern.ContainsWildcardCharacters(value) ? (object)new WildcardPattern(value) : value;
+                    object[] properties = null;
+                    switch (astPair.Argument)
+                    {
+                        case StringConstantExpressionAst stringConstant:
+                        {
+                            properties = new[] { ToWildCardOrString(stringConstant.Value) };
+                            break;
+                        }
+                        case ArrayLiteralAst arrayLiteral:
+                        {
+                            properties = arrayLiteral.Elements.OfType<StringConstantExpressionAst>().Select(c => ToWildCardOrString(c.Value)).ToArray();
+                            break;
+                        }
+                    }
+
+                    if (properties == null)
+                    {
+                        return;
+                    }
+
+                    bool IsInPropertyArgument(object o)
+                    {
+                        string name;
+                        switch (o)
+                        {
+                            case string s:
+                                name = s;
+                                break;
+                            default:
+                                name = GetMemberName(o);
+                                break;
+                        }
+
+                        foreach (var propertyNameOrPattern in properties)
+                        {
+                            switch (propertyNameOrPattern)
+                            {
+                                case string propertyName:
+                                {
+                                    if (string.Compare(name, propertyName, StringComparison.CurrentCultureIgnoreCase) == 0)
+                                    {
+                                        return includeMatchedProperties;
+                                    }
+
+                                    break;
+                                }
+                                case WildcardPattern pattern:
+                                {
+                                    if (pattern.IsMatch(name))
+                                    {
+                                        return includeMatchedProperties;
+                                    }
+
+                                    break;
+                                }
+                            }
+                        }
+
+                        return !includeMatchedProperties;
+                    }
+
+                    foreach (var t in InferTypes(previousPipelineElementAst))
+                    {
+                        var list = GetMemberNameAndTypeFromProperties(t, IsInPropertyArgument);
+                        inferredTypes.Add(PSSyntheticTypeName.Create(typeof(PSObject), list));
+                    }
+                }
             }
 
             var previousPipelineElement = GetPreviousPipelineCommand(commandAst);
             if (previousPipelineElement == null)
             {
+                return;
+            }
+
+            if (pseudoBinding.BoundArguments.TryGetValue("Property", out var property))
+            {
+                InferFromSelectProperties(property, previousPipelineElement);
+
+                return;
+            }
+
+            if (pseudoBinding.BoundArguments.TryGetValue("ExcludeProperty", out var excludeProperty))
+            {
+                InferFromSelectProperties(excludeProperty, previousPipelineElement, includeMatchedProperties: false);
+
                 return;
             }
 
@@ -1129,6 +1373,71 @@ namespace System.Management.Automation
             }
 
             InferTypesFromPreviousCommand(commandAst, inferredTypes);
+        }
+
+        private List<PSMemberNameAndType> GetMemberNameAndTypeFromProperties(PSTypeName t, Func<object, bool> isInPropertyList)
+        {
+            var list = new List<PSMemberNameAndType>(8);
+            var members = _context.GetMembersByInferredType(t, false, isInPropertyList);
+            var memberTypes = new List<PSTypeName>();
+            foreach (var mem in members)
+            {
+                if (!IsProperty(mem))
+                {
+                    continue;
+                }
+
+                var memberName = GetMemberName(mem);
+                if (!isInPropertyList(memberName))
+                {
+                    continue;
+                }
+
+                bool maybeWantDefaultCtor = false;
+                memberTypes.Clear();
+                GetTypesOfMembers(t, memberName, members, ref maybeWantDefaultCtor, isInvokeMemberExpressionAst: false, memberTypes);
+                if (memberTypes.Count > 0)
+                {
+                    list.Add(new PSMemberNameAndType(memberName, memberTypes[0]));
+                }
+            }
+
+            return list;
+        }
+
+        private static bool IsProperty(object member)
+        {
+            switch (member)
+            {
+                case PropertyInfo _: return true;
+                case PSMemberInfo memberInfo: return (memberInfo.MemberType & PSMemberTypes.Properties) == memberInfo.MemberType;
+                default: return false;
+            }
+        }
+
+        private static string GetMemberName(object member)
+        {
+            var name = string.Empty;
+            switch (member)
+            {
+                case PSMemberInfo psMemberInfo:
+                    name = psMemberInfo.Name;
+                    break;
+                case MemberInfo memberInfo:
+                    name = memberInfo.Name;
+                    break;
+                case PropertyMemberAst propertyMember:
+                    name = propertyMember.Name;
+                    break;
+                case FunctionMemberAst functionMember:
+                    name = functionMember.Name;
+                    break;
+                case DotNetAdapter.MethodCacheEntry methodCacheEntry:
+                    name = methodCacheEntry[0].method.Name;
+                    break;
+            }
+
+            return name;
         }
 
         private static PSTypeName InferTypesFromNewObjectCommand(PseudoBindingInfo pseudoBinding)
@@ -1359,6 +1668,11 @@ namespace System.Management.Automation
                         case PSScriptMethod scriptMethod:
                         {
                             scriptBlock = scriptMethod.Script;
+                            break;
+                        }
+                        case PSInferredProperty inferredProperty:
+                        {
+                            result.Add(inferredProperty.TypeName);
                             break;
                         }
                     }

--- a/src/System.Management.Automation/engine/parser/TypeInferenceVisitor.cs
+++ b/src/System.Management.Automation/engine/parser/TypeInferenceVisitor.cs
@@ -1211,7 +1211,7 @@ namespace System.Management.Automation
 
                 foreach (var propertyName in properties)
                 {
-                    if (string.Compare(name, propertyName, StringComparison.CurrentCultureIgnoreCase) == 0)
+                    if (name.Equals(propertyName, StringComparison.CurrentCultureIgnoreCase))
                     {
                         return true;
                     }


### PR DESCRIPTION
## PR Summary

Fixes #7230.

Adding the concept of a PSSyntheticTypeName, derived from PSTypeName,
that extends it with a list of synthetic members.

This allows us to express the inferred type of
```
[pscustomobject] @{
   A = 1
   B = "2"
}
```
as a "PSObject#A:B" and with information about the types of A and B.

This is also used to annotate the output of
```
Select-Object -Property
Select-Object -ExcludeProperty
Select-Object -ExpandProperty
```
Finally, it adds information about the types of the
`Group` and `Value` properties of the output of `Group-Object`

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
        - [x] Issue filed - Issue link:
- **Testing - New and feature**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [x] [Add `[feature]` if the change is significant or affects feature tests]


