### PR TITLE
Make 'Start-PsBuild -Clean' not prompt due to locked files when Visual Studio is open by excluding sqlite3 folder and use -x instead of -X option on git clean

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -458,10 +458,11 @@ function Start-PSBuild {
     }
 
     if ($Clean) {
-        Write-Log "Cleaning your working directory. You can also do it with 'git clean -fdX'"
+        Write-Log "Cleaning your working directory. You can also do it with 'git clean -fdx --exclude .vs/PowerShell/v15/Server/sqlite3'"
         Push-Location $PSScriptRoot
         try {
-            git clean -fdX
+            # Excluded sqlite3 folder is due to this Roslyn issue: https://github.com/dotnet/roslyn/issues/23060
+            git clean -fdx --exclude .vs/PowerShell/v15/Server/sqlite3
             # Extra cleaning is required to delete the CMake temporary files.
             # These are not cleaned when using "X" and cause CMake to retain state, leading to
             # mis-configured environment issues when switching between x86 and x64 compilation

--- a/build.psm1
+++ b/build.psm1
@@ -463,11 +463,6 @@ function Start-PSBuild {
         try {
             # Excluded sqlite3 folder is due to this Roslyn issue: https://github.com/dotnet/roslyn/issues/23060
             git clean -fdx --exclude .vs/PowerShell/v15/Server/sqlite3
-            # Extra cleaning is required to delete the CMake temporary files.
-            # These are not cleaned when using "X" and cause CMake to retain state, leading to
-            # mis-configured environment issues when switching between x86 and x64 compilation
-            # environments.
-            git clean -fdx .\src\powershell-native
         } finally {
             Pop-Location
         }


### PR DESCRIPTION
## PR Summary

Due to [this](https://github.com/dotnet/roslyn/issues/23060) Roslyn issue, some files in the `sqlite3` folder inside the temporary `.vs` folder get locked and cannot be cleaned. This happens when calling `Start-PSBuild -Clean` when VS is open and is very annoying.
This PR makes `Start-PSBuild -Clean` use the 'better' `-x` option on git clean and exclude this folder (both changes are needed to overcome the Roslyn issue).

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [x] Not Applicable or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
