### PR TITLE
Fix for #6938 Fixed prompt string to be platform agnostic in examples

### DIFF
--- a/src/System.Management.Automation/help/HelpCommentsParser.cs
+++ b/src/System.Management.Automation/help/HelpCommentsParser.cs
@@ -479,6 +479,7 @@ namespace System.Management.Automation
         {
             prompt_str = code_str = string.Empty;
             StringBuilder builder = new StringBuilder();
+            string default_prompt_str = "PS > ";
 
             int collectingPart = 1;
             foreach (char c in content)
@@ -495,7 +496,7 @@ namespace System.Management.Automation
                 {
                     if (collectingPart == 1)
                     {
-                        prompt_str = "PS C:\\>";
+                        prompt_str = default_prompt_str;
                     }
                     code_str = builder.ToString().Trim();
                     builder = new StringBuilder();
@@ -507,7 +508,7 @@ namespace System.Management.Automation
 
             if (collectingPart == 1)
             {
-                prompt_str = "PS C:\\>";
+                prompt_str = default_prompt_str;
                 code_str = builder.ToString().Trim();
                 remarks_str = string.Empty;
             }

--- a/src/System.Management.Automation/help/MamlNode.cs
+++ b/src/System.Management.Automation/help/MamlNode.cs
@@ -606,13 +606,14 @@ namespace System.Management.Automation
 
             int paraNodes = GetParaMamlNodeCount(xmlNode.ChildNodes);
             int count = 0;
-
+            // Don't trim the content if this is an "introduction" node.
+            bool trim = ! string.Equals(xmlNode.Name, "maml:introduction", StringComparison.OrdinalIgnoreCase);
             foreach (XmlNode childNode in xmlNode.ChildNodes)
             {
                 if (childNode.LocalName.Equals("para", StringComparison.OrdinalIgnoreCase))
                 {
                     ++count;
-                    PSObject paraPSObject = GetParaPSObject(childNode, count != paraNodes);
+                    PSObject paraPSObject = GetParaPSObject(childNode, count != paraNodes, trim: trim);
                     if (paraPSObject != null)
                         mshObjects.Add(paraPSObject);
                     continue;
@@ -752,8 +753,9 @@ namespace System.Management.Automation
         /// </summary>
         /// <param name="xmlNode"></param>
         /// <param name="newLine"></param>
+        /// <param name="trim"></param>
         /// <returns></returns>
-        private static PSObject GetParaPSObject(XmlNode xmlNode, bool newLine)
+        private static PSObject GetParaPSObject(XmlNode xmlNode, bool newLine, bool trim = true)
         {
             if (xmlNode == null)
                 return null;
@@ -771,7 +773,12 @@ namespace System.Management.Automation
             }
             else
             {
-                sb.Append(xmlNode.InnerText.Trim());
+                var innerText = xmlNode.InnerText;
+                if (trim)
+                {
+                    innerText = innerText.Trim();
+                }
+                sb.Append(innerText);
             }
 
             mshObject.Properties.Add(new PSNoteProperty("Text", sb.ToString()));

--- a/test/powershell/Language/Scripting/ScriptHelp.Tests.ps1
+++ b/test/powershell/Language/Scripting/ScriptHelp.Tests.ps1
@@ -557,4 +557,18 @@ Describe 'get-help other tests' -Tags "CI" {
         It '$x.Parameters.parameter[1].defaultValue' { $x.Parameters.parameter[1].defaultValue | Should -BeExactly '42' }
         It '$x.Parameters.parameter[2].defaultValue' { $x.Parameters.parameter[2].defaultValue | Should -BeExactly 'parameter is mandatory' }
     }
+
+    Context 'get-help -Examples prompt string should have trailing space' {
+        function foo {
+            <#
+              .EXAMPLE
+              foo bar
+            #>
+              param()
+        }
+
+        It 'prompt should be exactly "PS > " with trailing space' {
+            (Get-Help foo -Examples).examples.example.introduction.Text | Should -BeExactly "PS > "
+        }
+    }
 }


### PR DESCRIPTION


## PR Summary

Fix for #6938. Fixed the prompt string used when generating examples for script help to be platform agnostic and made changes to not strip trailing spaces from that prompt string. An example "foo bar" should now end up looking like "PS > foo bar" with a space between the '>' and 'foo'.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
