### PR TITLE
Allow .exe files to be used as binary modules

### DIFF
--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionAnalysis.cs
@@ -1446,6 +1446,7 @@ namespace System.Management.Automation
                                     StringLiterals.PowerShellDataFileExtension,
                                     StringLiterals.PowerShellNgenAssemblyExtension,
                                     StringLiterals.PowerShellILAssemblyExtension,
+                                    StringLiterals.PowerShellILExecutableExtension,
                                     StringLiterals.PowerShellCmdletizationFileExtension
                                 };
                                 result = CompletionCompleters.CompleteFilename(completionContext, false, moduleExtensions).ToList();

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -3141,6 +3141,7 @@ namespace System.Management.Automation
                                 StringLiterals.PowerShellDataFileExtension,
                                 StringLiterals.PowerShellNgenAssemblyExtension,
                                 StringLiterals.PowerShellILAssemblyExtension,
+                                StringLiterals.PowerShellILExecutableExtension,
                                 StringLiterals.PowerShellCmdletizationFileExtension
                             };
                     var moduleFilesResults = new List<CompletionResult>(CompleteFilename(context, containerOnly: false, moduleExtensions));

--- a/src/System.Management.Automation/engine/CommandInfo.cs
+++ b/src/System.Management.Automation/engine/CommandInfo.cs
@@ -212,9 +212,10 @@ namespace System.Management.Automation
                                 // Manifest module (.psd1)
                                 Module.SetVersion(ModuleIntrinsics.GetManifestModuleVersion(Module.Path));
                             }
-                            else if (Module.Path.EndsWith(StringLiterals.PowerShellILAssemblyExtension, StringComparison.OrdinalIgnoreCase))
+                            else if (Module.Path.EndsWith(StringLiterals.PowerShellILAssemblyExtension, StringComparison.OrdinalIgnoreCase) ||
+                                     Module.Path.EndsWith(StringLiterals.PowerShellILExecutableExtension, StringComparison.OrdinalIgnoreCase))
                             {
-                                // Binary module (.dll)
+                                // Binary module (.dll or .exe)
                                 Module.SetVersion(AssemblyName.GetAssemblyName(Module.Path).Version);
                             }
                         }

--- a/src/System.Management.Automation/engine/Modules/AnalysisCache.cs
+++ b/src/System.Management.Automation/engine/Modules/AnalysisCache.cs
@@ -70,11 +70,11 @@ namespace System.Management.Automation
                 {
                     result = AnalyzeCdxmlModule(modulePath, context, lastWriteTime);
                 }
-                else if (extension.Equals(".dll", StringComparison.OrdinalIgnoreCase))
+                else if (extension.Equals(StringLiterals.PowerShellILAssemblyExtension, StringComparison.OrdinalIgnoreCase))
                 {
                     result = AnalyzeDllModule(modulePath, context, lastWriteTime);
                 }
-                else if (extension.Equals(".exe", StringComparison.OrdinalIgnoreCase))
+                else if (extension.Equals(StringLiterals.PowerShellILExecutableExtension, StringComparison.OrdinalIgnoreCase))
                 {
                     result = AnalyzeDllModule(modulePath, context, lastWriteTime);
                 }

--- a/src/System.Management.Automation/engine/Modules/AnalysisCache.cs
+++ b/src/System.Management.Automation/engine/Modules/AnalysisCache.cs
@@ -74,6 +74,10 @@ namespace System.Management.Automation
                 {
                     result = AnalyzeDllModule(modulePath, context, lastWriteTime);
                 }
+                else if (extension.Equals(".exe", StringComparison.OrdinalIgnoreCase))
+                {
+                    result = AnalyzeDllModule(modulePath, context, lastWriteTime);
+                }
             }
 
             if (result != null)
@@ -207,7 +211,15 @@ namespace System.Management.Automation
                 return !hadFunctions || !hadAliases;
             }
 
-            if (modulePath.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+            if (modulePath.EndsWith(StringLiterals.PowerShellILAssemblyExtension, StringComparison.OrdinalIgnoreCase))
+            {
+                // A dll just exports cmdlets, so if the manifest doesn't explicitly export any cmdlets,
+                // more analysis is required. If the module exports aliases, we can't discover that analyzing
+                // the binary, so aliases are always required to be explicit (no wildcards) in the manifest.
+                return !hadCmdlets;
+            }
+
+            if (modulePath.EndsWith(StringLiterals.PowerShellILExecutableExtension, StringComparison.OrdinalIgnoreCase))
             {
                 // A dll just exports cmdlets, so if the manifest doesn't explicitly export any cmdlets,
                 // more analysis is required. If the module exports aliases, we can't discover that analyzing

--- a/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
@@ -2222,7 +2222,7 @@ namespace Microsoft.PowerShell.Commands
                             iss.Assemblies.Add(new SessionStateAssemblyEntry(assembly, fileName));
                             fixedUpAssemblyPathList.Add(fileName);
 
-                            fileName = FixupFileName(moduleBase, assembly, StringLiterals.PowerShellILExecutableExtension);
+                            fileName = FixupFileName(moduleBase, assembly, StringLiterals.PowerShellILExecutableExtension, importingModule);
                             loadMessage = StringUtil.Format(Modules.LoadingFile, "Executable", fileName);
                             WriteVerbose(loadMessage);
                             iss.Assemblies.Add(new SessionStateAssemblyEntry(assembly, fileName));
@@ -4634,13 +4634,15 @@ namespace Microsoft.PowerShell.Commands
                 return resolvedPath;
             }
 
+            // Path resolution failed, use the combined path as default.
+            string result = combinedPath;
+
             // For dlls, we cannot get the path from the provider.
             // We need to load the assembly and then get the path.
             // If the module is already loaded, this is not expensive since the assembly is already loaded in the AppDomain
-            if (!string.IsNullOrEmpty(ext) &&
-                (ext.Equals(StringLiterals.PowerShellILAssemblyExtension, StringComparison.OrdinalIgnoreCase) ||
-                ext.Equals(StringLiterals.PowerShellILExecutableExtension, StringComparison.OrdinalIgnoreCase))
-            )
+            if (!string.IsNullOrEmpty(extension) &&
+                (extension.Equals(StringLiterals.PowerShellILAssemblyExtension, StringComparison.OrdinalIgnoreCase) ||
+                extension.Equals(StringLiterals.PowerShellILExecutableExtension, StringComparison.OrdinalIgnoreCase)))
             {
                 Assembly assembly = ExecutionContext.LoadAssembly(name: originalName, filename: null, error: out _);
                 if (assembly != null)
@@ -5817,8 +5819,7 @@ namespace Microsoft.PowerShell.Commands
                 }
                 else if (ext.Equals(StringLiterals.PowerShellILAssemblyExtension, StringComparison.OrdinalIgnoreCase) ||
                          ext.Equals(StringLiterals.PowerShellNgenAssemblyExtension, StringComparison.OrdinalIgnoreCase) ||
-                         ext.Equals(StringLiterals.PowerShellILExecutableExtension, StringComparison.OrdinalIgnoreCase)
-                         )
+                         ext.Equals(StringLiterals.PowerShellILExecutableExtension, StringComparison.OrdinalIgnoreCase))
                 {
                     module = LoadBinaryModule(false, ModuleIntrinsics.GetModuleName(fileName), fileName, null,
                         moduleBase, ss, options, manifestProcessingFlags, prefix, true, true, out found);

--- a/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
@@ -1218,7 +1218,8 @@ namespace Microsoft.PowerShell.Commands
                 {
                     if (moduleInfo.RootModuleForManifest != null)
                     {
-                        if (moduleInfo.RootModuleForManifest.EndsWith(StringLiterals.PowerShellILAssemblyExtension, StringComparison.OrdinalIgnoreCase))
+                        if (moduleInfo.RootModuleForManifest.EndsWith(StringLiterals.PowerShellILAssemblyExtension, StringComparison.OrdinalIgnoreCase) ||
+                            moduleInfo.RootModuleForManifest.EndsWith(StringLiterals.PowerShellILExecutableExtension, StringComparison.OrdinalIgnoreCase))
                         {
                             moduleInfo.SetModuleType(ModuleType.Binary);
                         }
@@ -1243,7 +1244,9 @@ namespace Microsoft.PowerShell.Commands
                         moduleInfo.RootModule = moduleInfo.Path;
                     }
                 }
-                else if (extension.Equals(StringLiterals.PowerShellILAssemblyExtension, StringComparison.OrdinalIgnoreCase) || extension.Equals(StringLiterals.PowerShellNgenAssemblyExtension, StringComparison.OrdinalIgnoreCase))
+                else if (extension.Equals(StringLiterals.PowerShellILAssemblyExtension, StringComparison.OrdinalIgnoreCase) ||
+                         extension.Equals(StringLiterals.PowerShellNgenAssemblyExtension, StringComparison.OrdinalIgnoreCase) ||
+                         extension.Equals(StringLiterals.PowerShellILExecutableExtension, StringComparison.OrdinalIgnoreCase))
                 {
                     moduleInfo.SetModuleType(ModuleType.Binary);
                     moduleInfo.RootModule = moduleInfo.Path;
@@ -2218,6 +2221,13 @@ namespace Microsoft.PowerShell.Commands
                             WriteVerbose(loadMessage);
                             iss.Assemblies.Add(new SessionStateAssemblyEntry(assembly, fileName));
                             fixedUpAssemblyPathList.Add(fileName);
+
+                            fileName = FixupFileName(moduleBase, assembly, StringLiterals.PowerShellILExecutableExtension);
+                            loadMessage = StringUtil.Format(Modules.LoadingFile, "Executable", fileName);
+                            WriteVerbose(loadMessage);
+                            iss.Assemblies.Add(new SessionStateAssemblyEntry(assembly, fileName));
+                            fixedUpAssemblyPathList.Add(fileName);
+
                             doBind = true;
                         }
                     }
@@ -4624,12 +4634,13 @@ namespace Microsoft.PowerShell.Commands
                 return resolvedPath;
             }
 
-            // Path resolution failed, use the combined path as default.
-            string result = combinedPath;
-
-            // For the given assembly name, the intention could be to use the assembly from TPAs or GAC (on Windows).
-            // So try loading the assembly using the passed-in name only, and use the assembly location if that succeeds.
-            if (!string.IsNullOrEmpty(originalExt) && originalExt.Equals(".dll", StringComparison.OrdinalIgnoreCase))
+            // For dlls, we cannot get the path from the provider.
+            // We need to load the assembly and then get the path.
+            // If the module is already loaded, this is not expensive since the assembly is already loaded in the AppDomain
+            if (!string.IsNullOrEmpty(ext) &&
+                (ext.Equals(StringLiterals.PowerShellILAssemblyExtension, StringComparison.OrdinalIgnoreCase) ||
+                ext.Equals(StringLiterals.PowerShellILExecutableExtension, StringComparison.OrdinalIgnoreCase))
+            )
             {
                 Assembly assembly = ExecutionContext.LoadAssembly(name: originalName, filename: null, error: out _);
                 if (assembly != null)
@@ -5804,7 +5815,10 @@ namespace Microsoft.PowerShell.Commands
                         found = false;
                     }
                 }
-                else if (ext.Equals(".dll", StringComparison.OrdinalIgnoreCase) || ext.Equals(StringLiterals.PowerShellNgenAssemblyExtension))
+                else if (ext.Equals(StringLiterals.PowerShellILAssemblyExtension, StringComparison.OrdinalIgnoreCase) ||
+                         ext.Equals(StringLiterals.PowerShellNgenAssemblyExtension, StringComparison.OrdinalIgnoreCase) ||
+                         ext.Equals(StringLiterals.PowerShellILExecutableExtension, StringComparison.OrdinalIgnoreCase)
+                         )
                 {
                     module = LoadBinaryModule(false, ModuleIntrinsics.GetModuleName(fileName), fileName, null,
                         moduleBase, ss, options, manifestProcessingFlags, prefix, true, true, out found);

--- a/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
@@ -890,7 +890,9 @@ namespace System.Management.Automation
                             StringLiterals.PowerShellCmdletizationFileExtension,
                             StringLiterals.WorkflowFileExtension,
                             StringLiterals.PowerShellNgenAssemblyExtension,
-                            StringLiterals.PowerShellILAssemblyExtension};
+                            StringLiterals.PowerShellILAssemblyExtension,
+                            StringLiterals.PowerShellILExecutableExtension,
+                        };
 
         // A list of the extensions to check for implicit module loading and discovery, put the ni.dll in front of .dll to have higher priority to be loaded.
         internal static string[] PSModuleExtensions = new string[] {
@@ -899,7 +901,9 @@ namespace System.Management.Automation
                             StringLiterals.PowerShellCmdletizationFileExtension,
                             StringLiterals.WorkflowFileExtension,
                             StringLiterals.PowerShellNgenAssemblyExtension,
-                            StringLiterals.PowerShellILAssemblyExtension};
+                            StringLiterals.PowerShellILAssemblyExtension,
+                            StringLiterals.PowerShellILExecutableExtension,
+                        };
 
         /// <summary>
         /// Returns true if the extension is one of the module extensions...

--- a/src/System.Management.Automation/engine/Modules/ModuleUtils.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleUtils.cs
@@ -292,7 +292,7 @@ namespace System.Management.Automation.Internal
                             yield return moduleFile;
 
                             // when finding the default modules we stop when the first
-                            // match is hit - searching in order .psd1, .psm1, .dll
+                            // match is hit - searching in order .psd1, .psm1, .dll, .exe
                             // if a file is found but is not readable then it is an
                             // error
                             break;

--- a/src/System.Management.Automation/engine/Modules/TestModuleManifestCommand.cs
+++ b/src/System.Management.Automation/engine/Modules/TestModuleManifestCommand.cs
@@ -145,15 +145,16 @@ namespace Microsoft.PowerShell.Commands
                             }
                         }
 
-                        // RootModule can be null, empty string or point to a valid .psm1, , .cdxml, .xaml or .dll.  Anything else is invalid.
+                        // RootModule can be null, empty string or point to a valid .psm1, , .cdxml, .xaml, .dll or .exe.  Anything else is invalid.
                         if (module.RootModule != null && module.RootModule != string.Empty)
                         {
                             string rootModuleExt = System.IO.Path.GetExtension(module.RootModule);
                             if ((!IsValidFilePath(module.RootModule, module, true) && !IsValidGacAssembly(module.RootModule)) ||
                                 (!rootModuleExt.Equals(StringLiterals.PowerShellModuleFileExtension, StringComparison.OrdinalIgnoreCase) &&
-                                !rootModuleExt.Equals(".dll", StringComparison.OrdinalIgnoreCase) &&
-                                !rootModuleExt.Equals(".cdxml", StringComparison.OrdinalIgnoreCase) &&
-                                !rootModuleExt.Equals(".xaml", StringComparison.OrdinalIgnoreCase))
+                                !rootModuleExt.Equals(StringLiterals.PowerShellILAssemblyExtension, StringComparison.OrdinalIgnoreCase) &&
+                                !rootModuleExt.Equals(StringLiterals.PowerShellCmdletizationFileExtension, StringComparison.OrdinalIgnoreCase) &&
+                                !rootModuleExt.Equals(StringLiterals.WorkflowFileExtension, StringComparison.OrdinalIgnoreCase) &&
+                                !rootModuleExt.Equals(StringLiterals.PowerShellILExecutableExtension, StringComparison.OrdinalIgnoreCase))
                             )
                             {
                                 string errorMsg = StringUtil.Format(Modules.InvalidModuleManifest, module.RootModule, filePath);
@@ -176,6 +177,7 @@ namespace Microsoft.PowerShell.Commands
                                 if (!IsValidFilePath(nestedModule.Name, module, true)
                                     && !IsValidFilePath(nestedModule.Name + StringLiterals.PowerShellILAssemblyExtension, module, true)
                                     && !IsValidFilePath(nestedModule.Name + StringLiterals.PowerShellNgenAssemblyExtension, module, true)
+                                    && !IsValidFilePath(nestedModule.Name + StringLiterals.PowerShellILExecutableExtension, module, true)
                                     && !IsValidFilePath(nestedModule.Name + StringLiterals.PowerShellModuleFileExtension, module, true)
                                     && !IsValidGacAssembly(nestedModule.Name))
                                 {

--- a/src/System.Management.Automation/engine/SessionStateStrings.cs
+++ b/src/System.Management.Automation/engine/SessionStateStrings.cs
@@ -131,7 +131,7 @@ namespace System.Management.Automation
         internal const string PowerShellNgenAssemblyExtension = ".ni.dll";
 
         /// <summary>
-        /// The file extension (including the dot) of an executable file
+        /// The file extension (including the dot) of an executable file.
         /// </summary>
         internal const string PowerShellILExecutableExtension = ".exe";
 

--- a/src/System.Management.Automation/engine/SessionStateStrings.cs
+++ b/src/System.Management.Automation/engine/SessionStateStrings.cs
@@ -130,6 +130,11 @@ namespace System.Management.Automation
         /// </summary>
         internal const string PowerShellNgenAssemblyExtension = ".ni.dll";
 
+        /// <summary>
+        /// The file extension (including the dot) of an executable file
+        /// </summary>
+        internal const string PowerShellILExecutableExtension = ".exe";
+
         internal const string PowerShellConsoleFileExtension = ".psc1";
 
         /// <summary>

--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -1058,7 +1058,7 @@ namespace System.Management.Automation
             if (!string.IsNullOrWhiteSpace(assemblyName))
             {
                 // Remove the '.dll' if it's there...
-                var fixedName = assemblyName.EndsWith(".dll", StringComparison.OrdinalIgnoreCase)
+                var fixedName = assemblyName.EndsWith(StringLiterals.PowerShellILAssemblyExtension, StringComparison.OrdinalIgnoreCase)
                                 ? Path.GetFileNameWithoutExtension(assemblyName)
                                 : assemblyName;
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Import-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Import-Module.Tests.ps1
@@ -137,7 +137,7 @@ Describe "Import-Module for Binary Modules" -Tags 'CI' {
 
     BeforeAll {
         $src = @"
-            using System.Management.Automation;           // Windows PowerShell namespace.
+            using System.Management.Automation;
             namespace ModuleCmdlets
             {
                 [Cmdlet(VerbsDiagnostic.Test,"BinaryModuleCmdlet1")]
@@ -145,7 +145,7 @@ Describe "Import-Module for Binary Modules" -Tags 'CI' {
                 {
                     protected override void BeginProcessing()
                     {
-                    WriteObject("BinaryModuleCmdlet1 exported by the ModuleCmdlets module.");
+                        WriteObject("BinaryModuleCmdlet1 exported by the ModuleCmdlets module.");
                     }
                 }
             }

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Import-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Import-Module.Tests.ps1
@@ -160,23 +160,23 @@ Describe "Import-Module for Binary Modules" -Tags 'CI' {
      ) {
          param ($extension)
 
-        $ENV:TestModulePath = Join-Path $TESTDRIVE "System.$extension"
+        $TestModulePath = Join-Path $TESTDRIVE "System.$extension"
         $assemblyLocation, $cmdletOutput = pwsh {
-            $module = Import-Module $ENV:TestModulePath -Passthru
+            $module = Import-Module $TestModulePath -Passthru
             $module.ImplementingAssembly.Location
             Test-BinaryModuleCmdlet1
         }
-        $assemblyLocation | Should -BeExactly $ENV:TestModulePath
+        $assemblyLocation | Should -BeExactly $TestModulePath
         $cmdletOutput | Should -BeExactly "BinaryModuleCmdlet1 exported by the ModuleCmdlets module."
     }
 
     It 'PS should be able to load the executable as a root module' {
-        $ENV:psdFile = Join-Path $TESTDRIVE test.psd1
+        $psdFile = Join-Path $TESTDRIVE test.psd1
         $exe = Join-Path $TESTDRIVE System.exe
-        New-ModuleManifest -Path $ENV:psdFile -RootModule $exe
+        New-ModuleManifest -Path $psdFile -RootModule $exe
         try
         {
-            $module = pwsh { Import-Module $ENV:psdFile -PassThru }
+            $module = pwsh { Import-Module $psdFile -PassThru }
             $module | Should -Not -BeNullOrEmpty
             $module.ModuleType.ToString() | Should -Be 'Binary'
             $module.RootModule | Should -Be $exe
@@ -184,18 +184,18 @@ Describe "Import-Module for Binary Modules" -Tags 'CI' {
         }
         finally
         {
-            Remove-Item $ENV:psdFile
+            Remove-Item $psdFile
         }
     }
 
     It 'PS should be able to load the executable as a nested module' {
-        $ENV:psdFile = Join-Path $TESTDRIVE test.psd1
+        $psdFile = Join-Path $TESTDRIVE test.psd1
         $exe = Join-Path $TESTDRIVE System.exe
-        New-ModuleManifest -Path $ENV:psdFile -NestedModules $exe
+        New-ModuleManifest -Path $psdFile -NestedModules $exe
         try
         {
             $module, $location = pwsh {
-                $module = Import-Module $ENV:psdFile -PassThru
+                $module = Import-Module $psdFile -PassThru
                 # return the module and the nested module assembly location
                 $module
                 $module.NestedModules[0].ImplementingAssembly.Location
@@ -208,18 +208,18 @@ Describe "Import-Module for Binary Modules" -Tags 'CI' {
         }
         finally
         {
-            Remove-Item $ENV:psdFile
+            Remove-Item $psdFile
         }
     }
 
     It "PS should try to load the assembly from assembly name if file path doesn't exist" {
-        $ENV:psdFile = Join-Path $TESTDRIVE test.psd1
+        $psdFile = Join-Path $TESTDRIVE test.psd1
         $nestedModule = Join-Path NOExistedPath Microsoft.PowerShell.Commands.Utility.dll
-        New-ModuleManifest -Path $ENV:psdFile -NestedModules $nestedModule
+        New-ModuleManifest -Path $psdFile -NestedModules $nestedModule
         try
         {
             $module, $location = pwsh {
-                $module = Import-Module $ENV:psdFile -PassThru
+                $module = Import-Module $psdFile -PassThru
                 # return the module and the assembly location
                 $module
                 $module.NestedModules[0].ImplementingAssembly.Location
@@ -231,7 +231,7 @@ Describe "Import-Module for Binary Modules" -Tags 'CI' {
         finally
         {
             Remove-Module $module -ErrorAction SilentlyContinue
-            Remove-Item $ENV:psdFile
+            Remove-Item $psdFile
         }
     }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Import-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Import-Module.Tests.ps1
@@ -135,49 +135,104 @@ Describe "Import-Module for Binary Modules in GAC" -Tags 'Feature' {
 
 Describe "Import-Module for Binary Modules" -Tags 'CI' {
 
-    It "PS should try to load the assembly from file path first" {
- $src = @"
-using System.Management.Automation;           // Windows PowerShell namespace.
-
-namespace ModuleCmdlets
-{
-  [Cmdlet(VerbsDiagnostic.Test,"BinaryModuleCmdlet1")]
-  public class TestBinaryModuleCmdlet1Command : Cmdlet
-  {
-    protected override void BeginProcessing()
-    {
-      WriteObject("BinaryModuleCmdlet1 exported by the ModuleCmdlets module.");
-    }
-  }
-}
+    BeforeAll {
+        $src = @"
+            using System.Management.Automation;           // Windows PowerShell namespace.
+            namespace ModuleCmdlets
+            {
+                [Cmdlet(VerbsDiagnostic.Test,"BinaryModuleCmdlet1")]
+                public class TestBinaryModuleCmdlet1Command : Cmdlet
+                {
+                    protected override void BeginProcessing()
+                    {
+                    WriteObject("BinaryModuleCmdlet1 exported by the ModuleCmdlets module.");
+                    }
+                }
+            }
 "@
+        Add-Type -TypeDefinition $src -OutputAssembly $TESTDRIVE\System.dll
+        Add-Type -TypeDefinition $src -OutputAssembly $TESTDRIVE\System.exe
+    }
 
-    Add-Type -TypeDefinition $src -OutputAssembly $TESTDRIVE\System.dll
-    $results = pwsh -noprofile -c "`$module = Import-Module $TESTDRIVE\System.dll -Passthru; `$module.ImplementingAssembly.Location; Test-BinaryModuleCmdlet1"
+    It "PS should try to load the binary module from a file path" -TestCases (
+        @{extension = "dll"},
+        @{extension = "exe"}
+     ) {
+         param ($extension)
 
-    #Ignore slash format difference under windows/Unix
-    $path = (Get-ChildItem $TESTDRIVE\System.dll).FullName
-    $results[0] | Should -BeExactly $path
-    $results[1] | Should -BeExactly "BinaryModuleCmdlet1 exported by the ModuleCmdlets module."
+        $ENV:TestModulePath = Join-Path $TESTDRIVE "System.$extension"
+        $assemblyLocation, $cmdletOutput = pwsh {
+            $module = Import-Module $ENV:TestModulePath -Passthru
+            $module.ImplementingAssembly.Location
+            Test-BinaryModuleCmdlet1
+        }
+        $assemblyLocation | Should -BeExactly $ENV:TestModulePath
+        $cmdletOutput | Should -BeExactly "BinaryModuleCmdlet1 exported by the ModuleCmdlets module."
+    }
+
+    It 'PS should be able to load the executable as a root module' {
+        $ENV:psdFile = Join-Path $TESTDRIVE test.psd1
+        $exe = Join-Path $TESTDRIVE System.exe
+        New-ModuleManifest -Path $ENV:psdFile -RootModule $exe
+        try
+        {
+            $module = pwsh { Import-Module $ENV:psdFile -PassThru }
+            $module | Should -Not -BeNullOrEmpty
+            $module.ModuleType.ToString() | Should -Be 'Binary'
+            $module.RootModule | Should -Be $exe
+            $module.ExportedCmdlets['Test-BinaryModuleCmdlet1'].Name | Should -Be 'Test-BinaryModuleCmdlet1'
+        }
+        finally
+        {
+            Remove-Item $ENV:psdFile
+        }
+    }
+
+    It 'PS should be able to load the executable as a nested module' {
+        $ENV:psdFile = Join-Path $TESTDRIVE test.psd1
+        $exe = Join-Path $TESTDRIVE System.exe
+        New-ModuleManifest -Path $ENV:psdFile -NestedModules $exe
+        try
+        {
+            $module, $location = pwsh {
+                $module = Import-Module $ENV:psdFile -PassThru
+                # return the module and the nested module assembly location
+                $module
+                $module.NestedModules[0].ImplementingAssembly.Location
+            }
+            $module | Should -Not -BeNullOrEmpty
+            $module.ModuleType.ToString() | Should -Be 'Manifest'
+            $module.ExportedCmdlets['Test-BinaryModuleCmdlet1'].Name | Should -Be 'Test-BinaryModuleCmdlet1'
+            $module.NestedModules | Should -Not -BeNullOrEmpty
+            $location | Should -Be $exe
+        }
+        finally
+        {
+            Remove-Item $ENV:psdFile
+        }
     }
 
     It "PS should try to load the assembly from assembly name if file path doesn't exist" {
-
-        $psdFile = Join-Path $TESTDRIVE test.psd1
+        $ENV:psdFile = Join-Path $TESTDRIVE test.psd1
         $nestedModule = Join-Path NOExistedPath Microsoft.PowerShell.Commands.Utility.dll
-        New-ModuleManifest -Path $psdFile -NestedModules $nestedModule
+        New-ModuleManifest -Path $ENV:psdFile -NestedModules $nestedModule
         try
         {
-            $module = Import-Module $psdFile -PassThru
+            $module, $location = pwsh {
+                $module = Import-Module $ENV:psdFile -PassThru
+                # return the module and the assembly location
+                $module
+                $module.NestedModules[0].ImplementingAssembly.Location
+            }
             $module.NestedModules | Should -Not -BeNullOrEmpty
             $assemblyLocation = [Microsoft.PowerShell.Commands.AddTypeCommand].Assembly.Location
-            $module.NestedModules.ImplementingAssembly.Location | Should -Be $assemblyLocation
+            $location | Should -Be $assemblyLocation
         }
         finally
         {
             Remove-Module $module -ErrorAction SilentlyContinue
+            Remove-Item $ENV:psdFile
         }
-
     }
 
     It 'Should load from ModuleBase path before looking up in GAC' -Skip:(-not $IsWindows) {
@@ -259,7 +314,7 @@ Describe "Workflow .Xaml module is not supported in PSCore" -tags "Feature" {
         { Import-Module $xamlFile -ErrorAction Stop } | Should -Throw -ErrorId "Modules_WorkflowModuleNotSupported,Microsoft.PowerShell.Commands.ImportModuleCommand"
     }
 
-    It "Import a module with XAML root module should raise a 'NotSupportd' error" {
+    It "Import a module with XAML root module should raise a 'NotSupported' error" {
         { Import-Module $xamlRootModule -ErrorAction Stop } | Should -Throw -ErrorId "Modules_WorkflowModuleNotSupported,Microsoft.PowerShell.Commands.ImportModuleCommand"
     }
 

--- a/test/powershell/engine/Module/TestModuleManifest.Tests.ps1
+++ b/test/powershell/engine/Module/TestModuleManifest.Tests.ps1
@@ -54,7 +54,8 @@ Describe "Test-ModuleManifest tests" -tags "CI" {
 
     It "module manifest containing valid unprocessed rootmodule file type succeeds: <rootModuleValue>" -TestCases (
         @{rootModuleValue = "foo.psm1"},
-        @{rootModuleValue = "foo.dll"}
+        @{rootModuleValue = "foo.dll"},
+        @{rootModuleValue = "foo.exe"}
     ) {
 
         param($rootModuleValue)


### PR DESCRIPTION
## PR Summary

Fix for #6741 Allow .exe files to be used as binary modules. Basically anywhere a .dll could be used with modules, you can now use a .exe file.  Also did a little clean up, replacing constant strings with the StringLiteral values instead.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)


