### PR TITLE
Set the cursor to the place where a user hits tab key

### DIFF
--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ProgressPane.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ProgressPane.cs
@@ -101,8 +101,6 @@ namespace Microsoft.PowerShell
                 int scrollRows = rows - ((_rawui.BufferSize.Height - 1) - _location.Y);
                 if (scrollRows > 0)
                 {
-                    // The following can be possibly replaced by Console.Write ("\x1b[" + scrollRows + "S");
-                    // For details, see https://docs.microsoft.com/en-us/windows/console/console-virtual-terminal-sequences
                     // Scroll the console screen up by 'scrollRows'
                     var bottomLocation = _location;
                     bottomLocation.Y = _rawui.BufferSize.Height;

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ProgressPane.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ProgressPane.cs
@@ -99,12 +99,19 @@ namespace Microsoft.PowerShell
 
                 //if the cursor is at the bottom, create screen buffer space by scrolling
                 int scrollRows = rows - ((_rawui.BufferSize.Height - 1) - _location.Y);
-                for (int i = 0; i < rows; i++)
-                {
-                    Console.Out.Write('\n');
-                }
                 if (scrollRows > 0)
                 {
+                    // The following can be possibly replaced by Console.Write ("\x1b[" + scrollRows + "S");
+                    // For details, see https://docs.microsoft.com/en-us/windows/console/console-virtual-terminal-sequences
+                    // Scroll the console screen up by 'scrollRows'
+                    var bottomLocation = _location;
+                    bottomLocation.Y = _rawui.BufferSize.Height;
+                    _rawui.CursorPosition = bottomLocation;
+                    for (int i = 0; i < scrollRows; i++)
+                    {
+                        Console.Out.Write('\n');
+                    }
+
                     _location.Y -= scrollRows;
                     _savedCursor.Y -= scrollRows;
                 }

--- a/src/System.Management.Automation/engine/MshCommandRuntime.cs
+++ b/src/System.Management.Automation/engine/MshCommandRuntime.cs
@@ -2254,7 +2254,7 @@ namespace System.Management.Automation
             {
                 // Only generate these exceptions if a pipeline has already been declared as the 'writing' pipeline.
                 // Otherwise, these are probably infrastructure messages and can be ignored.
-                if (this.PipelineProcessor._permittedToWrite != null)
+                if (this.PipelineProcessor?._permittedToWrite != null)
                 {
                     throw PSTraceSource.NewInvalidOperationException(
                         PipelineStrings.WriteNotPermitted);


### PR DESCRIPTION

## PR Summary

To address the issue https://github.com/PowerShell/PowerShell/issues/7022, the changes are among the following repos:
- PSReadLine, see PR https://github.com/lzybkr/PSReadLine/pull/708
  For example, in the cloudshell, when a user types `get-azurermvmac` and then hits `tab`, we reach out to Azure to fetch the data and pwsh will show progress in the meantime, which in turn changes the cursor position. That requires PSReadLine to adjust the cursor position after calling GetCompletions().
- This PR is for fixing the cursor position calculation issue in PSCore when scrolling up screen is necessary so the PSReadLine can set the cursor to the right location
- With the above two fixes, the nested progress still does not work. I had a long conversation with  @iSazonov in my previous PR  https://github.com/PowerShell/PowerShell/pull/7023. We cannot call hide() because there is a small window where the progress won't get cleaned if ctrl+c.  Looking through the code, I think the easier way is to use the workaround `$ProgressPreference ='SilentlyContinue' `  at the AzurePSDrive module level for nested case, see https://github.com/PowerShell/AzurePSDrive/pull/53.
 With that, we can still show the fetching Azure data progress written by SHiPS,  suppress the  progress in the Get-AzureRmWebApp , but it does not change the ProgressPreference setting in the cloudshell. This means when a user type Azure cmdlet, the progress will still show.  That is the behavior we want.

Please note that we cannot use `$ProgressPreference ='SilentlyContinue' for both SHiPS and its provider AzurePSDrive because fetching data from Azure can take really long time. Showing progress is needed but keep (try keeping) one progress only. Thus the above fixes are all needed.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [x] Not Applicable or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
