### PR TITLE
Convert Newtonsoft.Json metadata properties in ConvertFrom-Json

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/JsonObject.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/JsonObject.cs
@@ -73,7 +73,14 @@ namespace Microsoft.PowerShell.Commands
                     // we just continue the deserialization.
                 }
 
-                obj = JsonConvert.DeserializeObject(input, new JsonSerializerSettings() { TypeNameHandling = TypeNameHandling.None, MaxDepth = 1024 });
+                obj = JsonConvert.DeserializeObject(
+                    input,
+                    new JsonSerializerSettings
+                    {
+                        TypeNameHandling = TypeNameHandling.None,
+                        MetadataPropertyHandling = MetadataPropertyHandling.Ignore,
+                        MaxDepth = 1024
+                    });
 
                 // JObject is a IDictionary
                 var dictionary = obj as JObject;

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertFrom-Json.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertFrom-Json.Tests.ps1
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 Describe 'ConvertFrom-Json' -tags "CI" {
-    
+
     BeforeAll {
         $testCasesWithAndWithoutAsHashtableSwitch = @(
             @{ AsHashtable = $true  }
@@ -29,6 +29,24 @@ Describe 'ConvertFrom-Json' -tags "CI" {
         Param($AsHashtable)
         $json = @('{"a" :', '"x"}') | ConvertFrom-Json -AsHashtable:$AsHashtable
         $json.a | Should -Be 'x'
+        if ($AsHashtable)
+        {
+            $json | Should -BeOfType Hashtable
+        }
+    }
+
+    It 'Can convert an object with Newtonsoft.Json metadata properties with AsHashtable switch set to <AsHashtable>' -TestCase $testCasesWithAndWithoutAsHashtableSwitch {
+        Param($AsHashtable)
+        $id = 13
+        $type = 'Calendar.Months.December'
+        $ref = 1989
+
+        $json = '{"$id":' + $id + ', "$type":"' + $type + '", "$ref":' + $ref + '}' | ConvertFrom-Json -AsHashtable:$AsHashtable
+
+        $json.'$id' | Should -Be $id
+        $json.'$type' | Should -Be $type
+        $json.'$ref' | Should -Be $ref
+
         if ($AsHashtable)
         {
             $json | Should -BeOfType Hashtable


### PR DESCRIPTION
## PR Summary
Use `MetadataPropertyHandling.Ignore` in `JsonSerializerSettings` when Deserializing instead of the default (`MetadataPropertyHandling.Default`). Documentation on this option can be found [here](https://www.newtonsoft.com/json/help/html/P_Newtonsoft_Json_JsonSerializerSettings_MetadataPropertyHandling.htm) and [here](https://www.newtonsoft.com/json/help/html/T_Newtonsoft_Json_MetadataPropertyHandling.htm). Basically `Newtonsoft.Json` specific metadata properties like `$id`/`$type`/`$ref` are by default read and used by `Newtonsoft.Json` to deserialize into types, use the same instance for different properties, etc.

`ConvertFrom-Json` deserializes into the generic type `PSCustomObject`, I *think* it doesn't make sense that these specific properties would not be converted as they are part of the json object. This restrict people from using these properties if they are not using `Newtonsoft.Json`, but even more likely, it restrict them from manipulating the entire raw json data of an object serialized with the library (which is probably what they want to do, otherwise they would be using the library directly to deserialize).

I don't know how "breaking" of a change this is considered to be, I would assume not many people rely on the current behavior, but it is changing with this PR.

Fixes #7307

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
