### PR TITLE
Add support for parsing Link Header with variable whitespace

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -1789,7 +1789,7 @@ namespace Microsoft.PowerShell.Commands
 
             // we only support the URL in angle brackets and `rel`, other attributes are ignored
             // user can still parse it themselves via the Headers property
-            string pattern = "<(?<url>.*?)>;\\srel=\"(?<rel>.*?)\"";
+            string pattern = "<(?<url>.*?)>;\\s*rel=\"(?<rel>.*?)\"";
             IEnumerable<string> links;
             if (response.Headers.TryGetValues("Link", out links))
             {

--- a/test/tools/WebListener/Constants.cs
+++ b/test/tools/WebListener/Constants.cs
@@ -8,7 +8,7 @@ namespace mvc.Controllers
     {
         public const string HeaderSeparator = ", ";
         public const string ApplicationJson = "application/json";
-        public const string LinkUriTemplate = "<{0}?maxlinks={1}&linknumber={2}&type={3}>; rel=\"{4}\"";
+        public const string LinkUriTemplate = "<{0}?maxlinks={1}&linknumber={2}&type={3}>;{4}rel=\"{5}\"";
         public const string MalformedUrlLinkHeader = "{url}; foo";
         public const string NoRelLinkHeader = "<url>; foo=\"bar\"";
         public const string NoUrlLinkHeader = "<>; rel=\"next\"";

--- a/test/tools/WebListener/Controllers/LinkController.cs
+++ b/test/tools/WebListener/Controllers/LinkController.cs
@@ -38,7 +38,7 @@ namespace mvc.Controllers
             }
             else if (type.ToUpper() == "NOWHITESPACE")
             {
-                whitespace = "";
+                whitespace = string.Empty;
             }
 
             var linkList = new List<String>();
@@ -108,7 +108,7 @@ namespace mvc.Controllers
 
         private string GetLink(string baseUri, int maxLinks, int linkNumber, string whitespace, string type, string rel)
         {
-            return String.Format(Constants.LinkUriTemplate, baseUri, maxLinks, linkNumber, type, whitespace, rel);
+            return string.Format(Constants.LinkUriTemplate, baseUri, maxLinks, linkNumber, type, whitespace, rel);
         }
     }
 }

--- a/test/tools/WebListener/Controllers/LinkController.cs
+++ b/test/tools/WebListener/Controllers/LinkController.cs
@@ -31,14 +31,24 @@ namespace mvc.Controllers
 
             string type = Request.Query.TryGetValue("type", out StringValues typeSV) ? typeSV.FirstOrDefault() : "default";
 
+            string whitespace = " ";
+            if (type.ToUpper() == "EXTRAWHITESPACE")
+            {
+                whitespace = "  ";
+            }
+            else if (type.ToUpper() == "NOWHITESPACE")
+            {
+                whitespace = "";
+            }
+
             var linkList = new List<String>();
             if (maxLinks > 1 && linkNumber > 1)
             {
-                linkList.Add(GetLink(baseUri: baseUri, maxLinks: maxLinks, linkNumber: linkNumber - 1, type: type, rel: "prev"));
+                linkList.Add(GetLink(baseUri: baseUri, maxLinks: maxLinks, linkNumber: linkNumber - 1, type: type, whitespace: whitespace, rel: "prev"));
             }
-            linkList.Add(GetLink(baseUri: baseUri, maxLinks: maxLinks, linkNumber: maxLinks, type: type, rel: "last"));
-            linkList.Add(GetLink(baseUri: baseUri, maxLinks: maxLinks, linkNumber: 1, type: type, rel: "first"));
-            linkList.Add(GetLink(baseUri: baseUri, maxLinks: maxLinks, linkNumber: linkNumber, type: type, rel: "self"));
+            linkList.Add(GetLink(baseUri: baseUri, maxLinks: maxLinks, linkNumber: maxLinks, type: type, whitespace: whitespace, rel: "last"));
+            linkList.Add(GetLink(baseUri: baseUri, maxLinks: maxLinks, linkNumber: 1, type: type, whitespace: whitespace, rel: "first"));
+            linkList.Add(GetLink(baseUri: baseUri, maxLinks: maxLinks, linkNumber: linkNumber, type: type, whitespace: whitespace, rel: "self"));
 
             bool sendMultipleHeaders = false;
             bool skipNextLink = false;
@@ -65,7 +75,7 @@ namespace mvc.Controllers
 
             if (!skipNextLink && maxLinks > 1 && linkNumber < maxLinks)
             {
-                linkList.Add(GetLink(baseUri: baseUri, maxLinks: maxLinks, linkNumber: linkNumber + 1, type: type, rel: "next"));
+                linkList.Add(GetLink(baseUri: baseUri, maxLinks: maxLinks, linkNumber: linkNumber + 1, type: type, whitespace: whitespace, rel: "next"));
             }
 
             StringValues linkHeader;
@@ -96,9 +106,9 @@ namespace mvc.Controllers
             return View(new ErrorViewModel { RequestId = Activity.Current?.Id ?? HttpContext.TraceIdentifier });
         }
 
-        private string GetLink(string baseUri, int maxLinks, int linkNumber, string type, string rel)
+        private string GetLink(string baseUri, int maxLinks, int linkNumber, string whitespace, string type, string rel)
         {
-            return String.Format(Constants.LinkUriTemplate, baseUri, maxLinks, linkNumber, type, rel);
+            return String.Format(Constants.LinkUriTemplate, baseUri, maxLinks, linkNumber, type, whitespace, rel);
         }
     }
 }

--- a/test/tools/WebListener/README.md
+++ b/test/tools/WebListener/README.md
@@ -277,6 +277,8 @@ Returns Link response headers to test paginated results. The endpoint accepts 3 
   * `nourl` - Returns a Link header that does not include the URI portion. Suppresses `next` link.
   * `malformed` - Returns a malformed Link header. Suppresses `next` link.
   * `multiple` - Returns multiple Link headers instead of a single Link header and returns `next` link if one is available.
+  * `nowhitespace` - Returns `default` links without any whitespace between the semicolon and `rel`
+  * `extrawhitespace` - Returns `default` links with double whitespace between the semicolon and `rel`
 
 The body will contain the same results as `/Get/` with the addition of the `type`, `linknumber`, and `maxlinks` for the current page.
 


### PR DESCRIPTION
add support for variable whitespace in link header

## PR Summary

Thanks to the @cruscio's analysis, it appears that the Link Header allows for any amount of whitespace or even no whitespace.  The currently explicitly expect a single whitespace after the semicolon in the Link Header before the `Rel` property.

Fix is to change the regex to allow for variable or no whitespace and associated tests to handle these two cases.  Changed `GetLink` helper to support passing in whitespace to use.

Fix https://github.com/PowerShell/PowerShell/issues/5667

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [x] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
