### PR TITLE
Use -HaveCount instead of -Be in Where-Object.Tests.ps1.

### DIFF
--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Where-Object.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Where-Object.Tests.ps1
@@ -27,118 +27,118 @@ Describe "Where-Object" -Tags "CI" {
 
     It "Where-Object -Not Prop" {
         $Result = $Computers | Where-Object -Not 'IPAddress'
-        $Result.Count | Should -Be 2
+        $Result | Should -HaveCount 2
     }
 
     It 'Where-Object -FilterScript {$true -ne $_.Prop}' {
         $Result = $Computers | Where-Object -FilterScript {$true -ne $_.IPAddress}
-        $Result.Count | Should -Be 2
+        $Result | Should -HaveCount 2
     }
 
     It "Where-Object Prop" {
         $Result = $Computers | Where-Object 'IPAddress'
-        $Result.Count | Should -Be 1
+        $Result | Should -HaveCount 1
     }
 
     It 'Where-Object -FilterScript {$true -eq $_.Prop}' {
         $Result = $Computers | Where-Object -FilterScript {$true -eq $_.IPAddress}
-        $Result.Count | Should -Be 1
+        $Result | Should -HaveCount 1
     }
 
     It 'Where-Object -FilterScript {$_.Prop -contains Value}' {
         $Result = $Computers | Where-Object -FilterScript {$_.Drives -contains 'D'}
-        $Result.Count | Should -Be 2
+        $Result | Should -HaveCount 2
     }
 
     It 'Where-Object Prop -contains Value' {
         $Result = $Computers | Where-Object Drives -contains 'D'
-        $Result.Count | Should -Be 2
+        $Result | Should -HaveCount 2
     }
 
     It 'Where-Object -FilterScript {$_.Prop -in $Array}' {
         $Array = 'SPC-1234','BGP-5678'
         $Result = $Computers | Where-Object -FilterScript {$_.ComputerName -in $Array}
-        $Result.Count | Should -Be 2
+        $Result | Should -HaveCount 2
     }
 
     It 'Where-Object $Array -in Prop' {
         $Array = 'SPC-1234','BGP-5678'
         $Result = $Computers | Where-Object ComputerName -in $Array
-        $Result.Count | Should -Be 2
+        $Result | Should -HaveCount 2
     }
 
     It 'Where-Object -FilterScript {$_.Prop -ge 2}' {
         $Result = $Computers | Where-Object -FilterScript {$_.NumberOfCores -ge 2}
-        $Result.Count | Should -Be 2
+        $Result | Should -HaveCount 2
     }
 
     It 'Where-Object Prop -ge 2' {
         $Result = $Computers | Where-Object NumberOfCores -ge 2
-        $Result.Count | Should -Be 2
+        $Result | Should -HaveCount 2
     }
 
     It 'Where-Object -FilterScript {$_.Prop -gt 2}' {
         $Result = $Computers | Where-Object -FilterScript {$_.NumberOfCores -gt 2}
-        $Result.Count | Should -Be 1
+        $Result | Should -HaveCount 1
     }
 
     It 'Where-Object Prop -gt 2' {
         $Result = $Computers | Where-Object NumberOfCores -gt 2
-        $Result.Count | Should -Be 1
+        $Result | Should -HaveCount 1
     }
 
     It 'Where-Object -FilterScript {$_.Prop -le 2}' {
         $Result = $Computers | Where-Object -FilterScript {$_.NumberOfCores -le 2}
-        $Result.Count | Should -Be 2
+        $Result | Should -HaveCount 2
     }
 
     It 'Where-Object Prop -le 2' {
         $Result = $Computers | Where-Object NumberOfCores -le 2
-        $Result.Count | Should -Be 2
+        $Result | Should -HaveCount 2
     }
 
     It 'Where-Object -FilterScript {$_.Prop -lt 2}' {
         $Result = $Computers | Where-Object -FilterScript {$_.NumberOfCores -lt 2}
-        $Result.Count | Should -Be 1
+        $Result | Should -HaveCount 1
     }
 
     It 'Where-Object Prop -lt 2' {
         $Result = $Computers | Where-Object NumberOfCores -lt 2
-        $Result.Count | Should -Be 1
+        $Result | Should -HaveCount 1
     }
 
     It 'Where-Object -FilterScript {$_.Prop -Like Value}' {
         $Result = $Computers | Where-Object -FilterScript {$_.ComputerName -like 'MGC-9101'}
-        $Result.Count | Should -Be 1
+        $Result | Should -HaveCount 1
     }
 
     It 'Where-Object Prop -like Value' {
         $Result = $Computers | Where-Object ComputerName -like 'MGC-9101'
-        $Result.Count | Should -Be 1
+        $Result | Should -HaveCount 1
     }
 
     It 'Where-Object -FilterScript {$_.Prop -Match Pattern}' {
         $Result = $Computers | Where-Object -FilterScript {$_.ComputerName -match '^MGC.+'}
-        $Result.Count | Should -Be 1
+        $Result | Should -HaveCount 1
     }
 
     It 'Where-Object Prop -like Value' {
         $Result = $Computers | Where-Object ComputerName -match '^MGC.+'
-        $Result.Count | Should -Be 1
+        $Result | Should -HaveCount 1
     }
 
     It 'Where-Object should handle dynamic (DLR) objects' {
         $dynObj = [TestDynamic]::new()
-        $Result = $dynObj, $dynObj | Where FooProp -eq 123
-        $Result.Count | Should -Be 2
+        $Result = $dynObj, $dynObj | Where-Object FooProp -eq 123
+        $Result | Should -HaveCount 2
         $Result[0] | Should -Be $dynObj
         $Result[1] | Should -Be $dynObj
     }
 
     It 'Where-Object should handle dynamic (DLR) objects, even without property name hint' {
         $dynObj = [TestDynamic]::new()
-        $Result = $dynObj, $dynObj | Where HiddenProp -eq 789
-        $Result.Count | Should -Be 2
+        $Result = $dynObj, $dynObj | Where-Object HiddenProp -eq 789
+        $Result | Should -HaveCount 2
         $Result[0] | Should -Be $dynObj
         $Result[1] | Should -Be $dynObj
     }


### PR DESCRIPTION
## PR Summary

Change **-Be** parameter to **-HaveCount** in Where-Object.Tests.ps1.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [x] Not Applicable or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
