### PR TITLE
Use -BeExactly and -HaveCount instead of -Be in TabCompletion.Tests.ps1.

### DIFF
--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -7,44 +7,44 @@ Describe "TabCompletion" -Tags CI {
 
     It 'Should complete Command' {
         $res = TabExpansion2 -inputScript 'Get-Com' -cursorColumn 'Get-Com'.Length
-        $res.CompletionMatches[0].CompletionText | Should -Be Get-Command
+        $res.CompletionMatches[0].CompletionText | Should -BeExactly 'Get-Command'
     }
 
     It 'Should complete native exe' -Skip:(!$IsWindows) {
         $res = TabExpansion2 -inputScript 'notep' -cursorColumn 'notep'.Length
-        $res.CompletionMatches[0].CompletionText | Should -Be notepad.exe
+        $res.CompletionMatches[0].CompletionText | Should -BeExactly 'notepad.exe'
     }
 
     It 'Should complete dotnet method' {
         $res = TabExpansion2 -inputScript '(1).ToSt' -cursorColumn '(1).ToSt'.Length
-        $res.CompletionMatches[0].CompletionText | Should -Be 'ToString('
+        $res.CompletionMatches[0].CompletionText | Should -BeExactly 'ToString('
     }
 
     It 'Should complete Magic foreach' {
         $res = TabExpansion2 -inputScript '(1..10).Fo' -cursorColumn '(1..10).Fo'.Length
-        $res.CompletionMatches[0].CompletionText | Should -Be 'Foreach('
+        $res.CompletionMatches[0].CompletionText | Should -BeExactly 'ForEach('
     }
 
     It "Should complete Magic where" {
         $res = TabExpansion2 -inputScript '(1..10).wh' -cursorColumn '(1..10).wh'.Length
-        $res.CompletionMatches[0].CompletionText | Should -Be 'Where('
+        $res.CompletionMatches[0].CompletionText | Should -BeExactly 'Where('
     }
 
     It 'Should complete types' {
         $res = TabExpansion2 -inputScript '[pscu' -cursorColumn '[pscu'.Length
-        $res.CompletionMatches[0].CompletionText | Should -Be 'pscustomobject'
+        $res.CompletionMatches[0].CompletionText | Should -BeExactly 'pscustomobject'
     }
 
     It 'Should complete namespaces' {
         $res = TabExpansion2 -inputScript 'using namespace Sys' -cursorColumn 'using namespace Sys'.Length
-        $res.CompletionMatches[0].CompletionText | Should -Be 'System'
+        $res.CompletionMatches[0].CompletionText | Should -BeExactly 'System'
     }
 
     It 'Should complete format-table hashtable' {
         $res = TabExpansion2 -inputScript 'Get-ChildItem | Format-Table @{ ' -cursorColumn 'Get-ChildItem | Format-Table @{ '.Length
-        $res.CompletionMatches.Count | Should -Be 5
+        $res.CompletionMatches | Should -HaveCount 5
         $completionText = $res.CompletionMatches.CompletionText | Sort-Object
-        $completionText -join ' ' | Should -Be 'Alignment Expression FormatString Label Width'
+        $completionText -join ' ' | Should -BeExactly 'Alignment Expression FormatString Label Width'
     }
 
     It 'Should complete format-* hashtable on GroupBy: <cmd>' -TestCases (
@@ -55,44 +55,44 @@ Describe "TabCompletion" -Tags CI {
     ) {
         param($cmd)
         $res = TabExpansion2 -inputScript "Get-ChildItem | $cmd -GroupBy @{ " -cursorColumn "Get-ChildItem | $cmd -GroupBy @{ ".Length
-        $res.CompletionMatches.Count | Should -Be 3
+        $res.CompletionMatches | Should -HaveCount 3
         $completionText = $res.CompletionMatches.CompletionText | Sort-Object
-        $completionText -join ' ' | Should -Be 'Expression FormatString Label'
+        $completionText -join ' ' | Should -BeExactly 'Expression FormatString Label'
     }
 
     It 'Should complete format-list hashtable' {
         $res = TabExpansion2 -inputScript 'Get-ChildItem | Format-List @{ ' -cursorColumn 'Get-ChildItem | Format-List @{ '.Length
-        $res.CompletionMatches.Count | Should -Be 3
+        $res.CompletionMatches | Should -HaveCount 3
         $completionText = $res.CompletionMatches.CompletionText | Sort-Object
-        $completionText -join ' ' | Should -Be 'Expression FormatString Label'
+        $completionText -join ' ' | Should -BeExactly 'Expression FormatString Label'
     }
 
     It 'Should complete format-wide hashtable' {
         $res = TabExpansion2 -inputScript 'Get-ChildItem | Format-Wide @{ ' -cursorColumn 'Get-ChildItem | Format-Wide @{ '.Length
-        $res.CompletionMatches.Count | Should -Be 2
+        $res.CompletionMatches | Should -HaveCount 2
         $completionText = $res.CompletionMatches.CompletionText | Sort-Object
-        $completionText -join ' ' | Should -Be 'Expression FormatString'
+        $completionText -join ' ' | Should -BeExactly 'Expression FormatString'
     }
 
     It 'Should complete format-custom hashtable' {
         $res = TabExpansion2 -inputScript 'Get-ChildItem | Format-Custom @{ ' -cursorColumn 'Get-ChildItem | Format-Custom @{ '.Length
-        $res.CompletionMatches.Count | Should -Be 2
+        $res.CompletionMatches | Should -HaveCount 2
         $completionText = $res.CompletionMatches.CompletionText | Sort-Object
-        $completionText -join ' ' | Should -Be 'Depth Expression'
+        $completionText -join ' ' | Should -BeExactly 'Depth Expression'
     }
 
     It 'Should complete Select-Object hashtable' {
         $res = TabExpansion2 -inputScript 'Get-ChildItem | Select-Object @{ ' -cursorColumn 'Get-ChildItem | Select-Object @{ '.Length
-        $res.CompletionMatches.Count | Should -Be 2
+        $res.CompletionMatches | Should -HaveCount 2
         $completionText = $res.CompletionMatches.CompletionText | Sort-Object
-        $completionText -join ' '| Should -Be 'Expression Name'
+        $completionText -join ' '| Should -BeExactly 'Expression Name'
     }
 
     It 'Should complete Sort-Object hashtable' {
         $res = TabExpansion2 -inputScript 'Get-ChildItem | Sort-Object @{ ' -cursorColumn 'Get-ChildItem | Sort-Object @{ '.Length
-        $res.CompletionMatches.Count | Should -Be 3
+        $res.CompletionMatches | Should -HaveCount 3
         $completionText = $res.CompletionMatches.CompletionText | Sort-Object
-        $completionText -join ' '| Should -Be 'Ascending Descending Expression'
+        $completionText -join ' '| Should -BeExactly 'Ascending Descending Expression'
     }
 
     It 'Should complete New-Object hashtable' {
@@ -102,8 +102,8 @@ Describe "TabCompletion" -Tags CI {
             $C
         }
         $res = TabExpansion2 -inputScript 'New-Object -TypeName X -Property @{ ' -cursorColumn 'New-Object -TypeName X -Property @{ '.Length
-        $res.CompletionMatches.Count | Should -Be 3
-        $res.CompletionMatches.CompletionText -join ' ' | Should -Be 'A B C'
+        $res.CompletionMatches | Should -HaveCount 3
+        $res.CompletionMatches.CompletionText -join ' ' | Should -BeExactly 'A B C'
     }
 
     It 'Should complete "Get-Process -Id " with Id and name in tooltip' {
@@ -125,7 +125,7 @@ Describe "TabCompletion" -Tags CI {
 
     It 'Should complete keyword' -skip {
         $res = TabExpansion2 -inputScript 'using nam' -cursorColumn 'using nam'.Length
-        $res.CompletionMatches[0].CompletionText | Should -Be 'namespace'
+        $res.CompletionMatches[0].CompletionText | Should -BeExactly 'namespace'
     }
 
     Context NativeCommand {
@@ -144,8 +144,8 @@ Describe "TabCompletion" -Tags CI {
             }
             $line = "$nativeCommand -"
             $res = TabExpansion2 -inputScript $line -cursorColumn $line.Length
-            $res.CompletionMatches.Count | Should -Be 1
-            $res.CompletionMatches.CompletionText | Should -Be "-flag"
+            $res.CompletionMatches | Should -HaveCount 1
+            $res.CompletionMatches.CompletionText | Should -BeExactly "-flag"
         }
 
         It 'Completes native commands with --' {
@@ -160,8 +160,8 @@ Describe "TabCompletion" -Tags CI {
             }
             $line = "$nativeCommand --"
             $res = TabExpansion2 -inputScript $line -cursorColumn $line.Length
-            $res.CompletionMatches.Count | Should -Be 1
-            $res.CompletionMatches.CompletionText | Should -Be "--flag"
+            $res.CompletionMatches | Should -HaveCount 1
+            $res.CompletionMatches.CompletionText | Should -BeExactly "--flag"
         }
 
         It 'Completes native commands with --f' {
@@ -176,8 +176,8 @@ Describe "TabCompletion" -Tags CI {
             }
             $line = "$nativeCommand --f"
             $res = TaBexpansion2 -inputScript $line -cursorColumn $line.Length
-            $res.CompletionMatches.Count | Should -Be 1
-            $res.CompletionMatches.CompletionText | Should -Be "--flag"
+            $res.CompletionMatches | Should -HaveCount 1
+            $res.CompletionMatches.CompletionText | Should -BeExactly "--flag"
         }
 
         It 'Completes native commands with -o' {
@@ -192,16 +192,16 @@ Describe "TabCompletion" -Tags CI {
             }
             $line = "$nativeCommand -o"
             $res = TaBexpansion2 -inputScript $line -cursorColumn $line.Length
-            $res.CompletionMatches.Count | Should -Be 1
-            $res.CompletionMatches.CompletionText | Should -Be "-option"
+            $res.CompletionMatches | Should -HaveCount 1
+            $res.CompletionMatches.CompletionText | Should -BeExactly "-option"
         }
     }
 
     It 'Should complete "Export-Counter -FileFormat" with available output formats' -Pending {
         $res = TabExpansion2 -inputScript 'Export-Counter -FileFormat ' -cursorColumn 'Export-Counter -FileFormat '.Length
-        $res.CompletionMatches.Count | Should -Be 3
+        $res.CompletionMatches | Should -HaveCount 3
         $completionText = $res.CompletionMatches.CompletionText | Sort-Object
-        $completionText -join ' '| Should -Be 'blg csv tsv'
+        $completionText -join ' '| Should -BeExactly 'blg csv tsv'
     }
 
     Context "File name completion" {
@@ -256,7 +256,7 @@ Describe "TabCompletion" -Tags CI {
             Push-Location -Path $tempDir
             $res = TabExpansion2 -inputScript $inputStr -cursorColumn $inputStr.Length
             $res.CompletionMatches.Count | Should -BeGreaterThan 0
-            $res.CompletionMatches[0].CompletionText | Should -Be $localExpected
+            $res.CompletionMatches[0].CompletionText | Should -BeExactly $localExpected
         }
 
         It "Input '<inputStr>' should successfully complete with relative path '..\'" -TestCases $testCases {
@@ -266,7 +266,7 @@ Describe "TabCompletion" -Tags CI {
             $inputStr = "..\${inputStr}"
             $res = TabExpansion2 -inputScript $inputStr -cursorColumn $inputStr.Length
             $res.CompletionMatches.Count | Should -BeGreaterThan 0
-            $res.CompletionMatches[0].CompletionText | Should -Be $oneSubExpected
+            $res.CompletionMatches[0].CompletionText | Should -BeExactly $oneSubExpected
         }
 
         It "Input '<inputStr>' should successfully complete with relative path '..\..\'" -TestCases $testCases {
@@ -276,7 +276,7 @@ Describe "TabCompletion" -Tags CI {
             $inputStr = "../../${inputStr}"
             $res = TabExpansion2 -inputScript $inputStr -cursorColumn $inputStr.Length
             $res.CompletionMatches.Count | Should -BeGreaterThan 0
-            $res.CompletionMatches[0].CompletionText | Should -Be $twoSubExpected
+            $res.CompletionMatches[0].CompletionText | Should -BeExactly $twoSubExpected
         }
 
         It "Input '<inputStr>' should successfully complete with relative path '..\..\..\ba*\'" -TestCases $testCases {
@@ -286,7 +286,7 @@ Describe "TabCompletion" -Tags CI {
             $inputStr = "..\..\..\ba*\${inputStr}"
             $res = TabExpansion2 -inputScript $inputStr -cursorColumn $inputStr.Length
             $res.CompletionMatches.Count | Should -BeGreaterThan 0
-            $res.CompletionMatches[0].CompletionText | Should -Be $twoSubExpected
+            $res.CompletionMatches[0].CompletionText | Should -BeExactly $twoSubExpected
         }
 
         It "Test relative path" {
@@ -294,8 +294,8 @@ Describe "TabCompletion" -Tags CI {
             $beforeTab = "twoSubDir/../../pri"
             $afterTab = "..${separator}prime"
             $res = TabExpansion2 -inputScript $beforeTab -cursorColumn $beforeTab.Length
-            $res.CompletionMatches.Count | Should -Be 1
-            $res.CompletionMatches[0].CompletionText | Should -Be $afterTab
+            $res.CompletionMatches | Should -HaveCount 1
+            $res.CompletionMatches[0].CompletionText | Should -BeExactly $afterTab
         }
 
         It "Test path with both '\' and '/'" {
@@ -303,30 +303,30 @@ Describe "TabCompletion" -Tags CI {
             $beforeTab = "..\../..\ba*/ab"
             $afterTab = "..${separator}..${separator}abc"
             $res = TabExpansion2 -inputScript $beforeTab -cursorColumn $beforeTab.Length
-            $res.CompletionMatches.Count | Should -Be 1
-            $res.CompletionMatches[0].CompletionText | Should -Be $afterTab
+            $res.CompletionMatches | Should -HaveCount 1
+            $res.CompletionMatches[0].CompletionText | Should -BeExactly $afterTab
         }
     }
 
     Context "Cmdlet name completion" {
         BeforeAll {
             $testCases = @(
-                @{ inputStr = "get-c*item"; expected = "get-childitem" }
-                @{ inputStr = "set-alia?"; expected = "set-alias" }
-                @{ inputStr = "s*-alias"; expected = "set-alias" }
-                @{ inputStr = "se*-alias"; expected = "set-alias" }
-                @{ inputStr = "set-al"; expected = "set-alias" }
-                @{ inputStr = "set-a?i"; expected = "set-alias" }
-                @{ inputStr = "set-?lias"; expected = "set-alias" }
-                @{ inputStr = "get-*ditem"; expected = "get-childitem" }
-                @{ inputStr = "Microsoft.PowerShell.Management\get-c*item"; expected = "Microsoft.PowerShell.Management\get-childitem" }
-                @{ inputStr = "Microsoft.PowerShell.Utility\set-alia?"; expected = "Microsoft.PowerShell.Utility\set-alias" }
-                @{ inputStr = "Microsoft.PowerShell.Utility\s*-alias"; expected = "Microsoft.PowerShell.Utility\set-alias" }
-                @{ inputStr = "Microsoft.PowerShell.Utility\se*-alias"; expected = "Microsoft.PowerShell.Utility\set-alias" }
-                @{ inputStr = "Microsoft.PowerShell.Utility\set-al"; expected = "Microsoft.PowerShell.Utility\set-alias" }
-                @{ inputStr = "Microsoft.PowerShell.Utility\set-a?i"; expected = "Microsoft.PowerShell.Utility\set-alias" }
-                @{ inputStr = "Microsoft.PowerShell.Utility\set-?lias"; expected = "Microsoft.PowerShell.Utility\set-alias" }
-                @{ inputStr = "Microsoft.PowerShell.Management\get-*ditem"; expected = "Microsoft.PowerShell.Management\get-childitem" }
+                @{ inputStr = "get-c*item"; expected = "Get-ChildItem" }
+                @{ inputStr = "set-alia?"; expected = "Set-Alias" }
+                @{ inputStr = "s*-alias"; expected = "Set-Alias" }
+                @{ inputStr = "se*-alias"; expected = "Set-Alias" }
+                @{ inputStr = "set-al"; expected = "Set-Alias" }
+                @{ inputStr = "set-a?i"; expected = "Set-Alias" }
+                @{ inputStr = "set-?lias"; expected = "Set-Alias" }
+                @{ inputStr = "get-*ditem"; expected = "Get-ChildItem" }
+                @{ inputStr = "Microsoft.PowerShell.Management\get-c*item"; expected = "Microsoft.PowerShell.Management\Get-ChildItem" }
+                @{ inputStr = "Microsoft.PowerShell.Utility\set-alia?"; expected = "Microsoft.PowerShell.Utility\Set-Alias" }
+                @{ inputStr = "Microsoft.PowerShell.Utility\s*-alias"; expected = "Microsoft.PowerShell.Utility\Set-Alias" }
+                @{ inputStr = "Microsoft.PowerShell.Utility\se*-alias"; expected = "Microsoft.PowerShell.Utility\Set-Alias" }
+                @{ inputStr = "Microsoft.PowerShell.Utility\set-al"; expected = "Microsoft.PowerShell.Utility\Set-Alias" }
+                @{ inputStr = "Microsoft.PowerShell.Utility\set-a?i"; expected = "Microsoft.PowerShell.Utility\Set-Alias" }
+                @{ inputStr = "Microsoft.PowerShell.Utility\set-?lias"; expected = "Microsoft.PowerShell.Utility\Set-Alias" }
+                @{ inputStr = "Microsoft.PowerShell.Management\get-*ditem"; expected = "Microsoft.PowerShell.Management\Get-ChildItem" }
             )
         }
 
@@ -334,7 +334,7 @@ Describe "TabCompletion" -Tags CI {
             param($inputStr, $expected)
 
             $res = TabExpansion2 -inputScript $inputStr -cursorColumn $inputStr.Length
-            $res.CompletionMatches[0].CompletionText | Should -Be $expected
+            $res.CompletionMatches[0].CompletionText | Should -BeExactly $expected
         }
     }
 
@@ -401,7 +401,7 @@ Describe "TabCompletion" -Tags CI {
                 @{ inputStr = 'Set-ExecutionPolicy -exe:b'; expected = 'Bypass'; setup = $null }
                 @{ inputStr = 'Set-ExecutionPolicy -ExecutionPolicy:'; expected = 'AllSigned'; setup = $null }
                 @{ inputStr = 'Set-ExecutionPolicy by -for:'; expected = '$true'; setup = $null }
-                @{ inputStr = 'Import-Csv -Encoding '; expected = 'ASCII'; setup = $null }
+                @{ inputStr = 'Import-Csv -Encoding '; expected = 'ascii'; setup = $null }
                 @{ inputStr = 'Get-Process | % ModuleM'; expected = 'ModuleMemorySize'; setup = $null }
                 @{ inputStr = 'Get-Process | % {$_.MainModule} | % Com'; expected = 'Company'; setup = $null }
                 @{ inputStr = 'Get-Process | % MainModule | % Com'; expected = 'Company'; setup = $null }
@@ -417,7 +417,7 @@ Describe "TabCompletion" -Tags CI {
                 @{ inputStr = "function bar { [OutputType('System.IO.FileInfo')][OutputType('System.Diagnostics.Process')]param() }; bar | ? { `$_.LastAc"; expected = 'LastAccessTime'; setup = $null }
                 @{ inputStr = "& 'get-comm"; expected = "'Get-Command'"; setup = $null }
                 @{ inputStr = 'alias:dir'; expected = Join-Path 'Alias:' 'dir'; setup = $null }
-                @{ inputStr = 'gc alias::ipm'; expected = 'Alias::ipmo'; setup = $null }
+                @{ inputStr = 'gc alias::ipm'; expected = 'alias::ipmo'; setup = $null }
                 @{ inputStr = 'gc enVironment::psmod'; expected = 'enVironment::PSModulePath'; setup = $null }
                 ## tab completion safe expression evaluator tests
                 @{ inputStr = '@{a=$(exit)}.Ke'; expected = 'Keys'; setup = $null }
@@ -455,7 +455,7 @@ Describe "TabCompletion" -Tags CI {
             if ($null -ne $setup) { . $setup }
             $res = TabExpansion2 -inputScript $inputStr -cursorColumn $inputStr.Length
             $res.CompletionMatches.Count | Should -BeGreaterThan 0
-            $res.CompletionMatches[0].CompletionText | Should -Be $expected
+            $res.CompletionMatches[0].CompletionText | Should -BeExactly $expected
         }
 
         It "Tab completion UNC path" -Skip:(!$IsWindows) {
@@ -464,23 +464,23 @@ Describe "TabCompletion" -Tags CI {
             $afterTab = "& '\\localhost\$homeDrive\Windows'"
             $res = TabExpansion2 -inputScript $beforeTab -cursorColumn $beforeTab.Length
             $res.CompletionMatches.Count | Should -BeGreaterThan 0
-            $res.CompletionMatches[0].CompletionText | Should -Be $afterTab
+            $res.CompletionMatches[0].CompletionText | Should -BeExactly $afterTab
         }
 
         It "Tab completion for registry" -Skip:(!$IsWindows) {
             $beforeTab = 'registry::HKEY_l'
             $afterTab = 'registry::HKEY_LOCAL_MACHINE'
             $res = TabExpansion2 -inputScript $beforeTab -cursorColumn $beforeTab.Length
-            $res.CompletionMatches.Count | Should -BeExactly 1
-            $res.CompletionMatches[0].CompletionText | Should -Be $afterTab
+            $res.CompletionMatches | Should -HaveCount 1
+            $res.CompletionMatches[0].CompletionText | Should -BeExactly $afterTab
         }
 
         It "Tab completion for wsman provider" -Skip:(!$IsWindows) {
             $beforeTab = 'wsman::localh'
             $afterTab = 'wsman::localhost'
             $res = TabExpansion2 -inputScript $beforeTab -cursorColumn $beforeTab.Length
-            $res.CompletionMatches.Count | Should -BeExactly 1
-            $res.CompletionMatches[0].CompletionText | Should -Be $afterTab
+            $res.CompletionMatches | Should -HaveCount 1
+            $res.CompletionMatches[0].CompletionText | Should -BeExactly $afterTab
         }
 
         It "Tab completion for filesystem provider qualified path" {
@@ -493,7 +493,7 @@ Describe "TabCompletion" -Tags CI {
                 $afterTab = 'filesystem::{0}helloworld' -f $tempFolder
                 $res = TabExpansion2 -inputScript $beforeTab -cursorColumn $beforeTab.Length
                 $res.CompletionMatches.Count | Should -BeGreaterThan 0
-                $res.CompletionMatches[0].CompletionText | Should -Be $afterTab
+                $res.CompletionMatches[0].CompletionText | Should -BeExactly $afterTab
             }
             finally
             {
@@ -526,9 +526,9 @@ Describe "TabCompletion" -Tags CI {
             $inputStr = "Test-DynamicParam -D"
             $res = TabExpansion2 -inputScript $inputStr -cursorColumn $inputStr.Length
             $res.CompletionMatches.Count | Should -BeGreaterThan 3
-            $res.CompletionMatches[0].CompletionText | Should -Be '-DeFirst'
-            $res.CompletionMatches[1].CompletionText | Should -Be '-DeSecond'
-            $res.CompletionMatches[2].CompletionText | Should -Be '-DeThird'
+            $res.CompletionMatches[0].CompletionText | Should -BeExactly '-DeFirst'
+            $res.CompletionMatches[1].CompletionText | Should -BeExactly '-DeSecond'
+            $res.CompletionMatches[2].CompletionText | Should -BeExactly '-DeThird'
         }
 
         It "Tab completion dynamic parameter '-CodeSigningCert'" -Skip:(!$IsWindows) {
@@ -536,7 +536,7 @@ Describe "TabCompletion" -Tags CI {
                 Push-Location cert:\
                 $inputStr = "gci -co"
                 $res = TabExpansion2 -inputScript $inputStr -cursorColumn $inputStr.Length
-                $res.CompletionMatches[0].CompletionText | Should -Be '-CodeSigningCert'
+                $res.CompletionMatches[0].CompletionText | Should -BeExactly '-CodeSigningCert'
             } finally {
                 Pop-Location
             }
@@ -550,9 +550,9 @@ Describe "TabCompletion" -Tags CI {
 
                 $inputStr = "myf"
                 $res = TabExpansion2 -inputScript $inputStr -cursorColumn $inputStr.Length
-                $res.CompletionMatches.Count | Should -BeExactly 2
-                $res.CompletionMatches[0].CompletionText | Should -Be (Resolve-Path myf -Relative)
-                $res.CompletionMatches[1].CompletionText | Should -Be "MyFunction"
+                $res.CompletionMatches | Should -HaveCount 2
+                $res.CompletionMatches[0].CompletionText | Should -BeExactly (Resolve-Path myf -Relative)
+                $res.CompletionMatches[1].CompletionText | Should -BeExactly "MyFunction"
             } finally {
                 Remove-Item -Path myf -Force
                 Pop-Location
@@ -563,40 +563,40 @@ Describe "TabCompletion" -Tags CI {
             function foo { param([ValidateSet('cat','dog')]$p) }
             $inputStr = "foo "
             $res = TabExpansion2 -inputScript $inputStr -cursorColumn $inputStr.Length
-            $res.CompletionMatches.Count | Should -BeExactly 2
-            $res.CompletionMatches[0].CompletionText | Should -Be 'cat'
-            $res.CompletionMatches[1].CompletionText | Should -Be 'dog'
+            $res.CompletionMatches | Should -HaveCount 2
+            $res.CompletionMatches[0].CompletionText | Should -BeExactly 'cat'
+            $res.CompletionMatches[1].CompletionText | Should -BeExactly 'dog'
         }
 
         It "Tab completion for enum type parameter of a custom function" {
             function baz ([consolecolor]$name, [ValidateSet('cat','dog')]$p){}
             $inputStr = "baz -name "
             $res = TabExpansion2 -inputScript $inputStr -cursorColumn $inputStr.Length
-            $res.CompletionMatches.Count | Should -BeExactly 16
-            $res.CompletionMatches[0].CompletionText | Should -Be 'Black'
+            $res.CompletionMatches | Should -HaveCount 16
+            $res.CompletionMatches[0].CompletionText | Should -BeExactly 'Black'
 
             $inputStr = "baz Black "
             $res = TabExpansion2 -inputScript $inputStr -cursorColumn $inputStr.Length
-            $res.CompletionMatches.Count | Should -BeExactly 2
-            $res.CompletionMatches[0].CompletionText | Should -Be 'cat'
-            $res.CompletionMatches[1].CompletionText | Should -Be 'dog'
+            $res.CompletionMatches | Should -HaveCount 2
+            $res.CompletionMatches[0].CompletionText | Should -BeExactly 'cat'
+            $res.CompletionMatches[1].CompletionText | Should -BeExactly 'dog'
         }
 
         It "Tab completion for enum members after comma" {
             $inputStr = "Get-Command -Type Alias,c"
             $res = TabExpansion2 -inputScript $inputStr -cursorColumn $inputStr.Length
-            $res.CompletionMatches.Count | Should -BeExactly 2
-            $res.CompletionMatches[0].CompletionText | Should -Be 'Cmdlet'
-            $res.CompletionMatches[1].CompletionText | Should -Be 'Configuration'
+            $res.CompletionMatches | Should -HaveCount 2
+            $res.CompletionMatches[0].CompletionText | Should -BeExactly 'Cmdlet'
+            $res.CompletionMatches[1].CompletionText | Should -BeExactly 'Configuration'
         }
 
         It "Test [CommandCompletion]::GetNextResult" {
             $inputStr = "Get-Command -Type Alias,c"
             $res = TabExpansion2 -inputScript $inputStr -cursorColumn $inputStr.Length
-            $res.CompletionMatches.Count | Should -BeExactly 2
-            $res.GetNextResult($false).CompletionText | Should -Be 'Configuration'
-            $res.GetNextResult($true).CompletionText | Should -Be 'Cmdlet'
-            $res.GetNextResult($true).CompletionText | Should -Be 'Configuration'
+            $res.CompletionMatches | Should -HaveCount 2
+            $res.GetNextResult($false).CompletionText | Should -BeExactly 'Configuration'
+            $res.GetNextResult($true).CompletionText | Should -BeExactly 'Cmdlet'
+            $res.GetNextResult($true).CompletionText | Should -BeExactly 'Configuration'
         }
 
         It "Test history completion" {
@@ -611,15 +611,15 @@ Describe "TabCompletion" -Tags CI {
             Add-History -InputObject $history
             $res = TabExpansion2 -inputScript "#" -cursorColumn 1
             $res.CompletionMatches.Count | Should -BeGreaterThan 0
-            $res.CompletionMatches[0].CompletionText | Should -Be "Test history completion"
+            $res.CompletionMatches[0].CompletionText | Should -BeExactly "Test history completion"
         }
 
         It "Test Attribute member completion" {
             $inputStr = "function bar { [parameter(]param() }"
             $res = TabExpansion2 -inputScript $inputStr -cursorColumn ($inputStr.IndexOf('(') + 1)
-            $res.CompletionMatches.Count | Should -Be 10
+            $res.CompletionMatches | Should -HaveCount 10
             $entry = $res.CompletionMatches | Where-Object CompletionText -EQ "Position"
-            $entry.CompletionText | Should -Be "Position"
+            $entry.CompletionText | Should -BeExactly "Position"
         }
 
         It "Test completion with line continuation" {
@@ -628,8 +628,8 @@ dir -Recurse `
 -Lite
 '@
             $res = TabExpansion2 -inputScript $inputStr -cursorColumn $inputStr.Length
-            $res.CompletionMatches.Count | Should -Be 1
-            $res.CompletionMatches[0].CompletionText | Should -Be "-LiteralPath"
+            $res.CompletionMatches | Should -HaveCount 1
+            $res.CompletionMatches[0].CompletionText | Should -BeExactly "-LiteralPath"
         }
     }
 
@@ -650,22 +650,22 @@ dir -Recurse `
         It "Test complete module file name" {
             $inputStr = "using module test"
             $res = TabExpansion2 -inputScript $inputStr -cursorColumn $inputStr.Length
-            $res.CompletionMatches.Count | Should -Be 1
-            $res.CompletionMatches[0].CompletionText | Should -Be ".${separator}testModule.psm1"
+            $res.CompletionMatches | Should -HaveCount 1
+            $res.CompletionMatches[0].CompletionText | Should -BeExactly ".${separator}testModule.psm1"
         }
 
         It "Test complete module name" {
             $inputStr = "using module PSRead"
             $res = TabExpansion2 -inputScript $inputStr -cursorColumn $inputStr.Length
             $res.CompletionMatches.Count | Should -BeGreaterThan 0
-            $res.CompletionMatches[0].CompletionText | Should -Be "PSReadLine"
+            $res.CompletionMatches[0].CompletionText | Should -BeExactly "PSReadLine"
         }
 
         It "Test complete module name with wildcard" {
             $inputStr = "using module *ReadLi"
             $res = TabExpansion2 -inputScript $inputStr -cursorColumn $inputStr.Length
             $res.CompletionMatches.Count | Should -BeGreaterThan 0
-            $res.CompletionMatches[0].CompletionText | Should -Be "PSReadLine"
+            $res.CompletionMatches[0].CompletionText | Should -BeExactly "PSReadLine"
         }
     }
 
@@ -696,30 +696,30 @@ dir -Recurse `
             $inputStr = "dir .\commaA.txt,"
             $expected = ".${separator}commaA.txt"
             $res = TabExpansion2 -inputScript $inputStr -cursorColumn $inputStr.Length
-            $res.CompletionMatches.Count | Should -Be 1
-            $res.CompletionMatches[0].CompletionText | Should -Be $expected
+            $res.CompletionMatches | Should -HaveCount 1
+            $res.CompletionMatches[0].CompletionText | Should -BeExactly $expected
         }
 
         It "Test comma with Enum array element" {
             $inputStr = "gcm -CommandType Cmdlet,"
             $res = TabExpansion2 -inputScript $inputStr -cursorColumn $inputStr.Length
-            $res.CompletionMatches.Count | Should -Be ([System.Enum]::GetNames([System.Management.Automation.CommandTypes]).Count)
-            $res.CompletionMatches[0].CompletionText | Should -Be "Alias"
+            $res.CompletionMatches | Should -HaveCount ([System.Enum]::GetNames([System.Management.Automation.CommandTypes]).Count)
+            $res.CompletionMatches[0].CompletionText | Should -BeExactly "Alias"
         }
 
         It "Test redirection operator '<inputStr>'" -TestCases $redirectionTestCases {
             param($inputStr, $expected)
 
             $res = TabExpansion2 -inputScript $inputStr -cursorColumn $inputStr.Length
-            $res.CompletionMatches.Count | Should -Be 1
-            $res.CompletionMatches[0].CompletionText | Should -Be $expected
+            $res.CompletionMatches | Should -HaveCount 1
+            $res.CompletionMatches[0].CompletionText | Should -BeExactly $expected
         }
 
         It "Test complete the minus token to operators" {
             $inputStr = "55 -"
             $res = TabExpansion2 -inputScript $inputStr -cursorColumn $inputStr.Length
-            $res.CompletionMatches.Count | Should -Be ([System.Management.Automation.CompletionCompleters]::CompleteOperator("").Count)
-            $res.CompletionMatches[0].CompletionText | Should -Be '-and'
+            $res.CompletionMatches | Should -HaveCount ([System.Management.Automation.CompletionCompleters]::CompleteOperator("").Count)
+            $res.CompletionMatches[0].CompletionText | Should -BeExactly '-and'
         }
     }
 
@@ -754,14 +754,14 @@ dir -Recurse `
 
             $res = TabExpansion2 -inputScript $inputStr -cursorColumn $inputStr.Length
             $res.CompletionMatches.Count | Should -BeGreaterThan 0
-            $res.CompletionMatches[0].CompletionText | Should -Be $expected
+            $res.CompletionMatches[0].CompletionText | Should -BeExactly $expected
         }
 
         It "Complete file name starting with special char" {
             $inputStr = ")"
             $res = TabExpansion2 -inputScript $inputStr -cursorColumn $inputStr.Length
-            $res.CompletionMatches.Count | Should -Be 1
-            $res.CompletionMatches[0].CompletionText | Should -Be "& '.${separator})file.txt'"
+            $res.CompletionMatches | Should -HaveCount 1
+            $res.CompletionMatches[0].CompletionText | Should -BeExactly "& '.${separator})file.txt'"
         }
     }
 
@@ -786,7 +786,7 @@ dir -Recurse `
 
             $res = TabExpansion2 -ast $ast -tokens $tokens -positionOfCursor $elementAst.Extent.EndScriptPosition
             $res.CompletionMatches.Count | Should -BeGreaterThan 0
-            $res.CompletionMatches[0].CompletionText | Should -Be $expected
+            $res.CompletionMatches[0].CompletionText | Should -BeExactly $expected
         }
     }
 
@@ -798,8 +798,8 @@ dir -Recurse `
 
             $inputStr = '$pid.'
             $res = [System.Management.Automation.CommandCompletion]::CompleteInput($inputStr, $inputst.Length, $null)
-            $res.CompletionMatches.Count | Should -BeExactly 1
-            $res.CompletionMatches[0].CompletionText | Should -Be 'Overridden-TabExpansion-Function'
+            $res.CompletionMatches | Should -HaveCount 1
+            $res.CompletionMatches[0].CompletionText | Should -BeExactly 'Overridden-TabExpansion-Function'
         }
 
         It "Override TabExpansion with alias" {
@@ -810,8 +810,8 @@ dir -Recurse `
 
             $inputStr = '$pid.'
             $res = [System.Management.Automation.CommandCompletion]::CompleteInput($inputStr, $inputst.Length, $null)
-            $res.CompletionMatches.Count | Should -BeExactly 1
-            $res.CompletionMatches[0].CompletionText | Should -Be "Overridden-TabExpansion-Alias"
+            $res.CompletionMatches | Should -HaveCount 1
+            $res.CompletionMatches[0].CompletionText | Should -BeExactly "Overridden-TabExpansion-Alias"
         }
     }
 
@@ -828,11 +828,11 @@ dir -Recurse `
             param($inputStr)
 
             $res = TabExpansion2 -inputScript $inputStr -cursorColumn $inputStr.Length
-            $res.CompletionMatches.Count | Should -BeExactly 0
+            $res.CompletionMatches | Should -BeNullOrEmpty
         }
     }
 
-    context "Tab completion error tests" {
+    Context "Tab completion error tests" {
         BeforeAll {
             $ast = {}.Ast;
             $tokens = [System.Management.Automation.Language.Token[]]@()
@@ -893,7 +893,7 @@ dir -Recurse `
 
             $res = TabExpansion2 -inputScript $inputStr -cursorColumn $inputStr.Length
             $res.CompletionMatches.Count | Should -BeGreaterThan 0
-            $res.CompletionMatches[0].CompletionText | Should -Be $expected
+            $res.CompletionMatches[0].CompletionText | Should -BeExactly $expected
         }
     }
 
@@ -933,7 +933,7 @@ dir -Recurse `
 
             $res = TabExpansion2 -inputScript $inputStr -cursorColumn $inputStr.Length
             $res.CompletionMatches.Count | Should -BeGreaterThan 0
-            $res.CompletionMatches[0].CompletionText | Should -Be $expected
+            $res.CompletionMatches[0].CompletionText | Should -BeExactly $expected
         }
     }
 
@@ -943,12 +943,12 @@ dir -Recurse `
         ) {
             param($cmd, $expected)
             $res = TabExpansion2 -inputScript $cmd -cursorColumn $cmd.Length
-            $res.CompletionMatches.Count | Should -Be $expected.Count
+            $res.CompletionMatches | Should -HaveCount $expected.Count
             $completionOptions = ""
             foreach ($completion in $res.CompletionMatches) {
                 $completionOptions += $completion.ListItemText
             }
-            $completionOptions | Should -Be ([string]::Join("", $expected))
+            $completionOptions | Should -BeExactly ([string]::Join("", $expected))
         }
     }
 
@@ -971,7 +971,7 @@ dir -Recurse `
             }
 
             $res = TabExpansion2 -inputScript 'get-help about_spla' -cursorColumn 'get-help about_spla'.Length
-            $res.CompletionMatches.Count | Should -Be 1
+            $res.CompletionMatches | Should -HaveCount 1
             $res.CompletionMatches[0].CompletionText | Should -BeExactly 'about_Splatting'
         }
     }
@@ -1013,7 +1013,7 @@ Describe "Tab completion tests with remote Runspace" -Tags Feature {
         param($inputStr, $expected)
         $res = [System.Management.Automation.CommandCompletion]::CompleteInput($inputStr, $inputStr.Length, $null, $powershell)
         $res.CompletionMatches.Count | Should -BeGreaterThan 0
-        $res.CompletionMatches[0].CompletionText | Should -Be $expected
+        $res.CompletionMatches[0].CompletionText | Should -BeExactly $expected
     }
 
     It "Input '<inputStr>' should successfully complete via AST in remote runspace" -TestCases $testCasesWithAst {
@@ -1028,7 +1028,7 @@ Describe "Tab completion tests with remote Runspace" -Tags Feature {
 
         $res = [System.Management.Automation.CommandCompletion]::CompleteInput($ast, $tokens, $elementAst.Extent.EndScriptPosition, $null, $powershell)
         $res.CompletionMatches.Count | Should -BeGreaterThan 0
-        $res.CompletionMatches[0].CompletionText | Should -Be $expected
+        $res.CompletionMatches[0].CompletionText | Should -BeExactly $expected
     }
 }
 
@@ -1078,12 +1078,12 @@ Describe "WSMan Config Provider tab complete tests" -Tags Feature,RequireAdminOn
         param($path, $parameter, $expected)
         $script = "new-item wsman:\$path $parameter"
         $res = TabExpansion2 -inputScript $script -cursorColumn $script.Length
-        $res.CompletionMatches.Count | Should -Be $expected.Count
+        $res.CompletionMatches | Should -HaveCount $expected.Count
         $completionOptions = ""
         foreach ($completion in $res.CompletionMatches) {
             $completionOptions += $completion.ListItemText
         }
-        $completionOptions | Should -Be ([string]::Join("", $expected))
+        $completionOptions | Should -BeExactly ([string]::Join("", $expected))
     }
 
     It "Tab completion get dynamic parameters for initialization parameters" -Pending -TestCases @(


### PR DESCRIPTION
## PR Summary

Use **-BeExactly** and **-HaveCount** instead of **-Be** in TabCompletion.Tests.ps1.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [x] Not Applicable or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
