### PR TITLE
Use -BeExactly and -HaveCount instead of -Be in BugFix.Tests.ps1.

### DIFF
--- a/test/powershell/Host/TabCompletion/BugFix.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/BugFix.Tests.ps1
@@ -4,39 +4,36 @@ Describe "Tab completion bug fix" -Tags "CI" {
 
     It "Issue#682 - '[system.manage<tab>' should work" {
         $result = TabExpansion2 -inputScript "[system.manage" -cursorColumn "[system.manage".Length
-        $result | Should -Not -BeNullOrEmpty
-        $result.CompletionMatches.Count | Should -Be 1
-        $result.CompletionMatches[0].CompletionText | Should -Be "System.Management"
+        $result.CompletionMatches | Should -HaveCount 1
+        $result.CompletionMatches[0].CompletionText | Should -BeExactly "System.Management"
     }
 
     It "Issue#1350 - '1 -sp<tab>' should work" {
         $result = TabExpansion2 -inputScript "1 -sp" -cursorColumn "1 -sp".Length
-        $result | Should -Not -BeNullOrEmpty
-        $result.CompletionMatches.Count | Should -Be 1
-        $result.CompletionMatches[0].CompletionText | Should -Be "-split"
+        $result.CompletionMatches | Should -HaveCount 1
+        $result.CompletionMatches[0].CompletionText | Should -BeExactly "-split"
     }
 
     It "Issue#1350 - '1 -a<tab>' should work" {
         $result = TabExpansion2 -inputScript "1 -a" -cursorColumn "1 -a".Length
-        $result | Should -Not -BeNullOrEmpty
-        $result.CompletionMatches.Count | Should -Be 2
-        $result.CompletionMatches[0].CompletionText | Should -Be "-and"
-        $result.CompletionMatches[1].CompletionText | Should -Be "-as"
+        $result.CompletionMatches | Should -HaveCount 2
+        $result.CompletionMatches[0].CompletionText | Should -BeExactly "-and"
+        $result.CompletionMatches[1].CompletionText | Should -BeExactly "-as"
     }
     It "Issue#2295 - '[pscu<tab>' should expand to [pscustomobject]" {
         $result = TabExpansion2 -inputScript "[pscu" -cursorColumn "[pscu".Length
-        $result | Should -Not -BeNullOrEmpty
-        $result.CompletionMatches.Count | Should -Be 1
-        $result.CompletionMatches[0].CompletionText | Should -Be "pscustomobject"
+        $result.CompletionMatches | Should -HaveCount 1
+        $result.CompletionMatches[0].CompletionText | Should -BeExactly "pscustomobject"
     }
     It "Issue#1345 - 'Import-Module -n<tab>' should work" {
         $cmd = "Import-Module -n"
         $result = TabExpansion2 -inputScript $cmd -cursorColumn $cmd.Length
-        $result.CompletionMatches.Count | Should -Be 3
-        $result.CompletionMatches[0].CompletionText | Should -Be "-Name"
-        $result.CompletionMatches[1].CompletionText | Should -Be "-NoClobber"
-        $result.CompletionMatches[2].CompletionText | Should -Be "-NoOverwrite"
+        $result.CompletionMatches | Should -HaveCount 3
+        $result.CompletionMatches[0].CompletionText | Should -BeExactly "-Name"
+        $result.CompletionMatches[1].CompletionText | Should -BeExactly "-NoClobber"
+        $result.CompletionMatches[2].CompletionText | Should -BeExactly "-NoOverwrite"
     }
+
     Context "Issue#3416 - 'Select-Object'" {
         BeforeAll {
             $DatetimeProperties = @((Get-Date).psobject.baseobject.psobject.properties) | Sort-Object -Property Name
@@ -44,32 +41,32 @@ Describe "Tab completion bug fix" -Tags "CI" {
         It "Issue#3416 - 'Select-Object -ExcludeProperty <tab>' should work" {
             $cmd = "Get-Date | Select-Object -ExcludeProperty "
             $result = TabExpansion2 -inputScript $cmd -cursorColumn $cmd.Length
-            $result.CompletionMatches.Count | Should -Be $DatetimeProperties.Count
-            $result.CompletionMatches[0].CompletionText | Should -Be $DatetimeProperties[0].Name # Date
-            $result.CompletionMatches[1].CompletionText | Should -Be $DatetimeProperties[1].Name # DateTime
+            $result.CompletionMatches | Should -HaveCount $DatetimeProperties.Count
+            $result.CompletionMatches[0].CompletionText | Should -BeExactly $DatetimeProperties[0].Name # Date
+            $result.CompletionMatches[1].CompletionText | Should -BeExactly $DatetimeProperties[1].Name # DateTime
        }
        It "Issue#3416 - 'Select-Object -ExpandProperty <tab>' should work" {
            $cmd = "Get-Date | Select-Object -ExpandProperty "
            $result = TabExpansion2 -inputScript $cmd -cursorColumn $cmd.Length
-           $result.CompletionMatches.Count | Should -Be $DatetimeProperties.Count
-           $result.CompletionMatches[0].CompletionText | Should -Be $DatetimeProperties[0].Name # Date
-           $result.CompletionMatches[1].CompletionText | Should -Be $DatetimeProperties[1].Name # DateTime
+           $result.CompletionMatches | Should -HaveCount $DatetimeProperties.Count
+           $result.CompletionMatches[0].CompletionText | Should -BeExactly $DatetimeProperties[0].Name # Date
+           $result.CompletionMatches[1].CompletionText | Should -BeExactly $DatetimeProperties[1].Name # DateTime
        }
     }
-                
+
     It "Issue#3628 - 'Sort-Object @{<tab>' should work" {
         $cmd = "Get-Date | Sort-Object @{"
         $result = TabExpansion2 -inputScript $cmd -cursorColumn $cmd.Length
-        $result.CompletionMatches.Count | Should -Be 3
-        $result.CompletionMatches[0].CompletionText | Should -Be 'Expression'
-        $result.CompletionMatches[1].CompletionText | Should -Be 'Ascending'
-        $result.CompletionMatches[2].CompletionText | Should -Be 'Descending'
+        $result.CompletionMatches | Should -HaveCount 3
+        $result.CompletionMatches[0].CompletionText | Should -BeExactly 'Expression'
+        $result.CompletionMatches[1].CompletionText | Should -BeExactly 'Ascending'
+        $result.CompletionMatches[2].CompletionText | Should -BeExactly 'Descending'
     }
 
     It "'Get-Date | Sort-Object @{Expression=<tab>' should work without completion" {
         $cmd = "Get-Date | Sort-Object @{Expression="
         $result = TabExpansion2 -inputScript $cmd -cursorColumn $cmd.Length
-        $result.CompletionMatches.Count | Should -Be 0
+        $result.CompletionMatches | Should -HaveCount 0
     }
 
     It "Issue#5322 - 'Get-Date | Sort-Object @{Expression=...;' should work" {
@@ -78,8 +75,8 @@ Describe "Tab completion bug fix" -Tags "CI" {
         $result.CurrentMatchIndex | Should -Be -1
         $result.ReplacementIndex | Should -Be 40
         $result.ReplacementLength | Should -Be 0
-        $result.CompletionMatches[0].CompletionText | Should -Be 'Expression'
-        $result.CompletionMatches[1].CompletionText | Should -Be 'Ascending'
-        $result.CompletionMatches[2].CompletionText | Should -Be 'Descending'
+        $result.CompletionMatches[0].CompletionText | Should -BeExactly 'Expression'
+        $result.CompletionMatches[1].CompletionText | Should -BeExactly 'Ascending'
+        $result.CompletionMatches[2].CompletionText | Should -BeExactly 'Descending'
     }
 }


### PR DESCRIPTION
## PR Summary

Use **-BeExactly** and **-HaveCount** instead of **-Be** in BugFix.Tests.ps1.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [x] Not Applicable or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
