### PR TITLE
[Feature] Fix path handling with wildcard char

### DIFF
--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -4303,6 +4303,12 @@ namespace System.Management.Automation
                         if (CompletionRequiresQuotes(completionText, !useLiteralPath))
                         {
                             var quoteInUse = quote == string.Empty ? "'" : quote;
+
+                            if (!useLiteralPath)
+                            {
+                                completionText = WildcardPattern.Escape(completionText);
+                            }
+
                             if (quoteInUse == "'")
                             {
                                 completionText = completionText.Replace("'", "''");
@@ -4313,20 +4319,6 @@ namespace System.Management.Automation
                                 //   Get-Content -LiteralPath ".\a``g.txt"
                                 completionText = completionText.Replace("`", "``");
                                 completionText = completionText.Replace("$", "`$");
-                            }
-
-                            if (!useLiteralPath)
-                            {
-                                if (quoteInUse == "'")
-                                {
-                                    completionText = completionText.Replace("[", "`[");
-                                    completionText = completionText.Replace("]", "`]");
-                                }
-                                else
-                                {
-                                    completionText = completionText.Replace("[", "``[");
-                                    completionText = completionText.Replace("]", "``]");
-                                }
                             }
 
                             completionText = quoteInUse + completionText + quoteInUse;

--- a/src/System.Management.Automation/engine/SessionStateContainer.cs
+++ b/src/System.Management.Automation/engine/SessionStateContainer.cs
@@ -1642,7 +1642,7 @@ namespace System.Management.Automation
                 string originalPath = path;
                 path =
                     Globber.GetProviderPath(
-                        path,
+                        context.SuppressWildcardExpansion ? path : WildcardPattern.Unescape(path),
                         context,
                         out provider,
                         out drive);
@@ -2689,7 +2689,7 @@ namespace System.Management.Automation
 
                 string providerPath =
                     Globber.GetProviderPath(
-                        path,
+                        context.SuppressWildcardExpansion ? path : WildcardPattern.Unescape(path),
                         context,
                         out provider,
                         out drive);
@@ -3798,7 +3798,7 @@ namespace System.Management.Automation
                 if (String.IsNullOrEmpty(name))
                 {
                     string providerPath =
-                        Globber.GetProviderPath(resolvePath, context, out provider, out driveInfo);
+                        Globber.GetProviderPath(WildcardPattern.Unescape(resolvePath), context, out provider, out driveInfo);
 
                     providerInstance = GetProviderInstance(provider);
                     providerPaths.Add(providerPath);

--- a/src/System.Management.Automation/engine/regex.cs
+++ b/src/System.Management.Automation/engine/regex.cs
@@ -204,9 +204,10 @@ namespace System.Management.Automation
                 char ch = pattern[i];
 
                 //
-                // if it is a wildcard char, escape it
+                // if it is a wildcard char or escape char, escape it
                 //
-                if (IsWildcardChar(ch) && !charsNotToEscape.Contains(ch))
+                if ((IsWildcardChar(ch) || ch == escapeChar) &&
+                    !charsNotToEscape.Contains(ch))
                 {
                     temp[tempIndex++] = escapeChar;
                 }

--- a/src/System.Management.Automation/namespaces/LocationGlobber.cs
+++ b/src/System.Management.Automation/namespaces/LocationGlobber.cs
@@ -460,7 +460,13 @@ namespace System.Management.Automation
 
             s_pathResolutionTracer.WriteLine("Path is DRIVE-QUALIFIED");
 
-            string relativePath = GetDriveRootRelativePathFromPSPath(path, context, true, out drive, out providerInstance);
+            string relativePath =
+                GetDriveRootRelativePathFromPSPath(
+                    path,
+                    context,
+                    !context.SuppressWildcardExpansion,
+                    out drive,
+                    out providerInstance);
 
             Dbg.Diagnostics.Assert(
                 drive != null,
@@ -3630,13 +3636,11 @@ namespace System.Management.Automation
                 StringContainsGlobCharacters(leafElement) ||
                 isLastLeaf)
             {
-                string regexEscapedLeafElement = ConvertMshEscapeToRegexEscape(leafElement);
-
                 // Construct the glob filter
 
                 WildcardPattern stringMatcher =
                     WildcardPattern.Get(
-                        regexEscapedLeafElement,
+                        leafElement,
                         WildcardOptions.IgnoreCase);
 
                 // Construct the include filter
@@ -4270,13 +4274,11 @@ namespace System.Management.Automation
                 (StringContainsGlobCharacters(leafElement) ||
                  isLastLeaf))
             {
-                string regexEscapedLeafElement = ConvertMshEscapeToRegexEscape(leafElement);
-
                 // Construct the glob filter
 
                 WildcardPattern stringMatcher =
                     WildcardPattern.Get(
-                        regexEscapedLeafElement,
+                        leafElement,
                         WildcardOptions.IgnoreCase);
 
                 // Construct the include filter

--- a/src/System.Management.Automation/utils/PathUtils.cs
+++ b/src/System.Management.Automation/utils/PathUtils.cs
@@ -293,7 +293,8 @@ namespace System.Management.Automation
                 PSDriveInfo drive = null;
                 path =
                     command.SessionState.Path.GetUnresolvedProviderPathFromPSPath(
-                        filePath, cmdletProviderContext, out provider, out drive);
+                        isLiteralPath ? filePath : WildcardPattern.Unescape(filePath),
+                        cmdletProviderContext, out provider, out drive);
                 cmdletProviderContext.ThrowFirstErrorOrDoNothing();
                 if (!provider.NameEquals(command.Context.ProviderNames.FileSystem))
                 {

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -739,6 +739,9 @@ dir -Recurse `
                 @{ inputStr = "Get-Process >'.\My ``[Path``]\'"; expected = "'.${separator}My ``[Path``]${separator}test.ps1'" }
                 @{ inputStr = "Get-Process >${tempDir}\My"; expected = "'${tempDir}${separator}My ``[Path``]'" }
                 @{ inputStr = "Get-Process > '${tempDir}\My ``[Path``]\'"; expected = "'${tempDir}${separator}My ``[Path``]${separator}test.ps1'" }
+                @{ inputStr = "cd 'My ``["; expected = "'.${separator}My ``[Path``]'" }
+                @{ inputStr = "Get-Process > 'My ``["; expected = "'.${separator}My ``[Path``]'" }
+                @{ inputStr = "Get-Process > '${tempDir}\My ``["; expected = "'${tempDir}${separator}My ``[Path``]'" }
             )
 
             Push-Location -Path $tempDir

--- a/test/powershell/Language/Parser/LanguageAndParser.TestFollowup.Tests.ps1
+++ b/test/powershell/Language/Parser/LanguageAndParser.TestFollowup.Tests.ps1
@@ -303,3 +303,16 @@ Describe "Hash expression with if statement as value" -Tags "CI" {
         $hash['h'] | Should -BeExactly 'h'
     }
 }
+
+Describe "WildcardPattern" -Tags "CI" {
+    It "Unescaping escaped string '<inputStr>' should get the original" -TestCases @(
+        @{inputStr = '*This'}
+        @{inputStr = 'Is?'}
+        @{inputStr = 'Real[ly]'}
+        @{inputStr = 'Ba`sic'}
+        @{inputStr = 'Test `[more`]?'}
+    ) {
+        param($inputStr)
+        [WildcardPattern]::Unescape([WildcardPattern]::Escape($inputStr)) | Should -BeExactly $inputStr
+    }
+}

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ChildItem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ChildItem.Tests.ps1
@@ -21,6 +21,9 @@ Describe "Get-ChildItem" -Tags "CI" {
             $null = New-Item -Path $TestDrive -Name $item_F -ItemType "File" -Force | ForEach-Object {$_.Attributes = "hidden"}
             $null = New-Item -Path (Join-Path -Path $TestDrive -ChildPath $item_E) -Name $item_G -ItemType "File" -Force
 
+            $specialDirName = "Test[Dir]"
+            $specialDir = "Test``[Dir``]"
+
             $searchRoot = Join-Path $TestDrive -ChildPath "TestPS"
             $file1 = Join-Path $searchRoot -ChildPath "D1" -AdditionalChildPath "File1.txt"
             $file2 = Join-Path $searchRoot -ChildPath "File1.txt"
@@ -140,6 +143,14 @@ Describe "Get-ChildItem" -Tags "CI" {
             (Get-ChildItem -LiteralPath $TestDrive -Recurse -Include *.dll).Count | Should Be (Get-ChildItem $TestDrive -Recurse -Include *.dll).Count
             (Get-ChildItem -LiteralPath $TestDrive -Depth 1 -Include $item_G).Count | Should Be 1
             (Get-ChildItem -LiteralPath $TestDrive -Depth 1 -Exclude $item_a).Count | Should Be 5
+        }
+
+        It "Should list files in directory contains special char" {
+            $null = New-Item -Path $TestDrive -Name $specialDirName -ItemType Directory -Force
+            $specialPath = Join-Path $TestDrive $specialDir
+            $null = New-Item -Path $specialPath -Name file1.txt -ItemType File -Force
+            $null = New-Item -Path $specialPath -Name file2.txt -ItemType File -Force
+            (Get-ChildItem -Path $specialPath).Count | Should -Be 2
         }
 
         It "get-childitem path wildcard - <title>" -TestCases $PathWildCardTestCases {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Out-File.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Out-File.Tests.ps1
@@ -24,6 +24,7 @@ Describe "Out-File" -Tags "CI" {
         $expectedContent = "some test text"
         $inObject = New-Object psobject -Property @{text=$expectedContent}
         $testfile = Join-Path -Path $TestDrive -ChildPath outfileTest.txt
+        $testfileSp = Join-Path -Path $TestDrive -ChildPath "``[outfileTest``].txt"
     }
 
     AfterEach {
@@ -89,6 +90,14 @@ Describe "Out-File" -Tags "CI" {
         $actual[9]  | Should -Match "some test text"
         $actual[10] | Should -BeNullOrEmpty
         $actual[11] | Should -BeNullOrEmpty
+    }
+
+    It "Should create the file with correct name when FilePath contains special char" {
+        Out-File -FilePath $testfile
+        Out-File -FilePath $testfileSp
+
+        $testfile | Should -Exist
+        $testfileSp | Should -Exist
     }
 
     It "Should limit each line to the specified number of characters when the width switch is used on objects" {


### PR DESCRIPTION
## PR Summary

_*System.Management.Automation/engine/CommandCompletion/CompletionCompleters:_
Use WildcardPattern::Escape to escape completion text of filename.

_*System.Management.Automation/engine/SessionStateContainer:_
@Get-ChildItem
Unescape non-literal, non-glob path before existence checking.
This solve the issue where Get-GhildItem does not behave correctly
when -Path contains special characters. For example,
```pwsh
Get-ChildItem -Path './`[dir`]'
```
will complain with error "Cannot find path ..." while
```pwsh
Get-ChildItem -Path './`[dir`]' -Depth 0
```
will work fine.

@New-Item
Unescape non-literal path when -Name is not set.
This works around for New-Item treating -Path as literal path while
it can also be globbable. For example, assuming there is ```"[file]1"```
in current directory, and tab completion suggests ```'./`[file`]1'```
for the -Path argument, but
```pwsh
New-Item -Path './`[file`]2'
```
will create a file named ```"`[file`]2"``` instead of ```"[file]2"```.

_*System.Management.Automation/engine/regex:_
WildcardPattern::Escape should also escape ```"`"``` since
WildcardPattern::Unescape would unescape it,
and the matcher parse it as escape character.

_*System.Management.Automation/namespaces/LocationGlobber:_
Do not escape CWD when LiteralPath is used. This causes issues when
both -LiteralPath and CWD contains special characters.
Do not pass regex escaped string to WildcardPattern::Get. This fails
tab completion when doing ```"./path/to/`[f"<TAB>```.

_*System.Management.Automation/utils/PathUtils:_
Unescape non-literal, non-glob path before calling
GetUnresolvedProviderPathFromPSPath since it only accepts literal path.
This solve the issue where some commands depending on that method
will treat -Path as literal unintentionally. For example,
```pwsh
Out-File -Path './`[out`].txt' -Append
```
will create a new file named ```"`[out`].txt"``` instead of writing to ```"[out].txt"```.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [x] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
