### PR TITLE
Fix Get-ChildItem -Path with wildcard char

### DIFF
--- a/src/System.Management.Automation/engine/SessionStateContainer.cs
+++ b/src/System.Management.Automation/engine/SessionStateContainer.cs
@@ -1642,7 +1642,7 @@ namespace System.Management.Automation
                 string originalPath = path;
                 path =
                     Globber.GetProviderPath(
-                        path,
+                        context.SuppressWildcardExpansion ? path : WildcardPattern.Unescape(path),
                         context,
                         out provider,
                         out drive);
@@ -2689,7 +2689,7 @@ namespace System.Management.Automation
 
                 string providerPath =
                     Globber.GetProviderPath(
-                        path,
+                        context.SuppressWildcardExpansion ? path : WildcardPattern.Unescape(path),
                         context,
                         out provider,
                         out drive);

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ChildItem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ChildItem.Tests.ps1
@@ -21,6 +21,9 @@ Describe "Get-ChildItem" -Tags "CI" {
             $null = New-Item -Path $TestDrive -Name $item_F -ItemType "File" -Force | ForEach-Object {$_.Attributes = "hidden"}
             $null = New-Item -Path (Join-Path -Path $TestDrive -ChildPath $item_E) -Name $item_G -ItemType "File" -Force
 
+            $specialDirName = "Test[Dir]"
+            $specialDir = "Test``[Dir``]"
+
             $searchRoot = Join-Path $TestDrive -ChildPath "TestPS"
             $file1 = Join-Path $searchRoot -ChildPath "D1" -AdditionalChildPath "File1.txt"
             $file2 = Join-Path $searchRoot -ChildPath "File1.txt"
@@ -140,6 +143,14 @@ Describe "Get-ChildItem" -Tags "CI" {
             (Get-ChildItem -LiteralPath $TestDrive -Recurse -Include *.dll).Count | Should Be (Get-ChildItem $TestDrive -Recurse -Include *.dll).Count
             (Get-ChildItem -LiteralPath $TestDrive -Depth 1 -Include $item_G).Count | Should Be 1
             (Get-ChildItem -LiteralPath $TestDrive -Depth 1 -Exclude $item_a).Count | Should Be 5
+        }
+
+        It "Should list files in directory contains special char" {
+            $null = New-Item -Path $TestDrive -Name $specialDirName -ItemType Directory -Force
+            $specialPath = Join-Path $TestDrive $specialDir
+            $null = New-Item -Path $specialPath -Name file1.txt -ItemType File -Force
+            $null = New-Item -Path $specialPath -Name file2.txt -ItemType File -Force
+            (Get-ChildItem -Path $specialPath).Count | Should -Be 2
         }
 
         It "get-childitem path wildcard - <title>" -TestCases $PathWildCardTestCases {


### PR DESCRIPTION
## PR Summary

Unescape non-literal, non-glob path before existence checking.
This solve the issue where Get-GhildItem does not behave correctly
when -Path contains special characters. For example,
```pwsh
Get-ChildItem -Path './`[dir`]'
```
will complain with error "Cannot find path ..." while
```pwsh
Get-ChildItem -Path './`[dir`]' -Depth 0
```
will work fine.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [x] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
