### PR TITLE
Fix New-Item -Path with wildcard char

### DIFF
--- a/src/System.Management.Automation/engine/SessionStateContainer.cs
+++ b/src/System.Management.Automation/engine/SessionStateContainer.cs
@@ -3798,7 +3798,7 @@ namespace System.Management.Automation
                 if (String.IsNullOrEmpty(name))
                 {
                     string providerPath =
-                        Globber.GetProviderPath(resolvePath, context, out provider, out driveInfo);
+                        Globber.GetProviderPath(WildcardPattern.Unescape(resolvePath), context, out provider, out driveInfo);
 
                     providerInstance = GetProviderInstance(provider);
                     providerPaths.Add(providerPath);

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/New-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/New-Item.Tests.ps1
@@ -266,9 +266,9 @@ Describe "New-Item with links" -Tags @('CI', 'RequireAdminOnWindows') {
         $null = New-Item -Path $FullyQualifiedLinkSp -Target $FullyQualifiedLSrcSp -ItemType SymbolicLink
         $FullyQualifiedLinkSp | Should -Exist
 
-        $expectedTarget = Join-Path $tmpDirectory $testlinkSrcSpName
+        $expectedTarget = Join-Path -Path $tmpDirectory -ChildPath $testlinkSrcSpName
 
-        $fileInfo = Get-ChildItem $FullyQualifiedLinkSp
+        $fileInfo = Get-ChildItem -Path $FullyQualifiedLinkSp
         $fileInfo.Target | Should -Match ([regex]::Escape($expectedTarget))
         $fileInfo.LinkType | Should -BeExactly "SymbolicLink"
         $fileInfo.Attributes -band $DirLinkMask | Should -BeExactly $SymLinkMask

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Remove-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Remove-Item.Tests.ps1
@@ -3,7 +3,10 @@
 Describe "Remove-Item" -Tags "CI" {
     $testpath = $TestDrive
     $testfile = "testfile.txt"
+    $testfileSpName = "[testfile].txt"
+    $testfileSp = "``[testfile``].txt"
     $testfilepath = Join-Path -Path $testpath -ChildPath $testfile
+    $testfilepathSp = Join-Path -Path $testpath -ChildPath $testfileSp
     Context "File removal Tests" {
 	BeforeEach {
 	    New-Item -Name $testfile -Path $testpath -ItemType "file" -Value "lorem ipsum" -Force
@@ -109,6 +112,14 @@ Describe "Remove-Item" -Tags "CI" {
 	    Test-Path (Join-Path -Path $testpath -ChildPath file1.wav) | Should -BeFalse
 	    Test-Path (Join-Path -Path $testpath -ChildPath file2.wav) | Should -BeFalse
 	}
+
+        It "Should be able to remove file when path contains special char" {
+            New-Item -Path $testpath -Name $testfileSpName -ItemType File -Force
+            $testfilepathSp | Should -Exist
+
+            Remove-Item -Path $testfilepathSp
+            $testfilepathSp | Should -Not -Exist
+        }
     }
 
     Context "Directory Removal Tests" {


### PR DESCRIPTION
## PR Summary

Unescape non-literal path when -Name is not set.
This works around for New-Item treating -Path as literal path while
it can also be globbable. For example, assuming there is ```"[file]1"```
in current directory, and tab completion suggests ```'./`[file`]1'```
for the -Path argument, but
```pwsh
New-Item -Path './`[file`]2'
```
will create a file named ```"`[file`]2"``` instead of ```"[file]2"```.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [x] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
