### PR TITLE
PathUtils: handle escaped -Path correctly

### DIFF
--- a/src/System.Management.Automation/utils/PathUtils.cs
+++ b/src/System.Management.Automation/utils/PathUtils.cs
@@ -293,7 +293,8 @@ namespace System.Management.Automation
                 PSDriveInfo drive = null;
                 path =
                     command.SessionState.Path.GetUnresolvedProviderPathFromPSPath(
-                        filePath, cmdletProviderContext, out provider, out drive);
+                        isLiteralPath ? filePath : WildcardPattern.Unescape(filePath),
+                        cmdletProviderContext, out provider, out drive);
                 cmdletProviderContext.ThrowFirstErrorOrDoNothing();
                 if (!provider.NameEquals(command.Context.ProviderNames.FileSystem))
                 {

--- a/src/System.Management.Automation/utils/PathUtils.cs
+++ b/src/System.Management.Automation/utils/PathUtils.cs
@@ -294,7 +294,9 @@ namespace System.Management.Automation
                 path =
                     command.SessionState.Path.GetUnresolvedProviderPathFromPSPath(
                         isLiteralPath ? filePath : WildcardPattern.Unescape(filePath),
-                        cmdletProviderContext, out provider, out drive);
+                        cmdletProviderContext,
+                        out provider,
+                        out drive);
                 cmdletProviderContext.ThrowFirstErrorOrDoNothing();
                 if (!provider.NameEquals(command.Context.ProviderNames.FileSystem))
                 {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Out-File.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Out-File.Tests.ps1
@@ -24,6 +24,7 @@ Describe "Out-File" -Tags "CI" {
         $expectedContent = "some test text"
         $inObject = New-Object psobject -Property @{text=$expectedContent}
         $testfile = Join-Path -Path $TestDrive -ChildPath outfileTest.txt
+        $testfileSp = Join-Path -Path $TestDrive -ChildPath "``[outfileTest``].txt"
     }
 
     AfterEach {
@@ -89,6 +90,14 @@ Describe "Out-File" -Tags "CI" {
         $actual[9]  | Should -Match "some test text"
         $actual[10] | Should -BeNullOrEmpty
         $actual[11] | Should -BeNullOrEmpty
+    }
+
+    It "Should create the file with correct name when FilePath contains special char" {
+        Out-File -FilePath $testfile
+        Out-File -FilePath $testfileSp
+
+        $testfile | Should -Exist
+        $testfileSp | Should -Exist
     }
 
     It "Should limit each line to the specified number of characters when the width switch is used on objects" {


### PR DESCRIPTION
## PR Summary

Unescape non-literal, non-glob path before calling
GetUnresolvedProviderPathFromPSPath since it only accepts literal path.
This solve the issue where some commands depending on that method
will treat -Path as literal unintentionally. For example,
```pwsh
Out-File -Path './`[out`].txt' -Append
```
will create a new file named ```"`[out`].txt"``` instead of writing to ```"[out].txt"```.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [x] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
