### PR TITLE
Improving performance of Import-CSV

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CSVCommands.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CSVCommands.cs
@@ -1234,10 +1234,11 @@ namespace Microsoft.PowerShell.Commands
             {
                 TypeName = ReadTypeInformation();
             }
-
+            var values = new List<string>(16);
+            var builder = new StringBuilder(256);
             while ((Header == null) && (!this.EOF))
             {
-                Collection<string> values = ParseNextRecord();
+                ParseNextRecord(values, builder);
 
                 // Trim all trailing blankspaces and delimiters ( single/multiple ).
                 // If there is only one element in the row and if its a blankspace we dont trim it.
@@ -1279,9 +1280,11 @@ namespace Microsoft.PowerShell.Commands
             _alreadyWarnedUnspecifiedName = alreadyWriteOutWarning;
             ReadHeader();
             var prevalidated = false;
+            var values = new List<string>(16);
+            var builder = new StringBuilder(256);
             while (true)
             {
-                Collection<string> values = ParseNextRecord();
+                ParseNextRecord(values, builder);
                 if (values.Count == 0)
                     break;
 
@@ -1367,13 +1370,12 @@ namespace Microsoft.PowerShell.Commands
         /// <returns>
         /// Parsed collection of strings.
         /// </returns>
-        private Collection<string>
-        ParseNextRecord()
+        private void 
+        ParseNextRecord(List<string> result, StringBuilder current)
         {
-            // Collection of strings to return
-            Collection<string> result = new Collection<string>();
+            result.Clear();
             // current string
-            StringBuilder current = new StringBuilder();
+            current.Clear();
 
             bool seenBeginQuote = false;
             // int i = 0;
@@ -1521,8 +1523,6 @@ namespace Microsoft.PowerShell.Commands
             {
                 result.Add(current.ToString());
             }
-
-            return result;
         }
 
         // If we detect a newline we return it as a string "\r", "\n" or "\r\n"
@@ -1613,7 +1613,7 @@ namespace Microsoft.PowerShell.Commands
 
         private
         PSObject
-        BuildMshobject(string type, IList<string> names, Collection<string> values, char delimiter, bool preValidated = false)
+        BuildMshobject(string type, IList<string> names, List<string> values, char delimiter, bool preValidated = false)
         {
             //string[] namesarray = null;
             PSObject result = new PSObject(names.Count);

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CSVCommands.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CSVCommands.cs
@@ -1234,8 +1234,15 @@ namespace Microsoft.PowerShell.Commands
             {
                 TypeName = ReadTypeInformation();
             }
-            var values = new List<string>(16);
-            var builder = new StringBuilder(256);
+
+            // initial sizes of the value list and the line stringbuilder
+            // set to reasonable initial sizes. They may grow beyond these,
+            // but this will prevent a few reallocations.
+            const int valueCountGuestimate = 16;
+            const int lineLengthGuestimate = 256;
+
+            var values = new List<string>(valueCountGuestimate);
+            var builder = new StringBuilder(lineLengthGuestimate);
             while ((Header == null) && (!this.EOF))
             {
                 ParseNextRecord(values, builder);
@@ -1370,7 +1377,7 @@ namespace Microsoft.PowerShell.Commands
         /// <returns>
         /// Parsed collection of strings.
         /// </returns>
-        private void 
+        private void
         ParseNextRecord(List<string> result, StringBuilder current)
         {
             result.Clear();

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CSVCommands.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CSVCommands.cs
@@ -1152,8 +1152,8 @@ namespace Microsoft.PowerShell.Commands
         // Initial sizes of the value list and the line stringbuilder.
         // Set to reasonable initial sizes. They may grow beyond these,
         // but this will prevent a few reallocations.
-        private const int valueCountGuestimate = 16;
-        private const int lineLengthGuestimate = 256;
+        private const int ValueCountGuestimate = 16;
+        private const int LineLengthGuestimate = 256;
 
         internal ImportCsvHelper(PSCmdlet cmdlet, char delimiter, IList<string> header, string typeName, StreamReader streamReader)
         {
@@ -1241,8 +1241,8 @@ namespace Microsoft.PowerShell.Commands
                 TypeName = ReadTypeInformation();
             }
 
-            var values = new List<string>(valueCountGuestimate);
-            var builder = new StringBuilder(lineLengthGuestimate);
+            var values = new List<string>(ValueCountGuestimate);
+            var builder = new StringBuilder(LineLengthGuestimate);
             while ((Header == null) && (!this.EOF))
             {
                 ParseNextRecord(values, builder);
@@ -1287,8 +1287,8 @@ namespace Microsoft.PowerShell.Commands
             _alreadyWarnedUnspecifiedName = alreadyWriteOutWarning;
             ReadHeader();
             var prevalidated = false;
-            var values = new List<string>(valueCountGuestimate);
-            var builder = new StringBuilder(lineLengthGuestimate);
+            var values = new List<string>(ValueCountGuestimate);
+            var builder = new StringBuilder(LineLengthGuestimate);
             while (true)
             {
                 ParseNextRecord(values, builder);

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CSVCommands.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CSVCommands.cs
@@ -1278,6 +1278,7 @@ namespace Microsoft.PowerShell.Commands
         {
             _alreadyWarnedUnspecifiedName = alreadyWriteOutWarning;
             ReadHeader();
+            var prevalidated = false;
             while (true)
             {
                 Collection<string> values = ParseNextRecord();
@@ -1290,7 +1291,8 @@ namespace Microsoft.PowerShell.Commands
                     continue;
                 }
 
-                PSObject result = BuildMshobject(TypeName, Header, values, _delimiter);
+                PSObject result = BuildMshobject(TypeName, Header, values, _delimiter, prevalidated);
+                prevalidated = true;
                 _cmdlet.WriteObject(result);
             }
             alreadyWriteOutWarning = _alreadyWarnedUnspecifiedName;
@@ -1611,10 +1613,10 @@ namespace Microsoft.PowerShell.Commands
 
         private
         PSObject
-        BuildMshobject(string type, IList<string> names, Collection<string> values, char delimiter)
+        BuildMshobject(string type, IList<string> names, Collection<string> values, char delimiter, bool preValidated = false)
         {
             //string[] namesarray = null;
-            PSObject result = new PSObject();
+            PSObject result = new PSObject(names.Count);
             char delimiterlocal = delimiter;
             int unspecifiedNameIndex = 1;
             for (int i = 0; i <= names.Count - 1; i++)
@@ -1635,7 +1637,8 @@ namespace Microsoft.PowerShell.Commands
                 {
                     value = values[i];
                 }
-                result.Properties.Add(new PSNoteProperty(name, value));
+
+                result.Properties.Add(new PSNoteProperty(name, value), preValidated);
             }
 
             if (!_alreadyWarnedUnspecifiedName && unspecifiedNameIndex != 1)
@@ -1644,7 +1647,7 @@ namespace Microsoft.PowerShell.Commands
                 _alreadyWarnedUnspecifiedName = true;
             }
 
-            if (type != null && type.Length > 0)
+            if (!string.IsNullOrEmpty(type))
             {
                 result.TypeNames.Clear();
                 result.TypeNames.Add(type);

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CSVCommands.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CSVCommands.cs
@@ -1149,6 +1149,12 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         private readonly StreamReader _sr;
 
+        // Initial sizes of the value list and the line stringbuilder.
+        // Set to reasonable initial sizes. They may grow beyond these,
+        // but this will prevent a few reallocations.
+        private const int valueCountGuestimate = 16;
+        private const int lineLengthGuestimate = 256;
+
         internal ImportCsvHelper(PSCmdlet cmdlet, char delimiter, IList<string> header, string typeName, StreamReader streamReader)
         {
             if (cmdlet == null)
@@ -1235,12 +1241,6 @@ namespace Microsoft.PowerShell.Commands
                 TypeName = ReadTypeInformation();
             }
 
-            // initial sizes of the value list and the line stringbuilder
-            // set to reasonable initial sizes. They may grow beyond these,
-            // but this will prevent a few reallocations.
-            const int valueCountGuestimate = 16;
-            const int lineLengthGuestimate = 256;
-
             var values = new List<string>(valueCountGuestimate);
             var builder = new StringBuilder(lineLengthGuestimate);
             while ((Header == null) && (!this.EOF))
@@ -1287,8 +1287,8 @@ namespace Microsoft.PowerShell.Commands
             _alreadyWarnedUnspecifiedName = alreadyWriteOutWarning;
             ReadHeader();
             var prevalidated = false;
-            var values = new List<string>(16);
-            var builder = new StringBuilder(256);
+            var values = new List<string>(valueCountGuestimate);
+            var builder = new StringBuilder(lineLengthGuestimate);
             while (true)
             {
                 ParseNextRecord(values, builder);

--- a/src/System.Management.Automation/engine/MshMemberInfo.cs
+++ b/src/System.Management.Automation/engine/MshMemberInfo.cs
@@ -4019,6 +4019,14 @@ namespace System.Management.Automation
             _members = new OrderedDictionary(StringComparer.OrdinalIgnoreCase);
         }
 
+        /// <summary>
+        /// Constructs this collection with an initial capacity
+        /// </summary>
+        internal PSMemberInfoInternalCollection(int capacity)
+        {
+            _members = new OrderedDictionary(capacity, StringComparer.OrdinalIgnoreCase);
+        }
+
         private void Replace(T oldMember, T newMember)
         {
             _members[newMember.Name] = newMember;
@@ -5010,6 +5018,7 @@ namespace System.Management.Automation
             public void Dispose() { }
         }
     }
+
 
     #endregion Member collection classes and its auxiliary classes
 }

--- a/src/System.Management.Automation/engine/MshMemberInfo.cs
+++ b/src/System.Management.Automation/engine/MshMemberInfo.cs
@@ -4575,8 +4575,9 @@ namespace System.Management.Automation
                     TypeTable typeTable = _mshOwner.GetTypeTable();
                     if (typeTable != null)
                     {
-                        PSMemberInfoInternalCollection<T> typesXmlMembers = typeTable.GetMembers<T>(_mshOwner.InternalTypeNames);
-                        if (typesXmlMembers[member.Name] != null)
+                        var typesXmlMembers = typeTable.GetMembers(_mshOwner.InternalTypeNames);
+                        var typesXmlMember = typesXmlMembers[member.Name];
+                        if (typesXmlMember is T)
                         {
                             throw new ExtendedTypeSystemException(
                                 "AlreadyPresentInTypesXml",

--- a/src/System.Management.Automation/engine/MshMemberInfo.cs
+++ b/src/System.Management.Automation/engine/MshMemberInfo.cs
@@ -5019,7 +5019,6 @@ namespace System.Management.Automation
         }
     }
 
-
     #endregion Member collection classes and its auxiliary classes
 }
 

--- a/src/System.Management.Automation/engine/MshObject.cs
+++ b/src/System.Management.Automation/engine/MshObject.cs
@@ -522,6 +522,17 @@ namespace System.Management.Automation
         }
 
         /// <summary>
+        /// Initializes a new instance of PSObject with an PSCustomObject BaseObject
+        /// with an initial capacity for members
+        /// </summary>
+        /// <param name="instanceMemberCapacity">The initial capacity for the instance member collection.</param>
+        public PSObject(int instanceMemberCapacity) : this()
+        {
+            _instanceMembers = new PSMemberInfoInternalCollection<PSMemberInfo>(instanceMemberCapacity);
+        }
+
+
+        /// <summary>
         /// Initializes a new instance of PSObject wrapping obj (accessible through BaseObject).
         /// </summary>
         /// <param name="obj">object we are wrapping</param>

--- a/src/System.Management.Automation/engine/MshObject.cs
+++ b/src/System.Management.Automation/engine/MshObject.cs
@@ -531,7 +531,6 @@ namespace System.Management.Automation
             _instanceMembers = new PSMemberInfoInternalCollection<PSMemberInfo>(instanceMemberCapacity);
         }
 
-
         /// <summary>
         /// Initializes a new instance of PSObject wrapping obj (accessible through BaseObject).
         /// </summary>

--- a/src/System.Management.Automation/engine/TypeTable.cs
+++ b/src/System.Management.Automation/engine/TypeTable.cs
@@ -2594,6 +2594,7 @@ namespace System.Management.Automation.Runspaces
         internal readonly bool isShared;
         private readonly List<string> _typeFileList;
 
+        // The member factory is cached to avoid allocating Func<> delegates on each call
         private readonly Func<string, ConsolidatedString, PSMemberInfoInternalCollection<PSMemberInfo>> _memberFactoryFunc;
 
         // This holds all the type information that is in the typetable
@@ -3464,16 +3465,13 @@ namespace System.Management.Automation.Runspaces
         /// 1. There were errors loading TypeTable. Look in the Errors property to get
         /// detailed error messages.
         /// </exception>
-        internal TypeTable(IEnumerable<string> typeFiles, AuthorizationManager authorizationManager, PSHost host)
+        internal TypeTable(IEnumerable<string> typeFiles, AuthorizationManager authorizationManager, PSHost host) : this(isShared: true)
         {
             if (typeFiles == null)
             {
                 throw PSTraceSource.NewArgumentNullException("typeFiles");
             }
 
-            isShared = true;
-
-            _typeFileList = new List<string>();
             ConcurrentBag<string> errors = new ConcurrentBag<string>();
             foreach (string typefile in typeFiles)
             {

--- a/src/System.Management.Automation/engine/TypeTable.cs
+++ b/src/System.Management.Automation/engine/TypeTable.cs
@@ -3551,7 +3551,7 @@ namespace System.Management.Automation.Runspaces
             return PSObject.TransformMemberInfoCollection<PSMemberInfo, T>(GetMembers(types));
         }
 
-        private PSMemberInfoInternalCollection<PSMemberInfo> GetMembers(ConsolidatedString types)
+        internal PSMemberInfoInternalCollection<PSMemberInfo> GetMembers(ConsolidatedString types)
         {
             if ((types == null) || string.IsNullOrEmpty(types.Key))
             {

--- a/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
+++ b/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
@@ -4848,7 +4848,7 @@ namespace System.Management.Automation.Language
 
             lock (binderList)
             {
-                if (!binderList.Any())
+                if (binderList.Count == 0)
                 {
                     // Force one binder to be created if one hasn't been created already.
                     PSGetMemberBinder.Get(memberName, (Type)null, @static: false);


### PR DESCRIPTION
## PR Summary
Fixes #7112 

Speed up the creation of PSObjects in CSV cmdlets by

- Use the overload Add(PSMember, bool prevalidated) for all objects except the first when adding the `NoteProperty` members.
- Add a new constructor to PSObject that preallocates the `_instanceMembers` collection with an initial capacity.
- Improve performance of AddToTypesXmlCache by avoiding an expensive copying of members just to check for the existence of one of them, perf is significantly increased, and allocations are reduced.
- Reduce allocations and GC pressure by preallocating and reusing `StringBuilders` and `List<string>` for line parsing in CSV cmdlets.
- Use `List<string>` instead of `Collection<string>` to get fewer virtual calls and better inlining.
- Reduce allocations by using a preallocated value factory in `TypeTable.GetMembers(ConsolidatedString types)`.
- Replace a `Linq.Any()` with a `List.Count > 0` in binder code.

The main gain is from taking advantage of the fact that all objects created by `Import-Csv` have the same shape (the same properties).

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [x ] Issue filed - Issue link:
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/powershell/7413)
<!-- Reviewable:end -->
