### PR TITLE
Mark logging tests for macOS pending

### DIFF
--- a/test/powershell/Host/Logging.Tests.ps1
+++ b/test/powershell/Host/Logging.Tests.ps1
@@ -201,7 +201,10 @@ Describe 'Basic os_log tests on MacOS' -Tag @('CI','RequireSudoOnUnix') {
         }
     }
 
-    It 'Verifies basic logging with no customizations' -Skip:(!$IsSupportedEnvironment) {
+    ## Logging seems broken on macOS 10.13. It works fine on macOS 10.12.6.
+    ## Travis CI updated macOS to 10.13.3 (kernel 17.4) and the logging tests start to fail.
+    # It 'Verifies basic logging with no customizations' -Skip:(!$IsSupportedEnvironment) {
+    It 'Verifies basic logging with no customizations' -Pending {
         $configFile = WriteLogSettings -LogId $logId
         & $powershell -NoProfile -SettingsFile $configFile -Command '$env:PSModulePath | out-null'
 
@@ -220,7 +223,8 @@ Describe 'Basic os_log tests on MacOS' -Tag @('CI','RequireSudoOnUnix') {
         }
     }
 
-    It 'Verifies logging level filtering works' -Skip:(!$IsSupportedEnvironment) {
+    # It 'Verifies logging level filtering works' -Skip:(!$IsSupportedEnvironment) {
+    It 'Verifies logging level filtering works' -Pending {
         $configFile = WriteLogSettings -LogId $logId -LogLevel Warning
         & $powershell -NoProfile -SettingsFile $configFile -Command '$env:PSModulePath | out-null'
 


### PR DESCRIPTION
## PR Summary

Travis CI update macOS to 10.13.3 from 10.12.6 and the logging tests for macOS started to fail after that.

Runtime kernel version was `16.7` before 8/1/2018
![image](https://user-images.githubusercontent.com/127450/43553483-05976f70-95a4-11e8-8d3a-24c600ece572.png)

Runtime kernel version is `17.4` starting from 8/1/2018
![image](https://user-images.githubusercontent.com/127450/43553521-3424e6ec-95a4-11e8-8dc0-b8fb8412d4a1.png)


This PR temporarily make the macOS logging tests pending. Also, #7432 was opened to track the issue.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [x] Issue filed - Issue link:
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [x] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
