### PR TITLE
Throw error on entering non-existing type in Get-FormatData

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/common/GetFormatDataCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/common/GetFormatDataCommand.cs
@@ -171,38 +171,40 @@ namespace Microsoft.PowerShell.Commands
                 viewList.Add(formatdef);
             }// foreach(ViewDefinition...
 
+            // If no Type Definitions are found for _typename throw a terminating error
             if (typedefs.Count == 0) {
-                System.ArgumentException exception = new System.ArgumentException("No such type");
                 // All files must have the same extension otherwise throw.
                 ErrorRecord errorRecord = new ErrorRecord(
-                    exception,
+                    new System.ArgumentException("No such type"),
                     "SPECIFIED_TYPE_NOT_FOUND",
                     ErrorCategory.ResourceUnavailable,
                     _typename);
 
                 ThrowTerminatingError(errorRecord);
             }
-            // write out all the available type definitions
-            foreach (var pair in typedefs)
-            {
-                var typeNames = pair.Key;
-
-                if (writeOldWay)
+            else {
+                // write out all the available type definitions
+                foreach (var pair in typedefs)
                 {
-                    foreach (var typeName in typeNames)
+                    var typeNames = pair.Key;
+
+                    if (writeOldWay)
                     {
-                        var etd = new ExtendedTypeDefinition(typeName, pair.Value);
+                        foreach (var typeName in typeNames)
+                        {
+                            var etd = new ExtendedTypeDefinition(typeName, pair.Value);
+                            WriteObject(etd);
+                        }
+                    }
+                    else
+                    {
+                        var etd = new ExtendedTypeDefinition(typeNames[0], pair.Value);
+                        for (int i = 1; i < typeNames.Count; i++)
+                        {
+                            etd.TypeNames.Add(typeNames[i]);
+                        }
                         WriteObject(etd);
                     }
-                }
-                else
-                {
-                    var etd = new ExtendedTypeDefinition(typeNames[0], pair.Value);
-                    for (int i = 1; i < typeNames.Count; i++)
-                    {
-                        etd.TypeNames.Add(typeNames[i]);
-                    }
-                    WriteObject(etd);
                 }
             }
         }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/common/GetFormatDataCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/common/GetFormatDataCommand.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Microsoft.PowerShell.Commands.Internal.Format;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
@@ -9,6 +8,7 @@ using System.Linq;
 using System.Management.Automation;
 using System.Management.Automation.Internal;
 using System.Management.Automation.Runspaces;
+using Microsoft.PowerShell.Commands.Internal.Format;
 
 namespace Microsoft.PowerShell.Commands
 {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/common/GetFormatDataCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/common/GetFormatDataCommand.cs
@@ -173,7 +173,7 @@ namespace Microsoft.PowerShell.Commands
             if (typedefs.Count == 0)
             {
                 ErrorRecord errorRecord = new ErrorRecord(
-                    new TypeLoadException(GetFormatDataStrings.SpecifiedTypeNotFound),
+                    new TypeLoadException(StringUtil.Format(GetFormatDataStrings.SpecifiedTypeNotFound, _typename),
                     "SpecifiedTypeNotFound",
                     ErrorCategory.InvalidOperation,
                     _typename);

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/common/GetFormatDataCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/common/GetFormatDataCommand.cs
@@ -175,11 +175,10 @@ namespace Microsoft.PowerShell.Commands
             if (typedefs.Count == 0) {
                 // All files must have the same extension otherwise throw.
                 ErrorRecord errorRecord = new ErrorRecord(
-                    new System.ArgumentException("No such type"),
+                    new System.Exception("No such type"),
                     "SPECIFIED_TYPE_NOT_FOUND",
                     ErrorCategory.ResourceUnavailable,
                     _typename);
-
                 ThrowTerminatingError(errorRecord);
             }
             else {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/common/GetFormatDataCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/common/GetFormatDataCommand.cs
@@ -1,15 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using Microsoft.PowerShell.Commands.Internal.Format;
 using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Management.Automation;
 using System.Management.Automation.Internal;
-
-using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Management.Automation.Runspaces;
-using Microsoft.PowerShell.Commands.Internal.Format;
 
 namespace Microsoft.PowerShell.Commands
 {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/common/GetFormatDataCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/common/GetFormatDataCommand.cs
@@ -4,6 +4,8 @@
 using System;
 using System.Linq;
 using System.Management.Automation;
+using System.Management.Automation.Internal;
+
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Management.Automation.Runspaces;
@@ -169,6 +171,17 @@ namespace Microsoft.PowerShell.Commands
                 viewList.Add(formatdef);
             }// foreach(ViewDefinition...
 
+            if (typedefs.Count == 0) {
+                System.ArgumentException exception = new System.ArgumentException("No such type");
+                // All files must have the same extension otherwise throw.
+                ErrorRecord errorRecord = new ErrorRecord(
+                    exception,
+                    "SPECIFIED_TYPE_NOT_FOUND",
+                    ErrorCategory.ResourceUnavailable,
+                    _typename);
+
+                ThrowTerminatingError(errorRecord);
+            }
             // write out all the available type definitions
             foreach (var pair in typedefs)
             {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/common/GetFormatDataCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/common/GetFormatDataCommand.cs
@@ -3,8 +3,8 @@
 
 using System;
 using System.Linq;
-using System.Management.Automation;
 using System.Management.Automation.Internal;
+using System.Management.Automation;
 
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
@@ -172,7 +172,8 @@ namespace Microsoft.PowerShell.Commands
             }// foreach(ViewDefinition...
 
             // If no Type Definitions are found for _typename throw a terminating error
-            if (typedefs.Count == 0) {
+            if (typedefs.Count == 0)
+            {
                 // All files must have the same extension otherwise throw.
                 ErrorRecord errorRecord = new ErrorRecord(
                     new System.Exception("No such type"),
@@ -181,7 +182,8 @@ namespace Microsoft.PowerShell.Commands
                     _typename);
                 ThrowTerminatingError(errorRecord);
             }
-            else {
+            else 
+            {
                 // write out all the available type definitions
                 foreach (var pair in typedefs)
                 {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/common/GetFormatDataCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/common/GetFormatDataCommand.cs
@@ -173,7 +173,7 @@ namespace Microsoft.PowerShell.Commands
             if (typedefs.Count == 0)
             {
                 ErrorRecord errorRecord = new ErrorRecord(
-                    new TypeLoadException("No such type could be found"),
+                    new TypeLoadException(GetFormatDataStrings.SpecifiedTypeNotFound),
                     "SpecifiedTypeNotFound",
                     ErrorCategory.InvalidOperation,
                     _typename);

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/common/GetFormatDataCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/common/GetFormatDataCommand.cs
@@ -3,8 +3,8 @@
 
 using System;
 using System.Linq;
-using System.Management.Automation.Internal;
 using System.Management.Automation;
+using System.Management.Automation.Internal;
 
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/common/GetFormatDataCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/common/GetFormatDataCommand.cs
@@ -168,12 +168,12 @@ namespace Microsoft.PowerShell.Commands
                     typedefs.Add(consolidatedTypeName, viewList);
                 }
                 viewList.Add(formatdef);
-            }// foreach(ViewDefinition...
+            }
 
             if (typedefs.Count == 0)
             {
                 ErrorRecord errorRecord = new ErrorRecord(
-                    new TypeLoadException(StringUtil.Format(GetFormatDataStrings.SpecifiedTypeNotFound, _typename),
+                    new TypeLoadException(StringUtil.Format(GetFormatDataStrings.SpecifiedTypeNotFound, _typename)),
                     "SpecifiedTypeNotFound",
                     ErrorCategory.InvalidOperation,
                     _typename);

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/common/GetFormatDataCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/common/GetFormatDataCommand.cs
@@ -174,12 +174,12 @@ namespace Microsoft.PowerShell.Commands
             {
                 ErrorRecord errorRecord = new ErrorRecord(
                     new TypeLoadException("No such type could be found"),
-                    "SPECIFIED_TYPE_NOT_FOUND",
-                    ErrorCategory.ResourceUnavailable,
+                    "SpecifiedTypeNotFound",
+                    ErrorCategory.InvalidOperation,
                     _typename);
-                ThrowTerminatingError(errorRecord);
+                WriteError(errorRecord);
             }
-            else 
+            else
             {
                 foreach (var pair in typedefs)
                 {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/common/GetFormatDataCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/common/GetFormatDataCommand.cs
@@ -171,12 +171,10 @@ namespace Microsoft.PowerShell.Commands
                 viewList.Add(formatdef);
             }// foreach(ViewDefinition...
 
-            // If no Type Definitions are found for _typename throw a terminating error
             if (typedefs.Count == 0)
             {
-                // All files must have the same extension otherwise throw.
                 ErrorRecord errorRecord = new ErrorRecord(
-                    new System.Exception("No such type"),
+                    new TypeLoadException("No such type could be found"),
                     "SPECIFIED_TYPE_NOT_FOUND",
                     ErrorCategory.ResourceUnavailable,
                     _typename);
@@ -184,7 +182,6 @@ namespace Microsoft.PowerShell.Commands
             }
             else 
             {
-                // write out all the available type definitions
                 foreach (var pair in typedefs)
                 {
                     var typeNames = pair.Key;

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/GetFormatDataStrings.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/GetFormatDataStrings.resx
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="SpecifiedTypeNotFound" xml:space="preserve">
-    <value>Cannot find the type.</value>
+    <value>The type name '{0}' could not be found.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/GetFormatDataStrings.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/GetFormatDataStrings.resx
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!--
+    Microsoft ResX Schema
+
+    Version 2.0
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
+    associated with the data types.
+
+    Example:
+
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+
+    There are any number of "resheader" rows that contain simple
+    name/value pairs.
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
+    mimetype set.
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
+    extensible. For a given mimetype the value must be set accordingly:
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
+    read any of the formats listed below.
+
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="https://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="https://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="SpecifiedTypeNotFound" xml:space="preserve">
+    <value>Cannot find the type.</value>
+  </data>
+</root>

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-FormatData.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-FormatData.Tests.ps1
@@ -9,4 +9,11 @@ Describe "Get-FormatData" -Tags "CI" {
             ,$result | Should -BeOfType "System.Object[]"
         }
     }
+
+    Context "Check for error on invalid type as argument" {
+
+        It "Should throw error on invalid type as argument" {
+            { Get-FormatData "NoSuch.Type.Exists.Or.IsLoaded" -ErrorAction Stop } | Should -Throw -ErrorId "SPECIFIED_TYPE_NOT_FOUND,Microsoft.PowerShell.Commands.GetFormatDataCommand"
+        }
+    }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-FormatData.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-FormatData.Tests.ps1
@@ -1,5 +1,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
+
 Describe "Get-FormatData" -Tags "CI" {
 
     Context "Check return type of Get-FormatData" {
@@ -13,7 +14,7 @@ Describe "Get-FormatData" -Tags "CI" {
     Context "Check for error on invalid type as argument" {
 
         It "Should throw error on invalid type as argument" {
-            { Get-FormatData "NoSuch.Type.Exists.Or.IsLoaded" -ErrorAction Stop } | Should -Throw -ErrorId "SPECIFIED_TYPE_NOT_FOUND,Microsoft.PowerShell.Commands.GetFormatDataCommand"
+            { Get-FormatData "NoSuch.Type.Exists.Or.IsLoaded" -ErrorAction Stop } | Should -Throw -ErrorId "SpecifiedTypeNotFound,Microsoft.PowerShell.Commands.GetFormatDataCommand"
         }
     }
 }


### PR DESCRIPTION
Fix #4235 

## PR Summary

Write non-terminating error when `Get-FormatData` doesn't found a type definition for the provided type,

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [x] Issue filed - Issue link: #4235 
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
