### PR TITLE
Remove extra allocations in PSMemberInfoInternalCollection<T>

### DIFF
--- a/src/System.Management.Automation/engine/MshMemberInfo.cs
+++ b/src/System.Management.Automation/engine/MshMemberInfo.cs
@@ -4251,7 +4251,7 @@ namespace System.Management.Automation
 
                 lock (_members)
                 {
-                    return Members.Count;
+                    return _members.Count;
                 }
             }
         }
@@ -4270,7 +4270,7 @@ namespace System.Management.Automation
 
                 lock (_members)
                 {
-                    return Members.Count - _countHidden;
+                    return _members.Count - _countHidden;
                 }
             }
         }

--- a/src/System.Management.Automation/engine/MshMemberInfo.cs
+++ b/src/System.Management.Automation/engine/MshMemberInfo.cs
@@ -4299,6 +4299,11 @@ namespace System.Management.Automation
         /// <returns>the enumerator for this collection</returns>
         public override IEnumerator<T> GetEnumerator()
         {
+            if (_members == null)
+            {
+                return Enumerable.Empty<T>().GetEnumerator();
+            }
+
             lock (_members)
             {
                 // Copy the members to a list so that iteration can be performed without holding a lock.

--- a/src/System.Management.Automation/engine/MshMemberInfo.cs
+++ b/src/System.Management.Automation/engine/MshMemberInfo.cs
@@ -4052,7 +4052,7 @@ namespace System.Management.Automation
         {
             Diagnostics.Assert(newMember != null, "called from internal code that checks for new member not null");
 
-            lock (_members)
+            lock (Members)
             {
                 var oldMember = Members[newMember.Name] as T;
                 Diagnostics.Assert(oldMember != null, "internal code checks member already exists");
@@ -4087,7 +4087,7 @@ namespace System.Management.Automation
                 throw PSTraceSource.NewArgumentNullException("member");
             }
 
-            lock (_members)
+            lock (Members)
             {
                 if (Members[member.Name] is T existingMember)
                 {
@@ -4130,7 +4130,7 @@ namespace System.Management.Automation
                 return;
             }
 
-            lock (_members)
+            lock (Members)
             {
                 if (Members[name] is PSMemberInfo member)
                 {
@@ -4163,7 +4163,7 @@ namespace System.Management.Automation
                     return null;
                 }
 
-                lock (_members)
+                lock (Members)
                 {
                     return Members[name] as T;
                 }
@@ -4223,7 +4223,7 @@ namespace System.Management.Automation
         private PSMemberInfoInternalCollection<T> GetInternalMembers(MshMemberMatchOptions matchOptions)
         {
             PSMemberInfoInternalCollection<T> returnValue = new PSMemberInfoInternalCollection<T>();
-            lock (_members)
+            lock (Members)
             {
                 foreach (T member in Members.Values.OfType<T>())
                 {
@@ -4249,7 +4249,7 @@ namespace System.Management.Automation
                     return 0;
                 }
 
-                lock (_members)
+                lock (Members)
                 {
                     return _members.Count;
                 }
@@ -4268,7 +4268,7 @@ namespace System.Management.Automation
                     return 0;
                 }
 
-                lock (_members)
+                lock (Members)
                 {
                     return _members.Count - _countHidden;
                 }
@@ -4289,7 +4289,7 @@ namespace System.Management.Automation
                     return null;
                 }
 
-                lock (_members)
+                lock (Members)
                 {
                     return _members[index] as T;
                 }
@@ -4309,7 +4309,7 @@ namespace System.Management.Automation
                 return Enumerable.Empty<T>().GetEnumerator();
             }
 
-            lock (_members)
+            lock (Members)
             {
                 // Copy the members to a list so that iteration can be performed without holding a lock.
                 return Members.Values.OfType<T>().ToList().GetEnumerator();

--- a/src/System.Management.Automation/engine/MshMemberInfo.cs
+++ b/src/System.Management.Automation/engine/MshMemberInfo.cs
@@ -4012,7 +4012,7 @@ namespace System.Management.Automation
         private int _countHidden;
 
         /// <summary>
-        /// Get the OrderedDictionary for holding all members.
+        /// Gets the OrderedDictionary for holding all members.
         /// We use this property to delay initializing _members until we absolutely need to.
         /// </summary>
         private OrderedDictionary Members
@@ -4056,9 +4056,11 @@ namespace System.Management.Automation
         {
             Diagnostics.Assert(newMember != null, "called from internal code that checks for new member not null");
 
-            lock (Members)
+            // Save to a local variable to reduce property access.
+            var members = Members;
+            lock (members)
             {
-                var oldMember = Members[newMember.Name] as T;
+                var oldMember = members[newMember.Name] as T;
                 Diagnostics.Assert(oldMember != null, "internal code checks member already exists");
                 Replace(oldMember, newMember);
             }
@@ -4091,15 +4093,17 @@ namespace System.Management.Automation
                 throw PSTraceSource.NewArgumentNullException("member");
             }
 
-            lock (Members)
+            // Save to a local variable to reduce property access.
+            var members = Members;
+            lock (members)
             {
-                if (Members[member.Name] is T existingMember)
+                if (members[member.Name] is T existingMember)
                 {
                     Replace(existingMember, member);
                 }
                 else
                 {
-                    Members[member.Name] = member;
+                    members[member.Name] = member;
                     if (member.IsHidden)
                     {
                         _countHidden++;

--- a/src/System.Management.Automation/engine/MshMemberInfo.cs
+++ b/src/System.Management.Automation/engine/MshMemberInfo.cs
@@ -4291,7 +4291,7 @@ namespace System.Management.Automation
 
                 lock (_members)
                 {
-                    return Members[index] as T;
+                    return _members[index] as T;
                 }
             }
         }

--- a/src/System.Management.Automation/engine/MshMemberInfo.cs
+++ b/src/System.Management.Automation/engine/MshMemberInfo.cs
@@ -4125,6 +4125,11 @@ namespace System.Management.Automation
                     name);
             }
 
+            if (_members == null)
+            {
+                return;
+            }
+
             lock (_members)
             {
                 if (Members[name] is PSMemberInfo member)

--- a/src/System.Management.Automation/engine/MshMemberInfo.cs
+++ b/src/System.Management.Automation/engine/MshMemberInfo.cs
@@ -4052,7 +4052,7 @@ namespace System.Management.Automation
         {
             Diagnostics.Assert(newMember != null, "called from internal code that checks for new member not null");
 
-            lock (Members)
+            lock (_members)
             {
                 var oldMember = Members[newMember.Name] as T;
                 Diagnostics.Assert(oldMember != null, "internal code checks member already exists");
@@ -4087,7 +4087,7 @@ namespace System.Management.Automation
                 throw PSTraceSource.NewArgumentNullException("member");
             }
 
-            lock (Members)
+            lock (_members)
             {
                 if (Members[member.Name] is T existingMember)
                 {
@@ -4125,7 +4125,7 @@ namespace System.Management.Automation
                     name);
             }
 
-            lock (Members)
+            lock (_members)
             {
                 if (Members[name] is PSMemberInfo member)
                 {
@@ -4158,7 +4158,7 @@ namespace System.Management.Automation
                     return null;
                 }
 
-                lock (Members)
+                lock (_members)
                 {
                     return Members[name] as T;
                 }
@@ -4218,7 +4218,7 @@ namespace System.Management.Automation
         private PSMemberInfoInternalCollection<T> GetInternalMembers(MshMemberMatchOptions matchOptions)
         {
             PSMemberInfoInternalCollection<T> returnValue = new PSMemberInfoInternalCollection<T>();
-            lock (Members)
+            lock (_members)
             {
                 foreach (T member in Members.Values.OfType<T>())
                 {
@@ -4244,7 +4244,7 @@ namespace System.Management.Automation
                     return 0;
                 }
 
-                lock (Members)
+                lock (_members)
                 {
                     return Members.Count;
                 }
@@ -4263,7 +4263,7 @@ namespace System.Management.Automation
                     return 0;
                 }
 
-                lock (Members)
+                lock (_members)
                 {
                     return Members.Count - _countHidden;
                 }
@@ -4284,7 +4284,7 @@ namespace System.Management.Automation
                     return null;
                 }
 
-                lock (Members)
+                lock (_members)
                 {
                     return Members[index] as T;
                 }
@@ -4299,7 +4299,7 @@ namespace System.Management.Automation
         /// <returns>the enumerator for this collection</returns>
         public override IEnumerator<T> GetEnumerator()
         {
-            lock (Members)
+            lock (_members)
             {
                 // Copy the members to a list so that iteration can be performed without holding a lock.
                 return Members.Values.OfType<T>().ToList().GetEnumerator();

--- a/src/System.Management.Automation/engine/MshMemberInfo.cs
+++ b/src/System.Management.Automation/engine/MshMemberInfo.cs
@@ -4017,7 +4017,7 @@ namespace System.Management.Automation
             {
                 if (_members == null)
                 {
-                    _members = new OrderedDictionary(StringComparer.OrdinalIgnoreCase);
+                    System.Threading.Interlocked.CompareExchange(ref _members, new OrderedDictionary(StringComparer.OrdinalIgnoreCase), null);
                 }
 
                 return _members;


### PR DESCRIPTION
## PR Summary

Related #7112.
PSMemberInfoInternalCollection<T> uses internally OrderedDictionary class.
The OrderedDictionary class in .Net Core 2.1 allocates internally ArrayList  and Hashtable  after any first using any property. Even if we check that OrderedDictionary is empty (Count==0) or use indexer it causes allocations.

The commit postpones the internall allocations until this is really necessary.

Taking into account that PSMemberInfoInternalCollection<T> is used in each PSObject and is often empty, this change dramatically reduces memory allocations.

### PerfView results
1. Startup test
- before - GC Stats Total Allocs : 13.274 MB
- after  - GC Stats Total Allocs : 10.082 MB

2. Script test (Import-Csv)
Before fix:
- GC Stats Total Allocs : 4,073.747 MB
![gcstatsbeforefix](https://user-images.githubusercontent.com/22290914/43588607-62cb0bbc-965c-11e8-82eb-0d007ebea9c0.jpg)
![gcheapallocbeforefix](https://user-images.githubusercontent.com/22290914/43588707-9b5b8484-965c-11e8-97a7-8db9e783c0b1.jpg)

After the fix:
- GC Stats Total Allocs : 1,186.017 MB
![gcstatsafterfix](https://user-images.githubusercontent.com/22290914/43588685-9243fafc-965c-11e8-8dce-90785ccb8f9b.jpg)
![gcheapallocafterfix](https://user-images.githubusercontent.com/22290914/43588713-9f8d1bd0-965c-11e8-9836-189cd64e0745.jpg)

Test script:
```powershell
cd c:\tmp\
function perf_test($source, $result) {
    Write-Host "Measuring Import-Csv performance over time..."

    "index,duration_ms,bytes_consumed" | Out-File $result
    for ($i=0; $i -le 400; $i++) {

            $millis = (Measure-Command { Import-Csv $source }).TotalMilliseconds
            # Uncomment this if you want analize results in Excel
            $memory = [System.GC]::GetTotalMemory($false)
	    $i.ToString() + "," + $millis.ToString() + "," + $memory | Out-File $result -Append
    }
    Write-Host "Done"
}

$fields = 0..19 | ForEach-Object { "random_numbers$_" }
($fields -join ",") | Out-File .\source2.csv
Get-Random -SetSeed 1 | Out-Null
for ($i=0; $i -le 500; $i++) {
    $values = 0..19 | ForEach-Object { (Get-Random).ToString() }
    ($values -join ",") | Out-File .\source2.csv -Append
}

perf_test .\source2.csv .\results.csv
```





## PR Checklist

- [ ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
