### PR TITLE
Adding LanguagePrimitives.TryCompare to provide faster comparisons

### DIFF
--- a/src/System.Management.Automation/FormatAndOutput/common/FormatGroupManager.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/FormatGroupManager.cs
@@ -83,18 +83,13 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
 
         private static bool IsEqual(object first, object second)
         {
-            try
+            if (LanguagePrimitives.TryCompare(first, second, true, CultureInfo.CurrentCulture, out int result))
             {
-                return LanguagePrimitives.Compare(first, second, true, CultureInfo.CurrentCulture) == 0;
+                return result == 0;
             }
-            catch (InvalidCastException)
-            {
-            }
-            catch (ArgumentException)
-            {
-                // Note that this will occur if the objects do not support
-                // IComparable.  We fall back to comparing as strings.
-            }
+
+            // Note that this will occur if the objects do not support
+            // IComparable.  We fall back to comparing as strings.
 
             // being here means the first object doesn't support ICompare
             // or an Exception was raised win Compare

--- a/src/System.Management.Automation/engine/LanguagePrimitives.cs
+++ b/src/System.Management.Automation/engine/LanguagePrimitives.cs
@@ -696,6 +696,30 @@ namespace System.Management.Automation
         }
 
         /// <summary>
+        /// Helper method for [Try]Compare to determine object ordering with null.
+        /// </summary>
+        /// <param name="value">the numeric value to compare to null</param>
+        /// <param name="numberIsRightHandSide">True if the number to compare is on the right hand side if the comparison.</param>
+        private static int CompareObjectToNull(object value, bool numberIsRightHandSide)
+        {
+            var i = numberIsRightHandSide ? -1 : 1;
+
+            // If it's a positive number, including 0, it's greater than null
+            // for everything else it's less than zero...
+            switch (value)
+            {
+                case Int16 i16: return Math.Sign(i16) < 0 ? -i : i;
+                case Int32 i32: return Math.Sign(i32) < 0 ? -i : i;
+                case Int64 i64: return Math.Sign(i64) < 0 ? -i : i;
+                case sbyte sby: return Math.Sign(sby) < 0 ? -i : i;
+                case float f: return Math.Sign(f) < 0 ? -i : i;
+                case double d: return Math.Sign(d) < 0 ? -i : i;
+                case decimal de: return Math.Sign(de) < 0 ? -i : i;
+                default: return i;
+            }
+        }
+
+        /// <summary>
         /// Compare first and second, converting second to the
         /// type of the first, if necessary.
         /// </summary>
@@ -762,43 +786,12 @@ namespace System.Management.Automation
 
             if (first == null)
             {
-                if (second == null)
-                {
-                    return 0;
-                }
-                else
-                {
-                    // If it's a positive number, including 0, it's greater than null
-                    // for everything else it's less than zero...
-                    switch (LanguagePrimitives.GetTypeCode(second.GetType()))
-                    {
-                        case TypeCode.Int16: return System.Math.Sign((Int16)second) < 0 ? 1 : -1;
-                        case TypeCode.Int32: return System.Math.Sign((Int32)second) < 0 ? 1 : -1;
-                        case TypeCode.Int64: return System.Math.Sign((Int64)second) < 0 ? 1 : -1;
-                        case TypeCode.SByte: return System.Math.Sign((sbyte)second) < 0 ? 1 : -1;
-                        case TypeCode.Single: return System.Math.Sign((System.Single)second) < 0 ? 1 : -1;
-                        case TypeCode.Double: return System.Math.Sign((System.Double)second) < 0 ? 1 : -1;
-                        case TypeCode.Decimal: return System.Math.Sign((System.Decimal)second) < 0 ? 1 : -1;
-                        default: return -1;
-                    }
-                }
+                return second == null ? 0 : CompareObjectToNull(second, true);
             }
 
             if (second == null)
             {
-                // If it's a positive number, including 0, it's greater than null
-                // for everything else it's less than zero...
-                switch (LanguagePrimitives.GetTypeCode(first.GetType()))
-                {
-                    case TypeCode.Int16: return System.Math.Sign((Int16)first) < 0 ? -1 : 1;
-                    case TypeCode.Int32: return System.Math.Sign((Int32)first) < 0 ? -1 : 1;
-                    case TypeCode.Int64: return System.Math.Sign((Int64)first) < 0 ? -1 : 1;
-                    case TypeCode.SByte: return System.Math.Sign((sbyte)first) < 0 ? -1 : 1;
-                    case TypeCode.Single: return System.Math.Sign((System.Single)first) < 0 ? -1 : 1;
-                    case TypeCode.Double: return System.Math.Sign((System.Double)first) < 0 ? -1 : 1;
-                    case TypeCode.Decimal: return System.Math.Sign((System.Decimal)first) < 0 ? -1 : 1;
-                    default: return 1;
-                }
+                return CompareObjectToNull(first, false);
             }
 
             if (first is string firstString)
@@ -909,24 +902,7 @@ namespace System.Management.Automation
             first = PSObject.Base(first);
             second = PSObject.Base(second);
 
-            int CompareNullToNumeric(object value, bool numberIsRightHandSide)
-            {
-                var i = numberIsRightHandSide ? -1 : 1;
 
-                // If it's a positive number, including 0, it's greater than null
-                // for everything else it's less than zero...
-                switch (GetTypeCode(value.GetType()))
-                {
-                    case TypeCode.Int16: return Math.Sign((Int16)value) < 0 ? -i : i;
-                    case TypeCode.Int32: return Math.Sign((Int32)value) < 0 ? -i : i;
-                    case TypeCode.Int64: return Math.Sign((Int64)value) < 0 ? -i : i;
-                    case TypeCode.SByte: return Math.Sign((sbyte)value) < 0 ? -i : i;
-                    case TypeCode.Single: return Math.Sign((Single)value) < 0 ? -i : i;
-                    case TypeCode.Double: return Math.Sign((Double)value) < 0 ? -i : i;
-                    case TypeCode.Decimal: return Math.Sign((Decimal)value) < 0 ? -i : i;
-                    default: return i;
-                }
-            }
 
             if (first == null && second == null)
             {
@@ -936,7 +912,7 @@ namespace System.Management.Automation
 
             if (first == null)
             {
-                result = CompareNullToNumeric(second, true);
+                result = CompareObjectToNull(second, true);
                 return true;
             }
 
@@ -944,7 +920,7 @@ namespace System.Management.Automation
             {
                 // If it's a positive number, including 0, it's greater than null
                 // for everything else it's less than zero...
-                result = CompareNullToNumeric(first, false);
+                result = CompareObjectToNull(first, false);
                 return true;
             }
 

--- a/src/System.Management.Automation/engine/LanguagePrimitives.cs
+++ b/src/System.Management.Automation/engine/LanguagePrimitives.cs
@@ -902,8 +902,6 @@ namespace System.Management.Automation
             first = PSObject.Base(first);
             second = PSObject.Base(second);
 
-
-
             if (first == null && second == null)
             {
                 result = 0;

--- a/src/System.Management.Automation/engine/LanguagePrimitives.cs
+++ b/src/System.Management.Automation/engine/LanguagePrimitives.cs
@@ -858,7 +858,7 @@ namespace System.Management.Automation
         /// <returns>True if the comparison was successful, false otherwise.</returns>
         public static bool TryCompare(object first, object second, out int result)
         {
-            return TryCompare(first, second, false, CultureInfo.InvariantCulture, out result);
+            return TryCompare(first, second, ignoreCase: false, CultureInfo.InvariantCulture, out result);
         }
 
         /// <summary>

--- a/test/powershell/engine/Api/LanguagePrimitive.Tests.ps1
+++ b/test/powershell/engine/Api/LanguagePrimitive.Tests.ps1
@@ -29,7 +29,7 @@ Describe "Language Primitive Tests" -Tags "CI" {
     }
 
     It "Casting recursive array to bool should not cause crash" {
-        $a[0] = $a = [PSObject](,1)
+        $a[0] = $a = [PSObject](, 1)
         [System.Management.Automation.LanguagePrimitives]::IsTrue($a) | Should -BeTrue
     }
 
@@ -45,5 +45,61 @@ Describe "Language Primitive Tests" -Tags "CI" {
         $count = 0
         [System.Management.Automation.LanguagePrimitives]::GetEnumerable($dt) | ForEach-Object { $count++ }
         $count | Should -Be 2
+    }
+
+    It "TryCompare should succeed on int and string" {
+        $result = $null
+        [System.Management.Automation.LanguagePrimitives]::TryCompare(1, "1", [ref] $result) | Should -BeTrue
+        $result | Should -BeExactly 0
+    }
+
+    It "TryCompare should fail on int and datetime" {
+        $result = $null
+        [System.Management.Automation.LanguagePrimitives]::TryCompare(1, [datetime]::Now, [ref] $result) | Should -BeFalse
+    }
+
+    It "TryCompare should succeed on int and int and compare correctly smaller" {
+        $result = $null
+        [System.Management.Automation.LanguagePrimitives]::TryCompare(1, 2, [ref] $result) | Should -BeTrue
+        $result | Should -BeExactly -1
+    }
+
+    It "TryCompare should succeed on string and string and compare correctly greater" {
+        $result = $null
+        [System.Management.Automation.LanguagePrimitives]::TryCompare("bbb", "aaa", [ref] $result) | Should -BeTrue
+        $result | Should -BeExactly 1
+    }
+
+    It "TryCompare should succeed on string and string and compare case insensitive correctly" {
+        $result = $null
+        [System.Management.Automation.LanguagePrimitives]::TryCompare("AAA", "aaa", $true, [ref] $result) | Should -BeTrue
+        $result | Should -BeExactly 0
+    }
+
+    It "TryCompare with cultureInfo is culture sensitive" {
+        $result = $null
+        $swedish = [cultureinfo] 'sv-SE'
+        # in Swedish, åäö appears at the end of the alphabet, and should compare greater than o
+        $val = [System.Management.Automation.LanguagePrimitives]::TryCompare("ooo", "ååå", $false, $swedish, [ref] $result)
+        $val | Should -BeTrue
+        $result | Should -BeExactly -1
+    }
+
+    It "TryCompare compares greater than null as Compare" {
+        $result = $null
+
+        $compareResult = [System.Management.Automation.LanguagePrimitives]::Compare($null, 10)
+        $val = [System.Management.Automation.LanguagePrimitives]::TryCompare($null, 10, [ref] $result)
+        $val | Should -BeTrue
+        $result | Should -BeExactly $compareResult
+    }
+
+    It "TryCompare compares less than null as Compare" {
+        $result = $null
+
+        $compareResult = [System.Management.Automation.LanguagePrimitives]::Compare(10, $null)
+        $val = [System.Management.Automation.LanguagePrimitives]::TryCompare(10, $null, [ref] $result)
+        $val | Should -BeTrue
+        $result | Should -BeExactly $compareResult
     }
 }

--- a/test/powershell/engine/Api/LanguagePrimitive.Tests.ps1
+++ b/test/powershell/engine/Api/LanguagePrimitive.Tests.ps1
@@ -50,7 +50,7 @@ Describe "Language Primitive Tests" -Tags "CI" {
     It "TryCompare should succeed on int and string" {
         $result = $null
         [System.Management.Automation.LanguagePrimitives]::TryCompare(1, "1", [ref] $result) | Should -BeTrue
-        $result | Should -BeExactly 0
+        $result | Should -Be 0
     }
 
     It "TryCompare should fail on int and datetime" {


### PR DESCRIPTION
## PR Summary

This PR adds the  `TryCompare` equivalent of `Compare`, just as we have a `TryConvert` alternative to `Convert`.
This enables faster comparison in the cases where the convertions throws exception.

As an example:

```powershell
 1..10000 | foreach{$_; [timespan]::FromSeconds($_)}  | sort
```
takes `3 800 ms` before and `280 ms` after.

```powershell
$b = 1..1000000 | %{100; [timespan]::FromSeconds(100)}  | group
```
takes `20 s` before and `15 s` after.


It is implemented equivalently to `LanguagePrimitives.Compare`, but returning false where `Compare` would have thrown an exception.

This is adding a new public API to `LanguagePrimitives`, so it will probably need a committee approval.

The new APIs are:

```CSharp
class LanguagePrimitives {
  public static bool TryCompare(object first, object second, out int result);
  public static bool TryCompare(object first, object second, bool ignoreCase, out int result);
  /// <summary>
  /// Tries to compare first and second, converting second to the type of the first, if necessary.
  /// If a conversion is needed but fails, false is return.
  /// </summary>
  /// <param name="first">First comparison value.</param>
  /// <param name="second">Second comparison value.</param>
  /// <param name="ignoreCase">Used if both values are strings.</param>
  /// <param name="formatProvider">Used in type conversions and if both values are strings.</param>
  /// <param name="result">Less than zero if first is smaller than second, more than  zero if it is greater or zero if they are the same.</param>
  /// <returns>True if the comparison was successful, false otherwise.</returns>
  /// <exception cref="ArgumentException">The parameter <paramref name="formatProvider"/> is not a <see cref="CultureInfo"/>.</exception>
  public static bool TryCompare(
      object first, 
      object second, 
      bool ignoreCase, 
      IFormatProvider formatProvider,
      out int result);
}
```

The new APIs are used by `ObjectCommandPropertyValue` (used by sort-object and group-object) and `FormatGroupManager`.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
