### PR TITLE
Fix null reference when markdown content is empty

### DIFF
--- a/src/Microsoft.PowerShell.MarkdownRender/FencedCodeBlockRenderer.cs
+++ b/src/Microsoft.PowerShell.MarkdownRender/FencedCodeBlockRenderer.cs
@@ -16,9 +16,9 @@ namespace Microsoft.PowerShell.MarkdownRender
     {
         protected override void Write(VT100Renderer renderer, FencedCodeBlock obj)
         {
-            if (obj?.Lines != null && obj.Lines.Lines != null)
+            if (obj?.Lines.Lines != null)
             {
-                foreach (var codeLine in obj?.Lines.Lines)
+                foreach (var codeLine in obj.Lines.Lines)
                 {
                     if (!string.IsNullOrWhiteSpace(codeLine.ToString()))
                     {

--- a/src/Microsoft.PowerShell.MarkdownRender/FencedCodeBlockRenderer.cs
+++ b/src/Microsoft.PowerShell.MarkdownRender/FencedCodeBlockRenderer.cs
@@ -16,25 +16,28 @@ namespace Microsoft.PowerShell.MarkdownRender
     {
         protected override void Write(VT100Renderer renderer, FencedCodeBlock obj)
         {
-            foreach (var codeLine in obj.Lines.Lines)
+            if (obj?.Lines != null && obj.Lines.Lines != null)
             {
-                if (!string.IsNullOrWhiteSpace(codeLine.ToString()))
+                foreach (var codeLine in obj?.Lines.Lines)
                 {
-                    // If the code block is of type YAML, then tab to right to improve readability.
-                    // This specifically helps for parameters help content.
-                    if (string.Equals(obj.Info, "yaml", StringComparison.OrdinalIgnoreCase))
+                    if (!string.IsNullOrWhiteSpace(codeLine.ToString()))
                     {
-                        renderer.Write("\t").WriteLine(codeLine.ToString());
-                    }
-                    else
-                    {
-                        renderer.WriteLine(renderer.EscapeSequences.FormatCode(codeLine.ToString(), isInline: false));
+                        // If the code block is of type YAML, then tab to right to improve readability.
+                        // This specifically helps for parameters help content.
+                        if (string.Equals(obj.Info, "yaml", StringComparison.OrdinalIgnoreCase))
+                        {
+                            renderer.Write("\t").WriteLine(codeLine.ToString());
+                        }
+                        else
+                        {
+                            renderer.WriteLine(renderer.EscapeSequences.FormatCode(codeLine.ToString(), isInline: false));
+                        }
                     }
                 }
-            }
 
-            // Add a blank line after the code block for better readability.
-            renderer.WriteLine();
+                // Add a blank line after the code block for better readability.
+                renderer.WriteLine();
+            }
         }
     }
 }

--- a/src/Microsoft.PowerShell.MarkdownRender/FencedCodeBlockRenderer.cs
+++ b/src/Microsoft.PowerShell.MarkdownRender/FencedCodeBlockRenderer.cs
@@ -18,7 +18,7 @@ namespace Microsoft.PowerShell.MarkdownRender
         {
             if (obj?.Lines.Lines != null)
             {
-                foreach (var codeLine in obj.Lines.Lines)
+                foreach (string codeLine in obj.Lines.Lines)
                 {
                     if (!string.IsNullOrWhiteSpace(codeLine.ToString()))
                     {

--- a/src/Microsoft.PowerShell.MarkdownRender/FencedCodeBlockRenderer.cs
+++ b/src/Microsoft.PowerShell.MarkdownRender/FencedCodeBlockRenderer.cs
@@ -4,6 +4,7 @@
 using System;
 using System.IO;
 using Markdig;
+using Markdig.Helpers;
 using Markdig.Renderers;
 using Markdig.Syntax;
 
@@ -18,7 +19,7 @@ namespace Microsoft.PowerShell.MarkdownRender
         {
             if (obj?.Lines.Lines != null)
             {
-                foreach (string codeLine in obj.Lines.Lines)
+                foreach (StringLine codeLine in obj.Lines.Lines)
                 {
                     if (!string.IsNullOrWhiteSpace(codeLine.ToString()))
                     {

--- a/src/Microsoft.PowerShell.MarkdownRender/HeaderBlockRenderer.cs
+++ b/src/Microsoft.PowerShell.MarkdownRender/HeaderBlockRenderer.cs
@@ -16,7 +16,7 @@ namespace Microsoft.PowerShell.MarkdownRender
     {
         protected override void Write(VT100Renderer renderer, HeadingBlock obj)
         {
-            string headerText = obj.Inline?.FirstChild?.ToString();
+            string headerText = obj?.Inline?.FirstChild?.ToString();
 
             if (!string.IsNullOrEmpty(headerText))
             {

--- a/src/Microsoft.PowerShell.MarkdownRender/HeaderBlockRenderer.cs
+++ b/src/Microsoft.PowerShell.MarkdownRender/HeaderBlockRenderer.cs
@@ -16,38 +16,43 @@ namespace Microsoft.PowerShell.MarkdownRender
     {
         protected override void Write(VT100Renderer renderer, HeadingBlock obj)
         {
-            // Format header and then add blank line to improve readability.
-            switch (obj.Level)
+            string headerText = obj.Inline?.FirstChild?.ToString();
+
+            if (!string.IsNullOrEmpty(headerText))
             {
-                case 1:
-                    renderer.WriteLine(renderer.EscapeSequences.FormatHeader1(obj.Inline.FirstChild.ToString()));
-                    renderer.WriteLine();
-                    break;
+                // Format header and then add blank line to improve readability.
+                switch (obj.Level)
+                {
+                    case 1:
+                        renderer.WriteLine(renderer.EscapeSequences.FormatHeader1(headerText));
+                        renderer.WriteLine();
+                        break;
 
-                case 2:
-                    renderer.WriteLine(renderer.EscapeSequences.FormatHeader2(obj.Inline.FirstChild.ToString()));
-                    renderer.WriteLine();
-                    break;
+                    case 2:
+                        renderer.WriteLine(renderer.EscapeSequences.FormatHeader2(headerText));
+                        renderer.WriteLine();
+                        break;
 
-                case 3:
-                    renderer.WriteLine(renderer.EscapeSequences.FormatHeader3(obj.Inline.FirstChild.ToString()));
-                    renderer.WriteLine();
-                    break;
+                    case 3:
+                        renderer.WriteLine(renderer.EscapeSequences.FormatHeader3(headerText));
+                        renderer.WriteLine();
+                        break;
 
-                case 4:
-                    renderer.WriteLine(renderer.EscapeSequences.FormatHeader4(obj.Inline.FirstChild.ToString()));
-                    renderer.WriteLine();
-                    break;
+                    case 4:
+                        renderer.WriteLine(renderer.EscapeSequences.FormatHeader4(headerText));
+                        renderer.WriteLine();
+                        break;
 
-                case 5:
-                    renderer.WriteLine(renderer.EscapeSequences.FormatHeader5(obj.Inline.FirstChild.ToString()));
-                    renderer.WriteLine();
-                    break;
+                    case 5:
+                        renderer.WriteLine(renderer.EscapeSequences.FormatHeader5(headerText));
+                        renderer.WriteLine();
+                        break;
 
-                case 6:
-                    renderer.WriteLine(renderer.EscapeSequences.FormatHeader6(obj.Inline.FirstChild.ToString()));
-                    renderer.WriteLine();
-                    break;
+                    case 6:
+                        renderer.WriteLine(renderer.EscapeSequences.FormatHeader6(headerText));
+                        renderer.WriteLine();
+                        break;
+                }
             }
         }
     }

--- a/src/Microsoft.PowerShell.MarkdownRender/LinkInlineRenderer.cs
+++ b/src/Microsoft.PowerShell.MarkdownRender/LinkInlineRenderer.cs
@@ -19,11 +19,11 @@ namespace Microsoft.PowerShell.MarkdownRender
             // Format link as image or link.
             if (obj.IsImage)
             {
-                renderer.Write(renderer.EscapeSequences.FormatImage(obj.FirstChild.ToString()));
+                renderer.Write(renderer.EscapeSequences.FormatImage(obj.FirstChild?.ToString()));
             }
             else
             {
-                renderer.Write(renderer.EscapeSequences.FormatLink(obj.FirstChild.ToString(), obj.Url));
+                renderer.Write(renderer.EscapeSequences.FormatLink(obj.FirstChild?.ToString(), obj.Url));
             }
         }
     }

--- a/src/Microsoft.PowerShell.MarkdownRender/LinkInlineRenderer.cs
+++ b/src/Microsoft.PowerShell.MarkdownRender/LinkInlineRenderer.cs
@@ -16,14 +16,16 @@ namespace Microsoft.PowerShell.MarkdownRender
     {
         protected override void Write(VT100Renderer renderer, LinkInline obj)
         {
+            string text = obj?.FirstChild?.ToString();
+
             // Format link as image or link.
             if (obj.IsImage)
             {
-                renderer.Write(renderer.EscapeSequences.FormatImage(obj.FirstChild?.ToString()));
+                renderer.Write(renderer.EscapeSequences.FormatImage(text));
             }
             else
             {
-                renderer.Write(renderer.EscapeSequences.FormatLink(obj.FirstChild?.ToString(), obj.Url));
+                renderer.Write(renderer.EscapeSequences.FormatLink(text, obj.Url));
             }
         }
     }

--- a/src/Microsoft.PowerShell.MarkdownRender/LinkInlineRenderer.cs
+++ b/src/Microsoft.PowerShell.MarkdownRender/LinkInlineRenderer.cs
@@ -16,7 +16,7 @@ namespace Microsoft.PowerShell.MarkdownRender
     {
         protected override void Write(VT100Renderer renderer, LinkInline obj)
         {
-            string text = obj?.FirstChild?.ToString();
+            string text = obj.FirstChild?.ToString();
 
             // Format link as image or link.
             if (obj.IsImage)


### PR DESCRIPTION
Fix #7453

## PR Summary

Fix cases where markdown content can be empty and we get a null reference exception.

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [X] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [X] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
