### PR TITLE
Add LocationChangedAction handler and tests to support the Windows Compat module.

### DIFF
--- a/src/System.Management.Automation/engine/MshCmdlet.cs
+++ b/src/System.Management.Automation/engine/MshCmdlet.cs
@@ -356,6 +356,11 @@ namespace System.Management.Automation
         /// </summary>
         public System.EventHandler<CommandLookupEventArgs> PostCommandLookupAction { get; set; }
 
+        ///<summary>
+        /// This action is invoked everytime the runspace location (cwd) is changed.
+        ///</summary>
+        public System.EventHandler<LocationChangedEventArgs> LocationChangedAction { get; set; }
+
         /// <summary>
         /// Returns the CmdletInfo object that corresponds to the name argument
         /// </summary>

--- a/src/System.Management.Automation/engine/MshCmdlet.cs
+++ b/src/System.Management.Automation/engine/MshCmdlet.cs
@@ -356,9 +356,9 @@ namespace System.Management.Automation
         /// </summary>
         public System.EventHandler<CommandLookupEventArgs> PostCommandLookupAction { get; set; }
 
-        ///<summary>
-        /// This action is invoked everytime the runspace location (cwd) is changed.
-        ///</summary>
+        /// <summary>
+        /// Gets or sets the action that is invoked everytime the runspace location (cwd) is changed.
+        /// </summary>
         public System.EventHandler<LocationChangedEventArgs> LocationChangedAction { get; set; }
 
         /// <summary>

--- a/src/System.Management.Automation/engine/SessionStateLocationAPIs.cs
+++ b/src/System.Management.Automation/engine/SessionStateLocationAPIs.cs
@@ -1057,35 +1057,46 @@ namespace System.Management.Automation
         #endregion push-Pop current working directory
     }           // SessionStateInternal class
 
-    ///<summary>
-    /// Arguments for the LocationChangedEvent
-    ///</summary>
+    /// <summary>
+    /// Event argument for the LocationChangedAction containing
+    /// information about the old location we were in and the new
+    /// location we changed to.
+    /// </summary>
     public class LocationChangedEventArgs : EventArgs
     {
-        ///<summary>
-        /// Construct an instance of this object.
-        ///</summary>
-        public LocationChangedEventArgs(SessionState sessionState, PathInfo oldPath, PathInfo newPath)
+        /// <summary>
+        ///  Initializes a new instance of the LocationChangedEventArgs class.
+        /// </summary>
+        /// <param name="sessionState">
+        /// The public session state instance associated with this runspace.
+        ///</param>
+        /// <param name="oldPath">
+        /// The path we changed locations from.
+        ///</param>
+        /// <param name="newPath">
+        /// The path we change locations to.
+        ///</param>
+        internal LocationChangedEventArgs(SessionState sessionState, PathInfo oldPath, PathInfo newPath)
         {
             SessionState = sessionState;
             OldPath = oldPath;
             NewPath = newPath;
         }
 
-        ///<summary>
-        /// The path we changed from
-        ///</summary>
-        public PathInfo OldPath { get; internal set;}
+        /// <summary>
+        /// Gets the path we changed location from.
+        /// </summary>
+        public PathInfo OldPath { get; internal set; }
 
-        ///<summary>
-        /// The path we changed to.
-        ///</summary>
-        public PathInfo NewPath { get; internal set;}
+        /// <summary>
+        /// Gets the path we changed location to.
+        /// </summary>
+        public PathInfo NewPath { get; internal set; }
 
-        ///<summary>
-        /// The session state instance for the current runspace.
-        ///</summary>
-        public SessionState SessionState {get; internal set; }
+        /// <summary>
+        /// Gets the session state instance for the current runspace.
+        /// </summary>
+        public SessionState SessionState { get; internal set; }
     }
 }
 

--- a/src/System.Management.Automation/engine/SessionStateLocationAPIs.cs
+++ b/src/System.Management.Automation/engine/SessionStateLocationAPIs.cs
@@ -1065,17 +1065,17 @@ namespace System.Management.Automation
     public class LocationChangedEventArgs : EventArgs
     {
         /// <summary>
-        ///  Initializes a new instance of the LocationChangedEventArgs class.
+        /// Initializes a new instance of the LocationChangedEventArgs class.
         /// </summary>
         /// <param name="sessionState">
         /// The public session state instance associated with this runspace.
-        ///</param>
+        /// </param>
         /// <param name="oldPath">
         /// The path we changed locations from.
-        ///</param>
+        /// </param>
         /// <param name="newPath">
         /// The path we change locations to.
-        ///</param>
+        /// </param>
         internal LocationChangedEventArgs(SessionState sessionState, PathInfo oldPath, PathInfo newPath)
         {
             SessionState = sessionState;

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Location.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Location.Tests.ps1
@@ -164,10 +164,10 @@ Describe "Set-Location" -Tags "CI" {
                 (Get-Variable newPath).Value = $_.newPath
             }
             Set-Location ..
-            $newPath.Path | Should Be $pwd.Path
-            $oldPath.Path | Should Be $initialPath.Path
-            $eventSessionState | Should Be $ExecutionContext.SessionState
-            $eventRunspace | Should Be ([runspace]::DefaultRunspace)
+            $newPath.Path | Should -Be $pwd.Path
+            $oldPath.Path | Should -Be $initialPath.Path
+            $eventSessionState | Should -Be $ExecutionContext.SessionState
+            $eventRunspace | Should -Be ([runspace]::DefaultRunspace)
         }
 
         It 'Errors in the LocationChangedAction should be catchable but not fail the cd' {
@@ -177,7 +177,7 @@ Describe "Set-Location" -Tags "CI" {
             # Verify that the exception occurred
             { Set-Location $location } | Should Throw "Boom"
             # But the location should still have changed
-            $PWD.Path | Should Be $location.Path
+            $PWD.Path | Should -Be $location.Path
         }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Location.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Location.Tests.ps1
@@ -144,4 +144,40 @@ Describe "Set-Location" -Tags "CI" {
             { Set-Location - } | Should -Throw -ErrorId 'System.InvalidOperationException,Microsoft.PowerShell.Commands.SetLocationCommand'
         }
     }
+
+    Context 'Test the LocationChangedAction event handler' {
+
+        AfterEach {
+            $ExecutionContext.InvokeCommand.LocationChangedAction = $null
+        }
+
+        It 'The LocationChangedAction should fire when changing location' {
+            $initialPath = $pwd
+            $oldPath = $null
+            $newPath = $null
+            $eventSessionState = $null
+            $eventRunspace = $null
+            $ExecutionContext.InvokeCommand.LocationChangedAction = {
+                (Get-Variable eventRunspace).Value = $this
+                (Get-Variable eventSessionState).Value = $_.SessionState
+                (Get-Variable oldPath).Value = $_.oldPath
+                (Get-Variable newPath).Value = $_.newPath
+            }
+            Set-Location ..
+            $newPath.Path | Should Be $pwd.Path
+            $oldPath.Path | Should Be $initialPath.Path
+            $eventSessionState | Should Be $ExecutionContext.SessionState
+            $eventRunspace | Should Be ([runspace]::DefaultRunspace)
+        }
+
+        It 'Errors in the LocationChangedAction should be catchable but not fail the cd' {
+            $location = $PWD
+            Set-Location ..
+            $ExecutionContext.InvokeCommand.LocationChangedAction = { throw "Boom" }
+            # Verify that the exception occurred
+            { Set-Location $location } | Should Throw "Boom"
+            # But the location should still have changed
+            $PWD.Path | Should Be $location.Path
+        }
+    }
 }


### PR DESCRIPTION
## PR Summary

Fix for #7551. Implemented a new action `LocationChangedAction ` that fires when the current directory in a runspace is changed.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
