### PR TITLE
Use non virtual call of 'family or assembly' methods of base class.

### DIFF
--- a/src/System.Management.Automation/engine/CoreAdapter.cs
+++ b/src/System.Management.Automation/engine/CoreAdapter.cs
@@ -1230,7 +1230,7 @@ namespace System.Management.Automation
                     var parameterTypes = methodInfo.method.GetParameters().Select(parameter => parameter.ParameterType).ToArray();
                     var targetTypeMethod = invocationConstraints.MethodTargetType.GetMethod(methodInfo.method.Name, BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance, null, parameterTypes, null);
 
-                    if (targetTypeMethod != null && (targetTypeMethod.IsPublic || targetTypeMethod.IsFamily))
+                    if (targetTypeMethod != null && (targetTypeMethod.IsPublic || targetTypeMethod.IsFamily || targetTypeMethod.IsFamilyOrAssembly))
                     {
                         methodInfo = new MethodInformation(targetTypeMethod, 0);
                         callNonVirtually = true;

--- a/test/powershell/Language/Classes/scripting.Classes.inheritance.tests.ps1
+++ b/test/powershell/Language/Classes/scripting.Classes.inheritance.tests.ps1
@@ -219,7 +219,69 @@ Describe 'Classes methods with inheritance' -Tags "CI" {
             [baz]::new().foo() | Should -Be 200600
         }
 
-        It 'allows base class method call and doesn''t fall into recursion' {
+        It 'allows base .NET class method call and doesn''t fall into recursion' {
+            Add-Type -TypeDefinition @'
+                public class BaseMembersTestClass
+                {
+                    public virtual int PublicMethod()
+                    {
+                        return 1001;
+                    }
+
+                    protected virtual int FamilyMethod()
+                    {
+                        return 2002;
+                    }
+
+                    protected internal virtual int FamilyOrAssemblyMethod()
+                    {
+                        return 3003;
+                    }
+                }
+'@
+            $derived = Invoke-Expression @'
+                class BaseCallTestClass : BaseMembersTestClass
+                {
+                    hidden [int] $publicMethodCallCounter
+                    [int] PublicMethod()
+                    {
+                        if ($this.publicMethodCallCounter++ -gt 0)
+                        {
+                            throw "Recursion happens"
+                        }
+                        return 3 * ([BaseMembersTestClass]$this).PublicMethod()
+                    }
+
+                    hidden [int] $familyMethodCallCounter
+                    [int] FamilyMethod()
+                    {
+                        if ($this.familyMethodCallCounter++ -gt 0)
+                        {
+                            throw "Recursion happens"
+                        }
+                        return 3 * ([BaseMembersTestClass]$this).FamilyMethod()
+                    }
+
+                    hidden [int] $familyOrAssemblyMethodCallCounter
+                    [int] FamilyOrAssemblyMethod()
+                    {
+                        if ($this.familyOrAssemblyMethodCallCounter++ -gt 0)
+                        {
+                            throw "Recursion happens"
+                        }
+                        return 3 * ([BaseMembersTestClass]$this).FamilyOrAssemblyMethod()
+                    }
+                }
+
+                [BaseCallTestClass]::new()
+'@
+
+            $derived.PublicMethod() | Should -Be 3003
+            $derived.FamilyMethod() | Should -Be 6006
+            $derived.FamilyOrAssemblyMethod() | Should -Be 9009
+        }
+
+        It 'allows base PowerShell class method call and doesn''t fall into recursion' {
             class bar
             {
                 [int]foo() {return 1001}


### PR DESCRIPTION
## PR Summary

Consider `protected internal` access modifier for non virtual calls of base class overridden methods.
Fix #7622

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link: #7622
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)

@PowerShellTeam, looks like the fix falls into bucket 3 of breaking changes.