### PR TITLE
Allow numeric Ids and name of registered code pages in '-Encoding' parameters

### DIFF
--- a/src/System.Management.Automation/utils/EncodingUtils.cs
+++ b/src/System.Management.Automation/utils/EncodingUtils.cs
@@ -91,15 +91,23 @@ namespace System.Management.Automation
     {
         public override object Transform(EngineIntrinsics engineIntrinsics, object inputData)
         {
-            string encodingName = inputData as String;
-            Encoding foundEncoding;
-            if (encodingName != null && EncodingConversion.encodingMap.TryGetValue(encodingName, out foundEncoding))
+            switch (inputData)
             {
-                return foundEncoding;
+                case string stringName:
+                    if (EncodingConversion.encodingMap.TryGetValue(stringName, out Encoding foundEncoding))
+                    {
+                        return foundEncoding;
+                    }
+                    else
+                    {
+                        return System.Text.Encoding.GetEncoding(stringName);
+                    }
+                case int intName:
+                        return System.Text.Encoding.GetEncoding(intName);
             }
+
             return inputData;
         }
-
     }
 
     /// <summary>

--- a/test/powershell/engine/Basic/Encoding.Tests.ps1
+++ b/test/powershell/engine/Basic/Encoding.Tests.ps1
@@ -79,6 +79,7 @@ Describe "File encoding tests" -Tag CI {
         BeforeAll {
             $testValue = "ф"
             if ($IsWindows) {
+                # Expected bytes: 244 - 'ф', 13  - '`r', 10  - '`n'.
                 $expectedBytes = 244,13,10 -join "-"
             } else {
                 $expectedBytes = 244,10 -join "-"

--- a/test/powershell/engine/Basic/Encoding.Tests.ps1
+++ b/test/powershell/engine/Basic/Encoding.Tests.ps1
@@ -78,7 +78,11 @@ Describe "File encoding tests" -Tag CI {
     Context "Parameter 'Encoding' should accept numeric and string Ids" {
         BeforeAll {
             $testValue = "ф"
-            $expectedBytes = 244,13,10 -join "-"
+            if ($IsWindows) {
+                $expectedBytes = 244,13,10 -join "-"
+            } else {
+                $expectedBytes = 244,10 -join "-"
+            }
         }
 
         It "Parameter 'Encoding' should accept '<encoding>'" -TestCases @(

--- a/test/powershell/engine/Basic/Encoding.Tests.ps1
+++ b/test/powershell/engine/Basic/Encoding.Tests.ps1
@@ -8,11 +8,13 @@ Describe "File encoding tests" -Tag CI {
                 Where-Object { $_.Parameters -and $_.Parameters['Encoding'] } |
                 ForEach-Object { @{ Command = $_ } }
         }
+
         It "Encoding parameter of command '<Command>' is type 'Encoding'" -Testcase $testCases {
             param ( $command )
             $command.Parameters['Encoding'].ParameterType.FullName | Should -BeExactly "System.Text.Encoding"
         }
     }
+
     Context "File contents are UTF8 without BOM" {
         BeforeAll {
             $testStr = "t" + ([char]233) + "st"
@@ -70,6 +72,26 @@ Describe "File encoding tests" -Tag CI {
             $bytes = Get-FileBytes $outputFile
             $Expected = $( $ExpectedWithNewline; $ExpectedWithNewline )
             $bytes -join "-" | should -Be ($Expected -join "-")
+        }
+    }
+
+    Context "Parameter 'Encoding' should accept numeric and string Ids" {
+        BeforeAll {
+            $testValue = "ф"
+            $expectedBytes = 244,13,10 -join "-"
+        }
+
+        It "Parameter 'Encoding' should accept '<encoding>'" -TestCases @(
+            @{ encoding = 1251 }
+            @{ encoding = "windows-1251" }
+        ) {
+            param ( $encoding )
+            $testFile = "${TESTDRIVE}/fileEncoding-$($encoding).txt"
+
+            Set-Content $testFile -Encoding $encoding -Value $testValue
+
+            Get-Content $testFile -Encoding $encoding | Should -BeExactly $testValue
+            (Get-Content $testFile -AsByteStream) -join "-" | Should -BeExactly $expectedBytes
         }
     }
 }


### PR DESCRIPTION
## PR Summary

Address #6581. 

The PR enhance the encoding transformation attribute:
- to allow numeric Ids of registered code pages (like -Encoding 1251)
- to allow string names of registered code pages (like -Encoding "windows-1251")

Full list supported code pages we can found in 
https://github.com/dotnet/corefx/blob/0b0f63d47951773cc46393312d80b40176d3a413/src/System.Text.Encoding.CodePages/src/System/Text/EncodingTable.Data.cs

We haven't encoding test at all so I tested the change locally.
```powershell
Set-Content -Path .\test1.txt -Value "я" -Encoding 1251
Set-Content -Path .\test2.txt -Value "я" -Encoding "windows-1251"
```

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [x] Issue filed - Issue link: https://github.com/PowerShell/PowerShell-Docs/issues/2937
- **Testing - New and feature**
    - [x] Not Applicable or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
