### PR TITLE
Fix perf issue using WSMan provider or Get-PSSessionConfiguration

### DIFF
--- a/src/Microsoft.WSMan.Management/ConfigProvider.cs
+++ b/src/Microsoft.WSMan.Management/ConfigProvider.cs
@@ -30,6 +30,8 @@ namespace Microsoft.WSMan.Management
         //Plugin Name Storage
         private PSObject objPluginNames = null;
 
+        private ServiceController winrmServiceController;
+
         /// <summary>
         /// Determines if Set-Item user input type validation is required or not.
         /// It is True by default, Clear-Item will set it to false so that it can
@@ -4436,15 +4438,16 @@ namespace Microsoft.WSMan.Management
         /// <returns></returns>
         private bool IsWSManServiceRunning()
         {
-            ServiceController svc = new ServiceController("WinRM");
-            if (svc != null)
+            if (winrmServiceController == null)
             {
-                if (svc.Status.Equals(ServiceControllerStatus.Running))
-                {
-                    return true;
-                }
+                winrmServiceController = new ServiceController("WinRM");
             }
-            return false;
+            else
+            {
+                winrmServiceController.Refresh();
+            }
+
+            return (winrmServiceController.Status.Equals(ServiceControllerStatus.Running));
         }
 
         /// <summary>


### PR DESCRIPTION
## PR Summary

.NET Core introduced a perf regression during instantiation of ServiceController which is used by the WSMan Config Provider to check if WinRM is running as it depends on WinRM to get configuration information.

Instead of creating new instance of ServiceController every time we need to check WinRM service status.  We can create it just once and use the `Refresh()` method on the instance to get latest status information.  This brings the perf back to comparable to Windows PowerShell.

Prior to this change, Windows PowerShell calling `Get-PSSessionConfiguration` took ~3 secs and PSCore6.1 took ~14 secs.  After this change, PSCore6.1 took ~4 secs.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [x] Not Applicable or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
