### PR TITLE
Support calling method with ByRef-like type parameters

### DIFF
--- a/src/System.Management.Automation/engine/LanguagePrimitives.cs
+++ b/src/System.Management.Automation/engine/LanguagePrimitives.cs
@@ -1410,6 +1410,7 @@ namespace System.Management.Automation
         #region type converter
 
         internal static PSTraceSource typeConversion = PSTraceSource.GetTracer("TypeConversion", "Traces the type conversion algorithm", false);
+        internal static ConversionData<object> NoConversion = new ConversionData<object>(ConvertNoConversion, ConversionRank.None);
 
         private static TypeConverter GetIntegerSystemConverter(Type type)
         {

--- a/src/System.Management.Automation/engine/parser/PSType.cs
+++ b/src/System.Management.Automation/engine/parser/PSType.cs
@@ -70,7 +70,17 @@ namespace System.Management.Automation.Language
             bool expandParamsOnBest;
             bool callNonVirtually;
             var positionalArgCount = positionalArgs.Length;
-            var bestMethod = Adapter.FindBestMethod(newConstructors, null, positionalArgs, ref errorId, ref errorMsg, out expandParamsOnBest, out callNonVirtually);
+
+            var bestMethod = Adapter.FindBestMethod(
+                newConstructors,
+                invocationConstraints: null,
+                allowCastingToByRefLikeType: false,
+                positionalArgs,
+                ref errorId,
+                ref errorMsg,
+                out expandParamsOnBest,
+                out callNonVirtually);
+
             if (bestMethod == null)
             {
                 parser.ReportError(new ParseError(attributeAst.Extent, errorId,

--- a/test/powershell/Language/Interop/DotNet/DotNetInterop.Tests.ps1
+++ b/test/powershell/Language/Interop/DotNet/DotNetInterop.Tests.ps1
@@ -6,6 +6,7 @@ Describe "Handle ByRef-like types gracefully" -Tags "CI" {
     BeforeAll {
         $code = @'
 using System;
+using System.Management.Automation;
 namespace DotNetInterop
 {
     public class Test
@@ -32,14 +33,57 @@ namespace DotNetInterop
         {
         }
 
-        public string PrintMySpan(string str, Span<int> mySpan = default)
+        public string PrintMySpan(string str, ReadOnlySpan<char> mySpan = default)
         {
-            return str;
+            if (mySpan.Length == 0)
+            {
+                return str;
+            }
+            else
+            {
+                return str + mySpan.Length;
+            }
         }
-    
+
         public Span<int> GetSpan(int[] array)
         {
             return array.AsSpan();
+        }
+    }
+
+    public class Test2
+    {
+        public Test2(ReadOnlySpan<char> span)
+        {
+            name = $"Number of chars: {span.Length}";
+        }
+
+        public Test2() {}
+
+        private string name = "Hello World";
+        public string this[ReadOnlySpan<char> span]
+        {
+            get { return name; }
+            set { name = value; }
+        }
+
+        public string Name => name;
+    }
+
+    public class CodeMethods
+    {
+        public static ReadOnlySpan<char> GetProperty(PSObject instance)
+        {
+            return default(ReadOnlySpan<char>);
+        }
+
+        public static void SetProperty(PSObject instance, ReadOnlySpan<char> span)
+        {
+        }
+
+        public static string RunMethod(PSObject instance, string str, ReadOnlySpan<char> span)
+        {
+            return str + span.Length;
         }
     }
 
@@ -56,6 +100,7 @@ namespace DotNetInterop
         }
 
         $testObj = [DotNetInterop.Test]::new()
+        $test2Obj = [DotNetInterop.Test2]::new()
     }
 
     It "New-Object should fail gracefully when used for a ByRef-like type" {
@@ -180,7 +225,95 @@ namespace DotNetInterop
         }
     }
 
-    It "Set access of an indexer that accepts ByRef-like type should fail gracefully" {
-        { $testObj[1] = 1 } | Should -Throw -ErrorId "InvalidCastToByRefLikeType"
+    It "Set access of an indexer that accepts ByRef-like type value should fail gracefully" {
+        { $testObj[1] = 1 } | Should -Throw -ErrorId "CannotIndexWithByRefLikeReturnType"
+    }
+
+    Context "Passing value that is implicitly/explicitly castable to ByRef-like parameter in method invocation" {
+        
+        BeforeAll {
+            $typeXml = @'
+<Types>
+    <Type>
+        <Name>DotNetInterop.Test2</Name>
+        <Members>
+            <CodeMethod>
+                <Name>RunTest</Name>
+                <CodeReference>
+                    <TypeName>DotNetInterop.CodeMethods</TypeName>
+                    <MethodName>RunMethod</MethodName>
+                </CodeReference>
+            </CodeMethod>
+            <CodeProperty>
+                <Name>TestName</Name>
+                <GetCodeReference>
+                    <TypeName>DotNetInterop.CodeMethods</TypeName>
+                    <MethodName>GetProperty</MethodName>
+                </GetCodeReference>
+                <SetCodeReference>
+                    <TypeName>DotNetInterop.CodeMethods</TypeName>
+                    <MethodName>SetProperty</MethodName>
+                </SetCodeReference>
+            </CodeProperty>
+        </Members>
+    </Type>
+</Types>
+'@
+            $typeXmlFile = Join-Path -Path $TestDrive -ChildPath "TestType.ps1xml"
+            Set-Content -Path $typeXmlFile -Value $typeXml -Encoding Ascii
+            $ps = [powershell]::Create()
+            $ps.AddCommand("Update-TypeData").AddParameter("AppendPath", $typeXmlFile).Invoke()
+            $ps.Commands.Clear()
+            $ps.AddScript('$test = [DotNetInterop.Test2]::new()').Invoke()
+            $ps.Commands.Clear()
+        }
+
+        AfterAll {
+            $ps.Dispose()
+        }
+
+        It "Support method calls with ByRef-like parameter as long as the argument can be casted to the ByRef-like type" {
+            $testObj.PrintMySpan("abc", "def") | Should -BeExactly "abc3"
+            $testObj.PrintMySpan("abc", "Hello".ToCharArray()) | Should -BeExactly "abc5"
+            { $testObj.PrintMySpan("abc", 12) } | Should -Throw -ErrorId "MethodArgumentConversionInvalidCastArgument"
+
+            $path = [System.IO.Path]::GetTempPath()
+            [System.IO.Path]::IsPathRooted($path.ToCharArray()) | Should -Be $true
+        }
+
+        It "Support constructor calls with ByRef-like parameter as long as the argument can be casted to the ByRef-like type" {
+            $result = [DotNetInterop.Test2]::new("abc")
+            $result.Name | Should -BeExactly "Number of chars: 3"
+
+            { [DotNetInterop.Test2]::new(12) } | Should -Throw -ErrorId "MethodCountCouldNotFindBest"
+        }
+
+        It "Support indexing operation with ByRef-like index as long as the argument can be casted to the ByRef-like type" {
+            $test2Obj["abc"] | Should -BeExactly "Hello World"
+            $test2Obj["abc"] = "pwsh"
+            $test2Obj["abc"] | Should -BeExactly "pwsh"
+        }
+
+        It "Support CodeMethod with ByRef-like parameter as long as the argument can be casted to the ByRef-like type" {
+            $result = $ps.AddScript('$test.RunTest("Hello", "World".ToCharArray())').Invoke()
+            $ps.Commands.Clear()
+            $result.Count | Should -Be 1
+            $result[0] | Should -Be 'Hello5'
+        }
+
+        It "Return null for getter access of a CodeProperty that returns a ByRef-like type, even in strict mode" {
+            $result = $ps.AddScript(
+                'try { Set-StrictMode -Version latest; $test.TestName } finally { Set-StrictMode -Off }').Invoke()
+            $ps.Commands.Clear()
+            $result.Count | Should -Be 1
+            $result[0] | Should -Be $null
+        }
+
+        It "Fail gracefully for setter access of a CodeProperty that returns a ByRef-like type" {
+            $result = $ps.AddScript('$test.TestName = "Hello"').Invoke()
+            $ps.Commands.Clear()
+            $result.Count | Should -Be 0
+            $ps.Streams.Error[0].FullyQualifiedErrorId | Should -Be "CannotAccessByRefLikePropertyOrField"
+        }
     }
 }

--- a/test/powershell/Language/Interop/DotNet/DotNetInterop.Tests.ps1
+++ b/test/powershell/Language/Interop/DotNet/DotNetInterop.Tests.ps1
@@ -232,38 +232,25 @@ namespace DotNetInterop
     Context "Passing value that is implicitly/explicitly castable to ByRef-like parameter in method invocation" {
         
         BeforeAll {
-            $typeXml = @'
-<Types>
-    <Type>
-        <Name>DotNetInterop.Test2</Name>
-        <Members>
-            <CodeMethod>
-                <Name>RunTest</Name>
-                <CodeReference>
-                    <TypeName>DotNetInterop.CodeMethods</TypeName>
-                    <MethodName>RunMethod</MethodName>
-                </CodeReference>
-            </CodeMethod>
-            <CodeProperty>
-                <Name>TestName</Name>
-                <GetCodeReference>
-                    <TypeName>DotNetInterop.CodeMethods</TypeName>
-                    <MethodName>GetProperty</MethodName>
-                </GetCodeReference>
-                <SetCodeReference>
-                    <TypeName>DotNetInterop.CodeMethods</TypeName>
-                    <MethodName>SetProperty</MethodName>
-                </SetCodeReference>
-            </CodeProperty>
-        </Members>
-    </Type>
-</Types>
-'@
-            $typeXmlFile = Join-Path -Path $TestDrive -ChildPath "TestType.ps1xml"
-            Set-Content -Path $typeXmlFile -Value $typeXml -Encoding Ascii
             $ps = [powershell]::Create()
-            $ps.AddCommand("Update-TypeData").AddParameter("AppendPath", $typeXmlFile).Invoke()
+
+            # Define the CodeMethod 'RunTest'
+            $ps.AddCommand("Update-TypeData").
+                AddParameter("TypeName", "DotNetInterop.Test2").
+                AddParameter("MemberType", "CodeMethod").
+                AddParameter("MemberName", "RunTest").
+                AddParameter("Value", [DotNetInterop.CodeMethods].GetMethod('RunMethod')).Invoke()
             $ps.Commands.Clear()
+
+            # Define the CodeProperty 'TestName'
+            $ps.AddCommand("Update-TypeData").
+                AddParameter("TypeName", "DotNetInterop.Test2").
+                AddParameter("MemberType", "CodeProperty").
+                AddParameter("MemberName", "TestName").
+                AddParameter("Value", [DotNetInterop.CodeMethods].GetMethod('GetProperty')).
+                AddParameter("SecondValue", [DotNetInterop.CodeMethods].GetMethod('SetProperty')).Invoke()
+            $ps.Commands.Clear()
+
             $ps.AddScript('$test = [DotNetInterop.Test2]::new()').Invoke()
             $ps.Commands.Clear()
         }


### PR DESCRIPTION
## PR Summary

Fix #7596

Support calling methods with ByRef-like type parameters in PowerShell, as long as the argument specified for the parameter can be implicitly/explicitly converted to the ByRef-like type.

We cannot create an instance of a ByRef-like type in PowerShell, but there are types that can be implicitly or explicitly converted to ByRef-like types, such as `T[] -> Span<T>`, `T[] -> ReadOnlySpan<T>`, `String -> ReadOnlySpan<T>`. `ArraySegment<T> -> Span<T>`, `ArraySegment<T> -> ReadOnlySpan<T>`. With changes in this PR, we can call methods with ByRef-like parameter types by providing the arguments of the types that can be casted to the target ByRef-like type. For example:

```
PS:5> $charArray = "F:\".ToCharArray()
PS:6> [System.IO.Path]::IsPathRooted($charArray)
True
```

**What is enabled?**
1. Invoking methods that have ByRef-like parameters, but the return type is not ByRef-like.
2. Invoking constructors with ByRef-like parameters via `[target-type]::new` syntax, but the `target-type` is not ByRef-like.
2. Accessing indexers that have ByRef-like parameters, but the return type is not ByRef-like.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [x] Issue filed - Issue link:
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [x] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
