### PR TITLE
Updating ModulePath.Tests for fxdependent package

### DIFF
--- a/test/powershell/engine/Module/ModulePath.Tests.ps1
+++ b/test/powershell/engine/Module/ModulePath.Tests.ps1
@@ -24,15 +24,8 @@ Describe "SxS Module Path Basic Tests" -tags "CI" {
         $expectedSystemPath = Join-Path -Path $PSHOME -ChildPath 'Modules'
 
         # Skip these tests in cases when there is no 'pwsh' executable (e.g. when framework dependent PS package is used)
-        if ( -not (Test-Path $powershell))
-        {
-            $skipNoPwsh = $true
-        }
-        else
-        {
-            $skipNoPwsh = $false
-        }
-
+        $skipNoPwsh = -not (Test-Path $powershell)
+        
         if ($IsWindows)
         {
             $expectedWindowsPowerShellPSHomePath = Join-Path $env:windir "System32" "WindowsPowerShell" "v1.0" "Modules"

--- a/test/powershell/engine/Module/ModulePath.Tests.ps1
+++ b/test/powershell/engine/Module/ModulePath.Tests.ps1
@@ -23,6 +23,16 @@ Describe "SxS Module Path Basic Tests" -tags "CI" {
         }
         $expectedSystemPath = Join-Path -Path $PSHOME -ChildPath 'Modules'
 
+        # Skip these tests in cases when there is no 'pwsh' executable (e.g. when framework dependent PS package is used)
+        if ( -not (Test-Path $powershell))
+        {
+            $skipNoPwsh = $true
+        }
+        else
+        {
+            $skipNoPwsh = $false
+        }
+
         if ($IsWindows)
         {
             $expectedWindowsPowerShellPSHomePath = Join-Path $env:windir "System32" "WindowsPowerShell" "v1.0" "Modules"
@@ -46,7 +56,7 @@ Describe "SxS Module Path Basic Tests" -tags "CI" {
         $env:PSModulePath = $originalModulePath
     }
 
-    It "validate sxs module path" {
+    It "validate sxs module path" -Skip:$skipNoPwsh {
 
         $env:PSModulePath = ""
         $defaultModulePath = & $powershell -nopro -c '$env:PSModulePath'
@@ -71,7 +81,7 @@ Describe "SxS Module Path Basic Tests" -tags "CI" {
         }
     }
 
-    It "ignore pshome module path derived from a different powershell core instance" -Skip:(!$IsCoreCLR) {
+    It "ignore pshome module path derived from a different powershell core instance" -Skip:(!$IsCoreCLR -or $skipNoPwsh) {
 
         ## Create 'powershell' and 'pwsh.deps.json' in the fake PSHome folder,
         ## so that the module path calculation logic would believe it's real.
@@ -110,7 +120,7 @@ Describe "SxS Module Path Basic Tests" -tags "CI" {
         }
     }
 
-    It "keep non-pshome module path derived from powershell core instance parent" -Skip:(!$IsCoreCLR) {
+    It "keep non-pshome module path derived from powershell core instance parent" -Skip:(!$IsCoreCLR -or $skipNoPwsh) {
 
         ## non-pshome module path derived from another powershell core instance should be preserved
         $customeModules = Join-Path -Path $TestDrive -ChildPath 'CustomModules'
@@ -130,7 +140,7 @@ Describe "SxS Module Path Basic Tests" -tags "CI" {
         $paths -contains $customeModules | Should -BeTrue
     }
 
-    It 'Ensures $PSHOME\Modules is inserted correctly when launched from a different version of PowerShell' -Skip:(!($IsCoreCLR -and $IsWindows)) {
+    It 'Ensures $PSHOME\Modules is inserted correctly when launched from a different version of PowerShell' -Skip:(!($IsCoreCLR -and $IsWindows) -or $skipNoPwsh) {
         # When launched from a different version of PowerShell, PSModulePath contains the other version's PSHOME\Modules path
         # and the Windows PowerShell modoule path. THe other version's module path should be removed and this version's
         # PSHOME\Modules path should be inserted before Windows PowerShell module path.


### PR DESCRIPTION
## PR Summary

It turns out that some tests rely on having 'pwsh' executable for starting powershell.
This is not the case when framework dependent 'fxdependent' package is used (in which case PS is started by command like `dotnet /opt/microsoft/powershell/pwsh.dll`.

Specifically ModulePath.Tests are used in package validation before every PS release and failures in them block testing fxdependent package that we are adding.

The fix is to skip failing tests that rely on 'pwsh' executable in testing fxdependent package.
A better fix would be to add a generic test utility function that returns proper PS starting command based on environment where Pester runs. But since current failures are blocking package validation, we can add this utility function later (I'll open an test issue to track this).

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [X] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [X] Not Applicable or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
