### PR TITLE
Fix .NET adapter to not throw when fails to create a PSMethod due to ByRef-like type

### DIFF
--- a/src/System.Management.Automation/engine/MshMemberInfo.cs
+++ b/src/System.Management.Automation/engine/MshMemberInfo.cs
@@ -2691,18 +2691,18 @@ namespace System.Management.Automation
                 return typeof(Func<PSNonBindableType>);
             }
 
-            var methodTypes = new Type[parameterInfos.Length + 1];
-            for (int i = 0; i < parameterInfos.Length; i++)
-            {
-                var parameterInfo = parameterInfos[i];
-                Type parameterType = parameterInfo.ParameterType;
-                methodTypes[i] = GetPSMethodProjectedType(parameterType, parameterInfo.IsOut);
-            }
-
-            methodTypes[parameterInfos.Length] = GetPSMethodProjectedType(methodInfo.ReturnType);
-
             try
             {
+                var methodTypes = new Type[parameterInfos.Length + 1];
+                for (int i = 0; i < parameterInfos.Length; i++)
+                {
+                    var parameterInfo = parameterInfos[i];
+                    Type parameterType = parameterInfo.ParameterType;
+                    methodTypes[i] = GetPSMethodProjectedType(parameterType, parameterInfo.IsOut);
+                }
+
+                methodTypes[parameterInfos.Length] = GetPSMethodProjectedType(methodInfo.ReturnType);
+
                 return DelegateHelpers.MakeDelegate(methodTypes);
             }
             catch (TypeLoadException)

--- a/test/powershell/Language/Interop/DotNet/DotNetInterop.Tests.ps1
+++ b/test/powershell/Language/Interop/DotNet/DotNetInterop.Tests.ps1
@@ -92,6 +92,13 @@ namespace DotNetInterop
         public MyByRefLikeType(int i) { }
         public static int Index;
     }
+
+    public class ExampleProblemClass
+    {
+        public void ProblemMethod(ref MyByRefLikeType value)
+        {
+        }
+    }
 }
 '@
         if (-not ("DotNetInterop.Test" -as [type]))
@@ -227,6 +234,11 @@ namespace DotNetInterop
 
     It "Set access of an indexer that accepts ByRef-like type value should fail gracefully" {
         { $testObj[1] = 1 } | Should -Throw -ErrorId "CannotIndexWithByRefLikeReturnType"
+    }
+
+    It "Create instance of type with method that use a ByRef-like type as a ByRef parameter" {
+        $obj = [DotNetInterop.ExampleProblemClass]::new()
+        $obj | Should -BeOfType DotNetInterop.ExampleProblemClass
     }
 
     Context "Passing value that is implicitly/explicitly castable to ByRef-like parameter in method invocation" {


### PR DESCRIPTION
## PR Summary

Fix #7786 

When embedding signatures of the overload methods into a `PSMethod`, we don't handle ByRef-like types -- overload methods with ByRef-like type parameters will be marked as 'NonBindable' and get ignored in the conversion from `PSMethod` to `Delegate`. This PR fix a bug that causes exception to be thrown when dealing with a ByRef-like type being used by a `ref` or `out` parameter.

/cc @SeeminglyScience

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [x] Issue filed - Issue link:
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
