### PR TITLE
Fix .NET adapter to be able to get members from System.IntPtr

### DIFF
--- a/src/System.Management.Automation/engine/MshMemberInfo.cs
+++ b/src/System.Management.Automation/engine/MshMemberInfo.cs
@@ -2757,13 +2757,14 @@ namespace System.Management.Automation
 
             if (type.IsByRef)
             {
-                var elementType = type.GetElementType();
+                var elementType = GetPSMethodProjectedType(type.GetElementType());
                 type = isOut ? typeof(PSOutParameter<>).MakeGenericType(elementType)
                              : typeof(PSReference<>).MakeGenericType(elementType);
             }
             else if (type.IsPointer)
             {
-                type = typeof(PSPointer<>).MakeGenericType(type.GetElementType());
+                var elementType = GetPSMethodProjectedType(type.GetElementType());
+                type = typeof(PSPointer<>).MakeGenericType(elementType);
             }
 
             return type;

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Member.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Member.Tests.ps1
@@ -40,6 +40,13 @@ Describe "Get-Member" -Tags "CI" {
 
 	Get-Member -InputObject $o | Should -Not -BeNullOrEmpty
     }
+
+    It "Should be able to be called on IntPtr" {
+        $results = [System.IntPtr] | Get-Member -Type Property -Static | Sort-Object -Property Name
+        $results.Count | Should -BeExactly 2
+        $results[0].Name | Should -BeExactly 'Size'
+        $results[1].Name | Should -BeExactly 'Zero'
+    }
 }
 
 Describe "Get-Member DRT Unit Tests" -Tags "CI" {


### PR DESCRIPTION
## PR Summary

Fix .NET adapter to be able to get members from `System.IntPtr`.
The type `System.IntPtr` has an explicit cast operator defined that takes a pointer type `System.void*` parameter. We didn't handle that type properly in `GetPSMethodProjectedType`.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
