### PR TITLE
Fix typo in -icontains description as "incase sensitive"

### DIFF
--- a/src/System.Management.Automation/resources/TabCompletionStrings.resx
+++ b/src/System.Management.Automation/resources/TabCompletionStrings.resx
@@ -232,7 +232,7 @@
     <value>Containment operator - case insensitive. Returns TRUE when the test value (right operand) exactly matches at least one of the values in the left operand.</value>
   </data>
   <data name="icontainsOperatorDescription" xml:space="preserve">
-    <value>Containment operator - incase sensitive. Returns TRUE when the test value (right operand) exactly matches at least one of the values in the left operand.</value>
+    <value>Containment operator - case insensitive. Returns TRUE when the test value (right operand) exactly matches at least one of the values in the left operand.</value>
   </data>
   <data name="ccontainsOperatorDescription" xml:space="preserve">
     <value>Containment operator - case sensitive. Returns TRUE only when the test value (right operand) exactly matches at least one of the values in the left operand.</value>


### PR DESCRIPTION
should be "case insensitive".

## PR Summary

Corrects a typographical error in the `-icontains` tooltip/resx

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed] (its a fix to a documentation component) (https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
