### PR TITLE
Ensure NestedModules property gets populated by Test-ModuleManifest

### DIFF
--- a/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
@@ -2797,6 +2797,20 @@ namespace Microsoft.PowerShell.Commands
 
                 if (!needToAnalyzeScriptModules)
                 {
+                    // need to add nested modules to the manifestInfo when no more analysis needs to be done
+                    PSModuleInfo fakeNestedModuleInfo = null;
+                    foreach (ModuleSpecification nestedModule in nestedModules)
+                    {
+                        fakeNestedModuleInfo = new PSModuleInfo(nestedModule.Name, Context, null);
+                        if (nestedModule.Guid.HasValue)
+                        {
+                            fakeNestedModuleInfo.SetGuid(nestedModule.Guid.Value);
+                        }
+                        fakeNestedModuleInfo.SetVersion(nestedModule.RequiredVersion ?? nestedModule.Version);
+
+                        manifestInfo.AddNestedModule(fakeNestedModuleInfo);
+                    }
+
                     return manifestInfo;
                 }
             }

--- a/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
@@ -1339,7 +1339,7 @@ namespace Microsoft.PowerShell.Commands
         }
 
         /// <summary>
-        /// Helper function to generate fake PSModuleInfo objects from ModuleSpecification objects
+        /// Helper function to generate fake PSModuleInfo objects from ModuleSpecification objects.
         /// </summary>
         /// <param name="moduleSpecs">Collection of ModuleSpecification objects</param>
         /// <returns>Collection of fake PSModuleInfo objects</returns>

--- a/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
@@ -1338,6 +1338,25 @@ namespace Microsoft.PowerShell.Commands
             return true;
         }
 
+        /// <summary>
+        /// Helper function to generate fake PSModuleInfo objects from ModuleSpecification objects
+        /// </summary>
+        /// <param name="moduleSpecs">Collection of ModuleSpecification objects</param>
+        /// <returns>Collection of fake PSModuleInfo objects</returns>
+        private IEnumerable<PSModuleInfo> CreateFakeModuleObject(IEnumerable<ModuleSpecification> moduleSpecs)
+        {
+            foreach (ModuleSpecification moduleSpec in moduleSpecs)
+            {
+                var fakeModuleInfo = new PSModuleInfo(moduleSpec.Name, Context, null);
+                if (moduleSpec.Guid.HasValue)
+                {
+                    fakeModuleInfo.SetGuid(moduleSpec.Guid.Value);
+                }
+                fakeModuleInfo.SetVersion(moduleSpec.RequiredVersion ?? moduleSpec.Version);
+                yield return fakeModuleInfo;
+            }
+        }
+
         private ErrorRecord GetErrorRecordIfUnsupportedRootCdxmlAndNestedModuleScenario(
             Hashtable data,
             string moduleManifestPath,
@@ -1977,16 +1996,8 @@ namespace Microsoft.PowerShell.Commands
                 }
                 else
                 {
-                    PSModuleInfo fakeRequiredModuleInfo = null;
-                    foreach (ModuleSpecification requiredModule in requiredModules)
+                    foreach (PSModuleInfo fakeRequiredModuleInfo in CreateFakeModuleObject(requiredModules))
                     {
-                        fakeRequiredModuleInfo = new PSModuleInfo(requiredModule.Name, Context, null);
-                        if (requiredModule.Guid.HasValue)
-                        {
-                            fakeRequiredModuleInfo.SetGuid(requiredModule.Guid.Value);
-                        }
-                        fakeRequiredModuleInfo.SetVersion(requiredModule.RequiredVersion ?? requiredModule.Version);
-
                         requiredModulesSpecifiedInModuleManifest.Add(fakeRequiredModuleInfo);
                     }
                 }
@@ -2798,16 +2809,8 @@ namespace Microsoft.PowerShell.Commands
                 if (!needToAnalyzeScriptModules)
                 {
                     // Add nested modules to the manifestInfo when no more analysis needs to be done
-                    PSModuleInfo fakeNestedModuleInfo = null;
-                    foreach (ModuleSpecification nestedModule in nestedModules)
+                    foreach (PSModuleInfo fakeNestedModuleInfo in CreateFakeModuleObject(nestedModules))
                     {
-                        fakeNestedModuleInfo = new PSModuleInfo(nestedModule.Name, Context, null);
-                        if (nestedModule.Guid.HasValue)
-                        {
-                            fakeNestedModuleInfo.SetGuid(nestedModule.Guid.Value);
-                        }
-                        fakeNestedModuleInfo.SetVersion(nestedModule.RequiredVersion ?? nestedModule.Version);
-
                         manifestInfo.AddNestedModule(fakeNestedModuleInfo);
                     }
 

--- a/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleCmdletBase.cs
@@ -2797,7 +2797,7 @@ namespace Microsoft.PowerShell.Commands
 
                 if (!needToAnalyzeScriptModules)
                 {
-                    // need to add nested modules to the manifestInfo when no more analysis needs to be done
+                    // Add nested modules to the manifestInfo when no more analysis needs to be done
                     PSModuleInfo fakeNestedModuleInfo = null;
                     foreach (ModuleSpecification nestedModule in nestedModules)
                     {
@@ -3442,6 +3442,7 @@ namespace Microsoft.PowerShell.Commands
                                     updated.Add(element);
                                 }
                             }
+
                             ss.Internal.ExportedVariables.Clear();
                             ss.Internal.ExportedVariables.AddRange(updated);
                         }

--- a/test/powershell/engine/Module/TestModuleManifest.Tests.ps1
+++ b/test/powershell/engine/Module/TestModuleManifest.Tests.ps1
@@ -4,7 +4,7 @@ Describe "Test-ModuleManifest tests" -tags "CI" {
 
     BeforeEach {
         $testModulePath = "testdrive:/module/test.psd1"
-        New-Item -ItemType Directory -Path testdrive:/module
+        New-Item -ItemType Directory -Path testdrive:/module > $null
     }
 
     AfterEach {
@@ -13,10 +13,10 @@ Describe "Test-ModuleManifest tests" -tags "CI" {
 
     It "module manifest containing paths with backslashes or forwardslashes are resolved correctly" {
 
-        New-Item -ItemType Directory -Path testdrive:/module/foo
-        New-Item -ItemType Directory -Path testdrive:/module/bar
-        New-Item -ItemType File -Path testdrive:/module/foo/bar.psm1
-        New-Item -ItemType File -Path testdrive:/module/bar/foo.psm1
+        New-Item -ItemType Directory -Path testdrive:/module/foo > $null
+        New-Item -ItemType Directory -Path testdrive:/module/bar > $null
+        New-Item -ItemType File -Path testdrive:/module/foo/bar.psm1 > $null
+        New-Item -ItemType File -Path testdrive:/module/bar/foo.psm1 > $null
         $testModulePath = "testdrive:/module/test.psd1"
         $fileList = "foo\bar.psm1","bar/foo.psm1"
 
@@ -42,8 +42,8 @@ Describe "Test-ModuleManifest tests" -tags "CI" {
 
         param ($parameter, $error)
 
-        New-Item -ItemType Directory -Path testdrive:/module/foo
-        New-Item -ItemType File -Path testdrive:/module/foo/bar.psm1
+        New-Item -ItemType Directory -Path testdrive:/module/foo > $null
+        New-Item -ItemType File -Path testdrive:/module/foo/bar.psm1 > $null
 
         $args = @{$parameter = "doesnotexist.psm1"}
         New-ModuleManifest -Path $testModulePath @args
@@ -59,7 +59,7 @@ Describe "Test-ModuleManifest tests" -tags "CI" {
 
         param($rootModuleValue)
 
-        New-Item -ItemType File -Path testdrive:/module/$rootModuleValue
+        New-Item -ItemType File -Path testdrive:/module/$rootModuleValue > $null
         New-ModuleManifest -Path $testModulePath -RootModule $rootModuleValue
         $moduleManifest = Test-ModuleManifest -Path $testModulePath -ErrorAction Stop
         $moduleManifest | Should -BeOfType System.Management.Automation.PSModuleInfo
@@ -73,7 +73,7 @@ Describe "Test-ModuleManifest tests" -tags "CI" {
 
         param($rootModuleValue, $error)
 
-        New-Item -ItemType File -Path testdrive:/module/$rootModuleValue
+        New-Item -ItemType File -Path testdrive:/module/$rootModuleValue > $null
         New-ModuleManifest -Path $testModulePath -RootModule $rootModuleValue
         { Test-ModuleManifest -Path $testModulePath -ErrorAction Stop } | Should -Throw -ErrorId "$error,Microsoft.PowerShell.Commands.TestModuleManifestCommand"
     }
@@ -97,7 +97,7 @@ Describe "Test-ModuleManifest tests" -tags "CI" {
 
         param($rootModuleValue, $error)
 
-        New-Item -ItemType File -Path testdrive:/module/$rootModuleValue
+        New-Item -ItemType File -Path testdrive:/module/$rootModuleValue > $null
 
         New-ModuleManifest -Path $testModulePath -RootModule $rootModuleValue
         { Test-ModuleManifest -Path $testModulePath -ErrorAction Stop } | Should -Throw -ErrorId "$error,Microsoft.PowerShell.Commands.TestModuleManifestCommand"
@@ -120,7 +120,7 @@ Describe "Test-ModuleManifest tests" -tags "CI" {
 
         param($exportValue)
 
-        New-Item -ItemType File -Path testdrive:/module/Foo.psm1
+        New-Item -ItemType File -Path testdrive:/module/Foo.psm1 > $null
         New-ModuleManifest -Path $testModulePath -NestedModules "Foo.psm1" -FunctionsToExport $exportValue -CmdletsToExport $exportValue -VariablesToExport $exportValue -AliasesToExport $exportValue
         $module = Test-ModuleManifest -Path $testModulePath
         $module.NestedModules | Should -HaveCount 1
@@ -176,7 +176,7 @@ Describe "Tests for circular references in required modules" -tags "CI" {
     function TestImportModule([bool]$AddVersion, [bool]$AddGuid, [bool]$AddCircularReference)
     {
         $moduleRootPath = Join-Path $TestDrive 'TestModules'
-        New-Item $moduleRootPath -ItemType Directory -Force
+        New-Item $moduleRootPath -ItemType Directory -Force > $null
         Push-Location $moduleRootPath
 
         $moduleCount = 6 # this depth was enough to find a bug in cyclic reference detection product code; greater depth will slow tests down

--- a/test/powershell/engine/Module/UpdateModuleManifest.Tests.ps1
+++ b/test/powershell/engine/Module/UpdateModuleManifest.Tests.ps1
@@ -5,7 +5,7 @@ Describe "Update-ModuleManifest tests" -tags "CI" {
 
     BeforeEach {
         $testModulePath = "testdrive:/module/test.psd1"
-        New-Item -ItemType Directory -Path testdrive:/module
+        New-Item -ItemType Directory -Path testdrive:/module > $null
     }
 
     AfterEach {
@@ -18,7 +18,7 @@ Describe "Update-ModuleManifest tests" -tags "CI" {
     ) {
         param($exportValue)
 
-        New-Item -ItemType File -Path testdrive:/module/foo.psm1
+        New-Item -ItemType File -Path testdrive:/module/foo.psm1 > $null
         New-ModuleManifest -Path $testModulePath -NestedModules foo.psm1 -HelpInfoUri http://foo.com -AliasesToExport $exportValue -CmdletsToExport $exportValue -FunctionsToExport $exportValue -VariablesToExport $exportValue -DscResourcesToExport $exportValue
         $module = Test-ModuleManifest -Path $testModulePath
         $module.HelpInfoUri | Should -BeExactly "http://foo.com/"

--- a/test/powershell/engine/Module/UpdateModuleManifest.Tests.ps1
+++ b/test/powershell/engine/Module/UpdateModuleManifest.Tests.ps1
@@ -1,0 +1,33 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+Describe "Update-ModuleManifest tests" -tags "CI" {
+
+    BeforeEach {
+        $testModulePath = "testdrive:/module/test.psd1"
+        New-Item -ItemType Directory -Path testdrive:/module
+    }
+
+    AfterEach {
+        Remove-Item -Recurse -Force -ErrorAction SilentlyContinue testdrive:/module
+    }
+
+    It "Update should not clear out NestedModules: <variation>" -TestCases @(
+        @{ variation = "export with wildcards"; exportValue = "*" },
+        @{ variation = "export without wildcards"; exportValue = "@()"}
+    ) {
+        param($exportValue)
+
+        New-Item -ItemType File -Path testdrive:/module/foo.psm1
+        New-ModuleManifest -Path $testModulePath -NestedModules foo.psm1 -HelpInfoUri http://foo.com -AliasesToExport $exportValue -CmdletsToExport $exportValue -FunctionsToExport $exportValue -VariablesToExport $exportValue -DscResourcesToExport $exportValue
+        $module = Test-ModuleManifest -Path $testModulePath
+        $module.HelpInfoUri | Should -BeExactly "http://foo.com/"
+        $module.NestedModules | Should -HaveCount 1
+        $module.NestedModules.Name | Should -BeExactly foo
+        Update-ModuleManifest -Path $testModulePath -HelpInfoUri https://bar.org
+        $module = Test-ModuleManifest -Path $testModulePath
+        $module.HelpInfoUri | Should -BeExactly "https://bar.org/"
+        $module.NestedModules | Should -HaveCount 1
+        $module.NestedModules.Name | Should -BeExactly foo
+    }
+}


### PR DESCRIPTION
## PR Summary

This is a regression introduced by https://github.com/PowerShell/PowerShell/pull/7145 as an optimization where no further analysis of the module is done if none of the exported capabilities have a wildcard.  However, the NestedModules property hasn't been populated yet, so it remains empty.  This is a regression as previously this property is always populated if the manifest contains a value.

Fix is to create PSModuleInfo entries for each specified NestedModule even though we don't do actual loading and analysis.  Creating the fake NestedModule is similar to how the code already creates fake RequiredModules when not importing.

Also some minor cleanup of repetitive code in the tests.

Fix https://github.com/PowerShell/PowerShell/issues/7833

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
