### PR TITLE
Add new Offset and Count parameters to Format-Hex and refactor the cmdlet

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/format-hex/Format-Hex.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/format-hex/Format-Hex.cs
@@ -71,7 +71,8 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// This parameter is no-op.
         /// </summary>
-        [Parameter(ParameterSetName = "ByInputObject")]
+        [Parameter(ParameterSetName = "ByInputObject", DontShow = true)]
+        [Obsolete("Raw parameter is deprecated.", true)]
         public SwitchParameter Raw { get; set; }
 
         #endregion

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/format-hex/Format-Hex.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/format-hex/Format-Hex.cs
@@ -55,7 +55,7 @@ namespace Microsoft.PowerShell.Commands
         public Encoding Encoding { get; set; } = ClrFacade.GetDefaultEncoding();
 
         /// <summary>
-        /// Gets and sets count of bytes to read from the input stream from.
+        /// Gets and sets count of bytes to read from the input stream.
         /// </summary>
         [Parameter()]
         [ValidateRange(ValidateRangeKind.Positive)]

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/format-hex/Format-Hex.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/format-hex/Format-Hex.cs
@@ -172,7 +172,7 @@ namespace Microsoft.PowerShell.Commands
 
         /// <summary>
         /// Creates a binary reader that reads the file content into a buffer (byte[]) 16 bytes at a time, and
-        /// passes a copy of that array on to the ConvertToHexidecimal method to output.
+        /// passes a copy of that array on to the WriteHexidecimal method to output.
         /// </summary>
         /// <param name="path"></param>
         private void ProcessFileContent(string path)
@@ -195,11 +195,11 @@ namespace Microsoft.PowerShell.Commands
                         if (count > Count)
                         {
                             bytesRead -= (int)(count - Count);
-                            ConvertToHexidecimal(buffer.Slice(0, bytesRead), path, offset);
+                            WriteHexidecimal(buffer.Slice(0, bytesRead), path, offset);
                             break;
                         }
 
-                        ConvertToHexidecimal(buffer.Slice(0, bytesRead), path, offset);
+                        WriteHexidecimal(buffer.Slice(0, bytesRead), path, offset);
 
                         offset += bytesRead;
                     }
@@ -230,7 +230,7 @@ namespace Microsoft.PowerShell.Commands
 
         /// <summary>
         /// Creates a byte array from the object passed to the cmdlet (based on type) and passes
-        /// that array on to the ConvertToHexidecimal method to output.
+        /// that array on to the WriteHexidecimal method to output.
         /// </summary>
         /// <param name="inputObject"></param>
         private void ProcessObjectContent(PSObject inputObject)
@@ -257,12 +257,12 @@ namespace Microsoft.PowerShell.Commands
                 case Int32 iInt32:
                     inputBytes = BitConverter.GetBytes(iInt32);
                     break;
-                case Int32[] inputInt32s:
+                case Int32[] i32s:
                     int i32 = 0;
-                    inputBytes = new byte[sizeof(Int32) * inputInt32s.Length];
+                    inputBytes = new byte[sizeof(Int32) * i32s.Length];
                     Span<byte> inputStreamArray32 = inputBytes;
 
-                    foreach (Int32 value in inputInt32s)
+                    foreach (Int32 value in i32s)
                     {
                         BitConverter.TryWriteBytes(inputStreamArray32.Slice(i32), value);
                         i32 += sizeof(Int32);
@@ -304,11 +304,11 @@ namespace Microsoft.PowerShell.Commands
                 int count = Math.Min(inputBytes.Length - offset, Count < (long)int.MaxValue ? (int)Count : int.MaxValue);
                 if (offset != 0 || count != inputBytes.Length)
                 {
-                    ConvertToHexidecimal(inputBytes.AsSpan().Slice(offset, count), null, 0);
+                    WriteHexidecimal(inputBytes.AsSpan().Slice(offset, count), null, 0);
                 }
                 else
                 {
-                    ConvertToHexidecimal(inputBytes, null, 0);
+                    WriteHexidecimal(inputBytes, null, 0);
                 }
             }
         }
@@ -323,13 +323,13 @@ namespace Microsoft.PowerShell.Commands
         /// <param name="inputBytes">Bytes for the hexadecimial representaion.</param>
         /// <param name="path">File path.</param>
         /// <param name="offset">Offset in the file.</param>
-        private void ConvertToHexidecimal(Span<byte> inputBytes, string path, Int64 offset)
+        private void WriteHexidecimal(Span<byte> inputBytes, string path, Int64 offset)
         {
             ByteCollection byteCollectionObject = new ByteCollection((UInt64)offset, inputBytes.ToArray(), path);
             WriteObject(byteCollectionObject);
         }
 
-        private void ConvertToHexidecimal(byte[] inputBytes, string path, Int64 offset)
+        private void WriteHexidecimal(byte[] inputBytes, string path, Int64 offset)
         {
             ByteCollection byteCollectionObject = new ByteCollection((UInt64)offset, inputBytes, path);
             WriteObject(byteCollectionObject);

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/UtilityCommon.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/UtilityCommon.cs
@@ -220,7 +220,7 @@ namespace Microsoft.PowerShell.Commands
             StringBuilder asciiEnd = new StringBuilder(BytesPerLine);
 
             // '+1' comes from 'result.Append(nextLine.ToString() + " " + asciiEnd.ToString());' below.
-            StringBuilder result = new StringBuilder(nextLine.Capacity+asciiEnd.Capacity+1);
+            StringBuilder result = new StringBuilder(nextLine.Capacity+asciiEnd.Capacity + 1);
 
             if (Bytes.Length > 0)
             {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/UtilityCommon.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/UtilityCommon.cs
@@ -99,12 +99,12 @@ namespace Microsoft.PowerShell.Commands
         /// <param name="offset">The Offset address to be used while displaying the bytes in the collection.</param>
         /// <param name="value">Underlying bytes stored in the collection.</param>
         /// <param name="path">Indicates the path of the file whose contents are wrapped in the ByteCollection.</param>
+        [Obsolete("The constructor is deprecated.", true)]
         public ByteCollection(UInt32 offset, Byte[] value, string path)
         {
-            this.Offset = offset;
-            _initialOffSet = offset;
-            this.Bytes = value;
-            this.Path = path;
+            Offset64 = offset;
+            Bytes = value;
+            Path = path;
         }
 
         /// <summary>
@@ -112,11 +112,50 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         /// <param name="offset">The Offset address to be used while displaying the bytes in the collection.</param>
         /// <param name="value">Underlying bytes stored in the collection.</param>
+        /// <param name="path">Indicates the path of the file whose contents are wrapped in the ByteCollection.</param>
+        public ByteCollection(UInt64 offset, Byte[] value, string path)
+        {
+            if (value == null)
+            {
+                throw PSTraceSource.NewArgumentNullException("value");
+            }
+
+            Offset64 = offset;
+            Bytes = value;
+            Path = path;
+        }
+
+        /// <summary>
+        /// ByteCollection constructor.
+        /// </summary>
+        /// <param name="offset">The Offset address to be used while displaying the bytes in the collection.</param>
+        /// <param name="value">Underlying bytes stored in the collection.</param>
+        [Obsolete("The constructor is deprecated.", true)]
         public ByteCollection(UInt32 offset, Byte[] value)
         {
-            this.Offset = offset;
-            _initialOffSet = offset;
-            this.Bytes = value;
+            if (value == null)
+            {
+                throw PSTraceSource.NewArgumentNullException("value");
+            }
+
+            Offset64 = offset;
+            Bytes = value;
+        }
+
+        /// <summary>
+        /// ByteCollection constructor.
+        /// </summary>
+        /// <param name="offset">The Offset address to be used while displaying the bytes in the collection.</param>
+        /// <param name="value">Underlying bytes stored in the collection.</param>
+        public ByteCollection(UInt64 offset, Byte[] value)
+        {
+            if (value == null)
+            {
+                throw PSTraceSource.NewArgumentNullException("value");
+            }
+
+            Offset64 = offset;
+            Bytes = value;
         }
 
         /// <summary>
@@ -125,23 +164,44 @@ namespace Microsoft.PowerShell.Commands
         /// <param name="value">Underlying bytes stored in the collection.</param>
         public ByteCollection(Byte[] value)
         {
-            this.Bytes = value;
+            if (value == null)
+            {
+                throw PSTraceSource.NewArgumentNullException("value");
+            }
+
+            Bytes = value;
         }
 
         /// <summary>
-        /// The Offset address to be used while displaying the bytes in the collection.
+        /// Gets the Offset address to be used while displaying the bytes in the collection.
         /// </summary>
-        public UInt32 Offset { get; private set; }
-        private UInt32 _initialOffSet = 0;
+        [Obsolete("The property is deprecated, please use Offset64 instead.", true)]
+        public UInt32 Offset
+        {
+             get
+             {
+                return (UInt32)Offset64;
+             }
+
+             private set
+             {
+                 Offset64 = value;
+             }
+        }
 
         /// <summary>
-        /// Underlying bytes stored in the collection.
+        /// Gets the Offset address to be used while displaying the bytes in the collection.
+        /// </summary>
+        public UInt64 Offset64 { get; private set; }
+
+        /// <summary>
+        /// Gets underlying bytes stored in the collection.
         /// </summary>
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays")]
         public Byte[] Bytes { get; private set; }
 
         /// <summary>
-        /// Indicates the path of the file whose contents are wrapped in the ByteCollection.
+        /// Gets the path of the file whose contents are wrapped in the ByteCollection.
         /// </summary>
         public string Path { get; private set; }
 
@@ -151,19 +211,27 @@ namespace Microsoft.PowerShell.Commands
         /// <returns></returns>
         public override string ToString()
         {
-            StringBuilder result = new StringBuilder();
-            StringBuilder nextLine = new StringBuilder();
-            StringBuilder asciiEnd = new StringBuilder();
+            const int BytesPerLine = 16;
+            const string LineFormat = "{0:X20}   ";
+
+            // '20 + 3' comes from format "{0:X20}   ".
+            // '20' comes from '[Uint64]::MaxValue.ToString().Length'.
+            StringBuilder nextLine = new StringBuilder(20 + 3 + BytesPerLine*3);
+            StringBuilder asciiEnd = new StringBuilder(BytesPerLine);
+
+            // '+1' comes from 'result.Append(nextLine.ToString() + " " + asciiEnd.ToString());' below.
+            StringBuilder result = new StringBuilder(nextLine.Capacity+asciiEnd.Capacity+1);
 
             if (Bytes.Length > 0)
             {
-                UInt32 charCounter = 0;
+                Int64 charCounter = 0;
 
                 // ToString() in invoked thrice by the F&O for the same content.
                 // Hence making sure that Offset is not getting incremented thrice for the same bytes being displayed.
-                Offset = _initialOffSet;
+                var currentOffset = Offset64;
 
-                nextLine.AppendFormat("{0:X2}   ", CultureInfo.InvariantCulture.TextInfo.ToUpper(Convert.ToString(Offset, 16)).PadLeft(8, '0'));
+                nextLine.AppendFormat(CultureInfo.InvariantCulture, LineFormat, currentOffset);
+
                 foreach (Byte currentByte in Bytes)
                 {
                     // Display each byte, in 2-digit hexadecimal, and add that to the left-hand side.
@@ -179,38 +247,40 @@ namespace Microsoft.PowerShell.Commands
                     {
                         asciiEnd.Append('.');
                     }
+
                     charCounter++;
 
                     // If we've hit the end of a line, combine the right half with the
                     // left half, and start a new line.
-                    if ((charCounter % 16) == 0)
+                    if ((charCounter % BytesPerLine) == 0)
                     {
-                        result.Append(nextLine.ToString() + " " + asciiEnd.ToString());
+                        result.Append(nextLine).Append(' ').Append(asciiEnd);
                         nextLine.Clear();
                         asciiEnd.Clear();
-                        Offset += 0x10;
-                        nextLine.AppendFormat("{0:X2}   ", CultureInfo.InvariantCulture.TextInfo.ToUpper(Convert.ToString(Offset, 16)).PadLeft(8, '0'));
+                        currentOffset += BytesPerLine;
+                        nextLine.AppendFormat(CultureInfo.InvariantCulture, LineFormat, currentOffset);
 
                         // Adding a newline to support long inputs strings flowing through InputObject parameterset.
                         if ((charCounter <= Bytes.Length) && string.IsNullOrEmpty(this.Path))
                         {
-                            result.Append("\r\n");
+                            result.AppendLine();
                         }
                     }
                 }
 
                 // At the end of the file, we might not have had the chance to output
-                // the end of the line yet.  Only do this if we didn't exit on the 16-byte
+                // the end of the line yet. Only do this if we didn't exit on the 16-byte
                 // boundary, though.
                 if ((charCounter % 16) != 0)
                 {
                     while ((charCounter % 16) != 0)
                     {
-                        nextLine.Append("   ");
+                        nextLine.Append(' ', 3);
                         asciiEnd.Append(' ');
                         charCounter++;
                     }
-                    result.Append(nextLine.ToString() + " " + asciiEnd.ToString());
+
+                    result.Append(nextLine).Append(' ').Append(asciiEnd);
                 }
             }
 

--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
@@ -23,8 +23,8 @@ namespace System.Management.Automation.Runspaces
                     .StartEntry()
                         .StartFrame()
                             .AddScriptBlockExpressionBinding(@"
-                      $header = ""           00 01 02 03 04 05 06 07 08 09 0A 0B 0C 0D 0E 0F""
-                      if($_.Path) { $header = ""           "" + [Microsoft.PowerShell.Commands.UtilityResources]::FormatHexPathPrefix + $_.Path + ""`r`n`r`n"" + $header }
+                      $header = ""                       00 01 02 03 04 05 06 07 08 09 0A 0B 0C 0D 0E 0F""
+                      if($_.Path) { $header = ""                       "" + [Microsoft.PowerShell.Commands.UtilityResources]::FormatHexPathPrefix + $_.Path + ""`r`n`r`n"" + $header }
                       $header
                     ")
                         .EndFrame()

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/FormatHex.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/FormatHex.Tests.ps1
@@ -423,9 +423,71 @@ Describe "FormatHex" -tags "CI" {
             $result.ToString() | Should -MatchExactly "00000000000000000000   61 61 61 61 61 61 61 61 61 61 61 61 61 61 61 61  aaaaaaaaaaaaaaaa$($newline)00000000000000000010   61 61 61 61 61 61 61 61 61 61 61 61 61 61        aaaaaaaaaaaaaa  "
         }
 
-        It "Validate that files do not have buffer underrun problems 'Format-Hex -path `$InputFile4'" {
+        It "Validate that files do not have buffer underrun problems 'Format-Hex -Path `$InputFile4'" {
 
-            $result = Format-Hex -path $InputFile4
+            $result = Format-Hex -Path $InputFile4
+
+            $result | Should -Not -BeNullOrEmpty
+            $result.Count | Should -Be 3
+            $result[0].ToString() | Should -MatchExactly "00000000000000000000   4E 6F 77 20 69 73 20 74 68 65 20 77 69 6E 74 65  Now is the winte"
+            $result[1].ToString() | Should -MatchExactly "00000000000000000010   72 20 6F 66 20 6F 75 72 20 64 69 73 63 6F 6E 74  r of our discont"
+            $result[2].ToString() | Should -MatchExactly "00000000000000000020   65 6E 74                                         ent             "
+        }
+    }
+
+    Context "Count and Offset parameters" {
+        It "Count = length" {
+
+            $result = Format-Hex -Path $InputFile4 -Count $inputText4.Length
+
+            $result | Should -Not -BeNullOrEmpty
+            $result.Count | Should -Be 3
+            $result[0].ToString() | Should -MatchExactly "00000000000000000000   4E 6F 77 20 69 73 20 74 68 65 20 77 69 6E 74 65  Now is the winte"
+            $result[1].ToString() | Should -MatchExactly "00000000000000000010   72 20 6F 66 20 6F 75 72 20 64 69 73 63 6F 6E 74  r of our discont"
+            $result[2].ToString() | Should -MatchExactly "00000000000000000020   65 6E 74                                         ent             "
+        }
+
+        It "Count = 1" {
+            $result = Format-Hex -Path $inputFile4 -Count 1
+            $result.ToString() | Should -MatchExactly    "00000000000000000000   4E                                               N               "
+        }
+
+        It "Offset = length" {
+
+            $result = Format-Hex -Path $InputFile4 -Offset $inputText4.Length
+            $result | Should -BeNullOrEmpty
+
+            $result = Format-Hex -InputObject $inputText4 -Offset $inputText4.Length
+            $result.Bytes | Should -HaveCount 0
+        }
+
+        It "Offset = 1" {
+
+            $result = Format-Hex -Path $InputFile4 -Offset 1
+
+            $result | Should -Not -BeNullOrEmpty
+            $result.Count | Should -Be 3
+            $result[0].ToString() | Should -MatchExactly "00000000000000000001   6F 77 20 69 73 20 74 68 65 20 77 69 6E 74 65 72  ow is the winter"
+            $result[1].ToString() | Should -MatchExactly "00000000000000000011   20 6F 66 20 6F 75 72 20 64 69 73 63 6F 6E 74 65   of our disconte"
+            $result[2].ToString() | Should -MatchExactly "00000000000000000021   6E 74                                            nt              "
+        }
+
+        It "Count = 1 and Offset = 1" {
+            $result = Format-Hex -Path $inputFile4 -Count 1 -Offset 1
+            $result.ToString() | Should -MatchExactly    "00000000000000000001   6F                                               o               "
+        }
+
+        It "Count should be > 0" {
+            { Format-Hex -Path $inputFile4 -Count 0 } | Should -Throw -ErrorId "ParameterArgumentValidationError,Microsoft.PowerShell.Commands.FormatHex"
+        }
+
+        It "Offset should be >= 0" {
+            { Format-Hex -Path $inputFile4 -Offset -1 } | Should -Throw -ErrorId "ParameterArgumentValidationError,Microsoft.PowerShell.Commands.FormatHex"
+        }
+
+        It "Offset = 0" {
+
+            $result = Format-Hex -Path $InputFile4 -Offset 0
 
             $result | Should -Not -BeNullOrEmpty
             $result.Count | Should -Be 3

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/FormatHex.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/FormatHex.Tests.ps1
@@ -18,6 +18,8 @@ Describe "FormatHex" -tags "CI" {
 
     BeforeAll {
 
+        $newline = [Environment]::Newline
+
         Setup -d FormatHexDataDir
         $inputText1 = 'Hello World'
         $inputText2 = 'More text'
@@ -77,25 +79,25 @@ Describe "FormatHex" -tags "CI" {
                 Name = "Can process int32[] type 'fhx -InputObject [int32[]](2032, 2033, 2034)'"
                 InputObject = [int32[]](2032, 2033, 2034)
                 Count = 1
-                ExpectedResult = "00000000   F0 07 00 00 F1 07 00 00 F2 07 00 00              ð...ñ...ò..."
+                ExpectedResult = "00000000000000000000   F0 07 00 00 F1 07 00 00 F2 07 00 00              ð...ñ...ò..."
             }
             @{
                 Name = "Can process Int64 type 'fhx -InputObject [Int64]9223372036854775807'"
                 InputObject = [Int64]9223372036854775807
                 Count = 1
-                ExpectedResult = "00000000   FF FF FF FF FF FF FF 7F                          ......."
+                ExpectedResult = "00000000000000000000   FF FF FF FF FF FF FF 7F                          ......."
             }
             @{
                 Name = "Can process Int64[] type 'fhx -InputObject [Int64[]](9223372036852,9223372036853)'"
                 InputObject = [Int64[]](9223372036852,9223372036853)
                 Count = 1
-                ExpectedResult = "00000000   F4 5A D0 7B 63 08 00 00 F5 5A D0 7B 63 08 00 00  ôZÐ{c...õZÐ{c..."
+                ExpectedResult = "00000000000000000000   F4 5A D0 7B 63 08 00 00 F5 5A D0 7B 63 08 00 00  ôZÐ{c...õZÐ{c..."
             }
             @{
                 Name = "Can process string type 'fhx -InputObject hello world'"
                 InputObject = "hello world"
                 Count = 1
-                ExpectedResult = "00000000   68 65 6C 6C 6F 20 77 6F 72 6C 64                 hello world"
+                ExpectedResult = "00000000000000000000   68 65 6C 6C 6F 20 77 6F 72 6C 64                 hello world"
             }
         )
 
@@ -117,59 +119,59 @@ Describe "FormatHex" -tags "CI" {
                 Name = "Can process byte type '[byte]5 | fhx'"
                 InputObject = [byte]5
                 Count = 1
-                ExpectedResult = "00000000   05"
+                ExpectedResult = "00000000000000000000   05"
             }
             @{
                 Name = "Can process byte[] type '[byte[]](1,2) | fhx'"
                 InputObject = [byte[]](1,2)
                 Count = 2
-                ExpectedResult = "00000000   01                                               ."
-                ExpectedSecondResult = "00000000   02                                               ."
+                ExpectedResult = "00000000000000000000   01                                               ."
+                ExpectedSecondResult = "00000000000000000000   02                                               ."
             }
             @{
                 Name = "Can process int type '7 | fhx'"
                 InputObject = 7
                 Count = 1
-                ExpectedResult = "00000000   07 00 00 00                                      ...."
+                ExpectedResult = "00000000000000000000   07 00 00 00                                      ...."
             }
             @{
                 Name = "Can process int[] type '[int[]](5,6) | fhx'"
                 InputObject = [int[]](5,6)
                 Count = 2
-                ExpectedResult = "00000000   05 00 00 00                                      ...."
-                ExpectedSecondResult = "00000000   06 00 00 00                                      ...."
+                ExpectedResult = "00000000000000000000   05 00 00 00                                      ...."
+                ExpectedSecondResult = "00000000000000000000   06 00 00 00                                      ...."
             }
             @{
                 Name = "Can process int32 type '[int32]2032 | fhx'"
                 InputObject = [int32]2032
                 Count = 1
-                ExpectedResult = "00000000   F0 07 00 00                                      ð..."
+                ExpectedResult = "00000000000000000000   F0 07 00 00                                      ð..."
             }
             @{
                 Name = "Can process int32[] type '[int32[]](2032, 2033) | fhx'"
                 InputObject = [int32[]](2032, 2033)
                 Count = 2
-                ExpectedResult = "00000000   F0 07 00 00                                      ð..."
-                ExpectedSecondResult = "00000000   F1 07 00 00                                      ñ..."
+                ExpectedResult = "00000000000000000000   F0 07 00 00                                      ð..."
+                ExpectedSecondResult = "00000000000000000000   F1 07 00 00                                      ñ..."
             }
             @{
                 Name = "Can process Int64 type '[Int64]9223372036854775807 | fhx'"
                 InputObject = [Int64]9223372036854775807
                 Count = 1
-                ExpectedResult = "00000000   FF FF FF FF FF FF FF 7F                          ......."
+                ExpectedResult = "00000000000000000000   FF FF FF FF FF FF FF 7F                          ......."
             }
             @{
                 Name = "Can process Int64[] type '[Int64[]](9223372036852,9223372036853) | fhx'"
                 InputObject = [Int64[]](9223372036852,9223372036853)
                 Count = 2
-                ExpectedResult = "00000000   F4 5A D0 7B 63 08 00 00                          ôZÐ{c..."
-                ExpectedSecondResult = "00000000   F5 5A D0 7B 63 08 00 00                          õZÐ{c..."
+                ExpectedResult = "00000000000000000000   F4 5A D0 7B 63 08 00 00                          ôZÐ{c..."
+                ExpectedSecondResult = "00000000000000000000   F5 5A D0 7B 63 08 00 00                          õZÐ{c..."
             }
             @{
                 Name = "Can process string type 'hello world | fhx'"
                 InputObject = "hello world"
                 Count = 1
-                ExpectedResult = "00000000   68 65 6C 6C 6F 20 77 6F 72 6C 64                 hello world"
+                ExpectedResult = "00000000000000000000   68 65 6C 6C 6F 20 77 6F 72 6C 64                 hello world"
             }
         )
 
@@ -262,37 +264,37 @@ Describe "FormatHex" -tags "CI" {
                 Name = "Can process ASCII encoding 'fhx -InputObject 'hello' -Encoding ASCII'"
                 Encoding = "ASCII"
                 Count = 1
-                ExpectedResult = "00000000   68 65 6C 6C 6F                                   hello"
+                ExpectedResult = "00000000000000000000   68 65 6C 6C 6F                                   hello"
             }
             @{
                 Name = "Can process BigEndianUnicode encoding 'fhx -InputObject 'hello' -Encoding BigEndianUnicode'"
                 Encoding = "BigEndianUnicode"
                 Count = 1
-                ExpectedResult = "00000000   00 68 00 65 00 6C 00 6C 00 6F                    .h.e.l.l.o"
+                ExpectedResult = "00000000000000000000   00 68 00 65 00 6C 00 6C 00 6F                    .h.e.l.l.o"
             }
             @{
                 Name = "Can process Unicode encoding 'fhx -InputObject 'hello' -Encoding Unicode'"
                 Encoding = "Unicode"
                 Count = 1
-                ExpectedResult = "00000000   68 00 65 00 6C 00 6C 00 6F 00                    h.e.l.l.o."
+                ExpectedResult = "00000000000000000000   68 00 65 00 6C 00 6C 00 6F 00                    h.e.l.l.o."
             }
             @{
                 Name = "Can process UTF7 encoding 'fhx -InputObject 'hello' -Encoding UTF7'"
                 Encoding = "UTF7"
                 Count = 1
-                ExpectedResult = "00000000   68 65 6C 6C 6F                                   hello"
+                ExpectedResult = "00000000000000000000   68 65 6C 6C 6F                                   hello"
             }
              @{
                 Name = "Can process UTF8 encoding 'fhx -InputObject 'hello' -Encoding UTF8'"
                 Encoding = "UTF8"
                 Count = 1
-                ExpectedResult = "00000000   68 65 6C 6C 6F                                   hello"
+                ExpectedResult = "00000000000000000000   68 65 6C 6C 6F                                   hello"
             }
              @{
                 Name = "Can process UTF32 encoding 'fhx -InputObject 'hello' -Encoding UTF32'"
                 Encoding = "UTF32"
                 Count = 1
-                ExpectedResult = "00000000   68 00 00 00 65 00 00 00 6C 00 00 00 6C 00 00 00  h...e...l...l...`r`n00000010   6F 00 00 00                                      o..."
+                ExpectedResult = "00000000000000000000   68 00 00 00 65 00 00 00 6C 00 00 00 6C 00 00 00  h...e...l...l...$($newline)00000000000000000010   6F 00 00 00                                      o..."
             }
         )
 
@@ -418,7 +420,7 @@ Describe "FormatHex" -tags "CI" {
 
             $result | Should -Not -BeNullOrEmpty
             ,$result | Should -BeOfType 'Microsoft.PowerShell.Commands.ByteCollection'
-            $result.ToString() | Should -MatchExactly "00000000   61 61 61 61 61 61 61 61 61 61 61 61 61 61 61 61  aaaaaaaaaaaaaaaa`r`n00000010   61 61 61 61 61 61 61 61 61 61 61 61 61 61        aaaaaaaaaaaaaa  "
+            $result.ToString() | Should -MatchExactly "00000000000000000000   61 61 61 61 61 61 61 61 61 61 61 61 61 61 61 61  aaaaaaaaaaaaaaaa$($newline)00000000000000000010   61 61 61 61 61 61 61 61 61 61 61 61 61 61        aaaaaaaaaaaaaa  "
         }
 
         It "Validate that files do not have buffer underrun problems 'Format-Hex -path `$InputFile4'" {
@@ -427,9 +429,9 @@ Describe "FormatHex" -tags "CI" {
 
             $result | Should -Not -BeNullOrEmpty
             $result.Count | Should -Be 3
-            $result[0].ToString() | Should -MatchExactly "00000000   4E 6F 77 20 69 73 20 74 68 65 20 77 69 6E 74 65  Now is the winte"
-            $result[1].ToString() | Should -MatchExactly "00000010   72 20 6F 66 20 6F 75 72 20 64 69 73 63 6F 6E 74  r of our discont"
-            $result[2].ToString() | Should -MatchExactly "00000020   65 6E 74                                         ent             "
+            $result[0].ToString() | Should -MatchExactly "00000000000000000000   4E 6F 77 20 69 73 20 74 68 65 20 77 69 6E 74 65  Now is the winte"
+            $result[1].ToString() | Should -MatchExactly "00000000000000000010   72 20 6F 66 20 6F 75 72 20 64 69 73 63 6F 6E 74  r of our discont"
+            $result[2].ToString() | Should -MatchExactly "00000000000000000020   65 6E 74                                         ent             "
         }
     }
 }


### PR DESCRIPTION
## PR Summary

1. Add new Offset and Count parameters. Resolve #3383.
2. Modify ByteCollection class to support offsets up to UInt64.MaxValue size.
3. Hide/obsolete Raw parameter because the behavior is by default. Related #7868.
4. Optimize conversion to bytes to reduce allocations for large input data.

### Additional comments

1. For review: Now Offset parameter does a shift in output byte stream. Since we accept objects as input we could consider Offset as "skip the Offset-count objects from input (array/pipeline)" although Skip parameter is more suitable for this (or  Select-Object -Skip) and this is contrary to the behavior for input streams (Path parameter or FileInfo input object).

2. I don't consider a scenario "get last count bytes". As a minimum, the PR should not block this enhancement.

3. New ReFS file system support files up to UInt64.MaxValue. So ByteCollection is modified to support UInt64.MaxValue too. 
On the other hand current .Net Core limitation is Int64.MaxValue for file size/offset. In result we have to use Int64 type for Offset and Count parameters.

/cc @rkeithhill @mklement0 @adamdriscoll 

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [x] Issue filed - Issue link: https://github.com/PowerShell/PowerShell-Docs/issues/2986
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
