### PR TITLE
install-powershell.sh: Adding autodetection of curl / wget

### DIFF
--- a/tools/install-powershell.sh
+++ b/tools/install-powershell.sh
@@ -4,7 +4,7 @@ install(){
     #Companion code for the blog https://cloudywindows.com
 
     #call this code direction from the web with:
-    #bash <(wget -O - https://raw.githubusercontent.com/PowerShell/PowerShell/master/tools/install-powershell.sh) <ARGUMENTS>
+    #bash <(wget -qO - https://raw.githubusercontent.com/PowerShell/PowerShell/master/tools/install-powershell.sh) <ARGUMENTS>
     #wget -O - https://raw.githubusercontent.com/PowerShell/PowerShell/master/tools/install-powershell.sh | bash -s <ARGUMENTS>
     #bash <(curl -s https://raw.githubusercontent.com/PowerShell/PowerShell/master/tools/install-powershell.sh) <ARGUMENTS>
 
@@ -128,9 +128,16 @@ install(){
         else
         #Script files are not local - pull from remote
         echo "Could not find \"appimage.sh\" next to this script..."
-        echo "Pulling it from \"$gitreposcriptroot/appimage.sh\""
-        bash <(wget -qO- $gitreposcriptroot/appimage.sh) $@
-    fi
+        echo "Pulling and executing it from \"$gitreposcriptroot/appimage.sh\""
+        if [ -n "$(command -v curl)" ]; then
+            echo "found and using curl"
+            bash <(curl -s $gitreposcriptroot/appimage.sh) $@
+        elif [ -n "$(command -v wget)" ]; then
+            echo "found and using wget"
+            bash <(wget -qO- $gitreposcriptroot/appimage.sh) $@
+        else
+            echo "Could not find curl or wget, install one of these or manually download \"$gitreposcriptroot/appimage.sh\""
+        fi
     elif [ "$DistroBasedOn" == "redhat" ] || [ "$DistroBasedOn" == "debian" ] || [ "$DistroBasedOn" == "osx" ] || [ "$DistroBasedOn" == "suse" ] || [ "$DistroBasedOn" == "amazonlinux" ]; then
         echo "Configuring PowerShell Core Enviornment for: $DistroBasedOn $DIST $REV"
         if [ -f $SCRIPTFOLDER/installpsh-$DistroBasedOn.sh ]; then
@@ -139,13 +146,16 @@ install(){
         else
         #Script files are not local - pull from remote
         echo "Could not find \"installpsh-$DistroBasedOn.sh\" next to this script..."
-        echo "Pulling it from \"$gitreposcriptroot/installpsh-$DistroBasedOn.sh\""
-        if [ "$OS" == "osx" ]; then
+        echo "Pulling and executing it from \"$gitreposcriptroot/installpsh-$DistroBasedOn.sh\""
+        if [ -n "$(command -v curl)" ]; then
+            echo "found and using curl"
             bash <(curl -s $gitreposcriptroot/installpsh-$DistroBasedOn.sh) $@
-        else
+        elif [ -n "$(command -v wget)" ]; then
+            echo "found and using wget"
             bash <(wget -qO- $gitreposcriptroot/installpsh-$DistroBasedOn.sh) $@
+        else
+            echo "Could not find curl or wget, install one of these or manually download \"$gitreposcriptroot/installpsh-$DistroBasedOn.sh\""
         fi
-    fi
     else
         echo "Sorry, your operating system is based on $DistroBasedOn and is not supported by PowerShell Core or this installer at this time."
     fi

--- a/tools/install-powershell.sh
+++ b/tools/install-powershell.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
 
 install(){
     #Companion code for the blog https://cloudywindows.com


### PR DESCRIPTION
## PR Summary

install-powershell.sh now autodetects whether curl or wget is installed to download secondary script when it is not found locally.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link: #7872 
- **Testing - New and feature**
    - [x] Not Applicable or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
