### PR TITLE
Fix BeginInvoke/EndInvoke to return results when Stop or BeginStop/EndStop was called previously

### DIFF
--- a/test/powershell/engine/Api/BasicEngine.Tests.ps1
+++ b/test/powershell/engine/Api/BasicEngine.Tests.ps1
@@ -48,7 +48,7 @@ exit
     }
 }
 
-Describe "EndInvoke() should return a collection of results" {
+Describe "EndInvoke() should return a collection of results" -Tags "CI" {
     BeforeAll {
         $ps = [powershell]::Create()
         $ps.AddScript("'Hello'; Sleep 1; 'World'") > $null

--- a/test/powershell/engine/Api/BasicEngine.Tests.ps1
+++ b/test/powershell/engine/Api/BasicEngine.Tests.ps1
@@ -51,7 +51,7 @@ exit
 Describe "EndInvoke() should return a collection of results" -Tags "CI" {
     BeforeAll {
         $ps = [powershell]::Create()
-        $ps.AddScript("'Hello'; Sleep 1; 'World'") > $null
+        $ps.AddScript("'Hello'; 'World'") > $null
     }
 
     It "BeginInvoke() and then EndInvoke() should return a collection of results" {
@@ -65,7 +65,6 @@ Describe "EndInvoke() should return a collection of results" -Tags "CI" {
 
     It "BeginInvoke() and then EndInvoke() should return a collection of results after a previous Stop() call" {
         $async = $ps.BeginInvoke()
-        Start-Sleep -Milliseconds 300
         $ps.Stop()
 
         $async = $ps.BeginInvoke()
@@ -78,7 +77,6 @@ Describe "EndInvoke() should return a collection of results" -Tags "CI" {
 
     It "BeginInvoke() and then EndInvoke() should return a collection of results after a previous BeginStop()/EndStop() call" {
         $asyncInvoke = $ps.BeginInvoke()
-        Start-Sleep -Milliseconds 300
         $asyncStop = $ps.BeginStop($null, $null)
         $ps.EndStop($asyncStop)
 


### PR DESCRIPTION
## PR Summary

Fix `BeginInvoke()`/`EndInvoke(IAsyncResult)` to return results when `Stop()` or `BeginStop(callback, state)`/`EndStop(IAsyncResult)` was called previously.

Without this fix, `EndInvoke(IAsyncResult)` returns null when it should return a collection of results:
```powershell
PS:1> $ps = [powershell]::Create()
PS:2> $ps.AddScript("'Hello'; Sleep 2; 'World'") > $null
PS:3> $a = $ps.BeginInvoke(); $ps.Stop()
PS:4> $a = $ps.BeginInvoke(); $m = $ps.EndInvoke($a)
PS:5> $m -eq $null
True
```

The root cause is that `OutputBuffer` is not set to `null` in `Stop` and `BeginStop/EndStop` when the powershell instance owns the `OutputBuffer` object. Since the pipeline has been intentionally stopped by the caller, the `OutputBuffer` should be set to `null` as well when it's owned by the PowerShell instance.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [x] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
