### PR TITLE
Allow dynamic parameter to be returned for `Get-Content` even if path matches nothing to get correct error

### DIFF
--- a/src/System.Management.Automation/engine/SessionStateContent.cs
+++ b/src/System.Management.Automation/engine/SessionStateContent.cs
@@ -275,13 +275,7 @@ namespace System.Management.Automation
                     out provider,
                     out providerInstance);
 
-            if (providerPaths.Count > 0)
-            {
-                // Get the dynamic parameters for the first resolved path
-
-                return GetContentReaderDynamicParameters(providerInstance, providerPaths[0], newContext);
-            }
-            return null;
+            return GetContentReaderDynamicParameters(providerInstance, path, newContext);
         } // GetContentReaderDynamicParameters
 
         /// <summary>

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Content.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-Content.Tests.ps1
@@ -278,6 +278,15 @@ baz
         } | Should -Throw -ErrorId "InvalidOperation,Microsoft.PowerShell.Commands.GetContentCommand"
     }
 
+    It "Should throw ItemNotFound when path matches no files with <variation>" -TestCases @(
+        @{ variation = "no additional parameters"; params = @{} },
+        @{ variation = "dynamic parameter"       ; params = @{ Raw = $true }}
+    ) {
+        param($params)
+
+        { Get-Content -Path "/DoesNotExist*.txt" @params -ErrorAction Stop } | Should -Throw -ErrorId "ItemNotFound,Microsoft.PowerShell.Commands.GetContentCommand"
+    }
+
     Context "Check Get-Content containing multi-byte chars" {
         BeforeAll {
             $firstLine = "Hello,World"


### PR DESCRIPTION
## PR Summary

`Get-Content` works against a provider (which is currently only supported by filesystemprovider).  In the case of dynamic parameters, `Get-Content` uses globbing to get the appropriate provider to request dynamic parameters.  Previously, after globbing it would use the first resolved path to obtain the dynamic parameter and if globbing returned nothing, it would not request the dynamic parameter from the provider.  This results in confusing errors to the user reporting that `-Raw` is not valid, when it is.

The fix is to let the provider decide what to do with the given path when obtaining the dynamic parameters.  In the case of the filesystem provider, it doesn't even use the path.

Fix https://github.com/PowerShell/PowerShell/issues/6954

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
