### PR TITLE
Allow root node of format.ps1xml to have attributes that are ignored

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Update-TypeData.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Update-TypeData.cs
@@ -987,11 +987,7 @@ namespace Microsoft.PowerShell.Commands
                 {
                     // revert Formats if there is a failure
                     Context.InitialSessionState.Formats.Clear();
-                    foreach (var format in originalFormats)
-                    {
-                        Context.InitialSessionState.Formats.Add(format);
-                    }
-
+                    Context.InitialSessionState.Formats.Add(originalFormats);
                     this.WriteError(new ErrorRecord(e, "FormatXmlUpdateException", ErrorCategory.InvalidOperation, null));
                 }
             }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Update-TypeData.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Update-TypeData.cs
@@ -939,6 +939,7 @@ namespace Microsoft.PowerShell.Commands
                     }
                 }
 
+                var originalFormats = Context.InitialSessionState.Formats;
                 try
                 {
                     // Always rebuild the format information
@@ -984,6 +985,13 @@ namespace Microsoft.PowerShell.Commands
                 }
                 catch (RuntimeException e)
                 {
+                    // revert Formats if there is a failure
+                    Context.InitialSessionState.Formats.Clear();
+                    foreach (var format in originalFormats)
+                    {
+                        Context.InitialSessionState.Formats.Add(format);
+                    }
+
                     this.WriteError(new ErrorRecord(e, "FormatXmlUpdateException", ErrorCategory.InvalidOperation, null));
                 }
             }

--- a/src/System.Management.Automation/FormatAndOutput/common/DisplayDatabase/typeDataXmlLoader.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/DisplayDatabase/typeDataXmlLoader.cs
@@ -344,7 +344,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             bool viewDefinitionsFound = false;
             bool controlDefinitionsFound = false;
 
-            if (MatchNodeName(documentElement, XmlTags.ConfigurationNode))
+            if (MatchNodeNameWithAttributes(documentElement, XmlTags.ConfigurationNode))
             {
                 // load the various sections
                 using (this.StackFrame(documentElement))

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-Table.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-Table.Tests.ps1
@@ -228,7 +228,7 @@ Describe "Format-Table" -Tags "CI" {
 </Configuration>
 "@
 
-            $ps1xmlPath = Join-Path -Path $TestDrive -ChildPath "test.format.ps1xml"
+            $ps1xmlPath = Join-Path -Path $TestDrive -ChildPath "alignment.format.ps1xml"
             Set-Content -Path $ps1xmlPath -Value $ps1xml
             # run in own runspace so not affect global sessionstate
             $ps = [powershell]::Create()
@@ -315,7 +315,7 @@ Left Center Right
 </Configuration>
 "@
 
-            $ps1xmlPath = Join-Path -Path $TestDrive -ChildPath "test.format.ps1xml"
+            $ps1xmlPath = Join-Path -Path $TestDrive -ChildPath "truncation.format.ps1xml"
             Set-Content -Path $ps1xmlPath -Value $ps1xml
             # run in own runspace so not affect global sessionstate
             $ps = [powershell]::Create()
@@ -456,7 +456,7 @@ er
 </Configuration>
 "@
             $ps1xml = $ps1xml.Replace("{0}", $widths[0]).Replace("{1}", $widths[1]).Replace("{2}", $widths[2])
-            $ps1xmlPath = Join-Path -Path $TestDrive -ChildPath "test.format.ps1xml"
+            $ps1xmlPath = Join-Path -Path $TestDrive -ChildPath "span.format.ps1xml"
             Set-Content -Path $ps1xmlPath -Value $ps1xml
             # run in own runspace so not affect global sessionstate
             $ps = [powershell]::Create()
@@ -662,7 +662,7 @@ er
 </Configuration>
 "@
             $ps1xml = $ps1xml.Replace("{0}", $widths[0]).Replace("{1}", $widths[1]).Replace("{2}", $widths[2])
-            $ps1xmlPath = Join-Path -Path $TestDrive -ChildPath "test.format.ps1xml"
+            $ps1xmlPath = Join-Path -Path $TestDrive -ChildPath "render.format.ps1xml"
             Set-Content -Path $ps1xmlPath -Value $ps1xml
             # run in own runspace so not affect global sessionstate
             $ps = [powershell]::Create()

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Update-FormatData.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Update-FormatData.Tests.ps1
@@ -99,8 +99,8 @@ Describe "Update-FormatData basic functionality" -Tags "CI" {
     </ViewDefinitions>
 </Configuration>
 "@
-        $xmlContent | Out-File -FilePath "$testdrive\test.format.ps1xml" -Encoding ascii
-        { Update-FormatData -Path "$testdrive\test.format.ps1xml" -ErrorAction Stop } | Should -Throw -ErrorId "FormatXmlUpdateException,Microsoft.PowerShell.Commands.UpdateFormatDataCommand"
+        $xmlContent | Out-File -FilePath "$testdrive\invalid.format.ps1xml" -Encoding ascii
+        { Update-FormatData -Path "$testdrive\invalid.format.ps1xml" -ErrorAction Stop } | Should -Throw -ErrorId "FormatXmlUpdateException,Microsoft.PowerShell.Commands.UpdateFormatDataCommand"
     }
 }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Update-FormatData.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Update-FormatData.Tests.ps1
@@ -2,18 +2,10 @@
 # Licensed under the MIT License.
 Describe "Update-FormatData" -Tags "CI" {
 
-    BeforeAll {
-        $path = Join-Path -Path $TestDrive -ChildPath "outputfile.ps1xml"
-        $ps = [powershell]::Create()
-        $iss = [system.management.automation.runspaces.initialsessionstate]::CreateDefault2()
-        $rs = [system.management.automation.runspaces.runspacefactory]::CreateRunspace($iss)
-        $rs.Open()
-        $ps.Runspace = $rs
+    BeforeEach {
+        $ps = [PowerShell]::Create()
     }
-    AfterAll {
-        $rs.Close()
-        $ps.Dispose()
-    }
+
     Context "Validate Update-FormatData update correctly" {
 
         It "Should not throw upon reloading previous formatting file" {
@@ -21,10 +13,48 @@ Describe "Update-FormatData" -Tags "CI" {
         }
 
         It "Should validly load formatting data" {
+            $path = Join-Path -Path $TestDrive -ChildPath "outputfile.ps1xml"
             Get-FormatData -typename System.Diagnostics.Process | Export-FormatData -Path $path
             $null = $ps.AddScript("Update-FormatData -prependPath $path")
             $ps.Invoke()
             $ps.HadErrors | Should -BeFalse
+        }
+
+        It "Update with atributes on Configuration node should be ignored" {
+            $xmlContent = @"
+    <Configuration xmlns:foo="bar">
+        <ViewDefinitions>
+            <View>
+                <Name>Test</Name>
+                <ViewSelectedBy>
+                    <TypeName>Test</TypeName>
+                </ViewSelectedBy>
+                <ListControl>
+                    <ListEntries>
+                        <ListEntry>
+                            <ListItems>
+                                <ListItem>
+                                    <PropertyName>Test</PropertyName>
+                                </ListItem>
+                            </ListItems>
+                        </ListEntry>
+                    </ListEntries>
+                </ListControl>
+            </View>
+        </ViewDefinitions>
+    </Configuration>
+"@
+            $path = "$testdrive\rootattribute.format.ps1xml"
+            Set-Content -Path $path -Value $xmlContent
+            $null = $ps.AddScript("Update-FormatData -prependPath $path")
+            $ps.Invoke()
+            $ps.HadErrors | Should -BeFalse
+            $ps.Commands.Clear()
+            $null = $ps.AddScript("Get-FormatData test")
+            $formatData = $ps.Invoke()
+            $formatData | Should -HaveCount 1
+            $formatData.TypeNames | Should -BeExactly "Test"
+            $formatData.FormatViewDefinition.Name | Should -BeExactly "Test"
         }
     }
 }
@@ -59,7 +89,7 @@ Describe "Update-FormatData basic functionality" -Tags "CI" {
         { Update-FormatData -Prepend $testfile -WhatIf } | Should -Not -Throw
     }
 
-    It "Update with invalid format xml should fail" -Pending {
+    It "Update with invalid format xml should fail" {
         $xmlContent = @"
 <Configuration>
     <ViewDefinitions>

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Update-TypeData.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Update-TypeData.Tests.ps1
@@ -48,7 +48,33 @@ Describe "Update-TypeData basic functionality" -Tags "CI" {
         $ps.Dispose()
     }
 
-  It "Update-TypeData with Invalid TypesXml should throw Exception" {
+    It "Update-TypeData with attributes on root node should succeed"   {
+        $xmlContent = @"
+        <Types xmlns:foo="bar">
+            <Type>
+                <Name>Test</Name>
+                    <Members>
+                        <AliasProperty>
+                            <Name>Yada</Name>
+                            <ReferencedMemberName>Length</ReferencedMemberName>
+                        </AliasProperty>
+                    </Members>
+            </Type>
+        </Types>
+"@
+        $path = "$testdrive\test.types.ps1xml"
+        Set-Content -Value $xmlContent -Path $path
+        $null = $ps.AddScript("Update-TypeData -AppendPath $path")
+        $ps.Invoke()
+        $ps.HadErrors | Should -BeFalse
+        $ps.Commands.Clear()
+        $null = $ps.AddScript("Get-TypeData test")
+        $typeData = $ps.Invoke()
+        $typeData | Should -HaveCount 1
+        $typeData.TypeName | Should -BeExactly "Test"
+    }
+
+    It "Update-TypeData with Invalid TypesXml should throw Exception" {
         $null = $ps.AddScript("Update-TypeData -PrependPath $testfile")
         $ps.Invoke()
         $ps.HadErrors | Should -BeTrue


### PR DESCRIPTION
## PR Summary

Currently, if a format.ps1xml file has attributes on the `<Configuration>` node, it is a terminating error.  We should allow for loose validation so that common attributes from other tooling is simply ignored if not understood.  @PowerShell/powershell-committee had discussed this and agreed with making this change.  Fix is to use a different method to find the root node that allows for attributes.

Types.ps1xml doesn't have this strict validation so no change was needed, but added tests for both format and types ps1xml.

There was a separate issue causing tests to fail.  A separate test used an invalid ps1xml file with update-formatdata.  Expectation is that an invalid file wouldn't be bound to the runspace so it didn't need to run in a separate runspace.  However, the runspace initialsessionstate kept this file in its list so subsequent attempts to update-formatdata (like importing a module that contains ps1xml) will again attempt to update with the invalid ps1xml file and result in a confusing error.  Fix is to revert initialsession state to previous list of format files if there is a failure updating the formats.  Renamed some of the test ps1xml files to be unique to determine which was causing the failure.

Also removed `Pending` from a test that passes.

Address one aspect of #7749

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
