### PR TITLE
Fix Test-Connection test to use same API to resolve DNS as cmdlet making it more reliable

### DIFF
--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Connection.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Test-Connection.Tests.ps1
@@ -21,7 +21,7 @@ Describe "Test-Connection" -tags "CI" {
         $UnreachableAddress = "10.11.12.13"
         # this resolves to an actual IP rather than 127.0.0.1
         # this can also include both IPv4 and IPv6, so select InterNetwork rather than InterNetworkV6
-        $realAddress = [System.Net.Dns]::GetHostEntry($hostName).AddressList | 
+        $realAddress = [System.Net.Dns]::GetHostEntry($hostName).AddressList |
             Where-Object {$_.AddressFamily -eq "InterNetwork"} |
             Select-Object -First 1 |
             Foreach-Object {$_.IPAddressToString}
@@ -166,7 +166,7 @@ Describe "Test-Connection" -tags "CI" {
 
         It "ResolveDestination for address" {
             $result = Test-Connection $targetAddress -ResolveDestination -Count 1
-            $resolvedName = [System.Net.DNS]::GetHostByName($targetName).HostName
+            $resolvedName = [System.Net.DNS]::GetHostEntry($targetAddress).HostName
 
             $result.Destination | Should -BeExactly $resolvedName
             $result.Replies[0].Address     | Should -BeExactly $targetAddress


### PR DESCRIPTION
## PR Summary

In AzDevOps Pipelines on Windows images, they have some sort of protection in place so that a reverse lookup returns the wrong name from a cache.  Fix is to use the same API used in the cmdlet to resolve DNS.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
