### PR TITLE
Add Type Inference for $_ / $PSItem in catch{ } blocks

### DIFF
--- a/src/System.Management.Automation/engine/ErrorPackage.cs
+++ b/src/System.Management.Automation/engine/ErrorPackage.cs
@@ -1671,6 +1671,17 @@ namespace System.Management.Automation
     } // class ErrorRecord
 
     /// <summary>
+    /// Dummy generic class for type inference purposes on typed catch blocks.
+    /// </summary>
+    /// <typeparam name="E">Anything that inherits Exception.</typeparam>
+    internal class ErrorRecord<E> : ErrorRecord where E : Exception
+    {
+        public new E Exception { get; }
+
+        public ErrorRecord(Exception exception, string errorId, ErrorCategory errorCategory, object targetObject) : base(exception, errorId, errorCategory, targetObject) { }
+    }
+
+    /// <summary>
     /// Implemented by exception classes which contain additional
     /// <see cref="System.Management.Automation.ErrorRecord"/>
     /// information.

--- a/src/System.Management.Automation/engine/ErrorPackage.cs
+++ b/src/System.Management.Automation/engine/ErrorPackage.cs
@@ -1673,12 +1673,14 @@ namespace System.Management.Automation
     /// <summary>
     /// Dummy generic class for type inference purposes on typed catch blocks.
     /// </summary>
-    /// <typeparam name="E">Anything that inherits Exception.</typeparam>
-    internal class ErrorRecord<E> : ErrorRecord where E : Exception
+    /// <typeparam name="TException">Anything that inherits Exception.</typeparam>
+    internal class ErrorRecord<TException> : ErrorRecord where TException : Exception
     {
-        public new E Exception { get; }
+        public new TException Exception { get; }
 
-        public ErrorRecord(Exception exception, string errorId, ErrorCategory errorCategory, object targetObject) : base(exception, errorId, errorCategory, targetObject) { }
+        public ErrorRecord(Exception exception, string errorId, ErrorCategory errorCategory, object targetObject) : base(exception, errorId, errorCategory, targetObject)
+        {
+        }
     }
 
     /// <summary>

--- a/src/System.Management.Automation/engine/parser/TypeInferenceVisitor.cs
+++ b/src/System.Management.Automation/engine/parser/TypeInferenceVisitor.cs
@@ -1803,7 +1803,7 @@ namespace System.Management.Automation
                 // $_ is special, see if we're used in a script block in some pipeline.
                 while (parent != null)
                 {
-                    if (parent is ScriptBlockExpressionAst)
+                    if (parent is ScriptBlockExpressionAst || parent is CatchClauseAst)
                     {
                         break;
                     }
@@ -1830,6 +1830,12 @@ namespace System.Management.Automation
                     if (parent.Parent is CommandParameterAst)
                     {
                         parent = parent.Parent;
+                    }
+
+                    if (parent is CatchClauseAst)
+                    {
+                        inferredTypes.Add(new PSTypeName(typeof(ErrorRecord)));
+                        return;
                     }
 
                     if (parent.Parent is CommandAst commandAst)

--- a/src/System.Management.Automation/engine/parser/TypeInferenceVisitor.cs
+++ b/src/System.Management.Automation/engine/parser/TypeInferenceVisitor.cs
@@ -1832,9 +1832,24 @@ namespace System.Management.Automation
                         parent = parent.Parent;
                     }
 
-                    if (parent is CatchClauseAst)
+                    if (parent is CatchClauseAst catchBlock)
                     {
-                        inferredTypes.Add(new PSTypeName(typeof(ErrorRecord)));
+                        if (catchBlock.CatchTypes.Count > 0)
+                        {
+                            foreach (TypeConstraintAst catchType in catchBlock.CatchTypes)
+                            {
+                                Type exceptionType = catchType.TypeName.GetReflectionType();
+                                if (exceptionType != null && typeof(Exception).IsAssignableFrom(exceptionType))
+                                {
+                                    inferredTypes.Add(new PSTypeName(typeof(ErrorRecord<>).MakeGenericType(exceptionType)));
+                                }
+                            }
+                        }
+                        else
+                        {
+                            inferredTypes.Add(new PSTypeName(typeof(ErrorRecord)));
+                        }
+
                         return;
                     }
 

--- a/test/powershell/engine/Api/TypeInference.Tests.ps1
+++ b/test/powershell/engine/Api/TypeInference.Tests.ps1
@@ -970,9 +970,9 @@ Describe "Type inference Tests" -tags "CI" {
     )
 
     It 'Infers type of $_.Exception in [<Type>] typed catch block' -TestCases $catchClauseTypes {
-        param([Type] $Type)
+        param($Type)
 
-        $memberAst = [scriptblock]::Create("try {} catch [$Type] { $_.Exception }").Ast.Find(
+        $memberAst = [scriptblock]::Create("try {} catch [$Type] { `$_.Exception }").Ast.Find(
             { param($a) $a -is [System.Management.Automation.Language.MemberExpressionAst] },
             $true
         )

--- a/test/powershell/engine/Api/TypeInference.Tests.ps1
+++ b/test/powershell/engine/Api/TypeInference.Tests.ps1
@@ -930,7 +930,7 @@ Describe "Type inference Tests" -tags "CI" {
         $variableAst = { try {} catch { $_ } }.Ast.Find({ param($a) $a -is [System.Management.Automation.Language.VariableExpressionAst] }, $true)
         $res = [AstTypeInference]::InferTypeOf($variableAst)
 
-        $res.Count | Should -Be 1
+        $res | Should -HaveCount 1
         $res.Name | Should -Be System.Management.Automation.ErrorRecord
     }
 
@@ -938,7 +938,7 @@ Describe "Type inference Tests" -tags "CI" {
         $memberAst = { try {} catch { $_.Exception } }.Ast.Find({ param($a) $a -is [System.Management.Automation.Language.MemberExpressionAst] }, $true)
         $res = [AstTypeInference]::InferTypeOf($memberAst)
 
-        $res.Count | Should -Be 1
+        $res | Should -HaveCount 1
         $res.Name | Should -Be System.Exception
     }
 

--- a/test/powershell/engine/Api/TypeInference.Tests.ps1
+++ b/test/powershell/engine/Api/TypeInference.Tests.ps1
@@ -934,6 +934,25 @@ Describe "Type inference Tests" -tags "CI" {
         $res.Name | Should -Be System.Management.Automation.ErrorRecord
     }
 
+    It 'Infers type of $_.Expression in catch block' {
+        $memberAst = { try {} catch { $_.Expression } }.Ast.Find({ param($a) $a -is [System.Management.Automation.Language.MemberExpressionAst] }, $true)
+        $res = [AstTypeInference]::InferTypeOf($memberAst)
+
+        $res.Count | Should -Be 1
+        $res.Name | Should -Be System.Exception
+    }
+
+    It 'Infers type of $_.Expression in typed catch block' {
+        $memberAst = { try {} catch [System.IO.FileNotFoundException] { $_.Expression } }.Ast.Find(
+            { param($a) $a -is [System.Management.Automation.Language.MemberExpressionAst] },
+            $true
+        )
+        $res = [AstTypeInference]::InferTypeOf($memberAst)
+
+        $res.Count | Should -Be 1
+        $res.Name | Should -Be System.Exception
+    }
+
     It 'Infers type of function member' {
         $res = [AstTypeInference]::InferTypeOf( {
                 class X {

--- a/test/powershell/engine/Api/TypeInference.Tests.ps1
+++ b/test/powershell/engine/Api/TypeInference.Tests.ps1
@@ -935,7 +935,7 @@ Describe "Type inference Tests" -tags "CI" {
     }
 
     It 'Infers type of $_.Expression in catch block' {
-        $memberAst = { try {} catch { $_.Expression } }.Ast.Find({ param($a) $a -is [System.Management.Automation.Language.MemberExpressionAst] }, $true)
+        $memberAst = { try {} catch { $_.Exception } }.Ast.Find({ param($a) $a -is [System.Management.Automation.Language.MemberExpressionAst] }, $true)
         $res = [AstTypeInference]::InferTypeOf($memberAst)
 
         $res.Count | Should -Be 1
@@ -943,14 +943,14 @@ Describe "Type inference Tests" -tags "CI" {
     }
 
     It 'Infers type of $_.Expression in typed catch block' {
-        $memberAst = { try {} catch [System.IO.FileNotFoundException] { $_.Expression } }.Ast.Find(
+        $memberAst = { try {} catch [System.IO.FileNotFoundException] { $_.Exception } }.Ast.Find(
             { param($a) $a -is [System.Management.Automation.Language.MemberExpressionAst] },
             $true
         )
         $res = [AstTypeInference]::InferTypeOf($memberAst)
 
         $res.Count | Should -Be 1
-        $res.Name | Should -Be System.Exception
+        $res.Name | Should -Be System.IO.FileNotFoundException
     }
 
     It 'Infers type of function member' {

--- a/test/powershell/engine/Api/TypeInference.Tests.ps1
+++ b/test/powershell/engine/Api/TypeInference.Tests.ps1
@@ -943,30 +943,30 @@ Describe "Type inference Tests" -tags "CI" {
     }
 
     $catchClauseTypes = @(
-        @{ Type = [System.ArgumentException] }
-        @{ Type = [System.ArgumentNullException] }
-        @{ Type = [System.ArgumentOutOfRangeException] }
-        @{ Type = [System.Collections.Generic.KeyNotFoundException] }
-        @{ Type = [System.DivideByZeroException] }
-        @{ Type = [System.FormatException] }
-        @{ Type = [System.IndexOutOfRangeException] }
-        @{ Type = [System.InvalidOperationException] }
-        @{ Type = [System.IO.DirectoryNotFoundException] }
-        @{ Type = [System.IO.DriveNotFoundException] }
-        @{ Type = [System.IO.FileNotFoundException] }
-        @{ Type = [System.IO.PathTooLongException] }
-        @{ Type = [System.Management.Automation.CommandNotFoundException] }
-        @{ Type = [System.Management.Automation.JobFailedException] }
-        @{ Type = [System.Management.Automation.RuntimeException] }
-        @{ Type = [System.Management.Automation.ValidationMetadataException] }
-        @{ Type = [System.NotImplementedException] }
-        @{ Type = [System.NotSupportedException] }
-        @{ Type = [System.ObjectDisposedException] }
-        @{ Type = [System.OverflowException] }
-        @{ Type = [System.PlatformNotSupportedException] }
-        @{ Type = [System.RankException] }
-        @{ Type = [System.TimeoutException] }
-        @{ Type = [System.UriFormatException] }
+        @{ Type = 'System.ArgumentException' }
+        @{ Type = 'System.ArgumentNullException' }
+        @{ Type = 'System.ArgumentOutOfRangeException' }
+        @{ Type = 'System.Collections.Generic.KeyNotFoundException' }
+        @{ Type = 'System.DivideByZeroException' }
+        @{ Type = 'System.FormatException' }
+        @{ Type = 'System.IndexOutOfRangeException' }
+        @{ Type = 'System.InvalidOperationException' }
+        @{ Type = 'System.IO.DirectoryNotFoundException' }
+        @{ Type = 'System.IO.DriveNotFoundException' }
+        @{ Type = 'System.IO.FileNotFoundException' }
+        @{ Type = 'System.IO.PathTooLongException' }
+        @{ Type = 'System.Management.Automation.CommandNotFoundException' }
+        @{ Type = 'System.Management.Automation.JobFailedException' }
+        @{ Type = 'System.Management.Automation.RuntimeException' }
+        @{ Type = 'System.Management.Automation.ValidationMetadataException' }
+        @{ Type = 'System.NotImplementedException' }
+        @{ Type = 'System.NotSupportedException' }
+        @{ Type = 'System.ObjectDisposedException' }
+        @{ Type = 'System.OverflowException' }
+        @{ Type = 'System.PlatformNotSupportedException' }
+        @{ Type = 'System.RankException' }
+        @{ Type = 'System.TimeoutException' }
+        @{ Type = 'System.UriFormatException' }
     )
 
     It 'Infers type of $_.Expression in [<Type>] typed catch block' -TestCases $catchClauseTypes {

--- a/test/powershell/engine/Api/TypeInference.Tests.ps1
+++ b/test/powershell/engine/Api/TypeInference.Tests.ps1
@@ -934,7 +934,7 @@ Describe "Type inference Tests" -tags "CI" {
         $res.Name | Should -Be System.Management.Automation.ErrorRecord
     }
 
-    It 'Infers type of $_.Expression in catch block' {
+    It 'Infers type of untyped $_.Exception in catch block' {
         $memberAst = { try {} catch { $_.Exception } }.Ast.Find({ param($a) $a -is [System.Management.Automation.Language.MemberExpressionAst] }, $true)
         $res = [AstTypeInference]::InferTypeOf($memberAst)
 
@@ -969,7 +969,7 @@ Describe "Type inference Tests" -tags "CI" {
         @{ Type = 'System.UriFormatException' }
     )
 
-    It 'Infers type of $_.Expression in [<Type>] typed catch block' -TestCases $catchClauseTypes {
+    It 'Infers type of $_.Exception in [<Type>] typed catch block' -TestCases $catchClauseTypes {
         param([Type] $Type)
 
         $memberAst = [scriptblock]::Create("try {} catch [$Type] { $_.Exception }").Ast.Find(
@@ -980,6 +980,34 @@ Describe "Type inference Tests" -tags "CI" {
 
         $res | Should -HaveCount 1
         $res.Name | Should -Be $Type
+    }
+
+    It 'Infers possible types of $_.Exception in multi-typed catch block' {
+        $memberAst = { try {} catch [System.ArgumentException], [System.NotImplementedException] { $_.Exception } }.Ast.Find(
+            { param($a) $a -is [System.Management.Automation.Language.MemberExpressionAst] },
+            $true
+        )
+        $res = [AstTypeInference]::InferTypeOf($memberAst)
+
+        $res | Should -HaveCount 2
+        $res[0].Name | Should -Be System.ArgumentException
+        $res[1].Name | Should -Be System.NotImplementedException
+    }
+
+    It 'Infers type of $_.Exception in each successive catch block' {
+        $memberAst = {
+            try {}
+            catch [System.ArgumentException] { $_.Exception }
+            catch { $_.Exception }
+        }.Ast.FindAll(
+            { param($a) $a -is [System.Management.Automation.Language.MemberExpressionAst] },
+            $true
+        )
+        $res = foreach ($item in $memberAst) { [AstTypeInference]::InferTypeOf($item) }
+
+        $res | Should -HaveCount 2
+        $res[0].Name | Should -Be System.ArgumentException
+        $res[1].Name | Should -Be System.Exception
     }
 
     It 'Infers type of function member' {

--- a/test/powershell/engine/Api/TypeInference.Tests.ps1
+++ b/test/powershell/engine/Api/TypeInference.Tests.ps1
@@ -942,15 +942,44 @@ Describe "Type inference Tests" -tags "CI" {
         $res.Name | Should -Be System.Exception
     }
 
-    It 'Infers type of $_.Expression in typed catch block' {
-        $memberAst = { try {} catch [System.IO.FileNotFoundException] { $_.Exception } }.Ast.Find(
+    $catchClauseTypes = @(
+        @{ Type = [System.ArgumentException] }
+        @{ Type = [System.ArgumentNullException] }
+        @{ Type = [System.ArgumentOutOfRangeException] }
+        @{ Type = [System.Collections.Generic.KeyNotFoundException] }
+        @{ Type = [System.DivideByZeroException] }
+        @{ Type = [System.FormatException] }
+        @{ Type = [System.IndexOutOfRangeException] }
+        @{ Type = [System.InvalidOperationException] }
+        @{ Type = [System.IO.DirectoryNotFoundException] }
+        @{ Type = [System.IO.DriveNotFoundException] }
+        @{ Type = [System.IO.FileNotFoundException] }
+        @{ Type = [System.IO.PathTooLongException] }
+        @{ Type = [System.Management.Automation.CommandNotFoundException] }
+        @{ Type = [System.Management.Automation.JobFailedException] }
+        @{ Type = [System.Management.Automation.RuntimeException] }
+        @{ Type = [System.Management.Automation.ValidationMetadataException] }
+        @{ Type = [System.NotImplementedException] }
+        @{ Type = [System.NotSupportedException] }
+        @{ Type = [System.ObjectDisposedException] }
+        @{ Type = [System.OverflowException] }
+        @{ Type = [System.PlatformNotSupportedException] }
+        @{ Type = [System.RankException] }
+        @{ Type = [System.TimeoutException] }
+        @{ Type = [System.UriFormatException] }
+    )
+
+    It 'Infers type of $_.Expression in [<Type>] typed catch block' -TestCases $catchClauseTypes {
+        param([Type] $Type)
+
+        $memberAst = [scriptblock]::Create("try {} catch [$Type] { $_.Exception }").Ast.Find(
             { param($a) $a -is [System.Management.Automation.Language.MemberExpressionAst] },
             $true
         )
         $res = [AstTypeInference]::InferTypeOf($memberAst)
 
-        $res.Count | Should -Be 1
-        $res.Name | Should -Be System.IO.FileNotFoundException
+        $res | Should -HaveCount 1
+        $res.Name | Should -Be $Type
     }
 
     It 'Infers type of function member' {

--- a/test/powershell/engine/Api/TypeInference.Tests.ps1
+++ b/test/powershell/engine/Api/TypeInference.Tests.ps1
@@ -926,6 +926,14 @@ Describe "Type inference Tests" -tags "CI" {
         $res.Name | Should -Be System.Int32
     }
 
+    It 'Infers type of variable $_ in catch block' {
+        $variableAst = { try {} catch { $_ } }.Ast.Find({ param($a) $a -is [System.Management.Automation.Language.VariableExpressionAst] }, $true)
+        $res = [AstTypeInference]::InferTypeOf($variableAst)
+
+        $res.Count | Should -Be 1
+        $res.Name | Should -Be System.Management.Automation.ErrorRecord
+    }
+
     It 'Infers type of function member' {
         $res = [AstTypeInference]::InferTypeOf( {
                 class X {


### PR DESCRIPTION
## PR Summary

Fix #7828 

* Adds type inference results to `$_` / `$PSItem` when it is used to refer to the `ErrorRecord` in a catch block.
* Adds test for the type inference.
* Includes type inference for typed `catch [ExceptionType] { $_ }` blocks such that `$_` is inferred as a dummy `ErrorRecord<TException>` which is identical to `ErrorRecord` but with a `TException`-typed `Exception` member.
  * In other words, using typed catch blocks correctly autocompletes the members for `$_.Exception.<tab>`

Example:
```powershell
PS> try {throw 'ball'} catch {$_.<tab>
# completes to:
PS> try {throw 'ball'} catch {$_.CategoryInfo
```

(Compare current behaviour, where tab completion is missing due to a lack of type inference on the `$_` / `$PSItem` variable.)

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [X] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [X] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
