### PR TITLE
Adding predicated instance member access to psobject to speed up formatting.

### DIFF
--- a/src/System.Management.Automation/FormatAndOutput/common/FormatViewManager.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/FormatViewManager.cs
@@ -464,65 +464,19 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
     /// </summary>
     internal static class OutOfBandFormatViewManager
     {
-        internal static bool IsPropertyLessObject(PSObject so)
+        static bool IsNotSpecialPropertyName(string name)
         {
-            List<MshResolvedExpressionParameterAssociation> allProperties = AssociationManager.ExpandAll(so);
-
-            if (allProperties.Count == 0)
-            {
-                return true;
-            }
-
-            if (allProperties.Count == 3)
-            {
-                foreach (MshResolvedExpressionParameterAssociation property in allProperties)
-                {
-                    if (!property.ResolvedExpression.ToString().Equals(RemotingConstants.ComputerNameNoteProperty, StringComparison.OrdinalIgnoreCase) &&
-                        !property.ResolvedExpression.ToString().Equals(RemotingConstants.ShowComputerNameNoteProperty, StringComparison.OrdinalIgnoreCase) &&
-                        !property.ResolvedExpression.ToString().Equals(RemotingConstants.RunspaceIdNoteProperty, StringComparison.OrdinalIgnoreCase))
-                    {
-                        return false;
-                    }
-                }
-
-                return true;
-            }
-
-            if (allProperties.Count == 4)
-            {
-                foreach (MshResolvedExpressionParameterAssociation property in allProperties)
-                {
-                    if (!property.ResolvedExpression.ToString().Equals(RemotingConstants.ComputerNameNoteProperty, StringComparison.OrdinalIgnoreCase) &&
-                        !property.ResolvedExpression.ToString().Equals(RemotingConstants.ShowComputerNameNoteProperty, StringComparison.OrdinalIgnoreCase) &&
-                        !property.ResolvedExpression.ToString().Equals(RemotingConstants.RunspaceIdNoteProperty, StringComparison.OrdinalIgnoreCase)
-                        && !property.ResolvedExpression.ToString().Equals(RemotingConstants.SourceJobInstanceId, StringComparison.OrdinalIgnoreCase))
-                    {
-                        return false;
-                    }
-                }
-
-                return true;
-            }
-
-            if (allProperties.Count == 5)
-            {
-                foreach (MshResolvedExpressionParameterAssociation property in allProperties)
-                {
-                    if (!property.ResolvedExpression.ToString().Equals(RemotingConstants.ComputerNameNoteProperty, StringComparison.OrdinalIgnoreCase) &&
-                        !property.ResolvedExpression.ToString().Equals(RemotingConstants.ShowComputerNameNoteProperty, StringComparison.OrdinalIgnoreCase) &&
-                        !property.ResolvedExpression.ToString().Equals(RemotingConstants.RunspaceIdNoteProperty, StringComparison.OrdinalIgnoreCase) &&
-                        !property.ResolvedExpression.ToString().Equals(RemotingConstants.SourceJobInstanceId, StringComparison.OrdinalIgnoreCase) &&
-                        !property.ResolvedExpression.ToString().Equals(RemotingConstants.SourceLength, StringComparison.OrdinalIgnoreCase))
-                    {
-                        return false;
-                    }
-                }
-
-                return true;
-            }
-
-            return false;
+            var isRemotingPropertyName =  name.Equals(RemotingConstants.ComputerNameNoteProperty, StringComparison.OrdinalIgnoreCase)
+                   || name.Equals(RemotingConstants.ShowComputerNameNoteProperty, StringComparison.OrdinalIgnoreCase)
+                   || name.Equals(RemotingConstants.RunspaceIdNoteProperty, StringComparison.OrdinalIgnoreCase)
+                   || name.Equals(RemotingConstants.SourceJobInstanceId, StringComparison.OrdinalIgnoreCase)
+                   || name.Equals(RemotingConstants.SourceLength,StringComparison.OrdinalIgnoreCase);
+            return !isRemotingPropertyName;
         }
+
+        private static readonly MemberNamePredicate NameIsNotRemotingProperty = IsNotSpecialPropertyName;
+
+        private static bool HasNonRemotingProperties(PSObject so) => so.GetFirstInstanceMemberOrDefault(NameIsNotRemotingProperty) == null;
 
         internal static FormatEntryData GenerateOutOfBandData(TerminatingErrorContext errorContext, PSPropertyExpressionFactory expressionFactory,
                     TypeInfoDataBase db, PSObject so, int enumerationLimit, bool useToStringFallback, out List<ErrorRecord> errors)
@@ -550,7 +504,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             else
             {
                 if (DefaultScalarTypes.IsTypeInList(typeNames) ||
-                    IsPropertyLessObject(so))
+                    HasNonRemotingProperties(so))
                 {
                     // we force a ToString() on well known types
                     return GenerateOutOfBandObjectAsToString(so);

--- a/src/System.Management.Automation/FormatAndOutput/common/Utilities/MshObjectUtil.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/Utilities/MshObjectUtil.cs
@@ -36,81 +36,6 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         }
 
         /// <summary>
-        /// WriteError adds a note property called WriteErrorStream to the error
-        /// record wrapped in an PSObject and set its value to true. When F and O detects
-        /// this note exists and its value is set to true, WriteErrorLine will be used
-        /// to emit the error; otherwise, F and O actions are regular.
-        /// </summary>
-        /// <param name="so"></param>
-        /// <returns></returns>
-        internal static bool IsWriteErrorStream(PSObject so)
-        {
-            return IsStreamType(so, "WriteErrorStream");
-        }
-
-        /// <summary>
-        /// Checks for WriteWarningStream property on object, indicating that
-        /// it is a warning stream.  Used by F and O.
-        /// </summary>
-        /// <param name="so"></param>
-        /// <returns></returns>
-        internal static bool IsWriteWarningStream(PSObject so)
-        {
-            return IsStreamType(so, "WriteWarningStream");
-        }
-
-        /// <summary>
-        /// Checks for WriteVerboseStream property on object, indicating that
-        /// it is a verbose stream.  Used by F and O.
-        /// </summary>
-        /// <param name="so"></param>
-        /// <returns></returns>
-        internal static bool IsWriteVerboseStream(PSObject so)
-        {
-            return IsStreamType(so, "WriteVerboseStream");
-        }
-
-        /// <summary>
-        /// Checks for WriteDebugStream property on object, indicating that
-        /// it is a debug stream.  Used by F and O.
-        /// </summary>
-        /// <param name="so"></param>
-        /// <returns></returns>
-        internal static bool IsWriteDebugStream(PSObject so)
-        {
-            return IsStreamType(so, "WriteDebugStream");
-        }
-
-        /// <summary>
-        /// Checks for WriteInformationStream property on object, indicating that
-        /// it is an informational stream.  Used by F and O.
-        /// </summary>
-        /// <param name="so"></param>
-        /// <returns></returns>
-        internal static bool IsWriteInformationStream(PSObject so)
-        {
-            return IsStreamType(so, "WriteInformationStream");
-        }
-
-        internal static bool IsStreamType(PSObject so, string streamFlag)
-        {
-            try
-            {
-                PSPropertyInfo streamProperty = so.Properties[streamFlag];
-                if (streamProperty != null && streamProperty.Value is bool)
-                {
-                    return (bool)streamProperty.Value;
-                }
-
-                return false;
-            }
-            catch (ExtendedTypeSystemException)
-            {
-                return false;
-            }
-        }
-
-        /// <summary>
         /// Retrieve the display name. It looks for a well known property and,
         /// if not found, it uses some heuristics to get a "close" match.
         /// </summary>
@@ -129,7 +54,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             // we failed the default display name, let's try some well known names
             // trying to get something potentially useful
             string[] knownPatterns = new string[] {
-                "name", "id", "key", "*key", "*name", "*id",
+                "name", "id", "key",  "*key", "*name", "*id",
             };
 
             // go over the patterns, looking for the first match

--- a/src/System.Management.Automation/engine/MshCommandRuntime.cs
+++ b/src/System.Management.Automation/engine/MshCommandRuntime.cs
@@ -28,6 +28,12 @@ namespace System.Management.Automation
     /// </summary>
     internal class MshCommandRuntime : ICommandRuntime2
     {
+        internal const string WriteErrorStreamPropertyName = "WriteErrorStream";
+        internal const string WriteWarningStreamPropertyName = "WriteWarningStream";
+        internal const string WriteVerboseStreamPropertyName = "WriteVerboseStream";
+        internal const string WriteDebugStreamPropertyName = "WriteDebugStream";
+        internal const string WriteInformationStreamPropertyName = "WriteInformationStream";
+
         #region private_members
 
         /// <summary>
@@ -488,9 +494,9 @@ namespace System.Management.Automation
 
                     // Add note property so that the debug output is formatted correctly.
                     PSObject debugWrap = PSObject.AsPSObject(record);
-                    if (debugWrap.Members["WriteDebugStream"] == null)
+                    if (debugWrap.Members[WriteDebugStreamPropertyName] == null)
                     {
-                        debugWrap.Properties.Add(new PSNoteProperty("WriteDebugStream", true));
+                        debugWrap.Properties.Add(new PSNoteProperty(WriteDebugStreamPropertyName, true));
                     }
 
                     DebugOutputPipe.Add(debugWrap);
@@ -579,9 +585,9 @@ namespace System.Management.Automation
 
                     // Add note property so that the verbose output is formatted correctly.
                     PSObject verboseWrap = PSObject.AsPSObject(record);
-                    if (verboseWrap.Members["WriteVerboseStream"] == null)
+                    if (verboseWrap.Members[WriteVerboseStreamPropertyName] == null)
                     {
-                        verboseWrap.Properties.Add(new PSNoteProperty("WriteVerboseStream", true));
+                        verboseWrap.Properties.Add(new PSNoteProperty(WriteVerboseStreamPropertyName, true));
                     }
 
                     VerboseOutputPipe.Add(verboseWrap);
@@ -670,9 +676,9 @@ namespace System.Management.Automation
 
                     // Add note property so that the warning output is formatted correctly.
                     PSObject warningWrap = PSObject.AsPSObject(record);
-                    if (warningWrap.Members["WriteWarningStream"] == null)
+                    if (warningWrap.Members[WriteWarningStreamPropertyName] == null)
                     {
-                        warningWrap.Properties.Add(new PSNoteProperty("WriteWarningStream", true));
+                        warningWrap.Properties.Add(new PSNoteProperty(WriteWarningStreamPropertyName, true));
                     }
 
                     WarningOutputPipe.AddWithoutAppendingOutVarList(warningWrap);
@@ -735,9 +741,9 @@ namespace System.Management.Automation
 
                     // Add note property so that the information output is formatted correctly.
                     PSObject informationWrap = PSObject.AsPSObject(record);
-                    if (informationWrap.Members["WriteInformationStream"] == null)
+                    if (informationWrap.Members[WriteInformationStreamPropertyName] == null)
                     {
-                        informationWrap.Properties.Add(new PSNoteProperty("WriteInformationStream", true));
+                        informationWrap.Properties.Add(new PSNoteProperty(WriteInformationStreamPropertyName, true));
                     }
 
                     InformationOutputPipe.Add(informationWrap);
@@ -2845,9 +2851,9 @@ namespace System.Management.Automation
             // when tracing), so don't add the member again.
 
             // We don't add a note property on messages that comes from stderr stream.
-            if (!isNativeError && errorWrap.Members["writeErrorStream"] == null)
+            if (!isNativeError && errorWrap.Members[WriteErrorStreamPropertyName] == null)
             {
-                PSNoteProperty note = new PSNoteProperty("writeErrorStream", true);
+                PSNoteProperty note = new PSNoteProperty(WriteErrorStreamPropertyName, true);
                 errorWrap.Properties.Add(note);
             }
 
@@ -3566,7 +3572,7 @@ namespace System.Management.Automation
                 CBhost.InternalUI.TranscribeResult(inquireCaption);
                 CBhost.InternalUI.TranscribeResult(inquireMessage);
 
-                System.Text.StringBuilder textChoices = new System.Text.StringBuilder();
+                Text.StringBuilder textChoices = new Text.StringBuilder();
                 foreach (ChoiceDescription choice in choices)
                 {
                     if (textChoices.Length > 0)

--- a/src/System.Management.Automation/engine/MshMemberInfo.cs
+++ b/src/System.Management.Automation/engine/MshMemberInfo.cs
@@ -3682,6 +3682,8 @@ namespace System.Management.Automation
         }
     }
 
+    internal delegate bool MemberNamePredicate(string memberName);
+
     /// <summary>
     /// Serves as the collection of members in an PSObject or MemberSet.
     /// </summary>

--- a/src/System.Management.Automation/engine/MshObject.cs
+++ b/src/System.Management.Automation/engine/MshObject.cs
@@ -2310,6 +2310,28 @@ namespace System.Management.Automation
             set => _isHelpObject = value;
         }
 
+        /// <summary>
+        /// Gets an instance member if it's name matches the predicate. Otherwise null.
+        /// </summary>
+        internal PSMemberInfo GetFirstInstanceMemberOrDefault(MemberNamePredicate predicate)
+        {
+            if (_instanceMembers == null)
+            {
+                return null;
+            }
+
+            foreach (var instanceMember in _instanceMembers)
+            {
+                var found = predicate.Invoke(instanceMember.Name);
+                if (found)
+                {
+                    return instanceMember;
+                }
+            }
+
+            return null;
+        }
+
         private bool _isHelpObject = false;
 
         #endregion

--- a/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
+++ b/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
@@ -1888,7 +1888,7 @@ namespace System.Management.Automation
                 rte.ErrorRecord.SetInvocationInfo(new InvocationInfo(null, extent, context));
             PSObject errorWrap = PSObject.AsPSObject(new ErrorRecord(rte.ErrorRecord, rte));
 
-            PSNoteProperty note = new PSNoteProperty("writeErrorStream", true);
+            PSNoteProperty note = new PSNoteProperty(MshCommandRuntime.WriteErrorStreamPropertyName, true);
             errorWrap.Properties.Add(note);
 
             // If this is an error pipe for a hosting application (i.e.: no downstream cmdlet),


### PR DESCRIPTION
## PR Summary

By not doing excessive amounts of extra work, formatting can be sped up quite significantly. 

The main change comes from adding new, more efficient, primitive to query an object for it's instance members. 

The formatting system has been checking for properties by retrieving all properties, and then determined whether a set of properties has been among them.

That enables early exit and for example responding with a bool instead of a set of objects, which reduces allocations and wastes less cycles. 

Test script:
```
$files = gci -ea:0 c:\windows -Recurse -File
$files | format-table Name, LastAccessTime, Length | out-null
```
version| time | speedup
--------|------|---------
6.1| 32.47s | 1.0x
PR 8024 |  ~~6.70s~~ 4.2s   | ~~4.8x~~ 8x



## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [x] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
