### PR TITLE
Fix PSVersion check in `Get-FormatData` to return format data

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/common/GetFormatDataCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/common/GetFormatDataCommand.cs
@@ -97,7 +97,7 @@ namespace Microsoft.PowerShell.Commands
         {
             bool writeOldWay = PowerShellVersion == null ||
                                PowerShellVersion.Major < 5 ||
-                               PowerShellVersion.Build < 11086;
+                               (PowerShellVersion.Major == 5 && PowerShellVersion.Minor < 1);
 
             TypeInfoDataBase db = this.Context.FormatDBManager.Database;
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-FormatData.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-FormatData.Tests.ps1
@@ -9,4 +9,16 @@ Describe "Get-FormatData" -Tags "CI" {
             ,$result | Should -BeOfType "System.Object[]"
         }
     }
+
+    It "Can get format data requiring '-PowerShellVersion 5.1'" {
+        $format = Get-FormatData System.IO.FileInfo -PowerShellVersion 5.1
+        $format.TypeNames | Should -HaveCount 2
+        $format.TypeNames[0] | Should -BeExactly "System.IO.DirectoryInfo"
+        $format.TypeNames[1] | Should -BeExactly "System.IO.FileInfo"
+        $format.FormatViewDefinition | Should -HaveCount 3
+    }
+
+    It "Should return nothing for format data requiring '-PowerShellVersion 5.1' and not provided" {
+        Get-FormatData System.IO.FileInfo | Should -BeNullOrEmpty
+    }
 }


### PR DESCRIPTION
## PR Summary

The FormatData format changed in version 5.1 so during remoting a client specifies the version of PowerShell FormatData it can understand.
In the case of FileInfo (and DirectoryInfo), the format requires 5.1 so remoting must pass the `-PowerShellVersion 5.1` parameter to successfully get format data.  There is a bug in the logic to validate the version and it was validating the build number.  So the version string `5.1` fails this check because it does not include a version number (which defaults to -1).  The fix is to remove the check on the build number and simply rely on major version and minor version.

Fix https://github.com/PowerShell/PowerShell/issues/4237

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
