### PR TITLE
Move processing of `-WorkingDirectory` before processing of profiles for pwsh.exe

### DIFF
--- a/test/powershell/Host/ConsoleHost.Tests.ps1
+++ b/test/powershell/Host/ConsoleHost.Tests.ps1
@@ -567,6 +567,25 @@ foo
             $LASTEXITCODE | Should -Be $ExitCodeBadCommandLineParameter
             $output | Should -Not -BeNullOrEmpty
         }
+
+        It "-WorkingDirectory should be processed before profiles" {
+
+            $currentProfile = Get-Content $PROFILE
+            @"
+                (Get-Location).Path
+                Set-Location $testdrive
+"@ > $PROFILE
+
+            try {
+                $out = pwsh -workingdirectory ~ -c '(Get-Location).Path'
+                $out | Should -HaveCount 2
+                $out[0] | Should -BeExactly (Get-Item ~).FullName
+                $out[1] | Should -BeExactly "$testdrive"
+            }
+            finally {
+                Set-Content $PROFILE -Value $currentProfile
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## PR Summary

Without this change, the processing of `-WorkingDirectory` happens after processing `$PROFILE` (all the profiles).  This means that any `$PROFILE` that explicitly uses `Set-Location` to a desired folder will be ovewritten by `-WorkingDirectory ~` which is added to the shortcut for pwsh by default.

The fix is to move the processing of `-WorkingDirectory` before processing of profiles.  Note that this is a `breaking change` for any `$PROFILE` that expects to start in $PSHOME instead of `~` but it seems unlikely.

Fix https://github.com/PowerShell/PowerShell/issues/7895
Fix https://github.com/PowerShell/PowerShell/issues/8144

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
