### PR TITLE
Use DefaultPathSeparator char instead of DefaultPathSeparatorString

### DIFF
--- a/src/System.Management.Automation/engine/SessionStateLocationAPIs.cs
+++ b/src/System.Management.Automation/engine/SessionStateLocationAPIs.cs
@@ -522,7 +522,7 @@ namespace System.Management.Automation
                 // current working directory is relative to the root.
 
                 if (!LocationGlobber.IsProviderDirectPath(path) &&
-                    path.StartsWith(StringLiterals.DefaultPathSeparatorString, StringComparison.CurrentCulture) &&
+                    path.StartsWith(StringLiterals.DefaultPathSeparator) &&
                     !pathIsProviderQualifiedPath)
                 {
                     path = path.Substring(1);

--- a/src/System.Management.Automation/engine/SessionStateStrings.cs
+++ b/src/System.Management.Automation/engine/SessionStateStrings.cs
@@ -170,7 +170,7 @@ namespace System.Management.Automation
         /// <summary>
         /// The escape character used in the language.
         /// </summary>
-        internal const string EscapeCharacter = "`";
+        internal const char EscapeCharacter = '`';
 
         /// <summary>
         /// The default cmdlet adapter for cmdletization / cdxml modules

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -1420,8 +1420,8 @@ namespace Microsoft.PowerShell.Commands
             // Don't handle full paths, paths that the user is already trying to
             // filter, or paths they are trying to escape.
             if ((!String.IsNullOrEmpty(filter)) ||
-                (path.Contains(StringLiterals.DefaultPathSeparatorString)) ||
-                (path.Contains(StringLiterals.AlternatePathSeparatorString)) ||
+                (path.Contains(StringLiterals.DefaultPathSeparator, StringComparison.Ordinal)) ||
+                (path.Contains(StringLiterals.AlternatePathSeparator, StringComparison.Ordinal)) ||
                 (path.Contains(StringLiterals.EscapeCharacter)))
             {
                 return false;
@@ -4809,13 +4809,13 @@ namespace Microsoft.PowerShell.Commands
                 try
                 {
                     string originalPathComparison = path;
-                    if (!originalPathComparison.EndsWith(StringLiterals.DefaultPathSeparatorString, StringComparison.OrdinalIgnoreCase))
+                    if (!originalPathComparison.EndsWith(StringLiterals.DefaultPathSeparator))
                     {
                         originalPathComparison += StringLiterals.DefaultPathSeparator;
                     }
 
                     string basePathComparison = basePath;
-                    if (!basePathComparison.EndsWith(StringLiterals.DefaultPathSeparatorString, StringComparison.OrdinalIgnoreCase))
+                    if (!basePathComparison.EndsWith(StringLiterals.DefaultPathSeparator))
                     {
                         basePathComparison += StringLiterals.DefaultPathSeparator;
                     }
@@ -5013,7 +5013,7 @@ namespace Microsoft.PowerShell.Commands
                 // See if the base and the path are already the same. We resolve this to
                 // ..\Leaf, since resolving "." to "." doesn't offer much information.
                 if (String.Equals(path, basePath, StringComparison.OrdinalIgnoreCase) &&
-                    (!originalPath.EndsWith(StringLiterals.DefaultPathSeparatorString, StringComparison.OrdinalIgnoreCase)))
+                    (!originalPath.EndsWith(StringLiterals.DefaultPathSeparator)))
                 {
                     string childName = GetChildName(path);
                     result = MakePath("..", childName);
@@ -5060,7 +5060,7 @@ namespace Microsoft.PowerShell.Commands
                     if (!String.IsNullOrEmpty(commonBase))
                     {
                         if (String.Equals(path, commonBase, StringComparison.OrdinalIgnoreCase) &&
-                            (!path.EndsWith(StringLiterals.DefaultPathSeparatorString, StringComparison.OrdinalIgnoreCase)))
+                            (!path.EndsWith(StringLiterals.DefaultPathSeparator)))
                         {
                             string childName = GetChildName(path);
                             result = MakePath("..", result);

--- a/src/System.Management.Automation/namespaces/LocationGlobber.cs
+++ b/src/System.Management.Automation/namespaces/LocationGlobber.cs
@@ -1436,8 +1436,8 @@ namespace System.Management.Automation
         internal static bool IsSingleFileSystemAbsolutePath(string path)
         {
 #if UNIX
-            return path.StartsWith(StringLiterals.DefaultPathSeparatorString, StringComparison.Ordinal)
-                || path.StartsWith(StringLiterals.AlternatePathSeparatorString, StringComparison.Ordinal);
+            return path.StartsWith(StringLiterals.DefaultPathSeparator)
+                || path.StartsWith(StringLiterals.AlternatePathSeparator);
 #else
             return false;
 #endif
@@ -2898,7 +2898,7 @@ namespace System.Management.Automation
                     }
                     else
                     {
-                        if (path.StartsWith(StringLiterals.DefaultPathSeparatorString, StringComparison.Ordinal))
+                        if (path.StartsWith(StringLiterals.DefaultPathSeparator))
                         {
                             formatString = "{0}:{1}";
                         }
@@ -3088,8 +3088,8 @@ namespace System.Management.Automation
                     // Check if the path begins with "\" or "/" (UNC Path or Path in Unix).
                     // Ignore if the path resolves to a drive path, this will happen when path is equal to "\" or "/".
                     // Drive path still need formatting, so treat them as relative.
-                    if (path.Length > 1 && (path.StartsWith(StringLiterals.DefaultPathSeparatorString, StringComparison.Ordinal) ||
-                        path.StartsWith(StringLiterals.AlternatePathSeparatorString, StringComparison.Ordinal)))
+                    if (path.Length > 1 && (path.StartsWith(StringLiterals.DefaultPathSeparator) ||
+                        path.StartsWith(StringLiterals.AlternatePathSeparator)))
                     {
                         treatAsRelative = false;
                     }
@@ -3109,7 +3109,7 @@ namespace System.Management.Automation
                 if (drive.VolumeSeparatedByColon)
                 {
                     formatString = "{0}:" + StringLiterals.DefaultPathSeparator + "{1}";
-                    if (path.StartsWith(StringLiterals.DefaultPathSeparatorString, StringComparison.Ordinal))
+                    if (path.StartsWith(StringLiterals.DefaultPathSeparator))
                     {
                         formatString = "{0}:{1}";
                     }

--- a/src/System.Management.Automation/namespaces/NavigationProviderBase.cs
+++ b/src/System.Management.Automation/namespaces/NavigationProviderBase.cs
@@ -345,7 +345,7 @@ namespace System.Management.Automation.Provider
 
                     // Append the default path separator
 
-                    if (parent.EndsWith(StringLiterals.DefaultPathSeparatorString, StringComparison.Ordinal))
+                    if (parent.EndsWith(StringLiterals.DefaultPathSeparator))
                     {
                         result = parent;
                     }
@@ -377,9 +377,9 @@ namespace System.Management.Automation.Provider
 
                     StringBuilder builder = new StringBuilder(parent, parent.Length + child.Length + 1);
 
-                    if (parent.EndsWith(StringLiterals.DefaultPathSeparatorString, StringComparison.Ordinal))
+                    if (parent.EndsWith(StringLiterals.DefaultPathSeparator))
                     {
-                        if (child.StartsWith(StringLiterals.DefaultPathSeparatorString, StringComparison.Ordinal))
+                        if (child.StartsWith(StringLiterals.DefaultPathSeparator))
                         {
                             builder.Append(child, 1, child.Length - 1);
                         }
@@ -390,7 +390,7 @@ namespace System.Management.Automation.Provider
                     }
                     else
                     {
-                        if (child.StartsWith(StringLiterals.DefaultPathSeparatorString, StringComparison.CurrentCulture))
+                        if (child.StartsWith(StringLiterals.DefaultPathSeparator))
                         {
                             if (parent.Length == 0)
                             {
@@ -598,7 +598,7 @@ namespace System.Management.Automation.Provider
                 string originalPath = path;
                 Stack<string> tokenizedPathStack = null;
 
-                if (path.EndsWith(StringLiterals.DefaultPathSeparatorString, StringComparison.OrdinalIgnoreCase))
+                if (path.EndsWith(StringLiterals.DefaultPathSeparator))
                 {
                     path = path.TrimEnd(StringLiterals.DefaultPathSeparator);
                     originalPathHadTrailingSlash = true;
@@ -608,7 +608,7 @@ namespace System.Management.Automation.Provider
                 // See if the base and the path are already the same. We resolve this to
                 // ..\Leaf, since resolving "." to "." doesn't offer much information.
                 if (String.Equals(normalizedPath, normalizedBasePath, StringComparison.OrdinalIgnoreCase) &&
-                    (!originalPath.EndsWith(StringLiterals.DefaultPathSeparatorString, StringComparison.OrdinalIgnoreCase)))
+                    (!originalPath.EndsWith(StringLiterals.DefaultPathSeparator)))
                 {
                     string childName = GetChildName(path);
                     result = MakePath("..", childName);
@@ -648,7 +648,7 @@ namespace System.Management.Automation.Provider
                     if (!String.IsNullOrEmpty(commonBase))
                     {
                         if (String.Equals(normalizedPath, commonBase, StringComparison.OrdinalIgnoreCase) &&
-                            (!normalizedPath.EndsWith(StringLiterals.DefaultPathSeparatorString, StringComparison.OrdinalIgnoreCase)))
+                            (!normalizedPath.EndsWith(StringLiterals.DefaultPathSeparator)))
                         {
                             string childName = GetChildName(path);
                             result = MakePath("..", result);


### PR DESCRIPTION
## PR Summary

Replace string operations on char ones by using overloads like `StartsWith(char)` and `EndsWith(char)`.

It speeds up path operations in filesystem provider and globbing.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [x] Not Applicable or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
