### PR TITLE
Improve type inference of array literals and foreach statement variables

### DIFF
--- a/src/System.Management.Automation/engine/parser/TypeInferenceVisitor.cs
+++ b/src/System.Management.Automation/engine/parser/TypeInferenceVisitor.cs
@@ -2082,6 +2082,19 @@ namespace System.Management.Automation
                 return enumerableType.GetElementType();
             }
 
+            // These types implement IEnumerable, but we intentionally do not enumerate them.
+            if (enumerableType == typeof(string) ||
+                typeof(IDictionary).IsAssignableFrom(enumerableType) ||
+                typeof(Xml.XmlNode).IsAssignableFrom(enumerableType))
+            {
+                return enumerableType;
+            }
+
+            if (enumerableType == typeof(Data.DataTable))
+            {
+                return typeof(Data.DataRow);
+            }
+
             bool hasSeenNonGeneric = false;
             bool hasSeenDictionaryEnumerator = false;
             Type collectionInterface = GetGenericCollectionLikeInterface(
@@ -2133,9 +2146,8 @@ namespace System.Management.Automation
             if (interfaceType.IsConstructedGenericType)
             {
                 Type openGeneric = interfaceType.GetGenericTypeDefinition();
-                if (openGeneric == typeof(IList<>) ||
-                    openGeneric == typeof(ICollection<>) ||
-                    openGeneric == typeof(IEnumerator<>))
+                if (openGeneric == typeof(IEnumerator<>) ||
+                    openGeneric == typeof(IEnumerable<>))
                 {
                     return interfaceType;
                 }
@@ -2146,9 +2158,8 @@ namespace System.Management.Automation
                 hasSeenDictionaryEnumerator = true;
             }
 
-            if (interfaceType == typeof(IList) ||
-                interfaceType == typeof(ICollection) ||
-                interfaceType == typeof(IEnumerator))
+            if (interfaceType == typeof(IEnumerator) ||
+                interfaceType == typeof(IEnumerable))
             {
                 hasSeenNonGeneric = true;
             }

--- a/src/System.Management.Automation/engine/parser/TypeInferenceVisitor.cs
+++ b/src/System.Management.Automation/engine/parser/TypeInferenceVisitor.cs
@@ -2024,6 +2024,11 @@ namespace System.Management.Automation
             }
         }
 
+        /// <summary>
+        /// Gets the most specific array type possible from a group of inferred types.
+        /// </summary>
+        /// <param name="inferredTypes">The inferred types all the items in the array.</param>
+        /// <returns>The inferred strongly typed array type.</returns>
         private PSTypeName GetArrayType(IEnumerable<PSTypeName> inferredTypes)
         {
             PSTypeName foundType = null;
@@ -2075,6 +2080,11 @@ namespace System.Management.Automation
             return new PSTypeName(foundType.Type.MakeArrayType());
         }
 
+        /// <summary>
+        /// Gets the most specific type item type from a type that is potentially enumerable.
+        /// </summary>
+        /// <param name="enumerableType">The type to infer enumerated item type from.</param>
+        /// <returns>The inferred enumerated item type.</returns>
         private Type GetMostSpecificEnumeratedItemType(Type enumerableType)
         {
             if (enumerableType.IsArray)
@@ -2133,6 +2143,24 @@ namespace System.Management.Automation
             return null;
         }
 
+        /// <summary>
+        /// Determines if the interface can be used to infer a specific enumerated type.
+        /// </summary>
+        /// <param name="interfaceType">The interface to test.</param>
+        /// <param name="hasSeenNonGeneric">
+        /// A reference to a value indicating whether a non-generic enumerable type has been
+        /// seen. If <see paramref="interfaceType" /> is a non-generic enumerable type this
+        /// value will be set to <see langword="true" />.
+        /// </param>
+        /// <param name="hasSeenDictionaryEnumerator">
+        /// A reference to a value indicating whether <see cref="IDictionaryEnumerator" /> has been
+        /// seen. If <paramref name="interfaceType" /> is a <see cref="IDictionaryEnumerator" /> this
+        /// value will be set to <see langword="true" />.
+        /// </param>
+        /// <returns>
+        /// The value of <paramref name="interfaceType" /> if it can be used to infer a specific
+        /// enumerated type, otherwise <see langword="null" />.
+        /// </returns>
         private Type GetGenericCollectionLikeInterface(
             Type interfaceType,
             ref bool hasSeenNonGeneric,
@@ -2229,6 +2257,14 @@ namespace System.Management.Automation
             }
         }
 
+        /// <summary>
+        /// Infers the types as if they were enumerated. For example, a <see cref="List{T}" />
+        /// of type <see cref="string" /> would be returned as <see cref="string" />.
+        /// </summary>
+        /// <param name="enumerableTypes">
+        /// The potentially enumerable types to infer enumerated type from.
+        /// </param>
+        /// <returns>The enumerated item types.</returns>
         private IEnumerable<PSTypeName> GetInferredEnumeratedTypes(IEnumerable<PSTypeName> enumerableTypes)
         {
             foreach (PSTypeName maybeEnumerableType in enumerableTypes)

--- a/src/System.Management.Automation/engine/parser/TypeInferenceVisitor.cs
+++ b/src/System.Management.Automation/engine/parser/TypeInferenceVisitor.cs
@@ -2091,19 +2091,19 @@ namespace System.Management.Automation
 
             if (collectionInterface != null)
             {
-                return collectionInterface;
+                return collectionInterface.GetGenericArguments()[0];
             }
 
             foreach (Type interfaceType in enumerableType.GetInterfaces())
             {
                 collectionInterface = GetGenericCollectionLikeInterface(
-                    enumerableType,
+                    interfaceType,
                     ref hasSeenNonGeneric,
                     ref hasSeenDictionaryEnumerator);
 
                 if (collectionInterface != null)
                 {
-                    return collectionInterface;
+                    return collectionInterface.GetGenericArguments()[0];
                 }
             }
 
@@ -2125,6 +2125,11 @@ namespace System.Management.Automation
             ref bool hasSeenNonGeneric,
             ref bool hasSeenDictionaryEnumerator)
         {
+            if (!interfaceType.IsInterface)
+            {
+                return null;
+            }
+
             if (interfaceType.IsConstructedGenericType)
             {
                 Type openGeneric = interfaceType.GetGenericTypeDefinition();

--- a/src/System.Management.Automation/engine/parser/TypeInferenceVisitor.cs
+++ b/src/System.Management.Automation/engine/parser/TypeInferenceVisitor.cs
@@ -1930,9 +1930,22 @@ namespace System.Management.Automation
             int startOffset = variableExpressionAst.Extent.StartOffset;
             var targetAsts = (List<Ast>)AstSearcher.FindAll(
                 parent,
-                ast => (ast is ParameterAst || ast is AssignmentStatementAst || ast is ForEachStatementAst || ast is CommandAst)
-                       && variableExpressionAst.AstAssignsToSameVariable(ast)
-                       && ast.Extent.EndOffset < startOffset,
+                ast =>
+                {
+                    if (ast is ParameterAst || ast is AssignmentStatementAst || ast is CommandAst)
+                    {
+                        return variableExpressionAst.AstAssignsToSameVariable(ast)
+                            && ast.Extent.EndOffset < startOffset;
+                    }
+
+                    if (ast is ForEachStatementAst)
+                    {
+                        return variableExpressionAst.AstAssignsToSameVariable(ast)
+                            && ast.Extent.StartOffset < startOffset;
+                    }
+
+                    return false;
+                },
                 searchNestedScriptBlocks: true);
 
             foreach (var ast in targetAsts)

--- a/test/powershell/engine/Api/TypeInference.Tests.ps1
+++ b/test/powershell/engine/Api/TypeInference.Tests.ps1
@@ -66,16 +66,102 @@ Describe "Type inference Tests" -tags "CI" {
         $res.Name | Should -Be 'System.object[]'
     }
 
+    It "Infers type from array expression with a single statement" {
+        $res = [AstTypeInference]::InferTypeOf( { @('test') }.Ast)
+        $res.Count | Should -Be 1
+        $res.Name | Should -Be 'System.String[]'
+    }
+
+    It "Infers type from array expression with multiple statements" {
+        $res = [AstTypeInference]::InferTypeOf( { @('test'; 'second test') }.Ast)
+        $res.Count | Should -Be 1
+        $res.Name | Should -Be 'System.String[]'
+    }
+
+    It "Infers type from array expression with mixed types" {
+        $res = [AstTypeInference]::InferTypeOf( { @('test'; 1) }.Ast)
+        $res.Count | Should -Be 1
+        $res.Name | Should -Be 'System.Object[]'
+    }
+
+    It "Infers type from array expression with nested arrays" {
+        $res = [AstTypeInference]::InferTypeOf( { @(@('test'); @('test2')) }.Ast)
+        $res.Count | Should -Be 1
+        $res.Name | Should -Be 'System.String[]'
+    }
+
+    It "Infers type from array expression with a non-generic dictionary enumerator" {
+        $res = [AstTypeInference]::InferTypeOf( { @(@{}.GetEnumerator()) }.Ast)
+        $res.Count | Should -Be 1
+        $res.Name | Should -Be 'System.Collections.DictionaryEntry[]'
+    }
+
+    It "Infers type from array expression with a generic dictionary enumerator" {
+        $res = [AstTypeInference]::InferTypeOf( { @([Dictionary[int, string]]::new().GetEnumerator()) }.Ast)
+        $res.Count | Should -Be 1
+        $res.Name | Should -Be ([KeyValuePair[int, string][]].FullName)
+    }
+
+    It "Infers type from array expression with nested non-array collections" {
+        $res = [AstTypeInference]::InferTypeOf( {
+            $list = [List[string]]::new()
+            $list2 = [List[string]]::new()
+            @($list; $list2)
+        }.Ast)
+        $res.Count | Should -Be 1
+        $res.Name | Should -Be 'System.String[]'
+    }
+
     It "Infers type from Array literal" {
         $res = [AstTypeInference]::InferTypeOf( { , 1 }.Ast)
         $res.Count | Should -Be 1
-        $res.Name | Should -Be 'System.object[]'
+        $res.Name | Should -Be 'System.Int32[]'
+    }
+
+    It "Infers type from Array literal with multiple elements" {
+        $res = [AstTypeInference]::InferTypeOf( { 0, 1 }.Ast)
+        $res.Count | Should -Be 1
+        $res.Name | Should -Be 'System.Int32[]'
+    }
+
+    It "Infers type from Array literal with mixed types" {
+        $res = [AstTypeInference]::InferTypeOf( { 'test', 1 }.Ast)
+        $res.Count | Should -Be 1
+        $res.Name | Should -Be 'System.Object[]'
+    }
+
+    It "Infers type from Array literal with nested arrays" {
+        $res = [AstTypeInference]::InferTypeOf( { @('test'), @('test2') }.Ast)
+        $res.Count | Should -Be 1
+        $res.Name | Should -Be 'System.String[]'
+    }
+
+    It "Infers type from array expression with a non-generic dictionary enumerator" {
+        $res = [AstTypeInference]::InferTypeOf( { , @{}.GetEnumerator() }.Ast)
+        $res.Count | Should -Be 1
+        $res.Name | Should -Be 'System.Collections.DictionaryEntry[]'
+    }
+
+    It "Infers type from array expression with a generic dictionary enumerator" {
+        $res = [AstTypeInference]::InferTypeOf( { , [Dictionary[int, string]]::new().GetEnumerator() }.Ast)
+        $res.Count | Should -Be 1
+        $res.Name | Should -Be ([KeyValuePair[int, string][]].FullName)
+    }
+
+    It "Infers type from Array literal with nested non-array collections" {
+        $res = [AstTypeInference]::InferTypeOf( {
+            $list = [List[string]]::new()
+            $list2 = [List[string]]::new()
+            $list, $list2
+        }.Ast.EndBlock.Statements[2].PipelineElements[0].Expression)
+        $res.Count | Should -Be 1
+        $res.Name | Should -Be 'System.String[]'
     }
 
     It "Infers type from array IndexExpresssion" {
         $res = [AstTypeInference]::InferTypeOf( { (1, 2, 3)[0] }.Ast)
         $res.Count | Should -Be 1
-        $res.Name | Should -Be 'System.object'
+        $res.Name | Should -Be 'System.Int32'
     }
 
     It "Infers type from generic container IndexExpression" {
@@ -558,6 +644,39 @@ Describe "Type inference Tests" -tags "CI" {
         foreach ($r in $res) {
             $r.Name -In 'System.Type', 'System.Int32', 'System.String' | Should -BeTrue
         }
+    }
+
+    It 'Infers type of a Foreach statement current value variable' {
+        $res = [AstTypeInference]::InferTypeOf( {
+            foreach ($intValue in 1, 2, 3) {
+                $intValue
+            }
+        }.Ast.EndBlock.Statements[0].Body.Statements[0].PipelineElements[0].Expression)
+
+        $res.Count | Should -Be 1
+        $res.Name | Should -BeExactly 'System.Int32'
+    }
+
+    It 'Infers type of a Foreach statement current value variable with hashtable enumerator' {
+        $res = [AstTypeInference]::InferTypeOf( {
+            foreach ($dictionaryEntry in @{}.GetEnumerator()) {
+                $dictionaryEntry
+            }
+        }.Ast.EndBlock.Statements[0].Body.Statements[0].PipelineElements[0].Expression)
+
+        $res.Count | Should -Be 2
+        $res.Name | Should -Be 'System.Collections.DictionaryEntry', 'System.Object'
+    }
+
+    It 'Infers type of a Foreach statement current value variable with dictionary enumerator' {
+        $res = [AstTypeInference]::InferTypeOf( {
+            foreach ($keyValuePair in [Dictionary[int, string]]::new().GetEnumerator()) {
+                $keyValuePair
+            }
+        }.Ast.EndBlock.Statements[0].Body.Statements[0].PipelineElements[0].Expression)
+
+        $res.Count | Should -Be 3
+        $res.Name | Should -Be ([KeyValuePair[int, string]].FullName), 'System.Object', 'System.Collections.DictionaryEntry'
     }
 
     It 'Infers type from While statement' {

--- a/test/powershell/engine/Api/TypeInference.Tests.ps1
+++ b/test/powershell/engine/Api/TypeInference.Tests.ps1
@@ -679,6 +679,18 @@ Describe "Type inference Tests" -tags "CI" {
         $res.Name | Should -Be ([KeyValuePair[int, string]].FullName), 'System.Object', 'System.Collections.DictionaryEntry'
     }
 
+    It 'Infers type of a Foreach statement current value variable with generic IEnumerable' {
+        $res = [AstTypeInference]::InferTypeOf( {
+            $debugger = [Debugger]$Host.Runspace.Debugger
+            foreach ($subscriber in $debugger.GetCallStack()) {
+                $subscriber
+            }
+        }.Ast.EndBlock.Statements[1].Body.Statements[0].PipelineElements[0].Expression)
+
+        $res.Count | Should -Be 1
+        $res.Name | Should -BeExactly 'System.Management.Automation.CallStackFrame'
+    }
+
     It 'Infers type from While statement' {
         $res = [AstTypeInference]::InferTypeOf( {
                 while ($true) {


### PR DESCRIPTION
## PR Summary

Improve type inference for `foreach` statement variables by:

1. Inferring strongly typed arrays from explicit array and array literal expressions when elements are of the same inferred type

1. Fix detection of `foreach` variable declaration.  The previous logic was to check if the variable expression's start offset was *after* the end offset of the `foreach` statement, which will never be true in the body

1. Improve inference of what type the "Condition" of a `foreach` statement will enumerate as

Here's some examples of scenarios that now work correctly:

```powershell
foreach ($i in 0, 1, 2) { $i.<tab> }
# CompareTo    GetType      ToByte       ToDecimal    ToInt32      ToSingle     ToUInt16     TryFormat
# Equals       GetTypeCode  ToChar       ToDouble     ToInt64      ToString     ToUInt32
# GetHashCode  ToBoolean    ToDateTime   ToInt16      ToSByte      ToType       ToUInt64
foreach ($i in @{}.GetEnumerator()) { $i.<tab> }
# Key          Name         Value        Deconstruct  Equals       GetHashCode  GetType      ToString
$dict = [System.Collections.Generic.Dictionary[string, string]]::new()
foreach ($i in $dict.GetEnumerator()) { $i.<tab> }
# Key          Value        Deconstruct  Equals       GetHashCode  GetType      ToString
foreach ($i in $dict.GetEnumerator()) { $i.Key.<tab> }
# Length            GetType           PadLeft           ToChar            ToLowerInvariant  ToUpperInvariant
# Clone             GetTypeCode       PadRight          ToCharArray       ToSByte           Trim
# CompareTo         IndexOf           Remove            ToDateTime        ToSingle          TrimEnd
# Contains          IndexOfAny        Replace           ToDecimal         ToString          TrimStart
# CopyTo            Insert            Split             ToDouble          ToType
# EndsWith          IsNormalized      StartsWith        ToInt16           ToUInt16
# Equals            LastIndexOf       Substring         ToInt32           ToUInt32
# GetEnumerator     LastIndexOfAny    ToBoolean         ToInt64           ToUInt64
# GetHashCode       Normalize         ToByte            ToLower           ToUpper
```

~~**Note:** I specifically avoided testing for `IEnumerable<>` directly because some types like `string` are not enumerated by PowerShell.  I know there's more types than `string`, if someone could point me to a full list of types that implement `IEnumerable` but PowerShell doesn't enumerate, I'll add in testing for that as well.~~ Found it, I used [PSEnumerableBinder](https://github.com/PowerShell/PowerShell/blob/0a4f33a872ab811d55ff0f255d87035dbf137fb2/src/System.Management.Automation/engine/runtime/Binding/Binders.cs#L514) for reference.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
