### PR TITLE
Enable experimental feature to support tab completion on abbreviated cmdlets

### DIFF
--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -176,10 +176,10 @@ namespace System.Management.Automation
                     .AddParameter("All")
                     .AddParameter("Name", commandName);
 
-                    if (ExperimentalFeature.IsEnabled("PSUseAbbreviationExpansion"))
-                    {
-                        powershell.AddParameter("UseAbbreviationExpansion");
-                    }
+                if (ExperimentalFeature.IsEnabled("PSUseAbbreviationExpansion"))
+                {
+                    powershell.AddParameter("UseAbbreviationExpansion");
+                }
 
                 if (moduleName != null)
                 {

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -164,6 +164,7 @@ namespace System.Management.Automation
                 powershell.AddParameter("CommandType", types);
             }
 
+            // Exception is ignored, the user simply does not get any completion results if the pipeline fails
             Exception exceptionThrown;
             var commandInfos = context.Helper.ExecuteCurrentPowerShell(out exceptionThrown);
 

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -87,7 +87,6 @@ namespace System.Management.Automation
             string commandName = context.WordToComplete;
             string quote = HandleDoubleAndSingleQuote(ref commandName);
 
-            commandName += "*";
             List<CompletionResult> commandResults = null;
 
             if (commandName.IndexOfAny(Utils.Separators.DirectoryOrDrive) == -1)
@@ -100,29 +99,7 @@ namespace System.Management.Automation
                     lastAst = context.RelatedAsts.Last();
                 }
 
-                var powershell = context.Helper
-                    .AddCommandWithPreferenceSetting("Get-Command", typeof(GetCommandCommand))
-                    .AddParameter("All")
-                    .AddParameter("Name", commandName);
-
-                if (moduleName != null)
-                    powershell.AddParameter("Module", moduleName);
-                if (!types.Equals(CommandTypes.All))
-                    powershell.AddParameter("CommandType", types);
-
-                Exception exceptionThrown;
-                var commandInfos = context.Helper.ExecuteCurrentPowerShell(out exceptionThrown);
-
-                if (commandInfos != null && commandInfos.Count > 1)
-                {
-                    // OrderBy is using stable sorting
-                    var sortedCommandInfos = commandInfos.OrderBy(a => a, new CommandNameComparer());
-                    commandResults = MakeCommandsUnique(sortedCommandInfos, /* includeModulePrefix: */ false, addAmpersandIfNecessary, quote);
-                }
-                else
-                {
-                    commandResults = MakeCommandsUnique(commandInfos, /* includeModulePrefix: */ false, addAmpersandIfNecessary, quote);
-                }
+                commandResults = ExecuteGetCommandCommand(context, moduleName, types, includeModulePrefix: false);
 
                 if (lastAst != null)
                 {
@@ -159,28 +136,74 @@ namespace System.Management.Automation
                     moduleName = commandName.Substring(0, indexOfFirstBackslash);
                     commandName = commandName.Substring(indexOfFirstBackslash + 1);
 
-                    var powershell = context.Helper
-                        .AddCommandWithPreferenceSetting("Get-Command", typeof(GetCommandCommand))
-                        .AddParameter("All")
-                        .AddParameter("Name", commandName)
-                        .AddParameter("Module", moduleName);
-
-                    if (!types.Equals(CommandTypes.All))
-                        powershell.AddParameter("CommandType", types);
-
-                    Exception exceptionThrown;
-                    var commandInfos = context.Helper.ExecuteCurrentPowerShell(out exceptionThrown);
-
-                    if (commandInfos != null && commandInfos.Count > 1)
-                    {
-                        var sortedCommandInfos = commandInfos.OrderBy(a => a, new CommandNameComparer());
-                        commandResults = MakeCommandsUnique(sortedCommandInfos, /* includeModulePrefix: */ true, addAmpersandIfNecessary, quote);
-                    }
-                    else
-                    {
-                        commandResults = MakeCommandsUnique(commandInfos, /* includeModulePrefix: */ true, addAmpersandIfNecessary, quote);
-                    }
+                    commandResults = ExecuteGetCommandCommand(context, moduleName, types, includeModulePrefix: true);
                 }
+            }
+
+            return commandResults;
+        }
+
+        private static List<CompletionResult> ExecuteGetCommandCommand(CompletionContext context, string moduleName, CommandTypes types, bool includeModulePrefix)
+        {
+            var addAmpersandIfNecessary = IsAmpersandNeeded(context, false);
+            string commandName = context.WordToComplete;
+            string quote = HandleDoubleAndSingleQuote(ref commandName);
+
+            var powershell = context.Helper
+                .AddCommandWithPreferenceSetting("Get-Command", typeof(GetCommandCommand))
+                .AddParameter("All")
+                .AddParameter("Name", commandName + "*");
+
+            if (moduleName != null)
+            {
+                powershell.AddParameter("Module", moduleName);
+            }
+
+            if (!types.Equals(CommandTypes.All))
+            {
+                powershell.AddParameter("CommandType", types);
+            }
+
+            Exception exceptionThrown;
+            var commandInfos = context.Helper.ExecuteCurrentPowerShell(out exceptionThrown);
+
+            if (commandInfos == null || commandInfos.Count == 0)
+            {
+                powershell.Commands.Clear();
+                powershell
+                    .AddCommandWithPreferenceSetting("Get-Command", typeof(GetCommandCommand))
+                    .AddParameter("All")
+                    .AddParameter("Name", commandName);
+
+                    if (ExperimentalFeature.IsEnabled("PSUseAbbreviationExpansion"))
+                    {
+                        powershell.AddParameter("UseAbbreviationExpansion");
+                    }
+
+                if (moduleName != null)
+                {
+                    powershell.AddParameter("Module", moduleName);
+                }
+
+                if (!types.Equals(CommandTypes.All))
+                {
+                    powershell.AddParameter("CommandType", types);
+                }
+
+                commandInfos = context.Helper.ExecuteCurrentPowerShell(out exceptionThrown);
+            }
+
+            List<CompletionResult> commandResults = null;
+
+            if (commandInfos != null && commandInfos.Count > 1)
+            {
+                // OrderBy is using stable sorting
+                var sortedCommandInfos = commandInfos.OrderBy(a => a, new CommandNameComparer());
+                commandResults = MakeCommandsUnique(sortedCommandInfos, includeModulePrefix, addAmpersandIfNecessary, quote);
+            }
+            else
+            {
+                commandResults = MakeCommandsUnique(commandInfos, includeModulePrefix, addAmpersandIfNecessary, quote);
             }
 
             return commandResults;

--- a/src/System.Management.Automation/engine/CommandDiscovery.cs
+++ b/src/System.Management.Automation/engine/CommandDiscovery.cs
@@ -1131,32 +1131,11 @@ namespace System.Management.Automation
                                 }
 
                                 result = LookupCommandInfo(commandName, commandTypes, searchResolutionOptions, commandOrigin, context);
-
-                                if (result != null)
-                                {
-                                    break;
-                                }
                             }
 
                             if (result != null)
                             {
                                 break;
-                            }
-                            else if (searchResolutionOptions.HasFlag(SearchResolutionOptions.UseAbbreviationExpansion))
-                            {
-                                foreach (var cmdlet in exportedCommands)
-                                {
-                                    string abbreviatedCmdlet = new string(cmdlet.Key.Where(c => char.IsUpper(c) || c == '-').ToArray());
-                                    if (commandName.Equals(abbreviatedCmdlet, StringComparison.OrdinalIgnoreCase))
-                                    {
-                                        // take only the first found command
-                                        result = LookupCommandInfo(cmdlet.Key, commandOrigin, context);
-                                        if (result != null)
-                                        {
-                                            break;
-                                        }
-                                    }
-                                }
                             }
                         }
 

--- a/src/System.Management.Automation/engine/CommandDiscovery.cs
+++ b/src/System.Management.Automation/engine/CommandDiscovery.cs
@@ -1142,7 +1142,7 @@ namespace System.Management.Automation
                             {
                                 foreach (var cmdlet in exportedCommands)
                                 {
-                                    string abbreviatedCmdlet = new String(cmdlet.Key.Where(c => Char.IsUpper(c) || c == '-').ToArray());
+                                    string abbreviatedCmdlet = new string(cmdlet.Key.Where(c => char.IsUpper(c) || c == '-').ToArray());
                                     if (commandName.Equals(abbreviatedCmdlet, StringComparison.OrdinalIgnoreCase))
                                     {
                                         result = LookupCommandInfo(cmdlet.Key, commandOrigin, context);
@@ -1512,7 +1512,6 @@ namespace System.Management.Automation
 
             // Check the current cmdlet cache then check the top level
             // if we aren't already at the top level.
-
             SessionStateScopeEnumerator scopeEnumerator =
                 new SessionStateScopeEnumerator(Context.EngineSessionState.CurrentScope);
 
@@ -1527,7 +1526,7 @@ namespace System.Management.Automation
                         {
                             foreach (CmdletInfo cmdletInfo in cmdletList)
                             {
-                                string abbreviatedCmdlet = new String(cmdletInfo.Name.Where(c => Char.IsUpper(c)).ToArray());
+                                string abbreviatedCmdlet = new string(cmdletInfo.Name.Where(c => char.IsUpper(c)).ToArray());
                                 if (cmdletName.Equals(abbreviatedCmdlet, StringComparison.OrdinalIgnoreCase))
                                 {
                                     yield return cmdletInfo;

--- a/src/System.Management.Automation/engine/CommandSearcher.cs
+++ b/src/System.Management.Automation/engine/CommandSearcher.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
+using System.Management.Automation.Internal;
 using Dbg = System.Management.Automation.Diagnostics;
 
 namespace System.Management.Automation
@@ -748,8 +749,7 @@ namespace System.Management.Automation
                         }
                         else if (_commandResolutionOptions.HasFlag(SearchResolutionOptions.UseAbbreviationExpansion))
                         {
-                            string abbreviatedFunction = new string(((string)functionEntry.Key).Where(c => char.IsUpper(c) || c == '-').ToArray());
-                            if (_commandName.Equals(abbreviatedFunction, StringComparison.OrdinalIgnoreCase))
+                            if (_commandName.Equals(ModuleUtils.AbbreviateName((string)functionEntry.Key), StringComparison.OrdinalIgnoreCase))
                             {
                                 matchingFunction.Add((CommandInfo)functionEntry.Value);
                             }
@@ -955,17 +955,18 @@ namespace System.Management.Automation
         private CmdletInfo GetNextCmdlet()
         {
             CmdletInfo result = null;
+            bool useAbbreviationExpansion = _commandResolutionOptions.HasFlag(SearchResolutionOptions.UseAbbreviationExpansion);
 
             if (_matchingCmdlet == null)
             {
-                if (_commandResolutionOptions.HasFlag(SearchResolutionOptions.CommandNameIsPattern) || _commandResolutionOptions.HasFlag(SearchResolutionOptions.UseAbbreviationExpansion))
+                if (_commandResolutionOptions.HasFlag(SearchResolutionOptions.CommandNameIsPattern) || useAbbreviationExpansion)
                 {
                     Collection<CmdletInfo> matchingCmdletInfo = new Collection<CmdletInfo>();
 
                     PSSnapinQualifiedName PSSnapinQualifiedCommandName =
                         PSSnapinQualifiedName.GetInstance(_commandName);
 
-                    if (!_commandResolutionOptions.HasFlag(SearchResolutionOptions.UseAbbreviationExpansion) && PSSnapinQualifiedCommandName == null)
+                    if (!useAbbreviationExpansion && PSSnapinQualifiedCommandName == null)
                     {
                         return null;
                     }
@@ -993,10 +994,9 @@ namespace System.Management.Automation
                                     matchingCmdletInfo.Add(cmdlet);
                                 }
                             }
-                            else if (_commandResolutionOptions.HasFlag(SearchResolutionOptions.UseAbbreviationExpansion))
+                            else if (useAbbreviationExpansion)
                             {
-                                string abbreviatedCmdlet = new string(cmdlet.Name.Where(c => char.IsUpper(c) || c == '-').ToArray());
-                                if (_commandName.Equals(abbreviatedCmdlet, StringComparison.OrdinalIgnoreCase))
+                                if (_commandName.Equals(ModuleUtils.AbbreviateName(cmdlet.Name), StringComparison.OrdinalIgnoreCase))
                                 {
                                     matchingCmdletInfo.Add(cmdlet);
                                 }

--- a/src/System.Management.Automation/engine/CommandSearcher.cs
+++ b/src/System.Management.Automation/engine/CommandSearcher.cs
@@ -726,8 +726,7 @@ namespace System.Management.Automation
         {
             CommandInfo result = null;
 
-            if (_commandResolutionOptions.HasFlag(SearchResolutionOptions.ResolveFunctionPatterns) ||
-                _commandResolutionOptions.HasFlag(SearchResolutionOptions.UseAbbreviationExpansion))
+            if (_commandResolutionOptions.HasFlag(SearchResolutionOptions.ResolveFunctionPatterns))
             {
                 if (_matchingFunctionEnumerator == null)
                 {
@@ -1010,8 +1009,7 @@ namespace System.Management.Automation
                 else
                 {
                     _matchingCmdlet = _context.CommandDiscovery.GetCmdletInfo(_commandName,
-                        _commandResolutionOptions.HasFlag(SearchResolutionOptions.SearchAllScopes),
-                        _commandResolutionOptions.HasFlag(SearchResolutionOptions.UseAbbreviationExpansion));
+                        _commandResolutionOptions.HasFlag(SearchResolutionOptions.SearchAllScopes));
                 }
             }
 

--- a/src/System.Management.Automation/engine/CommandSearcher.cs
+++ b/src/System.Management.Automation/engine/CommandSearcher.cs
@@ -749,7 +749,7 @@ namespace System.Management.Automation
                         }
                         else if (_commandResolutionOptions.HasFlag(SearchResolutionOptions.UseAbbreviationExpansion))
                         {
-                            string abbreviatedFunction = new String(((string)functionEntry.Key).Where(c => Char.IsUpper(c) || c == '-').ToArray());
+                            string abbreviatedFunction = new string(((string)functionEntry.Key).Where(c => char.IsUpper(c) || c == '-').ToArray());
                             if (_commandName.Equals(abbreviatedFunction, StringComparison.OrdinalIgnoreCase))
                             {
                                 matchingFunction.Add((CommandInfo)functionEntry.Value);
@@ -996,7 +996,7 @@ namespace System.Management.Automation
                             }
                             else if (_commandResolutionOptions.HasFlag(SearchResolutionOptions.UseAbbreviationExpansion))
                             {
-                                string abbreviatedCmdlet = new String(cmdlet.Name.Where(c => Char.IsUpper(c) || c == '-').ToArray());
+                                string abbreviatedCmdlet = new string(cmdlet.Name.Where(c => char.IsUpper(c) || c == '-').ToArray());
                                 if (_commandName.Equals(abbreviatedCmdlet, StringComparison.OrdinalIgnoreCase))
                                 {
                                     matchingCmdletInfo.Add(cmdlet);

--- a/src/System.Management.Automation/engine/CommandSearcher.cs
+++ b/src/System.Management.Automation/engine/CommandSearcher.cs
@@ -5,7 +5,6 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
-using System.Linq;
 using System.Management.Automation.Internal;
 using Dbg = System.Management.Automation.Diagnostics;
 

--- a/src/System.Management.Automation/engine/ExperimentalFeature/ExperimentalFeature.cs
+++ b/src/System.Management.Automation/engine/ExperimentalFeature/ExperimentalFeature.cs
@@ -91,7 +91,11 @@ namespace System.Management.Automation
                 new ExperimentalFeature(name: "PSImplicitRemotingBatching",
                                         description: "Batch implicit remoting proxy commands to improve performance",
                                         source: EngineSource,
-                                        isEnabled: false)
+                                        isEnabled: false),
+                new ExperimentalFeature(name: "PSUseAbbreviationExpansion",
+                                        description: "Allow tab completion of cmdlets and functions by abbreviation",
+                                        source: EngineSource,
+                                        isEnabled: false),
             };
             EngineExperimentalFeatures = new ReadOnlyCollection<ExperimentalFeature>(engineFeatures);
 

--- a/src/System.Management.Automation/engine/GetCommandCommand.cs
+++ b/src/System.Management.Automation/engine/GetCommandCommand.cs
@@ -715,6 +715,11 @@ namespace Microsoft.PowerShell.Commands
                 options |= SearchResolutionOptions.UseAbbreviationExpansion;
             }
 
+            if (UseFuzzyMatching)
+            {
+                options |= SearchResolutionOptions.FuzzyMatch;
+            }
+
             if ((this.CommandType & CommandTypes.Alias) != 0)
             {
                 options |= SearchResolutionOptions.ResolveAliasPatterns;
@@ -742,13 +747,7 @@ namespace Microsoft.PowerShell.Commands
                         moduleName = this.Module[0];
                     }
 
-                    bool isPattern = WildcardPattern.ContainsWildcardCharacters(plainCommandName);
-                    if (UseFuzzyMatching)
-                    {
-                        options |= SearchResolutionOptions.FuzzyMatch;
-                        isPattern = true;
-                    }
-
+                    bool isPattern = WildcardPattern.ContainsWildcardCharacters(plainCommandName) || UseAbbreviationExpansion || UseFuzzyMatching;
                     if (isPattern)
                     {
                         options |= SearchResolutionOptions.CommandNameIsPattern;
@@ -812,7 +811,8 @@ namespace Microsoft.PowerShell.Commands
                                         this.Context,
                                         this.MyInvocation.CommandOrigin,
                                         rediscoverImportedModules: true,
-                                        moduleVersionRequired: _isFullyQualifiedModuleSpecified);
+                                        moduleVersionRequired: _isFullyQualifiedModuleSpecified,
+                                        useAbbreviationExpansion: UseAbbreviationExpansion);
                                 }
 
                                 foreach (CommandInfo command in commands)

--- a/src/System.Management.Automation/engine/GetCommandCommand.cs
+++ b/src/System.Management.Automation/engine/GetCommandCommand.cs
@@ -775,7 +775,7 @@ namespace Microsoft.PowerShell.Commands
 
                             try
                             {
-                                CommandDiscovery.LookupCommandInfo(tempCommandName, CommandTypes.All, options, this.MyInvocation.CommandOrigin, this.Context);
+                                CommandDiscovery.LookupCommandInfo(tempCommandName, this.MyInvocation.CommandOrigin, this.Context);
                             }
                             catch (CommandNotFoundException)
                             {

--- a/src/System.Management.Automation/engine/GetCommandCommand.cs
+++ b/src/System.Management.Automation/engine/GetCommandCommand.cs
@@ -358,6 +358,14 @@ namespace Microsoft.PowerShell.Commands
 
         private List<CommandScore> _commandScores = new List<CommandScore>();
 
+        /// The parameter that determines if return cmdlets based on abbreviation expansion.
+        /// This means it matches cmdlets where the uppercase characters for the noun match
+        /// the given characters.  i.e., Get-sgc would match Get-SomeGreatCmdlet
+        /// </summary>
+        [Experimental("PSUseAbbreviationExpansion", ExperimentAction.Show)]
+        [Parameter(ValueFromPipelineByPropertyName = true, ParameterSetName = "AllCommandSet")]
+        public SwitchParameter UseAbbreviationExpansion { get; set; }
+
         #endregion Definitions of cmdlet parameters
 
         #region Overrides
@@ -701,6 +709,11 @@ namespace Microsoft.PowerShell.Commands
                 options = SearchResolutionOptions.SearchAllScopes;
             }
 
+            if (UseAbbreviationExpansion)
+            {
+                options |= SearchResolutionOptions.UseAbbreviationExpansion;
+            }
+
             if ((this.CommandType & CommandTypes.Alias) != 0)
             {
                 options |= SearchResolutionOptions.ResolveAliasPatterns;
@@ -762,7 +775,7 @@ namespace Microsoft.PowerShell.Commands
 
                             try
                             {
-                                CommandDiscovery.LookupCommandInfo(tempCommandName, this.MyInvocation.CommandOrigin, this.Context);
+                                CommandDiscovery.LookupCommandInfo(tempCommandName, CommandTypes.All, options, this.MyInvocation.CommandOrigin, this.Context);
                             }
                             catch (CommandNotFoundException)
                             {
@@ -964,7 +977,7 @@ namespace Microsoft.PowerShell.Commands
 
                     // Only for this case, the loop should exit
                     // Get-Command Foo
-                    if (isPattern || All || TotalCount != -1 || _isCommandTypeSpecified || _isModuleSpecified || _isFullyQualifiedModuleSpecified)
+                    if (UseAbbreviationExpansion || isPattern || All || TotalCount != -1 || _isCommandTypeSpecified || _isModuleSpecified || _isFullyQualifiedModuleSpecified)
                     {
                         continue;
                     }

--- a/src/System.Management.Automation/engine/GetCommandCommand.cs
+++ b/src/System.Management.Automation/engine/GetCommandCommand.cs
@@ -978,7 +978,7 @@ namespace Microsoft.PowerShell.Commands
 
                     // Only for this case, the loop should exit
                     // Get-Command Foo
-                    if (UseAbbreviationExpansion || isPattern || All || TotalCount != -1 || _isCommandTypeSpecified || _isModuleSpecified || _isFullyQualifiedModuleSpecified)
+                    if (isPattern || All || TotalCount != -1 || _isCommandTypeSpecified || _isModuleSpecified || _isFullyQualifiedModuleSpecified)
                     {
                         continue;
                     }

--- a/src/System.Management.Automation/engine/GetCommandCommand.cs
+++ b/src/System.Management.Automation/engine/GetCommandCommand.cs
@@ -358,9 +358,10 @@ namespace Microsoft.PowerShell.Commands
 
         private List<CommandScore> _commandScores = new List<CommandScore>();
 
-        /// The parameter that determines if return cmdlets based on abbreviation expansion.
+        /// <summary>
+        /// Gets or sets the parameter that determines if return cmdlets based on abbreviation expansion.
         /// This means it matches cmdlets where the uppercase characters for the noun match
-        /// the given characters.  i.e., Get-sgc would match Get-SomeGreatCmdlet
+        /// the given characters.  i.e., g-sgc would match Get-SomeGreatCmdlet.
         /// </summary>
         [Experimental("PSUseAbbreviationExpansion", ExperimentAction.Show)]
         [Parameter(ValueFromPipelineByPropertyName = true, ParameterSetName = "AllCommandSet")]

--- a/src/System.Management.Automation/engine/Modules/ModuleUtils.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleUtils.cs
@@ -4,7 +4,6 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
-using System.Linq;
 using System.Management.Automation.Runspaces;
 using System.Text;
 using Dbg = System.Management.Automation.Diagnostics;
@@ -591,7 +590,8 @@ namespace System.Management.Automation.Internal
         /// <returns>Abbreviated version of the command name.</returns>
         internal static string AbbreviateName(string commandName)
         {
-            StringBuilder abbreviation = new StringBuilder();
+            // Use default size of 6 which represents expected average abbreviation length
+            StringBuilder abbreviation = new StringBuilder(6);
             foreach (char c in commandName)
             {
                 if (char.IsUpper(c) || c == '-')

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -33,7 +33,7 @@ Describe "TabCompletion" -Tags CI {
 
         It 'Should complete abbreviated function' {
             $res = pwsh -settingsfile $configFilePath -c "(TabExpansion2 -inputScript 'pschrl' -cursorColumn 'pschr'.Length).CompletionMatches.CompletionText"
-            $res | Should -HaveCount 1
+            $res.Count | Should -BeGreaterOrEqual 1
             $res | Should -BeExactly 'PSConsoleHostReadLine'
         }
 

--- a/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
+++ b/test/powershell/Host/TabCompletion/TabCompletion.Tests.ps1
@@ -10,6 +10,35 @@ Describe "TabCompletion" -Tags CI {
         $res.CompletionMatches[0].CompletionText | Should -BeExactly 'Get-Command'
     }
 
+    Context "ExperimentalFeatures" {
+
+        BeforeAll {
+            $configFilePath = Join-Path $testdrive "useabbreviationexpansion.json"
+
+            @"
+            {
+                "ExperimentalFeatures": [
+                  "PSUseAbbreviationExpansion"
+                ]
+            }
+"@ > $configFilePath
+
+        }
+
+        It 'Should complete abbreviated cmdlet' {
+            $res = pwsh -settingsfile $configFilePath -c "(TabExpansion2 -inputScript 'i-psdf' -cursorColumn 'pschr'.Length).CompletionMatches.CompletionText"
+            $res | Should -HaveCount 1
+            $res | Should -BeExactly 'Import-PowerShellDataFile'
+        }
+
+        It 'Should complete abbreviated function' {
+            $res = pwsh -settingsfile $configFilePath -c "(TabExpansion2 -inputScript 'pschrl' -cursorColumn 'pschr'.Length).CompletionMatches.CompletionText"
+            $res | Should -HaveCount 1
+            $res | Should -BeExactly 'PSConsoleHostReadLine'
+        }
+
+    }
+
     It 'Should complete native exe' -Skip:(!$IsWindows) {
         $res = TabExpansion2 -inputScript 'notep' -cursorColumn 'notep'.Length
         $res.CompletionMatches[0].CompletionText | Should -BeExactly 'notepad.exe'

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Command.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Command.Tests.ps1
@@ -20,4 +20,70 @@ Describe "Get-Command CI tests" -Tag Feature {
             $cmds.Name | Should -Contain $ping
         }
     }
+
+    Context "-UseAbbreviationExpansion tests" {
+        BeforeAll {
+            $configFilePath = Join-Path $testdrive "useabbreviationexpansion.json"
+
+            @"
+            {
+                "ExperimentalFeatures": [
+                  "PSUseAbbreviationExpansion"
+                ]
+            }
+"@ > $configFilePath
+
+        }
+
+        It "Valid cmdlets works with name <name> and module <module>" -TestCases @(
+            @{ Name = "i-psdf"; expected = "Import-PowerShellDataFile"; module = $null },
+            @{ Name = "i-psdf"; expected = "Import-PowerShellDataFile"; module = "Microsoft.PowerShell.Utility" },
+            @{ Name = "r-psb" ; expected = "Remove-PSBreakpoint"      ; module = $null },
+            @{ Name = "r-psb" ; expected = "Remove-PSBreakpoint"      ; module = "Microsoft.PowerShell.Utility" }
+        ) {
+            param($name, $expected, $module)
+
+            $command = "Get-Command $name -UseAbbreviationExpansion"
+
+            if ($module) {
+                $command += " -Module $module"
+            }
+
+            $results = pwsh -settingsfile $configFilePath -c "$command | ConvertTo-Json" | ConvertFrom-Json
+            $results | Should -HaveCount 1
+            $results.Name | Should -BeExactly $expected
+        }
+
+        It "Can return multiple results for cmdlets matching abbreviation" {
+            $results = pwsh -settingsfile $configFilePath -c "Get-Command i-C -UseAbbreviationExpansion | ConvertTo-Json" | ConvertFrom-Json
+            $results | Should -HaveCount 3
+            $results[0].Name | Should -BeExactly "Invoke-Command"
+            $results[1].Name | Should -BeExactly "Import-Clixml"
+            $results[2].Name | Should -BeExactly "Import-Csv"
+        }
+
+        It "Will return multiple results for functions matching abbreviation" {
+            $manifestPath = Join-Path $testdrive "test.psd1"
+            $modulePath = Join-Path $testdrive "test.psm1"
+
+            New-ModuleManifest -Path $manifestPath -FunctionsToExport "Get-FooBar","Get-FB" -RootModule test.psm1
+            @"
+            function Get-FooBar { "foobar" }
+            function Get-FB { "fb" }
+"@ > $modulePath
+
+            $results = pwsh -settingsfile $configFilePath -c "Import-Module $manifestPath; Get-Command g-fb -UseAbbreviationExpansion | ConvertTo-Json" | ConvertFrom-Json
+            $results | Should -HaveCount 2
+            $results[0].Name | Should -BeExactly "Get-FB"
+            $results[1].Name | Should -BeExactly "Get-FooBar"
+        }
+
+        It "Non-existing cmdlets returns non-terminating error" {
+            pwsh -settingsfile $configFilePath -c 'try { get-command g-adf -ea stop } catch { $_.fullyqualifiederrorid }' | Should -BeExactly "CommandNotFoundException,Microsoft.PowerShell.Commands.GetCommandCommand"
+        }
+
+        It "No results if wildcard is used" {
+            pwsh -settingsfile $configFilePath -c Get-Command i-psd* -UseAbbreviationExpansion | Should -BeNullOrEmpty
+        }
+    }
 }


### PR DESCRIPTION
## PR Summary

While watching some demos at PSConfAsia, it's obvious that cmdlet nouns have gotten descriptive and wordy (Azure and AWS are good examples).  This `experimental` feature enables tab-completion of abbreviated cmdlets and functions:

```none
i-psdf<tab>

returns: Import-PowerShellDataFile

u-akvmssdr<tab>

returns: Undo-AzKeyVaultManagedStorageSasDefinitionRemoval
```

Note that this only works for tab completion (interactive use), so `i-psdf` is still an invalid cmdlet name in scripts.

The matching is entirely based on the capital letters of the verb and noun.  To test this, create test.json:

```json
{
  "ExperimentalFeatures": [
    "PSUseAbbreviationExpansion"
  ]
}
```

And run:

> pwsh -settingsfile ./test.json

Associated [RFC](https://github.com/PowerShell/PowerShell-RFC/pull/150/files)

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [x] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
