### PR TITLE
Add Microsoft Docs link to FAQ

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -3,6 +3,7 @@
 ## Where can I learn PowerShell's syntax?
 
 [SS64.com](http://ss64.com/ps/syntax.html) is a good resource.
+[Microsoft Docs](https://docs.microsoft.com/en-us/powershell/scripting/powershell-scripting) is another excellent resource.
 
 ## What are the best practices and style?
 


### PR DESCRIPTION
Linked to the Microsoft Docs for PowerShell as a reference on where to learn PowerShell's syntax.

## PR Summary

Added a link to the Microsoft Docs for PowerShell in the FAQ under "Where can I learn PowerShell's syntax?".