### PR TITLE
Whitelist Az module for culture directory skipping

### DIFF
--- a/src/System.Management.Automation/engine/Modules/ModuleUtils.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleUtils.cs
@@ -29,7 +29,7 @@ namespace System.Management.Automation.Internal
         /// by IsPossibleModuleDirectory(). While this is private, having a static HashSet means that
         /// further modules could be added using reflection in case a workaround is needed.
         /// </summary>
-        private static readonly HashSet<string> s_moduleNameCultureWhitelist = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        private static readonly HashSet<string> ModuleNameCultureWhitelist = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
         {
             "Az"
         };
@@ -55,7 +55,7 @@ namespace System.Management.Automation.Internal
 
             dir = Path.GetFileName(dir);
             // Use some simple pattern matching to avoid the call into GetCultureInfo when we know it will fail (and throw).
-            if (CouldBeCultureName(dir) && !s_moduleNameCultureWhitelist.Contains(dir))
+            if (CouldBeCultureName(dir) && !ModuleNameCultureWhitelist.Contains(dir))
             {
                 try
                 {

--- a/src/System.Management.Automation/engine/Modules/ModuleUtils.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleUtils.cs
@@ -29,7 +29,7 @@ namespace System.Management.Automation.Internal
         /// by IsPossibleModuleDirectory(). While this is private, having a static HashSet means that
         /// further modules could be added using reflection in case a workaround is needed.
         /// </summary>
-        private readonly static HashSet<string> s_moduleNameCultureWhitelist = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        private static readonly HashSet<string> s_moduleNameCultureWhitelist = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
         {
             "Az"
         };

--- a/src/System.Management.Automation/engine/Modules/ModuleUtils.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleUtils.cs
@@ -29,7 +29,7 @@ namespace System.Management.Automation.Internal
         /// by IsPossibleModuleDirectory(). While this is private, having a static HashSet means that
         /// further modules could be added using reflection in case a workaround is needed.
         /// </summary>
-        private static readonly HashSet<string> _moduleNameCultureWhitelist = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        private static readonly HashSet<string> s_moduleNameCultureWhitelist = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
         {
             "Az" // Microsoft Azure uber module -- conflicts with Azerbijani culture name
         };
@@ -55,7 +55,7 @@ namespace System.Management.Automation.Internal
 
             dir = Path.GetFileName(dir);
             // Use some simple pattern matching to avoid the call into GetCultureInfo when we know it will fail (and throw).
-            if (CouldBeCultureName(dir) && !_moduleNameCultureWhitelist.Contains(dir))
+            if (CouldBeCultureName(dir) && !s_moduleNameCultureWhitelist.Contains(dir))
             {
                 try
                 {

--- a/src/System.Management.Automation/engine/Modules/ModuleUtils.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleUtils.cs
@@ -29,9 +29,9 @@ namespace System.Management.Automation.Internal
         /// by IsPossibleModuleDirectory(). While this is private, having a static HashSet means that
         /// further modules could be added using reflection in case a workaround is needed.
         /// </summary>
-        private static readonly HashSet<string> ModuleNameCultureWhitelist = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        private static readonly HashSet<string> _moduleNameCultureWhitelist = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
         {
-            "Az"
+            "Az" // Microsoft Azure uber module -- conflicts with Azerbijani culture name
         };
 
         /// <summary>
@@ -55,7 +55,7 @@ namespace System.Management.Automation.Internal
 
             dir = Path.GetFileName(dir);
             // Use some simple pattern matching to avoid the call into GetCultureInfo when we know it will fail (and throw).
-            if (CouldBeCultureName(dir) && !ModuleNameCultureWhitelist.Contains(dir))
+            if (CouldBeCultureName(dir) && !_moduleNameCultureWhitelist.Contains(dir))
             {
                 try
                 {

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -137,7 +137,7 @@ Describe "Get-Module" -Tags "CI" {
         $modules[4].Version | Should -BeExactly "1.1"
         $modules[5].ModuleType | Should -BeExactly "Script"
         $modules[6].ModuleType | Should -BeExactly "Manifest"
-        $modules[6].Version | Should -Be "2.0"
+        $modules[6].Version | Should -BeExactly "2.0"
         $modules[7].ModuleType | Should -BeExactly "Script"
         $modules[8].ModuleType | Should -BeExactly "Script"
         $modules[8].Path | Should -BeExactly (Resolve-Path "$testdrive\Modules\Zoo\Too\Zoo.psm1").Path

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -164,7 +164,7 @@ Describe "Get-Module" -Tags "CI" {
         $modules.Count | Should -Be 5
         $modules = $modules | Sort-Object -Property Name, Version
         $modules.Name -join "," | Should -BeExactly "Az,Bar,Foo,Foo,Zoo"
-        $modules[2].Version | Should -Be "1.1"
+        $modules[2].Version | Should -BeExactly "1.1"
         $modules[3].Version | Should -Be '2.0'
     }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -110,7 +110,7 @@ Describe "Get-Module" -Tags "CI" {
         $modules | Should -HaveCount 5
         $modules = $modules | Sort-Object -Property Name, Version
         $modules.Name -join "," | Should -BeExactly "Az,Bar,Foo,Foo,Zoo"
-        $modules[2].Version | Should -Be "1.1"
+        $modules[2].Version | Should -BeExactly "1.1"
         $modules[3].Version | Should -Be '2.0'
     }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -83,6 +83,7 @@ $script:Modules = @(
     @{ Name = 'Foo'; Structure = @{ '1.1' = @{ 'Foo.psd1' = $null; 'Foo.psm1' = $null }; '2.0' = @{ 'Foo.psd1' = $null; 'Foo.psm1' = $null } } }
     @{ Name = 'Bar'; Structure = @{ 'Download' = @{ 'Download.psm1' = $null }; 'Bar.psd1' = $null; 'Bar.psm1' = $null } }
     @{ Name = 'Zoo'; Structure = @{ 'Zoo.psd1' = $null; 'Zoo.psm1' = $null; 'Too' = @{ 'Zoo.psm1' = $null } } }
+    @{ Name = 'Az'; Structure = @{ 'Az.psd1' = $null } }
 )
 
 Describe "Get-Module" -Tags "CI" {
@@ -106,11 +107,11 @@ Describe "Get-Module" -Tags "CI" {
 
     It "Get-Module -ListAvailable" {
         $modules = Get-Module -ListAvailable
-        $modules.Count | Should -Be 4
+        $modules.Count | Should -Be 5
         $modules = $modules | Sort-Object -Property Name, Version
-        $modules.Name -join "," | Should -BeExactly "Bar,Foo,Foo,Zoo"
-        $modules[1].Version | Should -Be "1.1"
-        $modules[2].Version | Should -Be '2.0'
+        $modules.Name -join "," | Should -BeExactly "Az,Bar,Foo,Foo,Zoo"
+        $modules[2].Version | Should -Be "1.1"
+        $modules[3].Version | Should -Be '2.0'
     }
 
     It "Get-Module <Name> -ListAvailable" {
@@ -124,25 +125,26 @@ Describe "Get-Module" -Tags "CI" {
 
     It "Get-Module -ListAvailable -All" {
         $modules = Get-Module -ListAvailable -All
-        $modules.Count | Should -Be 10
+        $modules.Count | Should -Be 11
         $modules = $modules | Sort-Object -Property Name, Path
-        $modules.Name -join "," | Should -BeExactly "Bar,Bar,Download,Foo,Foo,Foo,Foo,Zoo,Zoo,Zoo"
+        $modules.Name -join "," | Should -BeExactly "Az,Bar,Bar,Download,Foo,Foo,Foo,Foo,Zoo,Zoo,Zoo"
 
         $modules[0].ModuleType | Should -BeExactly "Manifest"
-        $modules[1].ModuleType | Should -BeExactly "Script"
+        $modules[1].ModuleType | Should -BeExactly "Manifest"
         $modules[2].ModuleType | Should -BeExactly "Script"
-        $modules[3].ModuleType | Should -BeExactly "Manifest"
-        $modules[3].Version | Should -Be "1.1"
-        $modules[4].ModuleType | Should -BeExactly "Script"
-        $modules[5].ModuleType | Should -BeExactly "Manifest"
-        $modules[5].Version | Should -Be "2.0"
-        $modules[6].ModuleType | Should -BeExactly "Script"
+        $modules[3].ModuleType | Should -BeExactly "Script"
+        $modules[4].ModuleType | Should -BeExactly "Manifest"
+        $modules[4].Version | Should -Be "1.1"
+        $modules[5].ModuleType | Should -BeExactly "Script"
+        $modules[6].ModuleType | Should -BeExactly "Manifest"
+        $modules[6].Version | Should -Be "2.0"
         $modules[7].ModuleType | Should -BeExactly "Script"
-        $modules[7].Path | Should -BeExactly (Resolve-Path "$testdrive\Modules\Zoo\Too\Zoo.psm1").Path
-        $modules[8].ModuleType | Should -BeExactly "Manifest"
-        $modules[8].Path | Should -BeExactly (Resolve-Path "$testdrive\Modules\Zoo\Zoo.psd1").Path
-        $modules[9].ModuleType | Should -BeExactly "Script"
-        $modules[9].Path | Should -BeExactly (Resolve-Path "$testdrive\Modules\Zoo\Zoo.psm1").Path
+        $modules[8].ModuleType | Should -BeExactly "Script"
+        $modules[8].Path | Should -BeExactly (Resolve-Path "$testdrive\Modules\Zoo\Too\Zoo.psm1").Path
+        $modules[9].ModuleType | Should -BeExactly "Manifest"
+        $modules[9].Path | Should -BeExactly (Resolve-Path "$testdrive\Modules\Zoo\Zoo.psd1").Path
+        $modules[10].ModuleType | Should -BeExactly "Script"
+        $modules[10].Path | Should -BeExactly (Resolve-Path "$testdrive\Modules\Zoo\Zoo.psm1").Path
     }
 
     It "Get-Module <Name> -ListAvailable -All" {
@@ -159,18 +161,18 @@ Describe "Get-Module" -Tags "CI" {
 
     It "Get-Module <Path> -ListAvailable" {
         $modules = Get-Module "$testdrive\Modules\*" -ListAvailable
-        $modules.Count | Should -Be 4
+        $modules.Count | Should -Be 5
         $modules = $modules | Sort-Object -Property Name, Version
-        $modules.Name -join "," | Should -BeExactly "Bar,Foo,Foo,Zoo"
-        $modules[1].Version | Should -Be "1.1"
-        $modules[2].Version | Should -Be '2.0'
+        $modules.Name -join "," | Should -BeExactly "Az,Bar,Foo,Foo,Zoo"
+        $modules[2].Version | Should -Be "1.1"
+        $modules[3].Version | Should -Be '2.0'
     }
 
     It "Get-Module <Path> -ListAvailable -All" {
         $modules = Get-Module "$testdrive\Modules\*" -ListAvailable -All
-        $modules.Count | Should -Be 5
+        $modules.Count | Should -Be 6
         $modules = $modules | Sort-Object -Property Name, Path
-        $modules.Name -join "," | Should -BeExactly "Bar,Foo,Foo,Zoo,Zoo"
-        $modules[3].Path | Should -BeExactly (Resolve-Path "$testdrive\Modules\Zoo\Too\Zoo.psm1").Path
+        $modules.Name -join "," | Should -BeExactly "Az,Bar,Foo,Foo,Zoo,Zoo"
+        $modules[4].Path | Should -BeExactly (Resolve-Path "$testdrive\Modules\Zoo\Too\Zoo.psm1").Path
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -125,7 +125,7 @@ Describe "Get-Module" -Tags "CI" {
 
     It "Get-Module -ListAvailable -All" {
         $modules = Get-Module -ListAvailable -All
-        $modules.Count | Should -Be 11
+        $modules | Should -HaveCount 11
         $modules = $modules | Sort-Object -Property Name, Path
         $modules.Name -join "," | Should -BeExactly "Az,Bar,Bar,Download,Foo,Foo,Foo,Foo,Zoo,Zoo,Zoo"
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -134,7 +134,7 @@ Describe "Get-Module" -Tags "CI" {
         $modules[2].ModuleType | Should -BeExactly "Script"
         $modules[3].ModuleType | Should -BeExactly "Script"
         $modules[4].ModuleType | Should -BeExactly "Manifest"
-        $modules[4].Version | Should -Be "1.1"
+        $modules[4].Version | Should -BeExactly "1.1"
         $modules[5].ModuleType | Should -BeExactly "Script"
         $modules[6].ModuleType | Should -BeExactly "Manifest"
         $modules[6].Version | Should -Be "2.0"

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -165,7 +165,7 @@ Describe "Get-Module" -Tags "CI" {
         $modules = $modules | Sort-Object -Property Name, Version
         $modules.Name -join "," | Should -BeExactly "Az,Bar,Foo,Foo,Zoo"
         $modules[2].Version | Should -BeExactly "1.1"
-        $modules[3].Version | Should -Be '2.0'
+        $modules[3].Version | Should -BeExactly '2.0'
     }
 
     It "Get-Module <Path> -ListAvailable -All" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -111,7 +111,7 @@ Describe "Get-Module" -Tags "CI" {
         $modules = $modules | Sort-Object -Property Name, Version
         $modules.Name -join "," | Should -BeExactly "Az,Bar,Foo,Foo,Zoo"
         $modules[2].Version | Should -BeExactly "1.1"
-        $modules[3].Version | Should -Be '2.0'
+        $modules[3].Version | Should -BeExactly '2.0'
     }
 
     It "Get-Module <Name> -ListAvailable" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -161,7 +161,7 @@ Describe "Get-Module" -Tags "CI" {
 
     It "Get-Module <Path> -ListAvailable" {
         $modules = Get-Module "$testdrive\Modules\*" -ListAvailable
-        $modules.Count | Should -Be 5
+        $modules | Should -HaveCount 5
         $modules = $modules | Sort-Object -Property Name, Version
         $modules.Name -join "," | Should -BeExactly "Az,Bar,Foo,Foo,Zoo"
         $modules[2].Version | Should -BeExactly "1.1"

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -107,7 +107,7 @@ Describe "Get-Module" -Tags "CI" {
 
     It "Get-Module -ListAvailable" {
         $modules = Get-Module -ListAvailable
-        $modules.Count | Should -Be 5
+        $modules | Should -HaveCount 5
         $modules = $modules | Sort-Object -Property Name, Version
         $modules.Name -join "," | Should -BeExactly "Az,Bar,Foo,Foo,Zoo"
         $modules[2].Version | Should -Be "1.1"

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -170,7 +170,7 @@ Describe "Get-Module" -Tags "CI" {
 
     It "Get-Module <Path> -ListAvailable -All" {
         $modules = Get-Module "$testdrive\Modules\*" -ListAvailable -All
-        $modules.Count | Should -Be 6
+        $modules | Should -HaveCount 6
         $modules = $modules | Sort-Object -Property Name, Path
         $modules.Name -join "," | Should -BeExactly "Az,Bar,Foo,Foo,Zoo,Zoo"
         $modules[4].Path | Should -BeExactly (Resolve-Path "$testdrive\Modules\Zoo\Too\Zoo.psm1").Path


### PR DESCRIPTION
## PR Summary

Fixes https://github.com/PowerShell/PowerShell/issues/8125.

Takes out the optimisation to skip directories named like cultures when listing modules. If we have a better way to preserve some of the performance benefits, I can happily implement!

Also generalised some of the test code a bit. Realised afterward that it wasn't as helpful as I thought, but it's done now at least. Commits are separate, so that can be dumped if we want.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [x] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)

I haven't marked "Not Breaking" yet, since technically this is a change in outward behaviour. But I don't think this behaviour is documented and I doubt anyone knew about it let alone relied upon it. But want to leave that judgement for others to decide.