### PR TITLE
Fix test for `-WorkingDirectory` when `$PROFILE` doesn't exist

### DIFF
--- a/test/powershell/Host/ConsoleHost.Tests.ps1
+++ b/test/powershell/Host/ConsoleHost.Tests.ps1
@@ -583,7 +583,13 @@ foo
 
         It "-WorkingDirectory should be processed before profiles" {
 
-            $currentProfile = Get-Content $PROFILE
+            if (Test-Path $PROFILE) {
+                $currentProfile = Get-Content $PROFILE
+            }
+            else {
+                New-Item -ItemType File -Path $PROFILE -Force
+            }
+
             @"
                 (Get-Location).Path
                 Set-Location $testdrive
@@ -596,7 +602,12 @@ foo
                 $out[1] | Should -BeExactly "$testdrive"
             }
             finally {
-                Set-Content $PROFILE -Value $currentProfile
+                if ($currentProfile) {
+                    Set-Content $PROFILE -Value $currentProfile
+                }
+                else {
+                    Remove-Item $PROFILE
+                }
             }
         }
     }


### PR DESCRIPTION
## PR Summary

Test expected $PROFILE to exist, but doesn't exist on CI systems.  Part of the path to $PROFILE doesn't exist so we forcibly create $PROFILE with full path.  Add checks if it exists and if not, make sure to remove test $PROFILE.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [x] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
