### PR TITLE
Adding verbose output for experimental implicit remoting batching feature

### DIFF
--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -1438,8 +1438,7 @@ namespace System.Management.Automation
                         // Commands must be from implicit remoting module
                         if (cmdInfo.Module == null || string.IsNullOrEmpty(cmdInfo.ModuleName))
                         {
-                            WriteVerbose(ps, 
-                                string.Format(CultureInfo.CurrentCulture, ParserStrings.ImplicitRemotingPipelineBatchingNotImplicitCommand, cmdInfo.Name));
+                            WriteVerbose(ps, string.Format(CultureInfo.CurrentCulture, ParserStrings.ImplicitRemotingPipelineBatchingNotImplicitCommand, cmdInfo.Name));
                             success = false;
                             break;
                         }
@@ -1450,8 +1449,7 @@ namespace System.Management.Automation
                             var sessionIdString = privateData["ImplicitSessionId"] as string;
                             if (string.IsNullOrEmpty(sessionIdString))
                             {
-                                WriteVerbose(ps,
-                                    string.Format(CultureInfo.CurrentCulture, ParserStrings.ImplicitRemotingPipelineBatchingNotImplicitCommand, cmdInfo.Name));
+                                WriteVerbose(ps, string.Format(CultureInfo.CurrentCulture, ParserStrings.ImplicitRemotingPipelineBatchingNotImplicitCommand, cmdInfo.Name));
                                 success = false;
                                 break;
                             }
@@ -1463,16 +1461,14 @@ namespace System.Management.Automation
                             }
                             else if (psSessionId != sessionId)
                             {
-                                WriteVerbose(ps,
-                                    string.Format(CultureInfo.CurrentCulture, ParserStrings.ImplicitRemotingPipelineBatchingWrongSession, cmdInfo.Name));
+                                WriteVerbose(ps, string.Format(CultureInfo.CurrentCulture, ParserStrings.ImplicitRemotingPipelineBatchingWrongSession, cmdInfo.Name));
                                 success = false;
                                 break;
                             }
                         }
                         else
                         {
-                            WriteVerbose(ps,
-                                string.Format(CultureInfo.CurrentCulture, ParserStrings.ImplicitRemotingPipelineBatchingNotImplicitCommand, cmdInfo.Name));
+                            WriteVerbose(ps, string.Format(CultureInfo.CurrentCulture, ParserStrings.ImplicitRemotingPipelineBatchingNotImplicitCommand, cmdInfo.Name));
                             success = false;
                             break;
                         }
@@ -1529,13 +1525,11 @@ namespace System.Management.Automation
                 }
                 catch (ImplicitRemotingBatchingNotSupportedException ex)
                 {
-                    WriteVerbose(ps,
-                        string.Format(CultureInfo.CurrentCulture, "{0} : {1}", ex.Message, ex.ErrorId));
+                    WriteVerbose(ps, string.Format(CultureInfo.CurrentCulture, "{0} : {1}", ex.Message, ex.ErrorId));
                 }
                 catch (Exception ex)
                 {
-                    WriteVerbose(ps,
-                        string.Format(CultureInfo.CurrentCulture, ParserStrings.ImplicitRemotingPipelineBatchingException, ex.Message));
+                    WriteVerbose(ps, string.Format(CultureInfo.CurrentCulture, ParserStrings.ImplicitRemotingPipelineBatchingException, ex.Message));
                 }
             }
             

--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -1507,6 +1507,10 @@ namespace System.Management.Automation
                         ps.Commands.Clear();
                         ps.AddCommand("Invoke-Command").AddParameter("Session", psSession).AddParameter("ScriptBlock", scriptBlock).AddParameter("HideComputerName", true)
                             .AddCommand("Out-Default");
+                        foreach (var cmd in ps.Commands.Commands)
+                        {
+                            cmd.MergeMyResults(PipelineResultTypes.Error, PipelineResultTypes.Output);
+                        }
 
                         try
                         {

--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -1382,38 +1382,40 @@ namespace System.Management.Automation
         //  c. Commands must be in a simple pipeline
         internal static bool TryRunAsImplicitBatch(string command, Runspace runspace)
         {
-            try
+            using (var ps = System.Management.Automation.PowerShell.Create())
             {
-                var scriptBlock = ScriptBlock.Create(command);
-                var scriptBlockAst = scriptBlock.Ast as ScriptBlockAst;
-                if (scriptBlockAst == null)
-                {
-                    return false;
-                }
+                ps.Runspace = runspace;
 
-                // Make sure that this is a simple pipeline
-                string errorId;
-                string errorMsg;
-                scriptBlockAst.GetSimplePipeline(true, out errorId, out errorMsg);
-                if (errorId != null)
+                try
                 {
-                    return false;
-                }
+                    var scriptBlock = ScriptBlock.Create(command);
+                    var scriptBlockAst = scriptBlock.Ast as ScriptBlockAst;
+                    if (scriptBlockAst == null)
+                    {
+                        return false;
+                    }
 
-                // Run checker
-                var checker = new PipelineForBatchingChecker { ScriptBeingConverted = scriptBlockAst };
-                scriptBlockAst.InternalVisit(checker);
+                    // Make sure that this is a simple pipeline
+                    string errorId;
+                    string errorMsg;
+                    scriptBlockAst.GetSimplePipeline(true, out errorId, out errorMsg);
+                    if (errorId != null)
+                    {
+                        WriteVerbose(ps, ParserStrings.ImplicitRemotingPipelineBatchingNotASimplePipeline);
+                        return false;
+                    }
 
-                // If this is just a single command, there is no point in batching it
-                if (checker.Commands.Count < 2)
-                {
-                    return false;
-                }
+                    // Run checker
+                    var checker = new PipelineForBatchingChecker { ScriptBeingConverted = scriptBlockAst };
+                    scriptBlockAst.InternalVisit(checker);
 
-                // We have a valid batching candidate
-                using (var ps = System.Management.Automation.PowerShell.Create())
-                {
-                    ps.Runspace = runspace;
+                    // If this is just a single command, there is no point in batching it
+                    if (checker.Commands.Count < 2)
+                    {
+                        return false;
+                    }
+
+                    // We have a valid batching candidate
 
                     // Check commands
                     if (!TryGetCommandInfoList(ps, checker.Commands, out Collection<CommandInfo> cmdInfoList))
@@ -1436,6 +1438,8 @@ namespace System.Management.Automation
                         // Commands must be from implicit remoting module
                         if (cmdInfo.Module == null || string.IsNullOrEmpty(cmdInfo.ModuleName))
                         {
+                            WriteVerbose(ps, 
+                                string.Format(CultureInfo.CurrentCulture, ParserStrings.ImplicitRemotingPipelineBatchingNotImplicitCommand, cmdInfo.Name));
                             success = false;
                             break;
                         }
@@ -1446,6 +1450,8 @@ namespace System.Management.Automation
                             var sessionIdString = privateData["ImplicitSessionId"] as string;
                             if (string.IsNullOrEmpty(sessionIdString))
                             {
+                                WriteVerbose(ps,
+                                    string.Format(CultureInfo.CurrentCulture, ParserStrings.ImplicitRemotingPipelineBatchingNotImplicitCommand, cmdInfo.Name));
                                 success = false;
                                 break;
                             }
@@ -1457,12 +1463,16 @@ namespace System.Management.Automation
                             }
                             else if (psSessionId != sessionId)
                             {
+                                WriteVerbose(ps,
+                                    string.Format(CultureInfo.CurrentCulture, ParserStrings.ImplicitRemotingPipelineBatchingWrongSession, cmdInfo.Name));
                                 success = false;
                                 break;
                             }
                         }
                         else
                         {
+                            WriteVerbose(ps,
+                                string.Format(CultureInfo.CurrentCulture, ParserStrings.ImplicitRemotingPipelineBatchingNotImplicitCommand, cmdInfo.Name));
                             success = false;
                             break;
                         }
@@ -1491,8 +1501,11 @@ namespace System.Management.Automation
                         var psSession = ps.Invoke<System.Management.Automation.Runspaces.PSSession>().FirstOrDefault();
                         if (psSession == null || (ps.Streams.Error.Count > 0) || (psSession.Availability != RunspaceAvailability.Available))
                         {
+                            WriteVerbose(ps, ParserStrings.ImplicitRemotingPipelineBatchingNoPSSession);
                             return false;
                         }
+
+                        WriteVerbose(ps, ParserStrings.ImplicitRemotingPipelineBatchingSuccess);
 
                         // Create and invoke implicit remoting command pipeline
                         ps.Commands.Clear();
@@ -1514,10 +1527,25 @@ namespace System.Management.Automation
                         return true;
                     }
                 }
+                catch (ImplicitRemotingBatchingNotSupportedException ex)
+                {
+                    WriteVerbose(ps,
+                        string.Format(CultureInfo.CurrentCulture, "{0} : {1}", ex.Message, ex.ErrorId));
+                }
+                catch (Exception ex)
+                {
+                    WriteVerbose(ps,
+                        string.Format(CultureInfo.CurrentCulture, ParserStrings.ImplicitRemotingPipelineBatchingException, ex.Message));
+                }
             }
-            catch (Exception) { }
-
+            
             return false;
+        }
+
+        private static void WriteVerbose(PowerShell ps, string msg)
+        {
+            ps.Commands.Clear();
+            ps.AddCommand("Write-Verbose").AddParameter("Message", msg).Invoke();
         }
 
         private const string WhereObjectCommandAlias = "?";

--- a/src/System.Management.Automation/resources/ParserStrings.resx
+++ b/src/System.Management.Automation/resources/ParserStrings.resx
@@ -1474,10 +1474,10 @@ ModuleVersion : Version of module to import. If used, ModuleName must represent 
     <value>Command is not a simple pipeline and cannot be batched.</value>
   </data>
   <data name="ImplicitRemotingPipelineBatchingNotImplicitCommand" xml:space="preserve">
-    <value>The pipeline command, {0}, is not an implicit remoting command or approved batching command.</value>
+    <value>The pipeline command '{0}' is not an implicit remoting command or approved batching command.</value>
   </data>
   <data name="ImplicitRemotingPipelineBatchingWrongSession" xml:space="preserve">
-    <value>The pipeline command, {0}, is for a different remote session and cannot be batched.</value>
+    <value>The pipeline command '{0}' is for a different remote session and cannot be batched.</value>
   </data>
   <data name="ImplicitRemotingPipelineBatchingNoPSSession" xml:space="preserve">
     <value>The implicit remoting PSSession for batching could not be retrieved.</value>

--- a/src/System.Management.Automation/resources/ParserStrings.resx
+++ b/src/System.Management.Automation/resources/ParserStrings.resx
@@ -1470,4 +1470,22 @@ ModuleVersion : Version of module to import. If used, ModuleName must represent 
   <data name="ImplicitRemotingPipelineBatchingNotSupported" xml:space="preserve">
     <value>Command pipeline not supported for implicit remoting batching.</value>
   </data>
+  <data name="ImplicitRemotingPipelineBatchingNotASimplePipeline" xml:space="preserve">
+    <value>Command is not a simple pipeline and cannot be batched.</value>
+  </data>
+  <data name="ImplicitRemotingPipelineBatchingNotImplicitCommand" xml:space="preserve">
+    <value>The pipeline command, {0}, is not an implicit remoting command or approved batching command.</value>
+  </data>
+  <data name="ImplicitRemotingPipelineBatchingWrongSession" xml:space="preserve">
+    <value>The pipeline command, {0}, is for a different remote session and cannot be batched.</value>
+  </data>
+  <data name="ImplicitRemotingPipelineBatchingNoPSSession" xml:space="preserve">
+    <value>The implicit remoting PSSession for batching could not be retrieved.</value>
+  </data>
+  <data name="ImplicitRemotingPipelineBatchingException" xml:space="preserve">
+    <value>Exception while checking the command for implicit remoting batching: {0}</value>
+  </data>
+  <data name="ImplicitRemotingPipelineBatchingSuccess" xml:space="preserve">
+    <value>Implicit remoting command pipeline has been batched for execution on remote target.</value>
+  </data>
 </root>

--- a/src/System.Management.Automation/resources/ParserStrings.resx
+++ b/src/System.Management.Automation/resources/ParserStrings.resx
@@ -1474,7 +1474,7 @@ ModuleVersion : Version of module to import. If used, ModuleName must represent 
     <value>Command is not a simple pipeline and cannot be batched.</value>
   </data>
   <data name="ImplicitRemotingPipelineBatchingNotImplicitCommand" xml:space="preserve">
-    <value>The pipeline command '{0}' is not an implicit remoting command or approved batching command.</value>
+    <value>The pipeline command '{0}' is not an implicit remoting command or an approved batching command.</value>
   </data>
   <data name="ImplicitRemotingPipelineBatchingWrongSession" xml:space="preserve">
     <value>The pipeline command '{0}' is for a different remote session and cannot be batched.</value>


### PR DESCRIPTION
## PR Summary
This change adds verbose output to the experimental implicit remoting batching feature, that provides information about whether the command line was batch-able for implicit remoting.  If it is not batch-able then the reason why is provided.  This is intended to help learn why a pipeline could not be batched and help address batching scenarios that should be covered.

Example:
```
$s = New-PSSession -host testVM -KeyFilePath -User paul
Invoke-Command $s { Import-PSSession 'c:\Modules\TestIMod\TestIMod.psd1' }
Import-PSSession $s -module TestIMod

$maxProcs = 1000
$filter = 'pwsh','powershell*'

$VerbosePreference = "Continue"

Get-AllProcesses -MaxCount $maxProcs | Select-Custom $filter | ForEach-Object { $_ }
VERBOSE: Implicit remoting command pipeline has been batched for execution on remote target.

NPM(K)    PM(M)      WS(M)     CPU(s)      Id  SI ProcessName
 ------    -----      -----     ------      --  -- -----------
     60   291.51     140.08     226.92   15184   2 powershell
     54   129.84     109.26     370.78   15832   2 powershell
     57    69.21      92.28      13.86     168   0 pwsh

100 | Get-AllProcesses -MaxCount $maxProcs | Select-Custom $filter | ForEach-Object { $_ }
VERBOSE: Command pipeline not supported for implicit remoting batching. : PipelineStartingWithExpressionNotSupported

NPM(K)    PM(M)      WS(M)     CPU(s)      Id  SI ProcessName
 ------    -----      -----     ------      --  -- -----------
     61   291.54     140.09     226.92   15184   2 powershell
     54   129.84     109.26     370.88   15832   2 powershell
     57    69.72      92.86      17.81     168   0 pwsh

```

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [x] Not Applicable or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
