### PR TITLE
Add code to use private NuGet feeds when running in internal CI system

### DIFF
--- a/.vsts-ci/linux.yml
+++ b/.vsts-ci/linux.yml
@@ -51,9 +51,15 @@ phases:
     condition: succeededOrFailed()
 
   - powershell: |
-      git submodule update --init
-    displayName: SubModule Init
-    condition: succeededOrFailed()
+      Import-Module $(Build.SourcesDirectory)/build.psm1 -Force
+      New-NugetConfigFile -NugetFeedUrl $(AzDevOpsFeed) -UserName $(AzDevOpsFeedUserName) -ClearTextPAT $(AzDevOpsFeedPAT) -FeedName AzDevOpsFeed -Destination $(Build.SourcesDirectory)/src/Modules
+
+      if(-not (Test-Path "$(Build.SourcesDirectory)/src/Modules/nuget.config"))
+      {
+          throw "nuget.config is not created"
+      }
+    displayName: 'Add nuget.config for AzDevOps feed for PSGallery modules '
+    condition: and(succeededOrFailed(), ne(variables['AzDevOpsFeed'], ''))
 
   - powershell: |
       tools/travis.ps1 -Stage Bootstrap

--- a/.vsts-ci/mac.yml
+++ b/.vsts-ci/mac.yml
@@ -26,9 +26,15 @@ phases:
     condition: ne(variables['Build.Reason'], 'PullRequest')
 
   - powershell: |
-      git submodule update --init
-    displayName: SubModule Init
-    condition: succeededOrFailed()
+      Import-Module $(Build.SourcesDirectory)/build.psm1 -Force
+      New-NugetConfigFile -NugetFeedUrl $(AzDevOpsFeed) -UserName $(AzDevOpsFeedUserName) -ClearTextPAT $(AzDevOpsFeedPAT) -FeedName AzDevOpsFeed -Destination $(Build.SourcesDirectory)/src/Modules
+
+      if(-not (Test-Path "$(Build.SourcesDirectory)/src/Modules/nuget.config"))
+      {
+          throw "nuget.config is not created"
+      }
+    displayName: 'Add nuget.config for AzDevOps feed for PSGallery modules '
+    condition: and(succeededOrFailed(), ne(variables['AzDevOpsFeed'], ''))
 
   - powershell: |
       tools/travis.ps1 -Stage Bootstrap

--- a/.vsts-ci/windows.yml
+++ b/.vsts-ci/windows.yml
@@ -30,9 +30,15 @@ steps:
     condition: ne(variables['Build.Reason'], 'PullRequest')
 
   - powershell: |
-      git submodule update --init
-    displayName: SubModule Init
-    condition: succeededOrFailed()
+      Import-Module $(Build.SourcesDirectory)/build.psm1 -Force
+      New-NugetConfigFile -NugetFeedUrl $(AzDevOpsFeed) -UserName $(AzDevOpsFeedUserName) -ClearTextPAT $(AzDevOpsFeedPAT) -FeedName AzDevOpsFeed -Destination $(Build.SourcesDirectory)/src/Modules
+
+      if(-not (Test-Path "$(Build.SourcesDirectory)/src/Modules/nuget.config"))
+      {
+          throw "nuget.config is not created"
+      }
+    displayName: 'Add nuget.config for AzDevOps feed for PSGallery modules '
+    condition: and(succeededOrFailed(), ne(variables['AzDevOpsFeed'], ''))
 
   - powershell: |
       [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12


### PR DESCRIPTION
## PR Summary

Add code to use private NuGet feeds when running in internal CI system

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [x] Not Applicable or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
