### PR TITLE
Workaround for accessing Az Artifacts

### DIFF
--- a/tools/releaseBuild/macOS/vsts.yml
+++ b/tools/releaseBuild/macOS/vsts.yml
@@ -23,6 +23,7 @@ steps:
        throw "nuget.config is not created"
    }
   displayName: 'Add nuget.config for AzDevOps feed for PSGallery modules '
+  condition: ne(Variable['SkipFxDependent'], 'true')
 - task: ShellScript@2
   inputs:
     scriptPath: 'tools/installpsh-osx.sh'
@@ -36,10 +37,8 @@ steps:
     scriptPath: 'tools/releaseBuild/macOS/PowerShellPackageVsts.sh'
     args: '-location $(Build.SourcesDirectory) -BootStrap'
   displayName: 'Bootstrap VM'
-- task: ShellScript@2
-  inputs:
-    scriptPath: 'tools/releaseBuild/macOS/PowerShellPackageVsts.sh'
-    args: '-ReleaseTag $(ReleaseTagVar) -Destination $(System.ArtifactsDirectory) -ExtraPackage "tar" -location $(Build.SourcesDirectory) -Build'
-    disableAutoCwd: true
-    cwd: 'tools/releaseBuild/macOS'
+- powershell: |
+    $env:AZDEVOPSFEEDPAT = '$(AzDevOpsFeedPAT)'
+    .\PowerShellPackageVsts.ps1 -ReleaseTag $(ReleaseTagVar) -Destination $(System.ArtifactsDirectory) -ExtraPackage "tar" -location $(Build.SourcesDirectory) -Build
+    $env:AZDEVOPSFEEDPAT = $null
   displayName: 'Build and Package'


### PR DESCRIPTION
## PR Summary

Added a workaround for accessing Az Artifacts feed from release build. Also converted the `sh` task to powershell.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [x] Not Applicable or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
