### PR TITLE
Ignoring backspace for empty lines on stdin/stdout mode

### DIFF
--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterface.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHostUserInterface.cs
@@ -1365,7 +1365,14 @@ namespace Microsoft.PowerShell
                 }
 
                 var c = unchecked((char)inC);
-                if (!NoPrompt) Console.Out.Write(c);
+                if (c == '\b' && !NoPrompt && sb.Length == 0)
+                {
+                    continue;
+                }
+                if (!NoPrompt)
+                {
+                    Console.Out.Write(c);
+                }
 
                 if (c == '\r')
                 {

--- a/test/powershell/Host/ConsoleHost.Tests.ps1
+++ b/test/powershell/Host/ConsoleHost.Tests.ps1
@@ -476,6 +476,18 @@ foo
             $process.StandardOutput.ReadToEnd() | Should -Be "PS> "
             EnsureChildHasExited $process
         }
+
+        It "Redirected input and sending backspace" {
+            # This test is for issue #8193, in which a backspace at the beginning of a command crashes powershell
+            $si = NewProcessStartInfo "-noprofile -nologo" -RedirectStdIn
+            $process = RunPowerShell $si
+            $process.StandardInput.Write("`$function:prompt = { 'PS> ' }`n")
+            $null = $process.StandardOutput.ReadLine()
+            $process.StandardInput.Write("`bexit`n")
+            $process.StandardOutput.ReadLine() | Should -Be "PS> exit"
+            $process.StandardInput.Close()
+            EnsureChildHasExited $process
+        }
     }
 
     Context "Exception handling" {


### PR DESCRIPTION
## PR Summary

Fix #8193.
On stdin/stdout mode (without console), when a backspace was sent, the code tried to remove the last character in the current line string builder. this was true even when the string builder is empty, thus crashing.
I fixed the issue by ignoring the backspace when the string builder is empty, not echoing it, and not trying to remove from the string builder.

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [X] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link: 
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [X] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
