### PR TITLE
Remove extra newlines from formatting which resulted in necessary double newlines

### DIFF
--- a/src/System.Management.Automation/FormatAndOutput/common/BaseOutputtingCommand.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/BaseOutputtingCommand.cs
@@ -476,8 +476,6 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 ComplexWriter writer = new ComplexWriter();
                 writer.Initialize(_lo, _lo.ColumnNumber);
                 writer.WriteObject(goc.Data.groupingEntry.formatValueList);
-
-                this.LineOutput.WriteLine(string.Empty);
             }
             goc.GroupStart();
         }
@@ -493,7 +491,6 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             GroupOutputContext goc = (GroupOutputContext)c;
 
             goc.GroupEnd();
-            this.LineOutput.WriteLine(string.Empty);
         }
 
         /// <summary>
@@ -761,7 +758,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         /// </summary>
         static private int GetConsoleWindowWidth(int columnNumber)
         {
-            if (InternalTestHooks.SetConsoleWidthToZero) 
+            if (InternalTestHooks.SetConsoleWidthToZero)
             {
                 return DefaultConsoleWidth;
             }
@@ -1106,7 +1103,6 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             /// </summary>
             internal override void GroupStart()
             {
-                this.InnerCommand._lo.WriteLine(string.Empty);
             }
 
             /// <summary>
@@ -1194,7 +1190,6 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             /// </summary>
             internal override void GroupStart()
             {
-                this.InnerCommand._lo.WriteLine(string.Empty);
             }
 
             /// <summary>

--- a/test/powershell/Language/Classes/Scripting.Classes.Attributes.Tests.ps1
+++ b/test/powershell/Language/Classes/Scripting.Classes.Attributes.Tests.ps1
@@ -401,7 +401,7 @@ Describe 'ValidateSet support a dynamically generated set' -Tag "CI" {
                 Import-Module -Name $moduleFile -Force
                 Test-ValidateSet 'Hello' | Should -BeExactly 'Hello'
             } finally {
-                Remove-Module -Name $moduleFile -Force
+                Remove-Module -Name $moduleFile -Force -ErrorAction SilentlyContinue
             }
         }
     }

--- a/test/powershell/Language/Classes/Scripting.Classes.BasicParsing.Tests.ps1
+++ b/test/powershell/Language/Classes/Scripting.Classes.BasicParsing.Tests.ps1
@@ -589,7 +589,6 @@ visibleX visibleY
       10       12
 
 
-
 "@
 
             $tableOutput = $instance | Format-Table -AutoSize | Out-String

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-Custom.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-Custom.Tests.ps1
@@ -399,16 +399,14 @@ Describe "Format-Custom with expression based EntrySelectedBy in a CustomControl
 
 
 Entry selected by property
-
 Name
 ----
 testing
 
 
+'@ -replace '\r?\n', "^"
 
-'@ -replace '\r?\n', [Environment]::NewLine
-
-        $ps.Invoke() | Should -BeExactly $expectedOutput
+        $ps.Invoke() -replace '\r?\n', "^" | Should -BeExactly $expectedOutput
         $ps.Streams.Error | Should -BeNullOrEmpty
     }
 
@@ -427,16 +425,14 @@ testing
 
 
 Entry selected by ScriptBlock
-
 Name
 ----
 SelectScriptBlock
 
 
+'@ -replace '\r?\n', "^"
 
-'@ -replace '\r?\n', [Environment]::NewLine
-
-        $ps.Invoke() | Should -BeExactly $expectedOutput
+        $ps.Invoke() -replace '\r?\n', "^" | Should -BeExactly $expectedOutput
         $ps.Streams.Error | Should -BeNullOrEmpty
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-List.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-List.Tests.ps1
@@ -23,7 +23,7 @@ Describe "Format-List" -Tags "CI" {
     }
 
     It "Should produce the expected output" {
-        $expected = "${nl}${nl}testName : testValue${nl}${nl}${nl}${nl}"
+        $expected = "${nl}testName : testValue${nl}${nl}${nl}"
         $in = New-Object PSObject
         Add-Member -InputObject $in -MemberType NoteProperty -Name testName -Value testValue
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-Table.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-Table.Tests.ps1
@@ -338,7 +338,6 @@ gHeader
 1       2       3
 
 
-
 "@ },
             @{ view = "Default"; widths = 4,7,4; variation = "4 row, 1 row, 2 row"; expectedTable = @"
 
@@ -348,7 +347,6 @@ Head
 er
 ---- ------- ----
 1    2       3
-
 
 
 "@ },
@@ -362,7 +360,6 @@ er
 1    2    3
 
 
-
 "@ },
             @{ view = "Default"; widths = 14,7,3; variation = "1 row, 1 row, 3 row"; expectedTable = @"
 
@@ -371,7 +368,6 @@ LongLongHeader Header2 Hea
                        3
 -------------- ------- ---
 1              2       3
-
 
 
 "@ },
@@ -383,7 +379,6 @@ Head
 er
 ----
 1
-
 
 
 "@ }
@@ -487,7 +482,6 @@ er
 1**********2***3
 
 
-
 "@ },
             @{ view = "Default"; widths = 4,7,5; variation = "narrow values with wrap"; values = [PSCustomObject]@{First=1;Second=2;Third=3}; wrap = $true; expectedTable = @"
 
@@ -499,7 +493,6 @@ er
 1**********2*3
 
 
-
 "@ },
             @{ view = "Default"; widths = 4,7,5; variation = "wide values"; values = [PSCustomObject]@{First="12345";Second="12345678";Third="123456"}; wrap = $false; expectedTable = @"
 
@@ -509,7 +502,6 @@ Head
 er
 ----*-------*-----
 1...*...5678*12...
-
 
 
 "@ },
@@ -524,7 +516,6 @@ er
 123
 
 
-
 "@ },
             @{ view = "Default"; widths = 4,8,6; variation = "wide values with wrap, 1st column"; values = [PSCustomObject]@{First="12345";Second="12345678";Third="123456"}; wrap = $true; expectedTable = @"
 
@@ -535,7 +526,6 @@ er
 ----**-------*------
 1234*12345678*123456
 5
-
 
 
 "@ },
@@ -549,7 +539,6 @@ ader
 ************8
 
 
-
 "@ },
             @{ view = "Default"; widths = 5,8,5; variation = "wide values with wrap, 3rd column"; values = [PSCustomObject]@{First="12345";Second="12345678";Third="123456"}; wrap = $true; expectedTable = @"
 
@@ -559,7 +548,6 @@ ader
 -----**-------*-----
 12345*12345678*12345
 ***************6
-
 
 
 "@ },
@@ -574,7 +562,6 @@ er
 5**********8*6
 
 
-
 "@ },
             @{ view = "One"; widths = 3,1,1; variation = "wide values with wrap, with 1 column"; values = [PSCustomObject]@{First="12345";Second="12345678";Third="123456"}; wrap = $true; expectedTable = @"
 
@@ -586,7 +573,6 @@ er
 ---
 123
 45
-
 
 
 "@ }
@@ -690,7 +676,6 @@ abc  bcd
 1    1234
 
 
-
 "@ },
             @{ variation = "both columns"; obj = [pscustomobject]@{abc="1234";bcd="1234"},[pscustomobject]@{abc="1";bcd="1"}; expectedTable = @"
 
@@ -700,7 +685,6 @@ abc  bcd
 1    1
 
 
-
 "@ },
             @{ variation = "second column"; obj = [pscustomobject]@{abc="123";bcd="1234"},[pscustomobject]@{abc="1";bcd="123"}; expectedTable = @"
 
@@ -708,7 +692,6 @@ abc bcd
 --- ---
 123 1234
 1   123
-
 
 
 "@ }
@@ -726,14 +709,12 @@ a     b
 abc 123
 
 
-
 "@ },
             @{ variation = "left/left"; obj = [PSCustomObject]@{a="abc";b="abc"}; expectedTable = @"
 
 a   b
 -   -
 abc abc
-
 
 
 "@ },
@@ -744,14 +725,12 @@ abc abc
 123 abc
 
 
-
 "@ },
             @{ variation = "right/right"; obj = [PSCustomObject]@{a=123;b=123}; expectedTable = @"
 
   a   b
   -   -
 123 123
-
 
 
 "@ }
@@ -771,7 +750,6 @@ A B Name
     multiline content
 
 
-
 "@ },
             @{ variation = "left"; obj = [pscustomobject] @{Name="This`nIs some random`nmultiline content";A=1;B=2}; expectedTable = @"
 
@@ -782,7 +760,6 @@ Is some random
 multiline content
 
 
-
 "@ },
             @{ variation = "middle"; obj = [pscustomobject] @{A=1;Name="This`nIs some random`nmultiline content";B=2}; expectedTable = @"
 
@@ -791,7 +768,6 @@ A Name                                  B
 1 This                                  2
   Is some random
   multiline content
-
 
 
 "@ }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Out-File.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Out-File.Tests.ps1
@@ -83,12 +83,11 @@ Describe "Out-File" -Tags "CI" {
         $actual[3]  | Should -Match "some test text"
         $actual[4]  | Should -BeNullOrEmpty
         $actual[5]  | Should -BeNullOrEmpty
-        $actual[6]  | Should -BeNullOrEmpty
-        $actual[7]  | Should -Match "text"
-        $actual[8]  | Should -Match "----"
-        $actual[9]  | Should -Match "some test text"
+        $actual[6]  | Should -Match "text"
+        $actual[7]  | Should -Match "----"
+        $actual[8]  | Should -Match "some test text"
+        $actual[9]  | Should -BeNullOrEmpty
         $actual[10] | Should -BeNullOrEmpty
-        $actual[11] | Should -BeNullOrEmpty
     }
 
     It "Should limit each line to the specified number of characters when the width switch is used on objects" {
@@ -119,12 +118,11 @@ Describe "Out-File" -Tags "CI" {
         $actual[3]  | Should -Match "some test text"
         $actual[4]  | Should -BeNullOrEmpty
         $actual[5]  | Should -BeNullOrEmpty
-        $actual[6]  | Should -BeNullOrEmpty
-        $actual[7]  | Should -Match "text"
-        $actual[8]  | Should -Match "----"
-        $actual[9]  | Should -Match "some test text"
+        $actual[6]  | Should -Match "text"
+        $actual[7]  | Should -Match "----"
+        $actual[8]  | Should -Match "some test text"
+        $actual[9]  | Should -BeNullOrEmpty
         $actual[10] | Should -BeNullOrEmpty
-        $actual[11] | Should -BeNullOrEmpty
 
         # reset to not read only so it can be deleted
         Set-ItemProperty -Path $testfile -Name IsReadOnly -Value $false


### PR DESCRIPTION
## PR Summary

When formatting, the `Group` start and end added unnecessary newlines which resulted in double newlines in many cases.  Formatting changes are not considered breaking.

```powershell
(get-module | out-string).replace("`n","\n`n")
```

Before:

```output
\n
ModuleType Version    Name                                ExportedCommands\n
---------- -------    ----                                ----------------\n
Manifest   6.1.0.0    Microsoft.PowerShell.Management     {Add-Content, Clear-Content, Clear-Item, Clear-ItemProperty...}\n
Manifest   6.1.0.0    Microsoft.PowerShell.Utility        {Add-Member, Add-Type, Clear-Variable, Compare-Object...}\n
Script     2.0.0      PSReadLine                          {Get-PSReadLineKeyHandler, Get-PSReadLineOption, Remove-PSReadLineKeyHandler, Set-PSReadLineKeyHandler...}\n
\n
\n
```

After:

```output
\n             
ModuleType Version    Name                                ExportedCommands\n
---------- -------    ----                                ----------------\n
Manifest   6.1.0.0    Microsoft.PowerShell.Management     {Add-Content, Clear-Content, Clear-Item, Clear-ItemProperty...}\n
Manifest   6.1.0.0    Microsoft.PowerShell.Utility        {Add-Member, Add-Type, Clear-Variable, Compare-Object...}\n
Script     2.0.0      PSReadLine                          {Get-PSReadLineKeyHandler, Get-PSReadLineOption, Remove-PSReadLineKeyHandler, Set-PSReadLineKeyHandler...}\n
\n
```

There are still a few cases where the final output has two newlines (but not three anymore!).  This is a bit more complicated to fix and would need to track state that either a newline was the last thing output or the item is the last in a collection and doesn't need a separator.

Fix https://github.com/PowerShell/PowerShell/issues/7186

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [x] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
