### PR TITLE
Fix CVE-2018-8415

### DIFF
--- a/src/System.Management.Automation/engine/runtime/CompiledScriptBlock.cs
+++ b/src/System.Management.Automation/engine/runtime/CompiledScriptBlock.cs
@@ -1363,14 +1363,13 @@ namespace System.Management.Automation
                 }
             }
 
-            if(!wasEncoded)
+            if (!wasEncoded)
             {
                 // The logging mechanism(s) cannot handle null and rendering may not be able to handle
                 // null as we have the string defined as a null terminated string in the manifest.
-                // So, replace null characters with the Unicode `SYMBOL FOR NULL` 
+                // So, replace null characters with the Unicode `SYMBOL FOR NULL`
                 // We don't just remove the characters to preserve the fact that a null character was there.
-
-                textToLog = textToLog.Replace('\u0000','\u2400');
+                textToLog = textToLog.Replace('\u0000', '\u2400');
             }
 
             if (scriptBlock._scriptBlockData.HasSuspiciousContent)

--- a/src/System.Management.Automation/engine/runtime/CompiledScriptBlock.cs
+++ b/src/System.Management.Automation/engine/runtime/CompiledScriptBlock.cs
@@ -1317,6 +1317,7 @@ namespace System.Management.Automation
             // See if we need to encrypt the event log message. This info is all cached by Utils.GetPolicySetting(),
             // so we're not hitting the configuration file for every script block we compile.
             ProtectedEventLogging logSetting = Utils.GetPolicySetting<ProtectedEventLogging>(Utils.SystemWideOnlyConfig);
+            bool wasEncoded = false;
             if (logSetting != null)
             {
                 lock (s_syncObject)
@@ -1334,6 +1335,7 @@ namespace System.Management.Automation
                     // version.
                     if (s_encryptionRecipients != null)
                     {
+                        // Encrypt the raw Text from the scriptblock.  The user may have to deal with any control characters in the data.
                         ExecutionContext executionContext = LocalPipeline.GetExecutionContextFromTLS();
                         ErrorRecord error = null;
                         byte[] contentBytes = System.Text.Encoding.UTF8.GetBytes(textToLog);
@@ -1355,9 +1357,20 @@ namespace System.Management.Automation
                         else
                         {
                             textToLog = encodedContent;
+                            wasEncoded = true;
                         }
                     }
                 }
+            }
+
+            if(!wasEncoded)
+            {
+                // The logging mechanism(s) cannot handle null and rendering may not be able to handle
+                // null as we have the string defined as a null terminated string in the manifest.
+                // So, replace null characters with the Unicode `SYMBOL FOR NULL` 
+                // We don't just remove the characters to preserve the fact that a null character was there.
+
+                textToLog = textToLog.Replace('\u0000','\u2400');
             }
 
             if (scriptBlock._scriptBlockData.HasSuspiciousContent)

--- a/test/powershell/Host/Logging.Tests.ps1
+++ b/test/powershell/Host/Logging.Tests.ps1
@@ -216,6 +216,35 @@ $pid
         $createdEvents[2].Message | Should -Match ($scriptBlockCreatedRegExTemplate -f "Write\-Verbose 'testheader123' ;Write\-verbose 'after'")
     }
 
+    It 'Verifies scriptblock logging with null character' -Skip:(!$IsSupportedEnvironment) {
+        $configFile = WriteLogSettings -LogId $logId -ScriptBlockLogging -LogLevel Verbose
+        $script = @'
+$pid
+& ([scriptblock]::create("Write-Verbose 'testheader123$([char]0x0000)' ;Write-verbose 'after'"))
+'@
+        $testFileName = 'test01.ps1'
+        $testScriptPath = Join-Path -Path $TestDrive -ChildPath $testFileName
+        $script | Out-File -FilePath $testScriptPath -Force
+        $null = & $powershell -NoProfile -SettingsFile $configFile -Command $testScriptPath
+
+        # Get log entries from the last 100 that match our id and are after the time we launched Powershell
+        $items = Get-PSSysLog -Path $SyslogFile -Id $logId -Tail 100 -Verbose -TotalCount 18
+
+        $items | Should -Not -Be $null
+        $items.Count | Should -BeGreaterThan 2
+        $createdEvents = $items | where-object {$_.EventId -eq 'ScriptBlock_Compile_Detail:ExecuteCommand.Create.Verbose'}
+        $createdEvents.Count | should -BeGreaterOrEqual 3
+
+        # Verify we log that we are executing a file
+        $createdEvents[0].Message | Should -Match ($scriptBlockCreatedRegExTemplate -f ".*/$testFileName")
+
+        # Verify we log that we are the script to create the scriptblock
+        $createdEvents[1].Message | Should -Match ($scriptBlockCreatedRegExTemplate -f (Get-RegEx -SimpleMatch $Script.Replace([System.Environment]::NewLine,'#012')))
+
+        # Verify we log that we are excuting the created scriptblock
+        $createdEvents[2].Message | Should -Match ($scriptBlockCreatedRegExTemplate -f "Write\-Verbose 'testheader123␀' ;Write\-verbose 'after'")
+    }
+
     It 'Verifies logging level filtering works' -Skip:(!$IsSupportedEnvironment) {
         $configFile = WriteLogSettings -LogId $logId -LogLevel Warning
         & $powershell -NoProfile -SettingsFile $configFile -Command '$env:PSModulePath | out-null'

--- a/test/powershell/Host/Logging.Tests.ps1
+++ b/test/powershell/Host/Logging.Tests.ps1
@@ -441,6 +441,11 @@ Describe 'Basic EventLog tests on Windows' -Tag @('CI','RequireAdminOnWindows') 
                 script = "Write-Verbose 'testheader123' ;Write-verbose 'after'"
                 expectedText="Write-Verbose 'testheader123' ;Write-verbose 'after'`r`n"
             }
+            @{
+                name = 'script block with Null'
+                script = "Write-Verbose 'testheader123$([char]0x0000)' ;Write-verbose 'after'"
+                expectedText="Write-Verbose 'testheader123␀' ;Write-verbose 'after'`r`n"
+            }
         )
 
         if ($IsSupportedEnvironment)


### PR DESCRIPTION
## PR Summary

Fix CVE-2018-8415
  - If there is a null character in a `scriptblock`, translate it to a null replacement character before logging with `scriptblock` logging.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [x] Not Applicable or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
