### PR TITLE
Publish test package to AppVeyor daily build

### DIFF
--- a/tools/appveyor.psm1
+++ b/tools/appveyor.psm1
@@ -506,7 +506,7 @@ function Invoke-AppVeyorAfterTest
         New-TestPackage -Destination (Get-Location).Path
         $testPackageFullName = Join-Path $pwd 'TestPackage.zip'
         Write-Verbose "Created TestPackage.zip" -Verbose
-        Write-Host -ForegroundColor Green -'Upload test package'
+        Write-Host -ForegroundColor Green 'Upload test package'
         Push-AppveyorArtifact $testPackageFullName
     }
 }

--- a/tools/appveyor.psm1
+++ b/tools/appveyor.psm1
@@ -507,7 +507,7 @@ function Invoke-AppVeyorAfterTest
         $testPackageFullName = Join-Path $pwd 'TestPackage.zip'
         Write-Verbose "Created TestPackage.zip" -Verbose
         Write-Host -ForegroundColor Green 'Upload test package'
-        Push-AppveyorArtifact $testPackageFullName
+        Push-Artifact $testPackageFullName
     }
 }
 

--- a/tools/appveyor.psm1
+++ b/tools/appveyor.psm1
@@ -502,6 +502,12 @@ function Invoke-AppVeyorAfterTest
         $codeCoverageArtifacts | ForEach-Object {
             Push-Artifact -Path $_
         }
+
+        New-TestPackage -Destination (Get-Location).Path
+        $testPackageFullName = Join-Path $pwd 'TestPackage.zip'
+        Write-Verbose "Created TestPackage.zip" -Verbose
+        Write-Host -ForegroundColor Green -'Upload test package'
+        Push-AppveyorArtifact $testPackageFullName
     }
 }
 


### PR DESCRIPTION
## PR Summary

PR #8220  inadvertently reverted the work done in #8087 

This PR brings the code back.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [x] Not Applicable or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
