### PR TITLE
Fix LiteralPath in Import-Csv to bind to Get-ChildItem output

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CSVCommands.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CSVCommands.cs
@@ -526,7 +526,7 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Mandatory file name to read from.
         /// </summary>
-        [Parameter(Position = 0, ValueFromPipeline = true)]
+        [Parameter(Position = 0, ValueFromPipelineByPropertyName = true)]
         [ValidateNotNullOrEmpty]
         public string[] Path
         {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CSVCommands.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CSVCommands.cs
@@ -1716,6 +1716,7 @@ namespace Microsoft.PowerShell.Commands
                     }
 
                     break;
+                case "UseCulture":
                 case "CulturePath":
                 case "CultureLiteralPath":
                     if (UseCulture == true)

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CSVCommands.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CSVCommands.cs
@@ -28,7 +28,8 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Property that sets delimiter.
         /// </summary>
-        [Parameter(Position = 1, ParameterSetName = "Delimiter")]
+        [Parameter(Position = 1, ParameterSetName = "DelimiterPath")]
+        [Parameter(Position = 1, ParameterSetName = "DelimiterLiteralPath")]
         [ValidateNotNull]
         public char Delimiter
         {
@@ -51,7 +52,8 @@ namespace Microsoft.PowerShell.Commands
         ///<summary>
         ///Culture switch for csv conversion
         ///</summary>
-        [Parameter(ParameterSetName = "UseCulture")]
+        [Parameter(ParameterSetName = "CulturePath")]
+        [Parameter(ParameterSetName = "CultureLiteralPath")]
         public SwitchParameter UseCulture { get; set; }
 
         /// <summary>
@@ -115,7 +117,7 @@ namespace Microsoft.PowerShell.Commands
     /// <summary>
     /// Implementation for the export-csv command.
     /// </summary>
-    [Cmdlet(VerbsData.Export, "Csv", SupportsShouldProcess = true, DefaultParameterSetName = "Delimiter", HelpUri = "https://go.microsoft.com/fwlink/?LinkID=113299")]
+    [Cmdlet(VerbsData.Export, "Csv", SupportsShouldProcess = true, DefaultParameterSetName = "DelimiterPath", HelpUri = "https://go.microsoft.com/fwlink/?LinkID=113299")]
     public sealed class ExportCsvCommand : BaseCsvWritingCommand, IDisposable
     {
         #region Command Line Parameters
@@ -668,7 +670,7 @@ namespace Microsoft.PowerShell.Commands
     /// <summary>
     /// Implements ConvertTo-Csv command.
     /// </summary>
-    [Cmdlet(VerbsData.ConvertTo, "Csv", DefaultParameterSetName = "Delimiter",
+    [Cmdlet(VerbsData.ConvertTo, "Csv", DefaultParameterSetName = "DelimiterPath",
         HelpUri = "https://go.microsoft.com/fwlink/?LinkID=135203", RemotingCapability = RemotingCapability.None)]
     [OutputType(typeof(string))]
     public sealed class ConvertToCsvCommand : BaseCsvWritingCommand
@@ -758,7 +760,7 @@ namespace Microsoft.PowerShell.Commands
     /// <summary>
     /// Implements ConvertFrom-Csv command.
     /// </summary>
-    [Cmdlet(VerbsData.ConvertFrom, "Csv", DefaultParameterSetName = "Delimiter",
+    [Cmdlet(VerbsData.ConvertFrom, "Csv", DefaultParameterSetName = "DelimiterPath",
         HelpUri = "https://go.microsoft.com/fwlink/?LinkID=135201", RemotingCapability = RemotingCapability.None)]
     public sealed
     class
@@ -769,7 +771,7 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Property that sets delimiter.
         /// </summary>
-        [Parameter(Position = 1, ParameterSetName = "Delimiter")]
+        [Parameter(Position = 1, ParameterSetName = "DelimiterPath")]
         [ValidateNotNull]
         [ValidateNotNullOrEmpty]
         public char Delimiter { get; set; }
@@ -777,7 +779,8 @@ namespace Microsoft.PowerShell.Commands
         ///<summary>
         ///Culture switch for csv conversion
         ///</summary>
-        [Parameter(ParameterSetName = "UseCulture", Mandatory = true)]
+        [Parameter(ParameterSetName = "CulturePath", Mandatory = true)]
+        [Parameter(ParameterSetName = "CultureLiteralPath", Mandatory = true)]
         [ValidateNotNull]
         [ValidateNotNullOrEmpty]
         public SwitchParameter UseCulture { get; set; }
@@ -1705,7 +1708,8 @@ namespace Microsoft.PowerShell.Commands
         {
             switch (ParameterSetName)
             {
-                case "Delimiter":
+                case "DelimiterPath":
+                case "DelimiterLiteralPath":
                     // if delimiter is not given, it should take , as value
                     if (Delimiter == '\0')
                     {
@@ -1713,7 +1717,8 @@ namespace Microsoft.PowerShell.Commands
                     }
 
                     break;
-                case "UseCulture":
+                case "CulturePath":
+                case "CultureLiteralPath":
                     if (UseCulture == true)
                     {
                         // ListSeparator is apparently always a character even though the property returns a string, checked via:

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CSVCommands.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CSVCommands.cs
@@ -28,8 +28,7 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Property that sets delimiter.
         /// </summary>
-        [Parameter(Position = 1, ParameterSetName = "DelimiterPath")]
-        [Parameter(Position = 1, ParameterSetName = "DelimiterLiteralPath")]
+        [Parameter(Position = 1, ParameterSetName = "Delimiter")]
         [ValidateNotNull]
         public char Delimiter
         {
@@ -52,8 +51,7 @@ namespace Microsoft.PowerShell.Commands
         ///<summary>
         ///Culture switch for csv conversion
         ///</summary>
-        [Parameter(ParameterSetName = "CulturePath")]
-        [Parameter(ParameterSetName = "CultureLiteralPath")]
+        [Parameter(ParameterSetName = "UseCulture")]
         public SwitchParameter UseCulture { get; set; }
 
         /// <summary>
@@ -117,7 +115,7 @@ namespace Microsoft.PowerShell.Commands
     /// <summary>
     /// Implementation for the export-csv command.
     /// </summary>
-    [Cmdlet(VerbsData.Export, "Csv", SupportsShouldProcess = true, DefaultParameterSetName = "DelimiterPath", HelpUri = "https://go.microsoft.com/fwlink/?LinkID=113299")]
+    [Cmdlet(VerbsData.Export, "Csv", SupportsShouldProcess = true, DefaultParameterSetName = "Delimiter", HelpUri = "https://go.microsoft.com/fwlink/?LinkID=113299")]
     public sealed class ExportCsvCommand : BaseCsvWritingCommand, IDisposable
     {
         #region Command Line Parameters
@@ -1708,6 +1706,7 @@ namespace Microsoft.PowerShell.Commands
         {
             switch (ParameterSetName)
             {
+                case "Delimiter":
                 case "DelimiterPath":
                 case "DelimiterLiteralPath":
                     // if delimiter is not given, it should take , as value

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CSVCommands.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CSVCommands.cs
@@ -509,7 +509,7 @@ namespace Microsoft.PowerShell.Commands
     /// <summary>
     /// Implements Import-Csv command.
     /// </summary>
-    [Cmdlet(VerbsData.Import, "Csv", DefaultParameterSetName = "Delimiter", HelpUri = "https://go.microsoft.com/fwlink/?LinkID=113341")]
+    [Cmdlet(VerbsData.Import, "Csv", DefaultParameterSetName = "DelimiterPath", HelpUri = "https://go.microsoft.com/fwlink/?LinkID=113341")]
     public sealed
     class
     ImportCsvCommand : PSCmdlet
@@ -519,14 +519,16 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Property that sets delimiter.
         /// </summary>
-        [Parameter(Position = 1, ParameterSetName = "Delimiter")]
+        [Parameter(Position = 1, ParameterSetName = "DelimiterPath")]
+        [Parameter(Position = 1, ParameterSetName = "DelimiterLiteralPath")]
         [ValidateNotNull]
         public char Delimiter { get; set; }
 
         /// <summary>
         /// Mandatory file name to read from.
         /// </summary>
-        [Parameter(Position = 0)]
+        [Parameter(Position = 0, ParameterSetName = "DelimiterPath", Mandatory = true, ValueFromPipeline = true, ValueFromPipelineByPropertyName = true)]
+        [Parameter(Position = 0, ParameterSetName = "CulturePath", Mandatory = true, ValueFromPipeline = true, ValueFromPipelineByPropertyName = true)]
         [ValidateNotNullOrEmpty]
         public string[] Path
         {
@@ -548,7 +550,8 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// The literal path of the mandatory file name to read from.
         /// </summary>
-        [Parameter(ValueFromPipelineByPropertyName = true)]
+        [Parameter(ParameterSetName = "DelimiterLiteralPath", Mandatory = true, ValueFromPipelineByPropertyName = true)]
+        [Parameter(ParameterSetName = "CultureLiteralPath", Mandatory = true, ValueFromPipelineByPropertyName = true)]
         [ValidateNotNullOrEmpty]
         [Alias("PSPath", "LP")]
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays")]
@@ -571,7 +574,8 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Property that sets UseCulture parameter.
         /// </summary>
-        [Parameter(ParameterSetName = "UseCulture", Mandatory = true)]
+        [Parameter(ParameterSetName = "CulturePath", Mandatory = true)]
+        [Parameter(ParameterSetName = "CultureLiteralPath", Mandatory = true)]
         [ValidateNotNull]
         public SwitchParameter UseCulture
         {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CSVCommands.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CSVCommands.cs
@@ -526,7 +526,7 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Mandatory file name to read from.
         /// </summary>
-        [Parameter(Position = 0, ValueFromPipelineByPropertyName = true)]
+        [Parameter(Position = 0)]
         [ValidateNotNullOrEmpty]
         public string[] Path
         {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Import-Csv.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Import-Csv.Tests.ps1
@@ -47,10 +47,44 @@ Describe "Import-Csv Double Quote Delimiter" -Tags "CI" {
         @{ name = "value enclosed in quote" ; expectedHeader = "a1,a2,a3"; file = "QuotedCharacter.csv" ; content = $quotedCharacterCsv ; delimiter = ',' }
         ){
         param($expectedHeader, $file, $content, $delimiter)
-        Set-Content testdrive:/$file -Value $content
-        $returnObject = Get-ChildItem -Path testdrive:/$file | Import-Csv -Delimiter $delimiter
+
+        $testPath = Join-Path $TestDrive $file
+        Set-Content $testPath -Value $content
+
+        $returnObject = Get-ChildItem -Path $testPath | Import-Csv -Delimiter $delimiter
         $actualHeader = $returnObject[0].psobject.Properties.name -join ','
-        $actualHeader | Should -Be $expectedHeader
+        $actualHeader | Should -BeExactly $expectedHeader
+
+        $returnObject = $testPath | Import-Csv -Delimiter $delimiter
+        $actualHeader = $returnObject[0].psobject.Properties.name -join ','
+        $actualHeader | Should -BeExactly $expectedHeader
+
+        $returnObject = [pscustomobject]@{ LiteralPath = $testPath } | Import-Csv -Delimiter $delimiter
+        $actualHeader = $returnObject[0].psobject.Properties.name -join ','
+        $actualHeader | Should -BeExactly $expectedHeader
+    }
+
+    It "Should handle <name> and bind to Path from pipeline" -TestCases @(
+        @{ name = "quote with empty value"  ; expectedHeader = "a1,H1,a3"; file = "EmptyValue.csv"      ; content = $empyValueCsv       ; delimiter = '"' }
+        @{ name = "quote with value"        ; expectedHeader = "a1,a2,a3"; file = "WithValue.csv"       ; content = $withValueCsv       ; delimiter = '"' }
+        @{ name = "value enclosed in quote" ; expectedHeader = "a1,a2,a3"; file = "QuotedCharacter.csv" ; content = $quotedCharacterCsv ; delimiter = ',' }
+        ){
+        param($expectedHeader, $file, $content, $delimiter)
+
+        $testPath = Join-Path $TestDrive $file
+        Set-Content $testPath -Value $content
+
+        $returnObject = Get-ChildItem -Path $testPath | Import-Csv -Delimiter $delimiter
+        $actualHeader = $returnObject[0].psobject.Properties.name -join ','
+        $actualHeader | Should -BeExactly $expectedHeader
+
+        $returnObject = $testPath | Import-Csv -Delimiter $delimiter
+        $actualHeader = $returnObject[0].psobject.Properties.name -join ','
+        $actualHeader | Should -BeExactly $expectedHeader
+
+        $returnObject = [pscustomobject]@{ Path = $testPath } | Import-Csv -Delimiter $delimiter
+        $actualHeader = $returnObject[0].psobject.Properties.name -join ','
+        $actualHeader | Should -BeExactly $expectedHeader
     }
 }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Import-Csv.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Import-Csv.Tests.ps1
@@ -41,14 +41,14 @@ Describe "Import-Csv Double Quote Delimiter" -Tags "CI" {
     }
 
 
-    It "Should handle <name>" -TestCases @(
+    It "Should handle <name> and bind to LiteralPath from pipeline" -TestCases @(
         @{ name = "quote with empty value"  ; expectedHeader = "a1,H1,a3"; file = "EmptyValue.csv"      ; content = $empyValueCsv       ; delimiter = '"' }
         @{ name = "quote with value"        ; expectedHeader = "a1,a2,a3"; file = "WithValue.csv"       ; content = $withValueCsv       ; delimiter = '"' }
         @{ name = "value enclosed in quote" ; expectedHeader = "a1,a2,a3"; file = "QuotedCharacter.csv" ; content = $quotedCharacterCsv ; delimiter = ',' }
         ){
         param($expectedHeader, $file, $content, $delimiter)
         Set-Content testdrive:/$file -Value $content
-        $returnObject = Import-Csv -Path testdrive:/$file -Delimiter $delimiter
+        $returnObject = Get-ChildItem -Path testdrive:/$file | Import-Csv -Delimiter $delimiter
         $actualHeader = $returnObject[0].psobject.Properties.name -join ','
         $actualHeader | Should -Be $expectedHeader
     }


### PR DESCRIPTION
## PR Summary

Fix #4473.

Now works:
```powershell
dir | Import-Csv
```
From source issue discussion the behavior should be "by design" like `Get-Content`.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
