### PR TITLE
Add fix for Start-Job initialization script in system lockdown

### DIFF
--- a/src/System.Management.Automation/engine/remoting/server/ServerRunspacePoolDriver.cs
+++ b/src/System.Management.Automation/engine/remoting/server/ServerRunspacePoolDriver.cs
@@ -546,7 +546,9 @@ namespace System.Management.Automation
         {
             Debug.Assert(cmdToRun != null, "cmdToRun shouldn't be null");
 
-            cmdToRun.CommandOrigin = CommandOrigin.Internal;
+            // Don't invoke initialization script as trusted (CommandOrigin == Internal) if the system is in lock down mode.
+            cmdToRun.CommandOrigin = (SystemPolicy.GetSystemLockdownPolicy() == SystemEnforcementMode.Enforce) ? CommandOrigin.Runspace : CommandOrigin.Internal;
+
             cmdToRun.MergeMyResults(PipelineResultTypes.Error, PipelineResultTypes.Output);
             PowerShell powershell = PowerShell.Create();
             powershell.AddCommand(cmdToRun).AddCommand("out-default");

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/ConstrainedLanguageValidation.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/ConstrainedLanguageValidation.Tests.ps1
@@ -54,6 +54,28 @@ try
         }
     }
 
+    Describe "Start-Job initialization script should work in system lock down" -Tags 'Feature','RequireAdminOnWindows' {
+
+        It "Verifies that Start-Job initialization script runs successfully in system lock down" {
+
+            try
+            {
+                Invoke-LanguageModeTestingSupportCmdlet -SetLockdownMode
+                $ExecutionContext.SessionState.LanguageMode = "ConstrainedLanguage"
+
+                $job = Start-Job -InitializationScript { function Hello { "Hello" } } -ScriptBlock { Hello }
+                $result = $job | Wait-Job | Receive-Job
+            }
+            finally
+            {
+                Invoke-LanguageModeTestingSupportCmdlet -RevertLockdownMode -EnableFullLanguageMode
+            }
+
+            $result | Should -BeExactly "Hello"
+            $job | Remove-Job
+        }
+    }
+
     # End Describe blocks
 }
 finally


### PR DESCRIPTION
## PR Summary

This is a Windows platform issue only.

When running remote initialization script, the script block is considered internal and marked as trusted.  In system lock down mode, PowerShell runs in ConstrainedLanguage mode and won't allow a trusted script block to run in the default scope.

Fix is to mark the initialization script as untrusted external when system is locked down.

Repro:
```powershell
# PowerShell running in locked down system
Start-Job -InitializationScript { function Hello { "Hello" } } -ScriptBlock { Hello } | Wait-Job | Receive-Job

# Result
Error: "Cannot dot-source this command because it was defined in a different language mode. To invoke this command without importing its contents, omit the '.' operator."
```
Fix is to mark initialization script as untrusted "external origin" when system is in lock down mode, so that it can run in ConstrainedLanguage session scope.
## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [x] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
