### PR TITLE
Enable `Open Here` context menu on Windows to work with root of a drive

### DIFF
--- a/assets/Product.wxs
+++ b/assets/Product.wxs
@@ -207,7 +207,7 @@
                 <RegistryValue Type="string" Name="Icon" Value="[$(var.ProductDirectoryName)]$(env.IconPath)"/>
               </RegistryKey>
               <RegistryKey Root="HKCR" Key="Directory\ContextMenus\$(var.ProductName)$(var.SimpleProductVersion)$(sys.BUILDARCH)\shell\openpwsh\command">
-                <RegistryValue Type="string" Value="[$(var.ProductDirectoryName)]pwsh.exe -NoExit -WorkingDirectory &quot;%V&quot; -Command &quot;$host.UI.RawUI.WindowTitle = '$(var.ProductName) $(var.SimpleProductVersion) ($(sys.BUILDARCH))'&quot;"/>
+                <RegistryValue Type="string" Value="[$(var.ProductDirectoryName)]pwsh.exe -NoExit -RemoveWorkingDirectoryTrailingCharacter -WorkingDirectory &quot;%V!&quot; -Command &quot;$host.UI.RawUI.WindowTitle = '$(var.ProductName) $(var.SimpleProductVersion) ($(sys.BUILDARCH))'&quot;"/>
               </RegistryKey>
               <RegistryKey Root="HKCR" Key="Directory\ContextMenus\$(var.ProductName)$(var.SimpleProductVersion)$(sys.BUILDARCH)\shell\runas">
                 <RegistryValue Type="string" Name="MUIVerb" Value="$(var.ExplorerContextSubMenuElevatedDialogText)"/>
@@ -215,7 +215,7 @@
                 <RegistryValue Type="string" Value="" Name="HasLUAShield"/>
               </RegistryKey>
               <RegistryKey Root="HKCR" Key="Directory\ContextMenus\$(var.ProductName)$(var.SimpleProductVersion)$(sys.BUILDARCH)\shell\runas\command">
-                <RegistryValue Type="string" Value="[$(var.ProductDirectoryName)]pwsh.exe -NoExit -WorkingDirectory &quot;%V&quot; -Command &quot;$host.UI.RawUI.WindowTitle = '$(var.ProductName) $(var.SimpleProductVersion) ($(sys.BUILDARCH))'&quot;"/>
+                <RegistryValue Type="string" Value="[$(var.ProductDirectoryName)]pwsh.exe -NoExit -RemoveWorkingDirectoryTrailingCharacter -WorkingDirectory &quot;%V!&quot; -Command &quot;$host.UI.RawUI.WindowTitle = '$(var.ProductName) $(var.SimpleProductVersion) ($(sys.BUILDARCH))'&quot;"/>
               </RegistryKey>
             </Component>
           </Directory>

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
@@ -188,7 +188,8 @@ namespace Microsoft.PowerShell
             "command",
             "settingsfile",
             "help",
-            "workingdirectory"
+            "workingdirectory",
+            "removeworkingdirectorytrailingcharacter"
         };
 
         internal CommandLineParameterParser(PSHostUserInterface hostUI, string bannerText, string helpText)
@@ -401,7 +402,20 @@ namespace Microsoft.PowerShell
 
         internal string WorkingDirectory
         {
-            get { return _workingDirectory; }
+            get
+            {
+                if (_removeWorkingDirectoryTrailingCharacter && _workingDirectory.Length > 0)
+                {
+                    return _workingDirectory.Remove(_workingDirectory.Length - 1);
+                }
+ 
+                return _workingDirectory;
+            }
+        }
+
+        internal bool RemoveWorkingDirectoryTrailingCharacter
+        {
+            get { return _removeWorkingDirectoryTrailingCharacter; }
         }
 
         #endregion Internal properties
@@ -934,6 +948,10 @@ namespace Microsoft.PowerShell
 
                     _workingDirectory = args[i];
                 }
+                else if (MatchSwitch(switchKey, "removeworkingdirectorytrailingcharacter", "removeworkingdirectorytrailingcharacter"))
+                {
+                    _removeWorkingDirectoryTrailingCharacter = true;
+                }
                 else
                 {
                     // The first parameter we fail to recognize marks the beginning of the file string.
@@ -1364,6 +1382,8 @@ namespace Microsoft.PowerShell
         private string _file;
         private string _executionPolicy;
         private string _workingDirectory;
+
+        private bool _removeWorkingDirectoryTrailingCharacter = false;
     }
 }   // namespace
 

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/CommandLineParameterParser.cs
@@ -404,19 +404,22 @@ namespace Microsoft.PowerShell
         {
             get
             {
+#if !UNIX
                 if (_removeWorkingDirectoryTrailingCharacter && _workingDirectory.Length > 0)
                 {
                     return _workingDirectory.Remove(_workingDirectory.Length - 1);
                 }
- 
+ #endif
                 return _workingDirectory;
             }
         }
 
+#if !UNIX
         internal bool RemoveWorkingDirectoryTrailingCharacter
         {
             get { return _removeWorkingDirectoryTrailingCharacter; }
         }
+#endif
 
         #endregion Internal properties
 
@@ -948,10 +951,12 @@ namespace Microsoft.PowerShell
 
                     _workingDirectory = args[i];
                 }
+#if !UNIX
                 else if (MatchSwitch(switchKey, "removeworkingdirectorytrailingcharacter", "removeworkingdirectorytrailingcharacter"))
                 {
                     _removeWorkingDirectoryTrailingCharacter = true;
                 }
+#endif
                 else
                 {
                     // The first parameter we fail to recognize marks the beginning of the file string.
@@ -1383,7 +1388,9 @@ namespace Microsoft.PowerShell
         private string _executionPolicy;
         private string _workingDirectory;
 
+#if !UNIX
         private bool _removeWorkingDirectoryTrailingCharacter = false;
+#endif
     }
 }   // namespace
 


### PR DESCRIPTION
## PR Summary

The fundamental problem is that [Microsoft cpp command line parsing](https://docs.microsoft.com/en-us/cpp/cpp/parsing-cpp-command-line-arguments?view=vs-2017) rules indicate that a backslash followed by a quote is a quote, otherwise, it is literal.  So this:

```powershell
pwsh -noexit -workingdirectory "c:\"
```

Is received as `c:"` at argument parsing time.  Of course, this is a bit more complicated as `Open Here` also uses `-Command`.  So:

```powershell
pwsh -noexit -workingdirectory "c:\" -command 1+1
```

Becomes `c:" -command 1+1` as the argument value to `-workingdirectory`.  And `-command` must be last in the command line.
Fix is to add a hidden switch for the purpose of the `Open Here` context menu called `-RemoveWorkingDirectoryTrailingCharacter`.  This allows `Open Here`'s command line to pad the path:

```powershell
pwsh -noexit -removeworkingdirectorytrailingcharacter -workingdirectory "C:\!" -command 1+1
```

Now all the args can get parsed appropriately as the working directory path never ends with a trailing backslash.

Fix https://github.com/PowerShell/PowerShell/issues/8278

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [x] Not Applicable or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
