### PR TITLE
Allow capability to specify specific SessionStateScope for Variable cmdlets

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Var.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Var.cs
@@ -794,7 +794,7 @@ namespace Microsoft.PowerShell.Commands
                 List<PSVariable> matchingVariables = new List<PSVariable>();
 
                 bool wasFiltered = false;
-                if ((Scope == null) || (Scope is string) && (!string.IsNullOrEmpty(Scope as string)))
+                if ((Scope != null) || (Scope is string) && (!string.IsNullOrEmpty(Scope as string)))
                 {
                     // We really only need to find matches if the scope was specified.
                     // If the scope wasn't specified then we need to create the

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Var.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Var.cs
@@ -24,6 +24,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         [Parameter]
         [ValidateNotNullOrEmpty]
+        [ArgumentCompletions(StringLiterals.Global, StringLiterals.Local, StringLiterals.Private, StringLiterals.Script)]
         public object Scope { get; set; }
 
         #endregion parameters

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Var.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Var.cs
@@ -100,7 +100,7 @@ namespace Microsoft.PowerShell.Commands
 
             List<PSVariable> result = new List<PSVariable>();
 
-            if (String.IsNullOrEmpty(name))
+            if (string.IsNullOrEmpty(name))
             {
                 name = "*";
             }
@@ -108,7 +108,6 @@ namespace Microsoft.PowerShell.Commands
             bool nameContainsWildcard = WildcardPattern.ContainsWildcardCharacters(name);
 
             // Now create the filters
-
             WildcardPattern nameFilter =
                 WildcardPattern.Get(
                     name,
@@ -129,7 +128,6 @@ namespace Microsoft.PowerShell.Commands
                 // Filter the name here against the include and exclude so that
                 // we can report if the name was filtered vs. there being no
                 // variable existing of that name.
-
                 bool isIncludeMatch =
                     SessionStateUtilities.MatchesAnyWildcardPattern(
                         name,
@@ -152,9 +150,8 @@ namespace Microsoft.PowerShell.Commands
             // First get the appropriate view of the variables. If no scope
             // is specified, flatten all scopes to produce a currently active
             // view.
-
             IDictionary<string, PSVariable> variableTable = null;
-            if (lookupScope == null || lookupScope is String && String.IsNullOrEmpty(lookupScope as String))
+            if ((lookupScope == null) || ((lookupScope is string) && (string.IsNullOrEmpty(lookupScope as string))))
             {
                 variableTable = SessionState.Internal.GetVariableTable();
             }
@@ -205,6 +202,7 @@ namespace Microsoft.PowerShell.Commands
                                         new ErrorRecord(
                                             sessionStateException.ErrorRecord,
                                             sessionStateException));
+
                                     // Only report the error once...
                                     wasFiltered = true;
                                     continue;
@@ -467,7 +465,7 @@ namespace Microsoft.PowerShell.Commands
             if (!Force)
             {
                 PSVariable varFound = null;
-                if (Scope == null || Scope is String && String.IsNullOrEmpty(Scope as String))
+                if ((Scope == null) || (Scope is string) && (string.IsNullOrEmpty(Scope as string)))
                 {
                     varFound =
                         SessionState.Internal.GetVariableAtScope(Name, "local");
@@ -519,7 +517,7 @@ namespace Microsoft.PowerShell.Commands
 
                 try
                 {
-                    if (Scope == null || Scope is String && String.IsNullOrEmpty(Scope as String))
+                    if ((Scope == null) || (Scope is string) && (String.IsNullOrEmpty(Scope as string)))
                     {
                         SessionState.Internal.NewVariable(newVariable, Force);
                     }
@@ -796,7 +794,7 @@ namespace Microsoft.PowerShell.Commands
                 List<PSVariable> matchingVariables = new List<PSVariable>();
 
                 bool wasFiltered = false;
-                if (Scope == null || Scope is String && !String.IsNullOrEmpty(Scope as String))
+                if ((Scope == null) || (Scope is string) && (!string.IsNullOrEmpty(Scope as string)))
                 {
                     // We really only need to find matches if the scope was specified.
                     // If the scope wasn't specified then we need to create the
@@ -828,9 +826,9 @@ namespace Microsoft.PowerShell.Commands
                     try
                     {
                         ScopedItemOptions newOptions = ScopedItemOptions.None;
-                        if (Scope is String &&
-                            !String.IsNullOrEmpty(Scope as String) &&
-                            String.Equals("private", Scope as String, StringComparison.OrdinalIgnoreCase))
+                        if ((Scope is string) &&
+                            (!string.IsNullOrEmpty(Scope as string)) &&
+                            (string.Equals("private", Scope as string, StringComparison.OrdinalIgnoreCase)))
                         {
                             newOptions = ScopedItemOptions.Private;
                         }
@@ -872,7 +870,7 @@ namespace Microsoft.PowerShell.Commands
                         {
                             object result = null;
 
-                            if (Scope == null || Scope is String && String.IsNullOrEmpty(Scope as String))
+                            if ((Scope == null) || (Scope is string) && (string.IsNullOrEmpty(Scope as string)))
                             {
                                 result =
                                     SessionState.Internal.SetVariable(varToSet, Force, origin);
@@ -1126,7 +1124,7 @@ namespace Microsoft.PowerShell.Commands
                     {
                         try
                         {
-                            if (Scope == null || Scope is String && String.IsNullOrEmpty(Scope as String))
+                            if ((Scope == null) || (Scope is string) && (string.IsNullOrEmpty(Scope as string)))
                             {
                                 SessionState.Internal.RemoveVariable(matchingVariable, _force);
                             }

--- a/src/System.Management.Automation/engine/SessionStateScopeAPIs.cs
+++ b/src/System.Management.Automation/engine/SessionStateScopeAPIs.cs
@@ -52,8 +52,7 @@ namespace System.Management.Automation
             // If LanguageMode is not set to FullLanguage prevent access to other scopeID options.
             if (LanguageMode != PSLanguageMode.FullLanguage && !(scopeID is int || scopeID is string))
             {
-                String errorMessage = String.Format("Scopes other than \"script\", \"global\", \"local\", or \"private\" or a numeric ID is only allowed in {0} LanguageMode", LanguageMode);
-                throw new System.Exception(errorMessage);
+                throw PSTraceSource.NewInvalidOperationException(AutomationExceptions.InvalidSecurityScopeIdArgument, ScopeParameterName, LanguageMode);
             }
 
             // Unwrap PSObject as it automatically gets wrapped when passed down a pipeline.
@@ -85,8 +84,7 @@ namespace System.Management.Automation
                     result = scope.SessionState.Internal.CurrentScope;
                     break;
                 default:
-                    // Todo: Figure out correct type of error to throw. Given proper Powershell Resources.
-                    throw new PSArgumentException(String.Format("Scope is not of usable type. {0}", scopeID.GetType() ));
+                    throw PSTraceSource.NewArgumentException(ScopeParameterName, AutomationExceptions.InvalidScopeIdArgument, ScopeParameterName);
             }
             return result;
         } // GetScopeByID

--- a/src/System.Management.Automation/engine/SessionStateScopeAPIs.cs
+++ b/src/System.Management.Automation/engine/SessionStateScopeAPIs.cs
@@ -25,6 +25,52 @@ namespace System.Management.Automation
         /// Cmdlet parameter name to return in the error message instead of "scopeID".
         /// </summary>
         internal const string ScopeParameterName = "Scope";
+        /// <summary>
+        /// Given a scope identifier, returns the proper session state scope.
+        /// </summary>
+        /// <param name="scopeID">
+        /// A scope identifier that is either one of the "special" scopes like
+        /// "global", "local", or "private, or a numeric ID of a relative scope
+        /// to the current scope.
+        /// </param>
+        /// <returns>
+        /// The scope identified by the scope ID or the current scope if the
+        /// scope ID is not defined as a special or numeric scope identifier.
+        /// </returns>
+        /// <exception cref="ArgumentException">
+        /// If <paramref name="scopeID"/> is less than zero, or not
+        /// a number and not "script", "global", "local", or "private"
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// If <paramref name="scopeID"/> is less than zero or greater than the number of currently
+        /// active scopes.
+        /// </exception>
+        internal SessionStateScope GetScopeByID(object scopeID)
+        {
+            SessionStateScope result = _currentScope;
+            switch (scopeID)
+            {
+                case int scope:
+                    result = GetScopeByID(scope);
+                    break;
+                case string scope:
+                    if (!String.IsNullOrEmpty(scope))
+                    {
+                        result = GetScopeByID(scope);
+                    }
+                    break;
+                case SessionState scope:
+                    result = scope.Internal.CurrentScope;
+                    break;
+                case SessionStateScope ls:
+                    result = ls;
+                    break;
+                default:
+                    // Todo: Figure out correct type of error to throw. Given proper Powershell Resources.
+                    throw new PSArgumentException(String.Format("Scope is not of usable type. {0}", scopeID.GetType() ));
+            }
+            return result;
+        } // GetScopeByID
 
         /// <summary>
         /// Given a scope identifier, returns the proper session state scope.

--- a/src/System.Management.Automation/engine/SessionStateVariableAPIs.cs
+++ b/src/System.Management.Automation/engine/SessionStateVariableAPIs.cs
@@ -617,6 +617,36 @@ namespace System.Management.Automation
         /// </exception>
         internal PSVariable GetVariableAtScope(string name, string scopeID)
         {
+            return GetVariableAtScope(name, scopeID as object);
+        } // GetVariable
+
+        /// <summary>
+        /// Get a variable out of session state. This interface supports
+        /// the "namespace:name" syntax so you can do things like
+        /// "env:PATH" or "global:foobar"
+        /// </summary>
+        /// <param name="name">
+        /// name of variable to look up
+        /// </param>
+        /// <param name="scopeID">
+        /// The ID of the scope to lookup the variable in.
+        /// </param>
+        /// <returns>
+        /// The value of the specified variable.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// If <paramref name="name"/> is null.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// If <paramref name="scopeID"/> is less than zero, or not
+        /// a number and not "script", "global", "local", or "private"
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// If <paramref name="scopeID"/> is less than zero or greater than the number of currently
+        /// active scopes.
+        /// </exception>
+        internal PSVariable GetVariableAtScope(string name, object scopeID)
+        {
             if (name == null)
             {
                 throw PSTraceSource.NewArgumentNullException("name");
@@ -630,7 +660,6 @@ namespace System.Management.Automation
             // ID.
 
             lookupScope = GetScopeByID(scopeID);
-
             PSVariable resultItem = null;
 
             if (variablePath.IsVariable)
@@ -1398,6 +1427,45 @@ namespace System.Management.Automation
         /// </exception>
         internal object SetVariableAtScope(PSVariable variable, string scopeID, bool force, CommandOrigin origin)
         {
+            return SetVariableAtScope(variable, scopeID as object, force, origin);
+        } // SetVariableAtScope
+
+        /// <summary>
+        /// Set a variable in session state.
+        /// </summary>
+        /// <param name="variable">
+        /// The variable to set
+        /// </param>
+        /// <param name="scopeID">
+        /// The ID of the scope to do the lookup in. The ID is either a zero based index
+        /// of the scope tree with the current scope being zero, its parent scope
+        /// being 1 and so on, or "global", "local", "private", or "script"
+        /// </param>
+        /// <param name="force">
+        /// If true, the variable is set even if it is ReadOnly.
+        /// </param>
+        /// <param name="origin">
+        /// The origin of the caller
+        /// </param>
+        /// <exception cref="ArgumentException">
+        /// If <paramref name="variable"/> is null or its name is null or empty.
+        /// or
+        /// If <paramref name="scopeID"/> is less than zero, or not
+        /// a number and not "script", "global", "local", or "private"
+        /// </exception>
+        /// <returns>
+        /// A PSVariable object if <paramref name="variable"/> refers to a variable.
+        /// An PSObject if <paramref name="variable"/> refers to a provider path.
+        /// </returns>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// If <paramref name="scopeID"/> is less than zero or greater than the number of currently
+        /// active scopes.
+        /// </exception>
+        /// <exception cref="SessionStateUnauthorizedAccessException">
+        /// If the variable is read-only or constant.
+        /// </exception>
+        internal object SetVariableAtScope(PSVariable variable, object scopeID, bool force, CommandOrigin origin)
+        {
             if (variable == null || String.IsNullOrEmpty(variable.Name))
             {
                 throw PSTraceSource.NewArgumentException("variable");
@@ -1477,6 +1545,41 @@ namespace System.Management.Automation
         /// If the variable is read-only or constant.
         /// </exception>
         internal object NewVariableAtScope(PSVariable variable, string scopeID, bool force)
+        {
+            return NewVariableAtScope(variable, scopeID as object, force);
+        } // NewVariableAtScope
+
+        /// <summary>
+        /// Creates a new variable in the specified scope
+        /// </summary>
+        /// <param name="variable">
+        /// The variable to create
+        /// </param>
+        /// <param name="scopeID">
+        /// The ID of the scope to do the lookup in. The ID is either a zero based index
+        /// of the scope tree with the current scope being zero, its parent scope
+        /// being 1 and so on, or "global", "local", "private", or "script"
+        /// </param>
+        /// <param name="force">
+        /// If true, the variable is set even if it is ReadOnly.
+        /// </param>
+        /// <exception cref="ArgumentException">
+        /// If <paramref name="variable"/> is null or its name is null or empty.
+        /// or
+        /// If <paramref name="scopeID"/> is less than zero, or not
+        /// a number and not "script", "global", "local", or "private"
+        /// </exception>
+        /// <returns>
+        /// A PSVariable representing the variable that was created.
+        /// </returns>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// If <paramref name="scopeID"/> is less than zero or greater than the number of currently
+        /// active scopes.
+        /// </exception>
+        /// <exception cref="SessionStateUnauthorizedAccessException">
+        /// If the variable is read-only or constant.
+        /// </exception>
+        internal object NewVariableAtScope(PSVariable variable, object scopeID, bool force)
         {
             if (variable == null || String.IsNullOrEmpty(variable.Name))
             {
@@ -1773,6 +1876,33 @@ namespace System.Management.Automation
         /// </exception>
         internal void RemoveVariableAtScope(PSVariable variable, string scopeID, bool force)
         {
+            RemoveVariableAtScope(variable, scopeID as object, force);
+        } // RemoveVariableAtScope
+
+        /// <summary>
+        /// Remove a variable from session state.
+        /// </summary>
+        /// <param name="variable">
+        /// The variable to remove
+        /// </param>
+        /// <param name="scopeID">
+        /// The ID of the scope to lookup the variable in.
+        /// </param>
+        /// <param name="force">
+        /// If true, the variable will be removed even if its ReadOnly.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// If <paramref name="variable"/> is null.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// If <paramref name="scopeID"/> is less than zero or greater than the number of currently
+        /// active scopes.
+        /// </exception>
+        /// <exception cref="SessionStateUnauthorizedAccessException">
+        /// if the variable is constant.
+        /// </exception>
+        internal void RemoveVariableAtScope(PSVariable variable, object scopeID, bool force)
+        {
             if (variable == null)
             {
                 throw PSTraceSource.NewArgumentNullException("variable");
@@ -1783,7 +1913,7 @@ namespace System.Management.Automation
             // The lookup scope is retrieved by ID.
 
             SessionStateScope lookupScope = GetScopeByID(scopeID);
-
+            
             lookupScope.RemoveVariable(variablePath.QualifiedName, force);
         } // RemoveVariableAtScope
 
@@ -1856,7 +1986,7 @@ namespace System.Management.Automation
         /// If <paramref name="scopeID"/> is less than zero or greater than the number of currently
         /// active scopes.
         /// </exception>
-        internal IDictionary<string, PSVariable> GetVariableTableAtScope(string scopeID)
+        internal IDictionary<string, PSVariable> GetVariableTableAtScope(object scopeID)
         {
             var result = new Dictionary<string, PSVariable>(StringComparer.OrdinalIgnoreCase);
             GetScopeVariableTable(GetScopeByID(scopeID), result, includePrivate: true);

--- a/src/System.Management.Automation/resources/AutomationExceptions.resx
+++ b/src/System.Management.Automation/resources/AutomationExceptions.resx
@@ -123,6 +123,9 @@
   <data name="InvalidScopeIdArgument" xml:space="preserve">
     <value>Cannot process argument because the value of parameter "{0}" is not valid. Valid values are "Global", "Local", or "Script", or a number relative to the current scope (0 through the number of scopes where 0 is the current scope and 1 is its parent). Change the value of the "{0}" parameter and run the operation again.</value>
   </data>
+  <data name="InvalidSecurityScopeIdArgument" xml:space="preserve">
+    <value>Cannot process argument "{0}" due to Constrained Language Mode being set to "{1}". Valid values are "Global", "Local", or "Script", or a number relative to the current scope (0 through the number of scopes where 0 is the current scope and 1 is its parent).</value>
+  </data>
   <data name="ArgumentNull" xml:space="preserve">
     <value>Cannot process argument because the value of argument "{0}" is null. Change the value of argument "{0}" to a non-null value.</value>
   </data>

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Variable.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Variable.Tests.ps1
@@ -163,7 +163,7 @@ Describe "Validate scope types in Variable provider cmdlets" -Tag "Feature" {
     }
 }
 
-Describe "Validate Security on scope in Variable provider cmdlets" -Tag "RequireAdminOnWindows" {
+Describe "Validate Security on scope in Variable provider cmdlets" -Tag "Feature","RequireAdminOnWindows" {
     BeforeAll {
         Set-Variable -Name TestApprovedScope -Value $true
         Set-Variable -Name Module -Value (New-Module -Name "Test-Variables" {


### PR DESCRIPTION
## PR Summary

#### The Goal:
    The Proposed change Allows for the capability to specify a specific SessionStateScope to Variable commandlets.
    
#### Example of new functionality:

```
    $Module = New-Module -Name "TestVariables" {
        $script:TestGetVariable = "True"
        $script:TestSetVariable = "Set"
        $script:TestClearVariable = "ShouldBeBlank"
        $Script:TestRemoveVariable = "Should Not Exist"
        write-host "Finished Loading Module"
    }
    $Module = Import-Module $Module -PassThru
    New-Variable -Scope $Module -Name "TestNewVariable" -Value "True"
    Set-Variable -Scope $Module -Name "TestSetVariable" -Value "True"
    Clear-Variable -Scope $Module -Name "TestClearVariable"
    Remove-Variable -Scope $Module -Name "TestRemoveVariable"
    Get-Variable -Scope $Module -Name "Test*"

```

#### Versus

```
    & (Get-Module ModuleName) { Get-Variable }

```

### Current issues this attempts to address:
https://github.com/PowerShell/PowerShell/issues/8106 - "-Scope Parameter on several Cmdlets not validated. Is this intentional? #8106"
- [X] Addresses the issue of parameters not Tab Completing correctly.
https://github.com/PowerShell/PowerShell/pull/7941 - "WIP: VariableFunctions outside of SessionState Capability #7941"
- [X] Addresses the underlying project issues
     
### Whats Changed:
- [X] Extended Scope Parameter to handle multiple ScopeCapable object types (PSModuleInfo, SessionState, SessionStateScope)
- [X] Added a Security so specified scopes outside of the core scope layers will throw an exception.
- [X] Created Tests for *-Variable to handle the new influx of changes.
- [X] Added the an AttributeCompletions() to Scope Attribute so it will assist with Tab Completion.
- [] Add Get-CurrentScope cmdlet so users can Specify specific scopes to work out of.

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [X] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [X] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
