### PR TITLE
OutputTypeProvider - a way to add output types for a fuction at runtime.

### DIFF
--- a/src/System.Management.Automation/engine/Attributes.cs
+++ b/src/System.Management.Automation/engine/Attributes.cs
@@ -557,17 +557,24 @@ namespace System.Management.Automation
     [SuppressMessage("Microsoft.Design", "CA1019:DefineAccessorsForAttributeArguments")]
     public class OutputTypeProviderAttribute : CmdletMetadataAttribute
     {
-        /// <summary/>
+        /// <summary>
+        /// Gets a type implementing the <see cref="IOutputTypeProvider"/> interface.
+        /// </summary>
         [SuppressMessage("Microsoft.Naming", "CA1721:PropertyNamesShouldNotMatchGetMethods")]
         public Type Type { get; private set; }
 
-        /// <summary/>
+        /// <summary>
+        /// Gets a ScriptBlock used to provide output types for a function.
+        /// </summary>
         public ScriptBlock ScriptBlock { get; private set; }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OutputTypeProviderAttribute"/> class.
+        /// </summary>
         /// <param name="type">The type must implement <see cref="IOutputTypeProvider"/> and have a default constructor.</param>
         public OutputTypeProviderAttribute(Type type)
         {
-            if (type == null || (type.GetInterfaces().All(t => t != typeof(IOutputTypeProvider))))
+            if (type == null || type.GetInterfaces().All(t => t != typeof(IOutputTypeProvider)))
             {
                 throw PSTraceSource.NewArgumentException("type");
             }
@@ -575,6 +582,9 @@ namespace System.Management.Automation
             Type = type;
         }
 
+        /// <summary>
+        /// Initializes a new instance of  <see cref="OutputTypeProviderAttribute"/> class.
+        /// </summary>
         /// <param name="scriptBlock">The scriptBlock must return types or PSTypeNames.</param>
         public OutputTypeProviderAttribute(ScriptBlock scriptBlock)
         {

--- a/src/System.Management.Automation/engine/CmdletInfo.cs
+++ b/src/System.Management.Automation/engine/CmdletInfo.cs
@@ -398,11 +398,12 @@ namespace System.Management.Automation
             {
                 if (ImplementingType != null)
                 {
-                    foreach (var tia in ImplementingType.GetCustomAttributes<OutputTypeProviderAttribute>(true))
+                    foreach (var outputTypeProviderAttribute in ImplementingType.GetCustomAttributes<OutputTypeProviderAttribute>(true))
                     {
-                        return tia.Type;
+                        return outputTypeProviderAttribute.Type;
                     }
                 }
+
                 return null;
             }
         }
@@ -416,11 +417,12 @@ namespace System.Management.Automation
             {
                 if (ImplementingType != null)
                 {
-                    foreach (var tia in ImplementingType.GetCustomAttributes<OutputTypeProviderAttribute>(true))
+                    foreach (var outputTypeProviderAttribute in ImplementingType.GetCustomAttributes<OutputTypeProviderAttribute>(true))
                     {
-                        return tia.ScriptBlock;
+                        return outputTypeProviderAttribute.ScriptBlock;
                     }
                 }
+
                 return null;
             }
         }

--- a/src/System.Management.Automation/engine/CmdletInfo.cs
+++ b/src/System.Management.Automation/engine/CmdletInfo.cs
@@ -390,6 +390,42 @@ namespace System.Management.Automation
         private List<PSTypeName> _outputType = null;
 
         /// <summary>
+        /// Return a type that can infer the output type of a cmdlet.
+        /// </summary>
+        public override Type OutputTypeProvider
+        {
+            get
+            {
+                if (ImplementingType != null)
+                {
+                    foreach (var tia in ImplementingType.GetCustomAttributes<OutputTypeProviderAttribute>(true))
+                    {
+                        return tia.Type;
+                    }
+                }
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Gets a ScriptBlock that returns the output types of the cmdlet
+        /// </summary>
+        public override ScriptBlock OutputTypeProviderScriptBlock
+        {
+            get
+            {
+                if (ImplementingType != null)
+                {
+                    foreach (var tia in ImplementingType.GetCustomAttributes<OutputTypeProviderAttribute>(true))
+                    {
+                        return tia.ScriptBlock;
+                    }
+                }
+                return null;
+            }
+        }
+
+        /// <summary>
         /// Gets or sets the scope options for the alias
         /// </summary>
         /// <exception cref="System.Management.Automation.SessionStateUnauthorizedAccessException">
@@ -520,7 +556,8 @@ namespace System.Management.Automation
         /// </exception>
         internal override CommandMetadata CommandMetadata
         {
-            get {
+            get
+            {
                 return _cmdletMetadata ??
                        (_cmdletMetadata = CommandMetadata.Get(this.Name, this.ImplementingType, Context));
             }

--- a/src/System.Management.Automation/engine/CommandInfo.cs
+++ b/src/System.Management.Automation/engine/CommandInfo.cs
@@ -180,14 +180,14 @@ namespace System.Management.Automation
         /// </summary>
         public string Name { get; private set; } = String.Empty;
 
-// Name
+        // Name
 
         /// <summary>
         /// Gets the type of the command
         /// </summary>
         public CommandTypes CommandType { get; private set; } = CommandTypes.Application;
 
-// CommandType
+        // CommandType
 
         /// <summary>
         /// Gets the source of the command (shown by default in Get-Command)
@@ -626,6 +626,16 @@ namespace System.Management.Automation
         public abstract ReadOnlyCollection<PSTypeName> OutputType { get; }
 
         /// <summary>
+        /// Gets a type that can infer output types of a command.
+        /// </summary>
+        public virtual Type OutputTypeProvider => null;
+
+        /// <summary>
+        /// Gets a ScriptBlock that can infer output types of a command.
+        /// </summary>
+        public virtual ScriptBlock OutputTypeProviderScriptBlock => null;
+
+        /// <summary>
         /// Specifies whether this command was imported from a module or not.
         /// This is used in Get-Command to figure out which of the commands in module session state were imported.
         /// </summary>
@@ -880,6 +890,9 @@ namespace System.Management.Automation
         /// When a type is defined by PowerShell, the ast for that type.
         /// </summary>
         public TypeDefinitionAst TypeDefinitionAst { get; private set; }
+
+        internal static PSTypeName[] EmptyArray = new PSTypeName[0];
+
         private bool _typeWasCalculated;
 
         /// <summary>
@@ -925,7 +938,7 @@ namespace System.Management.Automation
             var typeName = GetMemberTypeProjection(typename.Name, membersTypes);
             var members = new List<PSMemberNameAndType>();
             members.AddRange(membersTypes);
-            members.Sort((c1,c2) => string.Compare(c1.Name, c2.Name, StringComparison.OrdinalIgnoreCase));
+            members.Sort((c1, c2) => string.Compare(c1.Name, c2.Name, StringComparison.OrdinalIgnoreCase));
             return new PSSyntheticTypeName(typeName, typename.Type, members);
         }
 
@@ -984,5 +997,16 @@ namespace System.Management.Automation
     internal interface IScriptCommandInfo
     {
         ScriptBlock ScriptBlock { get; }
+    }
+
+    /// <summary>
+    /// A type specified by the <see cref="OutputTypeProviderAttribute"/> must implement this interface.
+    /// </summary>
+    public interface IOutputTypeProvider
+    {
+        /// <summary>
+        /// Gets output types that the function annotated with the corresponding <see cref="OutputTypeProviderAttribute"/> can produce.
+        /// </summary>
+        PSTypeName[] GetOutputTypes(CommandAst commandAst, PSTypeName[] pipelineInputTypes);
     }
 } // namespace System.Management.Automation

--- a/src/System.Management.Automation/engine/FunctionInfo.cs
+++ b/src/System.Management.Automation/engine/FunctionInfo.cs
@@ -51,7 +51,8 @@ namespace System.Management.Automation
         /// <exception cref="ArgumentNullException">
         /// If <paramref name="function"/> is null.
         /// </exception>
-        internal FunctionInfo(string name, ScriptBlock function, ExecutionContext context, string helpFile) : base(name, CommandTypes.Function, context)
+        internal FunctionInfo(string name, ScriptBlock function, ExecutionContext context, string helpFile) : base(name, CommandTypes.Function,
+            context)
         {
             if (function == null)
             {
@@ -84,7 +85,8 @@ namespace System.Management.Automation
         /// <exception cref="ArgumentNullException">
         /// If <paramref name="function"/> is null.
         /// </exception>
-        internal FunctionInfo(string name, ScriptBlock function, ScopedItemOptions options, ExecutionContext context) : this(name, function, options, context, null)
+        internal FunctionInfo(string name, ScriptBlock function, ScopedItemOptions options, ExecutionContext context) : this(name, function, options,
+            context, null)
         {
         } // FunctionInfo ctor
 
@@ -109,8 +111,8 @@ namespace System.Management.Automation
         /// <exception cref="ArgumentNullException">
         /// If <paramref name="function"/> is null.
         /// </exception>
-        internal FunctionInfo(string name, ScriptBlock function, ScopedItemOptions options, ExecutionContext context, string helpFile)
-            : this(name, function, context, helpFile)
+        internal FunctionInfo(string name, ScriptBlock function, ScopedItemOptions options, ExecutionContext context, string helpFile) : this(name,
+            function, context, helpFile)
         {
             _options = options;
         } // FunctionInfo ctor
@@ -118,8 +120,7 @@ namespace System.Management.Automation
         /// <summary>
         /// This is a copy constructor, used primarily for get-command.
         /// </summary>
-        internal FunctionInfo(FunctionInfo other)
-            : base(other)
+        internal FunctionInfo(FunctionInfo other) : base(other)
         {
             CopyFieldsFromOther(other);
         }
@@ -137,8 +138,7 @@ namespace System.Management.Automation
         /// <summary>
         /// This is a copy constructor, used primarily for get-command.
         /// </summary>
-        internal FunctionInfo(string name, FunctionInfo other)
-            : base(name, other)
+        internal FunctionInfo(string name, FunctionInfo other) : base(name, other)
         {
             CopyFieldsFromOther(other);
 
@@ -152,7 +152,11 @@ namespace System.Management.Automation
         /// </summary>
         internal override CommandInfo CreateGetCommandCopy(object[] arguments)
         {
-            FunctionInfo copy = new FunctionInfo(this) { IsGetCommandCopy = true, Arguments = arguments };
+            FunctionInfo copy = new FunctionInfo(this)
+            {
+                IsGetCommandCopy = true,
+                Arguments = arguments
+            };
             return copy;
         }
 
@@ -170,6 +174,7 @@ namespace System.Management.Automation
         {
             get { return _scriptBlock; }
         }
+
         private ScriptBlock _scriptBlock;
 
         /// <summary>
@@ -226,24 +231,16 @@ namespace System.Management.Automation
 
             if ((_options & ScopedItemOptions.Constant) != 0)
             {
-                SessionStateUnauthorizedAccessException e =
-                    new SessionStateUnauthorizedAccessException(
-                            Name,
-                            SessionStateCategory.Function,
-                            "FunctionIsConstant",
-                            SessionStateStrings.FunctionIsConstant);
+                SessionStateUnauthorizedAccessException e = new SessionStateUnauthorizedAccessException(Name, SessionStateCategory.Function,
+                    "FunctionIsConstant", SessionStateStrings.FunctionIsConstant);
 
                 throw e;
             }
 
             if (!force && (_options & ScopedItemOptions.ReadOnly) != 0)
             {
-                SessionStateUnauthorizedAccessException e =
-                    new SessionStateUnauthorizedAccessException(
-                            Name,
-                            SessionStateCategory.Function,
-                            "FunctionIsReadOnly",
-                            SessionStateStrings.FunctionIsReadOnly);
+                SessionStateUnauthorizedAccessException e = new SessionStateUnauthorizedAccessException(Name, SessionStateCategory.Function,
+                    "FunctionIsReadOnly", SessionStateStrings.FunctionIsReadOnly);
 
                 throw e;
             }
@@ -268,10 +265,7 @@ namespace System.Management.Automation
         /// </summary>
         public bool CmdletBinding
         {
-            get
-            {
-                return this.ScriptBlock.UsesCmdletBinding;
-            }
+            get { return this.ScriptBlock.UsesCmdletBinding; }
         }
 
         /// <summary>
@@ -280,17 +274,17 @@ namespace System.Management.Automation
         /// </summary>
         public string DefaultParameterSet
         {
-            get
-            {
-                return this.CmdletBinding ? this.CommandMetadata.DefaultParameterSetName : null;
-            }
+            get { return this.CmdletBinding ? this.CommandMetadata.DefaultParameterSetName : null; }
         }
 
         /// <summary>
         /// Gets the definition of the function which is the
         /// ToString() of the ScriptBlock that implements the function.
         /// </summary>
-        public override string Definition { get { return _scriptBlock.ToString(); } }
+        public override string Definition
+        {
+            get { return _scriptBlock.ToString(); }
+        }
 
         /// <summary>
         /// Gets or sets the scope options for the function.
@@ -301,10 +295,7 @@ namespace System.Management.Automation
         /// </exception>
         public ScopedItemOptions Options
         {
-            get
-            {
-                return CopiedCommand == null ? _options : ((FunctionInfo)CopiedCommand).Options;
-            }
+            get { return CopiedCommand == null ? _options : ((FunctionInfo)CopiedCommand).Options; }
 
             set
             {
@@ -315,12 +306,8 @@ namespace System.Management.Automation
 
                     if ((_options & ScopedItemOptions.Constant) != 0)
                     {
-                        SessionStateUnauthorizedAccessException e =
-                            new SessionStateUnauthorizedAccessException(
-                                    Name,
-                                    SessionStateCategory.Function,
-                                    "FunctionIsConstant",
-                                    SessionStateStrings.FunctionIsConstant);
+                        SessionStateUnauthorizedAccessException e = new SessionStateUnauthorizedAccessException(Name, SessionStateCategory.Function,
+                            "FunctionIsConstant", SessionStateStrings.FunctionIsConstant);
 
                         throw e;
                     }
@@ -334,27 +321,19 @@ namespace System.Management.Automation
                         // user is trying to set the function to constant after
                         // creating the function. Do not allow this (as per spec).
 
-                        SessionStateUnauthorizedAccessException e =
-                            new SessionStateUnauthorizedAccessException(
-                                    Name,
-                                    SessionStateCategory.Function,
-                                    "FunctionCannotBeMadeConstant",
-                                    SessionStateStrings.FunctionCannotBeMadeConstant);
+                        SessionStateUnauthorizedAccessException e = new SessionStateUnauthorizedAccessException(Name, SessionStateCategory.Function,
+                            "FunctionCannotBeMadeConstant", SessionStateStrings.FunctionCannotBeMadeConstant);
 
                         throw e;
                     }
 
                     // Ensure we are not trying to remove the AllScope option
 
-                    if ((value & ScopedItemOptions.AllScope) == 0 &&
-                        (_options & ScopedItemOptions.AllScope) != 0)
+                    if ((value & ScopedItemOptions.AllScope) == 0 && (_options & ScopedItemOptions.AllScope) != 0)
                     {
-                        SessionStateUnauthorizedAccessException e =
-                            new SessionStateUnauthorizedAccessException(
-                                    this.Name,
-                                    SessionStateCategory.Function,
-                                    "FunctionAllScopeOptionCannotBeRemoved",
-                                    SessionStateStrings.FunctionAllScopeOptionCannotBeRemoved);
+                        SessionStateUnauthorizedAccessException e = new SessionStateUnauthorizedAccessException(this.Name,
+                            SessionStateCategory.Function, "FunctionAllScopeOptionCannotBeRemoved",
+                            SessionStateStrings.FunctionAllScopeOptionCannotBeRemoved);
 
                         throw e;
                     }
@@ -367,6 +346,7 @@ namespace System.Management.Automation
                 }
             }
         }
+
         private ScopedItemOptions _options = ScopedItemOptions.None;
 
         /// <summary>
@@ -374,10 +354,7 @@ namespace System.Management.Automation
         /// </summary>
         public string Description
         {
-            get
-            {
-                return CopiedCommand == null ? _description : ((FunctionInfo)CopiedCommand).Description;
-            }
+            get { return CopiedCommand == null ? _description : ((FunctionInfo)CopiedCommand).Description; }
 
             set
             {
@@ -391,6 +368,7 @@ namespace System.Management.Automation
                 }
             }
         }
+
         private string _description = null;
 
         /// <summary>
@@ -398,11 +376,9 @@ namespace System.Management.Automation
         /// </summary>
         public string Verb
         {
-            get
-            {
-                return _verb;
-            }
+            get { return _verb; }
         } // Verb
+
         private string _verb = String.Empty;
 
         /// <summary>
@@ -410,11 +386,9 @@ namespace System.Management.Automation
         /// </summary>
         public string Noun
         {
-            get
-            {
-                return _noun;
-            }
+            get { return _noun; }
         } // Noun
+
         private string _noun = String.Empty;
 
         /// <summary>
@@ -422,15 +396,10 @@ namespace System.Management.Automation
         /// </summary>
         public string HelpFile
         {
-            get
-            {
-                return _helpFile;
-            }
-            internal set
-            {
-                _helpFile = value;
-            }
+            get { return _helpFile; }
+            internal set { _helpFile = value; }
         } // HelpFile
+
         private string _helpFile = String.Empty;
 
         /// <summary>
@@ -445,12 +414,7 @@ namespace System.Management.Automation
                 foreach (CommandParameterSetInfo parameterSet in ParameterSets)
                 {
                     synopsis.AppendLine();
-                    synopsis.AppendLine(
-                        String.Format(
-                            Globalization.CultureInfo.CurrentCulture,
-                            "{0} {1}",
-                            Name,
-                            parameterSet.ToString()));
+                    synopsis.AppendLine(String.Format(Globalization.CultureInfo.CurrentCulture, "{0} {1}", Name, parameterSet.ToString()));
                 }
 
                 return synopsis.ToString();
@@ -473,10 +437,10 @@ namespace System.Management.Automation
             get
             {
                 return _commandMetadata ??
-                       (_commandMetadata =
-                        new CommandMetadata(this.ScriptBlock, this.Name, LocalPipeline.GetExecutionContextFromTLS()));
+                       (_commandMetadata = new CommandMetadata(this.ScriptBlock, this.Name, LocalPipeline.GetExecutionContextFromTLS()));
             }
         }
+
         private CommandMetadata _commandMetadata;
 
         /// <summary>
@@ -486,5 +450,17 @@ namespace System.Management.Automation
         {
             get { return ScriptBlock.OutputType; }
         }
-    } // FunctionInfo
+
+
+        /// <summary>
+        /// Gets the type responsible for infering output types of the function.
+        /// </summary>
+        public override Type OutputTypeProvider => ScriptBlock.OutputTypeProvider;
+
+        /// <summary>
+        /// Return a ScriptBlock that can return the output type of a cmdlet.
+        /// </summary>
+        public override ScriptBlock OutputTypeProviderScriptBlock => ScriptBlock.OutputTypeScriptBlock;
+
+    }// FunctionInfo
 } // namespace System.Management.Automation

--- a/src/System.Management.Automation/engine/FunctionInfo.cs
+++ b/src/System.Management.Automation/engine/FunctionInfo.cs
@@ -51,8 +51,7 @@ namespace System.Management.Automation
         /// <exception cref="ArgumentNullException">
         /// If <paramref name="function"/> is null.
         /// </exception>
-        internal FunctionInfo(string name, ScriptBlock function, ExecutionContext context, string helpFile) : base(name, CommandTypes.Function,
-            context)
+        internal FunctionInfo(string name, ScriptBlock function, ExecutionContext context, string helpFile) : base(name, CommandTypes.Function, context)
         {
             if (function == null)
             {
@@ -85,8 +84,7 @@ namespace System.Management.Automation
         /// <exception cref="ArgumentNullException">
         /// If <paramref name="function"/> is null.
         /// </exception>
-        internal FunctionInfo(string name, ScriptBlock function, ScopedItemOptions options, ExecutionContext context) : this(name, function, options,
-            context, null)
+        internal FunctionInfo(string name, ScriptBlock function, ScopedItemOptions options, ExecutionContext context) : this(name, function, options, context, null)
         {
         } // FunctionInfo ctor
 
@@ -111,8 +109,8 @@ namespace System.Management.Automation
         /// <exception cref="ArgumentNullException">
         /// If <paramref name="function"/> is null.
         /// </exception>
-        internal FunctionInfo(string name, ScriptBlock function, ScopedItemOptions options, ExecutionContext context, string helpFile) : this(name,
-            function, context, helpFile)
+        internal FunctionInfo(string name, ScriptBlock function, ScopedItemOptions options, ExecutionContext context, string helpFile)
+            : this(name, function, context, helpFile)
         {
             _options = options;
         } // FunctionInfo ctor
@@ -231,16 +229,22 @@ namespace System.Management.Automation
 
             if ((_options & ScopedItemOptions.Constant) != 0)
             {
-                SessionStateUnauthorizedAccessException e = new SessionStateUnauthorizedAccessException(Name, SessionStateCategory.Function,
-                    "FunctionIsConstant", SessionStateStrings.FunctionIsConstant);
+                SessionStateUnauthorizedAccessException e = new SessionStateUnauthorizedAccessException(
+                    Name,
+                    SessionStateCategory.Function,
+                    "FunctionIsConstant",
+                    SessionStateStrings.FunctionIsConstant);
 
                 throw e;
             }
 
             if (!force && (_options & ScopedItemOptions.ReadOnly) != 0)
             {
-                SessionStateUnauthorizedAccessException e = new SessionStateUnauthorizedAccessException(Name, SessionStateCategory.Function,
-                    "FunctionIsReadOnly", SessionStateStrings.FunctionIsReadOnly);
+                SessionStateUnauthorizedAccessException e = new SessionStateUnauthorizedAccessException(
+                    Name,
+                    SessionStateCategory.Function,
+                    "FunctionIsReadOnly",
+                    SessionStateStrings.FunctionIsReadOnly);
 
                 throw e;
             }
@@ -295,7 +299,7 @@ namespace System.Management.Automation
         /// </exception>
         public ScopedItemOptions Options
         {
-            get { return CopiedCommand == null ? _options : ((FunctionInfo)CopiedCommand).Options; }
+            get => ((FunctionInfo) CopiedCommand)?.Options ?? _options;
 
             set
             {
@@ -306,8 +310,11 @@ namespace System.Management.Automation
 
                     if ((_options & ScopedItemOptions.Constant) != 0)
                     {
-                        SessionStateUnauthorizedAccessException e = new SessionStateUnauthorizedAccessException(Name, SessionStateCategory.Function,
-                            "FunctionIsConstant", SessionStateStrings.FunctionIsConstant);
+                        SessionStateUnauthorizedAccessException e = new SessionStateUnauthorizedAccessException(
+                            Name,
+                            SessionStateCategory.Function,
+                            "FunctionIsConstant",
+                            SessionStateStrings.FunctionIsConstant);
 
                         throw e;
                     }
@@ -321,8 +328,11 @@ namespace System.Management.Automation
                         // user is trying to set the function to constant after
                         // creating the function. Do not allow this (as per spec).
 
-                        SessionStateUnauthorizedAccessException e = new SessionStateUnauthorizedAccessException(Name, SessionStateCategory.Function,
-                            "FunctionCannotBeMadeConstant", SessionStateStrings.FunctionCannotBeMadeConstant);
+                        SessionStateUnauthorizedAccessException e = new SessionStateUnauthorizedAccessException(
+                            Name,
+                            SessionStateCategory.Function,
+                            "FunctionCannotBeMadeConstant",
+                            SessionStateStrings.FunctionCannotBeMadeConstant);
 
                         throw e;
                     }
@@ -331,8 +341,10 @@ namespace System.Management.Automation
 
                     if ((value & ScopedItemOptions.AllScope) == 0 && (_options & ScopedItemOptions.AllScope) != 0)
                     {
-                        SessionStateUnauthorizedAccessException e = new SessionStateUnauthorizedAccessException(this.Name,
-                            SessionStateCategory.Function, "FunctionAllScopeOptionCannotBeRemoved",
+                        SessionStateUnauthorizedAccessException e = new SessionStateUnauthorizedAccessException(
+                            this.Name,
+                            SessionStateCategory.Function,
+                            "FunctionAllScopeOptionCannotBeRemoved",
                             SessionStateStrings.FunctionAllScopeOptionCannotBeRemoved);
 
                         throw e;
@@ -350,7 +362,7 @@ namespace System.Management.Automation
         private ScopedItemOptions _options = ScopedItemOptions.None;
 
         /// <summary>
-        /// Gets or sets the description associated with the function
+        /// Gets or sets the description associated with the function.
         /// </summary>
         public string Description
         {
@@ -424,36 +436,23 @@ namespace System.Management.Automation
         /// <summary>
         /// True if the command has dynamic parameters, false otherwise.
         /// </summary>
-        internal override bool ImplementsDynamicParameters
-        {
-            get { return ScriptBlock.HasDynamicParameters; }
-        }
+        internal override bool ImplementsDynamicParameters => ScriptBlock.HasDynamicParameters;
 
         /// <summary>
         /// The command metadata for the function or filter
         /// </summary>
-        internal override CommandMetadata CommandMetadata
-        {
-            get
-            {
-                return _commandMetadata ??
-                       (_commandMetadata = new CommandMetadata(this.ScriptBlock, this.Name, LocalPipeline.GetExecutionContextFromTLS()));
-            }
-        }
+        internal override CommandMetadata CommandMetadata => _commandMetadata ??
+                                                             (_commandMetadata = new CommandMetadata(this.ScriptBlock, this.Name, LocalPipeline.GetExecutionContextFromTLS()));
 
         private CommandMetadata _commandMetadata;
 
         /// <summary>
-        /// The output type(s) is specified in the script block
+        /// Gets the output type(s) specified in the script block.
         /// </summary>
-        public override ReadOnlyCollection<PSTypeName> OutputType
-        {
-            get { return ScriptBlock.OutputType; }
-        }
-
+        public override ReadOnlyCollection<PSTypeName> OutputType => ScriptBlock.OutputType;
 
         /// <summary>
-        /// Gets the type responsible for infering output types of the function.
+        /// Gets the type responsible for providing output types of the function.
         /// </summary>
         public override Type OutputTypeProvider => ScriptBlock.OutputTypeProvider;
 
@@ -461,6 +460,5 @@ namespace System.Management.Automation
         /// Return a ScriptBlock that can return the output type of a cmdlet.
         /// </summary>
         public override ScriptBlock OutputTypeProviderScriptBlock => ScriptBlock.OutputTypeScriptBlock;
-
-    }// FunctionInfo
+    } // FunctionInfo
 } // namespace System.Management.Automation

--- a/src/System.Management.Automation/engine/lang/scriptblock.cs
+++ b/src/System.Management.Automation/engine/lang/scriptblock.cs
@@ -521,7 +521,7 @@ namespace System.Management.Automation
             // method returns [object]. If the argument to 'return'
             // is a pipeline that emits nothing then result.Count will
             // be zero so we catch that and "convert" it to null. Note that
-            // the return statement is still required in the method, it 
+            // the return statement is still required in the method, it
             // just recieves nothing from it's argument.
             if (result.Count == 0)
             {
@@ -625,13 +625,44 @@ namespace System.Management.Automation
                 List<PSTypeName> result = new List<PSTypeName>();
                 foreach (Attribute attribute in Attributes)
                 {
-                    OutputTypeAttribute outputType = attribute as OutputTypeAttribute;
-                    if (outputType != null)
+                    if (attribute is OutputTypeAttribute outputType)
                     {
                         result.AddRange(outputType.Type);
                     }
                 }
                 return new ReadOnlyCollection<PSTypeName>(result);
+            }
+        }
+
+        internal Type OutputTypeProvider
+        {
+            get
+            {
+                foreach (Attribute attribute in Attributes)
+                {
+                    if (attribute is OutputTypeProviderAttribute ti)
+                    {
+                        return ti.Type;
+                    }
+                }
+
+                return null;
+            }
+        }
+
+        internal ScriptBlock OutputTypeScriptBlock
+        {
+            get
+            {
+                foreach (Attribute attribute in Attributes)
+                {
+                    if (attribute is OutputTypeProviderAttribute ti)
+                    {
+                        return ti.ScriptBlock;
+                    }
+                }
+
+                return null;
             }
         }
 

--- a/src/System.Management.Automation/engine/parser/TypeInferenceVisitor.cs
+++ b/src/System.Management.Automation/engine/parser/TypeInferenceVisitor.cs
@@ -1029,6 +1029,11 @@ namespace System.Management.Automation
             // ParameterSetName in OutputType and of the ones I know about, it isn't that useful.
             inferredTypes.AddRange(commandInfo.OutputType);
 
+            AddTypesFromOutputTypeProvider(commandInfo, commandAst, inferredTypes);
+        }
+
+        private void AddTypesFromOutputTypeProvider(CommandInfo commandInfo, CommandAst commandAst, List<PSTypeName> inferredTypes)
+        {
             var inferenceType = commandInfo.OutputTypeProvider;
             if (inferenceType != null)
             {
@@ -1064,7 +1069,6 @@ namespace System.Management.Automation
                 }
             }
         }
-
 
         /// <summary>
         /// Infer types from the well-known object cmdlets, like foreach-object, where-object, sort-object etc.

--- a/src/System.Management.Automation/engine/parser/TypeResolver.cs
+++ b/src/System.Management.Automation/engine/parser/TypeResolver.cs
@@ -761,6 +761,7 @@ namespace System.Management.Automation
                     { typeof(PSReference),                                 new[] { "ref" } },
                     { typeof(PSTypeNameAttribute),                         new[] { "PSTypeNameAttribute" } },
                     { typeof(Regex),                                       new[] { "regex" } },
+                    { typeof(OutputTypeProviderAttribute),                 new[] { "OutputTypeProvider" } },
                     { typeof(DscPropertyAttribute),                        new[] { "DscProperty" } },
                     { typeof(SByte),                                       new[] { "sbyte" } },
                     { typeof(string),                                      new[] { "string" } },

--- a/test/powershell/Language/Parser/TypeAccelerator.Tests.ps1
+++ b/test/powershell/Language/Parser/TypeAccelerator.Tests.ps1
@@ -151,6 +151,10 @@ Describe "Type accelerators" -Tags "CI" {
                     Type        = [System.Management.Automation.OutputTypeAttribute]
                 }
                 @{
+                    Accelerator = 'OutputTypeProvider'
+                    Type        = [System.Management.Automation.OutputTypeProviderAttribute]
+                }
+                @{
                     Accelerator = 'ObjectSecurity'
                     Type        = [System.Security.AccessControl.ObjectSecurity]
                 }
@@ -400,17 +404,14 @@ Describe "Type accelerators" -Tags "CI" {
                 }
                 @{
                     Accelerator = 'pspropertyexpression'
-                    Type = [Microsoft.PowerShell.Commands.PSPropertyExpression]
+                    Type        = [Microsoft.PowerShell.Commands.PSPropertyExpression]
                 }
             )
 
-            if ( !$IsWindows )
-            {
-                $totalAccelerators = 99
-            }
-            else
-            {
-                $totalAccelerators = 104
+            if ( !$IsWindows ) {
+                $totalAccelerators = 100
+            } else {
+                $totalAccelerators = 105
 
                 $extraFullPSAcceleratorTestCases = @(
                     @{


### PR DESCRIPTION
## PR Summary

This PR adds an interface 
```csharp
    /// <summary>
    /// A type specified by the <see cref="OutputTypeProviderAttribute"/> must implement this interface.
    /// </summary>
    public interface IOutputTypeProvider
    {
        /// <summary>
        /// Gets output types that the function annotated with the corresponding <see cref="OutputTypeProviderAttribute"/> can produce.
        /// </summary>
        PSTypeName[] GetOutputTypes(CommandAst commandAst, PSTypeName[] pipelineInputTypes);
    }
```

And an attribute, `OutputTypeProviderAttribute` that works very similar to ArgumentCompleterAttribute, but for output types.


The main use case is for wrapping native commands, like `docker`, or `kubectl`. I.E. programs that has lots of subcommands, each producing different output. 

This mechanism enables writing a function `docker`, that delegates to docker.exe, but it can be annotated with the `OutputTypeProviderAttribute` and specify a class that provides the output types for each sub command (given that the implementer also provides a parser for the sub command.

This enables us to not force people to learn a new set of commands, and a quite nice workflow, were parsers can be added as needed over time.

A complete native command wrapper would consist of 
* A tab completer
* An OutputTypeProvider (this PR)
* Parsers to project the string output to structured output
* Formatters for the structured objects.

The other parts already have working solutions, even if we could make life easier  for the implementers by providing helper classes.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
