### PR TITLE
Reset output attributes if column had ESC char when using `Format-Table`; Replace "..." with unicode ellipsis

### DIFF
--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
@@ -1298,13 +1298,13 @@ namespace System.Management.Automation.Runspaces
                         .AddItemScriptBlock(@"
                                   $result = $_.Content
                                   $result = $result.Substring(0, [Math]::Min($result.Length, 200) )
-                                  if($result.Length -eq 200) { $result += ""…"" }
+                                  if($result.Length -eq 200) { $result += ""`u{2026}"" }
                                   $result
                                 ", label: "Content")
                         .AddItemScriptBlock(@"
                                   $result = $_.RawContent
                                   $result = $result.Substring(0, [Math]::Min($result.Length, 200) )
-                                  if($result.Length -eq 200) { $result += ""…"" }
+                                  if($result.Length -eq 200) { $result += ""`u{2026}"" }
                                   $result
                                 ", label: "RawContent")
                         .AddItemProperty(@"Headers")
@@ -1328,7 +1328,7 @@ namespace System.Management.Automation.Runspaces
                         .AddItemScriptBlock(@"
                                   $result = $_.RawContent
                                   $result = $result.Substring(0, [Math]::Min($result.Length, 200) )
-                                  if($result.Length -eq 200) { $result += ""…"" }
+                                  if($result.Length -eq 200) { $result += ""`u{2026}"" }
                                   $result
                                 ", label: "RawContent")
                         .AddItemProperty(@"Headers")

--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
@@ -1298,13 +1298,13 @@ namespace System.Management.Automation.Runspaces
                         .AddItemScriptBlock(@"
                                   $result = $_.Content
                                   $result = $result.Substring(0, [Math]::Min($result.Length, 200) )
-                                  if($result.Length -eq 200) { $result += ""..."" }
+                                  if($result.Length -eq 200) { $result += ""…"" }
                                   $result
                                 ", label: "Content")
                         .AddItemScriptBlock(@"
                                   $result = $_.RawContent
                                   $result = $result.Substring(0, [Math]::Min($result.Length, 200) )
-                                  if($result.Length -eq 200) { $result += ""..."" }
+                                  if($result.Length -eq 200) { $result += ""…"" }
                                   $result
                                 ", label: "RawContent")
                         .AddItemProperty(@"Headers")
@@ -1328,7 +1328,7 @@ namespace System.Management.Automation.Runspaces
                         .AddItemScriptBlock(@"
                                   $result = $_.RawContent
                                   $result = $result.Substring(0, [Math]::Min($result.Length, 200) )
-                                  if($result.Length -eq 200) { $result += ""..."" }
+                                  if($result.Length -eq 200) { $result += ""…"" }
                                   $result
                                 ", label: "RawContent")
                         .AddItemProperty(@"Headers")

--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/Registry_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/Registry_format_ps1xml.cs
@@ -45,7 +45,7 @@ namespace System.Management.Automation.Runspaces
                                       Select * -Exclude PSPath,PSParentPath,PSChildName,PSDrive,PsProvider |
                                       Format-List | Out-String | Sort).Trim()
                                   $result = $result.Substring(0, [Math]::Min($result.Length, 5000) )
-                                  if($result.Length -eq 5000) { $result += ""…"" }
+                                  if($result.Length -eq 5000) { $result += ""`u{2026}"" }
                                   $result
                                 ")
                     .EndRowDefinition()

--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/Registry_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/Registry_format_ps1xml.cs
@@ -45,7 +45,7 @@ namespace System.Management.Automation.Runspaces
                                       Select * -Exclude PSPath,PSParentPath,PSChildName,PSDrive,PsProvider |
                                       Format-List | Out-String | Sort).Trim()
                                   $result = $result.Substring(0, [Math]::Min($result.Length, 5000) )
-                                  if($result.Length -eq 5000) { $result += ""..."" }
+                                  if($result.Length -eq 5000) { $result += ""…"" }
                                   $result
                                 ")
                     .EndRowDefinition()

--- a/src/System.Management.Automation/FormatAndOutput/common/ComplexWriter.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/ComplexWriter.cs
@@ -711,7 +711,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 return s;
             }
 
-            return s.Substring(0, lineBreak) + PSObjectHelper.ellipses;
+            return s.Substring(0, lineBreak) + PSObjectHelper.Ellipsis;
         }
 
         internal static string PadLeft(string val, int count)

--- a/src/System.Management.Automation/FormatAndOutput/common/FormatViewGenerator_Complex.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/FormatViewGenerator_Complex.cs
@@ -623,7 +623,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 {
                     if (_enumerationLimit == enumCount)
                     {
-                        DisplayLeaf(PSObjectHelper.ellipses, formatValueList);
+                        DisplayLeaf(PSObjectHelper.Ellipsis, formatValueList);
                         break;
                     }
                     enumCount++;

--- a/src/System.Management.Automation/FormatAndOutput/common/TableWriter.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/TableWriter.cs
@@ -1,12 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Microsoft.PowerShell.Commands.Internal.Format;
 using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Management.Automation.Internal;
 using System.Text;
+using Microsoft.PowerShell.Commands.Internal.Format;
 
 namespace Microsoft.PowerShell.Commands.Internal.Format
 {

--- a/src/System.Management.Automation/FormatAndOutput/common/TableWriter.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/TableWriter.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using Microsoft.PowerShell.Commands.Internal.Format;
 using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
@@ -37,6 +38,8 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         }
 
         private ScreenInfo _si;
+        private const char ESC = '\u001b';
+        private const string ResetConsoleVt100Code = "\u001b[m";
 
         internal static int ComputeWideViewBestItemsPerRowFit(int stringLen, int screenColumns)
         {
@@ -415,10 +418,10 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 }
 
                 sb.Append(GenerateRowField(values[k], _si.columnInfo[k].width, alignment[k], dc, addPadding));
-                if (values[k].Contains("\u001b"))
+                if (values[k].IndexOf(ESC) != -1)
                 {
                     // Reset the console output if the content of this column contains ESC
-                    sb.Append("\u001b[m");
+                    sb.Append(ResetConsoleVt100Code);
                 }
             }
             return sb.ToString();
@@ -486,7 +489,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                                 // get from "abcdef" to "...f"
                                 int tailCount = dc.GetTailSplitLength(s, truncationDisplayLength);
                                 s = s.Substring(s.Length - tailCount);
-                                s = Ellipsis + s;
+                                s = PSObjectHelper.Ellipsis + s;
                             }
                             break;
 
@@ -494,7 +497,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                             {
                                 // get from "abcdef" to "a..."
                                 s = s.Substring(0, dc.GetHeadSplitLength(s, truncationDisplayLength));
-                                s += Ellipsis;
+                                s += PSObjectHelper.Ellipsis;
                             }
                             break;
 
@@ -503,7 +506,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                                 // left align is the default
                                 // get from "abcdef" to "a..."
                                 s = s.Substring(0, dc.GetHeadSplitLength(s, truncationDisplayLength));
-                                s += Ellipsis;
+                                s += PSObjectHelper.Ellipsis;
                             }
                             break;
                     }
@@ -580,7 +583,6 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             return s;
         }
 
-        private const char Ellipsis = '\u2026';
         private const int EllipsisSize = 1;
 
         private bool _disabled = false;

--- a/src/System.Management.Automation/FormatAndOutput/common/TableWriter.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/TableWriter.cs
@@ -385,7 +385,6 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             StringBuilder sb = new StringBuilder();
 
             bool addPadding = true;
-            bool resetVt100 = false;
             for (int k = 0; k < _si.columnInfo.Length; k++)
             {
                 // don't pad the last column
@@ -415,16 +414,11 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                     }
                 }
 
-                if (resetVt100)
-                {
-                    sb.Append("\u001b[m");
-                    resetVt100 = false;
-                }
-
                 sb.Append(GenerateRowField(values[k], _si.columnInfo[k].width, alignment[k], dc, addPadding));
                 if (values[k].Contains("\u001b"))
                 {
-                    resetVt100 = true;
+                    // Reset the console output if the content of this column contains ESC
+                    sb.Append("\u001b[m");
                 }
             }
             return sb.ToString();

--- a/src/System.Management.Automation/FormatAndOutput/common/Utilities/MshObjectUtil.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/Utilities/MshObjectUtil.cs
@@ -19,7 +19,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
     /// </summary>
     internal static class PSObjectHelper
     {
-        internal const char Ellipsis = '…';
+        internal const char Ellipsis = '\u2026';
 
         internal static string PSObjectIsOfExactType(Collection<string> typeNames)
         {

--- a/src/System.Management.Automation/FormatAndOutput/common/Utilities/MshObjectUtil.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/Utilities/MshObjectUtil.cs
@@ -19,7 +19,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
     /// </summary>
     internal static class PSObjectHelper
     {
-        internal const string ellipses = "...";
+        internal const char Ellipsis = '…';
 
         internal static string PSObjectIsOfExactType(Collection<string> typeNames)
         {
@@ -308,7 +308,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                                 {
                                     if (enumCount == enumerationLimit)
                                     {
-                                        sb.Append(ellipses);
+                                        sb.Append(Ellipsis);
                                         break;
                                     }
                                     enumCount++;
@@ -335,7 +335,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                                 {
                                     if (enumCount == enumerationLimit)
                                     {
-                                        sb.Append(ellipses);
+                                        sb.Append(Ellipsis);
                                         break;
                                     }
                                     enumCount++;

--- a/src/System.Management.Automation/engine/ErrorPackage.cs
+++ b/src/System.Management.Automation/engine/ErrorPackage.cs
@@ -462,7 +462,7 @@ namespace System.Management.Automation
         /// control the maximum length of the GetMessage() string, we
         /// ellipsize these strings.  The current heuristic is to take
         /// strings longer than 40 characters and ellipsize them to
-        /// the first and last 19 characters plus "…" in the middle.
+        /// the first and last 19 characters plus "..." in the middle.
         /// </summary>
         /// <param name="uiCultureInfo">culture to retrieve template if needed</param>
         /// <param name="original">original string</param>
@@ -476,8 +476,12 @@ namespace System.Management.Automation
             {
                 return original;
             }
-            string first = original.Substring(0, 19);
-            string last = original.Substring(original.Length - 19, 19);
+
+            // We are splitting a string > 40 chars in half, so left and right can be
+            // at most 19 characters to include the ellipsis in the middle.
+            const int MaxHalfWidth = 19;
+            string first = original.Substring(0, MaxHalfWidth);
+            string last = original.Substring(original.Length - MaxHalfWidth, MaxHalfWidth);
             return
                 string.Format(uiCultureInfo, ErrorPackage.Ellipsize, first, last);
         }

--- a/src/System.Management.Automation/engine/ErrorPackage.cs
+++ b/src/System.Management.Automation/engine/ErrorPackage.cs
@@ -462,7 +462,7 @@ namespace System.Management.Automation
         /// control the maximum length of the GetMessage() string, we
         /// ellipsize these strings.  The current heuristic is to take
         /// strings longer than 40 characters and ellipsize them to
-        /// the first and last 15 characters plus "..." in the middle.
+        /// the first and last 19 characters plus "…" in the middle.
         /// </summary>
         /// <param name="uiCultureInfo">culture to retrieve template if needed</param>
         /// <param name="original">original string</param>
@@ -476,8 +476,8 @@ namespace System.Management.Automation
             {
                 return original;
             }
-            string first = original.Substring(0, 15);
-            string last = original.Substring(original.Length - 15, 15);
+            string first = original.Substring(0, 19);
+            string last = original.Substring(original.Length - 19, 19);
             return
                 string.Format(uiCultureInfo, ErrorPackage.Ellipsize, first, last);
         }

--- a/src/System.Management.Automation/engine/Modules/ScriptAnalysis.cs
+++ b/src/System.Management.Automation/engine/Modules/ScriptAnalysis.cs
@@ -184,7 +184,7 @@ namespace System.Management.Automation
             ModuleIntrinsics.Tracer.WriteLine("Discovered function definition: {0}", functionName);
 
             // Check if they've defined any aliases
-            // function Foo-Bar { [Alias("Alias1", "...")] param() ... }
+            // function Foo-Bar { [Alias("Alias1", "…")] param() ... }
             var functionBody = functionDefinitionAst.Body;
             if ((functionBody.ParamBlock != null) && (functionBody.ParamBlock.Attributes != null))
             {

--- a/src/System.Management.Automation/engine/Modules/ScriptAnalysis.cs
+++ b/src/System.Management.Automation/engine/Modules/ScriptAnalysis.cs
@@ -184,7 +184,7 @@ namespace System.Management.Automation
             ModuleIntrinsics.Tracer.WriteLine("Discovered function definition: {0}", functionName);
 
             // Check if they've defined any aliases
-            // function Foo-Bar { [Alias("Alias1", "…")] param() ... }
+            // function Foo-Bar { [Alias("Alias1", "...")] param() ... }
             var functionBody = functionDefinitionAst.Body;
             if ((functionBody.ParamBlock != null) && (functionBody.ParamBlock.Attributes != null))
             {

--- a/src/System.Management.Automation/engine/debugger/debugger.cs
+++ b/src/System.Management.Automation/engine/debugger/debugger.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using Microsoft.PowerShell.Commands.Internal.Format;
 using System.Collections;
 using System.Diagnostics;
 using System.Globalization;
@@ -3984,7 +3985,7 @@ namespace System.Management.Automation
 
             if (valAsString.Length > msgLength)
             {
-                valAsString = valAsString.Substring(0, msgLength) + "…";
+                valAsString = valAsString.Substring(0, msgLength) + PSObjectHelper.Ellipsis;
             }
             Trace("TraceVariableAssignment", ParserStrings.TraceVariableAssignment, varName, valAsString);
         }

--- a/src/System.Management.Automation/engine/debugger/debugger.cs
+++ b/src/System.Management.Automation/engine/debugger/debugger.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Microsoft.PowerShell.Commands.Internal.Format;
 using System.Collections;
 using System.Diagnostics;
 using System.Globalization;
@@ -19,6 +18,7 @@ using System.Management.Automation.Internal;
 using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
 using System.Diagnostics.CodeAnalysis;
+using Microsoft.PowerShell.Commands.Internal.Format;
 
 namespace System.Management.Automation
 {

--- a/src/System.Management.Automation/engine/debugger/debugger.cs
+++ b/src/System.Management.Automation/engine/debugger/debugger.cs
@@ -3984,7 +3984,7 @@ namespace System.Management.Automation
 
             if (valAsString.Length > msgLength)
             {
-                valAsString = valAsString.Substring(0, msgLength) + "...";
+                valAsString = valAsString.Substring(0, msgLength) + "…";
             }
             Trace("TraceVariableAssignment", ParserStrings.TraceVariableAssignment, varName, valAsString);
         }

--- a/src/System.Management.Automation/engine/hostifaces/HostUtilities.cs
+++ b/src/System.Management.Automation/engine/hostifaces/HostUtilities.cs
@@ -1,11 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using Microsoft.PowerShell.Commands;
+using Microsoft.PowerShell.Commands.Internal.Format;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics.CodeAnalysis;
-using Microsoft.PowerShell.Commands;
 using System.Management.Automation.Host;
 using System.Management.Automation.Runspaces;
 using System.Management.Automation.Internal;
@@ -250,7 +251,7 @@ namespace System.Management.Automation
 
                 if (lineCount == maxLines)
                 {
-                    returnValue.Append('…');
+                    returnValue.Append(PSObjectHelper.Ellipsis);
                     break;
                 }
             }

--- a/src/System.Management.Automation/engine/hostifaces/HostUtilities.cs
+++ b/src/System.Management.Automation/engine/hostifaces/HostUtilities.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Microsoft.PowerShell.Commands;
-using Microsoft.PowerShell.Commands.Internal.Format;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -16,6 +14,8 @@ using System.Text.RegularExpressions;
 using System.Runtime.InteropServices;
 using System.Security;
 using System.Globalization;
+using Microsoft.PowerShell.Commands;
+using Microsoft.PowerShell.Commands.Internal.Format;
 
 namespace System.Management.Automation
 {

--- a/src/System.Management.Automation/engine/hostifaces/HostUtilities.cs
+++ b/src/System.Management.Automation/engine/hostifaces/HostUtilities.cs
@@ -250,7 +250,7 @@ namespace System.Management.Automation
 
                 if (lineCount == maxLines)
                 {
-                    returnValue.Append("...");
+                    returnValue.Append('…');
                     break;
                 }
             }

--- a/src/System.Management.Automation/engine/remoting/commands/PushRunspaceCommand.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/PushRunspaceCommand.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using Microsoft.PowerShell.Commands.Internal.Format;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -1151,7 +1152,7 @@ namespace Microsoft.PowerShell.Commands
 
                     case ContainerIdParameterSet:
                         targetName = (this.ContainerId.Length <= 15) ? this.ContainerId
-                                                                     : this.ContainerId.Remove(14) + "…";
+                                                                     : this.ContainerId.Remove(14) + PSObjectHelper.Ellipsis;
                         break;
 
                     case SessionParameterSet:

--- a/src/System.Management.Automation/engine/remoting/commands/PushRunspaceCommand.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/PushRunspaceCommand.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Microsoft.PowerShell.Commands.Internal.Format;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -14,6 +13,7 @@ using System.Management.Automation.Internal;
 using System.Management.Automation.Runspaces;
 using Dbg = System.Management.Automation.Diagnostics;
 using System.Collections;
+using Microsoft.PowerShell.Commands.Internal.Format;
 
 namespace Microsoft.PowerShell.Commands
 {

--- a/src/System.Management.Automation/engine/remoting/commands/PushRunspaceCommand.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/PushRunspaceCommand.cs
@@ -1151,7 +1151,7 @@ namespace Microsoft.PowerShell.Commands
 
                     case ContainerIdParameterSet:
                         targetName = (this.ContainerId.Length <= 15) ? this.ContainerId
-                                                                     : this.ContainerId.Remove(12) + "...";
+                                                                     : this.ContainerId.Remove(14) + "…";
                         break;
 
                     case SessionParameterSet:

--- a/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
+++ b/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Microsoft.PowerShell.Commands;
-using Microsoft.PowerShell.Commands.Internal.Format;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -18,6 +16,8 @@ using System.Management.Automation.Runspaces;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
+using Microsoft.PowerShell.Commands;
+using Microsoft.PowerShell.Commands.Internal.Format;
 
 // ReSharper disable UnusedMember.Global
 

--- a/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
+++ b/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
@@ -1234,7 +1234,7 @@ namespace System.Management.Automation
                 var expAttribute = scriptBlock.ExperimentalAttribute;
                 if (expAttribute == null || expAttribute.ToShow)
                 {
-                    context.EngineSessionState.SetFunctionRaw(functionDefinitionAst.Name, 
+                    context.EngineSessionState.SetFunctionRaw(functionDefinitionAst.Name,
                         scriptBlock, context.EngineSessionState.CurrentScope.ScopeOrigin);
                 }
             }
@@ -1294,7 +1294,7 @@ namespace System.Management.Automation
 
                 if (errorKeyString.Length > 40)
                 {
-                    errorKeyString = errorKeyString.Substring(0, 40) + "...";
+                    errorKeyString = errorKeyString.Substring(0, 40) + "…";
                 }
 
                 throw InterpreterError.NewInterpreterException(hashtable, typeof(RuntimeException), errorExtent,

--- a/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
+++ b/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using Microsoft.PowerShell.Commands;
+using Microsoft.PowerShell.Commands.Internal.Format;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -16,7 +18,6 @@ using System.Management.Automation.Runspaces;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
-using Microsoft.PowerShell.Commands;
 
 // ReSharper disable UnusedMember.Global
 
@@ -1294,7 +1295,7 @@ namespace System.Management.Automation
 
                 if (errorKeyString.Length > 40)
                 {
-                    errorKeyString = errorKeyString.Substring(0, 40) + "…";
+                    errorKeyString = errorKeyString.Substring(0, 40) + PSObjectHelper.Ellipsis;
                 }
 
                 throw InterpreterError.NewInterpreterException(hashtable, typeof(RuntimeException), errorExtent,

--- a/src/System.Management.Automation/resources/ErrorPackage.resx
+++ b/src/System.Management.Automation/resources/ErrorPackage.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="Ellipsize" xml:space="preserve">
-    <value>{0}...{1}</value>
+    <value>{0}…{1}</value>
   </data>
   <data name="ErrorDetailsEmptyTemplate" xml:space="preserve">
     <value>Error text is empty for error "{0}" : "{1}"</value>

--- a/src/System.Management.Automation/resources/ErrorPackage.resx
+++ b/src/System.Management.Automation/resources/ErrorPackage.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="Ellipsize" xml:space="preserve">
-    <value>{0}…{1}</value>
+    <value>{0}\u2026{1}</value>
   </data>
   <data name="ErrorDetailsEmptyTemplate" xml:space="preserve">
     <value>Error text is empty for error "{0}" : "{1}"</value>

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-List.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-List.Tests.ps1
@@ -75,7 +75,7 @@ Describe "Format-List DRT basic functionality" -Tags "CI" {
         $info = @{}
         $info.array = $al
         $result = $info | Format-List | Out-String
-        $result | Should -Match "Name  : array\s+Value : {0, 1, 2, 3...}"
+        $result | Should -Match "Name  : array\s+Value : {0, 1, 2, 3…}"
     }
 
 	It "Format-List with No Objects for End-To-End should work"{

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-List.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-List.Tests.ps1
@@ -75,7 +75,7 @@ Describe "Format-List DRT basic functionality" -Tags "CI" {
         $info = @{}
         $info.array = $al
         $result = $info | Format-List | Out-String
-        $result | Should -Match "Name  : array\s+Value : {0, 1, 2, 3…}"
+        $result | Should -Match "Name  : array\s+Value : {0, 1, 2, 3`u{2026}}" # ellipsis
     }
 
 	It "Format-List with No Objects for End-To-End should work"{

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-Table.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-Table.Tests.ps1
@@ -255,8 +255,8 @@ Left Center Right
 
         It "Format-Table should not have trailing whitespace if there is truncation: <view>" -TestCases @(
             # `u{2B758} is a double-byte Japanese character
-            @{view="Test.Format.Left"  ; object=[pscustomobject]@{Left="123`u{2B758}"}    ; expected="Left----1..."      },
-            @{view="Test.Format.Center"; object=[pscustomobject]@{Center="12345`u{2B758}"}; expected="Center------123..."}
+            @{view="Test.Format.Left"  ; object=[pscustomobject]@{Left="123`u{2B758}"}    ; expected="Left----123…"      },
+            @{view="Test.Format.Center"; object=[pscustomobject]@{Center="12345`u{2B758}"}; expected="Center------12345…"}
         ) {
             param($view, $object, $expected)
 
@@ -501,7 +501,7 @@ Long*********r3
 Head
 er
 ----*-------*-----
-1...*...5678*12...
+123…*…345678*1234…
 
 
 "@ },
@@ -513,7 +513,7 @@ ngH
 ead
 er
 ---
-123
+12…
 
 
 "@ },

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-Table.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-Table.Tests.ps1
@@ -31,7 +31,7 @@ Describe "Format-Table" -Tags "CI" {
                 $info = @{}
                 $info.array = $al
                 $result = $info | Format-Table | Out-String
-                $result | Should -Match "array\s+{0, 1, 2, 3…}"
+                $result | Should -Match "array\s+{0, 1, 2, 3`u{2026}}" # ellipsis
         }
 
         It "Format-Table with Negative Count should work" {
@@ -255,8 +255,9 @@ Left Center Right
 
         It "Format-Table should not have trailing whitespace if there is truncation: <view>" -TestCases @(
             # `u{2B758} is a double-byte Japanese character
-            @{view="Test.Format.Left"  ; object=[pscustomobject]@{Left="123`u{2B758}"}    ; expected="Left----123…"      },
-            @{view="Test.Format.Center"; object=[pscustomobject]@{Center="12345`u{2B758}"}; expected="Center------12345…"}
+            # `u{2026} is the ellipsis
+            @{view="Test.Format.Left"  ; object=[pscustomobject]@{Left="123`u{2B758}"}    ; expected="Left----123`u{2026}"      },
+            @{view="Test.Format.Center"; object=[pscustomobject]@{Center="12345`u{2B758}"}; expected="Center------12345`u{2026}"}
         ) {
             param($view, $object, $expected)
 
@@ -501,7 +502,7 @@ Long*********r3
 Head
 er
 ----*-------*-----
-123…*…345678*1234…
+123`u{2026}*`u{2026}345678*1234`u{2026}
 
 
 "@ },
@@ -513,7 +514,7 @@ ngH
 ead
 er
 ---
-12…
+12`u{2026}
 
 
 "@ },

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-Table.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-Table.Tests.ps1
@@ -31,7 +31,7 @@ Describe "Format-Table" -Tags "CI" {
                 $info = @{}
                 $info.array = $al
                 $result = $info | Format-Table | Out-String
-                $result | Should -Match "array\s+{0, 1, 2, 3...}"
+                $result | Should -Match "array\s+{0, 1, 2, 3…}"
         }
 
         It "Format-Table with Negative Count should work" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Out-File.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Out-File.Tests.ps1
@@ -99,7 +99,7 @@ Describe "Out-File" -Tags "CI" {
         $actual[0] | Should -BeNullOrEmpty
         $actual[1] | Should -BeExactly "text"
         $actual[2] | Should -BeExactly "----"
-        $actual[3] | Should -BeExactly "some te..."
+        $actual[3] | Should -BeExactly "some test…"
     }
 
     It "Should allow the cmdlet to overwrite an existing read-only file" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Out-File.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Out-File.Tests.ps1
@@ -99,7 +99,7 @@ Describe "Out-File" -Tags "CI" {
         $actual[0] | Should -BeNullOrEmpty
         $actual[1] | Should -BeExactly "text"
         $actual[2] | Should -BeExactly "----"
-        $actual[3] | Should -BeExactly "some test…"
+        $actual[3] | Should -BeExactly "some test`u{2026}" # ellipsis
     }
 
     It "Should allow the cmdlet to overwrite an existing read-only file" {


### PR DESCRIPTION
change ellipsis when truncating to single unicode character
reset console output if previous column contains ESC
update existing format-table tests

## PR Summary

If content included a VT100 ESC sequence (like changing color), this affected all output after that cell in the table.  Fix is to detect that a cell contained ESC and reset the console after it.  Also, change the 3 character ellipsis `...` to use the single unicode character `…` so that more text is available.

Fix https://github.com/PowerShell/PowerShell/issues/7767

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [x] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
