### PR TITLE
Remove workaround for fixed invalid json array deserializing bug

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/JsonObject.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/JsonObject.cs
@@ -59,22 +59,6 @@ namespace Microsoft.PowerShell.Commands
             error = null;
             try
             {
-                // JsonConvert.DeserializeObject does not throw an exception when an invalid Json array is passed.
-                // This issue is being tracked by https://github.com/JamesNK/Newtonsoft.Json/issues/1321.
-                // To work around this, we need to identify when input is a Json array, and then try to parse it via JArray.Parse().
-
-                // If input starts with '[' (ignoring white spaces).
-                if (Regex.Match(input, @"^\s*\[").Success)
-                {
-                    // JArray.Parse() will throw a JsonException if the array is invalid.
-                    // This will be caught by the catch block below, and then throw an
-                    // ArgumentException - this is done to have same behavior as the JavaScriptSerializer.
-                    JArray.Parse(input);
-
-                    // Please note that if the Json array is valid, we don't do anything,
-                    // we just continue the deserialization.
-                }
-
                 var obj = JsonConvert.DeserializeObject(
                     input,
                     new JsonSerializerSettings

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertFrom-Json.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertFrom-Json.Tests.ps1
@@ -52,4 +52,10 @@ Describe 'ConvertFrom-Json' -tags "CI" {
             $json | Should -BeOfType Hashtable
         }
     }
+
+    It 'Throws an ArgumentException with an incomplete array with AsHashtable switch set to <AsHashtable>' -TestCase $testCasesWithAndWithoutAsHashtableSwitch {
+        Param($AsHashtable)
+        { ConvertFrom-Json '["1",' -AsHashtable:$AsHashtable } |
+            Should -Throw -ErrorId "System.ArgumentException,Microsoft.PowerShell.Commands.ConvertFromJsonCommand"
+    }
 }


### PR DESCRIPTION
## PR Summary

This PR removes a workaround that was added because of a bug in the underlying json deserializing library [Newtonsoft.Json](https://github.com/JamesNK/Newtonsoft.Json).

It is no longer required as [the bug](https://github.com/JamesNK/Newtonsoft.Json/issues/1321) has been fixed in [Newtonsoft.Json 10.0.3](https://github.com/JamesNK/Newtonsoft.Json/releases/tag/10.0.3), see fix [here](https://github.com/JamesNK/Newtonsoft.Json/commit/1a0ae2a42ddd69f2584424731ae3212363a2bd5c).

This workaround was added in #3823 and involves using a regex to detect a json array and calling `JArray.Parse` before deserialization to throw an exception on an invalid array. As a result, removing it will increase `ConvertFrom-Json` & `Invoke-RestMethod` performance. 

### Current behavior
```powershell
PS D:\> ConvertFrom-Json '["1",'
ConvertFrom-Json : Conversion from JSON failed with error: Unexpected end of content while loading JArray. Path '[0]', line 1, position 5.
At line:1 char:1
+ ConvertFrom-Json '["1",'
+ ~~~~~~~~~~~~~~~~~~~~~~~~
+ CategoryInfo          : NotSpecified: (:) [ConvertFrom-Json], ArgumentException
+ FullyQualifiedErrorId : System.ArgumentException,Microsoft.PowerShell.Commands.ConvertFromJsonCommand
```


### After workaround removal
```powershell
PS D:\> ConvertFrom-Json '["1",'
ConvertFrom-Json : Conversion from JSON failed with error: Unexpected end when reading token. Path ''.
At line:1 char:1
+ ConvertFrom-Json '["1",'
+ ~~~~~~~~~~~~~~~~~~~~~~~~
+ CategoryInfo          : NotSpecified: (:) [ConvertFrom-Json], ArgumentException
+ FullyQualifiedErrorId : System.ArgumentException,Microsoft.PowerShell.Commands.ConvertFromJsonCommand
```

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [X] Not Applicable
- **Testing - New and feature**
    - [X] Not Applicable or can only be tested interactively
