### PR TITLE
Fire ArgumentCompleter for existing script files in case of no completion result found.

### DIFF
--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -542,6 +542,13 @@ namespace System.Management.Automation
                 case PseudoBindingInfoType.PseudoBindingSucceed:
                     // The command is a cmdlet or script cmdlet. Binding succeeded.
                     result = GetParameterCompletionResults(partialName, pseudoBinding, parameterAst, withColon);
+
+                    // Give a registered argument completer a chance to fire if no completion result has been found so far.
+                    if (result.Count == 0)
+                    {
+                        result = CompleteCommandArgument(context);
+                    }
+
                     break;
             }
 

--- a/test/powershell/Language/Parser/ExtensibleCompletion.Tests.ps1
+++ b/test/powershell/Language/Parser/ExtensibleCompletion.Tests.ps1
@@ -263,6 +263,19 @@ Describe "Test completion of parameters for native commands" -Tags "CI" {
     } | Get-CompletionTestCaseData | Test-Completions
 }
 
+Describe "Test completion of parameters for script files" -Tags "CI" {
+    Register-ArgumentCompleter -CommandName ExtensibleCompletion.Tests.ps1 -ScriptBlock { 
+        [CompletionResult]::new('-Param', '-Param', [CompletionResultType]::ParameterName, '-Param')
+    }
+
+    @{
+        ExpectedResults = @(
+            @{CompletionText = "-Param"; ResultType = "ParameterName"}
+        )
+        TestInput = "$(Join-Path $PSScriptRoot 'ExtensibleCompletion.Tests.ps1') -P"
+    } | Get-CompletionTestCaseData | Test-Completions
+}
+
 Describe "Test extensible completion of using namespace" -Tags "CI" {
     @{
         ExpectedResults = @(


### PR DESCRIPTION
## PR Summary
Added attempt to call CompleteCommandArgument if no completion result has been found for an existing cmdlet or script cmdlet.
Fix #8361

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [x] Issue filed - Issue link: #8361
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
