### PR TITLE
Fix Export-ModuleMember bug for scriptblocks having no context

### DIFF
--- a/src/System.Management.Automation/engine/Modules/ExportModuleMemberCommand.cs
+++ b/src/System.Management.Automation/engine/Modules/ExportModuleMemberCommand.cs
@@ -144,7 +144,7 @@ namespace Microsoft.PowerShell.Commands
 
             // Prevent script injection attack by disallowing ExportModuleMemberCommand to export module members across
             // language boundaries. This will prevent injected untrusted script from exporting private trusted module functions.
-            if (Context.EngineSessionState.Module != null &&
+            if (Context.EngineSessionState.Module?.LanguageMode != null &&
                 Context.LanguageMode != Context.EngineSessionState.Module.LanguageMode)
             {
                 var se = new PSSecurityException(Modules.CannotExportMembersAccrossLanguageBoundaries);

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/ConstrainedLanguageModules.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/ConstrainedLanguageModules.Tests.ps1
@@ -1401,59 +1401,59 @@ try
             $module.ExportedCommands.Values[0].Name | Should -BeExactly 'PublicFn'
         }
     }
+
+    Describe "Export-ModuleMember should succeed in FullLanguage mode with scriptblock created without context" -Tag 'Feature' {
+
+        BeforeAll {
+
+            $typeDef = @'
+            using System;
+            using System.Management.Automation;
+            using System.Management.Automation.Runspaces;
+
+            public class TestScriptBlockCreate
+            {
+                private ScriptBlock _scriptBlock;
+
+                public ScriptBlock CreateScriptBlock()
+                {
+                    var thread = new System.Threading.Thread(ThreadProc);
+                    thread.Start(null);
+                    thread.Join();
+
+                    return _scriptBlock;
+                }
+
+                private void ThreadProc(object state)
+                {
+                    // Create script block on thread with no PowerShell context
+                    _scriptBlock = ScriptBlock.Create(@"function Do-Nothing {}; Export-ModuleMember -Function Do-Nothing");
+                }
+            }
+'@
+
+            try
+            {
+                Add-Type -TypeDefinition $typeDef
+            }
+            catch { }
+        }
+
+        It "Verfies that Export-ModuleMember does not throw error with context-less scriptblock" {
+
+            $scriptBlockCreator = [TestScriptBlockCreate]::new()
+            $testScriptBlock = $scriptBlockCreator.CreateScriptBlock()
+
+            $testScriptBlock | Should -Not -BeNullOrEmpty
+
+            { New-Module -ScriptBlock $testScriptBlock -ErrorAction Stop } | Should -Not -Throw -Because "Scriptblock without execution context is allowed in Full Language"
+        }
+    }
 }
 finally
 {
     if ($defaultParamValues -ne $null)
     {
         $Global:PSDefaultParameterValues = $defaultParamValues
-    }
-}
-
-Describe "Export-ModuleMember should succeed in FullLanguage mode with scriptblock created without context" -Tag 'Feature' {
-
-    BeforeAll {
-
-        $typeDef = @'
-        using System;
-        using System.Management.Automation;
-        using System.Management.Automation.Runspaces;
-
-        public class TestScriptBlockCreate
-        {
-            private ScriptBlock _scriptBlock;
-
-            public ScriptBlock CreateScriptBlock()
-            {
-                var thread = new System.Threading.Thread(ThreadProc);
-                thread.Start(null);
-                thread.Join();
-
-                return _scriptBlock;
-            }
-
-            private void ThreadProc(object state)
-            {
-                // Create script block on thread with no PowerShell context
-                _scriptBlock = ScriptBlock.Create(@"function Do-Nothing {}; Export-ModuleMember -Function Do-Nothing");
-            }
-        }
-'@
-
-        try
-        {
-            Add-Type -TypeDefinition $typeDef
-        }
-        catch { }
-    }
-
-    It "Verfies that Export-ModuleMember does not throw error with context-less scriptblock" {
-
-        $scriptBlockCreator = [TestScriptBlockCreate]::new()
-        $testScriptBlock = $scriptBlockCreator.CreateScriptBlock()
-
-        $testScriptBlock | Should -Not -BeNullOrEmpty
-
-        { New-Module -ScriptBlock $testScriptBlock -ErrorAction Stop } | Should -Not -Throw -Because "Scriptblock without execution context is allowed in Full Language"
     }
 }


### PR DESCRIPTION
## PR Summary

Export-ModuleMember cmdlet throws an exception if module functions are exported across language boundaries (Windows only).  But a scriptblock LanguageMode property can be null if the scriptblock is created without a PowerShell context, and this can happen through the PowerShell API called from C#.  In this case Export-ModuleMember throws erroneously when no language mode restrictions are in play.

Fix is to check if LanguageMode is null before comparing context and scriptblock language modes.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [x] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
