### PR TITLE
Add validaterange to `New-FileCatalog -CatalogVersion`

### DIFF
--- a/src/Microsoft.PowerShell.Security/security/CatalogCommands.cs
+++ b/src/Microsoft.PowerShell.Security/security/CatalogCommands.cs
@@ -146,6 +146,7 @@ namespace Microsoft.PowerShell.Commands
         /// Catalog version
         /// </summary>
         [Parameter()]
+        [ValidateRange(1, 2)]
         public int CatalogVersion
         {
             get

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/FileCatalog.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/FileCatalog.Tests.ps1
@@ -410,6 +410,17 @@ Describe "Test suite for NewFileCatalogAndTestFileCatalogCmdlets" -Tags "CI" {
             $result | Should -Be "Valid"
         }
     }
+
+    Context "Parameter validation tests" {
+        It "Parameter validation error when CatalogVersion is out of range: <version>" -TestCases @(
+            @{ version = 0 },
+            @{ version = 3 }
+        ) {
+            param ($version)
+
+            { New-FileCatalog -Path $testDataPath\UserConfigProv -CatalogFilePath $script:catalogPath -CatalogVersion $version } | Should -Throw -ErrorId "ParameterArgumentValidationError,Microsoft.PowerShell.Commands.NewFileCatalogCommand"
+        }
+    }
 }
 
 } finally {


### PR DESCRIPTION
## PR Summary

Per https://docs.microsoft.com/en-us/windows/desktop/SecCrypto/makecat, the CatalogVersion can only have a value of 1 or 2.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
