### PR TITLE
Change Newtonsoft deserializing bug comment to link to the new issue

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/JsonObject.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/JsonObject.cs
@@ -60,7 +60,7 @@ namespace Microsoft.PowerShell.Commands
             try
             {
                 // JsonConvert.DeserializeObject does not throw an exception when an invalid Json array is passed.
-                // This issue is being tracked by https://github.com/JamesNK/Newtonsoft.Json/issues/1321.
+                // This issue is being tracked by https://github.com/JamesNK/Newtonsoft.Json/issues/1930.
                 // To work around this, we need to identify when input is a Json array, and then try to parse it via JArray.Parse().
 
                 // If input starts with '[' (ignoring white spaces).


### PR DESCRIPTION
## PR Summary

This is a follow up to reverted PR #8346. I removed a workaround that was used to avoid [a Newtonsoft.Json bug](https://github.com/JamesNK/Newtonsoft.Json/issues/1321) that caused some incomplete json array input to successfully be deserialized.

This bug being fixed, I thought the workaround was unnecessary, but after the merge some feature tests started to fail (which I did not run prior to merging).

It was discovered that the workaround is still needed because while the first Newtonsoft.Json bug was fixed, some cases of incomplete json array input still behave unexpectedly, namely json input `[`. 

This PR is just to update the comment explaining the workaround so it links to the newly created issue [here](https://github.com/JamesNK/Newtonsoft.Json/issues/1930).

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [X] Not Applicable
- **Testing - New and feature**
    - [X] Not Applicable or can only be tested interactively
