### PR TITLE
Update ShouldImplementProperty() to flatten interface hierarchy

### DIFF
--- a/src/System.Management.Automation/engine/parser/PSType.cs
+++ b/src/System.Management.Automation/engine/parser/PSType.cs
@@ -440,26 +440,29 @@ namespace System.Management.Automation.Language
                 if (_interfaceProperties == null)
                 {
                     _interfaceProperties = new HashSet<Tuple<string, Type>>();
+                    var allInterfaces = new HashSet<Type>();
+
+                    // TypeBuilder.GetInterfaces() returns only the interfaces that was explicitly passed to its constructor.
+                    // During compilation the interface hierarchy is flattened, so we only need to resolve one level of ancestral interfaces.
                     foreach (var interfaceType in _typeBuilder.GetInterfaces())
                     {
-                        // TypeBuilder.GetInterfaces() returns only the interfaces that was explicitly passed to its constructor.
-                        // During compilation the interface hierarchy is flattened, so we only need to resolve one level of ancestral interfaces.
                         foreach (var parentInterface in interfaceType.GetInterfaces())
                         {
-                            foreach (var property in parentInterface.GetProperties())
-                            {
-                                _interfaceProperties.Add(new Tuple<string, Type>(property.Name, property.PropertyType));
-                            }
+                            allInterfaces.Add(parentInterface);
                         }
+                        allInterfaces.Add(interfaceType);
+                    }
 
+                    foreach (var interfaceType in allInterfaces)
+                    {
                         foreach (var property in interfaceType.GetProperties())
                         {
-                            _interfaceProperties.Add(new Tuple<string, Type>(property.Name, property.PropertyType));
+                            _interfaceProperties.Add(Tuple.Create(property.Name, property.PropertyType));
                         }
                     }
                 }
 
-                return _interfaceProperties.Contains(new Tuple<string, Type>(name, type));
+                return _interfaceProperties.Contains(Tuple.Create(name, type));
             }
 
             public void DefineMembers()

--- a/src/System.Management.Automation/engine/parser/PSType.cs
+++ b/src/System.Management.Automation/engine/parser/PSType.cs
@@ -450,6 +450,7 @@ namespace System.Management.Automation.Language
                         {
                             allInterfaces.Add(parentInterface);
                         }
+
                         allInterfaces.Add(interfaceType);
                     }
 

--- a/src/System.Management.Automation/engine/parser/PSType.cs
+++ b/src/System.Management.Automation/engine/parser/PSType.cs
@@ -266,6 +266,7 @@ namespace System.Management.Automation.Language
             internal readonly TypeBuilder _staticHelpersTypeBuilder;
             private readonly Dictionary<string, PropertyMemberAst> _definedProperties;
             private readonly Dictionary<string, List<Tuple<FunctionMemberAst, Type[]>>> _definedMethods;
+            private HashSet<Tuple<string, Type>> _interfaceProperties;
             internal readonly List<(string fieldName, IParameterMetadataProvider bodyAst, bool isStatic)> _fieldsToInitForMemberFunctions;
             private bool _baseClassHasDefaultCtor;
 
@@ -436,15 +437,29 @@ namespace System.Management.Automation.Language
 
             private bool ShouldImplementProperty(string name, Type type)
             {
-                foreach (var interfaceType in _typeBuilder.GetInterfaces())
+                if (_interfaceProperties == null)
                 {
-                    if (interfaceType.GetProperty(name, type) != null)
+                    _interfaceProperties = new HashSet<Tuple<string, Type>>();
+                    foreach (var interfaceType in _typeBuilder.GetInterfaces())
                     {
-                        return true;
+                        // TypeBuilder.GetInterfaces() returns only the interfaces that was explicitly passed to its constructor.
+                        // During compilation the interface hierarchy is flattened, so we only need to resolve one level of ancestral interfaces.
+                        foreach (var parentInterface in interfaceType.GetInterfaces())
+                        {
+                            foreach (var property in parentInterface.GetProperties())
+                            {
+                                _interfaceProperties.Add(new Tuple<string, Type>(property.Name, property.PropertyType));
+                            }
+                        }
+
+                        foreach (var property in interfaceType.GetProperties())
+                        {
+                            _interfaceProperties.Add(new Tuple<string, Type>(property.Name, property.PropertyType));
+                        }
                     }
                 }
 
-                return false;
+                return _interfaceProperties.Contains(new Tuple<string, Type>(name, type));
             }
 
             public void DefineMembers()

--- a/test/powershell/Language/Classes/scripting.Classes.inheritance.tests.ps1
+++ b/test/powershell/Language/Classes/scripting.Classes.inheritance.tests.ps1
@@ -74,8 +74,8 @@ Describe 'Classes inheritance syntax' -Tags "CI" {
     It 'can implement inherited .NET interface properties' {
         Add-Type -TypeDefinition 'public interface IParent { int ParentInteger { get; set; } }
                                   public interface IChild : IParent { int ChildInteger { get; set; } }'
-        $C1 = Invoke-Expression 'class ClassWithInheritedInterfaces : IChild { [int]$ParentInteger; [int]$ChildInteger } [ClassWithInheritedInterfaces]::new()'
-        $getter = $C1.GetType().GetMember('get_ParentInteger')
+        $C1 = Invoke-Expression 'class ClassWithInheritedInterfaces : IChild { [int]$ParentInteger; [int]$ChildInteger } [ClassWithInheritedInterfaces]'
+        $getter = $C1.GetMember('get_ParentInteger')
         $getter.ReturnType.FullName | Should -Be System.Int32
         $getter.Attributes -band [System.Reflection.MethodAttributes]::Virtual |Should -Be ([System.Reflection.MethodAttributes]::Virtual)
     }

--- a/test/powershell/Language/Classes/scripting.Classes.inheritance.tests.ps1
+++ b/test/powershell/Language/Classes/scripting.Classes.inheritance.tests.ps1
@@ -71,6 +71,15 @@ Describe 'Classes inheritance syntax' -Tags "CI" {
         $getter.Attributes -band [System.Reflection.MethodAttributes]::Virtual |Should -Be ([System.Reflection.MethodAttributes]::Virtual)
     }
 
+    It 'can implement inherited .NET interface properties' {
+        Add-Type -TypeDefinition 'public interface IParent { int ParentInteger { get; set; } }
+                                  public interface IChild : IParent { int ChildInteger { get; set; } }'
+        $C1 = Invoke-Expression 'class ClassWithInheritedInterfaces : IChild { [int]$ParentInteger; [int]$ChildInteger } [ClassWithInheritedInterfaces]::new()'
+        $getter = $C1.GetType().GetMember('get_ParentInteger')
+        $getter.ReturnType.FullName | Should -Be System.Int32
+        $getter.Attributes -band [System.Reflection.MethodAttributes]::Virtual |Should -Be ([System.Reflection.MethodAttributes]::Virtual)
+    }
+
     It 'allows use of defined later type as a property type' {
         class A { static [B]$b }
         class B : A {}


### PR DESCRIPTION
## PR Summary

TypeBuilder.GetInterfaces(), as introduced in #8303 returns only the interfaces that was explicitly passed to its constructor, so the current implementation doesn't work for inherited interfaces:

```powershell
  Add-Type 'public interface ITestBase { string Base {get;} }
            public interface ITest : ITestBase { string Test {get;} }'
  class MyClass : ITest
  {
    [string]$Test
    [string]$Base
  }
```

In this example, ShouldImplementProperty() won't resolve ITestBase.Base and type definition fails because `get_Base()` isn't `virtual`.  
During compilation the interface hierarchy is flattened, so we only need to resolve one level of ancestral interfaces.

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [X] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [X] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
