### PR TITLE
Some more changes and cleanup to reduce the startup time

### DIFF
--- a/src/System.Management.Automation/CoreCLR/CorePsPlatform.cs
+++ b/src/System.Management.Automation/CoreCLR/CorePsPlatform.cs
@@ -122,32 +122,6 @@ namespace System.Management.Automation
         }
 
         /// <summary>
-        /// True if it is the inbox powershell for NanoServer or IoT.
-        /// </summary>
-        internal static bool IsInbox
-        {
-            get
-            {
-#if UNIX
-                return false;
-#else
-                if (_isInbox.HasValue) { return _isInbox.Value; }
-
-                _isInbox = false;
-                if (IsNanoServer || IsIoT)
-                {
-                    _isInbox = string.Equals(
-                        Utils.DefaultPowerShellAppBase,
-                        Utils.GetApplicationBaseFromRegistry(Utils.DefaultPowerShellShellID),
-                        StringComparison.OrdinalIgnoreCase);
-                }
-
-                return _isInbox.Value;
-#endif
-            }
-        }
-
-        /// <summary>
         /// True if underlying system is Windows Desktop.
         /// </summary>
         public static bool IsWindowsDesktop
@@ -168,7 +142,6 @@ namespace System.Management.Automation
 #if !UNIX
         private static bool? _isNanoServer = null;
         private static bool? _isIoT = null;
-        private static bool? _isInbox = null;
         private static bool? _isWindowsDesktop = null;
 #endif
 

--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -480,7 +480,7 @@ namespace System.Management.Automation
         /// <summary>
         /// This is used to construct the profile path.
         /// </summary>
-        internal static string ProductNameForDirectory = Platform.IsInbox ? "WindowsPowerShell" : "PowerShell";
+        internal const string ProductNameForDirectory = "PowerShell";
 
         /// <summary>
         /// The subdirectory of module paths

--- a/src/System.Management.Automation/engine/runtime/CompiledScriptBlock.cs
+++ b/src/System.Management.Automation/engine/runtime/CompiledScriptBlock.cs
@@ -263,7 +263,7 @@ namespace System.Management.Automation
 
                 // After the above steps, we know the ScriptBlockAst is in fact just a HashtableAst,
                 // now we need to check if the HashtableAst is safe.
-                return IsSafeValueVisitor.IsAstSafe(hashtableAst, GetSafeValueVisitor.SafeValueContext.Default);
+                return IsSafeValueVisitor.Default.IsAstSafe(hashtableAst);
             }
         }
 

--- a/src/System.Management.Automation/security/wldpNativeMethods.cs
+++ b/src/System.Management.Automation/security/wldpNativeMethods.cs
@@ -48,11 +48,11 @@ namespace System.Management.Automation.Security
         /// <returns>An EnforcementMode that describes the system policy</returns>
         public static SystemEnforcementMode GetSystemLockdownPolicy()
         {
-            if (s_wasSystemPolicyDebugPolicy || (s_systemLockdownPolicy == null))
+            if (s_allowDebugOverridePolicy || (s_systemLockdownPolicy == null))
             {
                 lock (s_systemLockdownPolicyLock)
                 {
-                    if (s_wasSystemPolicyDebugPolicy || (s_systemLockdownPolicy == null))
+                    if (s_allowDebugOverridePolicy || (s_systemLockdownPolicy == null))
                     {
                         s_systemLockdownPolicy = GetLockdownPolicy(null, null);
                     }
@@ -64,7 +64,7 @@ namespace System.Management.Automation.Security
 
         private static object s_systemLockdownPolicyLock = new Object();
         private static Nullable<SystemEnforcementMode> s_systemLockdownPolicy = null;
-        private static bool s_wasSystemPolicyDebugPolicy = false;
+        private static bool s_allowDebugOverridePolicy = false;
 
         /// <summary>
         /// Gets lockdown policy as applied to a file
@@ -340,7 +340,7 @@ namespace System.Management.Automation.Security
 
         private static SystemEnforcementMode GetDebugLockdownPolicy(string path)
         {
-            s_wasSystemPolicyDebugPolicy = true;
+            s_allowDebugOverridePolicy = true;
 
             // Support fall-back debug hook for path exclusions on non-WOA platforms
             if (path != null)
@@ -419,7 +419,7 @@ namespace System.Management.Automation.Security
                         // Hook for testability. If we've got an environmental override, say that ADODB.Parameter
                         // is not allowed.
                         // 0000050b-0000-0010-8000-00aa006d2ea4 = ADODB.Parameter
-                        if (s_wasSystemPolicyDebugPolicy)
+                        if (s_allowDebugOverridePolicy)
                         {
                             if (String.Equals(clsid.ToString(), "0000050b-0000-0010-8000-00aa006d2ea4", StringComparison.OrdinalIgnoreCase))
                             {

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/ConstrainedLanguageDebugger.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/ConstrainedLanguageDebugger.Tests.ps1
@@ -141,13 +141,12 @@ try
             # script debugger command processor.
             $script = @'
                 Import-Module -Name HelpersSecurity
-                Import-Module -Name {0} -Force
                 Invoke-LanguageModeTestingSupportCmdlet -SetLockdownMode
                 $ExecutionContext.SessionState.LanguageMode = "ConstrainedLanguage"
-                Import-Module -Name {1} -Force
+                Import-Module -Name {0} -Force
                 Set-PSBreakpoint -Command PublicFn
                 PublicFn
-'@ -f "$languageModuleDirectory\TestCmdletForConstrainedLanguage.dll", $trustedManifestFilePath
+'@ -f $trustedManifestFilePath
 
             [powershell] $ps = [powershell]::Create()
             $ps.Runspace = $runspace

--- a/test/tools/Modules/HelpersSecurity/HelpersSecurity.psm1
+++ b/test/tools/Modules/HelpersSecurity/HelpersSecurity.psm1
@@ -10,14 +10,6 @@ if ($IsWindows)
     #region Using directives
 
     using System;
-    using System.Globalization;
-    using System.Reflection;
-    using System.Collections;
-    using System.Collections.Generic;
-    using System.IO;
-    using System.Security;
-    using System.Runtime.InteropServices;
-    using System.Threading;
     using System.Management.Automation;
 
     #endregion
@@ -27,42 +19,27 @@ if ($IsWindows)
     public sealed class InvokeLanguageModeTestingSupportCmdlet : PSCmdlet
     {
         [Parameter()]
-        public SwitchParameter EnableFullLanguageMode
-        {
-            get { return enableFullLanguageMode; }
-            set { enableFullLanguageMode = value; }
-        }
-        private SwitchParameter enableFullLanguageMode;
+        public SwitchParameter EnableFullLanguageMode { get; set; }
 
         [Parameter()]
-        public SwitchParameter SetLockdownMode
-        {
-            get { return setLockdownMode; }
-            set { setLockdownMode = value; }
-        }
-        private SwitchParameter setLockdownMode;
+        public SwitchParameter SetLockdownMode { get; set; }
 
         [Parameter()]
-        public SwitchParameter RevertLockdownMode
-        {
-            get { return revertLockdownMode; }
-            set { revertLockdownMode = value; }
-        }
-        private SwitchParameter revertLockdownMode;
+        public SwitchParameter RevertLockdownMode { get; set; }
 
         protected override void BeginProcessing()
         {
-            if (enableFullLanguageMode)
+            if (EnableFullLanguageMode)
             {
                 SessionState.LanguageMode = PSLanguageMode.FullLanguage;
             }
 
-            if (setLockdownMode)
+            if (SetLockdownMode)
             {
                 Environment.SetEnvironmentVariable("__PSLockdownPolicy", "0x80000007", EnvironmentVariableTarget.Machine);
             }
 
-            if (revertLockdownMode)
+            if (RevertLockdownMode)
             {
                 Environment.SetEnvironmentVariable("__PSLockdownPolicy", null, EnvironmentVariableTarget.Machine);
             }


### PR DESCRIPTION
## PR Summary

This PR includes some changes and cleanups that will reduce the startup time. Each commit is self-contained, and the commit message serves as a summary of the changes in the commit.
- Rename `s_wasSystemPolicyDebugPolicy` to `s_allowDebugOverridePolicy` to make it less confusing. Also slightly refactor `HelperSecurity.psm1` and `ConstrainedLanguageDebugger.Tests.ps1` to remove unneeded code. There is no functional change in this commit.
- Remove the unneeded static property `IsInbox`, as PowerShell Core won't be shipped in-box with Windows in the foreseeable feature. Even if we do in future, we won't be needing it because Windows PowerShell will probably be gone by that time.
   - This static property was hit at startup time when constructing the value for `$env:PSModulePath`, and it will in turn cause `IsNanoServer` and `IsIoT` to be evaluated, all of which will trigger access to the Registry. By removing `IsInbox`, that can be all avoided.
- Update 'BindRunspace' to avoid getting all commands and unneeded method calls.
   - `BindRunspace` retrieves all available commands from the session state, but for the most common scenario of creating/opening a Runspace, the retrieved commands are never get used afterwards. The method is updated to avoid retrieving all commands unless it's necessary.
   - The method is also updated to add check before calling into a `ProcessXXX` method, so that we can avoid some unneeded method calls.
- Avoid creating a `IsSafeValueVisitor` every time when `IsScriptBlockInFactASafeHashtable` runs.
   - The static method `IsSafeValueVisitor.IsAstSafe` creates an instance of `IsSafeValueVisitor` every time it runs. Given that `IsScriptBlockInFactASafeHashtable` gets called relatively frequently in `PerformSecurityCheck`, this will result in some GC pressure as it will generate transient objects. This is updated to reuse a `IsSafeValueVisitor` singleton with the default `SafeValueContext`.
   - The `Default` and `_safeValueContext` fields are made `readonly`, so it cannot be changed by reflection.
   - The `_visitCount` is changed to `uint` type, so an attacker cannot change the value of it to a negative number in order to practically increase the max visit count limit.


## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [x] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
