### PR TITLE
Use correct overload for Write-Object in Get-Variable

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Var.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Var.cs
@@ -339,7 +339,7 @@ namespace Microsoft.PowerShell.Commands
                     matchFound = true;
                     if (_valueOnly)
                     {
-                        WriteObject(matchingVariable.Value, true);
+                        WriteObject(matchingVariable.Value, enumerateCollection: true);
                     }
                     else
                     {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Var.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Var.cs
@@ -339,7 +339,7 @@ namespace Microsoft.PowerShell.Commands
                     matchFound = true;
                     if (_valueOnly)
                     {
-                        WriteObject(matchingVariable.Value);
+                        WriteObject(matchingVariable.Value, true);
                     }
                     else
                     {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Variable.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Variable.Tests.ps1
@@ -96,8 +96,10 @@ Describe "Get-Variable" -Tags "CI" {
 		New-Variable -Name var1 -Value @(1, 2, 3)
 
 		# If output is not enumerated, Measure-Object will only see 1 object, not 3
-		$var1 | Measure-Object | Select-Object -ExpandProperty Count | Should -Be 3
-		Get-Variable -Name var1 -ValueOnly | Mesure-Object | Select-Object -ExpandProperty Count | Should -Be 3
+        Get-Variable -Name var1 -ValueOnly |
+            Measure-Object |
+            Select-Object -ExpandProperty Count |
+			Should -Be $var1.Count
 
 		Remove-Variable -Name var1
 	}

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Variable.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Variable.Tests.ps1
@@ -90,7 +90,15 @@ Describe "Get-Variable" -Tags "CI" {
 		Get-Variable -Name var1 -ValueOnly | Should -Be 4
 
 		Remove-Variable var1
-    }
+	}
+
+	It 'Should return the same value with -ValueOnly as directly calling the variable returns' {
+		New-Variable -Name var1 -Value @(1, 2, 3)
+
+		Get-Variable -Name var1 -ValueOnly | Should -Be $var1
+
+		Remove-Variable -Name var1
+	}
 
     It "Should pipe string to the name field without the Name field being specified"{
 		New-Variable -Name var1 -Value 3

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Variable.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Variable.Tests.ps1
@@ -2,95 +2,95 @@
 # Licensed under the MIT License.
 
 Describe "Get-Variable DRT Unit Tests" -Tags "CI" {
-	It "Get-Variable of not existing variable Name should throw ItemNotFoundException"{
-		{ Get-Variable -ErrorAction Stop -Name nonexistingVariableName } |
-			Should -Throw -ErrorId "VariableNotFound,Microsoft.PowerShell.Commands.GetVariableCommand"
-	}
+    It "Get-Variable of not existing variable Name should throw ItemNotFoundException" {
+        { Get-Variable -ErrorAction Stop -Name nonexistingVariableName } |
+            Should -Throw -ErrorId "VariableNotFound,Microsoft.PowerShell.Commands.GetVariableCommand"
+    }
 
-	It "Get-Variable of existing variable Name with include and bogus exclude should work"{
-		Set-Variable newVar testing
-		$var1=get-variable -Name newVar -Include newVar -Exclude bogus
-		$var1.Name|Should -BeExactly "newVar"
-		$var1.Value|Should -BeExactly "testing"
-	}
+    It "Get-Variable of existing variable Name with include and bogus exclude should work" {
+        Set-Variable newVar testing
+        $var1 = get-variable -Name newVar -Include newVar -Exclude bogus
+        $var1.Name|Should -BeExactly "newVar"
+        $var1.Value|Should -BeExactly "testing"
+    }
 
-	It "Get-Variable of existing variable Name with Description and Option should work"{
-		Set-Variable newVar testing -Option ReadOnly -Description "testing description"
-		$var1=get-variable -Name newVar
-		$var1.Name|Should -BeExactly "newVar"
-		$var1.Value|Should -BeExactly "testing"
-		$var1.Options|Should -BeExactly "ReadOnly"
-		$var1.Description|Should -BeExactly "testing description"
-	}
+    It "Get-Variable of existing variable Name with Description and Option should work" {
+        Set-Variable newVar testing -Option ReadOnly -Description "testing description"
+        $var1 = get-variable -Name newVar
+        $var1.Name|Should -BeExactly "newVar"
+        $var1.Value|Should -BeExactly "testing"
+        $var1.Options|Should -BeExactly "ReadOnly"
+        $var1.Description|Should -BeExactly "testing description"
+    }
 
-	It "Get-Variable of existing variable Globbing Name should work"{
-		Set-Variable abcaVar testing
-		Set-Variable bcdaVar "another test"
-		Set-Variable aVarfoo wow
-		$var1=get-variable -Name *aVar* -Scope local
-		$var1.Count | Should -Be 3
-		$var1[0].Name|Should -BeExactly "abcaVar"
-		$var1[0].Value|Should -BeExactly "testing"
-		$var1[1].Name|Should -BeExactly "aVarfoo"
-		$var1[1].Value|Should -BeExactly "wow"
-		$var1[2].Name|Should -BeExactly "bcdaVar"
-		$var1[2].Value|Should -BeExactly "another test"
-	}
+    It "Get-Variable of existing variable Globbing Name should work" {
+        Set-Variable abcaVar testing
+        Set-Variable bcdaVar "another test"
+        Set-Variable aVarfoo wow
+        $var1 = get-variable -Name *aVar* -Scope local
+        $var1.Count | Should -Be 3
+        $var1[0].Name|Should -BeExactly "abcaVar"
+        $var1[0].Value|Should -BeExactly "testing"
+        $var1[1].Name|Should -BeExactly "aVarfoo"
+        $var1[1].Value|Should -BeExactly "wow"
+        $var1[2].Name|Should -BeExactly "bcdaVar"
+        $var1[2].Value|Should -BeExactly "another test"
+    }
 
-	It "Get-Variable of existing private variable Name should throw ItemNotFoundException"{
-		Set-Variable newVar testing -Option Private
-		{Get-Variable -Name newVar -ErrorAction Stop} |
-			Should -Throw -ErrorId "VariableNotFound,Microsoft.PowerShell.Commands.GetVariableCommand"
-	}
+    It "Get-Variable of existing private variable Name should throw ItemNotFoundException" {
+        Set-Variable newVar testing -Option Private
+        {Get-Variable -Name newVar -ErrorAction Stop} |
+            Should -Throw -ErrorId "VariableNotFound,Microsoft.PowerShell.Commands.GetVariableCommand"
+    }
 }
 
 Describe "Get-Variable" -Tags "CI" {
     It "Should be able to call with no parameters without error" {
-		{ Get-Variable } | Should -Not -Throw
+        { Get-Variable } | Should -Not -Throw
     }
 
     It "Should return environment variables when called with no parameters" {
-		(Get-Variable).Name -contains "$" | Should -BeTrue
-		(Get-Variable).Name -contains "?" | Should -BeTrue
-		(Get-Variable).Name -contains "HOST" | Should -BeTrue
-		(Get-Variable).Name -contains "PWD" | Should -BeTrue
-		(Get-Variable).Name -contains "PID" | Should -BeTrue
-		(Get-Variable).Name -contains "^" | Should -BeTrue
+        (Get-Variable).Name -contains "$" | Should -BeTrue
+        (Get-Variable).Name -contains "?" | Should -BeTrue
+        (Get-Variable).Name -contains "HOST" | Should -BeTrue
+        (Get-Variable).Name -contains "PWD" | Should -BeTrue
+        (Get-Variable).Name -contains "PID" | Should -BeTrue
+        (Get-Variable).Name -contains "^" | Should -BeTrue
     }
 
     It "Should return the value of an object" {
-		New-Variable -Name tempVar -Value 1
-		(Get-Variable tempVar).Value | Should -Be (1)
+        New-Variable -Name tempVar -Value 1
+        (Get-Variable tempVar).Value | Should -Be (1)
     }
 
     It "Should be able to call using the Name switch" {
-		New-Variable -Name var1 -Value 4
+        New-Variable -Name var1 -Value 4
 
-		{ Get-Variable -Name var1 } | Should -Not -Throw
+        { Get-Variable -Name var1 } | Should -Not -Throw
 
-		(Get-Variable -Name var1).Value | Should -Be 4
+        (Get-Variable -Name var1).Value | Should -Be 4
 
-		Remove-Variable var1
+        Remove-Variable var1
     }
 
     It "Should be able to use wildcard characters in the Name field" {
-		New-Variable -Name var1 -Value 4
-		New-Variable -Name var2 -Value "test"
+        New-Variable -Name var1 -Value 4
+        New-Variable -Name var2 -Value "test"
 
-		(Get-Variable -Name var*).Value[0] | Should -Be 4
-		(Get-Variable -Name var*).Value[1] | Should -BeExactly "test"
+        (Get-Variable -Name var*).Value[0] | Should -Be 4
+        (Get-Variable -Name var*).Value[1] | Should -BeExactly "test"
 
-		Remove-Variable var1
-		Remove-Variable var2
+        Remove-Variable var1
+        Remove-Variable var2
     }
 
     It "Should return only the value if the value switch is used" {
-		New-Variable -Name var1 -Value 4
+        New-Variable -Name var1 -Value 4
 
-		Get-Variable -Name var1 -ValueOnly | Should -Be 4
+        Get-Variable -Name var1 -ValueOnly | Should -Be 4
 
-		Remove-Variable var1
-	}
+        Remove-Variable var1
+    }
 
     It 'Should enumerate its output in the same way that directly calling the value does' {
         New-Variable -Name var1 -Value @(1, 2, 3)
@@ -104,91 +104,91 @@ Describe "Get-Variable" -Tags "CI" {
         Remove-Variable -Name var1
     }
 
-    It "Should pipe string to the name field without the Name field being specified"{
-		New-Variable -Name var1 -Value 3
+    It "Should pipe string to the name field without the Name field being specified" {
+        New-Variable -Name var1 -Value 3
 
-		("var1" | Get-Variable ).Value | Should -Be 3
+        ("var1" | Get-Variable ).Value | Should -Be 3
 
-		Remove-Variable var1
+        Remove-Variable var1
     }
 
     It "Should be able to include a set of variables to get" {
-		New-Variable -Name var1 -Value 4
-		New-Variable -Name var2 -Value 2
+        New-Variable -Name var1 -Value 4
+        New-Variable -Name var2 -Value 2
 
-		$actual = Get-Variable -Include var1, var2
+        $actual = Get-Variable -Include var1, var2
 
-		$actual[0].Name | Should -Be var1
-		$actual[1].Name | Should -Be var2
+        $actual[0].Name | Should -Be var1
+        $actual[1].Name | Should -Be var2
 
-		$actual[0].Value | Should -Be 4
-		$actual[1].Value | Should -Be 2
+        $actual[0].Value | Should -Be 4
+        $actual[1].Value | Should -Be 2
 
-		Remove-Variable var1
-		Remove-Variable var2
+        Remove-Variable var1
+        Remove-Variable var2
     }
 
     It "Should be able to exclude a set of variables to get" {
-		New-Variable -Name var1 -Value 4
-		New-Variable -Name var2 -Value 2
-		New-Variable -Name var3 -Value "test"
+        New-Variable -Name var1 -Value 4
+        New-Variable -Name var2 -Value 2
+        New-Variable -Name var3 -Value "test"
 
-		$actual = Get-Variable -Exclude var1, var2
+        $actual = Get-Variable -Exclude var1, var2
 
-		$actual.Name -contains "var3" | Should -BeTrue
+        $actual.Name -contains "var3" | Should -BeTrue
     }
 
     Context "Scope Tests" {
-	# This will violate the DRY principle.  Tread softly.
-	It "Should be able to get a global scope variable using the global switch" {
-	    New-Variable globalVar -Value 1 -Scope global -Force
+        # This will violate the DRY principle.  Tread softly.
+        It "Should be able to get a global scope variable using the global switch" {
+            New-Variable globalVar -Value 1 -Scope global -Force
 
-	    (Get-Variable -Name globalVar -Scope global).Value | Should -Be 1
-	}
+            (Get-Variable -Name globalVar -Scope global).Value | Should -Be 1
+        }
 
-	It "Should not be able to clear a global scope variable using the local switch" {
-	    New-Variable globalVar -Value 1 -Scope global -Force
+        It "Should not be able to clear a global scope variable using the local switch" {
+            New-Variable globalVar -Value 1 -Scope global -Force
 
-	    { Get-Variable -Name globalVar -Scope local -ErrorAction Stop } | Should -Throw -ErrorId "VariableNotFound,Microsoft.PowerShell.Commands.GetVariableCommand"
-	}
+            { Get-Variable -Name globalVar -Scope local -ErrorAction Stop } | Should -Throw -ErrorId "VariableNotFound,Microsoft.PowerShell.Commands.GetVariableCommand"
+        }
 
-	It "Should be able to get a global variable when there's one in the script scope" {
-	    New-Variable globalVar -Value 1 -Scope global -Force
-	    { New-Variable globalVar -Value 2 -Scope script -Force}
+        It "Should be able to get a global variable when there's one in the script scope" {
+            New-Variable globalVar -Value 1 -Scope global -Force
+            { New-Variable globalVar -Value 2 -Scope script -Force}
 
-	    (Get-Variable -Name globalVar).Value | Should -Be 1
-	}
+            (Get-Variable -Name globalVar).Value | Should -Be 1
+        }
 
-	It "Should be able to get an item locally using the local switch" {
-	    {
-		New-Variable localVar -Value 1 -Scope local -Force
+        It "Should be able to get an item locally using the local switch" {
+            {
+                New-Variable localVar -Value 1 -Scope local -Force
 
-		Get-Variable -Name localVar -Scope local
-	    } | Should -Not -Throw
-	}
+                Get-Variable -Name localVar -Scope local
+            } | Should -Not -Throw
+        }
 
-	It "Should be able to get a variable created in the global scope when there's one in local scope" {
-	    New-Variable localVar -Value 1 -Scope local -Force
+        It "Should be able to get a variable created in the global scope when there's one in local scope" {
+            New-Variable localVar -Value 1 -Scope local -Force
 
-	    New-Variable localVar -Value 2 -Scope global -Force
+            New-Variable localVar -Value 2 -Scope global -Force
 
-	    (Get-Variable -Name localVar -Scope global).Value | Should -Be 2
-	}
+            (Get-Variable -Name localVar -Scope global).Value | Should -Be 2
+        }
 
-	It "Should be able to get a script variable created using the script switch" {
-	    {
-		New-Variable scriptVar -Value 1 -Scope script -Force
+        It "Should be able to get a script variable created using the script switch" {
+            {
+                New-Variable scriptVar -Value 1 -Scope script -Force
 
-		Get-Variable -Name scriptVar -Scope script
-	    } | Should -Not -Throw
-	}
+                Get-Variable -Name scriptVar -Scope script
+            } | Should -Not -Throw
+        }
 
-	It "Should be able to clear a global script variable that was created using the script scope switch" {
-	    {
-		New-Variable scriptVar -Value 1 -Scope script -Force
+        It "Should be able to clear a global script variable that was created using the script scope switch" {
+            {
+                New-Variable scriptVar -Value 1 -Scope script -Force
 
-		Get-Variable -Name scriptVar -Scope script
-	    } | Should -Not -Throw
-	}
+                Get-Variable -Name scriptVar -Scope script
+            } | Should -Not -Throw
+        }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Variable.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Variable.Tests.ps1
@@ -95,11 +95,9 @@ Describe "Get-Variable" -Tags "CI" {
 	It 'Should enumerate its output in the same way that directly calling the value does' {
 		New-Variable -Name var1 -Value @(1, 2, 3)
 
-		# If Get-Variable's output isn't enumerated, the latter value will return Object[], not Type[] { [int], [int], [int] }
-        $VariableType = $var1 | ForEach-Object -MemberName GetType
-        $GetVariableValueType = Get-Variable -Name var1 -ValueOnly | ForEach-Object -MemberName GetType
-
-        $GetVariableValueType | Should -Be $VariableType
+		# If output is not enumerated, Measure-Object will only see 1 object, not 3
+		$var1 | Measure-Object | Select-Object -ExpandProperty Count | Should -Be 3
+		Get-Variable -Name var1 -ValueOnly | Mesure-Object | Select-Object -ExpandProperty Count | Should -Be 3
 
 		Remove-Variable -Name var1
 	}

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Variable.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Variable.Tests.ps1
@@ -92,17 +92,17 @@ Describe "Get-Variable" -Tags "CI" {
 		Remove-Variable var1
 	}
 
-	It 'Should enumerate its output in the same way that directly calling the value does' {
-		New-Variable -Name var1 -Value @(1, 2, 3)
+    It 'Should enumerate its output in the same way that directly calling the value does' {
+        New-Variable -Name var1 -Value @(1, 2, 3)
 
-		# If output is not enumerated, Measure-Object will only see 1 object, not 3
+        # If output is not enumerated, Measure-Object will only see 1 object, not 3
         Get-Variable -Name var1 -ValueOnly |
             Measure-Object |
             Select-Object -ExpandProperty Count |
-			Should -Be $var1.Count
+            Should -Be $var1.Count
 
-		Remove-Variable -Name var1
-	}
+        Remove-Variable -Name var1
+    }
 
     It "Should pipe string to the name field without the Name field being specified"{
 		New-Variable -Name var1 -Value 3

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Variable.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Get-Variable.Tests.ps1
@@ -92,10 +92,14 @@ Describe "Get-Variable" -Tags "CI" {
 		Remove-Variable var1
 	}
 
-	It 'Should return the same value with -ValueOnly as directly calling the variable returns' {
+	It 'Should enumerate its output in the same way that directly calling the value does' {
 		New-Variable -Name var1 -Value @(1, 2, 3)
 
-		Get-Variable -Name var1 -ValueOnly | Should -Be $var1
+		# If Get-Variable's output isn't enumerated, the latter value will return Object[], not Type[] { [int], [int], [int] }
+        $VariableType = $var1 | ForEach-Object -MemberName GetType
+        $GetVariableValueType = Get-Variable -Name var1 -ValueOnly | ForEach-Object -MemberName GetType
+
+        $GetVariableValueType | Should -Be $VariableType
 
 		Remove-Variable -Name var1
 	}


### PR DESCRIPTION
## PR Summary

Currently Get-Variable sends output to the pipeline without enumerating it when using `-ValueOnly`. This is at odds with almost every other cmdlet, and furthermore is at odds with the intuitive behaviour &mdash; I think it is reasonable to expect (indeed, that the _intent_ for this switch is for) the variable value to be returned in the same manner as it is when simply calling the variable.

In other words, it appears reasonable to expect that the two statements following the declaration should be equivalent:

```powershell
$a = 1, 2, 3, 4, 5
$a | Get-Member
Get-Variable -Name a -ValueOnly | Get-Member
```

If this behaviour is instead actually _intentional_, then it needs to be documented properly ([it isn't](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/get-variable?view=powershell-6#optional-parameters)), but I suspect it is more a matter of oversight than design here.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
