### PR TITLE
[Feature] Define short alias names for all keys supported in calculated-property definitions

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/OrderObjectBase.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/OrderObjectBase.cs
@@ -12,7 +12,6 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.PowerShell.Commands
 {
-
     /// <summary>
     /// </summary>
     internal class SortObjectExpressionParameterDefinition : CommandParameterDefinition

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/OrderObjectBase.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/OrderObjectBase.cs
@@ -12,14 +12,6 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.PowerShell.Commands
 {
-    /// <summary>
-    /// Definitions for hash table keys.
-    /// </summary>
-    internal static class SortObjectParameterDefinitionKeys
-    {
-        internal const string AscendingEntryKey = "ascending";
-        internal const string DescendingEntryKey = "descending";
-    }
 
     /// <summary>
     /// </summary>
@@ -28,8 +20,8 @@ namespace Microsoft.PowerShell.Commands
         protected override void SetEntries()
         {
             this.hashEntries.Add(new ExpressionEntryDefinition(false));
-            this.hashEntries.Add(new BooleanEntryDefinition(SortObjectParameterDefinitionKeys.AscendingEntryKey));
-            this.hashEntries.Add(new BooleanEntryDefinition(SortObjectParameterDefinitionKeys.DescendingEntryKey));
+            this.hashEntries.Add(new BooleanEntryDefinition(CalculatedPropertyDefinitionKeys.AscendingEntryKey,  new string[] { CalculatedPropertyDefinitionKeys.AscendingEntryKeyShort }));
+            this.hashEntries.Add(new BooleanEntryDefinition(CalculatedPropertyDefinitionKeys.DescendingEntryKey, new string[] { CalculatedPropertyDefinitionKeys.DescendingEntryKeyShort }));
         }
     }
 
@@ -240,7 +232,7 @@ namespace Microsoft.PowerShell.Commands
 
                     foreach (MshParameter unexpandedParameter in _unexpandedParameterList)
                     {
-                        PSPropertyExpression mshExpression = (PSPropertyExpression)unexpandedParameter.GetEntry(FormatParameterDefinitionKeys.ExpressionEntryKey);
+                        PSPropertyExpression mshExpression = (PSPropertyExpression)unexpandedParameter.GetEntry(CalculatedPropertyDefinitionKeys.ExpressionEntryKey);
                         if (!mshExpression.HasWildCardCharacters) // this special cases 1) script blocks and 2) wildcard-less strings
                         {
                             _mshParameterList.Add(unexpandedParameter);
@@ -269,7 +261,7 @@ namespace Microsoft.PowerShell.Commands
             {
                 foreach (MshParameter unexpandedParameter in unexpandedParameterList)
                 {
-                    PSPropertyExpression ex = (PSPropertyExpression)unexpandedParameter.GetEntry(FormatParameterDefinitionKeys.ExpressionEntryKey);
+                    PSPropertyExpression ex = (PSPropertyExpression)unexpandedParameter.GetEntry(CalculatedPropertyDefinitionKeys.ExpressionEntryKey);
                     if (!ex.HasWildCardCharacters) // this special cases 1) script blocks and 2) wildcard-less strings
                     {
                         expandedParameterList.Add(unexpandedParameter);
@@ -297,7 +289,7 @@ namespace Microsoft.PowerShell.Commands
                         {
                             MshParameter expandedParameter = new MshParameter();
                             expandedParameter.hash = (Hashtable)unexpandedParameter.hash.Clone();
-                            expandedParameter.hash[FormatParameterDefinitionKeys.ExpressionEntryKey] = expandedExpression;
+                            expandedParameter.hash[CalculatedPropertyDefinitionKeys.ExpressionEntryKey] = expandedExpression;
 
                             expandedParameterList.Add(expandedParameter);
                         }
@@ -316,7 +308,7 @@ namespace Microsoft.PowerShell.Commands
             {
                 foreach (MshParameter unexpandedParameter in UnexpandedParametersWithWildCardPattern)
                 {
-                    PSPropertyExpression ex = (PSPropertyExpression)unexpandedParameter.GetEntry(FormatParameterDefinitionKeys.ExpressionEntryKey);
+                    PSPropertyExpression ex = (PSPropertyExpression)unexpandedParameter.GetEntry(CalculatedPropertyDefinitionKeys.ExpressionEntryKey);
 
                     SortedDictionary<string, PSPropertyExpression> expandedPropertyNames = new SortedDictionary<string, PSPropertyExpression>(StringComparer.OrdinalIgnoreCase);
                     if (inputObject == null)
@@ -333,7 +325,7 @@ namespace Microsoft.PowerShell.Commands
                     {
                         MshParameter expandedParameter = new MshParameter();
                         expandedParameter.hash = (Hashtable)unexpandedParameter.hash.Clone();
-                        expandedParameter.hash[FormatParameterDefinitionKeys.ExpressionEntryKey] = expandedExpression;
+                        expandedParameter.hash[CalculatedPropertyDefinitionKeys.ExpressionEntryKey] = expandedExpression;
 
                         expandedParameterList.Add(expandedParameter);
                     }
@@ -414,9 +406,9 @@ namespace Microsoft.PowerShell.Commands
                 for (int k = 0; k < ascendingOverrides.Length; k++)
                 {
                     object ascendingVal = mshParameterList[k].GetEntry(
-                        SortObjectParameterDefinitionKeys.AscendingEntryKey);
+                        CalculatedPropertyDefinitionKeys.AscendingEntryKey);
                     object descendingVal = mshParameterList[k].GetEntry(
-                        SortObjectParameterDefinitionKeys.DescendingEntryKey);
+                        CalculatedPropertyDefinitionKeys.DescendingEntryKey);
                     bool isAscendingDefined = isOrderEntryKeyDefined(ascendingVal);
                     bool isDescendingDefined = isOrderEntryKeyDefined(descendingVal);
                     if (!isAscendingDefined && !isDescendingDefined)
@@ -564,7 +556,7 @@ namespace Microsoft.PowerShell.Commands
             ref bool comparable)
         {
             // NOTE: we assume globbing was not allowed in input
-            PSPropertyExpression ex = p.GetEntry(FormatParameterDefinitionKeys.ExpressionEntryKey) as PSPropertyExpression;
+            PSPropertyExpression ex = p.GetEntry(CalculatedPropertyDefinitionKeys.ExpressionEntryKey) as PSPropertyExpression;
 
             // get the values, but do not expand aliases
             List<PSPropertyExpressionResult> expressionResults = ex.GetValues(inputObject, false, true);

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/compare-object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/compare-object.cs
@@ -330,7 +330,7 @@ namespace Microsoft.PowerShell.Commands
                         Diagnostics.Assert(mshParameter != null, "null mshParameter");
                         Hashtable hash = mshParameter.hash;
                         Diagnostics.Assert(hash != null, "null hash");
-                        object prop = hash[FormatParameterDefinitionKeys.ExpressionEntryKey];
+                        object prop = hash[CalculatedPropertyDefinitionKeys.ExpressionEntryKey];
                         Diagnostics.Assert(prop != null, "null prop");
                         string propName = prop.ToString();
                         PSNoteProperty propertyNote = new PSNoteProperty(

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/convert-HTML.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/convert-HTML.cs
@@ -283,16 +283,6 @@ namespace Microsoft.PowerShell.Commands
         private bool _transitional = false;
 
         /// <summary>
-        /// Definitions for hash table keys.
-        /// </summary>
-        internal static class ConvertHTMLParameterDefinitionKeys
-        {
-            internal const string LabelEntryKey = "label";
-            internal const string AlignmentEntryKey = "alignment";
-            internal const string WidthEntryKey = "width";
-        }
-
-        /// <summary>
         /// This allows for @{e='foo';label='bar';alignment='center';width='20'}.
         /// </summary>
         internal class ConvertHTMLExpressionParameterDefinition : CommandParameterDefinition
@@ -333,13 +323,13 @@ namespace Microsoft.PowerShell.Commands
 
             foreach (MshParameter p in _propertyMshParameterList)
             {
-                string label = p.GetEntry(ConvertHTMLParameterDefinitionKeys.LabelEntryKey) as string;
-                string alignment = p.GetEntry(ConvertHTMLParameterDefinitionKeys.AlignmentEntryKey) as string;
+                string label = p.GetEntry(CalculatedPropertyDefinitionKeys.LabelEntryKey) as string;
+                string alignment = p.GetEntry(CalculatedPropertyDefinitionKeys.AlignmentEntryKey) as string;
 
                 // Accept the width both as a string and as an int.
                 string width;
-                int? widthNum = p.GetEntry(ConvertHTMLParameterDefinitionKeys.WidthEntryKey) as int?;
-                width = widthNum != null ? widthNum.Value.ToString() : p.GetEntry(ConvertHTMLParameterDefinitionKeys.WidthEntryKey) as string;
+                int? widthNum = p.GetEntry(CalculatedPropertyDefinitionKeys.WidthEntryKey) as int?;
+                width = widthNum != null ? widthNum.Value.ToString() : p.GetEntry(CalculatedPropertyDefinitionKeys.WidthEntryKey) as string;
                 PSPropertyExpression ex = p.GetEntry(CalculatedPropertyDefinitionKeys.ExpressionEntryKey) as PSPropertyExpression;
                 List<PSPropertyExpression> resolvedNames = ex.ResolveNames(_inputObject);
                 foreach (PSPropertyExpression resolvedName in resolvedNames)
@@ -369,15 +359,15 @@ namespace Microsoft.PowerShell.Commands
             Hashtable ht = new Hashtable();
             if (label != null)
             {
-                ht.Add(ConvertHTMLParameterDefinitionKeys.LabelEntryKey, label);
+                ht.Add(CalculatedPropertyDefinitionKeys.LabelEntryKey, label);
             }
             if (alignment != null)
             {
-                ht.Add(ConvertHTMLParameterDefinitionKeys.AlignmentEntryKey, alignment);
+                ht.Add(CalculatedPropertyDefinitionKeys.AlignmentEntryKey, alignment);
             }
             if (width != null)
             {
-                ht.Add(ConvertHTMLParameterDefinitionKeys.WidthEntryKey, width);
+                ht.Add(CalculatedPropertyDefinitionKeys.WidthEntryKey, width);
             }
             return ht;
         }
@@ -515,14 +505,14 @@ namespace Microsoft.PowerShell.Commands
             foreach (MshParameter p in mshParams)
             {
                 COLTag.Append("<col");
-                string width = p.GetEntry(ConvertHTMLParameterDefinitionKeys.WidthEntryKey) as string;
+                string width = p.GetEntry(CalculatedPropertyDefinitionKeys.WidthEntryKey) as string;
                 if (width != null)
                 {
                     COLTag.Append(" width = \"");
                     COLTag.Append(width);
                     COLTag.Append("\"");
                 }
-                string alignment = p.GetEntry(ConvertHTMLParameterDefinitionKeys.AlignmentEntryKey) as string;
+                string alignment = p.GetEntry(CalculatedPropertyDefinitionKeys.AlignmentEntryKey) as string;
                 if (alignment != null)
                 {
                     COLTag.Append(" align = \"");
@@ -568,7 +558,7 @@ namespace Microsoft.PowerShell.Commands
         private void WritePropertyName(StringBuilder Listtag, MshParameter p)
         {
             //for writing the property name
-            string label = p.GetEntry(ConvertHTMLParameterDefinitionKeys.LabelEntryKey) as string;
+            string label = p.GetEntry(CalculatedPropertyDefinitionKeys.LabelEntryKey) as string;
             if (label != null)
             {
                 Listtag.Append(label);

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/convert-HTML.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/convert-HTML.cs
@@ -357,6 +357,7 @@ namespace Microsoft.PowerShell.Commands
                     resolvedNameProperty.Add(ht);
                 }
             }
+            
             _resolvedNameMshParameters = ProcessParameter(resolvedNameProperty.ToArray());
         }
 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/convert-HTML.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/convert-HTML.cs
@@ -347,12 +347,11 @@ namespace Microsoft.PowerShell.Commands
                     Hashtable ht = CreateAuxPropertyHT(label, alignment, width);
                     if (resolvedName.Script != null)
                     {
-                        // script block
+                        // The argument is a calculated property whose value is calculated by a script block.
                         ht.Add(CalculatedPropertyDefinitionKeys.ExpressionEntryKey, resolvedName.Script);
                     }
                     else
                     {
-                        // property name
                         ht.Add(CalculatedPropertyDefinitionKeys.ExpressionEntryKey, resolvedName.ToString());
                     }
                     resolvedNameProperty.Add(ht);

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/select-object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/select-object.cs
@@ -409,9 +409,9 @@ namespace Microsoft.PowerShell.Commands
 
         private void ProcessParameter(MshParameter p, PSObject inputObject, List<PSNoteProperty> result)
         {
-            string name = p.GetEntry(NameEntryDefinition.NameEntryKey) as string;
+            string name = p.GetEntry(CalculatedPropertyDefinitionKeys.NameEntryKey) as string;
 
-            PSPropertyExpression ex = p.GetEntry(FormatParameterDefinitionKeys.ExpressionEntryKey) as PSPropertyExpression;
+            PSPropertyExpression ex = p.GetEntry(CalculatedPropertyDefinitionKeys.ExpressionEntryKey) as PSPropertyExpression;
             List<PSPropertyExpressionResult> expressionResults = new List<PSPropertyExpressionResult>();
             foreach (PSPropertyExpression resolvedName in ex.ResolveNames(inputObject))
             {
@@ -479,7 +479,7 @@ namespace Microsoft.PowerShell.Commands
         private void ProcessExpandParameter(MshParameter p, PSObject inputObject,
             List<PSNoteProperty> matchedProperties)
         {
-            PSPropertyExpression ex = p.GetEntry(FormatParameterDefinitionKeys.ExpressionEntryKey) as PSPropertyExpression;
+            PSPropertyExpression ex = p.GetEntry(CalculatedPropertyDefinitionKeys.ExpressionEntryKey) as PSPropertyExpression;
             List<PSPropertyExpressionResult> expressionResults = ex.GetValues(inputObject);
 
             if (expressionResults.Count == 0)

--- a/src/System.Management.Automation/FormatAndOutput/common/BaseFormattingCommandParameters.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/BaseFormattingCommandParameters.cs
@@ -248,7 +248,6 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
 
     internal class AlignmentEntryDefinition : HashtableEntryDefinition
     {
-        private bool _forHtml;
         internal AlignmentEntryDefinition(bool forHtml = false) : base(
             CalculatedPropertyDefinitionKeys.AlignmentEntryKey,
             new string[] { CalculatedPropertyDefinitionKeys.AlignmentEntryKeyShort },
@@ -321,6 +320,8 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         private const string LeftAlign = "left";
         private const string CenterAlign = "center";
         private const string RightAlign = "right";
+
+        private bool _forHtml;
     }
 
     internal class WidthEntryDefinition : HashtableEntryDefinition

--- a/src/System.Management.Automation/FormatAndOutput/common/BaseFormattingCommandParameters.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/BaseFormattingCommandParameters.cs
@@ -114,8 +114,11 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         {
         }
 
-        internal ExpressionEntryDefinition(bool noGlobbing) : base(CalculatedPropertyDefinitionKeys.ExpressionEntryKey, new string[] { CalculatedPropertyDefinitionKeys.ExpressionEntryKeyShort },
-                                    new Type[] { typeof(string), typeof(ScriptBlock) }, true)
+        internal ExpressionEntryDefinition(bool noGlobbing) : base(
+            CalculatedPropertyDefinitionKeys.ExpressionEntryKey,
+            new string[] { CalculatedPropertyDefinitionKeys.ExpressionEntryKeyShort },
+            new Type[] { typeof(string), typeof(ScriptBlock) }, 
+            true)
         {
             _noGlobbing = noGlobbing;
         }
@@ -245,9 +248,12 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
 
     internal class AlignmentEntryDefinition : HashtableEntryDefinition
     {
-        internal bool _forHtml;
-        internal AlignmentEntryDefinition(bool forHtml = false) : base(CalculatedPropertyDefinitionKeys.AlignmentEntryKey, new string[] { CalculatedPropertyDefinitionKeys.AlignmentEntryKeyShort },
-                                    new Type[] { typeof(string) }, false)
+        private bool _forHtml;
+        internal AlignmentEntryDefinition(bool forHtml = false) : base(
+            CalculatedPropertyDefinitionKeys.AlignmentEntryKey,
+            new string[] { CalculatedPropertyDefinitionKeys.AlignmentEntryKeyShort },
+            new Type[] { typeof(string) },
+            false)
         {
             _forHtml = forHtml;
         }
@@ -319,8 +325,11 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
 
     internal class WidthEntryDefinition : HashtableEntryDefinition
     {
-        internal WidthEntryDefinition(bool forHtml = false) : base(CalculatedPropertyDefinitionKeys.WidthEntryKey, new string[] { CalculatedPropertyDefinitionKeys.WidthEntryKeyShort },
-                                    forHtml ? new Type[] { typeof(int), typeof(string) } : new Type[] { typeof(int) }, false)
+        internal WidthEntryDefinition(bool forHtml = false) : base(
+            CalculatedPropertyDefinitionKeys.WidthEntryKey, 
+            new string[] { CalculatedPropertyDefinitionKeys.WidthEntryKeyShort },
+            forHtml ? new Type[] { typeof(int), typeof(string) } : new Type[] { typeof(int) }, 
+            false)
         {
             // Note: For HTML use (ConvertTo-Html), we also accept 'width' as a string, for backward compatibility.
         }
@@ -345,6 +354,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 // it's an int, just check range, no need to change it
                 VerifyRange((int)val, invocationContext);
             }
+
             return null;
         }
 
@@ -365,15 +375,22 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
     {
         // Note: This is basically the same as NameEntryDefinition (both support 'name' as well as 'label' and their short aliases), 
         // except that the .KeyName property is 'label' here, not 'name.'
-        internal LabelEntryDefinition() : base(CalculatedPropertyDefinitionKeys.LabelEntryKey, new string[] { CalculatedPropertyDefinitionKeys.LabelEntryKeyShort, CalculatedPropertyDefinitionKeys.NameEntryKey, CalculatedPropertyDefinitionKeys.NameEntryKeyShort }, new Type[] { typeof(string) }, false)
+        internal LabelEntryDefinition() : base(
+            CalculatedPropertyDefinitionKeys.LabelEntryKey,
+            new string[] { CalculatedPropertyDefinitionKeys.LabelEntryKeyShort, CalculatedPropertyDefinitionKeys.NameEntryKey, CalculatedPropertyDefinitionKeys.NameEntryKeyShort },
+            new Type[] { typeof(string) },
+            false)
         {
         }
     }
 
     internal class FormatStringDefinition : HashtableEntryDefinition
     {
-        internal FormatStringDefinition() : base(CalculatedPropertyDefinitionKeys.FormatStringEntryKey, new string[] { CalculatedPropertyDefinitionKeys.FormatStringEntryKeyShort },
-                                    new Type[] { typeof(string) }, false)
+        internal FormatStringDefinition() : base(
+            CalculatedPropertyDefinitionKeys.FormatStringEntryKey,
+            new string[] { CalculatedPropertyDefinitionKeys.FormatStringEntryKeyShort },
+            new Type[] { typeof(string) },
+            false)
         {
         }
 
@@ -406,7 +423,11 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
 
     internal class BooleanEntryDefinition : HashtableEntryDefinition
     {
-        internal BooleanEntryDefinition(string entryKey, string[] secondaryNames) : base(entryKey, secondaryNames, new Type[] { typeof(bool)}, false)
+        internal BooleanEntryDefinition(string entryKey, string[] secondaryNames) : base(
+            entryKey,
+            secondaryNames,
+            new Type[] { typeof(bool) },
+            false)
         {
         }
 
@@ -422,7 +443,6 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             return LanguagePrimitives.IsTrue(val);
         }
     }
-
 
     internal class FormatGroupByParameterDefinition : CommandParameterDefinition
     {

--- a/src/System.Management.Automation/FormatAndOutput/common/FormatViewGenerator.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/FormatViewGenerator.cs
@@ -94,11 +94,11 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             if (parameters != null && parameters.groupByParameter != null)
             {
                 // get the expression to use
-                PSPropertyExpression groupingKeyExpression = parameters.groupByParameter.GetEntry(FormatParameterDefinitionKeys.ExpressionEntryKey) as PSPropertyExpression;
+                PSPropertyExpression groupingKeyExpression = parameters.groupByParameter.GetEntry(CalculatedPropertyDefinitionKeys.ExpressionEntryKey) as PSPropertyExpression;
 
                 // set the label
                 string label = null;
-                object labelKey = parameters.groupByParameter.GetEntry(FormatParameterDefinitionKeys.LabelEntryKey);
+                object labelKey = parameters.groupByParameter.GetEntry(CalculatedPropertyDefinitionKeys.LabelEntryKey);
                 if (labelKey != AutomationNull.Value)
                 {
                     label = labelKey as string;

--- a/src/System.Management.Automation/FormatAndOutput/common/FormatViewGenerator_Complex.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/FormatViewGenerator_Complex.cs
@@ -563,7 +563,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 TraversalInfo level = currentLevel;
                 if (a.OriginatingParameter != null)
                 {
-                    object maxDepthKey = a.OriginatingParameter.GetEntry(FormatParameterDefinitionKeys.DepthEntryKey);
+                    object maxDepthKey = a.OriginatingParameter.GetEntry(CalculatedPropertyDefinitionKeys.DepthEntryKey);
                     if (maxDepthKey != AutomationNull.Value)
                     {
                         int parameterMaxDept = (int)maxDepthKey;

--- a/src/System.Management.Automation/FormatAndOutput/common/FormatViewGenerator_List.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/FormatViewGenerator_List.cs
@@ -192,7 +192,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
 
                 if (a.OriginatingParameter != null)
                 {
-                    object key = a.OriginatingParameter.GetEntry(FormatParameterDefinitionKeys.LabelEntryKey);
+                    object key = a.OriginatingParameter.GetEntry(CalculatedPropertyDefinitionKeys.LabelEntryKey);
 
                     if (key != AutomationNull.Value)
                     {
@@ -211,7 +211,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 FieldFormattingDirective directive = null;
                 if (a.OriginatingParameter != null)
                 {
-                    directive = a.OriginatingParameter.GetEntry(FormatParameterDefinitionKeys.FormatStringEntryKey) as FieldFormattingDirective;
+                    directive = a.OriginatingParameter.GetEntry(CalculatedPropertyDefinitionKeys.FormatStringEntryKey) as FieldFormattingDirective;
                 }
                 lvf.formatPropertyField.propertyValue = this.GetExpressionDisplayValue(so, enumerationLimit, a.ResolvedExpression, directive);
                 lve.listViewFieldList.Add(lvf);

--- a/src/System.Management.Automation/FormatAndOutput/common/FormatViewGenerator_Table.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/FormatViewGenerator_Table.cs
@@ -225,7 +225,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 // set the label of the column
                 if (a.OriginatingParameter != null)
                 {
-                    object key = a.OriginatingParameter.GetEntry(FormatParameterDefinitionKeys.LabelEntryKey);
+                    object key = a.OriginatingParameter.GetEntry(CalculatedPropertyDefinitionKeys.LabelEntryKey);
                     if (key != AutomationNull.Value)
                         ci.propertyName = (string)key;
                 }
@@ -237,7 +237,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 // set the width of the table
                 if (a.OriginatingParameter != null)
                 {
-                    object key = a.OriginatingParameter.GetEntry(FormatParameterDefinitionKeys.WidthEntryKey);
+                    object key = a.OriginatingParameter.GetEntry(CalculatedPropertyDefinitionKeys.WidthEntryKey);
 
                     if (key != AutomationNull.Value)
                         ci.width = (int)key;
@@ -254,7 +254,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 // set the alignment
                 if (a.OriginatingParameter != null)
                 {
-                    object key = a.OriginatingParameter.GetEntry(FormatParameterDefinitionKeys.AlignmentEntryKey);
+                    object key = a.OriginatingParameter.GetEntry(CalculatedPropertyDefinitionKeys.AlignmentEntryKey);
 
                     if (key != AutomationNull.Value)
                         ci.alignment = (int)key;
@@ -456,7 +456,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 FieldFormattingDirective directive = null;
                 if (activeAssociationList[k].OriginatingParameter != null)
                 {
-                    directive = activeAssociationList[k].OriginatingParameter.GetEntry(FormatParameterDefinitionKeys.FormatStringEntryKey) as FieldFormattingDirective;
+                    directive = activeAssociationList[k].OriginatingParameter.GetEntry(CalculatedPropertyDefinitionKeys.FormatStringEntryKey) as FieldFormattingDirective;
                 }
                 fpf.propertyValue = this.GetExpressionDisplayValue(so, enumerationLimit, this.activeAssociationList[k].ResolvedExpression, directive);
                 tre.formatPropertyFieldList.Add(fpf);

--- a/src/System.Management.Automation/FormatAndOutput/common/FormatViewGenerator_Wide.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/FormatViewGenerator_Wide.cs
@@ -145,7 +145,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 FieldFormattingDirective directive = null;
                 if (a.OriginatingParameter != null)
                 {
-                    directive = a.OriginatingParameter.GetEntry(FormatParameterDefinitionKeys.FormatStringEntryKey) as FieldFormattingDirective;
+                    directive = a.OriginatingParameter.GetEntry(CalculatedPropertyDefinitionKeys.FormatStringEntryKey) as FieldFormattingDirective;
                 }
 
                 fpf.propertyValue = this.GetExpressionDisplayValue(so, enumerationLimit, a.ResolvedExpression, directive);

--- a/src/System.Management.Automation/FormatAndOutput/common/Utilities/MshParameter.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/Utilities/MshParameter.cs
@@ -53,7 +53,6 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         // For Sort-Object.
         internal const string AscendingEntryKey = "Ascending"; internal const string AscendingEntryKeyShort = "asc";
         internal const string DescendingEntryKey = "Descending"; internal const string DescendingEntryKeyShort = "desc";
-
     }
 
     /// <summary>
@@ -229,8 +228,11 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                     {
                         // This is the first (and possibly full and therefore only) match.
                         matchingEntry = this.hashEntries[k];
-                        // If it wasn't a full match, we keep going for ambiguity check.
-                        if (isFullMatch) break;
+                        // Unless it was a full match, we keep going for ambiguity check.
+                        if (isFullMatch)
+                        {
+                            break;
+                        }
                     }                    
                 }
             }

--- a/src/System.Management.Automation/FormatAndOutput/common/Utilities/MshParameterAssociation.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/Utilities/MshParameterAssociation.cs
@@ -77,7 +77,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
 
             foreach (MshParameter par in parameters)
             {
-                PSPropertyExpression expression = par.GetEntry(FormatParameterDefinitionKeys.ExpressionEntryKey) as PSPropertyExpression;
+                PSPropertyExpression expression = par.GetEntry(CalculatedPropertyDefinitionKeys.ExpressionEntryKey) as PSPropertyExpression;
                 List<PSPropertyExpression> expandedExpressionList = expression.ResolveNames(target);
 
                 if (!expression.HasWildCardCharacters && expandedExpressionList.Count == 0)
@@ -101,7 +101,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
 
             foreach (MshParameter par in parameters)
             {
-                PSPropertyExpression expression = par.GetEntry(FormatParameterDefinitionKeys.ExpressionEntryKey) as PSPropertyExpression;
+                PSPropertyExpression expression = par.GetEntry(CalculatedPropertyDefinitionKeys.ExpressionEntryKey) as PSPropertyExpression;
                 List<PSPropertyExpression> expandedExpressionList = expression.ResolveNames(target);
 
                 foreach (PSPropertyExpression ex in expandedExpressionList)

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Microsoft.PowerShell.Commands.Internal.Format;
 using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.ObjectModel;
@@ -24,6 +23,7 @@ using Microsoft.Management.Infrastructure.Options;
 using Microsoft.PowerShell;
 using Microsoft.PowerShell.Cim;
 using Microsoft.PowerShell.Commands;
+using Microsoft.PowerShell.Commands.Internal.Format;
 
 namespace System.Management.Automation
 {

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using Microsoft.PowerShell.Commands.Internal.Format;
 using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.ObjectModel;
@@ -6252,7 +6253,7 @@ namespace System.Management.Automation
                             case "Format-List":
                             case "Format-Wide":
                             case "Format-Custom":
-                                return GetSpecialHashTableKeyMembers("Expression", "FormatString", "Label");
+                                return GetSpecialHashTableKeyMembers(CalculatedPropertyDefinitionKeys.ExpressionEntryKey, CalculatedPropertyDefinitionKeys.FormatStringEntryKey, CalculatedPropertyDefinitionKeys.LabelEntryKey);
                         }
 
                         return null;
@@ -6270,19 +6271,19 @@ namespace System.Management.Automation
                                     result, completionContext.WordToComplete + "*", IsWriteablePropertyMember, isStatic: false);
                                 return result;
                             case "Select-Object":
-                                return GetSpecialHashTableKeyMembers("Name", "Expression");
+                                return GetSpecialHashTableKeyMembers(CalculatedPropertyDefinitionKeys.NameEntryKey, CalculatedPropertyDefinitionKeys.ExpressionEntryKey);
                             case "Sort-Object":
-                                return GetSpecialHashTableKeyMembers("Expression", "Ascending", "Descending");
+                                return GetSpecialHashTableKeyMembers(CalculatedPropertyDefinitionKeys.ExpressionEntryKey, CalculatedPropertyDefinitionKeys.AscendingEntryKey, CalculatedPropertyDefinitionKeys.DescendingEntryKey);
                             case "Group-Object":
-                                return GetSpecialHashTableKeyMembers("Expression");
+                                return GetSpecialHashTableKeyMembers(CalculatedPropertyDefinitionKeys.ExpressionEntryKey);
                             case "Format-Table":
-                                return GetSpecialHashTableKeyMembers("Expression", "FormatString", "Label", "Width", "Alignment");
+                                return GetSpecialHashTableKeyMembers(CalculatedPropertyDefinitionKeys.ExpressionEntryKey, CalculatedPropertyDefinitionKeys.FormatStringEntryKey, CalculatedPropertyDefinitionKeys.LabelEntryKey, CalculatedPropertyDefinitionKeys.WidthEntryKey, CalculatedPropertyDefinitionKeys.AlignmentEntryKey);
                             case "Format-List":
-                                return GetSpecialHashTableKeyMembers("Expression", "FormatString", "Label");
+                                return GetSpecialHashTableKeyMembers(CalculatedPropertyDefinitionKeys.ExpressionEntryKey, CalculatedPropertyDefinitionKeys.FormatStringEntryKey, CalculatedPropertyDefinitionKeys.LabelEntryKey);
                             case "Format-Wide":
-                                return GetSpecialHashTableKeyMembers("Expression", "FormatString");
+                                return GetSpecialHashTableKeyMembers(CalculatedPropertyDefinitionKeys.ExpressionEntryKey, CalculatedPropertyDefinitionKeys.FormatStringEntryKey);
                             case "Format-Custom":
-                                return GetSpecialHashTableKeyMembers("Expression", "Depth");
+                                return GetSpecialHashTableKeyMembers(CalculatedPropertyDefinitionKeys.ExpressionEntryKey, CalculatedPropertyDefinitionKeys.DepthEntryKey);
                         }
                     }
                 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Html.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Html.Tests.ps1
@@ -168,5 +168,31 @@ After the object
         $returnString = $customObject | ConvertTo-HTML -Transitional | Select-Object -First 1
         $returnString | Should -Be '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"  "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">'
     }
+
+    It "Test ConvertTo-HTML calculated property supports 'name' key as alias of 'label'" {
+        $returnString = ($customObject | ConvertTo-Html @{ name = 'AgeRenamed'; e = 'Age'}) -join $newLine
+        $returnString | Should -Match 'AgeRenamed'
+    }
+
+    It "Test ConvertTo-HTML calculated property supports integer 'width' entry" {
+        $returnString = ($customObject | ConvertTo-Html @{ e = 'Age'; width = 10 }) -join $newLine
+        $returnString | Should -Match '\swidth\s*=\s*(["''])10\1'
+    }
+
+    It "Test ConvertTo-HTML calculated property supports string 'width' entry" {
+        $returnString = ($customObject | ConvertTo-Html @{ e = 'Age'; width = '10' }) -join $newLine
+        $returnString | Should -Match '\swidth\s*=\s*(["''])10\1'
+    }
+
+    It "Test ConvertTo-HTML supports scriptblock-based calculated properties: by hashtable" {
+        $returnString = ($customObject | ConvertTo-HTML @{ l='NewAge'; e={ $_.Age + 1 } }) -join $newLine
+        $returnString | Should -Match '\b43\b'
+    }
+
+    It "Test ConvertTo-HTML supports scriptblock-based calculated properties: directly" {
+        $returnString = ($customObject | ConvertTo-HTML { $_.Age + 1 }) -join $newLine
+        $returnString | Should -Match '\b43\b'
+    }
+
 }
 


### PR DESCRIPTION
## PR Summary

Implements #8429.

Defines short alias names for all keys supported in calculated-property definitions, so that these aliases can be used safely, without fear of keys introduced in the future making previously unambiguous name prefixes ambiguous.

Note: 

* A single internal class, `CalculatedPropertyDefinitionKeys`, now defines all supported keys (entries) across all cmdlets, and all future keys should be added there as well.

* Most alias names are single-character names:
  * `l` for `label`
  * `n` for `name`
  * `e` for `expression`
  * `f` for `formatString`
  * `d` for `depth`
  * `a` for `alignment`
  * `w` for `width`

* The only exceptions:
   * `asc` for `ascending`
   * `desc` for `descending`

Should the latter two just be `a` and `d` too? It's a possibility, given that the conflicting names, `d(epth)` and `a(lignment)` only apply to _other_ cmdlets, or is cross-cmdlet consistency more important?

* Tests: Currently, no two keys for a given cmdlet start with the same letter, so how would we write a test that ensures, for instance, that adding an `example` key still unambiguously maps `e` to `expression`, whereas using the ambiguous `ex` should throw an exception?

* As before, there is no formal check for duplicate names / aliases; while maintaining all constants in class `CalculatedPropertyDefinitionKeys` helps, I wonder if we need a formal check to prevent duplicates - ideally as part of testing.

* Includes the changes for #8426 and #8427.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [x] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
