### PR TITLE
Fix Join-String cmdlet FormatString parameter logic

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/join-string.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/join-string.cs
@@ -139,7 +139,7 @@ namespace Microsoft.PowerShell.Commands.Utility
                 }
                 else
                 {
-                    _outputBuilder.AppendFormat(_cultureInfo, FormatString, stringValue);
+                    _outputBuilder.AppendFormat(_cultureInfo, FormatString, inputValue);
                 }
             }
         }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Join-String.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Join-String.Tests.ps1
@@ -54,6 +54,13 @@ Describe "Join-String" -Tags "CI" {
         $actual | Should -BeExactly $expected
     }
 
+    It "Should join numeric values Formatted" {
+        $testValues = 1.2, 3.4, 5.6
+        $expected = $testValues.Foreach{"{0:N2}" -f $_} -join "; "
+        $actual = $testValues | Join-String -Separator "; " -Format "{0:N2}"
+        $actual | Should -BeExactly $expected
+    }
+
     It "Should join script block results with default separator" {
         $sb = {$_.Name + $_.Length}
         $expected = ($testObject | ForEach-Object $sb) -join $ofs
@@ -105,8 +112,8 @@ Describe "Join-String" -Tags "CI" {
         $cmd = '[io.fileinfo]::new("c:\temp") | Join-String -Property '
         $res = tabexpansion2 $cmd $cmd.length
         $completionTexts = $res.CompletionMatches.CompletionText
-        $Propertys = [io.fileinfo]::new($PSScriptRoot).psobject.properties.Name
-        foreach ($n in $Propertys) {
+        $Properties = [io.fileinfo]::new($PSScriptRoot).psobject.properties.Name
+        foreach ($n in $Properties) {
             $n -in $completionTexts | Should -BeTrue
         }
     }


### PR DESCRIPTION
## PR Summary

Fix #8448 
PR changes logic when applying **FormatString** parameter value.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [x] Not Applicable or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
