### PR TITLE
Fix xml nesting bug in CustomSerializer.WriteMemberInfoCollection()

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CustomSerialization.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CustomSerialization.cs
@@ -691,7 +691,6 @@ namespace System.Management.Automation
         {
             Dbg.Assert(me != null, "caller should validate the parameter");
 
-            bool enclosingTagWritten = false;
             foreach (PSMemberInfo info in me)
             {
                 if (!info.ShouldSerialize)
@@ -705,15 +704,11 @@ namespace System.Management.Automation
                     continue;
                 }
 
-                enclosingTagWritten = true;
                 WriteStartElement(_writer, CustomSerializationStrings.Properties);
                 WriteAttribute(_writer, CustomSerializationStrings.NameAttribute, info.Name);
                 if (!_notypeinformation)
                     WriteAttribute(_writer, CustomSerializationStrings.TypeAttribute, info.GetType().ToString());
                 _writer.WriteString(property.Value.ToString());
-            }
-            if (enclosingTagWritten)
-            {
                 _writer.WriteEndElement();
             }
         }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CustomSerialization.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CustomSerialization.cs
@@ -731,8 +731,6 @@ namespace System.Management.Automation
 
             depth = GetDepthOfSerialization(source, depth);
 
-            //Depth available for each property is one less
-            --depth;
             Dbg.Assert(depth >= 0, "depth should be greater or equal to zero");
             if (source.GetSerializationMethod(null) == SerializationMethod.SpecificProperties)
             {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CustomSerialization.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CustomSerialization.cs
@@ -417,7 +417,7 @@ namespace System.Management.Automation
                 PSMemberInfoCollection<PSMemberInfo> instanceMembers = mshSource.InstanceMembers;
                 if (instanceMembers != null)
                 {
-                    WriteMemberInfoCollection(instanceMembers);
+                    WriteMemberInfoCollection(instanceMembers, depth, true);
                 }
             }
 
@@ -569,7 +569,7 @@ namespace System.Management.Automation
             PSMemberInfoCollection<PSMemberInfo> instanceMembers = source.InstanceMembers;
             if (instanceMembers != null)
             {
-                WriteMemberInfoCollection(instanceMembers);
+                WriteMemberInfoCollection(instanceMembers, depth, true);
             }
 
             _writer.WriteEndElement();
@@ -678,14 +678,20 @@ namespace System.Management.Automation
         /// Serialize member set. This method serializes without writing.
         /// enclosing tags and attributes.
         /// </summary>
-        /// <param name="members">
+        /// <param name="me">
         /// Enumerable containing members
         /// </param>
-        private void WriteMemberInfoCollection(PSMemberInfoCollection<PSMemberInfo> members)
+        /// <param name="depth"></param>
+        /// <param name="writeEnclosingMemberSetElementTag">
+        /// if this is true, write an enclosing "<memberset></memberset>" tag.
+        /// </param>
+        /// <returns></returns>
+        private void WriteMemberInfoCollection(
+            PSMemberInfoCollection<PSMemberInfo> me, int depth, bool writeEnclosingMemberSetElementTag)
         {
-            Dbg.Assert(members != null, "caller should validate the parameter");
+            Dbg.Assert(me != null, "caller should validate the parameter");
 
-            foreach (PSMemberInfo info in members)
+            foreach (PSMemberInfo info in me)
             {
                 if (!info.ShouldSerialize)
                 {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CustomSerialization.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CustomSerialization.cs
@@ -417,7 +417,7 @@ namespace System.Management.Automation
                 PSMemberInfoCollection<PSMemberInfo> instanceMembers = mshSource.InstanceMembers;
                 if (instanceMembers != null)
                 {
-                    WriteMemberInfoCollection(instanceMembers, depth, true);
+                    WriteMemberInfoCollection(instanceMembers);
                 }
             }
 
@@ -569,7 +569,7 @@ namespace System.Management.Automation
             PSMemberInfoCollection<PSMemberInfo> instanceMembers = source.InstanceMembers;
             if (instanceMembers != null)
             {
-                WriteMemberInfoCollection(instanceMembers, depth, true);
+                WriteMemberInfoCollection(instanceMembers);
             }
 
             _writer.WriteEndElement();
@@ -678,20 +678,14 @@ namespace System.Management.Automation
         /// Serialize member set. This method serializes without writing.
         /// enclosing tags and attributes.
         /// </summary>
-        /// <param name="me">
+        /// <param name="members">
         /// Enumerable containing members
         /// </param>
-        /// <param name="depth"></param>
-        /// <param name="writeEnclosingMemberSetElementTag">
-        /// if this is true, write an enclosing "<memberset></memberset>" tag.
-        /// </param>
-        /// <returns></returns>
-        private void WriteMemberInfoCollection(
-            PSMemberInfoCollection<PSMemberInfo> me, int depth, bool writeEnclosingMemberSetElementTag)
+        private void WriteMemberInfoCollection(PSMemberInfoCollection<PSMemberInfo> members)
         {
-            Dbg.Assert(me != null, "caller should validate the parameter");
+            Dbg.Assert(members != null, "caller should validate the parameter");
 
-            foreach (PSMemberInfo info in me)
+            foreach (PSMemberInfo info in members)
             {
                 if (!info.ShouldSerialize)
                 {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CustomSerialization.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CustomSerialization.cs
@@ -731,6 +731,8 @@ namespace System.Management.Automation
 
             depth = GetDepthOfSerialization(source, depth);
 
+            //Depth available for each property is one less
+            --depth;
             Dbg.Assert(depth >= 0, "depth should be greater or equal to zero");
             if (source.GetSerializationMethod(null) == SerializationMethod.SpecificProperties)
             {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Xml.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Xml.Tests.ps1
@@ -108,5 +108,20 @@ Describe "ConvertTo-Xml DRT Unit Tests" -Tags "CI" {
         $x.Objects.Object[1].Property.Name | Should -BeExactly "name"
         $x.Objects.Object[1].Property."#text" | Should -BeExactly "banana"
     }
+
+    It "Serialize nested PSObject properties" {
+        $nestedObject = [pscustomobject]@{
+            Prop1 = [pscustomobject]@{
+                Prop1 = [pscustomobject]@{
+                    Prop1 = 111
+                    Prop2 = 222
+                }
+                Prop2 = 22
+            }
+            Prop2 = 2
+        }
+        $x = $nestedObject | ConvertTo-Xml -Depth 1
+        $x.OuterXml | Should -Be '<?xml version="1.0" encoding="utf-8"?><Objects><Object Type="System.Management.Automation.PSCustomObject"><Property Name="Prop1" Type="System.Management.Automation.PSCustomObject"><Property Type="System.String">@{Prop1=; Prop2=22}</Property><Property Name="Prop1" Type="System.Management.Automation.PSNoteProperty">@{Prop1=111; Prop2=222}</Property><Property Name="Prop2" Type="System.Management.Automation.PSNoteProperty">22</Property></Property><Property Name="Prop2" Type="System.Int32">2</Property></Object></Objects>'
+    }
 }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Xml.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/ConvertTo-Xml.Tests.ps1
@@ -109,7 +109,7 @@ Describe "ConvertTo-Xml DRT Unit Tests" -Tags "CI" {
         $x.Objects.Object[1].Property."#text" | Should -BeExactly "banana"
     }
 
-    It "Serialize nested PSObject properties" {
+    It "Serialize nested pscustomobject properties" {
         $nestedObject = [pscustomobject]@{
             Prop1 = [pscustomobject]@{
                 Prop1 = [pscustomobject]@{


### PR DESCRIPTION
## PR Summary
Fix #8308 

`WriteMemberInfoCollection()` incorrectly nests sibling elements at depth==0
The reason seems to be that `WriteMemberInfoCollection()` calls `WriteEndElement()` at most once, even if `WriteStartElement()` has been called more than once.

This PR moves the `WriteEndElement()` call up immediately after the elements text value has been written.

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [X] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [X] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
