### PR TITLE
Add `-RepeatHeader` to `Format-Table` to enable repeating header for each screen full

### DIFF
--- a/src/System.Management.Automation/FormatAndOutput/common/BaseFormattingCommand.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/BaseFormattingCommand.cs
@@ -759,6 +759,12 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         private Nullable<bool> _autosize = null;
 
         /// <summary>
+        /// Gets or sets if header is repeated per screen.
+        /// </summary>
+        [Parameter]
+        public SwitchParameter RepeatHeader { get; set; }
+
+        /// <summary>
         /// optional, non positional parameter
         /// </summary>
         /// <value></value>
@@ -808,6 +814,11 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
 
             if (_autosize.HasValue)
                 parameters.autosize = _autosize.Value;
+
+            if (RepeatHeader)
+            {
+                parameters.repeatHeader = true;
+            }
 
             parameters.groupByParameter = this.ProcessGroupByParameter();
 

--- a/src/System.Management.Automation/FormatAndOutput/common/BaseFormattingCommandParameters.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/BaseFormattingCommandParameters.cs
@@ -46,6 +46,12 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         internal Nullable<bool> autosize = null;
 
         /// <summary>
+        /// If true, the header for a table is repeated after each screen full
+        /// of content.
+        /// </summary>
+        internal bool repeatHeader = false;
+
+        /// <summary>
         /// errors are shown as out of band messages
         /// </summary>
         internal Nullable<bool> showErrorsAsMessages = null;

--- a/src/System.Management.Automation/FormatAndOutput/common/BaseOutputtingCommand.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/BaseOutputtingCommand.cs
@@ -969,11 +969,9 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 GroupStartData formatData)
                 : base(cmd, parentContext, formatData)
             {
-                FormatOutputContext foc = parentContext as FormatOutputContext;
-                if (foc != null)
+                if (parentContext is FormatOutputContext foc)
                 {
-                    TableHeaderInfo thi = foc.Data.shapeInfo as TableHeaderInfo;
-                    if (thi != null)
+                    if (foc.Data.shapeInfo is TableHeaderInfo thi)
                     {
                         _repeatHeader = thi.repeatHeader;
                     }

--- a/src/System.Management.Automation/FormatAndOutput/common/BaseOutputtingCommand.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/BaseOutputtingCommand.cs
@@ -1067,7 +1067,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                         alignment[k] = TextAlignment.Left; // hard coded default
                     }
                 }
-                this.Writer.GenerateRow(values, this.InnerCommand._lo, tre.multiLine, alignment, InnerCommand._lo.DisplayCells);
+                this.Writer.GenerateRow(values, this.InnerCommand._lo, tre.multiLine, alignment, InnerCommand._lo.DisplayCells, generatedRows: null);
                 _rowCount++;
             }
 
@@ -1278,7 +1278,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                     else
                         values[k] = string.Empty;
                 }
-                this.Writer.GenerateRow(values, this.InnerCommand._lo, false, null, InnerCommand._lo.DisplayCells);
+                this.Writer.GenerateRow(values, this.InnerCommand._lo, false, null, InnerCommand._lo.DisplayCells, generatedRows: null);
                 _buffer.Reset();
             }
 

--- a/src/System.Management.Automation/FormatAndOutput/common/BaseOutputtingCommand.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/BaseOutputtingCommand.cs
@@ -375,8 +375,6 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             return _command.Process(o);
         }
 
-        internal bool _repeatHeader = false;
-
         /// <summary>
         /// class factory for output context
         /// </summary>
@@ -788,10 +786,9 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         }
 
         /// <summary>
-        /// However, if we can't read that (for example, implicit remoting has no console window), we default
-        /// to something reasonable: 120 columns.
+        /// Return the console height.null  If not available (like when remoting), treat as Int.MaxValue.
         /// </summary>
-        static private int GetConsoleWindowHeight()
+        private static int GetConsoleWindowHeight()
         {
             if (InternalTestHooks.SetConsoleHeightToZero)
             {

--- a/src/System.Management.Automation/FormatAndOutput/common/DisplayDatabase/displayDescriptionData.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/DisplayDatabase/displayDescriptionData.cs
@@ -424,6 +424,11 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         /// RULE: valid only for table and wide only
         /// </summary>
         internal bool? autosize = null;
+
+        /// <summary>
+        /// RULE: only valid for table
+        /// </summary>
+        internal bool repeatHeader = false;
     }
 
     /// <summary>

--- a/src/System.Management.Automation/FormatAndOutput/common/FormatViewGenerator.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/FormatViewGenerator.cs
@@ -63,6 +63,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             InitializeFormatErrorManager();
             InitializeGroupBy();
             InitializeAutoSize();
+            InitializeRepeatHeader();
         }
 
         private void InitializeFormatErrorManager()
@@ -144,6 +145,14 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 {
                     _autosize = controlBody.autosize.Value;
                 }
+            }
+        }
+
+        private void InitializeRepeatHeader()
+        {
+            if (parameters != null)
+            {
+                _repeatHeader = parameters.repeatHeader;
             }
         }
 
@@ -311,6 +320,12 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             get { return _autosize; }
         }
         private bool _autosize = false;
+
+        protected bool RepeatHeader
+        {
+            get { return _repeatHeader; }
+        }
+        private bool _repeatHeader = false;
 
         protected class DataBaseInfo
         {

--- a/src/System.Management.Automation/FormatAndOutput/common/FormatViewGenerator_Table.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/FormatViewGenerator_Table.cs
@@ -156,6 +156,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             bool dummy;
             List<TableRowItemDefinition> activeRowItemDefinitionList = GetActiveTableRowDefinition(_tableBody, so, out dummy);
             thi.hideHeader = this.HideHeaders;
+            thi.repeatHeader = this.RepeatHeader;
 
             int col = 0;
             foreach (TableRowItemDefinition rowItem in activeRowItemDefinitionList)
@@ -289,6 +290,19 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 {
                     return _tableBody.header.hideHeader;
                 }
+                return false;
+            }
+        }
+
+        private bool RepeatHeaders
+        {
+            get
+            {
+                if (this.parameters != null)
+                {
+                    return this.parameters.repeatHeader;
+                }
+
                 return false;
             }
         }

--- a/src/System.Management.Automation/FormatAndOutput/common/FormattingObjects.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/FormattingObjects.cs
@@ -220,6 +220,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         public override string ClassId2e4f51ef21dd47e99d3c952918aff9cd { get { return CLSID; } }
 
         public bool hideHeader;
+        public bool repeatHeader;
         public List<TableColumnInfo> tableColumnInfoList;
     }
 

--- a/src/System.Management.Automation/FormatAndOutput/common/FormattingObjectsDeserializer.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/FormattingObjectsDeserializer.cs
@@ -575,6 +575,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         {
             base.Deserialize(so, deserializer);
             this.hideHeader = deserializer.DeserializeBoolMemberVariable(so, "hideHeader");
+            this.hideHeader = deserializer.DeserializeBoolMemberVariable(so, "repeatHeader");
             FormatInfoDataListDeserializer<TableColumnInfo>.ReadList(so, "tableColumnInfoList", this.tableColumnInfoList, deserializer);
         }
     }

--- a/src/System.Management.Automation/FormatAndOutput/common/TableWriter.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/TableWriter.cs
@@ -27,6 +27,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         private class ScreenInfo
         {
             internal int screenColumns = 0;
+            internal int screenRows = 0;
 
             internal const int separatorCharacterCount = 1;
 
@@ -40,6 +41,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         private ScreenInfo _si;
         private const char ESC = '\u001b';
         private const string ResetConsoleVt100Code = "\u001b[m";
+        private string[] _header;
 
         internal static int ComputeWideViewBestItemsPerRowFit(int stringLen, int screenColumns)
         {
@@ -80,7 +82,8 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         /// <param name="columnWidths">array of specified column widths</param>
         /// <param name="alignment">array of alignment flags</param>
         /// <param name="suppressHeader">if true, suppress header printing</param>
-        internal void Initialize(int leftMarginIndent, int screenColumns, Span<int> columnWidths, ReadOnlySpan<int> alignment, bool suppressHeader)
+        /// <param name="screenRows">number of rows on the screen</param>
+        internal void Initialize(int leftMarginIndent, int screenColumns, Span<int> columnWidths, ReadOnlySpan<int> alignment, bool suppressHeader, int screenRows = int.MaxValue)
         {
             //Console.WriteLine("         1         2         3         4         5         6         7");
             //Console.WriteLine("01234567890123456789012345678901234567890123456789012345678901234567890123456789");
@@ -126,6 +129,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             // now set the run time data structures
             _si = new ScreenInfo();
             _si.screenColumns = screenColumns;
+            _si.screenRows = screenRows;
             _si.columnInfo = new ColumnInfo[columnWidths.Length];
 
             int startCol = _startColumn;
@@ -140,16 +144,29 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             }
         }
 
-        internal void GenerateHeader(string[] values, LineOutput lo)
+        internal int GenerateHeader(string[] values, LineOutput lo)
         {
-            if (_disabled)
-                return;
+            if (_disabled || _hideHeader)
+            {
+                return 0;
+            }
+            else if (_header != null)
+            {
+                foreach (string line in _header)
+                {
+                    lo.WriteLine(line);
+                }
 
-            if (_hideHeader)
-                return;
+                return _header.Length;
+            }
+
+            var header = new List<string>();
 
             // generate the row with the header labels
-            GenerateRow(values, lo, true, null, lo.DisplayCells);
+            foreach (string line in GenerateRow(values, lo, true, null, lo.DisplayCells))
+            {
+                header.Add(line);
+            }
 
             // generate an array of "--" as header markers below
             // the column header labels
@@ -175,13 +192,22 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 // would be invalidated
                 breakLine[k] = StringUtil.DashPadding(count);
             }
-            GenerateRow(breakLine, lo, false, null, lo.DisplayCells);
+
+            foreach (string line in GenerateRow(breakLine, lo, false, null, lo.DisplayCells))
+            {
+                header.Add(line);
+            }
+
+            _header = header.ToArray();
+            return _header.Length;
         }
 
-        internal void GenerateRow(string[] values, LineOutput lo, bool multiLine, ReadOnlySpan<int> alignment, DisplayCells dc)
+        internal string[] GenerateRow(string[] values, LineOutput lo, bool multiLine, ReadOnlySpan<int> alignment, DisplayCells dc)
         {
+            string[] lines = new string[]{};
+
             if (_disabled)
-                return;
+                return lines;
 
             // build the current row alignment settings
             int cols = _si.columnInfo.Length;
@@ -207,16 +233,20 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
 
             if (multiLine)
             {
-                string[] lines = GenerateTableRow(values, currentAlignment, lo.DisplayCells);
+                lines = GenerateTableRow(values, currentAlignment, lo.DisplayCells);
 
                 for (int k = 0; k < lines.Length; k++)
                 {
                     lo.WriteLine(lines[k]);
                 }
+
+                return lines;
             }
             else
             {
-                lo.WriteLine(GenerateRow(values, currentAlignment, dc));
+                string line = GenerateRow(values, currentAlignment, dc);
+                lo.WriteLine(line);
+                return new string[1]{line};
             }
         }
 

--- a/src/System.Management.Automation/FormatAndOutput/common/TableWriter.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/TableWriter.cs
@@ -158,10 +158,10 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 return _header.Count;
             }
 
-            var header = new List<string>();
+            _header = new List<string>();
 
             // generate the row with the header labels
-            header = GenerateRow(values, lo, true, null, lo.DisplayCells);
+            GenerateRow(values, lo, true, null, lo.DisplayCells, _header);
 
             // generate an array of "--" as header markers below
             // the column header labels
@@ -188,17 +188,14 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 breakLine[k] = StringUtil.DashPadding(count);
             }
 
-            header.AddRange(GenerateRow(breakLine, lo, false, null, lo.DisplayCells));
-            _header = header;
+            GenerateRow(breakLine, lo, false, null, lo.DisplayCells, _header);
             return _header.Count;
         }
 
-        internal List<string> GenerateRow(string[] values, LineOutput lo, bool multiLine, ReadOnlySpan<int> alignment, DisplayCells dc)
+        internal void GenerateRow(string[] values, LineOutput lo, bool multiLine, ReadOnlySpan<int> alignment, DisplayCells dc, List<string> generatedRows)
         {
-            List<string> lines = new List<string>();
-
             if (_disabled)
-                return lines;
+                return;
 
             // build the current row alignment settings
             int cols = _si.columnInfo.Length;
@@ -226,18 +223,15 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             {
                 foreach (string line in GenerateTableRow(values, currentAlignment, lo.DisplayCells))
                 {
-                    lines.Add(line);
+                    generatedRows?.Add(line);
                     lo.WriteLine(line);
                 }
-
-                return lines;
             }
             else
             {
                 string line = GenerateRow(values, currentAlignment, dc);
+                generatedRows?.Add(line);
                 lo.WriteLine(line);
-                lines.Add(line);
-                return lines;
             }
         }
 

--- a/src/System.Management.Automation/FormatAndOutput/common/TableWriter.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/TableWriter.cs
@@ -75,36 +75,35 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         }
 
         /// <summary>
-        /// Initialize the table specifying the width of each column
+        /// Initialize the table specifying the width of each column.
         /// </summary>
-        /// <param name="leftMarginIndent">left margin indentation</param>
-        /// <param name="screenColumns">number of character columns on the screen</param>
-        /// <param name="columnWidths">array of specified column widths</param>
-        /// <param name="alignment">array of alignment flags</param>
-        /// <param name="suppressHeader">if true, suppress header printing</param>
-        /// <param name="screenRows">number of rows on the screen</param>
+        /// <param name="leftMarginIndent">Left margin indentation</param>
+        /// <param name="screenColumns">Number of character columns on the screen</param>
+        /// <param name="columnWidths">Array of specified column widths</param>
+        /// <param name="alignment">Array of alignment flags</param>
+        /// <param name="suppressHeader">If true, suppress header printing</param>
+        /// <param name="screenRows">Number of rows on the screen</param>
         internal void Initialize(int leftMarginIndent, int screenColumns, Span<int> columnWidths, ReadOnlySpan<int> alignment, bool suppressHeader, int screenRows = int.MaxValue)
         {
-            //Console.WriteLine("         1         2         3         4         5         6         7");
-            //Console.WriteLine("01234567890123456789012345678901234567890123456789012345678901234567890123456789");
-
             if (leftMarginIndent < 0)
             {
                 leftMarginIndent = 0;
             }
+
             if (screenColumns - leftMarginIndent < ScreenInfo.minimumScreenColumns)
             {
                 _disabled = true;
                 return;
             }
-            _startColumn = leftMarginIndent;
 
+            _startColumn = leftMarginIndent;
             _hideHeader = suppressHeader;
 
             // make sure the column widths are correct; if not, take appropriate action
-            ColumnWidthManager manager = new ColumnWidthManager(screenColumns - leftMarginIndent,
-                                                        ScreenInfo.minimumColumnWidth,
-                                                        ScreenInfo.separatorCharacterCount);
+            ColumnWidthManager manager = new ColumnWidthManager(
+                screenColumns - leftMarginIndent,
+                ScreenInfo.minimumColumnWidth,
+                ScreenInfo.separatorCharacterCount);
 
             manager.CalculateColumnWidths(columnWidths);
 
@@ -140,7 +139,6 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 _si.columnInfo[k].width = columnWidths[k];
                 _si.columnInfo[k].alignment = alignment[k];
                 startCol += columnWidths[k] + ScreenInfo.separatorCharacterCount;
-                //Console.WriteLine("start = {0} width = {1}", si.columnInfo[k].startCol, si.columnInfo[k].width);
             }
         }
 
@@ -204,7 +202,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
 
         internal string[] GenerateRow(string[] values, LineOutput lo, bool multiLine, ReadOnlySpan<int> alignment, DisplayCells dc)
         {
-            string[] lines = new string[]{};
+            string[] lines = new string[] { };
 
             if (_disabled)
                 return lines;

--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -1531,7 +1531,7 @@ namespace System.Management.Automation
                     WriteVerbose(ps, string.Format(CultureInfo.CurrentCulture, ParserStrings.ImplicitRemotingPipelineBatchingException, ex.Message));
                 }
             }
-            
+
             return false;
         }
 
@@ -1781,6 +1781,7 @@ namespace System.Management.Automation.Internal
         internal static bool StopwatchIsNotHighResolution;
         internal static bool DisableGACLoading;
         internal static bool SetConsoleWidthToZero;
+        internal static bool SetConsoleHeightToZero;
 
         // A location to test PSEdition compatibility functionality for Windows PowerShell modules with
         // since we can't manipulate the System32 directory in a test

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-Table.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-Table.Tests.ps1
@@ -792,10 +792,11 @@ A Name                                  B
             }
         }
 
-        It "-RepeatHeader should output the header at every screen full" -Skip:([Console]::BufferHeight -eq 0) {
-            $numObjects = 250
-            $out = 1..$numObjects | ForEach-Object { @{foo=$_} } | Format-Table -RepeatHeaderPerScreen | Out-String
+        It "-RepeatHeader should output the header at every screen full" -Skip:([Console]::WindowHeight -eq 0) {
+            $numHeaders = 4
+            $numObjects = [Console]::WindowHeight * $numHeaders
+            $out = 1..$numObjects | ForEach-Object { @{foo=$_} } | Format-Table -RepeatHeader | Out-String
             $lines = $out.Split([System.Environment]::NewLine)
-            ($lines | Select-String "Name\s*Value").Count | Should -Be ([int]($numObjects / [Console]::BufferHeight) + 1)
+            ($lines | Select-String "Name\s*Value").Count | Should -Be ($numHeaders + 1)
         }
     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-Table.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-Table.Tests.ps1
@@ -791,4 +791,11 @@ A Name                                  B
                 [system.management.automation.internal.internaltesthooks]::SetTestHook('SetConsoleWidthToZero', $false)
             }
         }
+
+        It "-RepeatHeader should output the header at every screen full" -Skip:([Console]::BufferHeight -eq 0) {
+            $numObjects = 250
+            $out = 1..$numObjects | ForEach-Object { @{foo=$_} } | Format-Table -RepeatHeaderPerScreen | Out-String
+            $lines = $out.Split([System.Environment]::NewLine)
+            ($lines | Select-String "Name\s*Value").Count | Should -Be ([int]($numObjects / [Console]::BufferHeight) + 1)
+        }
     }


### PR DESCRIPTION
## PR Summary

When using a screen reader or just getting the output of a table with lots of rows, the header is no longer on the screen and the columns may no longer make sense without the context.  This PR adds a `-RepeatHeader` switch to `Format-Table` to enable re-outputting the header after every screen full (minus 1 row).  Expectation is that the user is piping the output to a pager (e.g. less) which uses the bottom row for pager information.  I followed the `AutoSize` parameter as the way to get the parameter from the cmdlet into the deep formatting object where it's needed.

![gifv](https://i.imgur.com/t9WbpnX.gif)

Fix https://github.com/PowerShell/PowerShell/issues/8455

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] User-facing https://github.com/PowerShell/PowerShell-Docs/pull/3443
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
