### PR TITLE
Fix formatting of header of table when center aligned

### DIFF
--- a/src/System.Management.Automation/FormatAndOutput/common/TableWriter.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/TableWriter.cs
@@ -386,7 +386,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         {
             StringCollection sc = StringManipulationHelper.GenerateLines(dc, val,
                                         _si.columnInfo[k].width, _si.columnInfo[k].width);
-            if (addPadding || alignment == TextAlignment.Right)
+            if (addPadding || alignment != TextAlignment.Left)
             {
                 // if length is shorter, do some padding
                 for (int col = 0; col < sc.Count; col++)

--- a/src/System.Management.Automation/FormatAndOutput/common/TableWriter.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/TableWriter.cs
@@ -386,7 +386,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         {
             StringCollection sc = StringManipulationHelper.GenerateLines(dc, val,
                                         _si.columnInfo[k].width, _si.columnInfo[k].width);
-            if (addPadding || alignment != TextAlignment.Left)
+            if (addPadding || alignment == TextAlignment.Right || alignment == TextAlignment.Center)
             {
                 // if length is shorter, do some padding
                 for (int col = 0; col < sc.Count; col++)

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-Table.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Format-Table.Tests.ps1
@@ -476,7 +476,7 @@ er
             @{ view = "Default"; widths = 4,7,5; variation = "narrow values"; values = [PSCustomObject]@{First=1;Second=2;Third=3}; wrap = $false; expectedTable = @"
 
 Long*Header2*Heade
-Long*********r3
+Long**********r3
 Head
 er
 ----*-------*-----
@@ -487,18 +487,18 @@ er
             @{ view = "Default"; widths = 4,7,5; variation = "narrow values with wrap"; values = [PSCustomObject]@{First=1;Second=2;Third=3}; wrap = $true; expectedTable = @"
 
 Long*Header2*Heade
-Long*********r3
+Long**********r3
 Head
 er
 ----*-------*-----
-1**********2*3
+1**********2***3
 
 
 "@ },
             @{ view = "Default"; widths = 4,7,5; variation = "wide values"; values = [PSCustomObject]@{First="12345";Second="12345678";Third="123456"}; wrap = $false; expectedTable = @"
 
 Long*Header2*Heade
-Long*********r3
+Long**********r3
 Head
 er
 ----*-------*-----
@@ -521,7 +521,7 @@ er
             @{ view = "Default"; widths = 4,8,6; variation = "wide values with wrap, 1st column"; values = [PSCustomObject]@{First="12345";Second="12345678";Third="123456"}; wrap = $true; expectedTable = @"
 
 Long**Header2*Header
-Long**********3
+Long************3
 Head
 er
 ----**-------*------
@@ -533,7 +533,7 @@ er
             @{ view = "Default"; widths = 5,7,6; variation = "wide values with wrap, 2nd column"; values = [PSCustomObject]@{First="12345";Second="12345678";Third="123456"}; wrap = $true; expectedTable = @"
 
 LongL*Header2*Header
-ongHe*********3
+ongHe***********3
 ader
 -----*-------*------
 12345*1234567*123456
@@ -544,23 +544,23 @@ ader
             @{ view = "Default"; widths = 5,8,5; variation = "wide values with wrap, 3rd column"; values = [PSCustomObject]@{First="12345";Second="12345678";Third="123456"}; wrap = $true; expectedTable = @"
 
 LongL**Header2*Heade
-ongHe**********r3
+ongHe***********r3
 ader
 -----**-------*-----
 12345*12345678*12345
-***************6
+*****************6
 
 
 "@ },
             @{ view = "Default"; widths = 4,7,5; variation = "wide values with wrap, all 3 columns"; values = [PSCustomObject]@{First="12345";Second="12345678";Third="123456"}; wrap = $true; expectedTable = @"
 
 Long*Header2*Heade
-Long*********r3
+Long**********r3
 Head
 er
 ----*-------*-----
 1234*1234567*12345
-5**********8*6
+5**********8***6
 
 
 "@ },
@@ -798,5 +798,18 @@ A Name                                  B
             $out = 1..$numObjects | ForEach-Object { @{foo=$_} } | Format-Table -RepeatHeader | Out-String
             $lines = $out.Split([System.Environment]::NewLine)
             ($lines | Select-String "Name\s*Value").Count | Should -Be ($numHeaders + 1)
+        }
+
+        It "Should be formatted correctly if width is declared and using center alignment" {
+            $expectedTable = @"
+
+   one
+   ---
+    1
+
+
+"@
+            $output = [pscustomobject] @{ one = 1 } | Format-Table @{ l='one'; e='one'; width=10; alignment='center' } | Out-String
+            $output.Replace("`r","").Replace(" ",".").Replace("`n","^") | Should -BeExactly $expectedTable.Replace("`r","").Replace(" ",".").Replace("`n","^")
         }
     }


### PR DESCRIPTION
## PR Summary

In a previous change, it only applied padding if alignment was "right", but it should have applied padding whenever alignment was not "left" so that "center" alignment was also padded.  Some existing tests needed to be updated where the third column was using `center` alignment and the test was expecting the header to be `left` aligned (due to this bug) when the header also needed to be `center` aligned.

Fix https://github.com/PowerShell/PowerShell/issues/8428

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
