### PR TITLE
Fix mistake in formatting deserialization for repeatheader

### DIFF
--- a/src/System.Management.Automation/FormatAndOutput/common/FormattingObjectsDeserializer.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/FormattingObjectsDeserializer.cs
@@ -575,7 +575,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         {
             base.Deserialize(so, deserializer);
             this.hideHeader = deserializer.DeserializeBoolMemberVariable(so, "hideHeader");
-            this.hideHeader = deserializer.DeserializeBoolMemberVariable(so, "repeatHeader");
+            this.repeatHeader = deserializer.DeserializeBoolMemberVariable(so, "repeatHeader");
             FormatInfoDataListDeserializer<TableColumnInfo>.ReadList(so, "tableColumnInfoList", this.tableColumnInfoList, deserializer);
         }
     }


### PR DESCRIPTION
## PR Summary

This was missed in https://github.com/PowerShell/PowerShell/pull/8481

The wrong member was being assigned the deserialized value.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [x] Not Applicable or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
