### PR TITLE
Style: The static keyword should be right after access modifier

### DIFF
--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/CimSessionOperations.cs
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/CimSessionOperations.cs
@@ -781,7 +781,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         /// can running parallelly under more than one runspace(s).
         /// </para>
         /// </summary>
-        static internal ConcurrentDictionary<Guid, CimSessionState> cimSessions
+        internal static ConcurrentDictionary<Guid, CimSessionState> cimSessions
             = new ConcurrentDictionary<Guid, CimSessionState>();
 
         /// <summary>
@@ -789,7 +789,7 @@ namespace Microsoft.Management.Infrastructure.CimCmdlets
         /// Default runspace id
         /// </para>
         /// </summary>
-        static internal Guid defaultRunspaceId = Guid.Empty;
+        internal static Guid defaultRunspaceId = Guid.Empty;
 
         /// <summary>
         /// <para>

--- a/src/Microsoft.PowerShell.ConsoleHost/WindowsTaskbarJumpList/ComInterfaces.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/WindowsTaskbarJumpList/ComInterfaces.cs
@@ -235,7 +235,7 @@ namespace Microsoft.PowerShell
         }
 
         [DllImport("ole32.Dll")]
-        static internal extern HResult CoCreateInstance(ref Guid clsid,
+        internal static extern HResult CoCreateInstance(ref Guid clsid,
            [MarshalAs(UnmanagedType.IUnknown)] object inner,
            uint context,
            ref Guid uuid,

--- a/src/Microsoft.PowerShell.ConsoleHost/WindowsTaskbarJumpList/PropVariant.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/WindowsTaskbarJumpList/PropVariant.cs
@@ -61,7 +61,7 @@ namespace Microsoft.PowerShell
         private class PropVariantNativeMethods
         {
             [DllImport("Ole32.dll", PreserveSig = false)]
-            internal extern static void PropVariantClear([In, Out] PropVariant pvar);
+            internal static extern void PropVariantClear([In, Out] PropVariant pvar);
         }
     }
 }

--- a/src/Microsoft.PowerShell.Security/security/AclCommands.cs
+++ b/src/Microsoft.PowerShell.Security/security/AclCommands.cs
@@ -110,7 +110,7 @@ namespace Microsoft.PowerShell.Commands
         /// Add brokered properties for easy access to important properties
         /// of security descriptor
         /// </summary>
-        static internal void AddBrokeredProperties(
+        internal static void AddBrokeredProperties(
             Collection<PSObject> results,
             bool audit,
             bool allCentralAccessPolicies)

--- a/src/Microsoft.PowerShell.Security/security/CertificateProvider.cs
+++ b/src/Microsoft.PowerShell.Security/security/CertificateProvider.cs
@@ -1355,7 +1355,7 @@ namespace Microsoft.PowerShell.Commands
             }
         }
 
-        static private string EnsureDriveIsRooted(string path)
+        private static string EnsureDriveIsRooted(string path)
         {
             string result = path;
 
@@ -1380,7 +1380,7 @@ namespace Microsoft.PowerShell.Commands
             return result;
         }
 
-        static private ErrorRecord CreateErrorRecord(string path,
+        private static ErrorRecord CreateErrorRecord(string path,
                                               CertificateProviderItem itemType)
         {
             Exception e = null;
@@ -1491,7 +1491,7 @@ namespace Microsoft.PowerShell.Commands
             ThrowTerminatingError(er);
         }
 
-        static private string NormalizePath(string path)
+        private static string NormalizePath(string path)
         {
             if (path.Length > 0)
             {
@@ -1510,7 +1510,7 @@ namespace Microsoft.PowerShell.Commands
             return path;
         }
 
-        static private string[] GetPathElements(string path)
+        private static string[] GetPathElements(string path)
         {
             string[] allElts = path.Split(s_pathSeparators);
             string[] result = null;
@@ -3068,7 +3068,7 @@ namespace Microsoft.PowerShell.Commands
         }
 
         private static readonly char[] s_separators = new char[] { '/', '\\' };
-        static private string[] GetPathElements(string path)
+        private static string[] GetPathElements(string path)
         {
             string[] allElts = path.Split(s_separators);
             string[] result = null;

--- a/src/Microsoft.WSMan.Management/WsManHelper.cs
+++ b/src/Microsoft.WSMan.Management/WsManHelper.cs
@@ -157,7 +157,7 @@ namespace Microsoft.WSMan.Management
             return _resourceMgr.GetString(rscname);
         }
 
-        static internal string FormatResourceMsgFromResourcetextS(string rscname,
+        internal static string FormatResourceMsgFromResourcetextS(string rscname,
             params object[] args)
         {
             return FormatResourceMsgFromResourcetextS(_resourceMgr, rscname, args);
@@ -169,7 +169,7 @@ namespace Microsoft.WSMan.Management
             return FormatResourceMsgFromResourcetextS(_resourceMgr, resourceName, args);
         }
 
-        static private string FormatResourceMsgFromResourcetextS(
+        private static string FormatResourceMsgFromResourcetextS(
             ResourceManager resourceManager,
             string resourceName,
             object[] args)
@@ -605,7 +605,7 @@ namespace Microsoft.WSMan.Management
         /// <exception cref="InvalidOperationException">
         /// If there is ambiguity as specified above.
         /// </exception>
-        static internal void ValidateSpecifiedAuthentication(AuthenticationMechanism authentication, PSCredential credential, string certificateThumbprint)
+        internal static void ValidateSpecifiedAuthentication(AuthenticationMechanism authentication, PSCredential credential, string certificateThumbprint)
         {
             if ((credential != null) && (certificateThumbprint != null))
             {

--- a/src/System.Management.Automation/CoreCLR/CorePsAssemblyLoadContext.cs
+++ b/src/System.Management.Automation/CoreCLR/CorePsAssemblyLoadContext.cs
@@ -100,7 +100,7 @@ namespace System.Management.Automation
 
         #region Fields
 
-        private readonly static object s_syncObj = new object();
+        private static readonly object s_syncObj = new object();
         private readonly string[] _probingPaths;
         private readonly string[] _extensions = new string[] { ".ni.dll", ".dll" };
         // CoreCLR type catalog dictionary

--- a/src/System.Management.Automation/engine/LanguagePrimitives.cs
+++ b/src/System.Management.Automation/engine/LanguagePrimitives.cs
@@ -583,7 +583,7 @@ namespace System.Management.Automation
         /// <param name="first">first object</param>
         /// <param name="second">object to compare first to</param>
         /// <returns>true if first is equal to the second</returns>
-        public new static bool Equals(object first, object second)
+        public static new bool Equals(object first, object second)
         {
             return Equals(first, second, false, CultureInfo.InvariantCulture);
         }

--- a/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
@@ -1459,7 +1459,7 @@ namespace System.Management.Automation
         /// Removes all functions not belonging to the parent module.
         /// </summary>
         /// <param name="module">Parent module</param>
-        static internal void RemoveNestedModuleFunctions(PSModuleInfo module)
+        internal static void RemoveNestedModuleFunctions(PSModuleInfo module)
         {
             var input = module.SessionState?.Internal?.ExportedFunctions;
             if ((input == null) || (input.Count == 0))

--- a/src/System.Management.Automation/engine/Modules/ModuleUtils.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleUtils.cs
@@ -14,14 +14,14 @@ namespace System.Management.Automation.Internal
         // Default option for local file system enumeration:
         //  - Ignore files/directories when access is denied;
         //  - Search top directory only.
-        private readonly static System.IO.EnumerationOptions s_defaultEnumerationOptions =
+        private static readonly System.IO.EnumerationOptions s_defaultEnumerationOptions =
                                         new System.IO.EnumerationOptions() { AttributesToSkip = 0 };
 
         // Default option for UNC path enumeration. Same as above plus a large buffer size.
         // For network shares, a large buffer may result in better performance as more results can be batched over the wire.
         // The buffer size 16K is recommended in the comment of the 'BufferSize' property:
         //    "A "large" buffer, for example, would be 16K. Typical is 4K."
-        private readonly static System.IO.EnumerationOptions s_uncPathEnumerationOptions =
+        private static readonly System.IO.EnumerationOptions s_uncPathEnumerationOptions =
                                         new System.IO.EnumerationOptions() { AttributesToSkip = 0, BufferSize = 16384 };
 
         /// <summary>

--- a/src/System.Management.Automation/engine/NativeCommandParameterBinder.cs
+++ b/src/System.Management.Automation/engine/NativeCommandParameterBinder.cs
@@ -347,7 +347,7 @@ namespace System.Management.Automation
             return needQuotes;
         }
 
-        static private string GetEnumerableArgSeparator(ArrayLiteralAst arrayLiteralAst, int index)
+        private static string GetEnumerableArgSeparator(ArrayLiteralAst arrayLiteralAst, int index)
         {
             if (arrayLiteralAst == null) return " ";
 

--- a/src/System.Management.Automation/engine/Utils.cs
+++ b/src/System.Management.Automation/engine/Utils.cs
@@ -490,10 +490,10 @@ namespace System.Management.Automation
         /// </summary>
         internal static string ModuleDirectory = Path.Combine(ProductNameForDirectory, "Modules");
 
-        internal readonly static ConfigScope[] SystemWideOnlyConfig = new[] { ConfigScope.AllUsers };
-        internal readonly static ConfigScope[] CurrentUserOnlyConfig = new[] { ConfigScope.CurrentUser };
-        internal readonly static ConfigScope[] SystemWideThenCurrentUserConfig = new[] { ConfigScope.AllUsers, ConfigScope.CurrentUser };
-        internal readonly static ConfigScope[] CurrentUserThenSystemWideConfig = new[] { ConfigScope.CurrentUser, ConfigScope.AllUsers };
+        internal static readonly ConfigScope[] SystemWideOnlyConfig = new[] { ConfigScope.AllUsers };
+        internal static readonly ConfigScope[] CurrentUserOnlyConfig = new[] { ConfigScope.CurrentUser };
+        internal static readonly ConfigScope[] SystemWideThenCurrentUserConfig = new[] { ConfigScope.AllUsers, ConfigScope.CurrentUser };
+        internal static readonly ConfigScope[] CurrentUserThenSystemWideConfig = new[] { ConfigScope.CurrentUser, ConfigScope.AllUsers };
 
         internal static T GetPolicySetting<T>(ConfigScope[] preferenceOrder) where T : PolicyBase, new()
         {
@@ -508,7 +508,7 @@ namespace System.Management.Automation
             return policy;
         }
 
-        private readonly static ConcurrentDictionary<ConfigScope, PowerShellPolicies> s_cachedPoliciesFromConfigFile =
+        private static readonly ConcurrentDictionary<ConfigScope, PowerShellPolicies> s_cachedPoliciesFromConfigFile =
             new ConcurrentDictionary<ConfigScope, PowerShellPolicies>();
 
         /// <summary>
@@ -564,7 +564,7 @@ namespace System.Management.Automation
             {nameof(UpdatableHelp), @"Software\Policies\Microsoft\PowerShellCore\UpdatableHelp"},
             {nameof(ConsoleSessionConfiguration), @"Software\Policies\Microsoft\PowerShellCore\ConsoleSessionConfiguration"}
         };
-        private readonly static ConcurrentDictionary<Tuple<ConfigScope, string>, PolicyBase> s_cachedPoliciesFromRegistry =
+        private static readonly ConcurrentDictionary<Tuple<ConfigScope, string>, PolicyBase> s_cachedPoliciesFromRegistry =
             new ConcurrentDictionary<Tuple<ConfigScope, string>, PolicyBase>();
 
         /// <summary>

--- a/src/System.Management.Automation/engine/parser/SafeValues.cs
+++ b/src/System.Management.Automation/engine/parser/SafeValues.cs
@@ -59,7 +59,7 @@ namespace System.Management.Automation.Language
         }
 
         // A readonly singleton with the default SafeValueContext.
-        internal readonly static IsSafeValueVisitor Default = new IsSafeValueVisitor(GetSafeValueVisitor.SafeValueContext.Default);
+        internal static readonly IsSafeValueVisitor Default = new IsSafeValueVisitor(GetSafeValueVisitor.SafeValueContext.Default);
 
         // This is a check of the number of visits
         private uint _visitCount = 0;

--- a/src/System.Management.Automation/engine/remoting/common/WireDataFormat/RemotingDataObject.cs
+++ b/src/System.Management.Automation/engine/remoting/common/WireDataFormat/RemotingDataObject.cs
@@ -293,7 +293,7 @@ namespace System.Management.Automation.Remoting
         /// <param name="powerShellId"></param>
         /// <param name="data"></param>
         /// <returns></returns>
-        internal new static RemoteDataObject CreateFrom(RemotingDestination destination,
+        internal static new RemoteDataObject CreateFrom(RemotingDestination destination,
             RemotingDataType dataType,
             Guid runspacePoolId,
             Guid powerShellId,


### PR DESCRIPTION
## PR Summary

The static keyword should be right after access modifier.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [x] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
