### PR TITLE
Enable install of Preview MSI release side-by-side with Stable release

### DIFF
--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -2530,6 +2530,7 @@ function New-MSIPackage
     if ($isPreview)
     {
         $simpleProductVersion += '-preview'
+        $FilesWxsPath = New-PreviewFileWxs -FilesWxsPath $FilesWxsPath
     }
 
     $ProductVersion = Get-PackageVersionAsMajorMinorBuildRevision -Version $ProductVersion
@@ -2581,7 +2582,14 @@ function New-MSIPackage
 
     $wixFragmentPath = Join-Path $env:Temp "Fragment.wxs"
     $wixObjProductPath = Join-Path $env:Temp "Product.wixobj"
-    $wixObjFragmentPath = Join-Path $env:Temp "files.wixobj"
+    if ($isPreview)
+    {
+        $wixObjFragmentPath = Join-Path $env:Temp "files-preview.wixobj"
+    }
+    else
+    {
+        $wixObjFragmentPath = Join-Path $env:Temp "files.wixobj"
+    }
 
     # cleanup any garbage on the system
     Remove-Item -ErrorAction SilentlyContinue $wixFragmentPath -Force
@@ -2634,6 +2642,36 @@ function New-MSIPackage
         }
         throw $errorMessage
     }
+}
+
+# generate a files.wxs for preview builds
+# so that the component ids are different than the stable builds
+# the file is created in the temp folder
+function New-PreviewFileWxs
+{
+    param
+    (
+        # File describing the MSI file components from the asset folder
+        [ValidateNotNullOrEmpty()]
+        [ValidateScript( {Test-Path $_})]
+        [string] $FilesWxsPath = "$RepoRoot\assets\Files.wxs"
+    )
+
+    Write-Verbose "Generating new component Ids for Files-Preview.wxs" -Verbose
+    [xml] $filesAssetXml = Get-Content -Raw -Path $FilesWxsPath
+    foreach($component in $filesAssetXml.GetElementsByTagName('Component'))
+    {
+        $component.Id = $component.Id + "_Preview"
+    }
+
+    foreach($componentRef in $filesAssetXml.GetElementsByTagName('ComponentRef'))
+    {
+        $componentRef.Id = $componentRef.Id + "_Preview"
+    }
+
+    $previewFilesWxsPath = Join-Path ([System.IO.Path]::GetTempPath()) "Files-Preview.wxs"
+    $filesAssetXml.Save($previewFilesWxsPath)
+    $previewFilesWxsPath
 }
 
 # verify no files have been added or removed

--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -2623,6 +2623,11 @@ function New-MSIPackage
     Remove-Item -ErrorAction SilentlyContinue $wixFragmentPath -Force
     Remove-Item -ErrorAction SilentlyContinue $wixObjProductPath -Force
     Remove-Item -ErrorAction SilentlyContinue $wixObjFragmentPath -Force
+    if ($isPreview)
+    {
+        # remove the temporary generated files.wxs for preview builds
+        Remove-Item -ErrorAction SilentlyContinue $FilesWxsPath -Force
+    }
 
     if ((Test-Path $msiLocationPath) -and (Test-Path $msiPdbLocationPath))
     {


### PR DESCRIPTION
## PR Summary

When installing (or upgrading) Preview builds the component ids for the files are the same as the installed files from the stable MSI.  MSI sees this and assumes the file is already installed so skips installing files that haven't changed (been updated) which results in missing files in the preview install folder and pwsh fails to start.  Fix is to dynamically generate new component ids (and compoentrefs) in `files.wxs` using `_Preview` suffix and use that when building a preview package.

Tested manually.

cc @bergmeister if you can help validate different scenarios.

Fix https://github.com/PowerShell/PowerShell/issues/8289

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [x] Not Applicable or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
