### PR TITLE
Improve Start-Sleep cmdlet to accept fractional seconds

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/StartSleepCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/StartSleepCommand.cs
@@ -43,8 +43,8 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         [Parameter(Position = 0, Mandatory = true, ParameterSetName = "Seconds", ValueFromPipeline = true,
                    ValueFromPipelineByPropertyName = true)]
-        [ValidateRangeAttribute(0, int.MaxValue / 1000)]
-        public int Seconds { get; set; }
+        [ValidateRangeAttribute(0.0, (double)(int.MaxValue / 1000))]
+        public double Seconds { get; set; }
 
         /// <summary>
         /// Allows sleep time to be specified in milliseconds.
@@ -97,7 +97,7 @@ namespace Microsoft.PowerShell.Commands
             switch (ParameterSetName)
             {
                 case "Seconds":
-                    sleepTime = Seconds * 1000;
+                    sleepTime = (int)(Seconds * 1000);
                     break;
 
                 case "Milliseconds":

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Start-Sleep.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Start-Sleep.Tests.ps1
@@ -3,9 +3,7 @@
 Describe "Start-Sleep DRT Unit Tests" -Tags "CI" {
 
     # WaitHandle.WaitOne(milliseconds, exitContext) is not accurate.
-    # The wait time varies from 980ms to 1150ms from observation
-    # when waiting for one second. To test fractional seconds
-    # the expected values start from 1450ms and end to 1700ms.
+    # The actual wait time can vary from 1450ms to 1700ms.
     $minTime = 1450
     $maxTime = 1700
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Start-Sleep.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Start-Sleep.Tests.ps1
@@ -7,6 +7,8 @@ Describe "Start-Sleep DRT Unit Tests" -Tags "CI" {
     # the tests here are changed to be greater than 950ms.
     $minTime = 950
     $maxTime = 1200
+    $minTimeFractional = 1450
+    $maxTimeFractional = 1700
 
     It "Should work properly when sleeping with Second" {
         $watch = [System.Diagnostics.Stopwatch]::StartNew()
@@ -30,6 +32,22 @@ Describe "Start-Sleep DRT Unit Tests" -Tags "CI" {
         $watch.Stop()
         $watch.ElapsedMilliseconds | Should -BeGreaterThan $minTime
         $watch.ElapsedMilliseconds | Should -BeLessThan $maxTime
+    }
+
+    It "Should work properly when sleeping 1.5 seconds without parameters" {
+        $watch = [System.Diagnostics.Stopwatch]::StartNew()
+        Start-Sleep 1.5
+        $watch.Stop()
+        $watch.ElapsedMilliseconds | Should -BeGreaterThan $minTimeFractional
+        $watch.ElapsedMilliseconds | Should -BeLessThan $maxTimeFractional
+    }
+
+    It "Should work properly when sleeping 1.5 seconds using Second parameter" {
+        $watch = [System.Diagnostics.Stopwatch]::StartNew()
+        Start-Sleep -Seconds 1.5
+        $watch.Stop()
+        $watch.ElapsedMilliseconds | Should -BeGreaterThan $minTimeFractional
+        $watch.ElapsedMilliseconds | Should -BeLessThan $maxTimeFractional
     }
 }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Start-Sleep.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Start-Sleep.Tests.ps1
@@ -3,16 +3,15 @@
 Describe "Start-Sleep DRT Unit Tests" -Tags "CI" {
 
     # WaitHandle.WaitOne(milliseconds, exitContext) is not accurate.
-    # The wait time varies from 980ms to 1150ms from observation, so
-    # the tests here are changed to be greater than 950ms.
-    $minTime = 950
-    $maxTime = 1200
-    $minTimeFractional = 1450
-    $maxTimeFractional = 1700
+    # The wait time varies from 980ms to 1150ms from observation
+    # when waiting for one second. To test fractional seconds
+    # the expected values start from 1450ms and end to 1700ms.
+    $minTime = 1450
+    $maxTime = 1700
 
     It "Should work properly when sleeping with Second" {
         $watch = [System.Diagnostics.Stopwatch]::StartNew()
-        Start-Sleep -Seconds 1
+        Start-Sleep -Seconds 1.5
         $watch.Stop()
         $watch.ElapsedMilliseconds | Should -BeGreaterThan $minTime
         $watch.ElapsedMilliseconds | Should -BeLessThan $maxTime
@@ -20,7 +19,7 @@ Describe "Start-Sleep DRT Unit Tests" -Tags "CI" {
 
     It "Should work properly when sleeping with Milliseconds" {
         $watch = [System.Diagnostics.Stopwatch]::StartNew()
-        Start-Sleep -Milliseconds 1000
+        Start-Sleep -Milliseconds 1500
         $watch.Stop()
         $watch.ElapsedMilliseconds | Should -BeGreaterThan $minTime
         $watch.ElapsedMilliseconds | Should -BeLessThan $maxTime
@@ -28,35 +27,26 @@ Describe "Start-Sleep DRT Unit Tests" -Tags "CI" {
 
     It "Should work properly when sleeping with ms alias" {
         $watch = [System.Diagnostics.Stopwatch]::StartNew()
-        Start-Sleep -ms 1000
+        Start-Sleep -ms 1500
         $watch.Stop()
         $watch.ElapsedMilliseconds | Should -BeGreaterThan $minTime
         $watch.ElapsedMilliseconds | Should -BeLessThan $maxTime
     }
 
-    It "Should work properly when sleeping 1.5 seconds without parameters" {
+    It "Should work properly when sleeping without parameters" {
         $watch = [System.Diagnostics.Stopwatch]::StartNew()
         Start-Sleep 1.5
         $watch.Stop()
-        $watch.ElapsedMilliseconds | Should -BeGreaterThan $minTimeFractional
-        $watch.ElapsedMilliseconds | Should -BeLessThan $maxTimeFractional
-    }
-
-    It "Should work properly when sleeping 1.5 seconds using Second parameter" {
-        $watch = [System.Diagnostics.Stopwatch]::StartNew()
-        Start-Sleep -Seconds 1.5
-        $watch.Stop()
-        $watch.ElapsedMilliseconds | Should -BeGreaterThan $minTimeFractional
-        $watch.ElapsedMilliseconds | Should -BeLessThan $maxTimeFractional
+        $watch.ElapsedMilliseconds | Should -BeGreaterThan $minTime
+        $watch.ElapsedMilliseconds | Should -BeLessThan $maxTime
     }
 }
 
 Describe "Start-Sleep" -Tags "CI" {
-
     Context "Validate Start-Sleep works properly" {
-	It "Should only sleep for at least 1 second" {
-	    $result = Measure-Command { Start-Sleep -s 1 }
-	    $result.TotalSeconds | Should -BeGreaterThan 0.25
-	}
+        It "Should only sleep for at least 1 second" {
+            $result = Measure-Command { Start-Sleep -s 1 }
+            $result.TotalSeconds | Should -BeGreaterThan 0.25
+        }
     }
 }


### PR DESCRIPTION
## PR Summary
- "Seconds" parameter of Start-Sleep function is now interpreted as
  double. This removes the rounding error when the parameter with
  fractions is converted to milliseconds.
- ValidateRangeAttribute parameters converted to double to remove error
  when Seconds parameter is now of double type.

Fix https://github.com/PowerShell/PowerShell/issues/8477

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
