### PR TITLE
Fix typo in AMSI test

### DIFF
--- a/test/powershell/Modules/Microsoft.PowerShell.Security/AmsiInterface.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/AmsiInterface.Tests.ps1
@@ -20,7 +20,7 @@ try
 
             $EICAR_STRING_B64 = "awZ8EmMWc3JjaAdvY2lrBgcbY20aBHBwGgROF3Z6cHJhHmBncn13cmF3HnJ9Z3plemFmYB5ndmBnHnV6f3YSF3sYexk= "
             $bytes = [System.Convert]::FromBase64String($EICAR_STRING_B64)
-            $EICAR_STRING = -join ($bytes | % { [char]($_ -bxor 0x33) })
+            $EICAR_STRING = -join ($bytes | ForEach-Object { [char]($_ -bxor 0x33) })
             { Invoke-Expression -Command "echo '$EICAR_STRING'" } |
                 Should -Throw -ErrorId "ScriptContainedMaliciousContent,Microsoft.PowerShell.Commands.InvokeExpressionCommand"
         }

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/AmsiInterface.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/AmsiInterface.Tests.ps1
@@ -20,7 +20,7 @@ try
 
             $EICAR_STRING_B64 = "awZ8EmMWc3JjaAdvY2lrBgcbY20aBHBwGgROF3Z6cHJhHmBncn13cmF3HnJ9Z3plemFmYB5ndmBnHnV6f3YSF3sYexk= "
             $bytes = [System.Convert]::FromBase64String($EICAR_STRING_B64)
-            $EICAR_STRING = -join ($bytes | ForeEach-Object { [char]($_ -bxor 0x33) })
+            $EICAR_STRING = -join ($bytes | % { [char]($_ -bxor 0x33) })
             { Invoke-Expression -Command "echo '$EICAR_STRING'" } |
                 Should -Throw -ErrorId "ScriptContainedMaliciousContent,Microsoft.PowerShell.Commands.InvokeExpressionCommand"
         }


### PR DESCRIPTION
## PR Summary

Now CI-Windows fail after #8546 : correct typo in cmdlet name in AMSI test.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [x] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
