### PR TITLE
Avoid use of mkdir alias in *.ps1 and *.psm1

### DIFF
--- a/src/Modules/Windows/PSDiagnostics/PSDiagnostics.psm1
+++ b/src/Modules/Windows/PSDiagnostics/PSDiagnostics.psm1
@@ -182,7 +182,7 @@ function Enable-PSWSManCombinedTrace
 
     if (!(Test-Path $pshome\Traces))
     {
-        New-Item -ItemType Directory -Force $pshome\Traces | out-null
+        mkdir -Force $pshome\Traces | out-null
     }
 
     if (Test-Path $logfile)

--- a/src/Modules/Windows/PSDiagnostics/PSDiagnostics.psm1
+++ b/src/Modules/Windows/PSDiagnostics/PSDiagnostics.psm1
@@ -182,7 +182,7 @@ function Enable-PSWSManCombinedTrace
 
     if (!(Test-Path $pshome\Traces))
     {
-        mkdir -Force $pshome\Traces | out-null
+        New-Item -ItemType Directory -Force $pshome\Traces | out-null
     }
 
     if (Test-Path $logfile)

--- a/test/powershell/Language/Classes/Scripting.Classes.BasicParsing.Tests.ps1
+++ b/test/powershell/Language/Classes/Scripting.Classes.BasicParsing.Tests.ps1
@@ -301,8 +301,8 @@ Describe 'Negative Parsing Tests' -Tags "CI" {
     ShouldBeParseError 'class C { [int]foo() { try { throw "foo"} catch [ArgumentException] {} catch {throw $_} } }' MethodHasCodePathNotReturn 15
     ShouldBeParseError 'class C { [int]foo() { try { throw "foo"} catch [ArgumentException] {return 1} catch {} } }' MethodHasCodePathNotReturn 15
     ShouldBeParseError 'class C { [int]foo() { while ($false) { return 1 } } }' MethodHasCodePathNotReturn 15
-    ShouldBeParseError 'class C { [int]foo() { try { New-Item -ItemType Directory foo } finally { rm -rec foo } } }' MethodHasCodePathNotReturn 15
-    ShouldBeParseError 'class C { [int]foo() { try { New-Item -ItemType Directory foo; return 1 } catch { } } }' MethodHasCodePathNotReturn 15
+    ShouldBeParseError 'class C { [int]foo() { try { mkdir foo } finally { rm -rec foo } } }' MethodHasCodePathNotReturn 15
+    ShouldBeParseError 'class C { [int]foo() { try { mkdir foo; return 1 } catch { } } }' MethodHasCodePathNotReturn 15
     ShouldBeParseError 'class C { [bool] Test() { if ($false) { return $true; } } }' MethodHasCodePathNotReturn 17
 
     ShouldBeParseError 'class C { [int]$i; [void] foo() {$i = 10} }' MissingThis 33

--- a/test/powershell/Language/Classes/Scripting.Classes.BasicParsing.Tests.ps1
+++ b/test/powershell/Language/Classes/Scripting.Classes.BasicParsing.Tests.ps1
@@ -301,8 +301,8 @@ Describe 'Negative Parsing Tests' -Tags "CI" {
     ShouldBeParseError 'class C { [int]foo() { try { throw "foo"} catch [ArgumentException] {} catch {throw $_} } }' MethodHasCodePathNotReturn 15
     ShouldBeParseError 'class C { [int]foo() { try { throw "foo"} catch [ArgumentException] {return 1} catch {} } }' MethodHasCodePathNotReturn 15
     ShouldBeParseError 'class C { [int]foo() { while ($false) { return 1 } } }' MethodHasCodePathNotReturn 15
-    ShouldBeParseError 'class C { [int]foo() { try { mkdir foo } finally { rm -rec foo } } }' MethodHasCodePathNotReturn 15
-    ShouldBeParseError 'class C { [int]foo() { try { mkdir foo; return 1 } catch { } } }' MethodHasCodePathNotReturn 15
+    ShouldBeParseError 'class C { [int]foo() { try { New-Item -ItemType Directory foo } finally { rm -rec foo } } }' MethodHasCodePathNotReturn 15
+    ShouldBeParseError 'class C { [int]foo() { try { New-Item -ItemType Directory foo; return 1 } catch { } } }' MethodHasCodePathNotReturn 15
     ShouldBeParseError 'class C { [bool] Test() { if ($false) { return $true; } } }' MethodHasCodePathNotReturn 17
 
     ShouldBeParseError 'class C { [int]$i; [void] foo() {$i = 10} }' MissingThis 33

--- a/test/powershell/Language/Scripting/Debugging/DebuggerScriptTests.Tests.ps1
+++ b/test/powershell/Language/Scripting/Debugging/DebuggerScriptTests.Tests.ps1
@@ -498,7 +498,7 @@ Describe "Unit tests for line breakpoints on modules" -Tags "CI" {
         $moduleDirectory = [io.path]::Combine($moduleRoot, $moduleName)
         $moduleFile = [io.path]::Combine($moduleDirectory, $moduleName + ".psm1")
 
-        mkdir $moduleDirectory 2> $null
+        New-Item -ItemType Directory $moduleDirectory 2> $null
 
         write-output '
         function ModuleFunction1

--- a/test/powershell/Language/Scripting/Debugging/DebuggerScriptTests.Tests.ps1
+++ b/test/powershell/Language/Scripting/Debugging/DebuggerScriptTests.Tests.ps1
@@ -498,7 +498,7 @@ Describe "Unit tests for line breakpoints on modules" -Tags "CI" {
         $moduleDirectory = [io.path]::Combine($moduleRoot, $moduleName)
         $moduleFile = [io.path]::Combine($moduleDirectory, $moduleName + ".psm1")
 
-        New-Item -ItemType Directory $moduleDirectory 2> $null
+        mkdir $moduleDirectory 2> $null
 
         write-output '
         function ModuleFunction1

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/ConstrainedLanguageModules.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/ConstrainedLanguageModules.Tests.ps1
@@ -41,7 +41,7 @@ try
 
             $modulePathName = "modulePath_$(Get-Random -Max 9999)"
             $modulePath = Join-Path $testdrive $modulePathName
-            New-Item -ItemType Directory $modulePath
+            mkdir $modulePath
             $trustedModuleFile = Join-Path $modulePath "T1TestModule_System32.psm1"
             $script | Out-File -FilePath $trustedModuleFile
         }
@@ -175,7 +175,7 @@ try
             function PublicFnE {{ "PublicFnE"; PublicDSFnE }}
             function PrivateFnE {{ "PrivateFnE"; PrivateDSFnE }}
 '@ -f $dotSourceFilePathE | Out-File -FilePath $moduleFilePathE
-
+    
             # Module with dot source ps1 file and nested modules that do use Export-ModuleMember
             $scriptModuleNameF = "ModuleDotSourceNestedExport_System32"
             $moduleFilePathF = Join-Path $TestModulePath ($scriptModuleNameF + ".psm1")
@@ -467,7 +467,7 @@ try
                 $module = Import-Module -Name $manifestFileName -Force -PassThru
 
                 & $module PrivateFn
-
+                
                 throw "No Exception!"
             }
             catch
@@ -492,7 +492,7 @@ try
             $modulePath = Join-Path $TestDrive $moduleName
             New-Item -ItemType Directory -Path $modulePath
 
-            # Parent module directory
+            # Parent module directory 
             $scriptModuleName = "TrustedParentModule_System32"
             $scriptModulePath = Join-Path $modulePath $scriptModuleName
             $moduleFileName = Join-Path $scriptModulePath ($scriptModuleName + ".psm1")
@@ -554,7 +554,7 @@ try
 
                 # Private functions should not be available in the session
                 # Get-Command will import the TrustedImportModule_System32 module from the PSModulePath to find PrivateFn1
-                # However, it should not get TrustedImportModule_System32 from the module cache because it was loaded in a
+                # However, it should not get TrustedImportModule_System32 from the module cache because it was loaded in a 
                 # different language mode, and should instead re-load it (equivalent to Import-Module -Force)
                 $GetCommandPrivateFnCmdInfo = Get-Command -Name "PrivateFn1" 2>$null
             }
@@ -581,7 +581,7 @@ try
                 Import-Module -Name $scriptModuleName -Force
 
                 # Directly import nested TrustedImportModule_System32 module.
-                # This makes TrustedImportModule_System32 functions visible but should not use the existing loaded module
+                # This makes TrustedImportModule_System32 functions visible but should not use the existing loaded module 
                 # since all functions are visible, but instead should re-load the module with the correct language context,
                 # ensuring only explictly exported functions are visible.
                 Import-Module -Name $scriptModuleImportName
@@ -631,8 +631,8 @@ try
                 Import-Module -Name $manifestFileName -Force -ErrorAction Stop
                 throw "No Exception!"
             }
-            catch
-            {
+            catch 
+            { 
                 $expectedError = $_
             }
             finally

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/ConstrainedLanguageModules.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/ConstrainedLanguageModules.Tests.ps1
@@ -41,7 +41,7 @@ try
 
             $modulePathName = "modulePath_$(Get-Random -Max 9999)"
             $modulePath = Join-Path $testdrive $modulePathName
-            mkdir $modulePath
+            New-Item -ItemType Directory $modulePath
             $trustedModuleFile = Join-Path $modulePath "T1TestModule_System32.psm1"
             $script | Out-File -FilePath $trustedModuleFile
         }
@@ -175,7 +175,7 @@ try
             function PublicFnE {{ "PublicFnE"; PublicDSFnE }}
             function PrivateFnE {{ "PrivateFnE"; PrivateDSFnE }}
 '@ -f $dotSourceFilePathE | Out-File -FilePath $moduleFilePathE
-    
+
             # Module with dot source ps1 file and nested modules that do use Export-ModuleMember
             $scriptModuleNameF = "ModuleDotSourceNestedExport_System32"
             $moduleFilePathF = Join-Path $TestModulePath ($scriptModuleNameF + ".psm1")
@@ -467,7 +467,7 @@ try
                 $module = Import-Module -Name $manifestFileName -Force -PassThru
 
                 & $module PrivateFn
-                
+
                 throw "No Exception!"
             }
             catch
@@ -492,7 +492,7 @@ try
             $modulePath = Join-Path $TestDrive $moduleName
             New-Item -ItemType Directory -Path $modulePath
 
-            # Parent module directory 
+            # Parent module directory
             $scriptModuleName = "TrustedParentModule_System32"
             $scriptModulePath = Join-Path $modulePath $scriptModuleName
             $moduleFileName = Join-Path $scriptModulePath ($scriptModuleName + ".psm1")
@@ -554,7 +554,7 @@ try
 
                 # Private functions should not be available in the session
                 # Get-Command will import the TrustedImportModule_System32 module from the PSModulePath to find PrivateFn1
-                # However, it should not get TrustedImportModule_System32 from the module cache because it was loaded in a 
+                # However, it should not get TrustedImportModule_System32 from the module cache because it was loaded in a
                 # different language mode, and should instead re-load it (equivalent to Import-Module -Force)
                 $GetCommandPrivateFnCmdInfo = Get-Command -Name "PrivateFn1" 2>$null
             }
@@ -581,7 +581,7 @@ try
                 Import-Module -Name $scriptModuleName -Force
 
                 # Directly import nested TrustedImportModule_System32 module.
-                # This makes TrustedImportModule_System32 functions visible but should not use the existing loaded module 
+                # This makes TrustedImportModule_System32 functions visible but should not use the existing loaded module
                 # since all functions are visible, but instead should re-load the module with the correct language context,
                 # ensuring only explictly exported functions are visible.
                 Import-Module -Name $scriptModuleImportName
@@ -631,8 +631,8 @@ try
                 Import-Module -Name $manifestFileName -Force -ErrorAction Stop
                 throw "No Exception!"
             }
-            catch 
-            { 
+            catch
+            {
                 $expectedError = $_
             }
             finally

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/ConstrainedLanguageRestriction.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/ConstrainedLanguageRestriction.Tests.ps1
@@ -27,13 +27,13 @@ try
 
             $trustedModuleName1 = "TrustedModule$(Get-Random -Max 999)_System32"
             $trustedModulePath1 = Join-Path $TestDrive $trustedModuleName1
-            mkdir $trustedModulePath1
+            New-Item -ItemType Directory $trustedModulePath1
             $trustedModuleFilePath1 = Join-Path $trustedModulePath1 ($trustedModuleName1 + ".psm1")
             $trustedModuleManifestPath1 = Join-Path $trustedModulePath1 ($trustedModuleName1 + ".psd1")
 
             $trustedModuleName2 = "TrustedModule$(Get-Random -Max 999)_System32"
             $trustedModulePath2 = Join-Path $TestDrive $trustedModuleName2
-            mkdir $trustedModulePath2
+            New-Item -ItemType Directory $trustedModulePath2
             $trustedModuleFilePath2 = Join-Path $trustedModulePath2 ($trustedModuleName2 + ".psm1")
 
             $trustedModuleScript1 = @'

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/ConstrainedLanguageRestriction.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/ConstrainedLanguageRestriction.Tests.ps1
@@ -27,13 +27,13 @@ try
 
             $trustedModuleName1 = "TrustedModule$(Get-Random -Max 999)_System32"
             $trustedModulePath1 = Join-Path $TestDrive $trustedModuleName1
-            New-Item -ItemType Directory $trustedModulePath1
+            mkdir $trustedModulePath1
             $trustedModuleFilePath1 = Join-Path $trustedModulePath1 ($trustedModuleName1 + ".psm1")
             $trustedModuleManifestPath1 = Join-Path $trustedModulePath1 ($trustedModuleName1 + ".psd1")
 
             $trustedModuleName2 = "TrustedModule$(Get-Random -Max 999)_System32"
             $trustedModulePath2 = Join-Path $TestDrive $trustedModuleName2
-            New-Item -ItemType Directory $trustedModulePath2
+            mkdir $trustedModulePath2
             $trustedModuleFilePath2 = Join-Path $trustedModulePath2 ($trustedModuleName2 + ".psm1")
 
             $trustedModuleScript1 = @'


### PR DESCRIPTION
## PR Summary

Follow-up to #8546

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
- **Testing - New and feature**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [x] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
