### PR TITLE
Correctly capitalize the ForEach operator in *.ps1

### DIFF
--- a/test/powershell/Modules/Microsoft.PowerShell.Security/ConstrainedLanguageRestriction.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/ConstrainedLanguageRestriction.Tests.ps1
@@ -858,16 +858,16 @@ try
                     }
                 )
 
-                $result = $data.foreach('value1')
+                $result = $data.ForEach('value1')
                 Write-Output $result
 
-                # Execute method in scriptblock of foreach operator, should throw in ConstrainedLanguage mode.
-                $data.foreach{[system.io.path]::GetRandomFileName().Length}
+                # Execute method in scriptblock of ForEach operator, should throw in ConstrainedLanguage mode.
+                $data.ForEach{[system.io.path]::GetRandomFileName().Length}
 '@
 
             $script3 = @'
             # Method call should throw error.
-            (Get-Process powershell*).Foreach('GetHashCode')
+            (Get-Process powershell*).ForEach('GetHashCode')
 '@
 
             $script4 = @'

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Join-String.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Join-String.Tests.ps1
@@ -37,19 +37,19 @@ Describe "Join-String" -Tags "CI" {
     }
 
     It "Should join property values SingleQuoted" {
-        $expected = ($testObject.Name).Foreach{"'$_'"} -join "; "
+        $expected = ($testObject.Name).ForEach{"'$_'"} -join "; "
         $actual = $testObject | Join-String -Property Name -Separator "; " -SingleQuote
         $actual | Should -BeExactly $expected
     }
 
     It "Should join property values DoubleQuoted" {
-        $expected = ($testObject.Name).Foreach{"""$_"""} -join "; "
+        $expected = ($testObject.Name).ForEach{"""$_"""} -join "; "
         $actual = $testObject | Join-String -Property Name -Separator "; " -DoubleQuote
         $actual | Should -BeExactly $expected
     }
 
     It "Should join property values Formatted" {
-        $expected = ($testObject.Name).Foreach{"[$_]"} -join "; "
+        $expected = ($testObject.Name).ForEach{"[$_]"} -join "; "
         $actual = $testObject | Join-String -Property Name -Separator "; " -Format "[{0}]"
         $actual | Should -BeExactly $expected
     }
@@ -70,20 +70,20 @@ Describe "Join-String" -Tags "CI" {
 
     It "Should join script block results SingleQuoted" {
         $sb = {$_.Name + $_.Length}
-        $expected = ($testObject | ForEach-Object $sb).Foreach{"'$_'"} -join $ofs
+        $expected = ($testObject | ForEach-Object $sb).ForEach{"'$_'"} -join $ofs
         $actual = $testObject | Join-String -Property $sb -SingleQuote
         $actual | Should -BeExactly $expected
     }
     It "Should join script block results DoubleQuoted" {
         $sb = {$_.Name + $_.Length}
-        $expected = ($testObject | ForEach-Object $sb).Foreach{"""$_"""} -join $ofs
+        $expected = ($testObject | ForEach-Object $sb).ForEach{"""$_"""} -join $ofs
         $actual = $testObject | Join-String -Property $sb -DoubleQuote
         $actual | Should -BeExactly $expected
     }
 
     It "Should join script block results with Format and separator" {
         $sb = {$_.Name + $_.Length}
-        $expected = ($testObject | ForEach-Object $sb).Foreach{"[{0}]" -f $_} -join "; "
+        $expected = ($testObject | ForEach-Object $sb).ForEach{"[{0}]" -f $_} -join "; "
         $actual = $testObject | Join-String -Property $sb -Separator "; " -Format "[{0}]"
         $actual | Should -BeExactly $expected
     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Measure-Object.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Measure-Object.Tests.ps1
@@ -411,7 +411,7 @@ Describe "Measure-Object DRT basic functionality" -Tags "CI" {
     }
 
     It "Test-PropertyExpression function with a wildcard property expression should sum numbers" {
-        $result = (1..10).foreach{@{value = $_}} | Test-PSPropertyExpression val*
+        $result = (1..10).ForEach{@{value = $_}} | Test-PSPropertyExpression val*
         $result | Should -Be 55
     }
 
@@ -484,7 +484,7 @@ Describe "Directly test the PSPropertyExpression type" -Tags "CI" {
     }
 
     It "Test-PropertyExpression function with a wildcard property expression should sum numbers" {
-        $result = (1..10).foreach{@{value = $_}} | Test-PSPropertyExpression val*
+        $result = (1..10).ForEach{@{value = $_}} | Test-PSPropertyExpression val*
         $result | Should -Be 55
     }
 
@@ -558,7 +558,7 @@ Describe "Directly test the PSPropertyExpression type" -Tags "CI" {
     }
 
     It "Test-PropertyExpression function with a wildcard property expression should sum numbers" {
-        $result = (1..10).foreach{@{value = $_}} | Test-PSPropertyExpression val*
+        $result = (1..10).ForEach{@{value = $_}} | Test-PSPropertyExpression val*
         $result | Should -Be 55
     }
 
@@ -631,7 +631,7 @@ Describe "Directly test the PSPropertyExpression type" -Tags "CI" {
     }
 
     It "Test-PropertyExpression function with a wildcard property expression should sum numbers" {
-        $result = (1..10).foreach{@{value = $_}} | Test-PSPropertyExpression val*
+        $result = (1..10).ForEach{@{value = $_}} | Test-PSPropertyExpression val*
         $result | Should -Be 55
     }
 

--- a/test/powershell/engine/ETS/Adapter.Tests.ps1
+++ b/test/powershell/engine/ETS/Adapter.Tests.ps1
@@ -174,7 +174,7 @@ Describe "Adapter Tests" -tags "CI" {
             $x.Count | Should -Be 1
             $x[0].foo | Should -BeExactly "bar"
 
-            $x = ([pscustomobject]@{ foo = 'bar' }).Foreach({$_ | Add-Member -NotePropertyName "foo2" -NotePropertyValue "bar2" -PassThru})
+            $x = ([pscustomobject]@{ foo = 'bar' }).ForEach({$_ | Add-Member -NotePropertyName "foo2" -NotePropertyValue "bar2" -PassThru})
             $x.Count | Should -Be 1
             $x[0].foo | Should -BeExactly "bar"
             $x[0].foo2 | Should -BeExactly "bar2"


### PR DESCRIPTION
## PR Summary

Correctly capitalize the ForEach operator.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
- **Testing - New and feature**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [x] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
