### PR TITLE
New-Object ErrorHandling fix #8580

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/new-object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/new-object.cs
@@ -165,7 +165,7 @@ namespace Microsoft.PowerShell.Commands
                                 "TypeNotFound",
                                 ErrorCategory.InvalidType,
                                 targetObject: null));
-                                return ;
+                                return;
                     }
 
                     throw e;

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/new-object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/new-object.cs
@@ -165,7 +165,7 @@ namespace Microsoft.PowerShell.Commands
                                 "TypeNotFound",
                                 ErrorCategory.InvalidType,
                                 targetObject: null));
-                                return;
+                            return;
                     }
 
                     throw e;

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/new-object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/new-object.cs
@@ -159,12 +159,13 @@ namespace Microsoft.PowerShell.Commands
                             NewObjectStrings.TypeNotFound,
                             TypeName);
 
-                        ThrowTerminatingError(
+                        WriteError(
                             new ErrorRecord(
                                 mshArgE,
                                 "TypeNotFound",
                                 ErrorCategory.InvalidType,
                                 targetObject: null));
+                                return ;
                     }
 
                     throw e;

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/New-Object.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/New-Object.Tests.ps1
@@ -88,6 +88,10 @@ Describe "New-Object DRT basic functionality" -Tags "CI" {
         $e.CategoryInfo | Should -Match "PSArgumentException"
     }
 
+    It "New-Object with invalid type and ErrorAction Ignore should not throw Exception"{
+        { New-Object -TypeName LiarType -ErrorAction Ignore } | Should -Not -Throw
+    }
+
     It "New-Object with invalid argument should throw Exception"{
         $e = { New-Object -TypeName System.Management.Automation.PSVariable -ArgumentList "A", 1, None, "asd" -ErrorAction Stop } |
 	        Should -Throw -ErrorId "ConstructorInvokedThrowException,Microsoft.PowerShell.Commands.NewObjectCommand" -PassThru


### PR DESCRIPTION
## PR Summary

Fix #8580.

New-Object ErrorHandling fix for issue #8580

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [x] Issue filed - Issue link: https://github.com/PowerShell/PowerShell/issues/8580
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
