### PR TITLE
Format-Hex: Handle all primitive types & better array input handling

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/format-hex/Format-Hex.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/FormatAndOutput/format-hex/Format-Hex.cs
@@ -26,7 +26,7 @@ namespace Microsoft.PowerShell.Commands
 
         /// <summary>
         /// For cases where a homogenous collection of bytes or other items are directly piped in, we collect all the
-        /// bytes in a List&lt;byte&gt; and then output the formatted result all at once in EndProcessing()
+        /// bytes in a List&lt;byte&gt; and then output the formatted result all at once in EndProcessing().
         /// </summary>
         private List<byte> _inputBytes;
 
@@ -44,14 +44,14 @@ namespace Microsoft.PowerShell.Commands
         #region Parameters
 
         /// <summary>
-        /// Path of file(s) to process.
+        /// Gets or sets the path of file(s) to process.
         /// </summary>
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "Path")]
         [ValidateNotNullOrEmpty]
         public string[] Path { get; set; }
 
         /// <summary>
-        /// Literal path of file to process.
+        /// Gets or sets the literal path of file to process.
         /// </summary>
         [Parameter(Mandatory = true, ParameterSetName = "LiteralPath", ValueFromPipelineByPropertyName = true)]
         [ValidateNotNullOrEmpty]
@@ -59,13 +59,13 @@ namespace Microsoft.PowerShell.Commands
         public string[] LiteralPath { get; set; }
 
         /// <summary>
-        /// Object to process.
+        /// Gets or sets the pipeline object to process.
         /// </summary>
         [Parameter(Mandatory = true, ParameterSetName = "ByInputObject", ValueFromPipeline = true)]
         public PSObject InputObject { get; set; }
 
         /// <summary>
-        /// Type of character encoding for InputObject.
+        /// Gets or sets the type of character encoding for InputObject.
         /// </summary>
         [Parameter(ParameterSetName = "ByInputObject")]
         [ArgumentToEncodingTransformationAttribute]
@@ -78,17 +78,17 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         [Parameter]
         [ValidateRange(ValidateRangeKind.Positive)]
-        public Int64 Count { get; set; } = Int64.MaxValue;
+        public long Count { get; set; } = long.MaxValue;
 
         /// <summary>
         /// Gets or sets offset of bytes to start reading the input stream from.
         /// </summary>
         [Parameter]
         [ValidateRange(ValidateRangeKind.NonNegative)]
-        public Int64 Offset { get; set; }
+        public long Offset { get; set; }
 
         /// <summary>
-        /// This parameter is no-op.
+        /// Gets or sets whether the file input should be swallowed as is. This parameter is no-op, deprecated.
         /// </summary>
         [Parameter(ParameterSetName = "ByInputObject", DontShow = true)]
         [Obsolete("Raw parameter is deprecated.", true)]
@@ -117,7 +117,7 @@ namespace Microsoft.PowerShell.Commands
         }
 
         /// <summary>
-        /// Implements the EndProcessing method for the FormatHex command
+        /// Implements the EndProcessing method for the FormatHex command.
         /// </summary>
         protected override void EndProcessing()
         {
@@ -145,9 +145,9 @@ namespace Microsoft.PowerShell.Commands
         /// If path is a literal path it is added to the array to process; we cannot validate them until we
         /// try to process file contents.
         /// </summary>
-        /// <param name="path"></param>
-        /// <param name="literalPath"></param>
-        /// <returns></returns>
+        /// <param name="path">The file path to resolve.</param>
+        /// <param name="literalPath">Indicates whether the path is to be resolved as literal or may have wildcards.</param>
+        /// <returns>Returns a list of resolved paths.</returns>
         private List<string> ResolvePaths(string[] path, bool literalPath)
         {
             List<string> pathsToProcess = new List<string>();
@@ -183,10 +183,11 @@ namespace Microsoft.PowerShell.Commands
                 {
                     // Write a non-terminating error message indicating that path specified is not supported.
                     string errorMessage = StringUtil.Format(UtilityCommonStrings.FormatHexOnlySupportsFileSystemPaths, currentPath);
-                    ErrorRecord errorRecord = new ErrorRecord(new ArgumentException(errorMessage),
-                                                                "FormatHexOnlySupportsFileSystemPaths",
-                                                                ErrorCategory.InvalidArgument,
-                                                                currentPath);
+                    ErrorRecord errorRecord = new ErrorRecord(
+                        new ArgumentException(errorMessage),
+                        "FormatHexOnlySupportsFileSystemPaths",
+                        ErrorCategory.InvalidArgument,
+                        currentPath);
                     WriteError(errorRecord);
                     continue;
                 }
@@ -200,7 +201,7 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Pass each valid path on to process its contents.
         /// </summary>
-        /// <param name="pathsToProcess"></param>
+        /// <param name="pathsToProcess">The paths to process.</param>
         private void ProcessPath(List<string> pathsToProcess)
         {
             foreach (string path in pathsToProcess)
@@ -213,7 +214,7 @@ namespace Microsoft.PowerShell.Commands
         /// Creates a binary reader that reads the file content into a buffer (byte[]) 16 bytes at a time, and
         /// passes a copy of that array on to the WriteHexidecimal method to output.
         /// </summary>
-        /// <param name="path"></param>
+        /// <param name="path">The file path to retrieve content from for processing.</param>
         private void ProcessFileContent(string path)
         {
             Span<byte> buffer = stackalloc byte[BUFFERSIZE];
@@ -222,9 +223,9 @@ namespace Microsoft.PowerShell.Commands
             {
                 using (BinaryReader reader = new BinaryReader(File.Open(path, FileMode.Open, FileAccess.Read, FileShare.Read)))
                 {
-                    Int64 offset = Offset;
-                    Int32 bytesRead = 0;
-                    Int64 count = 0;
+                    long offset = Offset;
+                    int bytesRead = 0;
+                    long count = 0;
 
                     reader.BaseStream.Position = Offset;
 
@@ -244,10 +245,10 @@ namespace Microsoft.PowerShell.Commands
                     }
                 }
             }
-            catch (IOException ioException)
+            catch (IOException fileException)
             {
                 // IOException takes care of FileNotFoundException, DirectoryNotFoundException, and PathTooLongException
-                WriteError(new ErrorRecord(ioException, "FormatHexIOError", ErrorCategory.WriteError, path));
+                WriteError(new ErrorRecord(fileException, "FormatHexIOError", ErrorCategory.WriteError, path));
             }
             catch (ArgumentException argException)
             {
@@ -271,7 +272,7 @@ namespace Microsoft.PowerShell.Commands
         /// Creates a byte array from the object passed to the cmdlet (based on type) and passes
         /// that array on to the WriteHexidecimal method to output.
         /// </summary>
-        /// <param name="inputObject"></param>
+        /// <param name="inputObject">The pipeline input object being processed.</param>
         private void ProcessObjectContent(PSObject inputObject)
         {
             dynamic baseObject = inputObject.BaseObject;
@@ -467,15 +468,15 @@ namespace Microsoft.PowerShell.Commands
         /// <param name="inputBytes">Bytes for the hexadecimial representaion.</param>
         /// <param name="path">File path.</param>
         /// <param name="offset">Offset in the file.</param>
-        private void WriteHexadecimal(Span<byte> inputBytes, string path, Int64 offset)
+        private void WriteHexadecimal(Span<byte> inputBytes, string path, long offset)
         {
-            ByteCollection byteCollectionObject = new ByteCollection((UInt64)offset, inputBytes.ToArray(), path);
+            ByteCollection byteCollectionObject = new ByteCollection((ulong)offset, inputBytes.ToArray(), path);
             WriteObject(byteCollectionObject);
         }
 
-        private void WriteHexadecimal(byte[] inputBytes, string path, Int64 offset)
+        private void WriteHexadecimal(byte[] inputBytes, string path, long offset)
         {
-            ByteCollection byteCollectionObject = new ByteCollection((UInt64)offset, inputBytes, path);
+            ByteCollection byteCollectionObject = new ByteCollection((ulong)offset, inputBytes, path);
             WriteObject(byteCollectionObject);
         }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/FormatHex.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/FormatHex.Tests.ps1
@@ -113,16 +113,16 @@ public enum TestSByteEnum : sbyte {
                 ExpectedResult = "00000000000000000000   68 65 6C 6C 6F 20 77 6F 72 6C 64                 hello world"
             }
             @{
-                Name                 = "Can process PS-native enum array '[TestEnum[]]('TestOne', 'TestTwo', 'TestThree', 'TestFour') | fhx'"
-                InputObject          = [TestEnum[]]('TestOne', 'TestTwo', 'TestThree', 'TestFour')
-                Count                = 1
-                ExpectedResult       = "00000000000000000000   01 00 00 00 02 00 00 00 03 00 00 00 04 00 00 00  ................"
+                Name           = "Can process PS-native enum array '[TestEnum[]]('TestOne', 'TestTwo', 'TestThree', 'TestFour') | fhx'"
+                InputObject    = [TestEnum[]]('TestOne', 'TestTwo', 'TestThree', 'TestFour')
+                Count          = 1
+                ExpectedResult = "00000000000000000000   01 00 00 00 02 00 00 00 03 00 00 00 04 00 00 00  ................"
             }
             @{
-                Name                 = "Can process C#-native sbyte enum array '[TestSByteEnum[]]('One', 'Two', 'Three', 'Four') | fhx'"
-                InputObject          = [TestSByteEnum[]]('One', 'Two', 'Three', 'Four')
-                Count                = 1
-                ExpectedResult       = "00000000000000000000   FF FE FD FC                                      .þýü"
+                Name           = "Can process C#-native sbyte enum array '[TestSByteEnum[]]('One', 'Two', 'Three', 'Four') | fhx'"
+                InputObject    = [TestSByteEnum[]]('One', 'Two', 'Three', 'Four')
+                Count          = 1
+                ExpectedResult = "00000000000000000000   FF FE FD FC                                      .þýü"
             }
         )
 
@@ -216,16 +216,16 @@ public enum TestSByteEnum : sbyte {
                 ExpectedSecondResult = "00000000000000000000   01 02 03 04 05 06                                ......"
             }
             @{
-                Name                 = "Can process PS-native enum array '[TestEnum[]]('TestOne', 'TestTwo', 'TestThree', 'TestFour') | fhx'"
-                InputObject          = [TestEnum[]]('TestOne', 'TestTwo', 'TestThree', 'TestFour')
-                Count                = 1
-                ExpectedResult       = "00000000000000000000   01 00 00 00 02 00 00 00 03 00 00 00 04 00 00 00  ................"
+                Name           = "Can process PS-native enum array '[TestEnum[]]('TestOne', 'TestTwo', 'TestThree', 'TestFour') | fhx'"
+                InputObject    = [TestEnum[]]('TestOne', 'TestTwo', 'TestThree', 'TestFour')
+                Count          = 1
+                ExpectedResult = "00000000000000000000   01 00 00 00 02 00 00 00 03 00 00 00 04 00 00 00  ................"
             }
             @{
-                Name                 = "Can process C#-native sbyte enum array '[TestSByteEnum[]]('One', 'Two', 'Three', 'Four') | fhx'"
-                InputObject          = [TestSByteEnum[]]('One', 'Two', 'Three', 'Four')
-                Count                = 1
-                ExpectedResult       = "00000000000000000000   FF FE FD FC                                      .þýü"
+                Name           = "Can process C#-native sbyte enum array '[TestSByteEnum[]]('One', 'Two', 'Three', 'Four') | fhx'"
+                InputObject    = [TestSByteEnum[]]('One', 'Two', 'Three', 'Four')
+                Count          = 1
+                ExpectedResult = "00000000000000000000   FF FE FD FC                                      .þýü"
             }
         )
 
@@ -294,7 +294,8 @@ public enum TestSByteEnum : sbyte {
 
             if ($PathCase) {
                 $result = Format-Hex -Path $Path
-            } else {
+            }
+            else {
                 # LiteralPath
                 $result = Format-Hex -LiteralPath $Path
             }
@@ -313,7 +314,12 @@ public enum TestSByteEnum : sbyte {
             $FileObject = Get-Item -Path $FilePath
 
             $result = $FileObject | Format-Hex
-            $ExpectedResult = "00000000000000000000   48 65 6C 6C 6F 20 57 6F 72 6C 64 21 0D 0A        Hello World!.."
+            if ($IsWindows) {
+                $ExpectedResult = "00000000000000000000   48 65 6C 6C 6F 20 57 6F 72 6C 64 21 0D 0A        Hello World!.."
+            }
+            else {
+                $ExpectedResult = "00000000000000000000   48 65 6C 6C 6F 20 57 6F 72 6C 64 21 0A           Hello World!."
+            }
 
             $result[0].ToString() | Should -MatchExactly $ExpectedResult
         }
@@ -437,7 +443,8 @@ public enum TestSByteEnum : sbyte {
 
             if ($PathCase) {
                 $output = Format-Hex -Path $InvalidPath, $inputFile1 -ErrorVariable errorThrown -ErrorAction SilentlyContinue
-            } else {
+            }
+            else {
                 # LiteralPath
                 $output = Format-Hex -LiteralPath $InvalidPath, $inputFile1 -ErrorVariable errorThrown -ErrorAction SilentlyContinue
             }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/FormatHex.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/FormatHex.Tests.ps1
@@ -34,8 +34,7 @@ Describe "FormatHex" -tags "CI" {
         $thumbprint = $null
         $certProviderAvailable = $false
 
-        if ($certificateProvider.Count -gt 0)
-        {
+        if ($certificateProvider.Count -gt 0) {
             $thumbprint = $certificateProvider[0].Thumbprint
             $certProviderAvailable = $true
         }
@@ -44,64 +43,90 @@ Describe "FormatHex" -tags "CI" {
     }
 
     Context "InputObject Paramater" {
+        BeforeAll {
+            enum TestEnum {
+                TestOne = 1; TestTwo = 2; TestThree = 3; TestFour = 4
+            }
+            Add-Type -TypeDefinition @'
+public enum TestSByteEnum : sbyte {
+    One   = -1,
+    Two   = -2,
+    Three = -3,
+    Four  = -4
+}
+'@
+        }
+
         $testCases = @(
             @{
-                Name = "Can process byte type 'fhx -InputObject [byte]5'"
-                InputObject = [byte]5
-                Count = 1
+                Name           = "Can process byte type 'fhx -InputObject [byte]5'"
+                InputObject    = [byte]5
+                Count          = 1
                 ExpectedResult = "00000000   05"
             }
             @{
-                Name = "Can process byte[] type 'fhx -InputObject [byte[]](1,2,3,4,5)'"
-                InputObject = [byte[]](1,2,3,4,5)
-                Count = 1
+                Name           = "Can process byte[] type 'fhx -InputObject [byte[]](1,2,3,4,5)'"
+                InputObject    = [byte[]](1, 2, 3, 4, 5)
+                Count          = 1
                 ExpectedResult = "00000000   01 02 03 04 05                                   ....."
             }
             @{
-                Name = "Can process int type 'fhx -InputObject 7'"
-                InputObject = 7
-                Count = 1
+                Name           = "Can process int type 'fhx -InputObject 7'"
+                InputObject    = 7
+                Count          = 1
                 ExpectedResult = "00000000   07 00 00 00                                      ...."
             }
             @{
-                Name = "Can process int[] type 'fhx -InputObject [int[]](5,6,7,8)'"
-                InputObject = [int[]](5,6,7,8)
-                Count = 1
+                Name           = "Can process int[] type 'fhx -InputObject [int[]](5,6,7,8)'"
+                InputObject    = [int[]](5, 6, 7, 8)
+                Count          = 1
                 ExpectedResult = "00000000   05 00 00 00 06 00 00 00 07 00 00 00 08 00 00 00  ................"
             }
             @{
-                Name = "Can process int32 type 'fhx -InputObject [int32]2032'"
-                InputObject = [int32]2032
-                Count = 1
+                Name           = "Can process int32 type 'fhx -InputObject [int32]2032'"
+                InputObject    = [int32]2032
+                Count          = 1
                 ExpectedResult = "00000000   F0 07 00 00                                      ð..."
             }
             @{
-                Name = "Can process int32[] type 'fhx -InputObject [int32[]](2032, 2033, 2034)'"
-                InputObject = [int32[]](2032, 2033, 2034)
-                Count = 1
+                Name           = "Can process int32[] type 'fhx -InputObject [int32[]](2032, 2033, 2034)'"
+                InputObject    = [int32[]](2032, 2033, 2034)
+                Count          = 1
                 ExpectedResult = "00000000000000000000   F0 07 00 00 F1 07 00 00 F2 07 00 00              ð...ñ...ò..."
             }
             @{
-                Name = "Can process Int64 type 'fhx -InputObject [Int64]9223372036854775807'"
-                InputObject = [Int64]9223372036854775807
-                Count = 1
+                Name           = "Can process Int64 type 'fhx -InputObject [Int64]9223372036854775807'"
+                InputObject    = [Int64]9223372036854775807
+                Count          = 1
                 ExpectedResult = "00000000000000000000   FF FF FF FF FF FF FF 7F                          ......."
             }
             @{
-                Name = "Can process Int64[] type 'fhx -InputObject [Int64[]](9223372036852,9223372036853)'"
-                InputObject = [Int64[]](9223372036852,9223372036853)
-                Count = 1
+                Name           = "Can process Int64[] type 'fhx -InputObject [Int64[]](9223372036852,9223372036853)'"
+                InputObject    = [Int64[]](9223372036852, 9223372036853)
+                Count          = 1
                 ExpectedResult = "00000000000000000000   F4 5A D0 7B 63 08 00 00 F5 5A D0 7B 63 08 00 00  ôZÐ{c...õZÐ{c..."
             }
             @{
-                Name = "Can process string type 'fhx -InputObject hello world'"
-                InputObject = "hello world"
-                Count = 1
+                Name           = "Can process string type 'fhx -InputObject hello world'"
+                InputObject    = "hello world"
+                Count          = 1
                 ExpectedResult = "00000000000000000000   68 65 6C 6C 6F 20 77 6F 72 6C 64                 hello world"
+            }
+            @{
+                Name                 = "Can process PS-native enum array '[TestEnum[]]('TestOne', 'TestTwo', 'TestThree', 'TestFour') | fhx'"
+                InputObject          = [TestEnum[]]('TestOne', 'TestTwo', 'TestThree', 'TestFour')
+                Count                = 1
+                ExpectedResult       = "00000000000000000000   01 00 00 00 02 00 00 00 03 00 00 00 04 00 00 00  ................"
+            }
+            @{
+                Name                 = "Can process C#-native sbyte enum array '[TestSByteEnum[]]('One', 'Two', 'Three', 'Four') | fhx'"
+                InputObject          = [TestSByteEnum[]]('One', 'Two', 'Three', 'Four')
+                Count                = 1
+                ExpectedResult       = "00000000000000000000   FF FE FD FC                                      .þýü"
             }
         )
 
-        It "<Name>" -TestCase $testCases{
+        It "<Name>" -TestCase $testCases {
 
             param ($Name, $InputObject, $Count, $ExpectedResult)
 
@@ -114,64 +139,93 @@ Describe "FormatHex" -tags "CI" {
     }
 
     Context "InputObject From Pipeline" {
+        BeforeAll {
+            enum TestEnum {
+                TestOne = 1; TestTwo = 2; TestThree = 3; TestFour = 4
+            }
+            Add-Type -TypeDefinition @'
+public enum TestSByteEnum : sbyte {
+    One   = -1,
+    Two   = -2,
+    Three = -3,
+    Four  = -4
+}
+'@
+        }
+
         $testCases = @(
             @{
-                Name = "Can process byte type '[byte]5 | fhx'"
-                InputObject = [byte]5
-                Count = 1
+                Name           = "Can process byte type '[byte]5 | fhx'"
+                InputObject    = [byte]5
+                Count          = 1
                 ExpectedResult = "00000000000000000000   05"
             }
             @{
-                Name = "Can process byte[] type '[byte[]](1,2) | fhx'"
-                InputObject = [byte[]](1,2)
-                Count = 2
-                ExpectedResult = "00000000000000000000   01                                               ."
-                ExpectedSecondResult = "00000000000000000000   02                                               ."
+                Name           = "Can process byte[] type '[byte[]](1,2) | fhx'"
+                InputObject    = [byte[]](1, 2)
+                Count          = 1
+                ExpectedResult = "00000000000000000000   01 02                                            .."
             }
             @{
-                Name = "Can process int type '7 | fhx'"
-                InputObject = 7
-                Count = 1
+                Name           = "Can process int type '7 | fhx'"
+                InputObject    = 7
+                Count          = 1
                 ExpectedResult = "00000000000000000000   07 00 00 00                                      ...."
             }
             @{
-                Name = "Can process int[] type '[int[]](5,6) | fhx'"
-                InputObject = [int[]](5,6)
-                Count = 2
-                ExpectedResult = "00000000000000000000   05 00 00 00                                      ...."
-                ExpectedSecondResult = "00000000000000000000   06 00 00 00                                      ...."
+                Name           = "Can process int[] type '[int[]](5,6) | fhx'"
+                InputObject    = [int[]](5, 6)
+                Count          = 1
+                ExpectedResult = "00000000000000000000   05 00 00 00 06 00 00 00                          ........"
             }
             @{
-                Name = "Can process int32 type '[int32]2032 | fhx'"
-                InputObject = [int32]2032
-                Count = 1
+                Name           = "Can process int32 type '[int32]2032 | fhx'"
+                InputObject    = [int32]2032
+                Count          = 1
                 ExpectedResult = "00000000000000000000   F0 07 00 00                                      ð..."
             }
             @{
-                Name = "Can process int32[] type '[int32[]](2032, 2033) | fhx'"
-                InputObject = [int32[]](2032, 2033)
-                Count = 2
-                ExpectedResult = "00000000000000000000   F0 07 00 00                                      ð..."
-                ExpectedSecondResult = "00000000000000000000   F1 07 00 00                                      ñ..."
+                Name           = "Can process int32[] type '[int32[]](2032, 2033) | fhx'"
+                InputObject    = [int32[]](2032, 2033)
+                Count          = 1
+                ExpectedResult = "00000000000000000000   F0 07 00 00 F1 07 00 00                          ð...ñ..."
             }
             @{
-                Name = "Can process Int64 type '[Int64]9223372036854775807 | fhx'"
-                InputObject = [Int64]9223372036854775807
-                Count = 1
+                Name           = "Can process Int64 type '[Int64]9223372036854775807 | fhx'"
+                InputObject    = [Int64]9223372036854775807
+                Count          = 1
                 ExpectedResult = "00000000000000000000   FF FF FF FF FF FF FF 7F                          ......."
             }
             @{
-                Name = "Can process Int64[] type '[Int64[]](9223372036852,9223372036853) | fhx'"
-                InputObject = [Int64[]](9223372036852,9223372036853)
-                Count = 2
-                ExpectedResult = "00000000000000000000   F4 5A D0 7B 63 08 00 00                          ôZÐ{c..."
-                ExpectedSecondResult = "00000000000000000000   F5 5A D0 7B 63 08 00 00                          õZÐ{c..."
+                Name           = "Can process Int64[] type '[Int64[]](9223372036852,9223372036853) | fhx'"
+                InputObject    = [Int64[]](9223372036852, 9223372036853)
+                Count          = 1
+                ExpectedResult = "00000000000000000000   F4 5A D0 7B 63 08 00 00 F5 5A D0 7B 63 08 00 00  ôZÐ{c...õZÐ{c..."
             }
             @{
-                Name = "Can process string type 'hello world | fhx'"
-                InputObject = "hello world"
-                Count = 1
+                Name           = "Can process string type 'hello world | fhx'"
+                InputObject    = "hello world"
+                Count          = 1
                 ExpectedResult = "00000000000000000000   68 65 6C 6C 6F 20 77 6F 72 6C 64                 hello world"
+            }
+            @{
+                Name                 = "Can process jagged array type '[sbyte[]](-15, 18, 21, -5), [byte[]](1, 2, 3, 4, 5, 6) | fhx'"
+                InputObject          = [sbyte[]](-15, 18, 21, -5), [byte[]](1, 2, 3, 4, 5, 6)
+                Count                = 2
+                ExpectedResult       = "00000000000000000000   F1 12 15 FB                                      ñ..û"
+                ExpectedSecondResult = "00000000000000000000   01 02 03 04 05 06                                ......"
+            }
+            @{
+                Name                 = "Can process PS-native enum array '[TestEnum[]]('TestOne', 'TestTwo', 'TestThree', 'TestFour') | fhx'"
+                InputObject          = [TestEnum[]]('TestOne', 'TestTwo', 'TestThree', 'TestFour')
+                Count                = 1
+                ExpectedResult       = "00000000000000000000   01 00 00 00 02 00 00 00 03 00 00 00 04 00 00 00  ................"
+            }
+            @{
+                Name                 = "Can process C#-native sbyte enum array '[TestSByteEnum[]]('One', 'Two', 'Three', 'Four') | fhx'"
+                InputObject          = [TestSByteEnum[]]('One', 'Two', 'Three', 'Four')
+                Count                = 1
+                ExpectedResult       = "00000000000000000000   FF FE FD FC                                      .þýü"
             }
         )
 
@@ -181,12 +235,11 @@ Describe "FormatHex" -tags "CI" {
 
             $result = $InputObject | Format-Hex
 
-            $result.count | Should -Be $Count
+            $result.Count | Should -Be $Count
             $result | Should -BeOfType 'Microsoft.PowerShell.Commands.ByteCollection'
             $result[0].ToString() | Should -MatchExactly $ExpectedResult
 
-            if ($result.count -gt 1)
-            {
+            if ($result.count -gt 1) {
                 $result[1].ToString() | Should -MatchExactly $ExpectedSecondResult
             }
         }
@@ -198,39 +251,39 @@ Describe "FormatHex" -tags "CI" {
 
         $testCases = @(
             @{
-                Name = "Can process file content from given file path 'fhx -Path `$inputFile1'"
-                PathCase = $true
-                Path =  $inputFile1
-                Count = 1
+                Name           = "Can process file content from given file path 'fhx -Path `$inputFile1'"
+                PathCase       = $true
+                Path           = $inputFile1
+                Count          = 1
                 ExpectedResult = $inputText1
             }
             @{
-                Name = "Can process file content from all files in array of file paths 'fhx -Path `$inputFile1, `$inputFile2'"
-                PathCase = $true
-                Path = @($inputFile1, $inputFile2)
-                Count = 2
-                ExpectedResult = $inputText1
+                Name                 = "Can process file content from all files in array of file paths 'fhx -Path `$inputFile1, `$inputFile2'"
+                PathCase             = $true
+                Path                 = @($inputFile1, $inputFile2)
+                Count                = 2
+                ExpectedResult       = $inputText1
                 ExpectedSecondResult = $inputText2
             }
             @{
-                Name = "Can process file content from all files when resolved to multiple paths 'fhx -Path '`$testDirectory\SourceFile-*''"
-                PathCase = $true
-                Path = "$testDirectory\SourceFile-*"
-                Count = 2
-                ExpectedResult = $inputText1
+                Name                 = "Can process file content from all files when resolved to multiple paths 'fhx -Path '`$testDirectory\SourceFile-*''"
+                PathCase             = $true
+                Path                 = "$testDirectory\SourceFile-*"
+                Count                = 2
+                ExpectedResult       = $inputText1
                 ExpectedSecondResult = $inputText2
             }
             @{
-                Name = "Can process file content from given file path 'fhx -LiteralPath `$inputFile3'"
-                Path =  $inputFile3
-                Count = 1
+                Name           = "Can process file content from given file path 'fhx -LiteralPath `$inputFile3'"
+                Path           = $inputFile3
+                Count          = 1
                 ExpectedResult = $inputText3
             }
             @{
-                Name = "Can process file content from all files in array of file paths 'fhx -LiteralPath `$inputFile1, `$inputFile3'"
-                Path = @($inputFile1, $inputFile3)
-                Count = 2
-                ExpectedResult = $inputText1
+                Name                 = "Can process file content from all files in array of file paths 'fhx -LiteralPath `$inputFile1, `$inputFile3'"
+                Path                 = @($inputFile1, $inputFile3)
+                Count                = 2
+                ExpectedResult       = $inputText1
                 ExpectedSecondResult = $inputText3
             }
         )
@@ -239,61 +292,69 @@ Describe "FormatHex" -tags "CI" {
 
             param ($Name, $PathCase, $Path, $ExpectedResult, $ExpectedSecondResult)
 
-            if ($PathCase)
-            {
-                $result =  Format-Hex -Path $Path
-            }
-            else # LiteralPath
-            {
+            if ($PathCase) {
+                $result = Format-Hex -Path $Path
+            } else {
+                # LiteralPath
                 $result = Format-Hex -LiteralPath $Path
             }
 
             $result | Should -BeOfType 'Microsoft.PowerShell.Commands.ByteCollection'
             $result[0].ToString() | Should -MatchExactly $ExpectedResult
 
-            if ($result.count -gt 1)
-            {
+            if ($result.count -gt 1) {
                 $result[1].ToString() | Should -MatchExactly $ExpectedSecondResult
             }
+        }
+
+        It 'properly accepts -LiteralPath input from a FileInfo object' {
+            $FilePath = 'TestDrive:\FHX-LitPathTest.txt'
+            "Hello World!" | Set-Content -Path $FilePath
+            $FileObject = Get-Item -Path $FilePath
+
+            $result = $FileObject | Format-Hex
+            $ExpectedResult = "00000000000000000000   48 65 6C 6C 6F 20 57 6F 72 6C 64 21 0D 0A        Hello World!.."
+
+            $result[0].ToString() | Should -MatchExactly $ExpectedResult
         }
     }
 
     Context "Encoding Parameter" {
         $testCases = @(
             @{
-                Name = "Can process ASCII encoding 'fhx -InputObject 'hello' -Encoding ASCII'"
-                Encoding = "ASCII"
-                Count = 1
+                Name           = "Can process ASCII encoding 'fhx -InputObject 'hello' -Encoding ASCII'"
+                Encoding       = "ASCII"
+                Count          = 1
                 ExpectedResult = "00000000000000000000   68 65 6C 6C 6F                                   hello"
             }
             @{
-                Name = "Can process BigEndianUnicode encoding 'fhx -InputObject 'hello' -Encoding BigEndianUnicode'"
-                Encoding = "BigEndianUnicode"
-                Count = 1
+                Name           = "Can process BigEndianUnicode encoding 'fhx -InputObject 'hello' -Encoding BigEndianUnicode'"
+                Encoding       = "BigEndianUnicode"
+                Count          = 1
                 ExpectedResult = "00000000000000000000   00 68 00 65 00 6C 00 6C 00 6F                    .h.e.l.l.o"
             }
             @{
-                Name = "Can process Unicode encoding 'fhx -InputObject 'hello' -Encoding Unicode'"
-                Encoding = "Unicode"
-                Count = 1
+                Name           = "Can process Unicode encoding 'fhx -InputObject 'hello' -Encoding Unicode'"
+                Encoding       = "Unicode"
+                Count          = 1
                 ExpectedResult = "00000000000000000000   68 00 65 00 6C 00 6C 00 6F 00                    h.e.l.l.o."
             }
             @{
-                Name = "Can process UTF7 encoding 'fhx -InputObject 'hello' -Encoding UTF7'"
-                Encoding = "UTF7"
-                Count = 1
+                Name           = "Can process UTF7 encoding 'fhx -InputObject 'hello' -Encoding UTF7'"
+                Encoding       = "UTF7"
+                Count          = 1
                 ExpectedResult = "00000000000000000000   68 65 6C 6C 6F                                   hello"
             }
-             @{
-                Name = "Can process UTF8 encoding 'fhx -InputObject 'hello' -Encoding UTF8'"
-                Encoding = "UTF8"
-                Count = 1
+            @{
+                Name           = "Can process UTF8 encoding 'fhx -InputObject 'hello' -Encoding UTF8'"
+                Encoding       = "UTF8"
+                Count          = 1
                 ExpectedResult = "00000000000000000000   68 65 6C 6C 6F                                   hello"
             }
-             @{
-                Name = "Can process UTF32 encoding 'fhx -InputObject 'hello' -Encoding UTF32'"
-                Encoding = "UTF32"
-                Count = 1
+            @{
+                Name           = "Can process UTF32 encoding 'fhx -InputObject 'hello' -Encoding UTF32'"
+                Encoding       = "UTF32"
+                Count          = 1
                 ExpectedResult = "00000000000000000000   68 00 00 00 65 00 00 00 6C 00 00 00 6C 00 00 00  h...e...l...l...$($newline)00000000000000000010   6F 00 00 00                                      o..."
             }
         )
@@ -316,16 +377,16 @@ Describe "FormatHex" -tags "CI" {
 
         $testCases = @(
             @{
-                Name = "Does not support non-FileSystem Provider paths 'fhx -Path 'Cert:\CurrentUser\My\`$thumbprint' -ErrorAction Stop'"
-                PathParameterErrorCase = $true
-                Path = "Cert:\CurrentUser\My\$thumbprint"
+                Name                          = "Does not support non-FileSystem Provider paths 'fhx -Path 'Cert:\CurrentUser\My\`$thumbprint' -ErrorAction Stop'"
+                PathParameterErrorCase        = $true
+                Path                          = "Cert:\CurrentUser\My\$thumbprint"
                 ExpectedFullyQualifiedErrorId = "FormatHexOnlySupportsFileSystemPaths,Microsoft.PowerShell.Commands.FormatHex"
             }
             @{
-                Name = "Type Not Supported 'fhx -InputObject @{'hash' = 'table'} -ErrorAction Stop'"
-                InputObjectErrorCase = $true
-                Path = $inputFile1
-                InputObject = @{ "hash" = "table" }
+                Name                          = "Type Not Supported 'fhx -InputObject @{'hash' = 'table'} -ErrorAction Stop'"
+                InputObjectErrorCase          = $true
+                Path                          = $inputFile1
+                InputObject                   = @{ "hash" = "table" }
                 ExpectedFullyQualifiedErrorId = "FormatHexTypeNotSupported,Microsoft.PowerShell.Commands.FormatHex"
             }
         )
@@ -335,12 +396,10 @@ Describe "FormatHex" -tags "CI" {
             param ($Name, $PathParameterErrorCase, $Path, $InputObject, $InputObjectErrorCase, $ExpectedFullyQualifiedErrorId)
 
             {
-                if ($PathParameterErrorCase)
-                {
+                if ($PathParameterErrorCase) {
                     $result = Format-Hex -Path $Path -ErrorAction Stop
                 }
-                if ($InputObjectErrorCase)
-                {
+                if ($InputObjectErrorCase) {
                     $result = Format-Hex -InputObject $InputObject -ErrorAction Stop
                 }
             } | Should -Throw -ErrorId $ExpectedFullyQualifiedErrorId
@@ -351,20 +410,20 @@ Describe "FormatHex" -tags "CI" {
 
         $testCases = @(
             @{
-                Name = "If given invalid path in array, continues to process valid paths 'fhx -Path `$invalidPath, `$inputFile1  -ErrorVariable e -ErrorAction SilentlyContinue'"
-                PathCase = $true
-                InvalidPath = "$($inputFile1.DirectoryName)\fakefile8888845345345348709.txt"
+                Name                          = "If given invalid path in array, continues to process valid paths 'fhx -Path `$invalidPath, `$inputFile1  -ErrorVariable e -ErrorAction SilentlyContinue'"
+                PathCase                      = $true
+                InvalidPath                   = "$($inputFile1.DirectoryName)\fakefile8888845345345348709.txt"
                 ExpectedFullyQualifiedErrorId = "FileNotFound,Microsoft.PowerShell.Commands.FormatHex"
             }
             @{
-                Name = "If given a non FileSystem path in array, continues to process valid paths 'fhx -Path `$invalidPath, `$inputFile1  -ErrorVariable e -ErrorAction SilentlyContinue'"
-                PathCase = $true
-                InvalidPath = "Cert:\CurrentUser\My\$thumbprint"
+                Name                          = "If given a non FileSystem path in array, continues to process valid paths 'fhx -Path `$invalidPath, `$inputFile1  -ErrorVariable e -ErrorAction SilentlyContinue'"
+                PathCase                      = $true
+                InvalidPath                   = "Cert:\CurrentUser\My\$thumbprint"
                 ExpectedFullyQualifiedErrorId = "FormatHexOnlySupportsFileSystemPaths,Microsoft.PowerShell.Commands.FormatHex"
             }
             @{
-                Name = "If given a non FileSystem path in array (with LiteralPath), continues to process valid paths 'fhx -Path `$invalidPath, `$inputFile1  -ErrorVariable e -ErrorAction SilentlyContinue'"
-                InvalidPath = "Cert:\CurrentUser\My\$thumbprint"
+                Name                          = "If given a non FileSystem path in array (with LiteralPath), continues to process valid paths 'fhx -Path `$invalidPath, `$inputFile1  -ErrorVariable e -ErrorAction SilentlyContinue'"
+                InvalidPath                   = "Cert:\CurrentUser\My\$thumbprint"
                 ExpectedFullyQualifiedErrorId = "FormatHexOnlySupportsFileSystemPaths,Microsoft.PowerShell.Commands.FormatHex"
             }
         )
@@ -376,12 +435,10 @@ Describe "FormatHex" -tags "CI" {
             $output = $null
             $errorThrown = $null
 
-            if ($PathCase)
-            {
+            if ($PathCase) {
                 $output = Format-Hex -Path $InvalidPath, $inputFile1 -ErrorVariable errorThrown -ErrorAction SilentlyContinue
-            }
-            else # LiteralPath
-            {
+            } else {
+                # LiteralPath
                 $output = Format-Hex -LiteralPath $InvalidPath, $inputFile1 -ErrorVariable errorThrown -ErrorAction SilentlyContinue
             }
 
@@ -396,10 +453,10 @@ Describe "FormatHex" -tags "CI" {
 
         It "Path is default Parameter Set 'fhx `$inputFile1'" {
 
-            $result =  Format-Hex $inputFile1
+            $result = Format-Hex $inputFile1
 
             $result | Should -Not -BeNullOrEmpty
-            ,$result | Should -BeOfType 'Microsoft.PowerShell.Commands.ByteCollection'
+            , $result | Should -BeOfType 'Microsoft.PowerShell.Commands.ByteCollection'
             $actualResult = $result.ToString()
             $actualResult | Should -MatchExactly $inputText1
         }
@@ -409,7 +466,7 @@ Describe "FormatHex" -tags "CI" {
             $result = Get-ChildItem $inputFile1 | Format-Hex
 
             $result | Should -Not -BeNullOrEmpty
-            ,$result | Should -BeOfType 'Microsoft.PowerShell.Commands.ByteCollection'
+            , $result | Should -BeOfType 'Microsoft.PowerShell.Commands.ByteCollection'
             $actualResult = $result.ToString()
             $actualResult | Should -MatchExactly $inputText1
         }
@@ -419,7 +476,7 @@ Describe "FormatHex" -tags "CI" {
             $result = "a" * 30 | Format-Hex
 
             $result | Should -Not -BeNullOrEmpty
-            ,$result | Should -BeOfType 'Microsoft.PowerShell.Commands.ByteCollection'
+            , $result | Should -BeOfType 'Microsoft.PowerShell.Commands.ByteCollection'
             $result.ToString() | Should -MatchExactly "00000000000000000000   61 61 61 61 61 61 61 61 61 61 61 61 61 61 61 61  aaaaaaaaaaaaaaaa$($newline)00000000000000000010   61 61 61 61 61 61 61 61 61 61 61 61 61 61        aaaaaaaaaaaaaa  "
         }
 


### PR DESCRIPTION
## PR Summary

Fixes #3358

Adds support to Format-Hex for any primitive type, along with strings and direct file input.

Notes:

* Renamed class according to standard naming convention `FormatHex` -> `FormatHexCommand`
  * Happy to revert if this change is inappropriate, but seemed weird it didn't follow convention
* -LiteralPath param altered to accept ValueFromPipelineByPropertyName
* Code borrowed from @lzybkr's POC in #3358 and repurposed to keep capability to process files and strings
* Additional code handling jagged arrays and various types of weird inputs that might happen with piped input
* Test for new behaviours added

### Behaviour change

Cmdlet now treats a homogenous piped input array as a single item, so that pipeline input behaviour should mirror directly presented `-InputObject` behaviour. In other words, `[byte[]](1, 2, 3) | fhx` will be treated as a single array and displayed in a single line, instead of being treated as completely separate items.

When a similar jagged array is presented, however, the cmdlet will notice and output each pipeline item as a separate display. This should have pretty high consistency in terms of handling string input mixed with other things, as well as just handling jagged input with pretty good consistency with how it would handle standalone input.

Enums are supported and will be processed according to their base type (int32 for PowerShell-native enums, all valid base primitives from C#).

Kinda fun to work with, now. 😄 

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
