### PR TITLE
Make `Join-String -InputObject 1,2,3` result equal to `1,2,3 | Join-String` result

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/join-string.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/join-string.cs
@@ -106,7 +106,7 @@ namespace Microsoft.PowerShell.Commands.Utility
         /// <inheritdoc />
         protected override void ProcessRecord()
         {
-            if (InputObject != null)
+            if (inputObject != null && inputObject != AutomationNull.Value)
             {
                 foreach (PSObject inputObject in InputObject)
                 {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/join-string.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/join-string.cs
@@ -106,42 +106,45 @@ namespace Microsoft.PowerShell.Commands.Utility
         /// <inheritdoc />
         protected override void ProcessRecord()
         {
-            foreach (PSObject inputObject in InputObject)
+            if (InputObject != null)
             {
-                if (inputObject != null && inputObject != AutomationNull.Value)
+                foreach (PSObject inputObject in InputObject)
                 {
-                    var inputValue = Property == null
-                                        ? inputObject
-                                        : Property.GetValues(inputObject, false, true).FirstOrDefault()?.Result;
+                    if (inputObject != null && inputObject != AutomationNull.Value)
+                    {
+                        var inputValue = Property == null
+                                            ? inputObject
+                                            : Property.GetValues(inputObject, false, true).FirstOrDefault()?.Result;
 
-                    // conversion to string always succeeds.
-                    if (!LanguagePrimitives.TryConvertTo<string>(inputValue, _cultureInfo, out var stringValue))
-                    {
-                        throw new PSInvalidCastException("InvalidCastFromAnyTypeToString", ExtendedTypeSystem.InvalidCastCannotRetrieveString, null);
-                    }
+                        // conversion to string always succeeds.
+                        if (!LanguagePrimitives.TryConvertTo<string>(inputValue, _cultureInfo, out var stringValue))
+                        {
+                            throw new PSInvalidCastException("InvalidCastFromAnyTypeToString", ExtendedTypeSystem.InvalidCastCannotRetrieveString, null);
+                        }
 
-                    if (_firstInputObject)
-                    {
-                        _firstInputObject = false;
-                    }
-                    else
-                    {
-                        _outputBuilder.Append(Separator);
-                    }
+                        if (_firstInputObject)
+                        {
+                            _firstInputObject = false;
+                        }
+                        else
+                        {
+                            _outputBuilder.Append(Separator);
+                        }
 
-                    if (_quoteChar != char.MinValue)
-                    {
-                        _outputBuilder.Append(_quoteChar);
-                        _outputBuilder.Append(stringValue);
-                        _outputBuilder.Append(_quoteChar);
-                    }
-                    else if (string.IsNullOrEmpty(FormatString))
-                    {
-                        _outputBuilder.Append(stringValue);
-                    }
-                    else
-                    {
-                        _outputBuilder.AppendFormat(_cultureInfo, FormatString, inputValue);
+                        if (_quoteChar != char.MinValue)
+                        {
+                            _outputBuilder.Append(_quoteChar);
+                            _outputBuilder.Append(stringValue);
+                            _outputBuilder.Append(_quoteChar);
+                        }
+                        else if (string.IsNullOrEmpty(FormatString))
+                        {
+                            _outputBuilder.Append(stringValue);
+                        }
+                        else
+                        {
+                            _outputBuilder.AppendFormat(_cultureInfo, FormatString, inputValue);
+                        }
                     }
                 }
             }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/join-string.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/join-string.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -90,7 +90,7 @@ namespace Microsoft.PowerShell.Commands.Utility
         /// Gets or sets the input object to join into text.
         /// </summary>
         [Parameter(ValueFromPipeline = true)]
-        public PSObject InputObject { get; set; }
+        public PSObject[] InputObject { get; set; }
 
         /// <inheritdoc />
         protected override void BeginProcessing()
@@ -106,40 +106,43 @@ namespace Microsoft.PowerShell.Commands.Utility
         /// <inheritdoc />
         protected override void ProcessRecord()
         {
-            if (InputObject != null && InputObject != AutomationNull.Value)
+            foreach (PSObject inputObject in InputObject)
             {
-                var inputValue = Property == null
-                                    ? InputObject
-                                    : Property.GetValues(InputObject, false, true).FirstOrDefault()?.Result;
+                if (inputObject != null && inputObject != AutomationNull.Value)
+                {
+                    var inputValue = Property == null
+                                        ? inputObject
+                                        : Property.GetValues(inputObject, false, true).FirstOrDefault()?.Result;
 
-                // conversion to string always succeeds.
-                if (!LanguagePrimitives.TryConvertTo<string>(inputValue, _cultureInfo, out var stringValue))
-                {
-                    throw new PSInvalidCastException("InvalidCastFromAnyTypeToString", ExtendedTypeSystem.InvalidCastCannotRetrieveString, null);
-                }
+                    // conversion to string always succeeds.
+                    if (!LanguagePrimitives.TryConvertTo<string>(inputValue, _cultureInfo, out var stringValue))
+                    {
+                        throw new PSInvalidCastException("InvalidCastFromAnyTypeToString", ExtendedTypeSystem.InvalidCastCannotRetrieveString, null);
+                    }
 
-                if (_firstInputObject)
-                {
-                    _firstInputObject = false;
-                }
-                else
-                {
-                    _outputBuilder.Append(Separator);
-                }
+                    if (_firstInputObject)
+                    {
+                        _firstInputObject = false;
+                    }
+                    else
+                    {
+                        _outputBuilder.Append(Separator);
+                    }
 
-                if (_quoteChar != char.MinValue)
-                {
-                    _outputBuilder.Append(_quoteChar);
-                    _outputBuilder.Append(stringValue);
-                    _outputBuilder.Append(_quoteChar);
-                }
-                else if (string.IsNullOrEmpty(FormatString))
-                {
-                    _outputBuilder.Append(stringValue);
-                }
-                else
-                {
-                    _outputBuilder.AppendFormat(_cultureInfo, FormatString, inputValue);
+                    if (_quoteChar != char.MinValue)
+                    {
+                        _outputBuilder.Append(_quoteChar);
+                        _outputBuilder.Append(stringValue);
+                        _outputBuilder.Append(_quoteChar);
+                    }
+                    else if (string.IsNullOrEmpty(FormatString))
+                    {
+                        _outputBuilder.Append(stringValue);
+                    }
+                    else
+                    {
+                        _outputBuilder.AppendFormat(_cultureInfo, FormatString, inputValue);
+                    }
                 }
             }
         }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/join-string.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/join-string.cs
@@ -106,7 +106,7 @@ namespace Microsoft.PowerShell.Commands.Utility
         /// <inheritdoc />
         protected override void ProcessRecord()
         {
-            if (inputObject != null && inputObject != AutomationNull.Value)
+            if (InputObject != null)
             {
                 foreach (PSObject inputObject in InputObject)
                 {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Join-String.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Join-String.Tests.ps1
@@ -11,6 +11,12 @@ Describe "Join-String" -Tags "CI" {
         { Join-String -InputObject $testObject } | Should -Not -Throw
     }
 
+    It "'Input | Join-String' should be equal to 'Join-String -InputObject Input'" {
+        $result1 = $testObject | Join-String
+        $result2 = Join-String -InputObject $testObject
+        $result1 | Should -BeExactly $result2
+    }
+
     It "Should return a single string" {
         $actual = $testObject | Join-String
 


### PR DESCRIPTION
## PR Summary
Make `Join-String -InputObject 1,2,3` result equal to `1,2,3 | Join-String` result.

Fix #8610 

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] User-facing [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed - Issue link:
- **Testing - New and feature**
    - [ ] Not Applicable or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
