### PR TITLE
Remove 'en-us' from docs.microsoft.com link

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,6 @@
 # EditorConfig is awesome: https://EditorConfig.org
 # .NET coding convention settings for EditorConfig
-# https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-code-style-settings-reference
+# https://docs.microsoft.com/visualstudio/ide/editorconfig-code-style-settings-reference
 #
 # The .editorconfig comes from Roslyn and CoreFX repositories:
 # https://github.com/dotnet/corefx/blob/master/.editorconfig


### PR DESCRIPTION
Remove 'en-us' from docs.microsoft.com link (follow-up to #8602)  
