### PR TITLE
Fix expect 100-continue Issue with Web Cmdlets

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/Common/WebRequestPSCmdlet.Common.cs
@@ -1142,11 +1142,6 @@ namespace Microsoft.PowerShell.Commands
                 }
             }
 
-            // Some web sites (e.g. Twitter) will return exception on POST when Expect100 is sent
-            // Default behavior is continue to send body content anyway after a short period
-            // Here it send the two part as a whole.
-            request.Headers.ExpectContinue = false;
-
             return (request);
         }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -1171,6 +1171,28 @@ Describe "Invoke-WebRequest tests" -Tags "Feature", "RequireAdminOnWindows" {
         $result.Output.RawContent | Should -Match ([regex]::Escape('X-Fake-Header: testvalue02'))
     }
 
+    It "Verifies Invoke-WebRequest Does not sent expect 100-continue headers by default" {
+        $uri = Get-WebListenerUrl -Test 'Get'
+
+        $response = Invoke-WebRequest -Uri $uri
+        $result = $response.Content | ConvertFrom-Json
+
+        $result.headers.Expect | Should -BeNullOrEmpty
+        $result.method | should -BeExactly "GET"
+        $result.url | should -BeExactly $uri.ToString()
+    }
+
+    It "Verifies Invoke-WebRequest sends expect 100-continue header when defined in -Headers" {
+        $uri = Get-WebListenerUrl -Test 'Get'
+
+        $response = Invoke-WebRequest -Uri $uri -Headers @{Expect = '100-continue'}
+        $result = $response.Content | ConvertFrom-Json
+
+        $result.headers.Expect | Should -BeExactly '100-continue'
+        $result.method | should -BeExactly "GET"
+        $result.url | should -BeExactly $uri.ToString()
+    }
+
     #endregion Content Header Inclusion
 
     Context "HTTPS Tests" {
@@ -2507,6 +2529,26 @@ Describe "Invoke-RestMethod tests" -Tags "Feature", "RequireAdminOnWindows" {
             {Invoke-RestMethod -Uri $uri -Form $form -InFile $file1Path -ErrorAction 'Stop'} |
                 Should -Throw -ErrorId 'WebCmdletFormInFileConflictException,Microsoft.PowerShell.Commands.InvokeRestMethodCommand'
         }
+    }
+
+    It "Verifies Invoke-RestMethod Does not sent expect 100-continue headers by default" {
+        $uri = Get-WebListenerUrl -Test 'Get'
+
+        $result = Invoke-RestMethod -Uri $uri
+
+        $result.headers.Expect | Should -BeNullOrEmpty
+        $result.method | should -BeExactly "GET"
+        $result.url | should -BeExactly $uri.ToString()
+    }
+
+    It "Verifies Invoke-RestMethod sends expect 100-continue header when defined in -Headers" {
+        $uri = Get-WebListenerUrl -Test 'Get'
+
+        $result = Invoke-RestMethod -Uri $uri -Headers @{Expect = '100-continue'}
+
+        $result.headers.Expect | Should -BeExactly '100-continue'
+        $result.method | should -BeExactly "GET"
+        $result.url | should -BeExactly $uri.ToString()
     }
 
     #region charset encoding tests

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/WebCmdlets.Tests.ps1
@@ -1171,15 +1171,15 @@ Describe "Invoke-WebRequest tests" -Tags "Feature", "RequireAdminOnWindows" {
         $result.Output.RawContent | Should -Match ([regex]::Escape('X-Fake-Header: testvalue02'))
     }
 
-    It "Verifies Invoke-WebRequest Does not sent expect 100-continue headers by default" {
+    It "Verifies Invoke-WebRequest does not sent expect 100-continue headers by default" {
         $uri = Get-WebListenerUrl -Test 'Get'
 
         $response = Invoke-WebRequest -Uri $uri
         $result = $response.Content | ConvertFrom-Json
 
         $result.headers.Expect | Should -BeNullOrEmpty
-        $result.method | should -BeExactly "GET"
-        $result.url | should -BeExactly $uri.ToString()
+        $result.method | Should -BeExactly "GET"
+        $result.url | Should -BeExactly $uri.ToString()
     }
 
     It "Verifies Invoke-WebRequest sends expect 100-continue header when defined in -Headers" {
@@ -1189,8 +1189,8 @@ Describe "Invoke-WebRequest tests" -Tags "Feature", "RequireAdminOnWindows" {
         $result = $response.Content | ConvertFrom-Json
 
         $result.headers.Expect | Should -BeExactly '100-continue'
-        $result.method | should -BeExactly "GET"
-        $result.url | should -BeExactly $uri.ToString()
+        $result.method | Should -BeExactly "GET"
+        $result.url | Should -BeExactly $uri.ToString()
     }
 
     #endregion Content Header Inclusion
@@ -2531,14 +2531,14 @@ Describe "Invoke-RestMethod tests" -Tags "Feature", "RequireAdminOnWindows" {
         }
     }
 
-    It "Verifies Invoke-RestMethod Does not sent expect 100-continue headers by default" {
+    It "Verifies Invoke-RestMethod does not sent expect 100-continue headers by default" {
         $uri = Get-WebListenerUrl -Test 'Get'
 
         $result = Invoke-RestMethod -Uri $uri
 
         $result.headers.Expect | Should -BeNullOrEmpty
-        $result.method | should -BeExactly "GET"
-        $result.url | should -BeExactly $uri.ToString()
+        $result.method | Should -BeExactly "GET"
+        $result.url | Should -BeExactly $uri.ToString()
     }
 
     It "Verifies Invoke-RestMethod sends expect 100-continue header when defined in -Headers" {
@@ -2547,8 +2547,8 @@ Describe "Invoke-RestMethod tests" -Tags "Feature", "RequireAdminOnWindows" {
         $result = Invoke-RestMethod -Uri $uri -Headers @{Expect = '100-continue'}
 
         $result.headers.Expect | Should -BeExactly '100-continue'
-        $result.method | should -BeExactly "GET"
-        $result.url | should -BeExactly $uri.ToString()
+        $result.method | Should -BeExactly "GET"
+        $result.url | Should -BeExactly $uri.ToString()
     }
 
     #region charset encoding tests


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->  

## PR Summary

Fixes #7199

Web Cmdlets will no longer forcibly remove `Expect: 100-continue` from web requests.
This was a legacy setting that needed to be there because of platform differences that have since been resolved in CoreFX.

## PR Context  

#7199

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.  
- **User-facing changes**
    - [x] Not Applicable
    - **OR**  
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [x] [Add `[feature]` to your commit messages if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
