### PR TITLE
Make various types public as they were already visible externally

### DIFF
--- a/src/System.Management.Automation/engine/ArgumentTypeConverterAttribute.cs
+++ b/src/System.Management.Automation/engine/ArgumentTypeConverterAttribute.cs
@@ -12,7 +12,7 @@ namespace System.Management.Automation
     /// <summary>
     /// This is used for automatic conversions to be performed in shell variables.
     /// </summary>
-    internal sealed class ArgumentTypeConverterAttribute : ArgumentTransformationAttribute
+    public sealed class ArgumentTypeConverterAttribute : ArgumentTransformationAttribute
     {
         /// <summary>
         /// This ctor form is used to initialize shell variables
@@ -36,6 +36,12 @@ namespace System.Management.Automation
             }
         }
 
+        /// <summary>
+        /// Transforms the inputData.
+        /// </summary>
+        /// <param name="engineIntrinsics">Object of type EngineIntrinsics.</param>
+        /// <param name="inputData">Object to be transformed.</param>
+        /// <returns>The object after transformation.</returns>
         public override object Transform(EngineIntrinsics engineIntrinsics, object inputData)
         {
             return Transform(engineIntrinsics, inputData, false, false);

--- a/src/System.Management.Automation/engine/CommonCommandParameters.cs
+++ b/src/System.Management.Automation/engine/CommonCommandParameters.cs
@@ -230,8 +230,20 @@ namespace System.Management.Automation.Internal
 
         private MshCommandRuntime _commandRuntime;
 
-        internal class ValidateVariableName : ValidateArgumentsAttribute
+        /// <summary>
+        /// Validates variable name to be valid.
+        /// </summary>
+        public class ValidateVariableName : ValidateArgumentsAttribute
         {
+            /// <summary>
+            /// Validate the value of arguments is a valid variable name.
+            /// </summary>
+            /// <param name="arguments">
+            /// The value of the arguments is a variable name to be validated.
+            /// </param>
+            /// <param name="engineIntrinsics">
+            /// Instance of EngineIntrinsics class.
+            /// </param>
             protected override void Validate(object arguments, EngineIntrinsics engineIntrinsics)
             {
                 string varName = arguments as string;

--- a/src/System.Management.Automation/engine/InternalCommands.cs
+++ b/src/System.Management.Automation/engine/InternalCommands.cs
@@ -2005,8 +2005,14 @@ namespace Microsoft.PowerShell.Commands
         ///   * A string without a dot, i.e. "2"
         ///   * The string 'latest', which we interpret to be the current version of PowerShell.
         /// </summary>
-        private sealed class ArgumentToVersionTransformationAttribute : ArgumentTransformationAttribute
+        public sealed class ArgumentToVersionTransformationAttribute : ArgumentTransformationAttribute
         {
+            /// <summary>
+            /// Transform the argument to a version.
+            /// </summary>
+            /// <param name="engineIntrinsics">EngineIntrinsics object.</param>
+            /// <param name="inputData">Value of attribute to be transformmed.</param>
+            /// <returns>The object after transformation.</returns>
             public override object Transform(EngineIntrinsics engineIntrinsics, object inputData)
             {
                 object version = PSObject.Base(inputData);
@@ -2043,8 +2049,16 @@ namespace Microsoft.PowerShell.Commands
             }
         }
 
-        private sealed class ValidateVersionAttribute : ValidateArgumentsAttribute
+        /// <summary>
+        /// Attribute to validate the version.
+        /// </summary>
+        public sealed class ValidateVersionAttribute : ValidateArgumentsAttribute
         {
+            /// <summary>
+            /// Validate the arguments is a valid version.
+            /// </summary>
+            /// <param name="arguments">Value of the version argument.</param>
+            /// <param name="engineIntrinsics">EngineIntrinsics object.</param>
             protected override void Validate(object arguments, EngineIntrinsics engineIntrinsics)
             {
                 Version version = arguments as Version;

--- a/src/System.Management.Automation/engine/LanguagePrimitives.cs
+++ b/src/System.Management.Automation/engine/LanguagePrimitives.cs
@@ -1896,10 +1896,11 @@ namespace System.Management.Automation
             /// <summary>
             /// Convert from sourceValue to the specified type.
             /// </summary>
-            /// <param name="sourceValue">value to be converted.</param>
-            /// <param name="destinationType">type to which sourceValue should be converted to.</param>
-            /// <param name="formatProvider">format provider for the conversion.</param>
-            /// <param name="ignoreCase">whether to ignore the case.</param>
+            /// <param name="sourceValue">Value to be converted.</param>
+            /// <param name="destinationType">Type to which sourceValue should be converted to.</param>
+            /// <param name="formatProvider">Format provider for the conversion.</param>
+            /// <param name="ignoreCase">Whether to ignore the case.</param>
+            /// <returns>The object after conversion.</returns>
             public override object ConvertFrom(object sourceValue, Type destinationType, IFormatProvider formatProvider, bool ignoreCase)
             {
                 return EnumSingleTypeConverter.BaseConvertFrom(sourceValue, destinationType, formatProvider, ignoreCase, true);
@@ -1992,9 +1993,9 @@ namespace System.Management.Automation
             /// <summary>
             /// Verify if conversion from sourceValue can be done to type destinationType.
             /// </summary>
-            /// <param name="sourceValue">value to be converted.</param>
-            /// <param name="destinationType">type to which sourceValue should be converted to.</param>
-            /// <returns>Whether the sourceValue can be converted to destinationType.</param>
+            /// <param name="sourceValue">Value to be converted.</param>
+            /// <param name="destinationType">Type to which sourceValue should be converted to.</param>
+            /// <returns>Whether the sourceValue can be converted to destinationType.</returns>
             public override bool CanConvertFrom(object sourceValue, Type destinationType)
             {
                 return sourceValue is string && destinationType.IsEnum;

--- a/src/System.Management.Automation/engine/LanguagePrimitives.cs
+++ b/src/System.Management.Automation/engine/LanguagePrimitives.cs
@@ -1888,15 +1888,28 @@ namespace System.Management.Automation
 
         #endregion public type conversion
 
-        internal class EnumMultipleTypeConverter : EnumSingleTypeConverter
+        /// <summary>
+        /// Convert multiple Enum types.
+        /// </summary>
+        public class EnumMultipleTypeConverter : EnumSingleTypeConverter
         {
+            /// <summary>
+            /// Convert from sourceValue to the specified type.
+            /// </summary>
+            /// <param name="sourceValue">value to be converted.</param>
+            /// <param name="destinationType">type to which sourceValue should be converted to.</param>
+            /// <param name="formatProvider">format provider for the conversion.</param>
+            /// <param name="ignoreCase">whether to ignore the case.</param>
             public override object ConvertFrom(object sourceValue, Type destinationType, IFormatProvider formatProvider, bool ignoreCase)
             {
                 return EnumSingleTypeConverter.BaseConvertFrom(sourceValue, destinationType, formatProvider, ignoreCase, true);
             }
         }
 
-        internal class EnumSingleTypeConverter : PSTypeConverter
+        /// <summary>
+        /// Convert single Enum type.
+        /// </summary>
+        public class EnumSingleTypeConverter : PSTypeConverter
         {
             private class EnumHashEntry
             {
@@ -1976,6 +1989,12 @@ namespace System.Management.Automation
                 }
             }
 
+            /// <summary>
+            /// Verify if conversion from sourceValue can be done to type destinationType.
+            /// </summary>
+            /// <param name="sourceValue">value to be converted.</param>
+            /// <param name="destinationType">type to which sourceValue should be converted to.</param>
+            /// <returns>Whether the sourceValue can be converted to destinationType.</param>
             public override bool CanConvertFrom(object sourceValue, Type destinationType)
             {
                 return sourceValue is string && destinationType.IsEnum;
@@ -2091,11 +2110,28 @@ namespace System.Management.Automation
                 return string.Join(CultureInfo.CurrentUICulture.TextInfo.ListSeparator, enumHashEntry.names);
             }
 
+            /// <summary>
+            /// Convert from sourceValue to the specified type.
+            /// </summary>
+            /// <param name="sourceValue">Value to be converted.</param>
+            /// <param name="destinationType">Type to which sourceValue should be converted to.</param>
+            /// <param name="formatProvider">Format provider for the conversion.</param>
+            /// <param name="ignoreCase">Whether to ignore the case.</param>
+            /// <returns>The converted object.</returns>
             public override object ConvertFrom(object sourceValue, Type destinationType, IFormatProvider formatProvider, bool ignoreCase)
             {
                 return EnumSingleTypeConverter.BaseConvertFrom(sourceValue, destinationType, formatProvider, ignoreCase, false);
             }
 
+            /// <summary>
+            /// Convert from sourceValue to the specified type.
+            /// </summary>
+            /// <param name="sourceValue">Value to be converted.</param>
+            /// <param name="destinationType">Type to which sourceValue should be converted to.</param>
+            /// <param name="formatProvider">Format provider for the conversion.</param>
+            /// <param name="ignoreCase">Whether to ignore the case.</param>
+            /// <param name="multipleValues">Whether to convert multiple values.</param>
+            /// <returns>The converted object.</returns>
             protected static object BaseConvertFrom(object sourceValue, Type destinationType, IFormatProvider formatProvider, bool ignoreCase, bool multipleValues)
             {
                 Diagnostics.Assert(sourceValue != null, "the type converter has a special case for null source values");
@@ -2235,11 +2271,25 @@ namespace System.Management.Automation
                 return Enum.ToObject(destinationType, returnUInt64);
             }
 
+            /// <summary>
+            /// Verify if conversion from sourceValue to destinationType can be done. This is always false.
+            /// </summary>
+            /// <param name="sourceValue">Value to be converted.</param>
+            /// <param name="destinationType">Type to which sourceValue should be converted to.</param>
+            /// <returns>Whether the object can be converted.</returns>
             public override bool CanConvertTo(object sourceValue, Type destinationType)
             {
                 return false;
             }
 
+            /// <summary>
+            /// Convert from sourceValue to the specified type.
+            /// </summary>
+            /// <param name="sourceValue">Value to be converted.</param>
+            /// <param name="destinationType">Type to which sourceValue should be converted to.</param>
+            /// <param name="formatProvider">Format provider for the conversion.</param>
+            /// <param name="ignoreCase">Whether to ignore the case.</param>
+            /// <returns>The converted object.</returns>
             public override object ConvertTo(object sourceValue, Type destinationType, IFormatProvider formatProvider, bool ignoreCase)
             {
                 throw PSTraceSource.NewNotSupportedException();

--- a/src/System.Management.Automation/engine/remoting/commands/StartJob.cs
+++ b/src/System.Management.Automation/engine/remoting/commands/StartJob.cs
@@ -17,7 +17,7 @@ namespace Microsoft.PowerShell.Commands
     /// This cmdlet start invocation of jobs in background.
     /// </summary>
     [Cmdlet(VerbsLifecycle.Start, "Job", DefaultParameterSetName = StartJobCommand.ComputerNameParameterSet, HelpUri = "https://go.microsoft.com/fwlink/?LinkID=113405")]
-    [OutputType(typeof(PSRemotingJob))]
+    [OutputType(typeof(Job))]
     public class StartJobCommand : PSExecutionCmdlet, IDisposable
     {
         #region Private members

--- a/src/System.Management.Automation/help/SaveHelpCommand.cs
+++ b/src/System.Management.Automation/help/SaveHelpCommand.cs
@@ -424,8 +424,17 @@ namespace Microsoft.PowerShell.Commands
         #endregion
     }
 
-    internal sealed class ArgumentToModuleTransformationAttribute : ArgumentTransformationAttribute
+    /// <summary>
+    /// Attribute to transform to a module.
+    /// </summary>
+    public sealed class ArgumentToModuleTransformationAttribute : ArgumentTransformationAttribute
     {
+        /// <summary>
+        /// Transform the engineIntrinsics to a module.
+        /// </summary>
+        /// <param name="engineIntrinsics">EngineInstrinsics object.</param>
+        /// <param name="inputData">Value of the attribute.</param>
+        /// <returns>The object after transformation.</returns>
         public override object Transform(EngineIntrinsics engineIntrinsics, object inputData)
         {
             object argument = PSObject.Base(inputData);

--- a/src/System.Management.Automation/utils/EncodingUtils.cs
+++ b/src/System.Management.Automation/utils/EncodingUtils.cs
@@ -87,8 +87,14 @@ namespace System.Management.Automation
     /// When the input data is of type string and is valid to be converted to System.Text.Encoding, we do
     /// the conversion and return the converted value. Otherwise, we just return the input data.
     /// </summary>
-    internal sealed class ArgumentToEncodingTransformationAttribute : ArgumentTransformationAttribute
+    public sealed class ArgumentToEncodingTransformationAttribute : ArgumentTransformationAttribute
     {
+        /// <summary>
+        /// Transform the argument to type System.Text.Encoding.
+        /// </summary>
+        /// <param name="engineIntrinsics">EngineIntrinsics object.</param>
+        /// <param name="inputData">Value of attribute to be transformmed.</param>
+        /// <returns>The object after transformation.</returns>
         public override object Transform(EngineIntrinsics engineIntrinsics, object inputData)
         {
             switch (inputData)


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->  

## PR Summary

Many types were already visible publicly either as attributes or as OutputType. This change marks them as public.

- `ValidateVariableNameAttribute`  - is used by a public property `CommonParameters.ErrorVariable`
- `ArgumentToVersionTransformationAttribute` - is used by a public property `SetStrictModeCommand.Version`
- `ValidateVersionAttribute` - is used by a public property `SetStrictModeCommand.Version`
- `EnumSingleTypeConverter` and `EnumMultipleTypeConverter ` - classes had public methods
- `ArgumentToModuleTransformationAttribute` - used by `Save-Help` command for `Module` parameter.
- `ArgumentToEncodingTransformationAttribute` - used by multiple cmdlets for `Encoding` parameter.

Also, changed the output type of `Start-Job` from `PSRemotingJob` to `Job`

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.  
- **User-facing changes**
    - [x] Not Applicable
    - **OR**  
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` to your commit messages if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
