### PR TITLE
Enable catching NotImplementedException when calling into RawUI for members that are not implemented

### DIFF
--- a/src/System.Management.Automation/FormatAndOutput/out-console/ConsoleLineOutput.cs
+++ b/src/System.Management.Automation/FormatAndOutput/out-console/ConsoleLineOutput.cs
@@ -5,6 +5,7 @@
 // characters
 //#define TEST_MULTICELL_ON_SINGLE_CELL_LOCALE
 
+using System;
 using System.Collections.Specialized;
 using System.Management.Automation;
 using System.Management.Automation.Internal;
@@ -93,7 +94,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             {
                 return _rawUserInterface.LengthInBufferCells(str, offset);
             }
-            catch (HostException)
+            catch (Exception ex) when (ex is HostException || ex is NotImplementedException)
             {
                 // thrown when external host rawui is not implemented, in which case
                 // we will fallback to the default value.
@@ -108,7 +109,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             {
                 return _rawUserInterface.LengthInBufferCells(str);
             }
-            catch (HostException)
+            catch (Exception ex) when (ex is HostException || ex is NotImplementedException)
             {
                 // thrown when external host rawui is not implemented, in which case
                 // we will fallback to the default value.
@@ -123,7 +124,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             {
                 return _rawUserInterface.LengthInBufferCells(character);
             }
-            catch (HostException)
+            catch (Exception ex) when (ex is HostException || ex is NotImplementedException)
             {
                 // thrown when external host rawui is not implemented, in which case
                 // we will fallback to the default value.
@@ -178,7 +179,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 {
                     return _forceNewLine ? raw.BufferSize.Width - 1 : raw.BufferSize.Width;
                 }
-                catch (HostException)
+                catch (Exception ex) when (ex is HostException || ex is NotImplementedException)
                 {
                     // thrown when external host rawui is not implemented, in which case
                     // we will fallback to the default value.
@@ -204,7 +205,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 {
                     return raw.WindowSize.Height;
                 }
-                catch (HostException)
+                catch (Exception ex) when (ex is HostException || ex is NotImplementedException)
                 {
                     // thrown when external host rawui is not implemented, in which case
                     // we will fallback to the default value.


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->  

## PR Summary

Based on sample hosts in PowerShell Documentation, the host should throw NotImplementedException if a
RawUI member is not implemented but this code which results in a call into RawUI doesn't handle this
exception.  Catch it so that a default value is used.  I believe HostException is thrown if the RawUI interface
is not implemented at all.

## PR Context  

ISE throws NotImplementedException for RawUI members that are not implemented and this class doesn't expect this and doesn't handle it correctly.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.  
- **User-facing changes**
    - [x] Not Applicable
    - **OR**  
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` to your commit messages if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
