### PR TITLE
Don't use Win32 native APIs on non-Windows for crypto of secure string over remoting

### DIFF
--- a/src/System.Management.Automation/engine/remoting/client/clientremotesession.cs
+++ b/src/System.Management.Automation/engine/remoting/client/clientremotesession.cs
@@ -364,12 +364,14 @@ namespace System.Management.Automation.Remoting
 
                     SessionDataStructureHandler.StateMachine.RaiseEvent(eventArgs);
                 }
+                else
+                {
+                    // send using data structure handler
+                    eventArgs = new RemoteSessionStateMachineEventArgs(RemoteSessionEvent.KeySent);
+                    SessionDataStructureHandler.StateMachine.RaiseEvent(eventArgs);
 
-                // send using data structure handler
-                eventArgs = new RemoteSessionStateMachineEventArgs(RemoteSessionEvent.KeySent);
-                SessionDataStructureHandler.StateMachine.RaiseEvent(eventArgs);
-
-                SessionDataStructureHandler.SendPublicKeyAsync(localPublicKey);
+                    SessionDataStructureHandler.SendPublicKeyAsync(localPublicKey);
+                }
             }
         }
 

--- a/src/System.Management.Automation/engine/serialization.cs
+++ b/src/System.Management.Automation/engine/serialization.cs
@@ -1109,46 +1109,39 @@ namespace System.Management.Automation
                     // the principle used in serialization is that serialization
                     // never throws, and if something can't be serialized nothing
                     // is written. So we write the elements only if encryption succeeds
-                    try
+                    string encryptedString;
+                    if (_context.cryptoHelper != null)
                     {
-                        string encryptedString;
-                        if (_context.cryptoHelper != null)
-                        {
-                            encryptedString = _context.cryptoHelper.EncryptSecureString(secureString);
-                        }
-                        else
-                        {
-                            encryptedString = Microsoft.PowerShell.SecureStringHelper.Protect(secureString);
-                        }
-
-                        if (property != null)
-                        {
-                            WriteStartElement(SerializationStrings.SecureStringTag);
-                            WriteNameAttribute(property);
-                        }
-                        else
-                        {
-                            WriteStartElement(SerializationStrings.SecureStringTag);
-                        }
-
-                        if (streamName != null)
-                        {
-                            WriteAttribute(SerializationStrings.StreamNameAttribute, streamName);
-                        }
-
-                        // Note: We do not use WriteRaw for serializing secure string. WriteString
-                        // does necessary escaping which may be needed for certain
-                        // characters.
-                        _writer.WriteString(encryptedString);
-
-                        _writer.WriteEndElement();
-
-                        return true;
+                        encryptedString = _context.cryptoHelper.EncryptSecureString(secureString);
                     }
-                    catch (PSCryptoException)
+                    else
                     {
-                        // do nothing
+                        encryptedString = Microsoft.PowerShell.SecureStringHelper.Protect(secureString);
                     }
+
+                    if (property != null)
+                    {
+                        WriteStartElement(SerializationStrings.SecureStringTag);
+                        WriteNameAttribute(property);
+                    }
+                    else
+                    {
+                        WriteStartElement(SerializationStrings.SecureStringTag);
+                    }
+
+                    if (streamName != null)
+                    {
+                        WriteAttribute(SerializationStrings.StreamNameAttribute, streamName);
+                    }
+
+                    // Note: We do not use WriteRaw for serializing secure string. WriteString
+                    // does necessary escaping which may be needed for certain
+                    // characters.
+                    _writer.WriteString(encryptedString);
+
+                    _writer.WriteEndElement();
+
+                    return true;
                 }
             }
 

--- a/src/System.Management.Automation/engine/serialization.cs
+++ b/src/System.Management.Automation/engine/serialization.cs
@@ -1108,7 +1108,9 @@ namespace System.Management.Automation
                 {
                     // the principle used in serialization is that serialization
                     // never throws, and if something can't be serialized nothing
-                    // is written. So we write the elements only if encryption succeeds
+                    // is written. So we write the elements only if encryption succeeds.
+                    // However, in the case for non-Windows where secure string encryption
+                    // is not yet supported, a PSCryptoException will be thrown.
                     string encryptedString;
                     if (_context.cryptoHelper != null)
                     {

--- a/src/System.Management.Automation/resources/SecuritySupportStrings.resx
+++ b/src/System.Management.Automation/resources/SecuritySupportStrings.resx
@@ -138,4 +138,7 @@
   <data name="CouldNotUseCertificate" xml:space="preserve">
     <value>ERROR: Could not find or use certificate: {0}</value>
   </data>
+  <data name="CannotEncryptSecureString" xml:space="preserve">
+    <value>Session key not available to encrypt secure string.</value>
+  </data>
 </root>

--- a/src/System.Management.Automation/utils/CryptoUtils.cs
+++ b/src/System.Management.Automation/utils/CryptoUtils.cs
@@ -92,14 +92,14 @@ namespace System.Management.Automation.Internal
             uint dwFlags,
             ref PSSafeCryptKey phKey)
         {
-            throw new PSCryptoException();;
+            throw new PSCryptoException();
         }
 
         /// Return Type: BOOL->int
         ///hKey: HCRYPTKEY->ULONG_PTR->unsigned int
         public static bool CryptDestroyKey(IntPtr hKey)
         {
-            throw new PSCryptoException();;
+            throw new PSCryptoException();
         }
 
         /// Return Type: BOOL->int
@@ -114,7 +114,7 @@ namespace System.Management.Automation.Internal
             uint dwProvType,
             uint dwFlags)
         {
-            throw new PSCryptoException();;
+            throw new PSCryptoException();
         }
 
         /// Return Type: BOOL->int
@@ -122,7 +122,7 @@ namespace System.Management.Automation.Internal
         ///dwFlags: DWORD->unsigned int
         public static bool CryptReleaseContext(IntPtr hProv, uint dwFlags)
         {
-            throw new PSCryptoException();;
+            throw new PSCryptoException();
         }
 
 
@@ -142,7 +142,7 @@ namespace System.Management.Automation.Internal
             ref int pdwDataLen,
             int dwBufLen)
         {
-            throw new PSCryptoException();;
+            throw new PSCryptoException();
         }
 
 
@@ -160,7 +160,7 @@ namespace System.Management.Automation.Internal
             byte[] pbData,
             ref int pdwDataLen)
         {
-            throw new PSCryptoException();;
+            throw new PSCryptoException();
         }
 
         /// Return Type: BOOL->int
@@ -177,7 +177,7 @@ namespace System.Management.Automation.Internal
             byte[] pbData,
             ref uint pdwDataLen)
         {
-            throw new PSCryptoException();;
+            throw new PSCryptoException();
         }
 
         /// Return Type: BOOL->int
@@ -194,7 +194,7 @@ namespace System.Management.Automation.Internal
             uint dwFlags,
             ref PSSafeCryptKey phKey)
         {
-            throw new PSCryptoException();;
+            throw new PSCryptoException();
         }
 
         /// Return Type: BOOL->int
@@ -207,13 +207,13 @@ namespace System.Management.Automation.Internal
                                                     uint dwFlags,
                                                     ref PSSafeCryptKey phKey)
         {
-            throw new PSCryptoException();;
+            throw new PSCryptoException();
         }
 
         /// Return Type: DWORD->unsigned int
         public static uint GetLastError()
         {
-            throw new PSCryptoException();;
+            throw new PSCryptoException();
         }
 #else
 

--- a/src/System.Management.Automation/utils/CryptoUtils.cs
+++ b/src/System.Management.Automation/utils/CryptoUtils.cs
@@ -80,6 +80,143 @@ namespace System.Management.Automation.Internal
     {
         #region Functions
 
+#if UNIX
+        /// Return Type: BOOL->int
+        ///hProv: HCRYPTPROV->ULONG_PTR->unsigned int
+        ///Algid: ALG_ID->unsigned int
+        ///dwFlags: DWORD->unsigned int
+        ///phKey: HCRYPTKEY*
+        public static bool CryptGenKey(
+            PSSafeCryptProvHandle hProv,
+            uint Algid,
+            uint dwFlags,
+            ref PSSafeCryptKey phKey)
+        {
+            throw new PSCryptoException();;
+        }
+
+        /// Return Type: BOOL->int
+        ///hKey: HCRYPTKEY->ULONG_PTR->unsigned int
+        public static bool CryptDestroyKey(IntPtr hKey)
+        {
+            throw new PSCryptoException();;
+        }
+
+        /// Return Type: BOOL->int
+        ///phProv: HCRYPTPROV*
+        ///szContainer: LPCWSTR->WCHAR*
+        ///szProvider: LPCWSTR->WCHAR*
+        ///dwProvType: DWORD->unsigned int
+        ///dwFlags: DWORD->unsigned int
+        public static bool CryptAcquireContext(ref PSSafeCryptProvHandle phProv,
+            [InAttribute()] [MarshalAsAttribute(UnmanagedType.LPWStr)] string szContainer,
+            [InAttribute()] [MarshalAsAttribute(UnmanagedType.LPWStr)] string szProvider,
+            uint dwProvType,
+            uint dwFlags)
+        {
+            throw new PSCryptoException();;
+        }
+
+        /// Return Type: BOOL->int
+        ///hProv: HCRYPTPROV->ULONG_PTR->unsigned int
+        ///dwFlags: DWORD->unsigned int
+        public static bool CryptReleaseContext(IntPtr hProv, uint dwFlags)
+        {
+            throw new PSCryptoException();;
+        }
+
+
+        /// Return Type: BOOL->int
+        ///hKey: HCRYPTKEY->ULONG_PTR->unsigned int
+        ///hHash: HCRYPTHASH->ULONG_PTR->unsigned int
+        ///Final: BOOL->int
+        ///dwFlags: DWORD->unsigned int
+        ///pbData: BYTE*
+        ///pdwDataLen: DWORD*
+        ///dwBufLen: DWORD->unsigned int
+        public static bool CryptEncrypt(PSSafeCryptKey hKey,
+            IntPtr hHash,
+            [MarshalAsAttribute(UnmanagedType.Bool)] bool Final,
+            uint dwFlags,
+            byte[] pbData,
+            ref int pdwDataLen,
+            int dwBufLen)
+        {
+            throw new PSCryptoException();;
+        }
+
+
+        /// Return Type: BOOL->int
+        ///hKey: HCRYPTKEY->ULONG_PTR->unsigned int
+        ///hHash: HCRYPTHASH->ULONG_PTR->unsigned int
+        ///Final: BOOL->int
+        ///dwFlags: DWORD->unsigned int
+        ///pbData: BYTE*
+        ///pdwDataLen: DWORD*
+        public static bool CryptDecrypt(PSSafeCryptKey hKey,
+            IntPtr hHash,
+            [MarshalAsAttribute(UnmanagedType.Bool)] bool Final,
+            uint dwFlags,
+            byte[] pbData,
+            ref int pdwDataLen)
+        {
+            throw new PSCryptoException();;
+        }
+
+        /// Return Type: BOOL->int
+        ///hKey: HCRYPTKEY->ULONG_PTR->unsigned int
+        ///hExpKey: HCRYPTKEY->ULONG_PTR->unsigned int
+        ///dwBlobType: DWORD->unsigned int
+        ///dwFlags: DWORD->unsigned int
+        ///pbData: BYTE*
+        ///pdwDataLen: DWORD*
+        public static bool CryptExportKey(PSSafeCryptKey hKey,
+            PSSafeCryptKey hExpKey,
+            uint dwBlobType,
+            uint dwFlags,
+            byte[] pbData,
+            ref uint pdwDataLen)
+        {
+            throw new PSCryptoException();;
+        }
+
+        /// Return Type: BOOL->int
+        ///hProv: HCRYPTPROV->ULONG_PTR->unsigned int
+        ///pbData: BYTE*
+        ///dwDataLen: DWORD->unsigned int
+        ///hPubKey: HCRYPTKEY->ULONG_PTR->unsigned int
+        ///dwFlags: DWORD->unsigned int
+        ///phKey: HCRYPTKEY*
+        public static bool CryptImportKey(PSSafeCryptProvHandle hProv,
+            byte[] pbData,
+            int dwDataLen,
+            PSSafeCryptKey hPubKey,
+            uint dwFlags,
+            ref PSSafeCryptKey phKey)
+        {
+            throw new PSCryptoException();;
+        }
+
+        /// Return Type: BOOL->int
+        ///hKey: HCRYPTKEY->ULONG_PTR->unsigned int
+        ///pdwReserved: DWORD*
+        ///dwFlags: DWORD->unsigned int
+        ///phKey: HCRYPTKEY*
+        public static bool CryptDuplicateKey(PSSafeCryptKey hKey,
+                                                    ref uint pdwReserved,
+                                                    uint dwFlags,
+                                                    ref PSSafeCryptKey phKey)
+        {
+            throw new PSCryptoException();;
+        }
+
+        /// Return Type: DWORD->unsigned int
+        public static uint GetLastError()
+        {
+            throw new PSCryptoException();;
+        }
+#else
+
         /// Return Type: BOOL->int
         ///hProv: HCRYPTPROV->ULONG_PTR->unsigned int
         ///Algid: ALG_ID->unsigned int
@@ -200,6 +337,7 @@ namespace System.Management.Automation.Internal
         /// Return Type: DWORD->unsigned int
         [DllImportAttribute(PinvokeDllNames.GetLastErrorDllName, EntryPoint = "GetLastError")]
         public static extern uint GetLastError();
+#endif
 
         #endregion Functions
 
@@ -1022,7 +1160,7 @@ namespace System.Management.Automation.Internal
             }
             else
             {
-                Dbg.Assert(false, "Session key not available to encrypt secure string");
+                throw new PSCryptoException(SecuritySupportStrings.CannotEncryptSecureString);
             }
 
             return encryptedDataAsString;


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->  

## PR Summary

Remoting relies on Windows native crypto APIs to pass a secure string.  Of course these APIs don't work on non-Windows.  However, the remoting code does not expect this to fail so ends up in a hang waiting for an event that never happens.

Have not figured out how to return an error to the user in the case `Get-Credential` is called within a PSSession.  Currently it just quietly closes the remote connection.  @PaulHigin can you give a pointer to where this code would exist?  Debugging the current code, it has a bunch of error handlers which just result in the pssession being closed and not sure where throwing is appropriate.

Fix https://github.com/PowerShell/PowerShell/issues/8723

## PR Context  

Fix is to provide implementations of the Win32 native pinvoke apis that throw an exception.  The reason to do it this way is that there's a bunch of code that calls some of the APIs of the wrapper .Net class to setup structures that eventually get passed to the win32 api.  Throwing in the managed class causes other things to fail early that should work on non-Windows.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.  
- **User-facing changes**
    - [x] Not Applicable
    - **OR**  
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` to your commit messages if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
