### PR TITLE
Fix `Get-Help` `PSTypeName` issue with `-Parameter` when only one parameter is declared

### DIFF
--- a/src/System.Management.Automation/help/BaseCommandHelpInfo.cs
+++ b/src/System.Management.Automation/help/BaseCommandHelpInfo.cs
@@ -393,8 +393,19 @@ namespace System.Management.Automation
                 return base.GetParameter(pattern);
             }
 
+            // The Maml format simplifies array fields containing only one object
+            // by transforming them into the objects themselves. To ensure the consistency
+            // of the help command result we change it back into an array.
+            var param = prmts.Properties["parameter"].Value;
+            PSObject[] paramAsPSObjArray = new PSObject[1];
+
+            if (param is PSObject paramPSObj)
+            {
+                paramAsPSObjArray[0] = paramPSObj;
+            }
+
             PSObject[] prmtArray = (PSObject[])LanguagePrimitives.ConvertTo(
-                prmts.Properties["parameter"].Value,
+                paramAsPSObjArray[0] != null ? paramAsPSObjArray : param,
                 typeof(PSObject[]),
                 CultureInfo.InvariantCulture);
 

--- a/test/powershell/engine/Help/HelpSystem.Tests.ps1
+++ b/test/powershell/engine/Help/HelpSystem.Tests.ps1
@@ -503,6 +503,45 @@ Describe "Get-Help should accept arrays as the -Parameter parameter value" -Tags
     }
 }
 
+Describe "Get-Help for function parameter should be consistent" -Tags 'CI' {
+    BeforeAll {
+        $test1 = @'
+            function test1 {
+                param (
+                    $First
+                )
+            }
+'@
+        $test2 = @'
+            function test2 {
+                param (
+                    $First,
+                    $Second
+                )
+            }
+'@
+        $test1Path = Join-Path $TestDrive "test1.ps1"
+        Set-Content -Path $test1Path -Value $test1
+
+        $test2Path = Join-Path $TestDrive "test2.ps1"
+        Set-Content -Path $test2Path -Value $test2
+
+        Import-Module $test1Path
+        Import-Module $test2Path
+    }
+
+    AfterAll {
+        Remove-Module -Name "test1"
+        Remove-Module -Name "test2"
+    }
+
+    It "Get-Help for function parameter should be consistent" {
+        $test1HelpPSType = (Get-Help test1 -Parameter First).PSTypeNames
+        $test2HelpPSType = (Get-Help test2 -Parameter First).PSTypeNames
+        $test1HelpPSType | Should -BeExactly $test2HelpPSType
+    }
+}
+
 Describe "Help failure cases" -Tags Feature {
     It "An error is returned for a topic that doesn't exist: <command>" -TestCases @(
         @{ command = "help" },


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->  

## PR Summary

Fix #8697 'Get-Help -Parameter does not correctly set PSTypeName when one parameter is declared'. 

## PR Context  

This issue occurs for the following reason : 
- For a single parameter the FullHelp object contains a PSObject representing the parameter
- For multiple parameters the FullHelp object conrains a PSObject[] with each element representing a parameter.
My fix is to manipulate a PSObject[] instead of a PSObject even in the event that it only contains one parameter.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.  
- **User-facing changes**
    - [x] Not Applicable
    - **OR**  
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` to your commit messages if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
