### PR TITLE
Enable `Write-Information` to accept $null

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/write.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/write.cs
@@ -165,6 +165,7 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         [Parameter(Position = 0, Mandatory = true, ValueFromPipeline = true)]
         [Alias("Msg", "Message")]
+        [AllowNull]
         public object MessageData { get; set; }
 
         /// <summary>

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Stream.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Stream.Tests.ps1
@@ -119,7 +119,7 @@ Describe "Stream writer tests" -Tags "CI" {
             $streamPath = Join-Path $testdrive information.txt
             $null | Write-Information -Tags myTag -ErrorAction Stop -InformationAction SilentlyContinue -InformationVariable i
             $i.Tags | Should -BeExactly "myTag"
-            $i.MessageData | Should -BeNullOrEmpty
+            $i.MessageData | Should -Be $null
         }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Stream.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Stream.Tests.ps1
@@ -115,8 +115,8 @@ Describe "Stream writer tests" -Tags "CI" {
             (Compare-Object $result $returnValue -SyncWindow 0).length | Should -Be 0
         }
 
-        It "Write-Information accespts `$Null" {
-            $null | Write-Information | Should -BeNullOrEmpty
+        It "Write-Information accepts `$Null" {
+            $null | Write-Information -ErrorAction Stop | Should -BeNullOrEmpty
         }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Stream.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Stream.Tests.ps1
@@ -114,5 +114,9 @@ Describe "Stream writer tests" -Tags "CI" {
             $result.Count | Should -Be $returnCount
             (Compare-Object $result $returnValue -SyncWindow 0).length | Should -Be 0
         }
+
+        It "Write-Information accespts `$Null" {
+            $null | Write-Information | Should -BeNullOrEmpty
+        }
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Stream.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Stream.Tests.ps1
@@ -116,7 +116,10 @@ Describe "Stream writer tests" -Tags "CI" {
         }
 
         It "Write-Information accepts `$Null" {
-            $null | Write-Information -ErrorAction Stop | Should -BeNullOrEmpty
+            $streamPath = Join-Path $testdrive information.txt
+            $null | Write-Information -Tags myTag -ErrorAction Stop -InformationAction SilentlyContinue -InformationVariable i
+            $i.Tags | Should -BeExactly "myTag"
+            $i.MessageData | Should -BeNullOrEmpty
         }
     }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->  

## PR Summary

`Write-Information` currently errors if $null is passed.

## PR Context  

There's no benefit to having it error out if $null is passed.  If a pipeline is sending objects to `Write-Information`, it would make sense for the cmdlet to handle $null which in this case is a no-op.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.  
- **User-facing changes**
    - [x] Not Applicable
    - **OR**  
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` to your commit messages if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
