### PR TITLE
Enable discovering modules that have names same as a culture (e.g. Az)

### DIFF
--- a/src/System.Management.Automation/engine/Modules/ModuleUtils.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleUtils.cs
@@ -486,7 +486,7 @@ namespace System.Management.Automation.Internal
                         }
                     }
 
-                    string moduleShortName = System.IO.Path.GetFileNameWithoutExtension(modulePath);
+                    string moduleShortName = Path.GetFileNameWithoutExtension(modulePath);
 
                     IDictionary<string, CommandTypes> exportedCommands = AnalysisCache.GetExportedCommands(modulePath, testOnly: false, context);
 

--- a/src/System.Management.Automation/engine/Modules/ModuleUtils.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleUtils.cs
@@ -16,14 +16,14 @@ namespace System.Management.Automation.Internal
         //  - Ignore files/directories when access is denied;
         //  - Search top directory only.
         private static readonly System.IO.EnumerationOptions s_defaultEnumerationOptions =
-                                        new System.IO.EnumerationOptions() { AttributesToSkip = System.IO.FileAttributes.Hidden };
+                                        new System.IO.EnumerationOptions() { AttributesToSkip = FileAttributes.Hidden };
 
         // Default option for UNC path enumeration. Same as above plus a large buffer size.
         // For network shares, a large buffer may result in better performance as more results can be batched over the wire.
         // The buffer size 16K is recommended in the comment of the 'BufferSize' property:
         //    "A "large" buffer, for example, would be 16K. Typical is 4K."
         private static readonly System.IO.EnumerationOptions s_uncPathEnumerationOptions =
-                                        new System.IO.EnumerationOptions() { AttributesToSkip = System.IO.FileAttributes.Hidden, BufferSize = 16384 };
+                                        new System.IO.EnumerationOptions() { AttributesToSkip = FileAttributes.Hidden, BufferSize = 16384 };
 
         private static readonly string EnCulturePath = Path.DirectorySeparatorChar + "en";
         private static readonly string EnUsCulturePath = Path.DirectorySeparatorChar + "en-us";

--- a/src/System.Management.Automation/engine/Modules/ModuleUtils.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleUtils.cs
@@ -92,6 +92,7 @@ namespace System.Management.Automation.Internal
                 catch (IOException) { }
                 catch (UnauthorizedAccessException) { }
 
+                firstSubDirs = false;
                 string[] files = Directory.GetFiles(directoryToCheck, "*", options);
                 foreach (string moduleFile in files)
                 {
@@ -105,8 +106,6 @@ namespace System.Management.Automation.Internal
                     }
                 }
             }
-
-            firstSubDirs = false;
         }
 
         /// <summary>

--- a/src/System.Management.Automation/engine/Modules/ModuleUtils.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleUtils.cs
@@ -26,8 +26,10 @@ namespace System.Management.Automation.Internal
                                         new System.IO.EnumerationOptions() { AttributesToSkip = System.IO.FileAttributes.Hidden, BufferSize = 16384 };
 
         /// <summary>
-        /// Check if a directory is likely a localized resources folder
+        /// Check if a directory is likely a localized resources folder.
         /// </summary>
+        /// <param name="dir">Directory to check if it is a possible resource folder.</param>
+        /// <returns>True if the directory name matches a culture.</returns>
         internal static bool IsPossibleResourceDirectory(string dir)
         {
             // Assume locale directories do not contain modules.
@@ -38,6 +40,7 @@ namespace System.Management.Automation.Internal
             }
 
             dir = Path.GetFileName(dir);
+
             // Use some simple pattern matching to avoid the call into GetCultureInfo when we know it will fail (and throw).
             if ((dir.Length == 2 && char.IsLetter(dir[0]) && char.IsLetter(dir[1]))
                 ||

--- a/src/System.Management.Automation/engine/Modules/ModuleUtils.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleUtils.cs
@@ -25,6 +25,9 @@ namespace System.Management.Automation.Internal
         private static readonly System.IO.EnumerationOptions s_uncPathEnumerationOptions =
                                         new System.IO.EnumerationOptions() { AttributesToSkip = System.IO.FileAttributes.Hidden, BufferSize = 16384 };
 
+        private static readonly string EnCulturePath = Path.DirectorySeparatorChar + "en";
+        private static readonly string EnUsCulturePath = Path.DirectorySeparatorChar + "en-us";
+
         /// <summary>
         /// Check if a directory is likely a localized resources folder.
         /// </summary>
@@ -33,8 +36,8 @@ namespace System.Management.Automation.Internal
         internal static bool IsPossibleResourceDirectory(string dir)
         {
             // Assume locale directories do not contain modules.
-            if (dir.EndsWith(Path.DirectorySeparatorChar + "en", StringComparison.OrdinalIgnoreCase) ||
-                dir.EndsWith(Path.DirectorySeparatorChar + "en-us", StringComparison.OrdinalIgnoreCase))
+            if (dir.EndsWith(EnCulturePath, StringComparison.OrdinalIgnoreCase) ||
+                dir.EndsWith(EnUsCulturePath, StringComparison.OrdinalIgnoreCase))
             {
                 return true;
             }

--- a/src/System.Management.Automation/help/HelpFileHelpProvider.cs
+++ b/src/System.Management.Automation/help/HelpFileHelpProvider.cs
@@ -370,7 +370,7 @@ namespace System.Management.Automation
                         // * and SearchOption.AllDirectories gets all the version directories.
                         string[] directories = Directory.GetDirectories(psModulePath, "*", SearchOption.AllDirectories);
 
-                        var possibleModuleDirectories = directories.Where(directory => ModuleUtils.IsPossibleModuleDirectory(directory));
+                        var possibleModuleDirectories = directories.Where(directory => !ModuleUtils.IsPossibleResourceDirectory(directory));
 
                         foreach (string directory in possibleModuleDirectories)
                         {

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -10,11 +10,13 @@ Describe "Get-Module -ListAvailable" -Tags "CI" {
         New-Item -ItemType Directory -Path "$testdrive\Modules\Foo\2.0" -Force > $null
         New-Item -ItemType Directory -Path "$testdrive\Modules\Bar\Download" -Force > $null
         New-Item -ItemType Directory -Path "$testdrive\Modules\Zoo\Too" -Force > $null
+        New-Item -ItemType Directory -Path "$testdrive\Modules\Az" -Force > $null
 
         New-ModuleManifest -Path "$testdrive\Modules\Foo\1.1\Foo.psd1" -ModuleVersion 1.1
         New-ModuleManifest -Path "$testdrive\Modules\Foo\2.0\Foo.psd1" -ModuleVersion 2.0
         New-ModuleManifest -Path "$testdrive\Modules\Bar\Bar.psd1"
         New-ModuleManifest -Path "$testdrive\Modules\Zoo\Zoo.psd1"
+        New-ModuleManifest -Path "$testdrive\Modules\Az\Az.psd1" -ModuleVersion 1.1
 
         New-Item -ItemType File -Path "$testdrive\Modules\Foo\1.1\Foo.psm1" > $null
         New-Item -ItemType File -Path "$testdrive\Modules\Foo\2.0\Foo.psm1" > $null
@@ -22,6 +24,7 @@ Describe "Get-Module -ListAvailable" -Tags "CI" {
         New-Item -ItemType File -Path "$testdrive\Modules\Bar\Download\Download.psm1" > $null
         New-Item -ItemType File -Path "$testdrive\Modules\Zoo\Zoo.psm1" > $null
         New-Item -ItemType File -Path "$testdrive\Modules\Zoo\Too\Zoo.psm1" > $null
+        New-Item -ItemType File -Path "$testdrive\Modules\Az\Az.psm1" > $null
 
         $fullyQualifiedPathTestCases = @(
             # The current behaviour in PowerShell is that version gets ignored when using Get-Module -FullyQualifiedName with a path
@@ -40,11 +43,13 @@ Describe "Get-Module -ListAvailable" -Tags "CI" {
 
     It "Get-Module -ListAvailable" {
         $modules = Get-Module -ListAvailable
-        $modules.Count | Should -Be 4
+        $modules.Count | Should -Be 5
         $modules = $modules | Sort-Object -Property Name, Version
-        $modules.Name -join "," | Should -BeExactly "Bar,Foo,Foo,Zoo"
-        $modules[1].Version | Should -Be "1.1"
-        $modules[2].Version | Should -Be '2.0'
+        $modules.Name -join "," | Should -BeExactly "Az,Bar,Foo,Foo,Zoo"
+        $modules[0].Version | Should -Be "1.1"
+        $modules[1].Version | Should -Be "0.0.1"
+        $modules[2].Version | Should -Be '1.1'
+        $modules[3].Version | Should -Be '2.0'
     }
 
     It "Get-Module <Name> -ListAvailable" {
@@ -58,25 +63,27 @@ Describe "Get-Module -ListAvailable" -Tags "CI" {
 
     It "Get-Module -ListAvailable -All" {
         $modules = Get-Module -ListAvailable -All
-        $modules.Count | Should -Be 10
+        $modules.Count | Should -Be 12
         $modules = $modules | Sort-Object -Property Name, Path
-        $modules.Name -join "," | Should -BeExactly "Bar,Bar,Download,Foo,Foo,Foo,Foo,Zoo,Zoo,Zoo"
+        $modules.Name -join "," | Should -BeExactly "Az,Az,Bar,Bar,Download,Foo,Foo,Foo,Foo,Zoo,Zoo,Zoo"
 
         $modules[0].ModuleType | Should -BeExactly "Manifest"
         $modules[1].ModuleType | Should -BeExactly "Script"
-        $modules[2].ModuleType | Should -BeExactly "Script"
-        $modules[3].ModuleType | Should -BeExactly "Manifest"
-        $modules[3].Version | Should -Be "1.1"
+        $modules[2].ModuleType | Should -BeExactly "Manifest"
+        $modules[3].ModuleType | Should -BeExactly "Script"
         $modules[4].ModuleType | Should -BeExactly "Script"
         $modules[5].ModuleType | Should -BeExactly "Manifest"
-        $modules[5].Version | Should -Be "2.0"
+        $modules[5].Version | Should -Be "1.1"
         $modules[6].ModuleType | Should -BeExactly "Script"
-        $modules[7].ModuleType | Should -BeExactly "Script"
-        $modules[7].Path | Should -BeExactly (Resolve-Path "$testdrive\Modules\Zoo\Too\Zoo.psm1").Path
-        $modules[8].ModuleType | Should -BeExactly "Manifest"
-        $modules[8].Path | Should -BeExactly (Resolve-Path "$testdrive\Modules\Zoo\Zoo.psd1").Path
+        $modules[7].ModuleType | Should -BeExactly "Manifest"
+        $modules[7].Version | Should -Be "2.0"
+        $modules[8].ModuleType | Should -BeExactly "Script"
         $modules[9].ModuleType | Should -BeExactly "Script"
-        $modules[9].Path | Should -BeExactly (Resolve-Path "$testdrive\Modules\Zoo\Zoo.psm1").Path
+        $modules[9].Path | Should -BeExactly (Resolve-Path "$testdrive\Modules\Zoo\Too\Zoo.psm1").Path
+        $modules[10].ModuleType | Should -BeExactly "Manifest"
+        $modules[10].Path | Should -BeExactly (Resolve-Path "$testdrive\Modules\Zoo\Zoo.psd1").Path
+        $modules[11].ModuleType | Should -BeExactly "Script"
+        $modules[11].Path | Should -BeExactly (Resolve-Path "$testdrive\Modules\Zoo\Zoo.psm1").Path
     }
 
     It "Get-Module <Name> -ListAvailable -All" {
@@ -93,19 +100,19 @@ Describe "Get-Module -ListAvailable" -Tags "CI" {
 
     It "Get-Module <Path> -ListAvailable" {
         $modules = Get-Module "$testdrive\Modules\*" -ListAvailable
-        $modules.Count | Should -Be 4
+        $modules.Count | Should -Be 5
         $modules = $modules | Sort-Object -Property Name, Version
-        $modules.Name -join "," | Should -BeExactly "Bar,Foo,Foo,Zoo"
-        $modules[1].Version | Should -Be "1.1"
-        $modules[2].Version | Should -Be '2.0'
+        $modules.Name -join "," | Should -BeExactly "Az,Bar,Foo,Foo,Zoo"
+        $modules[2].Version | Should -Be "1.1"
+        $modules[3].Version | Should -Be '2.0'
     }
 
     It "Get-Module <Path> -ListAvailable -All" {
         $modules = Get-Module "$testdrive\Modules\*" -ListAvailable -All
-        $modules.Count | Should -Be 5
+        $modules.Count | Should -Be 6
         $modules = $modules | Sort-Object -Property Name, Path
-        $modules.Name -join "," | Should -BeExactly "Bar,Foo,Foo,Zoo,Zoo"
-        $modules[3].Path | Should -BeExactly (Resolve-Path "$testdrive\Modules\Zoo\Too\Zoo.psm1").Path
+        $modules.Name -join "," | Should -BeExactly "Az,Bar,Foo,Foo,Zoo,Zoo"
+        $modules[4].Path | Should -BeExactly (Resolve-Path "$testdrive\Modules\Zoo\Too\Zoo.psm1").Path
     }
 
     It "Get-Module -FullyQualifiedName <FullyQualifiedName> -ListAvailable" {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->  

## PR Summary

The suggested fix by @lzybkr is to not do this additional culture name check for the first set of folders (which should be the module name).  This PR fixes a few things:

- Add logic to skip checking for possible resource directories for the first set of sub directories from the top level.
- There was an additional skip if the folder is hidden, rather than doing an explicit attribute check, change the `EnumerationOption` to skip hidden folders.
- Since the `IsPossibleModuleDirectory()` helper now only checks to see if the name matches a culture, renamed to `IsPossibleResourceDirectory()`
- When getting the default modules, we don't search recursively into individual module folders, so removed additional check for possible resource directory.

## PR Context  

The current code always checks if a potential module folder is named after a culture and assumes it contains resources files as an optimization to avoid looking in that folder.   This results in the new Az module not being found as `Az` is also the name of a culture.  

Fix #8125 

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.  
- **User-facing changes**
    - [x] Not Applicable
    - **OR**  
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [x] [Add `[feature]` to your commit messages if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
