### PR TITLE
Reduce race condition probability for config file access

### DIFF
--- a/src/System.Management.Automation/engine/PSConfiguration.cs
+++ b/src/System.Management.Automation/engine/PSConfiguration.cs
@@ -408,10 +408,6 @@ namespace System.Management.Automation.Configuration
                     }
                 }
             }
-            catch (IOException)
-            {
-                return defaultValue;
-            }
             finally
             {
                 fileLock.ExitReadLock();
@@ -422,7 +418,7 @@ namespace System.Management.Automation.Configuration
 
         private FileStream WaitForFile(string fullPath, FileMode mode, FileAccess access, FileShare share)
         {
-            const int MaxTries = 20;
+            const int MaxTries = 5;
             for (int numTries = 0; numTries < MaxTries; numTries++)
             {
                 try
@@ -436,7 +432,7 @@ namespace System.Management.Automation.Configuration
                         throw;
                     }
 
-                    Thread.Sleep(20);
+                    Thread.Sleep(50);
                 }
             }
 

--- a/src/System.Management.Automation/engine/PSConfiguration.cs
+++ b/src/System.Management.Automation/engine/PSConfiguration.cs
@@ -380,7 +380,7 @@ namespace System.Management.Automation.Configuration
         /// <typeparam name="T">The type of the value</typeparam>
         /// <param name="scope">The ConfigScope of the configuration file to update.</param>
         /// <param name="key">The string key of the value.</param>
-        /// <param name="defaultValue">The default value to return if the key is not present or the config file is not available.</param>
+        /// <param name="defaultValue">The default value to return if the key is not present.</param>
         /// <param name="readImpl"></param>
         private T ReadValueFromFile<T>(ConfigScope scope, string key, T defaultValue = default(T),
                                        Func<JToken, JsonSerializer, T, T> readImpl = null)
@@ -451,90 +451,96 @@ namespace System.Management.Automation.Configuration
         {
             string fileName = GetConfigFilePath(scope);
             fileLock.EnterWriteLock();
-
-            // Since multiple properties can be in a single file, replacement
-            // is required instead of overwrite if a file already exists.
-            // Handling the read and write operations within a single FileStream
-            // prevents other processes from reading or writing the file while
-            // the update is in progress. It also locks out readers during write
-            // operations.
-            using (FileStream fs = WaitForFile(fileName, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None))
+            try
             {
-                JObject jsonObject = null;
-
-                // UTF8, BOM detection, and bufferSize are the same as the basic stream constructor.
-                // The most important parameter here is the last one, which keeps the StreamReader
-                // (and FileStream) open during Dispose so that it can be reused for the write
-                // operation.
-                using (StreamReader streamRdr = new StreamReader(fs, Encoding.UTF8, true, 1024, true))
-                using (JsonTextReader jsonReader = new JsonTextReader(streamRdr))
+                // Since multiple properties can be in a single file, replacement
+                // is required instead of overwrite if a file already exists.
+                // Handling the read and write operations within a single FileStream
+                // prevents other processes from reading or writing the file while
+                // the update is in progress. It also locks out readers during write
+                // operations.
+                using (FileStream fs = WaitForFile(fileName, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None))
                 {
-                    // Safely determines whether there is content to read from the file
-                    bool isReadSuccess = jsonReader.Read();
-                    if (isReadSuccess)
-                    {
-                        // Read the stream into a root JObject for manipulation
-                        jsonObject = (JObject) JToken.ReadFrom(jsonReader);
-                        JProperty propertyToModify = jsonObject.Property(key);
+                    JObject jsonObject = null;
 
-                        if (propertyToModify == null)
+                    // UTF8, BOM detection, and bufferSize are the same as the basic stream constructor.
+                    // The most important parameter here is the last one, which keeps the StreamReader
+                    // (and FileStream) open during Dispose so that it can be reused for the write
+                    // operation.
+                    using (StreamReader streamRdr = new StreamReader(fs, Encoding.UTF8, true, 1024, true))
+                    using (JsonTextReader jsonReader = new JsonTextReader(streamRdr))
+                    {
+                        // Safely determines whether there is content to read from the file
+                        bool isReadSuccess = jsonReader.Read();
+                        if (isReadSuccess)
                         {
-                            // The property doesn't exist, so add it
-                            if (addValue)
+                            // Read the stream into a root JObject for manipulation
+                            jsonObject = (JObject) JToken.ReadFrom(jsonReader);
+                            JProperty propertyToModify = jsonObject.Property(key);
+
+                            if (propertyToModify == null)
                             {
-                                jsonObject.Add(new JProperty(key, value));
+                                // The property doesn't exist, so add it
+                                if (addValue)
+                                {
+                                    jsonObject.Add(new JProperty(key, value));
+                                }
+                                // else the property doesn't exist so there is nothing to remove
                             }
-                            // else the property doesn't exist so there is nothing to remove
+                            // The property exists
+                            else
+                            {
+                                if (addValue)
+                                {
+                                    propertyToModify.Replace(new JProperty(key, value));
+                                }
+                                else
+                                {
+                                    propertyToModify.Remove();
+                                }
+                            }
                         }
-                        // The property exists
                         else
                         {
+                            // The file doesn't already exist and we want to write to it
+                            // or it exists with no content.
+                            // A new file will be created that contains only this value.
+                            // If the file doesn't exist and a we don't want to write to it, no
+                            // action is necessary.
                             if (addValue)
                             {
-                                propertyToModify.Replace(new JProperty(key, value));
+                                jsonObject = new JObject(new JProperty(key, value));
                             }
                             else
                             {
-                                propertyToModify.Remove();
+                                return;
                             }
                         }
                     }
-                    else
+
+                    // Reset the stream position to the beginning so that the
+                    // changes to the file can be written to disk
+                    fs.Seek(0, SeekOrigin.Begin);
+
+                    // Update the file with new content
+                    using (StreamWriter streamWriter = new StreamWriter(fs))
+                    using (JsonTextWriter jsonWriter = new JsonTextWriter(streamWriter))
                     {
-                        // The file doesn't already exist and we want to write to it
-                        // or it exists with no content.
-                        // A new file will be created that contains only this value.
-                        // If the file doesn't exist and a we don't want to write to it, no
-                        // action is necessary.
-                        if (addValue)
-                        {
-                            jsonObject = new JObject(new JProperty(key, value));
-                        }
-                        else
-                        {
-                            return;
-                        }
+                        // The entire document exists within the root JObject.
+                        // I just need to write that object to produce the document.
+                        jsonObject.WriteTo(jsonWriter);
+
+                        // This trims the file if the file shrank. If the file grew,
+                        // it is a no-op. The purpose is to trim extraneous characters
+                        // from the file stream when the resultant JObject is smaller
+                        // than the input JObject.
+                        fs.SetLength(fs.Position);
                     }
                 }
-
-                // Reset the stream position to the beginning so that the
-                // changes to the file can be written to disk
-                fs.Seek(0, SeekOrigin.Begin);
-
-                // Update the file with new content
-                using (StreamWriter streamWriter = new StreamWriter(fs))
-                using (JsonTextWriter jsonWriter = new JsonTextWriter(streamWriter))
-                {
-                    // The entire document exists within the root JObject.
-                    // I just need to write that object to produce the document.
-                    jsonObject.WriteTo(jsonWriter);
-
-                    // This trims the file if the file shrank. If the file grew,
-                    // it is a no-op. The purpose is to trim extraneous characters
-                    // from the file stream when the resultant JObject is smaller
-                    // than the input JObject.
-                    fs.SetLength(fs.Position);
-                }
+            }
+            finally
+            {
+                fileLock.ExitWriteLock();
             }
         }
 


### PR DESCRIPTION
## PR Summary

Related #8715.

1. Replace EnterReadLock() with TryEnterReadLock().
EnterReadLock() might never return.
2. Increase the number of read file lock attempts.
Reduce inter-process race condition probability.
3. Use WaitForFile() for write file lock.
Reduce inter-process race condition probability.
4. Replace EnterWriteLock() with TryEnterWriteLock().
EnterWriteLock() might never return.
5. Return default if the config file can not be read (added `catch (IOExeption)`).

## PR Context  

Currently we see race condition failures in xUnit tests. The race conditions can be inter-thread and inter-process.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.  
- **User-facing changes**
    - [x] Not Applicable
    - **OR**  
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` to your commit messages if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
