### PR TITLE
Enable creating relative symlinks with `New-Item`

### DIFF
--- a/src/System.Management.Automation/engine/SessionStateContainer.cs
+++ b/src/System.Management.Automation/engine/SessionStateContainer.cs
@@ -3537,7 +3537,7 @@ namespace System.Management.Automation
 
                         // If the original target was a relative path, we want to leave it as relative if it did not require
                         // globbing to resolve.
-                        if (WildcardPattern.ContainsWildcardCharacters(content.ToString()))
+                        if (WildcardPattern.ContainsWildcardCharacters(targetPath))
                         {
                             content = globbedTarget[0];
                         }

--- a/src/System.Management.Automation/engine/SessionStateContainer.cs
+++ b/src/System.Management.Automation/engine/SessionStateContainer.cs
@@ -3535,7 +3535,12 @@ namespace System.Management.Automation
                             throw PSTraceSource.NewInvalidOperationException(SessionStateStrings.PathNotFound, targetPath);
                         }
 
-                        content = globbedTarget[0];
+                        // If the original target was a relative path, we want to leave it as relative if it did not require
+                        // globbing to resolve.
+                        if (WildcardPattern.ContainsWildcardCharacters(content.ToString()))
+                        {
+                            content = globbedTarget[0];
+                        }
                     }
 
                     NewItemPrivate(providerInstance, composedPath, type, content, context);

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/FileSystem.Tests.ps1
@@ -500,7 +500,6 @@ Describe "Hard link and symbolic link tests" -Tags "CI", "RequireAdminOnWindows"
 
     Context "Get-ChildItem and symbolic links" {
         BeforeAll {
-            $TestDrive = "TestDrive:"
             $alphaDir = Join-Path $TestDrive "sub-alpha"
             $alphaLink = Join-Path $TestDrive "link-alpha"
             $alphaFile1 = Join-Path $alphaDir "AlphaFile1.txt"
@@ -671,7 +670,6 @@ Describe "Copy-Item can avoid copying an item onto itself" -Tags "CI", "RequireA
         # attempt is made to copy an item onto itself.
         $selfCopyKey = "SelfCopy"
 
-        $TestDrive = "TestDrive:"
         $subDir = "$TestDrive/sub"
         $otherSubDir = "$TestDrive/other-sub"
         $fileName = "file.txt"

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/New-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/New-Item.Tests.ps1
@@ -258,7 +258,7 @@ Describe "New-Item with links" -Tags @('CI', 'RequireAdminOnWindows') {
     It "New-Item -ItemType SymbolicLink should be able to create a relative link" -Skip:(!$IsWindows) {
         try {
             Push-Location $TestDrive
-            $relativeFilePath = "." + [System.IO.Path]::DirectorySeparatorChar + "relativefile.txt"
+            $relativeFilePath = Join-Path . "relativefile.txt"
             $file = New-Item -ItemType File -Path $relativeFilePath
             $link = New-Item -ItemType SymbolicLink -Path ./link -Target $relativeFilePath
             $link.Target | Should -BeExactly $relativeFilePath

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/New-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/New-Item.Tests.ps1
@@ -255,7 +255,7 @@ Describe "New-Item with links" -Tags @('CI', 'RequireAdminOnWindows') {
         $symbolicLinkPath | Should -Not -BeNullOrEmpty
     }
 
-    It "New-Item -ItemType SymbolicLink should be able to create a relative link" {
+    It "New-Item -ItemType SymbolicLink should be able to create a relative link" -Skip:(!$IsWindows) {
         try {
             Push-Location $TestDrive
             $relativeFilePath = "." + [System.IO.Path]::DirectorySeparatorChar + "relativefile.txt"

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/New-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/New-Item.Tests.ps1
@@ -258,7 +258,7 @@ Describe "New-Item with links" -Tags @('CI', 'RequireAdminOnWindows') {
     It "New-Item -ItemType SymbolicLink should be able to create a relative link" -Skip:(!$IsWindows) {
         try {
             Push-Location $TestDrive
-            $relativeFilePath = Join-Path . "relativefile.txt"
+            $relativeFilePath = Join-Path -Path . -ChildPath "relativefile.txt"
             $file = New-Item -ItemType File -Path $relativeFilePath
             $link = New-Item -ItemType SymbolicLink -Path ./link -Target $relativeFilePath
             $link.Target | Should -BeExactly $relativeFilePath

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/New-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/New-Item.Tests.ps1
@@ -254,6 +254,18 @@ Describe "New-Item with links" -Tags @('CI', 'RequireAdminOnWindows') {
         $symbolicLinkPath = New-Item -ItemType SymbolicLink -Path "$tmpDirectory/$folderName/" -Value "/bar/"
         $symbolicLinkPath | Should -Not -BeNullOrEmpty
     }
+
+    It "New-Item -ItemType SymbolicLink should be able to create a relative link" {
+        try {
+            Push-Location $TestDrive
+            $relativeFilePath = "." + [System.IO.Path]::DirectorySeparatorChar + "relativefile.txt"
+            $file = New-Item -ItemType File -Path $relativeFilePath
+            $link = New-Item -ItemType SymbolicLink -Path ./link -Target $relativeFilePath
+            $link.Target | Should -BeExactly $relativeFilePath
+        } finally {
+            Pop-Location
+        }
+    }
 }
 
 Describe "New-Item with links fails for non elevated user if developer mode not enabled on Windows." -Tags "CI" {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->  

## PR Summary

The current code always tries to glob the target path which results in an absolute path and limits the usefulness of creating a symlink.  Fix is to see if the target path even contains any wildcards, if not, don't use the resolved globbed path and instead use the value as literal.  Since there isn't a `-LiteralTarget` parameter, this does mean that the globber can fail if the target path contains a wildcard character intended to be literal, but that is not in scope of this PR.

Note that relative links are only supported on Windows so skipping test on non-Windows.  On non-Windows, the relative path is passed to the symlink() api which ends up creating an absolute link.  Using the `ln` command line tool has the same result.

## PR Context  

Fix https://github.com/PowerShell/PowerShell/issues/3500

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.  
- **User-facing changes**
    - [x] Not Applicable
    - **OR**  
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [x] [Add `[feature]` to your commit messages if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
