### PR TITLE
Improve performance by having better primitives on PSObject

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CustomSerialization.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/CustomSerialization.cs
@@ -342,7 +342,7 @@ namespace System.Management.Automation
 
             bool sourceHandled = false;
             PSObject moSource = source as PSObject;
-            if (moSource != null && !moSource.immediateBaseObjectIsEmpty)
+            if (moSource != null && !moSource.ImmediateBaseObjectIsEmpty)
             {
                 // Check if baseObject is primitive known type
                 object baseObject = moSource.ImmediateBaseObject;
@@ -367,7 +367,7 @@ namespace System.Management.Automation
             IDictionary dictionary = null;
 
             // If passed in object is PSObject with no baseobject, return false.
-            if (mshSource != null && mshSource.immediateBaseObjectIsEmpty)
+            if (mshSource != null && mshSource.ImmediateBaseObjectIsEmpty)
             {
                 return false;
             }
@@ -411,7 +411,7 @@ namespace System.Management.Automation
             // We serialize properties of enumerable and on deserialization mark the object
             // as Deserialized. So if object is marked deserialized, we should write properties.
             // Note: we do not serialize the properties of IEnumerable if depth is zero.
-            if (depth != 0 && (ct == ContainerType.Enumerable || (mshSource != null && mshSource.isDeserialized)))
+            if (depth != 0 && (ct == ContainerType.Enumerable || (mshSource != null && mshSource.IsDeserialized)))
             {
                 // Note:Depth is the depth for serialization of baseObject.
                 // Depth for serialization of each property is one less.
@@ -595,7 +595,7 @@ namespace System.Management.Automation
             bool isEnum = false;
             bool isPSObject = false;
 
-            if (!source.immediateBaseObjectIsEmpty)
+            if (!source.ImmediateBaseObjectIsEmpty)
             {
                 isEnum = source.ImmediateBaseObject is Enum;
                 isPSObject = source.ImmediateBaseObject is PSObject;

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetMember.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/GetMember.cs
@@ -150,7 +150,7 @@ namespace Microsoft.PowerShell.Commands
             Adapter staticAdapter = null;
             if (this.Static == true)
             {
-                staticAdapter = PSObject.dotNetStaticAdapter;
+                staticAdapter = PSObject.DotNetStaticAdapter;
                 object baseObject = this.InputObject.BaseObject;
                 baseObjectAsType = baseObject as System.Type ?? baseObject.GetType();
                 typeName = baseObjectAsType.FullName;

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/JsonObject.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/JsonObject.cs
@@ -543,7 +543,7 @@ namespace Microsoft.PowerShell.Commands
                 {
                     if (currentDepth > context.MaxDepth)
                     {
-                        if (pso != null && pso.immediateBaseObjectIsEmpty)
+                        if (pso != null && pso.ImmediateBaseObjectIsEmpty)
                         {
                             // The obj is a pure PSObject, we convert the original PSObject to a string,
                             // instead of its base object in this case

--- a/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
+++ b/src/Microsoft.PowerShell.ConsoleHost/host/msh/ConsoleHost.cs
@@ -1975,9 +1975,10 @@ namespace Microsoft.PowerShell
                 error = (object)new ErrorRecord(e, "ConsoleHost.ReportException", ErrorCategory.NotSpecified, null);
             }
 
-            PSObject wrappedError = new PSObject(error);
-            PSNoteProperty note = new PSNoteProperty("writeErrorStream", true);
-            wrappedError.Properties.Add(note);
+            PSObject wrappedError = new PSObject(error)
+            {
+                WriteStream = WriteStreamType.Error
+            };
 
             Exception e1 = null;
 

--- a/src/System.Management.Automation/FormatAndOutput/common/BaseFormattingCommand.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/BaseFormattingCommand.cs
@@ -463,7 +463,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         {
             Diagnostics.Assert(so != null, "object so cannot be null");
             FormatEntryData fed = _viewManager.ViewGenerator.GeneratePayload(so, _enumerationLimit);
-            fed.SetStreamTypeFromPSObject(so);
+            fed.writeStream = so.WriteStream;
             this.WriteObject(fed);
 
             List<ErrorRecord> errors = _viewManager.ViewGenerator.ErrorManager.DrainFailedResultList();

--- a/src/System.Management.Automation/FormatAndOutput/common/FormatViewManager.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/FormatViewManager.cs
@@ -464,7 +464,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
     /// </summary>
     internal static class OutOfBandFormatViewManager
     {
-        static bool IsNotRemotingProperty(string name)
+        private static bool IsNotRemotingProperty(string name)
         {
             var isRemotingPropertyName =  name.Equals(RemotingConstants.ComputerNameNoteProperty, StringComparison.OrdinalIgnoreCase)
                    || name.Equals(RemotingConstants.ShowComputerNameNoteProperty, StringComparison.OrdinalIgnoreCase)

--- a/src/System.Management.Automation/FormatAndOutput/common/FormatViewManager.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/FormatViewManager.cs
@@ -529,7 +529,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
 
             FormatEntryData fed = outOfBandViewGenerator.GeneratePayload(so, enumerationLimit);
             fed.outOfBand = true;
-            fed.SetStreamTypeFromPSObject(so);
+            fed.writeStream = so.WriteStream;
 
             errors = outOfBandViewGenerator.ErrorManager.DrainFailedResultList();
 

--- a/src/System.Management.Automation/FormatAndOutput/common/FormatViewManager.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/FormatViewManager.cs
@@ -466,11 +466,11 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
     {
         private static bool IsNotRemotingProperty(string name)
         {
-            var isRemotingPropertyName =  name.Equals(RemotingConstants.ComputerNameNoteProperty, StringComparison.OrdinalIgnoreCase)
+            var isRemotingPropertyName = name.Equals(RemotingConstants.ComputerNameNoteProperty, StringComparison.OrdinalIgnoreCase)
                    || name.Equals(RemotingConstants.ShowComputerNameNoteProperty, StringComparison.OrdinalIgnoreCase)
                    || name.Equals(RemotingConstants.RunspaceIdNoteProperty, StringComparison.OrdinalIgnoreCase)
                    || name.Equals(RemotingConstants.SourceJobInstanceId, StringComparison.OrdinalIgnoreCase)
-                   || name.Equals(RemotingConstants.SourceLength,StringComparison.OrdinalIgnoreCase);
+                   || name.Equals(RemotingConstants.SourceLength, StringComparison.OrdinalIgnoreCase);
             return !isRemotingPropertyName;
         }
 

--- a/src/System.Management.Automation/FormatAndOutput/common/FormatViewManager.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/FormatViewManager.cs
@@ -476,7 +476,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
 
         private static readonly MemberNamePredicate NameIsNotRemotingProperty = IsNotRemotingProperty;
 
-        private static bool HasNonRemotingProperties(PSObject so) => so.GetFirstPropertyOrDefault(NameIsNotRemotingProperty) == null;
+        private static bool HasNonRemotingProperties(PSObject so) => so.GetFirstPropertyOrDefault(NameIsNotRemotingProperty) != null;
 
         internal static FormatEntryData GenerateOutOfBandData(TerminatingErrorContext errorContext, PSPropertyExpressionFactory expressionFactory,
                     TypeInfoDataBase db, PSObject so, int enumerationLimit, bool useToStringFallback, out List<ErrorRecord> errors)

--- a/src/System.Management.Automation/FormatAndOutput/common/FormatViewManager.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/FormatViewManager.cs
@@ -503,8 +503,8 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             }
             else
             {
-                if (DefaultScalarTypes.IsTypeInList(typeNames) ||
-                    !HasNonRemotingProperties(so))
+                if (DefaultScalarTypes.IsTypeInList(typeNames)
+                    || !HasNonRemotingProperties(so))
                 {
                     // we force a ToString() on well known types
                     return GenerateOutOfBandObjectAsToString(so);

--- a/src/System.Management.Automation/FormatAndOutput/common/FormatViewManager.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/FormatViewManager.cs
@@ -464,65 +464,20 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
     /// </summary>
     internal static class OutOfBandFormatViewManager
     {
-        internal static bool IsPropertyLessObject(PSObject so)
+        static bool IsNotRemotingProperty(string name)
         {
-            List<MshResolvedExpressionParameterAssociation> allProperties = AssociationManager.ExpandAll(so);
-
-            if (allProperties.Count == 0)
-            {
-                return true;
-            }
-
-            if (allProperties.Count == 3)
-            {
-                foreach (MshResolvedExpressionParameterAssociation property in allProperties)
-                {
-                    if (!property.ResolvedExpression.ToString().Equals(RemotingConstants.ComputerNameNoteProperty, StringComparison.OrdinalIgnoreCase) &&
-                        !property.ResolvedExpression.ToString().Equals(RemotingConstants.ShowComputerNameNoteProperty, StringComparison.OrdinalIgnoreCase) &&
-                        !property.ResolvedExpression.ToString().Equals(RemotingConstants.RunspaceIdNoteProperty, StringComparison.OrdinalIgnoreCase))
-                    {
-                        return false;
-                    }
-                }
-
-                return true;
-            }
-
-            if (allProperties.Count == 4)
-            {
-                foreach (MshResolvedExpressionParameterAssociation property in allProperties)
-                {
-                    if (!property.ResolvedExpression.ToString().Equals(RemotingConstants.ComputerNameNoteProperty, StringComparison.OrdinalIgnoreCase) &&
-                        !property.ResolvedExpression.ToString().Equals(RemotingConstants.ShowComputerNameNoteProperty, StringComparison.OrdinalIgnoreCase) &&
-                        !property.ResolvedExpression.ToString().Equals(RemotingConstants.RunspaceIdNoteProperty, StringComparison.OrdinalIgnoreCase)
-                        && !property.ResolvedExpression.ToString().Equals(RemotingConstants.SourceJobInstanceId, StringComparison.OrdinalIgnoreCase))
-                    {
-                        return false;
-                    }
-                }
-
-                return true;
-            }
-
-            if (allProperties.Count == 5)
-            {
-                foreach (MshResolvedExpressionParameterAssociation property in allProperties)
-                {
-                    if (!property.ResolvedExpression.ToString().Equals(RemotingConstants.ComputerNameNoteProperty, StringComparison.OrdinalIgnoreCase) &&
-                        !property.ResolvedExpression.ToString().Equals(RemotingConstants.ShowComputerNameNoteProperty, StringComparison.OrdinalIgnoreCase) &&
-                        !property.ResolvedExpression.ToString().Equals(RemotingConstants.RunspaceIdNoteProperty, StringComparison.OrdinalIgnoreCase) &&
-                        !property.ResolvedExpression.ToString().Equals(RemotingConstants.SourceJobInstanceId, StringComparison.OrdinalIgnoreCase) &&
-                        !property.ResolvedExpression.ToString().Equals(RemotingConstants.SourceLength, StringComparison.OrdinalIgnoreCase))
-                    {
-                        return false;
-                    }
-                }
-
-                return true;
-            }
-
-            return false;
+            var isRemotingPropertyName =  name.Equals(RemotingConstants.ComputerNameNoteProperty, StringComparison.OrdinalIgnoreCase)
+                   || name.Equals(RemotingConstants.ShowComputerNameNoteProperty, StringComparison.OrdinalIgnoreCase)
+                   || name.Equals(RemotingConstants.RunspaceIdNoteProperty, StringComparison.OrdinalIgnoreCase)
+                   || name.Equals(RemotingConstants.RunspaceIdNoteProperty, StringComparison.OrdinalIgnoreCase)
+                   || name.Equals(RemotingConstants.SourceJobInstanceId, StringComparison.OrdinalIgnoreCase)
+                   || name.Equals(RemotingConstants.SourceLength,StringComparison.OrdinalIgnoreCase);
+            return !isRemotingPropertyName;
         }
+
+        private static readonly MemberNamePredicate NameIsNotRemotingProperty = IsNotRemotingProperty;
+
+        private static bool HasNonRemotingProperties(PSObject so) => so.GetFirstPropertyOrDefault(NameIsNotRemotingProperty) == null;
 
         internal static FormatEntryData GenerateOutOfBandData(TerminatingErrorContext errorContext, PSPropertyExpressionFactory expressionFactory,
                     TypeInfoDataBase db, PSObject so, int enumerationLimit, bool useToStringFallback, out List<ErrorRecord> errors)
@@ -550,7 +505,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             else
             {
                 if (DefaultScalarTypes.IsTypeInList(typeNames) ||
-                    IsPropertyLessObject(so))
+                    HasNonRemotingProperties(so))
                 {
                     // we force a ToString() on well known types
                     return GenerateOutOfBandObjectAsToString(so);

--- a/src/System.Management.Automation/FormatAndOutput/common/FormatViewManager.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/FormatViewManager.cs
@@ -504,7 +504,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             else
             {
                 if (DefaultScalarTypes.IsTypeInList(typeNames) ||
-                    HasNonRemotingProperties(so))
+                    !HasNonRemotingProperties(so))
                 {
                     // we force a ToString() on well known types
                     return GenerateOutOfBandObjectAsToString(so);

--- a/src/System.Management.Automation/FormatAndOutput/common/FormatViewManager.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/FormatViewManager.cs
@@ -469,7 +469,6 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             var isRemotingPropertyName =  name.Equals(RemotingConstants.ComputerNameNoteProperty, StringComparison.OrdinalIgnoreCase)
                    || name.Equals(RemotingConstants.ShowComputerNameNoteProperty, StringComparison.OrdinalIgnoreCase)
                    || name.Equals(RemotingConstants.RunspaceIdNoteProperty, StringComparison.OrdinalIgnoreCase)
-                   || name.Equals(RemotingConstants.RunspaceIdNoteProperty, StringComparison.OrdinalIgnoreCase)
                    || name.Equals(RemotingConstants.SourceJobInstanceId, StringComparison.OrdinalIgnoreCase)
                    || name.Equals(RemotingConstants.SourceLength,StringComparison.OrdinalIgnoreCase);
             return !isRemotingPropertyName;

--- a/src/System.Management.Automation/FormatAndOutput/common/FormattingObjects.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/FormattingObjects.cs
@@ -177,7 +177,6 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 }
             }
 
-
             bool IsStreamName(string name)
             {
                 switch (name)

--- a/src/System.Management.Automation/FormatAndOutput/common/FormattingObjects.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/FormattingObjects.cs
@@ -23,7 +23,6 @@
 //
 
 using System.Collections.Generic;
-using System.Management.Automation;
 
 namespace Microsoft.PowerShell.Commands.Internal.Format
 {

--- a/src/System.Management.Automation/FormatAndOutput/common/FormattingObjects.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/FormattingObjects.cs
@@ -150,51 +150,6 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         public bool outOfBand = false;
         public WriteStreamType writeStream = WriteStreamType.None;
         internal bool isHelpObject = false;
-
-        /// <summary>
-        /// Helper method to set the <see cref="writeStream"/> field
-        /// based on note properties of a PSObject object.
-        /// </summary>
-        /// <param name="so">PSObject.</param>
-        internal void SetStreamTypeFromPSObject(PSObject so)
-        {
-            WriteStreamType GetStreamType(string propertyName)
-            {
-                switch (propertyName)
-                {
-                    case MshCommandRuntime.WriteErrorStreamPropertyName:
-                        return WriteStreamType.Error;
-                    case MshCommandRuntime.WriteWarningStreamPropertyName:
-                        return WriteStreamType.Warning;
-                    case MshCommandRuntime.WriteVerboseStreamPropertyName:
-                        return WriteStreamType.Verbose;
-                    case MshCommandRuntime.WriteDebugStreamPropertyName:
-                        return WriteStreamType.Debug;
-                    case MshCommandRuntime.WriteInformationStreamPropertyName:
-                        return WriteStreamType.Information;
-                    default:
-                        return WriteStreamType.None;
-                }
-            }
-
-            bool IsStreamName(string name)
-            {
-                switch (name)
-                {
-                    case MshCommandRuntime.WriteErrorStreamPropertyName:
-                    case MshCommandRuntime.WriteWarningStreamPropertyName:
-                    case MshCommandRuntime.WriteVerboseStreamPropertyName:
-                    case MshCommandRuntime.WriteDebugStreamPropertyName:
-                    case MshCommandRuntime.WriteInformationStreamPropertyName:
-                        return true;
-                    default:
-                        return false;
-                }
-            }
-
-            var member = so.GetFirstPropertyOrDefault(IsStreamName);
-            writeStream = member != null ? GetStreamType(member.Name) : WriteStreamType.None;
-        }
     }
     #endregion
 

--- a/src/System.Management.Automation/FormatAndOutput/common/FormattingObjects.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/FormattingObjects.cs
@@ -152,7 +152,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         internal bool isHelpObject = false;
 
         /// <summary>
-        /// Helper method to set the WriteStreamType property
+        /// Helper method to set the <see cref="writeStream"/> field
         /// based on note properties of a PSObject object.
         /// </summary>
         /// <param name="so">PSObject.</param>

--- a/src/System.Management.Automation/FormatAndOutput/common/FormattingObjects.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/FormattingObjects.cs
@@ -23,6 +23,7 @@
 //
 
 using System.Collections.Generic;
+using System.Management.Automation;
 
 namespace Microsoft.PowerShell.Commands.Internal.Format
 {

--- a/src/System.Management.Automation/FormatAndOutput/common/FormattingObjects.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/FormattingObjects.cs
@@ -23,6 +23,7 @@
 //
 
 using System.Collections.Generic;
+using System.Management.Automation;
 
 namespace Microsoft.PowerShell.Commands.Internal.Format
 {
@@ -155,33 +156,45 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         /// based on note properties of a PSObject object.
         /// </summary>
         /// <param name="so">PSObject.</param>
-        internal void SetStreamTypeFromPSObject(
-            System.Management.Automation.PSObject so)
+        internal void SetStreamTypeFromPSObject(PSObject so)
         {
-            if (PSObjectHelper.IsWriteErrorStream(so))
+            WriteStreamType GetStreamType(string propertyName)
             {
-                writeStream = WriteStreamType.Error;
+                switch (propertyName)
+                {
+                    case MshCommandRuntime.WriteErrorStreamPropertyName:
+                        return WriteStreamType.Error;
+                    case MshCommandRuntime.WriteWarningStreamPropertyName:
+                        return WriteStreamType.Warning;
+                    case MshCommandRuntime.WriteVerboseStreamPropertyName:
+                        return WriteStreamType.Verbose;
+                    case MshCommandRuntime.WriteDebugStreamPropertyName:
+                        return WriteStreamType.Debug;
+                    case MshCommandRuntime.WriteInformationStreamPropertyName:
+                        return WriteStreamType.Information;
+                    default:
+                        return WriteStreamType.None;
+                }
             }
-            else if (PSObjectHelper.IsWriteWarningStream(so))
+
+
+            bool IsStreamName(string name)
             {
-                writeStream = WriteStreamType.Warning;
+                switch (name)
+                {
+                    case MshCommandRuntime.WriteErrorStreamPropertyName:
+                    case MshCommandRuntime.WriteWarningStreamPropertyName:
+                    case MshCommandRuntime.WriteVerboseStreamPropertyName:
+                    case MshCommandRuntime.WriteDebugStreamPropertyName:
+                    case MshCommandRuntime.WriteInformationStreamPropertyName:
+                        return true;
+                    default:
+                        return false;
+                }
             }
-            else if (PSObjectHelper.IsWriteVerboseStream(so))
-            {
-                writeStream = WriteStreamType.Verbose;
-            }
-            else if (PSObjectHelper.IsWriteDebugStream(so))
-            {
-                writeStream = WriteStreamType.Debug;
-            }
-            else if (PSObjectHelper.IsWriteInformationStream(so))
-            {
-                writeStream = WriteStreamType.Information;
-            }
-            else
-            {
-                writeStream = WriteStreamType.None;
-            }
+
+            var member = so.GetFirstPropertyOrDefault(IsStreamName);
+            writeStream = member != null ? GetStreamType(member.Name) : WriteStreamType.None;
         }
     }
     #endregion

--- a/src/System.Management.Automation/FormatAndOutput/common/ILineOutput.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/ILineOutput.cs
@@ -110,19 +110,6 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
     }
 
     /// <summary>
-    /// Specifies special stream write processing.
-    /// </summary>
-    internal enum WriteStreamType
-    {
-        None,
-        Error,
-        Warning,
-        Verbose,
-        Debug,
-        Information
-    }
-
-    /// <summary>
     /// Base class providing information about the screen device capabilities
     /// and used to write the output strings to the text output device.
     /// Each device supported will have to derive from it.

--- a/src/System.Management.Automation/FormatAndOutput/common/Utilities/MshObjectUtil.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/Utilities/MshObjectUtil.cs
@@ -36,81 +36,6 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
         }
 
         /// <summary>
-        /// WriteError adds a note property called WriteErrorStream to the error
-        /// record wrapped in an PSObject and set its value to true. When F and O detects
-        /// this note exists and its value is set to true, WriteErrorLine will be used
-        /// to emit the error; otherwise, F and O actions are regular.
-        /// </summary>
-        /// <param name="so"></param>
-        /// <returns></returns>
-        internal static bool IsWriteErrorStream(PSObject so)
-        {
-            return IsStreamType(so, "WriteErrorStream");
-        }
-
-        /// <summary>
-        /// Checks for WriteWarningStream property on object, indicating that
-        /// it is a warning stream.  Used by F and O.
-        /// </summary>
-        /// <param name="so"></param>
-        /// <returns></returns>
-        internal static bool IsWriteWarningStream(PSObject so)
-        {
-            return IsStreamType(so, "WriteWarningStream");
-        }
-
-        /// <summary>
-        /// Checks for WriteVerboseStream property on object, indicating that
-        /// it is a verbose stream.  Used by F and O.
-        /// </summary>
-        /// <param name="so"></param>
-        /// <returns></returns>
-        internal static bool IsWriteVerboseStream(PSObject so)
-        {
-            return IsStreamType(so, "WriteVerboseStream");
-        }
-
-        /// <summary>
-        /// Checks for WriteDebugStream property on object, indicating that
-        /// it is a debug stream.  Used by F and O.
-        /// </summary>
-        /// <param name="so"></param>
-        /// <returns></returns>
-        internal static bool IsWriteDebugStream(PSObject so)
-        {
-            return IsStreamType(so, "WriteDebugStream");
-        }
-
-        /// <summary>
-        /// Checks for WriteInformationStream property on object, indicating that
-        /// it is an informational stream.  Used by F and O.
-        /// </summary>
-        /// <param name="so"></param>
-        /// <returns></returns>
-        internal static bool IsWriteInformationStream(PSObject so)
-        {
-            return IsStreamType(so, "WriteInformationStream");
-        }
-
-        internal static bool IsStreamType(PSObject so, string streamFlag)
-        {
-            try
-            {
-                PSPropertyInfo streamProperty = so.Properties[streamFlag];
-                if (streamProperty != null && streamProperty.Value is bool)
-                {
-                    return (bool)streamProperty.Value;
-                }
-
-                return false;
-            }
-            catch (ExtendedTypeSystemException)
-            {
-                return false;
-            }
-        }
-
-        /// <summary>
         /// Retrieve the display name. It looks for a well known property and,
         /// if not found, it uses some heuristics to get a "close" match.
         /// </summary>
@@ -129,7 +54,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             // we failed the default display name, let's try some well known names
             // trying to get something potentially useful
             string[] knownPatterns = new string[] {
-                "name", "id", "key", "*key", "*name", "*id",
+                "name", "id", "key",  "*key", "*name", "*id",
             };
 
             // go over the patterns, looking for the first match

--- a/src/System.Management.Automation/FormatAndOutput/common/Utilities/MshObjectUtil.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/Utilities/MshObjectUtil.cs
@@ -54,7 +54,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             // we failed the default display name, let's try some well known names
             // trying to get something potentially useful
             string[] knownPatterns = new string[] {
-                "name", "id", "key",  "*key", "*name", "*id",
+                "name", "id", "key", "*key", "*name", "*id",
             };
 
             // go over the patterns, looking for the first match

--- a/src/System.Management.Automation/cimSupport/other/ciminstancetypeadapter.cs
+++ b/src/System.Management.Automation/cimSupport/other/ciminstancetypeadapter.cs
@@ -154,13 +154,10 @@ namespace Microsoft.PowerShell.Cim
 
             foreach (CimProperty cimProperty in cimInstance.CimInstanceProperties)
             {
-                if (cimProperty != null)
+                if (cimProperty != null && predicate(cimProperty.Name))
                 {
-                    if (predicate(cimProperty.Name))
-                    {
-                        PSAdaptedProperty prop = GetCimPropertyAdapter(cimProperty, baseObject, cimProperty.Name);
-                        return prop;
-                    }
+                    PSAdaptedProperty prop = GetCimPropertyAdapter(cimProperty, baseObject, cimProperty.Name);
+                    return prop;
                 }
 
                 if (predicate(RemotingConstants.ComputerNameNoteProperty))

--- a/src/System.Management.Automation/cimSupport/other/ciminstancetypeadapter.cs
+++ b/src/System.Management.Automation/cimSupport/other/ciminstancetypeadapter.cs
@@ -133,7 +133,6 @@ namespace Microsoft.PowerShell.Cim
             return null;
         }
 
-        
         /// <inheritdoc />
         public override PSAdaptedProperty GetProperty(object baseObject, MemberNamePredicate predicate)
         {

--- a/src/System.Management.Automation/cimSupport/other/ciminstancetypeadapter.cs
+++ b/src/System.Management.Automation/cimSupport/other/ciminstancetypeadapter.cs
@@ -144,7 +144,8 @@ namespace Microsoft.PowerShell.Cim
             CimInstance cimInstance = baseObject as CimInstance;
             if (cimInstance == null)
             {
-                string msg = string.Format(CultureInfo.InvariantCulture,
+                string msg = string.Format(
+                    CultureInfo.InvariantCulture,
                     CimInstanceTypeAdapterResources.BaseObjectNotCimInstance,
                     "baseObject",
                     typeof(CimInstance).ToString());

--- a/src/System.Management.Automation/cimSupport/other/ciminstancetypeadapter.cs
+++ b/src/System.Management.Automation/cimSupport/other/ciminstancetypeadapter.cs
@@ -137,7 +137,7 @@ namespace Microsoft.PowerShell.Cim
         {
             if (predicate == null)
             {
-                throw new PSArgumentNullException("predicate");
+                throw new PSArgumentNullException(nameof(predicate));
             }
 
             // baseObject should never be null

--- a/src/System.Management.Automation/cimSupport/other/ciminstancetypeadapter.cs
+++ b/src/System.Management.Automation/cimSupport/other/ciminstancetypeadapter.cs
@@ -172,7 +172,6 @@ namespace Microsoft.PowerShell.Cim
             return null;
         }
 
-
         internal static string CimTypeToTypeNameDisplayString(CimType cimType)
         {
             switch (cimType)

--- a/src/System.Management.Automation/cimSupport/other/ciminstancetypeadapter.cs
+++ b/src/System.Management.Automation/cimSupport/other/ciminstancetypeadapter.cs
@@ -133,7 +133,9 @@ namespace Microsoft.PowerShell.Cim
             return null;
         }
 
-        internal override PSAdaptedProperty GetProperty(object baseObject, MemberNamePredicate predicate)
+        
+        /// <inheritdoc />
+        public override PSAdaptedProperty GetProperty(object baseObject, MemberNamePredicate predicate)
         {
             if (predicate == null)
             {
@@ -152,17 +154,17 @@ namespace Microsoft.PowerShell.Cim
                 throw new PSInvalidOperationException(msg);
             }
 
+            if (predicate(RemotingConstants.ComputerNameNoteProperty))
+            {
+                PSAdaptedProperty prop = GetPSComputerNameAdapter(cimInstance);
+                return prop;
+            }
+
             foreach (CimProperty cimProperty in cimInstance.CimInstanceProperties)
             {
                 if (cimProperty != null && predicate(cimProperty.Name))
                 {
                     PSAdaptedProperty prop = GetCimPropertyAdapter(cimProperty, baseObject, cimProperty.Name);
-                    return prop;
-                }
-
-                if (predicate(RemotingConstants.ComputerNameNoteProperty))
-                {
-                    PSAdaptedProperty prop = GetPSComputerNameAdapter(cimInstance);
                     return prop;
                 }
             }

--- a/src/System.Management.Automation/cimSupport/other/ciminstancetypeadapter.cs
+++ b/src/System.Management.Automation/cimSupport/other/ciminstancetypeadapter.cs
@@ -133,6 +133,46 @@ namespace Microsoft.PowerShell.Cim
             return null;
         }
 
+        internal override PSAdaptedProperty GetProperty(object baseObject, MemberNamePredicate predicate)
+        {
+            if (predicate == null)
+            {
+                throw new PSArgumentNullException("predicate");
+            }
+
+            // baseObject should never be null
+            CimInstance cimInstance = baseObject as CimInstance;
+            if (cimInstance == null)
+            {
+                string msg = string.Format(CultureInfo.InvariantCulture,
+                    CimInstanceTypeAdapterResources.BaseObjectNotCimInstance,
+                    "baseObject",
+                    typeof(CimInstance).ToString());
+                throw new PSInvalidOperationException(msg);
+            }
+
+            foreach (CimProperty cimProperty in cimInstance.CimInstanceProperties)
+            {
+                if (cimProperty != null)
+                {
+                    if (predicate(cimProperty.Name))
+                    {
+                        PSAdaptedProperty prop = GetCimPropertyAdapter(cimProperty, baseObject, cimProperty.Name);
+                        return prop;
+                    }
+                }
+
+                if (predicate(RemotingConstants.ComputerNameNoteProperty))
+                {
+                    PSAdaptedProperty prop = GetPSComputerNameAdapter(cimInstance);
+                    return prop;
+                }
+            }
+
+            return null;
+        }
+
+
         internal static string CimTypeToTypeNameDisplayString(CimType cimType)
         {
             switch (cimType)

--- a/src/System.Management.Automation/cimSupport/other/ciminstancetypeadapter.cs
+++ b/src/System.Management.Automation/cimSupport/other/ciminstancetypeadapter.cs
@@ -134,7 +134,7 @@ namespace Microsoft.PowerShell.Cim
         }
 
         /// <inheritdoc />
-        public override PSAdaptedProperty GetProperty(object baseObject, MemberNamePredicate predicate)
+        public override PSAdaptedProperty GetFirstPropertyOrDefault(object baseObject, MemberNamePredicate predicate)
         {
             if (predicate == null)
             {

--- a/src/System.Management.Automation/engine/COM/ComAdapter.cs
+++ b/src/System.Management.Automation/engine/COM/ComAdapter.cs
@@ -84,7 +84,10 @@ namespace System.Management.Automation
             return null;
         }
 
-        protected override T GetMember<T>(object obj, MemberNamePredicate predicate)
+        /// <summary>
+        /// Returns the first PSMemberInfo whose name matches the specified <see cref="MemberNamePredicate"/>.
+        /// </summary>
+        protected override T GetFirstMemberOrDefault<T>(object obj, MemberNamePredicate predicate)
         {
             bool lookingForProperties = typeof(T).IsAssignableFrom(typeof(PSProperty));
             bool lookingForParameterizedProperties = typeof(T).IsAssignableFrom(typeof(PSParameterizedProperty));

--- a/src/System.Management.Automation/engine/COM/ComAdapter.cs
+++ b/src/System.Management.Automation/engine/COM/ComAdapter.cs
@@ -97,12 +97,12 @@ namespace System.Management.Automation
                 {
                     if (prop.IsParameterized
                         && lookingForParameterizedProperties
-                        && predicate.Invoke(prop.Name))
+                        && predicate(prop.Name))
                     {
                         return new PSParameterizedProperty(prop.Name, this, obj, prop) as T;
                     }
 
-                    if (lookingForProperties && predicate.Invoke(prop.Name))
+                    if (lookingForProperties && predicate(prop.Name))
                     {
                         return new PSProperty(prop.Name, this, obj, prop) as T;
                     }
@@ -115,7 +115,7 @@ namespace System.Management.Automation
             {
                 foreach (ComMethod method in _comTypeInfo.Methods.Values)
                 {
-                    if (predicate.Invoke(method.Name))
+                    if (predicate(method.Name))
                     {
                         var mshMethod = new PSMethod(method.Name, this, obj, method);
                         return mshMethod as T;

--- a/src/System.Management.Automation/engine/COM/ComAdapter.cs
+++ b/src/System.Management.Automation/engine/COM/ComAdapter.cs
@@ -84,7 +84,7 @@ namespace System.Management.Automation
             return null;
         }
 
-        private protected override T GetMember<T>(object obj, MemberNamePredicate predicate)
+        protected override T GetMember<T>(object obj, MemberNamePredicate predicate)
         {
             bool lookingForProperties = typeof(T).IsAssignableFrom(typeof(PSProperty));
             bool lookingForParameterizedProperties = typeof(T).IsAssignableFrom(typeof(PSParameterizedProperty));

--- a/src/System.Management.Automation/engine/COM/ComAdapter.cs
+++ b/src/System.Management.Automation/engine/COM/ComAdapter.cs
@@ -84,6 +84,48 @@ namespace System.Management.Automation
             return null;
         }
 
+        private protected override T GetMember<T>(object obj, MemberNamePredicate predicate)
+        {
+            bool lookingForProperties = typeof(T).IsAssignableFrom(typeof(PSProperty));
+            bool lookingForParameterizedProperties = typeof(T).IsAssignableFrom(typeof(PSParameterizedProperty));
+            if (lookingForProperties || lookingForParameterizedProperties)
+            {
+                foreach (ComProperty prop in _comTypeInfo.Properties.Values)
+                {
+                    if (prop.IsParameterized)
+                    {
+                        if (lookingForParameterizedProperties)
+                        {
+                            if (predicate.Invoke(prop.Name))
+                            {
+                                return new PSParameterizedProperty(prop.Name, this, obj, prop) as T;
+                            }
+                        }
+                    }
+                    else if (lookingForProperties)
+                    {
+                        return new PSParameterizedProperty(prop.Name, this, obj, prop) as T;
+                    }
+                }
+            }
+
+            bool lookingForMethods = typeof(T).IsAssignableFrom(typeof(PSMethod));
+
+            if (lookingForMethods)
+            {
+                foreach (ComMethod method in _comTypeInfo.Methods.Values)
+                {
+                    if (predicate.Invoke(method.Name))
+                    {
+                        var mshMethod = new PSMethod(method.Name, this, obj, method);
+                        return mshMethod as T;
+                    }
+                }
+            }
+
+            return null;
+        }
+
         /// <summary>
         /// Retrieves all the members available in the object.
         /// The adapter implementation is encouraged to cache all properties/methods available

--- a/src/System.Management.Automation/engine/COM/ComAdapter.cs
+++ b/src/System.Management.Automation/engine/COM/ComAdapter.cs
@@ -92,19 +92,16 @@ namespace System.Management.Automation
             {
                 foreach (ComProperty prop in _comTypeInfo.Properties.Values)
                 {
-                    if (prop.IsParameterized)
-                    {
-                        if (lookingForParameterizedProperties)
-                        {
-                            if (predicate.Invoke(prop.Name))
-                            {
-                                return new PSParameterizedProperty(prop.Name, this, obj, prop) as T;
-                            }
-                        }
-                    }
-                    else if (lookingForProperties)
+                    if (prop.IsParameterized
+                        && lookingForParameterizedProperties
+                        && predicate.Invoke(prop.Name))
                     {
                         return new PSParameterizedProperty(prop.Name, this, obj, prop) as T;
+                    }
+
+                    if (lookingForProperties && predicate.Invoke(prop.Name))
+                    {
+                        return new PSProperty(prop.Name, this, obj, prop) as T;
                     }
                 }
             }

--- a/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
+++ b/src/System.Management.Automation/engine/CommandCompletion/CompletionCompleters.cs
@@ -6563,7 +6563,7 @@ namespace System.Management.Automation
                         return;
                     }
 
-                    members = PSObject.dotNetStaticAdapter.BaseGetMembers<PSMemberInfo>(type);
+                    members = PSObject.DotNetStaticAdapter.BaseGetMembers<PSMemberInfo>(type);
                 }
                 else
                 {

--- a/src/System.Management.Automation/engine/CoreAdapter.cs
+++ b/src/System.Management.Automation/engine/CoreAdapter.cs
@@ -89,7 +89,6 @@ namespace System.Management.Automation
         /// <returns>The PSMemberInfo corresponding to memberName from obj.</returns>
         protected abstract T GetMember<T>(object obj, string memberName) where T : PSMemberInfo;
 
-
         private protected abstract T GetMember<T>(object o, MemberNamePredicate predicate) where T : PSMemberInfo;
 
         /// <summary>
@@ -386,7 +385,6 @@ namespace System.Management.Automation
                     ExtendedTypeSystem.ExceptionGettingMember, memberName);
             }
         }
-
 
         public T BaseGetMember<T>(object obj, MemberNamePredicate predicate) where T : PSMemberInfo
         {
@@ -4617,10 +4615,10 @@ namespace System.Management.Automation
 
         #endregion virtual
 
-
     }
 
     #region DotNetAdapterWithOnlyPropertyLookup
+
     /// <summary>
     /// This is used by PSObject to support dotnet member lookup for the adapted
     /// objects.
@@ -5292,7 +5290,6 @@ namespace System.Management.Automation
 
             return new PSProperty(nodes[0].LocalName, this, obj, nodes);
         }
-
 
         private protected override PSProperty DoGetFirstPropertyOrDefault(object obj, MemberNamePredicate predicate)
         {

--- a/src/System.Management.Automation/engine/CoreAdapter.cs
+++ b/src/System.Management.Automation/engine/CoreAdapter.cs
@@ -5439,7 +5439,7 @@ namespace System.Management.Automation
 
         private static XmlNode FindNode(object obj, MemberNamePredicate predicate)
         {
-            XmlNode node = (XmlNode)obj;
+            var node = (XmlNode)obj;
 
             if (node.Attributes != null)
             {
@@ -5447,7 +5447,7 @@ namespace System.Management.Automation
                 {
                     if (predicate(attribute.LocalName))
                     {
-                        return node;
+                        return attribute;
                     }
                 }
             }

--- a/src/System.Management.Automation/engine/CoreAdapter.cs
+++ b/src/System.Management.Automation/engine/CoreAdapter.cs
@@ -5297,12 +5297,7 @@ namespace System.Management.Automation
         private protected override PSProperty DoGetFirstPropertyOrDefault(object obj, MemberNamePredicate predicate)
         {
             XmlNode node = FindFirstNodeOrDefault(obj, predicate);
-            if (node == null)
-            {
-                return null;
-            }
-
-            return new PSProperty(node.LocalName, this, obj, node);
+            return node == null ? null : new PSProperty(node.LocalName, this, obj, node);
         }
 
         /// <summary>

--- a/src/System.Management.Automation/engine/CoreAdapter.cs
+++ b/src/System.Management.Automation/engine/CoreAdapter.cs
@@ -1555,7 +1555,7 @@ namespace System.Management.Automation
 
         internal static void SetReferences(object[] arguments, MethodInformation methodInformation, object[] originalArguments)
         {
-            using (PSObject.memberResolution.TraceScope("Checking for possible references."))
+            using (PSObject.MemberResolution.TraceScope("Checking for possible references."))
             {
                 ParameterInformation[] parameters = methodInformation.parameters;
                 for (int i = 0; (i < originalArguments.Length) && (i < parameters.Length) && (i < arguments.Length); i++)
@@ -1585,7 +1585,7 @@ namespace System.Management.Automation
                     }
 
                     object argument = arguments[i];
-                    PSObject.memberResolution.WriteLine("Argument '{0}' was a reference so it will be set to \"{1}\".", i + 1, argument);
+                    PSObject.MemberResolution.WriteLine("Argument '{0}' was a reference so it will be set to \"{1}\".", i + 1, argument);
                     originalArgumentReference.Value = argument;
                 }
             }
@@ -1759,7 +1759,7 @@ namespace System.Management.Automation
             bool isParameterByRef, int parameterIndex, Type resultType,
             IFormatProvider formatProvider)
         {
-            using (PSObject.memberResolution.TraceScope("Method argument conversion."))
+            using (PSObject.MemberResolution.TraceScope("Method argument conversion."))
             {
                 if (resultType == null)
                 {
@@ -1790,7 +1790,7 @@ namespace System.Management.Automation
             PSReference reference = obj as PSReference;
             if (reference != null)
             {
-                PSObject.memberResolution.WriteLine("Parameter was a reference.");
+                PSObject.MemberResolution.WriteLine("Parameter was a reference.");
                 isArgumentByRef = true;
                 return reference.Value;
             }
@@ -1803,7 +1803,7 @@ namespace System.Management.Automation
 
             if (reference != null)
             {
-                PSObject.memberResolution.WriteLine("Parameter was an PSObject containing a reference.");
+                PSObject.MemberResolution.WriteLine("Parameter was an PSObject containing a reference.");
                 isArgumentByRef = true;
                 return reference.Value;
             }
@@ -1814,7 +1814,7 @@ namespace System.Management.Automation
         internal static object PropertySetAndMethodArgumentConvertTo(object valueToConvert,
             Type resultType, IFormatProvider formatProvider)
         {
-            using (PSObject.memberResolution.TraceScope("Converting parameter \"{0}\" to \"{1}\".", valueToConvert, resultType))
+            using (PSObject.MemberResolution.TraceScope("Converting parameter \"{0}\" to \"{1}\".", valueToConvert, resultType))
             {
                 if (resultType == null)
                 {
@@ -1826,7 +1826,7 @@ namespace System.Management.Automation
                 {
                     if (resultType == typeof(object))
                     {
-                        PSObject.memberResolution.WriteLine("Parameter was an PSObject and will be converted to System.Object.");
+                        PSObject.MemberResolution.WriteLine("Parameter was an PSObject and will be converted to System.Object.");
                         // we use PSObject.Base so we don't return
                         // PSCustomObject
                         return PSObject.Base(mshObj);
@@ -4302,7 +4302,7 @@ namespace System.Management.Automation
 
             string methodDefinition = bestMethod.methodDefinition;
             ScriptTrace.Trace(1, "TraceMethodCall", ParserStrings.TraceMethodCall, methodDefinition);
-            PSObject.memberResolution.WriteLine("Calling Method: {0}", methodDefinition);
+            PSObject.MemberResolution.WriteLine("Calling Method: {0}", methodDefinition);
             return AuxiliaryMethodInvoke(target, newArguments, bestMethod, arguments);
         }
 
@@ -4325,9 +4325,9 @@ namespace System.Management.Automation
 
         private static object InvokeResolvedConstructor(MethodInformation bestMethod, object[] newArguments, object[] arguments)
         {
-            if ((PSObject.memberResolution.Options & PSTraceSourceOptions.WriteLine) != 0)
+            if ((PSObject.MemberResolution.Options & PSTraceSourceOptions.WriteLine) != 0)
             {
-                PSObject.memberResolution.WriteLine("Calling Constructor: {0}", DotNetAdapter.GetMethodInfoOverloadDefinition(null,
+                PSObject.MemberResolution.WriteLine("Calling Constructor: {0}", DotNetAdapter.GetMethodInfoOverloadDefinition(null,
                     bestMethod.method, 0));
             }
 
@@ -4348,7 +4348,7 @@ namespace System.Management.Automation
             // of all parameters but the last one
             object[] newArguments;
             MethodInformation bestMethod = GetBestMethodAndArguments(propertyName, methodInformation, arguments, out newArguments);
-            PSObject.memberResolution.WriteLine("Calling Set Method: {0}", bestMethod.methodDefinition);
+            PSObject.MemberResolution.WriteLine("Calling Set Method: {0}", bestMethod.methodDefinition);
             ParameterInfo[] bestMethodParameters = bestMethod.method.GetParameters();
             Type propertyType = bestMethodParameters[bestMethodParameters.Length - 1].ParameterType;
 

--- a/src/System.Management.Automation/engine/ManagementObjectAdapter.cs
+++ b/src/System.Management.Automation/engine/ManagementObjectAdapter.cs
@@ -203,7 +203,13 @@ namespace System.Management.Automation
             // obj should never be null
             Diagnostics.Assert(obj != null, "Input object is null");
 
-            ManagementBaseObject wmiObject = (ManagementBaseObject)obj;
+            ManagementBaseObject wmiObject = obj as ManagementBaseObject;
+
+            if (wmiObject == null)
+            {
+                return null;
+            }
+
             return GetFirstOrDefaultProperty<T>(wmiObject, predicate)
                 ?? GetFirstOrDefaultMethod<T>(wmiObject, predicate);
         }

--- a/src/System.Management.Automation/engine/ManagementObjectAdapter.cs
+++ b/src/System.Management.Automation/engine/ManagementObjectAdapter.cs
@@ -884,6 +884,7 @@ namespace System.Management.Automation
         #region Abstract Methods
 
         protected abstract T GetFirstOrDefaultProperty<T>(ManagementBaseObject wmiObject, MemberNamePredicate predicate) where T : PSMemberInfo;
+
         protected abstract T GetFirstOrDefaultMethod<T>(ManagementBaseObject wmiObject, MemberNamePredicate predicate) where T : PSMemberInfo;
 
         /// <summary>

--- a/src/System.Management.Automation/engine/ManagementObjectAdapter.cs
+++ b/src/System.Management.Automation/engine/ManagementObjectAdapter.cs
@@ -198,7 +198,7 @@ namespace System.Management.Automation
             return null;
         }
 
-        private protected override T GetMember<T>(object obj, MemberNamePredicate predicate)
+        protected override T GetMember<T>(object obj, MemberNamePredicate predicate)
         {
             // obj should never be null
             Diagnostics.Assert(obj != null, "Input object is null");
@@ -206,7 +206,6 @@ namespace System.Management.Automation
             ManagementBaseObject wmiObject = (ManagementBaseObject)obj;
             return GetFirstOrDefaultProperty<T>(wmiObject, predicate)
                 ?? GetFirstOrDefaultMethod<T>(wmiObject, predicate);
-
         }
 
         /// <summary>

--- a/src/System.Management.Automation/engine/MshCommandRuntime.cs
+++ b/src/System.Management.Automation/engine/MshCommandRuntime.cs
@@ -28,6 +28,12 @@ namespace System.Management.Automation
     /// </summary>
     internal class MshCommandRuntime : ICommandRuntime2
     {
+        internal const string WriteErrorStreamPropertyName = "WriteErrorStream";
+        internal const string WriteWarningStreamPropertyName = "WriteWarningStream";
+        internal const string WriteVerboseStreamPropertyName = "WriteVerboseStream";
+        internal const string WriteDebugStreamPropertyName = "WriteDebugStream";
+        internal const string WriteInformationStreamPropertyName = "WriteInformationStream";
+
         #region private_members
 
         /// <summary>
@@ -488,9 +494,9 @@ namespace System.Management.Automation
 
                     // Add note property so that the debug output is formatted correctly.
                     PSObject debugWrap = PSObject.AsPSObject(record);
-                    if (debugWrap.Members["WriteDebugStream"] == null)
+                    if (debugWrap.Members[WriteDebugStreamPropertyName] == null)
                     {
-                        debugWrap.Properties.Add(new PSNoteProperty("WriteDebugStream", true));
+                        debugWrap.Properties.Add(new PSNoteProperty(WriteDebugStreamPropertyName, true));
                     }
 
                     DebugOutputPipe.Add(debugWrap);
@@ -579,9 +585,9 @@ namespace System.Management.Automation
 
                     // Add note property so that the verbose output is formatted correctly.
                     PSObject verboseWrap = PSObject.AsPSObject(record);
-                    if (verboseWrap.Members["WriteVerboseStream"] == null)
+                    if (verboseWrap.Members[WriteVerboseStreamPropertyName] == null)
                     {
-                        verboseWrap.Properties.Add(new PSNoteProperty("WriteVerboseStream", true));
+                        verboseWrap.Properties.Add(new PSNoteProperty(WriteVerboseStreamPropertyName, true));
                     }
 
                     VerboseOutputPipe.Add(verboseWrap);
@@ -670,9 +676,9 @@ namespace System.Management.Automation
 
                     // Add note property so that the warning output is formatted correctly.
                     PSObject warningWrap = PSObject.AsPSObject(record);
-                    if (warningWrap.Members["WriteWarningStream"] == null)
+                    if (warningWrap.Members[WriteWarningStreamPropertyName] == null)
                     {
-                        warningWrap.Properties.Add(new PSNoteProperty("WriteWarningStream", true));
+                        warningWrap.Properties.Add(new PSNoteProperty(WriteWarningStreamPropertyName, true));
                     }
 
                     WarningOutputPipe.AddWithoutAppendingOutVarList(warningWrap);
@@ -735,9 +741,9 @@ namespace System.Management.Automation
 
                     // Add note property so that the information output is formatted correctly.
                     PSObject informationWrap = PSObject.AsPSObject(record);
-                    if (informationWrap.Members["WriteInformationStream"] == null)
+                    if (informationWrap.Members[WriteInformationStreamPropertyName] == null)
                     {
-                        informationWrap.Properties.Add(new PSNoteProperty("WriteInformationStream", true));
+                        informationWrap.Properties.Add(new PSNoteProperty(WriteInformationStreamPropertyName, true));
                     }
 
                     InformationOutputPipe.Add(informationWrap);
@@ -2845,9 +2851,9 @@ namespace System.Management.Automation
             // when tracing), so don't add the member again.
 
             // We don't add a note property on messages that comes from stderr stream.
-            if (!isNativeError && errorWrap.Members["writeErrorStream"] == null)
+            if (!isNativeError && errorWrap.Members[WriteErrorStreamPropertyName] == null)
             {
-                PSNoteProperty note = new PSNoteProperty("writeErrorStream", true);
+                PSNoteProperty note = new PSNoteProperty(WriteErrorStreamPropertyName, true);
                 errorWrap.Properties.Add(note);
             }
 
@@ -3566,7 +3572,7 @@ namespace System.Management.Automation
                 CBhost.InternalUI.TranscribeResult(inquireCaption);
                 CBhost.InternalUI.TranscribeResult(inquireMessage);
 
-                System.Text.StringBuilder textChoices = new System.Text.StringBuilder();
+                Text.StringBuilder textChoices = new Text.StringBuilder();
                 foreach (ChoiceDescription choice in choices)
                 {
                     if (textChoices.Length > 0)

--- a/src/System.Management.Automation/engine/MshCommandRuntime.cs
+++ b/src/System.Management.Automation/engine/MshCommandRuntime.cs
@@ -28,12 +28,6 @@ namespace System.Management.Automation
     /// </summary>
     internal class MshCommandRuntime : ICommandRuntime2
     {
-        internal const string WriteErrorStreamPropertyName = "WriteErrorStream";
-        internal const string WriteWarningStreamPropertyName = "WriteWarningStream";
-        internal const string WriteVerboseStreamPropertyName = "WriteVerboseStream";
-        internal const string WriteDebugStreamPropertyName = "WriteDebugStream";
-        internal const string WriteInformationStreamPropertyName = "WriteInformationStream";
-
         #region private_members
 
         /// <summary>
@@ -492,12 +486,9 @@ namespace System.Management.Automation
                         CBhost.InternalUI.WriteDebugInfoBuffers(record);
                     }
 
-                    // Add note property so that the debug output is formatted correctly.
+                    // Set WriteStream so that the debug output is formatted correctly.
                     PSObject debugWrap = PSObject.AsPSObject(record);
-                    if (debugWrap.Members[WriteDebugStreamPropertyName] == null)
-                    {
-                        debugWrap.Properties.Add(new PSNoteProperty(WriteDebugStreamPropertyName, true));
-                    }
+                    debugWrap.WriteStream = WriteStreamType.Debug;
 
                     DebugOutputPipe.Add(debugWrap);
                 }
@@ -583,12 +574,9 @@ namespace System.Management.Automation
                         CBhost.InternalUI.WriteVerboseInfoBuffers(record);
                     }
 
-                    // Add note property so that the verbose output is formatted correctly.
+                    // Add WriteStream so that the verbose output is formatted correctly.
                     PSObject verboseWrap = PSObject.AsPSObject(record);
-                    if (verboseWrap.Members[WriteVerboseStreamPropertyName] == null)
-                    {
-                        verboseWrap.Properties.Add(new PSNoteProperty(WriteVerboseStreamPropertyName, true));
-                    }
+                    verboseWrap.WriteStream = WriteStreamType.Verbose;
 
                     VerboseOutputPipe.Add(verboseWrap);
                 }
@@ -674,12 +662,9 @@ namespace System.Management.Automation
                         CBhost.InternalUI.WriteWarningInfoBuffers(record);
                     }
 
-                    // Add note property so that the warning output is formatted correctly.
+                    // Add WriteStream so that the warning output is formatted correctly.
                     PSObject warningWrap = PSObject.AsPSObject(record);
-                    if (warningWrap.Members[WriteWarningStreamPropertyName] == null)
-                    {
-                        warningWrap.Properties.Add(new PSNoteProperty(WriteWarningStreamPropertyName, true));
-                    }
+                    warningWrap.WriteStream = WriteStreamType.Warning;
 
                     WarningOutputPipe.AddWithoutAppendingOutVarList(warningWrap);
                 }
@@ -739,12 +724,9 @@ namespace System.Management.Automation
                         CBhost.InternalUI.WriteInformationInfoBuffers(record);
                     }
 
-                    // Add note property so that the information output is formatted correctly.
+                    // Add WriteStream so that the information output is formatted correctly.
                     PSObject informationWrap = PSObject.AsPSObject(record);
-                    if (informationWrap.Members[WriteInformationStreamPropertyName] == null)
-                    {
-                        informationWrap.Properties.Add(new PSNoteProperty(WriteInformationStreamPropertyName, true));
-                    }
+                    informationWrap.WriteStream = WriteStreamType.Information;
 
                     InformationOutputPipe.Add(informationWrap);
                 }
@@ -2851,10 +2833,9 @@ namespace System.Management.Automation
             // when tracing), so don't add the member again.
 
             // We don't add a note property on messages that comes from stderr stream.
-            if (!isNativeError && errorWrap.Members[WriteErrorStreamPropertyName] == null)
+            if (!isNativeError)
             {
-                PSNoteProperty note = new PSNoteProperty(WriteErrorStreamPropertyName, true);
-                errorWrap.Properties.Add(note);
+                errorWrap.WriteStream = WriteStreamType.Error;
             }
 
             // 2003/11/19-JonN Previously, PSObject instances in ErrorOutputPipe

--- a/src/System.Management.Automation/engine/MshMemberInfo.cs
+++ b/src/System.Management.Automation/engine/MshMemberInfo.cs
@@ -3115,7 +3115,7 @@ namespace System.Management.Automation
             returnValue.Add(new CollectionEntry<PSMemberInfo>(
                 PSObject.TypeTableGetMembersDelegate<PSMemberInfo>,
                 PSObject.TypeTableGetMemberDelegate<PSMemberInfo>,
-                PSObject.TypeTableGetFirstOrDefaultMemberDelegate,
+                PSObject.TypeTableGetFirstOrDefaultMemberDelegate<PSMemberInfo>,
                 true, true, "type table members"));
             return returnValue;
         }
@@ -3126,7 +3126,7 @@ namespace System.Management.Automation
             returnValue.Add(new CollectionEntry<PSMethodInfo>(
                 PSObject.TypeTableGetMembersDelegate<PSMethodInfo>,
                 PSObject.TypeTableGetMemberDelegate<PSMethodInfo>,
-                PSObject.TypeTableGetFirstOrDefaultMemberDelegate,
+                PSObject.TypeTableGetFirstOrDefaultMemberDelegate<PSMethodInfo>,
                 true, true, "type table members"));
             return returnValue;
         }
@@ -3137,7 +3137,7 @@ namespace System.Management.Automation
             returnValue.Add(new CollectionEntry<PSPropertyInfo>(
                 PSObject.TypeTableGetMembersDelegate<PSPropertyInfo>,
                 PSObject.TypeTableGetMemberDelegate<PSPropertyInfo>,
-                PSObject.TypeTableGetFirstOrDefaultMemberDelegate,
+                PSObject.TypeTableGetFirstOrDefaultMemberDelegate<PSPropertyInfo>,
                 true, true, "type table members"));
             return returnValue;
         }

--- a/src/System.Management.Automation/engine/MshMemberInfo.cs
+++ b/src/System.Management.Automation/engine/MshMemberInfo.cs
@@ -4271,7 +4271,6 @@ namespace System.Management.Automation
 
         internal override PSMemberInfo GetFirstOrDefault(MemberNamePredicate predicate)
         {
-
             foreach (string name in _members.Keys)
             {
                 if (predicate.Invoke(name))
@@ -4308,15 +4307,14 @@ namespace System.Management.Automation
         internal GetMembersDelegate GetMembers { get; }
 
         internal GetMemberDelegate GetMember { get; }
-        public GetFirstOrDefaultDelegate GetGetFirstOrDefault { get; }
+
+        internal GetFirstOrDefaultDelegate GetGetFirstOrDefault { get; }
 
         internal bool ShouldReplicateWhenReturning { get; }
 
         internal bool ShouldCloneWhenReturning { get; }
 
         internal string CollectionNameForTracing { get; }
-
-
     }
 
     #endregion CollectionEntry

--- a/src/System.Management.Automation/engine/MshMemberInfo.cs
+++ b/src/System.Management.Automation/engine/MshMemberInfo.cs
@@ -4279,7 +4279,7 @@ namespace System.Management.Automation
             var enumerator = _members.GetEnumerator();
             while (enumerator.MoveNext())
             {
-                var key = (string) enumerator.Key;
+                var key = (string)enumerator.Key;
                 if (predicate(key))
                 {
                     return (T)enumerator.Value;
@@ -4327,7 +4327,6 @@ namespace System.Management.Automation
         private bool ShouldReplicateWhenReturning { get; }
 
         private bool ShouldCloneWhenReturning { get; }
-
 
         internal T CloneOrReplicateObject(object owner, T member)
         {

--- a/src/System.Management.Automation/engine/MshMemberInfo.cs
+++ b/src/System.Management.Automation/engine/MshMemberInfo.cs
@@ -3334,9 +3334,9 @@ namespace System.Management.Automation
         {
             if (_psObject.IsDeserialized)
             {
-                if (_psObject.clrMembers != null)
+                if (_psObject.ClrMembers != null)
                 {
-                    foreach (PSMemberInfo member in _psObject.clrMembers)
+                    foreach (PSMemberInfo member in _psObject.ClrMembers)
                     {
                         internalMembers.Add(member.Copy());
                     }
@@ -3345,7 +3345,7 @@ namespace System.Management.Automation
             else
             {
                 foreach (PSMemberInfo member in
-                    PSObject.dotNetInstanceAdapter.BaseGetMembers<PSMemberInfo>(_psObject.ImmediateBaseObject))
+                    PSObject.DotNetInstanceAdapter.BaseGetMembers<PSMemberInfo>(_psObject.ImmediateBaseObject))
                 {
                     internalMembers.Add(member.Copy());
                 }
@@ -3358,9 +3358,9 @@ namespace System.Management.Automation
 
             if (_psObject.IsDeserialized)
             {
-                if (_psObject.adaptedMembers != null)
+                if (_psObject.AdaptedMembers != null)
                 {
-                    foreach (PSMemberInfo member in _psObject.adaptedMembers)
+                    foreach (PSMemberInfo member in _psObject.AdaptedMembers)
                     {
                         retVal.Add(member.Copy());
                     }
@@ -3380,7 +3380,7 @@ namespace System.Management.Automation
 
         private void GenerateInternalMembersFromPSObject()
         {
-            PSMemberInfoCollection<PSMemberInfo> members = PSObject.dotNetInstanceAdapter.BaseGetMembers<PSMemberInfo>(
+            PSMemberInfoCollection<PSMemberInfo> members = PSObject.DotNetInstanceAdapter.BaseGetMembers<PSMemberInfo>(
                 _psObject);
             foreach (PSMemberInfo member in members)
             {
@@ -4706,7 +4706,7 @@ namespace System.Management.Automation
         {
             get
             {
-                using (PSObject.memberResolution.TraceScope("Lookup"))
+                using (PSObject.MemberResolution.TraceScope("Lookup"))
                 {
                     if (string.IsNullOrEmpty(name))
                     {
@@ -4727,7 +4727,7 @@ namespace System.Management.Automation
                             member = instanceMembers[name];
                             if (member is T memberAsT)
                             {
-                                PSObject.memberResolution.WriteLine("Found PSObject instance member: {0}.", name);
+                                PSObject.MemberResolution.WriteLine("Found PSObject instance member: {0}.", name);
                                 return memberAsT;
                             }
                         }
@@ -4741,7 +4741,7 @@ namespace System.Management.Automation
                             // In membersets we cannot replicate the instance when adding
                             // since the memberset might not yet have an associated PSObject.
                             // We replicate the instance when returning the members of the memberset.
-                            PSObject.memberResolution.WriteLine("Found PSMemberSet member: {0}.", name);
+                            PSObject.MemberResolution.WriteLine("Found PSMemberSet member: {0}.", name);
                             member.ReplicateInstance(delegateOwner);
                             return memberAsT;
                         }
@@ -4778,7 +4778,7 @@ namespace System.Management.Automation
 
         private PSMemberInfoInternalCollection<T> GetIntegratedMembers(MshMemberMatchOptions matchOptions)
         {
-            using (PSObject.memberResolution.TraceScope("Generating the total list of members"))
+            using (PSObject.MemberResolution.TraceScope("Generating the total list of members"))
             {
                 PSMemberInfoInternalCollection<T> returnValue = new PSMemberInfoInternalCollection<T>();
                 object delegateOwner;
@@ -4824,14 +4824,14 @@ namespace System.Management.Automation
                         PSMemberInfo previousMember = returnValue[member.Name];
                         if (previousMember != null)
                         {
-                            PSObject.memberResolution.WriteLine("Member \"{0}\" of type \"{1}\" has been ignored because a member with the same name and type \"{2}\" is already present.",
+                            PSObject.MemberResolution.WriteLine("Member \"{0}\" of type \"{1}\" has been ignored because a member with the same name and type \"{2}\" is already present.",
                                 member.Name, member.MemberType, previousMember.MemberType);
                             continue;
                         }
 
                         if (!member.MatchesOptions(matchOptions))
                         {
-                            PSObject.memberResolution.WriteLine("Skipping hidden member \"{0}\".", member.Name);
+                            PSObject.MemberResolution.WriteLine("Skipping hidden member \"{0}\".", member.Name);
                             continue;
                         }
 
@@ -4901,7 +4901,7 @@ namespace System.Management.Automation
         /// <exception cref="ArgumentException">For invalid arguments.</exception>
         internal override ReadOnlyPSMemberInfoCollection<T> Match(string name, PSMemberTypes memberTypes, MshMemberMatchOptions matchOptions)
         {
-            using (PSObject.memberResolution.TraceScope("Matching \"{0}\"", name))
+            using (PSObject.MemberResolution.TraceScope("Matching \"{0}\"", name))
             {
                 if (string.IsNullOrEmpty(name))
                 {
@@ -4916,7 +4916,7 @@ namespace System.Management.Automation
                 WildcardPattern nameMatch = MemberMatch.GetNamePattern(name);
                 PSMemberInfoInternalCollection<T> allMembers = GetIntegratedMembers(matchOptions);
                 ReadOnlyPSMemberInfoCollection<T> returnValue = new ReadOnlyPSMemberInfoCollection<T>(MemberMatch.Match(allMembers, name, nameMatch, memberTypes));
-                PSObject.memberResolution.WriteLine("{0} total matches.", returnValue.Count);
+                PSObject.MemberResolution.WriteLine("{0} total matches.", returnValue.Count);
                 return returnValue;
             }
         }
@@ -4964,7 +4964,7 @@ namespace System.Management.Automation
             /// <param name="integratingCollection">Members we are enumerating.</param>
             internal Enumerator(PSMemberInfoIntegratingCollection<S> integratingCollection)
             {
-                using (PSObject.memberResolution.TraceScope("Enumeration Start"))
+                using (PSObject.MemberResolution.TraceScope("Enumeration Start"))
                 {
                     _currentIndex = -1;
                     _current = null;
@@ -4972,13 +4972,13 @@ namespace System.Management.Automation
                     if (integratingCollection._mshOwner != null)
                     {
                         integratingCollection.GenerateAllReservedMembers();
-                        PSObject.memberResolution.WriteLine("Enumerating PSObject with type \"{0}\".", integratingCollection._mshOwner.ImmediateBaseObject.GetType().FullName);
-                        PSObject.memberResolution.WriteLine("PSObject instance members: {0}", _allMembers.VisibleCount);
+                        PSObject.MemberResolution.WriteLine("Enumerating PSObject with type \"{0}\".", integratingCollection._mshOwner.ImmediateBaseObject.GetType().FullName);
+                        PSObject.MemberResolution.WriteLine("PSObject instance members: {0}", _allMembers.VisibleCount);
                     }
                     else
                     {
-                        PSObject.memberResolution.WriteLine("Enumerating PSMemberSet \"{0}\".", integratingCollection._memberSetOwner.Name);
-                        PSObject.memberResolution.WriteLine("MemberSet instance members: {0}", _allMembers.VisibleCount);
+                        PSObject.MemberResolution.WriteLine("Enumerating PSMemberSet \"{0}\".", integratingCollection._memberSetOwner.Name);
+                        PSObject.MemberResolution.WriteLine("MemberSet instance members: {0}", _allMembers.VisibleCount);
                     }
                 }
             }

--- a/src/System.Management.Automation/engine/MshMemberInfo.cs
+++ b/src/System.Management.Automation/engine/MshMemberInfo.cs
@@ -4293,8 +4293,13 @@ namespace System.Management.Automation
 
         internal delegate PSMemberInfo GetFirstOrDefaultDelegate(PSObject obj, MemberNamePredicate predicate);
 
-        internal CollectionEntry(GetMembersDelegate getMembers, GetMemberDelegate getMember, GetFirstOrDefaultDelegate getGetFirstOrDefault,
-            bool shouldReplicateWhenReturning, bool shouldCloneWhenReturning, string collectionNameForTracing)
+        internal CollectionEntry(
+            GetMembersDelegate getMembers,
+            GetMemberDelegate getMember,
+            GetFirstOrDefaultDelegate getGetFirstOrDefault,
+            bool shouldReplicateWhenReturning,
+            bool shouldCloneWhenReturning,
+            string collectionNameForTracing)
         {
             GetMembers = getMembers;
             GetMember = getMember;

--- a/src/System.Management.Automation/engine/MshMemberInfo.cs
+++ b/src/System.Management.Automation/engine/MshMemberInfo.cs
@@ -3332,7 +3332,7 @@ namespace System.Management.Automation
 
         private void GenerateInternalMembersFromBase()
         {
-            if (_psObject.isDeserialized)
+            if (_psObject.IsDeserialized)
             {
                 if (_psObject.clrMembers != null)
                 {
@@ -3356,7 +3356,7 @@ namespace System.Management.Automation
         {
             PSMemberInfoInternalCollection<PSMemberInfo> retVal = new PSMemberInfoInternalCollection<PSMemberInfo>();
 
-            if (_psObject.isDeserialized)
+            if (_psObject.IsDeserialized)
             {
                 if (_psObject.adaptedMembers != null)
                 {
@@ -4407,9 +4407,9 @@ namespace System.Management.Automation
 
         private void GenerateAllReservedMembers()
         {
-            if (!_mshOwner.hasGeneratedReservedMembers)
+            if (!_mshOwner.HasGeneratedReservedMembers)
             {
-                _mshOwner.hasGeneratedReservedMembers = true;
+                _mshOwner.HasGeneratedReservedMembers = true;
                 ReservedNameMembers.GeneratePSExtendedMemberSet(_mshOwner);
                 ReservedNameMembers.GeneratePSBaseMemberSet(_mshOwner);
                 ReservedNameMembers.GeneratePSObjectMemberSet(_mshOwner);

--- a/src/System.Management.Automation/engine/MshObject.cs
+++ b/src/System.Management.Automation/engine/MshObject.cs
@@ -111,19 +111,19 @@ namespace System.Management.Automation
             return members;
         }
 
-        internal static PSMemberInfo TypeTableGetFirstOrDefaultMemberDelegate(PSObject msjObj, MemberNamePredicate predicate)
+        internal static T TypeTableGetFirstOrDefaultMemberDelegate<T>(PSObject msjObj, MemberNamePredicate predicate) where T : PSMemberInfo
         {
             TypeTable table = msjObj.GetTypeTable();
-            return TypeTableGetFirstOrDefaultMemberDelegate(msjObj, table, predicate);
+            return TypeTableGetFirstOrDefaultMemberDelegate<T>(msjObj, table, predicate);
         }
 
-        internal static PSMemberInfo TypeTableGetFirstOrDefaultMemberDelegate(PSObject msjObj, TypeTable typeTableToUse, MemberNamePredicate predicate)
+        internal static T TypeTableGetFirstOrDefaultMemberDelegate<T>(PSObject msjObj, TypeTable typeTableToUse, MemberNamePredicate predicate) where T : PSMemberInfo
         {
             if (typeTableToUse == null)
             {
                 return default;
             }
-            var member = typeTableToUse.GetFirstOrDefaultMember(msjObj.InternalTypeNames, predicate);
+            var member = typeTableToUse.GetFirstOrDefaultMember<T>(msjObj.InternalTypeNames, predicate);
 
             return member;
         }
@@ -285,7 +285,7 @@ namespace System.Management.Automation
                     returnValue.Add(new CollectionEntry<PSMemberInfo>(
                         PSObject.TypeTableGetMembersDelegate<PSMemberInfo>,
                         PSObject.TypeTableGetMemberDelegate<PSMemberInfo>,
-                        PSObject.TypeTableGetFirstOrDefaultMemberDelegate,
+                        PSObject.TypeTableGetFirstOrDefaultMemberDelegate<PSMemberInfo>,
                         true, true, "type table members"));
                 }
                 else
@@ -293,7 +293,7 @@ namespace System.Management.Automation
                     returnValue.Add(new CollectionEntry<PSMemberInfo>(
                         msjObj => TypeTableGetMembersDelegate<PSMemberInfo>(msjObj, backupTypeTable),
                         (msjObj, name) => TypeTableGetMemberDelegate<PSMemberInfo>(msjObj, backupTypeTable, name),
-                        (msjObj, predicate) => TypeTableGetFirstOrDefaultMemberDelegate(msjObj, backupTypeTable, predicate),
+                        (msjObj, predicate) => TypeTableGetFirstOrDefaultMemberDelegate<PSMemberInfo>(msjObj, backupTypeTable, predicate),
                         true, true, "type table members"));
                 }
             }
@@ -330,7 +330,7 @@ namespace System.Management.Automation
                 new CollectionEntry<PSMethodInfo>(
                     PSObject.TypeTableGetMembersDelegate<PSMethodInfo>,
                     PSObject.TypeTableGetMemberDelegate<PSMethodInfo>,
-                    PSObject.TypeTableGetFirstOrDefaultMemberDelegate,
+                    PSObject.TypeTableGetFirstOrDefaultMemberDelegate<PSMethodInfo>,
                     shouldReplicateWhenReturning: true,
                     shouldCloneWhenReturning: true,
                     collectionNameForTracing: "type table members"),
@@ -390,7 +390,7 @@ namespace System.Management.Automation
                     returnValue.Add(new CollectionEntry<PSPropertyInfo>(
                         PSObject.TypeTableGetMembersDelegate<PSPropertyInfo>,
                         PSObject.TypeTableGetMemberDelegate<PSPropertyInfo>,
-                        PSObject.TypeTableGetFirstOrDefaultMemberDelegate,
+                        PSObject.TypeTableGetFirstOrDefaultMemberDelegate<PSPropertyInfo>,
                         true, true, "type table members"));
                 }
                 else
@@ -398,7 +398,7 @@ namespace System.Management.Automation
                     returnValue.Add(new CollectionEntry<PSPropertyInfo>(
                         msjObj => TypeTableGetMembersDelegate<PSPropertyInfo>(msjObj, backupTypeTable),
                         (msjObj, name) => TypeTableGetMemberDelegate<PSPropertyInfo>(msjObj, backupTypeTable, name),
-                        PSObject.TypeTableGetFirstOrDefaultMemberDelegate,
+                        PSObject.TypeTableGetFirstOrDefaultMemberDelegate<PSPropertyInfo>,
                         true, true, "type table members"));
                 }
             }
@@ -2392,6 +2392,7 @@ namespace System.Management.Automation
                     }
                 }
             }
+
 
             return Properties.GetFirstOrDefault(predicate) as PSPropertyInfo;
         }

--- a/src/System.Management.Automation/engine/MshObject.cs
+++ b/src/System.Management.Automation/engine/MshObject.cs
@@ -337,7 +337,6 @@ namespace System.Management.Automation
             return returnValue;
         }
 
-
         /// <summary>
         /// A collection of delegates to get Extended/Adapted/Dotnet properties based on the
         /// <paramref name="viewType"/>
@@ -965,7 +964,6 @@ namespace System.Management.Automation
 
         private static readonly ConditionalWeakTable<object, PSMemberInfoInternalCollection<PSMemberInfo>> s_instanceMembersResurrectionTable =
             new ConditionalWeakTable<object, PSMemberInfoInternalCollection<PSMemberInfo>>();
-
 
         /// <summary>
         /// </summary>

--- a/src/System.Management.Automation/engine/MshObject.cs
+++ b/src/System.Management.Automation/engine/MshObject.cs
@@ -111,7 +111,7 @@ namespace System.Management.Automation
             return members;
         }
 
-        internal static T TypeTableGetFirstOrDefaultMemberDelegate<T>(PSObject msjObj, MemberNamePredicate predicate) where T : PSMemberInfo
+        internal static T TypeTableGetFirstMemberOrDefaultDelegate<T>(PSObject msjObj, MemberNamePredicate predicate) where T : PSMemberInfo
         {
             TypeTable table = msjObj.GetTypeTable();
             return TypeTableGetFirstOrDefaultMemberDelegate<T>(msjObj, table, predicate);
@@ -119,7 +119,7 @@ namespace System.Management.Automation
 
         internal static T TypeTableGetFirstOrDefaultMemberDelegate<T>(PSObject msjObj, TypeTable typeTableToUse, MemberNamePredicate predicate) where T : PSMemberInfo
         {
-            return typeTableToUse?.GetFirstOrDefaultMember<T>(msjObj.InternalTypeNames, predicate);
+            return typeTableToUse?.GetFirstMemberOrDefault<T>(msjObj.InternalTypeNames, predicate);
         }
 
         private static T AdapterGetMemberDelegate<T>(PSObject msjObj, string name) where T : PSMemberInfo
@@ -141,9 +141,9 @@ namespace System.Management.Automation
             return retValue;
         }
 
-        private static T AdapterGetFirstOrDefaultMemberDelegate<T>(PSObject msjObj, MemberNamePredicate predicate) where T : PSMemberInfo
+        private static T AdapterGetFirstMemberOrDefaultDelegate<T>(PSObject msjObj, MemberNamePredicate predicate) where T : PSMemberInfo
         {
-            if (msjObj.IsDeserialized && typeof(PSPropertyInfo).IsAssignableFrom(typeof(T)))
+            if (msjObj.IsDeserialized && typeof(T).IsAssignableFrom(typeof(PSPropertyInfo)))
             {
                 if (msjObj.AdaptedMembers == null)
                 {
@@ -227,12 +227,11 @@ namespace System.Management.Automation
             return null;
         }
 
-        private static T DotNetGetFirstOrDefaultMemberDelegate<T>(PSObject msjObj, MemberNamePredicate predicate) where T : PSMemberInfo
+        private static T DotNetGetFirstMemberOrDefaultDelegate<T>(PSObject msjObj, MemberNamePredicate predicate) where T : PSMemberInfo
         {
             // Don't lookup dotnet member if the object doesn't insist.
             return msjObj.InternalBaseDotNetAdapter?.BaseGetFirstMemberOrDefault<T>(msjObj._immediateBaseObject, predicate);
         }
-
 
         /// <summary>
         /// A collection of delegates to get Extended/Adapted/Dotnet members based on the
@@ -270,7 +269,7 @@ namespace System.Management.Automation
                     returnValue.Add(new CollectionEntry<PSMemberInfo>(
                         PSObject.TypeTableGetMembersDelegate<PSMemberInfo>,
                         PSObject.TypeTableGetMemberDelegate<PSMemberInfo>,
-                        PSObject.TypeTableGetFirstOrDefaultMemberDelegate<PSMemberInfo>,
+                        PSObject.TypeTableGetFirstMemberOrDefaultDelegate<PSMemberInfo>,
                         true, true, "type table members"));
                 }
                 else
@@ -288,7 +287,7 @@ namespace System.Management.Automation
                 returnValue.Add(new CollectionEntry<PSMemberInfo>(
                     PSObject.AdapterGetMembersDelegate<PSMemberInfo>,
                     PSObject.AdapterGetMemberDelegate<PSMemberInfo>,
-                    PSObject.AdapterGetFirstOrDefaultMemberDelegate<PSMemberInfo>,
+                    PSObject.AdapterGetFirstMemberOrDefaultDelegate<PSMemberInfo>,
                     shouldReplicateWhenReturning: false,
                     shouldCloneWhenReturning: false,
                     collectionNameForTracing: "adapted members"));
@@ -299,7 +298,7 @@ namespace System.Management.Automation
                 returnValue.Add(new CollectionEntry<PSMemberInfo>(
                     PSObject.DotNetGetMembersDelegate<PSMemberInfo>,
                     PSObject.DotNetGetMemberDelegate<PSMemberInfo>,
-                    PSObject.DotNetGetFirstOrDefaultMemberDelegate<PSMemberInfo>,
+                    PSObject.DotNetGetFirstMemberOrDefaultDelegate<PSMemberInfo>,
                     shouldReplicateWhenReturning: false,
                     shouldCloneWhenReturning: false,
                     collectionNameForTracing: "clr members"));
@@ -315,21 +314,21 @@ namespace System.Management.Automation
                 new CollectionEntry<PSMethodInfo>(
                     PSObject.TypeTableGetMembersDelegate<PSMethodInfo>,
                     PSObject.TypeTableGetMemberDelegate<PSMethodInfo>,
-                    PSObject.TypeTableGetFirstOrDefaultMemberDelegate<PSMethodInfo>,
+                    PSObject.TypeTableGetFirstMemberOrDefaultDelegate<PSMethodInfo>,
                     shouldReplicateWhenReturning: true,
                     shouldCloneWhenReturning: true,
                     collectionNameForTracing: "type table members"),
                 new CollectionEntry<PSMethodInfo>(
                     PSObject.AdapterGetMembersDelegate<PSMethodInfo>,
                     PSObject.AdapterGetMemberDelegate<PSMethodInfo>,
-                    PSObject.AdapterGetFirstOrDefaultMemberDelegate<PSMethodInfo>,
+                    PSObject.AdapterGetFirstMemberOrDefaultDelegate<PSMethodInfo>,
                     shouldReplicateWhenReturning: false,
                     shouldCloneWhenReturning: false,
                     collectionNameForTracing: "adapted members"),
                 new CollectionEntry<PSMethodInfo>(
                     PSObject.DotNetGetMembersDelegate<PSMethodInfo>,
                     PSObject.DotNetGetMemberDelegate<PSMethodInfo>,
-                    PSObject.DotNetGetFirstOrDefaultMemberDelegate<PSMethodInfo>,
+                    PSObject.DotNetGetFirstMemberOrDefaultDelegate<PSMethodInfo>,
                     shouldReplicateWhenReturning: false,
                     shouldCloneWhenReturning: false,
                     collectionNameForTracing: "clr members")
@@ -374,7 +373,7 @@ namespace System.Management.Automation
                     returnValue.Add(new CollectionEntry<PSPropertyInfo>(
                         PSObject.TypeTableGetMembersDelegate<PSPropertyInfo>,
                         PSObject.TypeTableGetMemberDelegate<PSPropertyInfo>,
-                        PSObject.TypeTableGetFirstOrDefaultMemberDelegate<PSPropertyInfo>,
+                        PSObject.TypeTableGetFirstMemberOrDefaultDelegate<PSPropertyInfo>,
                         true, true, "type table members"));
                 }
                 else
@@ -382,7 +381,7 @@ namespace System.Management.Automation
                     returnValue.Add(new CollectionEntry<PSPropertyInfo>(
                         msjObj => TypeTableGetMembersDelegate<PSPropertyInfo>(msjObj, backupTypeTable),
                         (msjObj, name) => TypeTableGetMemberDelegate<PSPropertyInfo>(msjObj, backupTypeTable, name),
-                        PSObject.TypeTableGetFirstOrDefaultMemberDelegate<PSPropertyInfo>,
+                        PSObject.TypeTableGetFirstMemberOrDefaultDelegate<PSPropertyInfo>,
                         true, true, "type table members"));
                 }
             }
@@ -392,7 +391,7 @@ namespace System.Management.Automation
                 returnValue.Add(new CollectionEntry<PSPropertyInfo>(
                     PSObject.AdapterGetMembersDelegate<PSPropertyInfo>,
                     PSObject.AdapterGetMemberDelegate<PSPropertyInfo>,
-                    PSObject.AdapterGetFirstOrDefaultMemberDelegate<PSPropertyInfo>,
+                    PSObject.AdapterGetFirstMemberOrDefaultDelegate<PSPropertyInfo>,
                     false, false, "adapted members"));
             }
 
@@ -401,7 +400,7 @@ namespace System.Management.Automation
                 returnValue.Add(new CollectionEntry<PSPropertyInfo>(
                     PSObject.DotNetGetMembersDelegate<PSPropertyInfo>,
                     PSObject.DotNetGetMemberDelegate<PSPropertyInfo>,
-                    PSObject.DotNetGetFirstOrDefaultMemberDelegate<PSPropertyInfo>,
+                    PSObject.DotNetGetFirstMemberOrDefaultDelegate<PSPropertyInfo>,
                     false, false, "clr members"));
             }
 
@@ -629,31 +628,6 @@ namespace System.Management.Automation
         private PSMemberInfoIntegratingCollection<PSMethodInfo> _methods;
 
         private PSObjectFlags _flags;
-
-        /// <summary>
-        /// This field contains a stream type used by the formatting system.
-        /// </summary>
-        private WriteStreamType _writeStream;
-
-        /// <summary>
-        /// Members from the adapter of the object before it was serialized
-        /// Null for live objects but not null for deserialized objects.
-        /// </summary>
-        private PSMemberInfoInternalCollection<PSPropertyInfo> _adaptedMembers;
-
-        /// <summary>
-        /// Members from the adapter of the object before it was serialized
-        /// Null for live objects but not null for deserialized objects.
-        /// </summary>
-        private PSMemberInfoInternalCollection<PSPropertyInfo> _clrMembers;
-
-        // This is toString value set on deserialization
-        private string _toStringFromDeserialization;
-
-        /// <summary>
-        /// If this is non-null return this string as the ToString() for this wrapped object.
-        /// </summary>
-        private string _tokenText;
 
         #endregion instance fields
 
@@ -943,8 +917,7 @@ namespace System.Management.Automation
                 {
                     if (psobj._instanceMembers == null)
                     {
-                        s_instanceMembersResurrectionTable.TryGetValue(GetKeyForResurrectionTables(psobj),
-                            out psobj._instanceMembers);
+                        s_instanceMembersResurrectionTable.TryGetValue(GetKeyForResurrectionTables(psobj), out psobj._instanceMembers);
                     }
                 }
 
@@ -1536,9 +1509,9 @@ namespace System.Management.Automation
         {
             // If ToString value from deserialization is available,
             // simply return it.
-            if (_toStringFromDeserialization != null)
+            if (ToStringFromDeserialization != null)
             {
-                return _toStringFromDeserialization;
+                return ToStringFromDeserialization;
             }
 
             return PSObject.ToString(null, this, null, null, null, true, false);
@@ -1557,9 +1530,9 @@ namespace System.Management.Automation
         {
             // If ToString value from deserialization is available,
             // simply return it.
-            if (_toStringFromDeserialization != null)
+            if (ToStringFromDeserialization != null)
             {
-                return _toStringFromDeserialization;
+                return ToStringFromDeserialization;
             }
 
             return PSObject.ToString(null, this, null, format, formatProvider, true, false);
@@ -1648,7 +1621,7 @@ namespace System.Management.Automation
                 }
             }
 
-            returnValue._writeStream = _writeStream;
+            returnValue.WriteStream = WriteStream;
             returnValue.HasGeneratedReservedMembers = false;
 
             return returnValue;
@@ -2051,21 +2024,15 @@ namespace System.Management.Automation
             if (!target.IsDeserialized)
             {
                 target.IsDeserialized = source.IsDeserialized;
-                target._adaptedMembers = source.AdaptedMembers;
-                target._clrMembers = source.ClrMembers;
+                target.AdaptedMembers = source.AdaptedMembers;
+                target.ClrMembers = source.ClrMembers;
             }
 
-            if (target._toStringFromDeserialization == null)
+            if (target.ToStringFromDeserialization == null)
             {
-                target._toStringFromDeserialization = source._toStringFromDeserialization;
-                target._tokenText = source.TokenText;
+                target.ToStringFromDeserialization = source.ToStringFromDeserialization;
+                target.TokenText = source.TokenText;
             }
-        }
-
-        internal string TokenText
-        {
-            get => _tokenText;
-            set => _tokenText = value;
         }
 
         /// <summary>
@@ -2085,16 +2052,6 @@ namespace System.Management.Automation
             {
                 this.InternalTypeNames = this.InternalAdapter.BaseGetTypeNameHierarchy(value);
             }
-        }
-
-
-        /// <summary>
-        /// Sets the to string value on deserialization.
-        /// </summary>
-        internal string ToStringFromDeserialization
-        {
-            get => _toStringFromDeserialization;
-            set => _toStringFromDeserialization = value;
         }
 
         #endregion serialization
@@ -2399,22 +2356,26 @@ namespace System.Management.Automation
             }
         }
 
+        /// <summary>
+        /// If 'this' is non-null, return this string as the ToString() for this wrapped object.
+        /// </summary>
+        internal string TokenText { get; set; }
 
-        internal WriteStreamType WriteStream
-        {
-            get => _writeStream;
-            set => _writeStream = value;
-        }
+        /// <summary>
+        /// Sets the 'ToString' value on deserialization.
+        /// </summary>
+        internal string ToStringFromDeserialization { get; set; }
+
+        /// <summary>
+        /// This property contains a stream type used by the formatting system.
+        /// </summary>
+        internal WriteStreamType WriteStream { get; set; }
 
         /// <summary>
         /// Members from the adapter of the object before it was serialized
         /// Null for live objects but not null for deserialized objects.
         /// </summary>
-        internal PSMemberInfoInternalCollection<PSPropertyInfo> AdaptedMembers
-        {
-            get => _adaptedMembers;
-            set => _adaptedMembers = value;
-        }
+        internal PSMemberInfoInternalCollection<PSPropertyInfo> AdaptedMembers { get; set; }
 
         internal static DotNetAdapter DotNetStaticAdapter => s_dotNetStaticAdapter;
 
@@ -2424,11 +2385,7 @@ namespace System.Management.Automation
         /// Members from the adapter of the object before it was serialized
         /// Null for live objects but not null for deserialized objects.
         /// </summary>
-        internal PSMemberInfoInternalCollection<PSPropertyInfo> ClrMembers
-        {
-            get => _clrMembers;
-            set => _clrMembers = value;
-        }
+        internal PSMemberInfoInternalCollection<PSPropertyInfo> ClrMembers { get; set; }
 
         internal static DotNetAdapter DotNetInstanceAdapter => s_dotNetInstanceAdapter;
 
@@ -2437,19 +2394,7 @@ namespace System.Management.Automation
         /// </summary>
         internal PSPropertyInfo GetFirstPropertyOrDefault(MemberNamePredicate predicate)
         {
-            if (_instanceMembers != null)
-            {
-                foreach (var instanceMember in _instanceMembers)
-                {
-                    if (instanceMember is PSPropertyInfo propInfo
-                        && predicate.Invoke(propInfo.Name))
-                    {
-                        return propInfo;
-                    }
-                }
-            }
-
-            return Properties.GetFirstOrDefault(predicate) as PSPropertyInfo;
+            return Properties.FirstOrDefault(predicate);
         }
 
         [Flags]

--- a/src/System.Management.Automation/engine/MshObject.cs
+++ b/src/System.Management.Automation/engine/MshObject.cs
@@ -141,7 +141,7 @@ namespace System.Management.Automation
             return retValue;
         }
 
-        private static PSMemberInfo AdapterGetFirstOrDefaultMemberDelegate<T>(PSObject msjObj, MemberNamePredicate predicate) where T : PSMemberInfo
+        private static T AdapterGetFirstOrDefaultMemberDelegate<T>(PSObject msjObj, MemberNamePredicate predicate) where T : PSMemberInfo
         {
             if (msjObj.IsDeserialized && typeof(PSPropertyInfo).IsAssignableFrom(typeof(T)))
             {
@@ -227,10 +227,10 @@ namespace System.Management.Automation
             return null;
         }
 
-        private static PSMemberInfo DotNetGetFirstOrDefaultMemberDelegate(PSObject msjObj, MemberNamePredicate predicate)
+        private static T DotNetGetFirstOrDefaultMemberDelegate<T>(PSObject msjObj, MemberNamePredicate predicate) where T : PSMemberInfo
         {
             // Don't lookup dotnet member if the object doesn't insist.
-            return msjObj.InternalBaseDotNetAdapter?.BaseGetMember<PSMemberInfo>(msjObj._immediateBaseObject, predicate);
+            return msjObj.InternalBaseDotNetAdapter?.BaseGetMember<T>(msjObj._immediateBaseObject, predicate);
         }
 
 
@@ -299,7 +299,7 @@ namespace System.Management.Automation
                 returnValue.Add(new CollectionEntry<PSMemberInfo>(
                     PSObject.DotNetGetMembersDelegate<PSMemberInfo>,
                     PSObject.DotNetGetMemberDelegate<PSMemberInfo>,
-                    PSObject.AdapterGetFirstOrDefaultMemberDelegate<PSMemberInfo>,
+                    PSObject.DotNetGetFirstOrDefaultMemberDelegate<PSMemberInfo>,
                     shouldReplicateWhenReturning: false,
                     shouldCloneWhenReturning: false,
                     collectionNameForTracing: "clr members"));
@@ -329,7 +329,7 @@ namespace System.Management.Automation
                 new CollectionEntry<PSMethodInfo>(
                     PSObject.DotNetGetMembersDelegate<PSMethodInfo>,
                     PSObject.DotNetGetMemberDelegate<PSMethodInfo>,
-                    PSObject.DotNetGetFirstOrDefaultMemberDelegate,
+                    PSObject.DotNetGetFirstOrDefaultMemberDelegate<PSMethodInfo>,
                     shouldReplicateWhenReturning: false,
                     shouldCloneWhenReturning: false,
                     collectionNameForTracing: "clr members")
@@ -401,7 +401,7 @@ namespace System.Management.Automation
                 returnValue.Add(new CollectionEntry<PSPropertyInfo>(
                     PSObject.DotNetGetMembersDelegate<PSPropertyInfo>,
                     PSObject.DotNetGetMemberDelegate<PSPropertyInfo>,
-                    PSObject.AdapterGetFirstOrDefaultMemberDelegate<PSPropertyInfo>,
+                    PSObject.DotNetGetFirstOrDefaultMemberDelegate<PSPropertyInfo>,
                     false, false, "clr members"));
             }
 

--- a/src/System.Management.Automation/engine/MshObject.cs
+++ b/src/System.Management.Automation/engine/MshObject.cs
@@ -2452,7 +2452,7 @@ namespace System.Management.Automation
         }
 
         [Flags]
-        enum PSObjectFlags : byte
+        private enum PSObjectFlags : byte
         {
             None = 0,
             /// <summary>

--- a/src/System.Management.Automation/engine/MshObject.cs
+++ b/src/System.Management.Automation/engine/MshObject.cs
@@ -641,13 +641,16 @@ namespace System.Management.Automation
         /// Null for live objects but not null for deserialized objects.
         /// </summary>
         private PSMemberInfoInternalCollection<PSPropertyInfo> _adaptedMembers;
+
         /// <summary>
         /// Members from the adapter of the object before it was serialized
         /// Null for live objects but not null for deserialized objects.
         /// </summary>
         private PSMemberInfoInternalCollection<PSPropertyInfo> _clrMembers;
+
         // This is toString value set on deserialization
         private string _toStringFromDeserialization;
+
         /// <summary>
         /// If this is non-null return this string as the ToString() for this wrapped object.
         /// </summary>
@@ -2455,16 +2458,19 @@ namespace System.Management.Automation
         private enum PSObjectFlags : byte
         {
             None = 0,
+
             /// <summary>
             /// This flag is set in deserialized shellobject.
             /// </summary>
             IsDeserialized = 0b00000001,
+
             /// <summary>
             /// Set to true when the BaseObject is PSCustomObject.
             /// </summary>
             HasGeneratedReservedMembers = 0b00000010,
             ImmediateBaseObjectIsEmpty = 0b00000100,
             IsHelpObject = 0b00001000,
+
             /// <summary>
             /// Indicate whether we store the instance members and type names locally
             /// for this PSObject instance.

--- a/src/System.Management.Automation/engine/MshObject.cs
+++ b/src/System.Management.Automation/engine/MshObject.cs
@@ -159,7 +159,7 @@ namespace System.Management.Automation
                 }
             }
 
-            T retValue = msjObj.InternalAdapter.BaseGetMember<T>(msjObj._immediateBaseObject, predicate);
+            T retValue = msjObj.InternalAdapter.BaseGetFirstMemberOrDefault<T>(msjObj._immediateBaseObject, predicate);
             return retValue;
         }
 
@@ -230,7 +230,7 @@ namespace System.Management.Automation
         private static T DotNetGetFirstOrDefaultMemberDelegate<T>(PSObject msjObj, MemberNamePredicate predicate) where T : PSMemberInfo
         {
             // Don't lookup dotnet member if the object doesn't insist.
-            return msjObj.InternalBaseDotNetAdapter?.BaseGetMember<T>(msjObj._immediateBaseObject, predicate);
+            return msjObj.InternalBaseDotNetAdapter?.BaseGetFirstMemberOrDefault<T>(msjObj._immediateBaseObject, predicate);
         }
 
 

--- a/src/System.Management.Automation/engine/MshObject.cs
+++ b/src/System.Management.Automation/engine/MshObject.cs
@@ -2376,25 +2376,25 @@ namespace System.Management.Automation
         /// <summary>
         /// Gets an instance member if it's name matches the predicate. Otherwise null.
         /// </summary>
-        internal PSMemberInfo GetFirstPropertyOrDefault(MemberNamePredicate predicate)
+        internal PSPropertyInfo GetFirstPropertyOrDefault(MemberNamePredicate predicate)
         {
             if (_instanceMembers != null)
             {
                 foreach (var instanceMember in _instanceMembers)
                 {
-                    var found = predicate.Invoke(instanceMember.Name);
-                    if (found)
+                    if (instanceMember is PSPropertyInfo propInfo)
                     {
-                        return instanceMember;
+                        var found = predicate.Invoke(propInfo.Name);
+                        if (found)
+                        {
+                            return propInfo;
+                        }
                     }
                 }
             }
 
-            return Properties.GetFirstOrDefault(predicate);
-
+            return Properties.GetFirstOrDefault(predicate) as PSPropertyInfo;
         }
-
-
 
         private bool _isHelpObject = false;
 

--- a/src/System.Management.Automation/engine/MshObject.cs
+++ b/src/System.Management.Automation/engine/MshObject.cs
@@ -119,13 +119,7 @@ namespace System.Management.Automation
 
         internal static T TypeTableGetFirstOrDefaultMemberDelegate<T>(PSObject msjObj, TypeTable typeTableToUse, MemberNamePredicate predicate) where T : PSMemberInfo
         {
-            if (typeTableToUse == null)
-            {
-                return default;
-            }
-            var member = typeTableToUse.GetFirstOrDefaultMember<T>(msjObj.InternalTypeNames, predicate);
-
-            return member;
+            return typeTableToUse?.GetFirstOrDefaultMember<T>(msjObj.InternalTypeNames, predicate);
         }
 
         private static T AdapterGetMemberDelegate<T>(PSObject msjObj, string name) where T : PSMemberInfo
@@ -236,13 +230,7 @@ namespace System.Management.Automation
         private static PSMemberInfo DotNetGetFirstOrDefaultMemberDelegate(PSObject msjObj, MemberNamePredicate predicate)
         {
             // Don't lookup dotnet member if the object doesn't insist.
-            if (msjObj.InternalBaseDotNetAdapter != null)
-            {
-                PSMemberInfo retValue = msjObj.InternalBaseDotNetAdapter.BaseGetMember<PSMemberInfo>(msjObj._immediateBaseObject, predicate);
-                return retValue;
-            }
-
-            return null;
+            return msjObj.InternalBaseDotNetAdapter?.BaseGetMember<PSMemberInfo>(msjObj._immediateBaseObject, predicate);
         }
 
 
@@ -2451,13 +2439,10 @@ namespace System.Management.Automation
             {
                 foreach (var instanceMember in _instanceMembers)
                 {
-                    if (instanceMember is PSPropertyInfo propInfo)
+                    if (instanceMember is PSPropertyInfo propInfo
+                        && predicate.Invoke(propInfo.Name))
                     {
-                        var found = predicate.Invoke(propInfo.Name);
-                        if (found)
-                        {
-                            return propInfo;
-                        }
+                        return propInfo;
                     }
                 }
             }

--- a/src/System.Management.Automation/engine/MshObject.cs
+++ b/src/System.Management.Automation/engine/MshObject.cs
@@ -630,8 +630,9 @@ namespace System.Management.Automation
         private PSMemberInfoIntegratingCollection<PSMethodInfo> _methods;
 
         private PSObjectFlags _flags;
+
         /// <summary>
-        /// This field contains a stream th
+        /// This field contains a stream type used by the formatting system.
         /// </summary>
         private WriteStreamType _writeStream;
 

--- a/src/System.Management.Automation/engine/ParameterBinderBase.cs
+++ b/src/System.Management.Automation/engine/ParameterBinderBase.cs
@@ -850,7 +850,7 @@ namespace System.Management.Automation
             }
 
             var psobj = parameterValue as PSObject;
-            if (psobj != null && !psobj.immediateBaseObjectIsEmpty)
+            if (psobj != null && !psobj.ImmediateBaseObjectIsEmpty)
             {
                 // See if the base object is of the same type or
                 // as subclass of the parameter

--- a/src/System.Management.Automation/engine/SessionStateDriveAPIs.cs
+++ b/src/System.Management.Automation/engine/SessionStateDriveAPIs.cs
@@ -88,7 +88,7 @@ namespace System.Management.Automation
 
                 // set the return value to the first drive (should only be one).
 
-                if (!successObjects[0].immediateBaseObjectIsEmpty)
+                if (!successObjects[0].ImmediateBaseObjectIsEmpty)
                 {
                     result = (PSDriveInfo)successObjects[0].BaseObject;
                 }

--- a/src/System.Management.Automation/engine/ThirdPartyAdapter.cs
+++ b/src/System.Management.Automation/engine/ThirdPartyAdapter.cs
@@ -128,6 +128,30 @@ namespace System.Management.Automation
             return property;
         }
 
+        private protected override PSProperty DoGetFirstPropertyOrDefault(object obj, MemberNamePredicate predicate)
+        {
+            PSAdaptedProperty property = null;
+
+            try
+            {
+                property = _externalAdapter.GetProperty(obj, predicate);
+            }
+            catch (Exception exception)
+            {
+                throw new ExtendedTypeSystemException(
+                    "PSPropertyAdapter.GetProperty",
+                    exception,
+                    ExtendedTypeSystem.GetProperty, "predicate", obj.ToString());
+            }
+
+            if (property != null)
+            {
+                InitializeProperty(property, obj);
+            }
+
+            return property;
+        }
+
         /// <summary>
         /// Ensures that the adapter and base object are set in the given PSAdaptedProperty.
         /// </summary>
@@ -323,5 +347,8 @@ namespace System.Management.Automation
         /// Returns the type for a given property.
         /// </summary>
         public abstract string GetPropertyTypeName(PSAdaptedProperty adaptedProperty);
+
+        internal abstract PSAdaptedProperty GetProperty(object baseObject, MemberNamePredicate propertyName);
+
     }
 }

--- a/src/System.Management.Automation/engine/ThirdPartyAdapter.cs
+++ b/src/System.Management.Automation/engine/ThirdPartyAdapter.cs
@@ -141,7 +141,7 @@ namespace System.Management.Automation
                 throw new ExtendedTypeSystemException(
                     "PSPropertyAdapter.GetProperty",
                     exception,
-                    ExtendedTypeSystem.GetProperty, "predicate", obj.ToString());
+                    ExtendedTypeSystem.GetProperty, nameof(predicate), obj.ToString());
             }
 
             if (property != null)

--- a/src/System.Management.Automation/engine/ThirdPartyAdapter.cs
+++ b/src/System.Management.Automation/engine/ThirdPartyAdapter.cs
@@ -349,6 +349,5 @@ namespace System.Management.Automation
         public abstract string GetPropertyTypeName(PSAdaptedProperty adaptedProperty);
 
         internal abstract PSAdaptedProperty GetProperty(object baseObject, MemberNamePredicate propertyName);
-
     }
 }

--- a/src/System.Management.Automation/engine/ThirdPartyAdapter.cs
+++ b/src/System.Management.Automation/engine/ThirdPartyAdapter.cs
@@ -128,7 +128,7 @@ namespace System.Management.Automation
             return property;
         }
 
-        private protected override PSProperty DoGetFirstPropertyOrDefault(object obj, MemberNamePredicate predicate)
+        protected override PSProperty DoGetProperty(object obj, MemberNamePredicate predicate)
         {
             PSAdaptedProperty property = null;
 

--- a/src/System.Management.Automation/engine/ThirdPartyAdapter.cs
+++ b/src/System.Management.Automation/engine/ThirdPartyAdapter.cs
@@ -351,6 +351,7 @@ namespace System.Management.Automation
         /// <summary>
         /// Returns a property if it's name matches the specified <see cref="MemberNamePredicate"/>, otherwise null.
         /// </summary>
+        /// <returns>An adapted property if the predicate matches, or <c>null</c>.</returns>
         public abstract PSAdaptedProperty GetProperty(object baseObject, MemberNamePredicate propertyName);
     }
 }

--- a/src/System.Management.Automation/engine/ThirdPartyAdapter.cs
+++ b/src/System.Management.Automation/engine/ThirdPartyAdapter.cs
@@ -128,13 +128,13 @@ namespace System.Management.Automation
             return property;
         }
 
-        protected override PSProperty DoGetProperty(object obj, MemberNamePredicate predicate)
+        protected override PSProperty DoGetFirstPropertyOrDefault(object obj, MemberNamePredicate predicate)
         {
             PSAdaptedProperty property = null;
 
             try
             {
-                property = _externalAdapter.GetProperty(obj, predicate);
+                property = _externalAdapter.GetFirstPropertyOrDefault(obj, predicate);
             }
             catch (Exception exception)
             {
@@ -352,6 +352,17 @@ namespace System.Management.Automation
         /// Returns a property if it's name matches the specified <see cref="MemberNamePredicate"/>, otherwise null.
         /// </summary>
         /// <returns>An adapted property if the predicate matches, or <c>null</c>.</returns>
-        public abstract PSAdaptedProperty GetProperty(object baseObject, MemberNamePredicate propertyName);
+        public virtual PSAdaptedProperty GetFirstPropertyOrDefault(object baseObject, MemberNamePredicate predicate)
+        {
+            foreach (var property in GetProperties(baseObject))
+            {
+                if (predicate(property.Name))
+                {
+                    return property;
+                }
+            }
+
+            return null;
+        }
     }
 }

--- a/src/System.Management.Automation/engine/ThirdPartyAdapter.cs
+++ b/src/System.Management.Automation/engine/ThirdPartyAdapter.cs
@@ -348,6 +348,9 @@ namespace System.Management.Automation
         /// </summary>
         public abstract string GetPropertyTypeName(PSAdaptedProperty adaptedProperty);
 
-        internal abstract PSAdaptedProperty GetProperty(object baseObject, MemberNamePredicate propertyName);
+        /// <summary>
+        /// Returns a property if it's name matches the specified <see cref="MemberNamePredicate"/>, otherwise null.
+        /// </summary>
+        public abstract PSAdaptedProperty GetProperty(object baseObject, MemberNamePredicate propertyName);
     }
 }

--- a/src/System.Management.Automation/engine/TypeTable.cs
+++ b/src/System.Management.Automation/engine/TypeTable.cs
@@ -3633,9 +3633,9 @@ namespace System.Management.Automation.Runspaces
             return PSObject.TransformMemberInfoCollection<PSMemberInfo, T>(GetMembers(types));
         }
 
-        internal PSMemberInfo GetFirstOrDefaultMember(ConsolidatedString types, MemberNamePredicate predicate)
+        internal T GetFirstOrDefaultMember<T>(ConsolidatedString types, MemberNamePredicate predicate) where T : PSMemberInfo
         {
-            return GetMembers(types).FirstOrDefault(t => predicate.Invoke(t.Name));
+            return GetMembers(types).FirstOrDefault(t => t is T && predicate.Invoke(t.Name)) as T;
         }
 
         internal PSMemberInfoInternalCollection<PSMemberInfo> GetMembers(ConsolidatedString types)

--- a/src/System.Management.Automation/engine/TypeTable.cs
+++ b/src/System.Management.Automation/engine/TypeTable.cs
@@ -3633,6 +3633,11 @@ namespace System.Management.Automation.Runspaces
             return PSObject.TransformMemberInfoCollection<PSMemberInfo, T>(GetMembers(types));
         }
 
+        internal PSMemberInfo GetFirstOrDefaultMember(ConsolidatedString types, MemberNamePredicate predicate)
+        {
+            return GetMembers(types).FirstOrDefault(t => predicate.Invoke(t.Name));
+        }
+
         internal PSMemberInfoInternalCollection<PSMemberInfo> GetMembers(ConsolidatedString types)
         {
             if ((types == null) || string.IsNullOrEmpty(types.Key))
@@ -4527,5 +4532,7 @@ namespace System.Management.Automation.Runspaces
         }
 
         #endregion internal methods
+
+
     }
 }

--- a/src/System.Management.Automation/engine/TypeTable.cs
+++ b/src/System.Management.Automation/engine/TypeTable.cs
@@ -4533,6 +4533,5 @@ namespace System.Management.Automation.Runspaces
 
         #endregion internal methods
 
-
     }
 }

--- a/src/System.Management.Automation/engine/TypeTable.cs
+++ b/src/System.Management.Automation/engine/TypeTable.cs
@@ -3633,9 +3633,9 @@ namespace System.Management.Automation.Runspaces
             return PSObject.TransformMemberInfoCollection<PSMemberInfo, T>(GetMembers(types));
         }
 
-        internal T GetFirstOrDefaultMember<T>(ConsolidatedString types, MemberNamePredicate predicate) where T : PSMemberInfo
+        internal T GetFirstMemberOrDefault<T>(ConsolidatedString types, MemberNamePredicate predicate) where T : PSMemberInfo
         {
-            return GetMembers(types).FirstOrDefault(t => t is T && predicate.Invoke(t.Name)) as T;
+            return GetMembers(types).FirstOrDefault(member => member is T && predicate(member.Name)) as T;
         }
 
         internal PSMemberInfoInternalCollection<PSMemberInfo> GetMembers(ConsolidatedString types)
@@ -3645,8 +3645,7 @@ namespace System.Management.Automation.Runspaces
                 return new PSMemberInfoInternalCollection<PSMemberInfo>();
             }
 
-            PSMemberInfoInternalCollection<PSMemberInfo> result = _consolidatedMembers.GetOrAdd(types.Key, _memberFactoryFunc, types);
-            return result;
+            return _consolidatedMembers.GetOrAdd(types.Key, _memberFactoryFunc, types);
         }
 
         private PSMemberInfoInternalCollection<PSMemberInfo> MemberFactory(string k, ConsolidatedString types)

--- a/src/System.Management.Automation/engine/parser/Compiler.cs
+++ b/src/System.Management.Automation/engine/parser/Compiler.cs
@@ -365,8 +365,8 @@ namespace System.Management.Automation.Language
             typeof(PSObject).GetMethod(nameof(PSObject.Base), staticFlags);
         internal static readonly PropertyInfo PSObject_BaseObject =
             typeof(PSObject).GetProperty(nameof(PSObject.BaseObject));
-        internal static readonly FieldInfo PSObject_isDeserialized =
-            typeof(PSObject).GetField(nameof(PSObject.isDeserialized), instanceFlags);
+        internal static readonly PropertyInfo PSObject_IsDeserialized =
+            typeof(PSObject).GetProperty(nameof(PSObject.IsDeserialized), instanceFlags);
         internal static readonly MethodInfo PSObject_ToStringParser =
             typeof(PSObject).GetMethod(nameof(PSObject.ToStringParser), staticFlags, null, new[] { typeof(ExecutionContext), typeof(object) }, null);
 

--- a/src/System.Management.Automation/engine/parser/TypeInferenceVisitor.cs
+++ b/src/System.Management.Automation/engine/parser/TypeInferenceVisitor.cs
@@ -249,8 +249,8 @@ namespace System.Management.Automation
                 }
 
                 var members = isStatic
-                              ? PSObject.dotNetStaticAdapter.BaseGetMembers<PSMemberInfo>(type)
-                              : PSObject.dotNetInstanceAdapter.GetPropertiesAndMethods(type, false);
+                              ? PSObject.DotNetStaticAdapter.BaseGetMembers<PSMemberInfo>(type)
+                              : PSObject.DotNetInstanceAdapter.GetPropertiesAndMethods(type, false);
 
                 if (filterToCall != null)
                 {

--- a/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
+++ b/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
@@ -5699,7 +5699,7 @@ namespace System.Management.Automation.Language
                 }
             }
 
-            if (_classScope != null && (target.LimitType == _classScope || target.LimitType.IsSubclassOf(_classScope)) && adapterSet.OriginalAdapter == PSObject.dotNetInstanceAdapter)
+            if (_classScope != null && (target.LimitType == _classScope || target.LimitType.IsSubclassOf(_classScope)) && adapterSet.OriginalAdapter == PSObject.DotNetInstanceAdapter)
             {
                 List<MethodBase> candidateMethods = null;
                 foreach (var member in _classScope.GetMembers(BindingFlags.Instance | BindingFlags.FlattenHierarchy | BindingFlags.NonPublic))
@@ -5715,7 +5715,7 @@ namespace System.Management.Automation.Language
                             if ((getMethod == null || getMethod.IsFamily || getMethod.IsPublic) &&
                                 (setMethod == null || setMethod.IsFamily || setMethod.IsPublic))
                             {
-                                memberInfo = new PSProperty(this.Name, PSObject.dotNetInstanceAdapter, target.Value, new DotNetAdapter.PropertyCacheEntry(propertyInfo));
+                                memberInfo = new PSProperty(this.Name, PSObject.DotNetInstanceAdapter, target.Value, new DotNetAdapter.PropertyCacheEntry(propertyInfo));
                             }
                         }
                         else
@@ -5725,7 +5725,7 @@ namespace System.Management.Automation.Language
                             {
                                 if (fieldInfo.IsFamily)
                                 {
-                                    memberInfo = new PSProperty(this.Name, PSObject.dotNetInstanceAdapter, target.Value, new DotNetAdapter.PropertyCacheEntry(fieldInfo));
+                                    memberInfo = new PSProperty(this.Name, PSObject.DotNetInstanceAdapter, target.Value, new DotNetAdapter.PropertyCacheEntry(fieldInfo));
                                 }
                             }
                             else
@@ -5763,7 +5763,7 @@ namespace System.Management.Automation.Language
                     else
                     {
                         DotNetAdapter.MethodCacheEntry method = new DotNetAdapter.MethodCacheEntry(candidateMethods.ToArray());
-                        memberInfo = PSMethod.Create(this.Name, PSObject.dotNetInstanceAdapter, null, method);
+                        memberInfo = PSMethod.Create(this.Name, PSObject.DotNetInstanceAdapter, null, method);
                     }
                 }
             }
@@ -6972,7 +6972,7 @@ namespace System.Management.Automation.Language
         {
             MethodInfo result = null;
 
-            var psMethod = PSObject.dotNetInstanceAdapter.GetDotNetMethod<PSMethod>(PSObject.Base(target.Value), methodName);
+            var psMethod = PSObject.DotNetInstanceAdapter.GetDotNetMethod<PSMethod>(PSObject.Base(target.Value), methodName);
             if (psMethod != null)
             {
                 var data = (DotNetAdapter.MethodCacheEntry)psMethod.adapterData;

--- a/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
+++ b/src/System.Management.Automation/engine/runtime/Binding/Binders.cs
@@ -5382,7 +5382,7 @@ namespace System.Management.Automation.Language
 
             // If the target value is actually a deserialized PSObject, we should use the original value
             var psobj = value as PSObject;
-            if (psobj != null && psobj != AutomationNull.Value && !psobj.isDeserialized)
+            if (psobj != null && psobj != AutomationNull.Value && !psobj.IsDeserialized)
             {
                 expr = Expression.Call(CachedReflectionInfo.PSObject_Base, expr);
                 value = PSObject.Base(value);
@@ -5646,7 +5646,7 @@ namespace System.Management.Automation.Language
             //
             // - If not, we want to use the base object, so that we might generate optimized code.
             var psobj = target.Value as PSObject;
-            bool isTargetDeserializedObject = (psobj != null) && (psobj.isDeserialized);
+            bool isTargetDeserializedObject = (psobj != null) && (psobj.IsDeserialized);
             object value = isTargetDeserializedObject ? target.Value : PSObject.Base(target.Value);
 
             var adapterSet = PSObject.GetMappedAdapter(value, typeTable);
@@ -5784,7 +5784,7 @@ namespace System.Management.Automation.Language
             if (isTargetDeserializedObject)
             {
                 restrictions = restrictions.Merge(BindingRestrictions.GetExpressionRestriction(
-                    Expression.Field(target.Expression.Cast(typeof(PSObject)), CachedReflectionInfo.PSObject_isDeserialized)));
+                    Expression.Property(target.Expression.Cast(typeof(PSObject)), CachedReflectionInfo.PSObject_IsDeserialized)));
             }
 
             if (hasTypeTableMember)
@@ -6740,8 +6740,8 @@ namespace System.Management.Automation.Language
             // If the target value is a PSObject and its base object happens to be a Hashtable or ArrayList,
             // we might have three interesting cases here:
             //  (1) the target value could be a regular PSObject that wraps the Hashtable/ArrayList, i.e. $target = [PSObject]::AsPSObject($hash)
-            //  (2) the target value could be a deserialized object (PSObject) with the 'isDeserialized' field to be false, i.e. deserialized Hashtable/ArrayList/Dictionary[string, string]
-            //  (3) the target value could be a deserialized object (PSObject) with the 'isDeserialized' field to be true, i.e. deserialized XmlElement
+            //  (2) the target value could be a deserialized object (PSObject) with the 'IsDeserialized' property to be false, i.e. deserialized Hashtable/ArrayList/Dictionary[string, string]
+            //  (3) the target value could be a deserialized object (PSObject) with the 'IsDeserialized' property to be true, i.e. deserialized XmlElement
             // For the first two cases, it's OK to call a .NET method from the base object, such as $target.Add().
             // For the third case, calling a .NET method from the base object is incorrect, because the original type of the deserialized object doesn't have the method.
             //  example: XmlElement derives from IEnumerable, so it's treated as a container object when powershell does the serialization -- using an ArrayList to hold
@@ -6757,11 +6757,11 @@ namespace System.Management.Automation.Language
                     // If we get here, then the target value should have 'isDeserialized == false', otherwise we cannot get a .NET methodInfo
                     // from _getMemberBinder.GetPSMemberInfo(). This is because when 'isDeserialized' is true, we use the PSObject to find the
                     // corresponding Adapter -- PSObjectAdapter, which cannot be optimized.
-                    Diagnostics.Assert(psObj.isDeserialized == false,
+                    Diagnostics.Assert(psObj.IsDeserialized == false,
                         "isDeserialized should be false, because if not, we cannot get a .NET method/parameterizedProperty from GetPSMemberInfo");
 
                     restrictions = restrictions.Merge(BindingRestrictions.GetExpressionRestriction(
-                        Expression.Not(Expression.Field(target.Expression.Cast(typeof(PSObject)), CachedReflectionInfo.PSObject_isDeserialized))));
+                        Expression.Not(Expression.Property(target.Expression.Cast(typeof(PSObject)), CachedReflectionInfo.PSObject_IsDeserialized))));
                 }
             }
 

--- a/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
+++ b/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
@@ -1888,7 +1888,7 @@ namespace System.Management.Automation
                 rte.ErrorRecord.SetInvocationInfo(new InvocationInfo(null, extent, context));
             PSObject errorWrap = PSObject.AsPSObject(new ErrorRecord(rte.ErrorRecord, rte));
 
-            PSNoteProperty note = new PSNoteProperty("writeErrorStream", true);
+            PSNoteProperty note = new PSNoteProperty(MshCommandRuntime.WriteErrorStreamPropertyName, true);
             errorWrap.Properties.Add(note);
 
             // If this is an error pipe for a hosting application (i.e.: no downstream cmdlet),

--- a/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
+++ b/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
@@ -1888,8 +1888,7 @@ namespace System.Management.Automation
                 rte.ErrorRecord.SetInvocationInfo(new InvocationInfo(null, extent, context));
             PSObject errorWrap = PSObject.AsPSObject(new ErrorRecord(rte.ErrorRecord, rte));
 
-            PSNoteProperty note = new PSNoteProperty(MshCommandRuntime.WriteErrorStreamPropertyName, true);
-            errorWrap.Properties.Add(note);
+            errorWrap.WriteStream = WriteStreamType.Error;
 
             // If this is an error pipe for a hosting application (i.e.: no downstream cmdlet),
             // and we are logging, then create a temporary PowerShell to log the error.

--- a/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
+++ b/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
@@ -659,7 +659,7 @@ namespace System.Management.Automation
                 // GetSteppablePipeline() is called on an arbitrary script block with the intention
                 // of invoking it. So the trustworthiness is defined by the trustworthiness of the
                 // script block's language mode.
-                bool isTrusted = (scriptBlock.LanguageMode == PSLanguageMode.FullLanguage);
+                bool isTrusted = scriptBlock.LanguageMode == PSLanguageMode.FullLanguage;
 
                 foreach (var commandAst in pipelineAst.PipelineElements.Cast<CommandAst>())
                 {

--- a/src/System.Management.Automation/engine/serialization.cs
+++ b/src/System.Management.Automation/engine/serialization.cs
@@ -3468,9 +3468,9 @@ namespace System.Management.Automation
             }
 
             // process properties that were originally "adapted" properties
-            if (deserializedObject.adaptedMembers != null)
+            if (deserializedObject.AdaptedMembers != null)
             {
-                foreach (PSMemberInfo deserializedMemberInfo in deserializedObject.adaptedMembers)
+                foreach (PSMemberInfo deserializedMemberInfo in deserializedObject.AdaptedMembers)
                 {
                     PSPropertyInfo deserializedProperty = deserializedMemberInfo as PSPropertyInfo;
                     if (deserializedProperty == null)
@@ -3500,7 +3500,7 @@ namespace System.Management.Automation
                 }
 
                 // skip adapted properties
-                if ((deserializedObject.adaptedMembers != null) && (deserializedObject.adaptedMembers[deserializedProperty.Name] != null))
+                if ((deserializedObject.AdaptedMembers != null) && (deserializedObject.AdaptedMembers[deserializedProperty.Name] != null))
                 {
                     continue;
                 }
@@ -3648,7 +3648,7 @@ namespace System.Management.Automation
                 else if (IsNextElement(SerializationStrings.ToStringElementTag))
                 {
                     dso.ToStringFromDeserialization = ReadDecodedElementString(SerializationStrings.ToStringElementTag);
-                    dso.InstanceMembers.Add(PSObject.dotNetInstanceAdapter.GetDotNetMethod<PSMemberInfo>(dso, "ToString"));
+                    dso.InstanceMembers.Add(PSObject.DotNetInstanceAdapter.GetDotNetMethod<PSMemberInfo>(dso, "ToString"));
                     PSGetMemberBinder.SetHasInstanceMember("ToString");
                     // Fix for Win8:75437
                     // The TokenText property is used in type conversion and it is not being populated during deserialization
@@ -3828,14 +3828,14 @@ namespace System.Management.Automation
             // Since we are adding baseobject properties as propertybag,
             // mark the object as deserialized.
             dso.IsDeserialized = true;
-            dso.adaptedMembers = new PSMemberInfoInternalCollection<PSPropertyInfo>();
+            dso.AdaptedMembers = new PSMemberInfoInternalCollection<PSPropertyInfo>();
 
             // Add the GetType method to the instance members, so that it works on deserialized psobjects
-            dso.InstanceMembers.Add(PSObject.dotNetInstanceAdapter.GetDotNetMethod<PSMemberInfo>(dso, "GetType"));
+            dso.InstanceMembers.Add(PSObject.DotNetInstanceAdapter.GetDotNetMethod<PSMemberInfo>(dso, "GetType"));
             PSGetMemberBinder.SetHasInstanceMember("GetType");
 
             // Set Clr members to a collection which is empty
-            dso.clrMembers = new PSMemberInfoInternalCollection<PSPropertyInfo>();
+            dso.ClrMembers = new PSMemberInfoInternalCollection<PSPropertyInfo>();
 
             if (ReadStartElementAndHandleEmpty(SerializationStrings.AdapterProperties))
             {
@@ -3845,7 +3845,7 @@ namespace System.Management.Automation
                     string property = ReadNameAttribute();
                     object value = ReadOneObject();
                     PSProperty prop = new PSProperty(property, value);
-                    dso.adaptedMembers.Add(prop);
+                    dso.AdaptedMembers.Add(prop);
                 }
 
                 ReadEndElement();

--- a/src/System.Management.Automation/engine/serialization.cs
+++ b/src/System.Management.Automation/engine/serialization.cs
@@ -1100,7 +1100,7 @@ namespace System.Management.Automation
                 moSource = source as PSObject;
             }
 
-            if (moSource != null && !moSource.immediateBaseObjectIsEmpty)
+            if (moSource != null && !moSource.ImmediateBaseObjectIsEmpty)
             {
                 // check if source is of type secure string
                 secureString = moSource.ImmediateBaseObject as SecureString;
@@ -1177,7 +1177,7 @@ namespace System.Management.Automation
 
             bool sourceHandled = false;
             PSObject moSource = source as PSObject;
-            if (moSource != null && !moSource.immediateBaseObjectIsEmpty)
+            if (moSource != null && !moSource.ImmediateBaseObjectIsEmpty)
             {
                 // Check if baseObject is primitive known type
                 object baseObject = moSource.ImmediateBaseObject;
@@ -1208,7 +1208,7 @@ namespace System.Management.Automation
             IDictionary dictionary = null;
 
             // If passed in object is PSObject with no baseobject, return false.
-            if (mshSource != null && mshSource.immediateBaseObjectIsEmpty)
+            if (mshSource != null && mshSource.ImmediateBaseObjectIsEmpty)
             {
                 return false;
             }
@@ -1257,7 +1257,7 @@ namespace System.Management.Automation
                 // So on roundtrip it will show up as List.
                 // We serialize properties of enumerable and on deserialization mark the object as Deserialized.
                 // So if object is marked deserialized, we should write properties.
-                if (ct == ContainerType.Enumerable || (mshSource != null && mshSource.isDeserialized))
+                if (ct == ContainerType.Enumerable || (mshSource != null && mshSource.IsDeserialized))
                 {
                     PSObject sourceAsPSObject = PSObject.AsPSObject(source);
                     PSMemberInfoInternalCollection<PSPropertyInfo> specificPropertiesToSerialize = SerializationUtilities.GetSpecificPropertiesToSerialize(sourceAsPSObject, AllPropertiesCollection, _typeTable);
@@ -1465,7 +1465,7 @@ namespace System.Management.Automation
             bool isPSObject = false;
             bool isCimInstance = false;
 
-            if (!mshSource.immediateBaseObjectIsEmpty)
+            if (!mshSource.ImmediateBaseObjectIsEmpty)
             {
                 do // false loop
                 {
@@ -1500,7 +1500,7 @@ namespace System.Management.Automation
             bool writeToString = true;
             if (mshSource.ToStringFromDeserialization == null) // continue to write ToString from deserialized objects, but...
             {
-                if (mshSource.immediateBaseObjectIsEmpty) // ... don't write ToString for property bags
+                if (mshSource.ImmediateBaseObjectIsEmpty) // ... don't write ToString for property bags
                 {
                     writeToString = false;
                 }
@@ -2332,7 +2332,7 @@ namespace System.Management.Automation
 
             if (0 != (_context.options & SerializationOptions.PreserveSerializationSettingOfOriginal))
             {
-                if ((pso.isDeserialized) && (depth <= 0))
+                if ((pso.IsDeserialized) && (depth <= 0))
                 {
                     return 1;
                 }
@@ -3827,7 +3827,7 @@ namespace System.Management.Automation
 
             // Since we are adding baseobject properties as propertybag,
             // mark the object as deserialized.
-            dso.isDeserialized = true;
+            dso.IsDeserialized = true;
             dso.adaptedMembers = new PSMemberInfoInternalCollection<PSPropertyInfo>();
 
             // Add the GetType method to the instance members, so that it works on deserialized psobjects

--- a/test/xUnit/csharp/test_PSObject.cs
+++ b/test/xUnit/csharp/test_PSObject.cs
@@ -1,0 +1,127 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Management.Automation.Language;
+using Xunit;
+
+namespace PSTests.Parallel
+{
+    using System.Linq;
+    using System.Management.Automation;
+    using System.Management.Automation.Runspaces;
+    using System.Xml;
+
+    using Microsoft.Management.Infrastructure;
+
+    public static class PSObjectTests
+    {
+        [Fact]
+        public static void TestEmptyObjectHasNoProperty()
+        {
+            var psObject = new PSObject();
+            var actual = psObject.GetFirstPropertyOrDefault(name => true);
+            Assert.Null(actual);
+        }
+
+        [Fact]
+        public static void TestWrappedDateTimeHasReflectedMember()
+        {
+            var psObject = new PSObject(DateTime.Now);
+            var member = psObject.GetFirstPropertyOrDefault(name => name == "DayOfWeek");
+            Assert.NotNull(member);
+            Assert.Equal("DayOfWeek", member.Name);
+        }
+
+        [Fact]
+        public static void TestAdaptedMember()
+        {
+            var psObject = new PSObject(DateTime.Now);
+            psObject.Members.Add(new PSNoteProperty("NewMember", "AValue"));
+            var member = psObject.GetFirstPropertyOrDefault(name => name == "NewMember");
+            Assert.NotNull(member);
+            Assert.Equal("NewMember", member.Name);
+        }
+
+        [Fact]
+        public static void TestShadowedMember()
+        {
+            var psObject = new PSObject(DateTime.Now);
+            psObject.Members.Add(new PSNoteProperty("DayOfWeek", "AValue"));
+            var member = psObject.GetFirstPropertyOrDefault(name => name == "DayOfWeek");
+            Assert.NotNull(member);
+            Assert.Equal("DayOfWeek", member.Name);
+            Assert.Equal("AValue", member.Value);
+        }
+
+        [Fact]
+        public static void TestMemberSetIsNotProperty()
+        {
+            var psObject = new PSObject(DateTime.Now);
+            var psNoteProperty = new PSNoteProperty("NewMember", "AValue");
+            psObject.Members.Add(psNoteProperty);
+            psObject.Members.Add(new PSMemberSet("NewMemberSet", new[] { psNoteProperty }));
+
+            var member = psObject.GetFirstPropertyOrDefault(name => name == "NewMemberSet");
+            Assert.Null(member);
+        }
+
+        [Fact]
+        public static void TestMemberSet()
+        {
+            var psObject = new PSObject(DateTime.Now);
+            var psNoteProperty = new PSNoteProperty("NewMember", "AValue");
+            psObject.Members.Add(psNoteProperty);
+            psObject.Members.Add(new PSMemberSet("NewMemberSet", new[] { psNoteProperty }));
+
+            var member = psObject.Members.FirstOrDefault(name => name == "NewMemberSet");
+            Assert.NotNull(member);
+            Assert.Equal("NewMemberSet", member.Name);
+        }
+
+        [Fact]
+        public static void TextXmlElementMember()
+        {
+            var doc = new XmlDocument();
+            var root = doc.CreateElement("root");
+            doc.AppendChild(root);
+            var firstChild = doc.CreateElement("elem1");
+            root.AppendChild(firstChild);
+            root.InsertAfter(doc.CreateElement("elem2"), firstChild);
+
+            var psObject = new PSObject(root);
+            var member = psObject.GetFirstPropertyOrDefault(name => name.StartsWith("elem"));
+            Assert.Equal("elem1", member.Name);
+        }
+
+        [Fact]
+        public static void TextXmlAttributeMember()
+        {
+            var doc = new XmlDocument();
+            var root = doc.CreateElement("root");
+            doc.AppendChild(root);
+            root.SetAttribute("attr", "value");
+            root.AppendChild(doc.CreateElement("elem"));
+
+            var psObject = new PSObject(root);
+            var member = psObject.GetFirstPropertyOrDefault(name => name.StartsWith("attr"));
+            Assert.Equal("attr", member.Name);
+        }
+
+        [SkippableFact]
+        public static void TestCimInstanceProperty()
+        {
+            Skip.IfNot(Platform.IsWindows);
+            var iss = InitialSessionState.CreateDefault2();
+            iss.Commands.Add(new SessionStateCmdletEntry("Get-CimInstance", typeof(Microsoft.Management.Infrastructure.CimCmdlets.GetCimInstanceCommand), null));
+            using (var ps = PowerShell.Create(iss))
+            {
+                ps.AddCommand("Get-CimInstance").AddParameter("ClassName", "Win32_BIOS");
+                var res = ps.Invoke().FirstOrDefault();
+                Assert.NotNull(res);
+                var member = res.GetFirstPropertyOrDefault(name => name == "Name");
+                Assert.NotNull(member);
+            }
+        }
+    }
+}

--- a/test/xUnit/xUnit.tests.csproj
+++ b/test/xUnit/xUnit.tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
 
-  <Import Project="../Test.Common.props"/>
+  <Import Project="../Test.Common.props" />
 
   <PropertyGroup>
     <Description>PowerShell xUnit Tests</Description>
@@ -16,9 +16,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="../../src/Microsoft.PowerShell.SDK/Microsoft.PowerShell.SDK.csproj"/>
-    <ProjectReference Include="../../src/Microsoft.PowerShell.Commands.Diagnostics/Microsoft.PowerShell.Commands.Diagnostics.csproj"/>
-    <ProjectReference Include="../../src/Microsoft.WSMan.Management/Microsoft.WSMan.Management.csproj"/>
+    <ProjectReference Include="../../src/Microsoft.PowerShell.SDK/Microsoft.PowerShell.SDK.csproj" />
+    <ProjectReference Include="../../src/Microsoft.PowerShell.Commands.Diagnostics/Microsoft.PowerShell.Commands.Diagnostics.csproj" />
+    <ProjectReference Include="../../src/Microsoft.WSMan.Management/Microsoft.WSMan.Management.csproj" />
+    <ProjectReference Include="..\..\src\Microsoft.Management.Infrastructure.CimCmdlets\Microsoft.Management.Infrastructure.CimCmdlets.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/xUnit/xUnit.tests.csproj
+++ b/test/xUnit/xUnit.tests.csproj
@@ -19,7 +19,7 @@
     <ProjectReference Include="../../src/Microsoft.PowerShell.SDK/Microsoft.PowerShell.SDK.csproj" />
     <ProjectReference Include="../../src/Microsoft.PowerShell.Commands.Diagnostics/Microsoft.PowerShell.Commands.Diagnostics.csproj" />
     <ProjectReference Include="../../src/Microsoft.WSMan.Management/Microsoft.WSMan.Management.csproj" />
-    <ProjectReference Include="..\..\src\Microsoft.Management.Infrastructure.CimCmdlets\Microsoft.Management.Infrastructure.CimCmdlets.csproj" />
+    <ProjectReference Include="../../src/Microsoft.Management.Infrastructure.CimCmdlets/Microsoft.Management.Infrastructure.CimCmdlets.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
By not doing excessive amounts of extra work, formatting can be sped up quite significantly.
The main change comes from adding new, more efficient, primitive to query an object for the existence of an instance member.
The formatting system has been checking for if an object has properties other than some decorated properties added by PS remoting, and it doesn't this by retrieving all properties which results in heavy allocations and wasted cycles.
By adding `GetFirstOrDefault` to `PSObject` and similar primitives to the underlying Adapters, we are able to return early, without having to get all properties back.

Test script:
```powershell
$files = gci -ea:0 c:\windows -Recurse -File
$files | format-table Name, LastAccessTime, Length | out-null
```
version | time | speedup
-- | -- | --
6.1 | 35.5s | 1.0x
PR 8785 | 4.5s | 8x

<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->  

## PR Summary

<!-- Summarize your PR between here and the checklist. -->  

## PR Context  

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.  
- **User-facing changes**
    - [x] Not Applicable
    - **OR**  
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [x] [Add `[feature]` to your commit messages if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
