### PR TITLE
Move CommandNotFoundException suggestion to an experimental feature

### DIFF
--- a/src/System.Management.Automation/engine/ExperimentalFeature/ExperimentalFeature.cs
+++ b/src/System.Management.Automation/engine/ExperimentalFeature/ExperimentalFeature.cs
@@ -111,6 +111,9 @@ namespace System.Management.Automation
                 new ExperimentalFeature(
                     name: "PSTempDrive",
                     description: "Create TEMP: PS Drive mapped to user's temporary directory path"),
+                new ExperimentalFeature(
+                    name: "PSCommandNotFoundSuggestion",
+                    description: "Recommend potential commands based on fuzzy search on a CommandNotFoundException"),
             };
             EngineExperimentalFeatures = new ReadOnlyCollection<ExperimentalFeature>(engineFeatures);
 

--- a/src/System.Management.Automation/engine/hostifaces/HostUtilities.cs
+++ b/src/System.Management.Automation/engine/hostifaces/HostUtilities.cs
@@ -71,27 +71,40 @@ namespace System.Management.Automation
             $formatString -f [string]::Join(', ', (Get-Command $lastError.TargetObject -UseFuzzyMatch | Select-Object -First 10 -Unique -ExpandProperty Name))
         ";
 
-        private static ArrayList s_suggestions = new ArrayList(
-            new Hashtable[] {
-                NewSuggestion(1, "Transactions", SuggestionMatchType.Command, "^Start-Transaction",
-                    SuggestionStrings.Suggestion_StartTransaction, true),
-                NewSuggestion(2, "Transactions", SuggestionMatchType.Command, "^Use-Transaction",
-                    SuggestionStrings.Suggestion_UseTransaction, true),
-                NewSuggestion(3, "General", SuggestionMatchType.Dynamic,
-                    ScriptBlock.CreateDelayParsedScriptBlock(s_checkForCommandInCurrentDirectoryScript, isProductCode: true),
-                    ScriptBlock.CreateDelayParsedScriptBlock(s_createCommandExistsInCurrentDirectoryScript, isProductCode: true),
-                    new object[] { CodeGeneration.EscapeSingleQuotedStringContent(SuggestionStrings.Suggestion_CommandExistsInCurrentDirectory) },
-                    true),
-                NewSuggestion(
-                    id: 4,
-                    category: "General",
-                    matchType: SuggestionMatchType.ErrorId,
-                    rule: "CommandNotFoundException",
-                    suggestion: ScriptBlock.CreateDelayParsedScriptBlock(s_getFuzzyMatchedCommands, isProductCode: true),
-                    suggestionArgs: new object[] { CodeGeneration.EscapeSingleQuotedStringContent(SuggestionStrings.Suggestion_CommandNotFound) },
-                    enabled: true)
+        private static ArrayList s_suggestions = InitializeSuggestions();
+
+        private static ArrayList InitializeSuggestions()
+        {
+            ArrayList suggestions = new ArrayList(
+                new Hashtable[] {
+                    NewSuggestion(1, "Transactions", SuggestionMatchType.Command, "^Start-Transaction",
+                        SuggestionStrings.Suggestion_StartTransaction, true),
+                    NewSuggestion(2, "Transactions", SuggestionMatchType.Command, "^Use-Transaction",
+                        SuggestionStrings.Suggestion_UseTransaction, true),
+                    NewSuggestion(3, "General", SuggestionMatchType.Dynamic,
+                        ScriptBlock.CreateDelayParsedScriptBlock(s_checkForCommandInCurrentDirectoryScript, isProductCode: true),
+                        ScriptBlock.CreateDelayParsedScriptBlock(s_createCommandExistsInCurrentDirectoryScript, isProductCode: true),
+                        new object[] { CodeGeneration.EscapeSingleQuotedStringContent(SuggestionStrings.Suggestion_CommandExistsInCurrentDirectory) },
+                        true)
+                }
+            );
+
+            if (ExperimentalFeature.IsEnabled("PSCommandNotFoundSuggestion"))
+            {
+                suggestions.Add(
+                    NewSuggestion(
+                        id: 4,
+                        category: "General",
+                        matchType: SuggestionMatchType.ErrorId,
+                        rule: "CommandNotFoundException",
+                        suggestion: ScriptBlock.CreateDelayParsedScriptBlock(s_getFuzzyMatchedCommands, isProductCode: true),
+                        suggestionArgs: new object[] { CodeGeneration.EscapeSingleQuotedStringContent(SuggestionStrings.Suggestion_CommandNotFound) },
+                        enabled: true)
+                );
             }
-        );
+
+            return suggestions;
+        }
 
         #region GetProfileCommands
         /// <summary>

--- a/src/System.Management.Automation/engine/hostifaces/HostUtilities.cs
+++ b/src/System.Management.Automation/engine/hostifaces/HostUtilities.cs
@@ -76,18 +76,31 @@ namespace System.Management.Automation
         private static ArrayList InitializeSuggestions()
         {
             ArrayList suggestions = new ArrayList(
-                new Hashtable[] {
-                    NewSuggestion(1, "Transactions", SuggestionMatchType.Command, "^Start-Transaction",
-                        SuggestionStrings.Suggestion_StartTransaction, true),
-                    NewSuggestion(2, "Transactions", SuggestionMatchType.Command, "^Use-Transaction",
-                        SuggestionStrings.Suggestion_UseTransaction, true),
-                    NewSuggestion(3, "General", SuggestionMatchType.Dynamic,
-                        ScriptBlock.CreateDelayParsedScriptBlock(s_checkForCommandInCurrentDirectoryScript, isProductCode: true),
-                        ScriptBlock.CreateDelayParsedScriptBlock(s_createCommandExistsInCurrentDirectoryScript, isProductCode: true),
-                        new object[] { CodeGeneration.EscapeSingleQuotedStringContent(SuggestionStrings.Suggestion_CommandExistsInCurrentDirectory) },
-                        true)
-                }
-            );
+                new Hashtable[]
+                {
+                    NewSuggestion(
+                        id: 1,
+                        category: "Transactions",
+                        matchType: SuggestionMatchType.Command,
+                        rule: "^Start-Transaction",
+                        suggestion: SuggestionStrings.Suggestion_StartTransaction,
+                        enabled: true),
+                    NewSuggestion(
+                        id: 2,
+                        category: "Transactions",
+                        matchType: SuggestionMatchType.Command,
+                        rule: "^Use-Transaction",
+                        suggestion: SuggestionStrings.Suggestion_UseTransaction,
+                        enabled: true),
+                    NewSuggestion(
+                        id: 3,
+                        category: "General",
+                        matchType: SuggestionMatchType.Dynamic,
+                        rule: ScriptBlock.CreateDelayParsedScriptBlock(s_checkForCommandInCurrentDirectoryScript, isProductCode: true),
+                        suggestion: ScriptBlock.CreateDelayParsedScriptBlock(s_createCommandExistsInCurrentDirectoryScript, isProductCode: true),
+                        suggestionArgs: new object[] { CodeGeneration.EscapeSingleQuotedStringContent(SuggestionStrings.Suggestion_CommandExistsInCurrentDirectory) },
+                        enabled: true)
+                });
 
             if (ExperimentalFeature.IsEnabled("PSCommandNotFoundSuggestion"))
             {
@@ -99,8 +112,7 @@ namespace System.Management.Automation
                         rule: "CommandNotFoundException",
                         suggestion: ScriptBlock.CreateDelayParsedScriptBlock(s_getFuzzyMatchedCommands, isProductCode: true),
                         suggestionArgs: new object[] { CodeGeneration.EscapeSingleQuotedStringContent(SuggestionStrings.Suggestion_CommandNotFound) },
-                        enabled: true)
-                );
+                        enabled: true));
             }
 
             return suggestions;


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->  

## PR Summary

Make the suggestion on a CommandNotFoundException an ExperimentalFeature.

## PR Context  

The current design of suggestions is closely tied to the host (ConsoleHost in this case).  The ConsoleHost checks if there was anything from the last command and initiates an evaluation of suggestions.  The evaluation of suggestions checks if the last command failed by looking at `$?`.  If so, then it applies each suggestion.  In the case of CommandNotFound, this is based on looking at the ErrorRecord at `$Error[0]` which is one problem with the suggestion framework as it only looks at the most recent error.  If found, it applies this new suggestion and it outputs the possible commands.  The problem is if a script is run in the command line (or part of a pipeline), and the ErrorAction is SilentlyContinue, the error still shows up in `$Error` so the suggestion applies, but because you don't see the non-terminating error message, you have no context of how the suggestion applies.

A proper fix is much more complicated as it requires redesigning the suggestion framework:

- Currently, suggestions are initiated by the host (consolehost in this case) and should be part of the ErrorRecord so that it works correctly remotely and in other hosts
- ErrorRecord has a member called RecommendedAction that should contain the suggestion
- The code to invoke getting suggestions needs to be moved out of consolehost and closer to where the ErrorRecord is created
- Formatter for ErrorRecord needs to be updated to show the RecommendedAction member
- Suggestions should be in its own stream or Information stream rather than written directly to the host

Temporary resolution to https://github.com/PowerShell/PowerShell/issues/8793

No test added/modified as suggestions are currently written directly to the host.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.  
- **User-facing changes**
    - [x] Not Applicable
    - **OR**  
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` to your commit messages if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
