### PR TITLE
Remove unneeded `Invoke-Expression` on unvalidated input

### DIFF
--- a/.vsts-ci/install-ps.yml
+++ b/.vsts-ci/install-ps.yml
@@ -14,6 +14,7 @@ trigger:
     - /tools/installpsh-osx.sh
     - /tools/installpsh-redhat.sh
     - /tools/installpsh-suse.sh
+    - /tools/install-powershell.ps1
 pr:
   branches:
     include:
@@ -27,6 +28,7 @@ pr:
     - /tools/installpsh-osx.sh
     - /tools/installpsh-redhat.sh
     - /tools/installpsh-suse.sh
+    - /tools/install-powershell.ps1
 
 variables:
   DOTNET_CLI_TELEMETRY_OPTOUT: 1
@@ -47,3 +49,9 @@ phases:
     scriptName: ./tools/install-powershell.sh
     jobName: InstallPowerShellMacOS
     pool: Hosted macOS
+
+- template: templates/install-ps-phase.yml
+  parameters:
+    scriptName: pwsh -c ./tools/install-powershell.ps1 -AddToPath
+    jobName: InstallPowerShellPS1Ubuntu
+    pool: Hosted Ubuntu 1604

--- a/tools/install-powershell.ps1
+++ b/tools/install-powershell.ps1
@@ -386,7 +386,7 @@ try {
                 if ($uid -ne "0") { $SUDO = "sudo" } else { $SUDO = "" }
 
                 Write-Verbose "Make symbolic link '$symlink' point to '$targetPath'..." -Verbose
-                Invoke-Expression -Command "$SUDO ln -fs $targetPath $symlink"
+                &$SUDO ln -fs $targetPath $symlink
 
                 if ($LASTEXITCODE -ne 0) {
                     Write-Error "Could not add to PATH: failed to make '$symlink' point to '$targetPath'."

--- a/tools/install-powershell.ps1
+++ b/tools/install-powershell.ps1
@@ -386,7 +386,7 @@ try {
                 if ($uid -ne "0") { $SUDO = "sudo" } else { $SUDO = "" }
 
                 Write-Verbose "Make symbolic link '$symlink' point to '$targetPath'..." -Verbose
-                &$SUDO ln -fs $targetPath $symlink
+                & $SUDO ln -fs $targetPath $symlink
 
                 if ($LASTEXITCODE -ne 0) {
                     Write-Error "Could not add to PATH: failed to make '$symlink' point to '$targetPath'."


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->  

## PR Summary

Remove unneeded `Invoke-Expression` on unvalidated input 

## PR Context  

Reviewing the script for security issue that might prevent signing as requested in #8814 

I didn't validate that this could actually be exploited but I ran this.

```powershell
$tp=join-path "./;Write-Host 'pwnd';" -ChildPath 'child'
Invoke-Expression -command "ls $tp"
```

With this output

>CHANGELOG.md		Dockerfile		Library			bin			manpages
CODE_OF_CONDUCT.md	Dockerfile.test.yml	README.md		completions
CONTRIBUTING.md		LICENSE.txt		azure-pipelines.yml	docs
**pwnd**
/child : The term '/child' is not recognized as the name of a cmdlet, function, script file, or operable program.
Check the spelling of the name, or if a path was included, verify that the path is correct and try again.
At line:1 char:25
\+ ls ./;Write-Host 'pwnd';/child
\+                         ~~~~~~
\+ CategoryInfo          : ObjectNotFound: (/child:String) [], CommandNotFoundException
\+ FullyQualifiedErrorId : CommandNotFoundException

While the equivalent new syntax:

```powershell
&ls $tp
```

results in: 

> ls: ./;Write-Host 'pwnd';/child: No such file or directory

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.  
- **User-facing changes**
    - [x] Not Applicable
    - **OR**  
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` to your commit messages if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
