### PR TITLE
Fix length check in `PSSnapinQualifiedName.GetInstance()`

### DIFF
--- a/src/System.Management.Automation/engine/MshSnapinQualifiedName.cs
+++ b/src/System.Management.Automation/engine/MshSnapinQualifiedName.cs
@@ -68,7 +68,7 @@ namespace System.Management.Automation
                 return null;
             PSSnapinQualifiedName result = null;
             string[] splitName = name.Split(Utils.Separators.Backslash);
-            if (splitName.Length < 0 || splitName.Length > 2)
+            if (splitName.Length == 0 || splitName.Length > 2)
                 return null;
             result = new PSSnapinQualifiedName(splitName);
             // If the shortname is empty, then return null...


### PR DESCRIPTION
Hi,

I came across this when looking at the alerts for this project on LGTM.com (full disclosure: I work on the C# analysis there). The existing check `splitName.Length < 0` is redundant, and I believe it should have been `splitName.Length == 0`, since the constructor of `PSSnapinQualifiedName` expects an array of length 1 or 2.

You can see the original alert on LGTM.com here: https://lgtm.com/projects/g/PowerShell/PowerShell/alerts/?mode=tree&ruleFocus=1506101336231

Best regards,
Tom