### PR TITLE
Enable cross-platform Send-MailMessage tests for CI

### DIFF
--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Send-MailMessage.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Send-MailMessage.Tests.ps1
@@ -3,10 +3,10 @@
 
 Describe "Send-MailMessage" -Tags CI, RequireSudoOnUnix {
     BeforeAll {
-        Register-PackageSource -Name nuget.org -Location https://www.nuget.org/api/v2 -ProviderName NuGet -ErrorAction SilentlyContinue
+        Register-PackageSource -Name nuget.org -Location https://api.nuget.org/v3/index.json -ProviderName NuGet -ErrorAction SilentlyContinue
 
         $nugetPackage = "netDumbster"
-        Find-Package $nugetPackage -ProviderName NuGet | Install-Package -Scope CurrentUser -Force
+        Install-Package -Name $nugetPackage -ProviderName NuGet -Scope CurrentUser -Force
 
         $dll = "$(Split-Path (Get-Package $nugetPackage).Source)\lib\netstandard2.0\netDumbster.dll"
         Add-Type -Path $dll

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Send-MailMessage.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Send-MailMessage.Tests.ps1
@@ -1,184 +1,109 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
-Describe "Basic Send-MailMessage tests" -Tags CI {
+
+Describe "Send-MailMessage" -Tags CI, RequireSudoOnUnix {
     BeforeAll {
-        function test-smtpserver
-        {
-            $rv = $false
+        Register-PackageSource -Name nuget.org -Location https://www.nuget.org/api/v2 -ProviderName NuGet -ErrorAction SilentlyContinue
 
-            try
+        $nugetPackage = "netDumbster"
+        Find-Package $nugetPackage -ProviderName NuGet | Install-Package -Scope CurrentUser -Force
+
+        $dll = "$(Split-Path (Get-Package $nugetPackage).Source)\lib\netstandard2.0\netDumbster.dll"
+        Add-Type -Path $dll
+
+        $server = [netDumbster.smtp.SimpleSmtpServer]::Start(25)
+
+        function Read-Mail
+        {
+            param()
+
+            if($server)
             {
-                $tc = New-Object -TypeName System.Net.Sockets.TcpClient -ArgumentList "localhost", 25
-                $rv = $tc.Connected
-                $tc.Close()
+                return $server.ReceivedEmail[0]
             }
-            catch
-            {
-                $rv = false
-            }
-
-            return $rv
+            return $null
         }
-
-        function read-mail
-        {
-            Param(
-                [parameter(Mandatory=$true)]
-                [String]
-                $mailBox
-            )
-
-            $state = "init"
-            $mail = Get-Content $mailBox
-            $rv = @{}
-            foreach ($line in $mail)
-            {
-                switch ($state)
-                {
-                    "init"
-                    {
-                        if ($line.Length -gt 0)
-                        {
-                            $state = "headers"
-                        }
-                    }
-                    "headers"
-                    {
-                        if ($line.StartsWith("From: "))
-                        {
-                            $rv.From = $line.Substring(6)
-                        }
-                        elseif ($line.StartsWith("To: "))
-                        {
-                            if ($null -eq $rv.To)
-                            {
-                                $rv.To = @()
-                            }
-
-                            $rv.To += $line.Substring(4)
-                        }
-                        elseif ($line.StartsWith("Reply-To: "))
-                        {
-                            if ($null -eq $rv.ReplyTo)
-                            {
-                                $rv.ReplyTo = @()
-                            }
-
-                            $rv.ReplyTo += $line.Substring(10)
-                        }
-                        elseif ($line.StartsWith("Subject: "))
-                        {
-                            $rv.Subject = $line.Substring(9);
-                        }
-                        elseif ($line.Length -eq 0)
-                        {
-                            $state = "body"
-                        }
-                    }
-                    "body"
-                    {
-                        if ($line.Length -eq 0)
-                        {
-                            $state = "done"
-                            continue
-                        }
-
-                        if ($null -eq $rv.Body)
-                        {
-                            $rv.Body = @()
-                        }
-
-                        $rv.Body += $line
-                    }
-                }
-            }
-
-            return $rv
-        }
-
-        $PesterArgs = @{Name = ""}
-        $alreadyHasMail = $true
-
-        if (-not $IsLinux)
-        {
-            $PesterArgs["Skip"] = $true
-            $PesterArgs["Name"] += " (skipped: not Linux)"
-            return
-        }
-
-        $domain = [Environment]::MachineName
-        if (-not (test-smtpserver))
-        {
-            $PesterArgs["Pending"] = $true
-            $PesterArgs["Name"] += " (pending: no mail server detected)"
-            return
-        }
-
-        $user = [Environment]::UserName
-        $inPassword = Select-String "^${user}:" /etc/passwd -ErrorAction SilentlyContinue
-        if (-not $inPassword)
-        {
-            $PesterArgs["Pending"] = $true
-            $PesterArgs["Name"] += " (pending: user not in /etc/passwd)"
-            return
-        }
-
-        $address = "$user@$domain"
-        $mailStore = "/var/mail"
-        $mailBox = Join-Path $mailStore $user
-        $mailBoxFile = Get-Item $mailBox -ErrorAction SilentlyContinue
-        if ($null -ne $mailBoxFile -and $mailBoxFile.Length -gt 2)
-        {
-            $PesterArgs["Pending"] = $true
-            $PesterArgs["Name"] += " (pending: mailbox not empty)"
-            return
-        }
-        $alreadyHasMail = $false
     }
 
     AfterEach {
-       if (-not $alreadyHasMail)
-       {
-           Set-Content -Value "" -Path $mailBox -Force -ErrorAction SilentlyContinue
-       }
+        if($server)
+        {
+            $server.ClearReceivedEmail()
+        }
     }
 
-    $ItArgs = $PesterArgs.Clone()
-    $ItArgs['Name'] = "Can send mail message from user to self " + $ItArgs['Name']
-
-    It @ItArgs {
-        $body = "Greetings from me."
-        $subject = "Test message"
-        Send-MailMessage -To $address -From $address -ReplyTo $address -Subject $subject -Body $body -SmtpServer 127.0.0.1
-        Test-Path -Path $mailBox | Should -BeTrue
-        $mail = read-mail $mailBox
-        $mail.From | Should -BeExactly $address
-        $mail.To.Count | Should -BeExactly 1
-        $mail.To[0] | Should -BeExactly $address
-        $mail.ReplyTo.Count | Should -BeExactly 1
-        $mail.ReplyTo[0] | Should -BeExactly $address
-        $mail.Subject | Should -BeExactly $subject
-        $mail.Body.Count | Should -BeExactly 1
-        $mail.Body[0] | Should -BeExactly $body
+    AfterAll {
+        if($server)
+        {
+            $server.Stop()
+        }
     }
 
-    $ItArgs = $PesterArgs.Clone()
-    $ItArgs['Name'] = "Can send mail message from user to self using pipeline " + $ItArgs['Name']
+    $testCases = @(
+        @{
+            Name = "with mandatory parameters"
+            InputObject = @{
+                From = "user01@example.com"
+                To = "user02@example.com"
+                Subject = "Subject $(Get-Date)"
+                Body = "Body $(Get-Date)"
+                SmtpServer = "127.0.0.1"
+            }
+        }
+        @{
+            Name = "with ReplyTo"
+            InputObject = @{
+                From = "user01@example.com"
+                To = "user02@example.com"
+                ReplyTo = "noreply@example.com"
+                Subject = "Subject $(Get-Date)"
+                Body = "Body $(Get-Date)"
+                SmtpServer = "127.0.0.1"
+            }
+        }
+    )
 
-    It @ItArgs {
-        $body = "Greetings from me again."
-        $subject = "Second test message"
-        $object = [PSCustomObject]@{To = $address; From = $address; ReplyTo = $address; Subject = $subject; Body = $body; SmtpServer = '127.0.0.1'}
-        $object | Send-MailMessage
-        Test-Path -Path $mailBox | Should -BeTrue
-        $mail = read-mail $mailBox
-        $mail.From | Should -BeExactly $address
-        $mail.To.Count | Should -BeExactly 1
-        $mail.To[0] | Should -BeExactly $address
-        $mail.ReplyTo.Count | Should -BeExactly 1
-        $mail.ReplyTo[0] | Should -BeExactly $address
-        $mail.Subject | Should -BeExactly $subject
-        $mail.Body.Count | Should -BeExactly 1
-        $mail.Body[0] | Should -BeExactly $body
+    It "Can send mail message using named parameters <Name>" -TestCases $testCases {
+        param($InputObject)
+
+        $server | Should -Not -Be $null
+
+        Send-MailMessage @InputObject -ErrorAction SilentlyContinue
+
+        $mail = Read-Mail
+
+        $mail.FromAddress | Should -BeExactly $InputObject.From
+        $mail.ToAddresses | Should -BeExactly $InputObject.To
+
+        $mail.Headers["From"] | Should -BeExactly $InputObject.From
+        $mail.Headers["To"] | Should -BeExactly $InputObject.To
+        $mail.Headers["Reply-To"] | Should -BeExactly $InputObject.ReplyTo
+        $mail.Headers["Subject"] | Should -BeExactly $InputObject.Subject
+
+        $mail.MessageParts.Count | Should -BeExactly 1
+        $mail.MessageParts[0].BodyData | Should -BeExactly $InputObject.Body
+    }
+
+    It "Can send mail message using pipline named parameters <Name>" -TestCases $testCases -Pending {
+        param($InputObject)
+
+        Set-TestInconclusive "As of right now the Send-MailMessage cmdlet does not support piping named parameters (see issue 7591)"
+
+        $server | Should -Not -Be $null
+
+        [PsCustomObject]$InputObject | Send-MailMessage -ErrorAction SilentlyContinue
+
+        $mail = Read-Mail
+
+        $mail.FromAddress | Should -BeExactly $InputObject.From
+        $mail.ToAddresses | Should -BeExactly $InputObject.To
+
+        $mail.Headers["From"] | Should -BeExactly $InputObject.From
+        $mail.Headers["To"] | Should -BeExactly $InputObject.To
+        $mail.Headers["Reply-To"] | Should -BeExactly $InputObject.ReplyTo
+        $mail.Headers["Subject"] | Should -BeExactly $InputObject.Subject
+
+        $mail.MessageParts.Count | Should -BeExactly 1
+        $mail.MessageParts[0].BodyData | Should -BeExactly $InputObject.Body
     }
 }


### PR DESCRIPTION
## PR Summary

Fixes #3950

This PR contains a cross-platform SMTP server mockup which allows to run the Send-MailMessage tests on the PowerShell CI system (Azure DevOps pipeline) as well as on local development machines for all supported platforms.

This PR includes:
- Use of netDumbster (see PR Context for more information) as a cross-platform SMTP server mockup
- Refactoring of Send-MailMessage tests with new Pester syntax
- Easier extensibility for further tests (Send-MailMessage cmdlets requires further test coverage)
- Added `RequireSudoOnUnix` tag as Linux and macOS on CI requires sudo for privileged port 25 (SMTP)
- Marked tests for named piping of objects into Send-MailMessage cmdlet as skipped, since this behaviour is not supported as of yet (see issue #7591)

## PR Context  

Before this PR the Send-MailMessage tests run only on local Linux development machines when a local SMTP server is set up and running.

This is rather inconvenient for testing because:
- Test code is only meant to be run under Linux
- One has to set up its own SMTP server
- Tests are not supported on CI system (Azure DevOps pipeline) for PowerShell

The Azure DevOps pipeline VMs don't have any local SMTP server set up. Therefore the tests for Send-MailMessage are skipped during CI checks.

This PR will provide a way to run the tests on the Azure DevOps pipeline for Windows, Linux and macOS as well on local development machines.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.  
- **User-facing changes**
    - [x] Not Applicable
    - **OR**  
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` to your commit messages if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
