### PR TITLE
Set-Location: Match $env:PWD & $PWD on UNIX

### DIFF
--- a/src/System.Management.Automation/engine/SessionStateLocationAPIs.cs
+++ b/src/System.Management.Automation/engine/SessionStateLocationAPIs.cs
@@ -579,6 +579,14 @@ namespace System.Management.Automation
             // Set the $PWD variable to the new location
             this.SetVariable(SpecialVariables.PWDVarPath, this.CurrentLocation, false, true, CommandOrigin.Internal);
 
+#if UNIX
+            // Set the $env:PWD variable to the new location on Unix
+            if (CurrentDrive.Provider.NameEquals("FileSystem"))
+            {
+                Environment.SetEnvironmentVariable("PWD", this.CurrentLocation.ProviderPath);
+            }
+#endif
+
             // If an action has been defined for location changes, invoke it now.
             if (PublicSessionState.InvokeCommand.LocationChangedAction != null)
             {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Location.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Location.Tests.ps1
@@ -218,12 +218,12 @@ Describe "Set-Location" -Tags "CI" {
         It 'Should set the PWD environment variable to the new filesystem location' -Skip:$IsWindows {
             # Use $env:TMPDIR or /tmp to ensure that we're testing a FileSystem path
             if ($env:TMPDIR) {
-                $tempDirectory = $env:TMPDIR
+                $TempDirectory = $env:TMPDIR
             } else {
-                $tempDirectory = '/tmp'
+                $TempDirectory = '/tmp'
             }
             $path = 'Directory1'
-            $location = Join-Path $tempDirectory $path
+            $location = Join-Path $TempDirectory $path
             # Create a directory that we know the path of
             New-Item -ItemType Directory -Path $location
             # Move into the known path
@@ -238,11 +238,11 @@ Describe "Set-Location" -Tags "CI" {
         It 'Should unwrap a FileSystem Provider PSDrive path when updating the PWD environment variable' -Skip:$IsWindows {
             # Use $env:TMPDIR or /tmp to ensure that we're testing a FileSystem path
             if ($env:TMPDIR) {
-                $tempDirectory = $env:TMPDIR
+                $TempDirectory = $env:TMPDIR
             } else {
-                $tempDirectory = '/tmp'
+                $TempDirectory = '/tmp'
             }
-            New-PSDrive -Name 'TempDirectory' -PSProvider 'FileSystem' -Root $tempDirectory
+            New-PSDrive -Name 'TempDirectory' -PSProvider 'FileSystem' -Root $TempDirectory
             $path = 'Directory1'
             $location = Join-Path 'TempDirectory:' $path
             # Create a directory that we know the path of

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Location.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Location.Tests.ps1
@@ -223,16 +223,16 @@ Describe "Set-Location" -Tags "CI" {
                 $TempDirectory = '/tmp'
             }
             $path = 'Directory1'
-            $location = Join-Path $TempDirectory $path
+            $location = Join-Path -Path $TempDirectory -ChildPath $path
             # Create a directory that we know the path of
             New-Item -ItemType Directory -Path $location
             # Move into the known path
-            Set-Location $location
+            Set-Location -Path $location
             # Check that the $env:PWD variable correctly points to the known path
             $env:PWD | Should -Be $PWD.ProviderPath
             # Clean up after ourselves
-            Set-Location $TestDrive
-            Remove-Item $location
+            Set-Location -Path $TestDrive
+            Remove-Item -Path $location
         }
 
         It 'Should unwrap a FileSystem Provider PSDrive path when updating the PWD environment variable' -Skip:$IsWindows {
@@ -244,23 +244,23 @@ Describe "Set-Location" -Tags "CI" {
             }
             New-PSDrive -Name 'TempDirectory' -PSProvider 'FileSystem' -Root $TempDirectory
             $path = 'Directory1'
-            $location = Join-Path 'TempDirectory:' $path
+            $location = Join-Path -Path 'TempDirectory:' -ChildPath $path
             # Create a directory that we know the path of
             New-Item -ItemType Directory -Path $location
             # Move into the known path
-            Set-Location $location
+            Set-Location -Path $location
             # Check that the $env:PWD variable correctly points to the known path
             $env:PWD | Should -Be $PWD.ProviderPath
             # Clean up after ourselves
-            Set-Location $TestDrive
-            Remove-Item $location
+            Set-Location -Path $TestDrive
+            Remove-Item -Path $location
             Remove-PSDrive -Name 'TempDirectory'
         }
 
         It 'Should not update the PWD environment variable for non-FileSystem PSDrive providers' -Skip:$IsWindows {
             # Initial Set-Location to ensure that $env:PWD is reset to a known value
-            Set-Location $env:HOME
-            Set-Location 'Variable:'
+            Set-Location -Path $env:HOME
+            Set-Location -Path 'Variable:'
             # Verify that $env:PWD did not update when changing to the Variable: PSDrive
             $env:PWD | Should -Be $env:HOME
         }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Location.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Location.Tests.ps1
@@ -222,17 +222,17 @@ Describe "Set-Location" -Tags "CI" {
             } else {
                 $TempDirectory = '/tmp'
             }
-            $path = 'Directory1'
-            $location = Join-Path -Path $TempDirectory -ChildPath $path
+            $Path = 'Directory1'
+            $Location = Join-Path -Path $TempDirectory -ChildPath $Path
             # Create a directory that we know the path of
-            New-Item -ItemType Directory -Path $location
+            New-Item -ItemType Directory -Path $Location
             # Move into the known path
-            Set-Location -Path $location
+            Set-Location -Path $Location
             # Check that the $env:PWD variable correctly points to the known path
             $env:PWD | Should -Be $PWD.ProviderPath
             # Clean up after ourselves
             Set-Location -Path $TestDrive
-            Remove-Item -Path $location
+            Remove-Item -Path $Location
         }
 
         It 'Should unwrap a FileSystem Provider PSDrive path when updating the PWD environment variable' -Skip:$IsWindows {
@@ -243,17 +243,17 @@ Describe "Set-Location" -Tags "CI" {
                 $TempDirectory = '/tmp'
             }
             New-PSDrive -Name 'TempDirectory' -PSProvider 'FileSystem' -Root $TempDirectory
-            $path = 'Directory1'
-            $location = Join-Path -Path 'TempDirectory:' -ChildPath $path
+            $Path = 'Directory1'
+            $Location = Join-Path -Path 'TempDirectory:' -ChildPath $Path
             # Create a directory that we know the path of
-            New-Item -ItemType Directory -Path $location
+            New-Item -ItemType Directory -Path $Location
             # Move into the known path
-            Set-Location -Path $location
+            Set-Location -Path $Location
             # Check that the $env:PWD variable correctly points to the known path
             $env:PWD | Should -Be $PWD.ProviderPath
             # Clean up after ourselves
             Set-Location -Path $TestDrive
-            Remove-Item -Path $location
+            Remove-Item -Path $Location
             Remove-PSDrive -Name 'TempDirectory'
         }
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->  

## PR Summary

Update the UNIX Environment variable `PWD` to the current location.

## PR Context  

Fixes #7388

Set the UNIX Environment variable $env:PWD to the full filesystem path
for the current working directory upon Set-Location. This also copes
when the current location is set to a PSDrive. In such circumstances the
environment variable is expanded to the full FileSystem provider path.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.  
- **User-facing changes**
    - [x] Not Applicable
    - **OR**  
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` to your commit messages if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
