### PR TITLE
Fix env:PAGER not tokenized properly by help command

### DIFF
--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -4184,8 +4184,11 @@ param(
         {
             $customPagerCommandLine = $env:PAGER
 
-            # Split the command line into tokens, respecting quoting.
-            $customPagerCommand, $customPagerCommandArgs = & { Write-Output -- $customPagerCommandLine }
+            # Split the command line into tokes, respecting quoting.
+            $errs = $null
+            $tokens = [System.Management.Automation.PSParser]::Tokenize($customPagerCommandLine, [ref]$errs)
+            $customPagerCommand = $tokens[0].Content
+            $customPagerCommandArgs = $tokens[1].Content
 
             # See if the first token refers to a known command (executable),
             # and if not, see if the command line as a whole is an executable path.

--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -4184,7 +4184,7 @@ param(
         {
             $customPagerCommandLine = $env:PAGER
 
-            # Split the command line into tokes, respecting quoting.
+            # Split the command line into tokens, respecting quoting.
             $errs = $null
             $tokens = [System.Management.Automation.PSParser]::Tokenize($customPagerCommandLine, [ref]$errs)
             $customPagerCommand = $tokens[0].Content

--- a/test/powershell/engine/Help/HelpSystem.Tests.ps1
+++ b/test/powershell/engine/Help/HelpSystem.Tests.ps1
@@ -557,7 +557,7 @@ Describe 'help renders when using a PAGER with a space in the path' -Tags 'CI' {
     BeforeAll {
         $fakePager = @'
         param(
-            [Parameter]
+            [string]
             $customCommandArgs,
 
             [Parameter(ValueFromPipelineByPropertyName)]
@@ -573,7 +573,8 @@ Describe 'help renders when using a PAGER with a space in the path' -Tags 'CI' {
         Set-Content -Path $fakePagerPath -Value $fakePager
 
         $SavedEnvPager = $env:PAGER
-        $env:PAGER = $fakePagerPath
+        $fakePagerCustomArgs = "here is a fake argument"
+        $env:PAGER = "`"$fakePagerPath`" `"$fakePagerCustomArgs`""
     }
     AfterAll {
         $env:PAGER = $SavedEnvPager

--- a/test/powershell/engine/Help/HelpSystem.Tests.ps1
+++ b/test/powershell/engine/Help/HelpSystem.Tests.ps1
@@ -557,6 +557,7 @@ Describe 'help renders when using a PAGER with a space in the path' -Tags 'CI' {
     BeforeAll {
         $fakePager = @'
         param(
+            [Parameter()]
             [string]
             $customCommandArgs,
 
@@ -574,7 +575,7 @@ Describe 'help renders when using a PAGER with a space in the path' -Tags 'CI' {
 
         $SavedEnvPager = $env:PAGER
         $fakePagerCustomArgs = "here is a fake argument"
-        $env:PAGER = "`"$fakePagerPath`" `"$fakePagerCustomArgs`""
+        $env:PAGER = '"{0}" "{1}"' -f $fakePagerPath, $fakePagerCustomArgs
     }
     AfterAll {
         $env:PAGER = $SavedEnvPager


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->  

## PR Summary

This PR fixes #8912 which is due to a tokenization issue in the help command.

## PR Context  


## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.  
- **User-facing changes**
    - [x] Not Applicable
    - **OR**  
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` to your commit messages if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
