### PR TITLE
Make xUnit test run sequentially to rule out race conditions around 'powershell.config.json'

### DIFF
--- a/.vsts-ci/windows.yml
+++ b/.vsts-ci/windows.yml
@@ -90,8 +90,8 @@ jobs:
 
   - powershell: |
       Import-Module .\tools\ci.psm1
-      $ParallelXUnitTestResultsFile = "$(System.ArtifactsDirectory)\xunit\ParallelXUnitTestResults.xml"
+      $xUnitTestResultsFile = "$(System.ArtifactsDirectory)\xunit\xUnitTestResults.xml"
 
-      Test-XUnitTestResults -TestResultsFile $ParallelXUnitTestResultsFile
+      Test-XUnitTestResults -TestResultsFile $xUnitTestResultsFile
     displayName: Test
     condition: succeeded()

--- a/build.psm1
+++ b/build.psm1
@@ -1420,15 +1420,13 @@ function Start-PSxUnit {
             }
         }
 
-        dotnet build --configuration $Options.configuration
-
         if (Test-Path $xUnitTestResultsFile) {
             Remove-Item $xUnitTestResultsFile -Force -ErrorAction SilentlyContinue
         }
 
         # We run the xUnit tests sequentially to avoid race conditions caused by manipulating the config.json file.
         # xUnit tests run in parallel by default. To make them run sequentially, we need to define the 'xunit.runner.json' file.
-        dotnet test --configuration $Options.configuration --no-restore --no-build --test-adapter-path:. "--logger:xunit;LogFilePath=$xUnitTestResultsFile"
+        dotnet test --configuration $Options.configuration --test-adapter-path:. "--logger:xunit;LogFilePath=$xUnitTestResultsFile"
 
         Publish-TestResults -Path $xUnitTestResultsFile -Type 'XUnit' -Title 'Xunit Sequential'
     }

--- a/build.psm1
+++ b/build.psm1
@@ -1374,7 +1374,7 @@ function Test-PSPesterResults
 
 function Start-PSxUnit {
     [CmdletBinding()]param(
-        [string] $ParallelTestResultsFile = "ParallelXUnitResults.xml"
+        [string] $xUnitTestResultsFile = "xUnitResults.xml"
     )
 
     # Add .NET CLI tools to PATH
@@ -1422,21 +1422,15 @@ function Start-PSxUnit {
 
         dotnet build --configuration $Options.configuration
 
-        if (Test-Path $ParallelTestResultsFile) {
-            Remove-Item $ParallelTestResultsFile -Force -ErrorAction SilentlyContinue
+        if (Test-Path $xUnitTestResultsFile) {
+            Remove-Item $xUnitTestResultsFile -Force -ErrorAction SilentlyContinue
         }
 
-        # we are having intermittent issues on macOS with these tests failing.
-        # VSTS has suggested forcing them to be sequential
-        if($env:TF_BUILD -and $IsMacOS)
-        {
-            Write-Log 'Forcing parallel xunit tests to run sequentially.'
-            dotnet test -p:ParallelizeTestCollections=false --configuration $Options.configuration --no-restore --no-build --test-adapter-path:. "--logger:xunit;LogFilePath=$ParallelTestResultsFile"
-        } else {
-            dotnet test --configuration $Options.configuration --no-restore --no-build --test-adapter-path:. "--logger:xunit;LogFilePath=$ParallelTestResultsFile"
-        }
+        # We run the xUnit tests sequentially to avoid race conditions caused by manipulating the config.json file.
+        # xUnit tests run in parallel by default. To make them run sequentially, we need to define the 'xunit.runner.json' file.
+        dotnet test --configuration $Options.configuration --no-restore --no-build --test-adapter-path:. "--logger:xunit;LogFilePath=$xUnitTestResultsFile"
 
-        Publish-TestResults -Path $ParallelTestResultsFile -Type 'XUnit' -Title 'Xunit Parallel'
+        Publish-TestResults -Path $xUnitTestResultsFile -Type 'XUnit' -Title 'Xunit Sequential'
     }
     finally {
         Pop-Location

--- a/test/xUnit/xUnit.tests.csproj
+++ b/test/xUnit/xUnit.tests.csproj
@@ -27,4 +27,12 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
     <PackageReference Include="XunitXml.TestLogger" Version="2.1.26" />
   </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="xunit.runner.json">
+      <Link>xunit.runner.json</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </Content>
+  </ItemGroup>
 </Project>

--- a/test/xUnit/xunit.runner.json
+++ b/test/xUnit/xunit.runner.json
@@ -1,0 +1,3 @@
+{
+  "parallelizeTestCollections": false
+}

--- a/tools/ci.psm1
+++ b/tools/ci.psm1
@@ -288,17 +288,17 @@ function Invoke-CIxUnit
         throw "CoreCLR pwsh.exe was not built"
     }
 
-    $ParallelXUnitTestResultsFile = "$pwd\ParallelXUnitTestResults.xml"
+    $xUnitTestResultsFile = "$pwd\xUnitTestResults.xml"
 
-    Start-PSxUnit -ParallelTestResultsFile $ParallelXUnitTestResultsFile
+    Start-PSxUnit -xUnitTestResultsFile $xUnitTestResultsFile
     Write-Host -ForegroundColor Green 'Uploading PSxUnit test results'
-    Update-TestResults -resultsFile $ParallelXUnitTestResultsFile
-    Push-Artifact -Path $ParallelXUnitTestResultsFile -name xunit
+    Update-TestResults -resultsFile $xUnitTestResultsFile
+    Push-Artifact -Path $xUnitTestResultsFile -name xunit
 
     if(!$SkipFailing.IsPresent)
     {
         # Fail the build, if tests failed
-        Test-XUnitTestResults -TestResultsFile $ParallelXUnitTestResultsFile
+        Test-XUnitTestResults -TestResultsFile $xUnitTestResultsFile
     }
 }
 
@@ -768,10 +768,10 @@ function Invoke-LinuxTests
     }
 
     try {
-        $ParallelXUnitTestResultsFile = "$pwd/ParallelXUnitTestResults.xml"
-        Start-PSxUnit -ParallelTestResultsFile $ParallelXUnitTestResultsFile
+        $xUnitTestResultsFile = "$pwd/xUnitTestResults.xml"
+        Start-PSxUnit -xUnitTestResultsFile $xUnitTestResultsFile
         # If there are failures, Test-XUnitTestResults throws
-        Test-XUnitTestResults -TestResultsFile $ParallelXUnitTestResultsFile
+        Test-XUnitTestResults -TestResultsFile $xUnitTestResultsFile
     } catch {
         $result = "FAIL"
         if (!$resultError)


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Make xUnit test truly run sequentially to rule out race conditions around `powershell.config.json`.
Fix #8784 #8715

## PR Context

We keep getting xUnit test failures due to the race condition around manipulating `powershell.config.json` file, even though we have been trying to run xUnit tests sequentially by having `dotnet test -p:ParallelizeTestCollections=false`. It turns out `-p:ParallelizeTestCollections=false` doesn't work, and we have to use `xunit.runner.json` to disable parallel running.

Failure example: https://powershell.visualstudio.com/PowerShell/_build/results?buildId=13830
From the exception below, we can see the all-user scope config file was there when we check for file existence in `ReadValueFromFile`, but was deleted when we came to creating a `FileStream` out of it.
This is because the all-user scope config file as created and deleted as part of the `PSConfiguration` tests. This is an evidence that tests are still running in parallel with `dotnet test -p:ParallelizeTestCollections=false`.

```
[xUnit.net 00:00:03.20]     PSTests.Sequential.RunspaceTests.TestRunspaceWithPowerShellAndInitialSessionState [FAIL]
Failed   PSTests.Sequential.RunspaceTests.TestRunspaceWithPowerShellAndInitialSessionState
Error Message:
 System.IO.FileNotFoundException : Could not find file 'C:\Users\VssAdministrator\Documents\PowerShell\powershell.config.json'.
Stack Trace:
   at System.IO.FileStream.ValidateFileHandle(SafeFileHandle fileHandle)
   at System.IO.FileStream.CreateFileOpenHandle(FileMode mode, FileShare share, FileOptions options)
   at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize, FileOptions options)
   at System.Management.Automation.Configuration.PowerShellConfig.WaitForFile(String fullPath, FileMode mode, FileAccess access, FileShare share) in D:\a\1\s\src\System.Management.Automation\engine\PSConfiguration.cs:line 426
   at System.Management.Automation.Configuration.PowerShellConfig.ReadValueFromFile[T](ConfigScope scope, String key, T defaultValue, Func`4 readImpl) in D:\a\1\s\src\System.Management.Automation\engine\PSConfiguration.cs:line 397
   at System.Management.Automation.Utils.GetPolicySettingFromConfigFile[T](ConfigScope[] preferenceOrder) in D:\a\1\s\src\System.Management.Automation\engine\Utils.cs:line 523
   at System.Management.Automation.Utils.GetPolicySetting[T](ConfigScope[] preferenceOrder) in D:\a\1\s\src\System.Management.Automation\engine\Utils.cs:line 509
   at Microsoft.PowerShell.Commands.ModuleCmdletBase.GetModuleLoggingInformation(IEnumerable`1& moduleNames) in D:\a\1\s\src\System.Management.Automation\engine\Modules\ModuleCmdletBase.cs:line 4507
   at System.Management.Automation.PSSnapInReader.ReadEnginePSSnapIns() in D:\a\1\s\src\System.Management.Automation\singleshell\config\MshSnapinInfo.cs:line 1068
   at System.Management.Automation.Runspaces.InitialSessionState.CreateDefault() in D:\a\1\s\src\System.Management.Automation\engine\InitialSessionState.cs:line 1526
   at PSTests.Sequential.RunspaceTests.TestRunspaceWithPowerShellAndInitialSessionState() in D:\a\1\s\test\xUnit\csharp\test_Runspace.cs:line 72
Results File: D:\a\1\s\ParallelXUnitTestResults.xml
```

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` to your commit messages if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
