### PR TITLE
Support negative numbers in -split operator

### DIFF
--- a/src/System.Management.Automation/engine/lang/parserutils.cs
+++ b/src/System.Management.Automation/engine/lang/parserutils.cs
@@ -664,7 +664,7 @@ namespace System.Management.Automation
                 var split = new List<string>();
 
                 // Used to traverse through the item
-                var cursor = item.Length - 1;
+                int cursor = item.Length - 1;
 
                 int subStringLength = 0;
 

--- a/src/System.Management.Automation/engine/lang/parserutils.cs
+++ b/src/System.Management.Automation/engine/lang/parserutils.cs
@@ -584,7 +584,7 @@ namespace System.Management.Automation
             return SplitOperatorImpl(context, errorPosition, lval, rval, SplitImplOptions.None, ignoreCase);
         }
 
-        private static object SplitOperatorImpl(ExecutionContext context, IScriptExtent errorPosition, object lval, object rval, SplitImplOptions implOptions, bool ignoreCase)
+        private static IReadOnlyList<string> SplitOperatorImpl(ExecutionContext context, IScriptExtent errorPosition, object lval, object rval, SplitImplOptions implOptions, bool ignoreCase)
         {
             IEnumerable<string> content = enumerateContent(context, errorPosition, implOptions, lval);
 
@@ -648,13 +648,13 @@ namespace System.Management.Automation
             }
         }
 
-        private static object NegativeSplitWithPredicate(ExecutionContext context, IScriptExtent errorPosition, IEnumerable<string> content, ScriptBlock predicate, int limit)
+        private static IReadOnlyList<string> NegativeSplitWithPredicate(ExecutionContext context, IScriptExtent errorPosition, IEnumerable<string> content, ScriptBlock predicate, int limit)
         {
             var results = new List<string>();
 
             if (limit == -1)
             {
-                // if the user just wants 1 string
+                // If the user just wants 1 string
                 // then just return the content
                 return new List<string>(content);
             }
@@ -722,13 +722,13 @@ namespace System.Management.Automation
             return results.ToArray();
         }
 
-        private static object SplitWithPredicate(ExecutionContext context, IScriptExtent errorPosition, IEnumerable<string> content, ScriptBlock predicate, int limit)
+        private static IReadOnlyList<string> SplitWithPredicate(ExecutionContext context, IScriptExtent errorPosition, IEnumerable<string> content, ScriptBlock predicate, int limit)
         {
             var results = new List<string>();
 
             if (limit == 1)
             {
-                // if the user just wants 1 string
+                // If the user just wants 1 string
                 // then just return the content
                 return new List<string>(content);
             }
@@ -802,7 +802,7 @@ namespace System.Management.Automation
             return results.ToArray();
         }
 
-        private static object SplitWithPattern(ExecutionContext context, IScriptExtent errorPosition, IEnumerable<string> content, string separatorPattern, int limit, SplitOptions options)
+        private static IReadOnlyList<string> SplitWithPattern(ExecutionContext context, IScriptExtent errorPosition, IEnumerable<string> content, string separatorPattern, int limit, SplitOptions options)
         {
             // Default to Regex matching if no match specified.
             if ((options & SplitOptions.SimpleMatch) == 0 &&

--- a/src/System.Management.Automation/engine/lang/parserutils.cs
+++ b/src/System.Management.Automation/engine/lang/parserutils.cs
@@ -644,13 +644,6 @@ namespace System.Management.Automation
             }
         }
 
-        private static string ReverseStringUtility(string str)
-        {
-            var revStr = str.ToCharArray();
-            Array.Reverse(revStr);
-            return new string(revStr);
-        }
-
         private static object SplitWithPredicate(ExecutionContext context, IScriptExtent errorPosition, IEnumerable<string> content, ScriptBlock predicate, int limit)
         {
             var results = new List<string>();

--- a/src/System.Management.Automation/engine/lang/parserutils.cs
+++ b/src/System.Management.Automation/engine/lang/parserutils.cs
@@ -738,12 +738,12 @@ namespace System.Management.Automation
                 var split = new List<string>();
 
                 // Used to traverse through the item
-                var cursor = 0;
+                int cursor = 0;
 
                 // This is used to calculate how much to split from item.
-                var subStringLength = 0;
+                int subStringLength = 0;
 
-                for (var charCount = 0; charCount < item.Length; charCount++)
+                for (int charCount = 0; charCount < item.Length; charCount++)
                 {
                     // Evaluate the predicate using the character at cursor.
                     object predicateResult = predicate.DoInvokeReturnAsIs(

--- a/src/System.Management.Automation/engine/lang/parserutils.cs
+++ b/src/System.Management.Automation/engine/lang/parserutils.cs
@@ -743,23 +743,22 @@ namespace System.Management.Automation
                 separatorPattern = Regex.Escape(separatorPattern);
             }
 
-            if (limit < 0)
-            {
-                // Regex only allows 0 to signify "no limit", whereas
-                // we allow any integer <= 0.
-                limit = 0;
-            }
-
             RegexOptions regexOptions = parseRegexOptions(options);
+            // if the limit is negative then set Regex to read from right to left
+            if (limit < 0) {
+                regexOptions |= RegexOptions.RightToLeft;
+                limit = -limit;
+            }
             Regex regex = NewRegex(separatorPattern, regexOptions);
 
             List<string> results = new List<string>();
+
             foreach (string item in content)
             {
                 string[] split = regex.Split(item, limit, 0);
                 results.AddRange(split);
             }
-
+            
             return results.ToArray();
         }
 

--- a/src/System.Management.Automation/engine/lang/parserutils.cs
+++ b/src/System.Management.Automation/engine/lang/parserutils.cs
@@ -697,7 +697,7 @@ namespace System.Management.Automation
                     
                     if (buf.Length != 0)
                     {
-                        split.Add((limit < 0)? ReverseStringUtility(buf.ToString()): buf.ToString());
+                        split.Add((limit < 0) ? ReverseStringUtility(buf.ToString()) : buf.ToString());
                     }
 
                     buf.Clear();
@@ -711,7 +711,7 @@ namespace System.Management.Automation
                             // else add an empty string
                             split.Add(item.Substring(cursor + 1));
                         }
-                        else if((cursor + 1) < item.Length && limit < 0)
+                        else if ((cursor + 1) < item.Length && limit < 0)
                         {
                             split.Add(item.Substring(0, cursor));
                         }
@@ -736,7 +736,7 @@ namespace System.Management.Automation
 
                 if (buf.Length > 0)
                 {
-                    split.Add((limit < 0)? ReverseStringUtility(buf.ToString()): buf.ToString());
+                    split.Add((limit < 0) ? ReverseStringUtility(buf.ToString()) : buf.ToString());
                 }
 
                 if (limit < 0)

--- a/src/System.Management.Automation/engine/lang/parserutils.cs
+++ b/src/System.Management.Automation/engine/lang/parserutils.cs
@@ -744,11 +744,13 @@ namespace System.Management.Automation
             }
 
             RegexOptions regexOptions = parseRegexOptions(options);
+
             // if the limit is negative then set Regex to read from right to left
             if (limit < 0) {
                 regexOptions |= RegexOptions.RightToLeft;
                 limit = -limit;
             }
+
             Regex regex = NewRegex(separatorPattern, regexOptions);
 
             List<string> results = new List<string>();
@@ -758,7 +760,7 @@ namespace System.Management.Automation
                 string[] split = regex.Split(item, limit, 0);
                 results.AddRange(split);
             }
-            
+
             return results.ToArray();
         }
 

--- a/src/System.Management.Automation/engine/lang/parserutils.cs
+++ b/src/System.Management.Automation/engine/lang/parserutils.cs
@@ -829,7 +829,7 @@ namespace System.Management.Automation
 
             int calculatedLimit = limit;
 
-            // if the limit is negative then set Regex to read from right to left
+            // If the limit is negative then set Regex to read from right to left
             if (calculatedLimit < 0)
             {
                 regexOptions |= RegexOptions.RightToLeft;

--- a/src/System.Management.Automation/engine/lang/parserutils.cs
+++ b/src/System.Management.Automation/engine/lang/parserutils.cs
@@ -745,11 +745,13 @@ namespace System.Management.Automation
 
             RegexOptions regexOptions = parseRegexOptions(options);
 
+            int calculatedLimit = limit;
+
             // if the limit is negative then set Regex to read from right to left
-            if (limit < 0) 
+            if (calculatedLimit < 0) 
             {
                 regexOptions |= RegexOptions.RightToLeft;
-                limit *= -1;
+                calculatedLimit *= -1;
             }
 
             Regex regex = NewRegex(separatorPattern, regexOptions);
@@ -758,8 +760,13 @@ namespace System.Management.Automation
 
             foreach (string item in content)
             {
+<<<<<<< HEAD
                 string[] split = regex.Split(item, limit, 0);
                 results.AddRange(split);
+=======
+                string[] split = regex.Split(item, calculatedLimit);
+                ExtendList(results, split);
+>>>>>>> dbe4d631f... [feature] added a couple more tests and made code work with the linter
             }
 
             return results.ToArray();

--- a/src/System.Management.Automation/engine/lang/parserutils.cs
+++ b/src/System.Management.Automation/engine/lang/parserutils.cs
@@ -781,16 +781,8 @@ namespace System.Management.Automation
                 {
                     split.Add(buf.ToString());
                 }
-<<<<<<< HEAD
 
                 results.AddRange(split);
-=======
-                if (limit < 0)
-                {
-                    split.Reverse();
-                }
-                ExtendList(results, split);
->>>>>>> e17cee10f... [feature] changed the predicate case to return strings in correct order
             }
             
 
@@ -837,13 +829,8 @@ namespace System.Management.Automation
 
             foreach (string item in content)
             {
-<<<<<<< HEAD
                 string[] split = regex.Split(item, limit, 0);
                 results.AddRange(split);
-=======
-                string[] split = regex.Split(item, calculatedLimit);
-                ExtendList(results, split);
->>>>>>> dbe4d631f... [feature] added a couple more tests and made code work with the linter
             }
 
             return results.ToArray();

--- a/src/System.Management.Automation/engine/lang/parserutils.cs
+++ b/src/System.Management.Automation/engine/lang/parserutils.cs
@@ -749,7 +749,7 @@ namespace System.Management.Automation
             if (limit < 0) 
             {
                 regexOptions |= RegexOptions.RightToLeft;
-                limit = -limit;
+                limit *= -1;
             }
 
             Regex regex = NewRegex(separatorPattern, regexOptions);

--- a/src/System.Management.Automation/engine/lang/parserutils.cs
+++ b/src/System.Management.Automation/engine/lang/parserutils.cs
@@ -781,9 +781,18 @@ namespace System.Management.Automation
                 {
                     split.Add(buf.ToString());
                 }
+<<<<<<< HEAD
 
                 results.AddRange(split);
+=======
+                if (limit < 0)
+                {
+                    split.Reverse();
+                }
+                ExtendList(results, split);
+>>>>>>> e17cee10f... [feature] changed the predicate case to return strings in correct order
             }
+            
 
             return results.ToArray();
         }

--- a/src/System.Management.Automation/engine/lang/parserutils.cs
+++ b/src/System.Management.Automation/engine/lang/parserutils.cs
@@ -746,7 +746,8 @@ namespace System.Management.Automation
             RegexOptions regexOptions = parseRegexOptions(options);
 
             // if the limit is negative then set Regex to read from right to left
-            if (limit < 0) {
+            if (limit < 0) 
+            {
                 regexOptions |= RegexOptions.RightToLeft;
                 limit = -limit;
             }

--- a/src/System.Management.Automation/engine/lang/parserutils.cs
+++ b/src/System.Management.Automation/engine/lang/parserutils.cs
@@ -666,7 +666,7 @@ namespace System.Management.Automation
                 // Used to traverse through the item
                 var cursor = item.Length - 1;
 
-                var subStringLength = 0;
+                int subStringLength = 0;
 
                 for (int charCount = 0; charCount < item.Length; charCount++) {
                     // Evaluate the predicate using the character at cursor.

--- a/src/System.Management.Automation/engine/lang/parserutils.cs
+++ b/src/System.Management.Automation/engine/lang/parserutils.cs
@@ -726,12 +726,14 @@ namespace System.Management.Automation
                         // it.
                         split.Add(string.Empty);
                     }
+                    
                     // Add any remainder, if we're under the limit.
                     if (buf.Length > 0 &&
                         (limit <= 0 || split.Count < limit))
                     {
                         split.Add(buf.ToString());
                     }
+
                     if (limit < 0)
                     {
                         split.Reverse();
@@ -739,6 +741,7 @@ namespace System.Management.Automation
                     results.AddRange(split);
                 }
             }
+
             return results.ToArray();
         }
 

--- a/src/System.Management.Automation/engine/lang/parserutils.cs
+++ b/src/System.Management.Automation/engine/lang/parserutils.cs
@@ -744,7 +744,7 @@ namespace System.Management.Automation
                     split.Reverse();
                 }
 
-                ExtendList(results, split);
+                results.AddRange(split);
             }
 
             return results.ToArray();
@@ -790,7 +790,7 @@ namespace System.Management.Automation
 
             foreach (string item in content)
             {
-                string[] split = regex.Split(item, limit, 0);
+                string[] split = regex.Split(item, calculatedLimit);
                 results.AddRange(split);
             }
 

--- a/src/System.Management.Automation/engine/lang/parserutils.cs
+++ b/src/System.Management.Automation/engine/lang/parserutils.cs
@@ -668,7 +668,7 @@ namespace System.Management.Automation
 
                 var subStringLength = 0;
 
-                for (var charCount = 0; charCount < item.Length; charCount++) {
+                for (int charCount = 0; charCount < item.Length; charCount++) {
                     // Evaluate the predicate using the character at cursor.
                     object predicateResult = predicate.DoInvokeReturnAsIs(
                         useLocalScope: true,

--- a/src/System.Management.Automation/engine/lang/parserutils.cs
+++ b/src/System.Management.Automation/engine/lang/parserutils.cs
@@ -644,7 +644,8 @@ namespace System.Management.Automation
             }
         }
 
-        private static string ReverseStringUtility(string str) {
+        private static string ReverseStringUtility(string str)
+        {
             var revStr = str.ToCharArray();
             Array.Reverse(revStr);
             return new string(revStr);
@@ -680,7 +681,8 @@ namespace System.Management.Automation
                             args: new object[] { item, strIndex });
                         if (LanguagePrimitives.IsTrue(predicateResult))
                         {
-                            if (buf.Length != 0) {
+                            if (buf.Length != 0)
+                            {
                                 split.Add(buf.ToString());
                             }
                             
@@ -772,7 +774,6 @@ namespace System.Management.Automation
                         }
                     }
                 }
-                
 
                 // Add any remainder, if we're under the limit.
                 if (buf.Length > 0 &&

--- a/test/powershell/Language/Operators/SplitOperator.Tests.ps1
+++ b/test/powershell/Language/Operators/SplitOperator.Tests.ps1
@@ -67,26 +67,31 @@ Describe "Split Operator" -Tags CI {
         It "Binary split operator with predicate can work with negative numbers" {
             $res = "a b c d" -split {$_ -like ' '},-2
             $res.count | Should -Be 2
-            $res[0] | Should -Be "d"
-            $res[1] | Should -Be "a b c"
+            $res[0] | Should -Be "a b c"
+            $res[1] | Should -Be "d"
 
             $res = "a b c d" -split {$_ -like ' '},-4
             $res.count | Should -Be 4
-            $res[0] | Should -Be "d"
-            $res[1] | Should -Be "c"
-            $res[2] | Should -Be "b"
-            $res[3] | Should -Be "a"
+            $res[0] | Should -Be "a"
+            $res[1] | Should -Be "b"
+            $res[2] | Should -Be "c"
+            $res[3] | Should -Be "d"
 
             $res = "a b c d" -split {$_ -like ' '},-8
             $res.count | Should -Be 4
-            $res[0] | Should -Be "d"
-            $res[1] | Should -Be "c"
-            $res[2] | Should -Be "b"
-            $res[3] | Should -Be "a"
+            $res[0] | Should -Be "a"
+            $res[1] | Should -Be "b"
+            $res[2] | Should -Be "c"
+            $res[3] | Should -Be "d"
 
             $res = " " -split {$_ -like ' '},-4
             $res.count | Should -Be 1
             $res[0] | Should -Be ""
+
+            $res = "folder/path/to/file" -split {$_ -like '/'}, -2
+            $res.count | Should -Be 2
+            $res[0] | Should -Be "folder/path/to"
+            $res[1] | Should -Be "file"
         }
 
         It "Binary split operator can work with regex expression" {

--- a/test/powershell/Language/Operators/SplitOperator.Tests.ps1
+++ b/test/powershell/Language/Operators/SplitOperator.Tests.ps1
@@ -33,7 +33,25 @@ Describe "Split Operator" -Tags CI {
             $res[2] | Should -Be "c"
             $res[3] | Should -Be "d"
 
+            $res = "a b c d" -split " ", -2
+            $res.count | Should -Be 2
+            $res[0] | Should -Be "a b c"
+            $res[1] | Should -Be "d"
+
             $res = "a b c d" -split " ", -1
+            $res.count | Should -Be 1
+            $res[0] | Should -Be "a b c d"
+        }
+
+        It "Binary split operator can work with greater than max substring" {
+            $res = "a b c d" -split " ",8
+            $res.count | Should -Be 4
+            $res[0] | Should -Be "a"
+            $res[1] | Should -Be "b"
+            $res[2] | Should -Be "c"
+            $res[3] | Should -Be "d"
+
+            $res = "a b c d" -split " ",-8
             $res.count | Should -Be 4
             $res[0] | Should -Be "a"
             $res[1] | Should -Be "b"

--- a/test/powershell/Language/Operators/SplitOperator.Tests.ps1
+++ b/test/powershell/Language/Operators/SplitOperator.Tests.ps1
@@ -64,6 +64,31 @@ Describe "Split Operator" -Tags CI {
             $res[1] | Should -Be ""
         }
 
+        It "Binary split operator with predicate can work with negative numbers" {
+            $res = "a b c d" -split {$_ -like ' '},-2
+            $res.count | Should -Be 2
+            $res[0] | Should -Be "d"
+            $res[1] | Should -Be "a b c"
+
+            $res = "a b c d" -split {$_ -like ' '},-4
+            $res.count | Should -Be 4
+            $res[0] | Should -Be "d"
+            $res[1] | Should -Be "c"
+            $res[2] | Should -Be "b"
+            $res[3] | Should -Be "a"
+
+            $res = "a b c d" -split {$_ -like ' '},-8
+            $res.count | Should -Be 4
+            $res[0] | Should -Be "d"
+            $res[1] | Should -Be "c"
+            $res[2] | Should -Be "b"
+            $res[3] | Should -Be "a"
+
+            $res = " " -split {$_ -like ' '},-4
+            $res.count | Should -Be 1
+            $res[0] | Should -Be ""
+        }
+
         It "Binary split operator can work with regex expression" {
             $res = "a2b3c4d" -split '\d+',2
             $res.count | Should -Be 2

--- a/test/powershell/Language/Operators/SplitOperator.Tests.ps1
+++ b/test/powershell/Language/Operators/SplitOperator.Tests.ps1
@@ -43,7 +43,7 @@ Describe "Split Operator" -Tags CI {
             $res[0] | Should -Be "a b c d"
         }
 
-        It "Binary split operator can work with greater than max substring" {
+        It "Binary split operator can work with different delimeter than split string" {
             $res = "a b c d" -split " ",8
             $res.count | Should -Be 4
             $res[0] | Should -Be "a"
@@ -57,6 +57,23 @@ Describe "Split Operator" -Tags CI {
             $res[1] | Should -Be "b"
             $res[2] | Should -Be "c"
             $res[3] | Should -Be "d"
+
+            $res = " " -split " ",-2
+            $res.count | Should -Be 2
+            $res[0] | Should -Be ""
+            $res[1] | Should -Be ""
+        }
+
+        It "Binary split operator can work with regex expression" {
+            $res = "a2b3c4d" -split '\d+',2
+            $res.count | Should -Be 2
+            $res[0] | Should -Be "a"
+            $res[1] | Should -Be "b3c4d"
+
+            $res = "a2b3c4d" -split '\d+',-2
+            $res.count | Should -Be 2
+            $res[0] | Should -Be "a2b3c"
+            $res[1] | Should -Be "d"
         }
 
         It "Binary split operator can works with freeform delimiter" {

--- a/test/powershell/Language/Operators/SplitOperator.Tests.ps1
+++ b/test/powershell/Language/Operators/SplitOperator.Tests.ps1
@@ -85,8 +85,9 @@ Describe "Split Operator" -Tags CI {
             $res[3] | Should -Be "d"
 
             $res = " " -split {$_ -like ' '},-4
-            $res.count | Should -Be 1
+            $res.count | Should -Be 2
             $res[0] | Should -Be ""
+            $res[1] | Should -Be ""
 
             $res = "folder/path/to/file" -split {$_ -like '/'}, -2
             $res.count | Should -Be 2


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

Fixes https://github.com/PowerShell/PowerShell/issues/4765
- Added functionality to facilitate negative arguments for the split command. 
- Added a couple tests to the split suite.

<!-- Summarize your PR between here and the checklist. -->

To solve the problem of negative number arguments in the split command I checked that the argument was in fact negative. If the argument is negative then the regex command gets run with the 'RightToLeft' property. This will grab the correct strings from the content and produce the correct output results. Else if the argument number is not negative then the regex is run normally.

I am competing in the HackIllinois event and was mentored by @rjmholt and @TylerLeonhardt 

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [x] Issue filed: https://github.com/MicrosoftDocs/PowerShell-Docs/issues/4396
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` to your commit messages if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
