### PR TITLE
Adds emphasis to Select-String default formatter

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
@@ -97,17 +97,17 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Stores the starting index of each match within the line.
         /// </summary>
-        private readonly List<int> matchIndexes;
+        private readonly List<int> _matchIndexes;
 
         /// <summary>
         /// Stores the length of each match within the line.
         /// </summary>
-        private readonly List<int> matchLengths;
+        private readonly List<int> _matchLengths;
 
         /// <summary>
         /// Stores a values indicating whether or not the terminal supports VT.
         /// </summary>
-        private readonly bool? supportsVirtualTerminal;
+        private readonly bool? _supportsVirtualTerminal;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="MatchInfo"/> class.
@@ -1623,8 +1623,8 @@ namespace Microsoft.PowerShell.Commands
             int patternIndex = 0;
             matchResult = null;
 
-            List<int> indexes = new List<int>();
-            List<int> lengths = new List<int>();
+            var indexes = new List<int>();
+            var lengths = new List<int>();
 
             if (!SimpleMatch)
             {

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
@@ -302,7 +302,7 @@ namespace Microsoft.PowerShell.Commands
 
                 if (_supportsVirtualTerminal)
                 {
-                    open = "\u001b[31m";
+                    open = "\u001b[7m";
                     close = "\u001b[0m";
                 }
                 else

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
@@ -91,8 +91,8 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Gets or sets a value indicating whether the matched portion of the string is highlighted.
         /// </summary>
-        /// <value>Whether the matched portion of the string is highlighted with asterisks.</value>
-        public bool Emphasize { get; set; }
+        /// <value>Whether the matched portion of the string is highlighted with the negative VT sequence.</value>
+        private bool Emphasize { get; set; }
 
         /// <summary>
         /// Stores the starting index of each match within the line.
@@ -1174,8 +1174,7 @@ namespace Microsoft.PowerShell.Commands
         public SwitchParameter List { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating if the matching portion of the string should be highlighted by 
-        /// surrounding it with asterisks.
+        /// Gets or sets a value indicating if the matching portion of the string should be highlighted.
         /// </summary>
         [Parameter]
         public SwitchParameter Emphasize { get; set; }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
@@ -94,7 +94,13 @@ namespace Microsoft.PowerShell.Commands
         /// <value>Whether the matched portion of the string is highlighted with asterisks.</value>
         public bool Color { get; set; }
 
+        /// <summary>
+        /// Stores the starting index of each match within the line.
+        /// </summary>
         private readonly List<int> MatchIndexes;
+        /// <summary>
+        /// Stores the length of each match within the line.
+        /// </summary>
         private readonly List<int> MatchLengths;
 
         /// <summary>

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
@@ -105,7 +105,7 @@ namespace Microsoft.PowerShell.Commands
         private readonly IReadOnlyList<int> _matchLengths;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="MatchInfo"/> class.
+        /// Initializes a new instance of the <see cref="MatchInfo"/> class with emphasis disabled.
         /// </summary>
         public MatchInfo()
         {
@@ -114,7 +114,7 @@ namespace Microsoft.PowerShell.Commands
 
         /// <summary>
         /// Initializes a new instance of the <see cref="MatchInfo"/> class with emphasized matched text.
-        /// Used when the Emphasize parameter is set and virtual terminal sequences are supported.
+        /// Used when virtual terminal sequences are supported.
         /// </summary>
         /// <param name="matchIndexes">Sets the matchIndexes.</param>
         /// <param name="matchLengths">Sets the matchLengths.</param>
@@ -1168,10 +1168,10 @@ namespace Microsoft.PowerShell.Commands
         public SwitchParameter List { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating if the matching portion of the string should be highlighted.
+        /// Gets or sets a value indicating if highlighting should be disabled.
         /// </summary>
         [Parameter]
-        public SwitchParameter Emphasize { get; set; }
+        public SwitchParameter NoEmphasis { get; set; }
 
         /// <summary>
         /// Gets or sets files to include. Files matching
@@ -1655,7 +1655,7 @@ namespace Microsoft.PowerShell.Commands
             List<int> indexes = null;
             List<int> lengths = null;
 
-            bool shouldEmphasize = Emphasize && Host.UI.SupportsVirtualTerminal;
+            bool shouldEmphasize = !NoEmphasis && Host.UI.SupportsVirtualTerminal;
 
             // If Emphasize is set and VT is supported,
             // the lengths and starting indexes of regex matches

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
@@ -92,7 +92,7 @@ namespace Microsoft.PowerShell.Commands
         /// Gets or sets whether the matched portion of the string is highlighted.
         /// </summary>
         /// <value>Whether the matched portion of the string is highlighted with asterisks.</value>
-        public bool Color { get; set; }
+        public bool Emphasize { get; set; }
 
         /// <summary>
         /// Stores the starting index of each match within the line.
@@ -112,8 +112,8 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Constructor.
         /// </summary>
-        public MatchInfo(bool isR, List<int> matchIndexes, List<int> matchLengths, bool color){
-            this.Color = color;
+        public MatchInfo(bool isR, List<int> matchIndexes, List<int> matchLengths, bool emphasize){
+            this.Emphasize = emphasize;
             this.MatchIndexes = matchIndexes;
             this.MatchLengths = matchLengths;
         }
@@ -249,7 +249,7 @@ namespace Microsoft.PowerShell.Commands
         {
             string displayPath = (directory != null) ? RelativePath(directory) : _path;
             string modifiedLine;
-            if (Color)
+            if (Emphasize)
             {
                 StringBuilder sb = new StringBuilder(Line);
                 for (int i = 0; i < MatchIndexes.Count; i++)
@@ -1115,7 +1115,7 @@ namespace Microsoft.PowerShell.Commands
         /// surrounding it with asterisks.
         /// </summary>
         [Parameter]
-        public SwitchParameter Color { get; set; }
+        public SwitchParameter Emphasize { get; set; }
 
         /// <summary>
         /// Gets or sets files to include. Files matching
@@ -1704,7 +1704,7 @@ namespace Microsoft.PowerShell.Commands
                 }
 
                 // otherwise construct and populate a new MatchInfo object
-                matchResult = new MatchInfo(false, indexes, lengths, Color)
+                matchResult = new MatchInfo(false, indexes, lengths, Emphasize)
                 {
                     IgnoreCase = !CaseSensitive,
                     Line = operandString,

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
@@ -311,7 +311,7 @@ namespace Microsoft.PowerShell.Commands
                     close = "*";
                 }
 
-                Line = String.Create(_matchIndexes.Count * (open.Length + close.Length) + Line.Length, Line, (chars, buf) =>
+                Line = string.Create((_matchIndexes.Count * (open.Length + close.Length)) + Line.Length, Line, (chars, buf) =>
                 {
                     int lineIndex = 0;
                     int charsIndex = 0;
@@ -333,7 +333,8 @@ namespace Microsoft.PowerShell.Commands
                         }
                         
                         // Adds characters being emphasized
-                        for (int j = 0; j < _matchLengths[i]; j++) {
+                        for (int j = 0; j < _matchLengths[i]; j++)
+                        {
                             chars[charsIndex] = Line[lineIndex];
                             lineIndex++;
                             charsIndex++; 

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
@@ -1654,10 +1654,12 @@ namespace Microsoft.PowerShell.Commands
             List<int> indexes = null;
             List<int> lengths = null;
 
+            bool shouldEmphasize = Emphasize && Host.UI.SupportsVirtualTerminal;
+
             // If Emphasize is set and VT is supported,
             // the lengths and starting indexes of regex matches
             // need to be passed in to the matchInfo object.
-            if (Emphasize && Host.UI.SupportsVirtualTerminal)
+            if (shouldEmphasize)
             {
                 indexes = new List<int>();
                 lengths = new List<int>();
@@ -1680,7 +1682,7 @@ namespace Microsoft.PowerShell.Commands
                             matches = new Match[mc.Count];
                             ((ICollection)mc).CopyTo(matches, 0);
 
-                            if (Emphasize && Host.UI.SupportsVirtualTerminal)
+                            if (shouldEmphasize)
                             {
                                 foreach (Match match in matches)
                                 {
@@ -1699,7 +1701,7 @@ namespace Microsoft.PowerShell.Commands
 
                         if (match.Success)
                         {
-                            if (Emphasize && Host.UI.SupportsVirtualTerminal)
+                            if (shouldEmphasize)
                             {
                                 indexes.Add(match.Index);
                                 lengths.Add(match.Length);
@@ -1727,7 +1729,7 @@ namespace Microsoft.PowerShell.Commands
                     int index = operandString.IndexOf(pat, compareOption);
                     if (index >= 0)
                     {
-                        if (Emphasize && Host.UI.SupportsVirtualTerminal)
+                        if (shouldEmphasize)
                         {
                             indexes.Add(index);
                             lengths.Add(pat.Length);
@@ -1780,7 +1782,7 @@ namespace Microsoft.PowerShell.Commands
                 }
 
                 // otherwise construct and populate a new MatchInfo object
-                matchResult = Emphasize && Host.UI.SupportsVirtualTerminal
+                matchResult = shouldEmphasize
                     ? new MatchInfo(indexes, lengths)
                     : new MatchInfo();
                 matchResult.IgnoreCase = !CaseSensitive;

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
@@ -107,7 +107,7 @@ namespace Microsoft.PowerShell.Commands
         /// <summary>
         /// Stores a values indicating whether or not the terminal supports VT.
         /// </summary>
-        private readonly bool? _supportsVirtualTerminal;
+        private readonly bool _supportsVirtualTerminal;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="MatchInfo"/> class.
@@ -124,12 +124,12 @@ namespace Microsoft.PowerShell.Commands
         /// <param name="matchLengths">Sets the matchLengths.</param>
         /// <param name="emphasize">Used for implementing -Emphasize.</param>
         /// <param name="vt">Sets a value indicating whether or not virtual terminal is supported.</param>
-        public MatchInfo(bool isRaw, List<int> matchIndexes, List<int> matchLengths, bool emphasize, bool? vt)
+        public MatchInfo(bool isRaw, List<int> matchIndexes, List<int> matchLengths, bool emphasize, bool vt)
         {
             this.Emphasize = emphasize;
-            this.matchIndexes = matchIndexes;
-            this.matchLengths = matchLengths;
-            this.supportsVirtualTerminal = vt;
+            this._matchIndexes = matchIndexes;
+            this._matchLengths = matchLengths;
+            this._supportsVirtualTerminal = vt;
         }
 
         /// <summary>
@@ -266,7 +266,7 @@ namespace Microsoft.PowerShell.Commands
                 string open;
                 string close;
 
-                if (supportsVirtualTerminal ?? false)
+                if (_supportsVirtualTerminal)
                 {
                     open = "\u001b[31m";
                     close = "\u001b[0m";
@@ -278,11 +278,11 @@ namespace Microsoft.PowerShell.Commands
                 }
 
                 StringBuilder sb = new StringBuilder(Line);
-                for (int i = 0; i < matchIndexes.Count; i++)
+                for (int i = 0; i < _matchIndexes.Count; i++)
                 {
                     int offset = open.Length + close.Length;
-                    sb.Insert(matchIndexes[i] + (i * offset), open);
-                    sb.Insert(matchIndexes[i] + matchLengths[i] + (i * offset + open.Length), close);
+                    sb.Insert(_matchIndexes[i] + (i * offset), open);
+                    sb.Insert(_matchIndexes[i] + _matchLengths[i] + ((i * offset) + open.Length), close);
                 }
 
                 modifiedLine = sb.ToString();
@@ -1733,7 +1733,7 @@ namespace Microsoft.PowerShell.Commands
                 }
 
                 // otherwise construct and populate a new MatchInfo object
-                matchResult = new MatchInfo(false, indexes, lengths, Emphasize.IsPresent, Host?.UI.SupportsVirtualTerminal)
+                matchResult = new MatchInfo(false, indexes, lengths, Emphasize.IsPresent, Host.UI.SupportsVirtualTerminal)
                 {
                     IgnoreCase = !CaseSensitive,
                     Line = operandString,

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
@@ -301,7 +301,8 @@ namespace Microsoft.PowerShell.Commands
         /// <returns>The string representation of the match object with matched text inverted.</returns>
         public string ToEmphasizedString(string directory)
         {
-            if (!_emphasize) {
+            if (!_emphasize)
+            {
                 return ToString(directory);
             }
 
@@ -314,22 +315,22 @@ namespace Microsoft.PowerShell.Commands
         /// <returns>The matched line with matched text inverted.</returns>
         private string EmphasizeLine()
         {
-            const string invertColorsVT100 = "\u001b[7m";
-            const string resetVT100 = "\u001b[0m";
+            const string InvertColorsVT100 = "\u001b[7m";
+            const string ResetVT100 = "\u001b[0m";
 
-            char[] chars = new char[(_matchIndexes.Count * (invertColorsVT100.Length + resetVT100.Length)) + Line.Length];
+            char[] chars = new char[(_matchIndexes.Count * (InvertColorsVT100.Length + ResetVT100.Length)) + Line.Length];
             int lineIndex = 0;
             int charsIndex = 0;
             for (int i = 0; i < _matchIndexes.Count; i++)
             {
                 // Adds characters before match
-                Line.CopyTo(lineIndex, chars, charsIndex, _matchIndexes[i]-lineIndex);
-                charsIndex += _matchIndexes[i]-lineIndex;
+                Line.CopyTo(lineIndex, chars, charsIndex, _matchIndexes[i] - lineIndex);
+                charsIndex += _matchIndexes[i] - lineIndex;
                 lineIndex = _matchIndexes[i];
 
                 // Adds opening vt sequence
-                invertColorsVT100.CopyTo(0, chars, charsIndex, invertColorsVT100.Length);
-                charsIndex += invertColorsVT100.Length;
+                InvertColorsVT100.CopyTo(0, chars, charsIndex, InvertColorsVT100.Length);
+                charsIndex += InvertColorsVT100.Length;
 
                 // Adds characters being emphasized
                 Line.CopyTo(lineIndex, chars, charsIndex, _matchLengths[i]);
@@ -337,8 +338,8 @@ namespace Microsoft.PowerShell.Commands
                 charsIndex += _matchLengths[i];
 
                 // Adds closing vt sequence
-                resetVT100.CopyTo(0, chars, charsIndex, resetVT100.Length);
-                charsIndex += resetVT100.Length;
+                ResetVT100.CopyTo(0, chars, charsIndex, ResetVT100.Length);
+                charsIndex += ResetVT100.Length;
             }
 
             // Adds remaining characters in line
@@ -1706,6 +1707,7 @@ namespace Microsoft.PowerShell.Commands
                                 indexes.Add(match.Index);
                                 lengths.Add(match.Length);
                             }
+
                             matches = new Match[] { match };
                         }
                     }
@@ -1734,6 +1736,7 @@ namespace Microsoft.PowerShell.Commands
                             indexes.Add(index);
                             lengths.Add(pat.Length);
                         }
+
                         gotMatch = true;
                         break;
                     }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
@@ -1733,7 +1733,7 @@ namespace Microsoft.PowerShell.Commands
                 }
 
                 // otherwise construct and populate a new MatchInfo object
-                matchResult = new MatchInfo(false, indexes, lengths, Emphasize, Host?.UI.SupportsVirtualTerminal)
+                matchResult = new MatchInfo(false, indexes, lengths, Emphasize.IsPresent, Host?.UI.SupportsVirtualTerminal)
                 {
                     IgnoreCase = !CaseSensitive,
                     Line = operandString,

--- a/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
+++ b/src/System.Management.Automation/FormatAndOutput/DefaultFormatters/PowerShellCore_format_ps1xml.cs
@@ -377,7 +377,7 @@ namespace System.Management.Automation.Runspaces
             yield return new FormatViewDefinition("MatchInfo",
                 CustomControl.Create()
                     .StartEntry()
-                        .AddScriptBlockExpressionBinding(@"$_.ToString(((get-location).path))")
+                        .AddScriptBlockExpressionBinding(@"$_.ToEmphasizedString(((get-location).path))")
                     .EndEntry()
                 .EndControl());
         }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-String.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-String.Tests.ps1
@@ -2,8 +2,10 @@
 # Licensed under the MIT License.
 
 Describe "Select-String" -Tags "CI" {
-    $nl = [Environment]::NewLine
-    $currentDirectory = $pwd.Path
+    BeforeAll {
+        $nl = [Environment]::NewLine
+        $currentDirectory = $pwd.Path
+    }
 
     Context "String actions" {
         $testinputone = "hello","Hello","goodbye"
@@ -13,10 +15,10 @@ Describe "Select-String" -Tags "CI" {
             { $testinputone | Select-String -Pattern "hello" } | Should -Not -Throw
         }
 
-            it "Should return an array data type when multiple matches are found" {
-                $result = $testinputtwo | Select-String -Pattern "hello"
+        it "Should return an array data type when multiple matches are found" {
+            $result = $testinputtwo | Select-String -Pattern "hello"
             ,$result | Should -BeOfType "System.Array"
-            }
+        }
 
         it "Should return an object type when one match is found" {
             $result = $testinputtwo | Select-String -Pattern "hello" -CaseSensitive
@@ -245,5 +247,8 @@ Describe "Select-String" -Tags "CI" {
             Select-String second $testInputFile -Raw -Context 2,2 | Should -BeExactly $expected
         }
     }
-    Push-Location $currentDirectory
+
+    AfterAll {
+        Push-Location $currentDirectory
+    }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-String.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-String.Tests.ps1
@@ -1,5 +1,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
+
 Describe "Select-String" -Tags "CI" {
     $nl = [Environment]::NewLine
     $currentDirectory = $pwd.Path
@@ -140,7 +141,7 @@ Describe "Select-String" -Tags "CI" {
 	    New-Item $testInputFile -Itemtype "file" -Force -Value "This is a text string, and another string${nl}This is the second line${nl}This is the third line${nl}This is the fourth line${nl}No matches"
 	}
 
-	AfterEach {
+	AfterEach 
 	    Remove-Item $testInputFile -Force
 	}
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-String.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-String.Tests.ps1
@@ -75,7 +75,7 @@ Describe "Select-String" -Tags "CI" {
 		if ($Host.UI.SupportsVirtualTerminal)
 		{
 			$result = $testinputone | Select-String -Pattern "l" -Emphasize | Out-String
-			$result | Should -Be "`nhe`e[31ml`e[0mlo`nHe`e[31ml`e[0mlo`n`n"
+			$result | Should -Be "`nhe`e[7ml`e[0mlo`nHe`e[7ml`e[0mlo`n`n"
 		}
 		else
 		{
@@ -88,7 +88,7 @@ Describe "Select-String" -Tags "CI" {
 		if ($Host.UI.SupportsVirtualTerminal)
 		{
 			$result = $testinputone | Select-String -Pattern "l" -Emphasize -AllMatch | Out-String
-			$result | Should -Be "`nhe`e[31ml`e[0m`e[31ml`e[0mo`nHe`e[31ml`e[0m`e[31ml`e[0mo`n`n"
+			$result | Should -Be "`nhe`e[7ml`e[0m`e[7ml`e[0mo`nHe`e[7ml`e[0m`e[7ml`e[0mo`n`n"
 		}
 		else
 		{
@@ -101,7 +101,7 @@ Describe "Select-String" -Tags "CI" {
 		if ($Host.UI.SupportsVirtualTerminal)
 		{
 			$result = $testinputone | Select-String -Pattern "l" -Emphasize -SimpleMatch | Out-String
-			$result | Should -Be "`nhe`e[31ml`e[0mlo`nHe`e[31ml`e[0mlo`n`n"
+			$result | Should -Be "`nhe`e[7ml`e[0mlo`nHe`e[7ml`e[0mlo`n`n"
 		}
 		else
 		{

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-String.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-String.Tests.ps1
@@ -72,15 +72,27 @@ Describe "Select-String" -Tags "CI" {
 	}
 
 	it "Should return an array of matching strings with the first match highlighted when Emphasize is used" {
-		$testinputone | Select-String -Pattern "l" -Emphasize | Should -Be "he*l*lo", "he*l*lo"
+		If ($IsWindows) {
+			$testinputone | Select-String -Pattern "l" -Emphasize | Should -Be "he*l*lo", "he*l*lo"
+		} Else {
+			$testinputone | Select-String -Pattern "l" -Emphasize | Should -Be "he[31ml[0mlo", "he[31ml[0mlo"
+		}
 	}
 
 	it "Should return an array of matching strings with all matches highlighted when Emphasize and AllMatch is used" {
-		$testinputone | Select-String -Pattern "l" -Emphasize -AllMatch | Should -Be "he*l**l*o", "he*l**l*o"
+		If ($IsWindows) {
+			$testinputone | Select-String -Pattern "l" -Emphasize | Should -Be "he*l**l*o", "he*l**l*o"
+		} Else {
+			$testinputone | Select-String -Pattern "l" -Emphasize -AllMatch | Should -Be "he[31ml[0m[31ml[0mo", "he[31ml[0m[31ml[0mo"
+		}
 	}
 
 	it "Should return an array of matching strings with the first match highlighted when Emphasize and SimpleMatch is used" {
-		$testinputone | Select-String -Pattern "l" -Emphasize -SimpleMatch | Should -Be "he*l*lo", "he*l*lo"
+		If ($IsWindows) {
+			$testinputone | Select-String -Pattern "l" -Emphasize | Should -Be "he*l*lo", "he*l*lo"
+		} Else {
+			$testinputone | Select-String -Pattern "l" -Emphasize -SimpleMatch | Should -Be "he[31ml[0mlo", "he[31ml[0mlo"
+		}
 	}
 
 	it "Should return the same as NotMatch" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-String.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-String.Tests.ps1
@@ -72,55 +72,52 @@ Describe "Select-String" -Tags "CI" {
 	    $testinputone | Select-String -Pattern "goodbye" -NotMatch | Should -BeExactly "hello", "Hello"
 	}
 
-	it "Should output a string with the first match highlighted when Emphasize is used" {
+	it "Should output a string with the first match highlighted" {
 		if ($Host.UI.SupportsVirtualTerminal)
 		{
-			$result = $testinputone | Select-String -Pattern "l" -Emphasize | Out-String
+			$result = $testinputone | Select-String -Pattern "l" | Out-String
 			$result | Should -Be "`nhe`e[7ml`e[0mlo`nHe`e[7ml`e[0mlo`n`n"
 		}
 		else
 		{
-			$result = $testinputone | Select-String -Pattern "l" -Emphasize -SimpleMatch | Out-String
+			$result = $testinputone | Select-String -Pattern "l" | Out-String
 			$result | Should -Be "`nhello`nHello`n`n"
 		}
 	}
 
-	it "Should output a string with all matches highlighted when Emphasize and AllMatch is used" {
+	it "Should output a string with all matches highlighted when AllMatch is used" {
 		if ($Host.UI.SupportsVirtualTerminal)
 		{
-			$result = $testinputone | Select-String -Pattern "l" -Emphasize -AllMatch | Out-String
+			$result = $testinputone | Select-String -Pattern "l" -AllMatch | Out-String
 			$result | Should -Be "`nhe`e[7ml`e[0m`e[7ml`e[0mo`nHe`e[7ml`e[0m`e[7ml`e[0mo`n`n"
 		}
 		else
 		{
-			$result = $testinputone | Select-String -Pattern "l" -Emphasize -SimpleMatch | Out-String
+			$result = $testinputone | Select-String -Pattern "l" -AllMatch | Out-String
 			$result | Should -Be "`nhello`nHello`n`n"
 		}
 	}
 
-	it "Should output a string with the first match highlighted when Emphasize and SimpleMatch is used" {
+	it "Should output a string with the first match highlighted when SimpleMatch is used" {
 		if ($Host.UI.SupportsVirtualTerminal)
 		{
-			$result = $testinputone | Select-String -Pattern "l" -Emphasize -SimpleMatch | Out-String
+			$result = $testinputone | Select-String -Pattern "l" -SimpleMatch | Out-String
 			$result | Should -Be "`nhe`e[7ml`e[0mlo`nHe`e[7ml`e[0mlo`n`n"
 		}
 		else
 		{
-			$result = $testinputone | Select-String -Pattern "l" -Emphasize -SimpleMatch | Out-String
+			$result = $testinputone | Select-String -Pattern "l" -SimpleMatch | Out-String
 			$result | Should -Be "`nhello`nHello`n`n"
 		}
 	}
 
-	it "Should return an array of matching strings without virtual terminal sequences when Emphasize is used" {
-		$testinputone | Select-String -Pattern "l" -Emphasize | Should -Be "hello", "hello"
+	it "Should output a string without highlighting when NoEmphasis is used" {
+		$result = $testinputone | Select-String -Pattern "l" -NoEmphasis | Out-String
+		$result | Should -Be "`nhello`nHello`n`n"
 	}
 
-	it "Should return the same as NotMatch" {
-	    $firstMatch = $testinputone | Select-String -pattern "goodbye" -NotMatch
-	    $secondMatch = $testinputone | Select-String -pattern "goodbye" -n
-
-	    $equal = @(Compare-Object $firstMatch $secondMatch).Length -eq 0
-	    $equal | Should -BeTrue
+	it "Should return an array of matching strings without virtual terminal sequences" {
+		$testinputone | Select-String -Pattern "l" | Should -Be "hello", "hello"
 	}
 
 	It "Should return a string type when -Raw is used" {
@@ -130,7 +127,6 @@ Describe "Select-String" -Tags "CI" {
 
 	It "Should return ParameterBindingException when -Raw and -Quiet are used together" {
 		{ $testinputone | Select-String -Pattern "hello" -Raw -Quiet -ErrorAction Stop } | Should -Throw -ExceptionType ([System.Management.Automation.ParameterBindingException])
-	}
     }
 
     Context "Filesystem actions" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-String.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-String.Tests.ps1
@@ -4,245 +4,246 @@
 Describe "Select-String" -Tags "CI" {
     $nl = [Environment]::NewLine
     $currentDirectory = $pwd.Path
+
     Context "String actions" {
-	$testinputone = "hello","Hello","goodbye"
-	$testinputtwo = "hello","Hello"
+        $testinputone = "hello","Hello","goodbye"
+        $testinputtwo = "hello","Hello"
 
-	it "Should be called without errors" {
-	    { $testinputone | Select-String -Pattern "hello" } | Should -Not -Throw
-	}
-
-        it "Should return an array data type when multiple matches are found" {
-            $result = $testinputtwo | Select-String -Pattern "hello"
-           ,$result | Should -BeOfType "System.Array"
+        it "Should be called without errors" {
+            { $testinputone | Select-String -Pattern "hello" } | Should -Not -Throw
         }
 
-    it "Should return an object type when one match is found" {
-        $result = $testinputtwo | Select-String -Pattern "hello" -CaseSensitive
-        ,$result | Should -BeOfType "System.Object"
-    }
+            it "Should return an array data type when multiple matches are found" {
+                $result = $testinputtwo | Select-String -Pattern "hello"
+            ,$result | Should -BeOfType "System.Array"
+            }
 
-    it "Should return matchinfo type" {
-        $result = $testinputtwo | Select-String -Pattern "hello" -CaseSensitive
-        ,$result | Should -BeOfType "Microsoft.PowerShell.Commands.MatchInfo"
-    }
+        it "Should return an object type when one match is found" {
+            $result = $testinputtwo | Select-String -Pattern "hello" -CaseSensitive
+            ,$result | Should -BeOfType "System.Object"
+        }
 
-	it "Should be called without an error using ca for casesensitive " {
-	    {$testinputone | Select-String -Pattern "hello" -ca } | Should -Not -Throw
-	}
+        it "Should return matchinfo type" {
+            $result = $testinputtwo | Select-String -Pattern "hello" -CaseSensitive
+            ,$result | Should -BeOfType "Microsoft.PowerShell.Commands.MatchInfo"
+        }
 
-	it "Should use the ca alias for casesensitive" {
-	    $firstMatch = $testinputtwo  | Select-String -Pattern "hello" -CaseSensitive
-	    $secondMatch = $testinputtwo | Select-String -Pattern "hello" -ca
+        it "Should be called without an error using ca for casesensitive " {
+            {$testinputone | Select-String -Pattern "hello" -ca } | Should -Not -Throw
+        }
 
-	    $equal = @(Compare-Object $firstMatch $secondMatch).Length -eq 0
-	    $equal | Should -Be True
-	}
+        it "Should use the ca alias for casesensitive" {
+            $firstMatch = $testinputtwo  | Select-String -Pattern "hello" -CaseSensitive
+            $secondMatch = $testinputtwo | Select-String -Pattern "hello" -ca
 
-	it "Should only return the case sensitive match when the casesensitive switch is used" {
-	    $testinputtwo | Select-String -Pattern "hello" -CaseSensitive | Should -Be "hello"
-	}
+            $equal = @(Compare-Object $firstMatch $secondMatch).Length -eq 0
+            $equal | Should -Be True
+        }
 
-	it "Should accept a collection of strings from the input object" {
-	    { Select-String -InputObject "some stuff", "other stuff" -Pattern "other" } | Should -Not -Throw
-	}
+        it "Should only return the case sensitive match when the casesensitive switch is used" {
+            $testinputtwo | Select-String -Pattern "hello" -CaseSensitive | Should -Be "hello"
+        }
 
-    it "Should return system.object when the input object switch is used on a collection" {
-        $result = Select-String -InputObject "some stuff", "other stuff" -pattern "other"
-        ,$result | Should -BeOfType "System.Object"
-    }
+        it "Should accept a collection of strings from the input object" {
+            { Select-String -InputObject "some stuff", "other stuff" -Pattern "other" } | Should -Not -Throw
+        }
 
-	it "Should return null or empty when the input object switch is used on a collection and the pattern does not exist" {
-	    Select-String -InputObject "some stuff", "other stuff" -Pattern "neither" | Should -BeNullOrEmpty
-	}
+        it "Should return system.object when the input object switch is used on a collection" {
+            $result = Select-String -InputObject "some stuff", "other stuff" -pattern "other"
+            ,$result | Should -BeOfType "System.Object"
+        }
 
-    it "Should return a bool type when the quiet switch is used" {
-        ,($testinputtwo | Select-String -Quiet "hello" -CaseSensitive) | Should -BeOfType "System.Boolean"
-    }
+        it "Should return null or empty when the input object switch is used on a collection and the pattern does not exist" {
+            Select-String -InputObject "some stuff", "other stuff" -Pattern "neither" | Should -BeNullOrEmpty
+        }
 
-	it "Should be true when select string returns a positive result when the quiet switch is used" {
-	    ($testinputtwo | Select-String -Quiet "hello" -CaseSensitive) | Should -BeTrue
-	}
+        it "Should return a bool type when the quiet switch is used" {
+            ,($testinputtwo | Select-String -Quiet "hello" -CaseSensitive) | Should -BeOfType "System.Boolean"
+        }
 
-	it "Should be empty when select string does not return a result when the quiet switch is used" {
-	    $testinputtwo | Select-String -Quiet "goodbye"  | Should -BeNullOrEmpty
-	}
+        it "Should be true when select string returns a positive result when the quiet switch is used" {
+            ($testinputtwo | Select-String -Quiet "hello" -CaseSensitive) | Should -BeTrue
+        }
 
-	it "Should return an array of non matching strings when the switch of NotMatch is used and the string do not match" {
-	    $testinputone | Select-String -Pattern "goodbye" -NotMatch | Should -BeExactly "hello", "Hello"
-	}
+        it "Should be empty when select string does not return a result when the quiet switch is used" {
+            $testinputtwo | Select-String -Quiet "goodbye"  | Should -BeNullOrEmpty
+        }
 
-	it "Should output a string with the first match highlighted" {
-		if ($Host.UI.SupportsVirtualTerminal)
-		{
-			$result = $testinputone | Select-String -Pattern "l" | Out-String
-			$result | Should -Be "`nhe`e[7ml`e[0mlo`nHe`e[7ml`e[0mlo`n`n"
-		}
-		else
-		{
-			$result = $testinputone | Select-String -Pattern "l" | Out-String
-			$result | Should -Be "`nhello`nHello`n`n"
-		}
-	}
+        it "Should return an array of non matching strings when the switch of NotMatch is used and the string do not match" {
+            $testinputone | Select-String -Pattern "goodbye" -NotMatch | Should -BeExactly "hello", "Hello"
+        }
 
-	it "Should output a string with all matches highlighted when AllMatch is used" {
-		if ($Host.UI.SupportsVirtualTerminal)
-		{
-			$result = $testinputone | Select-String -Pattern "l" -AllMatch | Out-String
-			$result | Should -Be "`nhe`e[7ml`e[0m`e[7ml`e[0mo`nHe`e[7ml`e[0m`e[7ml`e[0mo`n`n"
-		}
-		else
-		{
-			$result = $testinputone | Select-String -Pattern "l" -AllMatch | Out-String
-			$result | Should -Be "`nhello`nHello`n`n"
-		}
-	}
+        it "Should output a string with the first match highlighted" {
+            if ($Host.UI.SupportsVirtualTerminal)
+            {
+                $result = $testinputone | Select-String -Pattern "l" | Out-String
+                $result | Should -Be "`nhe`e[7ml`e[0mlo`nHe`e[7ml`e[0mlo`n`n"
+            }
+            else
+            {
+                $result = $testinputone | Select-String -Pattern "l" | Out-String
+                $result | Should -Be "`nhello`nHello`n`n"
+            }
+        }
 
-	it "Should output a string with the first match highlighted when SimpleMatch is used" {
-		if ($Host.UI.SupportsVirtualTerminal)
-		{
-			$result = $testinputone | Select-String -Pattern "l" -SimpleMatch | Out-String
-			$result | Should -Be "`nhe`e[7ml`e[0mlo`nHe`e[7ml`e[0mlo`n`n"
-		}
-		else
-		{
-			$result = $testinputone | Select-String -Pattern "l" -SimpleMatch | Out-String
-			$result | Should -Be "`nhello`nHello`n`n"
-		}
-	}
+        it "Should output a string with all matches highlighted when AllMatch is used" {
+            if ($Host.UI.SupportsVirtualTerminal)
+            {
+                $result = $testinputone | Select-String -Pattern "l" -AllMatch | Out-String
+                $result | Should -Be "`nhe`e[7ml`e[0m`e[7ml`e[0mo`nHe`e[7ml`e[0m`e[7ml`e[0mo`n`n"
+            }
+            else
+            {
+                $result = $testinputone | Select-String -Pattern "l" -AllMatch | Out-String
+                $result | Should -Be "`nhello`nHello`n`n"
+            }
+        }
 
-	it "Should output a string without highlighting when NoEmphasis is used" {
-		$result = $testinputone | Select-String -Pattern "l" -NoEmphasis | Out-String
-		$result | Should -Be "`nhello`nHello`n`n"
-	}
+        it "Should output a string with the first match highlighted when SimpleMatch is used" {
+            if ($Host.UI.SupportsVirtualTerminal)
+            {
+                $result = $testinputone | Select-String -Pattern "l" -SimpleMatch | Out-String
+                $result | Should -Be "`nhe`e[7ml`e[0mlo`nHe`e[7ml`e[0mlo`n`n"
+            }
+            else
+            {
+                $result = $testinputone | Select-String -Pattern "l" -SimpleMatch | Out-String
+                $result | Should -Be "`nhello`nHello`n`n"
+            }
+        }
 
-	it "Should return an array of matching strings without virtual terminal sequences" {
-		$testinputone | Select-String -Pattern "l" | Should -Be "hello", "hello"
-	}
+        it "Should output a string without highlighting when NoEmphasis is used" {
+            $result = $testinputone | Select-String -Pattern "l" -NoEmphasis | Out-String
+            $result | Should -Be "`nhello`nHello`n`n"
+        }
 
-	It "Should return a string type when -Raw is used" {
-		$result = $testinputtwo | Select-String -Pattern "hello" -CaseSensitive -Raw
-		$result | Should -BeOfType "System.String"
-	}
+        it "Should return an array of matching strings without virtual terminal sequences" {
+            $testinputone | Select-String -Pattern "l" | Should -Be "hello", "hello"
+        }
 
-	It "Should return ParameterBindingException when -Raw and -Quiet are used together" {
-		{ $testinputone | Select-String -Pattern "hello" -Raw -Quiet -ErrorAction Stop } | Should -Throw -ExceptionType ([System.Management.Automation.ParameterBindingException])
-	}
+        It "Should return a string type when -Raw is used" {
+            $result = $testinputtwo | Select-String -Pattern "hello" -CaseSensitive -Raw
+            $result | Should -BeOfType "System.String"
+        }
+
+        It "Should return ParameterBindingException when -Raw and -Quiet are used together" {
+            { $testinputone | Select-String -Pattern "hello" -Raw -Quiet -ErrorAction Stop } | Should -Throw -ExceptionType ([System.Management.Automation.ParameterBindingException])
+        }
     }
 
     Context "Filesystem actions" {
-	$testDirectory = $TestDrive
-	$testInputFile = Join-Path -Path $testDirectory -ChildPath testfile1.txt
+        $testDirectory = $TestDrive
+        $testInputFile = Join-Path -Path $testDirectory -ChildPath testfile1.txt
 
-	BeforeEach {
-	    New-Item $testInputFile -Itemtype "file" -Force -Value "This is a text string, and another string${nl}This is the second line${nl}This is the third line${nl}This is the fourth line${nl}No matches"
-	}
+        BeforeEach {
+            New-Item $testInputFile -Itemtype "file" -Force -Value "This is a text string, and another string${nl}This is the second line${nl}This is the third line${nl}This is the fourth line${nl}No matches"
+        }
 
-	AfterEach {
-	    Remove-Item $testInputFile -Force
-	}
+        AfterEach {
+            Remove-Item $testInputFile -Force
+        }
 
-    It "Should return an object when a match is found is the file on only one line" {
-        $result = Select-String $testInputFile -Pattern "string"
-        ,$result | Should -BeOfType "System.Object"
-    }
+        It "Should return an object when a match is found is the file on only one line" {
+            $result = Select-String $testInputFile -Pattern "string"
+            ,$result | Should -BeOfType "System.Object"
+        }
 
-    It "Should return an array when a match is found is the file on several lines" {
-        $result = Select-String $testInputFile -Pattern "in"
-        ,$result | Should -BeOfType "System.Array"
-        $result[0] | Should -BeOfType "Microsoft.PowerShell.Commands.MatchInfo"
-    }
+        It "Should return an array when a match is found is the file on several lines" {
+            $result = Select-String $testInputFile -Pattern "in"
+            ,$result | Should -BeOfType "System.Array"
+            $result[0] | Should -BeOfType "Microsoft.PowerShell.Commands.MatchInfo"
+        }
 
-	It "Should return the name of the file and the string that 'string' is found if there is only one lines that has a match" {
-	    $expected = $testInputFile + ":1:This is a text string, and another string"
+        It "Should return the name of the file and the string that 'string' is found if there is only one lines that has a match" {
+            $expected = $testInputFile + ":1:This is a text string, and another string"
 
-	    Select-String $testInputFile -Pattern "string" | Should -BeExactly $expected
-	}
+            Select-String $testInputFile -Pattern "string" | Should -BeExactly $expected
+        }
 
-	It "Should return all strings where 'second' is found in testfile1 if there is only one lines that has a match" {
-	    $expected = $testInputFile + ":2:This is the second line"
+        It "Should return all strings where 'second' is found in testfile1 if there is only one lines that has a match" {
+            $expected = $testInputFile + ":2:This is the second line"
 
-	    Select-String $testInputFile  -Pattern "second"| Should -BeExactly $expected
-	}
+            Select-String $testInputFile  -Pattern "second"| Should -BeExactly $expected
+        }
 
-	It "Should return all strings where 'in' is found in testfile1 pattern switch is not required" {
-	    $expected1 = "This is a text string, and another string"
-	    $expected2 = "This is the second line"
-	    $expected3 = "This is the third line"
-	    $expected4 = "This is the fourth line"
+        It "Should return all strings where 'in' is found in testfile1 pattern switch is not required" {
+            $expected1 = "This is a text string, and another string"
+            $expected2 = "This is the second line"
+            $expected3 = "This is the third line"
+            $expected4 = "This is the fourth line"
 
-	    (Select-String in $testInputFile)[0].Line | Should -BeExactly $expected1
-	    (Select-String in $testInputFile)[1].Line | Should -BeExactly $expected2
-	    (Select-String in $testInputFile)[2].Line | Should -BeExactly $expected3
-	    (Select-String in $testInputFile)[3].Line | Should -BeExactly $expected4
-	    (Select-String in $testInputFile)[4].Line | Should -BeNullOrEmpty
-	}
+            (Select-String in $testInputFile)[0].Line | Should -BeExactly $expected1
+            (Select-String in $testInputFile)[1].Line | Should -BeExactly $expected2
+            (Select-String in $testInputFile)[2].Line | Should -BeExactly $expected3
+            (Select-String in $testInputFile)[3].Line | Should -BeExactly $expected4
+            (Select-String in $testInputFile)[4].Line | Should -BeNullOrEmpty
+        }
 
-	It "Should return empty because 'for' is not found in testfile1 " {
-	    Select-String for $testInputFile | Should -BeNullOrEmpty
-	}
+        It "Should return empty because 'for' is not found in testfile1 " {
+            Select-String for $testInputFile | Should -BeNullOrEmpty
+        }
 
-	It "Should return the third line in testfile1 and the lines above and below it " {
-	    $expectedLine       = "testfile1.txt:2:This is the second line"
-	    $expectedLineBefore = "testfile1.txt:3:This is the third line"
-	    $expectedLineAfter  = "testfile1.txt:4:This is the fourth line"
+        It "Should return the third line in testfile1 and the lines above and below it " {
+            $expectedLine       = "testfile1.txt:2:This is the second line"
+            $expectedLineBefore = "testfile1.txt:3:This is the third line"
+            $expectedLineAfter  = "testfile1.txt:4:This is the fourth line"
 
-	    Select-String third $testInputFile -Context 1 | Should -Match $expectedLine
-	    Select-String third $testInputFile -Context 1 | Should -Match $expectedLineBefore
-	    Select-String third $testInputFile -Context 1 | Should -Match $expectedLineAfter
-	}
+            Select-String third $testInputFile -Context 1 | Should -Match $expectedLine
+            Select-String third $testInputFile -Context 1 | Should -Match $expectedLineBefore
+            Select-String third $testInputFile -Context 1 | Should -Match $expectedLineAfter
+        }
 
-	It "Should return the number of matches for 'is' in textfile1 " {
-	    (Select-String is $testInputFile -CaseSensitive).count| Should -Be 4
-	}
+        It "Should return the number of matches for 'is' in textfile1 " {
+            (Select-String is $testInputFile -CaseSensitive).count| Should -Be 4
+        }
 
-	It "Should return the third line in testfile1 when a relative path is used" {
-	    $expected  = "testfile1.txt:3:This is the third line"
+        It "Should return the third line in testfile1 when a relative path is used" {
+            $expected  = "testfile1.txt:3:This is the third line"
 
-	    $relativePath = Join-Path -Path $testDirectory -ChildPath ".."
-	    $relativePath = Join-Path -Path $relativePath -ChildPath $TestDirectory.Name
-	    $relativePath = Join-Path -Path $relativePath -ChildPath testfile1.txt
-	    Select-String third $relativePath  | Should -Match $expected
-	}
+            $relativePath = Join-Path -Path $testDirectory -ChildPath ".."
+            $relativePath = Join-Path -Path $relativePath -ChildPath $TestDirectory.Name
+            $relativePath = Join-Path -Path $relativePath -ChildPath testfile1.txt
+            Select-String third $relativePath  | Should -Match $expected
+        }
 
-	It "Should return the fourth line in testfile1 when a relative path is used" {
-	    $expected = "testfile1.txt:5:No matches"
+        It "Should return the fourth line in testfile1 when a relative path is used" {
+            $expected = "testfile1.txt:5:No matches"
 
-	    Push-Location $testDirectory
+            Push-Location $testDirectory
 
-	    Select-String matches (Join-Path -Path $testDirectory -ChildPath testfile1.txt)  | Should -Match $expected
-	    Pop-Location
-	}
+            Select-String matches (Join-Path -Path $testDirectory -ChildPath testfile1.txt)  | Should -Match $expected
+            Pop-Location
+        }
 
-	It "Should return the fourth line in testfile1 when a regular expression is used" {
-	    $expected  = "testfile1.txt:5:No matches"
+        It "Should return the fourth line in testfile1 when a regular expression is used" {
+            $expected  = "testfile1.txt:5:No matches"
 
-	    Select-String 'matc*' $testInputFile -CaseSensitive | Should -Match $expected
-	}
+            Select-String 'matc*' $testInputFile -CaseSensitive | Should -Match $expected
+        }
 
-	It "Should return the fourth line in testfile1 when a regular expression is used, using the alias for casesensitive" {
-	    $expected  = "testfile1.txt:5:No matches"
+        It "Should return the fourth line in testfile1 when a regular expression is used, using the alias for casesensitive" {
+            $expected  = "testfile1.txt:5:No matches"
 
-	    Select-String 'matc*' $testInputFile -ca | Should -Match $expected
-	}
+            Select-String 'matc*' $testInputFile -ca | Should -Match $expected
+        }
 
-	It "Should return all strings where 'in' is found in testfile1, when -Raw is used." {
-	    $expected1 = "This is a text string, and another string"
-	    $expected2 = "This is the second line"
-	    $expected3 = "This is the third line"
-	    $expected4 = "This is the fourth line"
+        It "Should return all strings where 'in' is found in testfile1, when -Raw is used." {
+            $expected1 = "This is a text string, and another string"
+            $expected2 = "This is the second line"
+            $expected3 = "This is the third line"
+            $expected4 = "This is the fourth line"
 
-	    (Select-String in $testInputFile -Raw)[0] | Should -BeExactly $expected1
-	    (Select-String in $testInputFile -Raw)[1] | Should -BeExactly $expected2
-	    (Select-String in $testInputFile -Raw)[2] | Should -BeExactly $expected3
-	    (Select-String in $testInputFile -Raw)[3] | Should -BeExactly $expected4
-	    (Select-String in $testInputFile -Raw)[4] | Should -BeNullOrEmpty
-	}
+            (Select-String in $testInputFile -Raw)[0] | Should -BeExactly $expected1
+            (Select-String in $testInputFile -Raw)[1] | Should -BeExactly $expected2
+            (Select-String in $testInputFile -Raw)[2] | Should -BeExactly $expected3
+            (Select-String in $testInputFile -Raw)[3] | Should -BeExactly $expected4
+            (Select-String in $testInputFile -Raw)[4] | Should -BeNullOrEmpty
+        }
 
-	It "Should ignore -Context parameter when -Raw is used." {
-		$expected = "This is the second line"
-		Select-String second $testInputFile -Raw -Context 2,2 | Should -BeExactly $expected
-	}
+        It "Should ignore -Context parameter when -Raw is used." {
+            $expected = "This is the second line"
+            Select-String second $testInputFile -Raw -Context 2,2 | Should -BeExactly $expected
+        }
     }
     Push-Location $currentDirectory
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-String.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-String.Tests.ps1
@@ -80,7 +80,7 @@ Describe "Select-String" -Tags "CI" {
 		else
 		{
 			$result = $testinputone | Select-String -Pattern "l" -Emphasize -SimpleMatch | Out-String
-			$result | Should -Be "`nhe*l*lo`nHe*l*lo`n`n"
+			$result | Should -Be "`nhello`nHello`n`n"
 		}
 	}
 
@@ -93,7 +93,7 @@ Describe "Select-String" -Tags "CI" {
 		else
 		{
 			$result = $testinputone | Select-String -Pattern "l" -Emphasize -SimpleMatch | Out-String
-			$result | Should -Be "`nhe*l**l*o`nHe*l**l*o`n`n"
+			$result | Should -Be "`nhello`nHello`n`n"
 		}
 	}
 
@@ -106,7 +106,7 @@ Describe "Select-String" -Tags "CI" {
 		else
 		{
 			$result = $testinputone | Select-String -Pattern "l" -Emphasize -SimpleMatch | Out-String
-			$result | Should -Be "`nhe*l*lo`nHe*l*lo`n`n"
+			$result | Should -Be "`nhello`nHello`n`n"
 		}
 	}
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-String.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-String.Tests.ps1
@@ -71,16 +71,16 @@ Describe "Select-String" -Tags "CI" {
 	    $testinputone | Select-String -Pattern "goodbye" -NotMatch | Should -BeExactly "hello", "Hello"
 	}
 
-	it "Should return an array of matching strings with the first match highlighted when Color is used" {
-		$testinputone | Select-String -Pattern "l" -Color | Should -Be "he*l*lo", "he*l*lo"
+	it "Should return an array of matching strings with the first match highlighted when Emphasize is used" {
+		$testinputone | Select-String -Pattern "l" -Emphasize | Should -Be "he*l*lo", "he*l*lo"
 	}
 
-	it "Should return an array of matching strings with all matches highlighted when Color and AllMatch is used" {
-		$testinputone | Select-String -Pattern "l" -Color -AllMatch | Should -Be "he*l**l*o", "he*l**l*o"
+	it "Should return an array of matching strings with all matches highlighted when Emphasize and AllMatch is used" {
+		$testinputone | Select-String -Pattern "l" -Emphasize -AllMatch | Should -Be "he*l**l*o", "he*l**l*o"
 	}
 
-	it "Should return an array of matching strings with the first match highlighted when Color and SimpleMatch is used" {
-		$testinputone | Select-String -Pattern "l" -Color -SimpleMatch | Should -Be "he*l*lo", "he*l*lo"
+	it "Should return an array of matching strings with the first match highlighted when Emphasize and SimpleMatch is used" {
+		$testinputone | Select-String -Pattern "l" -Emphasize -SimpleMatch | Should -Be "he*l*lo", "he*l*lo"
 	}
 
 	it "Should return the same as NotMatch" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-String.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-String.Tests.ps1
@@ -71,6 +71,18 @@ Describe "Select-String" -Tags "CI" {
 	    $testinputone | Select-String -Pattern "goodbye" -NotMatch | Should -BeExactly "hello", "Hello"
 	}
 
+	it "Should return an array of matching strings with the first match highlighted when Color is used" {
+		$testinputone | Select-String -Pattern "l" -Color | Should -Be "he*l*lo", "he*l*lo"
+	}
+
+	it "Should return an array of matching strings with all matches highlighted when Color and AllMatch is used" {
+		$testinputone | Select-String -Pattern "l" -Color -AllMatch | Should -Be "he*l**l*o", "he*l**l*o"
+	}
+
+	it "Should return an array of matching strings with the first match highlighted when Color and SimpleMatch is used" {
+		$testinputone | Select-String -Pattern "l" -Color -SimpleMatch | Should -Be "he*l*lo", "he*l*lo"
+	}
+
 	it "Should return the same as NotMatch" {
 	    $firstMatch = $testinputone | Select-String -pattern "goodbye" -NotMatch
 	    $secondMatch = $testinputone | Select-String -pattern "goodbye" -n

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-String.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-String.Tests.ps1
@@ -127,7 +127,7 @@ Describe "Select-String" -Tags "CI" {
 
 	It "Should return ParameterBindingException when -Raw and -Quiet are used together" {
 		{ $testinputone | Select-String -Pattern "hello" -Raw -Quiet -ErrorAction Stop } | Should -Throw -ExceptionType ([System.Management.Automation.ParameterBindingException])
-        }
+	}
     }
 
     Context "Filesystem actions" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-String.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-String.Tests.ps1
@@ -141,7 +141,7 @@ Describe "Select-String" -Tags "CI" {
 	    New-Item $testInputFile -Itemtype "file" -Force -Value "This is a text string, and another string${nl}This is the second line${nl}This is the third line${nl}This is the fourth line${nl}No matches"
 	}
 
-	AfterEach 
+	AfterEach {
 	    Remove-Item $testInputFile -Force
 	}
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-String.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-String.Tests.ps1
@@ -72,9 +72,12 @@ Describe "Select-String" -Tags "CI" {
 	}
 
 	it "Should return an array of matching strings with the first match highlighted when Emphasize is used" {
-		If ($IsWindows) {
+		if ($IsWindows)
+		{
 			$testinputone | Select-String -Pattern "l" -Emphasize | Should -Be "he*l*lo", "he*l*lo"
-		} Else {
+		}
+		else
+		{
 			$testinputone | Select-String -Pattern "l" -Emphasize | Should -Be "he[31ml[0mlo", "he[31ml[0mlo"
 		}
 	}

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-String.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-String.Tests.ps1
@@ -71,31 +71,47 @@ Describe "Select-String" -Tags "CI" {
 	    $testinputone | Select-String -Pattern "goodbye" -NotMatch | Should -BeExactly "hello", "Hello"
 	}
 
-	it "Should return an array of matching strings with the first match highlighted when Emphasize is used" {
-		if ($IsWindows)
+	it "Should output a string with the first match highlighted when Emphasize is used" {
+		if ($Host.UI.SupportsVirtualTerminal)
 		{
-			$testinputone | Select-String -Pattern "l" -Emphasize | Should -Be "he*l*lo", "he*l*lo"
+			$result = $testinputone | Select-String -Pattern "l" -Emphasize | Out-String
+			$result | Should -Be "`nhe`e[31ml`e[0mlo`nHe`e[31ml`e[0mlo`n`n"
 		}
 		else
 		{
-			$testinputone | Select-String -Pattern "l" -Emphasize | Should -Be "he[31ml[0mlo", "he[31ml[0mlo"
+			$result = $testinputone | Select-String -Pattern "l" -Emphasize -SimpleMatch | Out-String
+			$result | Should -Be "`nhe*l*lo`nHe*l*lo`n`n"
 		}
 	}
 
-	it "Should return an array of matching strings with all matches highlighted when Emphasize and AllMatch is used" {
-		if ($IsWindows) {
-			$testinputone | Select-String -Pattern "l" -Emphasize | Should -Be "he*l**l*o", "he*l**l*o"
-		} else {
-			$testinputone | Select-String -Pattern "l" -Emphasize -AllMatch | Should -Be "he[31ml[0m[31ml[0mo", "he[31ml[0m[31ml[0mo"
+	it "Should output a string with all matches highlighted when Emphasize and AllMatch is used" {
+		if ($Host.UI.SupportsVirtualTerminal)
+		{
+			$result = $testinputone | Select-String -Pattern "l" -Emphasize -AllMatch | Out-String
+			$result | Should -Be "`nhe`e[31ml`e[0m`e[31ml`e[0mo`nHe`e[31ml`e[0m`e[31ml`e[0mo`n`n"
+		}
+		else
+		{
+			$result = $testinputone | Select-String -Pattern "l" -Emphasize -SimpleMatch | Out-String
+			$result | Should -Be "`nhe*l**l*o`nHe*l**l*o`n`n"
 		}
 	}
 
-	it "Should return an array of matching strings with the first match highlighted when Emphasize and SimpleMatch is used" {
-		if ($IsWindows) {
-			$testinputone | Select-String -Pattern "l" -Emphasize | Should -Be "he*l*lo", "he*l*lo"
-		} else {
-			$testinputone | Select-String -Pattern "l" -Emphasize -SimpleMatch | Should -Be "he[31ml[0mlo", "he[31ml[0mlo"
+	it "Should output a string with the first match highlighted when Emphasize and SimpleMatch is used" {
+		if ($Host.UI.SupportsVirtualTerminal)
+		{
+			$result = $testinputone | Select-String -Pattern "l" -Emphasize -SimpleMatch | Out-String
+			$result | Should -Be "`nhe`e[31ml`e[0mlo`nHe`e[31ml`e[0mlo`n`n"
 		}
+		else
+		{
+			$result = $testinputone | Select-String -Pattern "l" -Emphasize -SimpleMatch | Out-String
+			$result | Should -Be "`nhe*l*lo`nHe*l*lo`n`n"
+		}
+	}
+
+	it "Should return an array of matching strings without virtual terminal sequences when Emphasize is used" {
+		$testinputone | Select-String -Pattern "l" -Emphasize | Should -Be "hello", "hello"
 	}
 
 	it "Should return the same as NotMatch" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-String.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-String.Tests.ps1
@@ -127,6 +127,7 @@ Describe "Select-String" -Tags "CI" {
 
 	It "Should return ParameterBindingException when -Raw and -Quiet are used together" {
 		{ $testinputone | Select-String -Pattern "hello" -Raw -Quiet -ErrorAction Stop } | Should -Throw -ExceptionType ([System.Management.Automation.ParameterBindingException])
+        }
     }
 
     Context "Filesystem actions" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-String.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Select-String.Tests.ps1
@@ -83,17 +83,17 @@ Describe "Select-String" -Tags "CI" {
 	}
 
 	it "Should return an array of matching strings with all matches highlighted when Emphasize and AllMatch is used" {
-		If ($IsWindows) {
+		if ($IsWindows) {
 			$testinputone | Select-String -Pattern "l" -Emphasize | Should -Be "he*l**l*o", "he*l**l*o"
-		} Else {
+		} else {
 			$testinputone | Select-String -Pattern "l" -Emphasize -AllMatch | Should -Be "he[31ml[0m[31ml[0mo", "he[31ml[0m[31ml[0mo"
 		}
 	}
 
 	it "Should return an array of matching strings with the first match highlighted when Emphasize and SimpleMatch is used" {
-		If ($IsWindows) {
+		if ($IsWindows) {
 			$testinputone | Select-String -Pattern "l" -Emphasize | Should -Be "he*l*lo", "he*l*lo"
-		} Else {
+		} else {
 			$testinputone | Select-String -Pattern "l" -Emphasize -SimpleMatch | Should -Be "he[31ml[0mlo", "he[31ml[0mlo"
 		}
 	}


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
Adds the -Emphasize parameter for Select-String and makes it work with -AllMatches and -SimpleMatch.
The -Emphasize parameter highlights the matched text using the negative escape sequence. Issue #2905.
Started at HackIllinois.
<!-- Summarize your PR between here and the checklist. -->

## PR Context
Makes it easier to distinguish what users are looking for when using the Select-String cmdlet. Helps resolve issue #2905.

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: https://github.com/MicrosoftDocs/PowerShell-Docs/issues/4479
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [x] [Add `[feature]` to your commit messages if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
