### PR TITLE
Adds an OnlyMatching parameter to Select-String to return only the string that matches the pattern

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
@@ -1314,7 +1314,7 @@ namespace Microsoft.PowerShell.Commands
                     Match match = regexValue.Match(line);
                     if (match.Success) 
                     {
-                        WriteObject(match.Value);
+                        WriteObject(match.Value, true);
                         break;
                     } 
                 }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
@@ -1049,6 +1049,12 @@ namespace Microsoft.PowerShell.Commands
         public SwitchParameter List { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating if the search contains the specified characters.
+        /// </summary>
+        [Parameter]
+        public SwitchParameter OnlyMatching { get; set; }
+
+        /// <summary>
         /// Gets or sets files to include. Files matching
         /// one of these (if specified) are included.
         /// </summary>
@@ -1274,6 +1280,43 @@ namespace Microsoft.PowerShell.Commands
                 {
                     var res = List ? null : Boxed.False;
                     WriteObject(res);
+                }
+            }
+            else if (OnlyMatching)
+            {
+                string line;
+                if (_inputObject.BaseObject is MatchInfo matchInfo)
+                {
+                    line = matchInfo.Line;
+                }
+                else 
+                {
+                    line = LanguagePrimitives.ConvertTo<string>(_inputObject.BaseObject);
+                }
+                
+                foreach (Regex regexValue in _regexPattern)
+                {
+                    if (AllMatches)
+                    {
+                        MatchCollection mc = regexValue.Matches(line);
+                        if (mc.Count <= 0)
+                        {
+                            continue;
+                        }
+
+                        foreach (Match matchObject in mc)
+                        {
+                            WriteObject(matchObject.Value);
+                        }
+                        break;
+                    }
+
+                    Match match = regexValue.Match(line);
+                    if (match.Success) 
+                    {
+                        WriteObject(match.Value);
+                        break;
+                    } 
                 }
             }
             else

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
@@ -1306,7 +1306,7 @@ namespace Microsoft.PowerShell.Commands
 
                         foreach (Match matchObject in mc)
                         {
-                            WriteObject(matchObject.Value);
+                            WriteObject(matchObject.Value, true);
                         }
                         break;
                     }

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/MatchString.cs
@@ -1049,7 +1049,7 @@ namespace Microsoft.PowerShell.Commands
         public SwitchParameter List { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating if the search contains the specified characters.
+        /// Gets or sets a value that when true, causes only the matching part of the string to be returned.
         /// </summary>
         [Parameter]
         public SwitchParameter OnlyMatching { get; set; }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->
Part of HackIllinois with @TylerLeonhardt and @rjmholt 
Added an OnlyMatching parameter to Select-String with similar behavior to grep -o. Also made OnlyMatching parameter to work with AllMatches.


## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
Resolves https://github.com/PowerShell/PowerShell/issues/7712.

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [X] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [X] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [X] [Add `[feature]` to your commit messages if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
