### PR TITLE
Join-Path: Add -SkipValidation for -Resolve

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/CombinePathCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/CombinePathCommand.cs
@@ -131,47 +131,12 @@ namespace Microsoft.PowerShell.Commands
 
                 if (Resolve.IsPresent)
                 {
-
-                    if (SkipValidation.IsPresent)
-                    {
-                        try
-                        {
-                            WriteObject(
-                                SessionState.Path.GetUnresolvedProviderPathFromPSPath(
-                                    joinedPath, CmdletProviderContext, out _, out _));
-                            return;
-                        }
-                        catch (PSNotSupportedException notSupported)
-                        {
-                            WriteError(
-                                new ErrorRecord(
-                                    notSupported.ErrorRecord,
-                                    notSupported));
-                            return;
-                        }
-                        catch (DriveNotFoundException driveNotFound)
-                        {
-                            WriteError(
-                                new ErrorRecord(
-                                    driveNotFound.ErrorRecord,
-                                    driveNotFound));
-                            return;
-                        }
-                        catch (ProviderNotFoundException providerNotFound)
-                        {
-                            WriteError(
-                                new ErrorRecord(
-                                    providerNotFound.ErrorRecord,
-                                    providerNotFound));
-                            return;
-                        }
-                    }
-
                     // Resolve the paths.
                     Collection<PathInfo> resolvedPaths = null;
                     try
                     {
-                        resolvedPaths = SessionState.Path.GetResolvedPSPathFromPSPath(joinedPath, CmdletProviderContext);
+                        resolvedPaths = SessionState.Path.GetResolvedPSPathFromPSPath(
+                            joinedPath, CmdletProviderContext, SkipValidation.IsPresent);
                     }
                     catch (PSNotSupportedException notSupported)
                     {

--- a/src/Microsoft.PowerShell.Commands.Management/commands/management/CombinePathCommand.cs
+++ b/src/Microsoft.PowerShell.Commands.Management/commands/management/CombinePathCommand.cs
@@ -52,8 +52,9 @@ namespace Microsoft.PowerShell.Commands
         public SwitchParameter Resolve { get; set; }
 
         /// <summary>
-        /// When used with -Resolve, specifies that the cmdlet skip the check for an
-        /// existing object at the resolved location.
+        /// Gets or sets whether the cmdlet should skip the check for an
+        /// existing object at the resolved location. Only usable in conjunction
+        /// with -Resolve.
         /// </summary>
         /// <value></value>
         [Parameter(ParameterSetName = "Resolve")]

--- a/src/System.Management.Automation/engine/PathInterfaces.cs
+++ b/src/System.Management.Automation/engine/PathInterfaces.cs
@@ -458,6 +458,56 @@ namespace System.Management.Automation
             return PathResolver.GetGlobbedMonadPathsFromMonadPath(path, false, context, out providerInstance);
         }
 
+
+        /// <summary>
+        /// Resolves a drive or provider qualified absolute or relative path that may contain
+        /// wildcard characters into one or more absolute drive or provider qualified paths.
+        /// </summary>
+        /// <param name="path">
+        /// The drive or provider qualified path to be resolved. This path may contain wildcard
+        /// characters which will get resolved.
+        /// </param>
+        /// <param name="context">
+        /// The context under which the command is running.
+        /// </param>
+        /// <param name="allowNonexistingPaths">
+        /// Determines whether the method permits resolving non-existing paths.
+        /// </param>
+        /// <returns>
+        /// An array of Msh paths that resolved from the given path.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// If <paramref name="path"/> or <paramref name="context"/> is null.
+        /// </exception>
+        /// <exception cref="ProviderNotFoundException">
+        /// If <paramref name="path"/> is a provider-qualified path
+        /// and the specified provider does not exist.
+        /// </exception>
+        /// <exception cref="ProviderInvocationException">
+        /// If the provider throws an exception when its MakePath gets
+        /// called.
+        /// </exception>
+        /// <exception cref="NotSupportedException">
+        /// If the provider does not support multiple items.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">
+        /// If the home location for the provider is not set and
+        /// <paramref name="path"/> starts with a "~".
+        /// </exception>
+        /// <exception cref="ItemNotFoundException">
+        /// If <paramref name="path"/> does not contain wildcard characters and
+        /// could not be found.
+        /// </exception>
+        internal Collection<PathInfo> GetResolvedPSPathFromPSPath(
+            string path,
+            CmdletProviderContext context,
+            bool allowNonexistingPaths)
+        {
+            // The parameters will be verified by the path resolver
+            Provider.CmdletProvider providerInstance = null;
+            return PathResolver.GetGlobbedMonadPathsFromMonadPath(path, allowNonexistingPaths, context, out providerInstance);
+        }
+
         /// <summary>
         /// Resolves a drive or provider qualified absolute or relative path that may contain
         /// wildcard characters into one or more provider-internal paths.

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Join-Path.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Join-Path.Tests.ps1
@@ -1,53 +1,63 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 Describe "Join-Path cmdlet tests" -Tags "CI" {
-  $SepChar=[io.path]::DirectorySeparatorChar
-  BeforeAll {
-    $StartingLocation = Get-Location
-  }
-  AfterEach {
-    Set-Location $StartingLocation
-  }
-  It "should output multiple paths when called with multiple -Path targets" {
-    Setup -Dir SubDir1
-    (Join-Path -Path TestDrive:,$TestDrive -ChildPath "SubDir1" -resolve).Length | Should -Be 2
-  }
-  It "should throw 'DriveNotFound' when called with -Resolve and drive does not exist" {
-    { Join-Path bogusdrive:\\somedir otherdir -resolve -ErrorAction Stop; Throw "Previous statement unexpectedly succeeded..." } |
-      Should -Throw -ErrorId "DriveNotFound,Microsoft.PowerShell.Commands.JoinPathCommand"
-  }
-  It "should throw 'PathNotFound' when called with -Resolve and item does not exist" {
-    { Join-Path "Bogus" "Path" -resolve -ErrorAction Stop; Throw "Previous statement unexpectedly succeeded..." } |
-      Should -Throw -ErrorId "PathNotFound,Microsoft.PowerShell.Commands.JoinPathCommand"
-  }
-  #[BugId(BugDatabase.WindowsOutOfBandReleases, 905237)] Note: Result should be the same on non-Windows platforms too
-  It "should return one object when called with a Windows FileSystem::Redirector" {
-    set-location ("env:"+$SepChar)
-    $result=join-path FileSystem::windir system32
-    $result.Count | Should -Be 1
-    $result       | Should -BeExactly ("FileSystem::windir"+$SepChar+"system32")
-  }
-  #[BugId(BugDatabase.WindowsOutOfBandReleases, 913084)]
-  It "should be able to join-path special string 'Variable:' with 'foo'" {
-    $result=Join-Path "Variable:" "foo"
-    $result.Count | Should -Be 1
-    $result       | Should -BeExactly ("Variable:"+$SepChar+"foo")
-  }
-  #[BugId(BugDatabase.WindowsOutOfBandReleases, 913084)]
-  It "should be able to join-path special string 'Alias:' with 'foo'" {
-    $result=Join-Path "Alias:" "foo"
-    $result.Count | Should -Be 1
-    $result       | Should -BeExactly ("Alias:"+$SepChar+"foo")
-  }
-  #[BugId(BugDatabase.WindowsOutOfBandReleases, 913084)]
-  It "should be able to join-path special string 'Env:' with 'foo'" {
-    $result=Join-Path "Env:" "foo"
-    $result.Count | Should -Be 1
-    $result       | Should -BeExactly ("Env:"+$SepChar+"foo")
-  }
-  It "should be able to join multiple child paths passed by position with remaining arguments" {
-    $result = Join-Path one two three four five
-    $result.Count | Should -Be 1
-    $result       | Should -BeExactly "one${sepChar}two${sepChar}three${sepChar}four${sepChar}five"
-  }
+    BeforeAll {
+        $SepChar = [IO.path]::DirectorySeparatorChar
+        $StartingLocation = Get-Location
+    }
+
+    AfterEach {
+        Set-Location $StartingLocation
+    }
+
+    It "should output multiple paths when called with multiple -Path targets" {
+        Setup -Dir SubDir1
+        (Join-Path -Path TestDrive:, $TestDrive -ChildPath "SubDir1" -resolve).Length | Should -Be 2
+    }
+
+    It "should throw 'DriveNotFound' when called with -Resolve and drive does not exist" {
+        { Join-Path bogusdrive:\\somedir otherdir -resolve -ErrorAction Stop; Throw "Previous statement unexpectedly succeeded..." } |
+            Should -Throw -ErrorId "DriveNotFound,Microsoft.PowerShell.Commands.JoinPathCommand"
+    }
+
+    It "should throw 'PathNotFound' when called with -Resolve and item does not exist" {
+        { Join-Path "Bogus" "Path" -resolve -ErrorAction Stop; Throw "Previous statement unexpectedly succeeded..." } |
+            Should -Throw -ErrorId "PathNotFound,Microsoft.PowerShell.Commands.JoinPathCommand"
+    }
+
+    #[BugId(BugDatabase.WindowsOutOfBandReleases, 905237)] Note: Result should be the same on non-Windows platforms too
+    It "should return one object when called with a Windows FileSystem::Redirector" {
+        set-location ("env:" + $SepChar)
+        $result = join-path FileSystem::windir system32
+        $result.Count | Should -Be 1
+        $result       | Should -BeExactly ("FileSystem::windir" + $SepChar + "system32")
+    }
+
+    #[BugId(BugDatabase.WindowsOutOfBandReleases, 913084)]
+    It "should be able to join-path special string 'Variable:' with 'foo'" {
+        $result = Join-Path "Variable:" "foo"
+        $result.Count | Should -Be 1
+        $result       | Should -BeExactly ("Variable:" + $SepChar + "foo")
+    }
+
+    #[BugId(BugDatabase.WindowsOutOfBandReleases, 913084)]
+    It "should be able to join-path special string 'Alias:' with 'foo'" {
+        $result = Join-Path "Alias:" "foo"
+        $result.Count | Should -Be 1
+        $result       | Should -BeExactly ("Alias:" + $SepChar + "foo")
+    }
+
+
+    #[BugId(BugDatabase.WindowsOutOfBandReleases, 913084)]
+    It "should be able to join-path special string 'Env:' with 'foo'" {
+        $result = Join-Path "Env:" "foo"
+        $result.Count | Should -Be 1
+        $result       | Should -BeExactly ("Env:" + $SepChar + "foo")
+    }
+
+    It "should be able to join multiple child paths passed by position with remaining arguments" {
+        $result = Join-Path one two three four five
+        $result.Count | Should -Be 1
+        $result       | Should -BeExactly "one${sepChar}two${sepChar}three${sepChar}four${sepChar}five"
+    }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Join-Path.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Join-Path.Tests.ps1
@@ -47,7 +47,6 @@ Describe "Join-Path cmdlet tests" -Tags "CI" {
         $result       | Should -BeExactly ("Alias:" + $SepChar + "foo")
     }
 
-
     #[BugId(BugDatabase.WindowsOutOfBandReleases, 913084)]
     It "should be able to join-path special string 'Env:' with 'foo'" {
         $result = Join-Path "Env:" "foo"
@@ -59,5 +58,12 @@ Describe "Join-Path cmdlet tests" -Tags "CI" {
         $result = Join-Path one two three four five
         $result.Count | Should -Be 1
         $result       | Should -BeExactly "one${sepChar}two${sepChar}three${sepChar}four${sepChar}five"
+    }
+
+    It "should be able to resolve nonexistent paths with -Resolve -SkipValidation" {
+        Setup -Dir Subdir1
+        $Result = Join-Path -Path $TestDrive -ChildPath 'Subdir1' -AdditionalChildPath 'Nope' -Resolve -SkipValidation
+        $Result.Count | Should -Be 1
+        $Result | Should -BeExactly "$TestDrive${sepChar}Subdir1${sepChar}Nope"
     }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

1. Moves -Resolve to its own parameter set, where it is mandatory.
2. Adds a -SkipValidation parameter to the same set, where it is optional.

The -SkipValidation switch allows Join-Path to use `SessionState.Path.GetUnresolvedProviderPathFromPSPath()` instead of `SessionState.Path.GetResolvedPSPathFromPSPath()`. This allows users to get a meaningful, properly-resolved path to items that may not yet exist.

Previously:
```powershell
PS> Join-Path C:\ .\Test\Test
C:\.\Test\Test
PS> Join-Path C:\ .\Test\Test -Resolve
Join-Path : Cannot find path 'C:\Test\Test' because it does not exist.
At line:1 char:1
+ Join-Path c:\ .\Test\Test -Resolve
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ CategoryInfo          : ObjectNotFound: (C:\test\test:String) [Join-Path], ItemNotFoundException
+ FullyQualifiedErrorId : PathNotFound,Microsoft.PowerShell.Commands.JoinPathCommand
```

Now:
```powershell
PS> Join-Path C:\ .\Test\Test -Resolve -SkipValidation
C:\Test\Test
```

## Remaining Work Items

* Add Tests

## PR Context

Related: #2993

Ideally, `Convert-Path`, `Join-Path`, and `Resolve-Path` should all eventually have similar capabilities, but one thing at a time, eh? 😄 

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` to your commit messages if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
