### PR TITLE
Fix MSI Upgrade failure for preview builds

### DIFF
--- a/assets/Product.wxs
+++ b/assets/Product.wxs
@@ -48,7 +48,7 @@
     <Property Id="WIXUI_EXITDIALOGOPTIONALCHECKBOXTEXT" Value="Open $(env.ProductName)" />
     <!-- Default value of Checkbox of starting PowerShell after installation -->
     <Property Id="WixShellExecTarget" Value="[$(var.ProductDirectoryName)]pwsh.exe"/>
-    <!-- This changes the default setting from reinstall if the file is a newer version to reinstall if the file is a different version -->
+    <!-- This changes the default setting from "reinstall if the file is a newer version" to "reinstall if the file is a different version" -->
     <Property Id=”REINSTALLMODE” Value="dmus"/>
     <CustomAction Id="LaunchApplication" BinaryKey="WixCA" DllEntry="WixShellExec" Impersonate="yes" />
 

--- a/assets/Product.wxs
+++ b/assets/Product.wxs
@@ -49,7 +49,7 @@
     <!-- Default value of Checkbox of starting PowerShell after installation -->
     <Property Id="WixShellExecTarget" Value="[$(var.ProductDirectoryName)]pwsh.exe"/>
     <!-- This changes the default setting from "reinstall if the file is a newer version" to "reinstall if the file is a different version" -->
-    <Property Id=”REINSTALLMODE” Value="dmus"/>
+    <Property Id="REINSTALLMODE" Value="dmus"/>
     <CustomAction Id="LaunchApplication" BinaryKey="WixCA" DllEntry="WixShellExec" Impersonate="yes" />
 
     <SetProperty Id="RegisterManifest"

--- a/assets/Product.wxs
+++ b/assets/Product.wxs
@@ -48,6 +48,8 @@
     <Property Id="WIXUI_EXITDIALOGOPTIONALCHECKBOXTEXT" Value="Open $(env.ProductName)" />
     <!-- Default value of Checkbox of starting PowerShell after installation -->
     <Property Id="WixShellExecTarget" Value="[$(var.ProductDirectoryName)]pwsh.exe"/>
+    <!-- This changes the default setting from reinstall if the file is a newer version to reinstall if the file is a different version -->
+    <Property Id=”REINSTALLMODE” Value="dmus"/>
     <CustomAction Id="LaunchApplication" BinaryKey="WixCA" DllEntry="WixShellExec" Impersonate="yes" />
 
     <SetProperty Id="RegisterManifest"

--- a/assets/Product.wxs
+++ b/assets/Product.wxs
@@ -25,12 +25,12 @@
   <?define ExplorerContextSubMenuDialogText = "Open &here"?>
   <?define ExplorerContextSubMenuElevatedDialogText = "Open here as &Administrator"?>
   <!-- The ProductCode is Product Id and needs to be unique for every PowerShell version to allow SxS install: http://wixtoolset.org/documentation/manual/v3/xsd/wix/product.html -->
-  <Product 
-    Id="$(var.ProductCode)" 
-    Name="PowerShell $(var.SimpleProductVersion)-$(sys.BUILDARCH)" 
-    Language="1033" 
-    Version="$(var.ProductVersion)" 
-    Manufacturer="Microsoft Corporation" 
+  <Product
+    Id="$(var.ProductCode)"
+    Name="PowerShell $(var.SimpleProductVersion)-$(sys.BUILDARCH)"
+    Language="1033"
+    Version="$(var.ProductVersion)"
+    Manufacturer="Microsoft Corporation"
     UpgradeCode="$(var.UpgradeCode)">
     <!-- Properties About The Package -->
     <Package Id="*" Keywords="Installer" Platform="$(sys.BUILDARCH)" InstallerVersion="200" Compressed="yes" InstallScope="perMachine" Description="PowerShell package" Comments="PowerShell for every system" />
@@ -156,7 +156,7 @@
               <CreateFolder/>
             </Component>
             <Component Id="RegistryEntries" Guid="{402e52f7-baf8-489d-af21-f756a6ca3530}">
-                <!-- create key for easy detection of a particular version of a powershell core package 
+                <!-- create key for easy detection of a particular version of a powershell core package
                      The upgrade code is used in the key because it will change when we allow SxS       -->
                 <RegistryKey Root="HKLM" Key="Software\Microsoft\PowerShellCore\InstalledVersions\$(var.UpgradeCode)" ForceCreateOnInstall="yes" ForceDeleteOnUninstall="yes">
                     <RegistryValue Type="string" Value="$(var.ProductSemanticVersion)" Name="SemanticVersion"/>
@@ -229,9 +229,9 @@
       <Directory Id="ProgramMenuFolder">
         <Directory Id="ApplicationProgramsFolder" Name="$(var.ProductName)">
           <Component Id="ApplicationProgramsMenuShortcut" Guid="*">
-            <Shortcut Id="PowerShell_ProgramsMenuShortcut" 
-                      Name="$(var.ProductSimpleVersionWithNameAndOptionalArchitecture)" 
-                      Description="$(var.ProductSimpleVersionWithNameAndOptionalArchitecture)" 
+            <Shortcut Id="PowerShell_ProgramsMenuShortcut"
+                      Name="$(var.ProductSimpleVersionWithNameAndOptionalArchitecture)"
+                      Description="$(var.ProductSimpleVersionWithNameAndOptionalArchitecture)"
                       Target="[$(var.ProductDirectoryName)]pwsh.exe"
                       Arguments="-WorkingDirectory ~"
                       Icon = "PowerShellExe.ico" />
@@ -267,7 +267,7 @@
         <Text><![CDATA[<a href="https://github.com/PowerShell/PowerShell/blob/master/ThirdPartyNotices.txt">Please review the ThirdPartyNotices.txt</a>]]></Text>
       </Control>
       <!-- divider and bottom buttons -->
-      <Control Id="BottomLine" Type="Line" X="0" Y="234" Width="370" Height="0" TabSkip="yes"/>    
+      <Control Id="BottomLine" Type="Line" X="0" Y="234" Width="370" Height="0" TabSkip="yes"/>
       <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17" Text="!(loc.WixUIBack)"/>
       <Control Id="Next" Type="PushButton" X="236" Y="243" Width="56" Height="17" Cancel="yes" Default="yes" Text="!(loc.WixUINext)"/>
       <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Cancel="yes" Text="!(loc.WixUICancel)">
@@ -279,7 +279,7 @@
 
 <!-- Customized version of WixUI_InstallDir, which is necessary to add custom dialogs. https://github.com/wixtoolset/wix3/blob/master/src/ext/UIExtension/wixlib/WixUI_InstallDir.wxs -->
 <Fragment>
-  <UI Id="CustomWixUI_InstallDir">        
+  <UI Id="CustomWixUI_InstallDir">
       <!--
       First-time install dialog sequence:
       - WixUI_WelcomeDlg
@@ -315,8 +315,8 @@
       <DialogRef Id="ResumeDlg" />
       <DialogRef Id="UserExit" />
       <DialogRef Id="ExplorerContextMenuDialog" />
-      
-      
+
+
       <Publish Dialog="BrowseDlg" Control="OK" Event="DoAction" Value="WixUIValidatePath" Order="3">1</Publish>
       <Publish Dialog="BrowseDlg" Control="OK" Event="SpawnDialog" Value="InvalidDirDlg" Order="4"><![CDATA[NOT WIXUI_DONTVALIDATEPATH AND WIXUI_INSTALLDIR_VALID<>"1"]]></Publish>
 
@@ -334,7 +334,7 @@
       <Publish Dialog="InstallDirDlg" Control="Next" Event="NewDialog" Value="ExplorerContextMenuDialog" Order="5">1</Publish>
       <Publish Dialog="InstallDirDlg" Control="ChangeFolder" Property="_BrowseProperty" Value="[WIXUI_INSTALLDIR]" Order="1">1</Publish>
       <Publish Dialog="InstallDirDlg" Control="ChangeFolder" Event="SpawnDialog" Value="BrowseDlg" Order="2">1</Publish>
-      
+
       <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="ExplorerContextMenuDialog" Order="1">NOT Installed</Publish>
       <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="MaintenanceTypeDlg" Order="2">Installed AND NOT PATCH</Publish>
       <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg" Order="2">Installed AND PATCH</Publish>

--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -2720,6 +2720,11 @@ function New-MSIPackage
     Start-NativeExecution -VerboseOutputOnError { & $wixPaths.wixHeatExePath dir  $ProductSourcePath -dr  $productDirectoryName -cg $productDirectoryName -gg -sfrag -srd -scom -sreg -out $wixFragmentPath -var env.ProductSourcePath -v}
     Test-FileWxs -FilesWxsPath $FilesWxsPath -HeatFilesWxsPath $wixFragmentPath
 
+    if ($isPreview)
+    {
+        $FilesWxsPath = $wixFragmentPath
+    }
+
     Write-Log "running candle..."
     Start-NativeExecution -VerboseOutputOnError { & $wixPaths.wixCandleExePath  "$ProductWxsPath"  "$FilesWxsPath" -out (Join-Path "$env:Temp" "\\") -ext WixUIExtension -ext WixUtilExtension -arch $ProductTargetArchitecture -v}
 

--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -2646,7 +2646,6 @@ function New-MSIPackage
     if ($isPreview)
     {
         $simpleProductVersion += '-preview'
-        $FilesWxsPath = New-PreviewFileWxs -FilesWxsPath $FilesWxsPath
     }
 
     $ProductVersion = Get-PackageVersionAsMajorMinorBuildRevision -Version $ProductVersion
@@ -2698,14 +2697,7 @@ function New-MSIPackage
 
     $wixFragmentPath = Join-Path $env:Temp "Fragment.wxs"
     $wixObjProductPath = Join-Path $env:Temp "Product.wixobj"
-    if ($isPreview)
-    {
-        $wixObjFragmentPath = Join-Path $env:Temp "files-preview.wixobj"
-    }
-    else
-    {
-        $wixObjFragmentPath = Join-Path $env:Temp "files.wixobj"
-    }
+    $wixObjFragmentPath = Join-Path $env:Temp "files.wixobj"
 
     # cleanup any garbage on the system
     Remove-Item -ErrorAction SilentlyContinue $wixFragmentPath -Force
@@ -2739,11 +2731,6 @@ function New-MSIPackage
     Remove-Item -ErrorAction SilentlyContinue $wixFragmentPath -Force
     Remove-Item -ErrorAction SilentlyContinue $wixObjProductPath -Force
     Remove-Item -ErrorAction SilentlyContinue $wixObjFragmentPath -Force
-    if ($isPreview)
-    {
-        # remove the temporary generated files.wxs for preview builds
-        Remove-Item -ErrorAction SilentlyContinue $FilesWxsPath -Force
-    }
 
     if ((Test-Path $msiLocationPath) -and (Test-Path $msiPdbLocationPath))
     {
@@ -2763,36 +2750,6 @@ function New-MSIPackage
         }
         throw $errorMessage
     }
-}
-
-# generate a files.wxs for preview builds
-# so that the component ids are different than the stable builds
-# the file is created in the temp folder
-function New-PreviewFileWxs
-{
-    param
-    (
-        # File describing the MSI file components from the asset folder
-        [ValidateNotNullOrEmpty()]
-        [ValidateScript( {Test-Path $_})]
-        [string] $FilesWxsPath = "$RepoRoot\assets\Files.wxs"
-    )
-
-    Write-Verbose "Generating new component Ids for Files-Preview.wxs" -Verbose
-    [xml] $filesAssetXml = Get-Content -Raw -Path $FilesWxsPath
-    foreach($component in $filesAssetXml.GetElementsByTagName('Component'))
-    {
-        $component.Id = $component.Id + "_Preview"
-    }
-
-    foreach($componentRef in $filesAssetXml.GetElementsByTagName('ComponentRef'))
-    {
-        $componentRef.Id = $componentRef.Id + "_Preview"
-    }
-
-    $previewFilesWxsPath = Join-Path ([System.IO.Path]::GetTempPath()) "Files-Preview.wxs"
-    $filesAssetXml.Save($previewFilesWxsPath)
-    $previewFilesWxsPath
 }
 
 # verify no files have been added or removed

--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -2718,10 +2718,16 @@ function New-MSIPackage
 
     Write-Log "verifying no new files have been added or removed..."
     Start-NativeExecution -VerboseOutputOnError { & $wixPaths.wixHeatExePath dir  $ProductSourcePath -dr  $productDirectoryName -cg $productDirectoryName -gg -sfrag -srd -scom -sreg -out $wixFragmentPath -var env.ProductSourcePath -v}
+
+    # We are verifying that the generated $wixFragmentPath and $FilesWxsPath are functionally the same
     Test-FileWxs -FilesWxsPath $FilesWxsPath -HeatFilesWxsPath $wixFragmentPath
 
     if ($isPreview)
     {
+        # Now that we know that the two are functionally the same,
+        # We only need to use $FilesWxsPath for release we want to be able to Path
+        # and two releases shouldn't have the same identifiers,
+        # so we use the generated one for preview
         $FilesWxsPath = $wixFragmentPath
     }
 

--- a/tools/packaging/packaging.psm1
+++ b/tools/packaging/packaging.psm1
@@ -2729,6 +2729,11 @@ function New-MSIPackage
         # and two releases shouldn't have the same identifiers,
         # so we use the generated one for preview
         $FilesWxsPath = $wixFragmentPath
+
+        $wixObjFragmentPath = Join-Path $env:Temp "Fragment.wixobj"
+
+        # cleanup any garbage on the system
+        Remove-Item -ErrorAction SilentlyContinue $wixObjFragmentPath -Force
     }
 
     Write-Log "running candle..."


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

- Fix MSI Upgrade failure for preview builds
  - Changing the identifiers every build should resolve this issue.
  - Also, tell MSI to reinstall components if the version changed in any way.

## PR Context

Hopefully really fix #8289 this time

Testing of RC.1 found we still got this error when upgrading from preview.4

```
MSI (s) (4C:A8) [10:18:32:354]: Disallowing installation of component: {A60E946A-2C86-4104-B883-D4B17B50B5B0} since the same component with higher versioned keyfile exists
MSI (s) (4C:A8) [10:18:32:487]: Disallowing installation of component: {7E693303-C675-4985-A1F0-84688E685656} since the same component with higher versioned keyfile exists
MSI (s) (4C:A8) [10:18:32:783]: Disallowing installation of component: {1CCDF75D-482A-4B20-B3D1-2934D374B96B} since the same component with higher versioned keyfile exists
MSI (s) (4C:A8) [10:18:32:787]: Disallowing installation of component: {267520C6-CD61-4FF4-9CA4-83400EAAC3E9} since the same component with higher versioned keyfile exists
MSI (s) (4C:A8) [10:18:32:825]: Disallowing installation of component: {F7B290E8-4DDD-4C20-B3F8-5DD38608DFEF} since the same component with higher versioned keyfile exists
```

With the component also being deleted.

The previous fix didn't change the GUID identifier which triggers the deletion.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` to your commit messages if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
