### PR TITLE
Fix help paging issues on macOS/Linux and with custom pager that takes arguments

### DIFF
--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -4204,7 +4204,7 @@ param(
                 $customPagerCommand = $tokens[0].Content
                 if (!(Get-Command $customPagerCommand -ErrorAction Ignore)) {
                     # Custom pager command is invalid, issue a warning.
-                    Write-Warning ""Ignoring invalid custom-paging utility command line specified in `$env:PAGER: $env:PAGER""
+                    Write-Warning ""Custom-paging utility command not found. Ignoring command specified in `$env:PAGER: $env:PAGER""
                 }
                 else {
                     # This approach will preserve all the pagers args.

--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -4205,11 +4205,11 @@ param(
 
         # Respect PAGER, use more on Windows, and use less on Linux
         if ($customPagerCommand) {
-            $help | & $customPagerCommand $customPagerCommandArgs
+            $help | Out-String -Width ([System.Console]::WindowWidth - 1) | & $customPagerCommand $customPagerCommandArgs
         } elseif ($IsWindows) {
             $help | more.com
         } else {
-            $help | less -Ps""Page %db?B of %D:.\. Press h for help or q to quit\.$""
+            $help | Out-String -Width ([System.Console]::WindowWidth - 1) | less -Ps""Page %db?B of %D:.\. Press h for help or q to quit\.$""
         }
     }
 ";

--- a/src/System.Management.Automation/engine/InitialSessionState.cs
+++ b/src/System.Management.Automation/engine/InitialSessionState.cs
@@ -4216,7 +4216,7 @@ param(
 
         # If the pager is an application, format the output width before sending to the app.
         if ((Get-Command $pagerCommand -ErrorAction Ignore).CommandType -eq 'Application') {
-            $consoleWidth = [System.Console]::WindowWidth
+            $consoleWidth = [System.Math]::Max([System.Console]::WindowWidth, 20)
 
             if ($pagerArgs) {
                 # Supply pager arguments to an application without any PowerShell parsing of the arguments.


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix #7175 by using `Out-String -Stream -Width` before piping to an application.  This improves the help experience on macOS and Linux by ensuring lines of help text wrap properly for the given console width.

Fix #8912 by using the PS tokenizer to separate the pager command from arguments if both are specified in $env:PAGER.  Also ensures that there is no PowerShell interpretation of arguments to an application by using the stop parsing operator.

## PR Context

The current reading experience of all help topics on macOS and Linux is sub-par giving PowerShell Core a bit of a black eye on those platforms.  See #7175 for images of what this looks like.

Specify a custom pager with arguments works in v6.1 but is broken in v6.2.  This PR fixes this issue - #8912.

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [x] Issue filed: <!-- Number/link of that issue here --> #7175 #8912
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` to your commit messages if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
