### PR TITLE
Fix -NoEnumerate behaviour in Write-Output

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Write-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Write-Object.cs
@@ -12,49 +12,34 @@ namespace Microsoft.PowerShell.Commands
     [Cmdlet(VerbsCommunications.Write, "Output", HelpUri = "https://go.microsoft.com/fwlink/?LinkID=113427", RemotingCapability = RemotingCapability.None)]
     public sealed class WriteOutputCommand : PSCmdlet
     {
-        private PSObject[] _inputObjects = null;
-
         /// <summary>
         /// Holds the list of objects to be written.
         /// </summary>
         [Parameter(Position = 0, Mandatory = true, ValueFromPipeline = true, ValueFromRemainingArguments = true)]
         [AllowNull]
         [AllowEmptyCollection]
-        public PSObject[] InputObject
-        {
-            get { return _inputObjects; }
-
-            set { _inputObjects = value; }
-        }
+        public PSObject[] InputObject { get; set; }
 
         /// <summary>
         /// Prevents Write-Output from unravelling collections passed to the InputObject parameter.
         /// </summary>
-        [Parameter()]
-        public SwitchParameter NoEnumerate
-        {
-            get;
-            set;
-        }
+        [Parameter]
+        public SwitchParameter NoEnumerate { get; set; }
 
         /// <summary>
         /// This method implements the ProcessRecord method for Write-output command.
         /// </summary>
         protected override void ProcessRecord()
         {
-            if (_inputObjects == null)
+            if (InputObject == null)
             {
-                WriteObject(_inputObjects);
+                WriteObject(InputObject);
                 return;
             }
 
-            bool enumerate = true;
-            if (NoEnumerate.IsPresent)
-            {
-                enumerate = false;
-            }
+            bool enumerate = !NoEnumerate.IsPresent;
 
-            WriteObject(_inputObjects, enumerate);
+            WriteObject(InputObject, enumerate);
         }
     }
     #endregion

--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Write-Object.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/Write-Object.cs
@@ -18,7 +18,7 @@ namespace Microsoft.PowerShell.Commands
         [Parameter(Position = 0, Mandatory = true, ValueFromPipeline = true, ValueFromRemainingArguments = true)]
         [AllowNull]
         [AllowEmptyCollection]
-        public PSObject[] InputObject { get; set; }
+        public PSObject InputObject { get; set; }
 
         /// <summary>
         /// Prevents Write-Output from unravelling collections passed to the InputObject parameter.
@@ -37,9 +37,7 @@ namespace Microsoft.PowerShell.Commands
                 return;
             }
 
-            bool enumerate = !NoEnumerate.IsPresent;
-
-            WriteObject(InputObject, enumerate);
+            WriteObject(InputObject, !NoEnumerate.IsPresent);
         }
     }
     #endregion

--- a/src/System.Management.Automation/engine/MshCommandRuntime.cs
+++ b/src/System.Management.Automation/engine/MshCommandRuntime.cs
@@ -249,7 +249,7 @@ namespace System.Management.Automation
 
 #if CORECLR
             // SecurityContext is not supported in CoreCLR
-            DoWriteObjects(sendToPipeline);
+            DoWriteEnumeratedObject(sendToPipeline);
 #else
             if (UseSecurityContextRun)
             {
@@ -278,11 +278,11 @@ namespace System.Management.Automation
         /// <exception cref="System.InvalidOperationException">
         /// Not permitted at this time or from this thread
         /// </exception>
-        private void DoWriteObjects(object sendToPipeline)
+        private void DoWriteEnumeratedObject(object sendToPipeline)
         {
             // NOTICE-2004/06/08-JonN 959638
             ThrowIfWriteNotPermitted(true);
-            _WriteObjectsSkipAllowCheck(sendToPipeline);
+            _EnumerateAndWriteObjectSkipAllowCheck(sendToPipeline);
         }
         // Trust:  public void WriteObject(object sendToPipeline, DataTrustCategory trustCategory);     // enumerateCollection defaults to false
         // Trust:  public void WriteObject(object sendToPipeline, bool enumerateCollection, DataTrustCategory trustCategory);
@@ -2591,7 +2591,7 @@ namespace System.Management.Automation
         /// The Cmdlet should generally just allow PipelineStoppedException
         /// to percolate up to the caller of ProcessRecord etc.
         /// </exception>
-        internal void _WriteObjectsSkipAllowCheck(object sendToPipeline)
+        internal void _EnumerateAndWriteObjectSkipAllowCheck(object sendToPipeline)
         {
             IEnumerable enumerable = LanguagePrimitives.GetEnumerable(sendToPipeline);
             if (enumerable == null)

--- a/src/System.Management.Automation/engine/MshCommandRuntime.cs
+++ b/src/System.Management.Automation/engine/MshCommandRuntime.cs
@@ -249,7 +249,7 @@ namespace System.Management.Automation
 
 #if CORECLR
             // SecurityContext is not supported in CoreCLR
-            DoWriteEnumeratedObject(sendToPipeline);
+            DoWriteObjects(sendToPipeline);
 #else
             if (UseSecurityContextRun)
             {
@@ -278,11 +278,11 @@ namespace System.Management.Automation
         /// <exception cref="System.InvalidOperationException">
         /// Not permitted at this time or from this thread
         /// </exception>
-        private void DoWriteEnumeratedObject(object sendToPipeline)
+        private void DoWriteObjects(object sendToPipeline)
         {
             // NOTICE-2004/06/08-JonN 959638
             ThrowIfWriteNotPermitted(true);
-            _EnumerateAndWriteObjectSkipAllowCheck(sendToPipeline);
+            _WriteObjectsSkipAllowCheck(sendToPipeline);
         }
         // Trust:  public void WriteObject(object sendToPipeline, DataTrustCategory trustCategory);     // enumerateCollection defaults to false
         // Trust:  public void WriteObject(object sendToPipeline, bool enumerateCollection, DataTrustCategory trustCategory);
@@ -2591,7 +2591,7 @@ namespace System.Management.Automation
         /// The Cmdlet should generally just allow PipelineStoppedException
         /// to percolate up to the caller of ProcessRecord etc.
         /// </exception>
-        internal void _EnumerateAndWriteObjectSkipAllowCheck(object sendToPipeline)
+        internal void _WriteObjectsSkipAllowCheck(object sendToPipeline)
         {
             IEnumerable enumerable = LanguagePrimitives.GetEnumerable(sendToPipeline);
             if (enumerable == null)

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Output.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Write-Output.Tests.ps1
@@ -18,60 +18,70 @@ Describe "Write-Output DRT Unit Tests" -Tags "CI" {
 
     It "Works with NoEnumerate switch" {
         $objectWritten = 1, 2.2, @("John", "Smith", 10), "abc"
-        [string]$s = Write-Output $objectWritten -NoEnumerate 6>&1 
+        [string]$s = Write-Output $objectWritten -NoEnumerate 6>&1
         $s | Should -Be  '1 2.2 System.Object[] abc'
+    }
+
+    It "Preserves the input collection type and contents with -NoEnumerate" {
+        $List = [System.Collections.Generic.List[string]]::new( [string[]]@("test", "one", "two") )
+        $ObjectWritten = Write-Output $List -NoEnumerate
+
+        $ObjectWritten.GetType() | Should -Be ([System.Collections.Generic.List[string]])
+        $ObjectWritten[0] | Should -BeExactly "test"
+        $ObjectWritten[1] | Should -BeExactly "one"
+        $ObjectWritten[2] | Should -BeExactly "two"
     }
 }
 
 Describe "Write-Output" -Tags "CI" {
     $testString = $testString
     Context "Input Tests" {
-	It "Should allow piped input" {
-	    { $testString | Write-Output } | Should -Not -Throw
-	}
+        It "Should allow piped input" {
+            { $testString | Write-Output } | Should -Not -Throw
+        }
 
-	It "Should write output to the output stream when using piped input" {
-	    $testString | Write-Output | Should -Be $testString
-	}
+        It "Should write output to the output stream when using piped input" {
+            $testString | Write-Output | Should -Be $testString
+        }
 
-	It "Should use inputobject switch" {
-	    { Write-Output -InputObject $testString } | Should -Not -Throw
-	}
+        It "Should use inputobject switch" {
+            { Write-Output -InputObject $testString } | Should -Not -Throw
+        }
 
-	It "Should write output to the output stream when using inputobject switch" {
-	    Write-Output -InputObject $testString | Should -Be $testString
-	}
+        It "Should write output to the output stream when using inputobject switch" {
+            Write-Output -InputObject $testString | Should -Be $testString
+        }
 
-	It "Should be able to write to a variable" {
-	    Write-Output -InputObject $testString -OutVariable var
-	    $var | Should -Be $testString
-	}
+        It "Should be able to write to a variable" {
+            Write-Output -InputObject $testString -OutVariable var
+            $var | Should -Be $testString
+        }
     }
 
     Context "Pipeline Command Tests" {
-	It "Should send object to the next command in the pipeline" {
-	    Write-Output -InputObject (1+1) | Should -Be 2
-	}
+        It "Should send object to the next command in the pipeline" {
+            Write-Output -InputObject (1 + 1) | Should -Be 2
+        }
 
-	It "Should have the same result between inputobject switch and piped input" {
-	    Write-Output -InputObject (1+1) | Should -Be 2
+        It "Should have the same result between inputobject switch and piped input" {
+            Write-Output -InputObject (1 + 1) | Should -Be 2
 
-	    1+1 | Write-Output | Should -Be 2
-	}
+            1 + 1 | Write-Output | Should -Be 2
+        }
     }
 
     Context "Enumerate Objects" {
-	$enumerationObject = @(1,2,3)
-	It "Should see individual objects when not using the NoEnumerate switch" {
-	    $singleCollection = $(Write-Output $enumerationObject| Measure-Object).Count
+        $enumerationObject = @(1, 2, 3)
+        It "Should see individual objects when not using the NoEnumerate switch" {
+            $singleCollection = $(Write-Output $enumerationObject| Measure-Object).Count
 
-	    $singleCollection | Should -Be $enumerationObject.length
-	}
+            $singleCollection | Should -Be $enumerationObject.length
+        }
 
-	It "Should be able to treat a collection as a single object using the NoEnumerate switch" {
-	    $singleCollection = $(Write-Output $enumerationObject -NoEnumerate | Measure-Object).Count
+        It "Should be able to treat a collection as a single object using the NoEnumerate switch" {
+            $singleCollection = $(Write-Output $enumerationObject -NoEnumerate | Measure-Object).Count
 
-	    $singleCollection | Should -Be 1
-	}
+            $singleCollection | Should -Be 1
+        }
     }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Write-Output's `InputObject` parameter was typed as `PSObject[]`. This was forcing **all** collections to be enumerated during parameter binding, making `-NoEnumerate` essentially useless; use of the switch would result in a `PSObject[]`-typed output collection instead of the usual `object[]`, but it was completely impossible to retain the original collection(s) via the switch.

Fixes #5955, a long-standing regression from Windows PowerShell.

Adds regression test.

~~As I was digging through the underlying code before I came upon the true cause, I also came across a pair of methods with names that are just _asking_ for misinterpretation. I renamed one of the pairs, the pair with only one reference each. As they are private methods, I doubt this will affect anything much, but it should make maintaining those code paths less confusing going forward.~~ Moved to #9074.

## PR Context

See issue #5955 for context.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` to your commit messages if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
