### PR TITLE
Rename private methods in MshCommandRuntime.cs

### DIFF
--- a/src/System.Management.Automation/engine/MshCommandRuntime.cs
+++ b/src/System.Management.Automation/engine/MshCommandRuntime.cs
@@ -249,7 +249,7 @@ namespace System.Management.Automation
 
 #if CORECLR
             // SecurityContext is not supported in CoreCLR
-            DoWriteObjects(sendToPipeline);
+            DoWriteEnumeratedObject(sendToPipeline);
 #else
             if (UseSecurityContextRun)
             {
@@ -278,11 +278,11 @@ namespace System.Management.Automation
         /// <exception cref="System.InvalidOperationException">
         /// Not permitted at this time or from this thread
         /// </exception>
-        private void DoWriteObjects(object sendToPipeline)
+        private void DoWriteEnumeratedObject(object sendToPipeline)
         {
             // NOTICE-2004/06/08-JonN 959638
             ThrowIfWriteNotPermitted(true);
-            _WriteObjectsSkipAllowCheck(sendToPipeline);
+            _EnumerateAndWriteObjectSkipAllowCheck(sendToPipeline);
         }
         // Trust:  public void WriteObject(object sendToPipeline, DataTrustCategory trustCategory);     // enumerateCollection defaults to false
         // Trust:  public void WriteObject(object sendToPipeline, bool enumerateCollection, DataTrustCategory trustCategory);
@@ -2591,7 +2591,7 @@ namespace System.Management.Automation
         /// The Cmdlet should generally just allow PipelineStoppedException
         /// to percolate up to the caller of ProcessRecord etc.
         /// </exception>
-        internal void _WriteObjectsSkipAllowCheck(object sendToPipeline)
+        internal void _EnumerateAndWriteObjectSkipAllowCheck(object sendToPipeline)
         {
             IEnumerable enumerable = LanguagePrimitives.GetEnumerable(sendToPipeline);
             if (enumerable == null)


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Renamed methods to avoid confusion when examining and maintaining core runtime code.

* `DoWriteObjects()` -> `DoWriteEnumeratedObject()`
  * This was almost identical in name to the distinct `DoWriteObject()` (no **s**) method.
* `_WriteObjectsSkipAllowCheck()` -> `_EnumerateAndWriteObjectSkipAllowCheck()`
  * Again, almost identical in name to `_WriteObjectSkipAllowCheck()`

This pair of methods is not actually referenced outside MshCommandRuntime.cs, and only in one or two places; I consider renaming it to be of no risk whatsoever as it is a private method.

There are no functional modifications, just renaming these before someone digs a little too deep here and breaks it by accident due to the very confusing naming scheme.

## PR Context

As I was debugging #5955 I noticed that there are two pairs of commands in MshCommandRuntime.cs that deal with writing objects, one set which permits enumerating collections, the other which does not.

These are named _far_ too similarly, where a mere typo could cause the wrong one to be used if this code is ever updated.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` to your commit messages if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
