### PR TITLE
Fix Get-Module -FullyQualifiedName option to work with paths

### DIFF
--- a/src/System.Management.Automation/engine/Modules/GetModuleCommand.cs
+++ b/src/System.Management.Automation/engine/Modules/GetModuleCommand.cs
@@ -375,9 +375,9 @@ namespace Microsoft.PowerShell.Commands
             var moduleSpecTable = new Dictionary<string, ModuleSpecification>(StringComparer.OrdinalIgnoreCase);
             if (FullyQualifiedName != null)
             {
-                FullyQualifiedName = FullyQualifiedName.Select(
-                    ModuleSpecification => ModuleSpecification.WithNormalizedName(Context, SessionState.Path.CurrentLocation.Path))
-                .ToArray();
+                for (int modSpecIndex = 0; modSpecIndex < FullyQualifiedName.Length; modSpecIndex++) {
+                    FullyQualifiedName[modSpecIndex] = FullyQualifiedName[modSpecIndex].WithNormalizedName(Context, SessionState.Path.CurrentLocation.Path);
+                }
                 moduleSpecTable = FullyQualifiedName.ToDictionary(moduleSpecification => moduleSpecification.Name, StringComparer.OrdinalIgnoreCase);
                 strNames.AddRange(FullyQualifiedName.Select(spec => spec.Name));
             }

--- a/src/System.Management.Automation/engine/Modules/GetModuleCommand.cs
+++ b/src/System.Management.Automation/engine/Modules/GetModuleCommand.cs
@@ -578,7 +578,6 @@ namespace Microsoft.PowerShell.Commands
         }
     }
 
-
     /// <summary>
     /// PSEditionArgumentCompleter for PowerShell Edition names.
     /// </summary>

--- a/src/System.Management.Automation/engine/Modules/GetModuleCommand.cs
+++ b/src/System.Management.Automation/engine/Modules/GetModuleCommand.cs
@@ -375,9 +375,11 @@ namespace Microsoft.PowerShell.Commands
             var moduleSpecTable = new Dictionary<string, ModuleSpecification>(StringComparer.OrdinalIgnoreCase);
             if (FullyQualifiedName != null)
             {
-                for (int modSpecIndex = 0; modSpecIndex < FullyQualifiedName.Length; modSpecIndex++) {
+                for (int modSpecIndex = 0; modSpecIndex < FullyQualifiedName.Length; modSpecIndex++)
+                {
                     FullyQualifiedName[modSpecIndex] = FullyQualifiedName[modSpecIndex].WithNormalizedName(Context, SessionState.Path.CurrentLocation.Path);
                 }
+
                 moduleSpecTable = FullyQualifiedName.ToDictionary(moduleSpecification => moduleSpecification.Name, StringComparer.OrdinalIgnoreCase);
                 strNames.AddRange(FullyQualifiedName.Select(spec => spec.Name));
             }

--- a/src/System.Management.Automation/engine/Modules/GetModuleCommand.cs
+++ b/src/System.Management.Automation/engine/Modules/GetModuleCommand.cs
@@ -556,7 +556,7 @@ namespace Microsoft.PowerShell.Commands
                 }
             }
         }
-    
+
         private static IEnumerable<ModuleSpecification> GetCandidateModuleSpecs(
             IDictionary<string, ModuleSpecification> moduleSpecTable,
             PSModuleInfo module)

--- a/src/System.Management.Automation/engine/Modules/GetModuleCommand.cs
+++ b/src/System.Management.Automation/engine/Modules/GetModuleCommand.cs
@@ -376,8 +376,8 @@ namespace Microsoft.PowerShell.Commands
             if (FullyQualifiedName != null)
             {
                 FullyQualifiedName = FullyQualifiedName.Select(
-                    ModuleSpecification => ModuleSpecification.WithNormalizedName(Context, SessionState.Path.CurrentLocation.Path)
-                ).ToArray();
+                    ModuleSpecification => ModuleSpecification.WithNormalizedName(Context, SessionState.Path.CurrentLocation.Path))
+                .ToArray();
                 moduleSpecTable = FullyQualifiedName.ToDictionary(moduleSpecification => moduleSpecification.Name, StringComparer.OrdinalIgnoreCase);
                 strNames.AddRange(FullyQualifiedName.Select(spec => spec.Name));
             }
@@ -557,12 +557,21 @@ namespace Microsoft.PowerShell.Commands
             }
         }
 
+        /// <summary>
+        /// Take a dictionary of module specifications and return those that potentially match the module
+        /// passed in as a parameter (checks on names and paths).
+        /// </summary>
+        /// <param name="moduleSpecTable">The module specifications to filter candidates from.</param>
+        /// <param name="module">The module to find candidates for from the module specification table.</param>
+        /// <returns>The module specifications matching the module based on name, path and subpath.</returns>
         private static IEnumerable<ModuleSpecification> GetCandidateModuleSpecs(
             IDictionary<string, ModuleSpecification> moduleSpecTable,
             PSModuleInfo module)
         {
-            foreach (ModuleSpecification moduleSpec in moduleSpecTable.Values) {
-                if (moduleSpec.Name == module.Name || moduleSpec.Name == module.Path || module.Path.Contains(moduleSpec.Name)) {
+            foreach (ModuleSpecification moduleSpec in moduleSpecTable.Values)
+            {
+                if (moduleSpec.Name == module.Name || moduleSpec.Name == module.Path || module.Path.Contains(moduleSpec.Name))
+                {
                     yield return moduleSpec;
                 }
             }

--- a/src/System.Management.Automation/engine/Modules/GetModuleCommand.cs
+++ b/src/System.Management.Automation/engine/Modules/GetModuleCommand.cs
@@ -548,7 +548,8 @@ namespace Microsoft.PowerShell.Commands
 
                 // Modules with table entries only get returned if they match them
                 // We skip the name check since modules have already been prefiltered base on the moduleSpec path/name
-                foreach(ModuleSpecification moduleSpec in candidateModuleSpecs) {
+                foreach (ModuleSpecification moduleSpec in candidateModuleSpecs)
+                {
                     if (ModuleIntrinsics.IsModuleMatchingModuleSpec(module, moduleSpec, skipNameCheck: true))
                     {
                         yield return module;

--- a/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
+++ b/src/System.Management.Automation/engine/Modules/ModuleIntrinsics.cs
@@ -423,10 +423,14 @@ namespace System.Management.Automation
         /// </summary>
         /// <param name="moduleInfo">The module info object to check.</param>
         /// <param name="moduleSpec">The module specification to match the module info object against.</param>
+        /// <param name="skipNameCheck">True if we should skip the name check on the module specification.</param>
         /// <returns>True if the module info object meets all the constraints on the module specification, false otherwise.</returns>
-        internal static bool IsModuleMatchingModuleSpec(PSModuleInfo moduleInfo, ModuleSpecification moduleSpec)
+        internal static bool IsModuleMatchingModuleSpec(
+            PSModuleInfo moduleInfo,
+            ModuleSpecification moduleSpec,
+            bool skipNameCheck = false)
         {
-            return IsModuleMatchingModuleSpec(out ModuleMatchFailure matchFailureReason, moduleInfo, moduleSpec);
+            return IsModuleMatchingModuleSpec(out ModuleMatchFailure matchFailureReason, moduleInfo, moduleSpec, skipNameCheck);
         }
 
         /// <summary>
@@ -435,8 +439,13 @@ namespace System.Management.Automation
         /// <param name="matchFailureReason">The constraint that caused the match failure, if any.</param>
         /// <param name="moduleInfo">The module info object to check.</param>
         /// <param name="moduleSpec">The module specification to match the module info object against.</param>
+        /// <param name="skipNameCheck">True if we should skip the name check on the module specification.</param>
         /// <returns>True if the module info object meets all the constraints on the module specification, false otherwise.</returns>
-        internal static bool IsModuleMatchingModuleSpec(out ModuleMatchFailure matchFailureReason, PSModuleInfo moduleInfo, ModuleSpecification moduleSpec)
+        internal static bool IsModuleMatchingModuleSpec(
+            out ModuleMatchFailure matchFailureReason,
+            PSModuleInfo moduleInfo,
+            ModuleSpecification moduleSpec,
+            bool skipNameCheck = false)
         {
             if (moduleSpec == null)
             {
@@ -447,7 +456,7 @@ namespace System.Management.Automation
             return IsModuleMatchingConstraints(
                 out matchFailureReason,
                 moduleInfo,
-                moduleSpec.Name,
+                skipNameCheck ? null : moduleSpec.Name,
                 moduleSpec.Guid,
                 moduleSpec.RequiredVersion,
                 moduleSpec.Version,

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -28,7 +28,7 @@ Describe "Get-Module -ListAvailable" -Tags "CI" {
 
         $fullyQualifiedPathTestCases = @(
             # The current behaviour in PowerShell is that version gets ignored when using Get-Module -FullyQualifiedName with a path
-            @{ ModPath = "$TestDrive/Modules\Foo"; Name = 'Foo'; Version = '2.0'; Count = 2 }
+            @{ ModPath = "$TestDrive/Modules\Foo"; Name = 'Foo'; Version = '2.0'; Count = 1 }
             @{ ModPath = "$TestDrive\Modules/Foo\1.1/Foo.psd1"; Name = 'Foo'; Version = '1.1'; Count = 1 }
             @{ ModPath = "$TestDrive\Modules/Bar.psd1"; Name = 'Bar'; Version = '0.0'; Count = 1 }
             @{ ModPath = "$TestDrive\Modules\Zoo\Too\Zoo.psm1"; Name = 'Zoo'; Version = '0.0'; Count = 1 }
@@ -223,5 +223,103 @@ Describe "Get-Module -ListAvailable" -Tags "CI" {
             $result = pwsh -c "`$env:PSModulePath = '$tempModulePath'; `$module = Get-Module -ListAvailable; `$fullName = [System.AppDomain]::CurrentDomain.GetAssemblies() | Where-Object Location -eq $assemblyPath | Foreach-Object FullName; `$module.Name + `$fullName"
             $result | Should -BeExactly "MyModuelTest"
         }
+    }
+}
+
+Describe 'Get-Module -ListAvailable with path' -Tags "CI" {
+    BeforeAll {
+        $moduleName = 'Banana'
+        $modulePath = Join-Path $TestDrive $moduleName
+        $v1 = '1.2.3'
+        $v2 = '4.8.3'
+        $v1DirPath = Join-Path $modulePath $v1
+        $v2DirPath = Join-Path $modulePath $v2
+        $manifestV1Path = Join-Path $v1DirPath "$moduleName.psd1"
+        $manifestV2Path = Join-Path $v2DirPath "$moduleName.psd1"
+
+        New-Item -ItemType Directory $modulePath
+        New-Item -ItemType Directory -Path $v1DirPath
+        New-Item -ItemType Directory -Path $v2DirPath
+        New-ModuleManifest -Path $manifestV1Path -ModuleVersion $v1
+        New-ModuleManifest -Path $manifestV2Path -ModuleVersion $v2
+    }
+
+    It "Gets all versions by path" {
+        $modules = Get-Module -ListAvailable $modulePath | Sort-Object -Property Version
+
+        $modules | Should -HaveCount 2
+        $modules[0].Name | Should -BeExactly $moduleName
+        $modules[0].Path | Should -BeExactly $manifestV1Path
+        $modules[0].Version | Should -Be $v1
+        $modules[1].Name | Should -BeExactly $moduleName
+        $modules[1].Path | Should -BeExactly $manifestV2Path
+        $modules[1].Version | Should -Be $v2
+    }
+
+    It "Gets all versions by FullyQualifiedName with path with lower version" {
+        $modules = Get-Module -ListAvailable -FullyQualifiedName @{ ModuleName = $modulePath; ModuleVersion = '0.0' } | Sort-Object -Property Version
+
+        $modules | Should -HaveCount 2
+        $modules[0].Name | Should -BeExactly $moduleName
+        $modules[0].Path | Should -BeExactly $manifestV1Path
+        $modules[0].Version | Should -Be $v1
+        $modules[1].Name | Should -BeExactly $moduleName
+        $modules[1].Path | Should -BeExactly $manifestV2Path
+        $modules[1].Version | Should -Be $v2
+    }
+
+    It "Gets high version by FullyQualifiedName with path with high version" {
+        $modules = Get-Module -ListAvailable -FullyQualifiedName @{ ModuleName = $modulePath; ModuleVersion = '2.0' } | Sort-Object -Property Version
+
+        $modules | Should -HaveCount 1
+        $modules[0].Name | Should -BeExactly $moduleName
+        $modules[0].Path | Should -BeExactly $manifestV2Path
+        $modules[0].Version | Should -Be $v2
+    }
+
+    It "Gets low version by FullyQualifiedName with path with low maximum version" {
+        $modules = Get-Module -ListAvailable -FullyQualifiedName @{ ModuleName = $modulePath; MaximumVersion = '2.0' } | Sort-Object -Property Version
+
+        $modules | Should -HaveCount 1
+        $modules[0].Name | Should -BeExactly $moduleName
+        $modules[0].Path | Should -BeExactly $manifestV1Path
+        $modules[0].Version | Should -Be $v1
+    }
+
+    It "Gets low version by FullyQualifiedName with path with low maximum version and version" {
+        $modules = Get-Module -ListAvailable -FullyQualifiedName @{ ModuleName = $modulePath; MaximumVersion = '2.0'; ModuleVersion = '1.0' } | Sort-Object -Property Version
+
+        $modules | Should -HaveCount 1
+        $modules[0].Name | Should -BeExactly $moduleName
+        $modules[0].Path | Should -BeExactly $manifestV1Path
+        $modules[0].Version | Should -Be $v1
+    }
+
+    It "Gets correct version by FullyQualifiedName with path with required version" -TestCases @(
+        @{ Version = $v1 }
+        @{ Version = $v2 }
+    ) {
+        param([version]$Version)
+
+        switch ($Version)
+        {
+            $v1
+            {
+                $expectedPath = $manifestV1Path
+                break
+            }
+
+            $v2
+            {
+                $expectedPath = $manifestV2Path
+            }
+        }
+
+        $modules = Get-Module -ListAvailable -FullyQualifiedName @{ ModuleName = $modulePath; RequiredVersion = $Version }
+
+        $modules | Should -HaveCount 1
+        $modules[0].Name | Should -BeExactly $moduleName
+        $modules[0].Path | Should -BeExactly $expectedPath
+        $modules[0].Version | Should -Be $Version
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Get-Module.Tests.ps1
@@ -27,7 +27,6 @@ Describe "Get-Module -ListAvailable" -Tags "CI" {
         New-Item -ItemType File -Path "$testdrive\Modules\Az\Az.psm1" > $null
 
         $fullyQualifiedPathTestCases = @(
-            # The current behaviour in PowerShell is that version gets ignored when using Get-Module -FullyQualifiedName with a path
             @{ ModPath = "$TestDrive/Modules\Foo"; Name = 'Foo'; Version = '2.0'; Count = 1 }
             @{ ModPath = "$TestDrive\Modules/Foo\1.1/Foo.psd1"; Name = 'Foo'; Version = '1.1'; Count = 1 }
             @{ ModPath = "$TestDrive\Modules/Bar.psd1"; Name = 'Bar'; Version = '0.0'; Count = 1 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This PR "fixes" the current behavior for get-module with -FullyQualifiedName specified and containing a path. Unfortunately this does mean that this PR is a breaking change.

To illustrate the current behavior and the new behavior we can look at the following example : 
/Foo/1.0/Foo.psd1
/Foo/2.0/Foo.psd1
Get-module -ListAvailable -FullyQualifiedName @{ModuleName = "/Foo"; ModuleVersion = "2.0"}

This will return both modules since "/Foo" is not correctly matched to either .psd1 file and the current behavior is to skip the version checks and simply return the modules.
With this PR the names are correctly matched and the version checks can take place thus resulting in only one module being returned. 

## PR Context

This PR is related to the following issues : 
https://github.com/PowerShell/PowerShell/issues/8936 (meta-issue tracking refactoring work on module commandlets in general)
https://github.com/PowerShell/PowerShell/issues/8262

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: https://github.com/PowerShell/PowerShell/issues/8262
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` to your commit messages if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
