### PR TITLE
Using supported syntax for restoring warnings 

### DIFF
--- a/src/Microsoft.PowerShell.Security/security/AclCommands.cs
+++ b/src/Microsoft.PowerShell.Security/security/AclCommands.cs
@@ -188,7 +188,7 @@ namespace Microsoft.PowerShell.Commands
 
                 // Get path
                 return instance.Properties["PSPath"].Value.ToString();
-#pragma warning enable 56506
+#pragma warning restore 56506
             }
         }
 

--- a/src/System.Management.Automation/engine/COM/ComUtil.cs
+++ b/src/System.Management.Automation/engine/COM/ComUtil.cs
@@ -315,7 +315,7 @@ namespace System.Management.Automation
                     ElementDescriptionPointer = (IntPtr)(ElementDescriptionArrayPtr.ToInt64() + ElementDescriptionArrayByteOffset);
                 }
 
-#pragma warning enable 56515
+#pragma warning restore 56515
 
                 ElementDescription = Marshal.PtrToStructure<COM.ELEMDESC>(ElementDescriptionPointer);
 

--- a/src/System.Management.Automation/security/Authenticode.cs
+++ b/src/System.Management.Automation/security/Authenticode.cs
@@ -190,7 +190,7 @@ namespace System.Management.Automation
                     IntPtr.Zero,
                     pSignInfo,
                     IntPtr.Zero);
-#pragma warning enable 56523
+#pragma warning restore 56523
 
                 if (si.pSignExtInfo != null)
                 {
@@ -513,7 +513,7 @@ namespace System.Management.Automation
                     IntPtr.Zero,
                     WINTRUST_ACTION_GENERIC_VERIFY_V2,
                     wtdBuffer);
-#pragma warning enable 56523
+#pragma warning restore 56523
 
                 wtData = Marshal.PtrToStructure<NativeMethods.WINTRUST_DATA>(wtdBuffer);
             }
@@ -538,7 +538,7 @@ namespace System.Management.Automation
 #pragma warning disable 56523
             IntPtr pCert =
                 NativeMethods.WTHelperGetProvCertFromChain(pSigner, 0);
-#pragma warning enable 56523
+#pragma warning restore 56523
 
             if (pCert != IntPtr.Zero)
             {
@@ -608,7 +608,7 @@ namespace System.Management.Automation
 #pragma warning disable 56523
             IntPtr pProvData =
                 NativeMethods.WTHelperProvDataFromStateData(wvtStateData);
-#pragma warning enable 56523
+#pragma warning restore 56523
 
             if (pProvData != IntPtr.Zero)
             {

--- a/src/System.Management.Automation/security/nativeMethods.cs
+++ b/src/System.Management.Automation/security/nativeMethods.cs
@@ -1067,7 +1067,7 @@ namespace System.Management.Automation.Security
                     IntPtr.Zero,
                     WINTRUST_ACTION_GENERIC_VERIFY_V2,
                     wtdBuffer);
-#pragma warning enable 56523
+#pragma warning restore 56523
 
                 wtd = Marshal.PtrToStructure<WINTRUST_DATA>(wtdBuffer);
             }
@@ -1202,7 +1202,7 @@ namespace System.Management.Automation.Security
                     IntPtr.Zero,
                     WINTRUST_ACTION_GENERIC_VERIFY_V2,
                     wtdBuffer);
-#pragma warning enable 56523
+#pragma warning restore 56523
             }
             finally
             {


### PR DESCRIPTION
For some reason, a syntax for enabling warnings that isn't documented was used. Build errors with vs2019.

Restore is the documented way.

https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/preprocessor-directives/preprocessor-pragma-warning

<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` to your commit messages if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
