### PR TITLE
Add support empty NoteProperty in Group-Object

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ObjectCommandComparer.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/ObjectCommandComparer.cs
@@ -113,12 +113,17 @@ namespace Microsoft.PowerShell.Commands
         public override int GetHashCode()
         {
             if (PropertyValue == null)
+            {
                 return 0;
+            }
 
             object baseObject = PSObject.Base(PropertyValue);
-            IComparable baseObjectComparable = baseObject as IComparable;
+            if (baseObject == null)
+            {
+                return 0;
+            }
 
-            if (baseObjectComparable != null)
+            if (baseObject is IComparable)
             {
                 return baseObject.GetHashCode();
             }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Group-Object.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Group-Object.Tests.ps1
@@ -123,6 +123,13 @@ Describe "Group-Object" -Tags "CI" {
         $result['Successful'].ErrorMessage.Count | Should -Be 4
         $result['Successful'].ErrorMessage[0] | Should -Be ''
     }
+
+    It "Should understand empty NoteProperty" {
+        $result = "dummy" | Select-Object -Property @{Name = 'X'; Expression = {}} | Group-Object X
+        $result.Count | Should -Be 1
+        $result[0].Name | Should -Be ""
+        $result[0].Group | Should -Be '@{X=}'
+    }
 }
 
 Describe "Check 'Culture' parameter in order object cmdlets (Group-Object, Sort-Object, Compare-Object)" -Tags "CI" {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix #3300


## PR Context

GetHashCode evaluates a hash for base object of PSObject that can be sometimes null.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` to your commit messages if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
