### PR TITLE
Update feature-request issue template to move instructions into comments.

### DIFF
--- a/.github/ISSUE_TEMPLATE/Feature_Request.md
+++ b/.github/ISSUE_TEMPLATE/Feature_Request.md
@@ -9,11 +9,15 @@ assignees: ''
 
 # Summary of the new feature/enhancement
 
+<!-- 
 A clear and concise description of what the problem is that the new feature would solve.
 Try formulating it in user story style (if applicable):
 'As a user I want X so that Y.' with X being the being the action and Y being the value of the action.
+-->
 
 # Proposed technical implementation details (optional)
 
+<!-- 
 A clear and concise description of what you want to happen.
 Consider providing an example PowerShell experience with expected result.
+-->

--- a/.vsts-ci/linux.yml
+++ b/.vsts-ci/linux.yml
@@ -12,6 +12,7 @@ trigger:
     exclude:
     - /tools/releaseBuild/**/*
     - /.vsts-ci/misc-analysis.yml
+    - /.github/ISSUE_TEMPLATE/*
 pr:
   branches:
     include:
@@ -23,6 +24,7 @@ pr:
     exclude:
     - /tools/releaseBuild/**/*
     - /.vsts-ci/misc-analysis.yml
+    - /.github/ISSUE_TEMPLATE/*
 variables:
   DOTNET_CLI_TELEMETRY_OPTOUT: 1
   POWERSHELL_TELEMETRY_OPTOUT: 1

--- a/.vsts-ci/mac.yml
+++ b/.vsts-ci/mac.yml
@@ -12,6 +12,7 @@ trigger:
     exclude:
     - /tools/releaseBuild/**/*
     - /.vsts-ci/misc-analysis.yml
+    - /.github/ISSUE_TEMPLATE/*
 pr:
   branches:
     include:
@@ -23,6 +24,7 @@ pr:
     exclude:
     - /tools/releaseBuild/**/*
     - /.vsts-ci/misc-analysis.yml
+    - /.github/ISSUE_TEMPLATE/*
 variables:
   DOTNET_CLI_TELEMETRY_OPTOUT: 1
   POWERSHELL_TELEMETRY_OPTOUT: 1

--- a/.vsts-ci/windows.yml
+++ b/.vsts-ci/windows.yml
@@ -12,6 +12,7 @@ trigger:
     exclude:
     - /tools/releaseBuild/**/*
     - /.vsts-ci/misc-analysis.yml
+    - /.github/ISSUE_TEMPLATE/*
 pr:
   branches:
     include:
@@ -23,7 +24,8 @@ pr:
     exclude:
     - /tools/releaseBuild/**/*
     - /.vsts-ci/misc-analysis.yml
-
+    - /.github/ISSUE_TEMPLATE/*
+    
 variables:
   GIT_CONFIG_PARAMETERS: "'core.autocrlf=false'"
   DOTNET_CLI_TELEMETRY_OPTOUT: 1


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Moved instructions into comments.

## PR Context

While users should _see_ instructions, they shouldn't be _included_ when the issue is created.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
