### PR TITLE
Enable securestring cmdlets for non-Windows

### DIFF
--- a/src/System.Management.Automation/security/SecureStringHelper.cs
+++ b/src/System.Management.Automation/security/SecureStringHelper.cs
@@ -196,7 +196,7 @@ namespace Microsoft.PowerShell
 
 #if UNIX
             // DPAPI isn't supported in UNIX, so we just translate the byte-array back to a string
-            data = ByteArrayFromString(input);
+            data = protectedData;
 #else
             data = ProtectedData.Unprotect(protectedData, null,
                                            DataProtectionScope.CurrentUser);

--- a/src/System.Management.Automation/security/SecureStringHelper.cs
+++ b/src/System.Management.Automation/security/SecureStringHelper.cs
@@ -459,13 +459,13 @@ namespace Microsoft.PowerShell
                 unsafe
                 {
                     if (!CAPI.CryptProtectData(
-                        new IntPtr(&dataIn),
-                        string.Empty,
-                        new IntPtr(&entropy),
-                        IntPtr.Zero,
-                        IntPtr.Zero,
-                        dwFlags,
-                        new IntPtr(&blob)))
+                        pDataIn: new IntPtr(&dataIn),
+                        szDataDescr: string.Empty,
+                        pOptionalEntropy: new IntPtr(&entropy),
+                        pvReserved: IntPtr.Zero,
+                        pPromptStruct: IntPtr.Zero,
+                        dwFlags: dwFlags,
+                        pDataBlob: new IntPtr(&blob)))
                     {
                         int lastWin32Error = Marshal.GetLastWin32Error();
 
@@ -550,16 +550,16 @@ namespace Microsoft.PowerShell
                 unsafe
                 {
                     if (!CAPI.CryptUnprotectData(
-                        new IntPtr(&dataIn),
-                        IntPtr.Zero,
-                        new IntPtr(&entropy),
-                        IntPtr.Zero,
-                        IntPtr.Zero,
-                        dwFlags,
-                        new IntPtr(&userData)))
-                        {
-                            throw new CryptographicException(Marshal.GetLastWin32Error());
-                        }
+                        pDataIn: new IntPtr(&dataIn),
+                        ppszDataDescr: IntPtr.Zero,
+                        pOptionalEntropy: new IntPtr(&entropy),
+                        pvReserved: IntPtr.Zero,
+                        pPromptStruct: IntPtr.Zero,
+                        dwFlags: dwFlags,
+                        pDataBlob: new IntPtr(&userData)))
+                    {
+                        throw new CryptographicException(Marshal.GetLastWin32Error());
+                    }
                 }
 
                 // In some cases, the API would fail due to OOM but simply return a null pointer.

--- a/src/System.Management.Automation/security/SecureStringHelper.cs
+++ b/src/System.Management.Automation/security/SecureStringHelper.cs
@@ -431,7 +431,9 @@ namespace Microsoft.PowerShell
         public static byte[] Protect(byte[] userData, byte[] optionalEntropy, DataProtectionScope scope)
         {
             if (userData == null)
+            {
                 throw new ArgumentNullException("userData");
+            }
 
             GCHandle pbDataIn = new GCHandle();
             GCHandle pOptionalEntropy = new GCHandle();
@@ -456,13 +458,14 @@ namespace Microsoft.PowerShell
                     dwFlags |= CAPI.CRYPTPROTECT_LOCAL_MACHINE;
                 unsafe
                 {
-                    if (!CAPI.CryptProtectData(new IntPtr(&dataIn),
-                                                string.Empty,
-                                                new IntPtr(&entropy),
-                                                IntPtr.Zero,
-                                                IntPtr.Zero,
-                                                dwFlags,
-                                                new IntPtr(&blob)))
+                    if (!CAPI.CryptProtectData(
+                        new IntPtr(&dataIn),
+                        string.Empty,
+                        new IntPtr(&entropy),
+                        IntPtr.Zero,
+                        IntPtr.Zero,
+                        dwFlags,
+                        new IntPtr(&blob)))
                     {
                         int lastWin32Error = Marshal.GetLastWin32Error();
 
@@ -483,7 +486,9 @@ namespace Microsoft.PowerShell
 
                 // In some cases, the API would fail due to OOM but simply return a null pointer.
                 if (blob.pbData == IntPtr.Zero)
+                {
                     throw new OutOfMemoryException();
+                }
 
                 byte[] encryptedData = new byte[(int)blob.cbData];
                 Marshal.Copy(blob.pbData, encryptedData, 0, encryptedData.Length);
@@ -493,9 +498,13 @@ namespace Microsoft.PowerShell
             finally
             {
                 if (pbDataIn.IsAllocated)
+                {
                     pbDataIn.Free();
+                }
                 if (pOptionalEntropy.IsAllocated)
+                {
                     pOptionalEntropy.Free();
+                }
                 if (blob.pbData != IntPtr.Zero)
                 {
                     CAPI.ZeroMemory(blob.pbData, blob.cbData);
@@ -510,7 +519,9 @@ namespace Microsoft.PowerShell
         public static byte[] Unprotect(byte[] encryptedData, byte[] optionalEntropy, DataProtectionScope scope)
         {
             if (encryptedData == null)
+            {
                 throw new ArgumentNullException("encryptedData");
+            }
 
             GCHandle pbDataIn = new GCHandle();
             GCHandle pOptionalEntropy = new GCHandle();
@@ -532,22 +543,30 @@ namespace Microsoft.PowerShell
 
                 uint dwFlags = CAPI.CRYPTPROTECT_UI_FORBIDDEN;
                 if (scope == DataProtectionScope.LocalMachine)
+                {
                     dwFlags |= CAPI.CRYPTPROTECT_LOCAL_MACHINE;
+                }
+
                 unsafe
                 {
-                    if (!CAPI.CryptUnprotectData(new IntPtr(&dataIn),
-                                                 IntPtr.Zero,
-                                                 new IntPtr(&entropy),
-                                                 IntPtr.Zero,
-                                                 IntPtr.Zero,
-                                                 dwFlags,
-                                                 new IntPtr(&userData)))
-                        throw new CryptographicException(Marshal.GetLastWin32Error());
+                    if (!CAPI.CryptUnprotectData(
+                        new IntPtr(&dataIn),
+                        IntPtr.Zero,
+                        new IntPtr(&entropy),
+                        IntPtr.Zero,
+                        IntPtr.Zero,
+                        dwFlags,
+                        new IntPtr(&userData)))
+                        {
+                            throw new CryptographicException(Marshal.GetLastWin32Error());
+                        }
                 }
 
                 // In some cases, the API would fail due to OOM but simply return a null pointer.
                 if (userData.pbData == IntPtr.Zero)
+                {
                     throw new OutOfMemoryException();
+                }
 
                 byte[] data = new byte[(int)userData.cbData];
                 Marshal.Copy(userData.pbData, data, 0, data.Length);
@@ -557,9 +576,13 @@ namespace Microsoft.PowerShell
             finally
             {
                 if (pbDataIn.IsAllocated)
+                {
                     pbDataIn.Free();
+                }
                 if (pOptionalEntropy.IsAllocated)
+                {
                     pOptionalEntropy.Free();
+                }
                 if (userData.pbData != IntPtr.Zero)
                 {
                     CAPI.ZeroMemory(userData.pbData, userData.cbData);

--- a/test/powershell/Modules/Microsoft.PowerShell.Security/SecureString.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/SecureString.Tests.ps1
@@ -5,12 +5,6 @@ Describe "SecureString conversion tests" -Tags "CI" {
         $string = "ABCD"
         $secureString = [System.Security.SecureString]::New()
         $string.ToCharArray() | foreach-object { $securestring.AppendChar($_) }
-        $defaultParamValues = $PSdefaultParameterValues.Clone()
-        $PSdefaultParameterValues = @{}
-        if ( ! $IsWindows ) { $PSdefaultParameterValues["it:pending"] = $true }
-    }
-    AfterAll {
-        $global:PSdefaultParameterValues = $defaultParamValues
     }
 
     It "using null arguments to ConvertFrom-SecureString produces an exception" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/clixml.tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/clixml.tests.ps1
@@ -170,29 +170,7 @@ Describe "CliXml test" -Tags "CI" {
             $testPath | Should -Not -Exist
         }
 
-        It "should fail to import PSCredential on non-Windows" -Skip:$IsWindows {
-            $cliXml = @"
-                <Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
-                <Obj RefId="0">
-                <TN RefId="0">
-                    <T>System.Management.Automation.PSCredential</T>
-                    <T>System.Object</T>
-                </TN>
-                <ToString>System.Management.Automation.PSCredential</ToString>
-                <Props>
-                    <S N="UserName">foo</S>
-                    <!-- this is just an empty password, but needs to be a valid hash -->
-                    <SS N="Password">01000000d08c9ddf0115d1118c7a00c04fc297eb01000000977756228672474da9bfbe7b6acc02cb0000000002000000000003660000c0000000100000002529194617877bbbc952c6aacb6535f00000000004800000a000000010000000703ca974777a8335d5e2f8b3e592ff4208000000635d9fcda035734e140000001b6940e3222117a1014c67377e8786549f3dca29</SS>
-                </Props>
-                </Obj>
-                </Objs>
-"@
-            $path = "$testdrive/cred.xml"
-            Set-Content -Path $path -Value $cliXml
-            { Import-Clixml -Path $path } | Should -Throw -ErrorId "System.PlatformNotSupportedException,Microsoft.PowerShell.Commands.ImportClixmlCommand"
-        }
-
-        It "should import PSCredential" -Skip:(!$IsWindows) {
+        It "should import PSCredential" {
             $UserName = "Foo"
             $pass = ConvertTo-SecureString (New-RandomHexString) -AsPlainText -Force
             $cred =  [PSCredential]::new($UserName, $pass)


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

On Unix systems, fallback to plaintext manipulation instead of using the DPAPI which is not available.

## PR Context

Currently, existing scripts that use SecureString cmdlets fail with an error complaining about crypt32.dll not being available.  This change allows these cmdlets to be used, but there is no encryption of the string.
.Net already [states](https://docs.microsoft.com/en-us/dotnet/api/system.security.securestring?view=netcore-2.1#remarks) that the contents of a SecureString are not encrypted on .Net Core.

Fix https://github.com/PowerShell/PowerShell/issues/1654

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [x] PR: https://github.com/MicrosoftDocs/PowerShell-Docs/pull/4030 https://github.com/MicrosoftDocs/PowerShell-Docs/pull/4034
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` to your commit messages if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
