### PR TITLE
Make command searcher not use wildcard search for execution

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -909,7 +909,7 @@ function Start-PSPester {
         [Parameter(HelpMessage='Title to publish the results as.')]
         [string]$Title = 'PowerShell Core Tests',
         [Parameter(ParameterSetName='Wait', Mandatory=$true,
-            HelpMessage='Wait for the debugger to attach to powershell before pester starts.  Debug builds only!')]
+            HelpMessage='Wait for the debugger to attach to PowerShell before Pester starts.  Debug builds only!')]
         [switch]$Wait
     )
 

--- a/build.psm1
+++ b/build.psm1
@@ -908,7 +908,8 @@ function Start-PSPester {
         [string]$ExperimentalFeatureName,
         [Parameter(HelpMessage='Title to publish the results as.')]
         [string]$Title = 'PowerShell Core Tests',
-		[Parameter(ParameterSetName='Wait',Mandatory=$true,HelpMessage='Wait for the debugger to attach to powershell before pester starts.  Debug builds only!')]
+        [Parameter(ParameterSetName='Wait', Mandatory=$true,
+            HelpMessage='Wait for the debugger to attach to powershell before pester starts.  Debug builds only!')]
         [switch]$Wait
     )
 
@@ -1104,7 +1105,7 @@ function Start-PSPester {
     }
 
 	# -Wait is only available on Debug builds
-	# It is used to allow the debugger to attach before PowerShell 
+	# It is used to allow the debugger to attach before PowerShell
 	# runs pester in this case
     if($Wait.IsPresent){
         $PSFlags += '-wait'

--- a/build.psm1
+++ b/build.psm1
@@ -907,7 +907,8 @@ function Start-PSPester {
         [switch]$IncludeCommonTests,
         [string]$ExperimentalFeatureName,
         [Parameter(HelpMessage='Title to publish the results as.')]
-        [string]$Title = 'PowerShell Core Tests'
+        [string]$Title = 'PowerShell Core Tests',
+        [switch]$Wait
     )
 
     if (-not (Get-Module -ListAvailable -Name $Pester -ErrorAction SilentlyContinue | Where-Object { $_.Version -ge "4.2" } ))
@@ -1099,6 +1100,9 @@ function Start-PSPester {
 
         Set-Content -Path $configFile -Value $content -Encoding Ascii -Force
         $PSFlags = @("-settings", $configFile, "-noprofile")
+    }
+    if($Wait.IsPresent){
+        $PSFlags += '-wait'
     }
 
     # To ensure proper testing, the module path must not be inherited by the spawned process

--- a/build.psm1
+++ b/build.psm1
@@ -908,6 +908,7 @@ function Start-PSPester {
         [string]$ExperimentalFeatureName,
         [Parameter(HelpMessage='Title to publish the results as.')]
         [string]$Title = 'PowerShell Core Tests',
+		[Parameter(ParameterSetName='Wait',Mandatory=$true,HelpMessage='Wait for the debugger to attach to powershell before pester starts.  Debug builds only!')]
         [switch]$Wait
     )
 
@@ -1101,6 +1102,10 @@ function Start-PSPester {
         Set-Content -Path $configFile -Value $content -Encoding Ascii -Force
         $PSFlags = @("-settings", $configFile, "-noprofile")
     }
+
+	# -Wait is only available on Debug builds
+	# It is used to allow the debugger to attach before PowerShell 
+	# runs pester in this case
     if($Wait.IsPresent){
         $PSFlags += '-wait'
     }

--- a/src/System.Management.Automation/engine/CommandDiscovery.cs
+++ b/src/System.Management.Automation/engine/CommandDiscovery.cs
@@ -735,7 +735,7 @@ namespace System.Management.Automation
 
         internal static CommandInfo LookupCommandInfo(string commandName, CommandOrigin commandOrigin, ExecutionContext context)
         {
-            return LookupCommandInfo(commandName, CommandTypes.All, SearchResolutionOptions.None, commandOrigin, context);
+            return LookupCommandInfo(commandName, CommandTypes.All, SearchResolutionOptions.ResolveLiteralThenPathPatterns, commandOrigin, context);
         }
 
         internal static CommandInfo LookupCommandInfo(

--- a/src/System.Management.Automation/engine/CommandSearcher.cs
+++ b/src/System.Management.Automation/engine/CommandSearcher.cs
@@ -1167,7 +1167,7 @@ namespace System.Management.Automation
                 }
 
                 // Verify the path was resolved to a file system path
-                if (provider !=null && provider.NameEquals(_context.ProviderNames.FileSystem))
+                if (provider != null && provider.NameEquals(_context.ProviderNames.FileSystem))
                 {
                     result = resolvedPath;
 

--- a/src/System.Management.Automation/engine/CommandSearcher.cs
+++ b/src/System.Management.Automation/engine/CommandSearcher.cs
@@ -518,7 +518,7 @@ namespace System.Management.Automation
         {
             try
             {
-                return _context.LocationGlobber.GetGlobbedProviderPathsFromMonadPath(command, false, out provider, out _);
+                return _context.LocationGlobber.GetGlobbedProviderPathsFromMonadPath(path: command, allowNonexistingPaths: false, provider: out provider, providerInstance:  out _);
             }
             catch (ItemNotFoundException)
             {

--- a/src/System.Management.Automation/engine/CommandSearcher.cs
+++ b/src/System.Management.Automation/engine/CommandSearcher.cs
@@ -509,7 +509,7 @@ namespace System.Management.Automation
                 }
 
                 // Try literal path resolution if wildcards are disable or wildcard search failed
-                if ((resolvedPaths == null))
+                if (resolvedPaths == null)
                 {
                     string path = _context.LocationGlobber.GetProviderPath(_commandName, out provider);
                     resolvedPaths = new System.Collections.ObjectModel.Collection<string>();
@@ -1627,6 +1627,5 @@ namespace System.Management.Automation
         /// Enable resolving wildcard in paths.
         /// </summary>
         ResolvePathPatterns = 0x40,
-
     }
 }

--- a/src/System.Management.Automation/engine/CommandSearcher.cs
+++ b/src/System.Management.Automation/engine/CommandSearcher.cs
@@ -1165,7 +1165,7 @@ namespace System.Management.Automation
 
                 // Try literal path resolution if wildcards are enabled first and wildcard search failed
                 if (!_commandResolutionOptions.HasFlag(SearchResolutionOptions.ResolveLiteralThenPathPatterns) &&
-                    ((resolvedPath == null) || (provider == null))
+                    ((resolvedPath == null) || (provider == null)))
                 {
                     resolvedPath = GetNextLiteralPathThatExists(path, out provider);
                 }

--- a/src/System.Management.Automation/engine/CommandSearcher.cs
+++ b/src/System.Management.Automation/engine/CommandSearcher.cs
@@ -466,8 +466,7 @@ namespace System.Management.Automation
                 }
 
                 Collection<string> resolvedPaths = new Collection<string>();
-                if (resolvedPaths.Count == 0 &&
-                    WildcardPattern.ContainsWildcardCharacters(_commandName))
+                if (WildcardPattern.ContainsWildcardCharacters(_commandName))
                 {
                     resolvedPaths = GetNextFromPathUsingWildcards(_commandName, out _);
                 }
@@ -1131,7 +1130,7 @@ namespace System.Management.Automation
                 if (_commandResolutionOptions.HasFlag(SearchResolutionOptions.ResolveLiteralThenPathPatterns))
                 {
                     // Cannot return early as this code path only expects
-                    // The file system provider and the final check for that 
+                    // The file system provider and the final check for that
                     // must verify this before we return.
                     resolvedPath = GetNextLiteralPathThatExists(path, out provider);
                 }

--- a/src/System.Management.Automation/engine/CommandSearcher.cs
+++ b/src/System.Management.Automation/engine/CommandSearcher.cs
@@ -461,9 +461,10 @@ namespace System.Management.Automation
                 {
                     var path = GetNextLiteralPathThatExists(_commandName, out _);
 
-                    // This can return null, but that is expected.
-                    // The searcher will continue, if it can.
-                    return GetInfoFromPath(path);
+                    if(path !=null)
+                    {
+                        return GetInfoFromPath(path);
+                    }
                 }
 
                 Collection<string> resolvedPaths = new Collection<string>();

--- a/src/System.Management.Automation/engine/CommandSearcher.cs
+++ b/src/System.Management.Automation/engine/CommandSearcher.cs
@@ -1167,7 +1167,7 @@ namespace System.Management.Automation
                 }
 
                 // Verify the path was resolved to a file system path
-                if (provider.NameEquals(_context.ProviderNames.FileSystem))
+                if (provider !=null && provider.NameEquals(_context.ProviderNames.FileSystem))
                 {
                     result = resolvedPath;
 

--- a/src/System.Management.Automation/engine/CommandSearcher.cs
+++ b/src/System.Management.Automation/engine/CommandSearcher.cs
@@ -519,8 +519,7 @@ namespace System.Management.Automation
         {
             try
             {
-                Provider.CmdletProvider providerInstance;
-                return _context.LocationGlobber.GetGlobbedProviderPathsFromMonadPath(command, false, out provider, out providerInstance);
+                return _context.LocationGlobber.GetGlobbedProviderPathsFromMonadPath(command, false, out provider, out _);
             }
             catch (ItemNotFoundException)
             {

--- a/src/System.Management.Automation/engine/CommandSearcher.cs
+++ b/src/System.Management.Automation/engine/CommandSearcher.cs
@@ -512,8 +512,8 @@ namespace System.Management.Automation
                 if ((resolvedPaths == null))
                 {
                     string path = _context.LocationGlobber.GetProviderPath(_commandName, out provider);
-                    result = GetInfoFromPath(path);
-                    return result;
+                    resolvedPaths = new System.Collections.ObjectModel.Collection<string>();
+                    resolvedPaths.Add(path);
                 }
 
                 if (resolvedPaths.Count > 1)

--- a/src/System.Management.Automation/engine/CommandSearcher.cs
+++ b/src/System.Management.Automation/engine/CommandSearcher.cs
@@ -460,7 +460,7 @@ namespace System.Management.Automation
                 Collection<string> resolvedPaths = new Collection<string>();
 
                 ProviderInfo provider;
-                if ((_commandResolutionOptions & SearchResolutionOptions.ResolvePathPatterns) != 0 &&
+                if (_commandResolutionOptions.HasFlag(SearchResolutionOptions.ResolvePathPatterns) &&
                     WildcardPattern.ContainsWildcardCharacters(_commandName))
                 {
                     try

--- a/src/System.Management.Automation/engine/CommandSearcher.cs
+++ b/src/System.Management.Automation/engine/CommandSearcher.cs
@@ -505,6 +505,16 @@ namespace System.Management.Automation
             return result;
         }
 
+        /// <summary>
+        /// Gets the next path using WildCards.
+        /// </summary>
+        /// <param name="command">
+        /// The command to search for
+        /// </param>
+        /// <param name="provider">The provider that the command was found in</param>
+        /// <returns>
+        /// A collection of full paths to the commands which were found
+        /// </returns>
         private Collection<string> GetNextFromPathUsingWildcards(string command, out ProviderInfo provider)
         {
             try
@@ -1206,6 +1216,17 @@ namespace System.Management.Automation
             return result;
         }
 
+        /// <summary>
+        /// Gets the next literal path.
+        /// filtering to ones that exist for the filesystem
+        /// </summary>
+        /// <param name="command">
+        /// The command to search for
+        /// </param>
+        /// <param name="provider">The provider that the command was found in</param>
+        /// <returns>
+        /// Full path to the command
+        /// </returns>
         private string GetNextLiteralPathThatExists(string command, out ProviderInfo provider)
         {
             string resolvedPath = _context.LocationGlobber.GetProviderPath(command, out provider);

--- a/src/System.Management.Automation/engine/CommandSearcher.cs
+++ b/src/System.Management.Automation/engine/CommandSearcher.cs
@@ -456,13 +456,10 @@ namespace System.Management.Automation
                     "Trying to resolve the path as an PSPath");
 
                 // Find the match if it is.
-
-                ProviderInfo provider;
-
                 // Try literal path resolution if it is set to run first
                 if (_commandResolutionOptions.HasFlag(SearchResolutionOptions.ResolveLiteralThenPathPatterns))
                 {
-                    string path = GetNextLiteralPathThatExists(_commandName, out provider);
+                    string path = GetNextLiteralPathThatExists(_commandName, out _);
                     return GetInfoFromPath(path);
                 }
 
@@ -470,14 +467,14 @@ namespace System.Management.Automation
                 if (resolvedPaths.Count == 0 &&
                     WildcardPattern.ContainsWildcardCharacters(_commandName))
                 {
-                    resolvedPaths = GetNextFromPathUsingWildcards(_commandName, out provider);
+                    resolvedPaths = GetNextFromPathUsingWildcards(_commandName, out _);
                 }
 
                 // Try literal path resolution if wildcards are enable first and wildcard search failed
                 if (!_commandResolutionOptions.HasFlag(SearchResolutionOptions.ResolveLiteralThenPathPatterns) &&
                     resolvedPaths.Count == 0)
                 {
-                    string path = GetNextLiteralPathThatExists(_commandName, out provider);
+                    string path = GetNextLiteralPathThatExists(_commandName, out _);
                     return GetInfoFromPath(path);
                 }
 

--- a/src/System.Management.Automation/engine/CommandSearcher.cs
+++ b/src/System.Management.Automation/engine/CommandSearcher.cs
@@ -1104,7 +1104,7 @@ namespace System.Management.Automation
             {
                 ProviderInfo provider = null;
                 string resolvedPath = null;
-                if ((_commandResolutionOptions & SearchResolutionOptions.ResolvePathPatterns) != 0 &&
+                if (_commandResolutionOptions.HasFlag(SearchResolutionOptions.ResolvePathPatterns) &&
                      WildcardPattern.ContainsWildcardCharacters(path))
                 {
                     // Let PowerShell resolve relative path with wildcards.

--- a/src/System.Management.Automation/engine/CommandSearcher.cs
+++ b/src/System.Management.Automation/engine/CommandSearcher.cs
@@ -461,7 +461,7 @@ namespace System.Management.Automation
                 {
                     var path = GetNextLiteralPathThatExists(_commandName, out _);
 
-                    if(path !=null)
+                    if (path != null)
                     {
                         return GetInfoFromPath(path);
                     }
@@ -519,7 +519,7 @@ namespace System.Management.Automation
         {
             try
             {
-                return _context.LocationGlobber.GetGlobbedProviderPathsFromMonadPath(path: command, allowNonexistingPaths: false, provider: out provider, providerInstance:  out _);
+                return _context.LocationGlobber.GetGlobbedProviderPathsFromMonadPath(path: command, allowNonexistingPaths: false, provider: out provider, providerInstance: out _);
             }
             catch (ItemNotFoundException)
             {

--- a/src/System.Management.Automation/engine/CommandSearcher.cs
+++ b/src/System.Management.Automation/engine/CommandSearcher.cs
@@ -1232,7 +1232,7 @@ namespace System.Management.Automation
         {
             string resolvedPath = _context.LocationGlobber.GetProviderPath(command, out provider);
 
-            if (provider.Name.Equals("FileSystem", StringComparison.OrdinalIgnoreCase)
+            if (provider.NameEquals(_context.ProviderNames.FileSystem)
                 && !File.Exists(resolvedPath)
                 && !Directory.Exists(resolvedPath))
             {

--- a/src/System.Management.Automation/engine/CommandSearcher.cs
+++ b/src/System.Management.Automation/engine/CommandSearcher.cs
@@ -459,7 +459,9 @@ namespace System.Management.Automation
                 // Try literal path resolution if it is set to run first
                 if (_commandResolutionOptions.HasFlag(SearchResolutionOptions.ResolveLiteralThenPathPatterns))
                 {
-                    string path = GetNextLiteralPathThatExists(_commandName, out _);
+                    var path = GetNextLiteralPathThatExists(_commandName, out _);
+                    // This can return null, but that is expected.
+                    // The searcher will continue, if it can.
                     return GetInfoFromPath(path);
                 }
 
@@ -1128,6 +1130,9 @@ namespace System.Management.Automation
                 // Try literal path resolution if it is set to run first
                 if (_commandResolutionOptions.HasFlag(SearchResolutionOptions.ResolveLiteralThenPathPatterns))
                 {
+                    // Cannot return early as this code path only expects
+                    // The file system provider and the final check for that 
+                    // must verify this before we return.
                     resolvedPath = GetNextLiteralPathThatExists(path, out provider);
                 }
 

--- a/src/System.Management.Automation/engine/CommandSearcher.cs
+++ b/src/System.Management.Automation/engine/CommandSearcher.cs
@@ -478,7 +478,11 @@ namespace System.Management.Automation
                     resolvedPaths.Count == 0)
                 {
                     string path = GetNextLiteralPathThatExists(_commandName, out _);
-                    return GetInfoFromPath(path);
+
+                    if (path != null)
+                    {
+                        return GetInfoFromPath(path);
+                    }
                 }
 
                 if (resolvedPaths.Count > 1)

--- a/src/System.Management.Automation/engine/CommandSearcher.cs
+++ b/src/System.Management.Automation/engine/CommandSearcher.cs
@@ -508,12 +508,12 @@ namespace System.Management.Automation
                     }
                 }
 
+                // Try literal path resolution if wildcards are disable or wildcard search failed
                 if ((resolvedPaths == null))
                 {
                     string path = _context.LocationGlobber.GetProviderPath(_commandName, out provider);
-                    var temp = new System.Collections.ObjectModel.Collection<string>();
-                    temp.Add(path);
-                    resolvedPaths = temp;
+                    result = GetInfoFromPath(path);
+                    return result;
                 }
 
                 if (resolvedPaths.Count > 1)
@@ -1137,7 +1137,7 @@ namespace System.Management.Automation
                     }
                 }
 
-                // Revert to previous path resolver if wildcards produces no results.
+                // Try literal path resolution if wildcards are disable or wildcard search failed
                 if ((resolvedPath == null) || (provider == null))
                 {
                     resolvedPath = _context.LocationGlobber.GetProviderPath(path, out provider);
@@ -1469,7 +1469,6 @@ namespace System.Management.Automation
                     // path lookup for relative paths.
 
                     string directory = Path.GetDirectoryName(_commandName);
-                    // Not using
                     directory = ResolvePSPath(directory);
 
                     CommandDiscovery.discoveryTracer.WriteLine(

--- a/src/System.Management.Automation/engine/CommandSearcher.cs
+++ b/src/System.Management.Automation/engine/CommandSearcher.cs
@@ -460,6 +460,7 @@ namespace System.Management.Automation
                 if (_commandResolutionOptions.HasFlag(SearchResolutionOptions.ResolveLiteralThenPathPatterns))
                 {
                     var path = GetNextLiteralPathThatExists(_commandName, out _);
+
                     // This can return null, but that is expected.
                     // The searcher will continue, if it can.
                     return GetInfoFromPath(path);

--- a/src/System.Management.Automation/engine/CommandSearcher.cs
+++ b/src/System.Management.Automation/engine/CommandSearcher.cs
@@ -512,7 +512,6 @@ namespace System.Management.Automation
                 if (resolvedPaths.Count == 0)
                 {
                     string path = _context.LocationGlobber.GetProviderPath(_commandName, out provider);
-                    resolvedPaths = new System.Collections.ObjectModel.Collection<string>();
                     resolvedPaths.Add(path);
                 }
 

--- a/src/System.Management.Automation/engine/CommandSearcher.cs
+++ b/src/System.Management.Automation/engine/CommandSearcher.cs
@@ -509,11 +509,11 @@ namespace System.Management.Automation
         /// Gets the next path using WildCards.
         /// </summary>
         /// <param name="command">
-        /// The command to search for
+        /// The command to search for.
         /// </param>
-        /// <param name="provider">The provider that the command was found in</param>
+        /// <param name="provider">The provider that the command was found in.</param>
         /// <returns>
-        /// A collection of full paths to the commands which were found
+        /// A collection of full paths to the commands which were found.
         /// </returns>
         private Collection<string> GetNextFromPathUsingWildcards(string command, out ProviderInfo provider)
         {
@@ -1165,7 +1165,7 @@ namespace System.Management.Automation
 
                 // Try literal path resolution if wildcards are enabled first and wildcard search failed
                 if (!_commandResolutionOptions.HasFlag(SearchResolutionOptions.ResolveLiteralThenPathPatterns) &&
-                    (resolvedPath == null) || (provider == null))
+                    ((resolvedPath == null) || (provider == null))
                 {
                     resolvedPath = GetNextLiteralPathThatExists(path, out provider);
                 }
@@ -1218,14 +1218,14 @@ namespace System.Management.Automation
 
         /// <summary>
         /// Gets the next literal path.
-        /// filtering to ones that exist for the filesystem
+        /// Filtering to ones that exist for the filesystem.
         /// </summary>
         /// <param name="command">
-        /// The command to search for
+        /// The command to search for.
         /// </param>
-        /// <param name="provider">The provider that the command was found in</param>
+        /// <param name="provider">The provider that the command was found in.</param>
         /// <returns>
-        /// Full path to the command
+        /// Full path to the command.
         /// </returns>
         private string GetNextLiteralPathThatExists(string command, out ProviderInfo provider)
         {

--- a/src/System.Management.Automation/engine/CommandSearcher.cs
+++ b/src/System.Management.Automation/engine/CommandSearcher.cs
@@ -1228,7 +1228,8 @@ namespace System.Management.Automation
             string resolvedPath = _context.LocationGlobber.GetProviderPath(command, out provider);
 
             if (provider.Name.Equals("FileSystem", StringComparison.OrdinalIgnoreCase)
-                && !File.Exists(resolvedPath))
+                && !File.Exists(resolvedPath)
+                && !Directory.Exists(resolvedPath))
             {
                 provider = null;
                 return null;

--- a/src/System.Management.Automation/engine/CommandSearcher.cs
+++ b/src/System.Management.Automation/engine/CommandSearcher.cs
@@ -509,7 +509,7 @@ namespace System.Management.Automation
                 }
 
                 // Try literal path resolution if wildcards are disable or wildcard search failed
-                if (resolvedPaths == null)
+                if (resolvedPaths.Count == 0)
                 {
                     string path = _context.LocationGlobber.GetProviderPath(_commandName, out provider);
                     resolvedPaths = new System.Collections.ObjectModel.Collection<string>();

--- a/src/System.Management.Automation/engine/GetCommandCommand.cs
+++ b/src/System.Management.Automation/engine/GetCommandCommand.cs
@@ -704,7 +704,7 @@ namespace Microsoft.PowerShell.Commands
         {
             // First set the search options
 
-            SearchResolutionOptions options = SearchResolutionOptions.ResolvePathPatterns;
+            SearchResolutionOptions options = SearchResolutionOptions.None;
             if (All)
             {
                 options = SearchResolutionOptions.SearchAllScopes;

--- a/src/System.Management.Automation/engine/GetCommandCommand.cs
+++ b/src/System.Management.Automation/engine/GetCommandCommand.cs
@@ -704,7 +704,7 @@ namespace Microsoft.PowerShell.Commands
         {
             // First set the search options
 
-            SearchResolutionOptions options = SearchResolutionOptions.None;
+            SearchResolutionOptions options = SearchResolutionOptions.ResolvePathPatterns;
             if (All)
             {
                 options = SearchResolutionOptions.SearchAllScopes;

--- a/test/powershell/engine/Basic/CommandDiscovery.Tests.ps1
+++ b/test/powershell/engine/Basic/CommandDiscovery.Tests.ps1
@@ -141,6 +141,7 @@ Describe "Command Discovery tests" -Tags "CI" {
             )
 
             $shouldNotExecuteCases = @(
+                @{command = 'subFolder\[test1].ps1' ; testName = 'Relative path that where module qualified syntax overlaps'; ExpectedErrorId = 'CouldNotAutoLoadModule'}
                 @{command = '.\[12].ps1' ; testName = 'relative path with bracket wildcard matctching multiple files'}
                 @{command = (Join-Path ${TestDrive}  -ChildPath '[12].ps1') ; testName = 'fully qualified path with bracket wildcard matctching multiple files'}
             )
@@ -164,8 +165,13 @@ Describe "Command Discovery tests" -Tags "CI" {
         }
 
         It "'<testName>' should not execute" -TestCases $shouldNotExecuteCases {
-            param($command)
-            { & $command } | Should -Throw -ErrorId 'CommandNotFoundException'
+            param(
+                [string]
+                $command,
+                [string]
+                $ExpectedErrorId = 'CommandNotFoundException'
+                )
+            { & $command } | Should -Throw -ErrorId $ExpectedErrorId
         }
     }
 

--- a/test/powershell/engine/Basic/CommandDiscovery.Tests.ps1
+++ b/test/powershell/engine/Basic/CommandDiscovery.Tests.ps1
@@ -93,8 +93,8 @@ Describe "Command Discovery tests" -Tags "CI" {
             setup -f '1.ps1' -content "'$secondResult'"
 
             $executionWithWildcardCases = @(
-                @{command = '.\[test1].ps1' ; expectedResult = $firstResult}
-                @{command = (Join-Path ${TestDrive}  -ChildPath '[test1].ps1') ; expectedResult = $firstResult}
+                @{command = '.\[test1].ps1' ; expectedResult = $firstResult; name = '.\[test1].ps1'}
+                @{command = (Join-Path ${TestDrive}  -ChildPath '[test1].ps1') ; expectedResult = $firstResult; name = '.\[test1].ps1 by fully qualified path'}
             )
 
             $shouldNotExecuteCases = @(
@@ -109,7 +109,7 @@ Describe "Command Discovery tests" -Tags "CI" {
             Pop-Location
         }
 
-        It "Invoking <command> should return '<expectedResult>'" -TestCases $executionWithWildcardCases {
+        It "Invoking <name> should return '<expectedResult>'" -TestCases $executionWithWildcardCases {
             param($command, $expectedResult)
             & $command | Should -BeExactly $expectedResult
         }

--- a/test/powershell/engine/Basic/CommandDiscovery.Tests.ps1
+++ b/test/powershell/engine/Basic/CommandDiscovery.Tests.ps1
@@ -160,6 +160,7 @@ Describe "Command Discovery tests" -Tags "CI" {
         }
 
         It "Get-Command should throw CommandNotFoundException when running '<testName>'" -TestCases $shouldNotFindCases {
+            param($command)
             {Get-Command -Name $command} | Should -Throw -ErrorId 'CommandNotFoundException'
         }
     }

--- a/test/powershell/engine/Basic/CommandDiscovery.Tests.ps1
+++ b/test/powershell/engine/Basic/CommandDiscovery.Tests.ps1
@@ -138,11 +138,8 @@ Describe "Command Discovery tests" -Tags "CI" {
                 @{command = (Join-Path ${TestDrive}  -ChildPath '?[tb]est1?.ps1'); expectedCommand = '[test1].ps1'; expectedCommandCount =1 ; name = '''.\?[tb]est1?.ps1'' by fully qualified path'}
                 @{command = '.\[test1].ps1'; expectedCommand = '1.ps1'; expectedCommandCount =1; name = '''.\[test1].ps1'''}
                 @{command = (Join-Path ${TestDrive}  -ChildPath '[test1].ps1'); expectedCommand = '1.ps1'; expectedCommandCount =1 ; name = '''.\[test1].ps1'' by fully qualified path'}
-            )
-
-            $shouldNotFindCases = @(
-                @{command = '.\[12].ps1' ; testName = 'relative path with bracket wildcard matctching multiple files'}
-                @{command = (Join-Path ${TestDrive}  -ChildPath '[12].ps1') ; testName = 'fully qualified path with bracket wildcard matctching multiple files'}
+                @{command = '.\[12].ps1'; expectedCommand = '1.ps1'; expectedCommandCount =0; name = 'relative path with bracket wildcard matctching multiple files'}
+                @{command = (Join-Path ${TestDrive}  -ChildPath '[12].ps1'); expectedCommand = '1.ps1'; expectedCommandCount =0 ; name = 'fully qualified path with bracket wildcard matctching multiple files'}
             )
 
             Push-Location ${TestDrive}\
@@ -154,14 +151,12 @@ Describe "Command Discovery tests" -Tags "CI" {
 
         It "Get-Command <name> should return <expectedCommandCount> command named '<expectedCommand>'" -TestCases $gcmWithWildcardCases {
             param($command, $expectedCommand, $expectedCommandCount)
-            $commands = Get-Command -Name $command
+            $commands = @(Get-Command -Name $command)
             $commands.Count | Should -Be $expectedCommandCount
-            $commands.Name | Should -BeExactly $expectedCommand
-        }
-
-        It "Get-Command should throw CommandNotFoundException when running '<testName>'" -TestCases $shouldNotFindCases {
-            param($command)
-            {Get-Command -Name $command} | Should -Throw -ErrorId 'CommandNotFoundException'
+            if($expectedCommandCount -gt 0)
+            {
+                $commands.Name | Should -BeExactly $expectedCommand
+            }
         }
     }
 }

--- a/test/powershell/engine/Basic/CommandDiscovery.Tests.ps1
+++ b/test/powershell/engine/Basic/CommandDiscovery.Tests.ps1
@@ -85,7 +85,7 @@ Describe "Command Discovery tests" -Tags "CI" {
         (& 'location').Path | Should -Be (get-location).Path
     }
 
-    Context "Use literal path when executing scripts" {
+    Context "Use literal path first when executing scripts" {
         BeforeAll {
             $firstResult = 'first script'
             $secondResult = 'alt script'
@@ -94,11 +94,11 @@ Describe "Command Discovery tests" -Tags "CI" {
 
             $executionWithWildcardCases = @(
                 @{command = '.\[test1].ps1' ; expectedResult = $firstResult; name = '.\[test1].ps1'}
+                @{command = '.\[t1].ps1' ; expectedResult = $secondResult; name = '.\[t1].ps1'}
                 @{command = (Join-Path ${TestDrive}  -ChildPath '[test1].ps1') ; expectedResult = $firstResult; name = '.\[test1].ps1 by fully qualified path'}
             )
 
             $shouldNotExecuteCases = @(
-                @{command = '.\[12].ps1'; testName = 'relative path with bracket wildcard matctching one file'}
                 @{command = (Join-Path ${TestDrive}  -ChildPath '[12].ps1') ; testName = 'fully qualified path with bracket wildcard matctching one file'}
             )
 
@@ -120,7 +120,7 @@ Describe "Command Discovery tests" -Tags "CI" {
         }
     }
 
-    Context "Get-Command should use globbing for scripts" {
+    Context "Get-Command should use globbing first for scripts" {
         BeforeAll {
             $firstResult = '[first script]'
             $secondResult = 'alt script'

--- a/test/powershell/engine/Basic/CommandDiscovery.Tests.ps1
+++ b/test/powershell/engine/Basic/CommandDiscovery.Tests.ps1
@@ -116,7 +116,7 @@ Describe "Command Discovery tests" -Tags "CI" {
                 #Region relative Subfolder paths without './'
                     @{command = $secondFileInSubFolder ; expectedResult = $secondResult; name = $secondFileInSubFolder}
 
-                    # Wildcard search is also not being performed in this scenario before this change.
+                    # Wildcard search is not being performed in this scenario before this change.
                     # I noted the issue in the pending message
                     @{command = $firstFileInSubFolder ; expectedResult = $firstResult; name = $firstFileInSubFolder; Pending="See note about wildcard in https://github.com/PowerShell/PowerShell/issues/9256"}
                     @{command = $secondFileSearchInSubfolder ; expectedResult = $secondResult; name = $secondFileSearchInSubfolder; Pending="See note about wildcard in https://github.com/PowerShell/PowerShell/issues/9256"}

--- a/test/powershell/engine/Basic/CommandDiscovery.Tests.ps1
+++ b/test/powershell/engine/Basic/CommandDiscovery.Tests.ps1
@@ -89,17 +89,20 @@ Describe "Command Discovery tests" -Tags "CI" {
         BeforeAll {
             $firstResult = 'first script'
             $secondResult = 'alt script'
+            $thirdResult = 'bad script'
             setup -f '[test1].ps1' -content "'$firstResult'"
             setup -f '1.ps1' -content "'$secondResult'"
+            setup -f '2.ps1' -content "'$thirdResult'"
 
             $executionWithWildcardCases = @(
                 @{command = '.\[test1].ps1' ; expectedResult = $firstResult; name = '.\[test1].ps1'}
                 @{command = '.\[t1].ps1' ; expectedResult = $secondResult; name = '.\[t1].ps1'}
                 @{command = (Join-Path ${TestDrive}  -ChildPath '[test1].ps1') ; expectedResult = $firstResult; name = '.\[test1].ps1 by fully qualified path'}
+                @{command = (Join-Path ${TestDrive}  -ChildPath '[t1].ps1') ; expectedResult = $firstResult; name = '.\1.ps1 by fully qualified path with wildcard'}
             )
 
             $shouldNotExecuteCases = @(
-                @{command = (Join-Path ${TestDrive}  -ChildPath '[12].ps1') ; testName = 'fully qualified path with bracket wildcard matctching one file'}
+                @{command = (Join-Path ${TestDrive}  -ChildPath '[12].ps1') ; testName = 'fully qualified path with bracket wildcard matctching multiple files'}
             )
 
             Push-Location ${TestDrive}\

--- a/test/powershell/engine/Basic/CommandDiscovery.Tests.ps1
+++ b/test/powershell/engine/Basic/CommandDiscovery.Tests.ps1
@@ -98,7 +98,7 @@ Describe "Command Discovery tests" -Tags "CI" {
                 @{command = '.\[test1].ps1' ; expectedResult = $firstResult; name = '.\[test1].ps1'}
                 @{command = '.\[t1].ps1' ; expectedResult = $secondResult; name = '.\[t1].ps1'}
                 @{command = (Join-Path ${TestDrive}  -ChildPath '[test1].ps1') ; expectedResult = $firstResult; name = '.\[test1].ps1 by fully qualified path'}
-                @{command = (Join-Path ${TestDrive}  -ChildPath '[t1].ps1') ; expectedResult = $firstResult; name = '.\1.ps1 by fully qualified path with wildcard'}
+                @{command = (Join-Path ${TestDrive}  -ChildPath '[t1].ps1') ; expectedResult = $secondResult; name = '.\1.ps1 by fully qualified path with wildcard'}
             )
 
             $shouldNotExecuteCases = @(

--- a/test/powershell/engine/Basic/CommandDiscovery.Tests.ps1
+++ b/test/powershell/engine/Basic/CommandDiscovery.Tests.ps1
@@ -116,11 +116,6 @@ Describe "Command Discovery tests" -Tags "CI" {
                 #Region relative Subfolder paths without './'
                     @{command = $secondFileInSubFolder ; expectedResult = $secondResult; name = $secondFileInSubFolder}
 
-                    # PowerShell fails if the directory separators are in the wrong direction in this case
-                    # https://github.com/PowerShell/PowerShell/issues/9256
-                    @{command = 'subFolder\[test1].ps1' ; expectedResult = $firstResult; name = 'subFolder\[test1].ps1'; Pending="See directory separator direction in https://github.com/PowerShell/PowerShell/issues/9256"}
-                    @{command = 'subFolder\[t1].ps1' ; expectedResult = $secondResult; name = $secondFileSearchInSubfolder; Pending="See directory separator direction in https://github.com/PowerShell/PowerShell/issues/9256"}
-
                     # Wildcard search is also not being performed in this scenario before this change.
                     # I noted this in the above issue and disabling these cases
                     @{command = $firstFileInSubFolder ; expectedResult = $firstResult; name = $firstFileInSubFolder; Pending="See note about wildcard in https://github.com/PowerShell/PowerShell/issues/9256"}

--- a/test/powershell/engine/Basic/CommandDiscovery.Tests.ps1
+++ b/test/powershell/engine/Basic/CommandDiscovery.Tests.ps1
@@ -138,7 +138,7 @@ Describe "Command Discovery tests" -Tags "CI" {
             $shouldNotExecuteCases = @(
                 @{command = 'subFolder\[test1].ps1' ; testName = 'Relative path that where module qualified syntax overlaps'; ExpectedErrorId = 'CouldNotAutoLoadModule'}
                 @{command = '.\[12].ps1' ; testName = 'relative path with bracket wildcard matctching multiple files'}
-                @{command = (Join-Path ${TestDrive}  -ChildPath '[12].ps1') ; testName = 'fully qualified path with bracket wildcard matctching multiple files'}
+                @{command = (Join-Path ${TestDrive}  -ChildPath '[12].ps1') ; testName = 'fully qualified path with bracket wildcard matching multiple files'}
             )
 
             Push-Location ${TestDrive}\

--- a/test/powershell/engine/Basic/CommandDiscovery.Tests.ps1
+++ b/test/powershell/engine/Basic/CommandDiscovery.Tests.ps1
@@ -117,7 +117,7 @@ Describe "Command Discovery tests" -Tags "CI" {
                     @{command = $secondFileInSubFolder ; expectedResult = $secondResult; name = $secondFileInSubFolder}
 
                     # Wildcard search is also not being performed in this scenario before this change.
-                    # I noted this in the above issue and disabling these cases
+                    # I noted the issue in the pending message
                     @{command = $firstFileInSubFolder ; expectedResult = $firstResult; name = $firstFileInSubFolder; Pending="See note about wildcard in https://github.com/PowerShell/PowerShell/issues/9256"}
                     @{command = $secondFileSearchInSubfolder ; expectedResult = $secondResult; name = $secondFileSearchInSubfolder; Pending="See note about wildcard in https://github.com/PowerShell/PowerShell/issues/9256"}
                 #endregion

--- a/test/powershell/engine/Basic/CommandDiscovery.Tests.ps1
+++ b/test/powershell/engine/Basic/CommandDiscovery.Tests.ps1
@@ -102,6 +102,7 @@ Describe "Command Discovery tests" -Tags "CI" {
             )
 
             $shouldNotExecuteCases = @(
+                @{command = '.\[12].ps1' ; testName = 'relative path with bracket wildcard matctching multiple files'}
                 @{command = (Join-Path ${TestDrive}  -ChildPath '[12].ps1') ; testName = 'fully qualified path with bracket wildcard matctching multiple files'}
             )
 
@@ -127,14 +128,21 @@ Describe "Command Discovery tests" -Tags "CI" {
         BeforeAll {
             $firstResult = '[first script]'
             $secondResult = 'alt script'
+            $thirdResult = 'bad script'
             setup -f '[test1].ps1' -content "'$firstResult'"
             setup -f '1.ps1' -content "'$secondResult'"
+            setup -f '2.ps1' -content "'$thirdResult'"
 
             $gcmWithWildcardCases = @(
                 @{command = '.\?[tb]est1?.ps1'; expectedCommand = '[test1].ps1'; expectedCommandCount =1; name = '''.\?[tb]est1?.ps1'''}
                 @{command = (Join-Path ${TestDrive}  -ChildPath '?[tb]est1?.ps1'); expectedCommand = '[test1].ps1'; expectedCommandCount =1 ; name = '''.\?[tb]est1?.ps1'' by fully qualified path'}
                 @{command = '.\[test1].ps1'; expectedCommand = '1.ps1'; expectedCommandCount =1; name = '''.\[test1].ps1'''}
                 @{command = (Join-Path ${TestDrive}  -ChildPath '[test1].ps1'); expectedCommand = '1.ps1'; expectedCommandCount =1 ; name = '''.\[test1].ps1'' by fully qualified path'}
+            )
+
+            $shouldNotFindCases = @(
+                @{command = '.\[12].ps1' ; testName = 'relative path with bracket wildcard matctching multiple files'}
+                @{command = (Join-Path ${TestDrive}  -ChildPath '[12].ps1') ; testName = 'fully qualified path with bracket wildcard matctching multiple files'}
             )
 
             Push-Location ${TestDrive}\
@@ -149,6 +157,10 @@ Describe "Command Discovery tests" -Tags "CI" {
             $commands = Get-Command -Name $command
             $commands.Count | Should -Be $expectedCommandCount
             $commands.Name | Should -BeExactly $expectedCommand
+        }
+
+        It "Get-Command should throw CommandNotFoundException when running '<testName>'" -TestCases $shouldNotFindCases {
+            {Get-Command -Name $command} | Should -Throw -ErrorId 'CommandNotFoundException'
         }
     }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Make command searcher not use wildcard search for execution

## PR Context

This is a Defense in Depth fix to prevent people from accidentally running a script. 

For example, if a user attempted to run `.\[my1].ps1` and there is a `1.ps1` in the same folder.  `1.ps1` would be executed instead.
The fix allows tab completion and `Get-Command` to continue to work with the wildcards (`[]`, `?`, and `*`).

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
        - [ ] [Add `[feature]` to your commit messages if the change is significant or affects feature tests](https://github.com/PowerShell/PowerShell/blob/master/docs/testing-guidelines/testing-guidelines.md#requesting-additional-tests-for-a-pr)
