### PR TITLE
Added more tests for import-alias by file, regarding parsing 'difficult' aliases strings

### DIFF
--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Import-Alias.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Import-Alias.Tests.ps1
@@ -95,7 +95,7 @@ Describe "Import-Alias" -Tags "CI" {
     }
 
     It "Should classify an alias as non existent when it is not imported yet" {
-        {Get-Alias -Name invalid_alias -ErrorAction Stop} | Should -Throw -ErrorId 'ItemNotFoundException,Microsoft.PowerShell.Commands.GetAliasCommand' }
+        {Get-Alias -Name invalid_alias -ErrorAction Stop} | Should -Throw -ErrorId 'ItemNotFoundException,Microsoft.PowerShell.Commands.GetAliasCommand'
     }
 
     It "Should be able to parse <aliasToTest>" -TestCases @(

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Import-Alias.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Import-Alias.Tests.ps1
@@ -95,7 +95,7 @@ Describe "Import-Alias" -Tags "CI" {
     }
 
     It "Should classify an alias as non existent when it is not imported yet" {
-        Get-Alias -Name invalid_alias -ErrorAction SilentlyContinue | Should -BeExactly $null
+        {Get-Alias -Name invalid_alias -ErrorAction Stop} | Should -Throw -ErrorId 'ItemNotFoundException,Microsoft.PowerShell.Commands.GetAliasCommand' }
     }
 
     It "Should be able to parse <aliasToTest>" -TestCases @(

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Import-Alias.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Import-Alias.Tests.ps1
@@ -6,113 +6,113 @@ Describe "Import-Alias DRT Unit Tests" -Tags "CI" {
     $fulltestpath       = Join-Path -Path $testAliasDirectory -ChildPath $aliasFilename
 
     BeforeEach {
-		New-Item -Path $testAliasDirectory -ItemType Directory -Force
-		remove-item alias:abcd* -force -ErrorAction SilentlyContinue
-		remove-item alias:ijkl* -force -ErrorAction SilentlyContinue
-		set-alias abcd01 efgh01
-		set-alias abcd02 efgh02
-		set-alias abcd03 efgh03
-		set-alias abcd04 efgh04
-		set-alias ijkl01 mnop01
-		set-alias ijkl02 mnop02
-		set-alias ijkl03 mnop03
-		set-alias ijkl04 mnop04
+        New-Item -Path $testAliasDirectory -ItemType Directory -Force
+        remove-item alias:abcd* -force -ErrorAction SilentlyContinue
+        remove-item alias:ijkl* -force -ErrorAction SilentlyContinue
+        set-alias abcd01 efgh01
+        set-alias abcd02 efgh02
+        set-alias abcd03 efgh03
+        set-alias abcd04 efgh04
+        set-alias ijkl01 mnop01
+        set-alias ijkl02 mnop02
+        set-alias ijkl03 mnop03
+        set-alias ijkl04 mnop04
     }
 
-	AfterEach {
-		Remove-Item -Path $testAliasDirectory -Recurse -Force -ErrorAction SilentlyContinue
-	}
-
-	It "Import-Alias Resolve To Multiple will throw PSInvalidOperationException" {
-		{ Import-Alias * -ErrorAction Stop } | Should -Throw -ErrorId "NotSupported,Microsoft.PowerShell.Commands.ImportAliasCommand"
-	}
-
-	It "Import-Alias From Exported Alias File Aliases Already Exist should throw SessionStateException" {
-		{ Export-Alias  $fulltestpath abcd* } | Should -Not -Throw
-		{ Import-Alias $fulltestpath -ErrorAction Stop } | Should -Throw -ErrorId "AliasAlreadyExists,Microsoft.PowerShell.Commands.ImportAliasCommand"
+    AfterEach {
+        Remove-Item -Path $testAliasDirectory -Recurse -Force -ErrorAction SilentlyContinue
     }
 
-	It "Import-Alias Into Invalid Scope should throw PSArgumentException"{
-		{ Export-Alias  $fulltestpath abcd* } | Should -Not -Throw
-		{ Import-Alias $fulltestpath -scope bogus } | Should -Throw -ErrorId "Argument,Microsoft.PowerShell.Commands.ImportAliasCommand"
+    It "Import-Alias Resolve To Multiple will throw PSInvalidOperationException" {
+        { Import-Alias * -ErrorAction Stop } | Should -Throw -ErrorId "NotSupported,Microsoft.PowerShell.Commands.ImportAliasCommand"
     }
 
-	It "Import-Alias From Exported Alias File Aliases Already Exist using force should not throw"{
-		{Export-Alias  $fulltestpath abcd*} | Should -Not -Throw
-		{Import-Alias $fulltestpath  -Force} | Should -Not -Throw
+    It "Import-Alias From Exported Alias File Aliases Already Exist should throw SessionStateException" {
+        { Export-Alias  $fulltestpath abcd* } | Should -Not -Throw
+        { Import-Alias $fulltestpath -ErrorAction Stop } | Should -Throw -ErrorId "AliasAlreadyExists,Microsoft.PowerShell.Commands.ImportAliasCommand"
+    }
+
+    It "Import-Alias Into Invalid Scope should throw PSArgumentException"{
+        { Export-Alias  $fulltestpath abcd* } | Should -Not -Throw
+        { Import-Alias $fulltestpath -scope bogus } | Should -Throw -ErrorId "Argument,Microsoft.PowerShell.Commands.ImportAliasCommand"
+    }
+
+    It "Import-Alias From Exported Alias File Aliases Already Exist using force should not throw"{
+        {Export-Alias  $fulltestpath abcd*} | Should -Not -Throw
+        {Import-Alias $fulltestpath  -Force} | Should -Not -Throw
     }
 }
 
 Describe "Import-Alias" -Tags "CI" {
 
-	BeforeAll {
-		$newLine = [Environment]::NewLine
+    BeforeAll {
+        $newLine = [Environment]::NewLine
 
-		$testAliasDirectory = Join-Path -Path $TestDrive -ChildPath ImportAliasTestDirectory
-		$aliasFilename = "pesteralias.txt"
-		$aliasFilenameMoreThanFourValues = "aliasFileMoreThanFourValues.txt"
-		$aliasFilenameLessThanFourValues = "aliasFileLessThanFourValues.txt"
+        $testAliasDirectory = Join-Path -Path $TestDrive -ChildPath ImportAliasTestDirectory
+        $aliasFilename = "pesteralias.txt"
+        $aliasFilenameMoreThanFourValues = "aliasFileMoreThanFourValues.txt"
+        $aliasFilenameLessThanFourValues = "aliasFileLessThanFourValues.txt"
 
-		$aliasfile = Join-Path -Path $testAliasDirectory -ChildPath $aliasFilename
-		$aliasPathMoreThanFourValues = Join-Path -Path $testAliasDirectory -ChildPath $aliasFileNameMoreThanFourValues
-		$aliasPathLessThanFourValues = Join-Path -Path $testAliasDirectory -ChildPath $aliasFileNameLessThanFourValues
+        $aliasfile = Join-Path -Path $testAliasDirectory -ChildPath $aliasFilename
+        $aliasPathMoreThanFourValues = Join-Path -Path $testAliasDirectory -ChildPath $aliasFileNameMoreThanFourValues
+        $aliasPathLessThanFourValues = Join-Path -Path $testAliasDirectory -ChildPath $aliasFileNameLessThanFourValues
 
-		$commandToAlias = "echo"
-		$alias1 = "pesterecho"
-		$alias2	= '"abc""def"'
-		$alias3	= '"aaa"'
-		$alias4	= '"a,b"'
+        $commandToAlias = "echo"
+        $alias1 = "pesterecho"
+        $alias2    = '"abc""def"'
+        $alias3    = '"aaa"'
+        $alias4    = '"a,b"'
 
-		# create alias file
-		New-Item -Path $testAliasDirectory -ItemType Directory -Force > $null
+        # create alias file
+        New-Item -Path $testAliasDirectory -ItemType Directory -Force > $null
 
-		# set header
-		$aliasFileContent = '# Alias File' + $newLine
-		$aliasFileContent += '# Exported by : alex' + $newLine
-		$aliasFileContent += '# Date/Time : Thursday, 12 November 2015 21:55:08' + $newLine
-		$aliasFileContent += '# Computer : archvm'
+        # set header
+        $aliasFileContent = '# Alias File' + $newLine
+        $aliasFileContent += '# Exported by : alex' + $newLine
+        $aliasFileContent += '# Date/Time : Thursday, 12 November 2015 21:55:08' + $newLine
+        $aliasFileContent += '# Computer : archvm'
 
-		# add various aliases
-		$aliasFileContent += $newLine + $alias1 + ',"' + $commandToAlias + '","","None"'
-		$aliasFileContent += $newLine + $alias2 + ',"' + $commandToAlias + '","","None"'
-		$aliasFileContent += $newLine + $alias3 + ',"' + $commandToAlias + '","","None"'
-		$aliasFileContent += $newLine + $alias4 + ',"' + $commandToAlias + '","","None"'
-		$aliasFileContent > $aliasfile
+        # add various aliases
+        $aliasFileContent += $newLine + $alias1 + ',"' + $commandToAlias + '","","None"'
+        $aliasFileContent += $newLine + $alias2 + ',"' + $commandToAlias + '","","None"'
+        $aliasFileContent += $newLine + $alias3 + ',"' + $commandToAlias + '","","None"'
+        $aliasFileContent += $newLine + $alias4 + ',"' + $commandToAlias + '","","None"'
+        $aliasFileContent > $aliasfile
 
-		# create invalid file with more than four values
-		New-Item -Path $testAliasDirectory -ItemType Directory -Force > $null
-		$aliasFileContent = $newLine + '"v_1","v_2","v_3","v_4","v_5"'
-		$aliasFileContent > $aliasPathMoreThanFourValues
+        # create invalid file with more than four values
+        New-Item -Path $testAliasDirectory -ItemType Directory -Force > $null
+        $aliasFileContent = $newLine + '"v_1","v_2","v_3","v_4","v_5"'
+        $aliasFileContent > $aliasPathMoreThanFourValues
 
-		# create invalid file with less than four values
-		New-Item -Path $testAliasDirectory -ItemType Directory -Force > $null
-		$aliasFileContent = $newLine + '"v_1","v_2","v_3"'
-		$aliasFileContent > $aliasPathLessThanFourValues
-	}
+        # create invalid file with less than four values
+        New-Item -Path $testAliasDirectory -ItemType Directory -Force > $null
+        $aliasFileContent = $newLine + '"v_1","v_2","v_3"'
+        $aliasFileContent > $aliasPathLessThanFourValues
+    }
 
-	It "Should be able to import an alias file successfully" {
-	    { Import-Alias -Path $aliasfile } | Should -Not -Throw
-	}
+    It "Should be able to import an alias file successfully" {
+        { Import-Alias -Path $aliasfile } | Should -Not -Throw
+    }
 
-	It "Should classify an alias as non existent when it is not imported yet" {
-		Get-Alias -Name invalid_alias -ErrorAction SilentlyContinue | Should -BeExactly $null
-	}
+    It "Should classify an alias as non existent when it is not imported yet" {
+        Get-Alias -Name invalid_alias -ErrorAction SilentlyContinue | Should -BeExactly $null
+    }
 
-	It "Should be able to parse <aliasToTest>" -TestCases @(
-		@{ aliasToTest = 'abc"def' }
-		@{ aliasToTest = 'aaa' }
-		@{ aliasToTest = 'a,b' }
-		) {
-		param($aliasToTest)
-		Import-Alias -Path $aliasfile
-		( Get-Alias -Name $aliasToTest ).Definition | Should -BeExactly $commandToAlias
-	}
+    It "Should be able to parse <aliasToTest>" -TestCases @(
+        @{ aliasToTest = 'abc"def' }
+        @{ aliasToTest = 'aaa' }
+        @{ aliasToTest = 'a,b' }
+        ) {
+        param($aliasToTest)
+        Import-Alias -Path $aliasfile
+        ( Get-Alias -Name $aliasToTest ).Definition | Should -BeExactly $commandToAlias
+    }
 
-	It "Should throw an error when reading more than four values" {
-	    { Import-Alias -Path $aliasPathMoreThanFourValues } | Should -Throw -ErrorId "ImportAliasFileFormatError,Microsoft.PowerShell.Commands.ImportAliasCommand"
-	}
+    It "Should throw an error when reading more than four values" {
+        { Import-Alias -Path $aliasPathMoreThanFourValues } | Should -Throw -ErrorId "ImportAliasFileFormatError,Microsoft.PowerShell.Commands.ImportAliasCommand"
+    }
 
-	It "Should throw an error when reading less than four values" {
-	    { Import-Alias -Path $aliasPathLessThanFourValues } | Should -Throw -ErrorId "ImportAliasFileFormatError,Microsoft.PowerShell.Commands.ImportAliasCommand"
-	}
+    It "Should throw an error when reading less than four values" {
+        { Import-Alias -Path $aliasPathLessThanFourValues } | Should -Throw -ErrorId "ImportAliasFileFormatError,Microsoft.PowerShell.Commands.ImportAliasCommand"
+    }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Import-Alias.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Import-Alias.Tests.ps1
@@ -103,9 +103,8 @@ Describe "Import-Alias" -Tags "CI" {
 	}
 
 	It "Should be able to import an alias file and recognize an imported alias" {
-		$aliasToTest = "pesterecho"
 		Import-Alias -Path $aliasfile
-	    (Get-Alias -Name $aliasToTest -ErrorAction SilentlyContinue).Definition | Should -BeExactly $commandToAlias
+	    (Get-Alias -Name $alias1 -ErrorAction SilentlyContinue).Definition | Should -BeExactly $commandToAlias
 	}
 
 	It "Should be able to parse ""abc""""def"" into abc""def " {
@@ -118,7 +117,6 @@ Describe "Import-Alias" -Tags "CI" {
 		$aliasToTest = "aaa"
 		Import-Alias -Path $aliasfile
 	    (Get-Alias -Name $aliasToTest -ErrorAction SilentlyContinue).Definition | Should -BeExactly $commandToAlias
-
 	}
 
 	It "Should be able to parse ""a,b"" into a,b " {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Import-Alias.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Import-Alias.Tests.ps1
@@ -46,7 +46,7 @@ Describe "Import-Alias DRT Unit Tests" -Tags "CI" {
 Describe "Import-Alias" -Tags "CI" {
 	$testAliasDirectory
 	$pesteraliasfile
-    $aliasPathMoreThanFourValues
+	$aliasPathMoreThanFourValues
 	$aliasPathLessThanFourValues
 	$commandToAlias
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Import-Alias.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Import-Alias.Tests.ps1
@@ -70,7 +70,7 @@ Describe "Import-Alias" -Tags "CI" {
 		$aliasFileContent = '# Alias File' + $newLine
 		$aliasFileContent+= '# Exported by : alex' + $newLine
 		$aliasFileContent+= '# Date/Time : Thursday, 12 November 2015 21:55:08' + $newLine
-		$aliasFileContent+='# Computer : archvm'
+		$aliasFileContent+= '# Computer : archvm'
 
 		# add various aliases
 		$aliasFileContent+= $newLine+$alias1+',"'+$commandToAlias+'","","None"'

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Import-Alias.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Import-Alias.Tests.ps1
@@ -68,12 +68,12 @@ Describe "Import-Alias" -Tags "CI" {
 
 		# set header
 		$aliasFileContent = '# Alias File' + $newLine
-		$aliasFileContent+= '# Exported by : alex' + $newLine
-		$aliasFileContent+= '# Date/Time : Thursday, 12 November 2015 21:55:08' + $newLine
-		$aliasFileContent+= '# Computer : archvm'
+		$aliasFileContent += '# Exported by : alex' + $newLine
+		$aliasFileContent += '# Date/Time : Thursday, 12 November 2015 21:55:08' + $newLine
+		$aliasFileContent += '# Computer : archvm'
 
 		# add various aliases
-		$aliasFileContent+= $newLine + $alias1 + ',"' + $commandToAlias + '","","None"'
+		$aliasFileContent += $newLine + $alias1 + ',"' + $commandToAlias + '","","None"'
 		$aliasFileContent += $newLine + $alias2 + ',"' + $commandToAlias + '","","None"'
 		$aliasFileContent += $newLine + $alias3 + ',"' + $commandToAlias + '","","None"'
 		$aliasFileContent += $newLine + $alias4 + ',"' + $commandToAlias + '","","None"'

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Import-Alias.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Import-Alias.Tests.ps1
@@ -74,7 +74,7 @@ Describe "Import-Alias" -Tags "CI" {
 
 		# add various aliases
 		$aliasFileContent+= $newLine + $alias1 + ',"' + $commandToAlias + '","","None"'
-		$aliasFileContent+= $newLine+$alias2+',"'+$commandToAlias+'","","None"'
+		$aliasFileContent += $newLine + $alias2 + ',"' + $commandToAlias + '","","None"'
 		$aliasFileContent+= $newLine+$alias3+',"'+$commandToAlias+'","","None"'
 		$aliasFileContent+= $newLine+$alias4+',"'+$commandToAlias+'","","None"'
 		$aliasFileContent > $aliasfile

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Import-Alias.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Import-Alias.Tests.ps1
@@ -46,7 +46,7 @@ Describe "Import-Alias DRT Unit Tests" -Tags "CI" {
 Describe "Import-Alias" -Tags "CI" {
 
 	BeforeAll {
-		$newLine=[Environment]::NewLine
+		$newLine = [Environment]::NewLine
 
 		$testAliasDirectory = Join-Path -Path $TestDrive -ChildPath ImportAliasTestDirectory
 		$aliasFilename = "pesteralias.txt"

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Import-Alias.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Import-Alias.Tests.ps1
@@ -86,7 +86,7 @@ Describe "Import-Alias" -Tags "CI" {
 
 		# create invalid file with less than four values
 		New-Item -Path $testAliasDirectory -ItemType Directory -Force > $null
-		$aliasFileContent = $newLine+'"v_1","v_2","v_3"'
+		$aliasFileContent = $newLine + '"v_1","v_2","v_3"'
 		$aliasFileContent > $aliasPathLessThanFourValues
 	}
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Import-Alias.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Import-Alias.Tests.ps1
@@ -75,7 +75,7 @@ Describe "Import-Alias" -Tags "CI" {
 		# add various aliases
 		$aliasFileContent+= $newLine + $alias1 + ',"' + $commandToAlias + '","","None"'
 		$aliasFileContent += $newLine + $alias2 + ',"' + $commandToAlias + '","","None"'
-		$aliasFileContent+= $newLine+$alias3+',"'+$commandToAlias+'","","None"'
+		$aliasFileContent += $newLine + $alias3 + ',"' + $commandToAlias + '","","None"'
 		$aliasFileContent += $newLine + $alias4 + ',"' + $commandToAlias + '","","None"'
 		$aliasFileContent > $aliasfile
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Import-Alias.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Import-Alias.Tests.ps1
@@ -2,8 +2,8 @@
 # Licensed under the MIT License.
 Describe "Import-Alias DRT Unit Tests" -Tags "CI" {
     $testAliasDirectory = Join-Path -Path $TestDrive -ChildPath ImportAliasTestDirectory
-    $testAliases        = "TestAliases"
-    $fulltestpath       = Join-Path -Path $testAliasDirectory -ChildPath $testAliases
+    $aliasFilename        = "aliasFilename"
+    $fulltestpath       = Join-Path -Path $testAliasDirectory -ChildPath $aliasFilename
 
     BeforeEach {
 		New-Item -Path $testAliasDirectory -ItemType Directory -Force
@@ -47,50 +47,47 @@ Describe "Import-Alias" -Tags "CI" {
 
 	BeforeAll {
 		$newLine=[Environment]::NewLine
-		# set paths and names for the alias files
+
 		$testAliasDirectory = Join-Path -Path $TestDrive -ChildPath ImportAliasTestDirectory
-		$testAliases        = "pesteralias.txt"
-		$aliasFilenameMoreThanFourValues        = "aliasFileMoreThanFourValues.txt"
-		$aliasFilenameLessThanFourValues        = "aliasFileLessThanFourValues.txt"
+		$aliasFilename = "pesteralias.txt"
+		$aliasFilenameMoreThanFourValues = "aliasFileMoreThanFourValues.txt"
+		$aliasFilenameLessThanFourValues = "aliasFileLessThanFourValues.txt"
 
-		$pesteraliasfile    = Join-Path -Path $testAliasDirectory -ChildPath $testAliases
-		$aliasPathMoreThanFourValues    = Join-Path -Path $testAliasDirectory -ChildPath $aliasFileNameMoreThanFourValues
-		$aliasPathLessThanFourValues    = Join-Path -Path $testAliasDirectory -ChildPath $aliasFileNameLessThanFourValues
+		$aliasfile = Join-Path -Path $testAliasDirectory -ChildPath $aliasFilename
+		$aliasPathMoreThanFourValues = Join-Path -Path $testAliasDirectory -ChildPath $aliasFileNameMoreThanFourValues
+		$aliasPathLessThanFourValues = Join-Path -Path $testAliasDirectory -ChildPath $aliasFileNameLessThanFourValues
 
-		# define command to alias for the tests
 		$commandToAlias = "echo"
+		$alias1 = "pesterecho"
+		$alias2	= '"abc""def"'
+		$alias3	= '"aaa"'
+		$alias4	= '"a,b"'
 
-		# write the files and content
-		$difficultToParseString_1		= '"abc""def"'
-		$difficultToParseString_2		= '"aaa"'
-		$difficultToParseString_3		= '"a,b"'
-
-		# create default pester testing file
-		# has three lines of comments, then a few different aliases for the echo command.
-		# the file assigns "pesterecho" as an alias to "echo"
+		# create alias file
 		New-Item -Path $testAliasDirectory -ItemType Directory -Force > $null
 
-		$pesteraliascontent ='# Alias File'+$newLine
-		$pesteraliascontent+='# Exported by : alex'+$newLine
-		$pesteraliascontent+='# Date/Time : Thursday, 12 November 2015 21:55:08'+$newLine
-		$pesteraliascontent+='# Computer : archvm'
+		# set header
+		$aliasFileContent ='# Alias File'+$newLine
+		$aliasFileContent+='# Exported by : alex'+$newLine
+		$aliasFileContent+='# Date/Time : Thursday, 12 November 2015 21:55:08'+$newLine
+		$aliasFileContent+='# Computer : archvm'
 
-		# add various aliases for echo which we can then test
-		$pesteraliascontent+= $newLine+'pesterecho,"'+$commandToAlias+'","","None"'
-		$pesteraliascontent+= $newLine+$difficultToParseString_1+',"'+$commandToAlias+'","","None"'
-		$pesteraliascontent+= $newLine+$difficultToParseString_2+',"'+$commandToAlias+'","","None"'
-		$pesteraliascontent+= $newLine+$difficultToParseString_3+',"'+$commandToAlias+'","","None"'
-		$pesteraliascontent > $pesteraliasfile
+		# add various aliases
+		$aliasFileContent+= $newLine+$alias1+',"'+$commandToAlias+'","","None"'
+		$aliasFileContent+= $newLine+$alias2+',"'+$commandToAlias+'","","None"'
+		$aliasFileContent+= $newLine+$alias3+',"'+$commandToAlias+'","","None"'
+		$aliasFileContent+= $newLine+$alias4+',"'+$commandToAlias+'","","None"'
+		$aliasFileContent > $aliasfile
 
 		# create invalid file with more than four values
 		New-Item -Path $testAliasDirectory -ItemType Directory -Force > $null
-		$pesteraliascontent+= $newLine+'"v_1","v_2","v_3","v_4","v_5"'
-		$pesteraliascontent > $aliasPathMoreThanFourValues
+		$aliasFileContent+= $newLine+'"v_1","v_2","v_3","v_4","v_5"'
+		$aliasFileContent > $aliasPathMoreThanFourValues
 
 		# create invalid file with less than four values
 		New-Item -Path $testAliasDirectory -ItemType Directory -Force > $null
-		$pesteraliascontent+= $newLine+'"v_1","v_2","v_3"'
-		$pesteraliascontent > $aliasPathLessThanFourValues
+		$aliasFileContent+= $newLine+'"v_1","v_2","v_3"'
+		$aliasFileContent > $aliasPathLessThanFourValues
 	}
 
 	AfterAll {
@@ -98,7 +95,7 @@ Describe "Import-Alias" -Tags "CI" {
 	}
 
 	It "Should be able to import an alias file successfully" {
-	    {Import-Alias -Path $pesteraliasfile} | Should -Not -Throw
+	    {Import-Alias -Path $aliasfile} | Should -Not -Throw
 	}
 
 	It "Should classify an alias as non existent when it is not imported yet" {
@@ -107,26 +104,26 @@ Describe "Import-Alias" -Tags "CI" {
 
 	It "Should be able to import an alias file and recognize an imported alias" {
 		$aliasToTest = "pesterecho"
-		Import-Alias -Path $pesteraliasfile
+		Import-Alias -Path $aliasfile
 	    (Get-Alias -Name $aliasToTest -ErrorAction SilentlyContinue).Definition | Should -BeExactly $commandToAlias
 	}
 
 	It "Should be able to parse ""abc""""def"" into abc""def " {
 		$aliasToTest = 'abc"def'
-		Import-Alias -Path $pesteraliasfile
+		Import-Alias -Path $aliasfile
 	    (Get-Alias -Name $aliasToTest -ErrorAction SilentlyContinue).Definition | Should -BeExactly $commandToAlias
 	}
 
 	It "Should be able to parse ""aaa"" into aaa " {
 		$aliasToTest = "aaa"
-		Import-Alias -Path $pesteraliasfile
+		Import-Alias -Path $aliasfile
 	    (Get-Alias -Name $aliasToTest -ErrorAction SilentlyContinue).Definition | Should -BeExactly $commandToAlias
 
 	}
 
 	It "Should be able to parse ""a,b"" into a,b " {
 		$aliasToTest = "a,b"
-		Import-Alias -Path $pesteraliasfile
+		Import-Alias -Path $aliasfile
 	    (Get-Alias -Name $aliasToTest -ErrorAction SilentlyContinue).Definition | Should -BeExactly $commandToAlias
 	}
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Import-Alias.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Import-Alias.Tests.ps1
@@ -81,7 +81,7 @@ Describe "Import-Alias" -Tags "CI" {
 
 		# create invalid file with more than four values
 		New-Item -Path $testAliasDirectory -ItemType Directory -Force > $null
-		$aliasFileContent = $newLine+'"v_1","v_2","v_3","v_4","v_5"'
+		$aliasFileContent = $newLine + '"v_1","v_2","v_3","v_4","v_5"'
 		$aliasFileContent > $aliasPathMoreThanFourValues
 
 		# create invalid file with less than four values

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Import-Alias.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Import-Alias.Tests.ps1
@@ -69,7 +69,7 @@ Describe "Import-Alias" -Tags "CI" {
 		# set header
 		$aliasFileContent = '# Alias File' + $newLine
 		$aliasFileContent+= '# Exported by : alex' + $newLine
-		$aliasFileContent+='# Date/Time : Thursday, 12 November 2015 21:55:08'+$newLine
+		$aliasFileContent+= '# Date/Time : Thursday, 12 November 2015 21:55:08' + $newLine
 		$aliasFileContent+='# Computer : archvm'
 
 		# add various aliases

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Import-Alias.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Import-Alias.Tests.ps1
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 Describe "Import-Alias DRT Unit Tests" -Tags "CI" {
     $testAliasDirectory = Join-Path -Path $TestDrive -ChildPath ImportAliasTestDirectory
-    $aliasFilename        = "aliasFilename"
+    $aliasFilename      = "aliasFilename"
     $fulltestpath       = Join-Path -Path $testAliasDirectory -ChildPath $aliasFilename
 
     BeforeEach {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Import-Alias.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Import-Alias.Tests.ps1
@@ -67,7 +67,7 @@ Describe "Import-Alias" -Tags "CI" {
 		New-Item -Path $testAliasDirectory -ItemType Directory -Force > $null
 
 		# set header
-		$aliasFileContent ='# Alias File'+$newLine
+		$aliasFileContent = '# Alias File' + $newLine
 		$aliasFileContent+='# Exported by : alex'+$newLine
 		$aliasFileContent+='# Date/Time : Thursday, 12 November 2015 21:55:08'+$newLine
 		$aliasFileContent+='# Computer : archvm'

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Import-Alias.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Import-Alias.Tests.ps1
@@ -81,12 +81,12 @@ Describe "Import-Alias" -Tags "CI" {
 
 		# create invalid file with more than four values
 		New-Item -Path $testAliasDirectory -ItemType Directory -Force > $null
-		$aliasFileContent+= $newLine+'"v_1","v_2","v_3","v_4","v_5"'
+		$aliasFileContent = $newLine+'"v_1","v_2","v_3","v_4","v_5"'
 		$aliasFileContent > $aliasPathMoreThanFourValues
 
 		# create invalid file with less than four values
 		New-Item -Path $testAliasDirectory -ItemType Directory -Force > $null
-		$aliasFileContent+= $newLine+'"v_1","v_2","v_3"'
+		$aliasFileContent = $newLine+'"v_1","v_2","v_3"'
 		$aliasFileContent > $aliasPathLessThanFourValues
 	}
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Import-Alias.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Import-Alias.Tests.ps1
@@ -73,7 +73,7 @@ Describe "Import-Alias" -Tags "CI" {
 		# create default pester testing file
 		# has three lines of comments, then a few different aliases for the echo command.
 		# the file assigns "pesterecho" as an alias to "echo"
-		New-Item -Path $testAliasDirectory -ItemType Directory -Force
+		New-Item -Path $testAliasDirectory -ItemType Directory -Force > $null
 
 		$pesteraliascontent ='# Alias File'+$newLine
 		$pesteraliascontent+='# Exported by : alex'+$newLine
@@ -88,12 +88,12 @@ Describe "Import-Alias" -Tags "CI" {
 		$pesteraliascontent > $pesteraliasfile
 
 		# create invalid file with more than four values
-		New-Item -Path $testAliasDirectory -ItemType Directory -Force
+		New-Item -Path $testAliasDirectory -ItemType Directory -Force > $null
 		$pesteraliascontent+= $newLine+'"v_1","v_2","v_3","v_4","v_5"'
 		$pesteraliascontent > $aliasPathMoreThanFourValues
 
 		# create invalid file with less than four values
-		New-Item -Path $testAliasDirectory -ItemType Directory -Force
+		New-Item -Path $testAliasDirectory -ItemType Directory -Force > $null
 		$pesteraliascontent+= $newLine+'"v_1","v_2","v_3"'
 		$pesteraliascontent > $aliasPathLessThanFourValues
 	}
@@ -103,43 +103,43 @@ Describe "Import-Alias" -Tags "CI" {
 	}
 
 	It "Should be able to import an alias file successfully" {
-	    { Import-Alias $pesteraliasfile } | Should -Not -throw
+	    {Import-Alias -Path $pesteraliasfile} | Should -Not -throw
 	}
 
 	It "Should classify an alias as non existent when it is not imported yet" {
-		{get-alias pesterecho} | Should --BeExactly null
+		{Get-Alias -Name pesterecho} | Should -Be null
 	}
 
 	It "Should be able to import an alias file and recognize an imported alias" {
 		$aliasToTest = "pesterecho"
-		Import-Alias $pesteraliasfile
-	    (get-alias $aliasToTest -ErrorAction SilentlyContinue).Definition | Should -BeExactly $commandToAlias
+		Import-Alias -Path $pesteraliasfile
+	    (Get-Alias -Name $aliasToTest -ErrorAction SilentlyContinue).Definition | Should -BeExactly $commandToAlias
 	}
 
 	It "Should be able to parse ""abc""""def"" into abc""def " {
 		$aliasToTest = 'abc"def'
-		Import-Alias $pesteraliasfile
-	    (get-alias $aliasToTest -ErrorAction SilentlyContinue).Definition | Should -BeExactly $commandToAlias
+		Import-Alias -Path $pesteraliasfile
+	    (Get-Alias -Name $aliasToTest -ErrorAction SilentlyContinue).Definition | Should -BeExactly $commandToAlias
 	}
 
 	It "Should be able to parse ""aaa"" into aaa " {
 		$aliasToTest = "aaa"
-		Import-Alias $pesteraliasfile
-	    (get-alias $aliasToTest -ErrorAction SilentlyContinue).Definition | Should -BeExactly $commandToAlias
+		Import-Alias -Path $pesteraliasfile
+	    (Get-Alias -Name $aliasToTest -ErrorAction SilentlyContinue).Definition | Should -BeExactly $commandToAlias
 
 	}
 
 	It "Should be able to parse ""a,b"" into a,b " {
 		$aliasToTest = "a,b"
-		Import-Alias $pesteraliasfile
-	    (get-alias $aliasToTest -ErrorAction SilentlyContinue).Definition | Should -BeExactly $commandToAlias
+		Import-Alias -Path $pesteraliasfile
+	    (Get-Alias -Name $aliasToTest -ErrorAction SilentlyContinue).Definition | Should -BeExactly $commandToAlias
 	}
 
 	It "Should throw an error when reading more than four values" {
-	    { Import-Alias $aliasPathMoreThanFourValues } | Should -Throw -ErrorId "ImportAliasFileFormatError,Microsoft.PowerShell.Commands.ImportAliasCommand"
+	    { Import-Alias -Path $aliasPathMoreThanFourValues } | Should -Throw -ErrorId "ImportAliasFileFormatError,Microsoft.PowerShell.Commands.ImportAliasCommand"
 	}
 
 	It "Should throw an error when reading less than four values" {
-	    { Import-Alias $aliasPathLessThanFourValues } | Should -Throw -ErrorId "ImportAliasFileFormatError,Microsoft.PowerShell.Commands.ImportAliasCommand"
+	    { Import-Alias -Path $aliasPathLessThanFourValues } | Should -Throw -ErrorId "ImportAliasFileFormatError,Microsoft.PowerShell.Commands.ImportAliasCommand"
 	}
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Import-Alias.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Import-Alias.Tests.ps1
@@ -90,39 +90,22 @@ Describe "Import-Alias" -Tags "CI" {
 		$aliasFileContent > $aliasPathLessThanFourValues
 	}
 
-	AfterAll {
-		Remove-Item -Path $testAliasDirectory -Recurse -Force
-	}
-
 	It "Should be able to import an alias file successfully" {
-	    {Import-Alias -Path $aliasfile} | Should -Not -Throw
+	    { Import-Alias -Path $aliasfile } | Should -Not -Throw
 	}
 
-	It "Should classify an alias as non existent when it is not imported yet" {
-		Get-Alias -Name invalid_alias -ErrorAction SilentlyContinue | Should -BeExactly $null
+	It "Should throw an exception when the alias is non existent" {
+		( Get-Alias -Name invalid_alias -ErrorAction SilentlyContinue ).Definition | Should -BeExactly $null
 	}
 
-	It "Should be able to import an alias file and recognize an imported alias" {
+	It "Should be able to parse <aliasToTest>" -TestCases @(
+		@{ aliasToTest = 'abc"def' }
+		@{ aliasToTest = 'aaa' }
+		@{ aliasToTest = 'a,b' }
+		) {
+		param($aliasToTest)
 		Import-Alias -Path $aliasfile
-	    (Get-Alias -Name $alias1 -ErrorAction SilentlyContinue).Definition | Should -BeExactly $commandToAlias
-	}
-
-	It "Should be able to parse ""abc""""def"" into abc""def " {
-		$aliasToTest = 'abc"def'
-		Import-Alias -Path $aliasfile
-	    (Get-Alias -Name $aliasToTest -ErrorAction SilentlyContinue).Definition | Should -BeExactly $commandToAlias
-	}
-
-	It "Should be able to parse ""aaa"" into aaa " {
-		$aliasToTest = "aaa"
-		Import-Alias -Path $aliasfile
-	    (Get-Alias -Name $aliasToTest -ErrorAction SilentlyContinue).Definition | Should -BeExactly $commandToAlias
-	}
-
-	It "Should be able to parse ""a,b"" into a,b " {
-		$aliasToTest = "a,b"
-		Import-Alias -Path $aliasfile
-	    (Get-Alias -Name $aliasToTest -ErrorAction SilentlyContinue).Definition | Should -BeExactly $commandToAlias
+		( Get-Alias -Name $aliasToTest ).Definition | Should -BeExactly $commandToAlias
 	}
 
 	It "Should throw an error when reading more than four values" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Import-Alias.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Import-Alias.Tests.ps1
@@ -44,11 +44,6 @@ Describe "Import-Alias DRT Unit Tests" -Tags "CI" {
 }
 
 Describe "Import-Alias" -Tags "CI" {
-	$testAliasDirectory
-	$pesteraliasfile
-	$aliasPathMoreThanFourValues
-	$aliasPathLessThanFourValues
-	$commandToAlias
 
 	BeforeAll {
 		$newLine=[Environment]::NewLine
@@ -103,11 +98,11 @@ Describe "Import-Alias" -Tags "CI" {
 	}
 
 	It "Should be able to import an alias file successfully" {
-	    {Import-Alias -Path $pesteraliasfile} | Should -Not -throw
+	    {Import-Alias -Path $pesteraliasfile} | Should -Not -Throw
 	}
 
 	It "Should classify an alias as non existent when it is not imported yet" {
-		{Get-Alias -Name pesterecho} | Should -Be null
+		Get-Alias -Name invalid_alias -ErrorAction SilentlyContinue | Should -BeExactly $null
 	}
 
 	It "Should be able to import an alias file and recognize an imported alias" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Import-Alias.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Import-Alias.Tests.ps1
@@ -68,7 +68,7 @@ Describe "Import-Alias" -Tags "CI" {
 
 		# set header
 		$aliasFileContent = '# Alias File' + $newLine
-		$aliasFileContent+='# Exported by : alex'+$newLine
+		$aliasFileContent+= '# Exported by : alex' + $newLine
 		$aliasFileContent+='# Date/Time : Thursday, 12 November 2015 21:55:08'+$newLine
 		$aliasFileContent+='# Computer : archvm'
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Import-Alias.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Import-Alias.Tests.ps1
@@ -73,7 +73,7 @@ Describe "Import-Alias" -Tags "CI" {
 		$aliasFileContent+= '# Computer : archvm'
 
 		# add various aliases
-		$aliasFileContent+= $newLine+$alias1+',"'+$commandToAlias+'","","None"'
+		$aliasFileContent+= $newLine + $alias1 + ',"' + $commandToAlias + '","","None"'
 		$aliasFileContent+= $newLine+$alias2+',"'+$commandToAlias+'","","None"'
 		$aliasFileContent+= $newLine+$alias3+',"'+$commandToAlias+'","","None"'
 		$aliasFileContent+= $newLine+$alias4+',"'+$commandToAlias+'","","None"'

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Import-Alias.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Import-Alias.Tests.ps1
@@ -95,7 +95,7 @@ Describe "Import-Alias" -Tags "CI" {
 	}
 
 	It "Should be able to import an alias file successfully" {
-	    {Import-Alias -Path $aliasfile} | Should -Not -Throw
+	    { Import-Alias -Path $aliasfile } | Should -Not -Throw
 	}
 
 	It "Should classify an alias as non existent when it is not imported yet" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Import-Alias.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Import-Alias.Tests.ps1
@@ -76,7 +76,7 @@ Describe "Import-Alias" -Tags "CI" {
 		$aliasFileContent+= $newLine + $alias1 + ',"' + $commandToAlias + '","","None"'
 		$aliasFileContent += $newLine + $alias2 + ',"' + $commandToAlias + '","","None"'
 		$aliasFileContent+= $newLine+$alias3+',"'+$commandToAlias+'","","None"'
-		$aliasFileContent+= $newLine+$alias4+',"'+$commandToAlias+'","","None"'
+		$aliasFileContent += $newLine + $alias4 + ',"' + $commandToAlias + '","","None"'
 		$aliasFileContent > $aliasfile
 
 		# create invalid file with more than four values


### PR DESCRIPTION
# PR Summary

According to [this comment by daxian-dbw](https://github.com/PowerShell/PowerShell/pull/9091#issuecomment-473704625), `"abc""def"`should be parsed to `abc"def`. This was not covered in the old test cases, but should be now with this PR.

This PR adds tests for the `import-alias` by file, in a seperate PR as discussed in #9091. After this gets accepted, it should be possible to start refactoring `import-alias`. Details about this refactorization can be found in #9091 .

This pr adds the following test cases for import alias by file:

* `"abc""def"` should parse to `abc"def`
* `"aaa"` should parse to `aaa`
* `"a,b"` should parse to `a,b`
* If an alias file is read with a line containing more than four values, throw an error
* If an alias file is read with a line containing less than four values, throw an error

If more exhaustive testing is required, please let me know.

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [X] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **User-facing changes**
    - [X] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [X] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
