### PR TITLE
Return correct casing of filesystem path during normalization

### DIFF
--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -148,6 +148,11 @@ namespace Microsoft.PowerShell.Commands
                     }
                 }
 
+                if (path.EndsWith(StringLiterals.DefaultPathSeparator))
+                {
+                    return exactPath + StringLiterals.DefaultPathSeparator;
+                }
+
                 return exactPath;
             }
             else

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -98,7 +98,46 @@ namespace Microsoft.PowerShell.Commands
         /// </returns>
         private static string NormalizePath(string path)
         {
-            return path.Replace(StringLiterals.AlternatePathSeparator, StringLiterals.DefaultPathSeparator);
+            return GetCorrectCasedPath(path.Replace(StringLiterals.AlternatePathSeparator, StringLiterals.DefaultPathSeparator));
+        }
+
+        /// <summary>
+        /// Get the correct casing for a path.  This method assumes it's being called by NormalizePath()
+        /// so that the path is already normalized.
+        /// </summary>
+        /// <param name="path">
+        /// The path to retrieve.
+        /// </param>
+        /// <returns>
+        /// The path with accurate casing if item exists, otherwise it returns path that was passed in.
+        /// </returns>
+        private static string GetCorrectCasedPath(string path)
+        {
+            string exactPath = string.Empty;
+            if (File.Exists(path) || Directory.Exists(path))
+            {
+                foreach (string item in path.Split(StringLiterals.DefaultPathSeparator))
+                {
+                    if (string.IsNullOrEmpty(exactPath))
+                    {
+                        exactPath = item + StringLiterals.DefaultPathSeparator;
+                    }
+                    else if (string.IsNullOrEmpty(item))
+                    {
+                        // This handles the trailing slash case
+                        continue;
+                    }
+                    else
+                    {
+                        exactPath = Directory.GetFileSystemEntries(exactPath, item).First();
+                    }
+                }
+                return exactPath;
+            }
+            else
+            {
+                return path;
+            }
         }
 
         /// <summary>

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -114,7 +114,9 @@ namespace Microsoft.PowerShell.Commands
         private static string GetCorrectCasedPath(string path)
         {
             string exactPath = string.Empty;
-            if (File.Exists(path) || Directory.Exists(path))
+            // Only apply to directories where there are issues with some tools if the casing
+            // doesn't match the source like git
+            if (Directory.Exists(path))
             {
                 int itemsToSkip = 0;
                 if (Utils.PathIsUnc(path))
@@ -142,14 +144,6 @@ namespace Microsoft.PowerShell.Commands
                         // This handles the trailing slash case
                         continue;
                     }
-#if !UNIX                    
-                    else if (item.Contains(":"))
-                    {
-                        // This handles the NTFS stream name
-                        var streamName = item.Split(":");
-                        exactPath = Directory.GetFileSystemEntries(exactPath, streamName[0]).First() + ":" + streamName[1];
-                    }
-#endif
                     else
                     {
                         exactPath = Directory.GetFileSystemEntries(exactPath, item).First();

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -142,6 +142,14 @@ namespace Microsoft.PowerShell.Commands
                         // This handles the trailing slash case
                         continue;
                     }
+#if !UNIX                    
+                    else if (item.Contains(":"))
+                    {
+                        // This handles the NTFS stream name
+                        var streamName = item.Split(":");
+                        exactPath = Directory.GetFileSystemEntries(exactPath, streamName[0]).First() + ":" + streamName[1];
+                    }
+#endif
                     else
                     {
                         exactPath = Directory.GetFileSystemEntries(exactPath, item).First();

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -129,7 +129,7 @@ namespace Microsoft.PowerShell.Commands
 
                 foreach (string item in path.Split(StringLiterals.DefaultPathSeparator))
                 {
-                    if (itemsToSkip-- > 0 || item.Contains('~'))
+                    if (itemsToSkip-- > 0)
                     {
                         // This handles the UNC server and share and 8.3 short path syntax
                         exactPath += item + StringLiterals.DefaultPathSeparator;
@@ -144,6 +144,11 @@ namespace Microsoft.PowerShell.Commands
                     {
                         // This handles the trailing slash case
                         continue;
+                    }
+                    else if (item.Contains('~'))
+                    {
+                        // This handles short path names
+                        exactPath += StringLiterals.DefaultPathSeparator + item;
                     }
                     else
                     {

--- a/src/System.Management.Automation/namespaces/FileSystemProvider.cs
+++ b/src/System.Management.Automation/namespaces/FileSystemProvider.cs
@@ -113,11 +113,11 @@ namespace Microsoft.PowerShell.Commands
         /// </returns>
         private static string GetCorrectCasedPath(string path)
         {
-            string exactPath = string.Empty;
             // Only apply to directories where there are issues with some tools if the casing
             // doesn't match the source like git
             if (Directory.Exists(path))
             {
+                string exactPath = string.Empty;
                 int itemsToSkip = 0;
                 if (Utils.PathIsUnc(path))
                 {
@@ -129,8 +129,9 @@ namespace Microsoft.PowerShell.Commands
 
                 foreach (string item in path.Split(StringLiterals.DefaultPathSeparator))
                 {
-                    if (itemsToSkip-- > 0)
+                    if (itemsToSkip-- > 0 || item.Contains('~'))
                     {
+                        // This handles the UNC server and share and 8.3 short path syntax
                         exactPath += item + StringLiterals.DefaultPathSeparator;
                         continue;
                     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Location.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Location.Tests.ps1
@@ -70,6 +70,12 @@ Describe "Set-Location" -Tags "CI" {
             Should -Throw -ErrorId "PathNotFound,Microsoft.PowerShell.Commands.SetLocationCommand"
     }
 
+    It "Should use actual casing of folder on case-insensitive filesystem" -Skip:($IsLinux) {
+        $testPath = New-Item -ItemType Directory -Path testdrive:/teST
+        Set-Location $testPath.FullName.ToUpper()
+        $(Get-Location).Path | Should -BeExactly $testPath.FullName
+    }
+
     Context 'Set-Location with no arguments' {
 
         It 'Should go to $env:HOME when Set-Location run with no arguments from FileSystem provider' {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Location.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Set-Location.Tests.ps1
@@ -76,6 +76,18 @@ Describe "Set-Location" -Tags "CI" {
         $(Get-Location).Path | Should -BeExactly $testPath.FullName
     }
 
+    It "Should use actual casing of folder on case-sensitive filesystem: <dir>" -Skip:(!$IsLinux)
+    {
+        $dir = "teST"
+        $testPathLower = New-Item -ItemType Directory -Path (Join-Path $TestDrive $dir.ToLower())
+        $testPathUpper = New-Item -ItemType Directory -Path (Join-Path $TestDrive $dir.ToUpper())
+        Set-Location $testPathLower.FullName
+        $(Get-Location).Path | Should -BeExactly $testPathLower.FullName
+        Set-Location $testPathUpper.FullName
+        $(Get-Location).Path | Should -BeExactly $testPathUpper.FullName
+        { Set-Locaiton (Join-Path $TestDrive $dir) } | Should -Throw -ErrorId "PathNotFound,Microsoft.PowerShell.Commands.SetLocationCommand"
+    }
+
     Context 'Set-Location with no arguments' {
 
         It 'Should go to $env:HOME when Set-Location run with no arguments from FileSystem provider' {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

On a case-insensitive filesystem, if the path exists, we propagate the user typed casing of the path and reuse it.  This causes problems with some native tools like `git` where it expects correct casing of filesystem paths.  The change is to step through the path and retrieve the actual casing of the items in the path and return that during the path normalization method.

## PR Context

Fix https://github.com/PowerShell/PowerShell/issues/5678

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
