### PR TITLE
Fix Get-ChildItem -Path with wildcard char

### DIFF
--- a/src/System.Management.Automation/engine/SessionStateContainer.cs
+++ b/src/System.Management.Automation/engine/SessionStateContainer.cs
@@ -1477,7 +1477,7 @@ namespace System.Management.Automation
                 string originalPath = path;
                 path =
                     Globber.GetProviderPath(
-                        path,
+                        context.SuppressWildcardExpansion ? path : WildcardPattern.Unescape(path),
                         context,
                         out provider,
                         out drive);
@@ -2441,7 +2441,7 @@ namespace System.Management.Automation
 
                 string providerPath =
                     Globber.GetProviderPath(
-                        path,
+                        context.SuppressWildcardExpansion ? path : WildcardPattern.Unescape(path),
                         context,
                         out provider,
                         out drive);

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ChildItem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ChildItem.Tests.ps1
@@ -21,6 +21,9 @@ Describe "Get-ChildItem" -Tags "CI" {
             $null = New-Item -Path $TestDrive -Name $item_F -ItemType "File" -Force | ForEach-Object {$_.Attributes = "hidden"}
             $null = New-Item -Path (Join-Path -Path $TestDrive -ChildPath $item_E) -Name $item_G -ItemType "File" -Force
 
+            $specialDirName = "Test[Dir]"
+            $specialDir = "Test``[Dir``]"
+
             $searchRoot = Join-Path $TestDrive -ChildPath "TestPS"
             $file1 = Join-Path $searchRoot -ChildPath "D1" -AdditionalChildPath "File1.txt"
             $file2 = Join-Path $searchRoot -ChildPath "File1.txt"
@@ -140,6 +143,14 @@ Describe "Get-ChildItem" -Tags "CI" {
             (Get-ChildItem -LiteralPath $TestDrive -Recurse -Include *.dll).Count | Should Be (Get-ChildItem $TestDrive -Recurse -Include *.dll).Count
             (Get-ChildItem -LiteralPath $TestDrive -Depth 1 -Include $item_G).Count | Should Be 1
             (Get-ChildItem -LiteralPath $TestDrive -Depth 1 -Exclude $item_a).Count | Should Be 5
+        }
+
+        It "Should list files in directory contains special char" {
+            $null = New-Item -Path $TestDrive -Name $specialDirName -ItemType Directory -Force
+            $specialPath = Join-Path $TestDrive $specialDir
+            $null = New-Item -Path $specialPath -Name file1.txt -ItemType File -Force
+            $null = New-Item -Path $specialPath -Name file2.txt -ItemType File -Force
+            (Get-ChildItem -Path $specialPath).Count | Should -Be 2
         }
 
         It "get-childitem path wildcard - <title>" -TestCases $PathWildCardTestCases {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ChildItem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ChildItem.Tests.ps1
@@ -150,7 +150,7 @@ Describe "Get-ChildItem" -Tags "CI" {
             $specialPath = Join-Path $TestDrive $specialDir
             $null = New-Item -Path $specialPath -Name file1.txt -ItemType File -Force
             $null = New-Item -Path $specialPath -Name file2.txt -ItemType File -Force
-            (Get-ChildItem -Path $specialPath).Count | Should -Be 2
+            Get-ChildItem -Path $specialPath | Should -HaveCount 2
         }
 
         It "get-childitem path wildcard - <title>" -TestCases $PathWildCardTestCases {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ChildItem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ChildItem.Tests.ps1
@@ -21,11 +21,6 @@ Describe "Get-ChildItem" -Tags "CI" {
             $null = New-Item -Path $TestDrive -Name $item_F -ItemType "File" -Force | ForEach-Object {$_.Attributes = "hidden"}
             $null = New-Item -Path (Join-Path -Path $TestDrive -ChildPath $item_E) -Name $item_G -ItemType "File" -Force
 
-            $specialDirName = "Test[Dir]"
-            $specialDir = "Test``[Dir``]"
-            $specialPath = Join-Path $TestDrive $specialDir
-            $null = New-Item -Path $TestDrive -Name $specialDirName -ItemType Directory -Force
-
             $searchRoot = Join-Path $TestDrive -ChildPath "TestPS"
             $file1 = Join-Path $searchRoot -ChildPath "D1" -AdditionalChildPath "File1.txt"
             $file2 = Join-Path $searchRoot -ChildPath "File1.txt"
@@ -147,12 +142,6 @@ Describe "Get-ChildItem" -Tags "CI" {
             (Get-ChildItem -LiteralPath $TestDrive -Depth 1 -Exclude $item_a).Count | Should Be 5
         }
 
-        It "Should list files in directory contains special char" {
-            $null = New-Item -Path $specialPath -Name file1.txt -ItemType File
-            $null = New-Item -Path $specialPath -Name file2.txt -ItemType File
-            Get-ChildItem -Path $specialPath | Should -HaveCount 2
-        }
-
         It "get-childitem path wildcard - <title>" -TestCases $PathWildCardTestCases {
             param($Parameters, $ExpectedCount)
 
@@ -199,6 +188,22 @@ Describe "Get-ChildItem" -Tags "CI" {
                 Get-ChildItem env: | Where-Object {$_.Name -eq '__foobar'} | Remove-Item -ErrorAction SilentlyContinue
             }
         }
+    }
+}
+
+Describe "Get-ChildItem with special path" -Tags "CI" {
+
+    BeforeAll {
+        $bracketDirName = "Test[Dir]"
+        $bracketDir = "Test``[Dir``]"
+        $bracketPath = Join-Path $TestDrive $bracketDir
+        $null = New-Item -Path $TestDrive -Name $bracketDirName -ItemType Directory -Force
+    }
+
+    It "Should list files in directory with name containing bracket char" {
+        $null = New-Item -Path $bracketPath -Name file1.txt -ItemType File
+        $null = New-Item -Path $bracketPath -Name file2.txt -ItemType File
+        Get-ChildItem -Path $bracketPath | Should -HaveCount 2
     }
 }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ChildItem.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Get-ChildItem.Tests.ps1
@@ -23,6 +23,8 @@ Describe "Get-ChildItem" -Tags "CI" {
 
             $specialDirName = "Test[Dir]"
             $specialDir = "Test``[Dir``]"
+            $specialPath = Join-Path $TestDrive $specialDir
+            $null = New-Item -Path $TestDrive -Name $specialDirName -ItemType Directory -Force
 
             $searchRoot = Join-Path $TestDrive -ChildPath "TestPS"
             $file1 = Join-Path $searchRoot -ChildPath "D1" -AdditionalChildPath "File1.txt"
@@ -146,10 +148,8 @@ Describe "Get-ChildItem" -Tags "CI" {
         }
 
         It "Should list files in directory contains special char" {
-            $null = New-Item -Path $TestDrive -Name $specialDirName -ItemType Directory -Force
-            $specialPath = Join-Path $TestDrive $specialDir
-            $null = New-Item -Path $specialPath -Name file1.txt -ItemType File -Force
-            $null = New-Item -Path $specialPath -Name file2.txt -ItemType File -Force
+            $null = New-Item -Path $specialPath -Name file1.txt -ItemType File
+            $null = New-Item -Path $specialPath -Name file2.txt -ItemType File
             Get-ChildItem -Path $specialPath | Should -HaveCount 2
         }
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->
Reopen #7403
Fix #9541 

# PR Summary

<!-- Summarize your PR between here and the checklist. -->
Unescape non-literal, non-glob path before existence checking.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
This solve the issue where Get-GhildItem does not behave correctly
when -Path contains special characters. For example,
```pwsh
Get-ChildItem -Path './`[dir`]'
```
will complain with error "Cannot find path ..." while
```pwsh
Get-ChildItem -Path './`[dir`]' -Depth 0
```
will work fine.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
