### PR TITLE
PathUtils: handle escaped -Path correctly

### DIFF
--- a/src/System.Management.Automation/utils/PathUtils.cs
+++ b/src/System.Management.Automation/utils/PathUtils.cs
@@ -295,7 +295,8 @@ namespace System.Management.Automation
                 PSDriveInfo drive = null;
                 path =
                     command.SessionState.Path.GetUnresolvedProviderPathFromPSPath(
-                        filePath, cmdletProviderContext, out provider, out drive);
+                        isLiteralPath ? filePath : WildcardPattern.Unescape(filePath),
+                        cmdletProviderContext, out provider, out drive);
                 cmdletProviderContext.ThrowFirstErrorOrDoNothing();
                 if (!provider.NameEquals(command.Context.ProviderNames.FileSystem))
                 {

--- a/src/System.Management.Automation/utils/PathUtils.cs
+++ b/src/System.Management.Automation/utils/PathUtils.cs
@@ -296,7 +296,9 @@ namespace System.Management.Automation
                 path =
                     command.SessionState.Path.GetUnresolvedProviderPathFromPSPath(
                         isLiteralPath ? filePath : WildcardPattern.Unescape(filePath),
-                        cmdletProviderContext, out provider, out drive);
+                        cmdletProviderContext,
+                        out provider,
+                        out drive);
                 cmdletProviderContext.ThrowFirstErrorOrDoNothing();
                 if (!provider.NameEquals(command.Context.ProviderNames.FileSystem))
                 {

--- a/test/powershell/Modules/Microsoft.PowerShell.Utility/Out-File.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Utility/Out-File.Tests.ps1
@@ -24,6 +24,7 @@ Describe "Out-File" -Tags "CI" {
         $expectedContent = "some test text"
         $inObject = New-Object psobject -Property @{text=$expectedContent}
         $testfile = Join-Path -Path $TestDrive -ChildPath outfileTest.txt
+        $testfileSp = Join-Path -Path $TestDrive -ChildPath "``[outfileTest``].txt"
     }
 
     AfterEach {
@@ -88,6 +89,14 @@ Describe "Out-File" -Tags "CI" {
         $actual[8]  | Should -Match "some test text"
         $actual[9]  | Should -BeNullOrEmpty
         $actual[10] | Should -BeNullOrEmpty
+    }
+
+    It "Should create the file with correct name when FilePath contains special char" {
+        Out-File -FilePath $testfile
+        Out-File -FilePath $testfileSp
+
+        $testfile | Should -Exist
+        $testfileSp | Should -Exist
     }
 
     It "Should limit each line to the specified number of characters when the width switch is used on objects" {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->
Reopen #7405

# PR Summary

<!-- Summarize your PR between here and the checklist. -->
Unescape non-literal, non-glob path before calling
GetUnresolvedProviderPathFromPSPath since it only accepts literal path.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
This solve the issue where some commands depending on that method
will treat -Path as literal unintentionally. For example,
```pwsh
Out-File -Path './`[out`].txt' -Append
```
will create a new file named ```"`[out`].txt"``` instead of writing to ```"[out].txt"```.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
