### PR TITLE
Fix New-Item -Path/-Target with wildcard char

### DIFF
--- a/src/System.Management.Automation/engine/SessionStateContainer.cs
+++ b/src/System.Management.Automation/engine/SessionStateContainer.cs
@@ -3536,10 +3536,11 @@ namespace System.Management.Automation
                         }
 
                         // If the original target was a relative path, we want to leave it as relative
-                        if (targetPath.StartsWith(".", StringComparison.OrdinalIgnoreCase))
+                        if (targetPath.StartsWith("."))
                         {
-                            var SessionStateInt = ExecutionContext.EngineSessionState;
-                            content = SessionStateInt.NormalizeRelativePath(globbedTarget[0], SessionStateInt.CurrentLocation.ProviderPath);
+                            var sessionState = ExecutionContext.EngineSessionState;
+                            string resolvedPath = sessionState.NormalizeRelativePath(globbedTarget[0], sessionState.CurrentLocation.ProviderPath);
+                            content = resolvedPath.StartsWith(".") ? resolvedPath : Path.Combine(".", resolvedPath);
                         }
                         else
                         {

--- a/src/System.Management.Automation/engine/SessionStateContainer.cs
+++ b/src/System.Management.Automation/engine/SessionStateContainer.cs
@@ -3535,9 +3535,13 @@ namespace System.Management.Automation
                             throw PSTraceSource.NewInvalidOperationException(SessionStateStrings.PathNotFound, targetPath);
                         }
 
-                        // If the original target was a relative path, we want to leave it as relative if it did not require
-                        // globbing to resolve.
-                        if (WildcardPattern.ContainsWildcardCharacters(targetPath))
+                        // If the original target was a relative path, we want to leave it as relative
+                        if (targetPath.StartsWith(".", StringComparison.OrdinalIgnoreCase))
+                        {
+                            var SessionStateInt = ExecutionContext.EngineSessionState;
+                            content = SessionStateInt.NormalizeRelativePath(globbedTarget[0], SessionStateInt.CurrentLocation.ProviderPath);
+                        }
+                        else
                         {
                             content = globbedTarget[0];
                         }

--- a/src/System.Management.Automation/engine/SessionStateContainer.cs
+++ b/src/System.Management.Automation/engine/SessionStateContainer.cs
@@ -3536,11 +3536,11 @@ namespace System.Management.Automation
                         }
 
                         // If the original target was a relative path, we want to leave it as relative
-                        if (targetPath.StartsWith("."))
+                        if (targetPath.StartsWith('.'))
                         {
                             var sessionState = ExecutionContext.EngineSessionState;
                             string resolvedPath = sessionState.NormalizeRelativePath(globbedTarget[0], sessionState.CurrentLocation.ProviderPath);
-                            content = resolvedPath.StartsWith(".") ? resolvedPath : Path.Combine(".", resolvedPath);
+                            content = resolvedPath.StartsWith('.') ? resolvedPath : Path.Combine(".", resolvedPath);
                         }
                         else
                         {

--- a/src/System.Management.Automation/engine/SessionStateContainer.cs
+++ b/src/System.Management.Automation/engine/SessionStateContainer.cs
@@ -3443,7 +3443,7 @@ namespace System.Management.Automation
                 if (string.IsNullOrEmpty(name))
                 {
                     string providerPath =
-                        Globber.GetProviderPath(resolvePath, context, out provider, out driveInfo);
+                        Globber.GetProviderPath(WildcardPattern.Unescape(resolvePath), context, out provider, out driveInfo);
 
                     providerInstance = GetProviderInstance(provider);
                     providerPaths.Add(providerPath);

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/New-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/New-Item.Tests.ps1
@@ -271,7 +271,7 @@ Describe "New-Item with links" -Tags @('CI', 'RequireAdminOnWindows') {
 
         $expectedTarget = Join-Path -Path $tmpDirectory -ChildPath $testlinkSrcSpName
 
-        $fileInfo = Get-ChildItem -Path $FullyQualifiedLinkSp
+        $fileInfo = Get-Item -Path $FullyQualifiedLinkSp
         $fileInfo.Target | Should -BeExactly $expectedTarget
         $fileInfo.LinkType | Should -BeExactly "SymbolicLink"
         $fileInfo.Attributes -band $DirLinkMask | Should -BeExactly $SymLinkMask

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/New-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/New-Item.Tests.ps1
@@ -272,7 +272,7 @@ Describe "New-Item with links" -Tags @('CI', 'RequireAdminOnWindows') {
         $expectedTarget = Join-Path -Path $tmpDirectory -ChildPath $testlinkSrcSpName
 
         $fileInfo = Get-ChildItem -Path $FullyQualifiedLinkSp
-        $fileInfo.Target | Should -Match ([regex]::Escape($expectedTarget))
+        $fileInfo.Target | Should -BeExactly $expectedTarget
         $fileInfo.LinkType | Should -BeExactly "SymbolicLink"
         $fileInfo.Attributes -band $DirLinkMask | Should -BeExactly $SymLinkMask
     }

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/New-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/New-Item.Tests.ps1
@@ -105,14 +105,14 @@ Describe "New-Item" -Tags "CI" {
     }
 
     It "Should create a file with correct name when Name switch is not used and Path contains special char" {
-        New-Item -Path $FullyQualifiedFileSp -ItemType file
+        New-Item -Path $FullyQualifiedFileSp -ItemType file > $null
 
         $FullyQualifiedFileSp | Should -Exist
     }
 
     It "Should be able to create a multiple items in different directories" {
         $FullyQualifiedFile2 = Join-Path -Path $tmpDirectory -ChildPath test2.txt
-        New-Item -ItemType file -Path $FullyQualifiedFile, $FullyQualifiedFile2
+        New-Item -ItemType file -Path $FullyQualifiedFile, $FullyQualifiedFile2 > $null
 
         Test-Path $FullyQualifiedFile  | Should -BeTrue
         Test-Path $FullyQualifiedFile2 | Should -BeTrue
@@ -263,10 +263,10 @@ Describe "New-Item with links" -Tags @('CI', 'RequireAdminOnWindows') {
     }
 
     It "Should create symbolic link with name contains special char" {
-        $null = New-Item -Path $tmpDirectory -Name $testlinkSrcSpName -ItemType File
+        New-Item -Path $tmpDirectory -Name $testlinkSrcSpName -ItemType File > $null
         $FullyQualifiedLSrcSp | Should -Exist
 
-        $null = New-Item -Path $FullyQualifiedLinkSp -Target $FullyQualifiedLSrcSp -ItemType SymbolicLink
+        New-Item -Path $FullyQualifiedLinkSp -Target $FullyQualifiedLSrcSp -ItemType SymbolicLink > $null
         $FullyQualifiedLinkSp | Should -Exist
 
         $expectedTarget = Join-Path -Path $tmpDirectory -ChildPath $testlinkSrcSpName

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/New-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/New-Item.Tests.ps1
@@ -269,9 +269,9 @@ Describe "New-Item with links" -Tags @('CI', 'RequireAdminOnWindows') {
         $null = New-Item -Path $FullyQualifiedLinkSp -Target $FullyQualifiedLSrcSp -ItemType SymbolicLink
         $FullyQualifiedLinkSp | Should -Exist
 
-        $expectedTarget = Join-Path $tmpDirectory $testlinkSrcSpName
+        $expectedTarget = Join-Path -Path $tmpDirectory -ChildPath $testlinkSrcSpName
 
-        $fileInfo = Get-ChildItem $FullyQualifiedLinkSp
+        $fileInfo = Get-ChildItem -Path $FullyQualifiedLinkSp
         $fileInfo.Target | Should -Match ([regex]::Escape($expectedTarget))
         $fileInfo.LinkType | Should -BeExactly "SymbolicLink"
         $fileInfo.Attributes -band $DirLinkMask | Should -BeExactly $SymLinkMask

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/New-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/New-Item.Tests.ps1
@@ -34,15 +34,16 @@ function Clean-State
 Describe "New-Item" -Tags "CI" {
     $tmpDirectory               = $TestDrive
     $testfile                   = "testfile.txt"
+    $testfileSp                 = "``[test``]file.txt"
     $testfolder                 = "newDirectory"
     $testsubfolder              = "newSubDirectory"
     $testlink                   = "testlink"
     $FullyQualifiedFile         = Join-Path -Path $tmpDirectory -ChildPath $testfile
+    $FullyQualifiedFileSp       = Join-Path -Path $tmpDirectory -ChildPath $testfileSp
     $FullyQualifiedFolder       = Join-Path -Path $tmpDirectory -ChildPath $testfolder
     $FullyQualifiedLink         = Join-Path -Path $tmpDirectory -ChildPath $testlink
     $FullyQualifiedSubFolder    = Join-Path -Path $FullyQualifiedFolder -ChildPath $testsubfolder
     $FullyQualifiedFileInFolder = Join-Path -Path $FullyQualifiedFolder -ChildPath $testfile
-
 
     BeforeEach {
         Clean-State
@@ -101,6 +102,12 @@ Describe "New-Item" -Tags "CI" {
         New-Item -Path $FullyQualifiedFile -ItemType file
 
         Test-Path $FullyQualifiedFile | Should -BeTrue
+    }
+
+    It "Should create a file with correct name when Name switch is not used and Path contains special char" {
+        New-Item -Path $FullyQualifiedFileSp -ItemType file
+
+        $FullyQualifiedFileSp | Should -Exist
     }
 
     It "Should be able to create a multiple items in different directories" {
@@ -196,9 +203,15 @@ Describe "New-Item with links" -Tags @('CI', 'RequireAdminOnWindows') {
     $testfile             = "testfile.txt"
     $testfolder           = "newDirectory"
     $testlink             = "testlink"
+    $testlinkSrcSpName    = "[test]src"
+    $testlinkSrcSp        = "``[test``]src"
+    $testlinkSpName       = "[test]link"
+    $testlinkSp           = "``[test``]link"
     $FullyQualifiedFile   = Join-Path -Path $tmpDirectory -ChildPath $testfile
     $FullyQualifiedFolder = Join-Path -Path $tmpDirectory -ChildPath $testfolder
     $FullyQualifiedLink   = Join-Path -Path $tmpDirectory -ChildPath $testlink
+    $FullyQualifiedLSrcSp = Join-Path -Path $tmpDirectory -ChildPath $testlinkSrcSp
+    $FullyQualifiedLinkSp = Join-Path -Path $tmpDirectory -ChildPath $testlinkSp
     $SymLinkMask          = [System.IO.FileAttributes]::ReparsePoint
     $DirLinkMask          = $SymLinkMask -bor [System.IO.FileAttributes]::Directory
 
@@ -247,6 +260,21 @@ Describe "New-Item with links" -Tags @('CI', 'RequireAdminOnWindows') {
         Remove-Item $FullyQualifiedLink -Force
         # Test a code path removing a symbolic link (reparse point)
         Test-Path $FullyQualifiedLink | Should -BeFalse
+    }
+
+    It "Should create symbolic link with name contains special char" {
+        $null = New-Item -Path $tmpDirectory -Name $testlinkSrcSpName -ItemType File
+        $FullyQualifiedLSrcSp | Should -Exist
+
+        $null = New-Item -Path $FullyQualifiedLinkSp -Target $FullyQualifiedLSrcSp -ItemType SymbolicLink
+        $FullyQualifiedLinkSp | Should -Exist
+
+        $expectedTarget = Join-Path $tmpDirectory $testlinkSrcSpName
+
+        $fileInfo = Get-ChildItem $FullyQualifiedLinkSp
+        $fileInfo.Target | Should -Match ([regex]::Escape($expectedTarget))
+        $fileInfo.LinkType | Should -BeExactly "SymbolicLink"
+        $fileInfo.Attributes -band $DirLinkMask | Should -BeExactly $SymLinkMask
     }
 
     It "New-Item -ItemType SymbolicLink should understand directory path ending with slash" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Remove-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Remove-Item.Tests.ps1
@@ -3,7 +3,10 @@
 Describe "Remove-Item" -Tags "CI" {
     $testpath = $TestDrive
     $testfile = "testfile.txt"
+    $testfileSpName = "[testfile].txt"
+    $testfileSp = "``[testfile``].txt"
     $testfilepath = Join-Path -Path $testpath -ChildPath $testfile
+    $testfilepathSp = Join-Path -Path $testpath -ChildPath $testfileSp
     Context "File removal Tests" {
 	BeforeEach {
 	    New-Item -Name $testfile -Path $testpath -ItemType "file" -Value "lorem ipsum" -Force
@@ -109,6 +112,14 @@ Describe "Remove-Item" -Tags "CI" {
 	    Test-Path (Join-Path -Path $testpath -ChildPath file1.wav) | Should -BeFalse
 	    Test-Path (Join-Path -Path $testpath -ChildPath file2.wav) | Should -BeFalse
 	}
+
+        It "Should be able to remove file when path contains special char" {
+            New-Item -Path $testpath -Name $testfileSpName -ItemType File -Force
+            $testfilepathSp | Should -Exist
+
+            Remove-Item -Path $testfilepathSp
+            $testfilepathSp | Should -Not -Exist
+        }
     }
 
     Context "Directory Removal Tests" {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Remove-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Remove-Item.Tests.ps1
@@ -1,11 +1,11 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 Describe "Remove-Item" -Tags "CI" {
-    $testpath = $TestDrive
-    $testfile = "testfile.txt"
+    $testpath       = $TestDrive
+    $testfile       = "testfile.txt"
     $testfileSpName = "[testfile].txt"
-    $testfileSp = "``[testfile``].txt"
-    $testfilepath = Join-Path -Path $testpath -ChildPath $testfile
+    $testfileSp     = "``[testfile``].txt"
+    $testfilepath   = Join-Path -Path $testpath -ChildPath $testfile
     $testfilepathSp = Join-Path -Path $testpath -ChildPath $testfileSp
     Context "File removal Tests" {
 	BeforeEach {

--- a/test/powershell/Modules/Microsoft.PowerShell.Management/Remove-Item.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Management/Remove-Item.Tests.ps1
@@ -114,10 +114,10 @@ Describe "Remove-Item" -Tags "CI" {
 	}
 
         It "Should be able to remove file when path contains special char" {
-            New-Item -Path $testpath -Name $testfileSpName -ItemType File -Force
+            New-Item -Path $testpath -Name $testfileSpName -ItemType File -Force > $null
             $testfilepathSp | Should -Exist
 
-            Remove-Item -Path $testfilepathSp
+            Remove-Item -Path $testfilepathSp -Force
             $testfilepathSp | Should -Not -Exist
         }
     }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->
Reopen #7404

# PR Summary

<!-- Summarize your PR between here and the checklist. -->
Unescape non-literal path when -Name is not set.
Fix failure with symlink/junction target which contains special character.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
This works around for New-Item treating -Path as literal path while
it can also be globbable. For example, assuming there is ```"[file]1"```
in current directory, and tab completion suggests ```'./`[file`]1'```
for the -Path argument, but
```pwsh
New-Item -Path './`[file`]2'
```
will create a file named ```"`[file`]2"``` instead of ```"[file]2"```.

Also fixes an issue that New-Item does not handle -Target properly
when it contains escaped wildcard character. For example, there is
a directory ```"[dir]1"``` in current directory, and tab completion
suggests ```'./`[dir`]1'``` for the -Target argument, but
```pwsh
New-Item -Type Junction -Path './`[dir`]2' -Target './`[dir`]1'
```
will complain that it cannot find the item.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
