### PR TITLE
Fix build order in windows-daily build

### DIFF
--- a/.vsts-ci/templates/windows-packaging.yml
+++ b/.vsts-ci/templates/windows-packaging.yml
@@ -5,6 +5,8 @@ parameters:
 
 jobs:
 - job: ${{ parameters.jobName }}
+  dependsOn:
+      ${{ parameters.parentJobs }}
   pool:
     name: ${{ parameters.pool }}
 

--- a/.vsts-ci/windows-daily.yml
+++ b/.vsts-ci/windows-daily.yml
@@ -73,6 +73,7 @@ jobs:
 - template: templates/windows-packaging.yml
   parameters:
     parentJobs:
+      - win_dsfsf
       - win_test_UnelevatedPesterTests_CI
       - win_test_ElevatedPesterTests_CI
       - win_test_UnelevatedPesterTests_Others

--- a/.vsts-ci/windows-daily.yml
+++ b/.vsts-ci/windows-daily.yml
@@ -73,7 +73,6 @@ jobs:
 - template: templates/windows-packaging.yml
   parameters:
     parentJobs:
-      - win_dsfsf
       - win_test_UnelevatedPesterTests_CI
       - win_test_ElevatedPesterTests_CI
       - win_test_UnelevatedPesterTests_Others

--- a/.vsts-ci/windows-daily.yml
+++ b/.vsts-ci/windows-daily.yml
@@ -68,10 +68,10 @@ jobs:
     parentJobs:
       - win_build
 
+# we wait for all tests to finish as this phase uploads the daily nuget package to MyGet.
+# we want to upload only if tests have passed.
 - template: templates/windows-packaging.yml
   parameters:
-  # we wait for all tests to finish as this phase uploads the daily nuget package to MyGet.
-  # we want to upload only if tests have passed.
     parentJobs:
       - win_test_UnelevatedPesterTests_CI
       - win_test_ElevatedPesterTests_CI

--- a/.vsts-ci/windows-daily.yml
+++ b/.vsts-ci/windows-daily.yml
@@ -72,7 +72,7 @@ jobs:
   parameters:
   # we wait for all tests to finish as this phase uploads the daily nuget package to MyGet.
   # we want to upload only if tests have passed.
-    dependsOn:
+    parentJobs:
       - win_test_UnelevatedPesterTests_CI
       - win_test_ElevatedPesterTests_CI
       - win_test_UnelevatedPesterTests_Others


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

The windows-daily build had a bug which caused the packaging builds to be kicked off before tests. This PR fixes the build order.

## PR Context

Fix for failing daily build.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [x] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
