### PR TITLE
Adding tests for `Remove-Module`

### DIFF
--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Remove-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Remove-Module.Tests.ps1
@@ -1,5 +1,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
+
 Describe "Remove-Module -Name | -FullyQualifiedName | -ModuleInfo" -Tags "CI" {
     BeforeAll {
         Remove-Module -Name "Foo", "Bar", "Baz" -ErrorAction SilentlyContinue

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Remove-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Remove-Module.Tests.ps1
@@ -2,6 +2,7 @@
 # Licensed under the MIT License.
 Describe "Remove-Module -Name" -Tags "CI" {
     BeforeAll {
+        Remove-Module -Name "Foo", "Bar", "Baz" -ErrorAction SilentlyContinue
 
         New-Item -ItemType Directory -Path "$testdrive\Modules\Foo\" -Force > $null
         New-Item -ItemType Directory -Path "$testdrive\Modules\Bar\" -Force > $null
@@ -41,16 +42,16 @@ Describe "Remove-Module -Name" -Tags "CI" {
         )
     }
 
-    AfterAll {
-        Remove-Module -Name "Foo", "Bar", "Baz"
-    }
-
     BeforeEach {
         Import-Module -Name "$testdrive\Modules\Foo\Foo.psd1" -Force
         Import-Module -Name "$testdrive\Modules\Bar\Bar.psd1" -Force
         Import-Module -Name "$testdrive\Modules\Baz\Baz.psd1" -Force
 
         (Get-Module -Name "Bar", "Baz", "Foo").Name | Should -BeExactly "Bar", "Baz", "Foo"
+    }
+
+    AfterAll {
+        Remove-Module -Name "Foo", "Bar", "Baz" -ErrorAction SilentlyContinue
     }
 
     It "Remove-Module -Name <PatternsToRemove>" -TestCases $removeModuleByNameTestCases {
@@ -84,6 +85,7 @@ Describe "Remove-Module -Name" -Tags "CI" {
 
 Describe "Remove-Module -FullyQualifiedName" -Tags "CI" {
     BeforeAll {
+        Remove-Module -Name "Foo", "Bar", "Baz" -ErrorAction SilentlyContinue
 
         New-Item -ItemType Directory -Path "$testdrive\Modules\Foo\1.0\" -Force > $null
         New-Item -ItemType Directory -Path "$testdrive\Modules\Foo\2.0\" -Force > $null
@@ -163,6 +165,10 @@ Describe "Remove-Module -FullyQualifiedName" -Tags "CI" {
         Import-Module -Name "$testdrive\Modules\Baz\Baz.psd1" -Force
 
         (Get-Module -Name "Bar", "Baz", "Foo").Name | Should -BeExactly "Bar", "Baz", "Foo", "Foo"
+    }
+
+    AfterAll {
+        Remove-Module -Name "Foo", "Bar", "Baz" -ErrorAction SilentlyContinue
     }
 
     It "Remove-Module -FullyQualifiedName <FullyQualifiedName>" -TestCases $removeModuleByFQNTestCases {

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Remove-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Remove-Module.Tests.ps1
@@ -1,89 +1,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
-Describe "Remove-Module -Name" -Tags "CI" {
-    BeforeAll {
-        Remove-Module -Name "Foo", "Bar", "Baz" -ErrorAction SilentlyContinue
-
-        New-Item -ItemType Directory -Path "$testdrive\Modules\Foo\" -Force > $null
-        New-Item -ItemType Directory -Path "$testdrive\Modules\Bar\" -Force > $null
-        New-Item -ItemType Directory -Path "$testdrive\Modules\Baz\" -Force > $null
-
-        New-ModuleManifest -Path "$testdrive\Modules\Foo\Foo.psd1"
-        New-ModuleManifest -Path "$testdrive\Modules\Bar\Bar.psd1"
-        New-ModuleManifest -Path "$testdrive\Modules\Baz\Baz.psd1"
-
-        New-Item -ItemType File -Path "$testdrive\Modules\Foo\Foo.psm1" > $null
-        New-Item -ItemType File -Path "$testdrive\Modules\Bar\Bar.psm1" > $null
-        New-Item -ItemType File -Path "$testdrive\Modules\Baz\Baz.psm1" > $null
-
-        $removeModuleByNameTestCases = @(
-            # Simple patterns
-            @{ PatternsToRemove = "Foo"; ShouldBeRemoved = "Foo"; ShouldBePresent = "Bar", "Baz"}
-            @{ PatternsToRemove = "Bar", "Foo"; ShouldBeRemoved = "Bar", "Foo"; ShouldBePresent = "Baz"}
-            @{ PatternsToRemove = "Bar", "Baz", "Foo"; ShouldBeRemoved = "Bar", "Baz", "Foo"; ShouldBePresent = ""}
-            @{ PatternsToRemove = "Foo", "Foo"; ShouldBeRemoved = "Foo"; ShouldBePresent = "Bar", "Baz"}
-            @{ PatternsToRemove = "Foo", "Foo", "Bar"; ShouldBeRemoved = "Bar", "Foo"; ShouldBePresent = "Baz"}
-            @{ PatternsToRemove = "Fo", "Foo"; ShouldBeRemoved = "Foo"; ShouldBePresent = "Bar", "Baz"}
-
-            # Regex patterns
-            #@{ PatternsToRemove = "*"; ShouldBeRemoved = "Bar", "Baz", "Foo"; ShouldBePresent = ""} -> this breaks pester for some reason
-            @{ PatternsToRemove = "B*"; ShouldBeRemoved = "Bar", "Baz"; ShouldBePresent = "Foo"}
-            @{ PatternsToRemove = "F*"; ShouldBeRemoved = "Foo"; ShouldBePresent = "Bar", "Baz"}
-            @{ PatternsToRemove = "Foo*"; ShouldBeRemoved = "Foo"; ShouldBePresent = "Bar", "Baz"}
-            @{ PatternsToRemove = "F*", "Bar"; ShouldBeRemoved = "Foo", "Bar"; ShouldBePresent = "Baz"}
-            @{ PatternsToRemove = "F*", "F*"; ShouldBeRemoved = "Foo"; ShouldBePresent = "Bar", "Baz"}
-            @{ PatternsToRemove = "FF*"; ShouldBeRemoved = ""; ShouldBePresent = "Bar", "Baz", "Foo"}
-        )
-
-        $removeModuleByNameErrorTestCases = @(
-            # Invalid patterns
-            @{ PatternsToRemove = "Fo"; ShouldBeRemoved = ""; ShouldBePresent = "Bar", "Baz", "Foo"}
-            @{ PatternsToRemove = "Fo", "Ba"; ShouldBeRemoved = ""; ShouldBePresent = "Bar", "Baz", "Foo"}
-        )
-    }
-
-    BeforeEach {
-        Import-Module -Name "$testdrive\Modules\Foo\Foo.psd1" -Force
-        Import-Module -Name "$testdrive\Modules\Bar\Bar.psd1" -Force
-        Import-Module -Name "$testdrive\Modules\Baz\Baz.psd1" -Force
-
-        (Get-Module -Name "Bar", "Baz", "Foo").Name | Should -BeExactly "Bar", "Baz", "Foo"
-    }
-
-    AfterAll {
-        Remove-Module -Name "Foo", "Bar", "Baz" -ErrorAction SilentlyContinue
-    }
-
-    It "Remove-Module -Name <PatternsToRemove>" -TestCases $removeModuleByNameTestCases {
-        param([string[]]$PatternsToRemove, [string[]]$ShouldBeRemoved, [string[]]$ShouldBePresent)
-
-        { Remove-Module -Name $PatternsToRemove} | Should -Not -Throw
-
-        if ($ShouldBeRemoved) {
-            (Get-Module -Name $ShouldBeRemoved).Name | Should -BeNullOrEmpty
-        }
-
-        if ($ShouldBePresent) {
-            (Get-Module -Name $ShouldBePresent).Name | Should -BeExactly $ShouldBePresent
-        }
-    }
-
-    It "Remove-Module -Name <PatternsToRemove> (Error cases)" -TestCases $removeModuleByNameErrorTestCases {
-        param([string[]]$PatternsToRemove, [string[]]$ShouldBeRemoved, [string[]]$ShouldBePresent)
-
-        { Remove-Module -Name $PatternsToRemove -ErrorAction Stop } | Should -Throw -ErrorId "Modules_NoModulesRemoved,Microsoft.PowerShell.Commands.RemoveModuleCommand"
-
-        if ($ShouldBeRemoved) {
-            (Get-Module -Name $ShouldBeRemoved).Name | Should -BeNullOrEmpty
-        }
-
-        if ($ShouldBePresent) {
-            (Get-Module -Name $ShouldBePresent).Name | Should -BeExactly $ShouldBePresent
-        }
-    }
-}
-
-Describe "Remove-Module -FullyQualifiedName | -ModuleInfo" -Tags "CI" {
+Describe "Remove-Module -Name | -FullyQualifiedName | -ModuleInfo" -Tags "CI" {
     BeforeAll {
         Remove-Module -Name "Foo", "Bar", "Baz" -ErrorAction SilentlyContinue
 
@@ -100,6 +17,32 @@ Describe "Remove-Module -FullyQualifiedName | -ModuleInfo" -Tags "CI" {
         New-Item -ItemType File -Path "$testdrive\Modules\Foo\1.0\Foo.psm1" > $null
         New-Item -ItemType File -Path "$testdrive\Modules\Foo\2.0\Foo.psm1" > $null
         New-Item -ItemType File -Path "$testdrive\Modules\Bar\Bar.psm1" > $null
+
+        $removeModuleByNameTestCases = @(
+            # Simple patterns
+            @{ PatternsToRemove = "Bar"; ShouldBeRemoved = "Bar"; ShouldBePresent = "Baz", "Foo", "Foo"}
+            @{ PatternsToRemove = "Foo"; ShouldBeRemoved = "Foo"; ShouldBePresent = "Bar", "Baz"}
+            @{ PatternsToRemove = "Bar", "Foo"; ShouldBeRemoved = "Bar", "Foo"; ShouldBePresent = "Baz"}
+            @{ PatternsToRemove = "Bar", "Baz", "Foo"; ShouldBeRemoved = "Bar", "Baz", "Foo"; ShouldBePresent = ""}
+            @{ PatternsToRemove = "Foo", "Foo"; ShouldBeRemoved = "Foo"; ShouldBePresent = "Bar", "Baz"}
+            @{ PatternsToRemove = "Foo", "Foo", "Bar"; ShouldBeRemoved = "Bar", "Foo"; ShouldBePresent = "Baz"}
+            @{ PatternsToRemove = "Fo", "Foo"; ShouldBeRemoved = "Foo"; ShouldBePresent = "Bar", "Baz"}
+
+            # Regex patterns
+            #@{ PatternsToRemove = "*"; ShouldBeRemoved = "Bar", "Baz", "Foo"; ShouldBePresent = ""} -> this breaks pester for some reason
+            @{ PatternsToRemove = "B*"; ShouldBeRemoved = "Bar", "Baz"; ShouldBePresent = "Foo", "Foo"}
+            @{ PatternsToRemove = "F*"; ShouldBeRemoved = "Foo"; ShouldBePresent = "Bar", "Baz"}
+            @{ PatternsToRemove = "Foo*"; ShouldBeRemoved = "Foo"; ShouldBePresent = "Bar", "Baz"}
+            @{ PatternsToRemove = "F*", "Bar"; ShouldBeRemoved = "Foo", "Bar"; ShouldBePresent = "Baz"}
+            @{ PatternsToRemove = "F*", "F*"; ShouldBeRemoved = "Foo"; ShouldBePresent = "Bar", "Baz"}
+            @{ PatternsToRemove = "FF*"; ShouldBeRemoved = ""; ShouldBePresent = "Bar", "Baz", "Foo", "Foo"}
+        )
+
+        $removeModuleByNameErrorTestCases = @(
+            # Invalid patterns
+            @{ PatternsToRemove = "Fo"; ShouldBeRemoved = ""; ShouldBePresent = "Bar", "Baz", "Foo", "Foo"}
+            @{ PatternsToRemove = "Fo", "Ba"; ShouldBeRemoved = ""; ShouldBePresent = "Bar", "Baz", "Foo", "Foo"}
+        )
 
         $removeModuleByFQNTestCases = @(
             @{
@@ -169,6 +112,34 @@ Describe "Remove-Module -FullyQualifiedName | -ModuleInfo" -Tags "CI" {
 
     AfterAll {
         Remove-Module -Name "Foo", "Bar", "Baz" -ErrorAction SilentlyContinue
+    }
+
+    It "Remove-Module -Name <PatternsToRemove>" -TestCases $removeModuleByNameTestCases {
+        param([string[]]$PatternsToRemove, [string[]]$ShouldBeRemoved, [string[]]$ShouldBePresent)
+
+        { Remove-Module -Name $PatternsToRemove} | Should -Not -Throw
+
+        if ($ShouldBeRemoved) {
+            (Get-Module -Name $ShouldBeRemoved).Name | Should -BeNullOrEmpty
+        }
+
+        if ($ShouldBePresent) {
+            (Get-Module -Name $ShouldBePresent).Name | Should -BeExactly $ShouldBePresent
+        }
+    }
+
+    It "Remove-Module -Name <PatternsToRemove> (Error cases)" -TestCases $removeModuleByNameErrorTestCases {
+        param([string[]]$PatternsToRemove, [string[]]$ShouldBeRemoved, [string[]]$ShouldBePresent)
+
+        { Remove-Module -Name $PatternsToRemove -ErrorAction Stop } | Should -Throw -ErrorId "Modules_NoModulesRemoved,Microsoft.PowerShell.Commands.RemoveModuleCommand"
+
+        if ($ShouldBeRemoved) {
+            (Get-Module -Name $ShouldBeRemoved).Name | Should -BeNullOrEmpty
+        }
+
+        if ($ShouldBePresent) {
+            (Get-Module -Name $ShouldBePresent).Name | Should -BeExactly $ShouldBePresent
+        }
     }
 
     It "Remove-Module -FullyQualifiedName <FullyQualifiedName>" -TestCases $removeModuleByFQNTestCases {

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Remove-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Remove-Module.Tests.ps1
@@ -374,8 +374,12 @@ Describe "Remove-Module : module contains nested modules" -Tags "CI" {
 
         Import-Module "$testdrive\Modules\Bar\Bar.psd1" -Force
         Import-Module "$testdrive\Modules\Foo\Foo.psd1" -Force
-
         (Get-Module -Name "Bar").Name | Should -BeExactly "Bar"
+        (Get-Module -Name "Foo").Name | Should -BeExactly "Foo"
+
+        {Remove-Module "Foo" -ErrorAction Stop } | Should -Not -Throw
+        Import-Module "$testdrive\Modules\Foo\Foo.psd1" -Force
+
         { Remove-Module "Bar" -ErrorAction Stop } | Should -Throw -ErrorId "Modules_ModuleIsRequired,Microsoft.PowerShell.Commands.RemoveModuleCommand"
     }
 }

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Remove-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Remove-Module.Tests.ps1
@@ -333,16 +333,24 @@ Describe "Remove-Module : module contains nested modules" -Tags "CI" {
 
         New-Item -ItemType Directory -Path "$testdrive\Modules\Foo\" -Force > $null
         New-Item -ItemType Directory -Path "$testdrive\Modules\Bar\" -Force > $null
+        New-Item -ItemType Directory -Path "$testdrive\Modules\Baz\" -Force > $null
 
-        New-ModuleManifest -Path "$testdrive\Modules\Foo\Foo.psd1" -NestedModules "..\Bar\Bar.psd1" -FunctionsToExport "BarFunc"
-        New-ModuleManifest -Path "$testdrive\Modules\Bar\Bar.psd1" -RootModule "Bar.psm1" -FunctionsToExport "BarFunc"
+        New-ModuleManifest -Path "$testdrive\Modules\Foo\Foo.psd1"
+        New-ModuleManifest -Path "$testdrive\Modules\Bar\Bar.psd1"
+        New-ModuleManifest -Path "$testdrive\Modules\Baz\Baz.psd1"
 
         New-Item -ItemType File -Path "$testdrive\Modules\Foo\Foo.psm1" > $null
         New-Item -ItemType File -Path "$testdrive\Modules\Bar\Bar.psm1" > $null
+        New-Item -ItemType File -Path "$testdrive\Modules\Baz\Baz.psm1" > $null
+        Set-Content -Path "$testdrive\Modules\Foo\Foo.psm1" -Value "function FooFunc {}"
         Set-Content -Path "$testdrive\Modules\Bar\Bar.psm1" -Value "function BarFunc {}"
+        Set-Content -Path "$testdrive\Modules\Baz\Baz.psm1" -Value "function BazFunc {}"
     }
 
     It "Remove-Module : module contains nested modules" {
+        Update-ModuleManifest -Path "$testdrive\Modules\Bar\Bar.psd1" -RootModule "Bar.psm1" -FunctionsToExport "BarFunc"
+        Update-ModuleManifest -Path "$testdrive\Modules\Foo\Foo.psd1" -NestedModules "..\Bar\Bar.psd1" -FunctionsToExport "BarFunc"
+
         Import-Module "$testdrive\Modules\Foo\Foo.psd1" -Force
         (Get-Module -Name "Foo").Name | Should -BeExactly "Foo"
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Remove-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Remove-Module.Tests.ps1
@@ -83,7 +83,7 @@ Describe "Remove-Module -Name" -Tags "CI" {
     }
 }
 
-Describe "Remove-Module -FullyQualifiedName" -Tags "CI" {
+Describe "Remove-Module -FullyQualifiedName | -ModuleInfo" -Tags "CI" {
     BeforeAll {
         Remove-Module -Name "Foo", "Bar", "Baz" -ErrorAction SilentlyContinue
 
@@ -197,6 +197,30 @@ Describe "Remove-Module -FullyQualifiedName" -Tags "CI" {
         if ($ShouldBePresent) {
             (Get-Module -Name $ShouldBePresent).Name | Should -BeExactly $ShouldBePresent
         }
+    }
+
+    It "Remove-Module -ModuleInfo <ModuleInfo>" -TestCases $removeModuleByFQNTestCases {
+        param([Microsoft.PowerShell.Commands.ModuleSpecification[]]$FqnToRemove, [string[]]$ShouldBeRemoved, [string[]]$ShouldBePresent)
+
+        $modInfo = Get-Module -FullyQualifiedName $FqnToRemove
+
+        { Remove-Module -ModuleInfo $modInfo } | Should -Not -Throw
+
+        if ($ShouldBeRemoved) {
+            (Get-Module -Name $ShouldBeRemoved).Name | Should -BeNullOrEmpty
+        }
+
+        if ($ShouldBePresent) {
+            (Get-Module -Name $ShouldBePresent).Name | Should -BeExactly $ShouldBePresent
+        }
+    }
+
+    It "Remove-Module -ModuleInfo (removing twice works)" {
+        $modInfo = Get-Module -Name "Bar"
+
+        # Contrary to -Name and -FullyQualifiedName removing a non imported module works using ModuleInfo
+        { Remove-Module -ModuleInfo $modInfo } | Should -Not -Throw
+        { Remove-Module -ModuleInfo $modInfo } | Should -Not -Throw
     }
 }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Remove-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Remove-Module.Tests.ps1
@@ -106,8 +106,6 @@ Describe "Remove-Module -Name | -FullyQualifiedName | -ModuleInfo" -Tags "CI" {
         Import-Module -Name "$testdrive\Modules\Foo\2.0\Foo.psd1" -Force
         Import-Module -Name "$testdrive\Modules\Bar\Bar.psd1" -Force
         Import-Module -Name "$testdrive\Modules\Baz\Baz.psd1" -Force
-
-        (Get-Module -Name "Bar", "Baz", "Foo").Name | Should -BeExactly "Bar", "Baz", "Foo", "Foo"
     }
 
     AfterAll {
@@ -116,6 +114,8 @@ Describe "Remove-Module -Name | -FullyQualifiedName | -ModuleInfo" -Tags "CI" {
 
     It "Remove-Module -Name <PatternsToRemove>" -TestCases $removeModuleByNameTestCases {
         param([string[]]$PatternsToRemove, [string[]]$ShouldBeRemoved, [string[]]$ShouldBePresent)
+
+        (Get-Module -Name "Bar", "Baz", "Foo").Name | Should -BeExactly "Bar", "Baz", "Foo", "Foo"
 
         { Remove-Module -Name $PatternsToRemove} | Should -Not -Throw
 
@@ -131,6 +131,8 @@ Describe "Remove-Module -Name | -FullyQualifiedName | -ModuleInfo" -Tags "CI" {
     It "Remove-Module -Name <PatternsToRemove> (Error cases)" -TestCases $removeModuleByNameErrorTestCases {
         param([string[]]$PatternsToRemove, [string[]]$ShouldBeRemoved, [string[]]$ShouldBePresent)
 
+        (Get-Module -Name "Bar", "Baz", "Foo").Name | Should -BeExactly "Bar", "Baz", "Foo", "Foo"
+
         { Remove-Module -Name $PatternsToRemove -ErrorAction Stop } | Should -Throw -ErrorId "Modules_NoModulesRemoved,Microsoft.PowerShell.Commands.RemoveModuleCommand"
 
         if ($ShouldBeRemoved) {
@@ -144,6 +146,8 @@ Describe "Remove-Module -Name | -FullyQualifiedName | -ModuleInfo" -Tags "CI" {
 
     It "Remove-Module -FullyQualifiedName <FullyQualifiedName>" -TestCases $removeModuleByFQNTestCases {
         param([Microsoft.PowerShell.Commands.ModuleSpecification[]]$FqnToRemove, [string[]]$ShouldBeRemoved, [string[]]$ShouldBePresent)
+
+        (Get-Module -Name "Bar", "Baz", "Foo").Name | Should -BeExactly "Bar", "Baz", "Foo", "Foo"
 
         { Remove-Module -FullyQualifiedName $FqnToRemove } | Should -Not -Throw
 
@@ -159,6 +163,8 @@ Describe "Remove-Module -Name | -FullyQualifiedName | -ModuleInfo" -Tags "CI" {
     It "Remove-Module -FullyQualifiedName <FullyQualifiedName> (Error cases)" -TestCases $removeModuleByFQNErrorTestCases {
         param([Microsoft.PowerShell.Commands.ModuleSpecification[]]$FqnToRemove, [string[]]$ShouldBeRemoved, [string[]]$ShouldBePresent)
 
+        (Get-Module -Name "Bar", "Baz", "Foo").Name | Should -BeExactly "Bar", "Baz", "Foo", "Foo"
+
         { Remove-Module -FullyQualifiedName $FqnToRemove -ErrorAction Stop } | Should -Throw -ErrorId "Modules_NoModulesRemoved,Microsoft.PowerShell.Commands.RemoveModuleCommand"
 
         if ($ShouldBeRemoved) {
@@ -173,8 +179,9 @@ Describe "Remove-Module -Name | -FullyQualifiedName | -ModuleInfo" -Tags "CI" {
     It "Remove-Module -ModuleInfo <ModuleInfo>" -TestCases $removeModuleByFQNTestCases {
         param([Microsoft.PowerShell.Commands.ModuleSpecification[]]$FqnToRemove, [string[]]$ShouldBeRemoved, [string[]]$ShouldBePresent)
 
-        $modInfo = Get-Module -FullyQualifiedName $FqnToRemove
+        (Get-Module -Name "Bar", "Baz", "Foo").Name | Should -BeExactly "Bar", "Baz", "Foo", "Foo"
 
+        $modInfo = Get-Module -FullyQualifiedName $FqnToRemove
         { Remove-Module -ModuleInfo $modInfo } | Should -Not -Throw
 
         if ($ShouldBeRemoved) {
@@ -187,8 +194,9 @@ Describe "Remove-Module -Name | -FullyQualifiedName | -ModuleInfo" -Tags "CI" {
     }
 
     It "Remove-Module -ModuleInfo (removing twice works)" {
-        $modInfo = Get-Module -Name "Bar"
+        (Get-Module -Name "Bar", "Baz", "Foo").Name | Should -BeExactly "Bar", "Baz", "Foo", "Foo"
 
+        $modInfo = Get-Module -Name "Bar"
         # Contrary to -Name and -FullyQualifiedName removing a non imported module works using ModuleInfo
         { Remove-Module -ModuleInfo $modInfo } | Should -Not -Throw
         { Remove-Module -ModuleInfo $modInfo } | Should -Not -Throw
@@ -259,12 +267,12 @@ Describe "Remove-Module : module is readOnly" -Tags "CI" {
         Import-Module -Name "$testdrive\Modules\Bar\Bar_rw.psd1" -Force
         Import-Module -Name "$testdrive\Modules\Baz\Baz_ro.psd1" -Force
         (Get-Module -Name "Baz_ro").AccessMode = "readOnly"
-
-        (Get-Module -Name "Bar_rw", "Baz_ro", "Foo_ro", "Foo_rw").Name | Should -BeExactly "Bar_rw", "Baz_ro", "Foo_ro", "Foo_rw"
     }
 
     It "Remove-Module -ErrorAction Stop (ReadOnly modules): <NamesToRemove>" -TestCases $removeReadOnlyModulesStopOnErrorTestCases{
         param([string[]]$NamesToRemove, [string[]]$ShouldBeRemoved, [string[]]$ShouldBePresent)
+
+        (Get-Module -Name "Bar_rw", "Baz_ro", "Foo_ro", "Foo_rw").Name | Should -BeExactly "Bar_rw", "Baz_ro", "Foo_ro", "Foo_rw"
 
         { Remove-Module -Name $NamesToRemove -ErrorAction Stop } | Should -Throw -ErrorId "Modules_ModuleIsReadOnly,Microsoft.PowerShell.Commands.RemoveModuleCommand"
 
@@ -280,6 +288,8 @@ Describe "Remove-Module : module is readOnly" -Tags "CI" {
     It "Remove-Module -ErrorAction SilentlyContinue (ReadOnly modules): <NamesToRemove>" -TestCases $removeReadOnlyModulesContinueOnErrorTestCases{
         param([string[]]$NamesToRemove, [string[]]$ShouldBeRemoved, [string[]]$ShouldBePresent)
 
+        (Get-Module -Name "Bar_rw", "Baz_ro", "Foo_ro", "Foo_rw").Name | Should -BeExactly "Bar_rw", "Baz_ro", "Foo_ro", "Foo_rw"
+
         { Remove-Module -Name $NamesToRemove -ErrorAction SilentlyContinue } | Should -Not -Throw
 
         if ($ShouldBeRemoved) {
@@ -293,6 +303,8 @@ Describe "Remove-Module : module is readOnly" -Tags "CI" {
 
     It "Remove-Module -Force (ReadOnly modules): <NamesToRemove>" -TestCases $removeForceReadOnlyModules{
         param([string[]]$NamesToRemove, [string[]]$ShouldBeRemoved, [string[]]$ShouldBePresent)
+
+        (Get-Module -Name "Bar_rw", "Baz_ro", "Foo_ro", "Foo_rw").Name | Should -BeExactly "Bar_rw", "Baz_ro", "Foo_ro", "Foo_rw"
 
         { Remove-Module -Force -Name $NamesToRemove -ErrorAction Stop } | Should -Not -Throw
 
@@ -311,15 +323,18 @@ Describe "Remove-Module core module on module path by name" -Tags "CI" {
 
     BeforeEach {
         Import-Module -Name $moduleName -Force
-        (Get-Module -Name $moduleName).Name | Should -BeExactly $moduleName
     }
 
     It "should be able to remove a module with using Name switch" {
+        (Get-Module -Name $moduleName).Name | Should -BeExactly $moduleName
+
         { Remove-Module -Name $moduleName } | Should -Not -Throw
         (Get-Module -Name $moduleName).Name | Should -BeNullOrEmpty
     }
 
     It "should be able to remove a module with using ModuleInfo switch" {
+        (Get-Module -Name $moduleName).Name | Should -BeExactly $moduleName
+
         $a = Get-Module -Name $moduleName
         { Remove-Module -ModuleInfo $a } | Should -Not -Throw
         (Get-Module -Name $moduleName).Name | Should -BeNullOrEmpty
@@ -350,12 +365,10 @@ Describe "Remove-Module custom module with FullyQualifiedName" -Tags "Feature" {
             @{ ModPath = "$TestDrive/Modules\$moduleName/$moduleName.psd1" }
         )
 
-        BeforeEach {
-            Get-Module $moduleName | Remove-Module
-        }
-
         It "Removes a module with fully qualified name with path <ModPath>" -TestCases $testCases -Pending {
             param([string]$ModPath)
+
+            Get-Module $moduleName | Remove-Module
 
             $m = Import-Module $modulePath -PassThru
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Remove-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Remove-Module.Tests.ps1
@@ -335,21 +335,17 @@ Describe "Remove-Module : module contains nested modules" -Tags "CI" {
         New-Item -ItemType Directory -Path "$testdrive\Modules\Bar\" -Force > $null
         New-Item -ItemType Directory -Path "$testdrive\Modules\Baz\" -Force > $null
 
-        New-ModuleManifest -Path "$testdrive\Modules\Foo\Foo.psd1"
-        New-ModuleManifest -Path "$testdrive\Modules\Bar\Bar.psd1"
-        New-ModuleManifest -Path "$testdrive\Modules\Baz\Baz.psd1"
-
         New-Item -ItemType File -Path "$testdrive\Modules\Foo\Foo.psm1" > $null
         New-Item -ItemType File -Path "$testdrive\Modules\Bar\Bar.psm1" > $null
         New-Item -ItemType File -Path "$testdrive\Modules\Baz\Baz.psm1" > $null
+
         Set-Content -Path "$testdrive\Modules\Foo\Foo.psm1" -Value "function FooFunc {}"
         Set-Content -Path "$testdrive\Modules\Bar\Bar.psm1" -Value "function BarFunc {}"
-        Set-Content -Path "$testdrive\Modules\Baz\Baz.psm1" -Value "function BazFunc {}"
     }
 
     It "Remove-Module : module contains nested modules" {
-        Update-ModuleManifest -Path "$testdrive\Modules\Bar\Bar.psd1" -RootModule "Bar.psm1" -FunctionsToExport "BarFunc"
-        Update-ModuleManifest -Path "$testdrive\Modules\Foo\Foo.psd1" -NestedModules "..\Bar\Bar.psd1" -FunctionsToExport "BarFunc"
+        New-ModuleManifest "$testdrive\Modules\Bar\Bar.psd1" -RootModule "./Bar.psm1" -FunctionsToExport "BarFunc"
+        New-ModuleManifest "$testdrive\Modules\Foo\Foo.psd1" -NestedModules "../Bar/Bar.psd1" -FunctionsToExport "BarFunc"
 
         Import-Module "$testdrive\Modules\Foo\Foo.psd1" -Force
         (Get-Module -Name "Foo").Name | Should -BeExactly "Foo"
@@ -358,6 +354,18 @@ Describe "Remove-Module : module contains nested modules" -Tags "CI" {
         { Remove-Module -Name Foo -ErrorAction Stop } | Should -Not -Throw
         { Get-Command BarFunc -ErrorAction Stop } | Should -Throw
         (Get-Module -Name Foo).Name | Should -BeNullOrEmpty
+    }
+
+    It "Remove-Module : module contains nested modules with circular dependencies" {
+        New-ModuleManifest "$testdrive\Modules\Bar\Bar.psd1" -RootModule "Bar" -FunctionsToExport "BarFunc" -NestedModules "Bar"
+
+        Import-Module "$testdrive\Modules\Bar\Bar.psd1" -Force
+        (Get-Module -Name "Bar").Name | Should -BeExactly "Bar"
+
+        { Get-Command BarFunc -ErrorAction Stop } | Should -Not -Throw
+        { Remove-Module -Name "Bar" -ErrorAction Stop } | Should -Not -Throw
+        { Get-Command BarFunc -ErrorAction Stop } | Should -Throw
+        (Get-Module -Name "Bar").Name | Should -BeNullOrEmpty
     }
 }
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Remove-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Remove-Module.Tests.ps1
@@ -1,5 +1,199 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
+Describe "Remove-Module -Name" -Tags "CI" {
+    BeforeAll {
+
+        New-Item -ItemType Directory -Path "$testdrive\Modules\Foo\" -Force > $null
+        New-Item -ItemType Directory -Path "$testdrive\Modules\Bar\" -Force > $null
+        New-Item -ItemType Directory -Path "$testdrive\Modules\Baz\" -Force > $null
+
+        New-ModuleManifest -Path "$testdrive\Modules\Foo\Foo.psd1"
+        New-ModuleManifest -Path "$testdrive\Modules\Bar\Bar.psd1"
+        New-ModuleManifest -Path "$testdrive\Modules\Baz\Baz.psd1"
+
+        New-Item -ItemType File -Path "$testdrive\Modules\Foo\Foo.psm1" > $null
+        New-Item -ItemType File -Path "$testdrive\Modules\Bar\Bar.psm1" > $null
+        New-Item -ItemType File -Path "$testdrive\Modules\Baz\Baz.psm1" > $null
+
+        $removeModuleByNameTestCases = @(
+            # Simple patterns
+            @{ PatternsToRemove = "Foo"; ShouldBeRemoved = "Foo"; ShouldBePresent = "Bar", "Baz"}
+            @{ PatternsToRemove = "Bar", "Foo"; ShouldBeRemoved = "Bar", "Foo"; ShouldBePresent = "Baz"}
+            @{ PatternsToRemove = "Bar", "Baz", "Foo"; ShouldBeRemoved = "Bar", "Baz", "Foo"; ShouldBePresent = ""}
+            @{ PatternsToRemove = "Foo", "Foo"; ShouldBeRemoved = "Foo"; ShouldBePresent = "Bar", "Baz"}
+            @{ PatternsToRemove = "Foo", "Foo", "Bar"; ShouldBeRemoved = "Bar", "Foo"; ShouldBePresent = "Baz"}
+            @{ PatternsToRemove = "Fo", "Foo"; ShouldBeRemoved = "Foo"; ShouldBePresent = "Bar", "Baz"}
+
+            # Regex patterns
+            #@{ PatternsToRemove = "*"; ShouldBeRemoved = "Bar", "Baz", "Foo"; ShouldBePresent = ""} -> this breaks pester for some reason
+            @{ PatternsToRemove = "B*"; ShouldBeRemoved = "Bar", "Baz"; ShouldBePresent = "Foo"}
+            @{ PatternsToRemove = "F*"; ShouldBeRemoved = "Foo"; ShouldBePresent = "Bar", "Baz"}
+            @{ PatternsToRemove = "Foo*"; ShouldBeRemoved = "Foo"; ShouldBePresent = "Bar", "Baz"}
+            @{ PatternsToRemove = "F*", "Bar"; ShouldBeRemoved = "Foo", "Bar"; ShouldBePresent = "Baz"}
+            @{ PatternsToRemove = "F*", "F*"; ShouldBeRemoved = "Foo"; ShouldBePresent = "Bar", "Baz"}
+            @{ PatternsToRemove = "FF*"; ShouldBeRemoved = ""; ShouldBePresent = "Bar", "Baz", "Foo"}
+        )
+
+        $removeModuleByNameErrorTestCases = @(
+            # Invalid patterns
+            @{ PatternsToRemove = "Fo"; ShouldBeRemoved = ""; ShouldBePresent = "Bar", "Baz", "Foo"}
+            @{ PatternsToRemove = "Fo", "Ba"; ShouldBeRemoved = ""; ShouldBePresent = "Bar", "Baz", "Foo"}
+        )
+    }
+
+    AfterAll {
+        Remove-Module -Name "Foo", "Bar", "Baz"
+    }
+
+    BeforeEach {
+        Import-Module -Name "$testdrive\Modules\Foo\Foo.psd1" -Force
+        Import-Module -Name "$testdrive\Modules\Bar\Bar.psd1" -Force
+        Import-Module -Name "$testdrive\Modules\Baz\Baz.psd1" -Force
+
+        (Get-Module -Name "Bar", "Baz", "Foo").Name | Should -BeExactly "Bar", "Baz", "Foo"
+    }
+
+    It "Remove-Module -Name <PatternsToRemove>" -TestCases $removeModuleByNameTestCases {
+        param([string[]]$PatternsToRemove, [string[]]$ShouldBeRemoved, [string[]]$ShouldBePresent)
+
+        { Remove-Module -Name $PatternsToRemove} | Should -Not -Throw
+
+        if ($ShouldBeRemoved) {
+            (Get-Module -Name $ShouldBeRemoved).Name | Should -BeNullOrEmpty
+        }
+
+        if ($ShouldBePresent) {
+            (Get-Module -Name $ShouldBePresent).Name | Should -BeExactly $ShouldBePresent
+        }
+    }
+
+    It "Remove-Module -Name <PatternsToRemove> (Error cases)" -TestCases $removeModuleByNameErrorTestCases {
+        param([string[]]$PatternsToRemove, [string[]]$ShouldBeRemoved, [string[]]$ShouldBePresent)
+
+        { Remove-Module -Name $PatternsToRemove -ErrorAction Stop } | Should -Throw -ErrorId "Modules_NoModulesRemoved,Microsoft.PowerShell.Commands.RemoveModuleCommand"
+
+        if ($ShouldBeRemoved) {
+            (Get-Module -Name $ShouldBeRemoved).Name | Should -BeNullOrEmpty
+        }
+
+        if ($ShouldBePresent) {
+            (Get-Module -Name $ShouldBePresent).Name | Should -BeExactly $ShouldBePresent
+        }
+    }
+}
+
+Describe "Remove-Module -FullyQualifiedName" -Tags "CI" {
+    BeforeAll {
+
+        New-Item -ItemType Directory -Path "$testdrive\Modules\Foo\1.0\" -Force > $null
+        New-Item -ItemType Directory -Path "$testdrive\Modules\Foo\2.0\" -Force > $null
+        New-Item -ItemType Directory -Path "$testdrive\Modules\Bar\" -Force > $null
+        New-Item -ItemType Directory -Path "$testdrive\Modules\Baz\" -Force > $null
+
+        New-ModuleManifest -Path "$testdrive\Modules\Foo\1.0\Foo.psd1" -ModuleVersion 1.0
+        New-ModuleManifest -Path "$testdrive\Modules\Foo\2.0\Foo.psd1" -ModuleVersion 2.0
+        New-ModuleManifest -Path "$testdrive\Modules\Bar\Bar.psd1" -ModuleVersion 1.0
+        New-ModuleManifest -Path "$testdrive\Modules\Baz\Baz.psd1" -ModuleVersion 1.0
+
+        New-Item -ItemType File -Path "$testdrive\Modules\Foo\1.0\Foo.psm1" > $null
+        New-Item -ItemType File -Path "$testdrive\Modules\Foo\2.0\Foo.psm1" > $null
+        New-Item -ItemType File -Path "$testdrive\Modules\Bar\Bar.psm1" > $null
+
+        $removeModuleByFQNTestCases = @(
+            @{
+                FqnToRemove = @{ModuleName = "Foo"; ModuleVersion = "1.0"};
+                ShouldBeRemoved = "Foo";
+                ShouldBePresent = "Bar", "Baz";
+            }
+            @{
+                FqnToRemove = @{ModuleName = "Foo"; RequiredVersion = "1.0"};
+                ShouldBeRemoved = "";
+                ShouldBePresent = "Bar", "Baz", "Foo";
+            }
+            @{
+                FqnToRemove = @{ModuleName = "Foo"; ModuleVersion = "2.0"};
+                ShouldBeRemoved = "";
+                ShouldBePresent = "Bar", "Baz", "Foo";
+            }
+            @{
+                FqnToRemove = @{ModuleName = "Foo"; RequiredVersion = "2.0"};
+                ShouldBeRemoved = "";
+                ShouldBePresent = "Bar", "Baz", "Foo";
+            }
+            @{
+                FqnToRemove = @{ModuleName = "Foo"; ModuleVersion = "1.0"};
+                ShouldBeRemoved = "Foo";
+                ShouldBePresent = "Bar", "Baz";
+            }
+            @{
+                FqnToRemove = @{ModuleName = "Foo"; ModuleVersion = "1.0"}, @{ModuleName = "Bar"; ModuleVersion = "1.0"};
+                ShouldBeRemoved = "Foo", "Bar";
+                ShouldBePresent = "Baz";
+            }
+            @{
+                FqnToRemove = @{ModuleName = "Foo"; ModuleVersion = "3.0"}, @{ModuleName = "Bar"; ModuleVersion = "1.0"};
+                ShouldBeRemoved = "Bar";
+                ShouldBePresent = "Baz", "Foo", "Foo";
+            }
+        )
+
+        $removeModuleByFQNErrorTestCases = @(
+            @{
+                FqnToRemove = @{ModuleName = "Fo"; ModuleVersion = "1.0"};
+                ShouldBeRemoved = "";
+                ShouldBePresent = "Bar", "Baz", "Foo", "Foo";
+            }
+            @{
+                FqnToRemove = @{ModuleName = "Foo"; ModuleVersion = "3.0"};
+                ShouldBeRemoved = "";
+                ShouldBePresent = "Bar", "Baz", "Foo", "Foo";
+            }
+            @{
+                FqnToRemove = @{ModuleName = "Baz"; RequiredVersion = "3.0"};
+                ShouldBeRemoved = "";
+                ShouldBePresent = "Bar", "Baz", "Foo", "Foo";
+            }
+        )
+    }
+
+    BeforeEach {
+        Import-Module -Name "$testdrive\Modules\Foo\1.0\Foo.psd1" -Force
+        Import-Module -Name "$testdrive\Modules\Foo\2.0\Foo.psd1" -Force
+        Import-Module -Name "$testdrive\Modules\Bar\Bar.psd1" -Force
+        Import-Module -Name "$testdrive\Modules\Baz\Baz.psd1" -Force
+
+        (Get-Module -Name "Bar", "Baz", "Foo").Name | Should -BeExactly "Bar", "Baz", "Foo", "Foo"
+    }
+
+    It "Remove-Module -FullyQualifiedName <FullyQualifiedName>" -TestCases $removeModuleByFQNTestCases {
+        param([Microsoft.PowerShell.Commands.ModuleSpecification[]]$FqnToRemove, [string[]]$ShouldBeRemoved, [string[]]$ShouldBePresent)
+
+        { Remove-Module -FullyQualifiedName $FqnToRemove } | Should -Not -Throw
+
+        if ($ShouldBeRemoved) {
+            (Get-Module -Name $ShouldBeRemoved).Name | Should -BeNullOrEmpty
+        }
+
+        if ($ShouldBePresent) {
+            (Get-Module -Name $ShouldBePresent).Name | Should -BeExactly $ShouldBePresent
+        }
+    }
+
+    It "Remove-Module -FullyQualifiedName <FullyQualifiedName> (Error cases)" -TestCases $removeModuleByFQNErrorTestCases {
+        param([Microsoft.PowerShell.Commands.ModuleSpecification[]]$FqnToRemove, [string[]]$ShouldBeRemoved, [string[]]$ShouldBePresent)
+
+        { Remove-Module -FullyQualifiedName $FqnToRemove -ErrorAction Stop } | Should -Throw -ErrorId "Modules_NoModulesRemoved,Microsoft.PowerShell.Commands.RemoveModuleCommand"
+
+        if ($ShouldBeRemoved) {
+            (Get-Module -Name $ShouldBeRemoved).Name | Should -BeNullOrEmpty
+        }
+
+        if ($ShouldBePresent) {
+            (Get-Module -Name $ShouldBePresent).Name | Should -BeExactly $ShouldBePresent
+        }
+    }
+}
+
 Describe "Remove-Module core module on module path by name" -Tags "CI" {
     $moduleName = "Microsoft.PowerShell.Security"
 

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Remove-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Remove-Module.Tests.ps1
@@ -206,7 +206,7 @@ Describe "Remove-Module -Name | -FullyQualifiedName | -ModuleInfo" -Tags "CI" {
 Describe "Remove-Module : module is readOnly" -Tags "CI" {
 
     BeforeAll {
-        Remove-Module -Name "Foo", "Bar", "Baz" -ErrorAction SilentlyContinue
+        Remove-Module -Force -Name "Foo", "Bar", "Baz" -ErrorAction SilentlyContinue
 
         New-Item -ItemType Directory -Path "$testdrive\Modules\Foo\" -Force > $null
         New-Item -ItemType Directory -Path "$testdrive\Modules\Bar\" -Force > $null
@@ -215,44 +215,42 @@ Describe "Remove-Module : module is readOnly" -Tags "CI" {
         New-ModuleManifest -Path "$testdrive\Modules\Foo\Foo_ro.psd1"
         New-ModuleManifest -Path "$testdrive\Modules\Foo\Foo_rw.psd1"
         New-ModuleManifest -Path "$testdrive\Modules\Bar\Bar_rw.psd1"
-        New-ModuleManifest -Path "$testdrive\Modules\Baz\Baz_ro.psd1"
+        New-ModuleManifest -Path "$testdrive\Modules\Baz\Baz_const.psd1"
 
         New-Item -ItemType File -Path "$testdrive\Modules\Foo\Foo_ro.psm1" > $null
         New-Item -ItemType File -Path "$testdrive\Modules\Foo\Foo_rw.psm1" > $null
         New-Item -ItemType File -Path "$testdrive\Modules\Bar\Bar_rw.psm1" > $null
-        New-Item -ItemType File -Path "$testdrive\Modules\Baz\Baz_ro.psm1" > $null
+        New-Item -ItemType File -Path "$testdrive\Modules\Baz\Baz_const.psm1" > $null
 
-        $removeReadOnlyModulesStopOnErrorTestCases = @(
+        $removeReadOnlyModulesTestCases = @(
             # Simple patterns
-            @{ NamesToRemove = "Foo_ro"; ShouldBeRemoved = ""; ShouldBePresent = "Bar_rw", "Baz_ro", "Foo_ro", "Foo_rw"}
-            @{ NamesToRemove = "Foo_ro", "Foo_rw"; ShouldBeRemoved = ""; ShouldBePresent = "Bar_rw", "Baz_ro", "Foo_ro", "Foo_rw"}
-            @{ NamesToRemove = "Bar_rw", "Baz_ro", "Foo_ro", "Foo_rw"; ShouldBeRemoved = ""; ShouldBePresent = "Bar_rw", "Baz_ro", "Foo_ro", "Foo_rw"}
+            @{ NamesToRemove = "Foo_ro"; ShouldBeRemoved = ""; ShouldBePresent = "Bar_rw", "Baz_const", "Foo_ro", "Foo_rw"}
+            @{ NamesToRemove = "Foo_ro", "Foo_rw"; ShouldBeRemoved = "Foo_rw"; ShouldBePresent = "Bar_rw", "Baz_const", "Foo_ro"}
+            @{ NamesToRemove = "Bar_rw", "Foo_ro", "Foo_rw"; ShouldBeRemoved = "Bar_rw", "Foo_rw"; ShouldBePresent = "Baz_const", "Foo_ro"}
 
             # Regex patterns
-            @{ NamesToRemove = "Foo_*"; ShouldBeRemoved = ""; ShouldBePresent = "Bar_rw", "Baz_ro", "Foo_ro", "Foo_rw"}
-            @{ NamesToRemove = "Foo_*", "Ba*"; ShouldBeRemoved = ""; ShouldBePresent = "Bar_rw", "Baz_ro", "Foo_ro", "Foo_rw"}
+            @{ NamesToRemove = "Foo_*"; ShouldBeRemoved = "Foo_rw"; ShouldBePresent = "Bar_rw", "Baz_const", "Foo_ro"}
+            @{ NamesToRemove = "Foo_*", "Bar_*"; ShouldBeRemoved = "Bar_rw", "Foo_rw"; ShouldBePresent = "Baz_const", "Foo_ro"}
         )
 
-        $removeReadOnlyModulesContinueOnErrorTestCases = @(
+        $removeForceReadOnlyModulesTestCases = @(
             # Simple patterns
-            @{ NamesToRemove = "Foo_ro"; ShouldBeRemoved = ""; ShouldBePresent = "Bar_rw", "Baz_ro", "Foo_ro", "Foo_rw"}
-            @{ NamesToRemove = "Foo_ro", "Foo_rw"; ShouldBeRemoved = "Foo_rw"; ShouldBePresent = "Bar_rw", "Baz_ro", "Foo_ro"}
-            @{ NamesToRemove = "Bar_rw", "Baz_ro", "Foo_ro", "Foo_rw"; ShouldBeRemoved = "Bar_rw", "Foo_rw"; ShouldBePresent = "Baz_ro", "Foo_ro"}
+            @{ NamesToRemove = "Foo_ro"; ShouldBeRemoved = "Foo_ro"; ShouldBePresent = "Bar_rw", "Baz_const", "Foo_rw"}
+            @{ NamesToRemove = "Foo_ro", "Foo_rw"; ShouldBeRemoved = "Foo_ro", "Foo_rw"; ShouldBePresent = "Bar_rw", "Baz_const"}
+            @{ NamesToRemove = "Bar_rw", "Foo_ro", "Foo_rw"; ShouldBeRemoved = "Bar_rw", "Foo_ro", "Foo_rw"; ShouldBePresent = "Baz_const"}
 
             # Regex patterns
-            @{ NamesToRemove = "Foo_*"; ShouldBeRemoved = "Foo_rw"; ShouldBePresent = "Bar_rw", "Baz_ro", "Foo_ro"}
-            @{ NamesToRemove = "Foo_*", "Ba*"; ShouldBeRemoved = "Bar_rw", "Foo_rw"; ShouldBePresent = "Baz_ro", "Foo_ro"}
+            @{ NamesToRemove = "Foo_*"; ShouldBeRemoved = "Foo_ro", "Foo_rw"; ShouldBePresent = "Bar_rw", "Baz_const"}
+            @{ NamesToRemove = "Foo_*", "Bar_*"; ShouldBeRemoved = "Bar_rw", "Foo_ro", "Foo_rw"; ShouldBePresent = "Baz_const"}
         )
 
-        $removeForceReadOnlyModules = @(
+        $removeConstantModulesTestCases = @(
             # Simple patterns
-            @{ NamesToRemove = "Foo_ro"; ShouldBeRemoved = "Foo_ro"; ShouldBePresent = "Bar_rw", "Baz_ro", "Foo_rw"}
-            @{ NamesToRemove = "Foo_ro", "Foo_rw"; ShouldBeRemoved = "Foo_ro", "Foo_rw"; ShouldBePresent = "Bar_rw", "Baz_ro"}
-            @{ NamesToRemove = "Bar_rw", "Baz_ro", "Foo_ro", "Foo_rw"; ShouldBeRemoved = "Bar_rw", "Baz_ro", "Foo_ro", "Foo_rw"; ShouldBePresent = ""}
+            @{ NamesToRemove = "Baz_const"; ShouldBeRemoved = ""; ShouldBePresent = "Bar_rw", "Baz_const", "Foo_ro", "Foo_rw"}
+            @{ NamesToRemove = "Baz_const", "Foo_ro", "Foo_rw"; ShouldBeRemoved = "Foo_ro", "Foo_rw"; ShouldBePresent = "Bar_rw", "Baz_const"}
 
             # Regex patterns
-            @{ NamesToRemove = "Foo_*"; ShouldBeRemoved = "Foo_ro", "Foo_rw"; ShouldBePresent = "Bar_rw", "Baz_ro"}
-            @{ NamesToRemove = "Foo_*", "Ba*"; ShouldBeRemoved = "Bar_rw", "Baz_ro", "Foo_ro", "Foo_rw"; ShouldBePresent = ""}
+            @{ NamesToRemove = "Foo_*", "Ba*"; ShouldBeRemoved = "Bar_rw", "Foo_ro", "Foo_rw"; ShouldBePresent = "Baz_const"}
         )
     }
 
@@ -265,31 +263,16 @@ Describe "Remove-Module : module is readOnly" -Tags "CI" {
         (Get-Module -Name "Foo_ro").AccessMode = "readOnly"
         Import-Module -Name "$testdrive\Modules\Foo\Foo_rw.psd1" -Force
         Import-Module -Name "$testdrive\Modules\Bar\Bar_rw.psd1" -Force
-        Import-Module -Name "$testdrive\Modules\Baz\Baz_ro.psd1" -Force
-        (Get-Module -Name "Baz_ro").AccessMode = "readOnly"
+        Import-Module -Name "$testdrive\Modules\Baz\Baz_const.psd1" -Force
+        (Get-Module -Name "Baz_const").AccessMode = "Constant"
     }
 
-    It "Remove-Module -ErrorAction Stop (ReadOnly modules): <NamesToRemove>" -TestCases $removeReadOnlyModulesStopOnErrorTestCases{
+    It "Remove-Module (ReadOnly modules): <NamesToRemove>" -TestCases $removeReadOnlyModulesTestCases {
         param([string[]]$NamesToRemove, [string[]]$ShouldBeRemoved, [string[]]$ShouldBePresent)
 
-        (Get-Module -Name "Bar_rw", "Baz_ro", "Foo_ro", "Foo_rw").Name | Should -BeExactly "Bar_rw", "Baz_ro", "Foo_ro", "Foo_rw"
+        (Get-Module -Name "Bar_rw", "Foo_ro", "Foo_rw").Name | Should -BeExactly "Bar_rw", "Foo_ro", "Foo_rw"
 
         { Remove-Module -Name $NamesToRemove -ErrorAction Stop } | Should -Throw -ErrorId "Modules_ModuleIsReadOnly,Microsoft.PowerShell.Commands.RemoveModuleCommand"
-
-        if ($ShouldBeRemoved) {
-            (Get-Module -Name $ShouldBeRemoved).Name | Should -BeNullOrEmpty
-        }
-
-        if ($ShouldBePresent) {
-            (Get-Module -Name $ShouldBePresent).Name | Should -BeExactly $ShouldBePresent
-        }
-    }
-
-    It "Remove-Module -ErrorAction SilentlyContinue (ReadOnly modules): <NamesToRemove>" -TestCases $removeReadOnlyModulesContinueOnErrorTestCases{
-        param([string[]]$NamesToRemove, [string[]]$ShouldBeRemoved, [string[]]$ShouldBePresent)
-
-        (Get-Module -Name "Bar_rw", "Baz_ro", "Foo_ro", "Foo_rw").Name | Should -BeExactly "Bar_rw", "Baz_ro", "Foo_ro", "Foo_rw"
-
         { Remove-Module -Name $NamesToRemove -ErrorAction SilentlyContinue } | Should -Not -Throw
 
         if ($ShouldBeRemoved) {
@@ -301,12 +284,29 @@ Describe "Remove-Module : module is readOnly" -Tags "CI" {
         }
     }
 
-    It "Remove-Module -Force (ReadOnly modules): <NamesToRemove>" -TestCases $removeForceReadOnlyModules{
+    It "Remove-Module -Force (ReadOnly modules): <NamesToRemove>" -TestCases $removeForceReadOnlyModulesTestCases {
         param([string[]]$NamesToRemove, [string[]]$ShouldBeRemoved, [string[]]$ShouldBePresent)
 
-        (Get-Module -Name "Bar_rw", "Baz_ro", "Foo_ro", "Foo_rw").Name | Should -BeExactly "Bar_rw", "Baz_ro", "Foo_ro", "Foo_rw"
+        (Get-Module -Name "Bar_rw", "Foo_ro", "Foo_rw").Name | Should -BeExactly "Bar_rw", "Foo_ro", "Foo_rw"
 
         { Remove-Module -Force -Name $NamesToRemove -ErrorAction Stop } | Should -Not -Throw
+
+        if ($ShouldBeRemoved) {
+            (Get-Module -Name $ShouldBeRemoved).Name | Should -BeNullOrEmpty
+        }
+
+        if ($ShouldBePresent) {
+            (Get-Module -Name $ShouldBePresent).Name | Should -BeExactly $ShouldBePresent
+        }
+    }
+
+    It "Remove-Module -Force (Constant modules): <NamesToRemove>" -TestCases $removeConstantModulesTestCases {
+        param([string[]]$NamesToRemove, [string[]]$ShouldBeRemoved, [string[]]$ShouldBePresent)
+
+        (Get-Module -Name "Bar_rw", "Baz_const", "Foo_ro", "Foo_rw").Name | Should -BeExactly "Bar_rw", "Baz_const", "Foo_ro", "Foo_rw"
+
+        { Remove-Module -Force -Name $NamesToRemove -ErrorAction Stop } | Should -Throw -ErrorId "Modules_ModuleIsConstant,Microsoft.PowerShell.Commands.RemoveModuleCommand"
+        { Remove-Module -Force -Name $NamesToRemove -ErrorAction SilentlyContinue } | Should -Not -Throw
 
         if ($ShouldBeRemoved) {
             (Get-Module -Name $ShouldBeRemoved).Name | Should -BeNullOrEmpty

--- a/test/powershell/Modules/Microsoft.PowerShell.Core/Remove-Module.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Core/Remove-Module.Tests.ps1
@@ -318,6 +318,14 @@ Describe "Remove-Module : module is readOnly" -Tags "CI" {
     }
 }
 
+Describe "Remove-Module : module provides the PSDrive for current PS Session" -Tags "CI" {
+    It "Remove-Module : module provides the PSDrive for current PS Session" {
+
+        $module = Get-Module (Join-Path $PSHome "System.Management.Automation.dll") -ListAvailable
+        { Remove-Module $module -ErrorAction Stop } | Should -Throw -ErrorId "InvalidOperation,Microsoft.PowerShell.Commands.RemoveModuleCommand"
+    }
+}
+
 Describe "Remove-Module core module on module path by name" -Tags "CI" {
     $moduleName = "Microsoft.PowerShell.Security"
 


### PR DESCRIPTION
# PR Summary

This PR adds approx 50 tests (+3 seconds when running locally) for the remove-module  cmdlet. 

If anyone has suggestions for test cases I missed please feel free to comment. Some of the cases listed are quite vague for the moment. My objective is to optimize the ````number of tests written / branches tested````. I will also screenshot some codeCov results once I get around to running it on the codebase.

Tests have been added tests for : 
  - [x] Remove-Module -Name
      - [x] simple module name (single, multiple, repeated)
      - [x] regular expressions (single, multiple, no matches) ["*" case breaks Pester (see code comment)]
      - [x] error cases (no matches for simple names)
  - [x] Remove-Module -FullyQualifiedName
     - [x] using ModuleVersion
     - [x] using RequiredVersion
     - [x] error cases (no matches for names and versions) 
  - [x] Remove-Module -ModuleInfo
  - [x] Remove-Module with constant module
      - [x] with -Force
      - [x] without -Force
  - [x] Remove-Module with readonly module
      - [x] with -Force
      - [x] without -Force
          - [ ] with constant engine module (I don't actually know how to hit this code path since these modules aren't visible in the first place via Get-Module)
          - [x] without constant engine module
  - [x] Remove-Module with module providing current session drive
  - [x] Remove-Module containing nested modules
     - [x] simple dependency A -> B
     - [x] circular dependency A -> A
  - [x] Remove-Module required by other modules which are also imported
     - [x] A -> B : remove B then A
     - [x] A -> B : remove A then B

## PR Context

This PR is aimed at increasing testing coverage for the module related cmdlets which we would like to refactor down the line.
This issue tracks the refactoring work : https://github.com/PowerShell/PowerShell/issues/8936

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
