### PR TITLE
Fixing test run crash by not passing script block to the callback

### DIFF
--- a/src/System.Management.Automation/engine/hostifaces/PowerShell.cs
+++ b/src/System.Management.Automation/engine/hostifaces/PowerShell.cs
@@ -2915,6 +2915,9 @@ namespace System.Management.Automation
         /// </param>
         /// <param name="callback">
         /// An AsyncCallback to call once the BeginInvoke completes.
+        /// Note: when using this API in script, don't pass in a delegate that is casted from a script block.
+        /// The callback could be invoked from a thread without a default Runspace and a delegate casted from
+        /// a script block would fail in that case.
         /// </param>
         /// <param name="state">
         /// A user supplied state to call the <paramref name="callback"/>
@@ -3036,6 +3039,9 @@ namespace System.Management.Automation
         /// </param>
         /// <param name="callback">
         /// An AsyncCallback to call once the BeginInvoke completes.
+        /// Note: when using this API in script, don't pass in a delegate that is casted from a script block.
+        /// The callback could be invoked from a thread without a default Runspace and a delegate casted from
+        /// a script block would fail in that case.
         /// </param>
         /// <param name="state">
         /// A user supplied state to call the <paramref name="callback"/>
@@ -3158,6 +3164,9 @@ namespace System.Management.Automation
         /// </param>
         /// <param name="callback">
         /// An AsyncCallback to call once the command is invoked.
+        /// Note: when using this API in script, don't pass in a delegate that is casted from a script block.
+        /// The callback could be invoked from a thread without a default Runspace and a delegate casted from
+        /// a script block would fail in that case.
         /// </param>
         /// <param name="state">
         /// A user supplied state to call the <paramref name="callback"/>
@@ -3264,6 +3273,9 @@ namespace System.Management.Automation
         /// </param>
         /// <param name="callback">
         /// An AsyncCallback to call once the command is invoked.
+        /// Note: when using this API in script, don't pass in a delegate that is casted from a script block.
+        /// The callback could be invoked from a thread without a default Runspace and a delegate casted from
+        /// a script block would fail in that case.
         /// </param>
         /// <param name="state">
         /// A user supplied state to call the <paramref name="callback"/>
@@ -3733,6 +3745,9 @@ namespace System.Management.Automation
         /// </summary>
         /// <param name="callback">
         /// A AsyncCallback to call once the BeginStop completes.
+        /// Note: when using this API in script, don't pass in a delegate that is casted from a script block.
+        /// The callback could be invoked from a thread without a default Runspace and a delegate casted from
+        /// a script block would fail in that case.
         /// </param>
         /// <param name="state">
         /// A user supplied state to call the <paramref name="callback"/>
@@ -3794,6 +3809,9 @@ namespace System.Management.Automation
         /// </remarks>
         /// <param name="callback">
         /// An AsyncCallback to call once the command is invoked.
+        /// Note: when using this API in script, don't pass in a delegate that is casted from a script block.
+        /// The callback could be invoked from a thread without a default Runspace and a delegate casted from
+        /// a script block would fail in that case.
         /// </param>
         /// <param name="state">
         /// A user supplied state to call the <paramref name="callback"/>

--- a/src/System.Management.Automation/engine/hostifaces/PowerShell.cs
+++ b/src/System.Management.Automation/engine/hostifaces/PowerShell.cs
@@ -2915,8 +2915,8 @@ namespace System.Management.Automation
         /// </param>
         /// <param name="callback">
         /// An AsyncCallback to call once the BeginInvoke completes.
-        /// Note: when using this API in script, don't pass in a delegate that is casted from a script block.
-        /// The callback could be invoked from a thread without a default Runspace and a delegate casted from
+        /// Note: when using this API in script, don't pass in a delegate that is cast from a script block.
+        /// The callback could be invoked from a thread without a default Runspace and a delegate cast from
         /// a script block would fail in that case.
         /// </param>
         /// <param name="state">
@@ -3039,8 +3039,8 @@ namespace System.Management.Automation
         /// </param>
         /// <param name="callback">
         /// An AsyncCallback to call once the BeginInvoke completes.
-        /// Note: when using this API in script, don't pass in a delegate that is casted from a script block.
-        /// The callback could be invoked from a thread without a default Runspace and a delegate casted from
+        /// Note: when using this API in script, don't pass in a delegate that is cast from a script block.
+        /// The callback could be invoked from a thread without a default Runspace and a delegate cast from
         /// a script block would fail in that case.
         /// </param>
         /// <param name="state">
@@ -3164,8 +3164,8 @@ namespace System.Management.Automation
         /// </param>
         /// <param name="callback">
         /// An AsyncCallback to call once the command is invoked.
-        /// Note: when using this API in script, don't pass in a delegate that is casted from a script block.
-        /// The callback could be invoked from a thread without a default Runspace and a delegate casted from
+        /// Note: when using this API in script, don't pass in a delegate that is cast from a script block.
+        /// The callback could be invoked from a thread without a default Runspace and a delegate cast from
         /// a script block would fail in that case.
         /// </param>
         /// <param name="state">
@@ -3273,8 +3273,8 @@ namespace System.Management.Automation
         /// </param>
         /// <param name="callback">
         /// An AsyncCallback to call once the command is invoked.
-        /// Note: when using this API in script, don't pass in a delegate that is casted from a script block.
-        /// The callback could be invoked from a thread without a default Runspace and a delegate casted from
+        /// Note: when using this API in script, don't pass in a delegate that is cast from a script block.
+        /// The callback could be invoked from a thread without a default Runspace and a delegate cast from
         /// a script block would fail in that case.
         /// </param>
         /// <param name="state">
@@ -3745,8 +3745,8 @@ namespace System.Management.Automation
         /// </summary>
         /// <param name="callback">
         /// A AsyncCallback to call once the BeginStop completes.
-        /// Note: when using this API in script, don't pass in a delegate that is casted from a script block.
-        /// The callback could be invoked from a thread without a default Runspace and a delegate casted from
+        /// Note: when using this API in script, don't pass in a delegate that is cast from a script block.
+        /// The callback could be invoked from a thread without a default Runspace and a delegate cast from
         /// a script block would fail in that case.
         /// </param>
         /// <param name="state">
@@ -3809,8 +3809,8 @@ namespace System.Management.Automation
         /// </remarks>
         /// <param name="callback">
         /// An AsyncCallback to call once the command is invoked.
-        /// Note: when using this API in script, don't pass in a delegate that is casted from a script block.
-        /// The callback could be invoked from a thread without a default Runspace and a delegate casted from
+        /// Note: when using this API in script, don't pass in a delegate that is cast from a script block.
+        /// The callback could be invoked from a thread without a default Runspace and a delegate cast from
         /// a script block would fail in that case.
         /// </param>
         /// <param name="state">

--- a/test/powershell/engine/Api/TaskBasedAsyncPowerShellAPI.Tests.ps1
+++ b/test/powershell/engine/Api/TaskBasedAsyncPowerShellAPI.Tests.ps1
@@ -207,7 +207,7 @@ try {
             try {
                 $ir = $ps.AddScript("Start-Sleep -Seconds 60").InvokeAsync()
                 Wait-UntilTrue { $ps.InvocationStateInfo.State -eq [System.Management.Automation.PSInvocationState]::Running }
-                $sr = $ps.StopAsync({}, $null)
+                $sr = $ps.StopAsync($null, $null)
                 [System.Threading.Tasks.Task]::WaitAll(@($sr))
                 $sr.IsCompletedSuccessfully | Should -Be $true
                 $ir.IsFaulted | Should -Be $true


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fixing test run crash by not passing script block to the callback.
Updated the test. Also updated the XML documentation of those asynchronous APIs to call out this.

## PR Context

When calling the asynchronous APIs on the `PowerShell` class, the passed in callback could be invoked on a thread without the default Runspace.
So if a delegate cast from script block is passed in, it would fail in such case.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
