### PR TITLE
Make sure non-Windows CI fails when a test fails

### DIFF
--- a/tools/ci.psm1
+++ b/tools/ci.psm1
@@ -122,7 +122,6 @@ function Invoke-CIInstall
     )
     # Make sure we have all the tags
     Sync-PSTags -AddRemoteIfMissing
-    $releaseTag = Get-ReleaseTag
 
     if(Test-DailyBuild)
     {
@@ -588,8 +587,6 @@ function Invoke-LinuxTestsCore
         'ExcludeTag' = $testExcludeTag
         'OutputFile' = $testResultsNoSudo
     }
-    # create packages if it is a full build
-    $isFullBuild = Test-DailyBuild
 
     # Get the experimental feature names and the tests associated with them
     $ExperimentalFeatureTests = Get-ExperimentalFeatureTests
@@ -662,7 +659,7 @@ function Invoke-LinuxTestsCore
     # Determine whether the build passed
     try {
         $allTestResultsWithNoExpFeature = @($pesterPassThruNoSudoObject, $pesterPassThruSudoObject)
-        $allTestResultsWithExpFeatures = $noSudoResultsWithExpFeatures + $sudoResultsWithExpFeatures
+        $allTestResultsWithExpFeatures = @($noSudoResultsWithExpFeatures, $sudoResultsWithExpFeatures)
         # This throws if there was an error:
         $allTestResultsWithNoExpFeature | ForEach-Object { Test-PSPesterResults -ResultObject $_ }
         $allTestResultsWithExpFeatures  | ForEach-Object { Test-PSPesterResults -ResultObject $_ -CanHaveNoResult }

--- a/tools/ci.psm1
+++ b/tools/ci.psm1
@@ -672,53 +672,6 @@ function Invoke-LinuxTestsCore
         $resultError = $_
         $result = "FAIL"
     }
-}
-
-# Build and test script for Linux and macOS:
-function Invoke-LinuxTests
-{
-    param(
-        [switch]
-        $SkipBuild
-    )
-
-    if(!$SkipBuild.IsPresent)
-    {
-        $releaseTag = Get-ReleaseTag
-        Write-Log -Message "Executing ci.psm1 build and test on a Linux based operating system."
-        $originalProgressPreference = $ProgressPreference
-        $ProgressPreference = 'SilentlyContinue'
-        try {
-            # We use CrossGen build to run tests only if it's the daily build.
-            Start-PSBuild -CrossGen -PSModuleRestore -CI -ReleaseTag $releaseTag -Configuration 'Release'
-        }
-        finally
-        {
-            $ProgressPreference = $originalProgressPreference
-        }
-    }
-
-    Invoke-LinuxTestsCore
-
-    try {
-        $xUnitTestResultsFile = "$pwd/xUnitTestResults.xml"
-        Start-PSxUnit -xUnitTestResultsFile $xUnitTestResultsFile
-        # If there are failures, Test-XUnitTestResults throws
-        Test-XUnitTestResults -TestResultsFile $xUnitTestResultsFile
-    } catch {
-        $result = "FAIL"
-        if (!$resultError)
-        {
-            $resultError = $_
-        }
-    }
-
-    $createPackages = $isFullBuild
-
-    if ($createPackages)
-    {
-        New-LinuxPackage -NugetKey $env:NugetKey
-    }
 
     # If the tests did not pass, throw the reason why
     if ( $result -eq "FAIL" )


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Make sure non-Windows CI fails when a test fails

## PR Context

We discovered that some tests were failing after a PR and the CI was not failing

## PR Checklist

- [ ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
