### PR TITLE
Fix skipping of tests in RemoteSession.Basic.Tests.ps1

### DIFF
--- a/test/powershell/Modules/Microsoft.PowerShell.Security/ExecutionPolicy.Tests.ps1
+++ b/test/powershell/Modules/Microsoft.PowerShell.Security/ExecutionPolicy.Tests.ps1
@@ -1147,7 +1147,7 @@ ZoneId=$FileType
             }
         }
 
-        It '-Scope LocalMachine is Settable, but overridden' -Skip:(!(Test-CanWriteToPsHome)) {
+        It '-Scope LocalMachine is Settable, but overridden' -Skip:$ShouldSkipTest {
             # In this test, we first setup execution policy in the following way:
             # CurrentUser is specified and takes precedence over LocalMachine.
             # That's why we will get an error, when we are setting up LocalMachine policy.
@@ -1169,7 +1169,7 @@ ZoneId=$FileType
             Get-ExecutionPolicy -Scope LocalMachine | Should -Be "ByPass"
         }
 
-        It '-Scope LocalMachine is Settable' -Skip:(!(Test-CanWriteToPsHome)) {
+        It '-Scope LocalMachine is Settable' -Skip:$ShouldSkipTest {
             # We need to make sure that both Process and CurrentUser policies are Undefined
             # before we can set LocalMachine policy without ExecutionPolicyOverride error.
             Set-ExecutionPolicy -Scope Process -ExecutionPolicy Undefined

--- a/test/powershell/engine/Remoting/RemoteSession.Basic.Tests.ps1
+++ b/test/powershell/engine/Remoting/RemoteSession.Basic.Tests.ps1
@@ -40,7 +40,7 @@ Describe "JEA session Transcript script test" -Tag @("Feature", 'RequireAdminOnW
     BeforeAll {
         $originalDefaultParameterValues = $PSDefaultParameterValues.Clone()
 
-        if ( ! $IsWindows )
+        if ( ! $IsWindows -or !(Test-CanWriteToPsHome))
         {
             $PSDefaultParameterValues["it:skip"] = $true
         }
@@ -54,7 +54,7 @@ Describe "JEA session Transcript script test" -Tag @("Feature", 'RequireAdminOnW
         $global:PSDefaultParameterValues = $originalDefaultParameterValues
     }
 
-    It "Configuration name should be in the transcript header" -Skip:(!(Test-CanWriteToPsHome)) {
+    It "Configuration name should be in the transcript header" {
         [string] $RoleCapDirectory = (New-Item -Path "$TestDrive\RoleCapability" -ItemType Directory -Force).FullName
         [string] $PSSessionConfigFile = "$RoleCapDirectory\TestConfig.pssc"
         [string] $transScriptFile = "$RoleCapDirectory\*.txt"
@@ -82,7 +82,7 @@ Describe "JEA session Get-Help test" -Tag @("CI", 'RequireAdminOnWindows') {
     BeforeAll {
         $originalDefaultParameterValues = $PSDefaultParameterValues.Clone()
 
-        if ( ! $IsWindows )
+        if ( ! $IsWindows -or !(Test-CanWriteToPsHome))
         {
             $PSDefaultParameterValues["it:skip"] = $true
         }
@@ -96,7 +96,7 @@ Describe "JEA session Get-Help test" -Tag @("CI", 'RequireAdminOnWindows') {
         $global:PSDefaultParameterValues = $originalDefaultParameterValues
     }
 
-    It "Get-Help should work in JEA sessions" -Skip:(!(Test-CanWriteToPsHome)) {
+    It "Get-Help should work in JEA sessions" {
         [string] $RoleCapDirectory = (New-Item -Path "$TestDrive\RoleCapability" -ItemType Directory -Force).FullName
         [string] $PSSessionConfigFile = "$RoleCapDirectory\TestConfig.pssc"
         try

--- a/tools/ci.psm1
+++ b/tools/ci.psm1
@@ -661,8 +661,8 @@ function Invoke-LinuxTestsCore
         $allTestResultsWithNoExpFeature = @($pesterPassThruNoSudoObject, $pesterPassThruSudoObject)
         $allTestResultsWithExpFeatures = @($noSudoResultsWithExpFeatures, $sudoResultsWithExpFeatures)
         # This throws if there was an error:
-        $allTestResultsWithNoExpFeature | ForEach-Object { Test-PSPesterResults -ResultObject $_ }
-        $allTestResultsWithExpFeatures  | ForEach-Object { Test-PSPesterResults -ResultObject $_ -CanHaveNoResult }
+        $allTestResultsWithNoExpFeature | Where-Object {$null -ne $_} | ForEach-Object { Test-PSPesterResults -ResultObject $_ }
+        $allTestResultsWithExpFeatures  | Where-Object {$null -ne $_} | ForEach-Object { Test-PSPesterResults -ResultObject $_ -CanHaveNoResult }
         $result = "PASS"
     } catch {
         # The build failed, set the result:


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Moved check if able to write to $PSHome as way to skip test to `BeforeAll` which already contained a check if running on Windows.

## PR Context

As part https://github.com/PowerShell/PowerShell/pull/9279, tests were updated to be skipped if the test requires writing to `$PSHome` but is not able to.  However, these tests already had a skip mechanism in place so the additional check caused the test to run when it should have skipped.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
