### PR TITLE
Move warning message to EndProcessing for ExperimentalFeature cmdlets so it only shows up once

### DIFF
--- a/src/System.Management.Automation/engine/ExperimentalFeature/EnableDisableExperimentalFeatureCommand.cs
+++ b/src/System.Management.Automation/engine/ExperimentalFeature/EnableDisableExperimentalFeatureCommand.cs
@@ -30,6 +30,14 @@ namespace Microsoft.PowerShell.Commands
         /// </summary>
         [Parameter]
         public ConfigScope Scope { get; set; } = ConfigScope.CurrentUser;
+
+        /// <summary>
+        /// EndProcessing method.
+        /// </summary>
+        protected override void EndProcessing()
+        {
+            WriteWarning(ExperimentalFeatureStrings.ExperimentalFeaturePending);
+        }
     }
 
     /// <summary>
@@ -87,8 +95,6 @@ namespace Microsoft.PowerShell.Commands
                 cmdlet.WriteError(new ErrorRecord(new ItemNotFoundException(errMsg), "ItemNotFoundException", ErrorCategory.ObjectNotFound, name));
                 return;
             }
-
-            cmdlet.WriteWarning(ExperimentalFeatureStrings.ExperimentalFeaturePending);
         }
     }
 

--- a/test/powershell/engine/ExperimentalFeature/EnableDisable-ExperimentalFeature.Tests.ps1
+++ b/test/powershell/engine/ExperimentalFeature/EnableDisable-ExperimentalFeature.Tests.ps1
@@ -94,4 +94,14 @@ Describe "Enable-ExperimentalFeature and Disable-ExperimentalFeature tests" -tag
         & $cmdlet ExpTest.FeatureOne -WarningVariable warning -WarningAction SilentlyContinue
         $warning | Should -Not -BeNullOrEmpty -Because "A warning message is always given indicating restart is required"
     }
+
+    It "Multiple features enabled will only output one warning message for <cmdlet>" -TestCases @(
+        @{ cmdlet = "Enable-ExperimentalFeature" },
+        @{ cmdlet = "Disable-Experimentalfeature" }
+    ) {
+        param ($cmdlet)
+
+        Get-ExperimentalFeature | & $cmdlet -WarningAction SilentlyContinue -WarningVariable warning
+        $warning | Should -HaveCount 1
+    }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Move warning message to EndProcessing()

## PR Context

Currently, if you do: `Get-ExperimentalFeature | Enable-ExperimentalFeature` you get a warning message for each feature.  This is redundant.  Moving the warning to EndProcessing() ensures it only shows up once.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` or `[ WIP ]` to the beginning of the title (the `WIP` bot will keep its status check at `Pending` while the prefix is present) and remove the prefix when the PR is ready.
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
        - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
    - [ ] N/A or can only be tested interactively
    - **OR**
    - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
